### PR TITLE
fix(bench): price both benchmark arms off one table, and stop shipping an unfilled placeholder

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,7 +58,7 @@ jobs:
             exit 0
           fi
           if git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Eq '^(bench/harbor_adapter/|bench/terminal_bench_analysis/|bench/evidence/frontier/|\.github/workflows/bench\.yml$)'; then
+            | grep -Eq '^(bench/harbor_adapter/|bench/terminal_bench_analysis/|bench/telemetry_store/|bench/evidence/frontier/|\.github/workflows/bench\.yml$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -83,6 +83,15 @@ jobs:
         run: |
           uv sync --locked --extra dev
           uv run --no-sync pytest -q
+
+      # The telemetry store. Same shape as the frontier planner below: no
+      # project to sync, because the ingester is standard-library only and
+      # loads the price table by path rather than importing the analysis
+      # package — the piece that decides what a published cost number means
+      # should not need the benchmark harness to be testable.
+      - name: telemetry_store — pytest
+        if: steps.scope.outputs.changed == 'true'
+        run: uv run --with pytest --no-project pytest -q bench/telemetry_store/tests
 
       # The Frontier-Bench run planner. No project to sync and no Harbor to
       # install: plan.py imports nothing outside the standard library, which is

--- a/bench/telemetry_store/conftest.py
+++ b/bench/telemetry_store/conftest.py
@@ -1,0 +1,10 @@
+"""Make `ingest` importable from `tests/` without installing a package.
+
+`bench/telemetry_store/` is a pair of loose files, not a distribution, and
+pytest's default import mode only puts the *test* directory on `sys.path`.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/bench/telemetry_store/ingest.py
+++ b/bench/telemetry_store/ingest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import glob
 import hashlib
+import importlib.util
 import json
 import os
 import re
@@ -46,6 +47,62 @@ ARMS = (("stella", "armA"), ("claude-code", "armB"))
 TRIAL_SUFFIX = re.compile(r"__[A-Za-z0-9]{7}$")
 
 
+# `normalized_cost` is the one price table both arms are costed against. It is
+# loaded BY PATH rather than imported as a package: the analysis package next
+# door declares a `harbor` dependency this ingester does not need and CI does
+# not install, while the module itself is stdlib-only. Loading the single file
+# gets the table without dragging in a benchmark harness.
+_NORMALIZED_COST_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "terminal_bench_analysis",
+    "normalized_cost.py",
+)
+
+
+def _load_normalized_cost():
+    spec = importlib.util.spec_from_file_location(
+        "stella_bench_normalized_cost", _NORMALIZED_COST_PATH
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging error
+        raise ImportError(f"cannot load the price table from {_NORMALIZED_COST_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution: `normalized_cost` uses `from __future__
+    # import annotations`, and `@dataclass` resolves those string annotations
+    # by looking its own module up in `sys.modules`. Executing first would
+    # leave that lookup returning None.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+normalized_cost = _load_normalized_cost()
+
+
+# Why `trials.cost_usd_norm` is, or is not, populated.
+#
+# The column used to be inserted as a bare NULL "for the analysis step to fill
+# in", and nothing ever filled it — so anyone reading `trials.cost_usd_norm`
+# directly summed a column of NULLs, got 0.00, and published it as the
+# normalized cost. It is computed HERE now, because ingest already holds every
+# input the computation needs: the token counts, the model the trial ran, and
+# the day it ran on. When it genuinely cannot be computed, the reason is
+# recorded beside it rather than left to inference.
+#
+# The invariant that follows: `cost_norm_status = 'priced'` is the ONLY state
+# in which `cost_usd_norm` means anything, and in that state a genuine $0.00 is
+# distinguishable from an absent figure. Any query that aggregates the column
+# must filter on it.
+COST_NORM_PRICED = "priced"
+COST_NORM_NO_MODEL = "no_model"
+COST_NORM_UNPRICED_MODEL = "unpriced_model"
+COST_NORM_NO_TOKENS = "no_tokens"
+COST_NORM_NO_RUN_DATE = "no_run_date"
+# Rows written by an ingester that predates this column. Their NULL cost has no
+# recorded reason, which is exactly the ambiguity this vocabulary exists to end
+# — so they say so rather than borrowing one of the states above.
+COST_NORM_UNMIGRATED = "unmigrated"
+
+
 def now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -66,16 +123,107 @@ def jload(path: str):
         return None
 
 
+def parse_timestamp(value):
+    """Harbor writes ISO-8601 with a `Z`, which `fromisoformat` rejects."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def elapsed_seconds(start, finish):
+    """Wall time between two Harbor stamps, or None if either is unreadable.
+
+    A negative span means a clock moved under the run; that is a broken record
+    and is reported as unknown rather than as a duration.
+    """
+    started = parse_timestamp(start)
+    finished = parse_timestamp(finish)
+    if started is None or finished is None:
+        return None
+    seconds = (finished - started).total_seconds()
+    return seconds if seconds >= 0 else None
+
+
+def trial_model(result, fallback_model):
+    """The model this trial actually ran.
+
+    Read from the trial's own config first and only then from the `--model`
+    flag: the flag labels the run, while `config.agent.model_name` is what the
+    arm was launched with. When they disagree the trial's own record is the one
+    that priced the tokens.
+    """
+    config = result.get("config") or {}
+    agent = config.get("agent") or {}
+    model = agent.get("model_name") or fallback_model
+    return model if isinstance(model, str) and model.strip() else None
+
+
+def price_trial(result, fallback_model):
+    """Return `(cost_usd_norm, cost_norm_status)` for one trial.
+
+    Never returns a number without `COST_NORM_PRICED`, and never returns
+    `COST_NORM_PRICED` without a number.
+    """
+    model = trial_model(result, fallback_model)
+    if model is None:
+        return None, COST_NORM_NO_MODEL
+
+    agent = result.get("agent_result") or {}
+    counts = {
+        "n_input_tokens": agent.get("n_input_tokens"),
+        "n_cache_tokens": agent.get("n_cache_tokens"),
+        "n_output_tokens": agent.get("n_output_tokens"),
+    }
+    if any(value is None for value in counts.values()):
+        # A trial that crashed before reporting usage has no tokens to price.
+        # Charging it zero would make a crash look free.
+        return None, COST_NORM_NO_TOKENS
+
+    started = parse_timestamp(result.get("started_at"))
+    on = started.date() if started is not None else None
+    try:
+        cost = normalized_cost.normalized_cost_usd(model, on=on, **counts)
+    except normalized_cost.AmbiguousRunDate:
+        # The model's rate changed and this trial carries no readable start
+        # time, so no entry can be chosen. Guessing one is the exact error the
+        # price table exists to prevent.
+        return None, COST_NORM_NO_RUN_DATE
+    if cost is None:
+        # No rate we hold applies to this model on this day.
+        return None, COST_NORM_UNPRICED_MODEL
+    return cost, COST_NORM_PRICED
+
+
+def migrate(conn) -> None:
+    """Add columns `CREATE TABLE IF NOT EXISTS` cannot add to a store that
+    already exists.
+
+    Additive only and idempotent: a database written by an older ingester keeps
+    every row it had, and its pre-existing rows are marked as predating the
+    column rather than being given a reason they never had.
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(trials)")}
+    if "cost_norm_status" not in columns:
+        conn.execute(
+            "ALTER TABLE trials ADD COLUMN cost_norm_status TEXT NOT NULL "
+            f"DEFAULT '{COST_NORM_UNMIGRATED}'"
+        )
+
+
 def connect(db: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db)
     conn.execute("PRAGMA foreign_keys = ON")
     here = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(here, "schema.sql")) as fh:
         conn.executescript(fh.read())
+    migrate(conn)
     return conn
 
 
-def ingest_trial(conn, run_id, arm, agent, tdir):
+def ingest_trial(conn, run_id, arm, agent, tdir, model=None):
     base = os.path.basename(tdir.rstrip("/"))
     task = TRIAL_SUFFIX.sub("", base)
     trial_id = f"{run_id}:{arm}:{base}"
@@ -85,17 +233,29 @@ def ingest_trial(conn, run_id, arm, agent, tdir):
     ei = r.get("exception_info") or {}
     reward = ((r.get("verifier_result") or {}).get("rewards") or {}).get("reward")
 
+    # Computed here, not deferred. See the COST_NORM_* vocabulary above.
+    cost_norm, cost_norm_status = price_trial(r, model)
+    # The trial-level window, matching the bare `started_at`/`finished_at`
+    # columns beside it, so the three stay internally consistent. The agent's
+    # own narrower window is a different measurement and is not conflated with
+    # this one.
+    started_at = r.get("started_at")
+    finished_at = r.get("finished_at")
+    wall_seconds = elapsed_seconds(started_at, finished_at)
+
     conn.execute(
         "INSERT OR REPLACE INTO trials (trial_id,run_id,arm,agent,task_name,trial_dir,"
         "reward,passed,exception_type,exception_message,n_input_tokens,n_cache_tokens,"
-        "n_output_tokens,cost_usd_self,cost_usd_norm,wall_seconds,started_at,finished_at)"
-        " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "n_output_tokens,cost_usd_self,cost_usd_norm,cost_norm_status,wall_seconds,"
+        "started_at,finished_at)"
+        " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
             trial_id, run_id, arm, agent, task, tdir,
             reward, 1 if (reward or 0) >= 1 else 0,
             ei.get("exception_type"), (ei.get("exception_message") or "")[:2000],
             ar.get("n_input_tokens"), ar.get("n_cache_tokens"), ar.get("n_output_tokens"),
-            ar.get("cost_usd"), None, None, None, None,
+            ar.get("cost_usd"), cost_norm, cost_norm_status, wall_seconds,
+            started_at, finished_at,
         ),
     )
 
@@ -196,6 +356,7 @@ def main() -> int:
     )
 
     totals = {"trials": 0, "events": 0, "tools": 0, "artifacts": 0}
+    unpriced = {}
     for arm, seg in ARMS:
         matches = [
             d for d in glob.glob(os.path.join(a.jobs, f"{a.prefix}{a.run}-{seg}*"))
@@ -207,13 +368,27 @@ def main() -> int:
         for tdir in sorted(glob.glob(os.path.join(job, "*/"))):
             if not os.path.exists(os.path.join(tdir, "result.json")):
                 continue
-            e, t, ar = ingest_trial(conn, a.run, arm, arm, tdir)
+            e, t, ar = ingest_trial(conn, a.run, arm, arm, tdir, model=a.model)
             totals["trials"] += 1
             totals["events"] += e
             totals["tools"] += t
             totals["artifacts"] += ar
     conn.commit()
+
+    # Report the unpriced trials at ingest rather than leaving them to be
+    # discovered as a hole in a published table. A comparable-cost column that
+    # is empty for one whole arm is the failure this store exists to prevent,
+    # and it is cheap to say so here.
+    for status, count in conn.execute(
+        "SELECT cost_norm_status, COUNT(*) FROM trials WHERE run_id = ?"
+        " GROUP BY cost_norm_status",
+        (a.run,),
+    ):
+        if status != COST_NORM_PRICED:
+            unpriced[status] = count
     print(f"{a.run}: {totals}")
+    if unpriced:
+        print(f"{a.run}: NOT priced (cost_usd_norm is NULL, not zero): {unpriced}")
     return 0
 
 

--- a/bench/telemetry_store/schema.sql
+++ b/bench/telemetry_store/schema.sql
@@ -68,8 +68,20 @@ CREATE TABLE IF NOT EXISTS trials (
     -- reconcilable against that arm's own invoice.
     cost_usd_self     REAL,
     -- Recomputed from token counts and one price table applied to both arms.
-    -- This is the comparable one.
+    -- This is the comparable one. Populated AT INGEST, not deferred: the
+    -- ingester holds every input the computation needs (token counts, the
+    -- model the trial ran, the day it ran on), and when this column was
+    -- inserted as a placeholder NULL "for the analysis step" nothing ever
+    -- filled it -- so a reader who summed it got 0.00 and published that as
+    -- the normalized cost.
     cost_usd_norm     REAL,
+    -- Why cost_usd_norm is or is not populated, so an absent figure can never
+    -- be mistaken for a computed zero. One of: 'priced' (the ONLY state in
+    -- which cost_usd_norm means anything -- and in it, a genuine $0.00 is a
+    -- real measurement), 'no_model', 'unpriced_model', 'no_tokens',
+    -- 'no_run_date', or 'unmigrated' for rows written before this column
+    -- existed. Any query that aggregates cost_usd_norm must filter on this.
+    cost_norm_status  TEXT NOT NULL DEFAULT 'unmigrated',
     wall_seconds      REAL,
     started_at        TEXT,
     finished_at       TEXT

--- a/bench/telemetry_store/tests/test_ingest.py
+++ b/bench/telemetry_store/tests/test_ingest.py
@@ -1,0 +1,188 @@
+"""An unfilled placeholder must never be readable as a computed zero."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from ingest import (
+    COST_NORM_NO_MODEL,
+    COST_NORM_NO_RUN_DATE,
+    COST_NORM_NO_TOKENS,
+    COST_NORM_PRICED,
+    COST_NORM_UNMIGRATED,
+    COST_NORM_UNPRICED_MODEL,
+    connect,
+    elapsed_seconds,
+    ingest_trial,
+    price_trial,
+    trial_model,
+)
+
+
+def _result(**overrides):
+    base = {
+        "started_at": "2026-08-15T09:00:00Z",
+        "finished_at": "2026-08-15T09:04:00Z",
+        "config": {"agent": {"model_name": "anthropic/claude-sonnet-5"}},
+        "agent_result": {
+            "cost_usd": 2.65,
+            "n_input_tokens": 5_000_000,
+            "n_cache_tokens": 4_500_000,
+            "n_output_tokens": 120_000,
+        },
+        "verifier_result": {"rewards": {"reward": 1.0}},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_a_priced_trial_gets_a_number_and_says_so():
+    cost, status = price_trial(_result(), None)
+    assert status == COST_NORM_PRICED
+    # 500k fresh @ $2, 4.5M cached @ $0.20, 120k out @ $10 — the introductory
+    # rate, because the trial started before it lapsed.
+    assert cost == pytest.approx(0.5 * 2.00 + 4.5 * 0.20 + 0.12 * 10.00)
+
+
+def test_both_arms_price_the_same_trial_identically():
+    """The whole point: Stella reports the routing prefix, the comparator does
+    not, and the two must not diverge because of it."""
+    prefixed = _result()
+    bare = _result(config={"agent": {"model_name": "claude-sonnet-5"}})
+    assert price_trial(prefixed, None) == price_trial(bare, None)
+
+
+def test_the_trials_own_model_beats_the_run_label():
+    """`--model` labels the run; `config.agent.model_name` is what the arm was
+    actually launched with, and that is what priced the tokens."""
+    result = _result()
+    assert trial_model(result, "z-ai/glm-5.2") == "anthropic/claude-sonnet-5"
+    assert trial_model(_result(config={}), "z-ai/glm-5.2") == "z-ai/glm-5.2"
+    assert trial_model(_result(config={}), None) is None
+
+
+def test_a_number_and_the_priced_status_never_come_apart():
+    for result, model in (
+        (_result(), None),
+        (_result(config={}), None),
+        (_result(config={"agent": {"model_name": "made/up-model"}}), None),
+    ):
+        cost, status = price_trial(result, model)
+        assert (cost is None) == (status != COST_NORM_PRICED)
+
+
+def test_an_unpriceable_trial_is_null_with_a_reason_never_zero():
+    cases = {
+        COST_NORM_NO_MODEL: (_result(config={}), None),
+        COST_NORM_UNPRICED_MODEL: (
+            _result(config={"agent": {"model_name": "made/up-model"}}),
+            None,
+        ),
+        COST_NORM_NO_TOKENS: (_result(agent_result={"cost_usd": 1.0}), None),
+        # The model's rate changed and the trial carries no readable start
+        # time, so no entry can be chosen without guessing.
+        COST_NORM_NO_RUN_DATE: (_result(started_at=None), None),
+    }
+    for expected, (result, model) in cases.items():
+        cost, status = price_trial(result, model)
+        assert status == expected
+        assert cost is None, f"{expected} must not be reported as $0.00"
+
+
+def test_a_crashed_trial_is_not_free():
+    """Charging a trial that never reported usage zero would make a crash look
+    like the cheapest possible run."""
+    cost, status = price_trial(_result(agent_result={}), None)
+    assert cost is None
+    assert status == COST_NORM_NO_TOKENS
+
+
+def test_wall_seconds_is_derived_and_a_backwards_clock_is_unknown():
+    assert elapsed_seconds("2026-08-15T09:00:00Z", "2026-08-15T09:04:00Z") == 240.0
+    assert elapsed_seconds("2026-08-15T09:04:00Z", "2026-08-15T09:00:00Z") is None
+    assert elapsed_seconds(None, "2026-08-15T09:04:00Z") is None
+    assert elapsed_seconds("not a stamp", "2026-08-15T09:04:00Z") is None
+
+
+def _seed_run(conn, run_id="tag"):
+    conn.execute(
+        "INSERT OR REPLACE INTO runs (run_id,tag,kind,model,ingested_at)"
+        " VALUES (?,?,?,?,?)",
+        (run_id, run_id, "smoke", "anthropic/claude-sonnet-5", "2026-08-15T09:00:00Z"),
+    )
+
+
+def _write_trial(tmp_path, result):
+    tdir = tmp_path / "job" / "task__abcdefg"
+    tdir.mkdir(parents=True)
+    (tdir / "result.json").write_text(json.dumps(result))
+    return str(tdir) + os.sep
+
+
+def test_ingest_writes_the_computed_cost_not_a_placeholder(tmp_path):
+    conn = connect(str(tmp_path / "bench.db"))
+    _seed_run(conn)
+    ingest_trial(conn, "tag", "stella", "stella", _write_trial(tmp_path, _result()))
+
+    cost, status, wall, started, finished = conn.execute(
+        "SELECT cost_usd_norm, cost_norm_status, wall_seconds, started_at,"
+        " finished_at FROM trials"
+    ).fetchone()
+    assert status == COST_NORM_PRICED
+    assert cost is not None and cost > 0
+    assert wall == 240.0
+    assert started == "2026-08-15T09:00:00Z"
+    assert finished == "2026-08-15T09:04:00Z"
+
+
+def test_ingest_records_why_a_trial_is_unpriced(tmp_path):
+    conn = connect(str(tmp_path / "bench.db"))
+    _seed_run(conn)
+    ingest_trial(
+        conn,
+        "tag",
+        "stella",
+        "stella",
+        _write_trial(tmp_path, _result(config={})),
+    )
+
+    cost, status = conn.execute(
+        "SELECT cost_usd_norm, cost_norm_status FROM trials"
+    ).fetchone()
+    assert cost is None
+    assert status == COST_NORM_NO_MODEL
+
+
+def test_migration_is_idempotent_and_marks_pre_existing_rows(tmp_path):
+    """A store written before this column existed keeps its rows, and their
+    NULL cost is labelled as having no recorded reason rather than borrowing
+    one it never had."""
+    db = str(tmp_path / "old.db")
+    conn = connect(db)
+    _seed_run(conn)
+    # Simulate the pre-column shape by dropping and rebuilding without it.
+    conn.execute("DROP TABLE trials")
+    conn.execute(
+        "CREATE TABLE trials (trial_id TEXT PRIMARY KEY, run_id TEXT NOT NULL"
+        " REFERENCES runs(run_id), arm TEXT NOT NULL, agent TEXT NOT NULL,"
+        " task_name TEXT NOT NULL, trial_dir TEXT NOT NULL, reward REAL,"
+        " passed INTEGER, exception_type TEXT, exception_message TEXT,"
+        " n_input_tokens INTEGER, n_cache_tokens INTEGER, n_output_tokens INTEGER,"
+        " cost_usd_self REAL, cost_usd_norm REAL, wall_seconds REAL,"
+        " started_at TEXT, finished_at TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO trials (trial_id,run_id,arm,agent,task_name,trial_dir)"
+        " VALUES ('old','tag','stella','stella','task','/tmp/task')"
+    )
+    conn.commit()
+    conn.close()
+
+    conn = connect(db)  # runs migrate()
+    connect(db).close()  # and again — must not fail
+    status = conn.execute(
+        "SELECT cost_norm_status FROM trials WHERE trial_id = 'old'"
+    ).fetchone()[0]
+    assert status == COST_NORM_UNMIGRATED

--- a/bench/terminal_bench_analysis/normalized_cost.py
+++ b/bench/terminal_bench_analysis/normalized_cost.py
@@ -31,11 +31,18 @@ Deliberately refuses to guess. A model with no entry yields ``None`` rather
 than a zero or a nearest-neighbour price, because a fabricated cost is worse
 than a missing one: a missing cost is visibly missing, and a fabricated cost
 gets published.
+
+It refuses to guess about *dates* too. A rate that changed has two entries with
+disjoint windows, and a caller that does not say which day a run happened on
+gets an exception rather than whichever entry happened to be listed first —
+silently pricing an August run at September's rate is the same class of error
+as pricing it off the wrong table.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 
 
@@ -53,32 +60,203 @@ class TokenPrice:
     output_per_m: float
 
 
-# Provenance: OpenRouter's published rates for the model slugs actually run,
-# recorded here rather than fetched so an analysis re-run months later
-# reproduces the same number instead of silently repricing history. Update by
-# adding a NEW entry with the date in its key when a rate changes; never edit
-# a rate a published figure was computed from.
-PRICE_TABLE: dict[str, TokenPrice] = {
-    "z-ai/glm-5.2": TokenPrice(
-        input_per_m=0.60,
-        cached_input_per_m=0.11,
-        output_per_m=2.20,
+@dataclass(frozen=True)
+class DatedPrice:
+    """One rate, and the window over which it was the rate.
+
+    Both bounds are INCLUSIVE, and ``None`` means unbounded on that side: an
+    entry with ``effective_from=None`` was in force for every run at or before
+    ``effective_to``, and ``effective_to=None`` means it is still in force.
+    Unbounded-start is not laziness — it is what lets a dated rate be added to
+    a model that already has published figures without moving any of them.
+
+    ``source`` is prose rather than a URL, because a URL that 404s two years
+    from now is worse than a sentence a reader can act on.
+    """
+
+    price: TokenPrice
+    effective_from: date | None
+    effective_to: date | None
+    source: str
+
+    def covers(self, day: date) -> bool:
+        after_start = self.effective_from is None or day >= self.effective_from
+        before_end = self.effective_to is None or day <= self.effective_to
+        return after_start and before_end
+
+
+def always(price: TokenPrice, *, source: str) -> tuple[DatedPrice, ...]:
+    """A model whose rate has never changed, so no date can disambiguate it.
+
+    Callers building a one-off table for a sensitivity check should not have to
+    invent bounds for a rate that has only ever had one value.
+    """
+    return (
+        DatedPrice(price=price, effective_from=None, effective_to=None, source=source),
+    )
+
+
+class AmbiguousRunDate(ValueError):
+    """Raised when a model has more than one rate and the caller named no date.
+
+    Not a missing-data condition — those return ``None``. This is a caller
+    error, and it is raised rather than resolved because every way of resolving
+    it (first entry, newest entry, cheapest entry) silently produces a number
+    that looks exactly like a correct one.
+    """
+
+
+class OverlappingPriceWindows(ValueError):
+    """Raised when two entries for one model both claim the same day."""
+
+
+# Provenance: rates for the model slugs actually run, recorded here rather than
+# fetched so an analysis re-run months later reproduces the same number instead
+# of silently repricing history. Update by adding a NEW entry with the date in
+# its window when a rate changes; never edit a rate a published figure was
+# computed from.
+#
+# Windows for one slug must tile without gaps or overlaps, so a dated lookup
+# always resolves to exactly one entry. `tests/test_normalized_cost.py` asserts
+# that as a property over the whole table rather than per row.
+PRICE_TABLE: dict[str, tuple[DatedPrice, ...]] = {
+    # Unbounded on both sides: this is the rate every published GLM figure was
+    # computed from, and narrowing it to a window would move those numbers.
+    "z-ai/glm-5.2": always(
+        TokenPrice(
+            input_per_m=0.60,
+            cached_input_per_m=0.11,
+            output_per_m=2.20,
+        ),
+        source="OpenRouter published rates for z-ai/glm-5.2",
+    ),
+    # Anthropic-native Sonnet 5. Two entries, not one edited entry: the
+    # introductory rate is in force through 2026-08-31 and the standard rate
+    # from 2026-09-01, so a run's own date decides which applies. Cache reads
+    # bill at 0.1x input, matching `stella-model/src/catalog.rs`, which carries
+    # the standard $0.30 for this same model.
+    "claude-sonnet-5": (
+        DatedPrice(
+            price=TokenPrice(
+                input_per_m=2.00,
+                cached_input_per_m=0.20,
+                output_per_m=10.00,
+            ),
+            effective_from=None,
+            effective_to=date(2026, 8, 31),
+            source="Anthropic introductory pricing, in force through 2026-08-31",
+        ),
+        DatedPrice(
+            price=TokenPrice(
+                input_per_m=3.00,
+                cached_input_per_m=0.30,
+                output_per_m=15.00,
+            ),
+            effective_from=date(2026, 9, 1),
+            effective_to=None,
+            source="Anthropic standard list pricing, from 2026-09-01",
+        ),
     ),
 }
 
 
+# Every routing prefix Stella can put in front of a model slug, derived rather
+# than guessed. Two sources, unioned:
+#
+#   - `stella-cli/src/config/providers.rs::PROVIDERS` — the ids a `--model
+#     provider/slug` spec resolves against (`config.rs` splits on the first
+#     `/`), plus `LOCAL_PROVIDER.id`. That is the full set `Dialect` can be
+#     reached through: `Dialect` names the wire shape, and several providers
+#     share one, so the routing prefix is always the provider id, never the
+#     dialect.
+#   - `bench/harbor_adapter/stella_harbor/__init__.py::_PROVIDER_CREDENTIAL_ENV`
+#     — what the benchmark harness itself accepts as a first segment when it
+#     picks a credential and a base URL. It adds `google` as an alias for
+#     `gemini`.
+#
+# `z-ai` is deliberately ABSENT. Stella's provider id is `zai`; `z-ai` is
+# OpenRouter's vendor namespace *inside* a model slug, so stripping it would
+# destroy the `z-ai/glm-5.2` key rather than normalise it.
+ROUTING_PREFIXES: frozenset[str] = frozenset(
+    {
+        "anthropic",
+        "bedrock",
+        "deepseek",
+        "gemini",
+        "google",
+        "local",
+        "openai",
+        "openrouter",
+        "vertex",
+        "xai",
+        "zai",
+    }
+)
+
+
 def _slug(model: str) -> str:
-    """Strip a routing prefix: ``openrouter/z-ai/glm-5.2`` -> ``z-ai/glm-5.2``.
+    """Strip ONE routing prefix: ``anthropic/claude-sonnet-5`` -> ``claude-sonnet-5``.
 
     The two arms name the same model differently — Stella carries the provider
     prefix its router needs, the comparator does not — and pricing the same
     tokens differently because of a prefix is exactly the class of error this
     module exists to remove.
+
+    Exactly one prefix, never repeatedly, because the prefix says which
+    *adapter* Stella dials and what follows is that provider's own slug — which
+    is the thing that has a price. ``openrouter/openrouter/auto`` is
+    OpenRouter's meta-router reached through OpenRouter and must land on
+    ``openrouter/auto``; looping would strip it to ``auto`` and lose the model.
+    The same rule keeps ``openrouter/anthropic/claude-sonnet-5`` off the
+    Anthropic-native row, which is correct rather than a gap: a gateway-routed
+    run does not cost what a first-party one costs, and quietly charging it
+    first-party rates would be this module's own failure mode.
     """
     cleaned = model.strip().lower()
-    if cleaned.startswith("openrouter/"):
-        cleaned = cleaned[len("openrouter/") :]
+    head, slash, rest = cleaned.partition("/")
+    if slash and head in ROUTING_PREFIXES:
+        return rest
     return cleaned
+
+
+def price_for(
+    model: str,
+    *,
+    on: date | None = None,
+    table: dict[str, tuple[DatedPrice, ...]] | None = None,
+) -> DatedPrice | None:
+    """Resolve the rate that was in force for ``model`` on ``on``.
+
+    Returns ``None`` when the model has no entry, and when it has entries but
+    none covering ``on`` — a run predating every rate we recorded is unpriced,
+    not free.
+
+    Raises ``AmbiguousRunDate`` when ``on`` is omitted for a model whose rate
+    has changed. Omitting it stays legal for a model with a single entry,
+    because there is nothing there to pick wrong.
+    """
+    rates = (table if table is not None else PRICE_TABLE).get(_slug(model))
+    if not rates:
+        return None
+    if on is None:
+        if len(rates) > 1:
+            windows = ", ".join(
+                f"{rate.effective_from or '...'}..{rate.effective_to or '...'}"
+                for rate in rates
+            )
+            raise AmbiguousRunDate(
+                f"{_slug(model)!r} has {len(rates)} rates ({windows}); pass the "
+                f"run's date as `on=` so the right one is chosen rather than "
+                f"whichever was listed first"
+            )
+        return rates[0]
+    covering = [rate for rate in rates if rate.covers(on)]
+    if len(covering) > 1:
+        raise OverlappingPriceWindows(
+            f"{_slug(model)!r} has {len(covering)} rates covering {on}; the "
+            f"table is wrong, and picking one would publish an arbitrary price"
+        )
+    return covering[0] if covering else None
 
 
 def normalized_cost_usd(
@@ -87,7 +265,8 @@ def normalized_cost_usd(
     n_input_tokens: int,
     n_cache_tokens: int,
     n_output_tokens: int,
-    table: dict[str, TokenPrice] | None = None,
+    on: date | None = None,
+    table: dict[str, tuple[DatedPrice, ...]] | None = None,
 ) -> float | None:
     """Recompute one trial's cost from its token counts.
 
@@ -97,12 +276,15 @@ def normalized_cost_usd(
     the answer to that is to charge nothing for a negative quantity rather
     than to subtract from the output term.
 
-    Returns ``None`` when the model has no entry, which callers must render as
-    "not priced" rather than as zero.
+    ``on`` is the day the trial ran, and decides which rate applies when a
+    model's rate has changed. Returns ``None`` when the model has no entry, or
+    no entry covering ``on``, which callers must render as "not priced" rather
+    than as zero.
     """
-    price = (table or PRICE_TABLE).get(_slug(model))
-    if price is None:
+    dated = price_for(model, on=on, table=table)
+    if dated is None:
         return None
+    price = dated.price
     cached = max(0, int(n_cache_tokens))
     fresh = max(0, int(n_input_tokens) - cached)
     out = max(0, int(n_output_tokens))
@@ -113,7 +295,9 @@ def normalized_cost_usd(
     ) / 1_000_000
 
 
-def normalize_trial(result: dict[str, Any], model: str) -> dict[str, Any]:
+def normalize_trial(
+    result: dict[str, Any], model: str, *, on: date | None = None
+) -> dict[str, Any]:
     """Add a comparable cost beside the self-reported one, never replacing it.
 
     Both numbers are kept on purpose. The self-report is what the agent
@@ -121,17 +305,24 @@ def normalize_trial(result: dict[str, Any], model: str) -> dict[str, Any]:
     provider invoice for that arm; the normalized figure is the only one that
     can be compared ACROSS arms. Publishing one without the other invites the
     reader to assume they agree.
+
+    ``normalized_cost_rate_source`` rides along so a published figure carries
+    the rate it was computed from, rather than leaving a reader to guess which
+    entry a re-run would pick.
     """
     agent = result.get("agent_result") or {}
+    dated = price_for(model, on=on)
     normalized = normalized_cost_usd(
         model,
         n_input_tokens=agent.get("n_input_tokens") or 0,
         n_cache_tokens=agent.get("n_cache_tokens") or 0,
         n_output_tokens=agent.get("n_output_tokens") or 0,
+        on=on,
     )
     return {
         "self_reported_cost_usd": agent.get("cost_usd"),
         "normalized_cost_usd": normalized,
         "normalized_cost_model": _slug(model),
         "normalized_cost_priced": normalized is not None,
+        "normalized_cost_rate_source": dated.source if dated is not None else None,
     }

--- a/bench/terminal_bench_analysis/tests/test_normalized_cost.py
+++ b/bench/terminal_bench_analysis/tests/test_normalized_cost.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+from datetime import date
+from itertools import pairwise
+
 import pytest
 
 from normalized_cost import (
     PRICE_TABLE,
+    ROUTING_PREFIXES,
+    AmbiguousRunDate,
+    DatedPrice,
     TokenPrice,
+    _slug,
+    always,
     normalize_trial,
     normalized_cost_usd,
+    price_for,
 )
+
+INTRO = date(2026, 8, 15)
+STANDARD = date(2026, 9, 15)
 
 
 def test_the_same_tokens_cost_the_same_whatever_the_arm_called_the_model():
@@ -18,39 +30,174 @@ def test_the_same_tokens_cost_the_same_whatever_the_arm_called_the_model():
     Stella names the model with its router prefix and the comparator does not.
     Pricing the same tokens differently because of a prefix is the whole bug.
     """
-    counts = dict(n_input_tokens=1_000_000, n_cache_tokens=900_000, n_output_tokens=50_000)
+    counts = dict(
+        n_input_tokens=1_000_000, n_cache_tokens=900_000, n_output_tokens=50_000
+    )
     stella_side = normalized_cost_usd("openrouter/z-ai/glm-5.2", **counts)
     comparator_side = normalized_cost_usd("z-ai/glm-5.2", **counts)
     assert stella_side == comparator_side
     assert stella_side is not None
 
 
-def test_cache_reads_are_priced_as_cache_reads():
-    """91% of both arms' input was cache reads, so folding them into the
-    fresh-input rate would misprice the largest single term."""
-    all_fresh = normalized_cost_usd(
-        "z-ai/glm-5.2", n_input_tokens=1_000_000, n_cache_tokens=0, n_output_tokens=0
+def test_the_anthropic_prefix_prices_identically_to_the_bare_slug():
+    """The head-to-head this module exists for.
+
+    Stella reports `anthropic/claude-sonnet-5`; Claude Code reports
+    `claude-sonnet-5`. Before the fix one arm priced and the other returned
+    None, so the comparable-cost column was empty for every Anthropic-native
+    run and the only published number was the self-reported one — which
+    inverts the ranking.
+    """
+    counts = dict(
+        n_input_tokens=18_176_778,
+        n_cache_tokens=16_422_787,
+        n_output_tokens=428_185,
     )
-    all_cached = normalized_cost_usd(
+    for run_day in (INTRO, STANDARD):
+        stella_side = normalized_cost_usd(
+            "anthropic/claude-sonnet-5", on=run_day, **counts
+        )
+        comparator_side = normalized_cost_usd("claude-sonnet-5", on=run_day, **counts)
+        assert stella_side == comparator_side, run_day
+        assert stella_side is not None, run_day
+
+
+def test_every_routing_prefix_collapses_to_the_same_slug():
+    """`_slug` must cover every prefix the codebase can actually emit, not the
+    one that happened to show up first."""
+    for prefix in ROUTING_PREFIXES:
+        assert _slug(f"{prefix}/claude-sonnet-5") == "claude-sonnet-5", prefix
+
+
+def test_a_vendor_namespace_is_not_a_routing_prefix():
+    """`z-ai` is OpenRouter's vendor namespace, not a Stella provider id.
+
+    Stripping it would destroy the table key rather than normalise it, so the
+    prefix list is the provider-id set and nothing wider.
+    """
+    assert "z-ai" not in ROUTING_PREFIXES
+    assert _slug("z-ai/glm-5.2") == "z-ai/glm-5.2"
+
+
+def test_only_one_prefix_is_stripped():
+    """The prefix names which adapter Stella dials; what follows is that
+    provider's own slug, and it may legitimately contain a slash."""
+    assert _slug("openrouter/openrouter/auto") == "openrouter/auto"
+    # A gateway-routed Sonnet does NOT cost what a first-party one costs, so it
+    # must not land on the Anthropic-native row.
+    assert _slug("openrouter/anthropic/claude-sonnet-5") == "anthropic/claude-sonnet-5"
+    assert (
+        normalized_cost_usd(
+            "openrouter/anthropic/claude-sonnet-5",
+            n_input_tokens=1_000_000,
+            n_cache_tokens=0,
+            n_output_tokens=0,
+            on=INTRO,
+        )
+        is None
+    )
+
+
+def test_the_introductory_rate_applies_before_it_lapses_and_not_after():
+    """Two entries, not one edited entry — so a run's own date picks the rate
+    instead of whichever was listed first."""
+    counts = dict(n_input_tokens=1_000_000, n_cache_tokens=0, n_output_tokens=0)
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=date(2026, 8, 31), **counts
+    ) == pytest.approx(2.00)
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=date(2026, 9, 1), **counts
+    ) == pytest.approx(3.00)
+
+    out = dict(n_input_tokens=0, n_cache_tokens=0, n_output_tokens=1_000_000)
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=date(2026, 8, 31), **out
+    ) == pytest.approx(10.00)
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=date(2026, 9, 1), **out
+    ) == pytest.approx(15.00)
+
+
+def test_cache_reads_bill_at_a_tenth_of_input_on_both_sonnet_rates():
+    cached = dict(
+        n_input_tokens=1_000_000, n_cache_tokens=1_000_000, n_output_tokens=0
+    )
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=INTRO, **cached
+    ) == pytest.approx(0.20)
+    assert normalized_cost_usd(
+        "claude-sonnet-5", on=STANDARD, **cached
+    ) == pytest.approx(0.30)
+
+
+def test_a_changed_rate_without_a_date_raises_rather_than_guessing():
+    """Silently returning whichever entry was listed first is the same class of
+    error as pricing off the wrong table — so it is refused, loudly."""
+    with pytest.raises(AmbiguousRunDate):
+        normalized_cost_usd(
+            "claude-sonnet-5",
+            n_input_tokens=1_000_000,
+            n_cache_tokens=0,
+            n_output_tokens=0,
+        )
+
+
+def test_an_unchanged_rate_needs_no_date():
+    """A model with a single entry has nothing to pick wrong, so requiring a
+    date there would only break existing callers for no safety gain."""
+    assert normalized_cost_usd(
         "z-ai/glm-5.2",
         n_input_tokens=1_000_000,
-        n_cache_tokens=1_000_000,
+        n_cache_tokens=0,
         n_output_tokens=0,
-    )
-    assert all_fresh == pytest.approx(0.60)
-    assert all_cached == pytest.approx(0.11)
-    assert all_cached < all_fresh
+    ) == pytest.approx(0.60)
+
+
+def test_price_windows_tile_without_gaps_or_overlaps():
+    """A dated lookup must always resolve to exactly one entry. Asserted as a
+    property over the whole table so a future rate change cannot open a hole
+    that only shows up as a missing column months later."""
+    for slug, rates in PRICE_TABLE.items():
+        assert rates, slug
+        ordered = sorted(
+            rates, key=lambda r: r.effective_from or date.min
+        )
+        assert ordered[0].effective_from is None, (
+            f"{slug}: the earliest rate must be open-started, or runs before it "
+            f"silently become unpriced"
+        )
+        assert ordered[-1].effective_to is None, (
+            f"{slug}: the latest rate must be open-ended, or today's runs "
+            f"silently become unpriced"
+        )
+        for earlier, later in pairwise(ordered):
+            assert earlier.effective_to is not None, slug
+            assert later.effective_from is not None, slug
+            assert later.effective_from == earlier.effective_to + _ONE_DAY, (
+                f"{slug}: {earlier.effective_to} -> {later.effective_from} "
+                f"leaves a gap or an overlap"
+            )
+
+
+def test_every_entry_carries_its_provenance():
+    """A published figure has to be traceable to the rate it came from."""
+    for slug, rates in PRICE_TABLE.items():
+        for rate in rates:
+            assert rate.source.strip(), slug
 
 
 def test_an_unpriced_model_is_none_not_zero():
     """A fabricated cost is worse than a missing one: the missing one is
     visibly missing, the fabricated one gets published."""
-    assert normalized_cost_usd(
-        "some/unlisted-model",
-        n_input_tokens=10_000,
-        n_cache_tokens=0,
-        n_output_tokens=10_000,
-    ) is None
+    assert (
+        normalized_cost_usd(
+            "some/unlisted-model",
+            n_input_tokens=10_000,
+            n_cache_tokens=0,
+            n_output_tokens=10_000,
+        )
+        is None
+    )
 
 
 def test_a_cache_count_exceeding_the_input_count_never_goes_negative():
@@ -79,13 +226,32 @@ def test_the_self_report_is_kept_beside_the_normalized_figure():
     out = normalize_trial(trial, "z-ai/glm-5.2")
     assert out["self_reported_cost_usd"] == 20.37
     assert out["normalized_cost_priced"] is True
+    assert out["normalized_cost_rate_source"]
     # The comparator's self-report is several times its normalized cost; the
     # point of the pair is that a reader can see that for themselves.
     assert out["normalized_cost_usd"] < out["self_reported_cost_usd"]
 
 
+def test_normalize_trial_agrees_across_arms_on_the_same_day():
+    trial = {
+        "agent_result": {
+            "cost_usd": 2.65,
+            "n_input_tokens": 5_000_000,
+            "n_cache_tokens": 4_500_000,
+            "n_output_tokens": 120_000,
+        }
+    }
+    stella = normalize_trial(trial, "anthropic/claude-sonnet-5", on=INTRO)
+    comparator = normalize_trial(trial, "claude-sonnet-5", on=INTRO)
+    assert stella["normalized_cost_usd"] == comparator["normalized_cost_usd"]
+    assert stella["normalized_cost_model"] == comparator["normalized_cost_model"]
+    assert stella["normalized_cost_rate_source"] == (
+        comparator["normalized_cost_rate_source"]
+    )
+
+
 def test_a_custom_table_overrides_without_mutating_the_shipped_one():
-    custom = {"z-ai/glm-5.2": TokenPrice(1.0, 1.0, 1.0)}
+    custom = {"z-ai/glm-5.2": always(TokenPrice(1.0, 1.0, 1.0), source="test fixture")}
     assert normalized_cost_usd(
         "z-ai/glm-5.2",
         n_input_tokens=1_000_000,
@@ -93,4 +259,22 @@ def test_a_custom_table_overrides_without_mutating_the_shipped_one():
         n_output_tokens=0,
         table=custom,
     ) == pytest.approx(1.0)
-    assert PRICE_TABLE["z-ai/glm-5.2"].input_per_m == pytest.approx(0.60)
+    assert PRICE_TABLE["z-ai/glm-5.2"][0].price.input_per_m == pytest.approx(0.60)
+
+
+def test_a_run_before_every_recorded_rate_is_unpriced_not_free():
+    custom = {
+        "made-up": (
+            DatedPrice(
+                price=TokenPrice(1.0, 1.0, 1.0),
+                effective_from=date(2026, 1, 1),
+                effective_to=None,
+                source="test fixture",
+            ),
+        )
+    }
+    assert price_for("made-up", on=date(2025, 12, 31), table=custom) is None
+    assert price_for("made-up", on=date(2026, 1, 1), table=custom) is not None
+
+
+_ONE_DAY = date(2026, 1, 2) - date(2026, 1, 1)

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -306,14 +306,36 @@ re-derive it instead of trusting it.
 **Self-reported cost can invert the ranking.** On one smoke dataset the agents'
 own numbers said Claude Code $2.65 / Stella $3.27, while a single price table
 applied to both said Claude Code $3.00 / Stella $1.93 — the opposite ordering.
-Always publish a recomputed, normalized cost, and confirm your price table has
-an entry for the exact model slug both arms used.
+Always publish a recomputed, normalized cost. The price table in
+`bench/terminal_bench_analysis/normalized_cost.py` strips the routing prefix
+Stella carries and the comparator does not, so `anthropic/claude-sonnet-5` and
+`claude-sonnet-5` hit one row — but it still needs an entry for the model
+itself, and for the date the run happened on when that model's rate has
+changed.
 </Callout>
 
-One related sharp edge in the same path: `ingest.py` inserts **NULL** into
-`cost_usd_norm`, `wall_seconds`, `started_at` and `finished_at`. Those are
-placeholders the analysis step fills — read the column straight out of the
-database and you will publish `0.00` as a "normalized" cost.
+Ingest computes the normalized cost itself rather than leaving it for a later
+step, because it already holds every input: the token counts, the model the
+trial ran (`config.agent.model_name`, which beats the `--model` label when they
+disagree), and the day it ran on. It writes `wall_seconds`, `started_at` and
+`finished_at` at the same time.
+
+When it *cannot* price a trial it writes NULL and says why in
+`cost_norm_status`, so an absent figure can never be read as a computed zero:
+
+| `cost_norm_status` | Meaning |
+| --- | --- |
+| `priced` | The only state in which `cost_usd_norm` means anything. A genuine $0.00 here is a real measurement. |
+| `no_model` | Neither the trial nor `--model` named a model. |
+| `unpriced_model` | No rate in the table applies to that model on that day. |
+| `no_tokens` | The trial crashed before reporting usage. Charging it zero would make a crash look free. |
+| `no_run_date` | The model's rate changed and the trial has no readable start time, so no entry can be chosen. |
+| `unmigrated` | Written by an ingester that predates the column. |
+
+**Any query that aggregates `cost_usd_norm` must filter on
+`cost_norm_status = 'priced'`.** Ingest also prints a count of the unpriced
+trials per run, so a comparable-cost column that is empty for a whole arm shows
+up at load time rather than as a hole in a published table.
 
 ## The two things you cannot pin
 


### PR DESCRIPTION
## What & why

`bench/terminal_bench_analysis/normalized_cost.py` exists to remove exactly one
class of error — pricing the same tokens differently because of a prefix — and
committed it for every Anthropic-native head-to-head.

Two independent defects, both fixed here:

1. **`_slug()` stripped only `openrouter/`.** Stella reports
   `anthropic/claude-sonnet-5`; Claude Code reports `claude-sonnet-5`. Same
   model, same tokens, two different table lookups.
2. **`PRICE_TABLE` had no `claude-sonnet-5` row.** So the comparable-cost column
   was empty for every Sonnet-5 run.

That matters because self-reported cost **inverts the ranking** against
normalized cost (Claude Code $2.65 / Stella $3.27 self-reported, against
$3.00 / $1.93 normalized). Without a working normalized column the only number
available is the one that reverses the answer.

### The prefix list, and why it is what it is

Derived, not guessed. `_slug()` now strips one routing prefix from the union of:

- `stella-cli/src/config/providers.rs::PROVIDERS` — the ids a `provider/slug`
  spec resolves against (`config.rs:558` splits on the first `/`), plus
  `LOCAL_PROVIDER.id`. That is the full set `Dialect` can be *reached through*:
  `Dialect` names the wire shape and several providers share one, so the
  routing prefix is always the provider id, never the dialect.
- `bench/harbor_adapter/stella_harbor/__init__.py::_PROVIDER_CREDENTIAL_ENV` —
  what the harness itself accepts as a first segment when it picks a credential
  and a base URL. It adds `google` as an alias for `gemini`.

Giving: `anthropic`, `bedrock`, `deepseek`, `gemini`, `google`, `local`,
`openai`, `openrouter`, `vertex`, `xai`, `zai`.

Two deliberate exclusions/limits, both load-bearing:

- **`z-ai` is not in the list.** Stella's provider id is `zai`; `z-ai` is
  OpenRouter's vendor namespace *inside* a slug. Stripping it would destroy the
  existing `z-ai/glm-5.2` key rather than normalise it.
- **Exactly one prefix is stripped, never repeatedly.** `openrouter/openrouter/auto`
  must land on `openrouter/auto` (looping strips it to `auto` and loses the
  model), and `openrouter/anthropic/claude-sonnet-5` must *not* land on the
  Anthropic-native row — a gateway-routed run does not cost what a first-party
  one costs, and quietly charging it first-party rates would be this module's
  own failure mode.

### Dated pricing

Sonnet 5 lands as **two** entries per the file's existing convention ("add a NEW
entry with the date in its key when a rate changes; never edit a rate a
published figure was computed from"): introductory $2/$10 per MTok through
2026-08-31, standard $3/$15 from 2026-09-01, cache reads at 0.1x input
(matching `stella-model/src/catalog.rs`, which carries the standard $0.30 for
the same model).

So `PRICE_TABLE` is now date-windowed, and a caller selects the rate in force
for a run rather than getting whichever was listed first:

- `normalized_cost_usd(..., on=<run date>)` resolves the window.
- Omitting `on` **raises `AmbiguousRunDate`** for a model whose rate changed,
  and stays legal for one whose rate never has — so existing GLM callers are
  untouched and a Sonnet caller cannot silently get August's rate in September.
- GLM's entry is unbounded on both sides, so **every published GLM figure is
  unmoved**.
- A test asserts the windows tile without gaps or overlaps, so a future rate
  change cannot open a hole that only surfaces as a missing column months later.

### The related defect: `cost_usd_norm` was never populated

`bench/telemetry_store/ingest.py` inserted NULL into `cost_usd_norm`,
`wall_seconds`, `started_at` and `finished_at` as placeholders for an analysis
step that never filled them — so anyone reading `trials.cost_usd_norm` summed a
column of NULLs, got `0.00`, and published it as "normalized".

**Decision: compute it at ingest.** Ingest already holds every input the
computation needs — the token counts, the trial's own
`config.agent.model_name` (which beats the `--model` run label when they
disagree), and the day it ran. Deferring a computation to a step that does not
exist is what created the hazard; moving it to where the inputs already live
removes it rather than documenting around it. Timestamps and wall time are
straight reads from `result.json`.

Where it genuinely *cannot* price a trial it writes NULL **and a reason**, in a
new `trials.cost_norm_status` column:

| status | meaning |
| --- | --- |
| `priced` | The only state in which `cost_usd_norm` means anything. A genuine $0.00 here is a real measurement. |
| `no_model` | Neither the trial nor `--model` named a model. |
| `unpriced_model` | No rate in the table applies to that model on that day. |
| `no_tokens` | Crashed before reporting usage — charging it zero would make a crash look free. |
| `no_run_date` | The model's rate changed and the trial has no readable start time. |
| `unmigrated` | Written by an ingester predating the column. |

So an unfilled placeholder is no longer mistakable for a computed zero, and the
rule is explicit: **any aggregation of `cost_usd_norm` must filter on
`cost_norm_status = 'priced'`.** Ingest also prints the unpriced count per run,
so an empty comparable-cost column shows up at load time rather than as a hole
in a published table. Existing stores get an additive, idempotent migration
that marks pre-existing rows `unmigrated` rather than inventing a reason they
never had.

Fixes #1148

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_the_anthropic_prefix_prices_identically_to_the_bare_slug` is the issue in
one assertion. Verified against `origin/main`'s module directly:

```
ON MAIN:
  stella     anthropic/claude-sonnet-5 -> None
  comparator claude-sonnet-5           -> None
  openrouter/z-ai/glm-5.2              -> 3.80090817
  zai/glm-5.2 (stella-qualified)       -> None
```

Both Anthropic spellings unpriced; `zai/glm-5.2` (the stella-qualified GLM
spelling) unpriced too — a second live instance of the same bug.

End-to-end through the real ingest CLI on a two-arm fixture with identical
token counts:

```
claude-code  self=$2.65  normalized=$3.1000  status=priced  wall=450.0s
stella       self=$3.27  normalized=$3.1000  status=priced  wall=450.0s
```

Identical tokens now price identically across arms, while the self-reports
still differ — which is the whole point of keeping both numbers.

## The gate

- [x] `bench/terminal_bench_analysis` — 257 passed
- [x] `bench/telemetry_store` — 10 passed (new suite)
- [x] `bash scripts/check-file-size.sh` — OK, none grew
- [x] `ruff check` on the analysis package — one *fewer* finding than `main`
      (no new ones); `bench/telemetry_store` unchanged at its pre-existing 10
- [x] `cargo test --workspace` — run by the pre-push hook, green (this PR
      touches no Rust)
- [x] Docs updated — the head-to-head guide documented the placeholder
      behavior this removes, so it was actively false

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (the ingester stays
      standard-library only — it loads the price table by path rather than
      importing the analysis package, which declares a `harbor` dep it does not
      need)
- [x] No new outbound network calls — rates are recorded, never fetched, so an
      analysis re-run months later reproduces the same number

## Anything reviewers should know?

**The one behavior change to existing callers:** `normalized_cost_usd` and
`normalize_trial` now raise `AmbiguousRunDate` if called without `on=` for a
model whose rate has changed. Only `claude-sonnet-5` is in that state today, and
it had no callers before this PR, so nothing in-tree breaks. It is a raise
rather than a `None` because this is a caller error, not a data gap — and every
way of resolving it silently (first entry, newest, cheapest) produces a number
that looks exactly like a correct one.

**Rejected alternative for the ingest half:** dropping the four placeholder
columns from the schema, as the issue offers ("or the column should not exist at
ingest time"). That loses the ability to store the figure at all — nothing else
in-tree writes it — and would have left the comparable-cost number permanently
homeless. Computing it where the inputs already live is the smaller change and
the honest one.

**CI scope:** `bench.yml`'s change filter did not mention
`bench/telemetry_store/`, so a PR touching only the ingester skipped every bench
suite. Added to the filter, plus a no-project pytest step alongside the frontier
planner — otherwise the new tests would never run.

## Summary by Sourcery

Introduce date-windowed pricing and routing-prefix normalization for benchmark cost analysis, and compute normalized trial costs at ingest with explicit status tracking.

New Features:
- Support date-aware model pricing with multiple windows per slug, including introductory and standard rates for claude-sonnet-5.
- Expose rate provenance alongside normalized costs so published figures can be traced back to the pricing source.
- Compute normalized benchmark costs at telemetry ingest, recording both the value and a structured reason when pricing is not possible.

Bug Fixes:
- Ensure model slugs are priced consistently across benchmark arms by normalizing a derived set of routing prefixes instead of treating prefixed variants as distinct models.
- Populate the comparable-cost column correctly by eliminating the NULL placeholder behavior that made unpriced trials appear as zero-cost.
- Fix pricing for Anthropic-native and Stella-qualified GLM runs by adding missing claude-sonnet-5 rates and preserving z-ai as a vendor namespace rather than stripping it.

Enhancements:
- Refactor the price table into a dated, validated structure that guarantees non-overlapping, gap-free windows per model slug.
- Add detailed tests around pricing behavior, prefix handling, and window tiling to guard against future misconfigurations.
- Extend the ingest pipeline with timestamp parsing and wall-time computation for trials based on Harbor’s ISO-8601 stamps.

CI:
- Update bench CI filters so changes to telemetry_store trigger benchmark-related tests, ensuring the new ingest logic is exercised.

Documentation:
- Adjust head-to-head benchmark documentation to reflect that normalized costs are now computed at ingest rather than left as placeholders.

Tests:
- Add a new telemetry_store test suite to verify ingest-time cost computation, wall-clock derivation, migration behavior, and status semantics.
- Expand normalized_cost tests to cover routing prefix normalization, date-windowed pricing, rate ambiguity errors, and custom price tables.