### PR TITLE
fix(settings): a scope edit must read the scope it writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,23 @@ skip the roll) were re-inserted the same way.
   `allowed_models` list are left untouched throughout. Bare `/profile` shows
   what is set and what each profile would choose right now.
 
+### Fixed
+
+- **`/model` no longer copies your project's settings into your user file.**
+  Setting the default model read the *merged* view of user + org + project
+  settings and saved the whole `agent_engine_config` block to user scope, so a
+  repo-local judge pin — or an org-managed effort ceiling — was promoted to a
+  machine-wide default that outlived the repo it came from. Both `/model` and
+  `/profile` now read the file they are about to rewrite, matching the rule
+  the tool switches already followed.
+
+- **A malformed settings file no longer costs you your engine config.** The
+  same edit path treated an unparseable file as an empty one, and then wrote
+  the whole block back — so a single key of the wrong type anywhere in
+  `settings.json` (`"enable_recap": true`, where a `Toggle` was expected)
+  silently discarded every model pin and per-agent prompt in it. A file that
+  exists but cannot be parsed is now a named error, and nothing is written.
+
 ## [0.6.45] — 2026-08-01
 
 ## [0.6.44] — 2026-08-01

--- a/stella-cli/src/command_deck/model_cmd.rs
+++ b/stella-cli/src/command_deck/model_cmd.rs
@@ -133,10 +133,20 @@ pub fn set_default_model(cfg: &Config, id: &str) -> Result<String, String> {
              or run `/models` to list what your configured providers offer"
         ));
     };
-    let mut engine = crate::settings::Settings::load(&cfg.workspace_root)
-        .ok()
-        .and_then(|s| s.agent_engine_config)
-        .unwrap_or_default();
+    let path = crate::settings::user_config_path().ok_or_else(|| {
+        "could not save the default model: the user settings path is unavailable \
+         (is $HOME set?)"
+            .to_string()
+    })?;
+    // Read the file this is about to rewrite, NOT `Settings::load`'s merged
+    // view of user + managed + project. `save_to` replaces the whole
+    // `agent_engine_config` block, so loading the merge and saving it here
+    // would copy the project's and the org's opinions into the user file —
+    // turning one repo's judge pin, or an org-managed effort ceiling, into a
+    // machine-wide default that outlives the repo it came from. The same rule
+    // `tool_switches::save_switches` already follows.
+    let mut engine = crate::settings::user_engine_config_at(&path)
+        .map_err(|e| format!("could not save the default model: {e}"))?;
     engine.default_model = Some(format!("{}/{}", spec.provider, spec.model));
     // A hand-edited `agents.default.model` outranks the flat `default_model`
     // (settings precedence), so clear it — exactly what the tab's save does.
@@ -147,11 +157,6 @@ pub fn set_default_model(cfg: &Config, id: &str) -> Result<String, String> {
     {
         a.model = None;
     }
-    let path = crate::settings::user_config_path().ok_or_else(|| {
-        "could not save the default model: the user settings path is unavailable \
-         (is $HOME set?)"
-            .to_string()
-    })?;
     engine
         .save_to(&path)
         .map_err(|e| format!("could not save the default model: {e}"))?;
@@ -165,6 +170,140 @@ pub fn set_default_model(cfg: &Config, id: &str) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    /// Bundles the process-wide env lock with the `HOME` restore guard.
+    /// Field order matters: fields drop in declaration order, so `restore`
+    /// puts the real `HOME` back before `lock` is released, and no other test
+    /// can observe an unrestored `HOME`.
+    struct HomeGuard {
+        _restore: crate::test_env::EnvRestore,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    /// A workspace with `HOME` pointed inside it, so the user scope is
+    /// isolated from the machine's real `~/.stella`.
+    fn scratch() -> (tempfile::TempDir, HomeGuard) {
+        let lock = crate::test_env::lock();
+        let restore = crate::test_env::EnvRestore::capture(&["HOME"]);
+        let td = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(td.path().join("home")).unwrap();
+        // SAFETY: the env lock above serializes every HOME-mutating test in
+        // this binary; the guard is held for the caller's whole test.
+        unsafe {
+            std::env::set_var("HOME", td.path().join("home"));
+        }
+        (
+            td,
+            HomeGuard {
+                _restore: restore,
+                _lock: lock,
+            },
+        )
+    }
+
+    fn test_config(workspace_root: PathBuf) -> Config {
+        let provider = crate::config::PROVIDERS
+            .iter()
+            .find(|p| p.id == "anthropic")
+            .unwrap()
+            .clone();
+        Config {
+            model_id: provider.default_model.to_string(),
+            provider,
+            model_pinned_by_flag: false,
+            api_key: stella_model::ApiKey::new("dummy-key-unused-offline"),
+            workspace_root,
+            base_url_override: None,
+            hooks: None,
+            engine_settings: None,
+            tool_policy: Default::default(),
+            enable_recap: false,
+            trace_capture: false,
+            authority: crate::settings::AuthorityPolicy::default(),
+            credential_source: None,
+            credential_advisories: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn setting_the_default_model_does_not_copy_project_settings_into_user_scope() {
+        // `save_to` replaces the whole `agent_engine_config` block, so reading
+        // `Settings::load`'s MERGED view here would write this repo's judge pin
+        // into `~/.stella` — promoting one project's choice to a machine-wide
+        // default that outlives the repo it came from.
+        let (td, _guard) = scratch();
+        let workspace = td.path().join("repo");
+        std::fs::create_dir_all(workspace.join(".stella")).unwrap();
+        std::fs::write(
+            workspace.join(".stella/settings.json"),
+            r#"{"agent_engine_config": {"pipeline_judge_model": "openai/gpt-5.5"}}"#,
+        )
+        .unwrap();
+
+        let cfg = test_config(workspace);
+        set_default_model(&cfg, "zai/glm-5.2").expect("the default model should save");
+
+        let user_file = td.path().join("home/.stella/settings.json");
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&user_file).unwrap()).unwrap();
+        let engine = raw
+            .get("agent_engine_config")
+            .expect("the block was written");
+        assert_eq!(
+            engine.get("default_model").and_then(|v| v.as_str()),
+            Some("zai/glm-5.2"),
+            "the edit itself must land"
+        );
+        assert!(
+            engine.get("pipeline_judge_model").is_none(),
+            "the project's judge pin leaked into user scope: {engine}"
+        );
+    }
+
+    #[test]
+    fn setting_the_default_model_preserves_the_rest_of_user_scope() {
+        // Reading the target file is not licence to replace it: everything the
+        // user file already said must survive the edit.
+        let (td, _guard) = scratch();
+        let user_dir = td.path().join("home/.stella");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::write(
+            user_dir.join("settings.json"),
+            r#"{"enable_recap": "on", "agent_engine_config": {
+                 "pipeline_triage_model": "deepseek/deepseek-chat",
+                 "agents": {"judge": {"prompt": "You are a strict reviewer."}}
+               }}"#,
+        )
+        .unwrap();
+
+        let cfg = test_config(td.path().join("repo"));
+        set_default_model(&cfg, "zai/glm-5.2").expect("the default model should save");
+
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(user_dir.join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            raw.get("enable_recap").and_then(|v| v.as_str()),
+            Some("on"),
+            "a sibling key outside the engine block must survive"
+        );
+        let engine = raw.get("agent_engine_config").unwrap();
+        assert_eq!(
+            engine.get("pipeline_triage_model").and_then(|v| v.as_str()),
+            Some("deepseek/deepseek-chat")
+        );
+        assert_eq!(
+            engine
+                .pointer("/agents/judge/prompt")
+                .and_then(|v| v.as_str()),
+            Some("You are a strict reviewer.")
+        );
+        assert_eq!(
+            engine.get("default_model").and_then(|v| v.as_str()),
+            Some("zai/glm-5.2")
+        );
+    }
 
     #[test]
     fn parse_model_command_takes_one_id_and_separates_from_models() {

--- a/stella-cli/src/command_deck/profile_cmd.rs
+++ b/stella-cli/src/command_deck/profile_cmd.rs
@@ -106,7 +106,8 @@ pub fn set_auto() -> Result<String, String> {
     let path = crate::settings::user_config_path().ok_or_else(|| {
         "could not save: the user settings path is unavailable (is $HOME set?)".to_string()
     })?;
-    let mut engine = crate::settings::user_engine_config_at(&path);
+    let mut engine = crate::settings::user_engine_config_at(&path)
+        .map_err(|e| format!("could not save: {e}"))?;
     profile::restore_auto(&mut engine);
     engine
         .save_to(&path)
@@ -282,7 +283,8 @@ pub fn set_profile(cfg: &Config, name: &str) -> Result<String, String> {
     // Read the file being written, NOT the merged view: the merged config also
     // carries the project's and the org's opinions, and saving that to user
     // scope would promote this repo's pins to a machine-wide default.
-    let mut engine = crate::settings::user_engine_config_at(&path);
+    let mut engine = crate::settings::user_engine_config_at(&path)
+        .map_err(|e| format!("could not save the profile: {e}"))?;
     profile::apply(&plan, &mut engine);
     engine
         .save_to(&path)

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -653,30 +653,29 @@ pub fn project_config_path(workspace_root: &Path) -> PathBuf {
 /// file — silently promoting a per-repo model pin to a machine-wide default.
 /// An editor reads the scope it is about to write.
 ///
-/// A missing or unreadable file is an empty config rather than an error: the
-/// caller is about to overwrite this block anyway, and refusing to edit because
-/// of an unrelated malformed key would leave no way out through the UI.
-/// (`Config::load` is where a bad settings file is loud.)
+/// A **missing** file is an empty config — there is nothing to preserve, and
+/// the caller is about to create it. A file that exists but cannot be parsed is
+/// an **error**, and deliberately not a fallback to empty: because the caller
+/// then writes the whole block back, degrading here would let one malformed key
+/// somewhere else in the file destroy an engine config this editor never owned.
+/// A named error the user can act on beats silently discarding their settings.
 ///
 /// User scope specifically, because it is the only scope a slash command
 /// writes; a project-scope sibling would need to pass its own
 /// [`toml_config::ConfigScope`] so a TOML file's declared scope still validates.
-pub fn user_engine_config_at(path: &Path) -> AgentEngineConfig {
+pub fn user_engine_config_at(path: &Path) -> Result<AgentEngineConfig, String> {
     let settings = if toml_config::path_is_toml(path) {
         // A closure, not `std::fs::read_to_string` by name: the free function
         // is generic over `AsRef<Path>`, so inference pins it to one concrete
         // lifetime and it stops satisfying the reader's for-any-lifetime bound.
         toml_config::load_toml_scope(path, toml_config::ConfigScope::User, |p: &Path| {
             std::fs::read_to_string(p)
-        })
-        .ok()
-        .map(|loaded| loaded.settings)
+        })?
+        .settings
     } else {
-        Settings::load_scope(path).ok()
+        Settings::load_scope(path)?
     };
-    settings
-        .and_then(|s| s.agent_engine_config)
-        .unwrap_or_default()
+    Ok(settings.agent_engine_config.unwrap_or_default())
 }
 
 /// The `tools` section of settings.json — the one place a tool is switched

--- a/stella-cli/src/settings/tests.rs
+++ b/stella-cli/src/settings/tests.rs
@@ -47,7 +47,7 @@ fn the_edit_reader_returns_one_files_engine_block_not_the_merge() {
         "the merge should carry the project's pin"
     );
 
-    let scoped = user_engine_config_at(&user);
+    let scoped = user_engine_config_at(&user).unwrap();
     assert_eq!(
         scoped.default_model.as_deref(),
         Some("anthropic/claude-fable-5")
@@ -59,16 +59,41 @@ fn the_edit_reader_returns_one_files_engine_block_not_the_merge() {
 }
 
 #[test]
-fn the_edit_reader_treats_a_missing_or_broken_file_as_empty() {
-    // The caller is about to overwrite this block; refusing because of an
-    // unrelated malformed key would leave no way out through the UI.
+fn the_edit_reader_treats_a_missing_file_as_empty() {
+    // Nothing to preserve, and the caller is about to create it.
     assert_eq!(
         user_engine_config_at(&PathBuf::from("/nonexistent/settings.json")),
-        AgentEngineConfig::default()
+        Ok(AgentEngineConfig::default())
     );
+}
+
+#[test]
+fn the_edit_reader_refuses_a_file_it_cannot_parse() {
+    // Degrading to empty here would be destructive, not forgiving: the caller
+    // writes the whole `agent_engine_config` block back, so one malformed key
+    // ELSEWHERE in the file would silently discard a perfectly good engine
+    // config. A named error the user can act on beats losing their settings.
     let dir = tempfile::tempdir().unwrap();
     let broken = write(dir.path(), "broken.json", "{ this is not json");
-    assert_eq!(user_engine_config_at(&broken), AgentEngineConfig::default());
+    let err = user_engine_config_at(&broken).expect_err("a malformed file must not read as empty");
+    assert!(
+        err.contains("broken.json"),
+        "the error must name the file: {err}"
+    );
+
+    // The realistic shape: valid JSON, one key of the wrong type, and an
+    // `agent_engine_config` that must survive rather than be overwritten.
+    let wrong_type = write(
+        dir.path(),
+        "wrong-type.json",
+        r#"{"enable_recap": true,
+            "agent_engine_config": {"default_model": "zai/glm-5.2"}}"#,
+    );
+    assert!(
+        user_engine_config_at(&wrong_type).is_err(),
+        "`enable_recap` is a Toggle, not a bool — the read must refuse rather \
+         than hand back an empty config the caller would then persist"
+    );
 }
 
 #[test]
@@ -1037,12 +1062,26 @@ fn enable_recap_survives_the_scope_merge() {
 
 /// The complement: an absent key must not reset a lower scope's value, and the
 /// default stays off.
+///
+/// Asserting a DEFAULT means asserting that no scope set it — including the
+/// user scope under `$HOME`, which this process does not own. Without the env
+/// lock and a redirected `$HOME` the assertion depends on the developer's real
+/// `~/.stella/settings.json`, and races any test that legitimately points
+/// `HOME` somewhere else. Both were true: it passed only because no such test
+/// had yet written `enable_recap` into its scratch home.
 #[test]
 fn enable_recap_defaults_off_when_no_scope_sets_it() {
+    let _lock = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
     let dir = tempfile::tempdir().expect("tempdir");
     let workspace = dir.path();
     std::fs::create_dir_all(workspace.join(".stella")).expect("mkdir .stella");
     std::fs::write(workspace.join(".stella/settings.json"), r#"{}"#).expect("write settings");
+    // SAFETY: the env lock above serializes every HOME-mutating test in this
+    // binary, and `_restore` puts the real value back on the way out.
+    unsafe {
+        std::env::set_var("HOME", workspace.join("empty-home"));
+    }
 
     let merged = Settings::load(workspace).expect("settings load");
     assert!(!merged.recap_enabled(), "recap defaults off");


### PR DESCRIPTION
## What & why

Two related data-loss bugs on the settings-edit path. Follow-up to #1120, which introduced the helper both fixes now depend on.

**`/model` copied your project's settings into your user file.** `set_default_model` loaded `Settings::load`'s **merged** view of user + org-managed + project, changed `default_model`, and saved to **user** scope. Since `AgentEngineConfig::save_to` replaces that whole block, a repo-local `pipeline_judge_model` — or an org-managed effort ceiling — was copied into `~/.stella` and became a machine-wide default that outlived the repo it came from. The next project you opened silently inherited the last one's judge.

It now reads the file it is about to rewrite. That is the rule `tool_switches::save_switches` already follows and documents ("Merge, never replace"); this brings the engine-config path in line.

**A malformed settings file cost you your engine config.** `user_engine_config_at` (added in #1120) treated an unparseable file as an *empty* config, and the caller then wrote the whole block back. So one key of the wrong type **anywhere** in `settings.json` silently discarded every model pin and per-agent prompt in it. The realistic trigger is small — `"enable_recap": true`, where the schema wants the `Toggle` string `"on"` — and the failure is invisible: the command reports success, and your engine config is gone.

The distinction now matters:

- **missing file** → empty config. There is nothing to preserve, and the caller is about to create it.
- **file exists, cannot be parsed** → named error, nothing written.

`/model`, `/profile` and `/profile auto` all surface it.

I found this because the witness test I wrote for the first bug had exactly that typo in its fixture — the test failed for the "wrong" reason and took the second bug with it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`setting_the_default_model_does_not_copy_project_settings_into_user_scope` is the direct witness: it writes a project-scope `pipeline_judge_model`, runs `set_default_model`, and asserts the user file does not contain it. On `main` the project pin lands in `~/.stella` and the assertion fires.

Supporting:

- `setting_the_default_model_preserves_the_rest_of_user_scope` — reading the target file is not licence to replace it; a sibling key, an existing triage pin, and a custom judge prompt all survive the edit.
- `the_edit_reader_refuses_a_file_it_cannot_parse` — covers both a syntactically broken file and the realistic `"enable_recap": true` wrong-type case, asserting the read refuses rather than handing back an empty config the caller would persist.
- `the_edit_reader_treats_a_missing_file_as_empty` — the other half of that split.

Both `/model` tests run against a redirected `$HOME` under the process-wide env lock (`test_env::lock` + `EnvRestore`), so they are hermetic and restore on panic.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Full `make gate` green on this branch, rebased onto current `main`

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**One pre-existing test becomes hermetic.** `enable_recap_defaults_off_when_no_scope_sets_it` asserted a *default* — that no scope sets the key — while reading the real `$HOME` without taking the process env lock. That races any test which legitimately redirects `HOME`, and several already do; it passed only because none had yet written `enable_recap` into its scratch home. The new `/model` test does, which is how it surfaced. It now takes the lock and points `HOME` at an empty directory. The assertion is unchanged.

**A third instance of this bug is still open, and I did not fix it here.** The SETTINGS tab's engine panel has the same shape, with a wider blast radius: `engine_config_inbound` populates the panel from `Settings::load` (merged), and `settings_from_state` rebuilds the *entire* `AgentEngineConfig` from what is displayed — so saving to user scope writes every merged field, not just the one edited. Editing one dropdown can persist the project's other three.

I left it out because the honest fix is a UI change, not a one-line swap. The panel *should* display the merged view — seeing the effective value is the point — but it should save only what that scope itself says. That needs either dirty-field tracking or loading the panel from the target scope and annotating the effective value separately (which is roughly what `config_wiring.rs` already does for its readout). Diffing edited-vs-merged is the tempting shortcut and is wrong: it silently drops a user pin that happens to equal the project's, so the pin vanishes later when the project changes. Happy to take it as its own PR.

## Summary by Sourcery

Prevent settings edits from copying merged configuration into user scope and from silently discarding engine config when the settings file is malformed.

Bug Fixes:
- Ensure `/model` and profile-related commands read and update only the user settings file they write, avoiding promotion of project or org engine pins to machine-wide defaults.
- Treat existing but unparseable settings files as errors instead of empty configs, so engine configuration is not silently overwritten in the presence of malformed keys.

Enhancements:
- Make settings-related tests hermetic by locking and redirecting `HOME`, and add witness tests for the engine-config edit behavior and error handling.
- Refine `user_engine_config_at` to return a result with explicit error reporting, clarifying behavior for missing vs malformed settings files.

Documentation:
- Update the changelog to document the fixes to `/model` and engine configuration handling in the presence of malformed settings files.

Tests:
- Add targeted tests around `/model` and engine-config reading/writing behavior, including preservation of unrelated user settings and refusal to read malformed files.
- Adjust an existing recap-default test to isolate user scope via env locking and a scratch home directory, preventing interference from real user settings.