### PR TITLE
fix(release): stop masking a failed manifest restore (shellcheck SC2015)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -180,9 +180,23 @@ ok "release commit $(git rev-parse --short "$release_sha") stamps ${VERSION} on 
 # `sed "0,/re/"` is GNU-only and silently no-ops on macOS — perl is portable.)
 cp Cargo.toml .Cargo.toml.relbak
 cp Cargo.lock .Cargo.lock.relbak   # cargo rewrites workspace-member versions in the lock during the stamped build
+# Restores both files even if the first `mv` fails, and never swallows a
+# failure: this trap is what backs the script's promise never to leave your
+# working tree modified, so a restore that did not happen has to be loud.
+# (A missing .relbak is not a failure — nothing was stamped yet.)
 restore_manifest() {
-  [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true
-  [ -f .Cargo.lock.relbak ] && mv .Cargo.lock.relbak Cargo.lock || true
+  local restore_status=0
+  if [ -f .Cargo.toml.relbak ]; then
+    mv .Cargo.toml.relbak Cargo.toml || restore_status=1
+  fi
+  if [ -f .Cargo.lock.relbak ]; then
+    mv .Cargo.lock.relbak Cargo.lock || restore_status=1
+  fi
+  if [ "$restore_status" -ne 0 ]; then
+    printf '\033[31mERROR: %s\033[0m\n' \
+      "could not restore Cargo.toml/Cargo.lock — your tree may still carry the \
+stamped version; recover by hand from .Cargo.toml.relbak / .Cargo.lock.relbak" >&2
+  fi
 }
 trap 'restore_manifest' EXIT
 perl -pi -e "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml


### PR DESCRIPTION
## What & why

The `ci` workflow's `fmt + clippy + test` job has been red on **every commit to main** since the shellcheck gate landed in #1088. It is a second, independent break from the `bench` failure in #1101 — both need to merge for main to go green.

`shellcheck install.sh scripts/*.sh .githooks/*` flags SC2015 twice in `scripts/release.sh`, and shellcheck exits non-zero on any finding, so the job fails:

```
In scripts/release.sh line 184:
  [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true
                            ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.
```

**The warning is pointing at a real defect, not a style nit.** The `|| true` was written for the absent-backup case, but it also catches a failing `mv`. This is the `EXIT` trap that backs the script's headline promise — "it never leaves your working tree modified (the version stamp is reverted on exit)" — so a restore that silently did not happen leaves the developer's tree carrying a stamped release version while the script reports success.

Rewritten as explicit `if` blocks with a status flag:

- both restores are still attempted even if the first one fails;
- an absent `.relbak` is still not an error (nothing was stamped yet);
- a genuine `mv` failure now prints a loud recovery message naming the backup files, instead of vanishing.

Adding `# shellcheck disable=SC2015` would have turned a real signal off, so I fixed the code instead.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The gate command itself is the witness — **but only under the shellcheck version CI actually runs**, which is worth flagging for anyone reproducing this:

- ubuntu-latest ships **shellcheck 0.10.0**, which flags this SC2015 case.
- **shellcheck 0.11.0** (current Homebrew) does *not* implement it — a local run on a newer shellcheck passes clean and cannot reproduce the failure at all.

Verified with 0.10.0, using the workflow's exact command `shellcheck install.sh scripts/*.sh .githooks/*`:

- On `main`: the two SC2015 findings above, **exit 1** — the identical CI failure. These were the *only* findings across every checked file, so this change closes the gate completely.
- On this branch: no findings, **exit 0**. Also exit 0 under 0.11.0, so the fix is not version-dependent.

Behavior verified beyond the linter — `bash -n` clean, plus `restore_manifest` exercised directly:

| case | result |
|---|---|
| both backups present | both files restored, exit 0 |
| no backups (nothing stamped) | silent, exit 0 |
| real `mv` failure (read-only dir) | both restores attempted, loud recovery message printed |

## The gate

- [x] `shellcheck install.sh scripts/*.sh .githooks/*` (0.10.0 and 0.11.0) — clean
- [x] `bash -n scripts/release.sh`
- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test` — no Rust touched (shell script only)
- [x] CLA signed

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- **This does not fully green main on its own** — #1101 fixes the separate `bench` workflow break. They are unrelated changes (Python packaging vs. a shell script), so they are split per the template's one-logical-change rule and can merge in either order.
- The function deliberately still returns 0 on a failed restore: it runs as an `EXIT` trap, and returning non-zero there would clobber the script's real exit code. The loud stderr message is the signal.
- The gate landed in #1088 already red rather than regressing later, which is why no single commit looks like the culprit. Worth considering whether new CI gates should be required to pass on the commit that introduces them.

## Summary by Sourcery

Harden the release script’s manifest restore trap so failed restores are surfaced instead of silently masked, aligning CI shellcheck gating with the script’s guarantee about not leaving the working tree modified.

Bug Fixes:
- Fix manifest restore logic in scripts/release.sh so mv failures no longer get swallowed by a catch-all `|| true`, preventing silent leftover stamped versions in developer trees.

Enhancements:
- Ensure both Cargo.toml and Cargo.lock backups are independently restored when present, and emit a clear error message to stderr if any restore fails.