### PR TITLE
fix(core): declining a continuation for time completes the turn, not aborts it

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,8 +20,8 @@
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2377 stella-core/src/driver.rs
-3134 stella-core/src/driver/tests.rs
+2418 stella-core/src/driver.rs
+3205 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs
 2037 stella-model/src/openai.rs

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -92,7 +92,10 @@ mod lifecycle;
 mod loop_evidence;
 mod truncation;
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
-use truncation::{ContinuationBudget, MAX_LENGTH_CONTINUATIONS, plan_continuation};
+use truncation::{
+    ContinuationBudget, ContinuationPlan, MAX_LENGTH_CONTINUATIONS, TIME_EXHAUSTED_PARTIAL,
+    plan_continuation,
+};
 // Named only by the tests that pin the nudge's exact body; the production path
 // reaches it through `Continuation::into_parts`.
 use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
@@ -1952,19 +1955,31 @@ impl<'a> Engine<'a> {
             // owns what happens next and what history keeps (see
             // `driver::truncation`); `None` means the turn's allowance is
             // spent and the terminal handling below applies.
-            if result.finish_reason == Some(FinishReason::Length)
-                && let Some(plan) = plan_continuation(
+            let mut out_of_time = false;
+            if result.finish_reason == Some(FinishReason::Length) {
+                match plan_continuation(
                     &result.text,
                     result.usage.output_tokens,
                     *length_continuations,
                     continuation_budget,
-                )
-            {
-                *length_continuations += 1;
-                let (note, appended) = plan.into_parts();
-                let _ = events.send(AgentEvent::Text { delta: note });
-                messages.extend(appended);
-                return None;
+                ) {
+                    ContinuationPlan::Continue(plan) => {
+                        *length_continuations += 1;
+                        let (note, appended) = plan.into_parts();
+                        let _ = events.send(AgentEvent::Text { delta: note });
+                        messages.extend(appended);
+                        return None;
+                    }
+                    // Declined because the turn is nearly out of wall clock,
+                    // not because it ran out of tries. The abort below is the
+                    // wrong ending for that: it exits nonzero, which a harness
+                    // records as the agent dying — the exact outcome the
+                    // deadline exists to avoid. Stopping early is only worth
+                    // anything if stopping produces a result, so this path
+                    // completes the turn with whatever it has.
+                    ContinuationPlan::OutOfTime => out_of_time = true,
+                    ContinuationPlan::AllowanceSpent => {}
+                }
             }
             // A turn that produced neither a tool call NOR any visible text is
             // never a real completion: the model was cut off at its output
@@ -1972,7 +1987,11 @@ impl<'a> Engine<'a> {
             // Recording it as `Completed` shows the user a silent, blank turn
             // (the "turn ends with no feedback" defect). Surface why and abort
             // cleanly so the caller can retry instead of swallowing it.
-            if result.text.trim().is_empty() {
+            //
+            // Except out of time, which is a deliberate stop rather than a
+            // failure to produce anything: it substitutes a truthful stand-in
+            // below and ends as an ordinary result.
+            if result.text.trim().is_empty() && !out_of_time {
                 let reason = match result.finish_reason {
                     // Advised `/compact` until #712; no such command exists,
                     // and compaction is automatic every step anyway.
@@ -2006,16 +2025,38 @@ impl<'a> Engine<'a> {
             // success past this point.
             if result.finish_reason == Some(FinishReason::Length) {
                 let _ = events.send(AgentEvent::Text {
-                    delta: format!(
-                        "\n\n⚠ Response was truncated at the output-token limit ({} tokens); \
-                         ask to continue if it was cut off mid-thought.",
-                        result.usage.output_tokens
-                    ),
+                    delta: if out_of_time {
+                        // Names the deadline, not the token limit, because the
+                        // token limit is what happened and the deadline is why
+                        // nothing followed it. A reader who sees only "output
+                        // limit" concludes the cap is mispriced and raises it,
+                        // which is the one change that cannot help here.
+                        format!(
+                            "\n\n⚠ Stopped at the output-token limit ({} tokens) with too little \
+                             time left in this turn to finish another continuation — ending here \
+                             with what the turn has already done.",
+                            result.usage.output_tokens
+                        )
+                    } else {
+                        format!(
+                            "\n\n⚠ Response was truncated at the output-token limit ({} tokens); \
+                             ask to continue if it was cut off mid-thought.",
+                            result.usage.output_tokens
+                        )
+                    },
                 });
             }
+            // Empty only on the out-of-time path — every other empty-text route
+            // aborted above — where the transcript and the turn's final text
+            // still owe an honest account of why nothing came back.
+            let text = if result.text.trim().is_empty() {
+                TIME_EXHAUSTED_PARTIAL.to_string()
+            } else {
+                result.text
+            };
             messages.push(CompletionMessage {
                 role: MessageRole::Assistant,
-                content: result.text.clone(),
+                content: text.clone(),
                 tool_calls: Vec::new(),
                 tool_results: Vec::new(),
                 attachments: Vec::new(),
@@ -2028,7 +2069,7 @@ impl<'a> Engine<'a> {
                 cost_usd: total_cost_usd,
             });
             return Some(TurnOutcome::Completed {
-                text: result.text,
+                text,
                 cost_usd: total_cost_usd,
             });
         }

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -1291,6 +1291,77 @@ async fn empty_completion_aborts_with_a_visible_message_not_a_silent_success() {
     );
 }
 
+#[tokio::test]
+async fn a_step_out_of_time_completes_with_a_truthful_partial_instead_of_aborting() {
+    // The same empty length-truncated shape as the test above, and the opposite
+    // ending, because the reason for stopping is opposite. Above, the model
+    // burned every continuation and still produced nothing — a failure, and the
+    // abort says so. Here the turn simply ran out of wall clock on its FIRST cap
+    // hit, with its whole allowance untouched.
+    //
+    // Both used to return `None` from `plan_continuation` and land on the same
+    // abort. That made `--turn-budget` self-defeating: it exists to stop a turn
+    // before a harness kills it, and a nonzero exit is scored as the agent dying
+    // just as a kill is. Four of the five nonzero exits on a ten-task
+    // Terminal-Bench 2.1 gate were this, each with zero continuations spent.
+    //
+    // A zero budget makes `remaining` zero however fast the step ran, so the
+    // decline is deterministic rather than a race against the test's own clock.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(empty_result(Some(FinishReason::Length)))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(
+        &provider,
+        &tools,
+        EngineConfig {
+            turn_budget: Some(Duration::ZERO),
+            ..EngineConfig::default()
+        },
+        &sleeper,
+    );
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("build the feature"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    match outcome {
+        TurnOutcome::Completed { text, .. } => assert!(
+            text.contains("too little of the turn's time remained"),
+            "a turn that stops early still owes an account of why, and it is the \
+             turn's own text that carries it downstream: {text}"
+        ),
+        other => panic!("out of time must end as an ordinary result, not an abort: {other:?}"),
+    }
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        1,
+        "no continuation is paid for when there is no time to finish one"
+    );
+
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, AgentEvent::Error { .. })),
+        "stopping on purpose is not an error"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::Complete { .. }))
+            .count(),
+        1,
+        "exactly one Complete, so the turn reads as finished rather than killed"
+    );
+}
+
 /// A `finish_reason: length` result that still carries text — the shape the
 /// zai adapter produces when a reasoning model spends its whole output budget
 /// on chain-of-thought and the reasoning-only fallback promotes it to text.

--- a/stella-core/src/driver/truncation.rs
+++ b/stella-core/src/driver/truncation.rs
@@ -283,7 +283,9 @@ mod tests {
     fn expect_continue(plan: ContinuationPlan) -> Continuation {
         match plan {
             ContinuationPlan::Continue(plan) => plan,
-            ContinuationPlan::AllowanceSpent => panic!("expected a continuation, got AllowanceSpent"),
+            ContinuationPlan::AllowanceSpent => {
+                panic!("expected a continuation, got AllowanceSpent")
+            }
             ContinuationPlan::OutOfTime => panic!("expected a continuation, got OutOfTime"),
         }
     }

--- a/stella-core/src/driver/truncation.rs
+++ b/stella-core/src/driver/truncation.rs
@@ -109,6 +109,18 @@ pub(super) const LENGTH_CONTINUATION_NUDGE: &str = "Your previous message hit th
 pub(super) const REASONING_ONLY_PARTIAL: &str = "[no answer produced: this step's entire output budget went to reasoning and was cut off \
      at the token limit before any answer or tool call — nothing was kept]";
 
+/// Stands in history — and in the turn's final text — for a turn that stopped
+/// at the output-token limit with nothing kept because its wall clock ran out.
+///
+/// [`REASONING_ONLY_PARTIAL`] cannot serve here: it is written for a step that
+/// is about to be continued, and says the step produced nothing. This one ends
+/// the turn, so it also has to say why nothing more is coming — otherwise the
+/// only record of a deliberate, time-aware stop is an assistant turn that reads
+/// as a silent failure.
+pub(super) const TIME_EXHAUSTED_PARTIAL: &str = "[no answer produced: this step's entire output budget went to reasoning and was cut off \
+     at the token limit, and too little of the turn's time remained to continue — the turn stops \
+     here, keeping whatever its earlier steps already did]";
+
 /// The two messages a continuation appends, plus the line the user sees.
 ///
 /// Returned as data rather than pushed here so the decision stays a pure
@@ -145,14 +157,6 @@ impl Continuation {
     }
 }
 
-/// Decide what a length-truncated, tool-less step continues with, or `None`
-/// when the turn's continuation allowance is spent and the caller should fall
-/// through to its terminal handling.
-///
-/// `spent` is the turn's running count and is incremented by the caller on
-/// `Some` — threaded rather than owned so the bound survives across steps.
-/// Callers establish `FinishReason::Length` and an empty `tool_calls` before
-/// calling; this decides only what happens next.
 /// What one turn has left to spend on continuing, in wall clock.
 ///
 /// The count alone cannot see the constraint that actually binds. A harness
@@ -192,25 +196,62 @@ impl ContinuationBudget {
     }
 }
 
+/// What a length-truncated, tool-less step does next.
+///
+/// Three outcomes rather than `Option<Continuation>`, because the two ways of
+/// *not* continuing need opposite terminal handling and collapsing them cost a
+/// measured benchmark gate. Both used to return `None`, and the caller's only
+/// reading of `None` was "the allowance is spent", whose empty-text branch
+/// aborts the turn. So a turn that declined *for time* — the one path whose
+/// entire purpose is to stop gracefully while it still can — exited nonzero
+/// instead. On a ten-task Terminal-Bench 2.1 set, four of five nonzero exits
+/// were exactly this, each on its **first** cap hit with zero continuations
+/// spent: the wall clock had already run out, so the allowance never applied.
+/// Trading a timeout for an abort is not a fix; both read at the results layer
+/// as the harness killing the agent.
+pub(super) enum ContinuationPlan {
+    /// Continue the turn with these two messages.
+    Continue(Continuation),
+    /// The turn spent its whole [`MAX_LENGTH_CONTINUATIONS`] allowance and
+    /// truncated again. Terminal handling applies: a model truncating past the
+    /// allowance is saying the effort tier is mispriced, not that one more
+    /// retry would land it.
+    AllowanceSpent,
+    /// There is not enough wall clock left to *finish* another continuation.
+    ///
+    /// Distinct from [`Self::AllowanceSpent`] because nothing here is the
+    /// model's fault and nothing is exhausted — the turn is choosing to stop
+    /// early while stopping is still cheap. It ends as an ordinary result
+    /// carrying whatever it has, and the verification ladder judges that
+    /// record like any other.
+    OutOfTime,
+}
+
+/// Decide what a length-truncated, tool-less step continues with.
+///
+/// `spent` is the turn's running count and is incremented by the caller on
+/// [`ContinuationPlan::Continue`] — threaded rather than owned so the bound
+/// survives across steps. Callers establish `FinishReason::Length` and an empty
+/// `tool_calls` before calling; this decides only what happens next.
 pub(super) fn plan_continuation(
     text: &str,
     output_tokens: u64,
     spent: u32,
     budget: Option<ContinuationBudget>,
-) -> Option<Continuation> {
+) -> ContinuationPlan {
     if spent >= MAX_LENGTH_CONTINUATIONS {
-        return None;
+        return ContinuationPlan::AllowanceSpent;
     }
     // Checked after the count, so a turn with no deadline configured behaves
     // exactly as before — the budget is opt-in and absent by default.
     if let Some(budget) = budget
         && !budget.affords_another()
     {
-        return None;
+        return ContinuationPlan::OutOfTime;
     }
     let attempt = spent + 1;
     if text.trim().is_empty() {
-        return Some(Continuation {
+        return ContinuationPlan::Continue(Continuation {
             retained: REASONING_ONLY_PARTIAL.to_string(),
             note: format!(
                 "\n\n⚠ Output-token limit reached ({output_tokens} tokens) with the budget spent \
@@ -219,7 +260,7 @@ pub(super) fn plan_continuation(
             ),
         });
     }
-    Some(Continuation {
+    ContinuationPlan::Continue(Continuation {
         retained: crate::compaction::elide_truncated_partial(text)
             .unwrap_or_else(|| text.to_string()),
         note: format!(
@@ -238,29 +279,58 @@ mod tests {
     /// without owning a second copy of the whole string.
     const PARTIAL_ELISION_SIGNPOST: &str = "middle of this cut-off message elided";
 
-    #[test]
-    fn a_spent_allowance_declines_to_continue() {
-        assert!(plan_continuation("cut off", 16_384, MAX_LENGTH_CONTINUATIONS, None).is_none());
-        assert!(plan_continuation("", 16_384, MAX_LENGTH_CONTINUATIONS, None).is_none());
-        // ...and every attempt below it does continue.
-        for spent in 0..MAX_LENGTH_CONTINUATIONS {
-            assert!(plan_continuation("cut off", 16_384, spent, None).is_some());
+    /// The continuation, or a panic naming what was decided instead.
+    fn expect_continue(plan: ContinuationPlan) -> Continuation {
+        match plan {
+            ContinuationPlan::Continue(plan) => plan,
+            ContinuationPlan::AllowanceSpent => panic!("expected a continuation, got AllowanceSpent"),
+            ContinuationPlan::OutOfTime => panic!("expected a continuation, got OutOfTime"),
         }
     }
 
     #[test]
-    fn a_continuation_it_cannot_finish_is_declined() {
+    fn a_spent_allowance_declines_to_continue() {
+        assert!(matches!(
+            plan_continuation("cut off", 16_384, MAX_LENGTH_CONTINUATIONS, None),
+            ContinuationPlan::AllowanceSpent
+        ));
+        assert!(matches!(
+            plan_continuation("", 16_384, MAX_LENGTH_CONTINUATIONS, None),
+            ContinuationPlan::AllowanceSpent
+        ));
+        // ...and every attempt below it does continue.
+        for spent in 0..MAX_LENGTH_CONTINUATIONS {
+            assert!(matches!(
+                plan_continuation("cut off", 16_384, spent, None),
+                ContinuationPlan::Continue(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn a_continuation_it_cannot_finish_is_declined_for_time_not_allowance() {
         // The continuation costs what its predecessor cost, so 60s of work with
         // 30s left is a continuation that gets killed mid-flight. Declining
         // keeps the truthful partial and lets the turn end as an ordinary
         // result; taking it trades that for an external timeout, which reads at
         // the results layer exactly like the agent failing the task.
+        //
+        // Reported as `OutOfTime` and never as `AllowanceSpent`, which is the
+        // whole distinction: the allowance here is untouched (`spent` is 0), and
+        // the caller's terminal handling for a spent allowance aborts the turn.
+        // Collapsing the two is what made a graceful stop exit nonzero.
         let broke = ContinuationBudget {
             remaining: Duration::from_secs(30),
             last_step: Duration::from_secs(60),
         };
-        assert!(plan_continuation("cut off", 16_384, 0, Some(broke)).is_none());
-        assert!(plan_continuation("", 16_384, 0, Some(broke)).is_none());
+        assert!(matches!(
+            plan_continuation("cut off", 16_384, 0, Some(broke)),
+            ContinuationPlan::OutOfTime
+        ));
+        assert!(matches!(
+            plan_continuation("", 16_384, 0, Some(broke)),
+            ContinuationPlan::OutOfTime
+        ));
     }
 
     #[test]
@@ -269,7 +339,26 @@ mod tests {
             remaining: Duration::from_secs(600),
             last_step: Duration::from_secs(60),
         };
-        assert!(plan_continuation("cut off", 16_384, 0, Some(flush)).is_some());
+        assert!(matches!(
+            plan_continuation("cut off", 16_384, 0, Some(flush)),
+            ContinuationPlan::Continue(_)
+        ));
+    }
+
+    #[test]
+    fn a_spent_allowance_outranks_a_broken_budget() {
+        // Both conditions true at once. The count is checked first, so this
+        // reports `AllowanceSpent` — the turn really did burn every retry, and
+        // the terminal abort naming the allowance is then accurate. The order
+        // matters only because the two arms now diverge.
+        let broke = ContinuationBudget {
+            remaining: Duration::from_secs(30),
+            last_step: Duration::from_secs(60),
+        };
+        assert!(matches!(
+            plan_continuation("cut off", 16_384, MAX_LENGTH_CONTINUATIONS, Some(broke)),
+            ContinuationPlan::AllowanceSpent
+        ));
     }
 
     #[test]
@@ -281,7 +370,10 @@ mod tests {
             remaining: Duration::from_secs(60),
             last_step: Duration::from_secs(60),
         };
-        assert!(plan_continuation("cut off", 16_384, 0, Some(exact)).is_none());
+        assert!(matches!(
+            plan_continuation("cut off", 16_384, 0, Some(exact)),
+            ContinuationPlan::OutOfTime
+        ));
     }
 
     #[test]
@@ -290,7 +382,10 @@ mod tests {
         // count it was before — a caller that knows nothing about its wall
         // clock must not have work declined on a guess.
         for spent in 0..MAX_LENGTH_CONTINUATIONS {
-            assert!(plan_continuation("cut off", 16_384, spent, None).is_some());
+            assert!(matches!(
+                plan_continuation("cut off", 16_384, spent, None),
+                ContinuationPlan::Continue(_)
+            ));
         }
     }
 
@@ -299,7 +394,7 @@ mod tests {
         // The shape the zai adapter used to hide by promoting reasoning into
         // `text`: no answer at all. There is nothing to resume from, so the
         // transcript records the fact and none of the deliberation.
-        let plan = plan_continuation("   \n  ", 16_384, 0, None).expect("continues");
+        let plan = expect_continue(plan_continuation("   \n  ", 16_384, 0, None));
         assert_eq!(plan.retained, REASONING_ONLY_PARTIAL);
         assert!(
             plan.note.contains("spent entirely on reasoning"),
@@ -314,7 +409,7 @@ mod tests {
         // never trimmed, so eliding can never lose an answer small enough to
         // have been worth reading whole.
         let answer = "The fix is to widen the guard in ";
-        let plan = plan_continuation(answer, 16_384, 0, None).expect("continues");
+        let plan = expect_continue(plan_continuation(answer, 16_384, 0, None));
         assert_eq!(plan.retained, answer);
     }
 
@@ -332,7 +427,7 @@ mod tests {
             "a".repeat(5_000),
             "b".repeat(5_000)
         );
-        let plan = plan_continuation(&partial, 16_384, 0, None).expect("continues");
+        let plan = expect_continue(plan_continuation(&partial, 16_384, 0, None));
 
         assert!(
             plan.retained.len() < partial.len() / 4,
@@ -369,9 +464,8 @@ mod tests {
 
     #[test]
     fn the_nudge_is_marked_so_it_is_never_mistaken_for_the_user() {
-        let (_note, [assistant, nudge]) = plan_continuation("cut off", 16_384, 0, None)
-            .expect("continues")
-            .into_parts();
+        let (_note, [assistant, nudge]) =
+            expect_continue(plan_continuation("cut off", 16_384, 0, None)).into_parts();
         assert_eq!(assistant.role, stella_protocol::MessageRole::Assistant);
         assert_eq!(nudge.role, stella_protocol::MessageRole::User);
         assert!(


### PR DESCRIPTION
## What

`plan_continuation` returned `None` for two unrelated reasons — the turn spent its `MAX_LENGTH_CONTINUATIONS` allowance, or it had too little wall clock left to finish another continuation. The caller had one reading of `None`: allowance gone, fall through to terminal handling, whose empty-text branch **aborts**. So the time path exited nonzero.

That made `--turn-budget` self-defeating. It exists to stop a turn before a harness kills it, and at the results layer a nonzero exit is scored exactly as a kill is. The flag traded a timeout for an abort and called it a fix.

## Measured, not assumed

From the ten-task Terminal-Bench 2.1 gate (`gate3c`), reading every trial's `exception.txt`, `reward.txt` and `stella-events.jsonl`:

| trial | exit | cause |
|---|---|---|
| circuit-fibsqrt, regex-chess, schemelike-metacircular-eval, write-compressor | 1 | this bug |
| torch-tensor-parallelism | 137 | SIGKILL — a different bug, untouched here |
| gpt2-codegolf (900s), path-tracing (1800s) | — | `AgentTimeoutError`, untouched here |

Every one of the four hit it on its **first** cap hit with **zero** continuations spent — the allowance was never the reason. The abort's own message ("did so on every one of its 4 continuations") was false on all four.

Each of those turns had already done real work that the abort discarded — 5, 12, 26 and 5 tool calls, with file changes in three of the four. Reconstructing worker steps from `step_usage.duration_ms` shows all four final steps landing on **exactly 32000 output tokens with zero tool calls**, after 273–390s.

## How

`ContinuationPlan` names which decline happened:

- `AllowanceSpent` — unchanged terminal handling, and its message is accurate for the first time.
- `OutOfTime` — completes the turn. The partial is kept; the warning names the **deadline** rather than the token limit (a reader told only "output limit" raises the cap, which is the one change that cannot help here); an empty partial becomes `TIME_EXHAUSTED_PARTIAL` so the turn still says why nothing came back. The verification ladder judges that record like any other.

Also detaches a `plan_continuation` doc comment that had drifted onto `ContinuationBudget` and described exactly the `None` semantics this PR changes.

## Expected effect

Harness health, **not** score: NonZero 5 → 1 predicted. Pass rate likely unchanged — Harbor runs the benchmark verifier even after a NonZero, so those four already scored reward 0. This converts four zero-scoring *crashes* into four zero-scoring *results*, which is what makes the gate a measurement at all.

## Tests

`stella-core` full suite green (821 passed), clippy `-D warnings` clean.

- `a_step_out_of_time_completes_with_a_truthful_partial_instead_of_aborting` — driver-level regression; a zero budget makes the decline deterministic rather than a race against the test clock.
- `a_continuation_it_cannot_finish_is_declined_for_time_not_allowance` — asserts the distinction itself.
- `a_spent_allowance_outranks_a_broken_budget` — both conditions true at once still reports `AllowanceSpent`, so the abort naming the allowance stays accurate.

Closes #1149.

## Summary by Sourcery

Distinguish continuation allowance exhaustion from wall-clock exhaustion so out-of-time continuations finish the turn with a truthful partial instead of aborting, improving harness behavior for budgeted turns.

Bug Fixes:
- Fix turns hitting the time budget so they produce a completed result with retained partial output instead of aborting with a nonzero exit code.

Enhancements:
- Introduce a `ContinuationPlan` outcome type to explicitly represent continuation vs allowance-spent vs out-of-time decisions.
- Add a dedicated `TIME_EXHAUSTED_PARTIAL` message and user-facing warning text to clearly explain time-based truncation in the final turn output.

Tests:
- Add driver and truncation tests covering out-of-time continuation behavior, allowance vs time distinction, and precedence when both constraints are met.