### PR TITLE
bench: run the Sonnet-5 head-to-head at xhigh, and instrument that effort actually lands

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -345,15 +345,45 @@ Stella compute the comparator never receives. Anthropic separately documents
 `xhigh` — not `max` — as the setting for coding and agentic work, and warns
 `max` is prone to overthinking, so parity and the model's own guidance agree.
 
-Digests move again, recomputed the same way. These supersede the table above:
+### 8.3.2 The output cap moves with the effort tier
+
+Raising the tier alone was not enough, and the smoke run said so before the
+scored run could. Two of three Stella trials at xhigh died with:
+
+```
+output_tokens=16384, tool_calls=0
+"reached its output-token limit before producing any visible response —
+ its budget was likely spent on reasoning"
+```
+
+Effort and the output cap are coupled. The engine's 16384 default carries a
+comment recording that it was itself raised from 8192 for this same failure on
+glm-5.2, and naming per-model caps as the real fix. Raising the tier without
+raising the cap buys reasoning with no room for an answer beside it, and the
+step ends emitting no tool call at all — which Harbor records as
+`NonZeroAgentExitCodeError`, indistinguishable at the results layer from the
+agent simply failing the task.
+
+The posture now sets `agents.<role>.params.max_tokens = 32000` for the three
+roles the outcome depends on. 32000 rather than more is bounded by
+`model_timeout` (600s): the effort preflight spent ~280s reaching 32000 output
+tokens, so ~64000 would sit close enough to that timeout to trade one
+truncation mode for another. Sonnet 5's own 128000 ceiling is not the binding
+constraint. `triage` keeps the default — at low effort it emits a three-line
+classification, so 16384 was never near binding.
+
+This is not compute handed to one side: Claude Code does not cap itself at 16k,
+so the cap was a Stella-side handicap and removing it restores parity.
+
+Digests move again, recomputed the same way. These supersede both tables above:
 
 | model | now |
 |---|---|
-| deepseek-v4-pro | `c19251f5…` |
-| z-ai/glm-5.2 | `29c1f162…` |
-| x-ai/grok-4.5 | `5402c38c…` |
-| z-ai/glm-5.1 | `641e98fd…` |
-| anthropic/claude-sonnet-5 | `5759a7ad…` |
+| deepseek-v4-pro | `4249a1f9…` |
+| z-ai/glm-5.2 | `b906090c…` |
+| x-ai/grok-4.5 | `a1b0df58…` |
+| z-ai/glm-5.1 | `b80a9d06…` |
+| anthropic/claude-sonnet-5 | `55c6ef4c…` |
 
 The GLM and deepseek rows are listed because the constant is shared, not
 because those arms were re-run. Runs published under the `max` posture remain

--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -330,6 +330,36 @@ the launcher emits:
 | x-ai/grok-4.5 | `3c7d6155…` | `ff61cb06…` |
 | z-ai/glm-5.1 | `55fdf342…` | `f15536e5…` |
 
+### 8.3.1 `max` → `xhigh`, for the Sonnet-5 comparator
+
+The rule that picked `max` above did not change; the comparator did. The rule
+is *spend what the other side spends*, because the leaderboard treats `high`,
+`xhigh` and `max` as distinct values, so a mismatch is less compute applied to
+one side rather than a naming variation. Against Claude Code on GLM-5.1 at max
+effort, that rule said `max`.
+
+The Sonnet-5 head-to-head compares against Claude Code on the **first-party
+Anthropic API**, which runs `xhigh` by default, so the same rule now says
+`xhigh`. Reading `max` as "more is safer" would invert the rule: it would hand
+Stella compute the comparator never receives. Anthropic separately documents
+`xhigh` — not `max` — as the setting for coding and agentic work, and warns
+`max` is prone to overthinking, so parity and the model's own guidance agree.
+
+Digests move again, recomputed the same way. These supersede the table above:
+
+| model | now |
+|---|---|
+| deepseek-v4-pro | `c19251f5…` |
+| z-ai/glm-5.2 | `29c1f162…` |
+| x-ai/grok-4.5 | `5402c38c…` |
+| z-ai/glm-5.1 | `641e98fd…` |
+| anthropic/claude-sonnet-5 | `5759a7ad…` |
+
+The GLM and deepseek rows are listed because the constant is shared, not
+because those arms were re-run. Runs published under the `max` posture remain
+described by the 8.3 table; a run states which posture it used in its own
+manifest, which is the point of hashing it.
+
 ### 8.4 The measured baseline
 
 See `bench/evidence/` for the run manifest, per-trial rows, per-task results and

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -48,12 +48,12 @@ A 3x3 grid of switches, each toggling itself and its orthogonal neighbours.
 Prove whether every configuration is solvable, and give the full reasoning.
 PROMPT_END
 
-# Deliberately far above what either tier should need. A probe that hits its
-# own ceiling reports max_tokens for BOTH tiers and the comparison silently
-# measures the cap instead of the effort — which is how the first version of
-# this check "passed" while proving nothing. MAX_TOKENS is asserted against
-# below, not just chosen generously.
-MAX_TOKENS=64000
+# Bounded by the request being non-streaming, not by generosity. Anthropic
+# documents that a large `max_tokens` without streaming exceeds HTTP timeouts
+# as idle connections drop, and that is not theoretical here: at 64000 both
+# xhigh probes died on the 300s read timeout while 32000 completed. Raising
+# this further requires switching the probe to streaming first.
+MAX_TOKENS=32000
 
 probe() { # $1=key  $2=effort  -> output_tokens | ERROR:...
   # The key goes through the environment, never argv. A process's command line
@@ -115,14 +115,26 @@ for arm in stella claude; do
   case "$lo$hi" in
     *ERROR*) echo "FAIL: $arm effort probe errored"; FAIL=1; continue ;;
   esac
-  # Saturation invalidates the comparison before it is made: at the ceiling
-  # both tiers report max_tokens and the check would compare the cap to
-  # itself. Fail loudly rather than report a meaningless pass.
-  if [ "$hi" -ge "$MAX_TOKENS" ] || [ "$lo" -ge "$MAX_TOKENS" ] 2>/dev/null; then
-    echo "FAIL: $arm probe saturated at max_tokens=$MAX_TOKENS (low=$lo $TIER=$hi)"
-    echo "      raise MAX_TOKENS — this comparison measures the cap, not effort"
+  # Only the LOW tier pinning at the ceiling destroys the comparison. If low
+  # pins, both tiers report max_tokens and the check compares the cap to
+  # itself — which is how the first version of this script "passed" while
+  # proving nothing.
+  #
+  # The high tier pinning is not the same failure. With low strictly under the
+  # ceiling and high at it, low < MAX = high, so `high > low` is established;
+  # the tier's true spend is merely unmeasured, not unproven. Failing that
+  # case would demand a ceiling high enough to contain xhigh, and this request
+  # is non-streaming, so raising the ceiling reintroduces the read timeout.
+  # Being unable to measure a bound is not the same as being unable to prove
+  # an inequality, and only the inequality is what this check claims.
+  if [ "$lo" -ge "$MAX_TOKENS" ] 2>/dev/null; then
+    echo "FAIL: $arm low tier pinned at max_tokens=$MAX_TOKENS — both tiers are"
+    echo "      at the ceiling, so this compares the cap to itself, not effort"
     FAIL=1
     continue
+  fi
+  if [ "$hi" -ge "$MAX_TOKENS" ] 2>/dev/null; then
+    echo "       note: $TIER clipped at $MAX_TOKENS — spend is >= that, exact value unmeasured"
   fi
   # Strictly greater, not >=: identical counts are the signature of a field
   # that was parsed and discarded, which is the exact defect being hunted.

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -26,7 +26,7 @@ set -uo pipefail
 
 MODEL="${1:-claude-sonnet-5}"
 TIER="${2:-xhigh}"
-EXPECT_DIGEST="${3:-5759a7ad}"
+EXPECT_DIGEST="${3:-55c6ef4c}"
 ENV_FILE="${TB_ANTHROPIC_ENV_FILE:-$HOME/.env.harbor-anthropic.local}"
 REPO="${TB_REPO:-$HOME/stella}"
 

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -56,10 +56,16 @@ PROMPT_END
 MAX_TOKENS=64000
 
 probe() { # $1=key  $2=effort  -> output_tokens | ERROR:...
-  python3 - "$1" "$2" "$MODEL" "$PROMPT" "$MAX_TOKENS" <<'PY'
-import json, sys, urllib.request, urllib.error
+  # The key goes through the environment, never argv. A process's command line
+  # is world-readable via ps/pgrep on a shared host, so passing a credential
+  # as an argument publishes it to every user on the box for the life of the
+  # call — and this script's calls are the slow ones. The env block of another
+  # user's process is not readable the same way.
+  PROBE_KEY="$1" python3 - "$2" "$MODEL" "$PROMPT" "$MAX_TOKENS" <<'PY'
+import json, os, sys, urllib.request, urllib.error
 
-key, effort, model, prompt, max_tokens = sys.argv[1:6]
+key = os.environ["PROBE_KEY"]
+effort, model, prompt, max_tokens = sys.argv[1:5]
 body = json.dumps({
     "model": model,
     "max_tokens": int(max_tokens),

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -48,14 +48,21 @@ A 3x3 grid of switches, each toggling itself and its orthogonal neighbours.
 Prove whether every configuration is solvable, and give the full reasoning.
 PROMPT_END
 
+# Deliberately far above what either tier should need. A probe that hits its
+# own ceiling reports max_tokens for BOTH tiers and the comparison silently
+# measures the cap instead of the effort — which is how the first version of
+# this check "passed" while proving nothing. MAX_TOKENS is asserted against
+# below, not just chosen generously.
+MAX_TOKENS=32000
+
 probe() { # $1=key  $2=effort  -> output_tokens | ERROR:...
-  python3 - "$1" "$2" "$MODEL" "$PROMPT" <<'PY'
+  python3 - "$1" "$2" "$MODEL" "$PROMPT" "$MAX_TOKENS" <<'PY'
 import json, sys, urllib.request, urllib.error
 
-key, effort, model, prompt = sys.argv[1:5]
+key, effort, model, prompt, max_tokens = sys.argv[1:6]
 body = json.dumps({
     "model": model,
-    "max_tokens": 8192,
+    "max_tokens": int(max_tokens),
     "thinking": {"type": "adaptive"},
     "output_config": {"effort": effort},
     "messages": [{"role": "user", "content": prompt}],
@@ -98,6 +105,15 @@ for arm in stella claude; do
   case "$lo$hi" in
     *ERROR*) echo "FAIL: $arm effort probe errored"; FAIL=1; continue ;;
   esac
+  # Saturation invalidates the comparison before it is made: at the ceiling
+  # both tiers report max_tokens and the check would compare the cap to
+  # itself. Fail loudly rather than report a meaningless pass.
+  if [ "$hi" -ge "$MAX_TOKENS" ] || [ "$lo" -ge "$MAX_TOKENS" ] 2>/dev/null; then
+    echo "FAIL: $arm probe saturated at max_tokens=$MAX_TOKENS (low=$lo $TIER=$hi)"
+    echo "      raise MAX_TOKENS — this comparison measures the cap, not effort"
+    FAIL=1
+    continue
+  fi
   # Strictly greater, not >=: identical counts are the signature of a field
   # that was parsed and discarded, which is the exact defect being hunted.
   if ! [ "$hi" -gt "$lo" ] 2>/dev/null; then
@@ -109,10 +125,21 @@ done
 # Assert by digest rather than by reading the constant: the digest is what the
 # trusted launcher delivers and what the manifest registers as the SUT, so a
 # match here proves the run and this check agree on one posture.
-posture=$(cd "$REPO" && PYTHONPATH=bench/harbor_adapter python3 - "$MODEL" <<'PY' 2>&1
-import sys
-from stella_harbor.posture import _benchmark_engine_posture
-p, _, d = _benchmark_engine_posture("anthropic/%s" % sys.argv[1])
+# Loaded by file path, not as `stella_harbor.posture`: the package __init__
+# imports `harbor`, so the package route only works inside the adapter venv and
+# would make this check silently venv-dependent. posture.py is a pure function
+# of the model and arm with no Harbor, Docker, or credential dependency —
+# which is exactly why it was split into its own module — so importing the
+# file directly is honest rather than a workaround.
+posture=$(cd "$REPO" && python3 - "$MODEL" <<'PY' 2>&1
+import importlib.util, sys
+
+spec = importlib.util.spec_from_file_location(
+    "_posture", "bench/harbor_adapter/stella_harbor/posture.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+p, _, d = mod._benchmark_engine_posture("anthropic/%s" % sys.argv[1])
 print("%s %s" % (d[:8], p["agents"]["worker"]["effort"]))
 PY
 )

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Prove EFFORT actually lands, on both arms, before a scored run spends anything.
+#
+# `preflight-parity` proves both keys reach the same model with thinking on. It
+# says nothing about effort, which is the whole variable a pinned-effort run
+# exists to fix. The failure being prevented is the one that voided three
+# earlier head-to-heads: a flag was passed, assumed effective, and never checked
+# on the wire. An unexercised guard is indistinguishable from a broken one.
+#
+# Three independent checks, because each can pass while another fails:
+#
+#   1. The API honours `output_config.effort` on this model, for BOTH keys.
+#      Probed behaviourally — same prompt at `low` and at the target tier — so
+#      the check tests the observable effect rather than that the field was
+#      accepted and ignored. Anthropic rejects unknown fields, but "accepted"
+#      and "acted on" are different claims and only one of them is the point.
+#   2. Stella's frozen posture actually carries the target tier. Asserted by
+#      digest, not by reading the constant, so the value the launcher delivers
+#      and the value asserted here cannot drift.
+#   3. Claude Code's CLI accepts `--effort <tier>`. Deferred to the in-container
+#      smoke run: the CLI is installed per trial from `claude.ai/install.sh`, so
+#      the host has no copy to interrogate.
+#
+# Usage: preflight_effort.sh [model] [tier] [expected-posture-digest-prefix]
+set -uo pipefail
+
+MODEL="${1:-claude-sonnet-5}"
+TIER="${2:-xhigh}"
+EXPECT_DIGEST="${3:-5759a7ad}"
+ENV_FILE="${TB_ANTHROPIC_ENV_FILE:-$HOME/.env.harbor-anthropic.local}"
+REPO="${TB_REPO:-$HOME/stella}"
+
+test -f "$ENV_FILE" || { echo "FATAL: no env file at $ENV_FILE"; exit 1; }
+set -a
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+set +a
+: "${STELLA_ANTHROPIC_API_KEY:?missing STELLA_ANTHROPIC_API_KEY}"
+: "${CLAUDE_CODE_ANTHROPIC_API_KEY:?missing CLAUDE_CODE_ANTHROPIC_API_KEY}"
+
+FAIL=0
+
+# A prompt with genuine reasoning depth, so the tiers have somewhere to differ.
+# A trivial prompt collapses every tier onto the same short answer and the
+# comparison proves nothing.
+read -r -d '' PROMPT <<'PROMPT_END'
+A 3x3 grid of switches, each toggling itself and its orthogonal neighbours.
+Prove whether every configuration is solvable, and give the full reasoning.
+PROMPT_END
+
+probe() { # $1=key  $2=effort  -> output_tokens | ERROR:...
+  python3 - "$1" "$2" "$MODEL" "$PROMPT" <<'PY'
+import json, sys, urllib.request, urllib.error
+
+key, effort, model, prompt = sys.argv[1:5]
+body = json.dumps({
+    "model": model,
+    "max_tokens": 8192,
+    "thinking": {"type": "adaptive"},
+    "output_config": {"effort": effort},
+    "messages": [{"role": "user", "content": prompt}],
+}).encode()
+req = urllib.request.Request(
+    "https://api.anthropic.com/v1/messages",
+    data=body,
+    headers={
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    },
+)
+try:
+    with urllib.request.urlopen(req, timeout=300) as r:
+        print(json.load(r).get("usage", {}).get("output_tokens", 0))
+except urllib.error.HTTPError as e:
+    # The body carries the actual reason (unknown field, bad tier, bad key);
+    # the status alone would not distinguish "effort rejected" from "no quota".
+    try:
+        msg = json.load(e).get("error", {}).get("message", "")
+    except Exception:
+        msg = e.reason
+    print("ERROR:%s" % str(msg)[:100])
+except Exception as e:
+    print("ERROR:%s" % str(e)[:100])
+PY
+}
+
+echo "== effort preflight: model=$MODEL tier=$TIER =="
+
+for arm in stella claude; do
+  case "$arm" in
+    stella) key="$STELLA_ANTHROPIC_API_KEY" ;;
+    claude) key="$CLAUDE_CODE_ANTHROPIC_API_KEY" ;;
+  esac
+  lo=$(probe "$key" low)
+  hi=$(probe "$key" "$TIER")
+  echo "  $arm: low=$lo $TIER=$hi"
+  case "$lo$hi" in
+    *ERROR*) echo "FAIL: $arm effort probe errored"; FAIL=1; continue ;;
+  esac
+  # Strictly greater, not >=: identical counts are the signature of a field
+  # that was parsed and discarded, which is the exact defect being hunted.
+  if ! [ "$hi" -gt "$lo" ] 2>/dev/null; then
+    echo "FAIL: $arm $TIER ($hi) did not exceed low ($lo) — effort may be ignored"
+    FAIL=1
+  fi
+done
+
+# Assert by digest rather than by reading the constant: the digest is what the
+# trusted launcher delivers and what the manifest registers as the SUT, so a
+# match here proves the run and this check agree on one posture.
+posture=$(cd "$REPO" && PYTHONPATH=bench/harbor_adapter python3 - "$MODEL" <<'PY' 2>&1
+import sys
+from stella_harbor.posture import _benchmark_engine_posture
+p, _, d = _benchmark_engine_posture("anthropic/%s" % sys.argv[1])
+print("%s %s" % (d[:8], p["agents"]["worker"]["effort"]))
+PY
+)
+echo "  posture: $posture"
+if [ "$posture" != "$EXPECT_DIGEST $TIER" ]; then
+  echo "FAIL: posture is not the $TIER arm (expected '$EXPECT_DIGEST $TIER')"
+  FAIL=1
+fi
+
+if [ $FAIL -eq 0 ]; then
+  echo "EFFORT PREFLIGHT PASS: $TIER honoured on both keys; Stella posture pinned $TIER"
+  echo "NOTE: Claude Code's own --effort flag is verified in-container by the smoke run."
+else
+  echo "EFFORT PREFLIGHT FAIL — do not launch"
+fi
+exit $FAIL

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -53,7 +53,7 @@ PROMPT_END
 # measures the cap instead of the effort — which is how the first version of
 # this check "passed" while proving nothing. MAX_TOKENS is asserted against
 # below, not just chosen generously.
-MAX_TOKENS=32000
+MAX_TOKENS=64000
 
 probe() { # $1=key  $2=effort  -> output_tokens | ERROR:...
   python3 - "$1" "$2" "$MODEL" "$PROMPT" "$MAX_TOKENS" <<'PY'
@@ -99,9 +99,13 @@ for arm in stella claude; do
     stella) key="$STELLA_ANTHROPIC_API_KEY" ;;
     claude) key="$CLAUDE_CODE_ANTHROPIC_API_KEY" ;;
   esac
-  lo=$(probe "$key" low)
-  hi=$(probe "$key" "$TIER")
-  echo "  $arm: low=$lo $TIER=$hi"
+  # Wall-clock is reported alongside tokens because an xhigh turn's duration is
+  # the direct input to the truncation risk: Harbor kills a trial at its agent
+  # timeout, and a tier that reasons for minutes per step is the most likely
+  # way this run degrades. Free to measure here, expensive to discover at 89x2.
+  t0=$(date +%s); lo=$(probe "$key" low);     t1=$(date +%s)
+  hi=$(probe "$key" "$TIER");                 t2=$(date +%s)
+  echo "  $arm: low=$lo ($((t1 - t0))s)  $TIER=$hi ($((t2 - t1))s)"
   case "$lo$hi" in
     *ERROR*) echo "FAIL: $arm effort probe errored"; FAIL=1; continue ;;
   esac

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -150,10 +150,46 @@ def _benchmark_engine_posture(
         # exception to it: it emits a three-line classification and never edits
         # the workspace, so raising it would change what Stella *is* rather than
         # what it was allowed to spend.
+        # `params.max_tokens` raises the engine's 16384 output cap, and at
+        # xhigh it is load-bearing rather than a tuning knob. Measured, not
+        # assumed: in the first xhigh smoke, 2 of 3 Stella trials died with
+        #
+        #   output_tokens=16384, tool_calls=0
+        #   "reached its output-token limit before producing any visible
+        #    response — its budget was likely spent on reasoning"
+        #
+        # The engine default carries a comment saying 16k was itself a raise
+        # from 8k for exactly this failure on glm-5.2, and names per-model caps
+        # as the real fix. Effort and the output cap are coupled: raising the
+        # tier without raising the cap buys reasoning that cannot fit an answer
+        # beside it, and the step ends with no tool call at all.
+        #
+        # 32000 rather than more, bounded by `model_timeout` (600s): the effort
+        # preflight spent ~280s reaching 32000 output tokens, so ~64000 would
+        # sit close enough to the model timeout to trade one truncation mode
+        # for another. Sonnet 5's own ceiling (128000) is not the constraint.
+        #
+        # This is not compute handed to one side. Claude Code does not cap
+        # itself at 16k, so the cap was a Stella-side handicap and removing it
+        # restores parity rather than breaking it. `triage` keeps the default:
+        # it runs at low effort and emits a three-line classification, so 16384
+        # was never near binding for it.
         "agents": {
-            "default": {"effort": "xhigh", "reasoning": "on"},
-            "worker": {"effort": "xhigh", "reasoning": "on"},
-            "judge": {"effort": "xhigh", "reasoning": "on"},
+            "default": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 32000},
+            },
+            "worker": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 32000},
+            },
+            "judge": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 32000},
+            },
             "triage": {"effort": "low", "reasoning": "off"},
         },
     }

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -123,23 +123,37 @@ def _benchmark_engine_posture(
         # so scope review has nothing to protect here and nobody to ask. Left
         # off, any plan over the thresholds (more than 5 steps) ends the run.
         "headless_scope_bypass": "on",
-        # `max`, not `high`, for every role the outcome depends on. The
-        # comparator this benchmark is scored against is "Claude Code using
-        # GLM-5.1 at **max effort**" (protocol, §Comparator and thresholds), and
-        # the public leaderboard carries `high`, `xhigh` and `max` as distinct
-        # values — so `high` was not a naming variation on the comparator's
-        # setting, it was less compute applied to one side only. Every
-        # Terminal-Bench number published before this change was produced under
-        # that handicap.
+        # `xhigh` for every role the outcome depends on, and the rule that
+        # picks it has not changed — only the comparator has. The rule is:
+        # spend what the other side spends, because the leaderboard carries
+        # `high`, `xhigh` and `max` as distinct values, so a mismatch is less
+        # compute applied to one side rather than a naming variation. Against
+        # "Claude Code using GLM-5.1 at **max effort**" that rule said `max`,
+        # and every Terminal-Bench number published before then was produced
+        # at `high` — under that handicap.
+        #
+        # The Sonnet-5 comparator is Claude Code on the first-party Anthropic
+        # API, which runs `xhigh` by default, so the same rule now says
+        # `xhigh`. Reading `max` as "more is safer" would invert it: `max`
+        # here would hand Stella compute the comparator never gets, and
+        # Anthropic documents `xhigh` — not `max` — as the setting for coding
+        # and agentic work, with `max` prone to overthinking. Parity and the
+        # model's own guidance agree.
+        #
+        # Changing this constant changes the posture digest, and therefore the
+        # registered SUT. That is the intended way to make the change — a run
+        # states which frozen posture it used in its manifest — but it does
+        # mean digests recorded against the `max` posture (bench/READINESS.md)
+        # describe the earlier arm, not this one.
         #
         # `triage` deliberately stays low/off, and that is parity rather than an
         # exception to it: it emits a three-line classification and never edits
         # the workspace, so raising it would change what Stella *is* rather than
         # what it was allowed to spend.
         "agents": {
-            "default": {"effort": "max", "reasoning": "on"},
-            "worker": {"effort": "max", "reasoning": "on"},
-            "judge": {"effort": "max", "reasoning": "on"},
+            "default": {"effort": "xhigh", "reasoning": "on"},
+            "worker": {"effort": "xhigh", "reasoning": "on"},
+            "judge": {"effort": "xhigh", "reasoning": "on"},
             "triage": {"effort": "low", "reasoning": "off"},
         },
     }

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -589,21 +589,21 @@ class TestForwardedEnv:
             "model" not in role and "provider" not in role
             for role in posture["agents"].values()
         )
+        # `xhigh` matches the comparator and the raised cap travels with the
+        # tier: at `xhigh` the 16384 default is spent before any tool call.
         for role in ("default", "worker", "judge"):
             assert posture["agents"][role] == {
-                "effort": "max",
+                "effort": "xhigh",
                 "reasoning": "on",
+                "params": {"max_tokens": 32000},
             }
-        assert posture["agents"]["triage"] == {
-            "effort": "low",
-            "reasoning": "off",
-        }
+        assert posture["agents"]["triage"] == {"effort": "low", "reasoning": "off"}
         assert json.loads(normalized) == posture
-        # 0.5.1 SUT posture: includes `headless_scope_bypass: "on"` (added in
-        # #322, after the #301 freeze). See bench/terminal-bench-2.1-protocol.md
-        # "Engine posture" prose + calibration table for the recomputed hashes.
+        # The digest is the registered SUT, so pinning it is the point: posture
+        # edits land here deliberately. Keep it in step with the superseding
+        # table in bench/READINESS.md, not the protocol's earlier `max` table.
         assert digest == (
-            "0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2"
+            "4249a1f95976f388cc8c5177a8c085ff0152fe5e6884d3dbfaada349d989b725"
         )
 
     def test_excludes_all_provider_keys_and_selects_only_effective_provider(


### PR DESCRIPTION
Configures the Terminal-Bench 2.1 head-to-head (`sonnet89x`) to run **both arms
at `effort: xhigh`** on `claude-sonnet-5` over the first-party Anthropic API,
and adds the instrument that was missing to prove it.

No Rust or Cargo change, so the cross-built SUT binary is untouched and its
recorded sha stays valid.

## Why xhigh, not max

The rule that picks the tier is unchanged — spend what the comparator spends,
because the leaderboard treats `high`/`xhigh`/`max` as distinct values. Only the
comparator changed. Against Claude Code on GLM-5.1 at max effort that rule said
`max`; the Sonnet-5 comparator is Claude Code on the first-party API, which runs
`xhigh` by default. Anthropic separately documents `xhigh` rather than `max` as
the setting for coding and agentic work, and warns `max` is prone to
overthinking, so parity and the model's own guidance agree.

## The effort preflight

The existing parity preflight proves both keys reach the same model with
thinking on. It said nothing about **effort** — the run's headline setting was
the one thing no instrument checked, which is the shape of the defect that
voided three earlier head-to-heads: a flag passed, assumed effective, never read
back off the wire.

The new check probes *behaviourally* (same prompt at `low` and at the tier,
asserting the tier spends strictly more), because "accepted" and "acted on" are
different claims and only the second one matters. It caught two defects in
itself before it caught anything else, both now encoded as guards:

- **A saturated probe proves nothing.** At `max_tokens=8192` both tiers returned
  exactly 8192 and it reported a pass while comparing the cap to itself. Only
  the *low* tier pinning invalidates the comparison, though: with low under the
  ceiling and high at it, `low < MAX = high` still establishes the inequality.
- **Non-streaming + large `max_tokens` = read timeout.** At 64000 both xhigh
  probes died on the 300s timeout; 32000 completes.

## The output cap has to move with the tier

The first xhigh smoke killed 2 of 3 Stella trials, and not by timing out:

```
output_tokens=16384, tool_calls=0, duration_ms=170851
"reached its output-token limit before producing any visible response —
 its budget was likely spent on reasoning"
```

Effort and the output cap are coupled, and only one had been raised. At `xhigh`
the model spends the whole 16384 budget reasoning and emits no visible response
and no tool call, so the step fails and Harbor records
`NonZeroAgentExitCodeError` — indistinguishable at the results layer from the
agent simply failing the task. The engine default's own comment records that
16384 was itself a raise from 8192 for this failure on glm-5.2, and names
per-model caps as the real fix.

`agents.<role>.params.max_tokens = 32000` for the three roles the outcome
depends on. Bounded by `model_timeout` (600s) rather than by the model: the
preflight spent ~280s reaching 32000 output tokens, and a 64000 trial ran 13+
minutes without completing a single step — trading truncation for a timeout.
Settable from the posture because `max_tokens` is already in
`ENGINE_PARAM_FIELDS`, hence no Rust change.

This is not compute handed to one side. Claude Code does not cap itself at 16k,
so the cap was a Stella-side handicap and lifting it restores parity.

Smoke went **1/3 → 2/3**. The residual failure is a large single-call
`write_file` cut off mid-arguments — disclosed rather than tuned away.

## Verified before spending

- effort honoured on both keys (stella 7395→≥32000, claude 5683→≥32000)
- posture digest is the xhigh arm (`55c6ef4c`)
- `--effort xhigh` observed in Claude Code's in-container command line
- 89/89 task images pre-pulled, 0 failures
- binary sha unchanged from the preregistration

Posture digest `5759a7ad` → `55c6ef4c`; `bench/READINESS.md` gains superseding
tables rather than edits to the historical ones.

## Summary by Sourcery

Configure the Sonnet-5 head-to-head benchmark to run both arms at xhigh effort with a higher output-token cap, and add a behavioural preflight plus documentation and tests to verify effort and posture parity before scored runs.

New Features:
- Add an effort preflight script that probes Anthropic API behaviour on both keys and validates the frozen posture digest matches the intended xhigh arm.

Enhancements:
- Update the benchmark engine posture so default, worker, and judge agents use xhigh effort with an increased max_tokens cap to remove a Stella-side handicap while preserving triage at low effort.

Documentation:
- Extend bench/READINESS.md with sections describing the move from max to xhigh for the Sonnet-5 comparator, the coupling between effort tier and output cap, and the superseding posture digest table for affected models.

Tests:
- Adjust harbor adapter posture tests to expect xhigh effort with raised max_tokens for primary roles and to pin the updated posture digest that matches the new configuration.