### PR TITLE
fix(deps): hold rusqlite at 0.39 so the declared MSRV still builds (unblocks msrv on every PR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,11 +1108,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1537,9 +1537,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2634,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,18 @@ roxmltree = "0.21"
 # stella-tools actually uses — `Html`, `Selector`, `ElementRef`, `Node` — lives
 # outside any feature gate.
 scraper = { version = "0.27", default-features = false, features = ["errors"] }
-rusqlite = { version = "0.40", features = ["bundled"] }
+# Held at 0.39 by the declared MSRV, not by anything this workspace needs from
+# it. rusqlite 0.40 requires libsqlite3-sys ^0.38, whose build script calls
+# `cfg_select!` — an unstable library feature until Rust 1.94, five releases
+# above the `rust-version` above. It arrived in a *patch* release (0.38.1), so
+# it reached every open branch at once through the lockfile and failed the msrv
+# job on all of them; 0.38.0 carries it too, which is why the pin has to be on
+# rusqlite rather than on libsqlite3-sys.
+#
+# Raising `rust-version` would also fix the job, and is the wrong trade: it
+# spends a five-version jump in a public compatibility promise to satisfy a
+# transitive build script. Revisit when the MSRV moves for a reason of its own.
+rusqlite = { version = "0.39", features = ["bundled"] }
 hmac = "0.13"
 sha2 = "0.11"
 tempfile = "3"


### PR DESCRIPTION
## What & why

The `msrv` job (`cargo +1.90 check --workspace --locked`) is failing on **every open pull request** in this repo — including the version-sync bot's — and has been since `libsqlite3-sys 0.38.1` reached `Cargo.lock`. Its build script calls `cfg_select!`, an unstable library feature until **Rust 1.94**, five releases above the workspace's declared `rust-version = "1.90"`.

Because it arrived in a *patch* release it propagated to every branch at once through the lockfile, which is why the failure looks unrelated to the change under review on all of them:

```
error[E0658]: use of unstable library feature `cfg_select`
  --> libsqlite3-sys-0.38.1/build.rs:110:9
```

The job runs on `pull_request` and a weekly cron only, so it does not appear in a branch-filtered run list for `main` — it is invisible until you open a PR.

### Why the pin is on `rusqlite` and not on `libsqlite3-sys`

`libsqlite3-sys 0.38.0` carries the same `cfg_select!` call, so pinning that crate alone does not help — I verified this by pinning it and re-running, and it fails identically. `rusqlite 0.40` requires `libsqlite3-sys ^0.38`, so the pin has to sit one level up. `rusqlite 0.39` resolves `libsqlite3-sys` to `0.37.0`, which predates the feature.

Lockfile movement is exactly three crates: `rusqlite 0.40.1 → 0.39.0`, `libsqlite3-sys 0.38.1 → 0.37.0`, `hashlink 0.12.1 → 0.11.1`.

### Why not raise `rust-version` instead

That would also fix the job, and it is the worse trade: a five-version jump in a public compatibility promise, spent to satisfy a transitive build script that made the jump in a patch release. Nothing in this workspace needs anything from `rusqlite 0.40`. The reasoning is recorded in a comment beside the pin so it is revisitable — the natural time to drop it is whenever the MSRV moves for a reason of its own.

## The witness

- [x] No witness needed (dependency pin, no source change) — because:

The witness here is the CI job itself, and it is reproducible locally on a real 1.90 toolchain:

| | `cargo +1.90 check --workspace --locked` |
|---|---|
| `main` (bd475df9^) | **exit 101** — `error[E0658]` |
| this branch | **exit 0** — `Finished` |

Bisected the requirement across installed toolchains to confirm the 1.94 claim rather than assume it: 1.90 ✗, 1.91 ✗, 1.93 ✗, 1.95 ✓.

No source file changes, so behavior is pinned by the existing suite: `stella-store`'s **269 tests pass unmodified** against `rusqlite 0.39`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo +1.90 check --workspace --locked` (the failing job, run locally)
- [x] `make check` — exit 0
- [x] Pre-push gate green end to end
- [x] Docs updated where behavior changed — n/a; the *why* is a comment on the pinned line

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new deps** (this only moves three existing ones down)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

- **This unblocks other people's branches, not just this one.** Every open PR should go green on `msrv` once this lands, so it is worth merging ahead of the queue.
- **The obvious fix is wrong and looks right.** Pinning `libsqlite3-sys` to 0.38.0 builds fine on the pinned 1.97 toolchain and only fails under `+1.90` — so it would have passed a normal local check and landed without fixing anything. Worth knowing if this recurs: reproduce with the toolchain the job actually uses, not the one `rust-toolchain.toml` pins.
- **This is a treadmill, and that is the job working as designed.** Pinning is the standard remedy for a dependency that raises its effective MSRV; the `msrv` job exists to catch exactly this drift before it reaches users. If the pin becomes expensive to hold, that is the signal to raise `rust-version` deliberately rather than by accident.

## Summary by Sourcery

Pin rusqlite to a version compatible with the declared MSRV to restore the failing msrv CI job.

Build:
- Pin rusqlite to 0.39 to avoid pulling in libsqlite3-sys versions that require a newer compiler than the workspace MSRV.

Documentation:
- Document the rationale for the rusqlite version pin inline in Cargo.toml for future MSRV changes.