### PR TITLE
fix(ci): drop the dead SQLite swap that now fails the MSRV gate itself

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -49,32 +49,21 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
-      # libsqlite3-sys's `bundled` build path (mod build_bundled, gated on the
-      # `bundled`/`bundled-windows`/`bundled-sqlcipher` features) hits an
-      # unstable `cfg_select!` macro in its build.rs on EVERY stable Rust
-      # tested (1.90 through 1.97, this repo's own dev pin) — not something
-      # a `rust-version` bump can fix, since no stable release has it (#1105).
-      # It's confined to that one module: swapping to system-linked SQLite
-      # (rusqlite's `modern_sqlite` instead of `bundled`) avoids it entirely
-      # while keeping the same libsqlite3-sys 0.38.1 already in Cargo.lock —
-      # `modern_sqlite` pulls in `bundled_bindings` for the same FFI surface
-      # (incl. rusqlite::Error::SqlInputError, used in stella-observatory)
-      # without the vendored-source build path. This only reshapes the
-      # ephemeral checkout for this job; shipped builds keep `bundled` so
-      # binaries don't need a system libsqlite3.
-      - name: Swap bundled SQLite for system-linked (MSRV job only, #1105)
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends pkg-config libsqlite3-dev
-          sed -i 's/rusqlite = { version = "0.40", features = \["bundled"\] }/rusqlite = { version = "0.40", features = ["modern_sqlite"] }/' Cargo.toml
-          grep -q 'features = \["modern_sqlite"\]' Cargo.toml || { echo "::error::rusqlite feature swap did not match — Cargo.toml's rusqlite line changed, update this sed"; exit 1; }
-
       # rust-toolchain.toml pins a NEWER toolchain for development; override it
-      # so the check genuinely runs on the floor. No --locked here: the
-      # feature swap above changes libsqlite3-sys's resolved dependency edges
-      # (drops `cc`, since nothing needs to compile SQLite from source), so
-      # the committed Cargo.lock no longer matches by design — we want cargo
-      # to resolve fresh against that swap, not enforce the unmodified graph.
+      # so the check genuinely runs on the floor.
+      #
+      # This step once rewrote Cargo.toml in the checkout to dodge the
+      # `cfg_select!` build failure (#1112). #1113 removed the need by holding
+      # rusqlite at 0.39, and left the rewrite behind actively broken: its
+      # `sed` matched `version = "0.40"`, so against the 0.39 pin it changed
+      # nothing and its own guard failed the job on every PR. The dependency
+      # is the right place to carry an MSRV constraint — see the rusqlite pin
+      # in Cargo.toml. Keep this job a plain check of what actually ships.
+      #
+      # `--locked` is the point of the gate, not an extra: it proves the
+      # COMMITTED lockfile builds on the floor. Without it cargo may resolve a
+      # different graph than any contributor or release ever uses, which is
+      # how a patch release of a transitive build script (libsqlite3-sys
+      # 0.38.1) reached every open branch at once and went unnoticed.
       - name: cargo check --workspace
-        run: cargo +${{ steps.msrv.outputs.version }} check --workspace
+        run: cargo +${{ steps.msrv.outputs.version }} check --workspace --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,18 @@ roxmltree = "0.21"
 scraper = { version = "0.27", default-features = false, features = ["errors"] }
 # Held at 0.39 by the declared MSRV, not by anything this workspace needs from
 # it. rusqlite 0.40 requires libsqlite3-sys ^0.38, whose build script calls
-# `cfg_select!` — an unstable library feature until Rust 1.94, five releases
-# above the `rust-version` above. It arrived in a *patch* release (0.38.1), so
-# it reached every open branch at once through the lockfile and failed the msrv
-# job on all of them; 0.38.0 carries it too, which is why the pin has to be on
-# rusqlite rather than on libsqlite3-sys.
+# `cfg_select!` — a library feature that stayed unstable through 1.94 and
+# stabilized in 1.95, five releases above the `rust-version` above (probed
+# directly on 1.90, 1.91, 1.93, 1.94 and 1.95). It arrived in a *patch* release
+# (0.38.1), so it reached every open branch at once through the lockfile and
+# failed the msrv job on all of them; 0.38.0 carries it too, which is why the
+# pin has to be on rusqlite rather than on libsqlite3-sys.
+#
+# The pin also has to be on rusqlite because 0.40.1 calls `cfg_select!` from
+# its OWN source — lib.rs, statement.rs, raw_statement.rs, inner_connection.rs
+# — not only from the build script. That is why selecting different
+# libsqlite3-sys features cannot avoid it (#1112 tried; the swap moved the
+# failure from the build script into the crate and the job still went red).
 #
 # Raising `rust-version` would also fix the job, and is the wrong trade: it
 # spends a five-version jump in a public compatibility promise to satisfy a


### PR DESCRIPTION
## What & why

`#1112` taught the MSRV job to rewrite `Cargo.toml` inside its checkout, swapping rusqlite's `bundled` feature for `modern_sqlite` to dodge a `cfg_select!` build failure. `#1113` then fixed the underlying problem properly — holding rusqlite at 0.39 — but left the rewrite behind. Together they are worse than either alone.

The swap's `sed` matches `rusqlite = { version = "0.40", ... }`. Against the 0.39 pin it matches nothing, so the step's own guard fires:

```
::error::rusqlite feature swap did not match — Cargo.toml's rusqlite line changed, update this sed
```

That is an unconditional failure on **every** PR — the same symptom #1112 set out to cure, arrived at from the opposite direction.

The swap could never have worked anyway. rusqlite 0.40.1 calls `cfg_select!` from its own **library** source, not only from libsqlite3-sys's build script:

- `src/lib.rs:339`
- `src/statement.rs:697`
- `src/raw_statement.rs:146`
- `src/inner_connection.rs:290` — whose arm is literally `feature = "modern_sqlite" => ...`

#1112's own CI log shows the swap succeeding and rusqlite then failing to compile with 12 `cfg_select!` errors. No feature selection avoids a macro the crate calls directly.

So this deletes the step and restores `--locked`. The gate goes back to checking, unmodified, exactly what ships.

Also corrects the rusqlite pin's rationale comment: `cfg_select!` stabilized in **1.95**, not 1.94 — which is what that comment's own "five releases above 1.90" already implied.

Closes #1105 (properly this time — the constraint lives on the dependency, per #1113)

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure CI change) — because there is no Rust behavior to assert. Verified instead by reproducing both directions:

**The breakage on `main`** — replaying the step's own two lines against `main`'s `Cargo.toml`:

```
$ sed -i 's/rusqlite = { version = "0.40", features = \["bundled"\] }/.../' Cargo.toml
$ grep -q 'features = \["modern_sqlite"\]' Cargo.toml || echo GUARD FIRES
GUARD FIRES          # rusqlite line is still version = "0.39"
```

**The gate passing here** — exactly what the job runs, minus the deleted step:

```
$ rustup run 1.90 cargo check --workspace --locked
   Checking rusqlite v0.39.0
   Finished `dev` profile in 53.52s     # exit 0, whole workspace, 0 errors
```

**The 1.95 stabilization claim** — probed directly rather than taken from the changelog:

```
1.90: unstable   1.91: unstable   1.93: unstable   1.94: unstable   1.95: STABLE
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] Docs updated where behavior/flags changed — N/A, no user-facing behavior or flags changed
- [x] `Closes #N` appears both above and as a commit trailer

All three ran clean via the repo's pre-push gate before this push.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — this *removes* an `apt-get` from CI rather than adding one
- [ ] New cross-boundary types round-trip through serde — N/A, no new types

## Anything reviewers should know?

This keeps `rust-version = "1.90"`. I initially raised it to 1.95 (the true floor for rusqlite 0.40) before #1113 landed; #1113's trade is the better one — an MSRV is a public compatibility promise and shouldn't be spent to satisfy a transitive build script — so that work is dropped in favor of this.

The `--locked` restoration is the substantive half. #1112 dropped it because its feature swap changed the resolved graph. With no swap, `--locked` is what gives the job its meaning: it proves the *committed* lockfile builds on the floor. Without it cargo can resolve a graph no contributor or release ever uses — which is precisely how a patch release of a transitive build script (libsqlite3-sys 0.38.1) reached every open branch at once and went unnoticed.

## Summary by Sourcery

Remove the broken rusqlite feature swap from the MSRV workflow and restore a locked dependency check on the declared minimum Rust version.

Bug Fixes:
- Fix the MSRV CI job failing on every PR due to a stale rusqlite feature swap guard that no longer matches Cargo.toml.

Enhancements:
- Clarify and expand the rusqlite version pin rationale in Cargo.toml to document the true cfg_select! stabilization version and why the constraint lives on rusqlite rather than libsqlite3-sys.

CI:
- Simplify the MSRV workflow by dropping the SQLite system-linking step (including apt-get usage) and running cargo check --workspace --locked against the committed lockfile.