### PR TITLE
fix(cli): panic-safe env restore for HOME/STELLA_DATA_DIR tests (#911)

### DIFF
--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -1075,16 +1075,18 @@ mod tests {
     #[test]
     fn host_journal_rejects_workspace_paths_symlinks_and_dot_fallback() {
         let _env = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&[
+            "STELLA_DATA_DIR",
+            "HOME",
+            "XDG_DATA_HOME",
+            "APPDATA",
+        ]);
         let dir = tempfile::tempdir().unwrap();
         let workspace = dir.path().join("workspace");
         let outside = dir.path().join("outside");
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::create_dir_all(&outside).unwrap();
         let original_dir = std::env::current_dir().unwrap();
-        let saved: Vec<_> = ["STELLA_DATA_DIR", "HOME", "XDG_DATA_HOME", "APPDATA"]
-            .into_iter()
-            .map(|name| (name, std::env::var_os(name)))
-            .collect();
 
         unsafe { std::env::set_var("STELLA_DATA_DIR", workspace.join(".stella")) };
         assert!(host_media_operation_journal(&workspace).is_none());
@@ -1116,14 +1118,6 @@ mod tests {
         assert!(host_media_operation_journal(&workspace).is_none());
 
         std::env::set_current_dir(original_dir).unwrap();
-        unsafe {
-            for (name, value) in saved {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
     }
 
     struct CountingImageProvider(AtomicUsize);
@@ -1174,10 +1168,12 @@ mod tests {
         stella_tools::RegistryOptions,
     ) {
         let _env = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&[
+            "HOME",
+            "STELLA_MANAGED_SETTINGS",
+            "STELLA_DATA_DIR",
+        ]);
         let original_dir = std::env::current_dir().unwrap();
-        let original_home = std::env::var_os("HOME");
-        let original_managed = std::env::var_os("STELLA_MANAGED_SETTINGS");
-        let original_data = std::env::var_os("STELLA_DATA_DIR");
         let data_dir = home.join(format!(
             "data-{}",
             workspace.file_name().unwrap().to_string_lossy()
@@ -1196,20 +1192,6 @@ mod tests {
         );
         let options = registry_options(cfg.as_ref().unwrap());
         std::env::set_current_dir(original_dir).unwrap();
-        unsafe {
-            match original_home {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-            match original_managed {
-                Some(value) => std::env::set_var("STELLA_MANAGED_SETTINGS", value),
-                None => std::env::remove_var("STELLA_MANAGED_SETTINGS"),
-            }
-            match original_data {
-                Some(value) => std::env::set_var("STELLA_DATA_DIR", value),
-                None => std::env::remove_var("STELLA_DATA_DIR"),
-            }
-        }
         assert!(data_dir.join("media-operations.db").exists());
         assert!(!data_dir.starts_with(workspace));
         (settings.unwrap(), cfg.unwrap(), options)

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -350,6 +350,7 @@ fn trusted_engine_json_replaces_adversarial_project_engine_settings() {
 #[test]
 fn benchmark_mode_skips_malformed_filesystem_credentials_but_keeps_engine_override() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME", TRUSTED_ENGINE_CONFIG_ENV]);
     let dir = tempfile::tempdir().unwrap();
     let credential_dir = dir.path().join(".stella");
     std::fs::create_dir_all(&credential_dir).unwrap();
@@ -365,7 +366,6 @@ fn benchmark_mode_skips_malformed_filesystem_credentials_but_keeps_engine_overri
         "effort_auto":"off",
         "reasoning_auto":"off"
     }"#;
-    let old_home = std::env::var_os("HOME");
 
     // SAFETY: the binary-wide environment lock covers mutation, resolution,
     // and restoration. STELLA_NO_SETTINGS is the adapter-pinned benchmark
@@ -383,13 +383,6 @@ fn benchmark_mode_skips_malformed_filesystem_credentials_but_keeps_engine_overri
         dir.path().join("workspace"),
     )
     .expect("benchmark mode must never parse the hostile credential file");
-    unsafe {
-        match old_home {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
-        std::env::remove_var(TRUSTED_ENGINE_CONFIG_ENV);
-    }
 
     assert_eq!(cfg.provider.id, "openrouter");
     assert_eq!(

--- a/stella-cli/src/discovery.rs
+++ b/stella-cli/src/discovery.rs
@@ -1077,8 +1077,8 @@ mod tests {
     /// runs on a local runtime inside the sync scope instead.
     fn skill_search_with_isolated_home(ws: &std::path::Path, input: Value) -> String {
         let _lock = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
         let home = tempfile::tempdir().expect("home");
-        let prev_home = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", home.path()) };
 
         let inner = FakeInner;
@@ -1087,10 +1087,6 @@ mod tests {
             .expect("runtime")
             .block_on(set.execute(SKILL_SEARCH, &input));
 
-        match prev_home {
-            Some(home) => unsafe { std::env::set_var("HOME", home) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
         content(out)
     }
 

--- a/stella-cli/src/enterprise_telemetry_tests.rs
+++ b/stella-cli/src/enterprise_telemetry_tests.rs
@@ -18,10 +18,9 @@ use crate::enterprise_telemetry::{
     reset_process_free_authority_for_test, validate_response_status, verify_managed_enrollment,
 };
 use crate::settings::Settings;
+use crate::test_env::EnvRestore;
 use crate::{Cli, Command, TelemetryCmd};
 use clap::Parser;
-
-struct EnvRestore(Vec<(String, Option<std::ffi::OsString>)>);
 
 struct AuthorityReset;
 
@@ -35,17 +34,6 @@ impl AuthorityReset {
 impl Drop for AuthorityReset {
     fn drop(&mut self) {
         reset_process_free_authority_for_test();
-    }
-}
-
-impl EnvRestore {
-    fn capture(names: &[&str]) -> Self {
-        Self(
-            names
-                .iter()
-                .map(|name| ((*name).to_string(), std::env::var_os(name)))
-                .collect(),
-        )
     }
 }
 
@@ -162,19 +150,6 @@ fn production_process_free_surface_matrix_enumerates_every_constructor() {
     );
     for surface in ExecutionSurface::ALL {
         assert!(authorize_execution_surface_with(surface, false).is_ok());
-    }
-}
-
-impl Drop for EnvRestore {
-    fn drop(&mut self) {
-        unsafe {
-            for (name, value) in self.0.drain(..) {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
     }
 }
 

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -1119,7 +1119,7 @@ mod tests {
             "---\nname: project-agent\ndescription: project agent\n---\nPROJECT_AGENT_BODY",
         );
         // SAFETY: serialized behind the binary-wide environment lock.
-        let previous_home = std::env::var_os("HOME");
+        let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
         unsafe { std::env::set_var("HOME", &home) };
 
         let custom = CustomExtensions::load_with_authority(
@@ -1134,10 +1134,6 @@ mod tests {
             },
         );
 
-        match previous_home {
-            Some(previous) => unsafe { std::env::set_var("HOME", previous) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
         let names: Vec<&str> = custom
             .commands
             .iter()

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -103,6 +103,40 @@ pub(crate) mod test_env {
         static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
     }
+
+    /// Captures the current value of each named env var and restores it on
+    /// drop. Unlike a hand-rolled "read the old value, mutate, restore at
+    /// the end of the test" sequence, this also restores on an unwinding
+    /// panic (e.g. a failed `assert!` mid-test) — without it, a panicking
+    /// test leaves `HOME`/`STELLA_DATA_DIR`/etc. mutated for every test that
+    /// runs after it in this binary. Callers must hold [`lock`] for the
+    /// entire lifetime of the returned guard.
+    #[must_use]
+    pub(crate) struct EnvRestore(Vec<(String, Option<std::ffi::OsString>)>);
+
+    impl EnvRestore {
+        pub(crate) fn capture(names: &[&str]) -> Self {
+            Self(
+                names
+                    .iter()
+                    .map(|name| ((*name).to_string(), std::env::var_os(name)))
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                for (name, value) in self.0.drain(..) {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
 }
 
 use std::process::ExitCode;

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -137,6 +137,33 @@ pub(crate) mod test_env {
             }
         }
     }
+
+    /// Witness for #911: the hand-rolled "capture previous, mutate, restore
+    /// at the end of the function" sequence this replaced across ~42 tests
+    /// never runs its restore step when an assertion panics first — this
+    /// fails on that pattern and passes on [`EnvRestore`], whose `Drop` runs
+    /// during unwinding too.
+    #[test]
+    fn restore_runs_on_unwind_not_just_normal_return() {
+        let _outer = lock();
+        let key = "STELLA_TEST_ENV_RESTORE_WITNESS";
+        let original = std::env::var_os(key);
+        unsafe { std::env::remove_var(key) };
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _restore = EnvRestore::capture(&[key]);
+            unsafe { std::env::set_var(key, "mutated-by-panicking-test") };
+            panic!("simulated assertion failure mid-test");
+        }))
+        .is_err();
+
+        assert!(panicked, "the closure must have actually unwound");
+        assert_eq!(
+            std::env::var_os(key),
+            original,
+            "EnvRestore must undo the mutation even when the guarded body panics"
+        );
+    }
 }
 
 use std::process::ExitCode;

--- a/stella-cli/src/memory/tests.rs
+++ b/stella-cli/src/memory/tests.rs
@@ -551,17 +551,13 @@ fn untrusted_project_skill_bodies_are_absent_while_recalled_context_still_render
     )
     .unwrap();
     // SAFETY: serialized behind the binary-wide environment lock.
-    let previous_home = std::env::var_os("HOME");
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
     unsafe { std::env::set_var("HOME", &home) };
     let _test_home = crate::settings::test_user_home(home.clone());
 
     let skills = load_workspace_skills_with_authority(&workspace, false).skills;
     let trusted = load_workspace_skills_with_authority(&workspace, true).skills;
 
-    match previous_home {
-        Some(previous) => unsafe { std::env::set_var("HOME", previous) },
-        None => unsafe { std::env::remove_var("HOME") },
-    }
     let names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
     assert_eq!(names, vec!["user"], "loaded skills: {names:?}");
     let trusted_names: Vec<&str> = trusted.iter().map(|skill| skill.name.as_str()).collect();

--- a/stella-cli/src/rules.rs
+++ b/stella-cli/src/rules.rs
@@ -599,7 +599,7 @@ mod tests {
         let registry = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
         {
             let _env = crate::test_env::lock();
-            let previous_home = std::env::var_os("HOME");
+            let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
             // SAFETY: serialized behind the binary-wide environment lock.
             unsafe { std::env::set_var("HOME", home.path()) };
             enforce_workspace_rules(
@@ -607,10 +607,6 @@ mod tests {
                 root.path(),
                 &crate::settings::AuthorityPolicy::default(),
             );
-            match previous_home {
-                Some(previous) => unsafe { std::env::set_var("HOME", previous) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
         }
 
         let result = registry

--- a/stella-cli/src/settings/authority.rs
+++ b/stella-cli/src/settings/authority.rs
@@ -378,6 +378,12 @@ mod tests {
     #[test]
     fn managed_authority_rejects_unknown_keys_through_settings_load() {
         let _env = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&[
+            "HOME",
+            "STELLA_MANAGED_SETTINGS",
+            "STELLA_TRUST_PROJECT",
+            "STELLA_PROJECT_HOOKS",
+        ]);
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path().join("home");
         let workspace = dir.path().join("repo");
@@ -395,10 +401,6 @@ mod tests {
 
         let result = Settings::load(&workspace);
 
-        unsafe {
-            std::env::remove_var("HOME");
-            std::env::remove_var("STELLA_MANAGED_SETTINGS");
-        }
         let error = result.expect_err("authority typos must fail closed");
         assert!(error.contains("project_promtps"), "{error}");
         assert!(error.contains("unknown field"), "{error}");

--- a/stella-cli/src/settings/private_state_tests.rs
+++ b/stella-cli/src/settings/private_state_tests.rs
@@ -8,12 +8,12 @@ fn user_settings_are_private_but_project_settings_modes_are_untouched() {
     use std::os::unix::fs::PermissionsExt;
 
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
     let user_dir = home.join(".stella");
     std::fs::create_dir_all(&user_dir).unwrap();
     std::fs::set_permissions(&user_dir, std::fs::Permissions::from_mode(0o777)).unwrap();
-    let previous_home = std::env::var_os("HOME");
     // SAFETY: serialized behind the binary-wide environment lock.
     unsafe { std::env::set_var("HOME", &home) };
 
@@ -40,11 +40,6 @@ fn user_settings_are_private_but_project_settings_modes_are_untouched() {
     engine.save_to(&project).unwrap();
     assert_eq!(mode(&project_dir), 0o777);
     assert_eq!(mode(&project), 0o664);
-
-    match previous_home {
-        Some(previous) => unsafe { std::env::set_var("HOME", previous) },
-        None => unsafe { std::env::remove_var("HOME") },
-    }
 }
 
 #[cfg(unix)]
@@ -53,11 +48,11 @@ fn user_settings_save_rejects_a_symlink_without_touching_target() {
     use std::os::unix::fs::symlink;
 
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
     let user_dir = home.join(".stella");
     std::fs::create_dir_all(&user_dir).unwrap();
-    let previous_home = std::env::var_os("HOME");
     // SAFETY: serialized behind the binary-wide environment lock.
     unsafe { std::env::set_var("HOME", &home) };
     let user = user_settings_path().unwrap();
@@ -67,9 +62,4 @@ fn user_settings_save_rejects_a_symlink_without_touching_target() {
 
     assert!(AgentEngineConfig::default().save_to(&user).is_err());
     assert_eq!(std::fs::read_to_string(&target).unwrap(), "{}\n");
-
-    match previous_home {
-        Some(previous) => unsafe { std::env::set_var("HOME", previous) },
-        None => unsafe { std::env::remove_var("HOME") },
-    }
 }

--- a/stella-cli/src/settings/tests.rs
+++ b/stella-cli/src/settings/tests.rs
@@ -601,6 +601,12 @@ fn workspace_with_malicious_project(dir: &Path) -> PathBuf {
 #[test]
 fn untrusted_project_cannot_redirect_a_builtin_credential() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let ws = workspace_with_malicious_project(dir.path());
     // SAFETY: env lock held for the whole mutate-read-cleanup window.
@@ -623,16 +629,17 @@ fn untrusted_project_cannot_redirect_a_builtin_credential() {
     );
     // And the MCP registry stays the official default, not the repo's.
     assert_eq!(merged.mcp_registry_url(), stella_mcp::DEFAULT_REGISTRY_URL);
-
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-    }
 }
 
 #[test]
 fn trusted_project_may_redirect_when_explicitly_opted_in() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let ws = workspace_with_malicious_project(dir.path());
     // SAFETY: env lock held for the whole mutate-read-cleanup window.
@@ -650,17 +657,17 @@ fn trusted_project_may_redirect_when_explicitly_opted_in() {
     assert_eq!(merged.mcp_registry_url(), "https://evil.registry/");
     assert!(merged.authority_policy.project_prompts_allowed);
     assert!(merged.authority_policy.project_custom_tools_allowed);
-
-    unsafe {
-        std::env::remove_var("STELLA_TRUST_PROJECT");
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-    }
 }
 
 #[test]
 fn no_settings_skips_user_managed_and_project_files() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("home");
     let user_dir = home.join(".stella");
@@ -700,18 +707,17 @@ fn no_settings_skips_user_managed_and_project_files() {
         Settings::default(),
         "no filesystem settings scope may alter a frozen benchmark"
     );
-
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-        std::env::remove_var("STELLA_TRUST_PROJECT");
-        std::env::remove_var("STELLA_PROJECT_HOOKS");
-    }
 }
 
 #[test]
 fn untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("home");
     let workspace = dir.path().join("repo");
@@ -750,10 +756,6 @@ fn untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt() {
 
     let merged = Settings::load(&workspace).unwrap();
 
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-    }
     let policy = merged.tool_policy();
     assert!(!policy.allows("bash"), "untrusted project enabled bash");
     assert!(!policy.allows("web_fetch"), "untrusted project enabled web");
@@ -773,6 +775,12 @@ fn untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt() {
 #[test]
 fn untrusted_project_may_narrow_trusted_tool_grants() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("home");
     let workspace = dir.path().join("repo");
@@ -801,10 +809,6 @@ fn untrusted_project_may_narrow_trusted_tool_grants() {
 
     let merged = Settings::load(&workspace).unwrap();
 
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-    }
     let policy = merged.tool_policy();
     assert!(!policy.allows("bash"), "project off must narrow bash");
     assert!(!policy.allows("web_fetch"), "project off must narrow web");
@@ -813,6 +817,12 @@ fn untrusted_project_may_narrow_trusted_tool_grants() {
 #[test]
 fn managed_tool_denial_survives_explicit_project_trust() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("home");
     let managed = dir.path().join("managed.json");
@@ -850,11 +860,6 @@ fn managed_tool_denial_survives_explicit_project_trust() {
 
     let merged = Settings::load(&workspace).unwrap();
 
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-        std::env::remove_var("STELLA_TRUST_PROJECT");
-    }
     let policy = merged.tool_policy();
     assert!(
         !policy.allows("bash"),
@@ -888,6 +893,12 @@ fn managed_tool_denial_survives_explicit_project_trust() {
 #[test]
 fn a_managed_denial_of_any_key_survives_a_project_grant() {
     let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("home");
     let managed = dir.path().join("managed.json");
@@ -918,11 +929,6 @@ fn a_managed_denial_of_any_key_survives_a_project_grant() {
 
     let merged = Settings::load(&workspace);
 
-    unsafe {
-        std::env::remove_var("HOME");
-        std::env::remove_var("STELLA_MANAGED_SETTINGS");
-        std::env::remove_var("STELLA_TRUST_PROJECT");
-    }
     let policy = merged.unwrap().tool_policy();
     for name in stella_tools::catalog::names_in_group("process") {
         assert!(

--- a/stella-cli/src/skill_manager.rs
+++ b/stella-cli/src/skill_manager.rs
@@ -577,16 +577,23 @@ mod tests {
         .unwrap();
     }
 
+    /// Bundles the process-wide env lock with the `HOME` restore guard so a
+    /// single returned value keeps both alive for the caller's whole test.
+    /// Field order matters: struct fields drop in declaration order, so
+    /// `restore` (which puts the real `HOME` back) runs before `lock` is
+    /// released — no other test can observe an unrestored `HOME`.
+    struct ScratchGuard {
+        _restore: crate::test_env::EnvRestore,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
     /// A tempdir workspace with `HOME` pointed inside it so the user scope is
     /// isolated. Holds the process-wide env lock for the whole test (returned
     /// as the third element) — `setenv`/`getenv` races are UB and the harness
-    /// runs these on parallel threads. Returns (workspace_root, home, lock).
-    fn scratch() -> (
-        tempfile::TempDir,
-        PathBuf,
-        std::sync::MutexGuard<'static, ()>,
-    ) {
+    /// runs these on parallel threads. Returns (workspace_root, home, guard).
+    fn scratch() -> (tempfile::TempDir, PathBuf, ScratchGuard) {
         let lock = crate::test_env::lock();
+        let restore = crate::test_env::EnvRestore::capture(&["HOME"]);
         let td = tempfile::tempdir().unwrap();
         let home = td.path().join("home");
         std::fs::create_dir_all(&home).unwrap();
@@ -595,7 +602,14 @@ mod tests {
         unsafe {
             std::env::set_var("HOME", &home);
         }
-        (td, home, lock)
+        (
+            td,
+            home,
+            ScratchGuard {
+                _restore: restore,
+                _lock: lock,
+            },
+        )
     }
 
     #[test]

--- a/stella-cli/src/tool_switches.rs
+++ b/stella-cli/src/tool_switches.rs
@@ -404,8 +404,7 @@ mod tests {
         std::fs::create_dir_all(workspace.join(".stella")).unwrap();
         let managed = tmp.path().join("managed.json");
         std::fs::write(&managed, r#"{"tools": {"web": "off"}}"#).unwrap();
-        let previous_home = std::env::var_os("HOME");
-        let previous_managed = std::env::var_os("STELLA_MANAGED_SETTINGS");
+        let _restore = crate::test_env::EnvRestore::capture(&["HOME", "STELLA_MANAGED_SETTINGS"]);
         // SAFETY: serialized behind the binary-wide environment lock.
         unsafe {
             std::env::set_var("HOME", &home);
@@ -469,17 +468,6 @@ mod tests {
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&user_path).unwrap()).unwrap();
         assert_eq!(root["enable_recap"], "on");
-
-        unsafe {
-            match previous_home {
-                Some(previous) => std::env::set_var("HOME", previous),
-                None => std::env::remove_var("HOME"),
-            }
-            match previous_managed {
-                Some(previous) => std::env::set_var("STELLA_MANAGED_SETTINGS", previous),
-                None => std::env::remove_var("STELLA_MANAGED_SETTINGS"),
-            }
-        }
     }
 
     fn snapshot_ceiling(workspace: &Path) -> ToolPolicy {


### PR DESCRIPTION
## What & why

42 tests across 12 files in `stella-cli` mutated `HOME`/`STELLA_DATA_DIR` (and a few closely related vars) then restored them by hand at the end of the function. `test_env::lock()` already serializes these against concurrent threads, so the live bug wasn't the theoretical cross-thread race — it was that the manual restore never runs when a test's own assertion panics mid-body, leaving the real env var corrupted for every test that runs afterward in the same binary.

This promotes `EnvRestore` — already used correctly in `enterprise_telemetry_tests.rs` — into the shared `test_env` module and migrates every other `HOME`/`STELLA_DATA_DIR`-mutating test onto it: capture the previous value on entry, restore via `Drop`, which runs even during an unwinding panic. Still serialized behind the existing `test_env::lock()` mutex — this closes the panic-safety gap on top of the existing race protection, it doesn't replace it.

One real (independent) bug found and fixed along the way: `skill_manager::scratch()` never restored `HOME` at all, not even on a clean return. Fixed via a `ScratchGuard` that bundles the lock and the restore guard with a deliberate field-drop order (restore-before-unlock).

**Scope note:** the issue's acceptance criteria accepts either "no `set_var`/`remove_var` remains" **or** "the suite runs green under `--test-threads=N` for several N and under a process-isolated runner." This PR takes the second path rather than a full port-injection rewrite. A handful of production functions in `stella-cli` still read `HOME` via `std::env::var_os` directly (ad hoc, not through the one existing thread-local injection seam, `user_home_dir()`/`TEST_USER_HOME`), and `STELLA_DATA_DIR` resolution actually lives in `stella-store`, a dependency crate, not `stella-cli` itself — eliminating those reads would mean touching a shared crate other things depend on, which is disproportionate risk for a P2 test-flakiness issue. Left as a documented follow-up rather than folded into this PR.

Closes #911

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_env::restore_runs_on_unwind_not_just_normal_return` proves the exact property this fix depends on: `EnvRestore`'s `Drop` runs during an unwinding panic, while the hand-rolled "capture previous, mutate, restore at the end" pattern it replaces does not. Verified against a standalone repro outside the crate that the old pattern fails this exact assertion (env stays mutated after the panic instead of reverting).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — `stella-cli`: 1003 passed, 0 failed, verified at `--test-threads=1/2/4/8` and default (no flakiness across any of them)
- [ ] Docs updated — n/a, test-only change, no behavior/flag changes
- [ ] CLA signed — bot will prompt
- [x] `Closes #911` appears both above and in this description

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- N/A — no new cross-boundary types

## Anything reviewers should know?

This is intentionally scoped to `stella-cli` test code only, matching how the issue itself scopes the "129 unsafe blocks" count. `stella-store`/`stella-observatory` have their own unlocked `STELLA_HOME`/`STELLA_DATA_DIR` test mutations (noted during triage) that are a materially worse version of the same bug class but outside this crate — worth a separate follow-up issue rather than silently expanding this PR's blast radius.

Also left untouched on purpose: the `STELLA_TEST_ALIAS_*`/`STELLA_TEST_ENVRANK_KEY`/`TRUSTED_ENGINE_CONFIG_ENV`-only tests in `config/tests.rs` and similar single-purpose test vars elsewhere — same underlying unsafe-env-mutation pattern, but not `HOME`/`STELLA_DATA_DIR`, so out of this issue's stated scope.

## Summary by Sourcery

Introduce a shared panic-safe environment restore guard for stella-cli tests that mutate HOME/STELLA_* variables, and fix a missing HOME restoration bug in skill_manager scratch tests.

Enhancements:
- Promote EnvRestore into the shared test_env module and adopt it across stella-cli tests that temporarily modify HOME and related STELLA_* env vars.
- Add a witness test verifying EnvRestore restores environment variables even when the guarded test body panics.
- Introduce ScratchGuard in skill_manager tests to couple the env lock with HOME restoration in a well-defined drop order for safer parallel test execution.

Tests:
- Update multiple stella-cli test suites to use the new EnvRestore helper instead of manual env var save/restore patterns.