### PR TITLE
fix(deps): consume the Context Graph Protocol crates from crates.io (#819)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ skip the roll) were re-inserted the same way.
 
 ## [Unreleased]
 
+- The four Context Graph Protocol crates (`contextgraph-types`,
+  `contextgraph-host`, `contextgraph-trace`, `contextgraph-conformance`) are now
+  ordinary crates.io dependencies at `=0.1.2`, declared once in the root
+  manifest, instead of git dependencies pinned by commit rev (#819). Building
+  stella from source no longer reaches out to the protocol repository, the
+  lockfile carries a checksum for each of them, and `cargo audit` / `cargo vet`
+  can see them — none of which was true of a git rev. `deny.toml`'s `allow-git`
+  exemption is removed, so the workspace now has no vetted git sources at all.
+
 ## [0.6.54] — 2026-08-01
 
 ## [0.6.53] — 2026-08-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,8 +395,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "contextgraph-conformance"
-version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=c5fb2fec5820494ab6921dc088c03d7f43301fa7#c5fb2fec5820494ab6921dc088c03d7f43301fa7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65478f263db1e54f2665b7653db5ee57130a108e78ec3785dc26036a263f7cd"
 dependencies = [
  "async-trait",
  "clap",
@@ -411,8 +412,9 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-host"
-version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=c5fb2fec5820494ab6921dc088c03d7f43301fa7#c5fb2fec5820494ab6921dc088c03d7f43301fa7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaf2a69d0e22494dcf0f890bad63edc436035d0116100215f650b3ca1d3f343"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -428,8 +430,9 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-trace"
-version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=c5fb2fec5820494ab6921dc088c03d7f43301fa7#c5fb2fec5820494ab6921dc088c03d7f43301fa7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d26ec325f040549af3ba16f6343b0e5d022e174185161d5a3334aca602731ca"
 dependencies = [
  "contextgraph-types",
  "serde",
@@ -439,8 +442,9 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-types"
-version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=c5fb2fec5820494ab6921dc088c03d7f43301fa7#c5fb2fec5820494ab6921dc088c03d7f43301fa7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b7acbbe63ff3a0a5eb104c5e9a4a81c9ec6de57d535b7e5216daac54ba6974"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,27 @@ homepage = "https://stella.oxagen.sh"
 publish = false
 
 [workspace.dependencies]
+# Context Graph Protocol — the wire types, host runtime, conformance suite, and
+# execution-trace vocabulary stella speaks (#819). Declared ONCE here so a
+# version bump is a one-line edit rather than six scattered across three member
+# manifests, which is how these drifted onto a git rev in the first place.
+#
+# These were `{ git = ..., rev = ... }` until #819. That pin named a commit
+# living on a history line this repository's upstream had since re-rooted away
+# from: it was on no branch and no PR, reachable only by raw SHA, and eligible
+# for garbage collection — a cold cargo cache away from breaking every build.
+# Registry versions get us a reviewable release, a checksum in Cargo.lock, and
+# an audit trail (`cargo audit`/`cargo vet` cannot see a git rev).
+#
+# `contextgraph-trace` is SKETCH STAGE and deliberately exempt from the
+# protocol's stability promise — its journal wire format may change in any 0.x
+# release. Gate behaviour on its `TRACE_FORMAT` constant, not on this version.
+# Hence exact `=` requirements: a silent minor bump here would change a wire
+# format `stella arena` writes to disk.
+contextgraph-types = "=0.1.2"
+contextgraph-host = "=0.1.2"
+contextgraph-trace = "=0.1.2"
+contextgraph-conformance = "=0.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # RFC 8785 JSON Canonicalization Scheme — pinned to the SAME version the Context

--- a/deny.toml
+++ b/deny.toml
@@ -121,7 +121,14 @@ wildcards = "warn"
 # unknown registry or an unvetted git source fails the build.
 unknown-registry = "deny"
 unknown-git = "deny"
-# Vetted git sources. The Context Graph Protocol crates (contextgraph-types,
-# contextgraph-host) live in their own repo and are consumed directly at a
-# pinned rev until they are published to crates.io.
-allow-git = ["https://github.com/macanderson/context-graph-protocol"]
+# No vetted git sources. The Context Graph Protocol crates (contextgraph-types,
+# contextgraph-host, contextgraph-trace, contextgraph-conformance) were exempted
+# here while they were consumed at a pinned rev; they are published to crates.io
+# as of 0.1.2 and are now ordinary registry dependencies (#819).
+#
+# Deliberately left EMPTY rather than deleted: an empty allow-list is the
+# statement that no git source is vetted, so re-introducing one is a visible
+# edit to this file and not a silent addition to an existing exemption. That
+# matters because the exemption above is what let the pin drift onto a commit
+# reachable from no branch at all.
+allow-git = []

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -23,11 +23,13 @@ formula = "stella"
 
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
-contextgraph-host = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
+contextgraph-types.workspace = true
+contextgraph-host.workspace = true
 # The host execution-trace journal + replay oracles (sketch stage) — the
-# vocabulary `stella arena` records for the arena-bench runner to judge.
-contextgraph-trace = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
+# vocabulary `stella arena` records for the arena-bench runner to judge. Sketch
+# stage means its wire format is exempt from the protocol's stability promise;
+# see the exact-version note in the root manifest.
+contextgraph-trace.workspace = true
 stella-core = { path = "../stella-core" }
 # The construction sequence (provider/registry/store/budget/calibration),
 # extracted so this bin-only crate is no longer its sole owner and
@@ -74,12 +76,12 @@ rpassword.workspace = true
 # dropped intact into freed heap. `stella-model` already zeroizes the `ApiKey`
 # these become; this closes the same hole one layer up, at the terminal.
 zeroize.workspace = true
-# The protocol's own conformance suite (SPEC.md 3.6), pinned to the same rev as
-# the types/host we consume. A RUNTIME dependency, not just a dev one: #453
+# The protocol's own conformance suite (SPEC.md 3.6), held at the same version
+# as the types/host we consume. A RUNTIME dependency, not just a dev one: #453
 # makes conformance an install/enable-time ADMISSION GATE for external
 # stdio/HTTP providers, so a non-conformant source is refused before it can
 # serve a turn. The same suite still audits the in-tree providers in tests.
-contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
+contextgraph-conformance.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/stella-context/Cargo.toml
+++ b/stella-context/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
+contextgraph-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/stella-graph/Cargo.toml
+++ b/stella-graph/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "c5fb2fec5820494ab6921dc088c03d7f43301fa7" }
+contextgraph-types.workspace = true
 # For the workspace's single durable-write + schema-version contract
 # (`stella_store::durable`, #617) — one implementation of temp + fsync +
 # rename, not one per crate.


### PR DESCRIPTION
Closes #819.

`stella-context`, `stella-graph`, and `stella-cli` took `contextgraph-types`, `-host`, `-trace`, and `-conformance` as git dependencies pinned by commit rev — **six lines repeated across three manifests**.

## The pin was worse than the issue described

The rev it named, `c5fb2fec`, was on **no branch and no PR** in the protocol repository. It was reachable only by raw SHA and eligible for garbage collection — one cold cargo cache away from breaking every build, including CI's.

It was also on a history line that repository had **re-rooted away from**: `git merge-base origin/main c5fb2fec` returns nothing. `context-graph-protocol` has two roots, and stella was pinned to the abandoned one.

And a git rev is invisible to `cargo audit` / `cargo vet`, and carries no checksum in `Cargo.lock`.

## Why this needed an upstream fix first

Two of the four crates could not simply be re-pointed at the published 0.1.0:

- `contextgraph-host` and `contextgraph-conformance` had **diverged** from 0.1.0 (composition conformance, C7 exported as public API), so 0.1.0 would not compile against this code.
- `contextgraph-trace` had **never been published** — `publish = false`, documented as "deliberately NOT published… sketch stage". `stella-cli/src/arena.rs` uses `EventBody`, `TraceEvent`, `Journal`, `run_oracles`, and `ToolStatus` from it, so it could not be inlined away.

Fixed upstream in **[context-graph-protocol#74](https://github.com/macanderson/context-graph-protocol/pull/74)** (all checks green): 0.1.2 is cut from that repo's `main`, `contextgraph-trace` is published for the first time, and `contextgraph-types` once again ships `src/record.rs` — the `ContextRecord` lifecycle vocabulary that 0.1.0 silently omitted because it too was published from the abandoned line. 0.1.1 was a mistake made while diagnosing that and is **yanked**.

## What changed here

- The four crates are declared **once** in `[workspace.dependencies]` at `=0.1.2`; members write `contextgraph-types.workspace = true`. The next bump is a one-line edit instead of six — that scattering is how these drifted onto a rev in the first place.
- **Exact `=` requirements, not caret.** `contextgraph-trace` is sketch stage and exempt from the protocol's stability promise; its journal wire format may change in any `0.x`, and `stella arena` writes that format to disk. Gate behaviour on its `TRACE_FORMAT` constant, not on the version.
- **`deny.toml`'s `allow-git` exemption is removed** — its own comment scoped it to "until they are published to crates.io." Left as an explicit empty list rather than deleted, so re-introducing a git source is a visible edit to that file and not a silent append to an existing exemption. That exemption is precisely what let the pin drift somewhere unreachable.

## Verification

- `make gate` — **exit 0** (fmt, clippy `-D warnings`, full workspace tests, rustdoc, file-size, invariants, licence parity, shellcheck, action pins).
- `cargo deny check sources` — **exit 0** with `allow-git = []`, proving the workspace has no git dependencies left at all.
- `Cargo.lock` shows all four as `registry+https://github.com/rust-lang/crates.io-index` at `0.1.2`, each now carrying a checksum; `rg 'git\+.*context-graph-protocol' Cargo.lock` returns nothing.
- No Rust source files were touched — the diff is manifests, lockfile, `deny.toml`, and a changelog entry.

## Note for the reviewer

`contextgraph-types` 0.1.2 **adds** `record.rs`, which the old git rev did not have. It is purely additive and nothing broke, but stella now has CGP's record types in scope alongside its own `record_hash` work — worth a look before building anything new in that area.

## Summary by Sourcery

Switch Context Graph Protocol dependencies from pinned git revisions to crates.io registry releases and centralize their version management in the workspace manifest.

Enhancements:
- Centralize declaration of `contextgraph-types`, `contextgraph-host`, `contextgraph-trace`, and `contextgraph-conformance` in `[workspace.dependencies]` with an exact `=0.1.2` version to avoid drift and simplify future bumps.
- Update member crates (`stella-cli`, `stella-context`, `stella-graph`) to consume Context Graph Protocol crates via workspace dependencies instead of direct git sources.
- Document the dependency change and auditability improvements in the changelog for the unreleased version.

Build:
- Ensure all Context Graph Protocol crates are pulled from crates.io with checksummed lockfile entries, eliminating the previous reliance on an unreachable git commit rev.

CI:
- Tighten `cargo-deny` configuration by clearing the `allow-git` list, so any future git dependency becomes a visible, audited change rather than relying on a lingering exemption.