### PR TITLE
fix: raise the three ceilings that truncated Stella below the comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,46 @@ skip the roll) were re-inserted the same way.
 
 ## [Unreleased]
 
+### Changed
+
+- **Stella now asks each model for what that model can actually emit.** The
+  engine carried one output cap (16,384 tokens) for every model on every
+  provider, and fell back to it even though each model's real ceiling was
+  already being read from models.dev, written to the `max_output_tokens`
+  column of the local model card, and read back out — then dropped when the
+  runtime catalog was assembled. `CatalogEntry` now carries the ceiling and
+  the engine uses it, in both directions: a model that can emit 64,000 gets
+  asked for 64,000, and one whose ceiling is below 16,384 stops being asked
+  for more than its provider will serve. An explicit `params.max_tokens` in
+  settings still wins, and a model the catalog has no ceiling for keeps the
+  previous default.
+
+  The symptom this fixes is truncation that looks like failure: a step that
+  spends its whole budget reasoning and is cut off before it can emit a tool
+  call does no work and reports nothing useful, and on a benchmark that is
+  scored identically to getting the answer wrong.
+
+- **`model_timeout` is 816s, up from 600s.** The old value assumed no
+  generation a caller still wants runs past ten minutes. At high effort
+  against a large output ceiling that is false — single steps producing
+  correct, complete work were measured at 624s and 756s, and a 600s bound
+  killed them after paying for them. Raising the output ceiling without this
+  only relocates the cliff, which is why earlier attempts to fix truncation
+  by raising the cap alone did not.
+
+### Fixed
+
+- **The benchmark adapter passes the turn deadline it is running under.** The
+  engine could already decline to start a length continuation it could not
+  finish, and end the turn with a truthful partial rather than being killed
+  mid-flight — but nothing told it the deadline, so the policy was inert in
+  the one place it was written for. The Harbor adapter now derives
+  `--turn-budget` per trial from Harbor's own agent timeout (via
+  `--agent-kwarg agent_timeout_sec=<seconds>`, the seam Harbor's Cline adapter
+  uses), holding back a fixed 60s so the turn ends as a result instead of a
+  kill. `STELLA_TURN_BUDGET` is accepted as a fallback and is now registered:
+  before this, exporting it did not enable the policy, it refused the run.
+
 ## [0.6.62] — 2026-08-01
 
 ## [0.6.61] — 2026-08-01

--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -390,6 +390,61 @@ because those arms were re-run. Runs published under the `max` posture remain
 described by the 8.3 table; a run states which posture it used in its own
 manifest, which is the point of hashing it.
 
+### 8.3.2 The output cap moves to the model's ceiling, and the two ceilings behind it
+
+The `xhigh` posture above kept `params.max_tokens` at 32000. Arm B telemetry
+from the gate3c head-to-head falsified that number directly. Claude Code passed
+all four of the tasks Stella aborted on — same model, same first-party API,
+same effort — and its winning steps on those tasks spent this much output:
+
+| task | Arm B's largest step | that step took | Stella's cap | Stella's outcome |
+|---|---|---|---|---|
+| `circuit-fibsqrt` | 45,001 tok | 527s | 32,000 | truncated, 0 tool calls, abort |
+| `regex-chess` | 64,000 tok | 756s | 32,000 | truncated, 0 tool calls, abort |
+| `schemelike-metacircular-eval` | 64,000 tok | 624s | 32,000 | truncated, 0 tool calls, abort |
+| `write-compressor` | 25,965 tok | — | 32,000 | truncated, 0 tool calls, abort |
+
+Two of those steps landed on exactly 64,000 — the comparator's own ceiling —
+and still had room to emit the tool call. Sonnet fills whatever budget it is
+given in either agent, so the only variable is whose number stops it first.
+Ours did, at half the height. On `circuit-fibsqrt` Stella spent *more* output
+than the comparator (~117k vs 97.6k) and scored 0, because 32k of it was
+truncated reasoning that was then thrown away — $2.02 for a failure against
+$2.52 for a pass.
+
+**Three ceilings, and they are one budget.** Each previous attempt moved one
+and left the others, which is why every one of them relocated the cliff rather
+than clearing it — 16384 → 32000 changed which trials truncated, and 64000
+"merely traded truncation for a `model_timeout`" because `model_timeout` was
+600s while the steps that earn rewards take 624–756s.
+
+| ceiling | was | now | fixed by |
+|---|---|---|---|
+| `params.max_tokens` | 32,000 | **64,000** (the model's ceiling) | this posture |
+| `EngineConfig::model_timeout` | 600s | **816s** | 60s above the longest rewarded Arm B step (756s) |
+| `--turn-budget` | unwired; 840s by hand on the box | **per-trial, from Harbor's own agent timeout −60s** | the adapter, which previously had no way to learn the deadline |
+
+The rule setting all three is the same, and it is the only one that makes a
+head-to-head mean anything: **never be the side that stops first.** A ceiling
+below what the comparator is allowed is not a tuning choice, it is a handicap
+that the score then reports as a capability difference.
+
+Recomputed digests, via the adapter's own `_benchmark_engine_posture`:
+
+| model | was (`xhigh`, 32000) | now (`xhigh`, 64000) |
+|---|---|---|
+| deepseek-v4-pro | `4249a1f9…` / `0de2116f…` | `9d7ad135…` |
+| z-ai/glm-5.2 | `a0ab8a75…` | `7e9da633…` |
+| x-ai/grok-4.5 | `ff61cb06…` | `19c4d345…` |
+| z-ai/glm-5.1 | `f15536e5…` | `8530a36f…` |
+| anthropic/claude-sonnet-5 | `55c6ef4c…` | `3c428a22…` |
+
+Runs published under the 32000 posture remain described by the 8.3.1 table.
+The registered tables in the protocol and the analyzer README carry the new
+values, because those describe the posture the launcher will actually emit —
+a document that disagrees with the code is the `harbor==0.6.1` failure again,
+in a different file.
+
 ### 8.4 The measured baseline
 
 See `bench/evidence/` for the run manifest, per-trial rows, per-task results and

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -26,7 +26,7 @@ set -uo pipefail
 
 MODEL="${1:-claude-sonnet-5}"
 TIER="${2:-xhigh}"
-EXPECT_DIGEST="${3:-55c6ef4c}"
+EXPECT_DIGEST="${3:-3c428a22}"
 ENV_FILE="${TB_ANTHROPIC_ENV_FILE:-$HOME/.env.harbor-anthropic.local}"
 REPO="${TB_REPO:-$HOME/stella}"
 

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -84,6 +84,12 @@ from .posture import (
     _benchmark_engine_posture,
     fold_witness_observations,
 )
+from .turn_budget import (
+    TURN_BUDGET_ENV as _TURN_BUDGET_ENV,
+)
+from .turn_budget import (
+    resolve_turn_budget as _resolve_turn_budget,
+)
 
 try:
     # Harbor renders prompt templates onto the ``instruction`` argument of a
@@ -122,6 +128,7 @@ _TELEMETRY_INCOMPLETE = "stella-adapter: TELEMETRY-INCOMPLETE"
 # Defaults when neither Harbor nor the environment specify a value.
 _DEFAULT_MODEL = "anthropic/claude-fable-5"
 _DEFAULT_BUDGET = "5.0"
+
 # What a run with no per-trial spend cap discloses as its cap. A word rather
 # than an omission, because the metadata dict drops `None` values entirely and
 # a published manifest would then spell "no cap" and "this adapter never
@@ -187,6 +194,11 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         "STELLA_SOURCE_COMMIT",
         "STELLA_MODEL",
         "STELLA_BASE_URL",
+        # The turn deadline (#1161/#1170/#1173). Host-only like STELLA_MODEL:
+        # read here, expressed as argv, never forwarded. Registered because the
+        # ambient check below fails closed — unregistered, exporting it refused
+        # the run rather than enabling the policy. See `turn_budget`.
+        _TURN_BUDGET_ENV,
         _WITNESS_AUTHOR_ENV,
         # The portability target triple and glibc floor (#1018). `env.sh` exports
         # both so `build_sut.sh` builds to the same floor `preflight` asserts
@@ -1102,6 +1114,23 @@ class StellaAgent(BaseInstalledAgent):
     _assurance_tiers_json: str
     _assurance_tiers_sha256: str
 
+    def __init__(self, *args: Any, agent_timeout_sec: Any = None, **kwargs: Any):
+        """Accept Harbor's per-trial agent deadline, and keep it off the base.
+
+        Harbor 0.6.1 hands ``agent_timeout_sec`` to the *oracle* agent only, so
+        an installed agent is never told the deadline it runs against — the
+        reason the continuation policy shipped inert. The supported route is
+        the agent kwarg (``--agent-kwarg agent_timeout_sec=<seconds>``), as
+        Harbor's own Cline adapter takes it. Popping it is required, not
+        stylistic: ``BaseInstalledAgent`` forwards unrecognized kwargs to
+        ``BaseAgent.__init__``, which rejects it. Why it matters:
+        :mod:`stella_harbor.turn_budget`.
+        """
+        # Raw: validation belongs at the point of use, since `__init__` is not
+        # the only way this is set (the suite uses `__new__`).
+        self._agent_timeout_sec = agent_timeout_sec
+        super().__init__(*args, **kwargs)
+
     @staticmethod
     def name() -> str:
         return "stella"
@@ -1422,6 +1451,7 @@ class StellaAgent(BaseInstalledAgent):
         """
         model = model or self._effective_model()
         budget = self._configured_budget()
+        turn_budget = self._configured_turn_budget()
         base_url = base_url or self._effective_base_url(model)
         parts = [
             _INSTALL_PATH,
@@ -1431,6 +1461,9 @@ class StellaAgent(BaseInstalledAgent):
             # budget" to clap, it is a malformed number, and it exits 2 before
             # the turn starts.
             *(["--budget", budget] if budget is not None else []),
+            # Omit-when-absent, same discipline and same reason as `--budget`:
+            # an absent flag is "no deadline", an empty value exits 2.
+            *(["--turn-budget", turn_budget] if turn_budget is not None else []),
             "--output-format",
             "stream-json",
         ]
@@ -1550,6 +1583,23 @@ class StellaAgent(BaseInstalledAgent):
         if budget is None or not str(budget).strip():
             return None
         return budget
+
+    def _configured_turn_budget(self) -> str | None:
+        """Resolve the turn deadline in seconds, or ``None`` for no deadline.
+
+        Policy and parsing live in :mod:`stella_harbor.turn_budget`; this
+        supplies the two inputs and nothing else.
+
+        ``getattr`` rather than attribute access: Harbor constructs this class,
+        but the suite builds instances without running ``__init__`` — the same
+        reason ``_configured_value`` reaches for ``_resolved_env_vars`` this
+        way — and an adapter that only works when fully constructed is an
+        adapter whose deadline handling is untested.
+        """
+        return _resolve_turn_budget(
+            getattr(self, "_agent_timeout_sec", None),
+            self._configured_value(_TURN_BUDGET_ENV),
+        )
 
     def _forwarded_env(self) -> dict[str, str]:
         """Build the registered minimal claim environment.

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -164,31 +164,47 @@ def _benchmark_engine_posture(
         # tier without raising the cap buys reasoning that cannot fit an answer
         # beside it, and the step ends with no tool call at all.
         #
-        # 32000 rather than more, bounded by `model_timeout` (600s): the effort
-        # preflight spent ~280s reaching 32000 output tokens, so ~64000 would
-        # sit close enough to the model timeout to trade one truncation mode
-        # for another. Sonnet 5's own ceiling (128000) is not the constraint.
+        # 64000, which is the model's own ceiling and therefore the
+        # comparator's. The previous value was 32000, held there because
+        # `model_timeout` was 600s and a 64000-token step would not fit inside
+        # it — one self-imposed ceiling justifying another. Both moved
+        # together; `model_timeout` is now 816s, and neither binds first.
+        #
+        # The 32000 value was falsified directly. On the gate, four trials
+        # ended on a step that emitted exactly 32000 output tokens with zero
+        # tool calls. Claude Code passed all four of those tasks (reward 1.0)
+        # on the same model, same API and same effort, and its winning steps
+        # on them spent 45,001, 64,000, 64,000 and 25,965 output tokens. Two
+        # landed on precisely 64,000 — its ceiling — and still had room to
+        # emit the tool call. Sonnet fills whatever budget it is given in
+        # either agent; the only variable is who stops it first.
+        #
+        # That is also why 16384 -> 32000 did not fix truncation and 64000
+        # "merely traded truncation for a model_timeout": each attempt moved
+        # one ceiling while the others held. The output cap, `model_timeout`
+        # and the turn budget are one budget, and the rule that sets all three
+        # is the same — never be the side that stops first.
         #
         # This is not compute handed to one side. Claude Code does not cap
-        # itself at 16k, so the cap was a Stella-side handicap and removing it
-        # restores parity rather than breaking it. `triage` keeps the default:
-        # it runs at low effort and emits a three-line classification, so 16384
-        # was never near binding for it.
+        # itself, so every number below the model's ceiling was a Stella-side
+        # handicap and removing it restores parity rather than breaking it.
+        # `triage` keeps the engine default: it runs at low effort and emits a
+        # three-line classification, so the cap was never near binding for it.
         "agents": {
             "default": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 32000},
+                "params": {"max_tokens": 64000},
             },
             "worker": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 32000},
+                "params": {"max_tokens": 64000},
             },
             "judge": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 32000},
+                "params": {"max_tokens": 64000},
             },
             "triage": {"effort": "low", "reasoning": "off"},
         },

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -79,6 +79,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",
+    "bench/harbor_adapter/stella_harbor/turn_budget.py",
 )
 _FIXED_READINESS_SOURCE_PATHS = (
     "bench/readiness/synthetic-adapter-sentinel/environment/Dockerfile",

--- a/bench/harbor_adapter/stella_harbor/turn_budget.py
+++ b/bench/harbor_adapter/stella_harbor/turn_budget.py
@@ -1,0 +1,118 @@
+"""The turn deadline a trial runs under, and how it is derived.
+
+Split out of the adapter package root for the same reason `posture.py` was:
+that file is over its recorded ceiling (`scripts/check-file-size.sh`), and the
+repository's rule is that separable new code becomes its own module rather than
+more length on an already-oversized file. It is a genuine seam — everything
+here is a pure function of a deadline and an environment value, with no Harbor,
+Docker, or credential dependency — so the adapter and its tests exercise one
+implementation rather than copies that can disagree.
+
+## Why this exists at all
+
+Stella's engine can decline to *start* a length continuation it cannot finish
+(`driver::truncation::ContinuationBudget`, #1161), and #1173 made that decline
+complete the turn with a truthful partial instead of aborting it. Both are
+inert without a deadline, and the benchmark — the one caller that actually runs
+under an external kill — had no way to supply one:
+
+* Harbor 0.6.1 passes `agent_timeout_sec` to the **oracle** agent only
+  (`trial.py`: `if config.agent.name == AgentName.ORACLE.value`), so an
+  installed agent is never told the deadline it is running against.
+* Exporting `STELLA_TURN_BUDGET` was worse than doing nothing: the adapter's
+  fail-closed ambient check rejects any unregistered `STELLA_*` name, so it
+  refused the run rather than enabling the policy.
+
+## The two things this gets right that a constant cannot
+
+**Shape.** Harbor's agent timeout is per-task — 900s and 1800s are both live in
+Terminal-Bench 2.1 — so any single global value is wrong for most tasks. The
+deadline has to come from the trial.
+
+**Size.** The value used by hand on the bench box was 840s, against a
+comparator whose winning `regex-chess` run took 2,746s of wall clock on this
+same dataset. Stella was declining continuations roughly 3x too early, which
+turns a policy meant to save turns into one that ends them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Host-side name for the deadline, forwarded to the CLI as `--turn-budget`.
+# Registered host-only in the adapter: it is read on the host and expressed as
+# argv, so the container environment stays exactly as narrow as it was and the
+# empty-string parse trap that killed six trials on `--budget` cannot recur on
+# a second variable.
+TURN_BUDGET_ENV = "STELLA_TURN_BUDGET"
+
+# Wall clock held back from the harness deadline so the turn ends as a result
+# rather than as a kill.
+#
+# Subtracted, never multiplied. A fraction scales the reserve with the task and
+# would throw away ~270s on an 1800s task — time the comparator spends
+# finishing. What the engine needs is room to write its partial and exit, which
+# is a constant.
+TEARDOWN_SEC = 60.0
+
+
+def coerce_timeout_seconds(raw: Any) -> float | None:
+    """Parse a deadline in seconds, or ``None`` when there is not one.
+
+    Harbor passes agent kwargs through as strings when they arrive from
+    ``--agent-kwarg`` and as floats when they arrive from a config object, so
+    both have to parse. Anything absent, blank, unparseable, non-finite, or
+    non-positive is ``None`` — "no deadline known" — and never a substituted
+    default, because guessing a deadline is what makes the engine decline
+    continuations it could afford.
+
+    ``bool`` is rejected explicitly: it is an ``int`` subclass in Python, so
+    ``float(True)`` is ``1.0`` and a stray flag would otherwise become a
+    one-second deadline.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        seconds = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    # NaN fails every comparison, so test it as itself; inf would produce an
+    # argv value clap cannot parse.
+    if seconds != seconds or seconds in (float("inf"), float("-inf")):
+        return None
+    if seconds <= 0:
+        return None
+    return seconds
+
+
+def resolve_turn_budget(
+    agent_timeout_sec: Any = None,
+    env_value: Any = None,
+) -> str | None:
+    """Return the ``--turn-budget`` argv value, or ``None`` to omit the flag.
+
+    Precedence is deadline-first: Harbor's own per-trial ``agent_timeout_sec``
+    wins because it *is* the constraint being modelled, and an operator-set
+    ``STELLA_TURN_BUDGET`` is the fallback for a runner that cannot pass an
+    agent kwarg.
+
+    ``None`` leaves the continuation allowance a pure count — exactly the
+    behaviour before #1161 — so a caller with no deadline is unaffected.
+
+    A deadline at or under the reserve also yields ``None`` rather than zero or
+    a negative. Zero would make every continuation unaffordable and turn a
+    whole run into truthful partials, which reads as a deliberate policy rather
+    than the misconfiguration it is.
+    """
+    deadline = coerce_timeout_seconds(agent_timeout_sec)
+    if deadline is None:
+        deadline = coerce_timeout_seconds(env_value)
+    if deadline is None:
+        return None
+    usable = deadline - TEARDOWN_SEC
+    if usable <= 0:
+        return None
+    # `%g` so a whole number of seconds is "840" rather than "840.0" — the
+    # value lands in a recorded argv that a reader compares against the task's
+    # own timeout.
+    return f"{usable:g}"

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -595,7 +595,7 @@ class TestForwardedEnv:
             assert posture["agents"][role] == {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 32000},
+                "params": {"max_tokens": 64000},
             }
         assert posture["agents"]["triage"] == {"effort": "low", "reasoning": "off"}
         assert json.loads(normalized) == posture
@@ -603,7 +603,7 @@ class TestForwardedEnv:
         # edits land here deliberately. Keep it in step with the superseding
         # table in bench/READINESS.md, not the protocol's earlier `max` table.
         assert digest == (
-            "4249a1f95976f388cc8c5177a8c085ff0152fe5e6884d3dbfaada349d989b725"
+            "9d7ad135db12e32d4519f893b8d8ed9d918b0ef54c7a4e4d22d1398b0015785b"
         )
 
     def test_excludes_all_provider_keys_and_selects_only_effective_provider(

--- a/bench/harbor_adapter/tests/test_turn_budget.py
+++ b/bench/harbor_adapter/tests/test_turn_budget.py
@@ -1,0 +1,194 @@
+"""The turn deadline reaches the CLI, and is derived from the real one.
+
+Split from `test_adapter.py`, which is over its recorded size ceiling
+(`scripts/check-file-size.sh`); the repository's rule is that separable new
+code becomes its own module. The subject is one seam —
+`stella_harbor.turn_budget` and the two adapter methods that feed it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stella_harbor.turn_budget import (
+    TEARDOWN_SEC,
+    coerce_timeout_seconds,
+    resolve_turn_budget,
+)
+
+from .test_adapter import _bare_agent
+
+
+class TestTurnBudgetReachesTheEngine:
+    """The turn deadline must reach the CLI, derived from the real one.
+
+    The engine gained ``turn_budget`` in #1161 and a ``--turn-budget`` flag in
+    #1170, and #1173 made declining for time complete the turn instead of
+    aborting it. None of that could fire in a benchmark trial, because the
+    adapter never passed the flag and Harbor 0.6.1 hands ``agent_timeout_sec``
+    to the *oracle* agent only — an installed agent was never told the deadline
+    it was running against. The policy shipped inert in the one place it was
+    built for.
+
+    Exporting ``STELLA_TURN_BUDGET`` was not a workaround: the fail-closed
+    ambient check rejects any unrecognized ``STELLA_*`` name, so it refused the
+    run rather than enabling the policy.
+    """
+
+    def test_the_flag_is_derived_from_harbors_own_per_trial_deadline(self) -> None:
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+        agent._agent_timeout_sec = 900.0
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--turn-budget" in cmd
+        assert cmd[cmd.index("--turn-budget") + 1] == "840"
+
+    def test_a_longer_task_gets_a_longer_budget_not_a_scaled_one(self) -> None:
+        """Reserve is subtracted, never multiplied.
+
+        Harbor's agent timeout is per-task — 900s and 1800s are both live in
+        this dataset — and the comparator's winning ``regex-chess`` run took
+        2,746s of wall clock. A fractional margin would throw away hundreds of
+        seconds on exactly the long tasks that need them, which is the same
+        defect as the global 840s in a different disguise.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+        agent._agent_timeout_sec = 3600.0
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "3540"
+
+    def test_no_known_deadline_omits_the_flag_entirely(self) -> None:
+        """Absent is not zero, and it is not a guess.
+
+        With no deadline the allowance stays a pure count — the behaviour
+        before #1161. Inventing one would decline continuations the turn could
+        afford, which is this policy's own failure mode inverted.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--turn-budget" not in cmd
+        assert "" not in cmd
+
+    def test_a_deadline_under_the_reserve_is_no_deadline_not_a_zero(self) -> None:
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+        agent._agent_timeout_sec = 45.0
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--turn-budget" not in cmd
+
+    def test_harbors_deadline_outranks_an_operator_set_variable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STELLA_TURN_BUDGET", "120")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+        agent._agent_timeout_sec = 900.0
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "840"
+
+    def test_the_variable_is_the_fallback_when_harbor_cannot_pass_a_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STELLA_TURN_BUDGET", "900")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "840"
+
+    def test_the_variable_no_longer_refuses_the_run_and_stays_host_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Registered, and registered in the *host-only* bucket.
+
+        It is read here and expressed as argv, so forwarding it into the
+        container would buy nothing and would re-open the empty-string parse
+        trap that killed six trials on ``--budget``.
+        """
+        monkeypatch.setenv("STELLA_TURN_BUDGET", "900")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        forwarded = agent._forwarded_env()  # must not raise
+
+        assert "STELLA_TURN_BUDGET" not in forwarded
+
+    def test_a_junk_deadline_is_ignored_rather_than_forwarded(self) -> None:
+        """A malformed value must never become an argv element.
+
+        ``--turn-budget`` is parsed by clap before the turn starts, so a bad
+        value exits 2 and Harbor scores it identically to the agent failing
+        the task — the #1018 / empty-budget shape, on a third variable.
+        """
+        for junk in ("", "   ", "abc", "-5", "0", None, True):
+            agent = _bare_agent()
+            agent.model_name = "openrouter/z-ai/glm-5.2"
+            agent._agent_timeout_sec = junk
+
+            cmd = agent._build_command("Fix the bug")
+
+            assert "--turn-budget" not in cmd, junk
+
+
+class TestResolveTurnBudgetIsPure:
+    """The policy, exercised without an agent, a container, or a credential."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "abc", "-5", "0", None, True, False, "nan", "inf", "-inf"],
+    )
+    def test_a_value_that_is_not_a_positive_deadline_is_no_deadline(
+        self, raw: object
+    ) -> None:
+        assert coerce_timeout_seconds(raw) is None
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("900", 900.0), (900, 900.0), (1800.5, 1800.5), (" 2746 ", 2746.0)],
+    )
+    def test_harbor_passes_strings_and_floats_and_both_parse(
+        self, raw: object, expected: float
+    ) -> None:
+        assert coerce_timeout_seconds(raw) == expected
+
+    def test_the_reserve_is_subtracted_so_it_does_not_scale_with_the_task(
+        self,
+    ) -> None:
+        """The 900s and 1800s tasks keep the same reserve, not the same ratio.
+
+        A multiplicative margin would cost the 1800s task 270s and the 2,746s
+        one over 400s — precisely the wall clock the comparator spends
+        finishing the tasks Stella truncates.
+        """
+        assert resolve_turn_budget(900) == f"{900 - TEARDOWN_SEC:g}"
+        assert resolve_turn_budget(1800) == f"{1800 - TEARDOWN_SEC:g}"
+        assert float(resolve_turn_budget(1800)) - float(
+            resolve_turn_budget(900)
+        ) == pytest.approx(900.0)
+
+    def test_a_deadline_under_the_reserve_yields_none_not_zero(self) -> None:
+        assert resolve_turn_budget(TEARDOWN_SEC) is None
+        assert resolve_turn_budget(TEARDOWN_SEC - 1) is None
+        assert resolve_turn_budget(TEARDOWN_SEC + 1) == "1"
+
+    def test_the_kwarg_outranks_the_variable_and_the_variable_is_the_fallback(
+        self,
+    ) -> None:
+        assert resolve_turn_budget(900, "120") == "840"
+        assert resolve_turn_budget(None, "900") == "840"
+        assert resolve_turn_budget(None, None) is None
+        # A junk kwarg falls through to the variable rather than poisoning it.
+        assert resolve_turn_budget("garbage", "900") == "840"

--- a/bench/terminal-bench-2.1-protocol.md
+++ b/bench/terminal-bench-2.1-protocol.md
@@ -524,9 +524,9 @@ includes `headless_scope_bypass: on` (see Engine posture above), are:
 
 | Configuration model | Engine-posture SHA-256 |
 |---|---|
-| `openrouter/deepseek/deepseek-v4-pro` | `0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2` |
-| `openrouter/z-ai/glm-5.2` | `a0ab8a753a4ffaf7eff5a4ec051f2e6ba3daef38bfb7455af07a634ebde7a407` |
-| `openrouter/x-ai/grok-4.5` | `ff61cb0609f4649df922fb19715bea826121c6eeaad72be9a0f4db20a4a1ea0e` |
+| `openrouter/deepseek/deepseek-v4-pro` | `9d7ad135db12e32d4519f893b8d8ed9d918b0ef54c7a4e4d22d1398b0015785b` |
+| `openrouter/z-ai/glm-5.2` | `7e9da63355a399025c537e6d26528a0500a533b096e4f1eda1b88a3e3c51c0b4` |
+| `openrouter/x-ai/grok-4.5` | `19c4d3454de88a1fe5560d17bdf9a063be1d1720190a90a5dc1bdcb2159c9f15` |
 
 Each posture differs only in the inherited selected model and its one-entry
 `allowed_models` list. A repository setting or Harbor extra that attempts to

--- a/bench/terminal_bench_analysis/README.md
+++ b/bench/terminal_bench_analysis/README.md
@@ -208,7 +208,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2"
+        "sha256": "9d7ad135db12e32d4519f893b8d8ed9d918b0ef54c7a4e4d22d1398b0015785b"
       },
       "openrouter/z-ai/glm-5.2": {
         "version": "stella-tb21-engine-posture-v1",
@@ -224,7 +224,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "a0ab8a753a4ffaf7eff5a4ec051f2e6ba3daef38bfb7455af07a634ebde7a407"
+        "sha256": "7e9da63355a399025c537e6d26528a0500a533b096e4f1eda1b88a3e3c51c0b4"
       },
       "openrouter/x-ai/grok-4.5": {
         "version": "stella-tb21-engine-posture-v1",
@@ -240,7 +240,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "ff61cb0609f4649df922fb19715bea826121c6eeaad72be9a0f4db20a4a1ea0e"
+        "sha256": "19c4d3454de88a1fe5560d17bdf9a063be1d1720190a90a5dc1bdcb2159c9f15"
       }
     },
     "job_name": "stella-tb21-calibration-20260721",

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,20 +7,20 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1928 bench/harbor_adapter/stella_harbor/__init__.py
-4270 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1978 bench/harbor_adapter/stella_harbor/__init__.py
+4271 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1910 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-1792 stella-cli/src/agent_tests.rs
 2316 stella-cli/src/agent.rs
+1792 stella-cli/src/agent_tests.rs
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2418 stella-core/src/driver.rs
+2436 stella-core/src/driver.rs
 3205 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1612 stella-model/src/anthropic/tests.rs

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -55,6 +55,23 @@ fn tuned_engine_config(
                 .compaction_budget_tokens
                 .min(window.saturating_mul(3) / 4);
         }
+        // The model's own completion ceiling replaces the global default,
+        // in BOTH directions. `EngineConfig::default()` carries one 16384 for
+        // every model on every provider and its own comment called per-model
+        // caps the eventual refinement; this is that refinement, and the data
+        // has been on the model card the whole time.
+        //
+        // Raising matters where the work is long: a comparator on the same
+        // model, same API and same effort spent 45,001–64,000 output tokens
+        // finishing tasks whose Stella runs ended at the cap with no tool
+        // call. Lowering matters too — a row whose ceiling is below 16384 was
+        // being asked for more than the provider will serve.
+        //
+        // Settings still win: this lands before the `engine_settings` block,
+        // so an explicit `params.max_tokens` overrides it.
+        if let Some(ceiling) = entry.max_output_tokens.filter(|c| *c > 0) {
+            engine.max_output_tokens = Some(ceiling);
+        }
     }
     if let Some(settings) = &cfg.engine_settings {
         let tuning = crate::engine_config::tuning_for(settings, kind);

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -571,3 +571,62 @@ fn the_trusted_control_arm_posture_does_not_arm_the_witness_refusal() {
         "the control arm claims no independent author and must keep running"
     );
 }
+
+#[test]
+fn the_models_own_output_ceiling_replaces_the_global_default() {
+    // `EngineConfig::default()` carries one `max_output_tokens` (16384) for
+    // every model on every provider, and its own comment named per-model caps
+    // as "the eventual refinement". The data was already on the model card —
+    // models.dev publishes `limit.output`, the store has the column — and was
+    // dropped when the runtime catalog was assembled, so nothing could read it.
+    //
+    // The cost was measured, not theoretical. On the Terminal-Bench 2.1 gate
+    // four trials ended on a step that emitted the cap exactly and made no
+    // tool call, while the comparator — same model, same API, same effort —
+    // spent 45,001-64,000 output tokens on those same four tasks and finished
+    // each one, reward 1.0. Two of its winning steps landed on precisely
+    // 64,000, its own ceiling. The model fills whatever budget it is given;
+    // the only question is whose number stops it first.
+    //
+    // Superset of the seed, matching `stella-model`'s own runtime-catalog test:
+    // the catalog is a process-global, so a test that installed less than the
+    // seed would perturb whatever runs beside it.
+    let mut entries = stella_model::catalog::Catalog::seed().entries().to_vec();
+    entries.push(
+        stella_model::catalog::CatalogEntry::new(
+            "test-only-wiring-model",
+            "anthropic",
+            "claude",
+            200_000,
+            stella_model::catalog::ToolDialect::AnthropicTools,
+            stella_model::catalog::Pricing {
+                input_usd_per_mtok: 3.0,
+                output_usd_per_mtok: 15.0,
+                cached_input_usd_per_mtok: 0.3,
+                cache_write_usd_per_mtok: 3.75,
+            },
+        )
+        .with_max_output_tokens(Some(64_000)),
+    );
+    stella_model::catalog::Catalog::install_runtime(stella_model::catalog::Catalog::with_entries(
+        entries,
+    ));
+
+    let mut cfg = cfg_for("anthropic");
+    cfg.model_id = "test-only-wiring-model".to_string();
+
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(64_000),
+        "the engine must ask for what the model can actually emit, not 16384",
+    );
+
+    // A model the catalog has no ceiling for keeps the default, so this
+    // widens nothing it does not have data for.
+    let mut unknown = cfg_for("anthropic");
+    unknown.model_id = "definitely-not-in-any-catalog".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&unknown).max_output_tokens,
+        stella_core::driver::EngineConfig::default().max_output_tokens,
+    );
+}

--- a/stella-cli/src/model_catalog.rs
+++ b/stella-cli/src/model_catalog.rs
@@ -734,7 +734,21 @@ fn install_runtime_catalog(store: &CatalogStore) {
                             }),
                     },
                 )
-                .with_reasoning(listing.pricing.supports_reasoning),
+                .with_reasoning(listing.pricing.supports_reasoning)
+                // The model's own completion ceiling, from `limit.output` on
+                // the card. Parsed, stored and read back before this line
+                // existed, then dropped here — the same way the cache-write
+                // rate was dropped at this site before #97, and with the same
+                // consequence: the engine fell back to one global 16384 for
+                // every model, and truncated steps that the model had room to
+                // finish. Saturating rather than wrapping, so an absurd card
+                // value cannot silently become a small one.
+                .with_max_output_tokens(
+                    listing
+                        .pricing
+                        .max_output_tokens
+                        .map(|v| v.min(u32::MAX as u64) as u32),
+                ),
             );
             known.insert(key);
         }

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -202,9 +202,27 @@ pub struct EngineConfig {
     /// once per retry, which would multiply the very window the deadline
     /// exists to close.
     ///
-    /// 10 minutes: above any generation a caller would still want (it matches
-    /// `UNARY_READ_TIMEOUT`, the most generous transport bound in the
-    /// workspace) while staying finite.
+    /// 13.6 minutes, and the number is measured rather than chosen. It was 10
+    /// (matching `UNARY_READ_TIMEOUT`) on the reasoning that no generation a
+    /// caller still wants runs longer. That premise is false at high effort
+    /// against a large output ceiling: on the Terminal-Bench 2.1 gate a
+    /// comparator on the same model, same API and same effort earned reward
+    /// `1.0` on single steps of 624s and 756s. A 600s bound kills exactly
+    /// those steps — and kills them *after* paying for them.
+    ///
+    /// The rule fixing the constant is "never be the side that stops first":
+    /// 60s above the longest single step the comparator was ever rewarded for
+    /// (756s). Raising it is what makes a raised output ceiling reachable —
+    /// the two are one budget, and moving either alone provably does nothing,
+    /// which is why the earlier 16384 → 32000 → 64000 attempts each traded
+    /// one truncation mode for another instead of clearing it.
+    ///
+    /// This bounds the *streaming* path, which is the real request path:
+    /// adapters bound their streams by `STREAM_IDLE_TIMEOUT` (120s between
+    /// chunks, not a total), so nothing under this cuts a generation that
+    /// keeps producing. A non-streaming adapter still carries its own
+    /// `UNARY_READ_TIMEOUT` (600s) and will bind before this does — that
+    /// ceiling is untouched here and remains a per-adapter transport concern.
     pub model_timeout: Option<Duration>,
     /// Wall clock one turn may spend, used to decide whether a length
     /// continuation is affordable. `None` — the default — leaves the
@@ -265,7 +283,7 @@ impl Default for EngineConfig {
             summarize_keep_recent: 8,
             max_steps: 200,
             tool_timeout: Some(Duration::from_secs(15 * 60)),
-            model_timeout: Some(Duration::from_secs(10 * 60)),
+            model_timeout: Some(Duration::from_secs(816)),
             // Off by default: only a caller that knows its own deadline can
             // supply a true one, and a guessed budget would decline work the
             // caller had time for.

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -126,6 +126,27 @@ pub struct CatalogEntry {
     /// effort picker hides its levels and the request path drops
     /// effort/reasoning instead of sending a parameter the API rejects.
     pub supports_reasoning: Option<bool>,
+    /// The model's own maximum completion length, from `limit.output` on the
+    /// model card. `None` is "unknown" and leaves the engine default standing.
+    ///
+    /// This exists because the engine had no way to ask. `EngineConfig`
+    /// carried one global `max_output_tokens` (16384) for every model on
+    /// every provider, and its comment named per-model caps as "the eventual
+    /// refinement" — while the value was already being parsed from
+    /// models.dev, written to the `max_output_tokens` column of the model
+    /// card, read back out, and then dropped at the runtime-catalog assembly
+    /// in `stella-cli`. Exactly the shape of the cache-write rate before #97,
+    /// at exactly the same site.
+    ///
+    /// The cost was not theoretical. On the Terminal-Bench 2.1 gate, four
+    /// trials ended on a step that emitted the cap exactly and made no tool
+    /// call, against a comparator that spent 45,001–64,000 output tokens on
+    /// those same four tasks and finished each with its tool call, reward
+    /// `1.0`. Two of the comparator's winning steps landed on precisely
+    /// 64,000 — its own ceiling — so the model fills whatever budget it is
+    /// given and the only question is whose number stops it first. Ours did,
+    /// at half the height, on data we already had.
+    pub max_output_tokens: Option<u32>,
 }
 
 impl CatalogEntry {
@@ -149,6 +170,7 @@ impl CatalogEntry {
             tool_dialect,
             pricing,
             supports_reasoning: None,
+            max_output_tokens: None,
         }
     }
 
@@ -157,6 +179,15 @@ impl CatalogEntry {
     #[must_use]
     pub fn with_reasoning(mut self, supports_reasoning: Option<bool>) -> Self {
         self.supports_reasoning = supports_reasoning;
+        self
+    }
+
+    /// Set the model's own completion ceiling (builder-style, same reason as
+    /// [`CatalogEntry::with_reasoning`] — the seed rows and the many `new`
+    /// call sites stay untouched, and a row without the data keeps `None`).
+    #[must_use]
+    pub fn with_max_output_tokens(mut self, max_output_tokens: Option<u32>) -> Self {
+        self.max_output_tokens = max_output_tokens;
         self
     }
 }
@@ -560,6 +591,48 @@ mod tests {
             Catalog::seed().resolve("glm-5.2").unwrap().pricing,
         );
         assert!(current.resolve_for("anthropic", "test-only-model").is_ok());
+    }
+
+    #[test]
+    fn a_row_carries_the_models_own_output_ceiling_and_defaults_to_unknown() {
+        // The value models.dev publishes as `limit.output`. It was parsed,
+        // written to the model card's `max_output_tokens` column and read
+        // back, then dropped when the runtime catalog was assembled — the
+        // same site, and the same shape, as the cache-write rate before #97.
+        // With nowhere to carry it, the engine fell back to one global 16384
+        // for every model, and truncated steps the model had room to finish.
+        let entry = CatalogEntry::new(
+            "test-only-ceiling-model",
+            "anthropic",
+            "claude",
+            200_000,
+            ToolDialect::AnthropicTools,
+            Pricing {
+                input_usd_per_mtok: 3.0,
+                output_usd_per_mtok: 15.0,
+                cached_input_usd_per_mtok: 0.3,
+                cache_write_usd_per_mtok: 3.75,
+            },
+        );
+        // Absent by default: a row without the data must not invent a ceiling.
+        assert_eq!(entry.max_output_tokens, None);
+
+        let entry = entry.with_max_output_tokens(Some(64_000));
+        assert_eq!(entry.max_output_tokens, Some(64_000));
+
+        // And it survives the lookup the engine actually performs. Superset of
+        // the seed, per `install_runtime_extends_current_without_disturbing_seed_rows`.
+        let mut entries = Catalog::seed().entries.clone();
+        entries.push(entry);
+        Catalog::install_runtime(Catalog::with_entries(entries));
+
+        assert_eq!(
+            Catalog::current()
+                .resolve_for("anthropic", "test-only-ceiling-model")
+                .unwrap()
+                .max_output_tokens,
+            Some(64_000),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Four Terminal-Bench 2.1 gate trials ended on a step that emitted **exactly** the output cap with **zero** tool calls. Claude Code passed all four of those tasks — same model, same first-party API, same effort — and its winning steps on them spent:

| task | Arm B's largest step | that step took | Stella's cap | Stella's outcome |
|---|---|---|---|---|
| `circuit-fibsqrt` | 45,001 tok | 527s | 32,000 | truncated, 0 tools, abort |
| `regex-chess` | 64,000 tok | 756s | 32,000 | truncated, 0 tools, abort |
| `schemelike-metacircular-eval` | 64,000 tok | 624s | 32,000 | truncated, 0 tools, abort |
| `write-compressor` | 25,965 tok | — | 32,000 | truncated, 0 tools, abort |

Two of those steps landed on precisely 64,000 — the comparator's own ceiling — and still had room to emit the tool call. Sonnet fills whatever budget it is given in either agent; the only variable is whose number stops it first. Ours did, at half the height. On `circuit-fibsqrt` Stella spent **more** output than the comparator (~117k vs 97.6k) and scored 0, because 32k of it was truncated reasoning that was then discarded — $2.02 for a failure against $2.52 for a pass.

**Three ceilings, and they are one budget.** Every previous attempt moved one and left the others, which is why each relocated the cliff rather than clearing it: 16384 → 32000 changed *which* trials truncated, and 64000 "merely traded truncation for a `model_timeout`" because `model_timeout` was 600s while the steps that earn rewards take 624–756s.

| ceiling | was | now |
|---|---|---|
| per-model output cap | one global 16,384 | the model's own ceiling, from the catalog |
| `EngineConfig::model_timeout` | 600s | 816s — 60s above the longest rewarded comparator step (756s) |
| `--turn-budget` in the bench | unwired | per-trial, from Harbor's own agent timeout, less 60s |

The rule setting all three is the one that makes a head-to-head mean anything: **never be the side that stops first.**

### The output ceiling was already on disk

models.dev publishes `limit.output`; `model_catalog.rs` ingested it; `stella-store` persisted it in a `max_output_tokens` column and read it back. Nothing carried it into the engine, so `EngineConfig::default()`'s 16384 stood for every model on every provider — its own comment called per-model caps "the eventual refinement". The value was dropped at the runtime-catalog assembly: the same site, and the same shape, as the cache-write rate before #97.

Applied in both directions — a model that can emit 64,000 is asked for 64,000, and one whose ceiling is under 16,384 stops being asked for more than its provider serves. Settings still win; an unknown ceiling keeps the default.

### The deadline the engine was never told

Harbor 0.6.1 passes `agent_timeout_sec` to the **oracle** agent only (`trial.py`), so an installed agent never learns the deadline it runs against — which is why the continuation policy from #1161/#1170/#1173 shipped inert. The adapter now takes it as an agent kwarg, the seam Harbor's own Cline adapter uses.

Derived per trial, not constant: Harbor's agent timeout is per-task (900s and 1800s are both live in this dataset) and the comparator's winning `regex-chess` run took **2,746s** of wall clock, so the 840s used by hand was both the wrong shape and roughly 3× too tight. The reserve is *subtracted*, not multiplied, so a long task keeps its length instead of donating a fraction of it.

`STELLA_TURN_BUDGET` is registered host-only. Before this it was not merely unwired — the fail-closed ambient check rejected it, so exporting it **refused the run** rather than enabling the policy.

Refs #1149

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

- `the_models_own_output_ceiling_replaces_the_global_default` — fails on the unwired engine with `left: Some(16384), right: Some(64000)`; verified by reverting only the wiring block.
- `a_row_carries_the_models_own_output_ceiling_and_defaults_to_unknown` — the ceiling survives the lookup the engine performs, and is absent by default so no row invents one.
- `tests/test_turn_budget.py` — 26 tests. Verified against `main`'s adapter: **5 fail**, one with `RuntimeError: unregistered STELLA_* knobs: STELLA_TURN_BUDGET` — the refusal described above. The 3 that pass on `main` assert *absence* and are regression guards, not witnesses.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **5,311 tests, 0 failures**
- [x] `harbor_adapter` pytest — 337 passed, 1 skipped
- [x] `terminal_bench_analysis` pytest — 257 passed
- [x] `scripts/check-file-size.sh`, plus check-doc-citations / invariants / normative-home / no-scratch / wire-schema
- [x] Docs updated where behavior changed (CHANGELOG, doc comments, `bench/READINESS.md` §8.3.2)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] New adapter module registered in `_FIXED_ADAPTER_SOURCE_PATHS`, so the launcher's byte-for-byte provenance check covers it

## Anything reviewers should know?

**Posture digests move.** `params.max_tokens` 32000 → 64000 changes the registered posture, so the protocol table, the analyzer README table, and `preflight_effort.sh`'s expected digest are updated together — a document that disagrees with the launcher is the `harbor==0.6.1` failure in a different file. `bench/READINESS.md` gains §8.3.2 recording was → now; its **historical** tables are deliberately left alone.

**Sequencing, and a real conflict to decide.** The standing rule is one measured change then a small task set, and **gate4 has not yet reported** — it exists to attribute #1173 (`22345e4b`). Since `build_sut.sh` defines the SUT as `origin/main` and refuses `.rs` drift, merging this makes the *next* build carry both changes. The already-built binary at `6a541de0…` is frozen at `22345e4b`, so the clean order is: **run gate4 against the existing binary first, then rebuild for gate5 with this change.** Nothing here forces that order — flagging it so it is chosen rather than discovered.

**Two ceilings deliberately not touched.** A non-streaming adapter still carries its own `UNARY_READ_TIMEOUT` (600s) and will bind before `model_timeout` does; the real request path streams (bounded by `STREAM_IDLE_TIMEOUT`, 120s *between chunks*, not a total), so this does not affect the benchmark — but it is a residual per-adapter ceiling and is named in the doc comment rather than silently left.

**Untested by me:** the exit-137 SIGKILL on `torch-tensor-parallelism` is a separate defect, untouched here and with no issue filed. And I could not execute a benchmark trial to confirm the end-to-end effect — no Docker-capable host with provider credentials was reachable from the authoring environment, so every claim above rests on the committed test suites plus the Arm A/Arm B trial artifacts, not on a fresh gate.

---

## Summary by Sourcery

Align Stella’s engine and Harbor benchmark posture with per-model output ceilings and real task deadlines to prevent premature truncation and timeouts in Terminal-Bench trials.

New Features:
- Carry each model’s own maximum output tokens in the runtime catalog and expose it to the engine configuration.
- Introduce turn-budget derivation logic that converts Harbor’s per-trial agent timeout (or a host env fallback) into a CLI --turn-budget for benchmark runs.

Enhancements:
- Use per-model output ceilings instead of a single global output cap when configuring the engine, while keeping explicit params.max_tokens settings authoritative.
- Increase the default model_timeout to a measured 816 seconds so long reasoning steps with larger output budgets can complete.
- Raise the benchmark engine posture max_tokens to 64,000 for high-effort agents to match the model’s ceiling and comparator configuration.
- Register the new turn_budget module in the secure launcher’s fixed source paths and keep the adapter’s environment handling host-only for deadline controls.

Documentation:
- Update bench readiness documentation, protocol tables, analyzer README, and preflight tooling to reflect the new engine posture digests and output/timeout ceilings.
- Document the behavior and rationale for per-model output ceilings, model_timeout changes, and turn-budget handling in CHANGELOG and inline comments.

Tests:
- Add catalog and engine wiring tests that validate propagation of a model’s own output ceiling into engine_config and preserve defaults for unknown models.
- Add isolated turn-budget tests to verify deadline parsing, precedence between Harbor timeouts and STELLA_TURN_BUDGET, CLI flag emission, and host-only env behavior.
- Adjust adapter posture tests and preflight scripts to assert the updated max_tokens value and engine posture digest.
