### PR TITLE
fix(openai): a hit output cap is Length, not a terminal error

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -25,7 +25,7 @@
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs
 1785 stella-model/src/bedrock.rs
-1955 stella-model/src/openai.rs
+2037 stella-model/src/openai.rs
 1773 stella-model/src/zai/tests.rs
 3204 stella-pipeline/src/pipeline.rs
 2393 stella-pipeline/src/pipeline/tests.rs

--- a/stella-core/src/driver/truncation.rs
+++ b/stella-core/src/driver/truncation.rs
@@ -46,14 +46,33 @@ use super::CompletionMessage;
 
 /// How many times one turn may continue past a step that ended at the
 /// output-token limit having called no tool (`FinishReason::Length`,
-/// `tool_calls` empty). Two, not one, because the observed failure is a
-/// reasoning model spending a whole output budget on chain-of-thought: the
-/// first continuation often finishes the thinking, and the second lands the
-/// action. Bounded because each continuation is a paid call, and a model that
-/// truncates a third time is not going to stop on its own — the turn falls
-/// through to the existing truncation warning and the verification ladder's
-/// no-op rung takes it from there.
-pub(super) const MAX_LENGTH_CONTINUATIONS: u32 = 2;
+/// `tool_calls` empty).
+///
+/// Four, measured. This was 2, on the argument that the first continuation
+/// finishes the thinking and the second lands the action — which held for the
+/// shape it was tuned against, where an adapter had promoted chain-of-thought
+/// into `text` and part of the reasoning had already landed. It does not
+/// transfer to an all-reasoning step that arrives empty, which is the shape
+/// the Anthropic dialect produces and which now reaches here.
+///
+/// On a ten-task adversarial Terminal-Bench 2.1 set at effort `xhigh`,
+/// `circuit-fibsqrt` hit the cap three times, spent both continuations and
+/// aborted on the third; a one-hit task recovered on its first; and a task
+/// that had previously died at the cap passed outright. Two was one short of
+/// the worst observed case.
+///
+/// Four and not more because the allowance is not independent of the agent
+/// timeout. A capped step at `xhigh` costs roughly 170–280s of wall clock, so
+/// three cap hits is already ~500–840s against a 900s agent timeout: past
+/// about four, a larger allowance stops buying recoveries and starts buying
+/// timeouts, which fail a harness-health bar exactly the way the abort does.
+/// Cap size, this count, and the agent timeout are one budget, not three.
+///
+/// Each continuation is still a paid call, and a turn that exhausts the
+/// allowance falls through to the truncation warning with the verification
+/// ladder's no-op rung behind it — a model truncating a fifth time is saying
+/// the effort tier is mispriced for the task, not that it needs one more retry.
+pub(super) const MAX_LENGTH_CONTINUATIONS: u32 = 4;
 
 /// Prefix of the engine-injected output-limit continuation nudge.
 ///

--- a/stella-model/src/openai.rs
+++ b/stella-model/src/openai.rs
@@ -649,14 +649,22 @@ impl OpenAiProvider {
             ));
         }
 
-        let (text, tool_calls, usage) = aggregate_openai_stream(response, observer).await?;
+        let (text, tool_calls, usage, truncated_at_limit) =
+            aggregate_openai_stream(response, observer).await?;
         let cost_usd = self.pricing.map(|p| p.cost_usd(&usage)).unwrap_or(0.0);
         // Map onto the neutral vocabulary like every sibling adapter, so the
-        // engine can tell a tool-calling stop from a natural one. `Length` is
-        // unreachable here: `response.incomplete` (including
-        // `max_output_tokens`) already aborts the turn with a typed error
-        // rather than returning a truncated `Ok`.
-        let finish_reason = if tool_calls.is_empty() {
+        // engine can tell a tool-calling stop from a natural one.
+        //
+        // `Length` wins over `ToolCalls` when the response was cut off at
+        // `max_output_tokens`: a step that hit the cap is not finished just
+        // because some tool call happened to complete before the cut, and the
+        // driver's continuation is what recovers the rest. Every sibling
+        // adapter reports the cap this way, and one adapter disagreeing is how
+        // the same truncation came to mean "continue" on four dialects and
+        // "the turn is dead" on this one.
+        let finish_reason = if truncated_at_limit {
+            FinishReason::Length
+        } else if tool_calls.is_empty() {
             FinishReason::Stop
         } else {
             FinishReason::ToolCalls
@@ -684,12 +692,17 @@ struct ToolCallAccumulator {
 async fn aggregate_openai_stream(
     response: reqwest::Response,
     observer: Option<&dyn ToolCallObserver>,
-) -> Result<(String, Vec<ToolCall>, CompletionUsage), ProviderError> {
+) -> Result<(String, Vec<ToolCall>, CompletionUsage, bool), ProviderError> {
     let mut decoder = SseDecoder::new();
     let mut text = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_calls: BTreeMap<usize, ToolCallAccumulator> = BTreeMap::new();
     let mut completed_seen = false;
+    // Set when the response stopped at `max_output_tokens`. Carried out as a
+    // normal result rather than an error so the engine sees the same
+    // `FinishReason::Length` every other adapter reports — see the
+    // `Incomplete` arm below.
+    let mut truncated_at_limit = false;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = http::next_with_timeout(&mut stream, http::STREAM_IDLE_TIMEOUT).await? {
@@ -783,6 +796,25 @@ async fn aggregate_openai_stream(
                         .incomplete_details
                         .and_then(|d| d.reason)
                         .unwrap_or_else(|| "unspecified".to_string());
+                    // Hitting the output cap is not a provider failure — it is
+                    // the ordinary "cut off mid-work" outcome that zai,
+                    // Anthropic, Gemini/Vertex and Bedrock all surface as
+                    // `FinishReason::Length`, and that the driver answers with
+                    // an in-turn continuation. Returning `Terminal` here made
+                    // this dialect the one place a truncation killed the turn
+                    // outright, and non-retryably at that: the same event, on
+                    // the same model, behaved differently depending on which
+                    // adapter carried it. Break with what accumulated and let
+                    // the engine apply one policy to every provider.
+                    if reason == "max_output_tokens" {
+                        truncated_at_limit = true;
+                        completed_seen = true;
+                        break;
+                    }
+                    // Every other incompletion (content filters, and whatever
+                    // OpenAI adds later) stays terminal: those are not
+                    // "continue and it will finish" conditions, and guessing
+                    // that they are would trade a loud stop for a silent loop.
                     return Err(ProviderError::Terminal(format!(
                         "OpenAI response incomplete: {reason}"
                     )));
@@ -825,7 +857,7 @@ async fn aggregate_openai_stream(
         })
         .collect();
 
-    Ok((text, tool_calls, usage))
+    Ok((text, tool_calls, usage, truncated_at_limit))
 }
 
 #[cfg(test)]
@@ -1565,8 +1597,19 @@ mod tests {
         assert!(err.is_retryable());
     }
 
+    /// Hitting the output cap must arrive as `FinishReason::Length`, not as a
+    /// terminal error.
+    ///
+    /// This test previously asserted the opposite, and that assertion was the
+    /// bug held in place: every sibling adapter (zai, Anthropic, Gemini/Vertex,
+    /// Bedrock) reports a cap hit as `Length`, and the driver answers it with
+    /// an in-turn continuation. Returning `Terminal` made this one dialect the
+    /// place where the same event killed the turn outright — and
+    /// non-retryably — so identical work on an identical model succeeded or
+    /// died depending only on which adapter carried the stream. A provider's
+    /// wire shape must not decide engine policy.
     #[tokio::test]
-    async fn complete_returns_err_on_response_incomplete_not_truncated_ok() {
+    async fn output_cap_arrives_as_length_not_a_terminal_error() {
         let server = MockServer::start().await;
         let sse_body = concat!(
             "event: response.output_text.delta\n",
@@ -1592,9 +1635,48 @@ mod tests {
             params: None,
         };
 
+        let result = provider
+            .complete(req)
+            .await
+            .expect("cap hit is not an error");
+        assert_eq!(result.finish_reason, Some(FinishReason::Length));
+        // The partial survives: it is what the continuation resumes from.
+        assert_eq!(result.text, "partial");
+    }
+
+    /// The other half of the same contract. Only the cap is "keep going" —
+    /// a content filter is a stop, and continuing past one would trade a loud
+    /// refusal for a silent retry loop.
+    #[tokio::test]
+    async fn a_non_cap_incompletion_is_still_terminal() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "event: response.incomplete\n",
+            "data: {\"type\":\"response.incomplete\",\"response\":{\"incomplete_details\":{\"reason\":\"content_filter\"}}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        };
+
         let err = provider.complete(req).await.unwrap_err();
         match err {
-            ProviderError::Terminal(msg) => assert!(msg.contains("max_output_tokens"), "{msg}"),
+            ProviderError::Terminal(msg) => assert!(msg.contains("content_filter"), "{msg}"),
             other => panic!("expected Terminal incomplete error, got {other:?}"),
         }
     }


### PR DESCRIPTION
Refs #1149. Completes the provider-truncation parity work that main already
carries most of.

## What main already has

Current main applies one truncation policy in the driver — continuation checked
*before* the empty-response abort, via `driver/truncation.rs::plan_continuation`
— and already suppresses zai's reasoning→text promotion when truncated. Both
were arrived at independently of this work, and both are right.

## What is still divergent

The OpenAI Responses adapter reaches neither. `response.incomplete` returns
`ProviderError::Terminal`, so a `max_output_tokens` cut-off kills the turn
outright, and **non-retryably**, while the same event on zai, Anthropic,
Gemini/Vertex and Bedrock arrives as `FinishReason::Length` and is answered
with an in-turn continuation.

Identical work, on an identical model, succeeding or dying depending only on
which adapter carried the stream. A provider's wire shape must not decide
engine policy.

The stale comment at the finish-reason derivation said so out loud:

```rust
// `Length` is unreachable here: `response.incomplete` (including
// `max_output_tokens`) already aborts the turn with a typed error
```

## Change

- `max_output_tokens` returns `Length` with whatever accumulated, so the
  partial is what the continuation resumes from.
- Every other incompletion (content filters, and whatever OpenAI adds later)
  **stays terminal**. Those are not "continue and it will finish" conditions,
  and guessing they are would trade a loud stop for a silent retry loop.
- `Length` wins over `ToolCalls` when truncated: a step that hit the cap is not
  finished merely because some tool call completed before the cut.

The test that asserted the old behaviour is **replaced rather than deleted** —
it was the divergence held in place, and its name (`..._not_truncated_ok`) said
so. Its twin now pins that a non-cap incompletion is still terminal.

## Also: MAX_LENGTH_CONTINUATIONS 2 → 4, measured

Two was tuned against the promoted-text shape, where an adapter had already
moved chain-of-thought into `text` and part of the reasoning had landed. It does
not transfer to an all-reasoning step that arrives empty — the shape main's
driver fix just made reachable.

Measured on a ten-task adversarial Terminal-Bench 2.1 set at effort `xhigh`:

| task | cap hits | continuations used | outcome |
|---|---|---|---|
| `write-compressor` | 1 | 1 | recovered |
| `circuit-fibsqrt` | 3 | **2 (exhausted)** | **aborted** |
| `mteb-leaderboard` | 0 | 0 | passed (was a cap death pre-fix) |

Two was one short of the worst observed case.

**Four and not more** because the allowance is not independent of the agent
timeout. A capped step at `xhigh` costs ~170–280s of wall clock, so three cap
hits is already ~500–840s against a 900s agent timeout: past about four, a
larger allowance stops buying recoveries and starts buying `AgentTimeoutError`,
which fails a harness-health bar exactly the way the abort does. Cap size, this
count, and the agent timeout are one budget, not three.

## Verification

- `cargo test -p stella-core -p stella-model` — **1,146 passing**, 0 failures
- `cargo fmt --check`, `check-file-size` — clean (ceiling re-baselined via
  `make file-size-update`; growth is the replaced test plus its twin)

## Known limitation, stated rather than hidden

A gate run on the adversarial ten showed this class of fix converts some
cap-aborts into **timeouts** rather than passes (3 tasks moved
`NonZeroAgentExitCodeError` → `AgentTimeoutError`). Those tasks are wall-clock
bound at `xhigh`, not truncation bound, and no continuation allowance fixes
that — the lever there is per-step cost (effort tier or cap size), which is a
posture decision rather than an engine one.

## Summary by Sourcery

Align OpenAI response handling and truncation behavior with other providers and adjust continuation limits for length-based truncations.

Bug Fixes:
- Treat OpenAI `max_output_tokens` truncations as `FinishReason::Length` with partial output instead of a terminal error, ensuring turns can continue consistently across providers.

Enhancements:
- Prioritize `Length` over `ToolCalls` when an OpenAI response is cut at the output cap so truncated steps are eligible for continuation.
- Increase the maximum number of length-based continuations per turn from 2 to 4 based on observed truncation behavior and timeout constraints.

Build:
- Update file-size baseline configuration to account for the new and modified tests.

Tests:
- Replace the OpenAI incomplete-response test to assert length-based truncation is non-terminal and add a complementary test that non-cap incompletions remain terminal.