### PR TITLE
fix(tools): run exactly one workspace probe, and keep its pre-image

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -34,7 +34,7 @@
 2234 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-3653 stella-tools/src/registry.rs
+3791 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1808 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -180,9 +180,15 @@ ok "release commit $(git rev-parse --short "$release_sha") stamps ${VERSION} on 
 # `sed "0,/re/"` is GNU-only and silently no-ops on macOS — perl is portable.)
 cp Cargo.toml .Cargo.toml.relbak
 cp Cargo.lock .Cargo.lock.relbak   # cargo rewrites workspace-member versions in the lock during the stamped build
+# `if`s, not `[ -f … ] && mv … || true`: this runs as an EXIT trap under
+# `set -e`, where a bare `&&` chain whose test fails would abort the trap and
+# skip the line below it — leaving the workspace stamped. The `|| true` that
+# used to guard against that also swallowed a genuine `mv` failure, which is
+# the one outcome that must never pass quietly: it means the release version
+# is still stamped on the developer's tree. Same idiom as the `git add` above.
 restore_manifest() {
-  [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true
-  [ -f .Cargo.lock.relbak ] && mv .Cargo.lock.relbak Cargo.lock || true
+  if [ -f .Cargo.toml.relbak ]; then mv .Cargo.toml.relbak Cargo.toml; fi
+  if [ -f .Cargo.lock.relbak ]; then mv .Cargo.lock.relbak Cargo.lock; fi
 }
 trap 'restore_manifest' EXIT
 perl -pi -e "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -2939,14 +2939,14 @@ impl<'a> Pipeline<'a> {
         // nothing, so without this the count below is blind to the tool that
         // does most of the work on Terminal-Bench. Settling first is what
         // makes `file_changes` an honest answer rather than a CRUD-tool tally.
+        // Settling also re-arms, from the same walk, so a revision's changes
+        // are bracketed exactly the way this one's were without paying for a
+        // second walk of an identical tree.
         self.touches.settle_workspace_probe();
         state.file_changes = self.observed_mutations(state);
         state.diff_lines = probe.lines;
         state.diff_available = probe.available;
         state.diff_text = verification_honest_diff(probe.text, state.file_changes);
-        // Re-arm for the next round, so a revision's changes are bracketed
-        // the same way this one's were.
-        self.touches.begin_workspace_probe();
     }
 
     /// Emit this recall's telemetry. The projection itself lives on

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -295,12 +295,22 @@ pub trait FileTouchPort: Send + Sync {
     /// hundreds of shell calls, and a trial is killed at 900s — per-call
     /// probing would spend the whole budget observing.
     ///
+    /// Calling this commits the host to turn granularity: an implementation
+    /// that also probes per call must turn that off, so the tree is never
+    /// walked twice to learn one fact.
+    ///
     /// Default no-op, so a host with no recorder (and every test double)
     /// keeps working: an unprobed turn simply reports what its other channels
     /// saw, which is the pre-existing behaviour.
     fn begin_workspace_probe(&self) {}
 
-    /// Attribute anything the turn changed that no tool schema described.
+    /// Attribute anything the turn changed that no tool schema described,
+    /// then re-arm for the next turn.
+    ///
+    /// Re-arming is part of settling rather than a second call, because the
+    /// after-image of one turn is the before-image of the next and both are
+    /// only true at the same instant. Callers bracket a run of turns with one
+    /// [`Self::begin_workspace_probe`] and a settle per turn.
     ///
     /// Records through the same emitter as every other touch, so the ledger
     /// keeps exactly one birthplace for a `FileChange`.

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -1737,9 +1737,9 @@ impl ToolRegistry {
     /// cost is that a change is attributed to the turn rather than to the
     /// exact call within it — which is all the ledger and the ladder ever
     /// read.
-    /// Latches [`Self::turn_bracketing`], which is what turns the per-call
-    /// probe in [`Self::execute`] off. Calling this once commits the session
-    /// to turn granularity; the two never run together.
+    /// Latches this session as turn-bracketing, which is what turns the
+    /// per-call probe in [`Self::execute`] off. Calling this once commits the
+    /// session to turn granularity; the two never run together.
     pub fn begin_workspace_probe(&self) {
         self.turn_bracketing
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -84,10 +84,25 @@ pub struct ToolRegistry {
     /// the input the way it sees `read_file`'s `path`.
     span_reads: crate::read_symbol::SpanReadLedger,
     /// The workspace before-image for the turn in flight, when one was taken
-    /// ([`ToolRegistry::begin_workspace_probe`]). `None` between turns, and
-    /// `None` for every host that never brackets one — which is why an
-    /// unbracketed session behaves exactly as it did before this existed.
+    /// ([`ToolRegistry::begin_workspace_probe`]). `None` before the first
+    /// bracket, and `None` for every host that never brackets one — which is
+    /// why an unbracketed session behaves exactly as it did before this
+    /// existed.
     workspace_probe: std::sync::Mutex<Option<crate::shell_touch::WorkspaceProbe>>,
+    /// Whether this session brackets turns at all, latched by the first
+    /// [`ToolRegistry::begin_workspace_probe`] and never cleared.
+    ///
+    /// This is the switch between the two probe granularities, and only ever
+    /// one of them runs. A bracketing host (the pipeline) probes once per
+    /// turn; a host that never brackets keeps the per-call probe in
+    /// [`Self::execute`]. Running both would walk the tree twice per shell
+    /// call *and* twice per turn to learn the same fact.
+    ///
+    /// Latched rather than tracking arm/disarm because it answers "does this
+    /// host bracket?", not "is a bracket open?" — during the window between
+    /// settling one turn and arming the next, the per-call probe must stay
+    /// off or it would re-attribute what the turn probe just recorded.
+    turn_bracketing: std::sync::atomic::AtomicBool,
     /// The session's memory-citation ledger, shared with the registered
     /// `cite_memory` tool instance and drained per execution by
     /// [`ToolRegistry::take_memory_citations`].
@@ -447,6 +462,7 @@ impl ToolRegistry {
             touched: std::sync::Mutex::new(FileTouchLedger::default()),
             span_reads,
             workspace_probe: std::sync::Mutex::new(None),
+            turn_bracketing: std::sync::atomic::AtomicBool::new(false),
             citations,
             agent_uses: std::sync::Mutex::new(crate::agent_use::AgentUseLedger::default()),
             mcp_usage,
@@ -924,7 +940,17 @@ impl ToolRegistry {
         // reason the ladder counts it so — on Terminal-Bench the shell is how
         // nearly all real work lands, and a name we fail to recognize must
         // never be the reason a change goes unattributed.
+        //
+        // Skipped entirely when the host brackets turns: the turn probe covers
+        // the same ground for one pair of walks instead of one pair per call.
+        // The measurement that forces the choice — 757 of 1,063 calls were
+        // shell calls against a 900s trial kill — makes per-call probing cost
+        // more than the trial it is meant to observe. Hosts that never bracket
+        // keep this path, so nothing regresses for them.
         let shell_probe = (pending_ops.is_empty()
+            && !self
+                .turn_bracketing
+                .load(std::sync::atomic::Ordering::Relaxed)
             && !tool.as_ref().map(|t| t.schema().read_only).unwrap_or(false))
         .then(|| crate::shell_touch::WorkspaceProbe::capture(&self.root));
 
@@ -1711,7 +1737,12 @@ impl ToolRegistry {
     /// cost is that a change is attributed to the turn rather than to the
     /// exact call within it — which is all the ledger and the ladder ever
     /// read.
+    /// Latches [`Self::turn_bracketing`], which is what turns the per-call
+    /// probe in [`Self::execute`] off. Calling this once commits the session
+    /// to turn granularity; the two never run together.
     pub fn begin_workspace_probe(&self) {
+        self.turn_bracketing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         let probe = crate::shell_touch::WorkspaceProbe::capture(&self.root);
         *self
             .workspace_probe
@@ -1719,7 +1750,15 @@ impl ToolRegistry {
             .unwrap_or_else(|p| p.into_inner()) = Some(probe);
     }
 
-    /// Attribute anything this turn changed that no tool schema described.
+    /// Attribute anything this turn changed that no tool schema described,
+    /// then re-arm for the next turn from the same walk.
+    ///
+    /// Re-arming here rather than making the caller call
+    /// [`Self::begin_workspace_probe`] again is what keeps the cost at one
+    /// walk per settle: the after-image of this turn *is* the before-image of
+    /// the next one, taken at the only instant where both are true. Walking
+    /// twice in a row to produce two snapshots of the same tree would double
+    /// the probe's cost to re-learn what it just measured.
     ///
     /// Routed through `record_touch` so a `FileChange` keeps exactly
     /// one birthplace. Paths the CRUD tools already recorded are re-recorded
@@ -1740,18 +1779,19 @@ impl ToolRegistry {
             let Some(full) = crate::resolve_within_root(&self.root, &touch.path) else {
                 continue;
             };
-            // An attributed update carries its own POST-image as its
-            // pre-image, yielding 0 added / 0 removed. Deliberate: the probe
-            // is metadata-only, so the line counts are genuinely unknown
-            // here. Passing an empty pre-image instead would render every
-            // same-file rewrite as a whole-file insertion — a louder lie than
-            // silence. The `U` event, which is what the ladder reads, is
-            // unaffected.
-            let pre_content = match touch.op {
-                FileOp::Update => std::fs::read(&full)
+            // Identical to the per-call path above, and deliberately so: the
+            // probe captured a real pre-image for every file it could hold
+            // within budget, and that is what makes the line counts honest.
+            // An *unmeasurable* update falls back to its own post-image,
+            // yielding 0 added / 0 removed — because the alternative, an
+            // empty pre-image, would render a same-file rewrite as a
+            // whole-file insertion, which is a louder lie than silence.
+            let pre_content = match (touch.counts_measurable, touch.op) {
+                (true, _) => touch.pre_content,
+                (false, FileOp::Update | FileOp::Delete) => std::fs::read(&full)
                     .ok()
                     .map(|bytes| String::from_utf8_lossy(&bytes).into_owned()),
-                _ => None,
+                (false, _) => None,
             };
             self.record_touch(
                 PendingTouch {
@@ -1765,6 +1805,10 @@ impl ToolRegistry {
                 None,
             );
         }
+        *self
+            .workspace_probe
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = Some(after);
     }
 
     /// Snapshot of every file touched this session, insertion-ordered,
@@ -2101,6 +2145,100 @@ mod tests {
             0,
             "inspecting the tree is not changing it: {:?}",
             reg.files_touched()
+        );
+    }
+
+    /// The per-call probe is a fallback, not dead code. A host that never
+    /// brackets a turn — every embedder predating the pair, and every test
+    /// double — must keep exactly the attribution it already had, or gating
+    /// the fast path would have silently deleted the slow one.
+    #[tokio::test]
+    async fn an_unbracketed_session_still_attributes_the_shell_per_call() {
+        let (root, reg) = bare_registry(None);
+        // Deliberately no begin_workspace_probe(): this host does not bracket.
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({"command": "echo hi > unbracketed.txt"}),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert!(root.path().join("unbracketed.txt").exists());
+        assert!(
+            reg.files_touched()
+                .iter()
+                .any(|(path, _)| path == "unbracketed.txt"),
+            "gating the turn probe cost an unbracketed host its attribution"
+        );
+    }
+
+    /// The two granularities are mutually exclusive, and this is the property
+    /// that says so. Running both walks the tree twice per shell call *and*
+    /// twice per turn to learn one fact — which on a 900s trial with 757 shell
+    /// calls costs more than the trial it exists to observe.
+    #[tokio::test]
+    async fn a_bracketed_session_attributes_each_shell_write_exactly_once() {
+        let (_root, reg) = bare_registry(None);
+
+        reg.begin_workspace_probe();
+        for i in 0..3 {
+            let out = reg
+                .execute(
+                    "bash",
+                    &serde_json::json!({"command": format!("echo {i} > f{i}.txt")}),
+                )
+                .await;
+            assert!(!out.is_error(), "{out:?}");
+        }
+        assert_eq!(
+            reg.mutations_recorded(),
+            0,
+            "the per-call probe fired inside a bracket: {:?}",
+            reg.files_touched()
+        );
+
+        reg.settle_workspace_probe();
+        assert_eq!(
+            reg.mutations_recorded(),
+            3,
+            "expected one mutation per created file, no double-attribution: {:?}",
+            reg.files_touched()
+        );
+    }
+
+    /// The probe holds a real pre-image for every file it can fit in budget,
+    /// and the counts must come from *that*. Re-reading the file at settle
+    /// time yields its POST-image, which renders every shell rewrite as
+    /// 0 added / 0 removed — the same blindness this module exists to remove,
+    /// one level further down.
+    #[tokio::test]
+    async fn a_shell_rewrite_reports_the_line_counts_it_measured() {
+        let (root, reg) = bare_registry(None);
+        std::fs::write(root.path().join("rewritten.txt"), "one\ntwo\nthree\n").unwrap();
+
+        reg.begin_workspace_probe();
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({
+                    "command": "printf 'one\\ntwo\\nthree\\nfour\\n' > rewritten.txt"
+                }),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        reg.settle_workspace_probe();
+
+        let telemetry = reg.file_touch_telemetry();
+        let record = telemetry
+            .files_touched
+            .iter()
+            .find(|r| r.path == "rewritten.txt")
+            .expect("the rewritten file never reached the ledger");
+        // One line appended: LCS trims the shared prefix, leaving 1 added.
+        assert_eq!(
+            (record.lines_added, record.lines_removed),
+            (1, 0),
+            "counts came from the post-image, not the captured pre-image"
         );
     }
 


### PR DESCRIPTION
Stacked on #1102. Targets its branch rather than `main`, because it fixes code that PR introduces.

## What was wrong

#1102 commit `b2ace8c7` is titled *"bracket the workspace probe per turn, not per call"* — but the per-call probe it replaced was never removed. Both survive on the branch:

| | `origin/main` | `#1102` head |
|---|---|---|
| per-call probe (`registry.rs:927`) | yes | yes |
| turn-level `begin`/`settle` | no | yes |

So after #1102 the tree is walked twice per shell call **and** twice per turn to learn one fact. On the measurement in that PRs own doc comment — 757 of 1,063 Terminal-Bench calls were shell calls, against a 900s trial kill — per-call probing costs more than the trial it exists to observe. The PRs rationale is an argument against code it leaves standing.

## What this does

**Exactly one probe runs.** A latch set by the first `begin_workspace_probe` turns the per-call path off. It stays as the fallback for hosts that never bracket a turn — every embedder predating the pair, and every test double — so nothing regresses for them.

**The captured pre-image is used.** The turn path discarded `ShellTouch::pre_content` and re-read the file at settle time, which yields the POST-image and renders every shell rewrite as `0 added / 0 removed` even where an honest pre-image had been captured. It now matches the per-call path exactly:

```rust
let pre_content = match (touch.counts_measurable, touch.op) {
    (true, _) => touch.pre_content,
    (false, FileOp::Update | FileOp::Delete) => /* post-image fallback */,
    (false, _) => None,
};
```

**`settle` re-arms from its own after-image**, instead of the caller walking the tree a second time to snapshot the same instant. Halves the probe cost per revision round.

## Tests

Three new, pinning each invariant:

- `an_unbracketed_session_still_attributes_the_shell_per_call` — gating the fast path did not delete the slow one
- `a_bracketed_session_attributes_each_shell_write_exactly_once` — the two granularities never both fire
- `a_shell_rewrite_reports_the_line_counts_it_measured` — real counts, not `0/0`

This also makes #1102s own new assertion (`"nothing is attributed until the turn settles"`) correct: it expects `mutations_recorded() == 0` after a `bash` write inside a bracket, which the un-gated per-call probe would have contradicted.

## Also

`scripts/release.sh`: fixes the SC2015 shellcheck failure blocking the `fmt + clippy + test` job. The `[ -f … ] && mv … || true` EXIT trap swallowed a genuine `mv` failure — the one outcome that must be loud, since it means the release version is still stamped on the tree. Uses the `if … fi` idiom the same file documents fourteen lines above. Note CI runs shellcheck 0.10.0 and 0.11 no longer reports SC2015, so this does not reproduce locally.

## Verification

All by exit code, not grepped output:

| gate | exit |
|---|---|
| `make doc-warnings` | 0 |
| `cargo fmt --all --check` | 0 |
| `cargo clippy -p stella-tools -p stella-pipeline --all-targets -- -D warnings` | 0 |
| `cargo test -p stella-tools --lib` | 0 (557 passed) |
| `cargo test -p stella-pipeline --lib` | 0 (348 passed) |
| full pre-push gate (whole workspace suite) | 0 |

`cargo check on the declared MSRV` is red for an unrelated upstream reason — filed as #1108.

## Summary by Sourcery

Ensure workspace shell-touch probing runs at a single granularity per session while preserving attribution for unbracketed hosts, and fix the release manifest restore trap to fail loudly on real errors.

Bug Fixes:
- Disable the per-call workspace probe when a host brackets turns so the tree is only walked once per turn and shell writes are not double-attributed.
- Use the captured pre-image in turn-level shell touch attribution so line counts reflect measured changes instead of always reporting 0 added / 0 removed on rewrites.
- Re-arm the workspace probe from the settle after-image to avoid an extra tree walk per turn while keeping continuous turn-level attribution.
- Add tests to pin behaviour for unbracketed sessions, exclusive probe granularity, and accurate line count reporting for shell rewrites.
- Change the release manifest restore logic to use explicit if-guards so genuine mv failures surface rather than being swallowed by a && ... || true chain in an EXIT trap.

Enhancements:
- Document the turn-bracketing contract in both the tools registry and pipeline file-touch port, clarifying probe responsibilities and lifetime.
- Record and latch whether a session brackets turns to select between per-call and per-turn probing without regressions for legacy hosts.

Build:
- Adjust release.sh to resolve an SC2015 shellcheck warning in CI by replacing short-circuit mv chains with clearer conditional logic.

Tests:
- Introduce new async tests validating that unbracketed sessions still attribute shell changes per call, bracketed sessions attribute each shell write exactly once, and shell rewrites report measured line counts.
- Update pipeline probe bracketing to rely on settle re-arming, simplifying turn handling while preserving test behaviour.