### PR TITLE
docs(site): set sidebar section headings apart from the links under them

### DIFF
--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -348,6 +348,30 @@ figure.shiki ::selection,
   border-radius: 0.375rem;
 }
 
+/* Section headings in the tree — the `---Start---` style entries in meta.json.
+ *
+ * Fumadocs renders a separator as a bare `<p>` with no class or data attribute
+ * of its own, and a separator is the only `<p>` the sidebar ever emits, so the
+ * element selector IS the hook. If a future fumadocs adds prose to the aside,
+ * this is the rule that needs a narrower selector.
+ *
+ * These are labels for the structure, not destinations, so they take the
+ * opposite treatment from the links below them: full-strength foreground and
+ * semibold, where an item is muted and regular. That inverts the usual "heading
+ * is quiet" instinct on purpose — the items recede as a field, and the thing
+ * that has to survive that recession is the label telling you which part of the
+ * tree you are in. Uppercase at 14.4px reads as a category rather than as a
+ * page, and the tracking is what keeps uppercase from setting tight. The gold
+ * active pill still outranks all of it, which is the intended order:
+ * item < category < where you are. */
+#nd-sidebar p {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.075em;
+  font-weight: 600;
+  color: var(--color-fd-foreground);
+}
+
 /* The active page is a solid gold pill with ink text — the one gold surface
  * in the tree, because the current location IS the signal (same law as the
  * CTA). Identical in both modes: gold on white chrome, gold on ink. */


### PR DESCRIPTION
The `---Start---` entries in `meta.json` rendered at the same size, weight, and colour as the pages beneath them, so the tree read as one undifferentiated column and the section labels did no work.

## The change

One rule in `global.css`:

```css
#nd-sidebar p {
  font-size: 0.9rem;
  text-transform: uppercase;
  letter-spacing: 0.075em;
  font-weight: 600;
  color: var(--color-fd-foreground);
}
```

Categories now take the **opposite** treatment from the items — full-strength foreground at 600, where a link is muted at 400.

Of the two directions available (darker categories, or lighter categories with darker items), this is the first, because the second would have meant making every link darker and bolder — which fights both the note already sitting above this block ("the sidebar and header exist to be ignored until wanted... no bold") and the gold active pill, the one thing in the tree that is supposed to win. The resulting order is **item < category < where you are**.

The tracking is not decoration: uppercase sets tight without it.

## Contrast

| | light ground `#ffffff` | dark ground `--stella-surface` |
|---|---|---|
| category | **19.7:1** | **16.6:1** |
| item | 5.4:1 | 6.4:1 |

A ~3× separation, so it reads as hierarchy rather than as two shades of the same thing. Both pass AA on both grounds. Light mode was verified numerically rather than visually — headless Chrome ignored `--force-prefers-color-scheme`, and the token (`--color-fd-foreground`) is defined for both grounds, which is the invariant that actually matters here.

## Selector note

Fumadocs renders a separator as a bare `<p>` with no class and no data attribute, so the element selector is the only hook available. I verified across four pages that a separator is the **only** `<p>` the sidebar emits — including the nested separators inside an expanded folder — and the code comment flags this in case a future fumadocs puts prose in the aside.

## Nested separators

The sub-group labels inside an expanded folder (`RUN THE AGENT`, `RUN MANY AT ONCE`, …) get the same treatment, which is correct — they are the same kind of object. Their indentation inside the folder's vertical rule carries the depth, so hierarchy holds rather than flattening. Checked visually on `/docs/commands/run`.

## Verification

`pnpm typecheck` and `pnpm build` both exit 0. Rendered and eyeballed on `/docs`, `/docs/inference-pipeline`, and `/docs/commands/run`.

Zero Rust files touched, so the pre-push Rust gate was bypassed with its own documented `SKIP_GATE=1`; the applicable gate is the `docs` workflow, run green above.

## Summary by Sourcery

Enhancements:
- Update global sidebar CSS so section headings use uppercase, increased weight, and full-strength foreground color to clarify navigation hierarchy.