### PR TITLE
feat(tool-foundry): author staged tools from proposals (#830 authorship slice)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "base64 0.23.0",
  "futures-util",
  "libc",
+ "proptest",
  "rand 0.10.2",
  "reqwest",
  "rusqlite",

--- a/stella-cli/src/cli.rs
+++ b/stella-cli/src/cli.rs
@@ -277,6 +277,14 @@ pub(crate) enum Command {
         /// ~/.stella/tools/).
         #[arg(long, value_name = "DIR")]
         validate: Option<Option<std::path::PathBuf>>,
+
+        /// Author a tool-foundry proposal into a staged custom tool:
+        /// writes `<name>.toml` + `<name>.sh` under .stella/tools/proposed/
+        /// (inert until a human moves the manifest into .stella/tools/).
+        /// Omit the value to list the current proposals mined from recent
+        /// bash receipts.
+        #[arg(long, value_name = "NAME", conflicts_with = "validate")]
+        author: Option<Option<String>>,
     },
 
     /// Fan tasks out to a fleet of worker agents in one tree

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -400,12 +400,15 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 }
             };
         }
-        Some(Command::Tools { validate }) => {
-            return match validate {
+        Some(Command::Tools { validate, author }) => {
+            return match (validate, author) {
+                // `--author` (name optional) stages a tool-foundry proposal
+                // as a reviewable manifest+script pair — or lists proposals.
+                (_, Some(name)) => tool_foundry::run_tools_author(name.as_deref()),
                 // `--validate` (dir optional) is the strict pre-flight path;
                 // a plain `stella tools` stays the lenient listing.
-                Some(dir) => agent::run_tools_validation(dir.as_deref()),
-                None => agent::run_tools_listing(),
+                (Some(dir), None) => agent::run_tools_validation(dir.as_deref()),
+                (None, None) => agent::run_tools_listing(),
             };
         }
         Some(Command::Graph { op, target }) => {

--- a/stella-cli/src/tool_foundry.rs
+++ b/stella-cli/src/tool_foundry.rs
@@ -12,9 +12,12 @@
 //! turn.
 
 use std::collections::HashSet;
+use std::path::Path;
 
+use colored::Colorize;
 use stella_core::{GapDetectionConfig, ProposedTool, ShellInvocation, detect_tool_gaps};
 use stella_store::{Notification, NotificationStore, Store, ToolCallRow};
+use stella_tools::foundry_author::{self, PROPOSED_DIR};
 
 /// How many recent `bash` receipts to mine per pass. A few hundred is plenty:
 /// the detector only needs enough history to see a shape recur, and the read
@@ -142,10 +145,158 @@ fn proposal_body(p: &ProposedTool) -> String {
         .join("\n");
     format!(
         "{desc}\n\nProposed command:\n  {template}\n\nParameters:\n{params}\n\nSeen:\n{examples}\n\n\
-         This is a suggestion only — no tool was installed. Review it before authoring one.",
+         This is a suggestion only — no tool was installed. Stage it for review with \
+         `stella tools --author {name}`.",
         desc = p.description,
         template = p.command_template,
+        name = p.name,
     )
+}
+
+/// `stella tools --author [NAME]` — the authorship slice of #830: turn one
+/// mined proposal into a staged, reviewable custom tool, or (with no name)
+/// list the proposals the detector currently mines from recent `bash`
+/// receipts. Authoring installs nothing: the manifest+script pair lands in
+/// `.stella/tools/proposed/`, a directory discovery's non-recursive scan can
+/// never register from, and enabling remains an explicit human move of the
+/// manifest into `.stella/tools/`.
+pub(crate) fn run_tools_author(name: Option<&str>) -> Result<(), String> {
+    let root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let store = Store::open(&root).map_err(|e| format!("cannot open the workspace store: {e}"))?;
+    run_tools_author_in(&root, &store, name, GapDetectionConfig::default())
+}
+
+/// The testable core of [`run_tools_author`]: store and workspace root
+/// injected, so a test can drive it with an in-memory store and a tempdir.
+fn run_tools_author_in(
+    root: &Path,
+    store: &Store,
+    name: Option<&str>,
+    config: GapDetectionConfig,
+) -> Result<(), String> {
+    let rows = store
+        .recent_tool_calls("bash", HISTORY_WINDOW)
+        .map_err(|e| format!("cannot read the bash receipt log: {e}"))?;
+    let invocations: Vec<ShellInvocation> =
+        rows.into_iter().filter_map(invocation_from_row).collect();
+    let proposals = detect_tool_gaps(&invocations, config);
+
+    let Some(name) = name else {
+        crate::tui::section_header("Tool-foundry proposals");
+        if proposals.is_empty() {
+            println!(
+                "  {}",
+                format!(
+                    "none right now — a shape must recur ≥{} times across ≥{} distinct \
+                     argument sets in the last {HISTORY_WINDOW} bash receipts",
+                    config.min_occurrences, config.min_distinct_arguments
+                )
+                .dimmed()
+            );
+            return Ok(());
+        }
+        for p in &proposals {
+            println!(
+                "  {} {} {}",
+                "·".dimmed(),
+                p.name.bright_magenta(),
+                format!(
+                    "— `{}` ({}× across {} argument sets)",
+                    p.signature, p.occurrences, p.distinct_arguments
+                )
+                .dimmed()
+            );
+        }
+        println!(
+            "\n  {}",
+            "stage one for review with `stella tools --author <name>`".dimmed()
+        );
+        return Ok(());
+    };
+
+    let Some(proposal) = proposals.iter().find(|p| p.name == name) else {
+        let available: Vec<&str> = proposals.iter().map(|p| p.name.as_str()).collect();
+        return Err(if available.is_empty() {
+            format!(
+                "no proposal named `{name}` — the detector currently proposes nothing \
+                 (run `stella tools --author` to see why)"
+            )
+        } else {
+            format!(
+                "no proposal named `{name}` — current proposals: {}",
+                available.join(", ")
+            )
+        });
+    };
+
+    let authored = foundry_author::author(proposal)?;
+    let staged_dir = root.join(PROPOSED_DIR);
+    std::fs::create_dir_all(&staged_dir)
+        .map_err(|e| format!("cannot create {}: {e}", staged_dir.display()))?;
+    let manifest_path = staged_dir.join(&authored.manifest_filename);
+    let script_path = staged_dir.join(&authored.script_filename);
+    // Never clobber: a staged pair may carry a reviewer's hand edits, and
+    // re-running the detector regenerates a fresh one anyway.
+    for path in [&manifest_path, &script_path] {
+        if path.exists() {
+            return Err(format!(
+                "`{}` is already staged — review it (or remove it) and re-run",
+                path.display()
+            ));
+        }
+    }
+    std::fs::write(&script_path, &authored.script)
+        .map_err(|e| format!("cannot write {}: {e}", script_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("cannot mark {} executable: {e}", script_path.display()))?;
+    }
+    std::fs::write(&manifest_path, &authored.manifest_toml)
+        .map_err(|e| format!("cannot write {}: {e}", manifest_path.display()))?;
+
+    crate::tui::section_header("Tool staged — not installed");
+    println!(
+        "  {} {}\n  {} {}",
+        "·".green(),
+        manifest_path.display(),
+        "·".green(),
+        script_path.display()
+    );
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+    let live = stella_tools::custom::discover_in(root, home.as_deref());
+    if live.tools.iter().any(|t| t.name == authored.name) {
+        println!(
+            "  {} {}",
+            "!".yellow(),
+            format!(
+                "a custom tool named `{}` already exists — adopting this one will be \
+                 ignored as a duplicate until that is resolved",
+                authored.name
+            )
+            .yellow()
+        );
+    }
+    println!(
+        "\n  {}",
+        format!(
+            "staged only — discovery cannot see {PROPOSED_DIR}/, so nothing is \
+             registered or executable until a human enables it:"
+        )
+        .dimmed()
+    );
+    println!(
+        "  {}\n  {}",
+        format!("pre-flight:  stella tools --validate {PROPOSED_DIR}").dimmed(),
+        format!(
+            "enable:      mv {PROPOSED_DIR}/{} .stella/tools/",
+            authored.manifest_filename
+        )
+        .dimmed()
+    );
+    Ok(())
 }
 
 #[cfg(test)]
@@ -267,6 +418,116 @@ mod tests {
         assert_eq!(
             surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default()),
             0
+        );
+    }
+
+    #[test]
+    fn author_stages_a_reviewable_pair_that_discovery_cannot_see() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let ws = tempfile::tempdir().expect("tmp");
+
+        run_tools_author_in(ws.path(), &store, Some("jq"), GapDetectionConfig::default())
+            .expect("authoring succeeds");
+
+        let manifest_path = ws.path().join(PROPOSED_DIR).join("jq.toml");
+        let script_path = ws.path().join(PROPOSED_DIR).join("jq.sh");
+        assert!(manifest_path.exists(), "manifest staged");
+        assert!(script_path.exists(), "script staged");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&script_path)
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o111, 0o111, "script is executable");
+        }
+
+        // The staged manifest is real: it parses with the discovery parser.
+        let text = std::fs::read_to_string(&manifest_path).unwrap();
+        let parsed = stella_tools::custom::parse_manifest(&text, &manifest_path)
+            .expect("staged manifest parses");
+        assert_eq!(parsed.name, "jq");
+
+        // The guardrail: discovery over this workspace registers nothing.
+        let report = stella_tools::custom::discover_in(ws.path(), None);
+        assert!(report.tools.is_empty(), "staged tool must not register");
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn author_refuses_to_clobber_a_staged_pair() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let ws = tempfile::tempdir().expect("tmp");
+        run_tools_author_in(ws.path(), &store, Some("jq"), GapDetectionConfig::default())
+            .expect("first authoring succeeds");
+
+        // A reviewer may have hand-edited the staged pair; re-authoring must
+        // fail closed instead of silently regenerating over it.
+        let err = run_tools_author_in(ws.path(), &store, Some("jq"), GapDetectionConfig::default())
+            .expect_err("second authoring refuses");
+        assert!(err.contains("already staged"), "{err}");
+    }
+
+    #[test]
+    fn author_with_unknown_name_lists_what_is_available() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let ws = tempfile::tempdir().expect("tmp");
+        let err = run_tools_author_in(
+            ws.path(),
+            &store,
+            Some("not_a_proposal"),
+            GapDetectionConfig::default(),
+        )
+        .expect_err("unknown name errors");
+        assert!(err.contains("jq"), "error names the real proposals: {err}");
+        assert!(
+            !ws.path().join(PROPOSED_DIR).exists(),
+            "nothing staged on error"
+        );
+    }
+
+    #[test]
+    fn author_listing_mode_writes_nothing() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let ws = tempfile::tempdir().expect("tmp");
+        run_tools_author_in(ws.path(), &store, None, GapDetectionConfig::default())
+            .expect("listing succeeds");
+        assert!(!ws.path().join(".stella").exists(), "listing is read-only");
+    }
+
+    #[test]
+    fn inbox_proposals_point_at_the_author_command() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let dir = tempfile::tempdir().expect("tmp");
+        let inbox = NotificationStore::open(dir.path());
+        surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default());
+        let items = inbox.list();
+        assert_eq!(items.len(), 1);
+        assert!(
+            items[0].body.contains("stella tools --author jq"),
+            "body must name the concrete next step: {}",
+            items[0].body
         );
     }
 

--- a/stella-tools/Cargo.toml
+++ b/stella-tools/Cargo.toml
@@ -35,6 +35,9 @@ toml.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "fs", "io-util"] }
 tempfile.workspace = true
+# Property tests for foundry authorship: every detector proposal must author
+# and round-trip through the real manifest parser.
+proptest.workspace = true
 wiremock.workspace = true
 # Tests only: install a trigger in the code-graph index so its next write pass
 # fails while every read still answers — the one way to exercise the non-fatal

--- a/stella-tools/src/foundry_author.rs
+++ b/stella-tools/src/foundry_author.rs
@@ -1,0 +1,519 @@
+//! Tool-foundry authorship — turn a detector proposal into a **staged**
+//! custom-tool definition: a manifest plus a POSIX-sh wrapper script.
+//!
+//! This is the second slice of self-improvement issue #830. The first slice
+//! (`stella_core::tool_foundry`) mines `bash` receipts and *proposes* a tool;
+//! this module *authors* one — a complete `<name>.toml` manifest and
+//! `<name>.sh` script, both rendered as text for the caller to write under
+//! `.stella/tools/proposed/`. That directory is the whole guardrail:
+//! discovery ([`crate::custom::discover`]) only scans `*.toml` files directly
+//! in `.stella/tools/`, so nothing staged in the `proposed/` subdirectory
+//! registers, advertises, or executes. A human reviews the staged pair and
+//! enables the tool by moving the manifest up one directory — the same
+//! zero-ceremony path any hand-written custom tool takes.
+//!
+//! **Authorship is proven before it is returned.** [`author`] feeds its own
+//! rendered manifest back through [`crate::custom::parse_manifest`] — the
+//! exact parser discovery uses — and fails closed on any disagreement. An
+//! authored tool can therefore never be malformed-on-arrival: if it returns
+//! `Ok`, the manifest parses, the name is valid and unreserved, and the
+//! schema round-trips.
+//!
+//! **Injection posture.** The generated script expands every parameter as a
+//! quoted `"$STELLA_INPUT_PN"` reference. Custom tools deliver each scalar
+//! input property as a `STELLA_INPUT_*` environment variable (see
+//! [`crate::custom`]), and a quoted variable expansion in POSIX sh is data —
+//! never word-split, globbed, or evaluated — so a parameter value cannot
+//! inject shell syntax into the authored command. What a value *can* still do
+//! is start with `-` and be read as a flag by the underlying program;
+//! argument-position vetting is exactly what the human review before adoption
+//! (and the later witness/gating slices) is for.
+
+use stella_core::{ParamKind, ProposedTool, ToolParameter};
+
+/// Workspace-relative directory staged tools land in. A subdirectory of the
+/// custom-tools dir on purpose: near where an adopted manifest will live, but
+/// invisible to discovery's non-recursive `*.toml` scan.
+pub const PROPOSED_DIR: &str = ".stella/tools/proposed";
+
+/// Suffix appended when a synthesized name collides with a reserved built-in
+/// (`grep`, `glob`, …): `grep` → `grep_cmd`.
+const DECONFLICT_SUFFIX: &str = "_cmd";
+
+/// A fully authored, self-validated tool definition, rendered as file text.
+/// Nothing here has touched the filesystem — writing (and the explicit human
+/// decision to adopt) belongs to the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthoredTool {
+    /// Final tool name — the proposal's name, deconflicted against
+    /// [`crate::custom::RESERVED_NAMES`].
+    pub name: String,
+    /// Complete manifest file text: provenance comment header + TOML body.
+    pub manifest_toml: String,
+    /// Complete wrapper-script text (`#!/bin/sh`, `set -eu`, the command).
+    pub script: String,
+    /// `<name>.toml` — file name to write under [`PROPOSED_DIR`].
+    pub manifest_filename: String,
+    /// `<name>.sh` — file name to write under [`PROPOSED_DIR`].
+    pub script_filename: String,
+}
+
+/// Wire shape of the manifest body. Field order is load-bearing for the TOML
+/// serializer: every scalar and array precedes `input_schema`, the one table,
+/// so serialization can never emit a value after a table.
+#[derive(serde::Serialize)]
+struct ManifestBody<'a> {
+    name: &'a str,
+    description: String,
+    command: [String; 1],
+    input_schema: serde_json::Value,
+}
+
+/// Author a staged tool definition from a detector proposal. Pure text-in,
+/// text-out; the only failure modes are a proposal whose signature and
+/// parameter list disagree (a detector-contract violation) and a rendered
+/// manifest the real parser rejects — both impossible for proposals built by
+/// `stella_core::detect_tool_gaps`, both checked anyway.
+pub fn author(proposal: &ProposedTool) -> Result<AuthoredTool, String> {
+    let name = deconflict_name(&proposal.name);
+    let (command_line, holes) = render_command(&proposal.signature);
+    if holes != proposal.parameters.len() {
+        return Err(format!(
+            "signature `{}` has {holes} holes but the proposal carries {} parameters",
+            proposal.signature,
+            proposal.parameters.len()
+        ));
+    }
+
+    let script = render_script(&name, &command_line);
+    let manifest_filename = format!("{name}.toml");
+    let script_filename = format!("{name}.sh");
+
+    let body = ManifestBody {
+        name: &name,
+        description: description_for(proposal),
+        command: [format!("./{PROPOSED_DIR}/{script_filename}")],
+        input_schema: input_schema_for(&proposal.parameters),
+    };
+    let toml_body = toml::to_string_pretty(&body)
+        .map_err(|e| format!("authored manifest failed to serialize: {e}"))?;
+    let manifest_toml = format!("{}{toml_body}", provenance_header(proposal, &name));
+
+    // The witness-before-write: the manifest must survive the exact parser
+    // discovery will apply, or authorship failed and nothing should be staged.
+    let parsed =
+        crate::custom::parse_manifest(&manifest_toml, std::path::Path::new(&manifest_filename))
+            .map_err(|e| format!("authored manifest failed its own parse check: {e}"))?;
+    if parsed.name != name {
+        return Err(format!(
+            "authored manifest parsed to name `{}`, expected `{name}`",
+            parsed.name
+        ));
+    }
+
+    Ok(AuthoredTool {
+        name,
+        manifest_toml,
+        script,
+        manifest_filename,
+        script_filename,
+    })
+}
+
+/// The proposal's name, made safe to adopt: reserved built-in names get
+/// [`DECONFLICT_SUFFIX`], with the base truncated first so the result stays
+/// within the 64-char name rule.
+fn deconflict_name(proposed: &str) -> String {
+    if !crate::custom::RESERVED_NAMES.contains(&proposed) {
+        return proposed.to_string();
+    }
+    let mut base = proposed.to_string();
+    base.truncate(64 - DECONFLICT_SUFFIX.len());
+    format!("{base}{DECONFLICT_SUFFIX}")
+}
+
+/// Rewrite the detector signature into the script's command line: each typed
+/// placeholder becomes a quoted `"$STELLA_INPUT_PN"` expansion (keeping any
+/// `--flag=` / `NAME=` prefix), every other token — skeleton words and shell
+/// operators — passes through verbatim. Returns the line and the hole count.
+///
+/// Exact by construction: the tokenizer that built the signature treats `<`
+/// and `>` as operator characters, so no skeleton word can contain a
+/// placeholder-shaped substring, and a bare `<`/`>` operator token never ends
+/// in `str>`/`path>`/`num>`.
+fn render_command(signature: &str) -> (String, usize) {
+    let mut parts: Vec<String> = Vec::new();
+    let mut n = 0usize;
+    'token: for part in signature.split(' ') {
+        for kind in [ParamKind::Str, ParamKind::Path, ParamKind::Number] {
+            if let Some(prefix) = part.strip_suffix(kind.placeholder())
+                && (prefix.is_empty() || prefix.ends_with('='))
+            {
+                n += 1;
+                parts.push(format!("{prefix}\"$STELLA_INPUT_P{n}\""));
+                continue 'token;
+            }
+        }
+        parts.push(part.to_string());
+    }
+    (parts.join(" "), n)
+}
+
+/// The wrapper script: shebang, a provenance note, strict mode, the command.
+fn render_script(name: &str, command_line: &str) -> String {
+    format!(
+        "#!/bin/sh\n\
+         # {name} — authored by stella's tool foundry from observed shell usage.\n\
+         # Parameters arrive as STELLA_INPUT_P* environment variables and are\n\
+         # expanded quoted, so values stay data — never shell syntax.\n\
+         set -eu\n\
+         {command_line}\n"
+    )
+}
+
+/// The description the model will see once the tool is adopted.
+fn description_for(proposal: &ProposedTool) -> String {
+    format!(
+        "Run `{}` with the parameters filling the placeholders in order. \
+         Authored by the tool foundry from {} observed uses of this shell shape.",
+        proposal.signature, proposal.occurrences
+    )
+}
+
+/// JSON Schema for the tool input: one required property per hole, typed
+/// string/number, described by what was actually observed at that position.
+fn input_schema_for(parameters: &[ToolParameter]) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required: Vec<serde_json::Value> = Vec::new();
+    for param in parameters {
+        let (json_type, noun) = match param.kind {
+            ParamKind::Str => ("string", "string value"),
+            ParamKind::Path => ("string", "path"),
+            ParamKind::Number => ("number", "number"),
+        };
+        let observed = if param.examples.is_empty() {
+            String::new()
+        } else {
+            format!(" (observed: {})", param.examples.join(", "))
+        };
+        properties.insert(
+            param.name.clone(),
+            serde_json::json!({
+                "type": json_type,
+                "description": format!("{noun} for this position{observed}"),
+            }),
+        );
+        required.push(serde_json::Value::String(param.name.clone()));
+    }
+    serde_json::json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false,
+    })
+}
+
+/// The comment block above the TOML body: what this is, why it is inert, how
+/// to enable it, and the receipts it was authored from. Every borrowed line is
+/// comment-sanitized so a multi-line or control-character command cannot break
+/// the file's TOML validity.
+fn provenance_header(proposal: &ProposedTool, name: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# {name} — authored by stella's tool foundry (self-improvement #830).\n\
+         # STAGED ONLY: discovery scans .stella/tools/*.toml non-recursively, so\n\
+         # nothing under proposed/ is registered, advertised, or executable.\n\
+         #\n\
+         # To pre-flight:  stella tools --validate {PROPOSED_DIR}\n\
+         # To enable:      mv {PROPOSED_DIR}/{name}.toml .stella/tools/\n\
+         #\n\
+         # Evidence: {} invocations, {} distinct argument sets.\n",
+        proposal.occurrences, proposal.distinct_arguments,
+    ));
+    for line in comment_lines(&format!("signature: {}", proposal.signature)) {
+        out.push_str(&format!("# {line}\n"));
+    }
+    for example in &proposal.examples {
+        for line in comment_lines(&format!("$ {example}")) {
+            out.push_str(&format!("#   {line}\n"));
+        }
+    }
+    out.push('\n');
+    out
+}
+
+/// Split borrowed text into TOML-comment-safe lines: newlines become separate
+/// comment lines, and remaining control characters (a bare `\r`, an escape
+/// byte) become spaces — TOML forbids them inside comments.
+fn comment_lines(text: &str) -> Vec<String> {
+    text.lines()
+        .map(|line| {
+            line.chars()
+                .map(|c| if c.is_control() && c != '\t' { ' ' } else { c })
+                .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_core::{GapDetectionConfig, ShellInvocation, detect_tool_gaps};
+
+    use super::*;
+
+    /// Run the real detector over a history and return its proposals — every
+    /// test authors from genuine detector output, never hand-built structs.
+    fn proposals_for(commands: &[&str]) -> Vec<ProposedTool> {
+        let history: Vec<ShellInvocation> =
+            commands.iter().map(|c| ShellInvocation::ok(*c)).collect();
+        detect_tool_gaps(&history, GapDetectionConfig::default())
+    }
+
+    fn author_one(commands: &[&str]) -> AuthoredTool {
+        let proposals = proposals_for(commands);
+        assert_eq!(proposals.len(), 1, "expected exactly one proposal");
+        author(&proposals[0]).expect("authorship must succeed")
+    }
+
+    #[test]
+    fn the_motivating_jq_case_authors_a_parseable_manifest() {
+        let authored = author_one(&[
+            "jq '.items[0]' a.json",
+            "jq '.name' b.json",
+            "jq '.error.code' c.json",
+        ]);
+        assert_eq!(authored.name, "jq");
+        assert_eq!(authored.manifest_filename, "jq.toml");
+        assert_eq!(authored.script_filename, "jq.sh");
+
+        // The parse check already ran inside author(); parse again here to
+        // inspect what discovery would see.
+        let parsed =
+            crate::custom::parse_manifest(&authored.manifest_toml, std::path::Path::new("jq.toml"))
+                .expect("manifest parses");
+        assert_eq!(parsed.name, "jq");
+        assert_eq!(parsed.command, vec![format!("./{PROPOSED_DIR}/jq.sh")]);
+        assert_eq!(parsed.input_schema["type"], "object");
+        assert_eq!(parsed.input_schema["properties"]["p1"]["type"], "string");
+        assert_eq!(parsed.input_schema["properties"]["p2"]["type"], "string");
+        assert_eq!(
+            parsed.input_schema["required"],
+            serde_json::json!(["p1", "p2"])
+        );
+        assert_eq!(parsed.input_schema["additionalProperties"], false);
+
+        assert!(
+            authored
+                .script
+                .contains("jq \"$STELLA_INPUT_P1\" \"$STELLA_INPUT_P2\""),
+            "script quotes every hole: {}",
+            authored.script
+        );
+        assert!(authored.script.starts_with("#!/bin/sh\n"));
+        assert!(authored.script.contains("set -eu"));
+    }
+
+    #[test]
+    fn a_reserved_name_is_deconflicted() {
+        // `grep <str> <path>` synthesizes the name `grep`, which is a
+        // reserved built-in — the authored tool must not shadow it.
+        let authored = author_one(&[
+            "grep 'todo' src/a.rs",
+            "grep 'fixme' src/b.rs",
+            "grep 'hack' src/c.rs",
+        ]);
+        assert_eq!(authored.name, "grep_cmd");
+        assert!(authored.manifest_toml.contains("name = \"grep_cmd\""));
+    }
+
+    #[test]
+    fn numeric_holes_are_typed_number() {
+        let authored = author_one(&[
+            "git log --oneline -5",
+            "git log --oneline -10",
+            "git log --oneline -20",
+        ]);
+        let parsed =
+            crate::custom::parse_manifest(&authored.manifest_toml, std::path::Path::new("x.toml"))
+                .unwrap();
+        assert_eq!(parsed.input_schema["properties"]["p1"]["type"], "number");
+        assert!(
+            authored
+                .script
+                .contains("git log --oneline \"$STELLA_INPUT_P1\""),
+            "{}",
+            authored.script
+        );
+    }
+
+    #[test]
+    fn flag_and_env_prefixes_survive_in_the_script() {
+        let flagged = author_one(&[
+            "curl --retry=3 https://a.test/x",
+            "curl --retry=5 https://b.test/y",
+            "curl --retry=1 https://c.test/z",
+        ]);
+        assert!(
+            flagged
+                .script
+                .contains("curl --retry=\"$STELLA_INPUT_P1\" \"$STELLA_INPUT_P2\""),
+            "{}",
+            flagged.script
+        );
+
+        let env_assign = author_one(&[
+            "env RUST_LOG=debug cargo test",
+            "env RUST_LOG=trace cargo test",
+            "env RUST_LOG=info cargo test",
+        ]);
+        assert!(
+            env_assign
+                .script
+                .contains("env RUST_LOG=\"$STELLA_INPUT_P1\" cargo test"),
+            "{}",
+            env_assign.script
+        );
+    }
+
+    #[test]
+    fn pipeline_operators_pass_through() {
+        let authored = author_one(&[
+            "jq '.a' one.json | head",
+            "jq '.b' two.json | head",
+            "jq '.c' three.json | head",
+        ]);
+        assert!(
+            authored
+                .script
+                .contains("jq \"$STELLA_INPUT_P1\" \"$STELLA_INPUT_P2\" | head"),
+            "{}",
+            authored.script
+        );
+    }
+
+    #[test]
+    fn provenance_header_carries_evidence_and_stays_valid_toml() {
+        let authored = author_one(&["jq '.a' a.json", "jq '.b' b.json", "jq '.c' c.json"]);
+        assert!(authored.manifest_toml.contains("STAGED ONLY"));
+        assert!(authored.manifest_toml.contains("3 invocations"));
+        assert!(authored.manifest_toml.contains("$ jq '.a' a.json"));
+        // The whole file — comments included — is valid TOML.
+        toml::from_str::<toml::Value>(&authored.manifest_toml).expect("valid TOML");
+    }
+
+    #[tokio::test]
+    async fn an_authored_tool_actually_executes_through_the_custom_path() {
+        use stella_core::ports::ToolExecutor;
+        use stella_protocol::tool::ToolOutput;
+
+        // A shape with no external dependency: `echo` + a path hole.
+        let authored = author_one(&["echo built a.txt", "echo built b.txt", "echo built c.txt"]);
+
+        // Stage it in a real workspace layout and run it via the same
+        // executor a session would use.
+        let ws = tempfile::tempdir().unwrap();
+        let staged = ws.path().join(PROPOSED_DIR);
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(
+            staged.join(&authored.manifest_filename),
+            &authored.manifest_toml,
+        )
+        .unwrap();
+        let script_path = staged.join(&authored.script_filename);
+        std::fs::write(&script_path, &authored.script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let tool = crate::custom::parse_manifest(
+            &authored.manifest_toml,
+            std::path::Path::new("echo_built.toml"),
+        )
+        .unwrap();
+        struct NoInner;
+        #[async_trait::async_trait]
+        impl ToolExecutor for NoInner {
+            fn schemas(&self) -> Vec<stella_protocol::tool::ToolSchema> {
+                Vec::new()
+            }
+            async fn execute(&self, _: &str, _: &serde_json::Value) -> ToolOutput {
+                ToolOutput::Error {
+                    message: "no inner".into(),
+                }
+            }
+        }
+        let inner = NoInner;
+        let name = tool.name.clone();
+        let set = crate::custom::CustomToolSet::new(&inner, vec![tool], ws.path().to_path_buf());
+        let out = set
+            .execute(&name, &serde_json::json!({ "p1": "delivered.txt" }))
+            .await;
+        match out {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("built delivered.txt"), "{content}")
+            }
+            ToolOutput::Error { message } => panic!("expected ok: {message}"),
+        }
+    }
+
+    #[test]
+    fn discovery_never_sees_a_staged_tool() {
+        // The guardrail itself: files under proposed/ are invisible to the
+        // scan that registers custom tools.
+        let authored = author_one(&["jq '.a' a.json", "jq '.b' b.json", "jq '.c' c.json"]);
+        let ws = tempfile::tempdir().unwrap();
+        let staged = ws.path().join(PROPOSED_DIR);
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(
+            staged.join(&authored.manifest_filename),
+            &authored.manifest_toml,
+        )
+        .unwrap();
+        std::fs::write(staged.join(&authored.script_filename), &authored.script).unwrap();
+
+        let report = crate::custom::discover_in(ws.path(), None);
+        assert!(report.tools.is_empty(), "staged tools must not register");
+        assert!(report.diagnostics.is_empty(), "and must not even warn");
+    }
+
+    proptest::proptest! {
+        /// Every proposal the detector can produce authors successfully, and
+        /// the authored manifest round-trips through the real parser with a
+        /// schema property per parameter and a quoted expansion per hole.
+        #[test]
+        fn every_detector_proposal_authors_and_round_trips(
+            history in proptest::collection::vec(arb_invocation(), 0..60),
+        ) {
+            for proposal in detect_tool_gaps(&history, GapDetectionConfig::default()) {
+                let authored = author(&proposal).expect("authorship succeeds");
+                let parsed = crate::custom::parse_manifest(
+                    &authored.manifest_toml,
+                    std::path::Path::new(&authored.manifest_filename),
+                ).expect("round-trips through the real parser");
+                proptest::prop_assert_eq!(&parsed.name, &authored.name);
+                let props = parsed.input_schema["properties"]
+                    .as_object()
+                    .expect("schema has properties");
+                proptest::prop_assert_eq!(props.len(), proposal.parameters.len());
+                let expansions = authored.script.matches("\"$STELLA_INPUT_P").count();
+                proptest::prop_assert_eq!(expansions, proposal.parameters.len());
+            }
+        }
+    }
+
+    /// Mirrors the detector's own property-test alphabet: overlapping shapes
+    /// so runs exercise real clustering.
+    fn arb_invocation() -> impl proptest::prelude::Strategy<Value = ShellInvocation> {
+        use proptest::prelude::*;
+        (0..4usize, 0..4usize, any::<bool>()).prop_map(|(prog, arg, succeeded)| {
+            let progs = ["jq", "sed", "grep", "git log"];
+            let args = ["'.x' a.json", "'.y' b.json", "-5", "--flag=1 c.json"];
+            ShellInvocation {
+                command: format!("{} {}", progs[prog], args[arg]),
+                succeeded,
+            }
+        })
+    }
+}

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -23,6 +23,7 @@ pub mod edit;
 pub mod exec;
 pub mod exploration;
 pub mod file_touch;
+pub mod foundry_author;
 pub mod gather;
 pub mod github_rest;
 pub mod glob;

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -8,7 +8,7 @@ List every tool available to the agent for the current session — built-in tool
 ## Synopsis
 
 ```bash
-stella tools [--validate [DIR]] [global flags]
+stella tools [--validate [DIR]] [--author [NAME]] [global flags]
 ```
 
 ## What it does
@@ -33,6 +33,12 @@ Custom tools come from a `<name>.toml` manifest dropped in `<workspace>/.stella/
     reports errors, warnings, and info per manifest, and exits non-zero if any manifest
     has errors.
   </OptionCard>
+  <OptionCard name="--author [NAME]">
+    Author a tool-foundry proposal into a staged custom tool: writes `NAME.toml` +
+    `NAME.sh` under `.stella/tools/proposed/`, where discovery cannot see them — nothing
+    registers or executes until you move the manifest into `.stella/tools/`. Omit `NAME`
+    to list the proposals currently mined from recent `bash` receipts.
+  </OptionCard>
 </CardGrid>
 
 `stella tools` otherwise takes the [global flags](/docs/commands); model selection rarely matters for this diagnostic command.
@@ -56,3 +62,18 @@ Validate one directory of manifests before installing them:
 ```bash
 stella tools --validate ./contrib/stella-tools
 ```
+
+Stage a tool-foundry proposal for review, pre-flight it, then enable it:
+
+```bash
+stella tools --author            # list current proposals
+stella tools --author jq         # stage jq.toml + jq.sh in .stella/tools/proposed/
+stella tools --validate .stella/tools/proposed
+mv .stella/tools/proposed/jq.toml .stella/tools/   # the explicit human enablement
+```
+
+When the agent keeps reconstructing the same shell shape by hand, the tool foundry
+proposes a reusable tool in `/inbox`. `--author` turns one proposal into a reviewable
+manifest + script pair — staged, never installed. The generated script expands every
+parameter as a quoted `"$STELLA_INPUT_*"` reference, so parameter values stay data
+rather than shell syntax.


### PR DESCRIPTION
## What & why

The second slice of the tool foundry (self-improvement track): `stella tools --author <name>` turns a capability-gap proposal — mined from `bash` receipts by the detector PR #845 landed — into a complete, reviewable custom-tool definition: a TOML manifest plus a POSIX-sh wrapper script, staged under `.stella/tools/proposed/`.

**Nothing installs.** Discovery's non-recursive `*.toml` scan of `.stella/tools/` cannot see the `proposed/` subdirectory, so a staged tool never registers, advertises, or executes. Enabling remains an explicit human `mv` of the manifest into `.stella/tools/` — the same zero-ceremony path a hand-written custom tool takes, preserving the issue's guardrail that authorship and enablement stay separate authorities.

Mechanics:

- `stella-tools/src/foundry_author.rs` — pure text-in/text-out authorship. The rendered manifest is fed back through `custom::parse_manifest` (the exact parser discovery uses) and authorship fails closed on any disagreement, so a staged tool can never be malformed-on-arrival. Reserved built-in names deconflict (`grep` → `grep_cmd`). Every parameter expands as a quoted `"$STELLA_INPUT_PN"` reference in the script, so values stay data — never shell syntax. The manifest carries a provenance comment header with the receipts it was authored from.
- `stella tools --author` (no name) lists current proposals; `--author <name>` stages one, refuses to clobber an existing staged pair (it may carry a reviewer's hand edits), and prints the pre-flight (`stella tools --validate .stella/tools/proposed`) and enablement steps.
- `/inbox` proposals now name the concrete next step: `stella tools --author <name>`.
- Docs: `website/content/docs/commands/tools.mdx` documents the flag and the review→enable flow.

Remaining #830 slices (not in this PR): witness proof (a test that fails on the missing capability and passes on the new tool) and gating + registration/persistence.

Refs #830

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`foundry_author` does not exist on `main`, so every test here fails there by construction; the load-bearing ones are behavioral:

- `every_detector_proposal_authors_and_round_trips` — property test: any proposal the detector can produce authors successfully and round-trips through the real manifest parser, one schema property and one quoted expansion per hole.
- `an_authored_tool_actually_executes_through_the_custom_path` — an authored tool staged in a real workspace layout runs through `CustomToolSet` and produces the expected output.
- `discovery_never_sees_a_staged_tool` / `author_stages_a_reviewable_pair_that_discovery_cannot_see` — the guardrail itself, asserted from both crates.
- `author_refuses_to_clobber_a_staged_pair` — re-authoring fails closed over a possibly hand-edited review artifact.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (touched crates + dependents, clean)
- [x] `cargo test --workspace` (`stella-tools` and `stella-cli` full suites green; detector crate untouched)
- [x] Docs updated where behavior/flags changed (`--help` text, `tools.mdx`, module docs)
- [x] CLA signed

## Ground-rule check

- [x] No I/O added to `stella-core`; one new dep: `proptest` as a **dev-dependency** of `stella-tools` (already a workspace dep, used by `stella-core`) for the authorship property test
- [x] No new outbound network calls

## Anything reviewers should know?

- The staged manifest's `command` points at `./.stella/tools/proposed/<name>.sh`, so adopting by moving only the manifest still resolves — the script stays quarantined in `proposed/` and the manifest remains the single registration authority. A later adopt/gating slice can relocate both.
- Argument-position injection (a parameter value starting with `-` read as a flag by the wrapped program) is deliberately left to human review before adoption; the quoted-expansion posture only guarantees values cannot become shell syntax. The module docs state this explicitly.
- `--author` is `conflicts_with = "validate"`; the clap wiring is covered by the existing `Cli::command().debug_assert()` test.

## Summary by Sourcery

Add a tool-foundry authorship flow that stages custom tools from detector proposals without installing them, and wire it into the `stella tools` CLI along with documentation and tests.

New Features:
- Introduce `stella tools --author [NAME]` to list tool-foundry proposals or author one into a staged manifest and script under `.stella/tools/proposed/` where discovery cannot register it.

Enhancements:
- Update detector inbox notifications so proposals explicitly reference the `stella tools --author <name>` command as the next step.

Documentation:
- Document the new `--author` flag and the review→validate→enable flow for staged tools in the `stella tools` command docs.

Tests:
- Add integration and property tests ensuring authored tools parse, execute via the custom-tool path, remain invisible to discovery while staged, refuse to clobber existing staged artifacts, and that every detector proposal authors and round-trips through the manifest parser.