### PR TITLE
Worktree sidenav docs tab

### DIFF
--- a/stella-cli/src/cli/help/tests.rs
+++ b/stella-cli/src/cli/help/tests.rs
@@ -298,6 +298,14 @@ fn site_commands_file(file: &str) -> (std::path::PathBuf, String) {
 /// in help order. Strict equality on the whole `pages` array means a
 /// regrouped GROUPS, a new command, or a hand-reordered sidebar all land
 /// here instead of shipping as silent drift.
+///
+/// `index` is deliberately absent from `pages`. Fumadocs attaches a folder's
+/// `index.mdx` as the folder's own link — the section header navigates to it —
+/// but only while the file is *not* also listed as a child; listing it moves
+/// the page into `children` and the header degrades to a plain toggle, so the
+/// section renders as two rows pointing at one URL. `index.mdx` must still
+/// exist, which `the_docs_index_summaries_are_the_clis_own` covers by reading
+/// the file directly.
 #[test]
 fn the_docs_nav_mirrors_these_groups() {
     let (path, raw) = site_commands_file("meta.json");
@@ -310,7 +318,7 @@ fn the_docs_nav_mirrors_these_groups() {
         .filter_map(|page| page.as_str().map(str::to_owned))
         .collect();
 
-    let mut expected = vec!["index".to_owned()];
+    let mut expected: Vec<String> = Vec::new();
     for (heading, names) in GROUPS {
         expected.push(format!("---{heading}---"));
         expected.extend(names.iter().map(|name| (*name).to_owned()));
@@ -319,9 +327,10 @@ fn the_docs_nav_mirrors_these_groups() {
     assert_eq!(
         actual,
         expected,
-        "{} does not mirror cli/help.rs GROUPS — the sidebar must list \
-         `index`, then each group as a `---Heading---` separator followed by \
-         that group's commands, all in help order",
+        "{} does not mirror cli/help.rs GROUPS — the sidebar must list each \
+         group as a `---Heading---` separator followed by that group's \
+         commands, all in help order, and must not list `index` (see this \
+         test's doc comment)",
         path.display()
     );
 }

--- a/website/content/docs/agent-tools/meta.json
+++ b/website/content/docs/agent-tools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Agent Tools",
-  "pages": ["index", "skills", "commands", "custom-agents", "mcp", "custom-tools", "hooks", "permissions"]
+  "pages": ["skills", "commands", "custom-agents", "mcp", "custom-tools", "hooks", "permissions"]
 }

--- a/website/content/docs/api-providers/meta.json
+++ b/website/content/docs/api-providers/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "API Providers",
-  "pages": ["index", "models"]
+  "pages": ["models"]
 }

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Commands",
   "pages": [
-    "index",
     "---Run the agent---",
     "run",
     "chat",

--- a/website/content/docs/configuration/meta.json
+++ b/website/content/docs/configuration/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Configuration & Settings",
-  "pages": ["index", "settings", "agent-engine-config", "credentials"]
+  "pages": ["settings", "agent-engine-config", "credentials"]
 }

--- a/website/content/docs/getting-started/meta.json
+++ b/website/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["index", "installation", "providers", "initialization"]
+  "pages": ["installation", "providers", "initialization"]
 }

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Guides",
   "pages": [
-    "index",
     "fix-failing-ci",
     "unfamiliar-codebase",
     "budget",

--- a/website/content/docs/principles/meta.json
+++ b/website/content/docs/principles/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Engineering Principles",
-  "pages": ["index", "determinism"]
+  "pages": ["determinism"]
 }

--- a/website/content/docs/telemetry/meta.json
+++ b/website/content/docs/telemetry/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Telemetry and trust",
-  "pages": ["index", "dashboard", "files-touched"]
+  "pages": ["dashboard", "files-touched"]
 }

--- a/website/src/app/docs/layout.tsx
+++ b/website/src/app/docs/layout.tsx
@@ -3,9 +3,15 @@ import type { ReactNode } from "react";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
+/**
+ * `docsLink: false` keeps the shared "Docs" nav link out of the sidebar, where
+ * fumadocs would render it as a pill above the page tree — a permanently
+ * highlighted entry that is really the parent of everything below it. See
+ * layout.shared.tsx for why the link still exists for the home layout.
+ */
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions()}>
+    <DocsLayout tree={source.pageTree} {...baseOptions({ docsLink: false })}>
       {children}
     </DocsLayout>
   );

--- a/website/src/lib/layout.shared.tsx
+++ b/website/src/lib/layout.shared.tsx
@@ -17,8 +17,24 @@ import { REPO_URL, SPONSOR_URL } from "@/lib/site";
  * mark 28px, wordmark 24px. The header's own height clamps it, so growing
  * these numbers never grows the chrome; past ~h-8 the mark starts touching
  * the header padding, which is the real ceiling.
+ *
+ * `docsLink` exists because fumadocs routes one `links` array to two very
+ * different places. A link with no `on` field lands in both `navItems` and
+ * `menuItems`, and the docs sidebar renders every non-icon `menuItem` as a
+ * flat pill *above* the page tree — so the home page's "Docs" nav link
+ * reappears on docs pages looking like a sibling of the tree's top-level
+ * entries. It is also permanently highlighted there: `active: "nested-url"`
+ * matches any `/docs/**` path, and every page on this site is under `/docs`,
+ * so it can never be inactive. Two lit pills at once, one of them the parent
+ * of the whole tree. The docs layout passes `false`; the home layout, where
+ * "Docs" is a real destination in both the bar and the mobile menu, keeps it.
+ *
+ * Setting `on: "nav"` instead would clear the sidebar too, but it would also
+ * drop "Docs" from the home page's mobile menu, which reads from `menuItems`.
  */
-export function baseOptions(): BaseLayoutProps {
+export function baseOptions({
+  docsLink = true,
+}: { docsLink?: boolean } = {}): BaseLayoutProps {
   return {
     nav: {
       title: (
@@ -30,11 +46,15 @@ export function baseOptions(): BaseLayoutProps {
       ),
     },
     links: [
-      {
-        text: "Docs",
-        url: "/docs",
-        active: "nested-url",
-      },
+      ...(docsLink
+        ? [
+            {
+              text: "Docs",
+              url: "/docs",
+              active: "nested-url" as const,
+            },
+          ]
+        : []),
       {
         type: "icon",
         text: "Sponsor",


### PR DESCRIPTION
Changes made to the side nav of the docs site, removing duplicate index pages/labels to category sections.

## Summary by Sourcery

Adjust docs site navigation to avoid duplicate root entries and align CLI help sidebar expectations with fumadocs behavior.

Bug Fixes:
- Prevent the docs sidebar from showing a permanently highlighted top-level "Docs" pill alongside the page tree.

Enhancements:
- Make base layout options configurable with a flag to include or exclude the shared "Docs" nav link for different layouts.
- Clarify and enforce that section index pages are not listed as separate children in docs navigation via metadata and test expectations.

Tests:
- Update CLI help navigation test to expect groups and commands without an explicit `index` entry and document the fumadocs index handling behavior.