### PR TITLE
docs(guides): fixing a backlog in parallel, and benchmarking against Claude Code

### DIFF
--- a/website/content/docs/agent-fleets.mdx
+++ b/website/content/docs/agent-fleets.mdx
@@ -273,3 +273,15 @@ git branch --list 'fleet/*' --format='%(refname:short)' | xargs -r git branch -D
   *are* the work product for isolated tasks. Run `git branch --list 'fleet/*'`
   on its own first and confirm the list is one you are finished with.
 </Callout>
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="Fix a backlog in parallel" href="/docs/guides/parallel-fixes">
+    The task-shaped walkthrough: decomposing a real list, writing prompts that
+    survive being run alone, and reviewing what the workers landed.
+  </SpecCard>
+  <SpecCard title="stella fleet" href="/docs/commands/fleet">
+    The reference — every flag, the ledger layout, exit behavior.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -19,6 +19,11 @@ stop and read the whole flag surface at the moment you need it and not before.
     causes, pushes, and re-checks — and stops only on a green run somebody else can
     see. Includes what to do when the fix doesn't hold.
   </SpecCard>
+  <SpecCard title="Fix a backlog in parallel" href="/docs/guides/parallel-fixes">
+    A list of independent fixes and one afternoon. `stella fleet` runs them
+    concurrently in one tree, with file claims keeping the workers off each other —
+    including how to decompose the list and how to review what landed.
+  </SpecCard>
   <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
     A repository you have never read, and a change that has to land in it. `stella
     init` builds the code graph, `stella graph` answers the blast-radius question
@@ -32,6 +37,11 @@ stop and read the whole flag surface at the moment you need it and not before.
     A hard ceiling in dollars, and what Stella does as it approaches one: where the
     abort lands, what compaction costs, and how to spend the money on the task
     instead of on the transcript.
+  </SpecCard>
+  <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
+    Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other. The
+    setup, the parity checks that make the comparison mean something, and the traps
+    that quietly void a result.
   </SpecCard>
   <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
     Config that isn't applying, a key that won't resolve, a hook that never fires, a

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -3,9 +3,11 @@
   "pages": [
     "index",
     "fix-failing-ci",
+    "parallel-fixes",
     "unfamiliar-codebase",
     "budget",
     "what-a-run-cost",
+    "terminal-bench-head-to-head",
     "troubleshooting"
   ]
 }

--- a/website/content/docs/guides/parallel-fixes.mdx
+++ b/website/content/docs/guides/parallel-fixes.mdx
@@ -1,0 +1,260 @@
+---
+title: Fix a backlog in parallel
+description: A list of independent fixes and one afternoon. Decompose it into a fleet plan, run the workers concurrently under file claims, and review what actually landed.
+---
+
+You have a list. Eleven clippy warnings across four crates, a dozen modules with
+no test coverage, every `TODO(deprecate)` left over from a migration. Each item
+is small, none of them depend on each other, and doing them one at a time is an
+afternoon of watching a progress bar.
+
+This is what [`stella fleet`](/docs/commands/fleet) is for: many tasks at once,
+each handled by a full Stella worker, coordinated so they don't overwrite each
+other.
+
+## The whole thing, first
+
+```bash
+stella --budget 6 fleet \
+  "Fix the clippy warnings in stella-store" \
+  "Fix the clippy warnings in stella-graph" \
+  "Add unit tests for the plan parser in stella-fleet"
+```
+
+Three workers, running together in your repository root, committing to your
+current branch as they finish. That is the guide for a short list. The rest of
+this page is how to make a *long* list work, and how to tell what you got.
+
+<Callout type="warn">
+Workers commit to the branch you are on. Start from a branch you are willing to
+have committed to — not `main` — and start from a **clean tree**, so
+`git log` afterwards separates their work from yours.
+</Callout>
+
+## Decide this first: does the list share files?
+
+Everything downstream follows from one question, and it is worth thirty seconds
+before you type anything.
+
+<CardGrid size="md">
+  <OptionCard name="Disjoint files → inline prompts">
+    Each item touches its own crate, module or directory. Nothing to declare. Pass
+    the prompts on the command line and let claim-on-first-write handle the rest.
+  </OptionCard>
+  <OptionCard name="Overlapping files → a plan with claims">
+    Two items might both edit `src/store/schema.rs`. Declare the paths up front so
+    the second dispatch fails *by name* instead of racing. This is the common case
+    for anything over about five items.
+  </OptionCard>
+  <OptionCard name="Ordered work → depends_on">
+    Item B only makes sense after item A lands — a migration before its read path.
+    Dependencies order the waves; they are not a performance hint.
+  </OptionCard>
+  <OptionCard name="Competing answers → isolation">
+    Two attempts at the *same* file, and you want to compare them. This is the one
+    case for `isolation = "isolated"`; see [when to isolate](#when-to-isolate-instead).
+  </OptionCard>
+</CardGrid>
+
+## Turning a backlog into a plan
+
+For anything beyond a handful of prompts, write the list down. A plan file is a
+`.toml` (or `.json`) with one `[[tasks]]` entry per item:
+
+```toml title="cleanup.toml"
+[[tasks]]
+id = "store-clippy"
+title = "Clippy: stella-store"
+prompt = "Fix every clippy warning in stella-store. Do not silence with #[allow]."
+claims = ["stella-store/src/lib.rs", "stella-store/src/write.rs"]
+
+[[tasks]]
+id = "graph-clippy"
+title = "Clippy: stella-graph"
+prompt = "Fix every clippy warning in stella-graph. Do not silence with #[allow]."
+claims = ["stella-graph/src/lib.rs"]
+
+[[tasks]]
+id = "workspace-lints"
+title = "Promote the shared lints"
+prompt = "Move the now-common lint config into [workspace.lints] and drop the per-crate duplicates"
+depends_on = ["store-clippy", "graph-clippy"]
+claims = ["Cargo.toml"]
+```
+
+```bash
+stella --budget 6 fleet --plan cleanup.toml --max-concurrency 3
+```
+
+Two crates get cleaned concurrently in wave one; the workspace-wide tidy runs
+alone in wave two, once both have actually succeeded. The
+[full plan schema](/docs/agent-fleets#plan-files) has every field.
+
+<Callout type="info">
+Plans are validated **before** anything runs. A duplicate `id`, a self-dependency,
+an unknown dependency, or a cycle is rejected up front with the offending task
+named — so a typo costs you a message, not half a run.
+</Callout>
+
+### Writing prompts that survive being run alone
+
+The failure mode specific to fleets is the prompt that reads fine in a list and
+is ambiguous in isolation. Each worker sees **only its own prompt** — not the
+other tasks, not your intent, not the conversation you would have had.
+
+Three habits that pay for themselves:
+
+- **Name the scope in the prompt itself.** "Fix the clippy warnings in
+  `stella-store`" — not "fix the clippy warnings", which invites a worker into
+  the whole workspace and straight into another worker's claims.
+- **Say what a fix is not.** "Do not silence with `#[allow]`", "do not delete the
+  test". Left unsaid, the cheapest path to a green build is sometimes the wrong
+  one.
+- **Give it something deterministic to check.** A prompt that names a test
+  command lets the worker's [verify stage](/docs/inference-pipeline#6-verify--the-deterministic-ladder)
+  finish on evidence rather than on a judge's opinion. It is the single biggest
+  lever on both cost and trustworthiness.
+
+### Claims are the thing that makes it safe
+
+By default every worker runs in **one shared tree** — your repository root. That
+is a deliberate trade: the build cache stays warm and commits interleave on one
+branch, but two workers editing one file would be a silent race.
+
+`claims` is what removes the race. A declared path is held as a cooperative lock
+for the attempt's duration; a second task claiming a held path fails that
+dispatch *by name*, in under a second, with the rival identified. Undeclared
+paths are claimed on first write at the tool layer, so you get the protection
+even for files you did not anticipate.
+
+<Callout type="warn">
+Claims are matched as **exact strings** — they are not path prefixes. Claiming
+`src/store/` does not protect `src/store/write.rs`. Name files, and spell each
+one the same way throughout the plan.
+</Callout>
+
+The locks live in `.stella/private/store.db`, separate from the fleet ledger, so
+they coordinate across *concurrent fleet runs* too — a second `stella fleet` in
+another terminal cannot walk into the first one's files.
+
+### When to isolate instead
+
+`isolation = "isolated"` gives a task its own git worktree under
+`.stella/worktrees/<slug>`, on a `fleet/<slug>-<hash>` branch. Reach for it when
+the work is genuinely **divergent** — two attempts at the same rewrite, where
+you want both and will pick one — or when a task mutates checkout state.
+
+It is not the safer default. Isolation costs a cold build cache per tree and
+defers every conflict to integration time. For a backlog of independent fixes,
+claims are cheaper and catch the collision an hour earlier.
+
+## What the budget actually does here
+
+`--budget` is a [global flag](/docs/commands#global-flags), and in a fleet it is
+divided, not shared: each child worker is guarded by
+`budget ÷ max-concurrency`. The fleet stops launching new waves once total
+metered spend crosses the cap.
+
+The practical consequence is that **concurrency and per-task headroom trade off
+against each other**. `--budget 6 --max-concurrency 3` gives each worker $2;
+raising concurrency to 6 halves that, and a task that needed $1.50 now aborts
+partway. If tasks are dying early, lower the concurrency before raising the
+budget.
+
+## Reading the result
+
+This is the part that distinguishes a fleet from a script, and it is where the
+time you save gets spent if you skip it.
+
+Nothing is retried automatically. A failed task does **not** unblock its
+dependents — they end the run as `skipped`, which is a distinct outcome from
+"failed" and means the work was never attempted.
+
+Start with the ledger, `.stella/private/fleet.db` — local SQLite, like all
+[Stella telemetry](/docs/telemetry):
+
+```bash
+# What failed in the most recent run, and what the worker said about it.
+sqlite3 .stella/private/fleet.db \
+  "SELECT a.task_id, a.branch, a.summary
+     FROM attempts a
+    WHERE a.run_id = (SELECT id FROM runs ORDER BY created_at_ms DESC LIMIT 1)
+      AND a.success = 0;"
+```
+
+Then read the diff, because eleven workers producing eleven small commits on one
+branch is exactly the shape that hides a bad one:
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+Past runs also surface on the **Fleet runs** card of the
+[Observatory dashboard](/docs/telemetry/dashboard) if you would rather not write
+SQL.
+
+<Callout type="info">
+Isolated tasks' worktrees and `fleet/*` branches are deliberately **left in
+place** — those branches *are* the work product. `git worktree list` shows them
+all. Nothing is merged for you.
+</Callout>
+
+## When it doesn't go cleanly
+
+### A task failed and took its dependents with it
+
+Expected, and the design is deliberate: a dependent that ran anyway would be
+building on work that isn't there. Fix the cause, then re-run — either the whole
+plan (completed work is cheap to redo and the claims still protect you) or a
+trimmed plan containing just the failed subtree.
+
+### A dispatch failed naming another task
+
+Your claims overlap. That is the system working — it caught at dispatch what
+would otherwise have been a corrupted file. Either widen the split so the two
+tasks own disjoint files, or add a `depends_on` edge so they run in different
+waves.
+
+### Everything is fighting over one file
+
+If three tasks all need `Cargo.toml`, they are not three tasks. Collapse them
+into one prompt, or sequence them with `depends_on`. A fleet parallelizes work
+that is *already* parallel; it cannot make a serial dependency concurrent.
+
+### The workers went wider than you meant
+
+Almost always an under-scoped prompt. Re-read the item as if you knew nothing
+else about the repository — that is the worker's position. Naming the crate,
+directory or file in the prompt fixes it more reliably than any flag.
+
+## Following it through to CI
+
+If your task prompts push their branches and open PRs, `--watch` keeps the run
+alive afterwards to watch each branch's CI to completion and reconcile PR status
+through `gh`. It exits non-zero if any watched branch ends red.
+
+```bash
+stella --budget 8 fleet --plan cleanup.toml --watch
+```
+
+It needs `gh` installed and authenticated, and it only does something once the
+branches are actually pushed — watching an unpushed branch has nothing to watch.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="Agent Fleets" href="/docs/agent-fleets">
+    The concept page: wave scheduling, the full plan schema, and how file claims
+    work underneath.
+  </SpecCard>
+  <SpecCard title="stella fleet" href="/docs/commands/fleet">
+    The reference — every flag, the ledger layout, exit behavior.
+  </SpecCard>
+  <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
+    One branch instead of many, driven to green by `stella monitor`.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    Why per-worker headroom is the number that matters, and where an abort lands.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -83,8 +83,14 @@ off the pin, check the help text before spending anything —
 scrub ANSI before searching it:
 
 ```bash
-harbor run --help 2>&1 | LC_ALL=C sed $'s/\033\[[0-9;?]*[a-zA-Z]//g' | rg -- '--agent'
+harbor run --help 2>&1 | LC_ALL=C sed $'s/\033\[[0-9;?]*[a-zA-Z]//g' \
+  | rg -- '--agent|--ak'
 ```
+
+Check `--ak` (the agent-kwargs flag, used below to pass Claude Code its effort
+tier) at the same time — it is the other spelling that has moved. Asserting the
+flags a script passes still appear in the help text costs one subprocess and
+turns a mid-run `No such option` into one message before launch.
 
 ## 2. Build a binary that can actually run in the containers
 

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -241,6 +241,8 @@ effort passed through — same dataset literal, same task list, same concurrency
 same `--n-attempts 1 --max-retries 0`:
 
 ```bash
+source bench/evidence/run/env.sh     # exports TB_DATASET and JOBS
+
 harbor run \
   --env docker \
   --dataset "$TB_DATASET" \
@@ -249,8 +251,13 @@ harbor run \
   --model claude-sonnet-5 \
   --job-name "<tag>-armB-claudecode" \
   --jobs-dir "$JOBS" \
-  --n-attempts 1 --n-concurrent "$CONC" --max-retries 0
+  --n-attempts 1 --n-concurrent 3 --max-retries 0
 ```
+
+Set `--n-concurrent` to the number arm A actually ran at, and pass the same
+`--include-task-name` list if you scoped arm A to a subset. Concurrency is not a
+free parameter in a head-to-head: it changes how much CPU and memory each trial
+gets, and a comparator run at a different width is running a different benchmark.
 
 The `armA` / `armB` segments in the job names are not cosmetic — the ingester
 matches on them, and it matches on the segment rather than the whole suffix so

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -1,0 +1,336 @@
+---
+title: Benchmark Stella against Claude Code
+description: Run Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other — the setup, and the parity checks that make the comparison mean anything.
+---
+
+You want a number: on the same tasks, with the same model, does Stella solve
+more than Claude Code — and at what cost? Terminal-Bench 2.1 is 89 containerized
+terminal tasks with a deterministic grader, which makes it the right instrument.
+Running it *twice*, once per agent, is the head-to-head.
+
+The hard part is not running the benchmark. It is making the two runs
+**comparable**, and most of this page is about that, because a head-to-head that
+differs in a second variable measures nothing and costs the same money.
+
+## The shape of it
+
+Two Harbor jobs over one frozen dataset. Arm A is Stella, arm B is Claude Code:
+
+```
+<tag>-armA-stella        harbor run --agent-import-path stella_harbor:StellaAgent
+<tag>-armB-claudecode    harbor run --agent claude-code
+```
+
+Same dataset digest, same model, same concurrency, same task list, one attempt
+each. Then both job directories are ingested into SQLite and joined on
+`task_name`.
+
+<Callout type="warn">
+This is the **development-baseline** path — a number you can trust internally and
+publish with its method attached. It is deliberately *not* the audited public
+claim path, which adds a preregistration ledger, host attestations and a
+spend-capped key on a dedicated Linux host. That procedure is
+[`bench/RUNBOOK.md`](https://github.com/macanderson/stella/blob/main/bench/RUNBOOK.md);
+read [`bench/README.md`](https://github.com/macanderson/stella/blob/main/bench/README.md)
+for the line between them before publishing anything from here.
+</Callout>
+
+## Before you start
+
+<CardGrid size="md">
+  <OptionCard name="A Docker host that runs linux/amd64">
+    Native x86_64 is simplest. Apple Silicon works through Rosetta — measured at
+    roughly native speed on a fixed CPU workload, with no degradation at three
+    concurrent containers, so no timeout multiplier is warranted.
+  </OptionCard>
+  <OptionCard name="Memory for the largest task">
+    Eight tasks want 8 GiB and three want 4 CPU. A host smaller than the largest
+    task must split the run by resource class rather than shrink the tasks.
+  </OptionCard>
+  <OptionCard name="~20 GiB of disk and patience">
+    The 89 task images are about 18.5 GiB. On a slow link the pull dominates the
+    schedule.
+  </OptionCard>
+  <OptionCard name="uv, zig, cargo-zigbuild, rustup">
+    `uv` provisions the adapter venv; the zig toolchain cross-compiles the Stella
+    binary that runs *inside* the task containers.
+  </OptionCard>
+  <OptionCard name="Two API keys, one per arm">
+    Not one key shared. See [keys](#give-each-arm-its-own-key) — this is a
+    measurement decision, not bookkeeping.
+  </OptionCard>
+</CardGrid>
+
+## 1. Install the harness
+
+```bash
+export TB_REPO="$(git rev-parse --show-toplevel)"
+export TB_ROOT=/absolute/path/for/run/scratch     # dataset, jobs, logs
+
+uv sync --project "$TB_REPO/bench/harbor_adapter" --locked --extra dev
+```
+
+That installs **Harbor 0.6.1**, and the pin is load-bearing. It is an *audited
+constant*, not an upgrade candidate: the adapter refuses to launch unless
+`harbor.__version__` matches exactly, five other sites name it, and
+`.github/dependabot.yml` ignores the package because an automated bump to 0.20.0
+once broke the run path for five days.
+
+The version also decides the CLI spelling. In 0.6.1 the Stella arm is selected
+with `--agent-import-path`; 0.20.0 folded that into `--agent`. If you ever move
+off the pin, check the help text before spending anything —
+`harbor run --help` is the authority, and Harbor renders it through Rich, so
+scrub ANSI before searching it:
+
+```bash
+harbor run --help 2>&1 | LC_ALL=C sed $'s/\033\[[0-9;?]*[a-zA-Z]//g' | rg -- '--agent'
+```
+
+## 2. Build a binary that can actually run in the containers
+
+The single most expensive mistake in this whole procedure, so it gets its own
+step.
+
+```bash
+bench/evidence/run/build_sut.sh
+```
+
+This cross-compiles Stella against `x86_64-unknown-linux-gnu.2.17` via
+`cargo-zigbuild`. That glibc floor is what lets **one** binary execute in every
+task image — including the two on `debian:bullseye-slim`, whose glibc 2.31 is the
+oldest in the dataset.
+
+<Callout type="warn">
+Do **not** substitute a plain `cargo build --release` artifact into the path the
+scripts export as `STELLA_BINARY`. On 2026-07-31 a run provisioned that way lost
+five trials before the agent ever started. Every integrity check still passed,
+because they all answer *did the file arrive intact* — and it had. Nothing
+answered *can this file run here*. Harbor recorded `NonZeroAgentExitCodeError`
+and scored each trial 0.0, which under a fixed denominator is arithmetically
+indistinguishable from Stella failing those tasks.
+</Callout>
+
+A host-side preflight now refuses to start a run whose binary requires a glibc
+symbol above the floor. To inspect one directly:
+
+```bash
+python3 bench/harbor_adapter/stella_harbor/portability.py "$STELLA_BINARY" --json
+```
+
+No musl build is needed, and that is a checked property of the pinned dataset
+rather than an assumption: all 89 task images are glibc-based. Repin the dataset
+and the tally has to be re-run.
+
+## 3. Fetch and pre-pull the dataset
+
+```bash
+bench/evidence/run/fetch_dataset.sh    # the pinned 89-task set, by digest
+bench/evidence/run/prepull.sh          # ~18.5 GiB, with retries
+```
+
+The pre-pull is not optional. The first attempt at a measured run lost four
+trials in its opening minutes to `TLS handshake timeout` while Docker Hub served
+image blobs. The container never started and spend was `$0.0000` — but with
+`--max-retries 0` each one is a permanent reward-`0` row, indistinguishable from
+a genuine failure. **Registry flakiness must not be able to enter the score.**
+
+The dataset is pinned by digest, not by name. An unversioned name is not a
+freeze, and the bare-name path (`harbor datasets download`) does not resolve
+anyway — use `harbor download <org/name@sha256:…>` and pass that same literal
+string to `harbor run --dataset`.
+
+## 4. Make the two arms comparable
+
+Everything so far applies to a solo Stella run. This step is what makes it a
+head-to-head, and it is the step people skip.
+
+### Pick one API surface for both arms
+
+Route both arms **directly at the provider**, on the same model. Proxying one
+arm through an aggregator introduces two confounds at once: the same model slug
+can be served by different upstream providers depending on app identity — a
+price spread of more than 3x has been observed — and Claude Code proxied that way
+runs with reasoning **off**, which is not the tool anyone means to compare
+against.
+
+Hitting `api.anthropic.com` directly on a single model gives one backend, no
+routing lottery, and Claude Code on its home API where thinking engages
+natively.
+
+### Give each arm its own key
+
+Two keys on the same account, one per arm:
+
+```bash
+# ~/.env.harbor-anthropic.local — loaded, never echoed, never passed in argv
+STELLA_ANTHROPIC_API_KEY=...
+CLAUDE_CODE_ANTHROPIC_API_KEY=...
+```
+
+This buys two things. Spend becomes attributable per arm without parsing
+trajectories, and neither arm's rate limiting can starve the other — which would
+otherwise show up as the slower arm timing out and losing tasks it would have
+solved.
+
+### Pin reasoning effort on both, then prove it landed
+
+Both arms should be pinned to the same effort tier, by whatever mechanism each
+one actually honors:
+
+- **Stella** — the frozen benchmark posture (`agents.<role>.effort`), which is
+  asserted by digest rather than by reading the constant, so the value the
+  launcher delivers and the value you assert cannot drift apart.
+- **Claude Code** — `harbor --ak reasoning_effort=<tier>`, which Harbor's
+  `ClaudeCode` agent maps onto the CLI's real `--effort` flag. Pass it
+  explicitly rather than trusting the documented default, so the setting is a
+  property of the recorded command.
+
+Then check it, before spending:
+
+```bash
+bench/evidence/run/preflight_effort.sh claude-sonnet-5 xhigh
+```
+
+<Callout type="info">
+Why a separate instrument: the older parity preflight proved both keys reached
+the same model with thinking **on**, and said nothing about **effort** — the
+headline setting of a pinned-effort run. A flag that is passed, assumed
+effective, and never checked on the wire is what voided three earlier
+head-to-heads. The probe is behavioral (same prompt at `low` versus the target
+tier, asserting strictly greater) because *accepted* and *acted on* are
+different claims, and only one of them is the point.
+</Callout>
+
+Two traps that check hit on itself, both now encoded in it: a probe saturated at
+`max_tokens` compares the cap to itself and "passes" while proving nothing; and
+a non-streaming request with a large `max_tokens` dies on the read timeout
+before it returns.
+
+### Decide the per-trial spend cap deliberately
+
+Stella can be given a per-trial budget. Claude Code, as Harbor runs it, has no
+spend ceiling. Leaving Stella's default cap in place therefore hands the
+comparator an advantage that will not appear anywhere in the output — Stella's
+capped trials simply abort and score 0.
+
+Setting `STELLA_BUDGET` to the empty string means *no per-trial cap*, and that
+posture is reachable on purpose. Choose it explicitly, and record which you
+chose.
+
+```bash
+export STELLA_BUDGET=          # empty: no per-trial cap, matching the comparator
+```
+
+## 5. Run both arms
+
+Sentinel first — one paid synthetic trial that must return reward 1.0 before 89
+of them depend on the same path:
+
+```bash
+bench/evidence/run/sentinel.sh
+```
+
+Then the arms. The committed scripts drive **arm A**:
+
+```bash
+bench/evidence/run/primary.sh ALL "<tag>-armA-stella"
+```
+
+Arm B is the same `harbor run` with the agent swapped and the comparator's
+effort passed through — same dataset literal, same task list, same concurrency,
+same `--n-attempts 1 --max-retries 0`:
+
+```bash
+harbor run \
+  --env docker \
+  --dataset "$TB_DATASET" \
+  --agent claude-code \
+  --ak reasoning_effort=xhigh \
+  --model claude-sonnet-5 \
+  --job-name "<tag>-armB-claudecode" \
+  --jobs-dir "$JOBS" \
+  --n-attempts 1 --n-concurrent "$CONC" --max-retries 0
+```
+
+The `armA` / `armB` segments in the job names are not cosmetic — the ingester
+matches on them, and it matches on the segment rather than the whole suffix so
+an archived or voided run still resolves.
+
+<Callout type="info">
+**Splitting by resource class.** On a host that cannot hold the largest task
+alongside its neighbours, run in two phases: phase A is tasks wanting ≤4 GiB and
+1 CPU at `n_concurrent=3`, phase B is the rest at `n_concurrent=1`
+(`primary.sh A` / `primary.sh B`). The union is still every task, one attempt
+each, over one denominator. Run phase B first if images are still downloading.
+The split is a host limitation, not part of the measurement.
+</Callout>
+
+### Rules the run has to follow to mean anything
+
+- **Fixed denominator.** Every task counts. Errors, timeouts, budget-cap hits and
+  missing rows all score 0 and stay in.
+- **No outcome-selected anything.** A discouraging early score is not a reason to
+  stop, change a parameter, or start over. Operational aborts — registry, VM,
+  balance, credentials — are allowed, must be disclosed, and must relaunch under
+  a **new job name**. A claim job never resumes.
+- **Publish the failures.** The per-task table lists every task, including the
+  ones that failed for infrastructure reasons.
+
+## 6. Score it — and recompute the cost
+
+```bash
+python3 bench/telemetry_store/ingest.py \
+  --db ~/.stella/bench.db --jobs "$JOBS" --run "<tag>" --kind scored
+```
+
+Ingest is idempotent: re-running replaces a run rather than duplicating it. The
+unit of truth is the **trial**; a run is a bag of trials and the comparison is a
+join of the two arms over `task_name`. No derived verdict is stored — pass/fail
+is `reward >= 1` from the benchmark's own grader, kept raw so a later reader can
+re-derive it instead of trusting it.
+
+<Callout type="warn">
+**Self-reported cost can invert the ranking.** On one smoke dataset the agents'
+own numbers said Claude Code $2.65 / Stella $3.27, while a single price table
+applied to both said Claude Code $3.00 / Stella $1.93 — the opposite ordering.
+Always publish a recomputed, normalized cost, and confirm your price table has
+an entry for the exact model slug both arms used.
+</Callout>
+
+One related sharp edge in the same path: `ingest.py` inserts **NULL** into
+`cost_usd_norm`, `wall_seconds`, `started_at` and `finished_at`. Those are
+placeholders the analysis step fills — read the column straight out of the
+database and you will publish `0.00` as a "normalized" cost.
+
+## The two things you cannot pin
+
+Worth knowing before you write up a result.
+
+**Claude Code's version is not pinned.** Harbor installs it per trial from
+`claude.ai/install.sh`, so the comparator can move between your run and someone
+else's. Read the resolved version out of the per-trial trajectory and report it;
+never assume it.
+
+**The grader is the benchmark's, not yours.** That is a feature — it is why the
+number is worth anything — but it means a task the grader scores 0 for a reason
+you disagree with is still a 0. Argue with it in the write-up, not in the
+denominator.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="Agent modes" href="/docs/agent-modes">
+    What the benchmarked configuration actually is — which surface a headless run
+    uses, and what it does per task.
+  </SpecCard>
+  <SpecCard title="The inference pipeline" href="/docs/inference-pipeline">
+    Triage, plan, witness, execute, verify — the staged loop each trial runs.
+  </SpecCard>
+  <SpecCard title="Telemetry" href="/docs/telemetry">
+    The local stores a run writes, and how to query them.
+  </SpecCard>
+  <SpecCard title="Scripting" href="/docs/scripting">
+    Driving Stella headlessly with JSON output — the same surface the adapter
+    uses.
+  </SpecCard>
+</CardGrid>


### PR DESCRIPTION
Two new guides in the user docs, both in the section's existing idiom: the whole command first, then what it is doing and how to tell whether it worked.

## Fix a backlog in parallel

`/docs/guides/parallel-fixes`

`stella fleet` had a reference page and a concept page, but no answer to the question it actually gets asked — *I have eleven independent fixes, how do I decompose them?*

The guide leads on the one decision everything else follows from (do the items share files), then covers plan files, claims as the thing that makes shared-tree safe, when isolation is genuinely right, how the budget divides per worker, and how to review what landed. It deliberately does **not** restate the plan schema — the guides index's rule is "nothing here restates the reference," so it links down instead.

Two things it makes explicit that were previously only implicit:

- **Prompts have to survive being run alone.** Each worker sees only its own prompt. Under-scoping is the failure mode specific to fleets, and it looks like "the workers went wider than I meant."
- **Concurrency and per-task headroom trade off.** `budget ÷ max-concurrency` is the number that decides whether a task aborts partway, so when tasks die early the fix is usually lower concurrency, not more money.

## Benchmark Stella against Claude Code

`/docs/guides/terminal-bench-head-to-head`

Terminal-Bench had **zero** coverage on the docs site. Everything lived in `bench/RUNBOOK.md` (the audited public-claim path — preregistration ledger, host attestations, spend-capped keys) or `bench/evidence/run/README.md`.

This documents the **development-baseline** path and says plainly which one it is, because the two are not interchangeable and publishing from the wrong one is the mistake worth preventing.

Most of the page is comparability rather than mechanics, on the grounds that a head-to-head differing in a second variable costs the same money and measures nothing:

- One API surface for both arms — proxying one arm through an aggregator introduces a routing lottery *and* silently runs Claude Code with reasoning off.
- A key per arm, so spend is attributable and neither arm's rate limit starves the other.
- Effort pinned on both and **proved behaviourally before launch** — a flag passed, assumed effective and never checked on the wire is what voided three earlier head-to-heads.
- A per-trial spend cap chosen deliberately rather than inherited: the default caps Stella against a comparator that has no ceiling, and the disadvantage shows up nowhere in the output.

It also carries the three failures that already cost real runs — the host-glibc binary that scores 0 while every integrity check passes, the un-prepulled image that turns registry flakiness into a benchmark result, and self-reported cost inverting the ranking.

Omits the runbook's "every trial burns its full timeout" caveat: that was #960, fixed in #970.

## Also

- Both guides wired into `guides/meta.json` and the guides index CardGrid.
- `agent-fleets.mdx` gets a "Next" pointer to the parallel-fixes guide — it explained the machinery but never sent anyone to a worked example. Mirrors how `commands/context.mdx` links its guide.

## Verification

- `next build` green — 98 static pages, TypeScript clean, re-run after every content edit.
- Both pages prerender to HTML and appear in the `llms.txt` route file trace, confirming the page-tree walk picks them up with no generator change.
- Every internal `/docs/...` link and every anchor fragment checked to resolve.
- Meta descriptions kept within the site's existing length range.
- No Rust touched; the pre-push gate ran clean.

## Summary by Sourcery

Add two new user guides for running parallel backlogs with agent fleets and benchmarking Stella against Claude Code, and wire them into the docs navigation.

Documentation:
- Introduce a guide for decomposing and running independent fixes in parallel with `stella fleet`, including prompts, claims, budgeting, and review workflow.
- Add a guide for running Terminal-Bench head-to-head with Stella and Claude Code, covering setup, comparability constraints, and common failure modes.
- Link the new guides from the main guides index and from the agent fleets concept page via "Next" cards to provide worked examples and benchmark documentation.