### PR TITLE
fix(engine): decline a length continuation the turn cannot finish

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2179 stella-core/src/driver.rs
+2220 stella-core/src/driver.rs
 3133 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -89,7 +89,7 @@ use crate::receipts::TranscriptRevision;
 mod loop_evidence;
 mod truncation;
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
-use truncation::{MAX_LENGTH_CONTINUATIONS, plan_continuation};
+use truncation::{ContinuationBudget, MAX_LENGTH_CONTINUATIONS, plan_continuation};
 // Named only by the tests that pin the nudge's exact body; the production path
 // reaches it through `Continuation::into_parts`.
 use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
@@ -200,6 +200,23 @@ pub struct EngineConfig {
     /// `UNARY_READ_TIMEOUT`, the most generous transport bound in the
     /// workspace) while staying finite.
     pub model_timeout: Option<Duration>,
+    /// Wall clock one turn may spend, used to decide whether a length
+    /// continuation is affordable. `None` — the default — leaves the
+    /// continuation allowance a pure count, exactly as before.
+    ///
+    /// This is not a timeout and nothing enforces it: no future is cancelled
+    /// when it elapses. It exists so the engine can decline to *start* work it
+    /// cannot finish. The constraint being modelled is external — a harness
+    /// kills a trial on elapsed time (Terminal-Bench at 900s) — and an engine
+    /// blind to it will spend its whole continuation allowance and be
+    /// destroyed mid-continuation, turning a truthful truncated answer into an
+    /// `AgentTimeoutError` that reads at the results layer exactly like the
+    /// agent failing the task.
+    ///
+    /// Set it slightly below the real deadline: the useful behaviour is
+    /// stopping with an honest partial while time remains, not racing the
+    /// harness to the last second.
+    pub turn_budget: Option<Duration>,
     /// Working directory reported to lifecycle hooks (`crate::hooks`) as the
     /// `cwd` of every [`HookPayload`]. Kept here — rather than sniffed via
     /// `std::env::current_dir()` inside the engine — so `stella-core`
@@ -243,6 +260,10 @@ impl Default for EngineConfig {
             max_steps: 200,
             tool_timeout: Some(Duration::from_secs(15 * 60)),
             model_timeout: Some(Duration::from_secs(10 * 60)),
+            // Off by default: only a caller that knows its own deadline can
+            // supply a true one, and a guessed budget would decline work the
+            // caller had time for.
+            turn_budget: None,
             cwd: ".".to_string(),
             turn_instance: 0,
             lifecycle_enabled: false,
@@ -727,6 +748,10 @@ impl<'a> Engine<'a> {
             return aborted.into();
         }
 
+        // Wall clock around the whole call including its retries, because that
+        // is what a continuation would actually cost again — not the duration
+        // of the one attempt that happened to succeed.
+        let step_started = std::time::Instant::now();
         let committed = match self
             .run_model_call(
                 state.step,
@@ -746,6 +771,7 @@ impl<'a> Engine<'a> {
                 };
             }
         };
+        state.last_step = Some(step_started.elapsed());
         state.calibration_model = Some(committed.result.model.clone());
         state.total_cost_usd += committed.result.cost_usd;
 
@@ -771,12 +797,25 @@ impl<'a> Engine<'a> {
             return aborted.into();
         }
 
+        // Only meaningful once a step has been timed and a budget configured:
+        // the forecast for one more continuation is what the last one cost, and
+        // without a deadline there is nothing to compare it against.
+        let continuation_budget =
+            self.config
+                .turn_budget
+                .zip(state.last_step)
+                .map(|(budget, last_step)| ContinuationBudget {
+                    remaining: budget.saturating_sub(state.started_at.elapsed()),
+                    last_step,
+                });
+
         if let Some(completed) = self
             .dispatch_completion(
                 committed,
                 state.total_cost_usd,
                 &mut state.messages,
                 &mut state.length_continuations,
+                continuation_budget,
                 events,
             )
             .await
@@ -1722,6 +1761,7 @@ impl<'a> Engine<'a> {
         total_cost_usd: f64,
         messages: &mut Vec<CompletionMessage>,
         length_continuations: &mut u32,
+        continuation_budget: Option<ContinuationBudget>,
         events: &EventSender,
     ) -> Option<TurnOutcome> {
         let CommittedStep {
@@ -1760,6 +1800,7 @@ impl<'a> Engine<'a> {
                     &result.text,
                     result.usage.output_tokens,
                     *length_continuations,
+                    continuation_budget,
                 )
             {
                 *length_continuations += 1;

--- a/stella-core/src/driver/truncation.rs
+++ b/stella-core/src/driver/truncation.rs
@@ -42,6 +42,8 @@
 //! ignore. Elided, the resume point sits immediately above the instruction that
 //! names it. The saving and the improvement are the same edit.
 
+use std::time::Duration;
+
 use super::CompletionMessage;
 
 /// How many times one turn may continue past a step that ended at the
@@ -151,12 +153,59 @@ impl Continuation {
 /// `Some` — threaded rather than owned so the bound survives across steps.
 /// Callers establish `FinishReason::Length` and an empty `tool_calls` before
 /// calling; this decides only what happens next.
+/// What one turn has left to spend on continuing, in wall clock.
+///
+/// The count alone cannot see the constraint that actually binds. A harness
+/// kills a trial on elapsed time — Terminal-Bench at 900s — and the engine
+/// continues blind to it, so a turn can spend its whole allowance and be
+/// destroyed externally mid-continuation. That arrives as
+/// `AgentTimeoutError`: a harness death, indistinguishable at the results
+/// layer from the agent failing the task, where an honest truncated answer
+/// would have been an ordinary result.
+///
+/// Measured on a ten-task adversarial Terminal-Bench set at effort `xhigh`:
+/// four of ten trials died on the wall clock, two of them without ever
+/// reaching the output cap. No continuation allowance can fix that, because
+/// more retries is the opposite of the fix.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ContinuationBudget {
+    /// Wall clock left before the turn's deadline.
+    pub(super) remaining: Duration,
+    /// How long the step that just truncated took.
+    pub(super) last_step: Duration,
+}
+
+impl ContinuationBudget {
+    /// Whether there is time to finish a continuation, not merely start one.
+    ///
+    /// A continuation re-runs the work that just truncated — same prompt shape,
+    /// same reasoning, same cap — so it costs at least what its predecessor
+    /// cost. Starting one with less time than that is choosing an external kill
+    /// over a truthful partial: the answer is thrown away and the trial reports
+    /// a timeout instead of a result.
+    ///
+    /// Strictly greater, and no safety margin invented here: the caller owns
+    /// the deadline and can set a conservative one. A margin baked in at this
+    /// level would be a second, invisible policy.
+    fn affords_another(&self) -> bool {
+        self.remaining > self.last_step
+    }
+}
+
 pub(super) fn plan_continuation(
     text: &str,
     output_tokens: u64,
     spent: u32,
+    budget: Option<ContinuationBudget>,
 ) -> Option<Continuation> {
     if spent >= MAX_LENGTH_CONTINUATIONS {
+        return None;
+    }
+    // Checked after the count, so a turn with no deadline configured behaves
+    // exactly as before — the budget is opt-in and absent by default.
+    if let Some(budget) = budget
+        && !budget.affords_another()
+    {
         return None;
     }
     let attempt = spent + 1;
@@ -191,11 +240,57 @@ mod tests {
 
     #[test]
     fn a_spent_allowance_declines_to_continue() {
-        assert!(plan_continuation("cut off", 16_384, MAX_LENGTH_CONTINUATIONS).is_none());
-        assert!(plan_continuation("", 16_384, MAX_LENGTH_CONTINUATIONS).is_none());
+        assert!(plan_continuation("cut off", 16_384, MAX_LENGTH_CONTINUATIONS, None).is_none());
+        assert!(plan_continuation("", 16_384, MAX_LENGTH_CONTINUATIONS, None).is_none());
         // ...and every attempt below it does continue.
         for spent in 0..MAX_LENGTH_CONTINUATIONS {
-            assert!(plan_continuation("cut off", 16_384, spent).is_some());
+            assert!(plan_continuation("cut off", 16_384, spent, None).is_some());
+        }
+    }
+
+    #[test]
+    fn a_continuation_it_cannot_finish_is_declined() {
+        // The continuation costs what its predecessor cost, so 60s of work with
+        // 30s left is a continuation that gets killed mid-flight. Declining
+        // keeps the truthful partial and lets the turn end as an ordinary
+        // result; taking it trades that for an external timeout, which reads at
+        // the results layer exactly like the agent failing the task.
+        let broke = ContinuationBudget {
+            remaining: Duration::from_secs(30),
+            last_step: Duration::from_secs(60),
+        };
+        assert!(plan_continuation("cut off", 16_384, 0, Some(broke)).is_none());
+        assert!(plan_continuation("", 16_384, 0, Some(broke)).is_none());
+    }
+
+    #[test]
+    fn a_continuation_it_can_finish_proceeds() {
+        let flush = ContinuationBudget {
+            remaining: Duration::from_secs(600),
+            last_step: Duration::from_secs(60),
+        };
+        assert!(plan_continuation("cut off", 16_384, 0, Some(flush)).is_some());
+    }
+
+    #[test]
+    fn exactly_enough_time_is_not_enough() {
+        // Equal is refused, not allowed. The forecast is an estimate drawn from
+        // one prior sample, so spending the last of the budget on it lands
+        // exactly on the deadline in the best case and past it in every other.
+        let exact = ContinuationBudget {
+            remaining: Duration::from_secs(60),
+            last_step: Duration::from_secs(60),
+        };
+        assert!(plan_continuation("cut off", 16_384, 0, Some(exact)).is_none());
+    }
+
+    #[test]
+    fn without_a_budget_the_allowance_is_the_only_bound() {
+        // The default path: no deadline configured, so behaviour is the pure
+        // count it was before — a caller that knows nothing about its wall
+        // clock must not have work declined on a guess.
+        for spent in 0..MAX_LENGTH_CONTINUATIONS {
+            assert!(plan_continuation("cut off", 16_384, spent, None).is_some());
         }
     }
 
@@ -204,7 +299,7 @@ mod tests {
         // The shape the zai adapter used to hide by promoting reasoning into
         // `text`: no answer at all. There is nothing to resume from, so the
         // transcript records the fact and none of the deliberation.
-        let plan = plan_continuation("   \n  ", 16_384, 0).expect("continues");
+        let plan = plan_continuation("   \n  ", 16_384, 0, None).expect("continues");
         assert_eq!(plan.retained, REASONING_ONLY_PARTIAL);
         assert!(
             plan.note.contains("spent entirely on reasoning"),
@@ -219,7 +314,7 @@ mod tests {
         // never trimmed, so eliding can never lose an answer small enough to
         // have been worth reading whole.
         let answer = "The fix is to widen the guard in ";
-        let plan = plan_continuation(answer, 16_384, 0).expect("continues");
+        let plan = plan_continuation(answer, 16_384, 0, None).expect("continues");
         assert_eq!(plan.retained, answer);
     }
 
@@ -237,7 +332,7 @@ mod tests {
             "a".repeat(5_000),
             "b".repeat(5_000)
         );
-        let plan = plan_continuation(&partial, 16_384, 0).expect("continues");
+        let plan = plan_continuation(&partial, 16_384, 0, None).expect("continues");
 
         assert!(
             plan.retained.len() < partial.len() / 4,
@@ -274,7 +369,7 @@ mod tests {
 
     #[test]
     fn the_nudge_is_marked_so_it_is_never_mistaken_for_the_user() {
-        let (_note, [assistant, nudge]) = plan_continuation("cut off", 16_384, 0)
+        let (_note, [assistant, nudge]) = plan_continuation("cut off", 16_384, 0, None)
             .expect("continues")
             .into_parts();
         assert_eq!(assistant.role, stella_protocol::MessageRole::Assistant);

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -248,6 +248,19 @@ pub struct TurnState {
     /// spend; deliberately NOT checkpointed — a resumed turn starts the
     /// allowance over, which only re-permits a bounded amount of work.
     pub(crate) length_continuations: u32,
+    /// When this turn began, for deciding whether a length continuation is
+    /// affordable against `EngineConfig::turn_budget`.
+    ///
+    /// Deliberately NOT checkpointed, and set fresh by `from_checkpoint`: a
+    /// resumed turn is resumed by a caller with its own deadline, so carrying
+    /// the original start would make the budget read as long spent before any
+    /// work happened. Same reasoning as `length_continuations` starting over.
+    pub(crate) started_at: std::time::Instant,
+    /// How long the most recent model call took, as the estimate of what one
+    /// more continuation would cost. A continuation re-runs the work that just
+    /// truncated, so its predecessor's duration is the honest forecast — and
+    /// the only one available without predicting the model.
+    pub(crate) last_step: Option<std::time::Duration>,
     /// The host's stop signal, checked at the top of every step.
     pub(crate) cancel: CancelToken,
 }
@@ -273,6 +286,8 @@ impl TurnState {
             step: 0,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),
             length_continuations: 0,
+            started_at: std::time::Instant::now(),
+            last_step: None,
             cancel: CancelToken::new(),
         }
     }
@@ -292,6 +307,8 @@ impl TurnState {
             step: checkpoint.step,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),
             length_continuations: 0,
+            started_at: std::time::Instant::now(),
+            last_step: None,
             cancel: CancelToken::new(),
         }
     }


### PR DESCRIPTION
Closes the remaining open item on #1149. The code fixes from #1126 and #1158
are merged; what was still outstanding is the one the gate data made urgent.

## The problem

The continuation allowance is a pure count, blind to the constraint that
actually binds. A harness kills a trial on **elapsed time** — Terminal-Bench at
900s — and the engine cannot see that deadline, so a turn spends its allowance
and is destroyed mid-continuation.

That arrives as `AgentTimeoutError`: a harness death, indistinguishable at the
results layer from the agent failing the task — where stopping one continuation
earlier would have produced an ordinary truncated result.

## Why more retries is the wrong lever

Measured on the ten-task adversarial Terminal-Bench set at effort `xhigh`:

| task | steps | max output | cap hits | died of |
|---|---|---|---|---|
| `cobol-modernization` | 44 | 7,087 | **0** | wall clock |
| `gpt2-codegolf` | 16 | 23,624 | **0** | wall clock |
| `write-compressor` | 6 | 32,000 | 1 | wall clock |
| `path-tracing` | — | — | — | wall clock |

Four of ten died on time, and **two never reached the output cap at all**.
Raising `MAX_LENGTH_CONTINUATIONS` (done separately, 2 → 4) cannot help those,
and makes them marginally worse — a continuation is more time spent.

## Change

`EngineConfig::turn_budget: Option<Duration>`, default `None`, so nothing
changes for callers who do not set it. When set, a continuation is declined
unless the time remaining **exceeds what the step that just truncated cost**.

A continuation re-runs the work that truncated — same prompt shape, same
reasoning, same cap — so its predecessor's duration is the honest forecast, and
the only one available without predicting the model.

Equal is refused, not allowed: the forecast comes from a single prior sample, so
spending the last of the budget lands exactly on the deadline in the best case
and past it in every other.

**This is not a timeout and cancels nothing.** No future is aborted when the
budget elapses. It only lets the engine decline to *start* work it cannot
finish — the difference between a truthful partial and an external kill.

The step is timed around the whole model call **including retries**, since that
is what a continuation would cost again, not the duration of whichever attempt
happened to succeed.

## Tests

Four new, covering the policy's edges: a continuation it cannot finish is
declined (both the empty and non-empty shapes), one it can finish proceeds,
exactly-enough time is refused, and with no budget configured the allowance is
the only bound. `cargo test -p stella-core` — **812 passing**, 0 failures; fmt
and file-size clean.

## Follow-up, deliberately not in this change

Nothing sets `turn_budget` yet, so the engine side is **inert** until the CLI
and the bench adapter can pass the harness deadline through. Landing the policy
first keeps that wiring a small reviewable change rather than one buried under
this. Worth pairing with a `--turn-budget` flag analogous to the existing
`--budget` (money), since the harness already knows its own agent timeout.

## Summary by Sourcery

Introduce an optional per-turn wall-clock budget to prevent length continuations that cannot finish within the harness deadline, keeping truthful truncated results instead of timing out mid-continuation.

Enhancements:
- Add a ContinuationBudget struct and integrate it into continuation planning so continuations are only taken when the remaining turn time exceeds the last step duration.
- Extend EngineConfig and TurnState with turn_budget and timing fields to compute remaining time and feed it into continuation decisions.
- Time model calls including retries to estimate the cost of another continuation and wire this estimate through the engine.
- Update existing continuation tests and add new tests covering budget-aware continuation behaviour and edge cases.