### PR TITLE
fix: unblock main CI (bench py-modules, shellcheck) and stop the continuation nudge truncating the loop window

### DIFF
--- a/bench/terminal_bench_analysis/pyproject.toml
+++ b/bench/terminal_bench_analysis/pyproject.toml
@@ -23,6 +23,7 @@ py-modules = [
     "artifact_secret_scan",
     "freeze_tb21_study_seed",
     "github_public_timing",
+    "normalized_cost",
     "tb21_analysis",
     "tb21_evidence_contract",
     "tb21_hybrid_analysis",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -181,8 +181,8 @@ ok "release commit $(git rev-parse --short "$release_sha") stamps ${VERSION} on 
 cp Cargo.toml .Cargo.toml.relbak
 cp Cargo.lock .Cargo.lock.relbak   # cargo rewrites workspace-member versions in the lock during the stamped build
 restore_manifest() {
-  [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true
-  [ -f .Cargo.lock.relbak ] && mv .Cargo.lock.relbak Cargo.lock || true
+  if [ -f .Cargo.toml.relbak ]; then mv .Cargo.toml.relbak Cargo.toml; fi
+  if [ -f .Cargo.lock.relbak ]; then mv .Cargo.lock.relbak Cargo.lock; fi
 }
 trap 'restore_manifest' EXIT
 perl -pi -e "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -382,7 +382,9 @@ const SPECULATION_DISCARD_BUDGET_ABORT: &str = "budget_abort";
 /// ladder's no-op rung takes it from there.
 const MAX_LENGTH_CONTINUATIONS: u32 = 2;
 
-/// The user message a length-truncated, tool-less step is continued with.
+/// The body of the user message a length-truncated, tool-less step is
+/// continued with. Pushed behind [`CONTINUATION_MARKER_PREFIX`], which is what
+/// marks it as engine-generated — see that constant.
 ///
 /// Written for the two shapes the trigger cannot distinguish and does not
 /// need to: chain-of-thought promoted to text by an adapter's reasoning-only
@@ -1857,7 +1859,9 @@ impl<'a> Engine<'a> {
                     tool_results: Vec::new(),
                     attachments: Vec::new(),
                 });
-                messages.push(CompletionMessage::user(LENGTH_CONTINUATION_NUDGE));
+                messages.push(CompletionMessage::user(format!(
+                    "{CONTINUATION_MARKER_PREFIX}] {LENGTH_CONTINUATION_NUDGE}"
+                )));
                 return None;
             }
             // A non-empty answer truncated with the continuation allowance
@@ -2230,6 +2234,18 @@ pub(crate) const SUMMARY_MARKER_PREFIX: &str = "[earlier history summarized";
 /// the abort-on-re-detection would need a whole fresh threshold's worth of
 /// looping instead of one more no-progress call.
 pub(crate) const LOOP_STEER_PREFIX: &str = "[stuck-loop warning";
+/// Prefix of the engine-injected output-limit continuation nudge
+/// ([`Engine::dispatch_completion`], body in [`LENGTH_CONTINUATION_NUDGE`]).
+///
+/// The third engine-written `User`-role message, and it needs the marker for
+/// exactly the two reasons the other two do. [`recent_call_records`] would
+/// otherwise take it as a turn boundary and discard every call the turn had
+/// made so far — on the one path where the turn demonstrably *is* still the
+/// same turn, so a stuck model that also truncates would have its evidence
+/// erased up to twice per turn. And `receipts::user_block_kind` would file it
+/// as [`stella_protocol::BlockKind::UserGoal`], attributing engine text to the
+/// person, which is the misattribution Phase 2 introduced that function to fix.
+pub(crate) const CONTINUATION_MARKER_PREFIX: &str = "[output-limit continuation";
 /// The [`TurnOutcome::Aborted`] reason of a user-requested soft stop —
 /// callers match on this to render "stopped" rather than "failed", and to
 /// keep (never truncate) the turn's completed work.

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -371,6 +371,12 @@ const SPECULATION_DISCARD_HARVEST_MISMATCH: &str = "harvest_mismatch";
 /// could harvest it, so it is discarded on the abort unwind instead (#460).
 const SPECULATION_DISCARD_BUDGET_ABORT: &str = "budget_abort";
 
+/// The `ToolOutput::Error` that closes a `tool_use` the budget abort refused
+/// to dispatch. The twin of `step::CANCELLED_TOOL_RESULT`: same repair, same
+/// helper, different reason — the model is told the call did not run, so the
+/// pairing is honest as well as structurally valid.
+const BUDGET_ABORT_TOOL_RESULT: &str = "not executed — turn aborted on budget";
+
 /// How many times one turn may continue past a step that ended at the
 /// output-token limit having called no tool (`FinishReason::Length`,
 /// `tool_calls` empty). Two, not one, because the observed failure is a
@@ -1687,40 +1693,13 @@ impl<'a> Engine<'a> {
         // with no matching `tool_result` is a broken history: when a
         // REPL caller reuses this `messages` vec, the next turn's first
         // provider call is hard-rejected ("tool_use must be followed by
-        // tool_result"). Close the pairing with a synthetic error
-        // result per un-run call so resumption stays valid.
-        if !result.tool_calls.is_empty() {
-            let tool_results: Vec<ToolResult> = result
-                .tool_calls
-                .iter()
-                .map(|call| ToolResult {
-                    call_id: call.call_id.clone(),
-                    output: ToolOutput::Error {
-                        message: "not executed — turn aborted on budget".to_string(),
-                    },
-                })
-                .collect();
-            // Mirror the synthetic results onto the event stream: this
-            // step's `StepUsage` already reported `tool_calls: N`, and a
-            // transcript reconstructed from events must resolve every
-            // announced call the same way `messages` does. No `ToolStart`
-            // — these calls never ran.
-            for tool_result in &tool_results {
-                let _ = events.send(AgentEvent::ToolResult {
-                    call_id: tool_result.call_id.clone(),
-                    output: tool_result.output.clone(),
-                    duration_ms: 0,
-                    speculated: false,
-                });
-            }
-            messages.push(CompletionMessage {
-                role: MessageRole::Tool,
-                content: String::new(),
-                tool_calls: Vec::new(),
-                tool_results,
-                attachments: Vec::new(),
-            });
-        }
+        // tool_result"). Close the pairing with a synthetic error result
+        // per un-run call so resumption stays valid — through the same
+        // helper the cancellation path uses, since a second copy of this
+        // repair is a second place for it to rot (the results are likewise
+        // mirrored onto the event stream, with no `ToolStart`, because this
+        // step's `StepUsage` already reported `tool_calls: N`).
+        crate::step::close_open_tool_calls(messages, BUDGET_ABORT_TOOL_RESULT, events);
         // The typed twin of the prose denial (receipts spec §6.3). Mode is
         // `Enforced` by construction — only enforced budgets abort.
         let _ = events.send(AgentEvent::BudgetDenied {

--- a/stella-core/src/driver/loop_evidence.rs
+++ b/stella-core/src/driver/loop_evidence.rs
@@ -20,7 +20,7 @@ use stella_protocol::{CompletionMessage, MessageRole, ToolCall, ToolOutput};
 use crate::loop_detect::CallRecord;
 use crate::receipts::TranscriptRevision;
 
-use super::{LOOP_STEER_PREFIX, SUMMARY_MARKER_PREFIX};
+use super::{CONTINUATION_MARKER_PREFIX, LOOP_STEER_PREFIX, SUMMARY_MARKER_PREFIX};
 
 /// Pair the tool calls of the CURRENT turn — assistant messages after the
 /// last user message — with the outputs they produced, in chronological
@@ -29,10 +29,12 @@ use super::{LOOP_STEER_PREFIX, SUMMARY_MARKER_PREFIX};
 /// question, not a stuck loop (a REPL session asking the same thing three
 /// times would otherwise trip the exact-repeat detector), and it keeps
 /// this per-step scan O(turn) instead of O(entire history). The overflow
-/// summary and the stuck-loop warning are also User-role but are not real
-/// user turns — treating either as a boundary would truncate the loop
-/// window (on every summarization pass, or right when re-detection needs
-/// the evidence), so both are skipped when locating the boundary.
+/// summary, the stuck-loop warning and the output-limit continuation nudge
+/// are also User-role but are not real user turns — treating any of them as a
+/// boundary would truncate the loop window (on every summarization pass, right
+/// when re-detection needs the evidence, or on the one path that exists
+/// precisely because the turn is *not* over), so all three are skipped when
+/// locating the boundary.
 ///
 /// Results attach to the most recent still-unresolved call with a matching
 /// `call_id` — providers only guarantee ids unique within one step, and a
@@ -57,6 +59,7 @@ pub(super) fn recent_call_records<'a>(
             m.role == MessageRole::User
                 && !m.content.starts_with(SUMMARY_MARKER_PREFIX)
                 && !m.content.starts_with(LOOP_STEER_PREFIX)
+                && !m.content.starts_with(CONTINUATION_MARKER_PREFIX)
         })
         .map(|i| i + 1)
         .unwrap_or(0);

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -9,7 +9,7 @@ use stella_protocol::event::BudgetMode;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
-use super::*;
+use super::{CONTINUATION_MARKER_PREFIX as NUDGE, *};
 use crate::hooks::{HookAction, HookExecError, HookExecResult, HookMatcher};
 use crate::retry::Sleeper;
 
@@ -1360,9 +1360,7 @@ async fn a_length_truncated_tool_less_step_continues_the_turn_instead_of_complet
     );
     let nudges = messages
         .iter()
-        .filter(|m| {
-            m.role == MessageRole::User && m.content.starts_with(CONTINUATION_MARKER_PREFIX)
-        })
+        .filter(|m| m.role == MessageRole::User && m.content.starts_with(NUDGE))
         .count();
     assert_eq!(nudges, 1, "exactly one continuation nudge in history");
     assert!(
@@ -1416,9 +1414,7 @@ async fn length_continuations_are_bounded_per_turn() {
     );
     let nudges = messages
         .iter()
-        .filter(|m| {
-            m.role == MessageRole::User && m.content.starts_with(CONTINUATION_MARKER_PREFIX)
-        })
+        .filter(|m| m.role == MessageRole::User && m.content.starts_with(NUDGE))
         .count();
     assert_eq!(nudges, MAX_LENGTH_CONTINUATIONS as usize);
     let events = drain_events(&mut rx);

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -1360,7 +1360,9 @@ async fn a_length_truncated_tool_less_step_continues_the_turn_instead_of_complet
     );
     let nudges = messages
         .iter()
-        .filter(|m| m.role == MessageRole::User && m.content == LENGTH_CONTINUATION_NUDGE)
+        .filter(|m| {
+            m.role == MessageRole::User && m.content.starts_with(CONTINUATION_MARKER_PREFIX)
+        })
         .count();
     assert_eq!(nudges, 1, "exactly one continuation nudge in history");
     assert!(
@@ -1414,7 +1416,9 @@ async fn length_continuations_are_bounded_per_turn() {
     );
     let nudges = messages
         .iter()
-        .filter(|m| m.role == MessageRole::User && m.content == LENGTH_CONTINUATION_NUDGE)
+        .filter(|m| {
+            m.role == MessageRole::User && m.content.starts_with(CONTINUATION_MARKER_PREFIX)
+        })
         .count();
     assert_eq!(nudges, MAX_LENGTH_CONTINUATIONS as usize);
     let events = drain_events(&mut rx);

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -256,6 +256,25 @@ fn engine_injected_user_messages_are_not_loop_window_boundaries() {
         "the stuck-loop warning must not truncate the loop window"
     );
 
+    // The output-limit continuation nudge is the third engine-written User
+    // message, and the one where truncating the window is least defensible:
+    // it is pushed *because* the turn is not over, so discarding the calls
+    // the turn already made would blind the detector on exactly the path a
+    // model that both truncates and loops takes.
+    let nudge = CompletionMessage::user(format!(
+        "{CONTINUATION_MARKER_PREFIX}] {LENGTH_CONTINUATION_NUDGE}"
+    ));
+    let continued = history(nudge);
+    let records = recent_call_records(&continued, &Default::default());
+    assert_eq!(
+        records
+            .iter()
+            .map(|r| r.call.call_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["c1", "c2"],
+        "the output-limit continuation nudge must not truncate the loop window"
+    );
+
     // A REAL user message (a steer, a REPL turn) still resets the window.
     let user_turn = history(CompletionMessage::user("also check the tests"));
     let records = recent_call_records(&user_turn, &Default::default());

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -313,17 +313,24 @@ pub const RECALL_MARKER: &str = "[auto-recalled context]";
 
 /// Which block kind a `User`-role message actually is.
 ///
-/// Not every `User` message is the user's goal. The driver injects two of its
-/// own — the overflow summary and the stuck-loop steer, both
-/// `CompletionMessage::user` — and the CLI injects the recalled-context block.
-/// Before Phase 2 all four collapsed onto [`BlockKind::UserGoal`], so a receipt
-/// attributed engine-generated text to the person. The three markers are
-/// prefixes on content the engine and CLI both write, which is why this is a
-/// prefix match and not a heuristic.
+/// Not every `User` message is the user's goal. The driver injects three of its
+/// own — the overflow summary, the stuck-loop steer and the output-limit
+/// continuation nudge, all `CompletionMessage::user` — and the CLI injects the
+/// recalled-context block. Before Phase 2 they all collapsed onto
+/// [`BlockKind::UserGoal`], so a receipt attributed engine-generated text to the
+/// person. The four markers are prefixes on content the engine and CLI both
+/// write, which is why this is a prefix match and not a heuristic.
+///
+/// The continuation nudge files as [`BlockKind::Steered`] rather than earning a
+/// kind of its own: it is a mid-turn injected instruction that redirects the
+/// model, which is exactly what that kind means, and reusing it keeps the wire
+/// enum (and every reader of it) unchanged.
 fn user_block_kind(content: &str) -> BlockKind {
     if content.starts_with(crate::driver::SUMMARY_MARKER_PREFIX) {
         BlockKind::Summary
-    } else if content.starts_with(crate::driver::LOOP_STEER_PREFIX) {
+    } else if content.starts_with(crate::driver::LOOP_STEER_PREFIX)
+        || content.starts_with(crate::driver::CONTINUATION_MARKER_PREFIX)
+    {
         BlockKind::Steered
     } else if content.starts_with(RECALL_MARKER) {
         BlockKind::RecalledFrame

--- a/stella-core/src/receipts/tests.rs
+++ b/stella-core/src/receipts/tests.rs
@@ -272,6 +272,12 @@ fn the_drivers_own_messages_stop_being_attributed_to_the_user() {
         user_block_kind(crate::driver::LOOP_STEER_PREFIX),
         BlockKind::Steered
     );
+    // The continuation nudge is engine-written too — it shares `Steered`
+    // rather than widening the wire enum.
+    assert_eq!(
+        user_block_kind(crate::driver::CONTINUATION_MARKER_PREFIX),
+        BlockKind::Steered
+    );
     assert_eq!(user_block_kind(RECALL_MARKER), BlockKind::RecalledFrame);
     assert_eq!(user_block_kind("fix the failing test"), BlockKind::UserGoal);
 }

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -414,7 +414,15 @@ impl TurnState {
 /// The results are mirrored onto the event stream (no `ToolStart` — these
 /// calls never ran) so a transcript reconstructed from events resolves every
 /// announced call the same way `messages` does.
-fn close_open_tool_calls(
+///
+/// Shared by the two places a turn can stop holding an unanswered call: the
+/// cancellation check above, and the budget abort in
+/// `Engine::handle_committed_result` (which appends the assistant message
+/// carrying the calls it is about to refuse to dispatch, then closes them
+/// here). They differ only in `message`. Keeping one implementation matters
+/// because the failure mode is silent and delayed — a missed pairing is not
+/// noticed until the NEXT provider call rejects the history outright.
+pub(crate) fn close_open_tool_calls(
     messages: &mut Vec<CompletionMessage>,
     message: &str,
     events: &EventSender,


### PR DESCRIPTION
## What & why

Unblocks `main`'s CI and fixes one real turn-loop correctness defect found while auditing the step driver end-to-end. Four commits, each independently reviewable.

### CI (main is red on both of these today)

1. **`fix(bench)`** — `bench/terminal_bench_analysis/pyproject.toml` listed every module in `[tool.setuptools] py-modules` *except* `normalized_cost`, so CI's locked sync built a venv without it and `pytest` aborted at collection with `ModuleNotFoundError`. The whole `bench` workflow has been failing on every push to main since that module landed. Verified with CI's exact invocation (`uv sync --locked --extra dev && uv run --no-sync pytest -q`): **246 passed**.

2. **`fix(ci)`** — `scripts/release.sh`'s `restore_manifest` used `[ -f X ] && mv X Y || true` twice, which shellcheck flags as SC2015. The `shellcheck` step is the first step of the `fmt + clippy + test` job, so it fast-failed the whole `ci` workflow before Rust ever compiled. Replaced with `if`/`then`, which is also strictly better behavior: a genuinely failed `mv` now surfaces instead of being swallowed by `|| true`.

### Turn loop

3. **`fix(engine)`** — the output-limit continuation nudge is engine text, not a user turn.

   The engine writes three of its own `User`-role messages, and two consumers tell them apart from the person only by a marker prefix. The nudge #1024 added to continue a length-truncated, tool-less step never got one, so:

   - **`recent_call_records` treated it as the loop-detection window boundary**, discarding every tool call the turn had already made — on the one path that exists *precisely because the turn is not over*. A model that both truncates and loops had its evidence erased up to twice per turn (`MAX_LENGTH_CONTINUATIONS`).
   - **`receipts::user_block_kind` filed it as `BlockKind::UserGoal`**, attributing engine-generated text to the person — the exact misattribution that function was introduced in Phase 2 to prevent.

   Fix: give it a marker (`CONTINUATION_MARKER_PREFIX`) like the summary and the stuck-loop steer, skip it at the boundary, and file it as `Steered` — a mid-turn injected instruction is what that kind means, so the wire enum and every reader of it are unchanged.

4. **`refactor(engine)`** — one implementation of the unpaired-`tool_use` repair. The budget abort in `handle_committed_result` hand-rolled the repair `step::close_open_tool_calls` already performs for the cancellation path (synthesize an error `tool_result` per unanswered call, mirror each onto the event stream with no `ToolStart`, append one `Tool` message). Two copies of a repair whose failure is *silent and delayed* — a missed pairing only surfaces when the **next** provider call rejects the history — is the kind that rots.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`engine_injected_user_messages_are_not_loop_window_boundaries` already pinned this invariant for the other two markers; the nudge was simply never added to it. With only the one boundary line reverted it fails:

```
assertion `left == right` failed: the output-limit continuation nudge must not truncate the loop window
  left: ["c2"]
 right: ["c1", "c2"]
```

Also extended `the_drivers_own_messages_stop_being_attributed_to_the_user` for the receipt-attribution half.

Commits 1, 2 and 4 need no witness: 1 and 2 are CI config whose witness is CI itself (both reproduced locally against the exact CI invocation), and 4 is a behavior-identical consolidation already pinned by the existing F5 test `budget_abort_synthetic_results_are_visible_in_the_event_stream`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `make check` (scratch, action pins, cargo-install pins, license parity, shellcheck, invariants, file-size, fmt, clippy) — exit 0
- [x] Pre-push gate green end to end (`✔ gate green — pushing`), which also runs `cargo doc -D warnings`
- [x] Docs updated where behavior changed (module/const doc comments on all three touched invariants)

The `driver/tests.rs` file-size ratchet initially failed at +4 lines; the growth was reducible, so it was shrunk back under the recorded ceiling rather than bumping the baseline.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types (`BlockKind` reuse is deliberate — see above)

## Anything reviewers should know?

**Audited and found sound — no change proposed.** Recording these so the next audit does not re-derive them:

- **The witness protocol / oracle flip is layered but not wasteful.** Every expensive check is gated on the *ladder decision* rather than on the flip transition, so a candidate headed to the judge pays nothing extra: the lint delta (#861), the confirmation re-run (#859) and the mutation audit (#870, ≤3 runs, authored witnesses only) each re-derive `ladder_decision` and bail. The free checks — the lexical assertion-density screen and the same-failure output fingerprint (#867) — run where they cost nothing. Each layer has a named, measured failure it prevents. I looked for a simplification here and did not find an honest one.
- **The `file_change_events == 0`-inside-a-candidate trap is closed.** The `FileTouchPort` trait reads a monotonic counter on the recorder that *emits* the events, and `observed_mutations` takes the delta and `max`es it with the event tally — so it no longer matters which wire the events took, or that a candidate registry is unattached. (Worth stating because the older diagnosis predicted a different fix — "tap the candidate tool stack" — which is not what shipped and should not be re-attempted.)
- **The two `oracle.observe_run` call sites are not duplicates**: one is the pre-execute `ProofTree::Baseline`, the other the post-execute `ProofTree::Candidate`. They are the two halves of the fail→pass flip.

**Deferred, deliberately.** On the continuation path the engine retains the full truncated assistant text — up to `max_output_tokens` (16k), and on the zai/OpenRouter dialects that text is often promoted chain-of-thought rather than an answer. It is protected content, so the pure compaction passes never touch it; it rides every later step of the turn until the overflow summarizer fires at 150k. That is real token cost, but trimming it risks discarding an answer the model was mid-sentence on, and the right fix needs measurement rather than a guess. Flagging, not changing.

**Not merged** — merges are frozen; this is ready for review only.

## Summary by Sourcery

Unblock CI and correct turn-loop handling by marking engine-injected continuation messages and consolidating tool-call repair logic.

Bug Fixes:
- Ensure the output-limit continuation nudge is marked as engine-generated so it no longer truncates the loop detection window or gets attributed to the user.
- Fix budget-abort handling so unanswered tool calls are consistently closed using the shared repair helper, keeping histories structurally valid.
- Include the missing `normalized_cost` module in the bench analysis Python configuration so terminal bench tests can import it.
- Adjust the release script manifest-restore logic to surface real `mv` failures while satisfying shellcheck, allowing CI to run past shellcheck.

Enhancements:
- Document and expose shared tool-call closure logic for both cancellation and budget-abort paths to avoid duplicated, fragile repairs.
- Extend loop-detection and receipt tests to cover the continuation nudge and the new markers without increasing the file-size baseline.

Build:
- Update `bench/terminal_bench_analysis/pyproject.toml` to list all required modules, including `normalized_cost`, for locked `uv` syncs.

CI:
- Modify `scripts/release.sh` to use `if`/`then` checks instead of `[ -f X ] && mv X Y || true`, resolving shellcheck SC2015 and improving failure visibility.

Documentation:
- Refresh inline documentation for continuation markers, loop evidence boundaries, and tool-call repair behavior where invariants changed.

Tests:
- Add and extend driver and receipts tests to assert that engine-injected continuation nudges neither reset loop windows nor get misattributed to the user, and that synthetic budget-abort results remain visible in the event stream.