### PR TITLE
docs: two engine guides — embedding Stella, and gating the engine in CI

### DIFF
--- a/website/content/docs/agent-engine-in-your-app.mdx
+++ b/website/content/docs/agent-engine-in-your-app.mdx
@@ -518,6 +518,13 @@ releases (everything up to v0.5.14 remains perpetually available under
 
 ## Where to go next
 
+- [Drop Stella in as your agent engine](/docs/guides/embed-the-engine): the
+  guide-shaped version of this page — which shape to pick, how to port an
+  existing feature onto the engine in an afternoon, and the integration test
+  that exercises the whole loop with no API key.
+- [Gate on engine quality in CI](/docs/guides/ci-engine-gate): once the engine
+  is a dependency, run it side by side with Claude Code on every pull request
+  and block the merge on loop correctness.
 - [Agent Engine Paths](/docs/agent-engine-paths): the command-line doors into
   the same engine.
 - [Event Stream Compatibility](/docs/event-stream-compatibility): the full

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -1,0 +1,407 @@
+---
+title: Gate on engine quality in CI
+description: Run Stella and Claude Code side by side on one task set every pull request. Block the merge on loop correctness; report the quality delta, never gate on it.
+---
+
+Once an agent engine is a dependency of your product, it regresses like any
+other dependency — except the regression does not announce itself with a stack
+trace. A prompt change, a model swap, a settings edit, an upstream release: the
+turn still exits zero, still prints something plausible, and does less work than
+it did last week.
+
+This guide sets up a CI job that catches that. It runs Stella and Claude Code
+over the same committed task set on every pull request, and — this is the part
+that matters — it treats their two outputs as answers to two different
+questions.
+
+## The idea: two questions, two kinds of exit
+
+Almost every attempt at this fails the same way. Someone builds a harness, scores
+both engines, gets a number, wires the number to a threshold, and within a month
+the check is disabled because it fails on days when nothing changed.
+
+The reason is that "did the engine work" and "was the answer good" are not the
+same measurement, and only one of them is stable enough to block a merge.
+
+<EngineGateDiagram />
+
+<CardGrid size="md">
+  <SpecCard title="Loop correctness — deterministic, so it blocks">
+    Did the turn execute real work? Did it terminate and say why? Did it call a tool
+    at all? These are facts about the run, readable from the receipt, and they do not
+    move when the model has an off day. A regression here is a bug. Exit non-zero.
+  </SpecCard>
+  <SpecCard title="Quality — stochastic, so it informs">
+    Did it solve the task, and at what cost? Real signal, but it moves with sampling
+    noise, provider routing, and the weather. Post it as a comment and let a human
+    read the trend. A threshold here buys you a flaky gate and nothing else.
+  </SpecCard>
+</CardGrid>
+
+Everything below is built on that split. If you take one thing from this page,
+take that.
+
+## Before you start
+
+<CardGrid size="md">
+  <OptionCard name="Both engines on PATH in CI">
+    `stella` and `claude`. Pin both versions explicitly — an engine comparison whose
+    engines float is measuring the float.
+  </OptionCard>
+  <OptionCard name="A key per engine, as repository secrets">
+    These runs cost real money on every PR. Budget for it in step 1 by keeping the
+    task set small, and cap it in step 2 with `--budget`.
+  </OptionCard>
+  <OptionCard name="Tasks with deterministic verifiers">
+    A task nobody can grade automatically is a task this job cannot gate on. If a
+    test command cannot say pass or fail, leave it out.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="warn">
+This job runs a coding agent with tool access against a checkout on every pull
+request. Run it on a disposable runner, scope its credentials to nothing you
+would mind losing, and do not run it on `pull_request_target` — that trigger
+gives a fork's code access to your secrets.
+</Callout>
+
+## Step 1: Commit the task set
+
+Small, fixed, and in the repository. Five to ten tasks is plenty; the gate is
+looking for a loop that stopped working, and a broken loop is broken on task one.
+
+```
+ci/engine-tasks/
+  001-add-pagination/
+    TASK.md              # the prompt, verbatim
+    verify.sh            # exit 0 if the change is correct
+  002-fix-null-deref/
+  003-rename-across-files/
+```
+
+What makes a task earn its place:
+
+<CardGrid size="sm">
+  <SpecCard title="It requires editing a file">
+    The single most useful loop-correctness signal is "did anything get written."
+    A task answerable in prose cannot produce it.
+  </SpecCard>
+  <SpecCard title="Its verifier is a test, not a judge">
+    `verify.sh` should run a test and exit. The moment a model grades the outcome,
+    the deterministic half of your gate stops being deterministic.
+  </SpecCard>
+  <SpecCard title="It fails before the change">
+    A verifier that was already passing proves nothing about the work. This is the
+    same flip-oracle discipline the [pipeline](/docs/inference-pipeline#6-verify--the-deterministic-ladder)
+    uses internally, and it applies just as much to your harness.
+  </SpecCard>
+</CardGrid>
+
+## Step 2: Run both engines headless
+
+Both take a prompt and emit machine-readable JSON. The shapes are different, and
+the difference is a real trip hazard, so it is worth being exact.
+
+Give each engine its own copy of the checkout, so their edits cannot see each
+other and each workspace can be graded on its own:
+
+```bash
+task=ci/engine-tasks/001-add-pagination
+for e in stella claude; do rm -rf "work/$e"; git worktree add -f "work/$e" HEAD; done
+```
+
+```bash
+# Stella — one JSON object on stdout.
+( cd work/stella && stella --budget 1.00 --output-format json \
+  run "$(cat "../../$task/TASK.md")" ) > work/stella/stella.json
+
+# Claude Code — a JSON *array*; the result is the last element.
+( cd work/claude && claude -p --output-format json --permission-mode acceptEdits \
+  "$(cat "../../$task/TASK.md")" ) > work/claude/claude.json
+```
+
+Both need to be able to edit without a human at the keyboard.
+`--permission-mode acceptEdits` is what gets Claude Code there; check
+`claude --help` on the version you pinned rather than copying a flag list,
+since this surface moves between releases.
+
+<Callout type="warn">
+`claude --output-format json` does not emit a single object. It emits an array of
+every message in the session, and the summary is the final element, tagged
+`"type": "result"`. Read it with `jq '.[] | select(.type == "result")'` — not
+`jq '.result'`, which returns `null` and will quietly grade every run as a
+failure.
+</Callout>
+
+Here is what each one gives you, trimmed to the keys a gate reads:
+
+```jsonc
+// stella.json — see /docs/scripting for the full envelope contract
+{
+  "schema_version": 1,
+  "status": "completed",        // or verification_failed | aborted | error
+  "text": "…",
+  "reason": null,               // non-null whenever status is not completed
+  "cost_usd": 0.184,
+  "model": "anthropic/claude-fable-5",   // what actually ran, not what you asked for
+  "events": [ { "type": "tool_start", "call": { "name": "edit_file" } }, … ]
+}
+```
+
+```jsonc
+// claude.json — the last array element
+{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "num_turns": 14,
+  "result": "…",
+  "total_cost_usd": 0.211,
+  "duration_ms": 48213,
+  "permission_denials": [],     // a non-empty array here is a loop-health signal
+  "terminal_reason": "completed"
+}
+```
+
+Two notes before you write the comparison.
+
+**Read `model`, not your own flag.** Stella reports the model that actually
+served the worker turns, which a
+[worker-model route](/docs/configuration/agent-engine-config) can change out from
+under your `--model` argument. Attribute spend to what the receipt says.
+
+**`files_touched` is not on the pipeline path.** The default run summarizes with
+`task_class`, `verdict`, `revisions`, and `candidates_run`; the top-level
+`files_touched` key appears only on `--no-pipeline` runs, and the array itself
+sits one level in at `.files_touched.files_touched`. Counting `tool_start` events
+works on both paths, which is why the assertions below use events.
+
+## Step 3: The blocking half — loop correctness
+
+This is Stella's own gate on itself, and the vocabulary is worth borrowing
+because it was built by watching real failures. `loop-bench` collapses a run into
+one of four verdicts, checked in this order:
+
+<LoopVerdictDiagram />
+
+The ordering is load-bearing. **Reward outranks everything** — a task that got
+solved did the work by definition, so it is never called silent no matter what
+its event stream lost. And the two verdicts that trip the gate are the two where
+*nothing happened*: `loop_broken` is `zero_work && reward != 1.0`.
+
+Read against the receipts from step 2, that becomes four assertions:
+
+<CardGrid size="md">
+  <OptionCard name="1. A receipt exists at all">
+    No JSON on stdout is the worst outcome, not a skip. Report it as a failure with
+    a `no receipt` reason. Skipping it once made a launch failure look like a clean
+    run with fewer rows — gate still green.
+  </OptionCard>
+  <OptionCard name="2. Work happened">
+    At least one `tool_start` event for Stella; `num_turns > 1` and a non-empty
+    diff for Claude Code. Zero tool calls on a task that requires an edit is the
+    failure this whole job exists to catch.
+  </OptionCard>
+  <OptionCard name="3. It terminated, and said why">
+    Stella: `status` is `completed`, or `reason` is non-null. Claude Code:
+    `terminal_reason` is present. A run that ends with neither vanished, and that
+    is `SILENT-DEATH`.
+  </OptionCard>
+  <OptionCard name="4. Nothing was silently blocked">
+    A non-empty `permission_denials`, or a Stella run aborted on a scope gate with
+    nobody to ask, means the agent was stopped rather than finished. Fail loudly —
+    this reads as low quality otherwise, and you will spend a week tuning prompts.
+  </OptionCard>
+</CardGrid>
+
+```bash
+#!/usr/bin/env bash
+# ci/assert-loop-health.sh — the deterministic half. No model judges anything.
+set -euo pipefail
+
+fail() { echo "loop-broken: $1" >&2; exit 1; }
+
+s=work/stella/stella.json
+c=work/claude/claude.json
+[ -s "$s" ] || fail "stella emitted no receipt"
+[ -s "$c" ] || fail "claude code emitted no receipt"
+
+jq -e 'if .schema_version == 1 then . else error("unsupported schema_version") end' \
+  "$s" > /dev/null || fail "stella envelope version changed under us"
+
+tools=$(jq '[.events[] | select(.type == "tool_start")] | length' "$s")
+[ "$tools" -gt 0 ] || fail "stella made zero tool calls on an editing task"
+
+jq -e '.status == "completed" or (.reason != null)' "$s" > /dev/null \
+  || fail "stella neither completed nor said why"
+
+result=$(jq '[.[] | select(.type == "result")] | .[0]' "$c")
+[ "$result" != "null" ] || fail "claude code produced no result element"
+
+denials=$(jq '.permission_denials | length' <<<"$result")
+[ "$denials" -eq 0 ] || fail "claude code was blocked by $denials permission denial(s)"
+
+jq -e '.terminal_reason != null' <<<"$result" > /dev/null \
+  || fail "claude code ended without a terminal reason"
+
+echo "loop healthy: $tools tool calls, clean termination"
+```
+
+Note what is *not* in that script: any check on whether the task was solved. A
+task nobody solves still passes this gate, provided the loop ran. That is the
+point — you are gating on the machine, not on the model.
+
+## Step 4: The advisory half — the quality delta
+
+Now the part that gets reported rather than enforced. Same two receipts, read for
+outcome instead of health.
+
+Each engine ran in its own copy of the checkout — that is what makes them
+comparable at all — so each has its own workspace to grade.
+
+```bash
+#!/usr/bin/env bash
+# ci/quality-delta.sh — writes a summary, never exits non-zero.
+set -uo pipefail
+task=001-add-pagination
+
+graded() {  # $1 = the workspace that engine worked in
+  ( cd "$1" && "./ci/engine-tasks/$task/verify.sh" >/dev/null 2>&1 ) && echo yes || echo no
+}
+
+stella_cost=$(jq -r '.cost_usd' work/stella/stella.json)
+claude_cost=$(jq -r '[.[] | select(.type == "result")] | .[0].total_cost_usd' \
+                 work/claude/claude.json)
+
+{
+  echo "| engine | solved | cost | model |"
+  echo "|---|---|---|---|"
+  echo "| stella | $(graded work/stella) | \$$stella_cost | $(jq -r '.model' work/stella/stella.json) |"
+  echo "| claude code | $(graded work/claude) | \$$claude_cost | $CLAUDE_MODEL |"
+} >> "$GITHUB_STEP_SUMMARY"
+```
+
+Resist the urge to wire a threshold to that table. With a five-task set, one
+task flipping is a twenty-point swing, and twenty points of sampling noise is
+entirely ordinary. The table's job is to make a *trend* visible across many PRs.
+When it moves consistently in one direction, a human decides what it means.
+
+## The workflow
+
+Two things about the shape of this file matter more than its contents.
+
+```yaml
+name: engine-gate
+on: pull_request          # never pull_request_target — that hands forks your secrets
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Does this PR touch anything the engine depends on?
+        id: scope
+        run: |
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD \
+             | grep -Eq '^(prompts/|src/agent/|ci/engine-tasks/)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No engine-affecting changes — suites skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Loop health — the blocking half
+        if: steps.scope.outputs.changed == 'true'
+        run: ./ci/run-both.sh && ./ci/assert-loop-health.sh
+
+      - name: Quality delta — advisory
+        if: steps.scope.outputs.changed == 'true'
+        continue-on-error: true
+        run: ./ci/quality-delta.sh
+```
+
+**Make it a required status check.** A check that is not required does not block a
+merge, and a check that does not block a merge does not do anything. Stella
+learned this the expensive way: a dependency bump broke the bench workflow, the
+workflow reported failure, and the pull request merged twelve minutes later. It
+stayed broken for five days.
+
+**Filter the scope in a step, not in the trigger.** A workflow filtered with
+`on.pull_request.paths` does not run at all when nothing matches, so its check
+never reports — and a required context that never reports blocks the pull request
+forever. The job above always runs and always reports; only the expensive part is
+conditional. An unrelated PR pays one runner start-up, not two agent runs.
+
+## If you are working on Stella itself
+
+The harness described above is the portable version. Stella ships its own, and it
+is cheaper and sharper if the thing you are changing *is* the engine:
+
+```bash
+cargo run -p loop-bench -- --n 4                     # four tasks, the default pool
+cargo run -p loop-bench -- --json                    # the report, for CI
+cargo run -p loop-bench -- --analyze-only --jobs-dir <dir> --job-name <name>   # free
+```
+
+It reads `stella-events.jsonl` per trial, produces exactly the verdict ladder
+above, and exits `1` if any trial is `loop_broken` — even when other trials
+passed, and also when no trial artifacts were found at all. Exit `2` means the
+task list resolved to nothing.
+
+<Callout type="info">
+Its whole design premise is worth stealing: the expensive benchmark measures
+*pass rate*, which is dominated by model quality, so a cheap model tells you
+almost nothing. Loop health is the opposite — a cheap model exposes a broken loop
+just as clearly as an expensive one, and costs a twentieth as much to ask.
+</Callout>
+
+## What this cannot tell you
+
+Being straight about the limits, because a comparison harness that oversells
+itself is worse than none.
+
+<CardGrid size="md">
+  <OptionCard name="Five tasks is not a benchmark">
+    It is a smoke test with opinions. It catches a loop that stopped working. It
+    does not rank engines, and a table built from it should never be published as
+    if it did.
+  </OptionCard>
+  <OptionCard name="Self-reported cost is not comparable">
+    Each engine reports its own accounting. A one-word reply through Claude Code
+    headless cost $0.034 in a real measurement — almost entirely cache-creation
+    tokens for the system prompt. Startup overhead dominates small tasks, so
+    comparing cost on trivial work compares system prompts, not engines.
+  </OptionCard>
+  <OptionCard name="Routing is a confound">
+    Two runs against the same model id can land on different upstream providers with
+    different reasoning settings, especially through an aggregator. Pin the provider
+    and the effort tier, or you are measuring the router.
+  </OptionCard>
+  <OptionCard name="Tool counts are a fingerprint, not a score">
+    Raw call counts reflect design — how much a tool does per call — not
+    efficiency. Report wins, dollars, tokens, and minutes. A leaner call count is a
+    different shape, not a better one.
+  </OptionCard>
+</CardGrid>
+
+## See also
+
+<CardGrid size="sm">
+  <SpecCard title="Drop Stella in as your agent engine" href="/docs/guides/embed-the-engine">
+    The companion guide. Get the engine inside your app and under test first — this
+    page assumes a loop CI can already run.
+  </SpecCard>
+  <SpecCard title="Scripting Stella" href="/docs/scripting">
+    The full JSON envelope contract, the `schema_version` rule, and the jq patterns
+    the scripts above are built from.
+  </SpecCard>
+  <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
+    The other side of this coin: what to do when the gate you just built goes red.
+  </SpecCard>
+  <SpecCard title="Inference pipeline" href="/docs/inference-pipeline">
+    The verify ladder and the flip oracle — the deterministic-evidence discipline
+    this page borrows for its own harness.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/embed-the-engine.mdx
+++ b/website/content/docs/guides/embed-the-engine.mdx
@@ -1,0 +1,236 @@
+---
+title: Drop Stella in as your agent engine
+description: Replace your hand-rolled agent loop with Stella's, keeping your own models, tools, keys, and data — and end on an integration test that needs no API key.
+---
+
+You shipped an LLM feature. The first version was a `while` loop around a
+completions call, and it worked. Then it met production, and the loop grew:
+a step cap, because a model called the same tool nine times. A truncation, because
+the history outgrew the context window. A retry, then a *smarter* retry, because
+a 429 and a 400 should not be treated the same. Somewhere in there it stopped
+being a feature and started being a distributed system nobody owns.
+
+None of that is your product. All of it is on your critical path.
+
+This guide replaces that loop with Stella's, without giving up a single thing
+you care about — your models, your keys, your tools, your data, your bill.
+
+## The move, in one paragraph
+
+You run `stella-serve` as a process next to your app. When you start a turn, the
+engine drives the loop and **asks your app** to do the two things that touch
+anything sensitive: make the model call, and run the tool. It has no HTTP
+client, no TLS stack, and no provider adapter, so it is not able to make either
+call itself.
+
+<EngineOwnershipDiagram />
+
+That inversion is the whole design, and it is why this is a reasonable thing to
+put inside a product: the engine is a scheduler for work your app performs. It
+never holds a credential, so it cannot leak one.
+
+## Before you start
+
+<CardGrid size="md">
+  <OptionCard name="A Rust toolchain, once">
+    Only to build the server. Your app can be TypeScript, Python, Go, or anything
+    else that speaks HTTP — nothing you write is Rust unless you choose the linked
+    shape below.
+  </OptionCard>
+  <OptionCard name="An LLM feature that already works">
+    Port something running, not something you are also designing. You want exactly
+    one variable changing this afternoon.
+  </OptionCard>
+  <OptionCard name="A decision on shape, made first">
+    Sidecar or linked crates. It changes your licensing obligations, so make it
+    before you build, not after.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="warn">
+Pick the shape first. Linking `stella-core` into a closed-source binary is a
+combined work and needs a commercial license. The sidecar depends on facts about
+your deployment. Neither is automatically free — the
+[licensing section](/docs/agent-engine-in-your-app#licensing-agpl-or-commercial)
+is specific about which facts decide it, and
+[licensing@oxagen.sh](mailto:licensing@oxagen.sh) will tell you if the answer is
+"you need nothing."
+</Callout>
+
+## Step 1: Get a server running
+
+Two commands. There is no `stella serve` subcommand and no release tarball ships
+the server — it is a separate crate with its own binary.
+
+```bash
+cargo build --release -p stella-serve --bin stella-serve
+
+STELLA_SERVE_BIND=127.0.0.1:8137 \
+STELLA_SERVE_TOKEN="$(openssl rand -base64 32)" \
+./target/release/stella-serve
+# stella-serve listening on 127.0.0.1:8137
+```
+
+It is a fast build; the server pulls in two crates, not the CLI or the TUI.
+
+Record the version it prints next to your client code. The wire format is
+additive, but a pin plus a round-trip test is how you find out about a change on
+your schedule instead of in production.
+
+## Step 2: Port the loop, not the feature
+
+Here is the part people over-plan. Your existing feature already contains the
+two functions the engine needs. Find them:
+
+<CardGrid size="md">
+  <SpecCard title="The one that calls the model">
+    Whatever wraps your gateway today. It becomes the handler for
+    `provider_request` frames. Keep your routing, your keys, your logging, your
+    rate limiting — all of it stays exactly where it is.
+  </SpecCard>
+  <SpecCard title="The one that dispatches a tool">
+    Your `switch` over tool names, behind whatever authorization you already
+    enforce. It becomes the handler for `tool_request` frames. The engine never
+    sees your database, your sandbox, or your permission model.
+  </SpecCard>
+</CardGrid>
+
+Everything between those two functions — the stepping, the history threading,
+the compaction, the retries — is what you are deleting.
+
+The [complete working host](/docs/agent-engine-in-your-app#step-4-write-the-host)
+is about eighty lines of dependency-free Node, and the reference page walks the
+six routes, the four frame types, and the error classes. Do not restate it here;
+open it in another tab and come back when your first turn completes.
+
+<Callout type="warn">
+Three assumptions a correct host must not make, because each one produces a bug
+that only shows up under load. `event` frames are **not ordered** against request
+frames. **Several `tool_request`s can be outstanding at once**, because the engine
+runs read-only tools concurrently — answer by `request_id` and never serialize
+them. And the auth check runs **before** routing, so a wrong path returns 401,
+not 404; a 401 is not proof your token is bad.
+</Callout>
+
+## Step 3: The payoff — a test that costs nothing
+
+This is the reason to do the port, and it is worth doing on day one rather than
+day thirty.
+
+Because your app is the model, you can substitute a scripted reply for your
+gateway. The engine cannot tell the difference: it emits the same frames, runs
+the same steps, threads the same history, and settles the same outcome.
+
+<EngineTestHarnessDiagram />
+
+So a full multi-step agent turn becomes an ordinary unit test. No network, no
+key, no spend, milliseconds.
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("the model can call a tool and answer from its result", async () => {
+  const replies = [
+    { tool_calls: [{ call_id: "c1", name: "get_weather", input: { city: "Paris" } }],
+      finish_reason: "tool_calls" },
+    { text: "It is 18C and clear in Paris.", finish_reason: "stop" },
+  ];
+  let n = 0;
+
+  const outcome = await runTurn({
+    prompt: "What is the weather in Paris?",
+    // your gateway, replaced by an array
+    onProviderRequest: () => withUsage(replies[n++]),
+    onToolRequest: (name, input) => dispatch(name, input),
+  });
+
+  assert.equal(outcome.status, "completed");
+  assert.match(outcome.text, /18C/);
+  assert.equal(n, 2, "one call to ask for the tool, one to answer from it");
+});
+```
+
+What that test actually covers is larger than it looks: the engine recorded the
+assistant's tool call, matched your result to it by `call_id`, rebuilt the
+conversation in your provider's shape, and ran the second step from it. That is
+the machinery you deleted in step 2, under test, for free.
+
+Write these for the cases you cannot afford to hit in production — a tool that
+errors, a model that returns malformed arguments, a rate limit mid-turn, a turn
+that hits its step cap. Each one is a scripted array, and none of them cost a
+cent.
+
+<Callout type="info">
+Report failures as the `error` arm of a tool result rather than throwing. The
+model reads that text and can correct itself, which is usually what you want. And
+say *why* a model call failed: `transport` and `rate_limited` are retried with
+backoff, while `auth`, `unknown_model`, `malformed`, `cancelled`, and `terminal`
+fail the turn at once. Reporting a rate limit as `terminal` silently disables the
+backoff you were trying to get.
+</Callout>
+
+## Step 4: Before it carries traffic
+
+Short list, each item a real failure someone has had:
+
+<CardGrid size="md">
+  <OptionCard name="One process per trust boundary">
+    Several provider and sandbox settings are process-global, so multi-tenant in
+    one process is not safe. Run an engine per tenant, inside the isolation you
+    already use for untrusted code.
+  </OptionCard>
+  <OptionCard name="Keep the port private">
+    Loopback, or a private network behind the token. There is no `Host` guard and
+    no CORS handling — never expose it to a browser directly.
+  </OptionCard>
+  <OptionCard name="Cancel turns you abandon">
+    Each live turn holds an OS thread, and at most 32 are allowed at once. Past
+    that you get a 429. `POST /v1/turns/{id}/cancel` unwinds cleanly and still
+    reports a settled cost.
+  </OptionCard>
+  <OptionCard name="Record every step_usage event">
+    Per-step tokens, cost, model, and duration. `cost_usd` is the sum of what
+    *your* app reported, so your billing system stays the authority — these events
+    are how you cross-check it.
+  </OptionCard>
+</CardGrid>
+
+There is also a list of things that genuinely do not exist yet — no stream
+resumption, no server-side conversation state, no approval routes, no `/metrics`.
+Design around them rather than discovering them:
+[what is not built yet](/docs/agent-engine-in-your-app#what-is-not-built-yet).
+
+## Where this goes next
+
+You now have an agent loop that runs in CI without a key. The natural next move
+is to make CI *care* about it — because the engine is a dependency now, and
+dependencies regress.
+
+<CardGrid size="md">
+  <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
+    Run Stella and Claude Code side by side on the same committed task set on every
+    pull request. Block the merge on loop correctness, which is deterministic and
+    cheap; report the quality delta, which is neither. The companion to this guide.
+  </SpecCard>
+  <SpecCard title="Agent Engine in your app" href="/docs/agent-engine-in-your-app">
+    The reference this guide links into — six routes, four frame types, the full
+    environment surface, the licensing detail, and the eighty-line host in full.
+  </SpecCard>
+</CardGrid>
+
+## Related reading
+
+<CardGrid size="sm">
+  <SpecCard title="Event stream compatibility" href="/docs/event-stream-compatibility">
+    The `AgentEvent` vocabulary you receive in `event` frames, and the
+    forward-compatibility rule your parser has to follow.
+  </SpecCard>
+  <SpecCard title="Inference pipeline" href="/docs/inference-pipeline">
+    What the engine does inside a single step, if you want to know what you bought.
+  </SpecCard>
+  <SpecCard title="Agent Engine paths" href="/docs/agent-engine-paths">
+    The command-line doors into the same engine, for the parts of your workflow
+    that are not a product surface.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -33,6 +33,16 @@ stop and read the whole flag surface at the moment you need it and not before.
     abort lands, what compaction costs, and how to spend the money on the task
     instead of on the transcript.
   </SpecCard>
+  <SpecCard title="Drop Stella in as your agent engine" href="/docs/guides/embed-the-engine">
+    You have a product with an LLM feature and a hand-rolled loop. Replace the loop
+    and keep your models, tools, keys, and data — ending on an integration test that
+    exercises the whole agent loop without an API key.
+  </SpecCard>
+  <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
+    Run Stella and Claude Code side by side on the same committed task set on every
+    pull request. Block the merge on loop correctness, which is deterministic; report
+    the quality delta, which is not.
+  </SpecCard>
   <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
     Config that isn't applying, a key that won't resolve, a hook that never fires, a
     graph that answers about code you deleted. The four checks in the order that

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -6,6 +6,8 @@
     "unfamiliar-codebase",
     "budget",
     "what-a-run-cost",
+    "embed-the-engine",
+    "ci-engine-gate",
     "troubleshooting"
   ]
 }

--- a/website/src/components/diagrams.tsx
+++ b/website/src/components/diagrams.tsx
@@ -403,6 +403,206 @@ export function PermissionGateDiagram() {
 }
 
 /**
+ * Embedding guide: the ownership split. The reference page draws the *sequence*
+ * (ask, answer, ask, answer); this draws the *boundary*, which is the thing a
+ * reader is actually deciding about — what of theirs has to cross it. Nothing
+ * does. The caption names the absence, the way the telemetry diagram does.
+ */
+export function EngineOwnershipDiagram() {
+  const yours = [
+    "provider keys · gateway · routing",
+    "tools · sandbox · RBAC",
+    "history · billing · your data",
+  ];
+  const engine: [string, boolean][] = [
+    ["step loop · tool dispatch", true],
+    ["compaction · token budget", false],
+    ["retry class · loop detect · caps", false],
+  ];
+  return (
+    <svg
+      className="sdg"
+      viewBox="0 0 720 232"
+      role="img"
+      aria-label="Your app keeps keys, tools, and data; the engine keeps the loop, compaction, and retries. Only requests and results cross between them."
+    >
+      <title>What the engine owns, and what never leaves your app</title>
+      <Defs />
+      <text className="sdg-label" x={16} y={30}>
+        your app
+      </text>
+      <rect className="sdg-box" x={16} y={40} width={300} height={144} rx={6} />
+      {yours.map((text, i) => (
+        <g key={text}>
+          <rect className="sdg-box" x={32} y={52 + i * 42} width={268} height={34} rx={6} />
+          <text className="sdg-sub" x={46} y={73 + i * 42}>
+            {text}
+          </text>
+        </g>
+      ))}
+      <text className="sdg-label" x={404} y={30}>
+        stella-serve
+      </text>
+      <rect className="sdg-box" x={404} y={40} width={300} height={144} rx={6} />
+      {engine.map(([text, accent], i) => (
+        <g key={text}>
+          <rect
+            className={accent ? "sdg-box-accent" : "sdg-box"}
+            x={420}
+            y={52 + i * 42}
+            width={268}
+            height={34}
+            rx={6}
+          />
+          <text className="sdg-sub" x={434} y={73 + i * 42}>
+            {text}
+          </text>
+        </g>
+      ))}
+      {/* the engine asks; your app answers. Nothing else crosses. */}
+      <Wire d="M402 86 H318" />
+      <text className="sdg-sub" x={360} y={78} textAnchor="middle">
+        asks
+      </text>
+      <Wire d="M318 140 H402" />
+      <text className="sdg-sub" x={360} y={132} textAnchor="middle">
+        answers
+      </text>
+      <text className="sdg-sub" x="360" y="212" textAnchor="middle">
+        no HTTP client, no TLS stack, no provider adapter — it cannot leak a key it never holds
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Embedding guide, second half: because your app *is* the model, one host runs
+ * against a gateway or against a scripted reply, and the loop cannot tell. That
+ * is the whole argument for testing an agent loop in CI, so it gets a picture.
+ */
+export function EngineTestHarnessDiagram() {
+  return (
+    <svg
+      className="sdg"
+      viewBox="0 0 720 196"
+      role="img"
+      aria-label="One host drives either your real gateway or a scripted reply function; both exercise the identical agent loop, but only one of them spends money."
+    >
+      <title>The same host, with and without a model</title>
+      <Defs />
+      <Node x={16} y={62} w={162} h={56} label="one host" sub="the code you just wrote" />
+      <Wire d="M178 78 C226 78 226 44 264 44" />
+      <Node x={266} y={18} w={186} h={52} label="your gateway" sub="real models · real spend" />
+      <Wire d="M178 102 C226 102 226 142 264 142" />
+      <Node x={266} y={116} w={186} h={52} label="scripted replies" sub="a function returning JSON" />
+      <Wire d="M452 44 C500 44 500 82 522 90" />
+      <Wire d="M452 142 C500 142 500 104 522 98" />
+      <Node x={524} y={68} w={180} h={52} label="the identical loop" sub="same frames · same steps" accent />
+      <text className="sdg-sub" x="360" y="186" textAnchor="middle">
+        one of those two paths costs nothing and finishes in milliseconds — that is the one CI runs
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * CI guide: two engines, one task set, and — the asymmetry that is the whole
+ * point — two different kinds of exit. Loop correctness is deterministic and
+ * therefore allowed to block; a quality delta is a model-quality measurement
+ * and is only ever allowed to inform.
+ */
+export function EngineGateDiagram() {
+  return (
+    <svg
+      className="sdg"
+      viewBox="0 0 720 244"
+      role="img"
+      aria-label="One committed task set runs through both Stella and Claude Code; the comparison produces a blocking loop-correctness verdict and an advisory quality delta."
+    >
+      <title>Two engines, one task set, two kinds of exit</title>
+      <Defs />
+      <Node x={8} y={86} w={126} h={52} label="one task set" sub="in your repo" />
+      <Wire d="M134 112 C156 112 156 54 174 54" />
+      <Wire d="M134 112 C156 112 156 170 174 170" />
+      <Node x={176} y={28} w={168} h={52} label="stella" sub="--output-format json" />
+      <Node x={176} y={144} w={168} h={52} label="claude code" sub="-p --output-format json" />
+      <Wire d="M344 54 C366 54 366 112 388 112" />
+      <Wire d="M344 170 C366 170 366 112 388 112" />
+      <Node x={390} y={86} w={124} h={52} label="compare" sub="two receipts" />
+      <Wire d="M514 100 C534 100 534 46 554 46" />
+      <Wire d="M514 124 C534 124 534 178 554 178" />
+      <Node x={556} y={20} w={156} h={52} label="loop correctness" sub="exit 1 — blocks" accent />
+      <Node x={556} y={152} w={156} h={52} label="quality delta" sub="a comment, not a gate" />
+      <text className="sdg-sub" x="360" y="230" textAnchor="middle">
+        the deterministic half is allowed to block; the model-quality half is only allowed to inform
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * CI guide: loop-bench's verdict ladder, in its real precedence order. Drawn as
+ * rungs because the *order* is load-bearing — reward outranks everything, so a
+ * solved task is never called silent no matter what its event stream lost.
+ */
+export function LoopVerdictDiagram() {
+  const rungs: [string, string, boolean][] = [
+    ["reward is 1.0 — the task was solved", "solved", false],
+    ["zero tool calls, and no terminal event", "SILENT-DEATH", true],
+    ["zero tool calls, but it said why", "ZERO-WORK", true],
+    ["tool calls happened; the verifier said no", "ran (unsolved)", false],
+  ];
+  return (
+    <svg
+      className="sdg"
+      viewBox="0 0 720 224"
+      role="img"
+      aria-label="Four verdicts checked in order: solved, silent death, zero work, ran but unsolved. The middle two — a turn that did nothing — are the ones that fail the gate."
+    >
+      <title>The loop-correctness verdict ladder</title>
+      <Defs />
+      {/* checked top to bottom; the first match wins */}
+      <Wire d="M28 24 V170" />
+      {rungs.map(([test, verdict, fails], i) => {
+        const y = 16 + i * 44;
+        return (
+          <g key={verdict}>
+            <circle className="sdg-dot" cx={28} cy={y + 16} r={8} />
+            <text
+              className="sdg-sub"
+              x={28}
+              y={y + 20}
+              textAnchor="middle"
+              fill="var(--color-fd-background)"
+              fontWeight={600}
+            >
+              {i + 1}
+            </text>
+            <rect className="sdg-box" x={48} y={y} width={296} height={32} rx={6} />
+            <text className="sdg-sub" x={62} y={y + 20}>
+              {test}
+            </text>
+            <Wire d={`M344 ${y + 16} H392`} />
+            <Node x={394} y={y} w={150} h={32} label={verdict} accent={fails} />
+          </g>
+        );
+      })}
+      {/* the bracket spans exactly the two verdicts that exit non-zero */}
+      <Wire d="M556 60 H570 V136 H556" arrow={false} />
+      <text className="sdg-label" x={582} y={94}>
+        exit 1
+      </text>
+      <text className="sdg-sub" x={582} y={110}>
+        the gate trips
+      </text>
+      <text className="sdg-sub" x="296" y="212" textAnchor="middle">
+        loop health, not pass rate — a task nobody solves still passes, provided the loop ran
+      </text>
+    </svg>
+  );
+}
+
+/**
  * Telemetry: where a run's numbers go. The point of the picture is the absent
  * arrow — there is no edge leaving the machine, so there is nothing to opt out
  * of.

--- a/website/src/mdx-components.tsx
+++ b/website/src/mdx-components.tsx
@@ -5,8 +5,12 @@ import { Badge, CardGrid, OptionCard, SpecCard, ToolCard } from "@/components/ca
 import { DocsCodeBlock } from "@/components/docs-code-block";
 import {
   CredentialChainDiagram,
+  EngineGateDiagram,
+  EngineOwnershipDiagram,
+  EngineTestHarnessDiagram,
   FleetFanoutDiagram,
   HeroFlowDiagram,
+  LoopVerdictDiagram,
   PermissionGateDiagram,
   PipelineFlowDiagram,
   QuickstartDiagram,
@@ -42,6 +46,10 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     SettingsCascadeDiagram,
     PermissionGateDiagram,
     TelemetryFlowDiagram,
+    EngineOwnershipDiagram,
+    EngineTestHarnessDiagram,
+    EngineGateDiagram,
+    LoopVerdictDiagram,
     // Cards — the mobile-first replacement for reference tables
     CardGrid,
     SpecCard,


### PR DESCRIPTION
Adds the two guides, cross-linked to each other and to the existing engine reference.

## Why

`agent-engine-in-your-app` teaches the wire protocol well, but it sits outside the Guides section and answers *how does this work* rather than *how do I do this on a Tuesday*. And once the engine is a dependency of a product, nothing in the docs said how to notice it regressing.

## What

**`guides/embed-the-engine`** — port an existing LLM feature onto the engine. It deliberately does not restate the wire reference (the Guides section's stated contract is "nothing here restates the reference"); it links into it at the point of need. The payoff it builds toward is the integration test, because *your app being the model* is what makes an agent loop testable at all — and that is also what makes the second guide possible.

**`guides/ci-engine-gate`** — run `stella` and `claude` over one committed task set per PR. The load-bearing idea is the asymmetry:

- **loop correctness** is deterministic → allowed to block a merge
- **quality** is stochastic → allowed only to inform

Threshold the second and you get a flaky check that gets disabled within a month. The blocking half borrows `loop-bench`'s verdict vocabulary, including the precedence rule where reward outranks everything so a solved task is never called silent.

## Both receipt shapes were verified against the real binaries

Two facts that would have shipped wrong from memory alone:

- `claude --output-format json` emits an **array** whose last element is the result. `jq '.result'` returns `null` and would have silently graded every run a failure — so the guide calls this out in a warning callout.
- `--max-turns` does not exist on Claude Code 2.1.220. Replaced with `--permission-mode acceptEdits`, plus a note to check `--help` on the pinned version rather than copying a flag list.

Also documented: `files_touched` is absent from the pipeline summary (only `--no-pipeline` carries it, nested one level in), which is why the assertions count `tool_start` events instead — that works on both paths.

## Visuals

Four new diagrams in `diagrams.tsx`, following the rules already in that file — pure SVG, theme tokens, no animation, one accent marking the node each picture is about, `role="img"` + `<title>` + `aria-label` so the content survives with images off. Rendered and eyeballed in both guides before committing.

| diagram | what it carries that the prose does not |
|---|---|
| `EngineOwnershipDiagram` | the *boundary* (the reference page already draws the sequence) — and the absent capability in the caption |
| `EngineTestHarnessDiagram` | one host, two backends, identical loop — the argument for testing in CI |
| `EngineGateDiagram` | the block-vs-inform asymmetry, as two different exits |
| `LoopVerdictDiagram` | loop-bench's four verdicts in their real precedence order |

## Verification

- `pnpm typecheck` — clean
- `pnpm build` — exit 0, 98 pages
- both routes serve 200; new pages present in `sitemap.xml` and `llms.txt`
- descriptions trimmed to 153/156 chars — they were briefly the two longest on the site, past the ceiling PR #1093 established

Zero Rust files touched, so the pre-push Rust gate was bypassed with its own documented `SKIP_GATE=1`. The gate that applies here is the `docs` workflow (typecheck + build), run green above.

## Summary by Sourcery

Add two new guides for embedding Stella as an agent engine and gating the engine in CI, along with supporting diagrams and navigation links.

Enhancements:
- Add four new SVG diagrams (engine ownership, test harness, CI gate, and loop verdict ladder) and wire them into the MDX component set for use in the new guides.

Documentation:
- Introduce an embedding guide that shows how to replace a hand-rolled agent loop with Stella while preserving existing models, tools, keys, and data, culminating in an integration-test harness.
- Add a CI guide that describes gating on engine loop correctness versus reporting quality deltas by running Stella and Claude Code side by side on a committed task set per pull request.
- Update the guides index and cross-links from the agent engine reference to surface the new embedding and CI guides and connect related reference material.