### PR TITLE
fix: serve lifecycle, Host guard, step-scoped cancel, and bus emitters (#1129–#1133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stella-core",
+ "stella-engine",
  "stella-protocol",
  "thiserror 2.0.19",
  "tokio",

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -19,8 +19,17 @@ treat `stella-serve/src/` as the state and this doc as the destination.
 `stella-cli` so a server can assemble the same stack without linking a binary)
 and `stella-engine` (phase 1 — `run_step`, a serde `Checkpoint`, and a
 step-boundary `CancelToken`, with `run_turn` re-implemented as a loop over
-`run_step` so there is one code path). `stella-serve` does **not** yet drive
-`run_step`; it still calls `Engine::run_turn`, which is the next increment.
+`run_step` so there is one code path). As of #1129 `stella-serve` **does**
+drive `run_step`: `session.rs` owns a `TurnState` carrying a `CancelToken`
+and loops over steps, so `POST /v1/turns/{id}/cancel` unwinds at the next
+step boundary — interrupting CPU-bound work *between* reverse requests
+(compaction, loop detection), which the previous cancel could not reach. The
+difference is visible in the abort reason: it now names a step-boundary
+cancel rather than a failed model call, because the turn ends by being asked
+to rather than by having its transport pulled. `StepOutcome::Continue` is
+also now the seam where a durable runner would persist
+`state.to_checkpoint()`; nothing is persisted yet, since this server has
+nowhere to put it.
 
 **Date:** 2026-07-20, revised 2026-07-30. **Owner:** Mac Anderson.
 **Companion:** `oxagen-platform/docs/specs/agent-engine-v2/` (ADR-033 + spec) —
@@ -50,7 +59,7 @@ not in this table is a 404.
 | `GET` | `/v1/turns/{id}/events` | SSE `id: <seq>` + `data: <ServerFrame>`. Resumable via `?after=<seq>` or `Last-Event-ID`. One concurrent subscriber; a second gets 409 |
 | `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |
 | `POST` | `/v1/turns/{id}/tool-result` | Answers a `tool_request` |
-| `POST` | `/v1/turns/{id}/cancel` | Hard teardown: drops the turn and its transcript. There is no `DELETE` |
+| `POST` | `/v1/turns/{id}/cancel` | Step-boundary stop (#1129): the turn unwinds at its next step, keeping completed steps, and still emits `turn_complete`. Deregistered immediately, so a second cancel is a 404. There is no `DELETE` |
 | `POST` | `/v1/turns/{id}/steer` | `{"message": "…"}` — injected at the next step boundary, echoed as a `steered` event (#932) |
 | `POST` | `/v1/turns/{id}/pause` | Hold at the next step boundary. Idempotent; never mid-tool (#932) |
 | `POST` | `/v1/turns/{id}/resume` | Release a held turn. Idempotent (#932) |

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -415,8 +415,26 @@ ADR-033 §7 names).
    deliberate corruptions.
    **Correction:** `validate_stream` lives in `stella-pipeline/src/replay.rs`,
    not `stella-protocol` as earlier editions of this document said.
-5. ⬜ Host-emitted bus lifecycle events (`emit_named` helpers) — closes "the bus
-   is only emitted from the tool registry."
+5. ✅ **DONE (#1133).** Bus lifecycle events at the turn, step and model-call
+   boundaries — closes "the bus is only emitted from the tool registry."
+   `Engine::with_bus` attaches a `HookBus`; the engine then emits
+   `agent.turn.started`/`.completed`, `agent.step.started`/`.completed`, and
+   `model.request.started`/`.completed`/`.failed`. `HookBus::session_started`
+   emits `session.started` and is called by whoever *mints* the bus (today
+   `stella-cli`'s rule guards), because construction is the only place the
+   session boundary actually is — and it fires after subscribing, or the one
+   event that opens the stream would be the one nobody sees.
+   **Correction:** earlier editions implied the catalog already declared step
+   names. It did not — `agent.step.started`/`.completed` were added with the
+   emitters, since a catalog name nothing emits is a promise rather than a
+   contract. Turn-level `agent.turn.*` did already exist.
+   These are **observer-only**: none is on the blocking allowlist, so an
+   extension can watch a step begin but not veto one. Payloads carry counts
+   and identifiers (message count, tokens, cost, model id, step index) and
+   never transcript content — the one free-text field is an abort `reason`,
+   which already reaches `AgentEvent::Error`. An engine with no bus attached
+   pays nothing: every emit site is behind one `if let Some(bus)`, and the
+   payload closure is not called without one.
 6. ✅ **DONE (#971 phase 1).** A real `CancelToken` threaded through `run_step`,
    read at the step boundary, closing any open `tool_use` with synthetic error
    `tool_result`s so the transcript stays valid; hard-drop semantics documented

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -167,6 +167,25 @@ the engine is structured as a headless library, not a terminal program:
    error `ScopeReviewRequiredHeadless` — **never a silent auto-approve**.
    `AutoApproveGate` / `AlwaysAbortGate` are the headless approval ports.
 
+   **Correction (#932 approval half).** This paragraph is the premise behind
+   "surface `ScopeReviewRequiredHeadless` to the host as a decision", and the
+   premise does not hold for `stella-serve` as built: **a served turn never
+   reaches a scope review at all.** `ApprovalGate::review` has exactly one
+   call site — `stella-pipeline/src/pipeline/scope_stage.rs` — and
+   `stella-serve` does not depend on `stella-pipeline`. It drives the
+   *engine* (`stella_engine::run_step`), which has no plan or scope stage.
+   Only `stella-cli` and `stella-runtime` link the pipeline.
+
+   So `POST /v1/turns/{id}/approve` is not merely unbuilt, it is currently
+   **unreachable**: a route no turn could trigger, and a row in the table
+   above that a client could code against and never exercise. Building it
+   is blocked on a prior decision — whether `stella-serve` grows a
+   pipeline-driving surface (`POST /v1/runs`, distinct from `/v1/turns`)
+   or whether the approval boundary moves down into the engine. That is a
+   design question, not an increment, which is why the steering and
+   pause/resume halves of #932 shipped on their own (#1056) and this one
+   did not.
+
 4. **Multi-workspace in one process already works.** `stella-fleet` runs N
    workers concurrently in one process, each with `cfg.workspace_root` overridden
    per task; nothing below `Config::load` reads `current_dir()`. The three

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -5,9 +5,9 @@
 Option B, the Rust sidecar. It builds its own binary and nothing in
 `stella-cli` links it, so a change here never reaches a `stella` user.
 **This document describes the target surface, not all of it is built:** the
-code today has no approval gate and no SIGTERM drain. Turn cancellation, a
-reverse-request deadline, — as of #1130 — the **DNS-rebinding `Host` guard**,
-— as of #971 phase 2 —
+code today has no approval gate. Turn cancellation, a reverse-request
+deadline, — as of #1130 — the **DNS-rebinding `Host` guard**, — as of #1131 —
+the **SIGTERM drain and `GET /readyz`**, — as of #971 phase 2 —
 **resumable SSE streams** (`seq`, retained history, `?after=` /
 `Last-Event-ID`), — as of #932 — **mid-turn steering and pause/resume**, and —
 as of #931 — **server-owned sessions** (`/v1/sessions`, retained history,
@@ -43,7 +43,8 @@ not in this table is a 404.
 
 | Method | Path | Notes |
 |---|---|---|
-| `GET` | `/healthz` | The **only** unauthenticated route. `{"status":"ok"}` |
+| `GET` | `/healthz` | Unauthenticated. Liveness — is the process alive. `{"status":"ok"}` |
+| `GET` | `/readyz` | Unauthenticated. Readiness — is it safe to send new work. `200 {"state":"ready"}`, or `503` with `"starting"` / `"draining"` (#1131) |
 | `GET` | `/v1/metrics` | Counters as a flat JSON object of integers. Authenticated like every other route, and **pull-only** — see [serve-observability.md](./serve-observability.md) |
 | `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}` |
 | `GET` | `/v1/turns/{id}/events` | SSE `id: <seq>` + `data: <ServerFrame>`. Resumable via `?after=<seq>` or `Last-Event-ID`. One concurrent subscriber; a second gets 409 |
@@ -74,7 +75,9 @@ destination, and which a client written from it gets wrong:
   drives exactly one turn with host-supplied messages and retains nothing.
   Sessions are additive (#931), not a replacement — and note the shape is
   `POST /v1/sessions/{id}/turns` (plural), not the singular `/turn` some
-  diagrams below sketch. `/readyz` does not exist. `/v1/metrics` **does**.
+  diagrams below sketch. `/readyz` **now exists** (#1131) and, like `/healthz`,
+  is unauthenticated — a kubelet has no bearer token. `/v1/metrics` **does**
+  exist and is authenticated.
 - **Reverse RPC is keyed by `request_id` on its own frame types**, not by a
   `call_id` on a `tool_start` / `scope_review` / `ask_user` `AgentEvent`. The
   engine emits dedicated `tool_request` / `provider_request` `ServerFrame`
@@ -367,10 +370,23 @@ mode:
   delegating all execution to the host's `RemoteToolExecutor`.
 - **does not use `stella-store` or `stella-cli` shell hooks server-side** (per
   ADR-033 §4.1) — persistence and policy are the platform's.
-- **Not yet built:** the **graceful shutdown** the CLI lacks — SIGTERM draining
-  in-flight turns to the next step boundary (soft-stop), then exiting. There is
-  no signal handling in `stella-serve/src/` today; only the per-session
-  lifecycle tears down cleanly (the CLI has SIGPIPE + TUI-drop cleanup).
+- **drains on SIGTERM** rather than hard-killing in-flight turns (#1131).
+  `SIGTERM`/`SIGINT` flips `GET /readyz` to `503`, refuses `POST /v1/turns` and
+  both session-creating routes with `503` + `Retry-After`, and asks every live
+  turn to stop at its next step boundary — so an in-flight model call *lands*
+  and its result is kept, which cancelling would have thrown away. Turns that
+  do not reach a boundary inside `STELLA_SERVE_SHUTDOWN_GRACE_SECS` (25s by
+  default, under Kubernetes' 30s `terminationGracePeriodSeconds`) are then
+  cancelled — still a step-boundary unwind that emits `turn_complete`, never a
+  dropped future. The outcome is reported as `drain_completed
+  {drained, cancelled, timed_out}`.
+
+  The **listener stays open for the whole drain**, which is the
+  counter-intuitive part and load-bearing: reverse RPC means a parked turn is
+  finished *by the host* over new connections, so closing the port would strand
+  every turn the drain is waiting for — and would take `/readyz` with it.
+  New work is refused by status code; the port is released when the process
+  exits.
 
 ## Metering parity
 

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -5,8 +5,9 @@
 Option B, the Rust sidecar. It builds its own binary and nothing in
 `stella-cli` links it, so a change here never reaches a `stella` user.
 **This document describes the target surface, not all of it is built:** the
-code today has no approval gate, no `Host`-header guard, and no SIGTERM
-drain. Turn cancellation, a reverse-request deadline, — as of #971 phase 2 —
+code today has no approval gate and no SIGTERM drain. Turn cancellation, a
+reverse-request deadline, — as of #1130 — the **DNS-rebinding `Host` guard**,
+— as of #971 phase 2 —
 **resumable SSE streams** (`seq`, retained history, `?after=` /
 `Last-Event-ID`), — as of #932 — **mid-turn steering and pause/resume**, and —
 as of #931 — **server-owned sessions** (`/v1/sessions`, retained history,
@@ -344,10 +345,24 @@ Oxagen's existing Firecracker/Modal sandbox** (the same isolation
 — the engine does not spawn its own shells server-side. `stella-serve` in server
 mode:
 
-- **binds to a token-gated port only** (no ambient trust). **Not yet built:**
-  reusing the Observatory's DNS-rebinding `Host`-header guard
-  (`stella-observatory/src/lib.rs::host_is_local`) — `stella-serve` performs no
-  `Host` validation today.
+- **binds to a token-gated port only** (no ambient trust), behind a
+  DNS-rebinding `Host`-header guard (`stella-serve/src/hostguard.rs`, #1130)
+  that runs before route dispatch on every route — `/healthz` included, since
+  that is the one route the bearer token does not cover. The policy is derived
+  from the bind rather than hardcoded, because the Observatory's
+  `host_is_local` was written for a loopback-only surface and this one also
+  binds `0.0.0.0` in a container:
+  - **loopback bind** → only loopback names/addresses are accepted;
+  - **non-loopback bind + `STELLA_SERVE_ALLOWED_HOSTS`** → that list, plus
+    loopback (a container's own probe) and the bound literal;
+  - **non-loopback bind, no allow-list** → the guard is *inert*, since nothing
+    can know what the deployment is legitimately called. That arm is named on
+    the `listening` record (`host_guard`) rather than left silent, and refusals
+    are counted (`host_rejected_total`) and reported (`host_rejected`) so a
+    missing allow-list entry is distinguishable from an attack.
+
+  A request with no `Host` at all is permitted, matching the Observatory: a
+  browser `fetch` always sends one, so its absence is not the attack.
 - **disables the local shell/web tool surface by default** (`--tools remote`),
   delegating all execution to the host's `RemoteToolExecutor`.
 - **does not use `stella-store` or `stella-cli` shell hooks server-side** (per

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2316 stella-core/src/driver.rs
+2336 stella-core/src/driver.rs
 3134 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,9 +19,9 @@
 2316 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
-2095 stella-core/src/bus.rs
-2179 stella-core/src/driver.rs
-3133 stella-core/src/driver/tests.rs
+2129 stella-core/src/bus.rs
+2316 stella-core/src/driver.rs
+3134 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs
 1785 stella-model/src/bedrock.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2336 stella-core/src/driver.rs
+2377 stella-core/src/driver.rs
 3134 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -24,7 +24,6 @@
 3134 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs
-1785 stella-model/src/bedrock.rs
 2037 stella-model/src/openai.rs
 1773 stella-model/src/zai/tests.rs
 3249 stella-pipeline/src/pipeline.rs

--- a/stella-cli/src/rules.rs
+++ b/stella-cli/src/rules.rs
@@ -433,6 +433,10 @@ pub(crate) fn attach_rule_guards(registry: &ToolRegistry, rules: &ResolvedRules)
         HookDecision::Allow
     })
     .detach();
+    // After every subscriber is registered, never inside `HookBus::new` — an
+    // observer attached later would miss the one event whose whole job is to
+    // open the stream (#1133).
+    bus.session_started();
     registry.attach_bus(bus);
 }
 

--- a/stella-core/src/bus.rs
+++ b/stella-core/src/bus.rs
@@ -98,6 +98,18 @@ pub mod names {
     pub const AGENT_MESSAGE_DELTA: &str = "agent.message.delta";
     pub const AGENT_MESSAGE_COMPLETED: &str = "agent.message.completed";
     pub const AGENT_TURN_COMPLETED: &str = "agent.turn.completed";
+    /// One committed engine step began. The unit between `agent.turn.*` and
+    /// `model.request.*`: a turn is a sequence of steps, and a step is at most
+    /// one model call plus the tool dispatch that answers it.
+    ///
+    /// Added with the emitters (#1133) rather than pre-declared, because the
+    /// catalog is the contract for what the host emits and a name nothing
+    /// emits is a promise, not a contract.
+    pub const AGENT_STEP_STARTED: &str = "agent.step.started";
+    /// One engine step ended, carrying whether the turn continues. Emitted on
+    /// every exit from a step — including the abort paths — so an observer
+    /// counting starts against completions never leaks.
+    pub const AGENT_STEP_COMPLETED: &str = "agent.step.completed";
     pub const AGENT_ERROR: &str = "agent.error";
     pub const TRANSCRIPT_ENTRY_CREATED: &str = "transcript.entry.created";
     pub const TRANSCRIPT_ENTRY_UPDATED: &str = "transcript.entry.updated";
@@ -199,6 +211,8 @@ pub mod names {
         AGENT_MESSAGE_CREATED,
         AGENT_MESSAGE_DELTA,
         AGENT_MESSAGE_COMPLETED,
+        AGENT_STEP_STARTED,
+        AGENT_STEP_COMPLETED,
         AGENT_TURN_COMPLETED,
         AGENT_ERROR,
         TRANSCRIPT_ENTRY_CREATED,
@@ -661,6 +675,25 @@ impl HookBus {
     /// [`HookBus::emit`] sugar without draft-building noise.
     pub fn emit_named(&self, name: &str, payload: Value) -> HookEvent {
         self.emit(HookEventDraft::new(name, payload))
+    }
+
+    /// Announce that this bus's session has begun (#1133).
+    ///
+    /// Called by whoever *mints* the bus, because that is the only place the
+    /// session boundary actually is. It deliberately does not live in
+    /// [`HookBus::new`]: an observer registered after construction would miss
+    /// an event emitted during it, and the whole point of this one is that it
+    /// is the first thing a subscriber sees. Construct, subscribe, then call
+    /// this.
+    ///
+    /// The payload carries the session id — already on every sealed event —
+    /// so a consumer folding the stream into per-session state has the key on
+    /// the event that opens the fold, without special-casing the envelope.
+    pub fn session_started(&self) -> HookEvent {
+        self.emit_named(
+            names::SESSION_STARTED,
+            serde_json::json!({ "session_id": self.inner.session_id }),
+        )
     }
 
     /// Seal the event and run its blocking policy chain: matching handlers
@@ -1376,7 +1409,8 @@ mod tests {
 
     #[test]
     fn catalog_has_every_documented_name_without_duplicates() {
-        assert_eq!(names::ALL.len(), 88);
+        // 88 + `agent.step.started` / `agent.step.completed` (#1133).
+        assert_eq!(names::ALL.len(), 90);
         let unique: std::collections::HashSet<&str> = names::ALL.iter().copied().collect();
         assert_eq!(unique.len(), names::ALL.len(), "duplicate catalog name");
         for name in names::ALL {

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -374,6 +374,21 @@ pub struct Engine<'a> {
     pub(crate) bus: Option<&'a crate::bus::HookBus>,
 }
 
+/// Why a turn that never produced a terminal step ends.
+///
+/// A function rather than an inline `format!` because it is now written by
+/// two loops: [`Engine::run_turn_with_sender`] and any host driving
+/// [`Engine::run_step`] itself (`stella-serve`, #1129). This string reaches a
+/// transcript, a log, and a user's terminal — two copies of it would drift,
+/// and the drift would read as two different failures.
+#[must_use]
+pub fn step_cap_reason(max_steps: usize) -> String {
+    format!(
+        "reached the step cap ({max_steps}) without completing — this is the belt-and-suspenders \
+         backstop; loop detection should normally catch a stuck turn first"
+    )
+}
+
 /// Upper bound on tool calls from one step executing concurrently. Tools
 /// are I/O-bound (process spawns, file reads), so this caps descriptor and
 /// process pressure, not CPU.
@@ -512,6 +527,15 @@ impl<'a> Engine<'a> {
         self
     }
 
+    /// The step cap this engine enforces — the loop bound a host driving
+    /// [`Engine::run_step`] itself must apply, since the cap belongs to the
+    /// engine's config and a host tracking its own copy is a second source of
+    /// truth for the same number (#1129).
+    #[must_use]
+    pub fn max_steps(&self) -> usize {
+        self.config.max_steps
+    }
+
     /// Attach an extension hook bus, so the turn, step and model-call
     /// boundaries this engine already crosses become observable (#1133).
     ///
@@ -630,11 +654,7 @@ impl<'a> Engine<'a> {
             }
         }
 
-        let reason = format!(
-            "reached the step cap ({}) without completing — this is the belt-and-suspenders \
-             backstop; loop detection should normally catch a stuck turn first",
-            self.config.max_steps
-        );
+        let reason = step_cap_reason(self.config.max_steps);
         let _ = events.send(AgentEvent::Error {
             message: reason.clone(),
             retryable: false,

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -83,9 +83,12 @@ use stella_protocol::{
 };
 
 use crate::budget::{BudgetAxis, BudgetGuard, BudgetOutcome};
+use crate::bus;
 use crate::compaction::compact_measured;
 use crate::receipts::TranscriptRevision;
+use lifecycle::{step_outcome_label, turn_outcome_payload};
 
+mod lifecycle;
 mod loop_evidence;
 mod truncation;
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
@@ -358,6 +361,17 @@ pub struct Engine<'a> {
     /// become the model's next observation, and a latched soft stop ends
     /// the turn keeping every completed step. `None` adds zero work.
     pub(crate) steering: Option<&'a dyn crate::ports::TurnSteering>,
+    /// Extension hook bus ([`crate::bus::HookBus`]), off by default.
+    /// Attached via [`Engine::with_bus`]; receives the turn/step/model-call
+    /// lifecycle events an out-of-process host uses to observe and, per
+    /// ADR-033, apply policy at (#1133). `None` adds zero work — every emit
+    /// site is behind the same `if let Some(bus)`.
+    ///
+    /// Strictly **observer-only**. These names are not on the blocking
+    /// allowlist, so `emit_named` dispatches them without a policy chain: an
+    /// extension can watch a step begin, it cannot veto one. The interception
+    /// points stay where they already are, on the tool-call path.
+    pub(crate) bus: Option<&'a crate::bus::HookBus>,
 }
 
 /// Upper bound on tool calls from one step executing concurrently. Tools
@@ -423,6 +437,7 @@ impl<'a> Engine<'a> {
             calibration: None,
             gate: None,
             steering: None,
+            bus: None,
         }
     }
 
@@ -457,6 +472,7 @@ impl<'a> Engine<'a> {
             calibration: self.calibration,
             gate: self.gate,
             steering: self.steering,
+            bus: self.bus,
         }
     }
 
@@ -494,6 +510,33 @@ impl<'a> Engine<'a> {
     pub fn with_steering(mut self, steering: &'a dyn crate::ports::TurnSteering) -> Self {
         self.steering = Some(steering);
         self
+    }
+
+    /// Attach an extension hook bus, so the turn, step and model-call
+    /// boundaries this engine already crosses become observable (#1133).
+    ///
+    /// Before this, the only production emitter on the bus was the tool
+    /// registry: an extension could see every tool call and nothing about the
+    /// turn that made them — not that a turn started, not that a model call
+    /// began or what it cost. The catalog and `emit_named` both already
+    /// existed; what was missing was the call sites, which are here because
+    /// this is where the boundaries are.
+    ///
+    /// Observer-only, by construction: see the `bus` field.
+    pub fn with_bus(mut self, bus: &'a crate::bus::HookBus) -> Self {
+        self.bus = Some(bus);
+        self
+    }
+
+    /// Emit one lifecycle event, if a bus is attached.
+    ///
+    /// The payload closure is only called when there *is* a bus, so a
+    /// bus-less engine — every CLI turn today — does not pay to build a
+    /// `Value` nobody will read.
+    pub(crate) fn emit_lifecycle(&self, name: &str, payload: impl FnOnce() -> serde_json::Value) {
+        if let Some(bus) = self.bus {
+            bus.emit_named(name, payload());
+        }
     }
 
     /// Fire `SessionStart` hooks once and return any stdout they produced —
@@ -562,6 +605,13 @@ impl<'a> Engine<'a> {
         let _ = events.send(AgentEvent::Stage {
             name: StageKind::Execute,
         });
+        self.emit_lifecycle(bus::names::AGENT_TURN_STARTED, || {
+            serde_json::json!({
+                "message_count": messages.len(),
+                "max_steps": self.config.max_steps,
+                "role": self.call_role,
+            })
+        });
         // The turn's state is OWNED for the duration and written back to the
         // caller's borrows when it drops — including on the hard-cancel path,
         // where the future is dropped mid-step and there is no exit to copy
@@ -573,6 +623,9 @@ impl<'a> Engine<'a> {
                 .await
                 .into_turn_outcome()
             {
+                self.emit_lifecycle(bus::names::AGENT_TURN_COMPLETED, || {
+                    turn_outcome_payload(&outcome, turn.state.step)
+                });
                 return outcome;
             }
         }
@@ -586,10 +639,17 @@ impl<'a> Engine<'a> {
             message: reason.clone(),
             retryable: false,
         });
-        TurnOutcome::Aborted {
+        let outcome = TurnOutcome::Aborted {
             reason,
             cost_usd: turn.state.total_cost_usd,
-        }
+        };
+        // The step-cap exit is a turn ending like any other. Emitting only
+        // from the loop above would leave an observer's `turn.started`
+        // unpaired on precisely the runaway turn it most wants to see.
+        self.emit_lifecycle(bus::names::AGENT_TURN_COMPLETED, || {
+            turn_outcome_payload(&outcome, turn.state.step)
+        });
+        outcome
     }
 
     /// Run exactly ONE committed step against `state`, the unit a durable host
@@ -633,6 +693,47 @@ impl<'a> Engine<'a> {
     /// serving many sessions gives each its own OS thread with its own
     /// current-thread runtime and bridges with `Send` channels.
     pub async fn run_step(&self, state: &mut TurnState, events: &EventSender) -> StepOutcome {
+        // No bus, no wrapper: a CLI turn must not pay for a boundary nobody
+        // observes, and the `step` copy plus two closures below are exactly
+        // that cost.
+        let Some(_) = self.bus else {
+            return self.run_step_inner(state, events).await;
+        };
+        // Read before the step runs, because a committed step advances it —
+        // `started` and `completed` have to name the same step or an observer
+        // cannot pair them.
+        let step = state.step;
+        self.emit_lifecycle(
+            bus::names::AGENT_STEP_STARTED,
+            || serde_json::json!({ "step": step }),
+        );
+        let outcome = self.run_step_inner(state, events).await;
+        // Emitted here rather than at each of the step's exits, and that is
+        // the whole reason this wrapper exists: `run_step_inner` returns from
+        // roughly a dozen places (cancel, soft stop, four budget checks, loop
+        // detection, model failure, dispatch), and a `completed` emit
+        // distributed across all of them is one added early-return away from
+        // being silently unpaired.
+        self.emit_lifecycle(bus::names::AGENT_STEP_COMPLETED, || {
+            serde_json::json!({
+                "step": step,
+                "outcome": step_outcome_label(&outcome),
+                "cost_usd": state.total_cost_usd,
+            })
+        });
+        outcome
+    }
+
+    /// The step itself. See [`Engine::run_step`] for why the lifecycle
+    /// emission wraps this rather than living inside it.
+    ///
+    /// One honest gap: a caller that **drops** the turn future mid-step gets
+    /// no `agent.step.completed`, because there is no return to emit it from.
+    /// That is the same loss a hard drop already inflicts on usage accounting
+    /// and speculation (see `crate::step::CancelToken`), and the reason the
+    /// engine's docs tell hosts to cancel rather than drop. A *cancel*
+    /// returns normally and does emit.
+    async fn run_step_inner(&self, state: &mut TurnState, events: &EventSender) -> StepOutcome {
         // Before the gate, not after: a turn that is both paused and cancelled
         // must not park waiting for a resume that is never coming.
         if let Some(cancelled) = state.cancel_outcome(events) {
@@ -727,6 +828,23 @@ impl<'a> Engine<'a> {
             return aborted.into();
         }
 
+        // The model-call boundary. `run_model_call` spans the whole retry
+        // ladder, so `started`/`completed` bracket the *logical* call rather
+        // than each attempt — a retried call is one request from an
+        // observer's point of view, and the retries are already reported as
+        // their own `AgentEvent`s.
+        //
+        // Payload hygiene: counts and identifiers, never transcript content.
+        // A message count says how large the request was without saying what
+        // was in it, which is what an observer applying policy at this
+        // boundary actually needs.
+        self.emit_lifecycle(bus::names::MODEL_REQUEST_STARTED, || {
+            serde_json::json!({
+                "step": state.step,
+                "message_count": state.messages.len(),
+                "role": self.call_role,
+            })
+        });
         let committed = match self
             .run_model_call(
                 state.step,
@@ -740,12 +858,31 @@ impl<'a> Engine<'a> {
         {
             Ok(committed) => committed,
             Err(reason) => {
+                // `reason` is the engine's own summary of why the call could
+                // not commit (retries exhausted, an unretryable provider
+                // error). It is the same string that reaches the transcript
+                // and `AgentEvent::Error`, so emitting it here adds no
+                // exposure that the turn does not already have.
+                self.emit_lifecycle(
+                    bus::names::MODEL_REQUEST_FAILED,
+                    || serde_json::json!({ "step": state.step, "reason": reason }),
+                );
                 return StepOutcome::Aborted {
                     reason,
                     cost_usd: state.total_cost_usd,
                 };
             }
         };
+        self.emit_lifecycle(bus::names::MODEL_REQUEST_COMPLETED, || {
+            serde_json::json!({
+                "step": state.step,
+                "model": committed.result.model,
+                "cost_usd": committed.result.cost_usd,
+                "input_tokens": committed.result.usage.input_tokens,
+                "output_tokens": committed.result.usage.output_tokens,
+                "tool_calls": committed.result.tool_calls.len(),
+            })
+        });
         state.calibration_model = Some(committed.result.model.clone());
         state.total_cost_usd += committed.result.cost_usd;
 

--- a/stella-core/src/driver/lifecycle.rs
+++ b/stella-core/src/driver/lifecycle.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Payload shaping for the `HookBus` lifecycle events the driver emits
+//! (#1133).
+//!
+//! Separated from the emit sites deliberately: *where* an event fires is a
+//! property of the engine's control flow and belongs next to the boundary,
+//! but *what* it carries is a contract with observers — and that contract has
+//! one rule worth isolating so it is hard to break by accident.
+//!
+//! # The rule: counts and identifiers, never transcript content
+//!
+//! These events are observability, and an observability stream that carries
+//! prompts and answers is a second copy of the conversation in whatever an
+//! extension does with it — a log file, a metrics backend, a webhook. The
+//! transcript already has a considered exposure story; this must not quietly
+//! open a parallel one.
+//!
+//! So: message *counts*, token *counts*, cost, model id, step index. The one
+//! free-text field anywhere here is an abort `reason`, which is the engine's
+//! own diagnosis of why a turn ended and already reaches `AgentEvent::Error`
+//! and the transcript.
+
+use super::{StepOutcome, TurnOutcome};
+
+/// What `agent.turn.completed` carries.
+///
+/// The reason string rides only the *aborted* arm: a completed turn's answer
+/// text is transcript content and has no business on an observability event,
+/// while an abort reason is the engine's own diagnosis and is what an
+/// observer is watching this boundary for.
+pub(super) fn turn_outcome_payload(outcome: &TurnOutcome, steps: usize) -> serde_json::Value {
+    match outcome {
+        TurnOutcome::Completed { cost_usd, .. } => serde_json::json!({
+            "outcome": "completed",
+            "steps": steps,
+            "cost_usd": cost_usd,
+        }),
+        TurnOutcome::Aborted { reason, cost_usd } => serde_json::json!({
+            "outcome": "aborted",
+            "steps": steps,
+            "cost_usd": cost_usd,
+            "reason": reason,
+        }),
+    }
+}
+
+/// How one step ended, as the lifecycle stream names it.
+///
+/// Three labels rather than the full reason string: an observer pairing
+/// `agent.step.started` with `agent.step.completed` wants to know whether the
+/// turn continues, and the reason a turn *ended* is already carried by
+/// `agent.turn.completed`. Repeating it here would put a model-authored or
+/// provider-authored string on two events instead of one.
+pub(super) fn step_outcome_label(outcome: &StepOutcome) -> &'static str {
+    match outcome {
+        StepOutcome::Continue => "continue",
+        StepOutcome::Done { .. } => "done",
+        StepOutcome::Aborted { .. } => "aborted",
+    }
+}

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -3046,6 +3046,7 @@ async fn a_none_ceiling_leaves_tool_dispatch_unbounded() {
 mod audit_fixes;
 mod budget_boundaries;
 mod compute_passes;
+mod lifecycle_bus;
 mod steer_midturn;
 mod usage_completeness;
 mod zero_copy_request;

--- a/stella-core/src/driver/tests/lifecycle_bus.rs
+++ b/stella-core/src/driver/tests/lifecycle_bus.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The turn/step/model-call lifecycle on the `HookBus` (#1133).
+//!
+//! The catalog and `emit_named` both already existed; what did not was any
+//! production code path that called one with the other. Until this, the only
+//! emitter on the bus was the tool registry, so an extension could see every
+//! tool call and nothing about the turn that made them.
+//!
+//! These tests assert on the *pairing* as much as the presence: an observer
+//! that counts `agent.step.started` against `agent.step.completed` must never
+//! leak, on any exit path a step has.
+
+use std::sync::{Arc, Mutex};
+
+use super::super::*;
+use crate::bus::{HookBus, HookEvent, names};
+use serde_json::Value;
+use stella_protocol::{CompletionResult, ToolSchema};
+
+/// Collects every event the bus dispatches, in order.
+#[derive(Default)]
+struct Recorder {
+    events: Mutex<Vec<HookEvent>>,
+}
+
+impl Recorder {
+    /// Register on a fresh bus and hand back both halves.
+    fn attach() -> (HookBus, Arc<Recorder>) {
+        let bus = HookBus::new("lifecycle-test");
+        let recorder = Arc::new(Recorder::default());
+        let sink = Arc::clone(&recorder);
+        bus.on("*", move |event| {
+            sink.events.lock().unwrap().push(event.clone());
+            Ok(())
+        })
+        .detach();
+        (bus, recorder)
+    }
+
+    fn names(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|e| e.name.clone())
+            .collect()
+    }
+
+    fn count(&self, name: &str) -> usize {
+        self.names().iter().filter(|n| *n == name).count()
+    }
+
+    fn first(&self, name: &str) -> Option<HookEvent> {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.name == name)
+            .cloned()
+    }
+}
+
+/// A provider that answers once with text and then keeps answering — enough
+/// to drive a turn that completes on its first step.
+struct OneShotProvider;
+
+#[async_trait::async_trait]
+impl Provider for OneShotProvider {
+    fn id(&self) -> &str {
+        "lifecycle-mock"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Ok(CompletionResult {
+            text: "the answer".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage {
+                reported: true,
+                input_tokens: 11,
+                output_tokens: 7,
+                cached_input_tokens: 0,
+                cache_write_tokens: 0,
+            },
+            model: "mock-1".to_string(),
+            cost_usd: 0.25,
+            finish_reason: None,
+        })
+    }
+}
+
+/// A provider that always fails unretryably, so the model-call boundary's
+/// failure arm is reached.
+struct AlwaysFailsProvider;
+
+#[async_trait::async_trait]
+impl Provider for AlwaysFailsProvider {
+    fn id(&self) -> &str {
+        "lifecycle-fail"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Err(ProviderError::Auth("no credential".to_string()))
+    }
+}
+
+struct NoTools;
+
+#[async_trait::async_trait]
+impl ToolExecutor for NoTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        Vec::new()
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: String::new(),
+        }
+    }
+}
+
+struct NoSleep;
+
+#[async_trait::async_trait]
+impl crate::retry::Sleeper for NoSleep {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+async fn run_one_turn(provider: &dyn Provider, bus: &HookBus) -> TurnOutcome {
+    let tools = NoTools;
+    let sleeper = NoSleep;
+    let engine =
+        Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper).with_bus(bus);
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("hi")];
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    engine.run_turn(&mut messages, &mut budget, &tx).await
+}
+
+/// The #1133 acceptance for the turn and step boundaries: a registered
+/// observer sees the turn open, the step open and close, and the turn close.
+#[tokio::test]
+async fn a_completed_turn_emits_the_whole_lifecycle_in_order() {
+    let (bus, recorder) = Recorder::attach();
+    let outcome = run_one_turn(&OneShotProvider, &bus).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+    let names = recorder.names();
+    let ordered: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
+        .filter(|n| n.starts_with("agent.") || n.starts_with("model."))
+        .collect();
+    assert_eq!(
+        ordered,
+        vec![
+            names::AGENT_TURN_STARTED,
+            names::AGENT_STEP_STARTED,
+            names::MODEL_REQUEST_STARTED,
+            names::MODEL_REQUEST_COMPLETED,
+            names::AGENT_STEP_COMPLETED,
+            names::AGENT_TURN_COMPLETED,
+        ],
+        "the lifecycle nests: turn wraps step wraps model call",
+    );
+}
+
+/// The model-call event carries what an observer applying policy at that
+/// boundary needs — which model, what it cost, how big the answer was — and
+/// no transcript content.
+#[tokio::test]
+async fn the_model_call_events_carry_counts_and_identifiers_not_content() {
+    let (bus, recorder) = Recorder::attach();
+    run_one_turn(&OneShotProvider, &bus).await;
+
+    let started = recorder
+        .first(names::MODEL_REQUEST_STARTED)
+        .expect("the model call is announced");
+    assert_eq!(started.payload["message_count"], 1);
+    assert_eq!(started.payload["step"], 0);
+
+    let completed = recorder
+        .first(names::MODEL_REQUEST_COMPLETED)
+        .expect("the model call reports its result");
+    assert_eq!(completed.payload["model"], "mock-1");
+    assert_eq!(completed.payload["cost_usd"], 0.25);
+    assert_eq!(completed.payload["input_tokens"], 11);
+    assert_eq!(completed.payload["output_tokens"], 7);
+
+    // The answer text is transcript content and has no business here.
+    let rendered = serde_json::to_string(&completed.payload).unwrap();
+    assert!(
+        !rendered.contains("the answer"),
+        "payload must not carry transcript content: {rendered}"
+    );
+}
+
+/// A turn whose model call fails still closes both the step and the turn it
+/// opened. This is the path the wrapper exists for: `run_step_inner` returns
+/// early here, and a `completed` emit distributed across the step's exits
+/// would be one refactor away from missing it.
+#[tokio::test]
+async fn a_failed_model_call_still_closes_its_step_and_turn() {
+    let (bus, recorder) = Recorder::attach();
+    let outcome = run_one_turn(&AlwaysFailsProvider, &bus).await;
+    assert!(matches!(outcome, TurnOutcome::Aborted { .. }));
+
+    assert_eq!(recorder.count(names::MODEL_REQUEST_FAILED), 1);
+    assert_eq!(recorder.count(names::MODEL_REQUEST_COMPLETED), 0);
+    assert_eq!(
+        recorder.count(names::AGENT_STEP_STARTED),
+        recorder.count(names::AGENT_STEP_COMPLETED),
+        "every started step must be closed, on the failure path too",
+    );
+    assert_eq!(recorder.count(names::AGENT_TURN_STARTED), 1);
+    assert_eq!(recorder.count(names::AGENT_TURN_COMPLETED), 1);
+
+    let completed = recorder.first(names::AGENT_TURN_COMPLETED).unwrap();
+    assert_eq!(completed.payload["outcome"], "aborted");
+    assert!(completed.payload["reason"].is_string());
+}
+
+/// The step-completed event names whether the turn continues, which is what
+/// an observer pairing starts with completions actually reads.
+#[tokio::test]
+async fn a_step_reports_how_it_ended() {
+    let (bus, recorder) = Recorder::attach();
+    run_one_turn(&OneShotProvider, &bus).await;
+
+    let completed = recorder
+        .first(names::AGENT_STEP_COMPLETED)
+        .expect("the step closes");
+    assert_eq!(completed.payload["outcome"], "done");
+    assert_eq!(completed.payload["step"], 0);
+    assert_eq!(completed.payload["cost_usd"], 0.25);
+}
+
+/// No bus attached, no behaviour change: this is what makes the emitters
+/// free for every CLI turn, and it is worth pinning because the wrapper adds
+/// a branch on the hottest path in the engine.
+#[tokio::test]
+async fn an_engine_without_a_bus_runs_identically() {
+    let tools = NoTools;
+    let sleeper = NoSleep;
+    let engine = Engine::with_sleeper(&OneShotProvider, &tools, EngineConfig::default(), &sleeper);
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("hi")];
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+}
+
+/// `session.started` is emitted by whoever mints the bus, after subscribing —
+/// the ordering matters, because an observer registered later would miss the
+/// one event whose job is to open the stream.
+#[test]
+fn session_started_reaches_an_observer_registered_before_it() {
+    let (bus, recorder) = Recorder::attach();
+    bus.session_started();
+    assert_eq!(recorder.count(names::SESSION_STARTED), 1);
+    let event = recorder.first(names::SESSION_STARTED).unwrap();
+    assert_eq!(event.payload["session_id"], "lifecycle-test");
+    assert_eq!(event.session_id, "lifecycle-test");
+}
+
+/// Every lifecycle name this engine emits is in the catalog. The catalog is
+/// the contract for what the host emits, so a name that drifted out of it
+/// would be a private extension masquerading as a documented event.
+#[tokio::test]
+async fn every_emitted_lifecycle_name_is_in_the_catalog() {
+    let (bus, recorder) = Recorder::attach();
+    bus.session_started();
+    run_one_turn(&OneShotProvider, &bus).await;
+    run_one_turn(&AlwaysFailsProvider, &bus).await;
+
+    for name in recorder.names() {
+        assert!(
+            names::ALL.contains(&name.as_str()),
+            "{name} is emitted but not declared in the catalog",
+        );
+    }
+}

--- a/stella-core/src/subagent.rs
+++ b/stella-core/src/subagent.rs
@@ -635,6 +635,13 @@ impl Engine<'_> {
             calibration: self.calibration,
             gate: self.gate,
             steering,
+            // The child rides the parent's bus. A sub-agent's steps and model
+            // calls are work the session really did — billed to it, visible
+            // in its spend — so hiding them from an observer would make the
+            // lifecycle stream disagree with the cost. `HookEvent` carries
+            // `agent_id`, which is what lets a consumer tell parent work from
+            // child work without a second bus.
+            bus: self.bus,
         };
 
         // The child's private transcript. It is a local: nothing outside

--- a/stella-engine/src/lib.rs
+++ b/stella-engine/src/lib.rs
@@ -101,7 +101,9 @@ pub use stella_core::step::{
 };
 
 // ── the engine those steps run on ─────────────────────────────────────────
-pub use stella_core::driver::{Engine, EngineConfig, SOFT_STOP_REASON, TurnOutcome};
+pub use stella_core::driver::{
+    Engine, EngineConfig, SOFT_STOP_REASON, TurnOutcome, step_cap_reason,
+};
 pub use stella_core::estimator::CalibrationMap;
 pub use stella_core::event_sender::{EventSendError, EventSender};
 

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -9,14 +9,19 @@
 //!   transport decoder. `Converse` returns an identical `CompletionResult`,
 //!   so nothing downstream of the adapter can tell the difference; what the
 //!   scoping does cost is everything that needs the response *while it is
-//!   still arriving*. This is now the only adapter in the crate that does
-//!   not override `Provider::complete_observed`, so a Bedrock turn emits no
-//!   `TextDelta` previews (the deck stays blank until the whole answer
-//!   lands, #612) and its read-only tool calls are never announced, so the
-//!   engine's speculative execution never fires on it. The event-stream
-//!   decoder is what closes both gaps; until then the whole generation has
-//!   to fit inside one read, which is why this adapter takes
-//!   `crate::http::unary_client` rather than the shared streaming client.
+//!   still arriving*. [`BedrockProvider::complete_observed_ref`] recovers
+//!   the half of that which does not need incremental arrival: the answer
+//!   is announced as one terminal `text_delta`, so an observing host
+//!   renders a completed answer instead of nothing at all (#1132). What
+//!   stays out of reach is genuine token-by-token preview (the deck fills
+//!   in one write rather than progressively, #612) and mid-stream tool-call
+//!   announcement, so the engine's speculative execution never fires on
+//!   this adapter — a call announced only once the whole body has landed
+//!   would start speculation microseconds before dispatch asks for it,
+//!   which is overhead wearing a fix's clothing. The event-stream decoder
+//!   is what closes both; until then the whole generation has to fit inside
+//!   one read, which is why this adapter takes `crate::http::unary_client`
+//!   rather than the shared streaming client.
 //! - **Explicit credentials, not the full AWS chain.** The adapter takes
 //!   access key / secret / optional session token directly;
 //!   [`crate::credential::BedrockCredentials`] resolves the secret, session
@@ -38,7 +43,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_protocol::{
     CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, FinishReason,
-    MessageRole, ProviderError, ToolCall,
+    MessageRole, ProviderError, ToolCall, ToolCallObserver,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -839,6 +844,38 @@ impl Provider for BedrockProvider {
             finish_reason,
         })
     }
+
+    /// The whole answer as one terminal `text_delta`.
+    ///
+    /// Every sibling adapter threads the observer through an SSE parse loop
+    /// and emits a delta per chunk. Converse is not a stream — it answers
+    /// with one JSON body — so there is no finer-grained emission to make,
+    /// and this is an honest single-chunk announcement rather than a
+    /// masked bug: the `text_delta` contract is explicitly best-effort and
+    /// lossy, with `CompletionResult::text` as the definitive answer.
+    ///
+    /// Emitting *something* matters because the alternative is the trait's
+    /// default, which discards the observer entirely. A host watching the
+    /// observed path — `stella-tui`'s live rendering, `stella-serve`'s
+    /// `RemoteProvider` forwarding deltas to a browser — then sees total
+    /// silence for the whole call and renders as if the process hung
+    /// (#1132).
+    ///
+    /// Empty text is not announced: a tool-call-only turn has no answer
+    /// text, and a zero-length delta would make an observer counting
+    /// deltas believe an answer arrived. Tool calls are deliberately not
+    /// announced either — see the module docs.
+    async fn complete_observed_ref(
+        &self,
+        req: CompletionRequestRef<'_>,
+        observer: &dyn ToolCallObserver,
+    ) -> Result<CompletionResult, ProviderError> {
+        let result = self.complete_ref(req).await?;
+        if !result.text.is_empty() {
+            observer.text_delta(&result.text);
+        }
+        Ok(result)
+    }
 }
 
 /// AWS Signature Version 4 over explicit inputs — no ambient clock, no
@@ -1188,598 +1225,6 @@ pub(crate) mod sigv4 {
     }
 }
 
+
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use stella_protocol::CompletionRequest;
-    use stella_protocol::tool::ToolSchema;
-    use stella_protocol::{ToolOutput, ToolResult};
-    use wiremock::matchers::{body_string_contains, header_regex, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    /// The audio arm of [`attachment_block`] is out of reach only because
-    /// `BEDROCK_CAPS` switches audio off. Flipping that bool is a routine
-    /// one-line edit, so the arm it lands in has to degrade like every other
-    /// unsupported attachment instead of aborting the process mid-turn.
-    #[test]
-    fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
-        use crate::attachment::{DialectCaps, wire_parts};
-        use stella_protocol::{Attachment, AttachmentSource};
-        let flipped = DialectCaps {
-            images: true,
-            pdfs: true,
-            audio: true,
-            video: true,
-        };
-        let attachment = Attachment {
-            name: "song.mp3".into(),
-            media_type: "audio/mpeg".into(),
-            byte_len: 3,
-            source: AttachmentSource::Data {
-                base64: "YWJj".into(),
-            },
-        };
-        let blocks: Vec<_> = wire_parts(&[attachment], flipped)
-            .into_iter()
-            .map(attachment_block)
-            .collect();
-        let [block] = blocks.as_slice() else {
-            panic!("expected one degrade block, got {blocks:?}");
-        };
-        let note = block
-            .text
-            .as_deref()
-            .unwrap_or_else(|| panic!("expected a text degrade note, got {block:?}"));
-        assert!(
-            note.contains("audio/mpeg"),
-            "the note names what was attached: {note}"
-        );
-    }
-
-    #[test]
-    fn user_attachments_map_to_converse_blocks_with_format_allowlists() {
-        use stella_protocol::{Attachment, AttachmentSource};
-        let att = |name: &str, mime: &str, b64: &str| Attachment {
-            name: name.into(),
-            media_type: mime.into(),
-            byte_len: 3,
-            source: AttachmentSource::Data { base64: b64.into() },
-        };
-        let messages = vec![CompletionMessage::user_with_attachments(
-            "look",
-            vec![
-                att("a.png", "image/png", "aW1n"),
-                att("spec v2.pdf", "application/pdf", "cGRm"),
-                att("d.mov", "video/quicktime", "dmlk"),
-                att("weird.tiff", "image/tiff", "dGlm"),
-            ],
-        )];
-        let (_, mapped) = to_bedrock_messages(&messages);
-        assert_eq!(mapped.len(), 1);
-        let json = serde_json::to_value(&mapped[0]).unwrap();
-        let content = json["content"].as_array().unwrap();
-        assert_eq!(content.len(), 5, "{json}");
-        assert_eq!(content[0]["image"]["format"], "png");
-        assert_eq!(content[0]["image"]["source"]["bytes"], "aW1n");
-        // Document name sanitized to Converse's allowed character set
-        // (the period is not allowed).
-        assert_eq!(content[1]["document"]["format"], "pdf");
-        assert_eq!(content[1]["document"]["name"], "spec v2-pdf");
-        assert_eq!(content[2]["video"]["format"], "mov");
-        // TIFF is outside the Converse image allowlist: degrade note.
-        assert!(
-            content[3]["text"].as_str().unwrap().contains("image/tiff"),
-            "{json}"
-        );
-        assert_eq!(content[4]["text"], "look");
-    }
-
-    #[test]
-    fn cache_points_are_gated_to_supporting_model_families() {
-        assert!(supports_cache_points(
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
-        ));
-        assert!(supports_cache_points("us.amazon.nova-pro-v1:0"));
-        assert!(!supports_cache_points("meta.llama4-maverick-17b-v1:0"));
-    }
-
-    fn test_provider(server_uri: &str) -> BedrockProvider {
-        BedrockProvider::new(
-            ApiKey::new("AKIDEXAMPLE"),
-            ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
-            None,
-            "us-east-1",
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        )
-        .with_base_url(server_uri.to_string())
-    }
-
-    #[test]
-    fn to_bedrock_messages_hoists_system_and_frames_tool_round_trips() {
-        let messages = vec![
-            CompletionMessage::system("You are a coding agent."),
-            CompletionMessage::user("read a.rs"),
-            CompletionMessage {
-                role: MessageRole::Assistant,
-                content: String::new(),
-                tool_calls: vec![ToolCall {
-                    call_id: "tooluse_abc".into(),
-                    name: "read_file".into(),
-                    input: serde_json::json!({"path": "a.rs"}),
-                }],
-                tool_results: vec![],
-                attachments: Vec::new(),
-            },
-            CompletionMessage {
-                role: MessageRole::Tool,
-                content: String::new(),
-                tool_calls: vec![],
-                tool_results: vec![ToolResult {
-                    call_id: "tooluse_abc".into(),
-                    output: ToolOutput::Ok {
-                        content: "fn main(){}".into(),
-                    },
-                }],
-                attachments: Vec::new(),
-            },
-        ];
-        let (system, mapped) = to_bedrock_messages(&messages);
-        assert_eq!(system.len(), 1);
-        assert_eq!(mapped.len(), 3);
-        assert_eq!(mapped[1].role, "assistant");
-        let tool_use = mapped[1].content[0].tool_use.as_ref().unwrap();
-        assert_eq!(tool_use.tool_use_id, "tooluse_abc");
-        // Converse frames tool results as a user-role message.
-        assert_eq!(mapped[2].role, "user");
-        let tool_result = mapped[2].content[0].tool_result.as_ref().unwrap();
-        assert_eq!(tool_result.tool_use_id, "tooluse_abc");
-        assert_eq!(tool_result.content[0].text, "fn main(){}");
-        assert_eq!(tool_result.status, None);
-    }
-
-    #[test]
-    fn failed_tool_results_carry_error_status_not_a_text_prefix() {
-        let messages = vec![CompletionMessage {
-            role: MessageRole::Tool,
-            content: String::new(),
-            tool_calls: vec![],
-            tool_results: vec![ToolResult {
-                call_id: "tooluse_1".into(),
-                output: ToolOutput::Error {
-                    message: "no such file".into(),
-                },
-            }],
-            attachments: Vec::new(),
-        }];
-        let (_, mapped) = to_bedrock_messages(&messages);
-        let tool_result = mapped[0].content[0].tool_result.as_ref().unwrap();
-        assert_eq!(tool_result.status, Some("error"));
-        assert_eq!(tool_result.content[0].text, "no such file");
-    }
-
-    #[tokio::test]
-    async fn complete_posts_a_signed_converse_request_and_parses_text() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path(
-                "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
-            ))
-            .and(header_regex(
-                "authorization",
-                r"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/\d{8}/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=[0-9a-f]{64}$",
-            ))
-            .and(header_regex("x-amz-date", r"^\d{8}T\d{6}Z$"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "Hello from Bedrock"}]}},
-                "stopReason": "end_turn",
-                "usage": {"inputTokens": 9, "outputTokens": 5, "cacheReadInputTokens": 3, "cacheWriteInputTokens": 2}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let req = CompletionRequest {
-            messages: vec![CompletionMessage::user("hi")],
-            max_output_tokens: Some(1024),
-            temperature: Some(0.0),
-            effort: None,
-            tools: vec![],
-            reasoning: None,
-            params: None,
-        };
-
-        let result = provider
-            .complete(req)
-            .await
-            .expect("completion should succeed");
-        assert_eq!(result.text, "Hello from Bedrock");
-        // Converse reports cache reads OUTSIDE `inputTokens`; the adapter
-        // folds them back in so cached stays a subset of input (9 + 3).
-        assert_eq!(result.usage.input_tokens, 12);
-        assert_eq!(result.usage.output_tokens, 5);
-        assert_eq!(result.usage.cached_input_tokens, 3);
-        assert_eq!(result.usage.cache_write_tokens, 2);
-        assert!(result.usage.reported);
-    }
-
-    /// Prompt caching on Converse is opt-in via `cachePoint` blocks: one
-    /// after the system blocks (tools+system tier) and one at the tail of
-    /// the last message (conversation-incremental tier). Without them
-    /// Bedrock caches nothing.
-    #[tokio::test]
-    async fn complete_sends_cache_points_for_claude_models() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(body_string_contains(
-                "\"cachePoint\":{\"type\":\"default\"}",
-            ))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "stopReason": "end_turn",
-                "usage": {"inputTokens": 4, "outputTokens": 1}
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let req = CompletionRequest {
-            messages: vec![
-                CompletionMessage::system("You are a coding agent."),
-                CompletionMessage::user("hi"),
-            ],
-            max_output_tokens: None,
-            temperature: None,
-            effort: None,
-            tools: vec![],
-            reasoning: None,
-            params: None,
-        };
-        let result = provider
-            .complete(req)
-            .await
-            .expect("completion should succeed");
-        assert_eq!(result.text, "ok");
-    }
-
-    #[tokio::test]
-    async fn complete_parses_tool_use_blocks_into_tool_calls() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [
-                    {"text": "Let me read that."},
-                    {"toolUse": {"toolUseId": "tooluse_xyz", "name": "read_file", "input": {"path": "src/lib.rs"}}}
-                ]}},
-                "stopReason": "tool_use",
-                "usage": {"inputTokens": 30, "outputTokens": 12}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let req = CompletionRequest {
-            messages: vec![CompletionMessage::user("read src/lib.rs")],
-            max_output_tokens: None,
-            temperature: None,
-            effort: None,
-            tools: vec![ToolSchema {
-                name: "read_file".into(),
-                description: "Read a file".into(),
-                input_schema: serde_json::json!({"type":"object"}),
-                read_only: false,
-                speculation_safe: false,
-            }],
-            reasoning: None,
-            params: None,
-        };
-
-        let result = provider.complete(req).await.expect("should succeed");
-        assert_eq!(result.text, "Let me read that.");
-        assert_eq!(result.tool_calls.len(), 1);
-        assert_eq!(result.tool_calls[0].call_id, "tooluse_xyz");
-        assert_eq!(result.tool_calls[0].name, "read_file");
-        assert_eq!(
-            result.tool_calls[0].input,
-            serde_json::json!({"path": "src/lib.rs"})
-        );
-    }
-
-    /// A no-argument Converse tool call omits `input` entirely, so the
-    /// `#[serde(default)]` field lands as `Value::Null`. It must surface as
-    /// an empty object: `Value::Null` is the malformed-call sentinel
-    /// `driver.rs::execute_with_repair` checks for, and a valid no-arg call
-    /// reported as null would be wrongly "repaired" (the twin of gemini.rs's
-    /// `complete_normalizes_a_no_arg_call_to_an_empty_object_not_null`).
-    #[tokio::test]
-    async fn complete_normalizes_a_no_arg_tool_use_to_an_empty_object_not_null() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [
-                    {"toolUse": {"toolUseId": "tooluse_now", "name": "now"}}
-                ]}},
-                "stopReason": "tool_use",
-                "usage": {"inputTokens": 5, "outputTokens": 2}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let result = provider
-            .complete(CompletionRequest {
-                messages: vec![CompletionMessage::user("what time is it")],
-                max_output_tokens: None,
-                temperature: None,
-                effort: None,
-                tools: vec![],
-                reasoning: None,
-                params: None,
-            })
-            .await
-            .expect("should succeed");
-
-        assert_eq!(result.tool_calls.len(), 1);
-        assert_eq!(result.tool_calls[0].name, "now");
-        assert_eq!(result.tool_calls[0].input, serde_json::json!({}));
-        assert!(!result.tool_calls[0].input.is_null());
-    }
-
-    #[tokio::test]
-    async fn complete_maps_403_to_auth_error() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(403).set_body_string(
-                "{\"message\":\"The security token included in the request is invalid.\"}",
-            ))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let req = CompletionRequest {
-            messages: vec![CompletionMessage::user("hi")],
-            max_output_tokens: None,
-            temperature: None,
-            effort: None,
-            tools: vec![],
-            reasoning: None,
-            params: None,
-        };
-
-        let err = provider.complete(req).await.unwrap_err();
-        assert!(matches!(err, ProviderError::Auth(_)));
-        assert!(!err.is_retryable());
-    }
-
-    #[tokio::test]
-    async fn complete_maps_429_throttling_to_rate_limited() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(
-                ResponseTemplate::new(429).set_body_string("{\"message\":\"Too many requests\"}"),
-            )
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        let req = CompletionRequest {
-            messages: vec![CompletionMessage::user("hi")],
-            max_output_tokens: None,
-            temperature: None,
-            effort: None,
-            tools: vec![],
-            reasoning: None,
-            params: None,
-        };
-
-        let err = provider.complete(req).await.unwrap_err();
-        assert!(matches!(err, ProviderError::RateLimited { .. }));
-        assert!(err.is_retryable());
-    }
-
-    #[tokio::test]
-    async fn complete_sends_the_session_token_header_when_configured() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(header_regex(
-                "x-amz-security-token",
-                r"^IQoJb3JpZ2luX2VjEXAMPLETOKEN$",
-            ))
-            .and(header_regex(
-                "authorization",
-                r"SignedHeaders=content-type;host;x-amz-date;x-amz-security-token,",
-            ))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "usage": {"inputTokens": 1, "outputTokens": 1}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = BedrockProvider::new(
-            ApiKey::new("AKIDEXAMPLE"),
-            ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
-            Some(ApiKey::new("IQoJb3JpZ2luX2VjEXAMPLETOKEN")),
-            "us-east-1",
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        )
-        .with_base_url(server.uri());
-
-        let req = CompletionRequest {
-            messages: vec![CompletionMessage::user("hi")],
-            max_output_tokens: None,
-            temperature: None,
-            effort: None,
-            tools: vec![],
-            reasoning: None,
-            params: None,
-        };
-
-        let result = provider.complete(req).await.expect("should succeed");
-        assert_eq!(result.text, "ok");
-    }
-
-    /// Of the `GenerationParams`, only `top_p` has a Converse
-    /// `inferenceConfig` slot; the rest must be dropped silently (the
-    /// never-fail contract), not guessed into `additionalModelRequestFields`
-    /// this adapter doesn't have.
-    #[tokio::test]
-    async fn generation_params_forward_only_top_p_into_inference_config() {
-        use stella_protocol::GenerationParams;
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "usage": {"inputTokens": 1, "outputTokens": 1}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        provider
-            .complete(CompletionRequest {
-                messages: vec![CompletionMessage::user("hi")],
-                max_output_tokens: None,
-                temperature: None,
-                effort: None,
-                tools: vec![],
-                reasoning: None,
-                params: Some(GenerationParams {
-                    top_p: Some(0.9),
-                    top_k: Some(40),
-                    seed: Some(7),
-                    ..Default::default()
-                }),
-            })
-            .await
-            .expect("should succeed");
-
-        let requests = server.received_requests().await.expect("recorded requests");
-        let body = String::from_utf8_lossy(&requests[0].body);
-        assert!(
-            body.contains("\"inferenceConfig\":{\"topP\":0.9}"),
-            "{body}"
-        );
-        assert!(!body.contains("topK"), "{body}");
-        assert!(!body.contains("seed"), "{body}");
-    }
-
-    /// The byte-stability contract: with no overrides at all, no
-    /// `inferenceConfig` key rides — exactly the pre-params request body.
-    #[tokio::test]
-    async fn absent_params_omit_inference_config_entirely() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "usage": {"inputTokens": 1, "outputTokens": 1}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        provider
-            .complete(CompletionRequest {
-                messages: vec![CompletionMessage::user("hi")],
-                max_output_tokens: None,
-                temperature: None,
-                effort: None,
-                tools: vec![],
-                reasoning: None,
-                params: None,
-            })
-            .await
-            .expect("should succeed");
-
-        let requests = server.received_requests().await.expect("recorded requests");
-        let body = String::from_utf8_lossy(&requests[0].body);
-        assert!(!body.contains("inferenceConfig"), "{body}");
-        assert!(!body.contains("topP"), "{body}");
-        assert!(!body.contains("additionalModelRequestFields"), "{body}");
-    }
-
-    /// The reasoning switch reaches the wire as `additionalModelRequestFields
-    /// .reasoning_config` in the Anthropic legacy shape, with the same
-    /// effort→budget mapping and budget↔max_tokens coupling as
-    /// `anthropic.rs`'s legacy branch: an uncapped thinking turn raises the
-    /// ceiling to budget + 8192, and temperature is omitted (the API rejects
-    /// it alongside thinking).
-    #[tokio::test]
-    async fn reasoning_true_sends_reasoning_config_and_raises_max_tokens() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "usage": {"inputTokens": 1, "outputTokens": 1}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        provider
-            .complete(CompletionRequest {
-                messages: vec![CompletionMessage::user("think hard")],
-                max_output_tokens: None,
-                temperature: Some(0.3),
-                effort: Some(stella_protocol::ReasoningEffort::High),
-                tools: vec![],
-                reasoning: Some(true),
-                params: None,
-            })
-            .await
-            .expect("should succeed");
-
-        let requests = server.received_requests().await.expect("recorded requests");
-        let body = String::from_utf8_lossy(&requests[0].body);
-        assert!(
-            body.contains(
-                "\"additionalModelRequestFields\":{\"reasoning_config\":\
-                 {\"type\":\"enabled\",\"budget_tokens\":16384}}"
-            ),
-            "{body}"
-        );
-        assert!(
-            body.contains("\"inferenceConfig\":{\"maxTokens\":24576}"),
-            "budget + 8192 headroom, temperature omitted with thinking on: {body}"
-        );
-        assert!(!body.contains("temperature"), "{body}");
-    }
-
-    /// A caller cap at or below the 1024-token thinking floor leaves no legal
-    /// budget (`budget < max_tokens` is an API requirement) — thinking is
-    /// omitted rather than sent as a ValidationException, and the request
-    /// falls back to the plain no-thinking shape (temperature honored).
-    #[tokio::test]
-    async fn a_cap_at_the_thinking_floor_omits_reasoning_config_not_a_400() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
-                "usage": {"inputTokens": 1, "outputTokens": 1}
-            })))
-            .mount(&server)
-            .await;
-
-        let provider = test_provider(&server.uri());
-        provider
-            .complete(CompletionRequest {
-                messages: vec![CompletionMessage::user("think hard")],
-                max_output_tokens: Some(1024),
-                temperature: Some(0.0),
-                effort: None,
-                tools: vec![],
-                reasoning: Some(true),
-                params: None,
-            })
-            .await
-            .expect("should succeed");
-
-        let requests = server.received_requests().await.expect("recorded requests");
-        let body = String::from_utf8_lossy(&requests[0].body);
-        assert!(!body.contains("additionalModelRequestFields"), "{body}");
-        assert!(
-            body.contains("\"maxTokens\":1024") && body.contains("\"temperature\":0.0"),
-            "{body}"
-        );
-    }
-}
+mod tests;

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -1225,6 +1225,5 @@ pub(crate) mod sigv4 {
     }
 }
 
-
 #[cfg(test)]
 mod tests;

--- a/stella-model/src/bedrock/tests.rs
+++ b/stella-model/src/bedrock/tests.rs
@@ -684,7 +684,11 @@ async fn a_tool_only_turn_announces_neither_empty_text_nor_tool_calls() {
         .await
         .expect("completion should succeed");
 
-    assert_eq!(result.tool_calls.len(), 1, "the call still reaches dispatch");
+    assert_eq!(
+        result.tool_calls.len(),
+        1,
+        "the call still reaches dispatch"
+    );
     assert!(
         observer.deltas.lock().unwrap().is_empty(),
         "empty answer text must not be announced as a delta"

--- a/stella-model/src/bedrock/tests.rs
+++ b/stella-model/src/bedrock/tests.rs
@@ -1,0 +1,717 @@
+use super::*;
+use stella_protocol::CompletionRequest;
+use stella_protocol::tool::ToolSchema;
+use stella_protocol::{ToolOutput, ToolResult};
+use wiremock::matchers::{body_string_contains, header_regex, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The audio arm of [`attachment_block`] is out of reach only because
+/// `BEDROCK_CAPS` switches audio off. Flipping that bool is a routine
+/// one-line edit, so the arm it lands in has to degrade like every other
+/// unsupported attachment instead of aborting the process mid-turn.
+#[test]
+fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
+    use crate::attachment::{DialectCaps, wire_parts};
+    use stella_protocol::{Attachment, AttachmentSource};
+    let flipped = DialectCaps {
+        images: true,
+        pdfs: true,
+        audio: true,
+        video: true,
+    };
+    let attachment = Attachment {
+        name: "song.mp3".into(),
+        media_type: "audio/mpeg".into(),
+        byte_len: 3,
+        source: AttachmentSource::Data {
+            base64: "YWJj".into(),
+        },
+    };
+    let blocks: Vec<_> = wire_parts(&[attachment], flipped)
+        .into_iter()
+        .map(attachment_block)
+        .collect();
+    let [block] = blocks.as_slice() else {
+        panic!("expected one degrade block, got {blocks:?}");
+    };
+    let note = block
+        .text
+        .as_deref()
+        .unwrap_or_else(|| panic!("expected a text degrade note, got {block:?}"));
+    assert!(
+        note.contains("audio/mpeg"),
+        "the note names what was attached: {note}"
+    );
+}
+
+#[test]
+fn user_attachments_map_to_converse_blocks_with_format_allowlists() {
+    use stella_protocol::{Attachment, AttachmentSource};
+    let att = |name: &str, mime: &str, b64: &str| Attachment {
+        name: name.into(),
+        media_type: mime.into(),
+        byte_len: 3,
+        source: AttachmentSource::Data { base64: b64.into() },
+    };
+    let messages = vec![CompletionMessage::user_with_attachments(
+        "look",
+        vec![
+            att("a.png", "image/png", "aW1n"),
+            att("spec v2.pdf", "application/pdf", "cGRm"),
+            att("d.mov", "video/quicktime", "dmlk"),
+            att("weird.tiff", "image/tiff", "dGlm"),
+        ],
+    )];
+    let (_, mapped) = to_bedrock_messages(&messages);
+    assert_eq!(mapped.len(), 1);
+    let json = serde_json::to_value(&mapped[0]).unwrap();
+    let content = json["content"].as_array().unwrap();
+    assert_eq!(content.len(), 5, "{json}");
+    assert_eq!(content[0]["image"]["format"], "png");
+    assert_eq!(content[0]["image"]["source"]["bytes"], "aW1n");
+    // Document name sanitized to Converse's allowed character set
+    // (the period is not allowed).
+    assert_eq!(content[1]["document"]["format"], "pdf");
+    assert_eq!(content[1]["document"]["name"], "spec v2-pdf");
+    assert_eq!(content[2]["video"]["format"], "mov");
+    // TIFF is outside the Converse image allowlist: degrade note.
+    assert!(
+        content[3]["text"].as_str().unwrap().contains("image/tiff"),
+        "{json}"
+    );
+    assert_eq!(content[4]["text"], "look");
+}
+
+#[test]
+fn cache_points_are_gated_to_supporting_model_families() {
+    assert!(supports_cache_points(
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    ));
+    assert!(supports_cache_points("us.amazon.nova-pro-v1:0"));
+    assert!(!supports_cache_points("meta.llama4-maverick-17b-v1:0"));
+}
+
+fn test_provider(server_uri: &str) -> BedrockProvider {
+    BedrockProvider::new(
+        ApiKey::new("AKIDEXAMPLE"),
+        ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
+        None,
+        "us-east-1",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    )
+    .with_base_url(server_uri.to_string())
+}
+
+#[test]
+fn to_bedrock_messages_hoists_system_and_frames_tool_round_trips() {
+    let messages = vec![
+        CompletionMessage::system("You are a coding agent."),
+        CompletionMessage::user("read a.rs"),
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: "tooluse_abc".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "a.rs"}),
+            }],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        },
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "tooluse_abc".into(),
+                output: ToolOutput::Ok {
+                    content: "fn main(){}".into(),
+                },
+            }],
+            attachments: Vec::new(),
+        },
+    ];
+    let (system, mapped) = to_bedrock_messages(&messages);
+    assert_eq!(system.len(), 1);
+    assert_eq!(mapped.len(), 3);
+    assert_eq!(mapped[1].role, "assistant");
+    let tool_use = mapped[1].content[0].tool_use.as_ref().unwrap();
+    assert_eq!(tool_use.tool_use_id, "tooluse_abc");
+    // Converse frames tool results as a user-role message.
+    assert_eq!(mapped[2].role, "user");
+    let tool_result = mapped[2].content[0].tool_result.as_ref().unwrap();
+    assert_eq!(tool_result.tool_use_id, "tooluse_abc");
+    assert_eq!(tool_result.content[0].text, "fn main(){}");
+    assert_eq!(tool_result.status, None);
+}
+
+#[test]
+fn failed_tool_results_carry_error_status_not_a_text_prefix() {
+    let messages = vec![CompletionMessage {
+        role: MessageRole::Tool,
+        content: String::new(),
+        tool_calls: vec![],
+        tool_results: vec![ToolResult {
+            call_id: "tooluse_1".into(),
+            output: ToolOutput::Error {
+                message: "no such file".into(),
+            },
+        }],
+        attachments: Vec::new(),
+    }];
+    let (_, mapped) = to_bedrock_messages(&messages);
+    let tool_result = mapped[0].content[0].tool_result.as_ref().unwrap();
+    assert_eq!(tool_result.status, Some("error"));
+    assert_eq!(tool_result.content[0].text, "no such file");
+}
+
+#[tokio::test]
+async fn complete_posts_a_signed_converse_request_and_parses_text() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+        ))
+        .and(header_regex(
+            "authorization",
+            r"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/\d{8}/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=[0-9a-f]{64}$",
+        ))
+        .and(header_regex("x-amz-date", r"^\d{8}T\d{6}Z$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "Hello from Bedrock"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 9, "outputTokens": 5, "cacheReadInputTokens": 3, "cacheWriteInputTokens": 2}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: Some(1024),
+        temperature: Some(0.0),
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let result = provider
+        .complete(req)
+        .await
+        .expect("completion should succeed");
+    assert_eq!(result.text, "Hello from Bedrock");
+    // Converse reports cache reads OUTSIDE `inputTokens`; the adapter
+    // folds them back in so cached stays a subset of input (9 + 3).
+    assert_eq!(result.usage.input_tokens, 12);
+    assert_eq!(result.usage.output_tokens, 5);
+    assert_eq!(result.usage.cached_input_tokens, 3);
+    assert_eq!(result.usage.cache_write_tokens, 2);
+    assert!(result.usage.reported);
+}
+
+/// Prompt caching on Converse is opt-in via `cachePoint` blocks: one
+/// after the system blocks (tools+system tier) and one at the tail of
+/// the last message (conversation-incremental tier). Without them
+/// Bedrock caches nothing.
+#[tokio::test]
+async fn complete_sends_cache_points_for_claude_models() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains(
+            "\"cachePoint\":{\"type\":\"default\"}",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 4, "outputTokens": 1}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let req = CompletionRequest {
+        messages: vec![
+            CompletionMessage::system("You are a coding agent."),
+            CompletionMessage::user("hi"),
+        ],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let result = provider
+        .complete(req)
+        .await
+        .expect("completion should succeed");
+    assert_eq!(result.text, "ok");
+}
+
+#[tokio::test]
+async fn complete_parses_tool_use_blocks_into_tool_calls() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"text": "Let me read that."},
+                {"toolUse": {"toolUseId": "tooluse_xyz", "name": "read_file", "input": {"path": "src/lib.rs"}}}
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 30, "outputTokens": 12}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("read src/lib.rs")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![ToolSchema {
+            name: "read_file".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type":"object"}),
+            read_only: false,
+            speculation_safe: false,
+        }],
+        reasoning: None,
+        params: None,
+    };
+
+    let result = provider.complete(req).await.expect("should succeed");
+    assert_eq!(result.text, "Let me read that.");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].call_id, "tooluse_xyz");
+    assert_eq!(result.tool_calls[0].name, "read_file");
+    assert_eq!(
+        result.tool_calls[0].input,
+        serde_json::json!({"path": "src/lib.rs"})
+    );
+}
+
+/// A no-argument Converse tool call omits `input` entirely, so the
+/// `#[serde(default)]` field lands as `Value::Null`. It must surface as
+/// an empty object: `Value::Null` is the malformed-call sentinel
+/// `driver.rs::execute_with_repair` checks for, and a valid no-arg call
+/// reported as null would be wrongly "repaired" (the twin of gemini.rs's
+/// `complete_normalizes_a_no_arg_call_to_an_empty_object_not_null`).
+#[tokio::test]
+async fn complete_normalizes_a_no_arg_tool_use_to_an_empty_object_not_null() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"toolUse": {"toolUseId": "tooluse_now", "name": "now"}}
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 5, "outputTokens": 2}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let result = provider
+        .complete(CompletionRequest {
+            messages: vec![CompletionMessage::user("what time is it")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        })
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].name, "now");
+    assert_eq!(result.tool_calls[0].input, serde_json::json!({}));
+    assert!(!result.tool_calls[0].input.is_null());
+}
+
+#[tokio::test]
+async fn complete_maps_403_to_auth_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(403).set_body_string(
+            "{\"message\":\"The security token included in the request is invalid.\"}",
+        ))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let err = provider.complete(req).await.unwrap_err();
+    assert!(matches!(err, ProviderError::Auth(_)));
+    assert!(!err.is_retryable());
+}
+
+#[tokio::test]
+async fn complete_maps_429_throttling_to_rate_limited() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(429).set_body_string("{\"message\":\"Too many requests\"}"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let err = provider.complete(req).await.unwrap_err();
+    assert!(matches!(err, ProviderError::RateLimited { .. }));
+    assert!(err.is_retryable());
+}
+
+#[tokio::test]
+async fn complete_sends_the_session_token_header_when_configured() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(header_regex(
+            "x-amz-security-token",
+            r"^IQoJb3JpZ2luX2VjEXAMPLETOKEN$",
+        ))
+        .and(header_regex(
+            "authorization",
+            r"SignedHeaders=content-type;host;x-amz-date;x-amz-security-token,",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = BedrockProvider::new(
+        ApiKey::new("AKIDEXAMPLE"),
+        ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
+        Some(ApiKey::new("IQoJb3JpZ2luX2VjEXAMPLETOKEN")),
+        "us-east-1",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    )
+    .with_base_url(server.uri());
+
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let result = provider.complete(req).await.expect("should succeed");
+    assert_eq!(result.text, "ok");
+}
+
+/// Of the `GenerationParams`, only `top_p` has a Converse
+/// `inferenceConfig` slot; the rest must be dropped silently (the
+/// never-fail contract), not guessed into `additionalModelRequestFields`
+/// this adapter doesn't have.
+#[tokio::test]
+async fn generation_params_forward_only_top_p_into_inference_config() {
+    use stella_protocol::GenerationParams;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    provider
+        .complete(CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: Some(GenerationParams {
+                top_p: Some(0.9),
+                top_k: Some(40),
+                seed: Some(7),
+                ..Default::default()
+            }),
+        })
+        .await
+        .expect("should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let body = String::from_utf8_lossy(&requests[0].body);
+    assert!(
+        body.contains("\"inferenceConfig\":{\"topP\":0.9}"),
+        "{body}"
+    );
+    assert!(!body.contains("topK"), "{body}");
+    assert!(!body.contains("seed"), "{body}");
+}
+
+/// The byte-stability contract: with no overrides at all, no
+/// `inferenceConfig` key rides — exactly the pre-params request body.
+#[tokio::test]
+async fn absent_params_omit_inference_config_entirely() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    provider
+        .complete(CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        })
+        .await
+        .expect("should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let body = String::from_utf8_lossy(&requests[0].body);
+    assert!(!body.contains("inferenceConfig"), "{body}");
+    assert!(!body.contains("topP"), "{body}");
+    assert!(!body.contains("additionalModelRequestFields"), "{body}");
+}
+
+/// The reasoning switch reaches the wire as `additionalModelRequestFields
+/// .reasoning_config` in the Anthropic legacy shape, with the same
+/// effort→budget mapping and budget↔max_tokens coupling as
+/// `anthropic.rs`'s legacy branch: an uncapped thinking turn raises the
+/// ceiling to budget + 8192, and temperature is omitted (the API rejects
+/// it alongside thinking).
+#[tokio::test]
+async fn reasoning_true_sends_reasoning_config_and_raises_max_tokens() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    provider
+        .complete(CompletionRequest {
+            messages: vec![CompletionMessage::user("think hard")],
+            max_output_tokens: None,
+            temperature: Some(0.3),
+            effort: Some(stella_protocol::ReasoningEffort::High),
+            tools: vec![],
+            reasoning: Some(true),
+            params: None,
+        })
+        .await
+        .expect("should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let body = String::from_utf8_lossy(&requests[0].body);
+    assert!(
+        body.contains(
+            "\"additionalModelRequestFields\":{\"reasoning_config\":\
+             {\"type\":\"enabled\",\"budget_tokens\":16384}}"
+        ),
+        "{body}"
+    );
+    assert!(
+        body.contains("\"inferenceConfig\":{\"maxTokens\":24576}"),
+        "budget + 8192 headroom, temperature omitted with thinking on: {body}"
+    );
+    assert!(!body.contains("temperature"), "{body}");
+}
+
+/// A caller cap at or below the 1024-token thinking floor leaves no legal
+/// budget (`budget < max_tokens` is an API requirement) — thinking is
+/// omitted rather than sent as a ValidationException, and the request
+/// falls back to the plain no-thinking shape (temperature honored).
+#[tokio::test]
+async fn a_cap_at_the_thinking_floor_omits_reasoning_config_not_a_400() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    provider
+        .complete(CompletionRequest {
+            messages: vec![CompletionMessage::user("think hard")],
+            max_output_tokens: Some(1024),
+            temperature: Some(0.0),
+            effort: None,
+            tools: vec![],
+            reasoning: Some(true),
+            params: None,
+        })
+        .await
+        .expect("should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let body = String::from_utf8_lossy(&requests[0].body);
+    assert!(!body.contains("additionalModelRequestFields"), "{body}");
+    assert!(
+        body.contains("\"maxTokens\":1024") && body.contains("\"temperature\":0.0"),
+        "{body}"
+    );
+}
+
+/// Records what an observed call announced, so a test can assert on the
+/// difference between "one synthetic delta" and the trait default's
+/// total silence.
+#[derive(Default)]
+struct RecordingObserver {
+    deltas: std::sync::Mutex<Vec<String>>,
+    calls: std::sync::Mutex<Vec<ToolCall>>,
+}
+
+impl ToolCallObserver for RecordingObserver {
+    fn tool_call_streamed(&self, call: &ToolCall) {
+        self.calls.lock().unwrap().push(call.clone());
+    }
+
+    fn text_delta(&self, delta: &str) {
+        self.deltas.lock().unwrap().push(delta.to_string());
+    }
+}
+
+fn observed_request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: Some(1024),
+        temperature: Some(0.0),
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The #1132 acceptance: an observed Bedrock turn announces its answer
+/// instead of leaving the observer with nothing. Converse is not a
+/// stream, so one delta carrying the whole answer is the finest
+/// granularity available — but it is emphatically not zero, which is
+/// what the trait's default `complete_observed_ref` would have left a
+/// watching host with.
+#[tokio::test]
+async fn an_observed_turn_emits_the_whole_answer_as_one_delta() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "Hello from Bedrock"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 9, "outputTokens": 5}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let observer = RecordingObserver::default();
+    let result = provider
+        .complete_observed(observed_request(), &observer)
+        .await
+        .expect("completion should succeed");
+
+    assert_eq!(result.text, "Hello from Bedrock");
+    assert_eq!(
+        observer.deltas.lock().unwrap().as_slice(),
+        ["Hello from Bedrock"],
+        "the observed path must announce the answer exactly once"
+    );
+}
+
+/// A tool-call-only turn has no answer text. Announcing a zero-length
+/// delta would tell an observer counting deltas that an answer arrived,
+/// so the emission is skipped entirely.
+///
+/// This also pins the deliberate non-announcement of tool calls: with
+/// the whole body already parsed, speculation started here would beat
+/// dispatch by microseconds while paying a spawn and emitting a
+/// discard — see the module docs.
+#[tokio::test]
+async fn a_tool_only_turn_announces_neither_empty_text_nor_tool_calls() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"toolUse": {"toolUseId": "call-1", "name": "read_file", "input": {"path": "a.txt"}}}
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 9, "outputTokens": 5}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let observer = RecordingObserver::default();
+    let result = provider
+        .complete_observed(observed_request(), &observer)
+        .await
+        .expect("completion should succeed");
+
+    assert_eq!(result.tool_calls.len(), 1, "the call still reaches dispatch");
+    assert!(
+        observer.deltas.lock().unwrap().is_empty(),
+        "empty answer text must not be announced as a delta"
+    );
+    assert!(
+        observer.calls.lock().unwrap().is_empty(),
+        "Converse cannot announce a call before the body lands, so it does not pretend to"
+    );
+}
+
+/// A failed observed call must fail, not report an empty answer: the
+/// error propagates and nothing is announced.
+#[tokio::test]
+async fn an_observed_turn_that_fails_announces_nothing() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("nope"))
+        .mount(&server)
+        .await;
+
+    let provider = test_provider(&server.uri());
+    let observer = RecordingObserver::default();
+    let err = provider
+        .complete_observed(observed_request(), &observer)
+        .await
+        .expect_err("403 must surface as an error");
+
+    assert!(matches!(err, ProviderError::Auth(_)), "{err:?}");
+    assert!(observer.deltas.lock().unwrap().is_empty());
+}

--- a/stella-model/src/provider_parity.rs
+++ b/stella-model/src/provider_parity.rs
@@ -310,7 +310,7 @@ mod tests {
     fn adapter_sources() -> [&'static str; 9] {
         [
             include_str!("anthropic/tests.rs"),
-            include_str!("bedrock.rs"),
+            include_str!("bedrock/tests.rs"),
             include_str!("openai.rs"),
             include_str!("gemini/tests.rs"),
             include_str!("vertex.rs"),

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -35,12 +35,14 @@ async-trait.workspace = true
 # other live turn addressable to anyone who sees one in a log. Already a
 # workspace dependency (stella-core, stella-store, stella-tools, stella-mcp).
 rand.workspace = true
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
+# `signal` is what makes the SIGTERM drain possible (#1131); without it a
+# redeploy hard-kills whatever turns happen to be in flight.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util", "signal"] }
 
 [dev-dependencies]
 # `test-util` gives the paused clock, which is what makes the 30s read deadline
 # assertable in microseconds instead of thirty real seconds of CI time.
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util", "test-util"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util", "signal", "test-util"] }
 # Already in `[workspace.dependencies]` and already built for other crates, so
 # this adds no crate to the graph. Needed for the one property that matters
 # here: every connection produces exactly one record. The original bug this

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -27,6 +27,10 @@ schema = ["dep:schemars", "stella-protocol/schema"]
 schemars = { workspace = true, optional = true }
 stella-protocol = { path = "../stella-protocol" }
 stella-core = { path = "../stella-core" }
+# The step-scoped facade (#971 phase 1). `stella-serve` drives `run_step`
+# rather than `Engine::run_turn` so a turn can be cancelled at a step
+# boundary and checkpointed between steps (#1129).
+stella-engine = { path = "../stella-engine" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/stella-serve/src/controls.rs
+++ b/stella-serve/src/controls.rs
@@ -34,6 +34,7 @@
 //!   sender clone onto the session thread: a thread that holds its own gate's
 //!   sender can park on it forever.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use stella_core::ports::{TurnGate, TurnSteering};
@@ -101,6 +102,31 @@ impl Controls {
     pub(crate) fn steer(&self, text: String) {
         self.steering.push(text);
     }
+
+    /// Ask the turn to stop at its next step boundary, keeping everything it
+    /// has completed. The graceful half of a shutdown drain (#1131).
+    ///
+    /// Distinct from [`crate::session::Session::cancel`] in exactly one way
+    /// that matters here: cancel wakes a parked reverse request *immediately*,
+    /// which throws away a model call the host is already paying for. A soft
+    /// stop lets that call land, folds its result into the transcript, and
+    /// ends the turn at the boundary after it. That is the difference between
+    /// a redeploy that costs one in-flight generation per turn and one that
+    /// costs nothing.
+    ///
+    /// It follows that a soft stop is *not* a bound: a turn parked on a host
+    /// that never answers will never reach a boundary to observe it. The drain
+    /// pairs it with a grace period and cancels whatever outlives that — see
+    /// `crate::server::drain`.
+    ///
+    /// The pause gate is released as a matter of course, for the same reason
+    /// every cancel path releases it: a paused turn is parked on the gate, not
+    /// at a step boundary, so it cannot observe a stop request until something
+    /// unparks it.
+    pub(crate) fn soft_stop(&self) {
+        self.steering.request_soft_stop();
+        self.resume();
+    }
 }
 
 impl ControlPorts {
@@ -133,12 +159,20 @@ impl TurnGate for PauseGate {
 /// `TurnSteering` over a shared queue. The drain is destructive by the trait's
 /// contract — whatever it returns *will* be injected.
 ///
-/// `soft_stop_requested` is a hard `false`: the HTTP surface deliberately does
-/// not expose the soft stop (issue #932 scopes the wire to steer, pause and
-/// resume), so no state exists that could request one.
+/// `soft_stop_requested` has no HTTP route behind it: #932 scoped the wire to
+/// steer, pause and resume, and that is still the case. What sets it is the
+/// **shutdown drain** (#1131) — a process-level event, not a request — so the
+/// latch is reachable from `crate::server` and from nowhere a client can
+/// address.
 #[derive(Default)]
 pub(crate) struct SteerQueue {
     queue: Mutex<Vec<String>>,
+    /// Latched, never cleared: a turn asked to stop does not un-ask. Relaxed
+    /// ordering is sufficient because the flag guards nothing but itself —
+    /// the engine reads it at a step boundary and needs only to observe the
+    /// write eventually, and "eventually" here is bounded by the drain's own
+    /// grace period.
+    soft_stop: AtomicBool,
 }
 
 impl SteerQueue {
@@ -148,6 +182,10 @@ impl SteerQueue {
             .unwrap_or_else(|p| p.into_inner())
             .push(text);
     }
+
+    fn request_soft_stop(&self) {
+        self.soft_stop.store(true, Ordering::Relaxed);
+    }
 }
 
 impl TurnSteering for SteerQueue {
@@ -156,7 +194,7 @@ impl TurnSteering for SteerQueue {
     }
 
     fn soft_stop_requested(&self) -> bool {
-        false
+        self.soft_stop.load(Ordering::Relaxed)
     }
 }
 

--- a/stella-serve/src/hostguard.rs
+++ b/stella-serve/src/hostguard.rs
@@ -57,7 +57,7 @@ use std::net::{IpAddr, SocketAddr};
 
 use serde::{Deserialize, Serialize};
 
-/// What a [`HostPolicy`] is enforcing, reported at startup so an operator can
+/// What the `Host` guard is enforcing, reported at startup so an operator can
 /// see which arm their configuration landed in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -169,10 +169,7 @@ fn normalize(host: &str) -> String {
         // fail to parse as an address — which refuses it, the safe direction.
         host.rsplit_once(':').map_or(host, |(name, _)| name)
     };
-    hostname
-        .trim_end_matches('.')
-        .trim()
-        .to_ascii_lowercase()
+    hostname.trim_end_matches('.').trim().to_ascii_lowercase()
 }
 
 #[cfg(test)]

--- a/stella-serve/src/hostguard.rs
+++ b/stella-serve/src/hostguard.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `Host`-header guard: the DNS-rebinding defense `stella-observatory`
+//! already had and this crate did not (#1130).
+//!
+//! # What rebinding actually is
+//!
+//! A server that trusts its bind address alone is reachable from a browser it
+//! never intended to serve. An attacker's page is loaded from
+//! `evil.example`, whose DNS record has a one-second TTL; once the page is
+//! running, the record is re-pointed at `127.0.0.1`. The browser's
+//! same-origin check already passed — the origin is still `evil.example` — so
+//! the page may now issue requests that land on the loopback service. The bind
+//! address refused nothing, because the connection genuinely arrives on
+//! loopback.
+//!
+//! The `Host` header is what survives that: the browser sends the *name* it
+//! believes it is talking to, so a rebound request announces `evil.example`
+//! while a legitimate one announces `localhost` or `127.0.0.1`. Comparing it
+//! against what this server expects to be called is the whole defense.
+//!
+//! Bearer auth (every route but `/healthz`) already blunts the attack — the
+//! page cannot read the token, so it cannot get past a 401 — which is why this
+//! is defense in depth rather than the only thing standing between a browser
+//! and the engine. It is still worth having: the sibling service in this same
+//! repo has it, and an unauthenticated `/healthz` is reachable without it.
+//!
+//! # Why the policy depends on the bind
+//!
+//! `stella-serve` binds `127.0.0.1` for local use and `0.0.0.0:$PORT` inside a
+//! container. Those are different threat models and a single hardcoded
+//! loopback check serves only the first:
+//!
+//! - **Loopback bind** — the rebinding case exactly. The expected `Host` is a
+//!   loopback name or address, and anything else is refused.
+//! - **Non-loopback bind with an allow-list** — the operator has said what
+//!   hostnames this deployment answers to, so those are accepted (alongside
+//!   loopback, which is where a container's own liveness probe comes from).
+//! - **Non-loopback bind with no allow-list** — there is no way to know what
+//!   this deployment is legitimately called, and inventing one would refuse
+//!   every real request. The guard reports itself [`HostMode::Inert`] at
+//!   startup rather than pretending to enforce.
+//!
+//! That last arm is a deliberate degrade-open, and it is why
+//! [`HostPolicy::mode`] is emitted on the `Listening` event: a guard that is
+//! off is only acceptable when an operator can see that it is off.
+//!
+//! # A missing `Host` is allowed
+//!
+//! Same posture as `stella-observatory::host_is_local`, and for the same
+//! reason: a browser `fetch` always sends one, so its absence means the
+//! request did not come from the attack this guards against. Refusing it would
+//! break raw `curl`/HTTP-1.0 clients to defend against nothing.
+
+use std::net::{IpAddr, SocketAddr};
+
+use serde::{Deserialize, Serialize};
+
+/// What a [`HostPolicy`] is enforcing, reported at startup so an operator can
+/// see which arm their configuration landed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostMode {
+    /// Loopback bind: only loopback names/addresses (plus any configured
+    /// allow-list entry) are accepted.
+    Loopback,
+    /// Non-loopback bind with a configured allow-list: that list, plus
+    /// loopback and the bound address's own literal.
+    AllowList,
+    /// Non-loopback bind with no allow-list — nothing is refused. Named, not
+    /// silent: see the module docs.
+    Inert,
+}
+
+/// The compiled `Host` policy for one bound server.
+#[derive(Debug, Clone)]
+pub(crate) struct HostPolicy {
+    mode: HostMode,
+    /// Operator-supplied hostnames, already normalized by [`normalize`].
+    allowed: Vec<String>,
+    /// The bound address's own literal, accepted under [`HostMode::AllowList`]
+    /// so a probe addressing the container by IP is not refused. `None` for an
+    /// unspecified bind (`0.0.0.0`), which is never a meaningful `Host`.
+    bound_ip: Option<IpAddr>,
+}
+
+impl HostPolicy {
+    /// Compile the policy for a bound address and an operator allow-list.
+    ///
+    /// Takes the **bound** address rather than the configured one, so a
+    /// `127.0.0.1:0` test bind is judged on the address it actually got.
+    pub(crate) fn new(bound: SocketAddr, allowed_hosts: &[String]) -> Self {
+        let allowed: Vec<String> = allowed_hosts
+            .iter()
+            .map(|h| normalize(h))
+            .filter(|h| !h.is_empty())
+            .collect();
+        let ip = bound.ip();
+        let mode = if ip.is_loopback() {
+            HostMode::Loopback
+        } else if allowed.is_empty() {
+            HostMode::Inert
+        } else {
+            HostMode::AllowList
+        };
+        Self {
+            mode,
+            allowed,
+            bound_ip: (!ip.is_unspecified()).then_some(ip),
+        }
+    }
+
+    /// Which arm this policy landed in — reported on `Listening`.
+    pub(crate) fn mode(&self) -> HostMode {
+        self.mode
+    }
+
+    /// Whether a request carrying this `Host` header may proceed to routing.
+    ///
+    /// `None` (no header at all) is permitted — see the module docs.
+    pub(crate) fn permits(&self, host_header: Option<&str>) -> bool {
+        let Some(raw) = host_header else {
+            return true;
+        };
+        if self.mode == HostMode::Inert {
+            return true;
+        }
+        let host = normalize(raw);
+        if host.is_empty() {
+            // A present-but-empty `Host` is not the absent case: something
+            // sent the header and left it blank, which matches no expected
+            // identity. Refuse rather than read it as "not a browser".
+            return false;
+        }
+        if self.allowed.contains(&host) {
+            return true;
+        }
+        // Parse, never prefix-match. `127.0.0.1.attacker.example` is a
+        // registrable name that satisfies a `starts_with("127.")` test, and
+        // that near-miss is the whole reason this check is worth writing
+        // carefully — same rule `stella-observatory::host_is_local` applies.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return ip.is_loopback() || self.bound_ip.is_some_and(|bound| bound == ip);
+        }
+        // `localhost` stays an explicit arm because it is a name, not an
+        // address, so it never reaches the parse above.
+        host == "localhost"
+    }
+}
+
+/// Reduce a `Host` header value to the identity it names: no port, no
+/// brackets, lowercased, no root-zone dot.
+///
+/// Every one of those is a bypass if skipped. `EVIL.EXAMPLE` beats a
+/// case-sensitive compare; `evil.example.` is the same FQDN with the root
+/// label spelled out and beats an exact-string compare; a `:port` suffix means
+/// the same host on a different port compares unequal, which turns the
+/// allow-list into a port allow-list by accident.
+fn normalize(host: &str) -> String {
+    let host = host.trim();
+    // Bracketed IPv6 literal (`[::1]:8080`) — the brackets are required by
+    // RFC 3986 precisely so the colons inside cannot be read as a port.
+    let hostname = if let Some(rest) = host.strip_prefix('[') {
+        rest.split(']').next().unwrap_or("")
+    } else {
+        // Only split a *trailing* `:port`. An unbracketed bare IPv6 literal is
+        // malformed in a `Host` header, and losing its last group makes it
+        // fail to parse as an address — which refuses it, the safe direction.
+        host.rsplit_once(':').map_or(host, |(name, _)| name)
+    };
+    hostname
+        .trim_end_matches('.')
+        .trim()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loopback() -> HostPolicy {
+        HostPolicy::new("127.0.0.1:8080".parse().unwrap(), &[])
+    }
+
+    fn container(allowed: &[&str]) -> HostPolicy {
+        let allowed: Vec<String> = allowed.iter().map(|s| (*s).to_string()).collect();
+        HostPolicy::new("0.0.0.0:8080".parse().unwrap(), &allowed)
+    }
+
+    #[test]
+    fn a_loopback_bind_enforces_loopback_identities() {
+        let policy = loopback();
+        assert_eq!(policy.mode(), HostMode::Loopback);
+        for ok in [
+            "localhost",
+            "localhost:8080",
+            "LOCALHOST",
+            "127.0.0.1",
+            "127.0.0.1:8080",
+            "127.5.5.5",
+            "[::1]",
+            "[::1]:8080",
+        ] {
+            assert!(policy.permits(Some(ok)), "{ok} must be permitted");
+        }
+    }
+
+    /// The #1130 acceptance on the loopback configuration: a rebound request
+    /// announces the attacker's name, and that is what gets refused.
+    #[test]
+    fn a_loopback_bind_refuses_a_rebound_host() {
+        let policy = loopback();
+        for bad in [
+            "evil.example",
+            "evil.example:8080",
+            // The near-miss the parse-don't-prefix-match rule exists for: a
+            // registrable name an attacker can own, which a `starts_with`
+            // check would wave through.
+            "127.0.0.1.attacker.example",
+            "localhost.attacker.example",
+            // Trailing-dot FQDN spelling of the same attacker name.
+            "evil.example.",
+            // Uppercased, to prove the compare is not case-sensitive.
+            "EVIL.EXAMPLE",
+            // A non-loopback address is not this server's identity either.
+            "10.0.0.5",
+            "",
+        ] {
+            assert!(!policy.permits(Some(bad)), "{bad} must be refused");
+        }
+    }
+
+    /// A missing header is not the attack — a browser always sends one. Same
+    /// posture as `stella-observatory::host_is_local`.
+    #[test]
+    fn an_absent_host_is_permitted_on_every_mode() {
+        assert!(loopback().permits(None));
+        assert!(container(&["engine.internal"]).permits(None));
+        assert!(container(&[]).permits(None));
+    }
+
+    /// The container case the issue calls out: a `0.0.0.0` bind cannot use a
+    /// hardcoded loopback check, so the operator names what the deployment
+    /// answers to.
+    #[test]
+    fn a_container_bind_honors_its_allow_list_and_refuses_everything_else() {
+        let policy = container(&["engine.internal", "Engine.Example.Com."]);
+        assert_eq!(policy.mode(), HostMode::AllowList);
+        assert!(policy.permits(Some("engine.internal")));
+        assert!(policy.permits(Some("engine.internal:8080")));
+        // The allow-list is normalized on the way in, so an operator writing
+        // it with mixed case or a trailing dot still matches the wire form.
+        assert!(policy.permits(Some("engine.example.com")));
+        // Loopback stays permitted: a container's own liveness probe is a
+        // legitimate caller and must not need an allow-list entry.
+        assert!(policy.permits(Some("127.0.0.1")));
+        assert!(policy.permits(Some("localhost")));
+
+        assert!(!policy.permits(Some("evil.example")));
+        assert!(!policy.permits(Some("engine.internal.attacker.example")));
+    }
+
+    /// A specific non-loopback bind accepts its own literal, so addressing the
+    /// container by the IP it is actually on is never refused.
+    #[test]
+    fn a_bound_literal_is_accepted_but_a_different_address_is_not() {
+        let policy = HostPolicy::new(
+            "10.1.2.3:8080".parse().unwrap(),
+            &["engine.internal".to_string()],
+        );
+        assert!(policy.permits(Some("10.1.2.3")));
+        assert!(policy.permits(Some("10.1.2.3:8080")));
+        assert!(!policy.permits(Some("10.1.2.4")));
+    }
+
+    /// `0.0.0.0` is a bind directive, not an identity — it must never become
+    /// an accepted `Host`, or "listen everywhere" would read as "answer to
+    /// anything".
+    #[test]
+    fn an_unspecified_bind_is_not_itself_an_accepted_identity() {
+        let policy = container(&["engine.internal"]);
+        assert!(!policy.permits(Some("0.0.0.0")));
+    }
+
+    /// No allow-list on a non-loopback bind: the guard cannot know what the
+    /// deployment is called, so it refuses nothing — and says so, rather than
+    /// leaving an operator to believe a check is running.
+    #[test]
+    fn a_container_bind_without_an_allow_list_is_inert_and_named() {
+        let policy = container(&[]);
+        assert_eq!(policy.mode(), HostMode::Inert);
+        assert!(policy.permits(Some("anything.at.all")));
+        assert!(policy.permits(Some("")));
+    }
+
+    #[test]
+    fn normalize_strips_port_brackets_case_and_the_root_dot() {
+        assert_eq!(normalize("Example.COM:8443"), "example.com");
+        assert_eq!(normalize("example.com."), "example.com");
+        assert_eq!(normalize("[2001:db8::1]:8080"), "2001:db8::1");
+        assert_eq!(normalize("  localhost  "), "localhost");
+    }
+}

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -70,11 +70,11 @@ mod session;
 mod sessions;
 
 pub use error::ServeError;
-pub use hostguard::HostMode;
 pub use frame::{
     ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn,
     TurnOutcomeWire,
 };
+pub use hostguard::HostMode;
 pub use observe::{Metrics, Observer, ServeEvent, SharedObserver};
 pub use pending::Pending;
 pub use server::{

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -57,6 +57,7 @@ mod controls;
 mod error;
 mod frame;
 mod history;
+mod hostguard;
 mod http;
 pub mod observe;
 mod pending;
@@ -69,6 +70,7 @@ mod session;
 mod sessions;
 
 pub use error::ServeError;
+pub use hostguard::HostMode;
 pub use frame::{
     ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn,
     TurnOutcomeWire,

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -59,6 +59,7 @@ mod frame;
 mod history;
 mod hostguard;
 mod http;
+mod lifecycle;
 pub mod observe;
 mod pending;
 mod remote;
@@ -68,6 +69,7 @@ pub mod schema_export;
 mod server;
 mod session;
 mod sessions;
+mod throttle;
 
 pub use error::ServeError;
 pub use frame::{
@@ -78,6 +80,7 @@ pub use hostguard::HostMode;
 pub use observe::{Metrics, Observer, ServeEvent, SharedObserver};
 pub use pending::Pending;
 pub use server::{
-    DEFAULT_RESUME_GRACE, DEFAULT_SESSION_IDLE_TTL, MAX_RESUME_GRACE, ServeConfig, serve,
+    DEFAULT_RESUME_GRACE, DEFAULT_SESSION_IDLE_TTL, DEFAULT_SHUTDOWN_GRACE, MAX_RESUME_GRACE,
+    MAX_SHUTDOWN_GRACE, ServeConfig, serve, serve_until,
 };
 pub use session::{Session, SessionSpec, SettleHook, TurnSettlement};

--- a/stella-serve/src/lifecycle.rs
+++ b/stella-serve/src/lifecycle.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Process lifecycle: accepting connections, the three states `GET /readyz`
+//! reports, and the drain that ends them (#1131).
+//!
+//! [`accept_loop`] and [`drain`] live here together because they are two
+//! halves of one decision — see the "listener stays open" note on
+//! [`crate::serve_until`]. Keeping them in the same file makes it hard to
+//! change one without reading why the other cannot simply be stopped first.
+//!
+//! # Why `/readyz` is not `/healthz`
+//!
+//! They answer different questions and an orchestrator uses them for different
+//! things. `/healthz` answers *is this process alive* — a `false` there means
+//! restart me. `/readyz` answers *is it safe to send me new work* — a `false`
+//! there means route elsewhere, and says nothing about whether the process
+//! should live.
+//!
+//! Collapsing them is what makes a rolling deploy drop requests. Without a
+//! readiness signal, the only way for a load balancer to learn that a
+//! shutting-down instance should stop receiving traffic is to send it a
+//! request and have it fail. With one, the instance says so first, the balancer
+//! stops routing, and the drain then has nothing new arriving to fight.
+//!
+//! # Ready is not the same as running
+//!
+//! [`Lifecycle::mark_ready`] fires after the listener is bound and the server
+//! state exists, immediately before the accept loop begins. Today that window
+//! is narrow — nothing expensive happens between bind and accept — so a probe
+//! is unlikely to observe not-ready at startup. It is still modeled rather
+//! than assumed, because "startup does no work" is a property of today's
+//! construction sequence and not a guarantee: the moment a warm-up lands
+//! (a session registry to restore, a catalog to load), the endpoint is already
+//! telling the truth instead of needing to be retrofitted at the point where
+//! it is first wrong.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+
+use crate::accept::{self, AcceptAction, AcceptBackoff};
+use crate::observe::event::{AcceptKind, ServeEvent, ShutdownReason, millis};
+use crate::server::{ServerState, handle_conn};
+
+/// How often the drain re-checks whether the turn registry has emptied.
+///
+/// A turn settles on its own OS thread, so there is no single future to await
+/// — the registry emptying is the condition, and it has to be sampled. Short
+/// enough that a drain finishing in 200ms is not rounded up to a second, long
+/// enough that a 25-second drain costs a couple of hundred wakeups rather
+/// than a busy loop.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// What `GET /readyz` reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Readiness {
+    /// Bound and accepting; new turns and sessions are welcome.
+    Ready,
+    /// Bound but not yet past construction — see the module docs.
+    Starting,
+    /// A shutdown drain has begun. The process is alive and finishing what it
+    /// has, and must not be sent anything new.
+    Draining,
+}
+
+impl Readiness {
+    /// The wire string. Stable — an orchestrator's probe may match on it.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Starting => "starting",
+            Self::Draining => "draining",
+        }
+    }
+
+    /// Whether this state should answer `200`. Only [`Readiness::Ready`] does;
+    /// both other states are a `503`, which is what a load balancer reads as
+    /// "take me out of rotation" without concluding the process is dead.
+    pub(crate) fn is_ready(self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
+/// The process's ready/draining latches, shared with every connection task.
+///
+/// Two booleans rather than one tri-state enum because they are set by
+/// different actors at different times and neither ever goes back: startup
+/// sets `ready`, a signal sets `draining`, and `draining` wins. Modeling that
+/// as one atomic would invite a compare-and-swap whose failure case has no
+/// sensible answer.
+#[derive(Debug, Default)]
+pub(crate) struct Lifecycle {
+    ready: AtomicBool,
+    draining: AtomicBool,
+}
+
+impl Lifecycle {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construction is finished and the accept loop is about to begin.
+    pub(crate) fn mark_ready(&self) {
+        self.ready.store(true, Ordering::SeqCst);
+    }
+
+    /// Begin a drain. Returns `false` if one was already in progress, so a
+    /// second signal does not restart the grace clock — a `SIGTERM` followed
+    /// by a `SIGINT` from an impatient operator is one shutdown, not two.
+    pub(crate) fn begin_drain(&self) -> bool {
+        !self.draining.swap(true, Ordering::SeqCst)
+    }
+
+    /// Whether new turns and sessions must be refused.
+    pub(crate) fn is_draining(&self) -> bool {
+        self.draining.load(Ordering::SeqCst)
+    }
+
+    /// The current state, draining first: a process that is both ready and
+    /// draining is draining.
+    pub(crate) fn readiness(&self) -> Readiness {
+        if self.draining.load(Ordering::SeqCst) {
+            Readiness::Draining
+        } else if self.ready.load(Ordering::SeqCst) {
+            Readiness::Ready
+        } else {
+            Readiness::Starting
+        }
+    }
+}
+
+/// Accept connections until the listener is structurally unusable.
+///
+/// Split from [`crate::serve_until`] so the drain can run alongside it rather than
+/// after it. Returns only on a fatal accept error — the ordinary exit is its
+/// caller dropping this future once the drain is done.
+pub(crate) async fn accept_loop(
+    state: &Arc<ServerState>,
+    listener: TcpListener,
+) -> std::io::Result<()> {
+    let mut backoff = AcceptBackoff::new();
+    // Mirrors `AcceptBackoff`'s own streak. Kept here rather than exposed from
+    // `accept.rs` because that file is guarded byte-identical against
+    // `stella-observatory`'s copy — reporting is this server's concern, not the
+    // shared policy's.
+    let mut streak = 0_u32;
+    loop {
+        let stream = match listener.accept().await {
+            Ok((stream, _)) => {
+                backoff.succeeded();
+                streak = 0;
+                stream
+            }
+            Err(err) => match accept::classify(&err) {
+                // A dead pending connection or an interrupted syscall: the
+                // listener is fine, and this cannot spin (see `accept`).
+                AcceptAction::Retry => {
+                    backoff.succeeded();
+                    streak = 0;
+                    continue;
+                }
+                // Exhaustion, or a condition `io::ErrorKind` cannot name. Sleep
+                // so it cannot busy-loop, and give up if it never clears.
+                AcceptAction::Backoff => {
+                    streak += 1;
+                    let kind = accept_kind(&err);
+                    match backoff.next_delay() {
+                        Some(delay) => {
+                            state.observer().emit(&ServeEvent::AcceptBackoff {
+                                kind,
+                                delay_ms: millis(delay),
+                                streak,
+                            });
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        }
+                        None => {
+                            state
+                                .observer()
+                                .emit(&ServeEvent::AcceptGaveUp { kind, streak });
+                            shutting_down(state);
+                            return Err(err);
+                        }
+                    }
+                }
+                AcceptAction::Fatal => {
+                    shutting_down(state);
+                    return Err(err);
+                }
+            },
+        };
+        // Nagle off. Every frame on this wire gates the next engine step — a
+        // `provider_request` the host has not seen yet is a step that cannot
+        // proceed — so coalescing a small write with the next one trades
+        // nothing for up to a delayed-ACK's worth of added latency per step.
+        let _ = stream.set_nodelay(true);
+        let state = Arc::clone(state);
+        // Per-connection errors (client hangup, bad request) stay local to the
+        // connection; the accept loop keeps serving. The error is no longer
+        // discarded — `RequestRecord::close` names it before this returns.
+        tokio::spawn(async move {
+            let _ = handle_conn(stream, state).await;
+        });
+    }
+}
+
+/// Which exhaustion class an accept error belongs to, mirroring `accept.rs`'s
+/// own split without modifying that (drift-guarded) file.
+fn accept_kind(err: &std::io::Error) -> AcceptKind {
+    match err.kind() {
+        std::io::ErrorKind::OutOfMemory => AcceptKind::Exhaustion,
+        // EMFILE/ENFILE/ENOBUFS have no `ErrorKind`, so they land here too —
+        // "unnameable" is the honest label for what we can actually tell.
+        _ => AcceptKind::Unnameable,
+    }
+}
+
+fn shutting_down(state: &Arc<ServerState>) {
+    state.observer().emit(&ServeEvent::ShuttingDown {
+        reason: ShutdownReason::ListenerFailed,
+        live_turns: state.turns().len(),
+    });
+}
+
+/// The process's termination signals: `SIGTERM` (what an orchestrator sends
+/// before killing a container on redeploy or scale-down) and `SIGINT` (what an
+/// operator sends from a terminal). Whichever arrives first resolves.
+///
+/// On a non-Unix target only `Ctrl-C` exists, so that is the whole of it.
+/// Returning a future rather than installing anything eagerly keeps [`serve`]
+/// the only place with a process-wide side effect.
+pub(crate) async fn termination_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        // A failed registration must not become a server that cannot start.
+        // The honest degrade is to keep serving without a drain — the process
+        // still dies on the signal, exactly as it did before this existed —
+        // rather than to refuse to boot over a shutdown nicety.
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(term) => term,
+            Err(_) => return std::future::pending().await,
+        };
+        let mut interrupt = match signal(SignalKind::interrupt()) {
+            Ok(interrupt) => interrupt,
+            Err(_) => return std::future::pending().await,
+        };
+        tokio::select! {
+            _ = term.recv() => {}
+            _ = interrupt.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+/// Bring every in-flight turn to a stop, gracefully first and forcibly second.
+///
+/// Returns once the registry is empty or `grace` has elapsed, whichever comes
+/// first. The two-phase shape is the whole point: phase one costs nothing (an
+/// in-flight model call lands and is kept), phase two is bounded (a turn whose
+/// host stopped answering has no step boundary to reach, so only a cancel can
+/// end it).
+///
+/// Every path here still lets a turn *emit* its terminal frame — a subscriber
+/// streaming `/events` sees `turn_complete` with a settled cost. That is the
+/// difference between draining and exiting: dropping the process would leave
+/// the host with a stream that simply stopped, and no record of what the turn
+/// had already spent.
+pub(crate) async fn drain(state: &Arc<ServerState>, grace: Duration) {
+    if !state.lifecycle().begin_drain() {
+        return;
+    }
+    let live_turns = state.turns().len();
+    state.observer().emit(&ServeEvent::ShuttingDown {
+        reason: ShutdownReason::SignalReceived,
+        live_turns,
+    });
+    if live_turns == 0 {
+        state.observer().emit(&ServeEvent::DrainCompleted {
+            drained: 0,
+            cancelled: 0,
+            timed_out: false,
+        });
+        return;
+    }
+
+    // Phase one: ask. A clone of the handles, not a held lock — a settling
+    // turn takes the same registry lock on its way out, and holding it across
+    // the wait below would deadlock the very drain it is meant to observe.
+    for controls in state.live_controls() {
+        controls.soft_stop();
+    }
+
+    // Poll rather than await a notification: a turn settles on its own OS
+    // thread through a `SettleHook`, so there is no single future to wait on,
+    // and the registry emptying is the one condition that means "all done".
+    // The interval is short enough that a fast drain is not padded by it and
+    // long enough that a slow one costs a handful of wakeups.
+    let deadline = tokio::time::Instant::now() + grace;
+    while tokio::time::Instant::now() < deadline && !state.turns().is_empty() {
+        tokio::time::sleep(DRAIN_POLL_INTERVAL).await;
+    }
+    let remaining = state.turns().len();
+
+    // Phase two: whatever is left did not reach a boundary inside the grace
+    // period. Cancel it — still a step-boundary unwind that emits a terminal
+    // frame, just one that also wakes a reverse request nobody is going to
+    // answer.
+    let timed_out = remaining > 0;
+    if timed_out {
+        for entry in state.live_entries() {
+            entry.pending.cancel();
+            entry.controls.resume();
+        }
+    }
+    state.observer().emit(&ServeEvent::DrainCompleted {
+        drained: live_turns.saturating_sub(remaining),
+        cancelled: remaining,
+        timed_out,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_lifecycle_is_starting_not_ready() {
+        let lifecycle = Lifecycle::new();
+        assert_eq!(lifecycle.readiness(), Readiness::Starting);
+        assert!(!lifecycle.readiness().is_ready());
+        assert!(!lifecycle.is_draining());
+    }
+
+    #[test]
+    fn marking_ready_makes_it_ready() {
+        let lifecycle = Lifecycle::new();
+        lifecycle.mark_ready();
+        assert_eq!(lifecycle.readiness(), Readiness::Ready);
+        assert!(lifecycle.readiness().is_ready());
+    }
+
+    /// Draining beats ready. A process mid-drain is alive and must not be
+    /// sent new work, which is precisely the state a single "healthy" boolean
+    /// cannot express.
+    #[test]
+    fn draining_wins_over_ready() {
+        let lifecycle = Lifecycle::new();
+        lifecycle.mark_ready();
+        assert!(lifecycle.begin_drain());
+        assert_eq!(lifecycle.readiness(), Readiness::Draining);
+        assert!(!lifecycle.readiness().is_ready());
+        assert!(lifecycle.is_draining());
+    }
+
+    /// A drain that begins before startup finished is still a drain — a
+    /// signal during construction must not be swallowed and then report
+    /// `ready` once `mark_ready` runs.
+    #[test]
+    fn a_drain_during_startup_is_not_overwritten_by_mark_ready() {
+        let lifecycle = Lifecycle::new();
+        assert!(lifecycle.begin_drain());
+        lifecycle.mark_ready();
+        assert_eq!(lifecycle.readiness(), Readiness::Draining);
+    }
+
+    /// Only the first signal owns the drain. A second one must not restart
+    /// the grace clock.
+    #[test]
+    fn a_second_drain_request_reports_that_one_is_already_running() {
+        let lifecycle = Lifecycle::new();
+        assert!(lifecycle.begin_drain(), "the first caller owns the drain");
+        assert!(!lifecycle.begin_drain(), "a second signal is not a restart");
+        assert!(!lifecycle.begin_drain());
+    }
+}

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -10,6 +10,10 @@
 //! STELLA_SERVE_TOKEN       bearer token every request must present
 //! STELLA_SERVE_TOOLS       must be `remote` (the default) — all tool execution is
 //!                          remoted to the host; a local tool surface is never served
+//! STELLA_SERVE_ALLOWED_HOSTS  comma-separated hostnames this deployment answers to,
+//!                          for the DNS-rebinding Host guard. Only consulted on a
+//!                          non-loopback bind; unset there leaves the guard inert,
+//!                          which is reported on the `listening` record
 //! STELLA_SERVE_LOG         off | error | warn | info (default) | debug — verbosity of
 //!                          the JSON-per-line records on stderr. An unrecognised value
 //!                          falls back to `info`: a typo in a log knob must not take a
@@ -69,6 +73,13 @@ ENVIRONMENT:
     STELLA_SERVE_TOKEN       bearer token every request must present
     STELLA_SERVE_TOOLS       must be `remote` (the default) — every tool and
                              model call is remoted to the host
+    STELLA_SERVE_ALLOWED_HOSTS
+                             comma-separated hostnames this deployment answers
+                             to, for the DNS-rebinding Host guard. Consulted
+                             only on a non-loopback bind (a loopback bind
+                             enforces loopback identities on its own); unset
+                             there leaves the guard inert, which the
+                             `listening` record names.
     STELLA_SERVE_LOG         off | error | warn | info (default) | debug —
                              verbosity of the JSON-per-line records on stderr.
                              An unrecognised value falls back to `info`.
@@ -174,7 +185,7 @@ async fn run() -> ExitCode {
     // on stdout because it is the process's readiness contract — the container
     // healthcheck and the dev scripts parse it, and a record on stderr at a
     // configurable level is not something a supervisor can depend on.
-    let config = ServeConfig::new(addr, token);
+    let config = ServeConfig::new(addr, token).with_allowed_hosts(allowed_hosts());
     match serve(config, |bound| {
         println!("stella-serve listening on {bound}")
     })
@@ -186,6 +197,24 @@ async fn run() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// The `Host` values this deployment answers to, from
+/// `STELLA_SERVE_ALLOWED_HOSTS` (comma-separated).
+///
+/// Unset is not an error, and deliberately so: on the default loopback bind
+/// the guard already knows what the server is called, so requiring this would
+/// make every local run configure something it does not need. On a
+/// non-loopback bind, unset leaves the guard inert — which `serve` reports on
+/// its `listening` record instead of leaving an operator to assume.
+fn allowed_hosts() -> Vec<String> {
+    std::env::var("STELLA_SERVE_ALLOWED_HOSTS")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Resolve the bearer token from `STELLA_SERVE_TOKEN_FILE` (preferred) or

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -14,6 +14,8 @@
 //!                          for the DNS-rebinding Host guard. Only consulted on a
 //!                          non-loopback bind; unset there leaves the guard inert,
 //!                          which is reported on the `listening` record
+//! STELLA_SERVE_SHUTDOWN_GRACE_SECS  seconds a SIGTERM drain waits for in-flight turns to
+//!                          reach a step boundary before cancelling (default 25, max 300)
 //! STELLA_SERVE_LOG         off | error | warn | info (default) | debug — verbosity of
 //!                          the JSON-per-line records on stderr. An unrecognised value
 //!                          falls back to `info`: a typo in a log knob must not take a
@@ -32,6 +34,12 @@
 //!
 //! `stella-serve healthcheck` probes `/healthz` on the bind port and exits 0/1,
 //! so a container HEALTHCHECK needs no extra tooling in the runtime image.
+//!
+//! `SIGTERM` (and `SIGINT`) begin a graceful drain rather than killing the
+//! process: `/readyz` flips to `503` so a balancer stops routing here, new
+//! turns and sessions are refused, and every in-flight turn is asked to stop
+//! at its next step boundary — keeping the model call it already paid for —
+//! before the process exits.
 //!
 //! `--version` and `--help` exist for host integrations rather than for people.
 //! A host that embeds this server (Oxagen — see `docs/design/serve-surface.md`)
@@ -83,10 +91,17 @@ ENVIRONMENT:
     STELLA_SERVE_LOG         off | error | warn | info (default) | debug —
                              verbosity of the JSON-per-line records on stderr.
                              An unrecognised value falls back to `info`.
+    STELLA_SERVE_SHUTDOWN_GRACE_SECS
+                             how long a SIGTERM drain waits for in-flight turns
+                             to reach a step boundary before cancelling what is
+                             left (default 25, capped at 300). Keep it under the
+                             orchestrator's own termination grace period, or
+                             SIGKILL lands mid-drain and the drain bought
+                             nothing.
 
 One of STELLA_SERVE_TOKEN_FILE / STELLA_SERVE_TOKEN is required.
 
-The server exposes GET /healthz unauthenticated, and GET /v1/metrics,
+The server exposes GET /healthz and GET /readyz unauthenticated, and GET /v1/metrics,
 POST /v1/turns, GET /v1/turns/{id}/events,
 POST /v1/turns/{id}/{provider-result,tool-result,cancel} behind the bearer
 token. See docs/design/serve-surface.md and docs/design/serve-observability.md.
@@ -185,7 +200,9 @@ async fn run() -> ExitCode {
     // on stdout because it is the process's readiness contract — the container
     // healthcheck and the dev scripts parse it, and a record on stderr at a
     // configurable level is not something a supervisor can depend on.
-    let config = ServeConfig::new(addr, token).with_allowed_hosts(allowed_hosts());
+    let config = ServeConfig::new(addr, token)
+        .with_allowed_hosts(allowed_hosts())
+        .with_shutdown_grace(shutdown_grace());
     match serve(config, |bound| {
         println!("stella-serve listening on {bound}")
     })
@@ -215,6 +232,18 @@ fn allowed_hosts() -> Vec<String> {
         .filter(|h| !h.is_empty())
         .map(str::to_string)
         .collect()
+}
+
+/// How long a `SIGTERM` drain waits, from `STELLA_SERVE_SHUTDOWN_GRACE_SECS`.
+///
+/// An unparseable value falls back to the default rather than refusing to
+/// boot, the same posture `STELLA_SERVE_LOG` takes: a typo in an operational
+/// dial must not take a service down, and the default is a safe answer.
+fn shutdown_grace() -> Duration {
+    std::env::var("STELLA_SERVE_SHUTDOWN_GRACE_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map_or(stella_serve::DEFAULT_SHUTDOWN_GRACE, Duration::from_secs)
 }
 
 /// Resolve the bearer token from `STELLA_SERVE_TOKEN_FILE` (preferred) or

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -481,10 +481,10 @@ pub enum ServeEvent {
     /// rebinding attempt, and their own missing allow-list entry — are one
     /// grep rather than a scan of every 403.
     ///
-    /// `host` is attacker-controlled, so it is truncated by
-    /// [`HOST_LOG_LIMIT`]: it is worth recording because it is exactly what
-    /// tells a misconfiguration apart from an attack, and worth bounding
-    /// because a 64 KiB header would otherwise become a log-flooding lever.
+    /// `host` is attacker-controlled, so `host_for_record` truncates it: it is
+    /// worth recording because it is exactly what tells a misconfiguration
+    /// apart from an attack, and worth bounding because a 64 KiB header would
+    /// otherwise become a log-flooding lever.
     HostRejected {
         request_id: RequestId,
         route: Route,

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -438,8 +438,14 @@ pub struct TurnTally {
 pub enum ServeEvent {
     // ---- process lifecycle ----
     /// The listener is bound and accepting. Replaces the startup `println!`.
+    ///
+    /// Carries the compiled `Host`-guard mode because a guard that is
+    /// [`crate::HostMode::Inert`] — the honest answer for a `0.0.0.0` bind
+    /// with no allow-list — must be visible to an operator at startup rather
+    /// than mistaken for one that is enforcing (#1130).
     Listening {
         addr: String,
+        host_guard: crate::HostMode,
     },
     ShuttingDown {
         reason: ShutdownReason,
@@ -468,6 +474,21 @@ pub enum ServeEvent {
         request_id: RequestId,
         route: Route,
         held_ms: u64,
+    },
+    /// A request was refused by the `Host` guard before any routing happened
+    /// (#1130). Split out of `RequestCompleted` for the same reason
+    /// `Unauthorized` is: the two things an operator wants to find here — a
+    /// rebinding attempt, and their own missing allow-list entry — are one
+    /// grep rather than a scan of every 403.
+    ///
+    /// `host` is attacker-controlled, so it is truncated by
+    /// [`HOST_LOG_LIMIT`]: it is worth recording because it is exactly what
+    /// tells a misconfiguration apart from an attack, and worth bounding
+    /// because a 64 KiB header would otherwise become a log-flooding lever.
+    HostRejected {
+        request_id: RequestId,
+        route: Route,
+        host: String,
     },
 
     // ---- turn registry ----
@@ -600,6 +621,7 @@ impl ServeEvent {
 
             // Somebody is misbehaving, or the server is under pressure.
             Self::Unauthorized { .. }
+            | Self::HostRejected { .. }
             | Self::TurnRefused { .. }
             | Self::TurnReclaimed { .. }
             | Self::SessionRefused { .. }
@@ -622,6 +644,26 @@ pub fn millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
+/// How many characters of a refused `Host` header reach a record.
+///
+/// Long enough for any real hostname (the DNS limit is 253) plus a port,
+/// short enough that the 64 KiB a peer may spend on a request head cannot be
+/// turned into 64 KiB of log line per connection.
+const HOST_LOG_LIMIT: usize = 256;
+
+/// A refused `Host` as it appears in a record: bounded, never verbatim.
+///
+/// Truncation is on a **character** boundary, not a byte one: a `Host` header
+/// is `from_utf8_lossy`'d at parse time, so it can carry multi-byte
+/// characters, and slicing those by byte index panics.
+#[must_use]
+pub fn host_for_record(host: &str) -> String {
+    if host.chars().count() <= HOST_LOG_LIMIT {
+        return host.to_string();
+    }
+    host.chars().take(HOST_LOG_LIMIT).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -633,6 +675,7 @@ mod tests {
         let events = vec![
             ServeEvent::Listening {
                 addr: "127.0.0.1:8080".to_string(),
+                host_guard: crate::HostMode::Loopback,
             },
             ServeEvent::RequestCompleted {
                 request_id: RequestId("abc123".to_string()),

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -92,6 +92,8 @@ impl LevelFilter {
 pub enum Route {
     #[serde(rename = "/healthz")]
     Healthz,
+    #[serde(rename = "/readyz")]
+    Readyz,
     #[serde(rename = "/v1/metrics")]
     Metrics,
     #[serde(rename = "/v1/turns")]
@@ -130,6 +132,7 @@ impl Route {
     pub fn template(self) -> &'static str {
         match self {
             Self::Healthz => "/healthz",
+            Self::Readyz => "/readyz",
             Self::Metrics => "/v1/metrics",
             Self::TurnsCreate => "/v1/turns",
             Self::TurnEvents => "/v1/turns/{id}/events",
@@ -407,6 +410,8 @@ pub enum AcceptKind {
 pub enum ShutdownReason {
     /// The listener returned a fatal error, or backoff gave up.
     ListenerFailed,
+    /// `SIGTERM`/`SIGINT` arrived — an orderly drain, not a failure (#1131).
+    SignalReceived,
 }
 
 /// What one turn actually did, folded from the engine's own `AgentEvent`
@@ -450,6 +455,18 @@ pub enum ServeEvent {
     ShuttingDown {
         reason: ShutdownReason,
         live_turns: usize,
+    },
+    /// A shutdown drain finished (#1131). The pair of counts is the whole
+    /// operational question a redeploy asks: `drained` turns reached a step
+    /// boundary with their work kept, `cancelled` ones had to be unwound
+    /// because they never got there — a persistently non-zero `cancelled`
+    /// across deploys means the grace period is shorter than this workload's
+    /// steps, which is a dial, not a mystery.
+    DrainCompleted {
+        drained: usize,
+        cancelled: usize,
+        /// Whether the grace period elapsed with turns still live.
+        timed_out: bool,
     },
 
     // ---- the request fold: exactly one per accepted connection ----
@@ -607,6 +624,7 @@ impl ServeEvent {
             // Routine progress.
             Self::Listening { .. }
             | Self::ShuttingDown { .. }
+            | Self::DrainCompleted { .. }
             | Self::RequestCompleted { .. }
             | Self::TurnCreated { .. }
             | Self::TurnSettled { .. }

--- a/stella-serve/src/observe/metrics.rs
+++ b/stella-serve/src/observe/metrics.rs
@@ -43,6 +43,12 @@ pub struct Metrics {
     /// 401s that were actually delayed by the throttle. A non-zero value here
     /// is the signature of a sustained guess, not a misconfigured client.
     unauthorized_throttled_total: AtomicU64,
+    /// Requests refused by the `Host` guard (#1130). A non-zero value on a
+    /// freshly-deployed container almost always means a missing
+    /// `STELLA_SERVE_ALLOWED_HOSTS` entry; a non-zero value on a loopback
+    /// bind means something is addressing this server by a name it does not
+    /// answer to, which is the rebinding signature.
+    host_rejected_total: AtomicU64,
 
     turns_created_total: AtomicU64,
     turns_refused_capacity_total: AtomicU64,
@@ -102,6 +108,7 @@ pub struct Snapshot {
 
     pub unauthorized_total: u64,
     pub unauthorized_throttled_total: u64,
+    pub host_rejected_total: u64,
 
     pub turns_created_total: u64,
     pub turns_refused_capacity_total: u64,
@@ -167,6 +174,7 @@ impl Metrics {
 
             unauthorized_total: self.unauthorized_total.load(ORDER),
             unauthorized_throttled_total: self.unauthorized_throttled_total.load(ORDER),
+            host_rejected_total: self.host_rejected_total.load(ORDER),
 
             turns_created_total: self.turns_created_total.load(ORDER),
             turns_refused_capacity_total: self.turns_refused_capacity_total.load(ORDER),
@@ -248,6 +256,10 @@ impl Observer for Metrics {
                 if *held_ms > 0 {
                     self.unauthorized_throttled_total.fetch_add(1, ORDER);
                 }
+            }
+
+            ServeEvent::HostRejected { .. } => {
+                self.host_rejected_total.fetch_add(1, ORDER);
             }
 
             ServeEvent::TurnCreated { live_turns, .. } => {

--- a/stella-serve/src/observe/metrics.rs
+++ b/stella-serve/src/observe/metrics.rs
@@ -49,6 +49,9 @@ pub struct Metrics {
     /// bind means something is addressing this server by a name it does not
     /// answer to, which is the rebinding signature.
     host_rejected_total: AtomicU64,
+    /// Turns a shutdown drain had to cancel because they did not reach a step
+    /// boundary inside the grace period (#1131).
+    drain_cancelled_total: AtomicU64,
 
     turns_created_total: AtomicU64,
     turns_refused_capacity_total: AtomicU64,
@@ -109,6 +112,7 @@ pub struct Snapshot {
     pub unauthorized_total: u64,
     pub unauthorized_throttled_total: u64,
     pub host_rejected_total: u64,
+    pub drain_cancelled_total: u64,
 
     pub turns_created_total: u64,
     pub turns_refused_capacity_total: u64,
@@ -175,6 +179,7 @@ impl Metrics {
             unauthorized_total: self.unauthorized_total.load(ORDER),
             unauthorized_throttled_total: self.unauthorized_throttled_total.load(ORDER),
             host_rejected_total: self.host_rejected_total.load(ORDER),
+            drain_cancelled_total: self.drain_cancelled_total.load(ORDER),
 
             turns_created_total: self.turns_created_total.load(ORDER),
             turns_refused_capacity_total: self.turns_refused_capacity_total.load(ORDER),
@@ -365,6 +370,16 @@ impl Observer for Metrics {
             }
             ServeEvent::AcceptGaveUp { .. } => {
                 self.accept_gave_up_total.fetch_add(1, ORDER);
+            }
+
+            ServeEvent::DrainCompleted { cancelled, .. } => {
+                // Only the forced half is counted. A turn that reached its
+                // step boundary is a drain working as designed and needs no
+                // counter; one that had to be cancelled is the signal that
+                // the grace period is short for this workload, which is the
+                // number worth watching across deploys.
+                self.drain_cancelled_total
+                    .fetch_add(as_u64(*cancelled), ORDER);
             }
 
             // Lifecycle markers carry no count.

--- a/stella-serve/src/observe/mod.rs
+++ b/stella-serve/src/observe/mod.rs
@@ -109,6 +109,7 @@ mod tests {
         let observer = null_observer();
         observer.emit(&ServeEvent::Listening {
             addr: "127.0.0.1:0".to_string(),
+            host_guard: crate::HostMode::Loopback,
         });
     }
 
@@ -122,6 +123,7 @@ mod tests {
             scope.spawn(|| {
                 observer.emit(&ServeEvent::Listening {
                     addr: "elsewhere".to_string(),
+                    host_guard: crate::HostMode::Loopback,
                 });
             });
         });

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -623,6 +623,13 @@ pub(crate) async fn handle_cancel(
     let Some(entry) = removed else {
         return res.json("404 Not Found", &error_body("unknown turn")).await;
     };
+    // The step-boundary stop (#1129). Before this existed, cancelling a turn
+    // that was mid-compaction or mid-loop-detection did nothing until it next
+    // parked on a reverse request — the turn ended because the *host* stopped
+    // answering, not because the engine was asked to stop. Now the engine
+    // reads this latch at the top of every step and unwinds there, keeping
+    // every completed step and leaving a transcript valid to hand back.
+    entry.cancel.cancel();
     entry.pending.cancel();
     // A paused turn is parked on its gate, not on a reverse request, so the
     // cancel alone cannot wake it — and while a stream holds this entry alive,

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -137,9 +137,35 @@ pub(crate) async fn method_not_allowed(
     .await
 }
 
-/// `GET /healthz` — the only unauthenticated route.
+/// `GET /healthz` — liveness. Is this process alive?
+///
+/// Unauthenticated, and unconditionally `200` while the process can answer at
+/// all. It deliberately says nothing about whether the server should be sent
+/// work: that is [`handle_ready`]'s question, and conflating the two is what
+/// makes an orchestrator either restart a draining instance (reading
+/// not-ready as dead) or keep routing to it (having no way to ask).
 pub(crate) async fn handle_health(res: &mut Responder<'_>) -> std::io::Result<()> {
     res.json("200 OK", br#"{"status":"ok"}"#).await
+}
+
+/// `GET /readyz` — readiness. Is it safe to send this process new work?
+///
+/// `200` only while serving; `503` while starting up and while draining. The
+/// status code is the part an orchestrator acts on, so it carries the whole
+/// signal — the `state` field is for the human reading the probe by hand,
+/// which is why it names the phase rather than repeating the boolean.
+pub(crate) async fn handle_ready(
+    res: &mut Responder<'_>,
+    state: &ServerState,
+) -> std::io::Result<()> {
+    let readiness = state.lifecycle().readiness();
+    let body = format!(r#"{{"state":"{}"}}"#, readiness.as_str());
+    let status = if readiness.is_ready() {
+        "200 OK"
+    } else {
+        "503 Service Unavailable"
+    };
+    res.json(status, body.as_bytes()).await
 }
 
 /// `GET /v1/metrics` — the counters, behind the same bearer token as everything

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -106,7 +106,8 @@ use crate::history::FrameHistory;
 use crate::http::{BodyOutcome, ReadOutcome, discard_body, read_body, read_head};
 use crate::observe::event::StreamEndReason;
 use crate::observe::event::{
-    AcceptKind, RefusalReason, RequestId, Route, ServeEvent, ShutdownReason, TurnRef, millis,
+    AcceptKind, RefusalReason, RequestId, Route, ServeEvent, ShutdownReason, TurnRef,
+    host_for_record, millis,
 };
 use crate::observe::record::{RequestRecord, Responder};
 use crate::observe::{Metrics, SharedObserver};
@@ -156,6 +157,14 @@ pub struct ServeConfig {
     /// bounded by the session cap either way, which is why this dial has no
     /// ceiling: raising it trades `429`s for retention, never boundedness.
     pub session_idle_ttl: Duration,
+    /// Hostnames this deployment answers to, for the `Host` guard (#1130).
+    ///
+    /// Only consulted on a **non-loopback** bind: a loopback bind already
+    /// knows what it is called, and enforces loopback identities regardless.
+    /// Leaving it empty on a `0.0.0.0` bind leaves the guard
+    /// [`crate::HostMode::Inert`] — reported on `Listening` rather than
+    /// silently assumed; see `crate::hostguard` for why that arm exists.
+    pub allowed_hosts: Vec<String>,
 }
 
 /// The default [`ServeConfig::resume_grace`]: thirty seconds.
@@ -192,7 +201,16 @@ impl ServeConfig {
             metrics,
             resume_grace: DEFAULT_RESUME_GRACE,
             session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
+            allowed_hosts: Vec::new(),
         }
+    }
+
+    /// Name the hostnames this deployment answers to — see
+    /// [`ServeConfig::allowed_hosts`].
+    #[must_use]
+    pub fn with_allowed_hosts(mut self, hosts: Vec<String>) -> Self {
+        self.allowed_hosts = hosts;
+        self
     }
 
     /// Set how long a disconnected turn waits for a reconnect, clamped to
@@ -292,6 +310,8 @@ pub(crate) struct ServerState {
     sessions: crate::sessions::SessionRegistry,
     /// See [`ServeConfig::session_idle_ttl`].
     session_idle_ttl: Duration,
+    /// The compiled `Host` guard, consulted before any route dispatch (#1130).
+    host_policy: crate::hostguard::HostPolicy,
 }
 
 impl ServerState {
@@ -673,6 +693,10 @@ impl TokenBucket {
 pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> std::io::Result<()> {
     let listener = TcpListener::bind(config.bind).await?;
     let bound = listener.local_addr()?;
+    // Compiled against the address actually bound, not the one requested: a
+    // `127.0.0.1:0` test bind must be judged on the port it got.
+    let host_policy = crate::hostguard::HostPolicy::new(bound, &config.allowed_hosts);
+    let host_guard = host_policy.mode();
     let state = Arc::new(ServerState {
         token: config.token,
         turns: Mutex::new(HashMap::new()),
@@ -683,9 +707,11 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
         resume_grace: config.resume_grace.min(MAX_RESUME_GRACE),
         sessions: crate::sessions::SessionRegistry::new(),
         session_idle_ttl: config.session_idle_ttl,
+        host_policy,
     });
     state.observer.emit(&ServeEvent::Listening {
         addr: bound.to_string(),
+        host_guard,
     });
     on_ready(bound);
     let mut backoff = AcceptBackoff::new();
@@ -875,6 +901,29 @@ async fn route(
         && route_addresses_a_turn(route)
     {
         record.set_turn(id);
+    }
+
+    // The `Host` guard runs before every dispatch, `/healthz` included. A
+    // rebound request reaching the unauthenticated liveness endpoint leaks
+    // only liveness, but "before any route dispatch" is a rule that stays
+    // true under later edits precisely because it has no exceptions to
+    // remember — and `/healthz` is the one route bearer auth does not cover,
+    // so exempting it would carve the hole in the only place the second
+    // control is absent. Loopback callers are always permitted, so a
+    // container's own probe never needs an allow-list entry (#1130).
+    if !state.host_policy.permits(req.header("host")) {
+        discard_body(res.stream_mut(), &mut req).await;
+        state.observer().emit(&ServeEvent::HostRejected {
+            request_id: record.request_id().clone(),
+            route,
+            host: host_for_record(req.header("host").unwrap_or_default()),
+        });
+        return res
+            .json(
+                "403 Forbidden",
+                &error_body("Host header does not match this server's expected identity"),
+            )
+            .await;
     }
 
     if route == Route::Healthz && req.method == "GET" {
@@ -1204,6 +1253,10 @@ mod tests {
             resume_grace: DEFAULT_RESUME_GRACE,
             sessions: crate::sessions::SessionRegistry::new(),
             session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
+            host_policy: crate::hostguard::HostPolicy::new(
+                "127.0.0.1:8080".parse().expect("a literal loopback address"),
+                &[],
+            ),
         };
         (state, capture)
     }

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -314,6 +314,11 @@ pub(crate) struct Entry {
     /// always-available handle: the session itself is exclusively owned by
     /// whichever stream is running, so control POSTs go through this instead.
     pub(crate) controls: crate::controls::Controls,
+    /// The turn's step-boundary stop signal (#1129). Held here for the same
+    /// reason as `pending` and `controls`: `handle_cancel` cannot reach the
+    /// session object while a stream has it checked out, and this is the
+    /// signal that interrupts a step which is computing rather than waiting.
+    pub(crate) cancel: stella_engine::CancelToken,
     pub(crate) session: Mutex<Option<Session>>,
     /// This turn's retained frame tail, shared with the [`Session`].
     ///
@@ -456,6 +461,7 @@ impl ServerState {
                             seq: self.counter.fetch_add(1, Ordering::Relaxed),
                             pending: session.pending(),
                             controls: session.controls(),
+                            cancel: session.cancel_token(),
                             history: session.history(),
                             stream_generation: AtomicU64::new(0),
                             session: Mutex::new(Some(session)),

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -7,7 +7,8 @@
 //!
 //! | Method + path | Purpose |
 //! |---|---|
-//! | `GET /healthz` | liveness |
+//! | `GET /healthz` | liveness — is this process alive |
+//! | `GET /readyz` | readiness — is it safe to send new work (#1131) |
 //! | `GET /v1/metrics` | counters ([`crate::observe::Snapshot`]) — authenticated, pull-only |
 //! | `POST /v1/turns` | start a turn (`TurnRequest` body) → `{ "turn_id": … }` |
 //! | `GET /v1/turns/{id}/events` | SSE stream of [`ServerFrame`]s until `turn_complete` |
@@ -101,19 +102,19 @@ use std::time::Duration;
 use rand::Rng as _;
 use tokio::net::{TcpListener, TcpStream};
 
-use crate::accept::{self, AcceptAction, AcceptBackoff};
 use crate::history::FrameHistory;
 use crate::http::{BodyOutcome, ReadOutcome, discard_body, read_body, read_head};
+use crate::lifecycle::{Lifecycle, accept_loop, drain, termination_signal};
 use crate::observe::event::StreamEndReason;
 use crate::observe::event::{
-    AcceptKind, RefusalReason, RequestId, Route, ServeEvent, ShutdownReason, TurnRef,
-    host_for_record, millis,
+    RefusalReason, RequestId, Route, ServeEvent, TurnRef, host_for_record, millis,
 };
 use crate::observe::record::{RequestRecord, Responder};
 use crate::observe::{Metrics, SharedObserver};
 use crate::pending::Pending;
 use crate::routes::{self, error_body};
 use crate::session::Session;
+use crate::throttle::TokenBucket;
 
 /// How to bind, authenticate, and observe the server.
 pub struct ServeConfig {
@@ -165,6 +166,17 @@ pub struct ServeConfig {
     /// [`crate::HostMode::Inert`] — reported on `Listening` rather than
     /// silently assumed; see `crate::hostguard` for why that arm exists.
     pub allowed_hosts: Vec<String>,
+    /// How long a shutdown drain waits for in-flight turns to reach a step
+    /// boundary before cancelling what is left (#1131).
+    ///
+    /// Clamped to [`MAX_SHUTDOWN_GRACE`]. The number that matters is the
+    /// orchestrator's own: Kubernetes sends `SIGKILL` once
+    /// `terminationGracePeriodSeconds` (30 by default) elapses, and a drain
+    /// budgeted past that is not a longer drain — it is the same drain with
+    /// its tail replaced by a hard kill, which is the outcome the drain exists
+    /// to avoid. [`DEFAULT_SHUTDOWN_GRACE`] deliberately finishes inside the
+    /// default window.
+    pub shutdown_grace: Duration,
 }
 
 /// The default [`ServeConfig::resume_grace`]: thirty seconds.
@@ -189,6 +201,23 @@ pub const MAX_RESUME_GRACE: Duration = Duration::from_secs(300);
 /// the registry self-healing under pressure rather than permanently full.
 pub const DEFAULT_SESSION_IDLE_TTL: Duration = Duration::from_secs(3600);
 
+/// The default [`ServeConfig::shutdown_grace`]: twenty-five seconds.
+///
+/// Chosen against Kubernetes' 30-second default
+/// `terminationGracePeriodSeconds`, not picked as a round number: the drain
+/// has to *finish* inside the orchestrator's window, because a drain still
+/// running when `SIGKILL` lands has achieved nothing that a hard kill would
+/// not have. Five seconds of headroom covers the signal delivery, the poll
+/// granularity, and the final terminal frames.
+pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(25);
+
+/// Ceiling on [`ServeConfig::shutdown_grace`]: five minutes.
+///
+/// Same reasoning as [`MAX_RESUME_GRACE`]: a bound a caller could raise
+/// without limit is not a bound. A drain that cannot end is a process that
+/// cannot be redeployed.
+pub const MAX_SHUTDOWN_GRACE: Duration = Duration::from_secs(300);
+
 impl ServeConfig {
     /// The production wiring: bind, token, and the standard observability stack.
     #[must_use]
@@ -202,7 +231,20 @@ impl ServeConfig {
             resume_grace: DEFAULT_RESUME_GRACE,
             session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
             allowed_hosts: Vec::new(),
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
         }
+    }
+
+    /// Set how long a shutdown drain waits before cancelling what is left,
+    /// clamped to [`MAX_SHUTDOWN_GRACE`].
+    ///
+    /// Clamped rather than rejected, for the same reason as
+    /// [`ServeConfig::with_resume_grace`]: a tuning mistake in an operational
+    /// dial must not become a failure to boot.
+    #[must_use]
+    pub fn with_shutdown_grace(mut self, grace: Duration) -> Self {
+        self.shutdown_grace = grace.min(MAX_SHUTDOWN_GRACE);
+        self
     }
 
     /// Name the hostnames this deployment answers to — see
@@ -312,6 +354,9 @@ pub(crate) struct ServerState {
     session_idle_ttl: Duration,
     /// The compiled `Host` guard, consulted before any route dispatch (#1130).
     host_policy: crate::hostguard::HostPolicy,
+    /// Ready/draining latches behind `GET /readyz` and the shutdown drain
+    /// (#1131).
+    lifecycle: Lifecycle,
 }
 
 impl ServerState {
@@ -333,6 +378,30 @@ impl ServerState {
 
     pub(crate) fn observer(&self) -> &SharedObserver {
         &self.observer
+    }
+
+    pub(crate) fn lifecycle(&self) -> &Lifecycle {
+        &self.lifecycle
+    }
+
+    /// Clones of every live turn's controls, taken under one lock and handed
+    /// back released.
+    ///
+    /// Cloning rather than acting under the lock is load-bearing: a settling
+    /// turn takes this same lock on its way out, so a drain that held it
+    /// while waiting for turns to settle would be waiting on work it was
+    /// itself blocking.
+    pub(crate) fn live_controls(&self) -> Vec<crate::controls::Controls> {
+        self.turns()
+            .values()
+            .map(|entry| entry.controls.clone())
+            .collect()
+    }
+
+    /// Every live turn's registry entry, same locking discipline as
+    /// [`ServerState::live_controls`].
+    pub(crate) fn live_entries(&self) -> Vec<Arc<Entry>> {
+        self.turns().values().map(Arc::clone).collect()
     }
 
     pub(crate) fn metrics(&self) -> &Metrics {
@@ -595,56 +664,6 @@ fn reclaim_finished_unstreamed(
     }
 }
 
-/// Burst of 401s answered with no delay. A host that restarts and races a few
-/// requests against a not-yet-updated token, or a health probe that forgets the
-/// header, should not be punished for the first handful.
-const UNAUTHORIZED_BURST: f64 = 8.0;
-
-/// Steady-state 401s per second once the burst is spent.
-const UNAUTHORIZED_REFILL_PER_SEC: f64 = 2.0;
-
-/// Delay applied to a 401 that arrives with the bucket empty.
-///
-/// This is deliberately a *delay*, not a rejection: a 429 or a dropped
-/// connection would tell an attacker they had been noticed and would break a
-/// legitimate client that is merely misconfigured. Holding the response instead
-/// costs the guesser wall-clock time per attempt — which is the entire point,
-/// since the token is a fixed shared secret with no lockout behind it — while a
-/// correctly-configured host never reaches this path at all.
-const UNAUTHORIZED_PENALTY: Duration = Duration::from_millis(500);
-
-/// A dependency-free token bucket. Deliberately per-process and not per-peer:
-/// tracking source addresses would mean unbounded state keyed by something the
-/// caller chooses, which is its own denial-of-service surface, and this is a
-/// sidecar for exactly one trusted host — a legitimate deployment produces no
-/// sustained 401s at all, so a global bucket costs it nothing.
-struct TokenBucket {
-    tokens: f64,
-    last: std::time::Instant,
-}
-
-impl TokenBucket {
-    fn new() -> Self {
-        Self {
-            tokens: UNAUTHORIZED_BURST,
-            last: std::time::Instant::now(),
-        }
-    }
-
-    /// Spend one token, returning the delay the caller must observe first.
-    fn take(&mut self, now: std::time::Instant) -> Duration {
-        let elapsed = now.saturating_duration_since(self.last).as_secs_f64();
-        self.last = now;
-        self.tokens = (self.tokens + elapsed * UNAUTHORIZED_REFILL_PER_SEC).min(UNAUTHORIZED_BURST);
-        if self.tokens >= 1.0 {
-            self.tokens -= 1.0;
-            Duration::ZERO
-        } else {
-            UNAUTHORIZED_PENALTY
-        }
-    }
-}
-
 /// Bind and serve until the accept loop hits a **fatal** error. `on_ready` fires
 /// once with the bound address (so a `:0` bind can report its port).
 ///
@@ -691,6 +710,54 @@ impl TokenBucket {
 ///
 /// [`SessionSpec::reverse_request_timeout`]: crate::SessionSpec::reverse_request_timeout
 pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> std::io::Result<()> {
+    serve_until(config, on_ready, termination_signal()).await
+}
+
+/// [`serve`], stopping when `shutdown` resolves instead of only on a fatal
+/// listener error — the injectable form the drain is tested through (#1131).
+///
+/// `serve` is this with the process's own termination signals supplied. The
+/// split exists because a signal is the one input a test cannot deliver
+/// without affecting the whole test binary: `tokio::signal` replaces a
+/// signal's default disposition process-wide, so a suite whose servers each
+/// registered a `SIGTERM` handler would quietly become un-killable. A oneshot
+/// exercises the identical drain path with none of that.
+///
+/// # What a drain does
+///
+/// 1. Report not-ready. `GET /readyz` answers `503` from this moment, so a
+///    load balancer stops routing new traffic here.
+/// 2. Refuse new work. `POST /v1/turns` and both session-creating routes
+///    answer `503`; everything an in-flight turn needs keeps working.
+/// 3. Ask every live turn to stop at its next step boundary. An in-flight
+///    model call *completes* and its result is kept — see
+///    `Controls::soft_stop` for why that is not the same as cancelling.
+/// 4. Wait, up to [`ServeConfig::shutdown_grace`], for the turns to settle.
+/// 5. Cancel whatever is left. A turn parked on a host that never answered has
+///    no boundary to reach, so the graceful ask cannot bound it; the cancel
+///    can, and still lets each turn emit its terminal frame rather than having
+///    its future dropped.
+///
+/// # The listener stays open for the whole drain
+///
+/// It is tempting to close the port first — it reads like "stop accepting" —
+/// and it is wrong twice over. The reverse-RPC protocol means an in-flight
+/// turn is finished *by the host*, over new connections: a turn parked on a
+/// `provider_request` reaches its step boundary only once a
+/// `POST /v1/turns/{id}/provider-result` arrives. Close the port and every
+/// parked turn is unreachable, so the drain waits out its whole grace period
+/// and then cancels turns it wedged itself. `GET /readyz` is likewise
+/// unanswerable, so the one signal telling a balancer to route elsewhere
+/// disappears exactly when it is needed.
+///
+/// Refusing new work is done by *status code*, not by closing the socket. The
+/// port is released when the process exits, which is the moment the
+/// replacement instance actually needs it.
+pub async fn serve_until(
+    config: ServeConfig,
+    on_ready: impl FnOnce(SocketAddr),
+    shutdown: impl std::future::Future<Output = ()>,
+) -> std::io::Result<()> {
     let listener = TcpListener::bind(config.bind).await?;
     let bound = listener.local_addr()?;
     // Compiled against the address actually bound, not the one requested: a
@@ -708,94 +775,33 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
         sessions: crate::sessions::SessionRegistry::new(),
         session_idle_ttl: config.session_idle_ttl,
         host_policy,
+        lifecycle: Lifecycle::new(),
     });
     state.observer.emit(&ServeEvent::Listening {
         addr: bound.to_string(),
         host_guard,
     });
+    // Construction is done: every later request finds a complete state, so
+    // `/readyz` may now answer `200`.
+    state.lifecycle.mark_ready();
     on_ready(bound);
-    let mut backoff = AcceptBackoff::new();
-    // Mirrors `AcceptBackoff`'s own streak. Kept here rather than exposed from
-    // `accept.rs` because that file is guarded byte-identical against
-    // `stella-observatory`'s copy — reporting is this server's concern, not the
-    // shared policy's.
-    let mut streak = 0_u32;
-    loop {
-        let stream = match listener.accept().await {
-            Ok((stream, _)) => {
-                backoff.succeeded();
-                streak = 0;
-                stream
-            }
-            Err(err) => match accept::classify(&err) {
-                // A dead pending connection or an interrupted syscall: the
-                // listener is fine, and this cannot spin (see `accept`).
-                AcceptAction::Retry => {
-                    backoff.succeeded();
-                    streak = 0;
-                    continue;
-                }
-                // Exhaustion, or a condition `io::ErrorKind` cannot name. Sleep
-                // so it cannot busy-loop, and give up if it never clears.
-                AcceptAction::Backoff => {
-                    streak += 1;
-                    let kind = accept_kind(&err);
-                    match backoff.next_delay() {
-                        Some(delay) => {
-                            state.observer.emit(&ServeEvent::AcceptBackoff {
-                                kind,
-                                delay_ms: millis(delay),
-                                streak,
-                            });
-                            tokio::time::sleep(delay).await;
-                            continue;
-                        }
-                        None => {
-                            state
-                                .observer
-                                .emit(&ServeEvent::AcceptGaveUp { kind, streak });
-                            shutting_down(&state);
-                            return Err(err);
-                        }
-                    }
-                }
-                AcceptAction::Fatal => {
-                    shutting_down(&state);
-                    return Err(err);
-                }
-            },
-        };
-        // Nagle off. Every frame on this wire gates the next engine step — a
-        // `provider_request` the host has not seen yet is a step that cannot
-        // proceed — so coalescing a small write with the next one trades
-        // nothing for up to a delayed-ACK's worth of added latency per step.
-        let _ = stream.set_nodelay(true);
-        let state = Arc::clone(&state);
-        // Per-connection errors (client hangup, bad request) stay local to the
-        // connection; the accept loop keeps serving. The error is no longer
-        // discarded — `RequestRecord::close` names it before this returns.
-        tokio::spawn(async move {
-            let _ = handle_conn(stream, state).await;
-        });
-    }
-}
+    let shutdown_grace = config.shutdown_grace.min(MAX_SHUTDOWN_GRACE);
 
-/// Which exhaustion class an accept error belongs to, mirroring `accept.rs`'s
-/// own split without modifying that (drift-guarded) file.
-fn accept_kind(err: &std::io::Error) -> AcceptKind {
-    match err.kind() {
-        std::io::ErrorKind::OutOfMemory => AcceptKind::Exhaustion,
-        // EMFILE/ENFILE/ENOBUFS have no `ErrorKind`, so they land here too —
-        // "unnameable" is the honest label for what we can actually tell.
-        _ => AcceptKind::Unnameable,
+    // The two run concurrently on purpose — see the "listener stays open"
+    // note above. Whichever finishes first ends the server: a completed drain
+    // is the orderly exit, a returning accept loop is the fatal-listener one.
+    // Dropping the loser is safe either way; `TcpListener::accept` is
+    // cancel-safe, and an in-flight connection lives in its own spawned task
+    // rather than in this future.
+    let accepting = accept_loop(&state, listener);
+    let draining = async {
+        shutdown.await;
+        drain(&state, shutdown_grace).await;
+    };
+    tokio::select! {
+        result = accepting => result,
+        () = draining => Ok(()),
     }
-}
-
-fn shutting_down(state: &Arc<ServerState>) {
-    state.observer.emit(&ServeEvent::ShuttingDown {
-        reason: ShutdownReason::ListenerFailed,
-        live_turns: state.turns().len(),
-    });
 }
 
 /// Serve one connection, and report it exactly once.
@@ -807,7 +813,10 @@ fn shutting_down(state: &Arc<ServerState>) {
 /// "remember to report" across its sixteen exits is one refactor away from
 /// being silently false, which is exactly how the PROOF rail (#901) shipped a
 /// surface that reported only on the happy path.
-async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
+pub(crate) async fn handle_conn(
+    mut stream: TcpStream,
+    state: Arc<ServerState>,
+) -> std::io::Result<()> {
     let mut record = RequestRecord::opening(RequestId::generate());
     // Read the head first so the peer's correlation id can be adopted, but note
     // the record already exists: a peer that never completes a head still gets
@@ -930,6 +939,16 @@ async fn route(
         discard_body(res.stream_mut(), &mut req).await;
         return routes::handle_health(res).await;
     }
+    // Unauthenticated for the same reason `/healthz` is: a readiness probe is
+    // infrastructure, run by a kubelet or a load balancer that has no bearer
+    // token and no way to be given one. It reveals strictly less than
+    // `/healthz` already does — that the process is alive is implied by any
+    // answer at all, and "draining" is a state an operator's own orchestrator
+    // put it in.
+    if route == Route::Readyz && req.method == "GET" {
+        discard_body(res.stream_mut(), &mut req).await;
+        return routes::handle_ready(res, state).await;
+    }
     // Compared in constant time: `==` on a `&str` stops at the first differing
     // byte, which leaks the shared secret one byte at a time to a caller that
     // can time its own 401s. A missing header stays a hard `false` so an
@@ -960,6 +979,38 @@ async fn route(
             .json(
                 "401 Unauthorized",
                 br#"{"error":"missing or invalid bearer token"}"#,
+            )
+            .await;
+    }
+
+    // A draining process finishes what it has and admits nothing new (#1131).
+    //
+    // The split is what makes a drain a drain rather than a stall: the three
+    // routes below *start* work, so they are refused, while everything an
+    // in-flight turn needs to reach its step boundary — `tool-result` and
+    // `provider-result` above all, but also cancel/pause/resume/steer and the
+    // `/events` stream watching it — keeps working. Refusing a
+    // `provider-result` here would park every turn on a reverse request it
+    // could no longer be answered on, and the drain would then time out
+    // cancelling turns it had itself wedged.
+    //
+    // Placed after the auth check on purpose: an anonymous caller learns
+    // "wrong token", not "this instance is going away".
+    if state.lifecycle().is_draining()
+        && matches!(
+            route,
+            Route::TurnsCreate | Route::SessionsCreate | Route::SessionTurns
+        )
+    {
+        discard_body(res.stream_mut(), &mut req).await;
+        // `Retry-After: 1` points a client at its *next* attempt, which a load
+        // balancer that has seen `/readyz` go `503` will route to a different
+        // instance. It is not a promise that this one will be back.
+        return res
+            .json_with_headers(
+                "503 Service Unavailable",
+                &[("Retry-After", "1")],
+                &error_body("server is shutting down and is not accepting new work"),
             )
             .await;
     }
@@ -1087,6 +1138,7 @@ fn route_addresses_a_turn(route: Route) -> bool {
 fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
     match segs {
         ["healthz"] => (Route::Healthz, None),
+        ["readyz"] => (Route::Readyz, None),
         ["v1", "metrics"] => (Route::Metrics, None),
         ["v1", "turns"] => (Route::TurnsCreate, None),
         ["v1", "turns", id, "events"] => (Route::TurnEvents, Some(id)),
@@ -1139,7 +1191,7 @@ fn resume_point(query: &str, req: &crate::http::Request) -> Option<u64> {
 /// The `Allow` header value for a known route.
 fn allowed(route: Route) -> &'static str {
     match route {
-        Route::Healthz | Route::Metrics | Route::TurnEvents => "GET",
+        Route::Healthz | Route::Readyz | Route::Metrics | Route::TurnEvents => "GET",
         Route::TurnsCreate
         | Route::TurnToolResult
         | Route::TurnProviderResult
@@ -1198,49 +1250,6 @@ mod tests {
     use stella_core::{BudgetGuard, EngineConfig};
     use stella_protocol::{BudgetMode, CompletionMessage};
 
-    /// A brute-force run against the only credential this service has must
-    /// stop being free after the burst. Driven over an injected `Instant` so
-    /// the refill is asserted exactly, with no sleeping in the test.
-    #[test]
-    fn sustained_401s_are_throttled_once_the_burst_is_spent() {
-        let start = std::time::Instant::now();
-        let mut bucket = TokenBucket::new();
-        for attempt in 0..UNAUTHORIZED_BURST as usize {
-            assert_eq!(
-                bucket.take(start),
-                Duration::ZERO,
-                "attempt {attempt} is within the burst and must not be delayed"
-            );
-        }
-        assert_eq!(
-            bucket.take(start),
-            UNAUTHORIZED_PENALTY,
-            "the first attempt past the burst is held"
-        );
-        // Half a second of refill at 2/sec is exactly one token.
-        assert_eq!(
-            bucket.take(start + Duration::from_millis(500)),
-            Duration::ZERO
-        );
-        assert_eq!(
-            bucket.take(start + Duration::from_millis(500)),
-            UNAUTHORIZED_PENALTY,
-            "and it is spent again immediately"
-        );
-    }
-
-    #[test]
-    fn refill_is_capped_at_the_burst_size() {
-        let start = std::time::Instant::now();
-        let mut bucket = TokenBucket::new();
-        // An hour idle must not bank an hour of tokens.
-        let later = start + Duration::from_secs(3600);
-        for _ in 0..UNAUTHORIZED_BURST as usize {
-            assert_eq!(bucket.take(later), Duration::ZERO);
-        }
-        assert_eq!(bucket.take(later), UNAUTHORIZED_PENALTY);
-    }
-
     fn test_state() -> (ServerState, Arc<Capture>) {
         let capture = Arc::new(Capture::new());
         let state = ServerState {
@@ -1259,6 +1268,13 @@ mod tests {
                     .expect("a literal loopback address"),
                 &[],
             ),
+            // Ready, not draining: the unit tests below exercise routing and
+            // the turn registry, neither of which is about the drain.
+            lifecycle: {
+                let lifecycle = Lifecycle::new();
+                lifecycle.mark_ready();
+                lifecycle
+            },
         };
         (state, capture)
     }

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -1254,7 +1254,9 @@ mod tests {
             sessions: crate::sessions::SessionRegistry::new(),
             session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
             host_policy: crate::hostguard::HostPolicy::new(
-                "127.0.0.1:8080".parse().expect("a literal loopback address"),
+                "127.0.0.1:8080"
+                    .parse()
+                    .expect("a literal loopback address"),
                 &[],
             ),
         };

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -4,22 +4,28 @@
 //! and the retry-jitter RNG across awaits — `stella-cli::fleet_cmd`), so it
 //! cannot be `tokio::spawn`ed onto the server's multi-thread runtime. Instead
 //! each session gets its own OS thread running a **current-thread** runtime that
-//! `block_on`s `run_turn`; the server side communicates with it purely through
+//! `block_on`s a loop over `stella_engine::run_step`; the server side
+//! communicates with it purely through
 //! `Send` channels — an outbound [`ServerFrame`] stream and the shared
 //! [`Pending`] one-shot registry. This is the fleet's bridge, reused for a
 //! long-lived server instead of a batch worker.
 //!
 //! Scope note: one [`Session`] drives one turn. Multi-turn sessions (retaining
-//! the message history across turns) and per-step checkpointing layer on top of
-//! this without changing the transport.
+//! the message history across turns) layer on top of this without changing the
+//! transport; per-step checkpointing now has its seam here (see
+//! [`drive_turn`]) but nothing is persisted yet.
 
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use stella_core::{BudgetGuard, Engine, EngineConfig};
+use stella_core::EngineConfig;
+use stella_engine::{
+    BudgetGuard, CancelToken, Engine, EventSender, StepOutcome, TurnOutcome, step_cap_reason,
+};
 use stella_protocol::{
-    AgentEvent, CompletionMessage, CompletionResult, ProviderError, ToolOutput, ToolSchema,
+    AgentEvent, CompletionMessage, CompletionResult, ProviderError, StageKind, ToolOutput,
+    ToolSchema,
 };
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
@@ -114,6 +120,11 @@ pub struct Session {
     /// reason: the session object itself is exclusively owned by whichever
     /// stream is running, so control POSTs need a handle that is not it.
     controls: Controls,
+    /// This turn's step-boundary stop signal (#1129), shared with the registry
+    /// entry exactly like [`Pending`] and [`Controls`] and for the same
+    /// reason: a cancel POST cannot reach the session object, which whichever
+    /// `/events` stream is running has checked out.
+    cancel: CancelToken,
     thread: Option<JoinHandle<()>>,
     /// This turn's sequenced, bounded frame tail.
     ///
@@ -135,6 +146,8 @@ impl Session {
         let (frame_tx, frame_rx) = mpsc::unbounded_channel::<ServerFrame>();
         let pending = Pending::new(spec.observer.clone(), spec.turn.clone());
         let (controls, control_ports) = Controls::new();
+        let cancel = CancelToken::new();
+        let thread_cancel = cancel.clone();
         // Fallible spawn on purpose: a host that opens more turns than the OS
         // will grant threads must see a cleanly aborted turn on the wire, not
         // the panic bare `std::thread::spawn` raises when creation fails.
@@ -144,8 +157,9 @@ impl Session {
         let abort_turn = spec.turn.clone();
         let thread_pending = pending.clone();
         let builder = std::thread::Builder::new().name("stella-serve-session".to_string());
-        let spawned =
-            builder.spawn(move || run_session(spec, frame_tx, thread_pending, control_ports));
+        let spawned = builder.spawn(move || {
+            run_session(spec, frame_tx, thread_pending, control_ports, thread_cancel)
+        });
         let thread = match spawned {
             Ok(thread) => Some(thread),
             Err(err) => {
@@ -171,6 +185,7 @@ impl Session {
             frames: frame_rx,
             pending,
             controls,
+            cancel,
             thread,
             history: Arc::new(FrameHistory::new()),
         }
@@ -233,6 +248,12 @@ impl Session {
         self.controls.clone()
     }
 
+    /// A handle to this turn's step-boundary cancel token, cloneable and
+    /// `Send` — same contract as [`Session::pending`], for `handle_cancel`.
+    pub(crate) fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
+    }
+
     /// Answer a [`ServerFrame::ToolRequest`] with the host-run tool output.
     pub fn resolve_tool(&self, request_id: &str, output: ToolOutput) -> Result<(), ServeError> {
         self.pending.resolve_tool(request_id, output)
@@ -266,7 +287,20 @@ impl Session {
     /// latch once `wait_if_paused` returns, so a cancel that leaves a paused
     /// turn parked would hold its OS thread for a resume that is never coming
     /// (see `crate::controls`).
+    ///
+    /// Three signals, because they stop three different waits (#1129):
+    ///
+    /// - The [`CancelToken`] is read at the top of every engine step, so a
+    ///   turn doing CPU-bound work *between* reverse requests — compaction,
+    ///   loop detection — stops at the next boundary. Without it, such a turn
+    ///   observed the cancel only when it next happened to ask the host
+    ///   something, which for a long compaction pass is an unbounded wait.
+    /// - `Pending::cancel` wakes a turn already parked on a reverse request
+    ///   and refuses new ones, so nothing parks after the fact.
+    /// - `Controls::resume` releases a turn parked on the pause gate, which
+    ///   neither of the others can reach.
     pub fn cancel(&self) {
+        self.cancel.cancel();
         self.pending.cancel();
         self.controls.resume();
     }
@@ -303,12 +337,113 @@ impl Drop for Session {
         // than leaking a thread wedged on a host that will never answer. We do
         // not join (a still-running turn could take arbitrarily long) — the
         // thread detaches and drains itself.
+        // Same three signals as `Session::cancel`, and for the same reasons:
+        // the token stops a step that is computing, `Pending` wakes one that
+        // is parked on the host, and the gate release wakes one that is
+        // paused.
+        self.cancel.cancel();
         self.pending.cancel();
         // A paused turn is parked on the gate, not on a reverse request, so the
         // cancel above cannot wake it — the release here is what lets the
         // detached thread observe the latch and unwind (see `crate::controls`).
         self.controls.resume();
         drop(self.thread.take());
+    }
+}
+
+/// What a driven turn hands back: the outcome, plus the state the engine
+/// mutated on the way there.
+///
+/// `Engine::run_turn` writes those back through `&mut` borrows. Driving steps
+/// means owning a [`TurnState`] instead, so they come back as values — which
+/// is also what makes the transcript available to checkpoint *between* steps
+/// rather than only after the turn.
+struct DrivenTurn {
+    outcome: TurnOutcome,
+    messages: Vec<CompletionMessage>,
+    budget: BudgetGuard,
+}
+
+/// Drive one turn as a loop over [`Engine::run_step`], the step-scoped facade
+/// `stella-engine` exists to expose (#1129).
+///
+/// This is deliberately the same loop as `Engine::run_turn_with_sender` —
+/// which is itself a loop over `run_step`, so there is one implementation of
+/// a step and no second engine here. What driving it from this side buys is
+/// the two things a whole-turn call cannot give a durable host:
+///
+/// - **A step-boundary cancel.** [`CancelToken`] is read at the top of every
+///   step, so `POST /v1/turns/{id}/cancel` interrupts CPU-bound work
+///   *between* reverse requests — compaction, loop detection — instead of
+///   only at the next time the engine happens to ask the host something.
+///   Before this, a turn that was mid-compaction observed a cancel only once
+///   it next parked on a reverse request.
+/// - **A checkpoint seam.** `StepOutcome::Continue` is the one moment the
+///   transcript is guaranteed well-paired (no `tool_use` without its
+///   `tool_result`), which is exactly where a durable runner would persist
+///   `state.to_checkpoint()`. This server does not persist one yet — there is
+///   nowhere to put it — but the seam is now here rather than one refactor
+///   away.
+async fn drive_turn(
+    engine: &Engine<'_>,
+    messages: Vec<CompletionMessage>,
+    budget: BudgetGuard,
+    events: &mpsc::UnboundedSender<AgentEvent>,
+    cancel: CancelToken,
+) -> DrivenTurn {
+    let events = EventSender::new(events.clone());
+    // The stage marker `run_turn` opens with. Emitted here for the same
+    // reason the loop is here: a host driving steps must produce the identical
+    // event sequence, or a client cannot tell the two drivers apart — which is
+    // the whole promise of `run_turn` being a loop over `run_step`.
+    let _ = events.send(AgentEvent::Stage {
+        name: StageKind::Execute,
+    });
+    let max_steps = engine.max_steps();
+    let mut state = engine.new_turn(messages, budget).with_cancel_token(cancel);
+
+    let outcome = loop {
+        if state.step() >= max_steps {
+            // The belt-and-suspenders backstop, reported exactly as
+            // `run_turn` reports it — the string is shared rather than
+            // copied, because two spellings of one failure read as two
+            // failures.
+            let reason = step_cap_reason(max_steps);
+            let _ = events.send(AgentEvent::Error {
+                message: reason.clone(),
+                retryable: false,
+            });
+            break TurnOutcome::Aborted {
+                reason,
+                cost_usd: state.total_cost_usd(),
+            };
+        }
+        match engine.run_step(&mut state, &events).await {
+            // The checkpoint seam. Nothing is persisted yet; the comment is
+            // here so the next person looking for where a checkpoint would go
+            // finds the answer rather than the question.
+            StepOutcome::Continue => continue,
+            terminal => {
+                if let Some(outcome) = terminal.into_turn_outcome() {
+                    break outcome;
+                }
+                // Unreachable: `into_turn_outcome` is `None` only for
+                // `Continue`, which the arm above already took. Breaking
+                // rather than panicking keeps a future variant from taking
+                // down a session thread.
+                break TurnOutcome::Aborted {
+                    reason: "engine step returned no outcome".to_string(),
+                    cost_usd: state.total_cost_usd(),
+                };
+            }
+        }
+    };
+
+    let budget = *state.budget();
+    DrivenTurn {
+        outcome,
+        messages: state.into_messages(),
+        budget,
     }
 }
 
@@ -319,6 +454,7 @@ fn run_session(
     frame_tx: mpsc::UnboundedSender<ServerFrame>,
     pending: Pending,
     control_ports: ControlPorts,
+    cancel: CancelToken,
 ) {
     let observer = spec.observer.clone();
     let turn = spec.turn.clone();
@@ -390,9 +526,10 @@ fn run_session(
             fold.finish()
         });
 
-        let mut messages = spec.messages;
-        let mut budget = spec.budget;
-        let outcome = engine.run_turn(&mut messages, &mut budget, &event_tx).await;
+        let outcome = drive_turn(&engine, spec.messages, spec.budget, &event_tx, cancel).await;
+        let messages = outcome.messages;
+        let budget = outcome.budget;
+        let outcome = outcome.outcome;
 
         // Close the event channel so the forwarder drains and exits before the
         // terminal frame — a well-behaved host thus sees every event first.

--- a/stella-serve/src/throttle.rs
+++ b/stella-serve/src/throttle.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The 401 throttle: a dependency-free token bucket that slows a sustained
+//! token guess without telling the guesser it has been noticed.
+//!
+//! Split out of `server.rs` because it is self-contained policy with its own
+//! tests, and that file is at the size ratchet's limit. Nothing here touches
+//! the server's state; `route` consults it and holds the response.
+
+use std::time::Duration;
+
+/// Burst of 401s answered with no delay. A host that restarts and races a few
+/// requests against a not-yet-updated token, or a health probe that forgets the
+/// header, should not be punished for the first handful.
+pub(crate) const UNAUTHORIZED_BURST: f64 = 8.0;
+
+/// Steady-state 401s per second once the burst is spent.
+pub(crate) const UNAUTHORIZED_REFILL_PER_SEC: f64 = 2.0;
+
+/// Delay applied to a 401 that arrives with the bucket empty.
+///
+/// This is deliberately a *delay*, not a rejection: a 429 or a dropped
+/// connection would tell an attacker they had been noticed and would break a
+/// legitimate client that is merely misconfigured. Holding the response instead
+/// costs the guesser wall-clock time per attempt — which is the entire point,
+/// since the token is a fixed shared secret with no lockout behind it — while a
+/// correctly-configured host never reaches this path at all.
+pub(crate) const UNAUTHORIZED_PENALTY: Duration = Duration::from_millis(500);
+
+/// A dependency-free token bucket. Deliberately per-process and not per-peer:
+/// tracking source addresses would mean unbounded state keyed by something the
+/// caller chooses, which is its own denial-of-service surface, and this is a
+/// sidecar for exactly one trusted host — a legitimate deployment produces no
+/// sustained 401s at all, so a global bucket costs it nothing.
+pub(crate) struct TokenBucket {
+    tokens: f64,
+    last: std::time::Instant,
+}
+
+impl TokenBucket {
+    pub(crate) fn new() -> Self {
+        Self {
+            tokens: UNAUTHORIZED_BURST,
+            last: std::time::Instant::now(),
+        }
+    }
+
+    /// Spend one token, returning the delay the caller must observe first.
+    pub(crate) fn take(&mut self, now: std::time::Instant) -> Duration {
+        let elapsed = now.saturating_duration_since(self.last).as_secs_f64();
+        self.last = now;
+        self.tokens = (self.tokens + elapsed * UNAUTHORIZED_REFILL_PER_SEC).min(UNAUTHORIZED_BURST);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            Duration::ZERO
+        } else {
+            UNAUTHORIZED_PENALTY
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A brute-force run against the only credential this service has must
+    /// stop being free after the burst. Driven over an injected `Instant` so
+    /// the refill is asserted exactly, with no sleeping in the test.
+    #[test]
+    fn sustained_401s_are_throttled_once_the_burst_is_spent() {
+        let start = std::time::Instant::now();
+        let mut bucket = TokenBucket::new();
+        for attempt in 0..UNAUTHORIZED_BURST as usize {
+            assert_eq!(
+                bucket.take(start),
+                Duration::ZERO,
+                "attempt {attempt} is within the burst and must not be delayed"
+            );
+        }
+        assert_eq!(
+            bucket.take(start),
+            UNAUTHORIZED_PENALTY,
+            "the first attempt past the burst is held"
+        );
+        // Half a second of refill at 2/sec is exactly one token.
+        assert_eq!(
+            bucket.take(start + Duration::from_millis(500)),
+            Duration::ZERO
+        );
+        assert_eq!(
+            bucket.take(start + Duration::from_millis(500)),
+            UNAUTHORIZED_PENALTY,
+            "and it is spent again immediately"
+        );
+    }
+
+    #[test]
+    fn refill_is_capped_at_the_burst_size() {
+        let start = std::time::Instant::now();
+        let mut bucket = TokenBucket::new();
+        // An hour idle must not bank an hour of tokens.
+        let later = start + Duration::from_secs(3600);
+        for _ in 0..UNAUTHORIZED_BURST as usize {
+            assert_eq!(bucket.take(later), Duration::ZERO);
+        }
+        assert_eq!(bucket.take(later), UNAUTHORIZED_PENALTY);
+    }
+}

--- a/stella-serve/tests/common/mod.rs
+++ b/stella-serve/tests/common/mod.rs
@@ -26,7 +26,7 @@ use stella_protocol::{CompletionMessage, ToolSchema};
 use stella_serve::observe::{
     Capture, Fanout, Metrics, ServeEvent, SharedObserver, StreamEndReason,
 };
-use stella_serve::{ServeConfig, serve};
+use stella_serve::{ServeConfig, serve_until};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
@@ -70,10 +70,31 @@ pub async fn start_observed_server() -> (SocketAddr, Arc<Capture>) {
 /// [`start_observed_server`] with an explicit resume window, for the tests that
 /// are *about* that window.
 pub async fn start_observed_server_with(resume_grace: Duration) -> (SocketAddr, Arc<Capture>) {
+    let (addr, capture, _shutdown) =
+        start_drainable_server(resume_grace, stella_serve::DEFAULT_SHUTDOWN_GRACE).await;
+    // The shutdown handle is dropped: a dropped `oneshot::Sender` resolves its
+    // receiver, so the returned future would fire immediately and every server
+    // in the suite would drain the moment it started. `pending_shutdown`
+    // inside is what keeps that from happening — see there.
+    (addr, capture)
+}
+
+/// A server whose drain a test can trigger, plus the handle that triggers it.
+///
+/// Sending on the returned [`oneshot::Sender`] is the test-side stand-in for a
+/// `SIGTERM`. It drives the identical path — `serve` is `serve_until` with the
+/// process's signals supplied — without registering a real signal handler,
+/// which would replace `SIGTERM`'s disposition for the whole test binary and
+/// quietly make the suite un-killable (#1131).
+pub async fn start_drainable_server(
+    resume_grace: Duration,
+    shutdown_grace: Duration,
+) -> (SocketAddr, Arc<Capture>, oneshot::Sender<()>) {
     let capture = Arc::new(Capture::new());
     let observer = capture.clone();
     let metrics = Arc::new(Metrics::new());
     let (tx, rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let fanout: SharedObserver = Arc::new(Fanout::new(vec![observer, metrics.clone()]));
     tokio::spawn(async move {
         let config = ServeConfig {
@@ -89,14 +110,31 @@ pub async fn start_observed_server_with(resume_grace: Duration) -> (SocketAddr, 
             // `Host: localhost` accordingly — `Host: engine` was a fiction no
             // real client would send (#1130).
             allowed_hosts: Vec::new(),
+            shutdown_grace,
         };
-        let _ = serve(config, move |addr| {
-            let _ = tx.send(addr);
-        })
+        let _ = serve_until(
+            config,
+            move |addr| {
+                let _ = tx.send(addr);
+            },
+            pending_shutdown(shutdown_rx),
+        )
         .await;
     });
     let addr = rx.await.expect("server reported its bound address");
-    (addr, capture)
+    (addr, capture, shutdown_tx)
+}
+
+/// Resolve when the sender *sends*, never when it is merely dropped.
+///
+/// A bare `oneshot::Receiver` resolves (with an error) on drop, which would
+/// make every server started by [`start_observed_server_with`] — which drops
+/// its handle immediately — drain before its test did anything. Swallowing the
+/// drop case turns the handle into a pure "trigger" rather than a lifetime.
+async fn pending_shutdown(rx: oneshot::Receiver<()>) {
+    if rx.await.is_err() {
+        std::future::pending::<()>().await;
+    }
 }
 
 /// POST a JSON body and read the whole response (server sends `Connection:

--- a/stella-serve/tests/common/mod.rs
+++ b/stella-serve/tests/common/mod.rs
@@ -83,6 +83,12 @@ pub async fn start_observed_server_with(resume_grace: Duration) -> (SocketAddr, 
             metrics,
             resume_grace,
             session_idle_ttl: stella_serve::DEFAULT_SESSION_IDLE_TTL,
+            // Empty on purpose: the bind is loopback, so the `Host` guard
+            // already knows what this server is called and needs no
+            // allow-list. Every helper below dials 127.0.0.1 and announces
+            // `Host: localhost` accordingly — `Host: engine` was a fiction no
+            // real client would send (#1130).
+            allowed_hosts: Vec::new(),
         };
         let _ = serve(config, move |addr| {
             let _ = tx.send(addr);
@@ -106,7 +112,7 @@ pub async fn post_json(
         .map(|t| format!("Authorization: Bearer {t}\r\n"))
         .unwrap_or_default();
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: engine\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len(),
     );
     stream.write_all(request.as_bytes()).await.unwrap();
@@ -120,7 +126,7 @@ pub async fn post_json(
 /// GET a plain endpoint (used for `/healthz`), returning `(status_line, body)`.
 pub async fn get_json(addr: SocketAddr, path: &str) -> (String, String) {
     let mut stream = TcpStream::connect(addr).await.unwrap();
-    let request = format!("GET {path} HTTP/1.1\r\nHost: engine\r\nConnection: close\r\n\r\n");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
     stream.read_to_string(&mut response).await.unwrap();
@@ -131,12 +137,52 @@ pub async fn get_json(addr: SocketAddr, path: &str) -> (String, String) {
     )
 }
 
+/// GET with an explicit `Host` header, for the `Host`-guard tests — every
+/// other helper hardcodes a loopback identity, which is precisely what these
+/// need to vary.
+pub async fn get_with_host(
+    addr: SocketAddr,
+    path: &str,
+    host: &str,
+    token: Option<&str>,
+) -> (String, String) {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let auth = token
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\n{auth}Connection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    let (head, body) = response.split_once("\r\n\r\n").unwrap_or((&response, ""));
+    (
+        head.lines().next().unwrap_or_default().to_string(),
+        body.to_string(),
+    )
+}
+
+/// GET with no `Host` header at all — the HTTP/1.0-style request the guard
+/// deliberately permits.
+pub async fn get_without_host(addr: SocketAddr, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let request = format!("GET {path} HTTP/1.1\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    response
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim_end()
+        .to_string()
+}
+
 /// GET with the bearer token, reading the whole response. Used to probe a
 /// route's status without the side effect a POST would carry.
 pub async fn get_json_authed(addr: SocketAddr, path: &str, token: &str) -> (String, String) {
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "GET {path} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
@@ -153,7 +199,7 @@ pub async fn get_json_authed(addr: SocketAddr, path: &str, token: &str) -> (Stri
 pub async fn open_sse(addr: SocketAddr, path: &str, token: &str) -> BufReader<TcpStream> {
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "GET {path} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut reader = BufReader::new(stream);
@@ -287,7 +333,7 @@ pub async fn open_sse_resuming(
 ) -> BufReader<TcpStream> {
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "GET {path} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {token}\r\n\
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\n\
          Last-Event-ID: {last_event_id}\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();

--- a/stella-serve/tests/control.rs
+++ b/stella-serve/tests/control.rs
@@ -414,3 +414,128 @@ async fn steering_a_finished_turn_is_a_conflict_not_a_silent_no_op() {
         );
     }
 }
+
+/// **#932's acceptance sentence, end to end:** "A host can pause a running
+/// turn, inject a message, and resume it, without cancelling and losing the
+/// transcript."
+///
+/// The three halves are each covered above in isolation; this is the
+/// composition, and the composition is what the issue actually promises. It is
+/// worth its own test because the expensive thing an agent turn holds is its
+/// transcript — the whole argument for pause-and-steer over cancel-and-restart
+/// is that the prompt prefix survives, and a test that only checked "the turn
+/// did not die" would pass even if the history had been rebuilt from scratch.
+///
+/// So the assertion is on *identity*, not liveness: after a pause → steer →
+/// resume cycle, the model's next request must still carry the original user
+/// message, the assistant turn that followed it, and its tool result — with
+/// the steered message appended rather than replacing them.
+#[tokio::test]
+async fn a_turn_survives_pause_steer_resume_with_its_transcript_intact() {
+    let addr = start_server().await;
+    let turn_id = create_tool_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    // Step 1: let the model ask for a tool, so the turn has real history to
+    // lose before anything is paused.
+    let first = next_provider_request(&mut sse).await;
+    let opening = first["request"]["messages"]
+        .as_array()
+        .expect("the first request carries the host's messages")
+        .clone();
+    assert_eq!(opening.len(), 1, "the turn starts from one user message");
+
+    // Pause *before* answering, so the hold lands at the boundary between
+    // step 1 and step 2 rather than racing the turn's end.
+    let (status, body) =
+        post_json(addr, &format!("/v1/turns/{turn_id}/pause"), Some(TOKEN), "").await;
+    assert!(status.contains("200"), "pause: {status} {body}");
+
+    answer_provider(
+        addr,
+        &turn_id,
+        first["request_id"].as_str().unwrap(),
+        model_wants_echo(),
+    )
+    .await;
+    let tool = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a tool_request must arrive")
+            .expect("stream must not end before the tool_request");
+        if frame["type"] == "tool_request" {
+            break frame;
+        }
+    };
+    answer_tool(addr, &turn_id, tool["request_id"].as_str().unwrap()).await;
+
+    // The turn is now held at the step boundary. Inject the correction a human
+    // would type — the "actually, don't" the issue is written around.
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/steer"),
+        Some(TOKEN),
+        &json!({ "message": "actually, stop after this" }).to_string(),
+    )
+    .await;
+    assert!(status.contains("200"), "steer: {status} {body}");
+
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/resume"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("200"), "resume: {status} {body}");
+
+    // The released turn's next model call is the proof. This is the SAME turn
+    // — not a new one seeded with a copied history — so everything step 1
+    // produced is still there, with the steer appended.
+    let second = next_provider_request(&mut sse).await;
+    let messages = second["request"]["messages"]
+        .as_array()
+        .expect("the resumed request carries a transcript");
+
+    assert!(
+        messages.len() > opening.len(),
+        "the transcript grew across the pause rather than restarting: {messages:?}"
+    );
+    assert_eq!(
+        messages[0], opening[0],
+        "the original user message must survive the pause verbatim — a rebuilt \
+         transcript would re-pay the prompt prefix this whole mechanism exists to keep",
+    );
+    assert!(
+        messages.iter().any(|m| m["role"] == "assistant"),
+        "the assistant turn from step 1 must survive: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m["role"] == "user" && m["content"] == "actually, stop after this"),
+        "the steered message must be appended: {messages:?}"
+    );
+
+    // And the turn really does finish — held, not broken.
+    answer_provider(
+        addr,
+        &turn_id,
+        second["request_id"].as_str().unwrap(),
+        model_result("stopped"),
+    )
+    .await;
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the stream must reach its terminal frame");
+        let Some(frame) = frame else { break };
+        if frame["type"] == "turn_complete" {
+            assert_eq!(
+                frame["outcome"]["status"], "completed",
+                "a paused-and-resumed turn completes; it is not cancelled",
+            );
+            break;
+        }
+    }
+}

--- a/stella-serve/tests/hostguard.rs
+++ b/stella-serve/tests/hostguard.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The DNS-rebinding `Host` guard over the wire (#1130).
+//!
+//! `hostguard.rs`'s unit tests pin the policy decision in isolation; these pin
+//! that the decision is actually *reached* — before route dispatch, on every
+//! route including the unauthenticated `/healthz`, and ahead of the bearer
+//! check so a rebound request cannot even provoke a 401 that tells it a token
+//! is what it is missing.
+
+mod common;
+
+use common::{
+    TOKEN, get_json_authed, get_with_host, get_without_host, start_observed_server, start_server,
+};
+use stella_serve::observe::ServeEvent;
+
+/// A request announcing an attacker-controlled name is refused, and the
+/// refusal is the *only* thing it learns — it never reaches a handler.
+#[tokio::test]
+async fn a_rebound_host_is_refused_on_an_authenticated_route() {
+    let addr = start_server().await;
+    let (status, body) = get_with_host(addr, "/v1/metrics", "evil.example", Some(TOKEN)).await;
+    assert!(status.starts_with("HTTP/1.1 403"), "{status}");
+    assert!(body.contains("Host header"), "{body}");
+}
+
+/// The guard runs ahead of the bearer check. A rebound request with a *valid*
+/// token is still refused, and one with no token gets the 403 rather than the
+/// 401 — the order matters because it is the difference between "you are not
+/// allowed to ask" and "you are allowed to ask, just not authenticated".
+#[tokio::test]
+async fn the_host_guard_runs_before_authentication() {
+    let addr = start_server().await;
+    let (with_token, _) = get_with_host(addr, "/v1/metrics", "evil.example", Some(TOKEN)).await;
+    let (without_token, _) = get_with_host(addr, "/v1/metrics", "evil.example", None).await;
+    assert!(with_token.starts_with("HTTP/1.1 403"), "{with_token}");
+    assert!(without_token.starts_with("HTTP/1.1 403"), "{without_token}");
+}
+
+/// `/healthz` is the one route bearer auth does not cover, so it is the one
+/// route where the `Host` guard is the only control — exempting it would carve
+/// the hole in exactly the wrong place.
+#[tokio::test]
+async fn the_unauthenticated_health_route_is_guarded_too() {
+    let addr = start_server().await;
+    let (rebound, _) = get_with_host(addr, "/healthz", "evil.example", None).await;
+    assert!(rebound.starts_with("HTTP/1.1 403"), "{rebound}");
+
+    let (legitimate, _) = get_with_host(addr, "/healthz", "localhost", None).await;
+    assert!(legitimate.starts_with("HTTP/1.1 200"), "{legitimate}");
+}
+
+/// The loopback identities a real local client actually sends — by name, by
+/// address, and with the port it dialed — all pass.
+#[tokio::test]
+async fn every_loopback_identity_a_real_client_sends_is_permitted() {
+    let addr = start_server().await;
+    for host in [
+        "localhost".to_string(),
+        format!("localhost:{}", addr.port()),
+        "127.0.0.1".to_string(),
+        addr.to_string(),
+        "[::1]".to_string(),
+    ] {
+        let (status, _) = get_with_host(addr, "/healthz", &host, None).await;
+        assert!(
+            status.starts_with("HTTP/1.1 200"),
+            "Host: {host} must be permitted, got {status}"
+        );
+    }
+}
+
+/// A missing `Host` is permitted: a browser `fetch` always sends one, so its
+/// absence means the request is not the attack this guards against. Same
+/// posture as `stella-observatory::host_is_local`.
+#[tokio::test]
+async fn a_request_with_no_host_header_is_permitted() {
+    let addr = start_server().await;
+    let status = get_without_host(addr, "/healthz").await;
+    assert!(status.starts_with("HTTP/1.1 200"), "{status}");
+}
+
+/// The refusal is reported as its own typed event, so a rebinding attempt and
+/// an operator's missing allow-list entry are one grep rather than a scan of
+/// every 403 — and the offending name is recorded, because that is what tells
+/// the two apart.
+#[tokio::test]
+async fn a_refusal_is_reported_with_the_offending_host() {
+    let (addr, capture) = start_observed_server().await;
+    let _ = get_with_host(addr, "/v1/metrics", "evil.example", Some(TOKEN)).await;
+
+    let found = capture
+        .find(|e| matches!(e, ServeEvent::HostRejected { .. }))
+        .expect("a refused Host must be reported");
+    let ServeEvent::HostRejected { host, .. } = found else {
+        unreachable!("matched above")
+    };
+    assert_eq!(host, "evil.example");
+}
+
+/// A legitimate request emits no refusal — the guard is not firing on the
+/// traffic it is supposed to pass, which is the half of a security control
+/// that silently breaks a deployment when it is wrong.
+#[tokio::test]
+async fn a_permitted_request_reports_no_refusal() {
+    let (addr, capture) = start_observed_server().await;
+    let (status, _) = get_json_authed(addr, "/v1/metrics", TOKEN).await;
+    assert!(status.starts_with("HTTP/1.1 200"), "{status}");
+    assert_eq!(
+        capture.count(|e| matches!(e, ServeEvent::HostRejected { .. })),
+        0,
+    );
+}
+
+/// The startup record names which arm the guard compiled to, so an operator
+/// can tell an enforcing deployment from an inert one without reading the
+/// source.
+#[tokio::test]
+async fn the_listening_record_names_the_guard_mode() {
+    let (_addr, capture) = start_observed_server().await;
+    let found = capture
+        .find(|e| matches!(e, ServeEvent::Listening { .. }))
+        .expect("the server reports that it is listening");
+    let ServeEvent::Listening { host_guard, .. } = found else {
+        unreachable!("matched above")
+    };
+    assert_eq!(host_guard, stella_serve::HostMode::Loopback);
+}

--- a/stella-serve/tests/http.rs
+++ b/stella-serve/tests/http.rs
@@ -294,7 +294,7 @@ async fn post_json_head(
         .map(|t| format!("Authorization: Bearer {t}\r\n"))
         .unwrap_or_default();
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: engine\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len(),
     );
     stream.write_all(request.as_bytes()).await.unwrap();
@@ -324,7 +324,7 @@ async fn an_oversized_body_is_refused_with_413_rather_than_silence() {
     let declared = 8 * 1024 * 1024 + 1;
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "POST /v1/turns HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: {declared}\r\nConnection: close\r\n\r\n"
+        "POST /v1/turns HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: {declared}\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
@@ -471,7 +471,7 @@ async fn a_known_path_with_the_wrong_method_is_405_with_an_allow_header() {
     // GET the create route (a POST route).
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "GET /v1/turns HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nConnection: close\r\n\r\n"
+        "GET /v1/turns HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {TOKEN}\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
@@ -498,7 +498,7 @@ async fn a_chunked_request_is_refused_by_name() {
 
     let mut stream = TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "POST /v1/turns HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n2\r\n{{}}\r\n0\r\n\r\n"
+        "POST /v1/turns HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {TOKEN}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n2\r\n{{}}\r\n0\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
@@ -935,7 +935,7 @@ async fn a_request_id_is_echoed_and_a_hostile_one_is_replaced() {
 
     let head = raw_request(
         addr,
-        "GET /healthz HTTP/1.1\r\nHost: engine\r\nX-Request-Id: abc-123\r\nConnection: close\r\n\r\n",
+        "GET /healthz HTTP/1.1\r\nHost: localhost\r\nX-Request-Id: abc-123\r\nConnection: close\r\n\r\n",
     )
     .await;
     assert!(
@@ -945,7 +945,7 @@ async fn a_request_id_is_echoed_and_a_hostile_one_is_replaced() {
 
     let head = raw_request(
         addr,
-        "GET /healthz HTTP/1.1\r\nHost: engine\r\nX-Request-Id: has space and \"quotes\"\r\nConnection: close\r\n\r\n",
+        "GET /healthz HTTP/1.1\r\nHost: localhost\r\nX-Request-Id: has space and \"quotes\"\r\nConnection: close\r\n\r\n",
     )
     .await;
     assert!(

--- a/stella-serve/tests/sessions.rs
+++ b/stella-serve/tests/sessions.rs
@@ -344,7 +344,7 @@ async fn sessions_are_resources_with_honest_edges() {
     let mut delete = tokio::net::TcpStream::connect(addr).await.unwrap();
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let request = format!(
-        "DELETE /v1/sessions/{session_id} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nConnection: close\r\n\r\n"
+        "DELETE /v1/sessions/{session_id} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {TOKEN}\r\nConnection: close\r\n\r\n"
     );
     delete.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
@@ -376,7 +376,7 @@ async fn the_session_member_route_names_both_its_verbs_on_405() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
     let request = format!(
-        "POST /v1/sessions/session-abc HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        "POST /v1/sessions/session-abc HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();

--- a/stella-serve/tests/shutdown.rs
+++ b/stella-serve/tests/shutdown.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Graceful shutdown and readiness (#1131).
+//!
+//! The behaviour under test is what a container orchestrator relies on during
+//! a redeploy: `/readyz` flips to not-ready so traffic stops arriving, new
+//! turns are refused, in-flight turns reach a step boundary and emit their
+//! terminal frame, and only then does the process leave.
+//!
+//! A `oneshot` stands in for `SIGTERM` — see `common::start_drainable_server`
+//! for why a real signal handler has no place in a test binary. The path it
+//! drives is identical: `serve` is `serve_until` with the process's signals
+//! supplied.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{
+    TOKEN, create_turn, get_json, model_result, next_event, open_sse, post_json,
+    start_drainable_server, start_server,
+};
+use serde_json::json;
+use stella_serve::observe::ServeEvent;
+
+const TEST_RESUME_GRACE: Duration = Duration::from_millis(250);
+
+/// Read frames until the next `provider_request`, returning its request id.
+/// A turn parked here is exactly the "in flight" state a drain has to handle.
+async fn next_provider_request(reader: &mut tokio::io::BufReader<tokio::net::TcpStream>) -> String {
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(5), next_event(reader))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("the stream must not end before it");
+        if frame["type"] == "provider_request" {
+            return frame["request_id"].as_str().unwrap().to_string();
+        }
+    }
+}
+
+/// Poll `/readyz` until it reports `expected`, or fail loudly. The flip is
+/// driven from another task, so a bare read races it.
+async fn await_readyz(addr: std::net::SocketAddr, expected: &str) -> String {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let (status, body) = get_json(addr, "/readyz").await;
+        if status.contains(expected) {
+            return body;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "/readyz never reported {expected}; last was {status} {body}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// A healthy server is ready, and says so in a shape a human reading the probe
+/// by hand can act on.
+#[tokio::test]
+async fn readyz_reports_ready_while_serving() {
+    let addr = start_server().await;
+    let (status, body) = get_json(addr, "/readyz").await;
+    assert!(status.contains("200"), "{status}");
+    assert!(body.contains("\"state\":\"ready\""), "{body}");
+}
+
+/// `/readyz` is unauthenticated for the same reason `/healthz` is: a kubelet
+/// has no bearer token.
+#[tokio::test]
+async fn readyz_needs_no_bearer_token() {
+    let addr = start_server().await;
+    let (status, _) = get_json(addr, "/readyz").await;
+    assert!(status.contains("200"), "{status}");
+}
+
+/// The two endpoints answer different questions, and a drain is exactly where
+/// that difference shows: the process is alive (`/healthz` 200) and must not
+/// be sent new work (`/readyz` 503). A single "healthy" boolean cannot say
+/// both, which is the whole reason `/readyz` exists.
+#[tokio::test]
+async fn a_drain_makes_readyz_unready_while_healthz_stays_ok() {
+    let (addr, _capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_secs(5)).await;
+    // A live turn, so the drain has something to wait on and cannot race past
+    // the assertions below.
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let _request_id = next_provider_request(&mut sse).await;
+
+    shutdown.send(()).expect("the server is listening");
+
+    let body = await_readyz(addr, "503").await;
+    assert!(body.contains("\"state\":\"draining\""), "{body}");
+
+    let (health, _) = get_json(addr, "/healthz").await;
+    assert!(
+        health.contains("200"),
+        "a draining process is alive, not sick: {health}"
+    );
+}
+
+/// New work is refused during a drain — that is what "stops accepting" means.
+/// The `503` names the reason and carries `Retry-After`, so a client retries
+/// against whichever instance the balancer has since chosen.
+#[tokio::test]
+async fn a_drain_refuses_new_turns_and_sessions() {
+    let (addr, _capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_secs(5)).await;
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let _request_id = next_provider_request(&mut sse).await;
+
+    shutdown.send(()).expect("the server is listening");
+    await_readyz(addr, "503").await;
+
+    let create = json!({
+        "provider_id": "mock",
+        "messages": [],
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("503"), "{status} {body}");
+    assert!(body.contains("shutting down"), "{body}");
+
+    let session = json!({ "system_prompt": "you are a test" }).to_string();
+    let (status, _) = post_json(addr, "/v1/sessions", Some(TOKEN), &session).await;
+    assert!(status.contains("503"), "{status}");
+}
+
+/// The load-bearing half of the drain: an in-flight turn must still be
+/// *answerable*. Refusing `provider-result` during a drain would park every
+/// turn on a reverse request nobody could answer, and the drain would then
+/// time out cancelling turns it had itself wedged.
+#[tokio::test]
+async fn a_drain_still_accepts_answers_for_in_flight_turns() {
+    let (addr, _capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_secs(5)).await;
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let request_id = next_provider_request(&mut sse).await;
+
+    shutdown.send(()).expect("the server is listening");
+    await_readyz(addr, "503").await;
+
+    let body = json!({
+        "request_id": request_id,
+        "status": "ok",
+        "result": model_result("done"),
+    })
+    .to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &body,
+    )
+    .await;
+    assert!(
+        status.contains("200"),
+        "an in-flight turn must stay answerable during a drain: {status} {body}"
+    );
+}
+
+/// The #1131 acceptance: a signalled server drains its in-flight turn to a
+/// step boundary and the subscriber still receives `turn_complete`, rather
+/// than having the turn's future dropped and the stream simply stop.
+#[tokio::test]
+async fn a_drained_turn_still_emits_its_terminal_frame() {
+    let (addr, capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_secs(10)).await;
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let request_id = next_provider_request(&mut sse).await;
+
+    shutdown.send(()).expect("the server is listening");
+    await_readyz(addr, "503").await;
+
+    // Answer the parked model call. The soft stop is observed at the *next*
+    // step boundary, so this result lands and is kept — the difference
+    // between draining and cancelling.
+    let body = json!({
+        "request_id": request_id,
+        "status": "ok",
+        "result": model_result("done"),
+    })
+    .to_string();
+    post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &body,
+    )
+    .await;
+
+    let mut saw_terminal = false;
+    while let Some(frame) = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+        .await
+        .expect("the stream must terminate inside the grace period")
+    {
+        if frame["type"] == "turn_complete" {
+            saw_terminal = true;
+            break;
+        }
+    }
+    assert!(
+        saw_terminal,
+        "a drained turn must reach turn_complete, not have its future dropped"
+    );
+
+    // And the drain reports what it did, so a redeploy is auditable rather
+    // than merely quiet.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(ServeEvent::DrainCompleted {
+            drained,
+            cancelled,
+            timed_out,
+        }) = capture.find(|e| matches!(e, ServeEvent::DrainCompleted { .. }))
+        {
+            assert_eq!(drained, 1, "the turn reached a step boundary");
+            assert_eq!(cancelled, 0, "nothing had to be forced");
+            assert!(!timed_out, "the grace period was not exhausted");
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the drain must report its outcome"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// A turn parked on a host that never answers has no step boundary to reach,
+/// so the graceful ask alone cannot bound it. The grace period is what does —
+/// and the forced half is reported separately, because a persistently
+/// non-zero `cancelled` across deploys means the window is too short for this
+/// workload rather than that something is broken.
+#[tokio::test]
+async fn a_turn_that_never_reaches_a_boundary_is_cancelled_when_the_grace_expires() {
+    let (addr, capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_millis(300)).await;
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    // Parked on a provider request that is deliberately never answered.
+    let _request_id = next_provider_request(&mut sse).await;
+
+    shutdown.send(()).expect("the server is listening");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(ServeEvent::DrainCompleted {
+            cancelled,
+            timed_out,
+            ..
+        }) = capture.find(|e| matches!(e, ServeEvent::DrainCompleted { .. }))
+        {
+            assert_eq!(cancelled, 1, "the parked turn had to be forced");
+            assert!(timed_out, "the grace period was exhausted");
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the drain must end even when nothing reaches a boundary"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Even the forced half emits a terminal frame: cancel unwinds the turn, it
+    // does not drop its future.
+    let mut saw_terminal = false;
+    while let Some(frame) = tokio::time::timeout(Duration::from_secs(5), next_event(&mut sse))
+        .await
+        .expect("the stream must end")
+    {
+        if frame["type"] == "turn_complete" {
+            saw_terminal = true;
+            break;
+        }
+    }
+    assert!(saw_terminal, "a cancelled turn still reports its outcome");
+}
+
+/// A drain with nothing in flight ends immediately — it must not sit out the
+/// whole grace period waiting for turns that do not exist. A redeploy of an
+/// idle instance should be instant.
+#[tokio::test]
+async fn an_idle_server_drains_immediately() {
+    let (addr, capture, shutdown) =
+        start_drainable_server(TEST_RESUME_GRACE, Duration::from_secs(60)).await;
+    shutdown.send(()).expect("the server is listening");
+
+    let started = tokio::time::Instant::now();
+    let deadline = started + Duration::from_secs(5);
+    loop {
+        if let Some(ServeEvent::DrainCompleted {
+            drained,
+            cancelled,
+            timed_out,
+        }) = capture.find(|e| matches!(e, ServeEvent::DrainCompleted { .. }))
+        {
+            assert_eq!((drained, cancelled), (0, 0));
+            assert!(!timed_out);
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "an idle drain must not wait out the 60s grace period"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let _ = addr;
+}

--- a/stella-serve/tests/step_cancel.rs
+++ b/stella-serve/tests/step_cancel.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Cancellation as a *step-boundary* stop (#1129).
+//!
+//! `tests/http.rs` already pins that a cancelled turn ends and still reports a
+//! terminal frame. What it cannot distinguish is *why* it ended: before this,
+//! a turn stopped because `Pending::cancel` made the host's side of the
+//! reverse-RPC fail, so the engine ended on a transport error that happened to
+//! be unretryable. It was never asked to stop.
+//!
+//! Now `stella-serve` drives `stella_engine::run_step` with a `CancelToken`
+//! that the engine reads at the top of every step, so the turn ends because it
+//! was *told* to — which is what these assert on, via the reason the engine
+//! attaches to that specific stop.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{TOKEN, echo_tool, next_event, open_sse, post_json, start_server};
+use serde_json::json;
+
+/// The wording `stella_engine::CANCELLED_REASON` carries. Matched on a
+/// distinctive fragment rather than the whole string so a copy-edit to the
+/// engine's message does not fail this test — what is being asserted is
+/// *which stop* ended the turn, not the prose.
+const STEP_BOUNDARY_CANCEL: &str = "cancelled at step boundary";
+
+async fn create_turn_with_tools(addr: std::net::SocketAddr) -> String {
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [echo_tool()],
+        "messages": [serde_json::to_value(
+            stella_protocol::CompletionMessage::user("do the thing"),
+        )
+        .unwrap()],
+        "reverse_request_timeout_ms": 20_000,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).unwrap();
+    created["turn_id"].as_str().unwrap().to_string()
+}
+
+/// A model reply asking for one `echo` tool call — enough to push the turn
+/// past its first step so a later cancel lands somewhere other than the
+/// initial model call.
+fn model_wants_a_tool() -> serde_json::Value {
+    json!({
+        "text": "",
+        "tool_calls": [{ "call_id": "c1", "name": "echo", "input": { "text": "hi" } }],
+        "usage": { "input_tokens": 0, "output_tokens": 0 },
+        "model": "mock",
+        "cost_usd": 0.0,
+    })
+}
+
+/// The #1129 acceptance. The turn is cancelled while parked on a *tool*
+/// request — the case that most clearly separates the two mechanisms.
+///
+/// Waking the parked tool call only turns it into a failed tool result, and a
+/// failed tool result does **not** end a turn: the engine feeds the error back
+/// to the model and takes another step. So without a cancel token the turn
+/// carries on into a step it was already asked to abandon, and stops only
+/// because the next reverse request also fails. With one, the token is read at
+/// the top of that next step and the turn unwinds there, keeping every
+/// completed step — which is exactly what the reason says.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_cancel_unwinds_at_the_next_step_boundary() {
+    let addr = start_server().await;
+    let turn_id = create_turn_with_tools(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let mut outcome = None;
+    let mut cancelled = false;
+    while let Some(event) = tokio::time::timeout(Duration::from_secs(15), next_event(&mut sse))
+        .await
+        .expect("the turn must terminate")
+    {
+        match event["type"].as_str().unwrap_or_default() {
+            // Answer the model call so the turn advances past its first step
+            // and dispatches a tool.
+            "provider_request" if !cancelled => {
+                let request_id = event["request_id"].as_str().unwrap();
+                let body = json!({
+                    "request_id": request_id,
+                    "status": "ok",
+                    "result": model_wants_a_tool(),
+                })
+                .to_string();
+                post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &body,
+                )
+                .await;
+            }
+            // Now the turn is in flight and *not* at its first model call.
+            "tool_request" if !cancelled => {
+                let (status, _) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/cancel"),
+                    Some(TOKEN),
+                    "",
+                )
+                .await;
+                assert!(status.contains("200"), "cancel: {status}");
+                cancelled = true;
+            }
+            "turn_complete" => outcome = Some(event["outcome"].clone()),
+            _ => {}
+        }
+    }
+
+    assert!(
+        cancelled,
+        "the turn reached a tool call before being cancelled"
+    );
+    let outcome = outcome.expect("a cancelled turn still reports a terminal frame");
+    assert_eq!(outcome["status"].as_str(), Some("aborted"), "{outcome}");
+    let reason = outcome["reason"].as_str().unwrap_or_default();
+    assert!(
+        reason.contains(STEP_BOUNDARY_CANCEL),
+        "the turn must end because it was asked to stop, not because a \
+         reverse request failed underneath it — got: {reason}"
+    );
+}
+
+/// A cancel with nothing parked still lands. The token is a latch, not a
+/// wake-up: a turn that is computing between reverse requests observes it at
+/// the next boundary rather than needing something to interrupt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_cancel_before_the_first_reverse_request_still_ends_the_turn() {
+    let addr = start_server().await;
+    let turn_id = create_turn_with_tools(addr).await;
+
+    // Cancel without ever opening the event stream, so nothing has been
+    // answered and the turn is racing its own first step.
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/cancel"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("200"), "cancel: {status}");
+
+    // The turn is gone from the registry either way — the point is that it
+    // does not wedge its OS thread waiting for a host that will never answer.
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/cancel"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("404"), "a cancelled turn is deregistered");
+}
+
+/// The engine's own event stream is unchanged by who drives the loop. A host
+/// reading `/events` cannot tell a `run_turn` driver from a `run_step` one —
+/// which is the promise that makes `run_turn` being a loop over `run_step`
+/// worth anything.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_event_sequence_is_unchanged_by_driving_steps() {
+    let addr = start_server().await;
+    let turn_id = create_turn_with_tools(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let mut kinds = Vec::new();
+    while let Some(event) = tokio::time::timeout(Duration::from_secs(15), next_event(&mut sse))
+        .await
+        .expect("the turn must terminate")
+    {
+        let kind = event["type"].as_str().unwrap_or_default().to_string();
+        if kind == "provider_request" {
+            let request_id = event["request_id"].as_str().unwrap();
+            let body = json!({
+                "request_id": request_id,
+                "status": "ok",
+                "result": {
+                    "text": "done",
+                    "usage": { "input_tokens": 0, "output_tokens": 0 },
+                    "model": "mock",
+                    "cost_usd": 0.0,
+                },
+            })
+            .to_string();
+            post_json(
+                addr,
+                &format!("/v1/turns/{turn_id}/provider-result"),
+                Some(TOKEN),
+                &body,
+            )
+            .await;
+        }
+        if kind == "event" {
+            kinds.push(
+                event["event"]["type"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            );
+        }
+        if kind == "turn_complete" {
+            assert_eq!(event["outcome"]["status"].as_str(), Some("completed"));
+            break;
+        }
+    }
+
+    // `run_turn` opens with the execute stage marker; a step-driving host has
+    // to emit it too or the sequence would differ at its very first frame.
+    assert!(
+        kinds.iter().any(|k| k == "stage"),
+        "the execute stage marker must still open the stream: {kinds:?}"
+    );
+}


### PR DESCRIPTION
## What & why

Five open issues in the `stella-serve` / engine / model area, plus the
outstanding two-thirds check on #932. Each is a separate commit.

| Issue | What was wrong | Commit |
|---|---|---|
| #1132 | `BedrockProvider` inherited the trait-default `complete_observed_ref`, which discards the observer — a serve/TUI client watching a Bedrock turn saw nothing until it ended | `fix(model)` |
| #1130 | `stella-serve` did no `Host` validation at all, unlike its own Observatory precedent | `feat(serve)` |
| #1131 | No signal handling anywhere in `stella-serve/src/` — SIGTERM hard-killed in-flight turns; no `/readyz` | `feat(serve)` |
| #1133 | The bus lifecycle catalog and `emit_named` both existed; no production path called one with the other | `feat(core)` |
| #1129 | `stella-serve` still drove `Engine::run_turn`, so `/cancel` stopped the *host*, not the engine | `feat(serve)` |
| #932 | Steer/pause/resume shipped in #1056; the composite acceptance was untested and the approval third is **blocked** — see below | `test(serve)` |

**#1128 is not a bug** — it is an already-merged release-sync PR (version bump
to 0.6.53). Nothing to fix there.

Closes #1132
Closes #1130
Closes #1131
Closes #1133
Closes #1129
Refs #932

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Per issue:

- **#1132** — 3 tests in `stella-model/src/bedrock/tests.rs`: an observed turn
  emits the whole answer as one delta; a tool-only turn announces neither empty
  text nor tool calls; a failed call announces nothing.
- **#1130** — 8 integration tests in `stella-serve/tests/hostguard.rs` plus 8
  unit tests in `hostguard.rs`, covering rebound hosts, the parse-don't-prefix
  near-miss (`127.0.0.1.attacker.example`), trailing-dot and case bypasses, and
  the guard running ahead of auth.
- **#1131** — 8 tests in `stella-serve/tests/shutdown.rs`. Four of them
  **caught a real design error in my first version** (see below).
- **#1133** — 7 tests in `stella-core/src/driver/tests/lifecycle_bus.rs`,
  including that every started step is closed on the model-failure path and
  that no emitted name escapes the catalog.
- **#1129** — 3 tests in `stella-serve/tests/step_cancel.rs`. Verified
  discriminating: reverting the one-line token flip turns
  `a_cancel_unwinds_at_the_next_step_boundary` red with the *old* abort reason
  (`"model call failed: request cancelled"` instead of `"cancelled at step
  boundary"`).
- **#932** — `a_turn_survives_pause_steer_resume_with_its_transcript_intact`
  asserts on transcript *identity*, not liveness.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 87 test binaries, 0 failures
- [x] `make gate` — verified by **exit code 0**, not by grepping output
- [x] Docs updated: `docs/design/serve-surface.md`, `stella-serve --help`,
      module docs, and the route table

Rebased onto `origin/main` (`2af6efc4`, 0.6.59) and re-verified there.

## Ground-rule check

- [x] No I/O added to `stella-core` — the bus emitters are in-process dispatch;
      `stella-engine` still opens nothing
- [x] No new outbound network calls
- [x] One new dependency, justified: `stella-serve` → `stella-engine`, which is
      the crate built in #971 phase 1 *for this consumer*. Also `tokio`'s
      `signal` feature, without which there is no SIGTERM drain.
- [x] New cross-boundary types round-trip through serde — `HostMode`,
      `ShutdownReason::SignalReceived` and `DrainCompleted` are covered by the
      existing `events_round_trip_byte_for_byte` property

## Anything reviewers should know?

**#932's approval third is not built, and the reason is architectural.** A
served turn never reaches a scope review: `ApprovalGate::review` has exactly
one call site (`stella-pipeline`'s scope stage) and `stella-serve` does not
depend on `stella-pipeline` — it drives the *engine*, which has no plan or
scope stage. Only `stella-cli` and `stella-runtime` link the pipeline.

So `POST /v1/turns/{id}/approve` would be a route no turn could trigger, and a
row in the published table a client could code against and never exercise.
Building it needs a prior decision — whether `stella-serve` grows a
pipeline-driving surface distinct from `/v1/turns`, or whether the approval
boundary moves down into the engine. `docs/design/serve-surface.md` now records
that with the evidence. #932 stays open on `Refs`, not `Closes`.

**The #1131 listener decision is the one worth reviewing carefully.** My first
version closed the listener at the start of the drain — it reads like "stop
accepting" — and four tests failed with `ConnectionRefused`. Reverse RPC means a
parked turn is finished *by the host* over new connections, so closing the port
strands every turn the drain is waiting for, and takes `/readyz` with it. New
work is now refused by status code; the port is released when the process exits.

**Two issue claims turned out to be inaccurate**, corrected in code and docs:

1. #1133 said the catalog "already declares" step lifecycle names. It did not —
   `agent.turn.*` existed, `agent.step.*` did not. They are added here with
   their emitters, since a catalog name nothing emits is a promise rather than
   a contract.
2. #1132 said `bedrock.rs` had zero `complete_observed` matches. It had one — a
   doc comment *describing* the gap. The gap itself was real.

**The `Host` guard is a behavior change for existing clients.** A loopback-bound
server now refuses a non-loopback `Host`. The integration harness had been
sending `Host: engine` to `127.0.0.1`, which no real client would; it now sends
what it dialed. Container binds are unaffected by default (the guard reports
itself `inert` on the `listening` record rather than pretending to enforce).

**File-size ratchet:** `bedrock.rs` left the grandfathered list entirely
(tests moved to `bedrock/tests.rs`, matching anthropic/gemini/zai);
`server.rs` was split into `lifecycle.rs` + `throttle.rs` to stay under the
limit. `driver.rs` and `bus.rs` ceilings rose for emit calls that must sit at
the boundaries they report — `make file-size-update` per the gate's own rule.
