### PR TITLE
fix(docs): close the SpecCard that #1146 left open — main's website build is red

### DIFF
--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -47,6 +47,7 @@ stop and read the whole flag surface at the moment you need it and not before.
     Run Stella and Claude Code side by side on the same committed task set on every
     pull request. Block the merge on loop correctness, which is deterministic; report
     the quality delta, which is not.
+  </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
     Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other. The
     setup, the parity checks that make the comparison mean something, and the traps


### PR DESCRIPTION
## What & why

`main` does not build. The Vercel/Turbopack build fails on
`website/content/docs/guides/index.mdx`:

```
Error evaluating Node.js code
60:1-60:12: Unexpected closing tag `</CardGrid>`, expected corresponding
closing tag for `<SpecCard>` (46:3-46:85)
```

The "Gate on engine quality in CI" card, added in #1146, has no
`</SpecCard>`. MDX therefore reads the following "Benchmark against Claude
Code" card as its *child* and only notices the imbalance when it reaches
`</CardGrid>` — which is why the error points at line 60 rather than 46.

This is a semantic merge conflict, not a bad edit in either PR. #1145 and
#1146 each appended a card to the same `<CardGrid>` at different line
ranges, so git merged both hunks without a conflict. Clean text merge, invalid
tree.

One line, no prose changes:

```diff
     the quality delta, which is not.
+  </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
```

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the build *is*
      the witness. `next build` fails on `main` and passes here.

Verified in a clean worktree off `origin/main` (46becd16):

- `pnpm build` — **exit code 0**, "Compiled successfully", TypeScript clean,
  100/100 static pages generated.
- `.next/server/app/docs/guides.html` renders, and all **nine** cards appear in
  it — including the two that the missing tag had fused into one.
- Swept every `.mdx` under `website/content/docs` for the same class of
  unbalanced-JSX bug. No other real instances. (Apparent hits like `<KEY>` in
  `configuration/credentials.mdx` are placeholders inside JSX attribute strings,
  which MDX parses correctly.)
- All nine `href`s in the grid resolve to files that exist, and
  `guides/meta.json` lists all nine.

## The gate

Website-only diff — no Rust touched, so the cargo gate is not the relevant one.
The real gate for `website/` is `pnpm typecheck` + `pnpm build`, both of which
run inside `next build` above and both of which pass.

- [x] `pnpm build` (includes TypeScript) — exit 0
- [ ] `cargo fmt --check` — n/a, no Rust changed
- [ ] `cargo clippy` — n/a, no Rust changed
- [ ] `cargo test --workspace` — n/a, no Rust changed

## Anything reviewers should know?

This blocks the docs deploy, so it wants merging ahead of anything else in the
queue.

Worth considering as a follow-up: an MDX parse check in the website CI job would
have caught this at PR time on #1146 rather than after the merge. The failure
mode — two PRs appending to one JSX container — will recur as the card grids
grow.

## Summary by Sourcery

Documentation:
- Correct the SpecCard markup in the guides index MDX to restore a valid card grid in the rendered docs.