### PR TITLE
fix: 3 P2 backlog issues — supply-chain policy, RetriesExhausted semantics, cla.yml permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,16 @@ jobs:
         run: cargo build --workspace --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'
 
   supply-chain:
+    # NOTE: name is pinned to main's branch-protection required-status-check
+    # list (`cargo deny + cargo audit`) even though this job no longer runs
+    # cargo-audit (#919 — cargo-deny with unmaintained="all"/yanked="deny" is
+    # a strict superset of what cargo-audit contributed here, and two tools
+    # reading advisory-suppression policy from two different files meant a
+    # suppression added to deny.toml's `[advisories] ignore` never applied to
+    # cargo-audit). Renaming it would make GitHub wait forever on a context
+    # that never reports again — see bench/READINESS.md for the same failure
+    # mode with a different check. Do not rename without updating branch
+    # protection (repo admin, out of band) in the same change.
     name: cargo deny + cargo audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -225,14 +235,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      # Pinned by exact version, not just `--locked`: `--locked` fixes each
+      # Pinned by exact version, not just `--locked`: `--locked` fixes the
       # tool's own transitive graph but not the tool itself, so an unpinned
-      # `cargo install` here resolves whatever cargo-deny/cargo-audit are
-      # newest at run time — the one job whose purpose is keeping untrusted
-      # code out is also the only one fetching an unversioned executable from
-      # the network (#915). Bump these deliberately, like the toolchain pin.
-      - name: Install cargo-deny + cargo-audit
-        run: cargo install --locked cargo-deny@0.20.2 cargo-audit@0.22.2
+      # `cargo install` here resolves whatever cargo-deny is newest at run
+      # time — the one job whose purpose is keeping untrusted code out is
+      # also the only one fetching an unversioned executable from the
+      # network (#915). Bump this deliberately, like the toolchain pin.
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny@0.20.2
 
       # Real gate (no `|| true`): advisories + dependency bans + source
       # provenance + licenses, configured in deny.toml. The license check is a
@@ -241,6 +251,3 @@ jobs:
       # and the commercial track (see deny.toml and LICENSING.md).
       - name: cargo deny check
         run: cargo deny check advisories bans sources licenses
-
-      - name: cargo audit
-        run: cargo audit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,6 +26,15 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  # Genuinely required, not copy-pasted from the upstream README (#918):
+  # signing happens via an `issue_comment` on the PR, which has no commit SHA
+  # of its own to attach a passing status to. `contributor-assistant`'s
+  # `setupClaCheck.ts` reacts to "all contributors now signed" by calling
+  # `reRunLastWorkFlowIfRequired()` (src/pullRerunRunner.ts), which calls
+  # `octokit.actions.reRunWorkflow()` on the ORIGINAL `pull_request_target`
+  # run that failed before the signature existed — that's what flips the
+  # PR's check to green without waiting for a new push. Without `actions:
+  # write` a contributor could sign and the PR would stay red forever.
   actions: write
   contents: read
   pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,11 @@ happened before — see RELEASING.md's local-release path), it is the only gate
 running at all.
 
 Supply-chain checks run as a separate CI job: `make supply-chain` (or
-`cargo deny check advisories bans sources licenses` + `cargo audit`). All four
-are real gates. The license gate matters more than it looks: the workspace is
+`cargo deny check advisories bans sources licenses`). All four are real
+gates. (The CI job is still named "cargo deny + cargo audit" to match main's
+branch-protection required check, even though cargo-audit itself was dropped
+in #919 — cargo-deny's `unmaintained`/`yanked` settings are a strict superset
+of what it added.) The license gate matters more than it looks: the workspace is
 AGPL-3.0-only and dual-licensed, so a dependency carrying any further
 restriction (non-commercial clause, field-of-use limit, or no license at all)
 breaks both AGPL redistribution and the commercial track. **If `cargo deny`

--- a/Makefile
+++ b/Makefile
@@ -176,12 +176,8 @@ docs: ## Build rustdoc for the workspace (skip dep docs)
 deny: ## cargo deny: advisories, dependency bans, source provenance, licenses
 	cargo deny check advisories bans sources licenses
 
-.PHONY: vuln-scan
-vuln-scan: ## cargo audit: security vulnerability scan
-	cargo audit
-
 .PHONY: supply-chain
-supply-chain: deny vuln-scan ## Run both supply-chain checks
+supply-chain: deny ## Run the supply-chain check (alias for `deny`; see #919)
 
 CARGO_WATCH := $(shell command -v cargo-watch 2>/dev/null)
 
@@ -252,8 +248,8 @@ reap-agents: ## List orphaned stella agents/tool-subprocesses idle 20m+ (dry run
 reap-agents-kill: ## Kill orphaned stella agents/tool-subprocesses idle 20m+ (asks first)
 	scripts/reap-agents.sh
 
-# The supply-chain steps gate on the TOOL being present, not on its exit code:
-# a missing cargo-deny/cargo-audit soft-skips with a message, but a real
+# The supply-chain step gates on the TOOL being present, not on its exit code:
+# a missing cargo-deny soft-skips with a message, but a real
 # advisory/license/vulnerability failure from an installed tool fails the
 # target. (The old `cmd || printf` form swallowed genuine failures too.)
 .PHONY: audit
@@ -267,11 +263,6 @@ audit: ## Run full codebase audit (clippy, tests, supply-chain, dead-code scan)
 		cargo deny check advisories bans sources licenses; \
 	else \
 		printf '  \033[33mcargo-deny not installed — skipping (cargo install cargo-deny)\033[0m\n'; \
-	fi
-	@if command -v cargo-audit >/dev/null 2>&1; then \
-		cargo audit; \
-	else \
-		printf '  \033[33mcargo-audit not installed — skipping (cargo install cargo-audit)\033[0m\n'; \
 	fi
 	@printf '\n\033[1m=== Unused dependencies ===\033[0m\n'
 	@# Same shape as the two steps above, and for the same reason: gate on the

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,10 @@
 # precisely because nothing gated on licenses.
 #
 # Only version-stable lint-level keys are set here so the config parses across
-# cargo-deny releases; `cargo audit` (a separate CI step) is the primary
-# advisory gate, and defaults already fail the build on a known vulnerability.
+# cargo-deny releases; cargo-deny is the sole advisory gate (#919 dropped the
+# separate cargo-audit step — two tools reading suppression policy from two
+# files meant an entry added here never reached the other one), and defaults
+# already fail the build on a known vulnerability.
 
 [licenses]
 # Every license here is compatible with distributing the combined work under

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -856,6 +856,23 @@ export type AgentEvent = {
    * Per-attempt failure reasons, oldest first.
    */
   reasons: string[];
+  /**
+   * Whether the LAST attempt's error was of a retryable class —
+   * mirrors the paired [`AgentEvent::Error`]'s `retryable` field,
+   * computed from the same `ProviderError::is_retryable()` call.
+   * `false` means retrying again could never have helped: the
+   * clearest case is `ProviderError::Auth` failing on attempt 1,
+   * where `attempts` is 1 and no retry was ever attempted despite
+   * this event's name (#926) — a receipts/telemetry consumer that
+   * only sees `RetriesExhausted` would otherwise record a
+   * reliability incident for what is really a bad credential.
+   * `#[serde(default = "retries_exhausted_retryable_default")]`:
+   * event logs recorded before this field existed predate the
+   * distinction, so on replay they read as "genuinely retryable"
+   * — the pre-#926 behavior — rather than being silently
+   * reclassified as terminal.
+   */
+  retryable?: boolean;
   turn_instance: number;
   type: "retries_exhausted";
 } | {

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1640,6 +1640,11 @@
           },
           "type": "array"
         },
+        "retryable": {
+          "default": true,
+          "description": "Whether the LAST attempt's error was of a retryable class —\nmirrors the paired [`AgentEvent::Error`]'s `retryable` field,\ncomputed from the same `ProviderError::is_retryable()` call.\n`false` means retrying again could never have helped: the\nclearest case is `ProviderError::Auth` failing on attempt 1,\nwhere `attempts` is 1 and no retry was ever attempted despite\nthis event's name (#926) — a receipts/telemetry consumer that\nonly sees `RetriesExhausted` would otherwise record a\nreliability incident for what is really a bad credential.\n`#[serde(default = \"retries_exhausted_retryable_default\")]`:\nevent logs recorded before this field existed predate the\ndistinction, so on replay they read as \"genuinely retryable\"\n— the pre-#926 behavior — rather than being silently\nreclassified as terminal.",
+          "type": "boolean"
+        },
         "turn_instance": {
           "format": "uint32",
           "minimum": 0,

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -114,6 +114,23 @@ export type AgentEvent = {
    * Per-attempt failure reasons, oldest first.
    */
   reasons: string[];
+  /**
+   * Whether the LAST attempt's error was of a retryable class —
+   * mirrors the paired [`AgentEvent::Error`]'s `retryable` field,
+   * computed from the same `ProviderError::is_retryable()` call.
+   * `false` means retrying again could never have helped: the
+   * clearest case is `ProviderError::Auth` failing on attempt 1,
+   * where `attempts` is 1 and no retry was ever attempted despite
+   * this event's name (#926) — a receipts/telemetry consumer that
+   * only sees `RetriesExhausted` would otherwise record a
+   * reliability incident for what is really a bad credential.
+   * `#[serde(default = "retries_exhausted_retryable_default")]`:
+   * event logs recorded before this field existed predate the
+   * distinction, so on replay they read as "genuinely retryable"
+   * — the pre-#926 behavior — rather than being silently
+   * reclassified as terminal.
+   */
+  retryable?: boolean;
   turn_instance: number;
   type: "retries_exhausted";
 } | {

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -283,6 +283,11 @@
               },
               "type": "array"
             },
+            "retryable": {
+              "default": true,
+              "description": "Whether the LAST attempt's error was of a retryable class —\nmirrors the paired [`AgentEvent::Error`]'s `retryable` field,\ncomputed from the same `ProviderError::is_retryable()` call.\n`false` means retrying again could never have helped: the\nclearest case is `ProviderError::Auth` failing on attempt 1,\nwhere `attempts` is 1 and no retry was ever attempted despite\nthis event's name (#926) — a receipts/telemetry consumer that\nonly sees `RetriesExhausted` would otherwise record a\nreliability incident for what is really a bad credential.\n`#[serde(default = \"retries_exhausted_retryable_default\")]`:\nevent logs recorded before this field existed predate the\ndistinction, so on replay they read as \"genuinely retryable\"\n— the pre-#926 behavior — rather than being silently\nreclassified as terminal.",
+              "type": "boolean"
+            },
             "turn_instance": {
               "format": "uint32",
               "minimum": 0,

--- a/scripts/check-cargo-install-pins.sh
+++ b/scripts/check-cargo-install-pins.sh
@@ -4,8 +4,8 @@
 # for each crate it installs (#915).
 #
 # `--locked` pins a tool's own transitive dependency graph; it does not pin
-# the tool itself. An unpinned `cargo install cargo-deny cargo-audit` in the
-# supply-chain job resolved whatever those crates' newest published version
+# the tool itself. An unpinned `cargo install cargo-deny` in the
+# supply-chain job resolved whatever that crate's newest published version
 # was at run time — the one job whose purpose is keeping untrusted code out
 # was also the only one fetching an unversioned executable from the network.
 #
@@ -53,7 +53,7 @@ if [ "$fail" -ne 0 ]; then
   echo >&2
   echo "Pin each crate to an exact version, e.g.:" >&2
   echo >&2
-  echo "    run: cargo install --locked cargo-deny@0.20.2 cargo-audit@0.22.2" >&2
+  echo "    run: cargo install --locked cargo-deny@0.20.2" >&2
   exit 1
 fi
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4390 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2231 stella-core/src/driver.rs
+2239 stella-core/src/driver.rs
 3133 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs
@@ -29,7 +29,7 @@
 1723 stella-model/src/zai/tests.rs
 3190 stella-pipeline/src/pipeline.rs
 2393 stella-pipeline/src/pipeline/tests.rs
-2752 stella-protocol/src/event.rs
+2778 stella-protocol/src/event.rs
 2074 stella-store/src/lib.rs
 2234 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -246,8 +246,7 @@ fi
 # Format: name|tier|why|installer|package
 tool_table() {
   cat <<'EOF'
-cargo-deny|ci|CI job "cargo deny + cargo audit" is a required check; make deny|cargo|cargo-deny
-cargo-audit|ci|same required check; make vuln-scan|cargo|cargo-audit
+cargo-deny|ci|CI job "cargo deny + cargo audit" (name kept for branch protection; only cargo-deny actually runs, see #919) is a required check; make deny|cargo|cargo-deny
 gh|repo|PR + release flow (scripts/release.sh hard-requires it)|brew|gh
 rg|repo|repo convention: rg over grep, and it is gitignore-aware|brew|ripgrep
 fd|repo|repo convention: fd over find|brew|fd
@@ -481,8 +480,10 @@ cat <<'EOF'
     - release smoke   CI also runs `cargo build --workspace --release`
                       (thin LTO). Not in any make target.
     - normative-home  scripts/check-normative-home.sh runs in CI only.
-    - supply chain    `cargo deny` + `cargo audit` are a SEPARATE required
-                      check. `make gate` does not run them; `make supply-chain` does.
+    - supply chain    `cargo deny` is a SEPARATE required check (the CI job
+                      keeps the name "cargo deny + cargo audit" for branch
+                      protection; cargo-audit itself was dropped in #919).
+                      `make gate` does not run it; `make supply-chain` does.
 EOF
 
 hdr "Next"

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -1457,15 +1457,23 @@ impl<'a> Engine<'a> {
                 cancel_guard.disarm();
                 let reasons =
                     std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
+                // Shared with the paired `Error` event below: whether the
+                // FINAL attempt's error is of a retryable class. `false`
+                // means every attempt (typically just one — see
+                // `retry_with_backoff_observed`, which bails on the first
+                // non-retryable error) was doomed from the start, not
+                // exhausted by an actual retry loop (#926).
+                let retryable = error.is_retryable();
                 let _ = events.send(AgentEvent::RetriesExhausted {
                     turn_instance: self.config.turn_instance,
                     attempts: reasons.len() as u32,
                     reasons,
+                    retryable,
                 });
                 let message = error.to_string();
                 let _ = events.send(AgentEvent::Error {
                     message: message.clone(),
-                    retryable: error.is_retryable(),
+                    retryable,
                 });
                 return Err(format!("model call failed: {message}"));
             }

--- a/stella-core/src/driver/tests/usage_completeness.rs
+++ b/stella-core/src/driver/tests/usage_completeness.rs
@@ -109,6 +109,65 @@ async fn exhausted_retries_emit_typed_reasons_before_the_error() {
 }
 
 #[tokio::test]
+async fn auth_failure_on_first_attempt_reports_not_retryable() {
+    // #926: a terminal `ProviderError::Auth` on attempt 1 was previously
+    // indistinguishable, at the typed level, from a genuine retry-budget
+    // exhaustion — both emitted `RetriesExhausted`, and only `attempts == 1`
+    // (an implicit contract) hinted that no retry was ever attempted. This
+    // is the acceptance case: attempts is 1, and `retryable` says so
+    // explicitly.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Err(ProviderError::Auth("bad api key".into()))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("work"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Aborted { .. }));
+    let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    let exhausted: Vec<_> = events
+        .iter()
+        .filter(|event| matches!(event, AgentEvent::RetriesExhausted { .. }))
+        .collect();
+    assert_eq!(exhausted.len(), 1, "{events:?}");
+    match exhausted[0] {
+        AgentEvent::RetriesExhausted {
+            attempts,
+            retryable,
+            ..
+        } => {
+            assert_eq!(*attempts, 1, "no retry was ever attempted");
+            assert!(!*retryable, "auth errors are never retryable");
+        }
+        other => panic!("filtered above: {other:?}"),
+    }
+    let error = events
+        .iter()
+        .find(|event| matches!(event, AgentEvent::Error { .. }));
+    assert!(
+        matches!(
+            error,
+            Some(AgentEvent::Error {
+                retryable: false,
+                ..
+            })
+        ),
+        "{error:?}"
+    );
+}
+
+#[tokio::test]
 async fn successful_retry_keeps_the_failed_attempt_usage_incomplete() {
     let provider = ScriptedProvider {
         id: "scripted".into(),

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -249,6 +249,15 @@ pub enum UsageIncompleteReason {
     Cancelled,
 }
 
+/// `serde(default)` value for [`AgentEvent::RetriesExhausted::retryable`]:
+/// event logs recorded before the field existed (#926) replay as if every
+/// failure were a genuine, potentially-retryable exhaustion — the reading
+/// that was already implied by the event's name before this distinction
+/// existed — rather than being silently reclassified as terminal.
+fn retries_exhausted_retryable_default() -> bool {
+    true
+}
+
 /// One event in the turn's stream. Every stage boundary emits an event;
 /// nothing user-visible is derived from internal state that isn't also in
 /// this stream.
@@ -381,6 +390,22 @@ pub enum AgentEvent {
         attempts: u32,
         /// Per-attempt failure reasons, oldest first.
         reasons: Vec<String>,
+        /// Whether the LAST attempt's error was of a retryable class —
+        /// mirrors the paired [`AgentEvent::Error`]'s `retryable` field,
+        /// computed from the same `ProviderError::is_retryable()` call.
+        /// `false` means retrying again could never have helped: the
+        /// clearest case is `ProviderError::Auth` failing on attempt 1,
+        /// where `attempts` is 1 and no retry was ever attempted despite
+        /// this event's name (#926) — a receipts/telemetry consumer that
+        /// only sees `RetriesExhausted` would otherwise record a
+        /// reliability incident for what is really a bad credential.
+        /// `#[serde(default = "retries_exhausted_retryable_default")]`:
+        /// event logs recorded before this field existed predate the
+        /// distinction, so on replay they read as "genuinely retryable"
+        /// — the pre-#926 behavior — rather than being silently
+        /// reclassified as terminal.
+        #[serde(default = "retries_exhausted_retryable_default")]
+        retryable: bool,
     },
     /// One decision from the extension/policy audit plane bridged into the
     /// event stream (receipts spec §6.4, #364 gap 6). The `HookBus` audit
@@ -2523,6 +2548,7 @@ mod tests {
                 turn_instance: 1,
                 attempts: 3,
                 reasons: vec!["t".into()],
+                retryable: true,
             },
             AgentEvent::PolicyDecision {
                 kind: PolicyKind::Blocked,

--- a/stella-protocol/tests/wire_contract.rs
+++ b/stella-protocol/tests/wire_contract.rs
@@ -506,6 +506,7 @@ fn sample_events() -> Vec<AgentEvent> {
             turn_instance: 3,
             attempts: 2,
             reasons: vec!["timeout".into(), "timeout".into()],
+            retryable: true,
         },
         AgentEvent::Compaction {
             before_tokens: 10_000,

--- a/stella-serve/src/observe/tally.rs
+++ b/stella-serve/src/observe/tally.rs
@@ -162,6 +162,7 @@ mod tests {
             turn_instance: 0,
             attempts: 4,
             reasons: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            retryable: true,
         });
         // Four dispatched attempts is one initial call plus three retries.
         assert_eq!(fold.finish().retries, 3);

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -1074,9 +1074,21 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             TraceKind::Other,
             format!("budget denied ${spent_usd:.4}/${limit_usd:.2}"),
         ),
-        AgentEvent::RetriesExhausted { attempts, .. } => {
-            (TraceKind::Other, format!("retries exhausted ({attempts})"))
-        }
+        AgentEvent::RetriesExhausted {
+            attempts,
+            retryable,
+            ..
+        } => (
+            TraceKind::Other,
+            if *retryable {
+                format!("retries exhausted ({attempts})")
+            } else {
+                format!(
+                    "terminal failure, not retryable ({attempts} attempt{})",
+                    if *attempts == 1 { "" } else { "s" }
+                )
+            },
+        ),
         AgentEvent::PolicyDecision { kind, subject, .. } => {
             (TraceKind::Other, format!("policy {kind:?}: {subject}"))
         }


### PR DESCRIPTION
Three independent, unrelated P2 backlog fixes bundled per this repo's established pattern for small batches (cf. #1088).

## #919 — cargo-audit/cargo-deny policy can never be unified

`cargo deny` and `cargo audit` read advisory-suppression policy from two different files (`deny.toml`'s `[advisories] ignore` vs. a `.cargo/audit.toml` that doesn't exist), so a suppression in one silently never reaches the other. `cargo deny` with `unmaintained = "all"` / `yanked = "deny"` is already a strict superset of what `cargo-audit` contributed here, so it's dropped.

The CI job keeps its exact display name (`cargo deny + cargo audit`) — verified against `main`'s branch protection (`gh api repos/.../branches/main/protection`), which matches required checks by that literal string. Renaming it would leave the required check permanently unsatisfied, the same failure mode `bench/READINESS.md` already documents for a different check.

## #926 — RetriesExhausted fires even when no retry was attempted

`AgentEvent::RetriesExhausted` fired for every terminal step failure, including a `ProviderError::Auth` on attempt 1 that the retry policy correctly never retried — `attempts: 1` was the only (implicit) signal. Adds a `retryable: bool` field, computed from the same `ProviderError::is_retryable()` call already used for the paired `Error` event. Additive to the wire contract (`#[serde(default = "...")]`, regenerated `docs/wire/` artifacts, `check-wire-schema.sh` passes clean). Includes a new test reproducing the exact acceptance scenario (`attempts: 1, retryable: false` for a first-attempt auth failure) and fixes the one place that rendered a literal "retries exhausted" string regardless of retryability (a TUI trace-panel formatter).

## #918 — cla.yml's actions:write permission

Verified against `contributor-assistant/github-action`'s actual source at the pinned SHA rather than assuming: `actions:write` is genuinely required. `setupClaCheck.ts` calls `reRunLastWorkFlowIfRequired()` once every committer has signed, which calls `octokit.actions.reRunWorkflow()` on the original `pull_request_target` run that failed before the signature existed — signing happens via an `issue_comment`, which has no commit SHA of its own to attach a passing status to. Documented inline with the exact call chain.

**Not done** (needs a repo admin, not a code change): rotating `PERSONAL_ACCESS_TOKEN` to a fine-grained token scoped to `contents:write` on `stella-cla-signatures` only, as the issue also proposes. That requires minting a new token in GitHub settings and updating the repo secret.

## Out of scope

#932 (steering/pause/approval-gate over HTTP) was in the same batch but is a much larger architectural change — the issue's own thread already establishes that `stella-serve` would need to drive a `stella-pipeline`-shaped session (triage, planning, the scope stage) instead of a bare `stella_core::Engine`, with real open wire-schema design questions. Not attempted here; scoped out rather than attempted half-done.

Closes #919
Closes #926
Closes #918

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p stella-core -p stella-protocol -p stella-serve` (touched suites)
- [x] `cargo clippy -p stella-core -p stella-protocol -p stella-serve -p stella-tui -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `scripts/check-wire-schema.sh`
- [x] `bash scripts/check-cargo-install-pins.sh`
- [x] `make gate` — green (ran automatically on push via pre-push hook)

## Summary by Sourcery

Clarify retry semantics in agent events, tighten supply-chain security checks around cargo-deny, and correct CLA workflow permissions to match actual GitHub API usage.

New Features:
- Expose a retryability flag on RetriesExhausted agent events in the wire protocol and UI, allowing consumers to distinguish genuine retry exhaustion from non-retryable terminal failures.

Bug Fixes:
- Fix RetriesExhausted events firing for first-attempt non-retryable errors by marking them explicitly as not retryable and updating the TUI trace output.
- Ensure the CLA GitHub Action has actions:write permission so signed contributors correctly trigger reruns and green status checks.

Enhancements:
- Make cargo-deny the single supply-chain advisory gate, remove cargo-audit usage from CI, Makefile, and audit scripts, while preserving the CI job name for branch protection compatibility.
- Update wire contract tests and observation tally tests to cover the new retryable field and keep telemetry accounting correct.
- Improve repository scripts and documentation to reflect the simplified supply-chain check setup and pinned cargo-deny installation.