### PR TITLE
fix(cli): say which chat surface you got, and why

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,9 +18,9 @@
 1790 stella-cli/src/agent_tests.rs
 2316 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4406 stella-cli/src/command_deck.rs
+4413 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2234 stella-core/src/driver.rs
+2179 stella-core/src/driver.rs
 3133 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -816,21 +816,38 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // The Command Deck (tabbed TUI) is the default chat surface on a
             // real terminal; `--plain` / STELLA_PLAIN=1 / a non-TTY stream
             // falls back to the line-based REPL.
-            if term_policy::use_deck(cli.globals.plain) {
-                signals::block_on_interruptible(
-                    rt()?,
-                    command_deck::run_deck_session(
-                        &cfg,
-                        cli.globals.budget,
-                        term_policy::animation_disabled(cli.globals.no_anim),
-                        None,
-                    ),
-                )?;
-            } else {
-                signals::block_on_interruptible(
-                    rt()?,
-                    agent::run_interactive(&cfg, cli.globals.budget),
-                )?;
+            match term_policy::plain_fallback(cli.globals.plain) {
+                None => {
+                    signals::block_on_interruptible(
+                        rt()?,
+                        command_deck::run_deck_session(
+                            &cfg,
+                            cli.globals.budget,
+                            term_policy::animation_disabled(cli.globals.no_anim),
+                            None,
+                        ),
+                    )?;
+                }
+                Some(reason) => {
+                    // Say which surface this is and why, BEFORE the REPL's
+                    // banner — which otherwise looks enough like a normal
+                    // start that the missing features read as breakage. The
+                    // REPL has no prompt queue and no mid-turn steering, and
+                    // it exits at stdin EOF, so a silent downgrade presents
+                    // as "stella dies when a turn completes" with nothing to
+                    // point at. To stderr: stdout may be the pipe that caused
+                    // the fallback in the first place.
+                    eprintln!(
+                        "▸ plain REPL ({}) — no prompt queue, no mid-turn steering; \
+                         exits at end of input.",
+                        reason.explain()
+                    );
+                    eprintln!("  The Command Deck needs both stdin and stdout on a terminal.");
+                    signals::block_on_interruptible(
+                        rt()?,
+                        agent::run_interactive(&cfg, cli.globals.budget),
+                    )?;
+                }
             }
         }
         Command::Resume { id, list } => {

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -10,7 +10,7 @@ use clap::{CommandFactory, Parser};
 use super::build_info::{
     BUILD_VERSION_IDENTITY, long_version_static, version_static, version_string,
 };
-use super::term_policy::{animation_disabled, dumb_terminal};
+use super::term_policy::{PlainReason, animation_disabled, deck_decision, dumb_terminal};
 use super::{AuthCmd, Cli, Command, ConnectCmd, OutputFormat, TelemetryCmd, error_summary_json};
 
 /// `-V` stays one greppable line; `--version` answers the two questions a bug
@@ -192,6 +192,56 @@ fn a_dumb_terminal_disables_colour_unless_the_user_forces_it() {
     assert!(!dumb_terminal(term("xterm-256color").as_deref(), None));
     assert!(!dumb_terminal(term("dumb-but-not-really").as_deref(), None));
     assert!(!dumb_terminal(None, None));
+}
+
+/// The deck and the line REPL are different programs: the REPL has no prompt
+/// queue, no mid-turn steering, and exits at stdin EOF. Downgrading between
+/// them without saying so presents as "stella dies when a turn completes",
+/// because the surface that would have queued the next prompt is not running
+/// and nothing said so. Every fallback path must therefore name a reason —
+/// that is what the caller prints.
+#[test]
+fn every_plain_fallback_names_a_reason_and_a_real_terminal_gets_the_deck() {
+    // The only combination that earns the deck.
+    assert_eq!(deck_decision(false, false, true, true), None);
+
+    // Explicit opt-outs outrank stream shape: someone who passed `--plain`
+    // does not need to be told about their tty.
+    assert_eq!(
+        deck_decision(true, false, true, true),
+        Some(PlainReason::Flag)
+    );
+    assert_eq!(
+        deck_decision(false, true, true, true),
+        Some(PlainReason::Env)
+    );
+    assert_eq!(
+        deck_decision(true, false, false, false),
+        Some(PlainReason::Flag),
+        "the flag is reported ahead of the ttys it makes irrelevant"
+    );
+
+    // A piped stdin is the case behind the bug report: the deck never starts,
+    // and the REPL exits the moment that pipe ends.
+    assert_eq!(
+        deck_decision(false, false, false, true),
+        Some(PlainReason::StdinNotTty)
+    );
+    assert_eq!(
+        deck_decision(false, false, true, false),
+        Some(PlainReason::StdoutNotTty)
+    );
+
+    // No fallback is allowed to be silent — an empty explanation would print
+    // a notice that says nothing.
+    for reason in [
+        PlainReason::Flag,
+        PlainReason::Env,
+        PlainReason::StdinNotTty,
+        PlainReason::StdoutNotTty,
+    ] {
+        assert!(!reason.explain().is_empty(), "{reason:?} explains nothing");
+    }
 }
 
 /// `--no-anim`'s help promises "Also forced on by STELLA_NO_ANIM or NO_COLOR",

--- a/stella-cli/src/term_policy.rs
+++ b/stella-cli/src/term_policy.rs
@@ -70,10 +70,81 @@ pub(crate) fn animation_disabled(no_anim_flag: bool) -> bool {
     no_anim_flag || stella || no_color
 }
 
+/// Why `chat` fell back to the line REPL instead of the Command Deck.
+///
+/// Carried rather than collapsed to a bool because the two surfaces are not
+/// the same program with different paint. The REPL has no prompt queue and no
+/// mid-turn steering, and it exits the moment stdin reaches EOF — so a user
+/// who is silently downgraded sees follow-up prompts vanish, a queue that
+/// never drains, and an exit the instant a turn ends, with nothing anywhere
+/// saying why. Naming the reason is what lets the caller say it out loud.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlainReason {
+    /// `--plain` was passed.
+    Flag,
+    /// `STELLA_PLAIN` is set to something other than `0`.
+    Env,
+    /// stdin is a pipe or a file, so there are no keystrokes to read.
+    StdinNotTty,
+    /// stdout is redirected, so raw mode and the alternate screen are moot.
+    StdoutNotTty,
+}
+
+impl PlainReason {
+    /// One line naming the cause, for the notice printed before the REPL
+    /// banner. Phrased as the condition observed, not as an instruction —
+    /// `--plain` and a piped stdin are both legitimate ways to run.
+    pub(crate) fn explain(self) -> &'static str {
+        match self {
+            Self::Flag => "--plain was passed",
+            Self::Env => "STELLA_PLAIN is set",
+            Self::StdinNotTty => "stdin is not a terminal (piped or redirected)",
+            Self::StdoutNotTty => "stdout is not a terminal (piped or redirected)",
+        }
+    }
+}
+
+/// The deck-or-REPL decision, kept pure so both branches are testable without
+/// a pty and without touching the process's real streams. `None` means the
+/// Command Deck runs.
+///
+/// Explicit opt-outs are reported ahead of stream shape: someone who passed
+/// `--plain` does not need to be told about their tty.
+pub(crate) fn deck_decision(
+    plain_flag: bool,
+    plain_env: bool,
+    stdin_tty: bool,
+    stdout_tty: bool,
+) -> Option<PlainReason> {
+    if plain_flag {
+        Some(PlainReason::Flag)
+    } else if plain_env {
+        Some(PlainReason::Env)
+    } else if !stdin_tty {
+        Some(PlainReason::StdinNotTty)
+    } else if !stdout_tty {
+        Some(PlainReason::StdoutNotTty)
+    } else {
+        None
+    }
+}
+
 /// Whether `chat` should launch the Command Deck: an explicit `--plain` or
 /// STELLA_PLAIN=1 opts out, and both stdin and stdout must be real terminals
 /// (raw mode + the alternate screen are meaningless on a pipe).
+///
+/// [`deck_decision`] is the same question with the reason kept; this wrapper
+/// exists for the call sites that only branch on it.
 pub(crate) fn use_deck(plain_flag: bool) -> bool {
-    let plain_env = std::env::var_os("STELLA_PLAIN").is_some_and(|v| !v.is_empty() && v != "0");
-    !plain_flag && !plain_env && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+    plain_fallback(plain_flag).is_none()
+}
+
+/// [`deck_decision`] applied to this process's real environment and streams.
+pub(crate) fn plain_fallback(plain_flag: bool) -> Option<PlainReason> {
+    deck_decision(
+        plain_flag,
+        std::env::var_os("STELLA_PLAIN").is_some_and(|v| !v.is_empty() && v != "0"),
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    )
 }


### PR DESCRIPTION
## What & why

Reported symptom: *"I can't submit a follow-up prompt at all. When a turn completes stella just dies. It never takes any messages left in the queue, and it never stops to receive steering mid-turn."*

Three faults that look unrelated, with one cause. `stella chat` silently falls back from the Command Deck to the line REPL when **either stdin or stdout is not a terminal** (`term_policy::use_deck`). The two surfaces are not the same program with different paint:

| | Command Deck | line REPL |
|---|---|---|
| prompt queue | yes | **none** |
| mid-turn steering | yes (`>` prefix) | **none** — `read_line` only runs between turns |
| end of input | keeps running | **exits** (`agent.rs`: `Ok(Ok((0, _))) => break`) |

So a downgraded session cannot submit a follow-up, never drains a queue, and exits the moment a turn ends and stdin is at EOF — exactly the three reported symptoms, in one step. Nothing named a cause, and the REPL banner looks enough like a normal start that the absence reads as breakage.

`use_deck` collapsed the decision to a `bool`, so the reason was discarded before any caller could report it.

## What changed

- `term_policy::deck_decision(plain_flag, plain_env, stdin_tty, stdout_tty) -> Option<PlainReason>` — the same decision with the reason kept, pure so both branches are testable without a pty. `use_deck` stays as a thin wrapper.
- `Command::Chat` prints the reason **to stderr** (stdout may be the pipe that caused the fallback) before the REPL banner, naming what the surface does not have.

```
▸ plain REPL (stdin is not a terminal (piped or redirected)) — no prompt queue,
  no mid-turn steering; exits at end of input.
  The Command Deck needs both stdin and stdout on a terminal.
```

**No change to which surface is chosen** — only to whether the choice is visible.

## Second commit: main is over its own file-size ceiling

Unrelated to the fix, but it blocks every push in the repo through the pre-push gate:

```
stella-cli/src/command_deck.rs grew to 4413 lines, over its baseline ceiling of 4406 (+7)
```

#1120 added 16 lines to `command_deck.rs` without moving its baseline entry, so `make file-size` has been red on main since it merged. `make file-size-update` also ratchets `stella-core/src/driver.rs` **down** 2234 → 2179 (#1114 moved truncation into its own module and the baseline never followed) — tightening, so it is taken rather than left as slack.

## The witness

- [x] Witness test: `every_plain_fallback_names_a_reason_and_a_real_terminal_gets_the_deck` in `stella-cli/src/main_tests.rs`.

It pins the whole decision table — the one combination that earns the deck, explicit opt-outs outranking stream shape, and the piped-stdin case behind this report — plus the invariant that **no fallback may be silent**: every `PlainReason` must return a non-empty explanation, so a future variant cannot print a notice that says nothing.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] Docs — N/A, no flags or documented behaviour changed
- [x] `Closes` trailer n/a (no issue filed yet)

All ran clean via the repo's pre-push gate.

## Anything reviewers should know?

This makes the existing downgrade *legible*; it does not claim the reporter's session was necessarily a downgrade. If they were on a real TTY and the deck still exited at turn end, that is a separate crash and this notice is what will distinguish the two on the next run — the deck path prints nothing, the REPL path now says so.

Worth considering separately: whether a non-tty **stdin** should fall back at all, or whether `stella chat` with piped stdin should be an explicit error pointing at `stella run`. That is a behaviour change, so it is not in this PR.

## Summary by Sourcery

Make the CLI’s chat surface choice explicit by reporting when and why it falls back from the Command Deck to the plain REPL, and update supporting tests and file-size baselines.

New Features:
- Emit a stderr notice when chat falls back to the plain REPL, explaining the cause and the behavioral differences from the Command Deck.

Bug Fixes:
- Prevent silent downgrades from the Command Deck to the plain REPL that caused follow-up prompts and queued input to appear to vanish when stdin/stdout were not TTYs.

Enhancements:
- Introduce a pure deck_decision API that preserves the reason for choosing the plain REPL, enabling clearer branching and test coverage of the terminal policy.
- Refine the chat command’s surface selection logic to branch on detailed fallback reasons instead of a bare boolean.
- Ensure every plain fallback reason produces a non-empty human-readable explanation string.

Build:
- Update file-size baseline configuration to reflect current sizes of command_deck.rs and driver.rs so file-size gates pass on main.

Tests:
- Add a test that exhaustively covers the deck vs. plain REPL decision matrix and asserts that all plain fallback reasons provide non-empty explanations.