### PR TITLE
feat(cli): --turn-budget, so the continuation policy stops being inert

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,7 +15,7 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-1791 stella-cli/src/agent_tests.rs
+1792 stella-cli/src/agent_tests.rs
 2316 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -31,6 +31,11 @@ fn tuned_engine_config(
     let (provider_id, model_id) = catalog_ref;
     let mut engine = EngineConfig {
         cwd: cfg.workspace_root.display().to_string(),
+        // Every role gets the same turn budget: the deadline it guards is the
+        // process's, not one agent's, so a worker that declines a continuation
+        // while a judge spends the remaining time past it would defeat the
+        // point. `None` unless `--turn-budget` was given.
+        turn_budget: cfg.turn_budget,
         // Phase 2 (#713): the adaptive-context lifecycle switch, off by
         // default. Read here rather than at each receipt site so every engine
         // this session builds — default, worker, judge — agrees on it.

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -813,6 +813,7 @@ fn cfg_for(provider_id: &str) -> Config {
     Config {
         provider,
         model_id,
+        turn_budget: None,
         // The default posture for these tests is "no --model given", so the
         // settings-driven wiring under test is the thing exercised. The
         // flag-pinned case sets this explicitly.

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -24,6 +24,33 @@ fn cfg_with_engine(provider_id: &str, engine_settings_json: &str) -> Config {
 }
 
 #[test]
+fn the_turn_budget_flag_reaches_every_role_that_can_continue() {
+    // The policy it feeds (`driver::truncation::ContinuationBudget`) is inert
+    // unless something sets it, and "inert" is indistinguishable from "working"
+    // in every test that only exercises the engine crate. This is the wire, so
+    // it is what proves the flag is not decorative.
+    //
+    // Every role, not just the worker: the deadline being guarded belongs to
+    // the process, so a worker that declines a continuation while a judge
+    // spends the remaining time past it would defeat the point.
+    let mut cfg = cfg_for("zai");
+    cfg.turn_budget = Some(std::time::Duration::from_secs(840));
+
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).turn_budget,
+        Some(std::time::Duration::from_secs(840)),
+    );
+    assert_eq!(
+        crate::agent::judge_engine_config_for(&cfg).turn_budget,
+        Some(std::time::Duration::from_secs(840)),
+    );
+
+    // And absent by default, so no existing caller starts declining work.
+    let plain = cfg_for("zai");
+    assert_eq!(crate::agent::engine_config_for(&plain).turn_budget, None);
+}
+
+#[test]
 fn pipeline_worker_model_is_inert_without_the_fix_but_routes_with_it() {
     // Issue #276: `pipeline_worker_model` (and `agents.worker.*`) must
     // actually change what `Role::Worker` resolves to — previously the

--- a/stella-cli/src/cli.rs
+++ b/stella-cli/src/cli.rs
@@ -126,6 +126,18 @@ pub(crate) struct GlobalArgs {
     #[arg(long, global = true, env = "STELLA_BUDGET", value_parser = parse_budget)]
     pub(crate) budget: Option<f64>,
 
+    /// Wall-clock seconds one turn may spend, for continuation decisions
+    ///
+    /// The time twin of `--budget`, and deliberately weaker: this enforces
+    /// nothing and cancels nothing. It exists for callers running under an
+    /// EXTERNAL deadline — a benchmark harness that kills the process on
+    /// elapsed time — so the engine can decline to start an output-limit
+    /// continuation it cannot finish, and end with a truthful partial instead
+    /// of being destroyed mid-flight. Set it slightly below the real deadline.
+    /// Omit for no time-based continuation limit. Env: STELLA_TURN_BUDGET.
+    #[arg(long, global = true, env = "STELLA_TURN_BUDGET", value_parser = parse_turn_budget)]
+    pub(crate) turn_budget: Option<std::time::Duration>,
+
     /// Use the plain line REPL instead of the Command Deck
     ///
     /// The deck (the tabbed TUI) also steps aside automatically when stdin or
@@ -836,4 +848,23 @@ fn parse_budget(raw: &str) -> Result<f64, String> {
         ));
     }
     Ok(value)
+}
+
+/// `--turn-budget` must be a positive, finite number of seconds.
+///
+/// Same reasoning as `parse_budget`, one step stronger: a zero or negative
+/// budget would make every continuation unaffordable and silently disable the
+/// recovery path entirely, which looks exactly like the truncation bug it
+/// exists to mitigate. Refusing at parse is the only place that is cheap to
+/// notice.
+fn parse_turn_budget(raw: &str) -> Result<std::time::Duration, String> {
+    let value: f64 = raw
+        .parse()
+        .map_err(|_| format!("`{raw}` is not a number"))?;
+    if !value.is_finite() || value <= 0.0 {
+        return Err(format!(
+            "turn budget must be a positive number of seconds, got `{raw}`"
+        ));
+    }
+    Ok(std::time::Duration::from_secs_f64(value))
 }

--- a/stella-cli/src/command_deck/model_cmd.rs
+++ b/stella-cli/src/command_deck/model_cmd.rs
@@ -211,6 +211,7 @@ mod tests {
         Config {
             model_id: provider.default_model.to_string(),
             provider,
+            turn_budget: None,
             model_pinned_by_flag: false,
             api_key: stella_model::ApiKey::new("dummy-key-unused-offline"),
             workspace_root,

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -314,6 +314,16 @@ pub struct Config {
     /// must not override (see `crate::agent::resolve_engine_wiring`).
     pub model_pinned_by_flag: bool,
     pub api_key: ApiKey,
+    /// `--turn-budget`: the wall clock one turn may spend, used only to decide
+    /// whether an output-limit continuation is affordable
+    /// (`EngineConfig::turn_budget`). `None` leaves that a pure count.
+    ///
+    /// It enforces nothing and cancels nothing — there is no deadline killer
+    /// behind it. It exists so a caller running under an EXTERNAL deadline
+    /// (a benchmark harness that kills the process on elapsed time) can let
+    /// the engine decline to start a continuation it cannot finish, ending
+    /// with a truthful partial instead of being destroyed mid-flight.
+    pub turn_budget: Option<std::time::Duration>,
     pub workspace_root: std::path::PathBuf,
     /// `--base-url`: required for the `local` provider (it IS the server
     /// address), an optional proxy/override for every other provider.
@@ -664,6 +674,9 @@ impl Config {
                     // Stamped by `load_with_settings`, the only place that
                     // still knows whether the flag or the settings answered.
                     model_pinned_by_flag: false,
+                    // Stamped by the caller that holds the parsed CLI; see the
+                    // field's doc comment.
+                    turn_budget: None,
                     api_key: ApiKey::new(api_key),
                     workspace_root,
                     base_url_override: Some(base_url),
@@ -853,6 +866,8 @@ impl Config {
             model_id,
             // Stamped by `load_with_settings` — see the field's doc comment.
             model_pinned_by_flag: false,
+            // Likewise stamped by the caller that holds the parsed CLI.
+            turn_budget: None,
             api_key: key,
             workspace_root: workspace_root.to_path_buf(),
             base_url_override: base_url_override.map(str::to_string),

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -210,6 +210,7 @@ fn config_debug_never_leaks_the_api_key() {
     let cfg = Config {
         provider: PROVIDERS[0].clone(),
         model_id: "glm-5.2".to_string(),
+        turn_budget: None,
         model_pinned_by_flag: false,
         api_key: ApiKey::new(secret),
         workspace_root: std::path::PathBuf::from("/tmp/ws"),

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -702,11 +702,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
     }
 
     // Run/Chat/Config need a resolved config (which requires an API key).
-    let cfg = config::Config::load(
+    let mut cfg = config::Config::load(
         cli.globals.model.as_deref(),
         cli.globals.api_key.as_deref(),
         cli.globals.base_url.as_deref(),
     )?;
+    // Stamped here for the same reason `model_pinned_by_flag` is: `Config::load`
+    // resolves provider and credentials and has no view of the parsed CLI, and
+    // giving it one for a value it never consults would widen its signature to
+    // carry something straight through. `main` is where the flag and the config
+    // are both in hand.
+    cfg.turn_budget = cli.globals.turn_budget;
 
     // Correctness pass over the resolved settings — model-slug problems (an
     // unknown provider, a typo, an over-qualified slug that would 400 on the


### PR DESCRIPTION
Follow-up to #1161, which landed the policy but nothing that sets it.

## Why

#1161 added `EngineConfig::turn_budget` and the rule it feeds: decline an
output-limit continuation the turn cannot finish. No caller could reach it, and
an engine-crate test cannot tell an unreachable policy from a broken one. This
is the wire.

## What

`--turn-budget <seconds>` (global, `STELLA_TURN_BUDGET`) — the time twin of
`--budget`, and deliberately weaker: **it enforces nothing and cancels
nothing.** No future is aborted when it elapses.

It exists for callers running under an **external** deadline — a benchmark
harness that kills the process on elapsed time — so the engine can decline to
*start* a continuation it cannot finish, and end with a truthful partial rather
than being destroyed mid-flight. That distinction is the entire point: an
external kill arrives as `AgentTimeoutError`, which Harbor records identically
to the agent simply failing the task.

Applied to **every role**, not just the worker. The deadline belongs to the
process, so a worker that declines a continuation while a judge spends the
remaining time past it would defeat the purpose.

Stamped in `main` rather than resolved inside `Config::load`, matching the
existing `model_pinned_by_flag` pattern: `load` resolves provider and
credentials and has no view of the parsed CLI, and widening its signature to
carry a value it never consults is worse than a one-line stamp.

Zero and negative are rejected at parse. A non-positive budget makes every
continuation unaffordable and silently disables the recovery path — which looks
exactly like the truncation bug it exists to mitigate, and parse is the only
place that is cheap to notice.

## Motivation, measured

On the ten-task adversarial Terminal-Bench set at effort `xhigh`:

| gate | passed | blocking | timeouts |
|---|---|---|---|
| gate1 (`MAX_LENGTH_CONTINUATIONS=2`) | 2/10 | 7 | 4 |
| gate2 (`=4`) | 3/10 | **10** | **6** |

Raising the continuation allowance made the timeout class **worse**, exactly as
predicted — a continuation is more wall clock. Two of the six timeouts never
reached the output cap at all, so no allowance could have saved them. This is
the lever that does not have that property.

## Tests

New test asserts the flag reaches `engine_config_for` **and**
`judge_engine_config_for`, and stays `None` by default so no existing caller
starts declining work. Full `cargo test -p stella-cli` green; fmt and
file-size clean.

## Next

With this landed, the bench runner can pass `--turn-budget` slightly under the
harness's agent timeout (e.g. 840 against 900s) and gate-3 can measure whether
the timeout class converts into ordinary results.

## Summary by Sourcery

Introduce a CLI turn-level wall-clock budget and wire it through configuration so all engine roles can use it when deciding whether to start continuations.

New Features:
- Add a global `--turn-budget` CLI flag (and STELLA_TURN_BUDGET env var) to specify per-turn wall-clock duration for continuation affordability decisions.

Enhancements:
- Propagate the configured turn budget into `Config` and engine configs for both worker and judge roles so they share the same process-level deadline semantics.

Tests:
- Add an agent wiring test to ensure the turn-budget flag reaches both worker and judge engine configurations and remains unset by default.