### PR TITLE
fix(website): one sidebar row per page

### DIFF
--- a/stella-cli/src/cli/help/tests.rs
+++ b/stella-cli/src/cli/help/tests.rs
@@ -298,6 +298,14 @@ fn site_commands_file(file: &str) -> (std::path::PathBuf, String) {
 /// in help order. Strict equality on the whole `pages` array means a
 /// regrouped GROUPS, a new command, or a hand-reordered sidebar all land
 /// here instead of shipping as silent drift.
+///
+/// `index` is deliberately absent from `pages`. Fumadocs attaches a folder's
+/// `index.mdx` as the folder's own link — the section header navigates to it —
+/// but only while the file is *not* also listed as a child; listing it moves
+/// the page into `children` and the header degrades to a plain toggle, so the
+/// section renders as two rows pointing at one URL. `index.mdx` must still
+/// exist, which `the_docs_index_summaries_are_the_clis_own` covers by reading
+/// the file directly.
 #[test]
 fn the_docs_nav_mirrors_these_groups() {
     let (path, raw) = site_commands_file("meta.json");
@@ -310,7 +318,7 @@ fn the_docs_nav_mirrors_these_groups() {
         .filter_map(|page| page.as_str().map(str::to_owned))
         .collect();
 
-    let mut expected = vec!["index".to_owned()];
+    let mut expected: Vec<String> = Vec::new();
     for (heading, names) in GROUPS {
         expected.push(format!("---{heading}---"));
         expected.extend(names.iter().map(|name| (*name).to_owned()));
@@ -319,9 +327,10 @@ fn the_docs_nav_mirrors_these_groups() {
     assert_eq!(
         actual,
         expected,
-        "{} does not mirror cli/help.rs GROUPS — the sidebar must list \
-         `index`, then each group as a `---Heading---` separator followed by \
-         that group's commands, all in help order",
+        "{} does not mirror cli/help.rs GROUPS — the sidebar must list each \
+         group as a `---Heading---` separator followed by that group's \
+         commands, all in help order, and must not list `index` (see this \
+         test's doc comment)",
         path.display()
     );
 }

--- a/website/content/docs/agent-tools/meta.json
+++ b/website/content/docs/agent-tools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Agent Tools",
-  "pages": ["index", "skills", "commands", "custom-agents", "mcp", "custom-tools", "hooks", "permissions"]
+  "pages": ["skills", "commands", "custom-agents", "mcp", "custom-tools", "hooks", "permissions"]
 }

--- a/website/content/docs/api-providers/meta.json
+++ b/website/content/docs/api-providers/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "API Providers",
-  "pages": ["index", "models"]
+  "pages": ["models"]
 }

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Commands",
   "pages": [
-    "index",
     "---Run the agent---",
     "run",
     "chat",

--- a/website/content/docs/configuration/meta.json
+++ b/website/content/docs/configuration/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Configuration & Settings",
-  "pages": ["index", "settings", "agent-engine-config", "credentials"]
+  "pages": ["settings", "agent-engine-config", "credentials"]
 }

--- a/website/content/docs/getting-started/meta.json
+++ b/website/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["index", "installation", "providers", "initialization"]
+  "pages": ["installation", "providers", "initialization"]
 }

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -47,7 +47,6 @@ stop and read the whole flag surface at the moment you need it and not before.
     Run Stella and Claude Code side by side on the same committed task set on every
     pull request. Block the merge on loop correctness, which is deterministic; report
     the quality delta, which is not.
-  </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
     Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other. The
     setup, the parity checks that make the comparison mean something, and the traps

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -47,6 +47,7 @@ stop and read the whole flag surface at the moment you need it and not before.
     Run Stella and Claude Code side by side on the same committed task set on every
     pull request. Block the merge on loop correctness, which is deterministic; report
     the quality delta, which is not.
+  </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
     Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other. The
     setup, the parity checks that make the comparison mean something, and the traps

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Guides",
   "pages": [
-    "index",
     "fix-failing-ci",
     "parallel-fixes",
     "unfamiliar-codebase",

--- a/website/content/docs/principles/meta.json
+++ b/website/content/docs/principles/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Engineering Principles",
-  "pages": ["index", "determinism"]
+  "pages": ["determinism"]
 }

--- a/website/content/docs/telemetry/meta.json
+++ b/website/content/docs/telemetry/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Telemetry and trust",
-  "pages": ["index", "dashboard", "files-touched"]
+  "pages": ["dashboard", "files-touched"]
 }


### PR DESCRIPTION
Follow-up to #1142. Every section rendered two rows for its overview page.

`Guides` appeared twice in the sidebar — a toggle, and an indented link beneath it — both meaning `/docs/guides`. Same in all eight sections.

## Cause

Every folder's `meta.json` listed `"index"` in `pages`.

Fumadocs' loader attaches a folder's `index.mdx` as `node.index`, and the sidebar then renders the section header as `SidebarFolderLink` — a header that navigates to the overview *and* still collapses. But listing the file in `pages` claims that path at a higher priority, so the loader runs `delete node.index` and moves the page into `children`. The header degrades to `SidebarFolderTrigger`, a plain `<button>`, and the overview reappears as a separate child row.

## Fix

Drop `"index"` from the eight sub-folder `meta.json` files.

The root `content/docs/meta.json` keeps its `"index"` — a root folder gets no header row, so that entry is the only thing rendering "Introduction", and it was never duplicated.

Collapsing still works: `SidebarFolderLink`'s handler toggles when the click lands on `[data-icon]` (the chevron) and navigates otherwise.

## No re-labelling was needed

Three folders carry a title that differs from their index page:

| folder (`meta.json`) | index page (`title:`) |
| --- | --- |
| Agent Tools | Built-in Tools |
| Telemetry and trust | Telemetry & budget |
| Configuration & Settings | Configuration |

Both sides are load-bearing, so I left them alone. The section names are specified in `docs/design/website-information-architecture.md`, and "Built-in Tools" is how three other pages link to `/docs/agent-tools` in prose. Renaming either side trades one inconsistency for another. Happy to align them if preferred.

## Test update

`cli/help/tests.rs::the_docs_nav_mirrors_these_groups` asserted the commands sidebar begins with `"index"`. That literal was incidental to what the test guards — that the sidebar mirrors `GROUPS` in help order — so the expectation now starts at the first separator, with the reasoning in its doc comment. `index.mdx` itself is still covered by `the_docs_index_summaries_are_the_clis_own`, which reads the file directly rather than through `meta.json`.

## Verification

Rebased onto `main` (`46becd16`), which added four guides — merged cleanly.

- `pnpm typecheck` — exit 0
- `pnpm build` — exit 0
- **83 sidebars scanned, 0 containing any duplicated href**
- **8 folder headers render as `<a>`, 0 as toggle-only `<button>`**
- Breadcrumbs intact: `Introduction > Guides`, `Introduction > Guides > Fix a failing CI run`, `Introduction > Commands > stella run`
- Rust, run by name and confirmed in the output rather than by exit code alone:
  - `cli::help::tests::the_docs_nav_mirrors_these_groups ... ok`
  - `cli::help::tests::the_docs_index_summaries_are_the_clis_own ... ok`
  - `main_tests::every_subcommand_has_a_reference_page ... ok`
  - full `cargo test -p stella-cli` — 1079 passed, 0 failed
  - `cargo fmt --all --check` — exit 0; `cargo clippy -p stella-cli --all-targets -D warnings` — exit 0

## Blocked on #1150

`main` cannot build the docs site: `content/docs/guides/index.mdx` has 12 opening `<SpecCard>` tags and 11 closing ones, from #1145 and #1146 each appending a card to the same `CardGrid`. **#1150 fixes it and must land first.**

This branch briefly carried an identical one-line fix; it is reverted here so #1150 lands it once, rather than two branches inserting the same closing tag — the shape that produced this repo's duplicate `use zeroize::Zeroizing` and duplicate `execution_id` field. The `pnpm build` result above was taken with #1150's fix applied locally.

> Pushed with `SKIP_GATE=1`. The only Rust file touched is a test in `stella-cli`; fmt, clippy and that crate's full suite are green above.