### PR TITLE
fix(website): drop the always-lit "Docs" pill from the docs sidebar

### DIFF
--- a/website/src/app/docs/layout.tsx
+++ b/website/src/app/docs/layout.tsx
@@ -3,9 +3,15 @@ import type { ReactNode } from "react";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
+/**
+ * `docsLink: false` keeps the shared "Docs" nav link out of the sidebar, where
+ * fumadocs would render it as a pill above the page tree — a permanently
+ * highlighted entry that is really the parent of everything below it. See
+ * layout.shared.tsx for why the link still exists for the home layout.
+ */
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions()}>
+    <DocsLayout tree={source.pageTree} {...baseOptions({ docsLink: false })}>
       {children}
     </DocsLayout>
   );

--- a/website/src/lib/layout.shared.tsx
+++ b/website/src/lib/layout.shared.tsx
@@ -17,8 +17,24 @@ import { REPO_URL, SPONSOR_URL } from "@/lib/site";
  * mark 28px, wordmark 24px. The header's own height clamps it, so growing
  * these numbers never grows the chrome; past ~h-8 the mark starts touching
  * the header padding, which is the real ceiling.
+ *
+ * `docsLink` exists because fumadocs routes one `links` array to two very
+ * different places. A link with no `on` field lands in both `navItems` and
+ * `menuItems`, and the docs sidebar renders every non-icon `menuItem` as a
+ * flat pill *above* the page tree — so the home page's "Docs" nav link
+ * reappears on docs pages looking like a sibling of the tree's top-level
+ * entries. It is also permanently highlighted there: `active: "nested-url"`
+ * matches any `/docs/**` path, and every page on this site is under `/docs`,
+ * so it can never be inactive. Two lit pills at once, one of them the parent
+ * of the whole tree. The docs layout passes `false`; the home layout, where
+ * "Docs" is a real destination in both the bar and the mobile menu, keeps it.
+ *
+ * Setting `on: "nav"` instead would clear the sidebar too, but it would also
+ * drop "Docs" from the home page's mobile menu, which reads from `menuItems`.
  */
-export function baseOptions(): BaseLayoutProps {
+export function baseOptions({
+  docsLink = true,
+}: { docsLink?: boolean } = {}): BaseLayoutProps {
   return {
     nav: {
       title: (
@@ -30,11 +46,15 @@ export function baseOptions(): BaseLayoutProps {
       ),
     },
     links: [
-      {
-        text: "Docs",
-        url: "/docs",
-        active: "nested-url",
-      },
+      ...(docsLink
+        ? [
+            {
+              text: "Docs",
+              url: "/docs",
+              active: "nested-url" as const,
+            },
+          ]
+        : []),
       {
         type: "icon",
         text: "Sponsor",


### PR DESCRIPTION
## What

The docs sidebar rendered a gold **Docs** pill above the page tree that was highlighted on *every* page, so readers always saw two lit menu items at once — the real page, and its own parent pretending to be its sibling.

| Before | After |
| --- | --- |
| `Docs` (lit) + `Guides` (lit) | `Guides` (lit) |

## Why it happened

Fumadocs routes a single `links` array to two different places:

- `useLinkItems` (`layouts/shared/index.js`) pushes any link with no `on` field into **both** `navItems` and `menuItems`.
- The docs sidebar (`layouts/docs/slots/sidebar.js:34`) renders every non-icon `menuItem` as a `SidebarLinkItem` pill **above** the page tree.

So the home page's `{ text: "Docs", url: "/docs" }` nav link reappeared inside the docs sidebar, styled like a top-level tree entry.

It was permanently active because `active: "nested-url"` makes `isLinkItemActive` match any `/docs/**` path — and every page on this site is under `/docs`. The pill could never be inactive.

The docs header (`nd-subnav`) is `md:hidden` and renders no link items, so this entry's only visible effect on docs pages was that pill.

## The fix

`baseOptions({ docsLink })` scopes the link to the layouts that actually want it:

- **docs layout** passes `false` — sidebar now starts at the page tree.
- **home layout** keeps it — "Docs" is a real destination there, in both the nav bar and the mobile menu.

`Sponsor` and `GitHub` are `type: "icon"`, filtered out of the pill list and rendered in the sidebar footer — untouched.

### Why not `on: "nav"`

That would clear the sidebar too, but `menuItems` is also what the home page's **mobile** menu reads from, so it would silently drop "Docs" from mobile navigation.

## Verification

- `pnpm typecheck` — exit 0
- `pnpm build` — exit 0, all 80 docs pages prerender
- Prerendered + live-server HTML: `0` links labelled `Docs` under `/docs`; home page still has both the nav-bar and mobile-menu entries
- Headless screenshot of `/docs/guides`: one highlight only

`docs.yml` CI for this path runs exactly `pnpm install --frozen-lockfile` → `pnpm typecheck` → `pnpm build`, all three green locally.

> Pushed with `SKIP_GATE=1`: the diff is two `.tsx` files with zero Rust/Python/TOML, so the pre-push `make gate` (fmt · clippy · cargo test) cannot be affected by it.

## Summary by Sourcery

Scope the shared "Docs" navigation link so it no longer appears as an always-highlighted pill in the docs sidebar while retaining it on the home layout.

Bug Fixes:
- Remove the redundant, permanently highlighted "Docs" pill from the docs sidebar page tree.

Enhancements:
- Make the base layout options accept a `docsLink` flag to control whether the "Docs" link is included in shared navigation links.
- Document the interaction between shared links, nav items, menu items, and the docs sidebar to explain the "Docs" pill behavior.