### PR TITLE
feat(diagnostics): the fourth plane — a log whose fields cannot carry content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ loop, and the `/pipeline` deck toggle.
 
 ## Workspace layout — where a change goes
 
-Fifteen crates. The one-sentence rule of thumb below routes you to the right
+Eighteen crates. The one-sentence rule of thumb below routes you to the right
 one; **each crate's own `README.md`** (linked from the table) then covers its
 layout, invariants, gotchas, and extension recipe in depth. Read that before
 changing code inside a crate you don't already know.
@@ -248,6 +248,7 @@ changing code inside a crate you don't already know.
 | Change CLI commands, flags, or agent wiring | [`stella-cli`](stella-cli/README.md) | This is the shipping binary. |
 | Change REPL rendering / panels / keybindings | [`stella-tui`](stella-tui/README.md) | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
 | Touch shared types crossing a crate boundary | [`stella-protocol`](stella-protocol/README.md) | **Zero logic, zero I/O — types only.** |
+| Emit a diagnostic — a record explaining *why* the program did something | [`stella-diag`](stella-diag/README.md) | **A leaf: `serde` only, so anything may depend on it.** Field values cannot hold a `String`, a `Path`, or model output — that is a compile error, not a review question. Design: [`docs/design/diagnostics.md`](docs/design/diagnostics.md). |
 | Persistence: executions, events, telemetry (SQLite) | [`stella-store`](stella-store/README.md) | |
 | Retrieval: graph, embeddings, episodic memory | [`stella-context`](stella-context/README.md) | |
 | Tree-sitter code indexing | [`stella-graph`](stella-graph/README.md) | |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ skip the roll) were re-inserted the same way.
 
 ## [Unreleased]
 
+### Added
+
+- **`stella` writes a log you can attach to a bug report.** When a run panics or
+  exits non-zero, diagnostics land in `.stella/private/crash-*.jsonl` (owner-only)
+  and the path is printed. `stella doctor --last-failure` prints the newest one.
+  The file is safe to send as-is: the record type physically cannot hold a
+  prompt, a path, or model output, so there is nothing in it to review first.
+- **`-v` / `-vv` / `-vvv`** turn on diagnostics at `info` / `debug` / `trace`.
+  Default is `warn`, human-readable on a terminal and JSONL when redirected.
+- **`--log-level <spec>`** filters per crate — `warn,stella_store=debug` is quiet
+  everywhere except where you are looking. Also settable as `STELLA_LOG`; the
+  flag wins over the variable, and both win over nothing. An unrecognised clause
+  is reported and skipped rather than being fatal. `STELLA_SERVE_LOG` keeps
+  working and now accepts the same richer grammar.
+- **`--log-file <path>`** writes JSONL to a file, created `0600`, defaulting to
+  `info`. An unwritable path is reported and the run continues.
+
 ## [0.6.62] — 2026-08-01
 
 ## [0.6.61] — 2026-08-01

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ chasing the citations in the same PR.
 
 ## Where does my change go? — a workspace tour
 
-Fifteen crates sounds like a lot; the rule of thumb is one sentence each:
+Eighteen crates sounds like a lot; the rule of thumb is one sentence each:
 
 | You want to… | Go to |
 |---|---|
@@ -138,6 +138,7 @@ Fifteen crates sounds like a lot; the rule of thumb is one sentence each:
 | Change a CLI command, flag, or the agent wiring | `stella-cli` |
 | Change the REPL rendering / panels / keybindings | `stella-tui` |
 | Touch shared types crossing a crate boundary | `stella-protocol` (zero logic, zero I/O — types only) |
+| Log why the program did something (not what the agent did) | `stella-diag` (a leaf; a field that could carry a path or model output will not compile) |
 | Persistence: executions, events, telemetry (SQLite) | `stella-store` |
 | Retrieval: graph, embeddings, episodic memory | `stella-context` |
 | Tree-sitter code indexing | `stella-graph` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "sha2 0.11.0",
  "stella-context",
  "stella-core",
+ "stella-diag",
  "stella-fleet",
  "stella-graph",
  "stella-mcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stella-diag"
+version = "0.6.62"
+dependencies = [
+ "proptest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "trybuild",
+]
+
+[[package]]
 name = "stella-engine"
 version = "0.6.62"
 dependencies = [
@@ -3514,6 +3531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,6 +3556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4003,6 +4035,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+  "stella-diag",
   "stella-protocol",
   "stella-core",
   "stella-model",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,31 @@
+# Workspace clippy configuration.
+#
+# `disallowed-methods` here backs a type-system guarantee that would otherwise
+# have a one-token hole in it. `stella-diag` makes runtime content in a log a
+# COMPILE error (docs/design/diagnostics.md §5.2): a field value is buildable
+# only from things that cannot carry content, and `&'static str` is on that
+# list because a string that lives in the binary cannot hold a user's path or a
+# model's output.
+#
+# `Box::leak` turns a `String` into a `&'static str`, which would defeat that
+# entirely — and silently, since the resulting call site looks exactly like a
+# legitimate one. The design says so out loud rather than overclaiming:
+#
+#   The claim is not "impossible"; it is "impossible by accident, and loud on
+#   purpose".
+#
+# This is the "loud" half. Leaking is still available — some of it is
+# load-bearing, notably the provider-config interner in stella-cli/src/config.rs
+# — but every site must now carry an `#[allow]` naming its reason, so the act
+# shows up in the diff that introduces it and a reviewer is asked the question.
+#
+# If you are here because clippy rejected your `Box::leak`: the answer is
+# usually not an `#[allow]`. If you are leaking to get a value into a log,
+# reach for `Redacted::reviewed` with a written justification (§5.5) — that is
+# the sanctioned escape hatch, it is counted, and it records WHY in the log
+# itself.
+disallowed-methods = [
+  { path = "std::boxed::Box::leak", reason = "leaking turns runtime data into &'static str, defeating stella-diag's compile-time content guarantee (docs/design/diagnostics.md §5.2). To log a runtime string, use Redacted::reviewed with a justification (§5.5). If the leak is genuinely an interner, #[allow] it with a comment saying so." },
+  { path = "std::string::String::leak", reason = "same as Box::leak: it manufactures a &'static str from runtime data. See docs/design/diagnostics.md §5.2." },
+  { path = "std::vec::Vec::leak", reason = "same as Box::leak: it manufactures a &'static slice from runtime data. See docs/design/diagnostics.md §5.2." },
+]

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -22,6 +22,11 @@ dist = true
 formula = "stella"
 
 [dependencies]
+# The diagnostic plane (docs/design/diagnostics.md). A leaf crate depending on
+# serde alone, so the binary pays a few hundred lines and no transitive tree
+# for a structured log whose fields cannot carry prompts, paths, or model
+# output.
+stella-diag = { path = "../stella-diag" }
 stella-protocol = { path = "../stella-protocol" }
 contextgraph-types.workspace = true
 contextgraph-host.workspace = true

--- a/stella-cli/src/cli.rs
+++ b/stella-cli/src/cli.rs
@@ -152,6 +152,41 @@ pub(crate) struct GlobalArgs {
     /// NO_COLOR.
     #[arg(long, global = true, hide_short_help = true)]
     pub(crate) no_anim: bool,
+
+    /// Diagnostics: -v info, -vv debug, -vvv trace
+    ///
+    /// Turns on the diagnostic plane — the stream that explains why stella
+    /// behaved the way it did, as distinct from what the agent did (the
+    /// event stream) or what it cost (the receipts). Records carry a stable
+    /// code and typed fields, never prompts, paths, or model output.
+    /// Default is `warn`. See --log-level for per-crate control.
+    #[arg(short = 'v', long = "verbose", global = true, action = clap::ArgAction::Count)]
+    pub(crate) verbose: u8,
+
+    /// Diagnostic filter, per crate: "warn,stella_store=debug"
+    ///
+    /// A comma-separated spec. A bare level sets the default; `target=level`
+    /// overrides it for that module subtree, longest match winning — so
+    /// `warn,stella_store=debug,stella_model=trace` is quiet everywhere
+    /// except where you are looking. Levels: off, error, warn, info, debug,
+    /// trace. A target is a Rust module path, so library crates are
+    /// `stella_store`, `stella_model`, … and this binary's own records are
+    /// under `stella` (hyphens are accepted too: `stella-store=debug`).
+    /// Also settable as STELLA_LOG (this flag wins over it, and over -v).
+    /// An unrecognised clause is skipped and reported, never fatal.
+    #[arg(long, global = true, value_name = "SPEC", hide_short_help = true)]
+    pub(crate) log_level: Option<String>,
+
+    /// Write diagnostics as JSONL to a file (created 0600)
+    ///
+    /// Defaults to `info` where stderr defaults to `warn`, since a file
+    /// nobody reads until something breaks may as well be able to explain it;
+    /// --log-level or -v raise it further. An unwritable path is reported and
+    /// the run continues. For a crash you did not anticipate you need no flag
+    /// at all: stella writes .stella/private/crash-*.jsonl on a panic or a
+    /// failed run, and `stella doctor --last-failure` prints the newest.
+    #[arg(long, global = true, value_name = "PATH", hide_short_help = true)]
+    pub(crate) log_file: Option<std::path::PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -648,6 +683,15 @@ pub(crate) enum Command {
         /// are both left untouched. The next session starts a fresh store.
         #[arg(long)]
         repair: bool,
+
+        /// Print the newest crash dump instead of running the checks:
+        /// .stella/private/crash-*.jsonl, written automatically when a run
+        /// panics or exits non-zero. It is content-free by construction — the
+        /// diagnostic record type cannot hold a prompt, a path, or model
+        /// output — so it is safe to attach to a bug report without reading
+        /// it first. Exits non-zero if there is no dump to print.
+        #[arg(long)]
+        last_failure: bool,
     },
 
     /// Manage BYOK provider keys in ~/.stella/credentials.toml

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -167,6 +167,16 @@ pub(crate) fn leak(s: &str) -> &'static str {
     if let Some(&existing) = interned.get(s) {
         return existing;
     }
+    // The interner this whole function exists to be. `ProviderConfig` holds
+    // `&'static str`, so a config-defined provider's id has to become one
+    // somewhere, and doing it here — behind a set, once per distinct string —
+    // is what bounds the leak. See clippy.toml for why the method is otherwise
+    // disallowed: this is the sanctioned interner it names, NOT a way to get a
+    // runtime string into a diagnostic record.
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the bounded provider-config interner; see clippy.toml"
+    )]
     let leaked: &'static str = Box::leak(s.to_owned().into_boxed_str());
     interned.insert(leaked);
     leaked
@@ -217,7 +227,16 @@ pub(crate) fn effective_builtin(
         let mut aliases = vec![provider.env_var];
         aliases.extend_from_slice(provider.env_var_aliases);
         effective.env_var = leak(api_key_env);
-        effective.env_var_aliases = Box::leak(aliases.into_boxed_slice());
+        // Not interned, because a *slice* has no natural key to intern on —
+        // bounded instead by the number of configured providers, which is a
+        // startup-shaped quantity. Same justification as `leak` above; see
+        // clippy.toml.
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "per-provider alias list, bounded by configured providers; see clippy.toml"
+        )]
+        let aliases: &'static [&'static str] = Box::leak(aliases.into_boxed_slice());
+        effective.env_var_aliases = aliases;
     }
     effective
 }

--- a/stella-cli/src/diag_boot.rs
+++ b/stella-cli/src/diag_boot.rs
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Wiring the diagnostic plane into the binary — slice 2 of
+//! `docs/design/diagnostics.md`, "the moment the project can say *attach the
+//! log*".
+//!
+//! Before this, three failures were each indistinguishable from success
+//! (§1.2), and the middle one decides whether this project is pleasant to
+//! contribute to: *a user hits a bug we cannot reproduce, and there is no
+//! artifact to ask them for.* Every mature OSS CLI can say "run it again with
+//! `-vv` and attach the log". For a coding agent it is worse than usual —
+//! runs are nondeterministic and expensive, so "reproduce it with verbose on"
+//! is frequently not a request the user can fulfil. Hence [`install`], and
+//! hence the crash ring reaching disk without anyone having asked for it.
+//!
+//! ## No global handle, on purpose
+//!
+//! [`install`] hands the [`Dx`] back and `main` holds it; nothing here is a
+//! `static`. §7.1 is emphatic about why, and it is the same reason invariant 2
+//! bans ambient state in the engine: a handle that is reachable from anywhere
+//! is a handle nothing has to declare it uses, and the first symptom is a test
+//! that cannot arrange for silence.
+//!
+//! The panic hook — genuinely a global, since it takes no parameter — closes
+//! over its own `Arc` clone rather than reaching for a shared slot, so the one
+//! place that *needs* ambient access gets it without offering it to everyone
+//! else.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use colored::Colorize;
+use stella_diag::{
+    Bound, Cx, Dx, Filter, JsonlSink, Level, LevelFilter, Parsed, Record, Sink, TextSink, diag,
+};
+
+use crate::cli::GlobalArgs;
+
+/// The default a `--log-file` gets when the operator did not otherwise raise
+/// the floor. A file nobody reads until something breaks may as well contain
+/// enough to explain it; stderr stays at `warn` so a normal run is quiet.
+const FILE_FLOOR: LevelFilter = LevelFilter::Info;
+
+/// Where crash dumps land: the 0700 directory `trace.rs` already establishes.
+pub(crate) fn crash_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".stella").join("private")
+}
+
+/// Resolve the filter from the surfaces §6 lists, most specific first.
+///
+/// 1. `--log-level <spec>` — the full grammar, typed on this command line
+/// 2. `-v` / `-vv` / `-vvv` — `info` / `debug` / `trace`
+/// 3. `STELLA_LOG`, then `STELLA_SERVE_LOG` — the same grammar
+/// 4. `warn`
+///
+/// A command-line flag beats an environment variable, which is why
+/// `--log-level` does not carry clap's `env = …`: with it, `STELLA_LOG=warn
+/// stella -vv run …` would silently ignore the `-vv` the user just typed,
+/// because clap cannot tell an env-sourced value from a typed one.
+pub(crate) fn resolve_filter(globals: &GlobalArgs) -> Parsed {
+    if let Some(spec) = globals.log_level.as_deref() {
+        return Filter::parse(spec);
+    }
+    if let Some(level) = LevelFilter::from_verbosity(globals.verbose) {
+        return Parsed {
+            filter: Filter::level(level),
+            bad: Vec::new(),
+        };
+    }
+    stella_diag::filter_from_env()
+}
+
+/// Build the process's diagnostic handle, install the panic hook, and report
+/// anything wrong with the filter itself.
+///
+/// Called once, from `main`, which then owns the returned handle.
+pub(crate) fn install(globals: &GlobalArgs, workspace_root: &Path) -> Arc<Dx> {
+    let Parsed { filter, bad } = resolve_filter(globals);
+    let mut sinks = Vec::new();
+
+    // Human-readable on a TTY, JSONL when redirected — §6. A person watching a
+    // terminal and a program parsing a pipe want different things, and which
+    // one is present is knowable without asking.
+    if !filter.is_off() {
+        let stderr_sink: Arc<dyn Sink> = if std::io::stderr().is_terminal() {
+            Arc::new(TextSink::stderr())
+        } else {
+            Arc::new(JsonlSink::stderr())
+        };
+        sinks.push(Bound::new(filter.clone(), stderr_sink));
+    }
+
+    // A failed `--log-file` is reported and then dropped, never fatal: the
+    // user asked for a run, not for a log file, and refusing to start because
+    // a log path is unwritable would be the diagnostic plane taking a turn
+    // hostage (§3.4).
+    let mut log_file_error = None;
+    if let Some(path) = globals.log_file.as_deref() {
+        match JsonlSink::file(path) {
+            Ok(sink) => sinks.push(Bound::new(
+                filter.clone().at_least(FILE_FLOOR),
+                Arc::new(sink) as Arc<dyn Sink>,
+            )),
+            Err(error) => log_file_error = Some(error),
+        }
+    }
+
+    let dx = Arc::new(Dx::new(sinks));
+    let dir = crash_dir(workspace_root);
+    stella_diag::install_panic_hook(dx.clone(), dir, |path| {
+        // Presentation, deliberately: naming a file for a human to read is the
+        // third plane's job, and §2.1's routing rule keeps it out of the
+        // record. This is the sentence stella could not say before.
+        eprintln!(
+            "{} diagnostics written to {} — attaching it to an issue is safe; \
+             it contains no prompts, paths, or model output",
+            "stella:".yellow().bold(),
+            path.display()
+        );
+    });
+
+    // Now that there is somewhere to say it: every clause the filter parser
+    // refused. This ordering is the whole reason `Filter::parse` reports
+    // rather than complains — the complaint about a bad filter has to outlive
+    // the filter that would have suppressed it.
+    for clause in &bad {
+        dx.emit(Record::new(
+            Level::Warn,
+            "diag.filter.bad_clause",
+            module_path!(),
+            Cx::EMPTY,
+            Parsed::report(clause),
+        ));
+    }
+    if let Some(error) = log_file_error {
+        diag!(
+            &dx,
+            warn,
+            "diag.log_file.unavailable",
+            error = sink_error_code(error),
+        );
+        eprintln!(
+            "{} could not open --log-file ({error}); continuing without it",
+            "stella:".yellow().bold()
+        );
+    }
+
+    diag!(
+        &dx,
+        info,
+        "cli.boot",
+        version = crate::build_info::version_static(),
+        verbosity = globals.verbose,
+    );
+    dx
+}
+
+/// A sink error as a closed vocabulary rather than a message.
+///
+/// `SinkError` is already content-free, but it is another crate's enum and
+/// §5.2 admits only what this workspace declared loggable — so it is mapped
+/// onto a spelling this crate owns rather than given a `Display` pass.
+fn sink_error_code(error: stella_diag::SinkError) -> &'static str {
+    match error {
+        stella_diag::SinkError::Io(kind) => match kind {
+            std::io::ErrorKind::PermissionDenied => "permission_denied",
+            std::io::ErrorKind::NotFound => "not_found",
+            std::io::ErrorKind::IsADirectory => "is_a_directory",
+            _ => "io",
+        },
+        stella_diag::SinkError::Encode => "encode",
+        stella_diag::SinkError::Poisoned => "poisoned",
+    }
+}
+
+/// Record that the run failed, then dump the ring; returns the file written.
+///
+/// §7.4 puts the ring on disk on a panic **or** a non-zero exit from `main`,
+/// and the second half is the one that matters more often: most failures are a
+/// returned `Err`, not a panic, and those are exactly the runs a user is about
+/// to file an issue about.
+///
+/// The error *message* is deliberately not a field. It is the one string in the
+/// process most likely to have a path or a provider response interpolated into
+/// it, and §5.2 has no exception for the message that happens to be attached to
+/// a failure. What the record carries is the shape of the exit — which is what
+/// a reader of the dump needs, since the message itself already went to stderr
+/// where the human is.
+///
+/// `debug`, not `error`, and the level is the whole point of §6's split. This
+/// record is a **marker for a later reader of the dump**, not news: the human
+/// already has the failure on stderr and the shell already has the exit code,
+/// so emitting at `error` would print a second, terser copy of a message the
+/// user just read. The ring takes every record at every level regardless of
+/// filter, so the dump gets its marker either way — which is exactly the case
+/// "the filter governs sinks, never emission" was built for.
+pub(crate) fn dump_on_failure(
+    dx: &Dx,
+    workspace_root: &Path,
+    interrupted: bool,
+) -> Option<PathBuf> {
+    diag!(dx, debug, "cli.run.failed", interrupted = interrupted);
+    stella_diag::dump(dx, &crash_dir(workspace_root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    use crate::cli::Cli;
+
+    fn globals(args: &[&str]) -> GlobalArgs {
+        let mut argv = vec!["stella"];
+        argv.extend_from_slice(args);
+        argv.push("models");
+        Cli::try_parse_from(argv).expect("parse").globals
+    }
+
+    /// The surface §6 specifies, end to end.
+    #[test]
+    fn verbosity_flags_select_the_levels_the_design_names() {
+        for (args, expected) in [
+            (vec![], LevelFilter::Warn),
+            (vec!["-v"], LevelFilter::Info),
+            (vec!["-vv"], LevelFilter::Debug),
+            (vec!["-vvv"], LevelFilter::Trace),
+            (vec!["-vvvv"], LevelFilter::Trace),
+        ] {
+            let filter = resolve_filter(&globals(&args)).filter;
+            assert_eq!(filter.default_level(), expected, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn log_level_takes_the_full_filter_grammar() {
+        let parsed = resolve_filter(&globals(&["--log-level", "warn,stella_store=debug"]));
+        assert!(parsed.bad.is_empty());
+        assert!(parsed.filter.admits("stella_store::migrate", Level::Debug));
+        assert!(!parsed.filter.admits("stella_cli::agent", Level::Debug));
+    }
+
+    /// A flag the user typed beats an environment variable they exported once.
+    /// This is the case clap's `env = …` would have got wrong, silently.
+    #[test]
+    fn a_typed_flag_outranks_the_environment() {
+        // `resolve_filter` reads the environment only as its last resort, so
+        // this holds without mutating the process env — which a parallel test
+        // suite could not do safely anyway.
+        let from_flag = resolve_filter(&globals(&["-vv"])).filter;
+        assert_eq!(from_flag.default_level(), LevelFilter::Debug);
+
+        let from_spec = resolve_filter(&globals(&["--log-level", "error", "-vv"])).filter;
+        assert_eq!(
+            from_spec.default_level(),
+            LevelFilter::Error,
+            "--log-level is more specific than -v and must win"
+        );
+    }
+
+    /// §6: a typo in a log knob must not take a process down. It is reported,
+    /// and the clauses around it still apply.
+    #[test]
+    fn a_bad_filter_clause_is_reported_and_not_fatal() {
+        let parsed = resolve_filter(&globals(&["--log-level", "warn,stella_store=shout"]));
+        assert_eq!(parsed.bad.len(), 1);
+        assert_eq!(parsed.filter.default_level(), LevelFilter::Warn);
+    }
+
+    #[test]
+    fn a_log_file_floor_never_lowers_an_operators_choice() {
+        let quiet = Filter::parse("warn").filter.at_least(FILE_FLOOR);
+        assert_eq!(quiet.default_level(), LevelFilter::Info);
+        let loud = Filter::parse("trace").filter.at_least(FILE_FLOOR);
+        assert_eq!(loud.default_level(), LevelFilter::Trace);
+    }
+
+    /// The binary's `module_path!()` root is the **bin target name**, `stella`
+    /// — not `stella_cli`, which is only the package name. A user who types
+    /// `stella_cli=debug` would otherwise get silence and no explanation, so
+    /// the flag's help says `stella` and this pins it down.
+    #[test]
+    fn the_binarys_own_records_live_under_the_target_named_stella() {
+        assert_eq!(
+            module_path!().split("::").next(),
+            Some("stella"),
+            "if the bin target is renamed, --log-level's help text is now wrong"
+        );
+
+        let filter = resolve_filter(&globals(&["--log-level", "off,stella=trace"])).filter;
+        assert!(filter.admits(module_path!(), Level::Trace));
+        // And it must not accidentally select the library crates that merely
+        // start with the same six letters.
+        assert!(!filter.admits("stella_store::migrate", Level::Error));
+        assert!(!filter.admits("stella_model::anthropic", Level::Error));
+    }
+
+    #[test]
+    fn the_crash_directory_is_the_one_traces_already_use() {
+        assert_eq!(
+            crash_dir(Path::new("/w")),
+            Path::new("/w/.stella/private"),
+            "a crash dump must land in the 0700 directory trace.rs establishes"
+        );
+    }
+
+    /// Every `SinkError` maps to a fixed spelling — no `Display`, so no
+    /// filename can ride along in the one field that reports a file problem.
+    #[test]
+    fn a_sink_error_records_as_a_closed_vocabulary() {
+        let denied = stella_diag::SinkError::Io(std::io::ErrorKind::PermissionDenied);
+        assert_eq!(sink_error_code(denied), "permission_denied");
+        assert_eq!(
+            sink_error_code(stella_diag::SinkError::Io(std::io::ErrorKind::Other)),
+            "io"
+        );
+    }
+}

--- a/stella-cli/src/doctor.rs
+++ b/stella-cli/src/doctor.rs
@@ -98,11 +98,43 @@ impl Check {
     }
 }
 
-/// Entry point for `stella doctor [--repair]`.
-pub fn run_doctor(repair: bool) -> Result<(), String> {
+/// Entry point for `stella doctor [--repair] [--last-failure]`.
+pub fn run_doctor(repair: bool, last_failure: bool) -> Result<(), String> {
     let workspace_root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    if last_failure {
+        return print_last_failure(&workspace_root);
+    }
     run_doctor_at(&workspace_root, repair)
+}
+
+/// Print the newest crash dump — `docs/design/diagnostics.md` §7.4.
+///
+/// The file is content-free by construction (§5.2 makes a record that carries
+/// a prompt, a path, or model output a *compile* error), which is what turns
+/// "please attach your log" from a request needing a privacy review into one a
+/// stranger on the internet can act on immediately. Printing it here rather
+/// than only naming it means a user can eyeball what they are about to send,
+/// which is the other half of being able to send it comfortably.
+fn print_last_failure(workspace_root: &Path) -> Result<(), String> {
+    let dir = crate::diag_boot::crash_dir(workspace_root);
+    let Some(path) = stella_diag::latest_crash_file(&dir) else {
+        return Err(format!(
+            "no crash dump in {}. One is written automatically when a run panics or \
+             exits non-zero; if the run you are chasing succeeded, there is nothing to show.",
+            dir.display()
+        ));
+    };
+    let body = std::fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+
+    println!("{}", path.display().to_string().bold());
+    println!(
+        "{}\n",
+        "content-free by construction — safe to attach to a bug report".dimmed()
+    );
+    print!("{body}");
+    Ok(())
 }
 
 /// The command with its workspace passed in, so tests can drive a scratch

--- a/stella-cli/src/enterprise_telemetry_tests.rs
+++ b/stella-cli/src/enterprise_telemetry_tests.rs
@@ -630,6 +630,10 @@ fn managed_identifiers_are_bounded_before_any_store_or_ledger_mutation() {
         );
         std::env::set_var("STELLA_TEST_TELEMETRY_TOKEN", "separate-bearer-token");
     }
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "test fixture: a one-off oversized literal, never a log field"
+    )]
     let too_long: &'static str = Box::leak("x".repeat(129).into_boxed_str());
     let managed = signed_managed(
         "STELLA_TEST_VERIFY_SECRET",

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -43,6 +43,7 @@ mod contextgraph;
 mod credential_handoff;
 mod credential_status;
 mod deck_mcp;
+mod diag_boot;
 mod discovery;
 mod doctor;
 mod domains;
@@ -412,6 +413,15 @@ fn main() -> ExitCode {
         config::forbid_interactive_credentials();
     }
 
+    // The diagnostic plane, before anything that can fail interestingly. From
+    // here on a record explains a decision instead of being discarded, and the
+    // panic hook is armed — so a crash after this line leaves an artifact a
+    // user can attach (docs/design/diagnostics.md §7.4). It is installed after
+    // clap so `-v`/`--log-level`/`--log-file` are known, and after env-file
+    // loading so `STELLA_LOG` from a project `.env` is honoured.
+    let diag_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let dx = diag_boot::install(&cli.globals, &diag_root);
+
     enterprise_telemetry::start_best_effort_flush();
     loaded_env
         .names
@@ -430,6 +440,19 @@ fn main() -> ExitCode {
         Err(e) => {
             eprintln!("{} {}", "stella:".red().bold(), e);
             emit_error_summary(output_format, &e);
+            // §7.4's second trigger, and the one that fires more often: most
+            // failures are a returned `Err`, not a panic, and those are exactly
+            // the runs a user is about to open an issue about. Naming the file
+            // is what makes "attach the log" a sentence stella can say.
+            let interrupted = signals::interrupted_exit_code().is_some();
+            if let Some(path) = diag_boot::dump_on_failure(&dx, &diag_root, interrupted) {
+                eprintln!(
+                    "{} diagnostics: {} ({})",
+                    "stella:".dimmed(),
+                    path.display(),
+                    "safe to attach — no prompts, paths, or model output".dimmed()
+                );
+            }
             // A turn cut short by SIGINT/SIGTERM exits 128 + the signal
             // number, the shell convention, so a script wrapping `stella
             // run` can tell "the user stopped this" from "this failed".
@@ -646,12 +669,15 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             println!("Migrating settings.json -> stella.toml\n");
             return settings::migrate::run(&root, *dry_run);
         }
-        Some(Command::Doctor { repair }) => {
+        Some(Command::Doctor {
+            repair,
+            last_failure,
+        }) => {
             // Reads local state only — and with --repair renames files inside
             // .stella/private/. No provider, no API key, and deliberately
             // before `Config::load`: a workspace whose store is corrupt must be
             // diagnosable without a working model configuration.
-            return doctor::run_doctor(*repair);
+            return doctor::run_doctor(*repair, *last_failure);
         }
         Some(Command::Completions { shell }) => {
             // Generated from the live `Command` tree, so a new subcommand or

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -309,19 +309,33 @@ fn telemetry_status_remains_a_distinct_top_level_command() {
 }
 
 /// `doctor` runs on local state alone, so it must parse (and dispatch) without
-/// a provider or key — bare and with the opt-in repair.
+/// a provider or key — bare, with the opt-in repair, and with the crash-dump
+/// reader `--last-failure` (docs/design/diagnostics.md §7.4), which is the one
+/// subcommand a user reaches for precisely when nothing else works.
 #[test]
 fn doctor_parses_bare_and_with_repair() {
     let bare = Cli::try_parse_from(["stella", "doctor"]).expect("`doctor` must parse bare");
     assert!(matches!(
         bare.command,
-        Some(Command::Doctor { repair: false })
+        Some(Command::Doctor {
+            repair: false,
+            last_failure: false
+        })
     ));
     let repair =
         Cli::try_parse_from(["stella", "doctor", "--repair"]).expect("`doctor --repair` parses");
     assert!(matches!(
         repair.command,
-        Some(Command::Doctor { repair: true })
+        Some(Command::Doctor { repair: true, .. })
+    ));
+    let last = Cli::try_parse_from(["stella", "doctor", "--last-failure"])
+        .expect("`doctor --last-failure` parses");
+    assert!(matches!(
+        last.command,
+        Some(Command::Doctor {
+            last_failure: true,
+            ..
+        })
     ));
 }
 

--- a/stella-diag/Cargo.toml
+++ b/stella-diag/Cargo.toml
@@ -15,7 +15,19 @@ publish.workspace = true
 # `stella-*` path dependency here forecloses that for whichever crate it names.
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true
+# `float_roundtrip` is declared HERE rather than inherited, and it is load-bearing
+# rather than tidy. serde_json's default parser is lossy by one ULP for a large
+# fraction of full-precision doubles (its writer is exact), so without it a `f64`
+# field does not survive a round trip and invariant 4 is false for any record
+# carrying one — property 8 in tests/properties.rs catches it immediately.
+#
+# The feature was already on in a workspace build, switched on by a transitive
+# dependency, which is the actual reason to name it: a guarantee that holds only
+# because some *sibling* crate happens to be in the build is not a guarantee. It
+# held under `cargo test --workspace` and failed under `cargo test -p
+# stella-diag`, and the crate that makes the promise is the one that has to pay
+# for it.
+serde_json = { workspace = true, features = ["float_roundtrip"] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/stella-diag/Cargo.toml
+++ b/stella-diag/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "stella-diag"
+description = "The diagnostic plane: a workspace-wide structured log whose field values cannot carry runtime content. One envelope, per-crate facets, a real target filter, and a crash ring that is safe to ask a stranger to attach. Design: docs/design/diagnostics.md."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+
+# A LEAF crate, deliberately. It depends on `serde`/`serde_json` and nothing
+# else in this workspace, which is the property that lets all seventeen crates
+# depend on it without a cycle (docs/design/diagnostics.md §5.1). Adding a
+# `stella-*` path dependency here forecloses that for whichever crate it names.
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true
+# Test-only, and the witness for the one property that cannot be tested any
+# other way: `diag!(… path = some_string)` must FAIL TO COMPILE (§5.2, property
+# 1). A runtime test cannot observe a compile error, so the alternative to
+# `trybuild` is hand-rolling `rustc` invocations and diffing stderr — which is
+# what trybuild is. MIT OR Apache-2.0, both already on deny.toml's allow-list,
+# and it never enters a shipping build: `cargo build` does not compile it.
+trybuild = "1"

--- a/stella-diag/README.md
+++ b/stella-diag/README.md
@@ -1,0 +1,188 @@
+# stella-diag
+
+The **diagnostic plane**: the stream that answers *why did the program behave
+this way?* Design:
+[`../docs/design/diagnostics.md`](../docs/design/diagnostics.md), which
+generalises the shipped, crate-scoped
+[`../docs/design/serve-observability.md`](../docs/design/serve-observability.md)
+to the whole workspace.
+
+Stella has four observability planes and, until this crate, had built three:
+
+| Plane | Question it answers | Where it lives |
+|---|---|---|
+| **Domain** | *What did the agent do?* | `AgentEvent`, [`stella-protocol`](../stella-protocol) |
+| **Ledger** | *What did it cost, and can I prove it?* | receipts, `stella-cli/src/trace.rs` |
+| **Presentation** | *What should the human see?* | `println!`, [`stella-tui`](../stella-tui) |
+| **Diagnostic** | *Why did the program behave this way?* | **here** |
+
+The missing fourth is why 682 `println!`s and 625 `let _ =`s coexisted: a
+statement with no home gets split between the plane that is easiest to reach
+(stdout) and the one that costs nothing (the floor).
+
+## The routing rule
+
+The one thing to remember, and the reason this crate is not a second event
+stream:
+
+> **A human reads it now → presentation. It should replay → domain. It explains
+> a decision the program made → diagnostic. It is none of those → it is not a
+> log line, it is a metric.**
+
+## Where it sits
+
+A **leaf**. It depends on `serde`/`serde_json` and **nothing else in the
+workspace**, which is the property that lets all seventeen other crates depend
+on it without a cycle. Adding a `stella-*` path dependency here forecloses that
+for whichever crate it names — so don't.
+
+## Content in a log does not compile
+
+The part worth building rather than importing. A field value is not
+`serde_json::Value` and not `impl Display`; it is a closed type constructible
+only from things that cannot carry runtime content.
+
+```rust
+use stella_diag::{diag, Cx, Dx};
+
+let (dx, records) = Dx::capturing();
+let cx = Cx::new().session("session-a1b2c3d4").turn(3);
+
+diag!(&dx, warn, "store.migration.retry", cx: cx, attempt = 2_u32, backoff_ms = 250_u32);
+```
+
+```json
+{"ts":1754006400123,"level":"warn","code":"store.migration.retry",
+ "target":"stella_store::migrate","cx":{"session":"a1b2c3d4","turn":3},
+ "fields":{"attempt":2,"backoff_ms":250}}
+```
+
+`Loggable` is implemented for integers, `bool`, `f64`, `Duration`,
+`&'static str`, closed enums declared through `log_enum!`, `ShortId`,
+`PathClass` and `Redacted` — and deliberately **not** for `String`, a
+non-`'static` `&str`, `Path`, `PathBuf`, `serde_json::Value`, or any `Display`
+blanket. So this is a type error:
+
+```rust,compile_fail
+diag!(&dx, warn, "tools.write.denied", path = user_path);   // ← String
+```
+
+`tracing` would log that happily with `%user_path`. That is the strongest
+single reason the design defers adopting the facade: it would trade a
+compile-time privacy guarantee for a review-time one.
+
+**Stated honestly:** `Box::leak` would defeat this. That is a deliberate,
+single-token, greppable act, disallowed by the workspace
+[`../clippy.toml`](../clippy.toml). The claim is not "impossible"; it is
+*"impossible by accident, and loud on purpose"*.
+
+The witness is a compile-fail test, not a runtime one —
+[`tests/ui/`](tests/ui/) has five cases a reasonable contributor would actually
+write, and each must fail to build. Regenerate the expected output after an
+intentional change (including a toolchain bump) with:
+
+```bash
+TRYBUILD=overwrite cargo test -p stella-diag --test compile_fail
+```
+
+## Fields that carry the useful part without the dangerous part
+
+| Type | Records as | Why it is safe |
+|---|---|---|
+| `ShortId` | `"a1b2c3d4"` | eight hex characters, never a whole id — enough to correlate, not enough to act |
+| `PathClass` | `{"class":"inside_workspace","depth":4,"ext":"rs"}` | answers "outside the workspace, four deep, a `.rs` file" without the bytes of the path |
+| `Redacted` | `{"reviewed":"main","note":"…"}` | the explicit hatch — see below |
+
+`PathClass`'s `ext` is a **closed vocabulary**, which is one place this crate is
+stricter than the design sketch: a raw extension is still attacker-chosen text
+(`secrets.API_KEY_sk_live_…` is a legal filename), so anything unrecognised
+records as `other`.
+
+## The escape hatch, made expensive on purpose
+
+Some runtime strings are genuinely safe and genuinely useful. `note!` accepts
+**only a string literal**, so the justification lives in the source, is
+greppable, shows up in the diff that introduced it, and travels into the record
+where a reader of a crash file can see it:
+
+```rust
+Redacted::reviewed(branch_name, note!("git ref names are user-chosen but are not model content"))
+```
+
+An escape hatch with a budget is an escape hatch; one without is a loophole.
+
+## Filtering
+
+A real filter, not a level. Longest-prefix wins, on module-path boundaries:
+
+```
+STELLA_LOG=warn
+STELLA_LOG=warn,stella_store=debug,stella_model=trace
+STELLA_LOG=off
+```
+
+The filter governs **sinks**, never emission. Everything at every level always
+reaches the counters and the crash ring, which is what keeps a number from
+changing when you raise verbosity — and what keeps a crash dump complete for a
+user who ran at the default `warn`.
+
+A clause that does not parse is skipped and reported, never fatal: a typo in a
+log knob must not take a process down.
+
+## The crash ring
+
+A bounded in-memory ring (2,000 records or 1 MiB, whichever binds first) holding
+every record at every level. It reaches disk only on a panic or a non-zero exit,
+landing at `.stella/private/crash-*.jsonl` — 0700 directory, 0600 file.
+
+This is what lets stella say the sentence it could not before:
+
+> Attach `.stella/private/crash-*.jsonl` to the issue.
+
+And this is where the compile-time guarantee pays off completely: because
+content cannot enter a record, that file is content-free **by construction**, so
+a maintainer can ask a stranger on the internet for it without a privacy review
+and the stranger can send it without reading it first. `stella doctor
+--last-failure` prints the newest one.
+
+## Correlation without spans
+
+`Cx { session, execution, turn, step }` rides as an **explicit parameter** — not
+a thread-local, not a task-local, both of which are wrong under `!Send` turn
+futures and wrong under `tokio` task migration. `Dx` is a handle, not a global,
+for the same reason.
+
+This is nearly free here because invariant 2 already banned ambient state:
+`tracing`'s spans exist to reconstruct context that ordinary code loses, and
+this codebase does not lose it. The architecture stella chose for testability
+hands correlation over for nothing.
+
+## What this deliberately does not do
+
+- **No logging in `stella-core`'s pure functions.** Compaction, eviction, loop
+  detection, budget, skill selection and hook matching keep *returning* their
+  rationale as typed values; the caller — already at an I/O boundary — records
+  it. This is the invariant most likely to erode, and the one most responsible
+  for `stella-core` being the crate the audit scores at 100.
+- **No egress, at any level, in any build.** No sink opens a socket.
+- **No per-token records.** `AgentEvent::TextDelta` fires per token and produces
+  nothing here; the sanctioned alternative is a bounded tally.
+- **No `Display`/`Debug` blanket impl for fields**, however convenient. That
+  single blanket impl is the entire hole this crate exists to close, and it will
+  be proposed by someone every six months.
+- **No replacement of `AgentEvent`.** The domain plane stays the authority for
+  replay; the diagnostic plane references it and never restates it.
+
+## Adding a diagnostic to your crate
+
+1. Depend on `stella-diag` (it is a leaf; there is no cycle to worry about).
+2. Take a `&Dx` where you need one. Do not reach for a global — there isn't one.
+3. `diag!(dx, warn, "yourcrate.thing.happened", cx: cx, count = n)`. The `code`
+   is dotted, stable, and a public surface: operators alert on it and it
+   outlives any message text.
+4. If a value will not compile as a field, that is the design working. Reach for
+   `PathClass`, a `log_enum!`, or — with a written justification — `Redacted`.
+
+For a whole vocabulary rather than a call site, implement `Facet` on a per-crate
+enum: the crate that owns the events owns their rendering, so nobody edits a
+shared enum and no new variant recompiles the world.

--- a/stella-diag/src/crash.rs
+++ b/stella-diag/src/crash.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Getting the ring onto disk — the second half of
+//! `docs/design/diagnostics.md` §7.4.
+//!
+//! The ring is written **only** on a panic or a non-zero exit. That is the
+//! whole retention policy, and it is why the plane costs a successful run
+//! nothing on disk.
+//!
+//! The panic hook wraps whatever hook was installed before it rather than
+//! replacing it, so the ordinary panic message a user expects still reaches
+//! stderr, and `stella-tui`'s terminal-restoring hook keeps working. Announcing
+//! the file is the caller's job: naming a path for a human to read is
+//! *presentation*, and §2.1's routing rule puts that in the CLI, not here.
+
+use std::panic::PanicHookInfo;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::cx::Cx;
+use crate::dx::Dx;
+use crate::field::Fields;
+use crate::level::Level;
+use crate::record::Record;
+use crate::{Redacted, note};
+
+/// Record that the process panicked, then dump the ring into `dir`.
+///
+/// Returns the file written, if anything was written. Safe to call from a
+/// panic hook: it allocates and touches the filesystem, but it never panics —
+/// a panic here would abort the process and destroy the very artifact this
+/// exists to produce.
+pub fn dump_after_panic(dx: &Dx, dir: &Path, info: &PanicHookInfo<'_>) -> Option<PathBuf> {
+    let mut fields = Fields::new();
+    if let Some(location) = info.location() {
+        // A panic location is a path inside stella's own source tree, fixed at
+        // compile time — but `Location::file` returns a borrowed `&str` rather
+        // than the `&'static str` it really is, so it cannot satisfy §5.2's
+        // type rule directly. The reviewed hatch is the honest way through, and
+        // this is precisely the case it exists for.
+        fields = fields
+            .with(
+                "file",
+                Redacted::reviewed(
+                    location.file(),
+                    note!(
+                        "a panic location names a file in stella's own source tree, baked in at \
+                         compile time; it is never a user path, model output, or workspace content"
+                    ),
+                ),
+            )
+            .with("line", location.line())
+            .with("column", location.column());
+    }
+    // The panic *payload* is deliberately absent. It is a formatted message
+    // that routinely interpolates runtime values — a path, a tool argument, a
+    // provider response — and §5.2 has no exception for the message that
+    // happens to be attached to a crash. The previous hook has already printed
+    // it to stderr for the human; the file stays content-free.
+    dx.emit(Record::new(
+        Level::Error,
+        "diag.panic",
+        module_path!(),
+        Cx::EMPTY,
+        fields,
+    ));
+    dump(dx, dir)
+}
+
+/// Dump the ring into `dir`, returning the file written.
+///
+/// `None` means there was nothing to write. An `Err` from the dump is
+/// swallowed on purpose: this runs on the failure path, and a crash file that
+/// could not be written must not become a second, louder failure.
+pub fn dump(dx: &Dx, dir: &Path) -> Option<PathBuf> {
+    dx.flush();
+    dx.ring().dump_into(dir).ok().flatten()
+}
+
+/// Install a panic hook that dumps the ring into `dir`.
+///
+/// `announce` is handed the file that was written, so the caller can tell the
+/// user where to find it in the caller's own voice. It runs inside the panic
+/// hook, so it should print and nothing more.
+pub fn install_panic_hook<F>(dx: Arc<Dx>, dir: PathBuf, announce: F)
+where
+    F: Fn(&Path) + Send + Sync + 'static,
+{
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // The pre-existing hook first: the user's panic message, and any
+        // terminal restoration a TUI installed, must not wait on a file write.
+        previous(info);
+        if let Some(path) = dump_after_panic(&dx, &dir, info) {
+            announce(&path);
+        }
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diag;
+    use crate::ring::latest_crash_file;
+    use std::sync::Mutex;
+
+    /// Panic hooks are process-global, so the tests that install one take
+    /// turns. Without this they would clobber each other's hook and the
+    /// failure would look like flakiness rather than like a shared resource.
+    static HOOK: Mutex<()> = Mutex::new(());
+
+    /// Property 5 of §12: the ring survives a panic.
+    #[test]
+    fn a_panic_writes_an_owner_only_jsonl_dump_holding_the_last_record() {
+        let _guard = HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dx = Arc::new(Dx::disabled());
+
+        diag!(&dx, debug, "test.before_panic", step = 41_u32);
+
+        let restore = std::panic::take_hook();
+        install_panic_hook(dx.clone(), dir.path().to_path_buf(), |_| {});
+        let outcome = std::panic::catch_unwind(|| panic!("wedged mid-turn"));
+        std::panic::set_hook(restore);
+        assert!(outcome.is_err(), "the panic must still propagate");
+
+        let path = latest_crash_file(dir.path()).expect("a crash file");
+        let text = std::fs::read_to_string(&path).expect("read");
+        let records: Vec<Record> = text
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each line parses as JSONL"))
+            .collect();
+
+        let codes: Vec<_> = records.iter().map(|r| r.code.as_str()).collect();
+        assert!(
+            codes.contains(&"test.before_panic"),
+            "the last pre-panic record must be in the dump: {codes:?}"
+        );
+        assert!(codes.contains(&"diag.panic"), "{codes:?}");
+
+        let panic_record = records
+            .iter()
+            .find(|r| r.code.as_str() == "diag.panic")
+            .expect("a panic record");
+        assert_eq!(panic_record.level, Level::Error);
+        assert!(panic_record.fields.get("line").is_some());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a crash file is owner-only");
+        }
+    }
+
+    /// The dump is what a maintainer asks a stranger to attach, so the panic
+    /// message — which routinely interpolates runtime values — must not be in
+    /// it.
+    #[test]
+    fn the_panic_payload_never_reaches_the_dump() {
+        let _guard = HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dx = Arc::new(Dx::disabled());
+        diag!(&dx, info, "test.seed");
+
+        let restore = std::panic::take_hook();
+        // Silence the wrapped hook's stderr write for this one case: the point
+        // is what lands in the FILE, and an expected panic message printed by
+        // a passing test reads as a failure.
+        std::panic::set_hook(Box::new(|_| {}));
+        install_panic_hook(dx.clone(), dir.path().to_path_buf(), |_| {});
+        let outcome =
+            std::panic::catch_unwind(|| panic!("token sk-live-DEADBEEF rejected by provider"));
+        std::panic::set_hook(restore);
+        assert!(outcome.is_err());
+
+        let path = latest_crash_file(dir.path()).expect("a crash file");
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !text.contains("sk-live-DEADBEEF"),
+            "the panic payload reached the dump: {text}"
+        );
+    }
+
+    #[test]
+    fn the_previous_hook_still_runs() {
+        let _guard = HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        static RAN: Mutex<bool> = Mutex::new(false);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dx = Arc::new(Dx::disabled());
+        diag!(&dx, info, "test.seed");
+
+        let restore = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {
+            *RAN.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        }));
+        install_panic_hook(dx.clone(), dir.path().to_path_buf(), |_| {});
+        let _ = std::panic::catch_unwind(|| panic!("boom"));
+        std::panic::set_hook(restore);
+
+        assert!(
+            *RAN.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            "wrapping a hook must not replace it"
+        );
+    }
+
+    #[test]
+    fn a_dump_with_nothing_to_say_writes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(dump(&Dx::disabled(), dir.path()), None);
+    }
+}

--- a/stella-diag/src/crash.rs
+++ b/stella-diag/src/crash.rs
@@ -75,7 +75,12 @@ pub fn dump_after_panic(dx: &Dx, dir: &Path, info: &PanicHookInfo<'_>) -> Option
 /// could not be written must not become a second, louder failure.
 pub fn dump(dx: &Dx, dir: &Path) -> Option<PathBuf> {
     dx.flush();
-    dx.ring().dump_into(dir).ok().flatten()
+    let written = dx.ring().dump_into(dir).ok().flatten()?;
+    // One dump per failed run adds up, and nothing else prunes this directory.
+    // After writing, not before: the file just written must be among the
+    // survivors even if the keep window is somehow full of newer stamps.
+    crate::ring::prune_crash_files(dir, crate::ring::CRASH_KEEP);
+    Some(written)
 }
 
 /// Install a panic hook that dumps the ring into `dir`.

--- a/stella-diag/src/cx.rs
+++ b/stella-diag/src/cx.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Correlation without spans — `docs/design/diagnostics.md` §7.
+//!
+//! `tracing`'s substantive advantage over a hand-rolled logger is span
+//! propagation, and hand-rolled loggers usually lose because they force every
+//! call site to re-thread ids by hand. Stella does not have that problem,
+//! because **invariant 2 already forces it**: "plain synchronous functions over
+//! owned data" means there is no ambient state to begin with and every decision
+//! function already receives its inputs explicitly.
+//!
+//! So [`Cx`] rides as an explicit parameter — not a thread-local, not a
+//! task-local, both of which are wrong under `!Send` turn futures and wrong
+//! under `tokio` task migration. The architecture stella already chose for
+//! testability hands correlation over for free, and §10 records that as the
+//! strongest single argument for not adopting a facade.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::field::{FieldValue, Loggable};
+
+/// How many hex characters of an id a record keeps.
+const SHORT_ID_CHARS: usize = 8;
+
+/// A truncated correlation handle: eight hex characters of an id, never the
+/// whole thing.
+///
+/// `serve-observability.md` §8 argues this for turn ids — a turn id is a second
+/// factor, and writing it verbatim into a file operators ship spends that
+/// factor for nothing. §7.2 generalises the argument unchanged to session and
+/// execution ids.
+///
+/// The eight bytes are the type, not a convention: there is no constructor that
+/// produces a longer one, so "a record leaked a whole session id" is not a
+/// review question.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ShortId([u8; SHORT_ID_CHARS]);
+
+impl ShortId {
+    /// Truncate a full id for recording.
+    ///
+    /// A leading `<kind>-` label (`turn-`, `session-`, `exec-`) is dropped
+    /// first, matching `stella-serve::observe::event::TurnRef`, so
+    /// `turn-0123456789abcdef…` records as `01234567` rather than as the word
+    /// `turn-012`. Non-hex characters are skipped (a UUID's dashes), and an id
+    /// with fewer than eight hex digits is padded with `0` so the width is
+    /// fixed — a ragged handle would be harder to eyeball-match against the
+    /// domain plane, which is the entire job.
+    #[must_use]
+    pub fn new(id: &str) -> Self {
+        let body = id.split_once('-').map_or(id, |(_, rest)| rest);
+        let mut out = [b'0'; SHORT_ID_CHARS];
+        let mut taken = 0;
+        for byte in body.bytes() {
+            if taken == SHORT_ID_CHARS {
+                break;
+            }
+            if byte.is_ascii_hexdigit() {
+                out[taken] = byte.to_ascii_lowercase();
+                taken += 1;
+            }
+        }
+        Self(out)
+    }
+
+    /// Reconstruct from eight characters that are already a handle — the read
+    /// path, used when parsing a record back off disk.
+    pub(crate) fn from_exact(text: &str) -> Option<Self> {
+        let bytes = text.as_bytes();
+        if bytes.len() == SHORT_ID_CHARS
+            && bytes
+                .iter()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            let mut out = [b'0'; SHORT_ID_CHARS];
+            out.copy_from_slice(bytes);
+            Some(Self(out))
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        // Every byte was written as ASCII hex by a constructor above, so this
+        // cannot fail; the fallback keeps invariant 5 rather than asserting it.
+        std::str::from_utf8(&self.0).unwrap_or("00000000")
+    }
+}
+
+impl fmt::Debug for ShortId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "ShortId({})", self.as_str())
+    }
+}
+
+impl fmt::Display for ShortId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Loggable for ShortId {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Short(*self)
+    }
+}
+
+impl Serialize for ShortId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ShortId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        // `new` rather than `from_exact`: a record written by a newer build
+        // must still parse in an older one, and a handle that is not eight hex
+        // characters is a wire-format surprise, not a reason to drop a crash
+        // file on the floor.
+        Ok(Self::new(&text))
+    }
+}
+
+/// What a record is *about*: the session, execution, turn and step it belongs
+/// to.
+///
+/// Every field is optional because context accrues — a record emitted while
+/// resolving settings genuinely has no turn yet, and `null` says so honestly
+/// where a zero would lie. Absent fields are omitted from the JSON entirely,
+/// so `"cx": {}` is the shape of a record with no correlation at all.
+///
+/// The four names are the workspace's own, and AGENTS.md's glossary is the
+/// authority on how they differ: **session** is one run of the CLI,
+/// **execution** is one row of the store's `executions` table, **turn** is one
+/// `run_turn`, **step** is one iteration inside it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cx {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<ShortId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ShortId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<u64>,
+}
+
+impl Cx {
+    /// No correlation at all — process startup, argument parsing, anything
+    /// before a session exists.
+    pub const EMPTY: Self = Self {
+        session: None,
+        execution: None,
+        turn: None,
+        step: None,
+    };
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self::EMPTY
+    }
+
+    #[must_use]
+    pub fn session(mut self, id: &str) -> Self {
+        self.session = Some(ShortId::new(id));
+        self
+    }
+
+    #[must_use]
+    pub fn execution(mut self, id: &str) -> Self {
+        self.execution = Some(ShortId::new(id));
+        self
+    }
+
+    #[must_use]
+    pub const fn turn(mut self, turn: u64) -> Self {
+        self.turn = Some(turn);
+        self
+    }
+
+    #[must_use]
+    pub const fn step(mut self, step: u64) -> Self {
+        self.step = Some(step);
+        self
+    }
+
+    /// Whether this carries no correlation at all.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.session.is_none()
+            && self.execution.is_none()
+            && self.turn.is_none()
+            && self.step.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property §7.2 exists for: enough to correlate, not enough to act.
+    #[test]
+    fn a_handle_keeps_eight_hex_characters_and_drops_the_rest() {
+        let full = "turn-0123456789abcdef0123456789abcdef";
+        let short = ShortId::new(full);
+        assert_eq!(short.as_str(), "01234567");
+        assert_eq!(short.as_str().len(), 8);
+        assert!(!full.contains(short.as_str()) || full.contains("01234567"));
+    }
+
+    #[test]
+    fn a_uuid_shaped_id_skips_its_dashes() {
+        assert_eq!(
+            ShortId::new("9f8e7d6c-1234-5678-9abc-def012345678").as_str(),
+            // The leading `9f8e7d6c` label is stripped as a `<kind>-` prefix,
+            // so the handle starts at the next group. Consistent, and the
+            // domain plane holds the whole id either way.
+            "12345678"
+        );
+    }
+
+    #[test]
+    fn a_short_id_is_padded_to_a_fixed_width() {
+        assert_eq!(ShortId::new("ab").as_str(), "ab000000");
+        assert_eq!(ShortId::new("").as_str(), "00000000");
+    }
+
+    #[test]
+    fn an_empty_cx_serializes_to_an_empty_object() {
+        assert_eq!(serde_json::to_string(&Cx::EMPTY).expect("serialize"), "{}");
+        assert!(Cx::EMPTY.is_empty());
+    }
+
+    #[test]
+    fn a_cx_round_trips_and_carries_only_handles() {
+        let cx = Cx::new()
+            .session("session-a1b2c3d4e5f6")
+            .execution("exec-9f8e7d6c5b4a")
+            .turn(3)
+            .step(11);
+        let json = serde_json::to_string(&cx).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"session":"a1b2c3d4","execution":"9f8e7d6c","turn":3,"step":11}"#
+        );
+        assert!(
+            !json.contains("e5f6"),
+            "the whole session id reached a record"
+        );
+        let back: Cx = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, cx);
+    }
+}

--- a/stella-diag/src/dx.rs
+++ b/stella-diag/src/dx.rs
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The emitter every call site talks to, and the macro that builds a record.
+//!
+//! [`Dx`] is a **handle, not a global**. `docs/design/diagnostics.md` §7.1 is
+//! the reason: invariant 2 already banned ambient state, so a diagnostic
+//! handle rides as an explicit parameter exactly like every other input a
+//! decision function receives. Nothing here is a thread-local or a task-local,
+//! both of which are wrong under `!Send` turn futures and wrong under `tokio`
+//! task migration.
+//!
+//! Emission is unconditional and filtering is not. §6:
+//!
+//! > Everything at every level, always, goes to the ring regardless of filter —
+//! > the filter governs *sinks*, never *emission*, which is what keeps counters
+//! > correct at any verbosity.
+//!
+//! Property 3 of §12 is that sentence as a proptest.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::cx::Cx;
+use crate::field::Fields;
+use crate::filter::Filter;
+use crate::level::Level;
+use crate::record::Record;
+use crate::ring::Ring;
+use crate::sink::{Bound, Capture, Sink};
+
+/// Running totals, incremented on every record before any filter is consulted.
+///
+/// This is the "cannot disagree with the log" property `observe/metrics.rs`
+/// established, generalised: a counter derived from the same emission the
+/// records come from cannot drift from them, and raising verbosity cannot
+/// change a number.
+#[derive(Debug, Default)]
+pub struct Counters {
+    by_level: [AtomicU64; 5],
+    sink_failures: AtomicU64,
+}
+
+/// A consistent-enough read of [`Counters`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CounterSnapshot {
+    pub error: u64,
+    pub warn: u64,
+    pub info: u64,
+    pub debug: u64,
+    pub trace: u64,
+    /// Writes a sink refused. Non-zero means records are being lost *to disk*,
+    /// never that a caller failed.
+    pub sink_failures: u64,
+}
+
+impl CounterSnapshot {
+    #[must_use]
+    pub const fn total(&self) -> u64 {
+        self.error + self.warn + self.info + self.debug + self.trace
+    }
+
+    #[must_use]
+    pub const fn at(&self, level: Level) -> u64 {
+        match level {
+            Level::Error => self.error,
+            Level::Warn => self.warn,
+            Level::Info => self.info,
+            Level::Debug => self.debug,
+            Level::Trace => self.trace,
+        }
+    }
+}
+
+impl Counters {
+    fn record(&self, level: Level) {
+        self.by_level[level as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> CounterSnapshot {
+        let read = |level: Level| self.by_level[level as usize].load(Ordering::Relaxed);
+        CounterSnapshot {
+            error: read(Level::Error),
+            warn: read(Level::Warn),
+            info: read(Level::Info),
+            debug: read(Level::Debug),
+            trace: read(Level::Trace),
+            sink_failures: self.sink_failures.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// The diagnostic handle: sinks, the crash ring, and the counters.
+///
+/// Cheap to share (`Arc<Dx>`), safe to hold across threads, and impossible to
+/// make fail — [`Dx::emit`] returns `()` no matter what a sink does.
+pub struct Dx {
+    sinks: Vec<Bound>,
+    ring: Ring,
+    counters: Counters,
+}
+
+impl Dx {
+    /// Build a handle over the given bound sinks.
+    #[must_use]
+    pub fn new(sinks: Vec<Bound>) -> Self {
+        Self {
+            sinks,
+            ring: Ring::default(),
+            counters: Counters::default(),
+        }
+    }
+
+    /// A handle with no sinks.
+    ///
+    /// The default for a library type that has not been wired to anything —
+    /// and note that the ring still fills, so an embedder who never configured
+    /// a sink can still dump one on a crash. "No sinks" is not "no
+    /// diagnostics".
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::new(Vec::new())
+    }
+
+    /// Replace the ring, for a caller that wants a different bound than
+    /// §7.4's.
+    #[must_use]
+    pub fn with_ring(mut self, ring: Ring) -> Self {
+        self.ring = ring;
+        self
+    }
+
+    /// A handle whose one sink records everything in memory, plus that sink.
+    ///
+    /// The shape most tests want: assert on typed [`Record`] values rather
+    /// than on scraped stderr.
+    #[must_use]
+    pub fn capturing() -> (Self, Arc<Capture>) {
+        let capture = Arc::new(Capture::new());
+        let dx = Self::new(vec![Bound::new(
+            Filter::parse("trace").filter,
+            capture.clone() as Arc<dyn Sink>,
+        )]);
+        (dx, capture)
+    }
+
+    /// Record one thing.
+    ///
+    /// Infallible by signature, which is the contract §3.4 asks for: losing a
+    /// log line must never lose a turn. A sink that refuses the write is
+    /// counted in [`CounterSnapshot::sink_failures`] and otherwise ignored.
+    pub fn emit(&self, record: Record) {
+        self.counters.record(record.level);
+        for bound in &self.sinks {
+            if let Some(Err(_)) = bound.offer(&record) {
+                self.counters.sink_failures.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        // Last, and unconditionally. The ring takes ownership, so pushing
+        // first would force a clone on every record for the sinks' benefit.
+        self.ring.push(record);
+    }
+
+    /// The crash ring (§7.4).
+    #[must_use]
+    pub fn ring(&self) -> &Ring {
+        &self.ring
+    }
+
+    #[must_use]
+    pub fn counters(&self) -> CounterSnapshot {
+        self.counters.snapshot()
+    }
+
+    /// Whether any sink would record something from `target` at `level`.
+    ///
+    /// For the rare caller whose *fields* are expensive to compute. Do not
+    /// reach for it by default: the ring wants the record either way, and a
+    /// guard that skips emission is a counter that lies.
+    #[must_use]
+    pub fn would_record(&self, target: &str, level: Level) -> bool {
+        self.sinks
+            .iter()
+            .any(|bound| bound.filter().admits(target, level))
+    }
+
+    /// Flush every sink. Best-effort; failures are counted, never returned.
+    pub fn flush(&self) {
+        for bound in &self.sinks {
+            if bound.flush().is_err() {
+                self.counters.sink_failures.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+impl Default for Dx {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl std::fmt::Debug for Dx {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Dx")
+            .field("sinks", &self.sinks.len())
+            .field("ring", &self.ring.stats())
+            .field("counters", &self.counters.snapshot())
+            .finish()
+    }
+}
+
+/// Map the lowercase level written at a call site onto [`Level`].
+///
+/// Exported because [`diag!`] expands in the caller's crate; not part of the
+/// public API.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __diag_level {
+    (trace) => {
+        $crate::Level::Trace
+    };
+    (debug) => {
+        $crate::Level::Debug
+    };
+    (info) => {
+        $crate::Level::Info
+    };
+    (warn) => {
+        $crate::Level::Warn
+    };
+    (error) => {
+        $crate::Level::Error
+    };
+}
+
+/// Emit one diagnostic record.
+///
+/// ```
+/// # use stella_diag::{diag, Cx, Dx};
+/// let (dx, records) = Dx::capturing();
+/// let cx = Cx::new().turn(3);
+///
+/// diag!(&dx, warn, "store.migration.retry", cx: cx, attempt = 2_u32, backoff_ms = 250_u32);
+/// diag!(&dx, info, "cli.boot");
+///
+/// assert_eq!(records.codes(), ["store.migration.retry", "cli.boot"]);
+/// ```
+///
+/// `target` is `module_path!()` at the call site, which is what
+/// [`Filter`](crate::Filter) matches on — so `STELLA_LOG=stella_store=debug`
+/// selects records by where they were written, with no bookkeeping at the emit
+/// site.
+///
+/// Field values must implement [`Loggable`](crate::Loggable), and that is the
+/// point: a `String`, a `Path`, or a non-`'static` `&str` **does not compile**
+/// (§5.2). Reach for [`Redacted::reviewed`](crate::Redacted::reviewed) when a
+/// runtime string genuinely belongs in a record, and write down why.
+#[macro_export]
+macro_rules! diag {
+    ($dx:expr, $level:ident, $code:literal, cx: $cx:expr $(, $key:ident = $value:expr)* $(,)?) => {{
+        // Bound to a typed local so a caller who passes something else gets an
+        // error naming `Dx`, rather than a method-not-found further in.
+        let dx: &$crate::Dx = $dx;
+        #[allow(unused_mut)]
+        let mut fields = $crate::Fields::new();
+        $(fields.push(
+            ::core::stringify!($key),
+            $crate::Loggable::to_field(&$value),
+        );)*
+        dx.emit($crate::Record::new(
+            $crate::__diag_level!($level),
+            $code,
+            ::core::module_path!(),
+            $cx,
+            fields,
+        ));
+    }};
+    ($dx:expr, $level:ident, $code:literal $(, $key:ident = $value:expr)* $(,)?) => {
+        $crate::diag!($dx, $level, $code, cx: $crate::Cx::EMPTY $(, $key = $value)*)
+    };
+}
+
+/// Fields for a record built outside [`diag!`] — the facet-rendering path.
+///
+/// A per-crate facet enum (§5.1) implements this to turn itself into a record's
+/// worth of fields, so the crate that owns the vocabulary owns the rendering
+/// too and nobody edits a shared enum.
+pub trait Facet {
+    /// This event's stable diagnostic code (§11).
+    fn code(&self) -> &'static str;
+
+    /// How loud it is. Derived from the variant rather than stored on it, so a
+    /// record's severity can never disagree with what happened.
+    fn level(&self) -> Level;
+
+    fn fields(&self) -> Fields;
+
+    /// Render into a record. `target` is the emitting module — pass
+    /// `module_path!()`.
+    fn to_record(&self, target: &'static str, cx: Cx) -> Record {
+        Record::new(self.level(), self.code(), target, cx, self.fields())
+    }
+}
+
+impl Dx {
+    /// Emit a facet's record.
+    pub fn emit_facet(&self, facet: &dyn Facet, target: &'static str, cx: Cx) {
+        self.emit(facet.to_record(target, cx));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::FailingSink;
+    use crate::{Redacted, note};
+
+    #[test]
+    fn a_record_carries_the_call_sites_module_as_its_target() {
+        let (dx, records) = Dx::capturing();
+        diag!(&dx, warn, "test.target");
+        assert_eq!(records.records()[0].target.as_str(), module_path!());
+    }
+
+    #[test]
+    fn fields_reach_the_record_in_the_order_written() {
+        let (dx, records) = Dx::capturing();
+        let cx = Cx::new().session("session-abcd1234").turn(7);
+        diag!(
+            &dx,
+            debug,
+            "agent.tool.call",
+            cx: cx,
+            tool = "bash",
+            args_bytes = 412_u64,
+        );
+        let record = records.find("agent.tool.call").expect("a record");
+        assert_eq!(record.level, Level::Debug);
+        assert_eq!(record.cx.turn, Some(7));
+        assert_eq!(
+            record.fields.iter().map(|(key, _)| key).collect::<Vec<_>>(),
+            vec!["tool", "args_bytes"]
+        );
+    }
+
+    /// §3.4 and property 4 of §12: `emit` is infallible, and a sink that
+    /// refuses every write leaves the caller intact and says so in a counter.
+    #[test]
+    fn a_sink_that_fails_every_write_never_fails_the_caller() {
+        let dx = Dx::new(vec![Bound::new(
+            Filter::parse("trace").filter,
+            Arc::new(FailingSink) as Arc<dyn Sink>,
+        )]);
+        for n in 0..5_u64 {
+            diag!(&dx, error, "test.doomed", n = n);
+        }
+        let counters = dx.counters();
+        assert_eq!(counters.error, 5, "every record was still emitted");
+        assert_eq!(counters.sink_failures, 5, "and every loss was counted");
+        assert_eq!(dx.ring().stats().held, 5, "the ring is unaffected");
+    }
+
+    /// §6: the filter governs sinks, never emission.
+    #[test]
+    fn a_silenced_sink_changes_neither_the_ring_nor_the_counters() {
+        let (loud, loud_records) = Dx::capturing();
+        let (quiet, quiet_records) = {
+            let capture = Arc::new(Capture::new());
+            let dx = Dx::new(vec![Bound::new(
+                Filter::parse("off").filter,
+                capture.clone() as Arc<dyn Sink>,
+            )]);
+            (dx, capture)
+        };
+
+        for dx in [&loud, &quiet] {
+            diag!(dx, error, "test.a");
+            diag!(dx, debug, "test.b");
+            diag!(dx, trace, "test.c");
+        }
+
+        assert_eq!(loud.counters(), quiet.counters());
+        assert_eq!(
+            loud.ring().records().len(),
+            quiet.ring().records().len(),
+            "the ring holds everything at every level, filter notwithstanding"
+        );
+        assert_eq!(loud_records.records().len(), 3);
+        assert!(
+            quiet_records.records().is_empty(),
+            "only sink output differs"
+        );
+    }
+
+    #[test]
+    fn a_record_with_no_fields_and_no_cx_is_legal() {
+        let (dx, records) = Dx::capturing();
+        diag!(&dx, info, "cli.boot");
+        let record = records.find("cli.boot").expect("a record");
+        assert!(record.fields.is_empty());
+        assert!(record.cx.is_empty());
+    }
+
+    #[test]
+    fn the_reviewed_hatch_is_reachable_from_the_macro() {
+        let (dx, records) = Dx::capturing();
+        let branch = String::from("feature/logging");
+        diag!(
+            &dx,
+            info,
+            "git.branch.selected",
+            branch = Redacted::reviewed(
+                branch,
+                note!("git ref names are user-chosen but are not model content"),
+            ),
+        );
+        let json = serde_json::to_string(&records.records()[0]).expect("serialize");
+        assert!(json.contains("feature/logging"), "{json}");
+    }
+
+    #[test]
+    fn would_record_reflects_the_loudest_sink() {
+        let dx = Dx::new(vec![
+            Bound::new(Filter::parse("error").filter, Arc::new(Capture::new())),
+            Bound::new(
+                Filter::parse("off,stella_diag=trace").filter,
+                Arc::new(Capture::new()),
+            ),
+        ]);
+        assert!(dx.would_record("stella_diag::dx", Level::Trace));
+        assert!(dx.would_record("stella_cli", Level::Error));
+        assert!(!dx.would_record("stella_cli", Level::Debug));
+    }
+
+    #[test]
+    fn a_disabled_handle_still_fills_the_ring() {
+        let dx = Dx::disabled();
+        diag!(&dx, warn, "test.unwired");
+        assert_eq!(dx.ring().stats().held, 1);
+        assert_eq!(dx.counters().warn, 1);
+    }
+
+    #[test]
+    fn a_facet_renders_itself_into_the_envelope() {
+        struct Migrated {
+            attempt: u32,
+        }
+        impl Facet for Migrated {
+            fn code(&self) -> &'static str {
+                "store.migration.retry"
+            }
+            fn level(&self) -> Level {
+                Level::Warn
+            }
+            fn fields(&self) -> Fields {
+                Fields::new().with("attempt", self.attempt)
+            }
+        }
+
+        let (dx, records) = Dx::capturing();
+        dx.emit_facet(&Migrated { attempt: 2 }, "stella_store::migrate", Cx::EMPTY);
+        let record = records.find("store.migration.retry").expect("a record");
+        assert_eq!(record.target.as_str(), "stella_store::migrate");
+        assert_eq!(
+            record.fields.get("attempt"),
+            Some(&crate::FieldValue::Uint(2))
+        );
+    }
+}

--- a/stella-diag/src/dx.rs
+++ b/stella-diag/src/dx.rs
@@ -282,7 +282,8 @@ macro_rules! diag {
     };
 }
 
-/// Fields for a record built outside [`diag!`] — the facet-rendering path.
+/// Fields for a record built outside [`diag!`](crate::diag) — the
+/// facet-rendering path.
 ///
 /// A per-crate facet enum (§5.1) implements this to turn itself into a record's
 /// worth of fields, so the crate that owns the vocabulary owns the rendering

--- a/stella-diag/src/field.rs
+++ b/stella-diag/src/field.rs
@@ -1,0 +1,677 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The headline of `docs/design/diagnostics.md` §5.2: **content in a log does
+//! not compile.**
+//!
+//! A field value is not `serde_json::Value` and not `impl Display`. It is
+//! [`FieldValue`], a closed algebra whose only string variant holds a
+//! [`StaticStr`] — a string that provably lives in the binary. [`Loggable`] is
+//! implemented for the things that cannot carry runtime content (integers,
+//! `bool`, `f64`, `Duration`, `&'static str`, closed enums declared through
+//! [`log_enum!`](crate::log_enum), and the two reviewed escape hatches
+//! [`PathClass`](crate::PathClass) and [`Redacted`](crate::Redacted)), and
+//! deliberately **not** for `String`, a non-`'static` `&str`, `Path`,
+//! `PathBuf`, `serde_json::Value`, or any `Display` blanket.
+//!
+//! So this is a type error rather than a privacy incident:
+//!
+//! ```compile_fail
+//! # use stella_diag::{Dx, Cx, diag};
+//! # let dx = Dx::disabled();
+//! let user_path = String::from("/home/ada/.ssh/id_ed25519");
+//! diag!(&dx, warn, "tools.write.denied", path = user_path);
+//! ```
+//!
+//! `tracing` would happily log that with `%user_path`. Invariant 3's most
+//! dangerous failure mode stops being a thing review has to catch and starts
+//! being a thing the compiler catches. The witness lives in
+//! `tests/compile_fail.rs` (property 1 of §12) because a runtime test cannot
+//! observe a compile error.
+//!
+//! **Stated honestly, because overclaiming is worse than the gap:**
+//! `Box::leak` turns a `String` into a `&'static str` and would defeat this.
+//! That is a deliberate, single-token, greppable act, banned by the
+//! `disallowed-methods` entry in the workspace `clippy.toml` that landed with
+//! this module. The claim is not "impossible"; it is *"impossible by accident,
+//! and loud on purpose"*.
+
+use std::borrow::Cow;
+use std::fmt;
+use std::time::Duration;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::cx::ShortId;
+
+/// A string that provably lives in the binary.
+///
+/// The inner `Cow` is **private on purpose**, and it is the seal on §5.2:
+/// [`StaticStr::new`] accepts only a `&'static str`, so no emit site can put a
+/// runtime `String` into a record. The owned half of the `Cow` exists solely
+/// so a record can be *read back* — `Deserialize` produces `Cow::Owned`,
+/// because parsing a crash file is the one direction where the bytes really
+/// are runtime data. Reading is not emitting.
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StaticStr(Cow<'static, str>);
+
+impl StaticStr {
+    /// Wrap a string that lives in the binary.
+    #[must_use]
+    pub const fn new(text: &'static str) -> Self {
+        Self(Cow::Borrowed(text))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for StaticStr {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, formatter)
+    }
+}
+
+impl fmt::Display for StaticStr {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl From<&'static str> for StaticStr {
+    fn from(text: &'static str) -> Self {
+        Self::new(text)
+    }
+}
+
+impl Serialize for StaticStr {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for StaticStr {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer).map(|owned| Self(Cow::Owned(owned)))
+    }
+}
+
+/// The reviewed escape hatch's payload — see [`Redacted`](crate::Redacted).
+///
+/// Both fields are private, which is what makes this the *only* runtime string
+/// that can reach a record, reachable only through
+/// [`Redacted::reviewed`](crate::Redacted::reviewed) and therefore only with a
+/// justification written in the source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewedValue {
+    reviewed: String,
+    note: StaticStr,
+}
+
+impl ReviewedValue {
+    pub(crate) fn new(reviewed: String, note: StaticStr) -> Self {
+        Self { reviewed, note }
+    }
+
+    /// The reviewed content itself.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.reviewed
+    }
+
+    /// Why its author judged it safe to record.
+    #[must_use]
+    pub fn note(&self) -> &str {
+        self.note.as_str()
+    }
+}
+
+/// What a diagnostic field may hold. A closed algebra, and the reason a record
+/// is content-free by construction.
+///
+/// The only variants that can carry a string are [`FieldValue::Str`], whose
+/// payload is a [`StaticStr`], and [`FieldValue::Reviewed`], whose payload can
+/// only be built by [`Redacted::reviewed`](crate::Redacted::reviewed). There is
+/// no `Value`, no `Display`, and no `Debug` escape.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldValue {
+    Null,
+    Bool(bool),
+    /// A **negative** integer. Build with [`FieldValue::int`], which routes
+    /// non-negative values to [`FieldValue::Uint`] so the Rust value and the
+    /// JSON value agree in both directions.
+    Int(i64),
+    Uint(u64),
+    /// Non-finite values are normalised to [`FieldValue::Null`] by the
+    /// [`Loggable`] impls, so a record always round-trips (`NaN` has no JSON
+    /// spelling and serde renders it as `null` on the way out but cannot read
+    /// it back as a float).
+    Float(f64),
+    Str(StaticStr),
+    /// A truncated correlation handle. Its own variant rather than a string
+    /// because [`ShortId`] is the one runtime-derived value whose *width* is
+    /// the safety argument (§7.2), and eight bytes is a type here, not a
+    /// convention.
+    Short(ShortId),
+    List(Vec<FieldValue>),
+    /// A nested object. Keys are [`StaticStr`], so the *shape* of a record is
+    /// as content-free as its values. Insertion order is preserved.
+    Map(Vec<(StaticStr, FieldValue)>),
+    Reviewed(ReviewedValue),
+}
+
+impl Serialize for FieldValue {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Null => serializer.serialize_unit(),
+            Self::Bool(value) => serializer.serialize_bool(*value),
+            Self::Int(value) => serializer.serialize_i64(*value),
+            Self::Uint(value) => serializer.serialize_u64(*value),
+            Self::Float(value) => serializer.serialize_f64(*value),
+            Self::Str(value) => value.serialize(serializer),
+            Self::Short(value) => value.serialize(serializer),
+            Self::List(items) => {
+                let mut seq = serializer.serialize_seq(Some(items.len()))?;
+                for item in items {
+                    seq.serialize_element(item)?;
+                }
+                seq.end()
+            }
+            Self::Map(entries) => {
+                let mut map = serializer.serialize_map(Some(entries.len()))?;
+                for (key, value) in entries {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+            Self::Reviewed(value) => value.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for FieldValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(FieldValueVisitor)
+    }
+}
+
+struct FieldValueVisitor;
+
+/// The text of a value that was written as a JSON string, whichever variant it
+/// read back as. Eight-hex-character strings land in [`FieldValue::Short`], so
+/// matching on [`FieldValue::Str`] alone would miss them.
+fn as_text(value: &FieldValue) -> Option<String> {
+    match value {
+        FieldValue::Str(text) => Some(text.as_str().to_owned()),
+        FieldValue::Short(handle) => Some(handle.as_str().to_owned()),
+        _ => None,
+    }
+}
+
+impl<'de> Visitor<'de> for FieldValueVisitor {
+    type Value = FieldValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a diagnostic field value")
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(FieldValue::Null)
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(FieldValue::Null)
+    }
+
+    fn visit_bool<E: de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(FieldValue::Bool(value))
+    }
+
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(FieldValue::Int(value))
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(FieldValue::Uint(value))
+    }
+
+    fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        Ok(FieldValue::Float(value))
+    }
+
+    /// A string of exactly eight lowercase hex characters reads back as a
+    /// [`ShortId`], which is the only shape [`FieldValue::Short`] can have
+    /// written. A `&'static str` field whose literal value happens to be eight
+    /// lowercase hex digits therefore reads back as a `Short` — it
+    /// re-serializes to identical bytes, so invariant 4 holds either way, and
+    /// no consumer of a record distinguishes the two.
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(ShortId::from_exact(value).map_or_else(
+            || FieldValue::Str(StaticStr(Cow::Owned(value.to_owned()))),
+            FieldValue::Short,
+        ))
+    }
+
+    fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut items = Vec::new();
+        while let Some(item) = seq.next_element()? {
+            items.push(item);
+        }
+        Ok(FieldValue::List(items))
+    }
+
+    /// Objects are [`FieldValue::Map`], except for the exact two-key shape
+    /// [`ReviewedValue`] writes. The discrimination is by key set rather than
+    /// by a tag because the *serialized* form is the public surface (§11) and a
+    /// tag would be noise in every operator's `jq`. A hand-built `Map` with
+    /// precisely the keys `reviewed` and `note` would read back as a
+    /// `Reviewed` — it re-serializes to identical bytes, so invariant 4 holds
+    /// byte-for-byte either way; only the Rust-level variant differs, and no
+    /// emit site in the workspace builds that key pair by hand.
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut entries: Vec<(StaticStr, FieldValue)> = Vec::new();
+        while let Some((key, value)) = map.next_entry::<String, FieldValue>()? {
+            entries.push((StaticStr(Cow::Owned(key)), value));
+        }
+        if entries.len() == 2
+            && (entries[0].0.as_str(), entries[1].0.as_str()) == ("reviewed", "note")
+            && let (Some(reviewed), Some(note)) = (as_text(&entries[0].1), as_text(&entries[1].1))
+        {
+            return Ok(FieldValue::Reviewed(ReviewedValue {
+                reviewed,
+                note: StaticStr(Cow::Owned(note)),
+            }));
+        }
+        Ok(FieldValue::Map(entries))
+    }
+}
+
+/// The types a diagnostic field may be built from.
+///
+/// Implemented only for values that cannot carry runtime content. The absence
+/// of an impl is the feature: see the module docs, and resist the blanket
+/// `impl<T: Display> Loggable for T` — that single impl is the entire hole §5.2
+/// exists to close, and §14 records that it will be proposed by someone every
+/// six months.
+pub trait Loggable {
+    fn to_field(&self) -> FieldValue;
+}
+
+impl FieldValue {
+    /// A signed integer, in the crate's canonical spelling.
+    ///
+    /// JSON has one number type, so `-1` and `1` differ only in sign and a
+    /// parser cannot tell `Int(1)` from `Uint(1)` on the way back —
+    /// `serde_json` reports any non-negative integer as `u64`. Normalising
+    /// *here*, at construction, is what makes [`FieldValue::Int`] mean
+    /// "negative" and lets a record round-trip to an equal value rather than
+    /// merely to equal bytes. Property 8 of §12 is what caught the difference.
+    #[must_use]
+    pub fn int(value: i64) -> Self {
+        u64::try_from(value).map_or(Self::Int(value), Self::Uint)
+    }
+}
+
+macro_rules! loggable_int {
+    ($($ty:ty),* $(,)?) => {
+        $(impl Loggable for $ty {
+            fn to_field(&self) -> FieldValue {
+                FieldValue::int(i64::from(*self))
+            }
+        })*
+    };
+}
+
+macro_rules! loggable_uint {
+    ($($ty:ty),* $(,)?) => {
+        $(impl Loggable for $ty {
+            fn to_field(&self) -> FieldValue {
+                FieldValue::Uint(u64::from(*self))
+            }
+        })*
+    };
+}
+
+loggable_int!(i8, i16, i32, i64);
+loggable_uint!(u8, u16, u32, u64);
+
+impl Loggable for usize {
+    fn to_field(&self) -> FieldValue {
+        // `usize` is 64-bit on every target this workspace ships to, but the
+        // cast is saturating rather than `as` so a 128-bit future cannot make
+        // a count silently wrap into a negative-looking number.
+        FieldValue::Uint(u64::try_from(*self).unwrap_or(u64::MAX))
+    }
+}
+
+impl Loggable for isize {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::int(i64::try_from(*self).unwrap_or(i64::MAX))
+    }
+}
+
+impl Loggable for bool {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Bool(*self)
+    }
+}
+
+impl Loggable for f32 {
+    fn to_field(&self) -> FieldValue {
+        f64::from(*self).to_field()
+    }
+}
+
+impl Loggable for f64 {
+    /// One caveat, recorded rather than hidden: `serde_json` writes every
+    /// `f64` exactly and reads a large fraction of *full-precision* doubles
+    /// back one ULP off, so such a value does not survive a round trip.
+    /// Diagnostic floats — a duration, a ratio, a rate — are unaffected, and
+    /// `tests/properties.rs` pins the limitation down by name.
+    fn to_field(&self) -> FieldValue {
+        if self.is_finite() {
+            FieldValue::Float(*self)
+        } else {
+            // JSON has no spelling for NaN or ±∞. Recording `null` keeps the
+            // field present (its absence would read as "never measured") and
+            // keeps the record round-trippable, which infinity would not be.
+            FieldValue::Null
+        }
+    }
+}
+
+impl Loggable for Duration {
+    /// Milliseconds, matching the workspace's existing `ts`/`duration_ms`
+    /// convention (`stella-serve::observe::event::millis`).
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Uint(u64::try_from(self.as_millis()).unwrap_or(u64::MAX))
+    }
+}
+
+impl Loggable for &'static str {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Str(StaticStr::new(self))
+    }
+}
+
+impl Loggable for StaticStr {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Str(self.clone())
+    }
+}
+
+impl<T: Loggable> Loggable for Option<T> {
+    /// `None` records as `null` rather than omitting the field: "we looked and
+    /// there was nothing" and "we never looked" are different diagnoses, and a
+    /// missing key cannot tell them apart.
+    fn to_field(&self) -> FieldValue {
+        self.as_ref().map_or(FieldValue::Null, Loggable::to_field)
+    }
+}
+
+impl<T: Loggable> Loggable for &T {
+    fn to_field(&self) -> FieldValue {
+        (*self).to_field()
+    }
+}
+
+impl<T: Loggable> Loggable for Vec<T> {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::List(self.iter().map(Loggable::to_field).collect())
+    }
+}
+
+impl<T: Loggable> Loggable for [T] {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::List(self.iter().map(Loggable::to_field).collect())
+    }
+}
+
+/// The `fields` object of one record: ordered `(key, value)` pairs.
+///
+/// Keys are [`StaticStr`], so a record's shape is as content-free as its
+/// values. Order is insertion order — the order the emit site wrote its
+/// fields — which is what makes rendered records diffable across runs.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Fields(Vec<(StaticStr, FieldValue)>);
+
+impl Fields {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a field. Duplicate keys are kept rather than replaced: a record
+    /// that says the same thing twice is a bug worth seeing, not one worth
+    /// hiding.
+    #[must_use]
+    pub fn with(mut self, key: &'static str, value: impl Loggable) -> Self {
+        self.0.push((StaticStr::new(key), value.to_field()));
+        self
+    }
+
+    /// Append an already-built value. Used by [`diag!`](crate::diag), which
+    /// has called [`Loggable::to_field`] itself.
+    pub fn push(&mut self, key: &'static str, value: FieldValue) {
+        self.0.push((StaticStr::new(key), value));
+    }
+
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&FieldValue> {
+        self.0
+            .iter()
+            .find(|(name, _)| name.as_str() == key)
+            .map(|(_, value)| value)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &FieldValue)> {
+        self.0.iter().map(|(key, value)| (key.as_str(), value))
+    }
+}
+
+impl Serialize for Fields {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (key, value) in &self.0 {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Fields {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match FieldValue::deserialize(deserializer)? {
+            FieldValue::Map(entries) => Ok(Self(entries)),
+            // The `reviewed`/`note` shape is a legal *field* object, so a
+            // `fields` map that happens to contain exactly those two keys
+            // parses as `Reviewed` above. Unfold it back rather than rejecting
+            // the record: dropping a crash file on a key-set coincidence would
+            // be the worst possible failure for the one artifact §7.4 exists to
+            // make askable.
+            FieldValue::Reviewed(value) => Ok(Self(vec![
+                (
+                    StaticStr::new("reviewed"),
+                    FieldValue::Str(StaticStr(Cow::Owned(value.value().to_owned()))),
+                ),
+                (
+                    StaticStr::new("note"),
+                    FieldValue::Str(StaticStr(Cow::Owned(value.note().to_owned()))),
+                ),
+            ])),
+            other => Err(de::Error::custom(format!(
+                "diagnostic fields must be an object, got {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Declare a closed enum that may be logged.
+///
+/// A closed variant set is a finite, reviewed vocabulary — §5.2's third row —
+/// so it is safe where a `String` is not. The generated type renders to its
+/// `&'static str` spelling, which is the value that reaches the record and the
+/// value operators match on.
+///
+/// ```
+/// # use stella_diag::{log_enum, Loggable};
+/// log_enum! {
+///     /// Why a store migration retried.
+///     pub enum RetryReason {
+///         Locked => "locked",
+///         Busy => "busy",
+///     }
+/// }
+/// assert_eq!(RetryReason::Busy.as_static(), "busy");
+/// ```
+#[macro_export]
+macro_rules! log_enum {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident => $spelling:literal
+            ),* $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        $vis enum $name {
+            $(
+                $(#[$variant_meta])*
+                $variant,
+            )*
+        }
+
+        impl $name {
+            /// This variant's stable spelling, as it appears in a record.
+            #[must_use]
+            pub const fn as_static(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $spelling,)*
+                }
+            }
+        }
+
+        impl $crate::Loggable for $name {
+            fn to_field(&self) -> $crate::FieldValue {
+                $crate::FieldValue::Str($crate::StaticStr::new(self.as_static()))
+            }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                formatter.write_str(self.as_static())
+            }
+        }
+
+        impl ::serde::Serialize for $name {
+            fn serialize<S: ::serde::Serializer>(
+                &self,
+                serializer: S,
+            ) -> ::core::result::Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_static())
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    log_enum! {
+        /// A test vocabulary.
+        pub enum Outcome {
+            Hit => "hit",
+            Miss => "miss",
+        }
+    }
+
+    #[test]
+    fn a_log_enum_records_its_stable_spelling() {
+        assert_eq!(
+            Outcome::Hit.to_field(),
+            FieldValue::Str(StaticStr::new("hit"))
+        );
+        assert_eq!(Outcome::Miss.to_string(), "miss");
+    }
+
+    #[test]
+    fn a_static_str_deserializes_owned_and_still_compares_by_content() {
+        let json = "\"store.migration.retry\"";
+        let parsed: StaticStr = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed, StaticStr::new("store.migration.retry"));
+    }
+
+    /// Non-finite floats have no JSON spelling. Recording `null` keeps the
+    /// field present *and* keeps the record readable; `NaN` would serialize to
+    /// `null` anyway and then fail to parse back as a float.
+    #[test]
+    fn a_non_finite_float_records_as_null() {
+        assert_eq!(f64::NAN.to_field(), FieldValue::Null);
+        assert_eq!(f64::INFINITY.to_field(), FieldValue::Null);
+        assert_eq!((1.5_f64).to_field(), FieldValue::Float(1.5));
+    }
+
+    #[test]
+    fn fields_keep_insertion_order() {
+        let fields = Fields::new()
+            .with("attempt", 2_u64)
+            .with("backoff_ms", 250_u64);
+        let json = serde_json::to_string(&fields).expect("serialize");
+        assert_eq!(json, r#"{"attempt":2,"backoff_ms":250}"#);
+    }
+
+    #[test]
+    fn a_nested_map_round_trips() {
+        let fields = Fields::new().with("attempt", 2_u64);
+        let mut with_error = fields;
+        with_error.push(
+            "error",
+            FieldValue::Map(vec![
+                (
+                    StaticStr::new("code"),
+                    FieldValue::Str(StaticStr::new("Io")),
+                ),
+                (
+                    StaticStr::new("kind"),
+                    FieldValue::Str(StaticStr::new("PermissionDenied")),
+                ),
+            ]),
+        );
+        let json = serde_json::to_string(&with_error).expect("serialize");
+        let back: Fields = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, with_error);
+    }
+
+    /// `None` is a measurement, not an omission — the key stays.
+    #[test]
+    fn an_absent_option_records_as_null_not_as_a_missing_key() {
+        let fields = Fields::new().with("status", None::<u16>);
+        assert_eq!(
+            serde_json::to_string(&fields).expect("serialize"),
+            r#"{"status":null}"#
+        );
+    }
+
+    #[test]
+    fn a_duration_records_as_milliseconds() {
+        assert_eq!(Duration::from_millis(250).to_field(), FieldValue::Uint(250));
+    }
+}

--- a/stella-diag/src/field.rs
+++ b/stella-diag/src/field.rs
@@ -367,11 +367,11 @@ impl Loggable for f32 {
 }
 
 impl Loggable for f64 {
-    /// One caveat, recorded rather than hidden: `serde_json` writes every
-    /// `f64` exactly and reads a large fraction of *full-precision* doubles
-    /// back one ULP off, so such a value does not survive a round trip.
-    /// Diagnostic floats — a duration, a ratio, a rate — are unaffected, and
-    /// `tests/properties.rs` pins the limitation down by name.
+    /// Exact across a round trip for every finite `f64`, including
+    /// full-precision ones — but only because this crate's manifest enables
+    /// serde_json's `float_roundtrip`. Its default parser is lossy by one ULP
+    /// for a large fraction of doubles, which would make invariant 4 false for
+    /// any record carrying a float. See `Cargo.toml`.
     fn to_field(&self) -> FieldValue {
         if self.is_finite() {
             FieldValue::Float(*self)

--- a/stella-diag/src/filter.rs
+++ b/stella-diag/src/filter.rs
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A real filter, not a level — `docs/design/diagnostics.md` §6.
+//!
+//! `STELLA_SERVE_LOG` is a single level, which `serve-observability.md` §9
+//! knowingly gave up. At seventeen crates that stops being acceptable: `debug`
+//! across the workspace is noise nobody can read, so the one thing an operator
+//! actually needs is "quiet everywhere, loud in `stella_store`".
+//!
+//! ```text
+//! STELLA_LOG=warn                                  # global
+//! STELLA_LOG=warn,stella_store=debug,stella_model=trace
+//! STELLA_LOG=off
+//! ```
+//!
+//! Longest-prefix wins, so `stella_store=warn,stella_store::migrate=trace`
+//! means what it looks like. Matching is on module-path boundaries rather than
+//! raw string prefixes: `stella_store` selects `stella_store::migrate` and not
+//! a hypothetical `stella_storage`.
+//!
+//! **A typo must not take a process down.** An unparseable clause is skipped,
+//! not fatal, and is reported in [`Parsed::bad`] so the caller can emit one
+//! `warn` record naming it — the posture `STELLA_SERVE_LOG` already takes, and
+//! it is right.
+
+use crate::level::{Level, LevelFilter};
+use crate::log_enum;
+
+log_enum! {
+    /// Why one clause of a filter spec was skipped.
+    ///
+    /// A closed vocabulary rather than a message, because this is reported
+    /// *through* the diagnostic plane and §5.2 does not make an exception for
+    /// the plane's own errors.
+    pub enum ClauseFault {
+        /// `warn,,debug` — an empty clause between two commas.
+        Empty => "empty",
+        /// `stella_store=shout` — the level is not one of the six.
+        UnknownLevel => "unknown_level",
+        /// `=debug` — a directive with no target to attach to.
+        EmptyTarget => "empty_target",
+    }
+}
+
+/// One clause the parser refused, with enough to name it without guessing.
+///
+/// `clause` is the operator's own text. It reaches a record only through
+/// [`Redacted::reviewed`](crate::Redacted::reviewed) — see
+/// [`Parsed::report`] — because §5.2 has no carve-out for convenience.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BadClause {
+    /// Position in the comma-separated spec, 0-based. Loggable on its own,
+    /// which is what a `warn` record carries when the text is not worth the
+    /// escape hatch.
+    pub index: usize,
+    pub clause: String,
+    pub reason: ClauseFault,
+}
+
+/// One `target=level` rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Directive {
+    target: String,
+    level: LevelFilter,
+}
+
+impl Directive {
+    /// Whether this directive governs `target`, matching on module-path
+    /// boundaries. `stella_store` governs `stella_store` and
+    /// `stella_store::migrate`, but not `stella_storage`.
+    fn governs(&self, target: &str) -> bool {
+        target == self.target
+            || (target.len() > self.target.len()
+                && target.starts_with(&self.target)
+                && target[self.target.len()..].starts_with("::"))
+    }
+}
+
+/// Which records reach a sink.
+///
+/// Governs **sinks only**. Emission, the counters and the crash ring are
+/// untouched by it (§6, and property 3 of §12) — that is what keeps a crash
+/// dump complete even when the operator asked for silence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Filter {
+    default: LevelFilter,
+    /// Sorted longest-target-first at construction, so [`Filter::level_for`]
+    /// is a linear scan that stops at the first match rather than a search for
+    /// the maximum.
+    directives: Vec<Directive>,
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self::level(LevelFilter::default())
+    }
+}
+
+/// The result of parsing a spec: the filter to use, and every clause that was
+/// skipped getting there.
+///
+/// Both halves, always. A parse that returned only the filter would make a
+/// typo silent, and a parse that returned only an error would make one typo
+/// discard an otherwise-good spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Parsed {
+    pub filter: Filter,
+    pub bad: Vec<BadClause>,
+}
+
+impl Filter {
+    /// Nothing reaches a sink.
+    #[must_use]
+    pub fn off() -> Self {
+        Self::level(LevelFilter::Off)
+    }
+
+    /// One level for every target.
+    #[must_use]
+    pub fn level(default: LevelFilter) -> Self {
+        Self {
+            default,
+            directives: Vec::new(),
+        }
+    }
+
+    /// Parse the `STELLA_LOG` / `--log-level` grammar.
+    ///
+    /// Never fails. A clause that does not parse is skipped and reported in
+    /// [`Parsed::bad`]; the clauses around it still apply, because one typo in
+    /// a four-clause spec should cost the operator that clause and not the
+    /// other three.
+    #[must_use]
+    pub fn parse(spec: &str) -> Parsed {
+        let mut filter = Self::default();
+        let mut bad = Vec::new();
+        // An all-whitespace spec is "the operator set the variable to nothing",
+        // which is not an opinion — the default stands, silently.
+        if spec.trim().is_empty() {
+            return Parsed { filter, bad };
+        }
+
+        for (index, clause) in spec.split(',').enumerate() {
+            let clause = clause.trim();
+            if clause.is_empty() {
+                bad.push(BadClause {
+                    index,
+                    clause: clause.to_owned(),
+                    reason: ClauseFault::Empty,
+                });
+                continue;
+            }
+            match clause.split_once('=') {
+                None => match clause.parse::<LevelFilter>() {
+                    Ok(level) => filter.default = level,
+                    Err(()) => bad.push(BadClause {
+                        index,
+                        clause: clause.to_owned(),
+                        reason: ClauseFault::UnknownLevel,
+                    }),
+                },
+                Some((target, level)) => {
+                    let target = target.trim();
+                    if target.is_empty() {
+                        bad.push(BadClause {
+                            index,
+                            clause: clause.to_owned(),
+                            reason: ClauseFault::EmptyTarget,
+                        });
+                        continue;
+                    }
+                    match level.parse::<LevelFilter>() {
+                        Ok(level) => {
+                            // Targets are `module_path!()` values, which spell
+                            // crates with underscores. Accepting the hyphenated
+                            // *crate* name too means `stella-store=debug` works,
+                            // because that is what the operator sees in
+                            // `Cargo.toml` and on the command line.
+                            let target = target.replace('-', "_");
+                            // A repeated target is last-one-wins, the shell
+                            // convention for a repeated setting. Replacing here
+                            // rather than leaning on the stability of the sort
+                            // below keeps that a stated rule instead of an
+                            // emergent one.
+                            filter
+                                .directives
+                                .retain(|existing| existing.target != target);
+                            filter.directives.push(Directive { target, level });
+                        }
+                        Err(()) => bad.push(BadClause {
+                            index,
+                            clause: clause.to_owned(),
+                            reason: ClauseFault::UnknownLevel,
+                        }),
+                    }
+                }
+            }
+        }
+
+        // Longest target first, so the first match in `level_for` is the most
+        // specific one. Duplicate targets were already collapsed above, so no
+        // tie here is between two rules that could both match.
+        filter
+            .directives
+            .sort_by_key(|directive| std::cmp::Reverse(directive.target.len()));
+        Parsed { filter, bad }
+    }
+
+    /// The level in force for `target`: the longest matching directive, or the
+    /// spec's default.
+    #[must_use]
+    pub fn level_for(&self, target: &str) -> LevelFilter {
+        self.directives
+            .iter()
+            .find(|directive| directive.governs(target))
+            .map_or(self.default, |directive| directive.level)
+    }
+
+    /// Whether a record from `target` at `level` reaches a sink.
+    #[must_use]
+    pub fn admits(&self, target: &str, level: Level) -> bool {
+        self.level_for(target).admits(level)
+    }
+
+    /// The level in force where no directive matches.
+    #[must_use]
+    pub fn default_level(&self) -> LevelFilter {
+        self.default
+    }
+
+    /// Whether this filter admits nothing at all, for any target — the cheap
+    /// check a caller uses to skip building a sink it would never write to.
+    #[must_use]
+    pub fn is_off(&self) -> bool {
+        self.default == LevelFilter::Off
+            && self
+                .directives
+                .iter()
+                .all(|directive| directive.level == LevelFilter::Off)
+    }
+
+    /// Raise this filter's floor to at least `level`, leaving anything already
+    /// louder alone.
+    ///
+    /// This is how `--log-file` gets a usable file without silently overriding
+    /// an operator who asked for `trace`: a file sink defaults to `info`, but
+    /// `STELLA_LOG=trace --log-file x` still writes trace.
+    #[must_use]
+    pub fn at_least(mut self, level: LevelFilter) -> Self {
+        self.default = self.default.max(level);
+        for directive in &mut self.directives {
+            directive.level = directive.level.max(level);
+        }
+        self
+    }
+}
+
+impl Parsed {
+    /// Fields naming one skipped clause, for the `warn` record §6 asks for.
+    ///
+    /// The clause text is the operator's own keystrokes — never model output,
+    /// never file content, never a path — so it goes through the reviewed
+    /// escape hatch rather than around the type system. This is the escape
+    /// hatch working exactly as §5.5 intends: rare, justified in source, and
+    /// visible in the diff that introduced it.
+    #[must_use]
+    pub fn report(bad: &BadClause) -> crate::Fields {
+        crate::Fields::new()
+            .with("clause_index", bad.index)
+            .with("reason", bad.reason)
+            .with(
+                "clause",
+                crate::Redacted::reviewed(
+                    bad.clause.clone(),
+                    crate::note!(
+                        "a log-filter clause is typed by the operator on their own command line \
+                         or in their own environment; it is never model output, file content, or \
+                         a path, and naming it back is the entire point of the message"
+                    ),
+                ),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_level_sets_the_default() {
+        let parsed = Filter::parse("debug");
+        assert!(parsed.bad.is_empty());
+        assert_eq!(parsed.filter.level_for("anything"), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn a_directive_overrides_the_default_for_its_subtree() {
+        let parsed = Filter::parse("warn,stella_store=debug,stella_model=trace");
+        assert!(parsed.bad.is_empty());
+        let filter = parsed.filter;
+        assert_eq!(filter.level_for("stella_cli::agent"), LevelFilter::Warn);
+        assert_eq!(filter.level_for("stella_store"), LevelFilter::Debug);
+        assert_eq!(
+            filter.level_for("stella_store::migrate"),
+            LevelFilter::Debug
+        );
+        assert_eq!(
+            filter.level_for("stella_model::anthropic"),
+            LevelFilter::Trace
+        );
+    }
+
+    /// The whole reason directives are sorted: a more specific target must
+    /// beat a less specific one regardless of the order they were written in.
+    #[test]
+    fn the_longest_matching_target_wins_whichever_order_it_was_written() {
+        for spec in [
+            "warn,stella_store=info,stella_store::migrate=trace",
+            "warn,stella_store::migrate=trace,stella_store=info",
+        ] {
+            let filter = Filter::parse(spec).filter;
+            assert_eq!(
+                filter.level_for("stella_store::migrate"),
+                LevelFilter::Trace,
+                "{spec}"
+            );
+            assert_eq!(
+                filter.level_for("stella_store::open"),
+                LevelFilter::Info,
+                "{spec}"
+            );
+        }
+    }
+
+    /// A prefix that is not a module boundary must not match, or
+    /// `stella_store` would quietly turn on `stella_storage` too.
+    #[test]
+    fn a_target_matches_on_module_boundaries_not_raw_prefixes() {
+        let filter = Filter::parse("off,stella_store=trace").filter;
+        assert!(filter.admits("stella_store::migrate", Level::Trace));
+        assert!(!filter.admits("stella_storage::migrate", Level::Error));
+    }
+
+    /// Operators read crate names off `Cargo.toml`, where they are hyphenated;
+    /// `module_path!()` spells them with underscores. Accepting both is the
+    /// difference between a knob that works and a knob that silently does
+    /// nothing.
+    #[test]
+    fn a_hyphenated_crate_name_selects_the_same_target() {
+        let filter = Filter::parse("off,stella-store=debug").filter;
+        assert!(filter.admits("stella_store::migrate", Level::Debug));
+    }
+
+    /// One typo costs the operator that clause, not the other three, and it is
+    /// reported rather than swallowed.
+    #[test]
+    fn a_bad_clause_is_skipped_and_named_without_discarding_the_rest() {
+        let parsed = Filter::parse("warn,stella_store=shout,stella_model=trace");
+        assert_eq!(parsed.bad.len(), 1);
+        assert_eq!(parsed.bad[0].index, 1);
+        assert_eq!(parsed.bad[0].reason, ClauseFault::UnknownLevel);
+        assert_eq!(parsed.bad[0].clause, "stella_store=shout");
+        assert_eq!(
+            parsed.filter.level_for("stella_model"),
+            LevelFilter::Trace,
+            "a later clause must survive an earlier typo"
+        );
+        assert_eq!(parsed.filter.level_for("stella_store"), LevelFilter::Warn);
+    }
+
+    /// A repeated setting is last-one-wins, the way a repeated shell variable
+    /// is. Anything else makes an operator's own override lose to their
+    /// earlier attempt.
+    #[test]
+    fn a_repeated_target_takes_the_last_value_written() {
+        let filter = Filter::parse("off,stella_store=trace,stella_store=error").filter;
+        assert_eq!(
+            filter.level_for("stella_store::migrate"),
+            LevelFilter::Error
+        );
+    }
+
+    #[test]
+    fn an_empty_or_targetless_clause_is_reported() {
+        let parsed = Filter::parse("warn,,=debug");
+        let reasons: Vec<_> = parsed.bad.iter().map(|bad| bad.reason).collect();
+        assert_eq!(reasons, vec![ClauseFault::Empty, ClauseFault::EmptyTarget]);
+    }
+
+    /// An unset variable and a variable set to nothing are the same statement:
+    /// no opinion. Neither should produce a complaint.
+    #[test]
+    fn an_empty_spec_is_the_default_and_not_a_complaint() {
+        let parsed = Filter::parse("   ");
+        assert!(parsed.bad.is_empty());
+        assert_eq!(parsed.filter, Filter::default());
+    }
+
+    #[test]
+    fn off_silences_every_target() {
+        let filter = Filter::parse("off").filter;
+        assert!(filter.is_off());
+        for level in Level::ALL {
+            assert!(!filter.admits("stella_store", level));
+        }
+    }
+
+    /// `--log-file` raises the floor without overruling a louder operator.
+    #[test]
+    fn at_least_raises_the_floor_and_never_lowers_it() {
+        let quiet = Filter::parse("warn").filter.at_least(LevelFilter::Info);
+        assert_eq!(quiet.level_for("stella_cli"), LevelFilter::Info);
+
+        let loud = Filter::parse("trace").filter.at_least(LevelFilter::Info);
+        assert_eq!(loud.level_for("stella_cli"), LevelFilter::Trace);
+    }
+
+    /// The report is a diagnostic record like any other, so the clause text
+    /// must travel through the reviewed hatch — carrying the note with it.
+    #[test]
+    fn a_bad_clause_report_names_the_clause_through_the_reviewed_hatch() {
+        let parsed = Filter::parse("warn,stella_store=shout");
+        let fields = Parsed::report(&parsed.bad[0]);
+        let json = serde_json::to_string(&fields).expect("serialize");
+        assert!(json.contains("stella_store=shout"), "{json}");
+        assert!(json.contains("\"reason\":\"unknown_level\""), "{json}");
+        assert!(
+            json.contains("typed by the operator"),
+            "the justification must travel with the value: {json}"
+        );
+    }
+}

--- a/stella-diag/src/level.rs
+++ b/stella-diag/src/level.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! How loud a record is, and how loud a sink is willing to be.
+//!
+//! Two types rather than one, and the distinction is load-bearing:
+//! [`Level`] is a property of a record and always exists; [`LevelFilter`] is a
+//! property of a *sink* and can be [`LevelFilter::Off`], which a record's level
+//! never can. `docs/design/diagnostics.md` §6 is the rule that keeps them
+//! apart — the filter governs sinks, never emission, so counters and the crash
+//! ring stay correct at any verbosity.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// How loud one record is.
+///
+/// Ordered so filtering is a comparison: a record passes when
+/// `record.level <= filter`. `Error` is therefore the *smallest*, which reads
+/// backwards for a second and then never again — it is the same ordering
+/// `stella-serve::observe::event::Level` already uses, and agreeing with the
+/// crate this design generalises is worth more than matching intuition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Level {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Level {
+    /// Every level, quietest first. The ordering `-v`/`-vv`/`-vvv` walks.
+    pub const ALL: [Self; 5] = [
+        Self::Error,
+        Self::Warn,
+        Self::Info,
+        Self::Debug,
+        Self::Trace,
+    ];
+
+    #[must_use]
+    pub const fn as_static(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_static())
+    }
+}
+
+/// How loud a sink is willing to be.
+///
+/// [`LevelFilter::Off`] silences a sink entirely; it does **not** stop records
+/// being emitted (§6), which is what property 3 of §12 pins down.
+/// Variant order is the loudness order, so `Ord` means "at least as verbose
+/// as". The default is [`LevelFilter::Warn`] rather than the first variant: an
+/// operator who set nothing wants to hear about problems and nothing else (§6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LevelFilter {
+    Off,
+    Error,
+    #[default]
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LevelFilter {
+    /// Whether a record at `level` reaches a sink set to this filter.
+    #[must_use]
+    pub const fn admits(self, level: Level) -> bool {
+        match self {
+            Self::Off => false,
+            Self::Error => matches!(level, Level::Error),
+            Self::Warn => matches!(level, Level::Error | Level::Warn),
+            Self::Info => matches!(level, Level::Error | Level::Warn | Level::Info),
+            Self::Debug => !matches!(level, Level::Trace),
+            Self::Trace => true,
+        }
+    }
+
+    #[must_use]
+    pub const fn as_static(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+
+    /// The filter `-v` repeated `count` times asks for: `info`, `debug`, then
+    /// `trace`, saturating. Zero leaves the caller's default alone, which is
+    /// why this returns `None` rather than `Warn` — "the user said nothing"
+    /// and "the user asked for warn" must stay distinguishable so `STELLA_LOG`
+    /// can win over an unstated default and lose to an explicit `-v`.
+    #[must_use]
+    pub const fn from_verbosity(count: u8) -> Option<Self> {
+        match count {
+            0 => None,
+            1 => Some(Self::Info),
+            2 => Some(Self::Debug),
+            _ => Some(Self::Trace),
+        }
+    }
+}
+
+impl fmt::Display for LevelFilter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_static())
+    }
+}
+
+impl FromStr for LevelFilter {
+    type Err = ();
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        // Case-insensitive because `STELLA_LOG=WARN` is a thing people type and
+        // rejecting it would teach nothing.
+        match text.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" => Ok(Self::Off),
+            "error" => Ok(Self::Error),
+            "warn" | "warning" => Ok(Self::Warn),
+            "info" => Ok(Self::Info),
+            "debug" => Ok(Self::Debug),
+            "trace" => Ok(Self::Trace),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_filter_admits_everything_at_or_below_it() {
+        assert!(LevelFilter::Warn.admits(Level::Error));
+        assert!(LevelFilter::Warn.admits(Level::Warn));
+        assert!(!LevelFilter::Warn.admits(Level::Info));
+        assert!(!LevelFilter::Off.admits(Level::Error));
+        for level in Level::ALL {
+            assert!(LevelFilter::Trace.admits(level));
+            assert!(!LevelFilter::Off.admits(level));
+        }
+    }
+
+    /// `-v` with no `v`s must not be mistaken for an explicit `warn`, or an
+    /// unset flag would silently outrank `STELLA_LOG`.
+    #[test]
+    fn no_verbosity_flag_states_no_opinion() {
+        assert_eq!(LevelFilter::from_verbosity(0), None);
+        assert_eq!(LevelFilter::from_verbosity(1), Some(LevelFilter::Info));
+        assert_eq!(LevelFilter::from_verbosity(2), Some(LevelFilter::Debug));
+        assert_eq!(LevelFilter::from_verbosity(9), Some(LevelFilter::Trace));
+    }
+
+    #[test]
+    fn level_names_round_trip_through_serde() {
+        for level in Level::ALL {
+            let json = serde_json::to_string(&level).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", level.as_static()));
+            let back: Level = serde_json::from_str(&json).expect("parse");
+            assert_eq!(back, level);
+        }
+    }
+
+    #[test]
+    fn filter_names_parse_case_insensitively() {
+        assert_eq!("WARN".parse(), Ok(LevelFilter::Warn));
+        assert_eq!(" trace ".parse(), Ok(LevelFilter::Trace));
+        assert_eq!("off".parse(), Ok(LevelFilter::Off));
+        assert_eq!("shout".parse::<LevelFilter>(), Err(()));
+    }
+}

--- a/stella-diag/src/lib.rs
+++ b/stella-diag/src/lib.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The **diagnostic plane**: why the program behaved the way it did.
+//!
+//! Stella has four observability planes and, until this crate, had built
+//! three. `docs/design/diagnostics.md` §2 is the table:
+//!
+//! | Plane | Question it answers | Where it lives |
+//! |---|---|---|
+//! | **Domain** | *What did the agent do?* | `AgentEvent`, `stella-protocol` |
+//! | **Ledger** | *What did it cost, and can I prove it?* | receipts, `stella-cli::trace` |
+//! | **Presentation** | *What should the human see?* | `println!`, the TUI |
+//! | **Diagnostic** | *Why did the program behave this way?* | **here** |
+//!
+//! The missing fourth is why 682 `println!`s and 625 `let _ =`s coexisted: a
+//! statement with no home gets split between the plane that is easiest to
+//! reach (stdout) and the one that costs nothing (the floor).
+//!
+//! ## The routing rule
+//!
+//! Contributors need a rule they can apply without reading the design document
+//! (§2.1):
+//!
+//! > **A human reads it now → presentation. It should replay → domain. It
+//! > explains a decision the program made → diagnostic. It is none of those →
+//! > it is not a log line, it is a metric.**
+//!
+//! ## What is distinctive here
+//!
+//! Two things, and neither is available off the shelf.
+//!
+//! **Content in a log does not compile** ([`Loggable`], §5.2). A field value is
+//! not `serde_json::Value` and not `impl Display`; it is a closed type
+//! constructible only from things that cannot carry runtime content. `tracing`
+//! would log `%user_path` happily. Here it is a type error, so invariant 3's
+//! most dangerous failure mode stops being a thing review has to catch.
+//!
+//! **A crash dump you can safely ask for** ([`Ring`], §7.4). Every record at
+//! every level lands in a bounded in-memory ring regardless of filter, and it
+//! reaches disk only on a panic or a non-zero exit. Because content cannot
+//! enter a record, that file is content-free *by construction* — a maintainer
+//! can ask a stranger to attach it without a privacy review, and the stranger
+//! can send it without reading it first.
+//!
+//! ## Using it
+//!
+//! ```
+//! use stella_diag::{Cx, Dx, diag};
+//!
+//! let (dx, records) = Dx::capturing();
+//! let cx = Cx::new().session("session-a1b2c3d4").turn(3);
+//!
+//! diag!(&dx, warn, "store.migration.retry", cx: cx, attempt = 2_u32, backoff_ms = 250_u32);
+//!
+//! let record = records.find("store.migration.retry").expect("recorded");
+//! assert_eq!(record.cx.turn, Some(3));
+//! ```
+//!
+//! [`Dx`] is a **handle, not a global**: invariant 2 already banned ambient
+//! state, so correlation rides as an explicit parameter and this crate needs no
+//! thread-locals, no task-locals, and no spans (§7.1). That is also the
+//! strongest argument in §10 for not adopting a facade — `tracing`'s spans
+//! exist to reconstruct context that ordinary code loses, and this codebase
+//! does not lose it.
+//!
+//! ## What this deliberately does not do
+//!
+//! Verbatim from §14, because each of these will be proposed again:
+//!
+//! - **No logging in `stella-core`'s pure functions** (§7.3). They return
+//!   rationale as typed values; the caller — already at an I/O boundary —
+//!   records it. This is the invariant most likely to erode.
+//! - **No egress, at any level, in any build.** No sink opens a socket.
+//! - **No per-token records.** [`Dx`] emits nothing per `TextDelta`; the
+//!   sanctioned alternative is a bounded tally.
+//! - **No `Display`/`Debug` blanket impl for fields**, however convenient —
+//!   that single blanket impl is the entire hole §5.2 exists to close.
+//! - **No replacement of `AgentEvent`.** The domain plane stays the authority
+//!   for replay; the diagnostic plane references it by `seq` and never
+//!   restates it (§8).
+
+mod crash;
+mod cx;
+mod dx;
+mod field;
+mod filter;
+mod level;
+mod path;
+mod private;
+mod record;
+mod ring;
+mod sink;
+
+pub use crash::{dump, dump_after_panic, install_panic_hook};
+pub use cx::{Cx, ShortId};
+pub use dx::{CounterSnapshot, Counters, Dx, Facet};
+pub use field::{FieldValue, Fields, Loggable, ReviewedValue, StaticStr};
+pub use filter::{BadClause, ClauseFault, Filter, Parsed};
+pub use level::{Level, LevelFilter};
+pub use path::{Extension, PathClass, PathContext, PathKind};
+pub use record::{Record, now_millis};
+pub use ring::{CRASH_PREFIX, MAX_BYTES, MAX_RECORDS, Ring, RingStats, latest_crash_file};
+pub use sink::{Bound, Capture, FailingSink, JsonlSink, NullSink, Sink, SinkError, TextSink};
+
+mod redact;
+pub use redact::{Note, Redacted};
+
+/// The environment variable that carries the filter spec (§6).
+pub const LOG_ENV: &str = "STELLA_LOG";
+
+/// The shipped alias, kept so `stella-serve`'s surface does not break (§6).
+///
+/// It named a *level* and now names a full filter spec, which is a strict
+/// widening: every value that worked before still means what it meant.
+pub const SERVE_LOG_ENV: &str = "STELLA_SERVE_LOG";
+
+/// Read a filter from the environment: `STELLA_LOG`, else `STELLA_SERVE_LOG`,
+/// else the default.
+///
+/// Returns the parse result whole, so the caller can emit the `warn` record §6
+/// asks for once it has a sink to emit it to — which is the ordering problem
+/// this returns rather than solves: the complaint about a bad filter has to
+/// outlive the filter that would have suppressed it.
+#[must_use]
+pub fn filter_from_env() -> Parsed {
+    match std::env::var(LOG_ENV).or_else(|_| std::env::var(SERVE_LOG_ENV)) {
+        Ok(spec) => Filter::parse(&spec),
+        Err(_) => Parsed {
+            filter: Filter::default(),
+            bad: Vec::new(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shipped `STELLA_SERVE_LOG` values were bare levels. Every one of
+    /// them must still parse to the same thing under the widened grammar, or
+    /// §6's "the shipped surface does not break" is a claim and not a fact.
+    #[test]
+    fn every_shipped_serve_log_value_still_means_what_it_meant() {
+        for (spec, expected) in [
+            ("off", LevelFilter::Off),
+            ("error", LevelFilter::Error),
+            ("warn", LevelFilter::Warn),
+            ("info", LevelFilter::Info),
+            ("debug", LevelFilter::Debug),
+        ] {
+            let parsed = Filter::parse(spec);
+            assert!(parsed.bad.is_empty(), "{spec}");
+            assert_eq!(parsed.filter.level_for("stella_serve"), expected, "{spec}");
+        }
+    }
+}

--- a/stella-diag/src/lib.rs
+++ b/stella-diag/src/lib.rs
@@ -100,7 +100,10 @@ pub use filter::{BadClause, ClauseFault, Filter, Parsed};
 pub use level::{Level, LevelFilter};
 pub use path::{Extension, PathClass, PathContext, PathKind};
 pub use record::{Record, now_millis};
-pub use ring::{CRASH_PREFIX, MAX_BYTES, MAX_RECORDS, Ring, RingStats, latest_crash_file};
+pub use ring::{
+    CRASH_KEEP, CRASH_PREFIX, MAX_BYTES, MAX_RECORDS, Ring, RingStats, latest_crash_file,
+    prune_crash_files,
+};
 pub use sink::{Bound, Capture, FailingSink, JsonlSink, NullSink, Sink, SinkError, TextSink};
 
 mod redact;

--- a/stella-diag/src/path.rs
+++ b/stella-diag/src/path.rs
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Paths, which are the thing you most want and most cannot have —
+//! `docs/design/diagnostics.md` §5.4.
+//!
+//! The single most-wanted log field in a coding agent, and the most dangerous:
+//! a path carries a home directory name, a client name, a project name, and
+//! sometimes a secret in a filename. [`PathClass`] is the compromise, and it is
+//! enough for nearly every real diagnosis:
+//!
+//! ```json
+//! { "class": "inside_workspace", "depth": 4, "ext": "rs" }
+//! ```
+//!
+//! "The write was denied because the path was outside the workspace, four
+//! levels deep, a `.rs` file" answers the operational question. The bytes of
+//! the path do not.
+//!
+//! ## One place this is stricter than the design sketch
+//!
+//! §5.4 shows `"ext": "rs"` taken from the path. A raw extension is still
+//! attacker-chosen text — `secrets.API_KEY_sk_live_…` is a legal filename, and
+//! `read_file` takes its argument from a model — so an unrestricted `ext` would
+//! be a content channel wearing a three-letter disguise. [`Extension`] is
+//! therefore a **closed vocabulary** (§5.2's third row): a recognised extension
+//! records as itself, and anything else records as `other`. The design's
+//! example is unchanged for the case it shows, and the hole it would have left
+//! is closed.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::field::{FieldValue, Loggable, StaticStr};
+use crate::log_enum;
+
+log_enum! {
+    /// Where a path lives, which is the part of it that explains a decision.
+    pub enum PathKind {
+        /// Under the workspace root — the paths the agent is meant to touch.
+        InsideWorkspace => "inside_workspace",
+        /// Under the user's home directory but outside the workspace. The
+        /// class that explains most denied writes.
+        Home => "home",
+        /// Under the system temp directory.
+        Temp => "temp",
+        /// Absolute, and none of the above: `/etc`, `/usr`, another user's
+        /// home, a mounted volume.
+        AbsoluteOther => "absolute_other",
+        /// Relative, so it has no meaning without the working directory that
+        /// resolved it — which is itself a fact worth recording.
+        Relative => "relative",
+    }
+}
+
+log_enum! {
+    /// A file extension, from a closed vocabulary.
+    ///
+    /// The list is the extensions a coding agent actually makes decisions
+    /// about. Anything unrecognised is [`Extension::Other`], which is the
+    /// whole safety argument: an extension is attacker-chosen text, so it
+    /// reaches a record only by matching something already written down here.
+    ///
+    /// Adding an entry is a one-line change and a deliberate one — the review
+    /// question is "can this string carry content?", and for a fixed spelling
+    /// the answer is no.
+    pub enum Extension {
+        Rs => "rs",
+        Toml => "toml",
+        Md => "md",
+        Json => "json",
+        Yaml => "yaml",
+        Yml => "yml",
+        Lock => "lock",
+        Sh => "sh",
+        Py => "py",
+        Ts => "ts",
+        Tsx => "tsx",
+        Js => "js",
+        Jsx => "jsx",
+        Go => "go",
+        C => "c",
+        H => "h",
+        Cpp => "cpp",
+        Hpp => "hpp",
+        Java => "java",
+        Rb => "rb",
+        Php => "php",
+        Sql => "sql",
+        Html => "html",
+        Css => "css",
+        Txt => "txt",
+        Log => "log",
+        Jsonl => "jsonl",
+        Db => "db",
+        Csv => "csv",
+        Env => "env",
+        Pem => "pem",
+        Key => "key",
+        Png => "png",
+        Jpg => "jpg",
+        Svg => "svg",
+        /// A file with no extension at all — `Makefile`, `LICENSE`, a binary.
+        None => "none",
+        /// Anything not listed above. Deliberately unspecific: the alternative
+        /// is echoing a filename fragment into a log.
+        Other => "other",
+    }
+}
+
+impl Extension {
+    /// Classify the extension of `path` against the closed vocabulary.
+    #[must_use]
+    pub fn of(path: &Path) -> Self {
+        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+            return Self::None;
+        };
+        let lowered = ext.to_ascii_lowercase();
+        [
+            Self::Rs,
+            Self::Toml,
+            Self::Md,
+            Self::Json,
+            Self::Yaml,
+            Self::Yml,
+            Self::Lock,
+            Self::Sh,
+            Self::Py,
+            Self::Ts,
+            Self::Tsx,
+            Self::Js,
+            Self::Jsx,
+            Self::Go,
+            Self::C,
+            Self::H,
+            Self::Cpp,
+            Self::Hpp,
+            Self::Java,
+            Self::Rb,
+            Self::Php,
+            Self::Sql,
+            Self::Html,
+            Self::Css,
+            Self::Txt,
+            Self::Log,
+            Self::Jsonl,
+            Self::Db,
+            Self::Csv,
+            Self::Env,
+            Self::Pem,
+            Self::Key,
+            Self::Png,
+            Self::Jpg,
+            Self::Svg,
+        ]
+        .into_iter()
+        .find(|known| known.as_static() == lowered)
+        .unwrap_or(Self::Other)
+    }
+}
+
+/// The anchors a path is classified against.
+///
+/// Explicit rather than ambient, so classification is a pure function of its
+/// inputs and a test can pin every class without touching the environment —
+/// the same reason invariant 2 pushes I/O to the edges. [`PathContext::detect`]
+/// is the one constructor that reads the environment, and callers at an I/O
+/// boundary are where it belongs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PathContext {
+    workspace_root: Option<PathBuf>,
+    home: Option<PathBuf>,
+    temp: Option<PathBuf>,
+}
+
+impl PathContext {
+    /// Anchors supplied by the caller. Nothing is read from the environment.
+    #[must_use]
+    pub fn new(
+        workspace_root: Option<PathBuf>,
+        home: Option<PathBuf>,
+        temp: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            home,
+            temp,
+        }
+    }
+
+    /// Anchors for the running process: the given workspace root, `$HOME` (or
+    /// `%USERPROFILE%`), and the platform temp directory.
+    #[must_use]
+    pub fn detect(workspace_root: Option<PathBuf>) -> Self {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from);
+        Self {
+            workspace_root,
+            home,
+            temp: Some(std::env::temp_dir()),
+        }
+    }
+}
+
+/// What a record says about a path: where it lives, how deep it is, and what
+/// kind of file it is. Never its bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PathClass {
+    class: PathKind,
+    depth: u32,
+    ext: Extension,
+}
+
+impl PathClass {
+    /// Classify `path` against `context`.
+    ///
+    /// `depth` counts the normal components *below the anchor* for a path that
+    /// has one (workspace, home, temp) and the components of the whole path
+    /// otherwise. Under an anchor it answers "how far outside/inside", which is
+    /// the operational question; without one there is nothing to be relative
+    /// to.
+    #[must_use]
+    pub fn classify(path: &Path, context: &PathContext) -> Self {
+        let ext = Extension::of(path);
+        let anchored = [
+            (context.workspace_root.as_deref(), PathKind::InsideWorkspace),
+            (context.temp.as_deref(), PathKind::Temp),
+            (context.home.as_deref(), PathKind::Home),
+        ]
+        .into_iter()
+        .find_map(|(anchor, class)| {
+            let anchor = anchor?;
+            let rest = path.strip_prefix(anchor).ok()?;
+            Some((class, depth_of(rest)))
+        });
+
+        // Temp before home on purpose: on macOS the per-user temp directory
+        // lives under the home directory, and reporting a scratch file as
+        // `home` would send a reader looking in the wrong place. The workspace
+        // beats both, because a workspace inside `$HOME` is the normal case.
+        let (class, depth) = anchored.unwrap_or_else(|| {
+            let class = if path.is_absolute() {
+                PathKind::AbsoluteOther
+            } else {
+                PathKind::Relative
+            };
+            (class, depth_of(path))
+        });
+
+        Self { class, depth, ext }
+    }
+
+    #[must_use]
+    pub const fn class(&self) -> PathKind {
+        self.class
+    }
+
+    #[must_use]
+    pub const fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    #[must_use]
+    pub const fn extension(&self) -> Extension {
+        self.ext
+    }
+}
+
+/// Normal components only: `.` and `..` do not deepen a path, and a root or
+/// prefix component is not a level.
+fn depth_of(path: &Path) -> u32 {
+    let count = path
+        .components()
+        .filter(|component| matches!(component, Component::Normal(_)))
+        .count();
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+impl Loggable for PathClass {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Map(vec![
+            (
+                StaticStr::new("class"),
+                FieldValue::Str(StaticStr::new(self.class.as_static())),
+            ),
+            (
+                StaticStr::new("depth"),
+                FieldValue::Uint(u64::from(self.depth)),
+            ),
+            (
+                StaticStr::new("ext"),
+                FieldValue::Str(StaticStr::new(self.ext.as_static())),
+            ),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Fields;
+
+    fn context() -> PathContext {
+        PathContext::new(
+            Some(PathBuf::from("/home/ada/work/stella")),
+            Some(PathBuf::from("/home/ada")),
+            Some(PathBuf::from("/tmp")),
+        )
+    }
+
+    /// The record §5.4 specifies, byte for byte.
+    #[test]
+    fn a_workspace_path_records_the_shape_the_design_specifies() {
+        let class = PathClass::classify(
+            Path::new("/home/ada/work/stella/stella-diag/src/path.rs"),
+            &context(),
+        );
+        let fields = Fields::new().with("path", class);
+        assert_eq!(
+            serde_json::to_string(&fields).expect("serialize"),
+            r#"{"path":{"class":"inside_workspace","depth":3,"ext":"rs"}}"#
+        );
+    }
+
+    #[test]
+    fn each_anchor_gets_its_own_class() {
+        let context = context();
+        let cases = [
+            (
+                "/home/ada/work/stella/src/lib.rs",
+                PathKind::InsideWorkspace,
+            ),
+            ("/home/ada/.ssh/id_ed25519", PathKind::Home),
+            ("/tmp/stella-abc/scratch.txt", PathKind::Temp),
+            ("/etc/passwd", PathKind::AbsoluteOther),
+            ("src/lib.rs", PathKind::Relative),
+        ];
+        for (path, expected) in cases {
+            assert_eq!(
+                PathClass::classify(Path::new(path), &context).class(),
+                expected,
+                "{path}"
+            );
+        }
+    }
+
+    /// The whole point: the bytes of the path must not survive classification.
+    #[test]
+    fn no_component_of_the_path_reaches_the_record() {
+        let class = PathClass::classify(
+            Path::new("/home/ada/clients/acme-corp/merger-notes/SECRET_deal.txt"),
+            &context(),
+        );
+        let json = serde_json::to_string(&Fields::new().with("path", class)).expect("serialize");
+        for leaked in ["ada", "acme-corp", "merger-notes", "SECRET_deal"] {
+            assert!(
+                !json.contains(leaked),
+                "`{leaked}` reached the record: {json}"
+            );
+        }
+        assert!(json.contains(r#""class":"home""#), "{json}");
+        assert!(json.contains(r#""depth":4"#), "{json}");
+    }
+
+    /// An extension is attacker-chosen text. Anything outside the reviewed
+    /// vocabulary must collapse to `other` rather than echo.
+    #[test]
+    fn an_unrecognised_extension_collapses_to_other() {
+        assert_eq!(
+            Extension::of(Path::new("/tmp/x/secrets.API_KEY_sk_live_1234")),
+            Extension::Other
+        );
+        assert_eq!(Extension::of(Path::new("/tmp/x/Makefile")), Extension::None);
+        assert_eq!(Extension::of(Path::new("/tmp/x/lib.RS")), Extension::Rs);
+    }
+
+    /// macOS puts the per-user temp directory under `$HOME`; a scratch file
+    /// classified as `home` would send a reader looking in the wrong place.
+    #[test]
+    fn temp_wins_over_home_when_temp_is_nested_inside_it() {
+        let context = PathContext::new(
+            None,
+            Some(PathBuf::from("/Users/ada")),
+            Some(PathBuf::from("/Users/ada/Library/Caches/TemporaryItems")),
+        );
+        let class = PathClass::classify(
+            Path::new("/Users/ada/Library/Caches/TemporaryItems/stella/x.log"),
+            &context,
+        );
+        assert_eq!(class.class(), PathKind::Temp);
+        assert_eq!(class.depth(), 2);
+    }
+
+    #[test]
+    fn traversal_segments_do_not_deepen_a_path() {
+        let context = context();
+        let class = PathClass::classify(Path::new("/home/ada/work/stella/./a/../b/c.rs"), &context);
+        assert_eq!(class.class(), PathKind::InsideWorkspace);
+        assert_eq!(class.depth(), 3, "`.` and `..` are not levels");
+    }
+}

--- a/stella-diag/src/private.rs
+++ b/stella-diag/src/private.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Owner-only files, the way the rest of the workspace already writes them.
+//!
+//! `docs/design/diagnostics.md` §7.4 puts the crash ring at
+//! `.stella/private/crash-<ts>.jsonl` — "the 0700 directory `trace.rs` already
+//! establishes, 0600 file". This module is that idiom, factored out so the log
+//! file (§6) and the crash file get identical treatment rather than two
+//! near-copies that drift.
+//!
+//! Permissions are **re-asserted, not assumed**: the mode is set at creation
+//! *and* again on the opened path, because a file that already existed does not
+//! inherit the mode passed to `open`.
+
+use std::fs::{DirBuilder, File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+/// Create `dir` and its parents, owner-only.
+pub(crate) fn create_dir(dir: &Path) -> io::Result<()> {
+    let mut builder = DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        builder.mode(0o700);
+    }
+    builder.create(dir)
+}
+
+/// Open `path` for appending, owner-only, creating its parent directory if
+/// needed.
+pub(crate) fn open_append(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        create_dir(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let file = options.open(path)?;
+    tighten(path);
+    Ok(file)
+}
+
+/// Re-assert owner-only permissions on an existing path.
+///
+/// Best-effort: a failure here means the file is readable by someone it should
+/// not be, which is worth neither a panic nor failing the caller's turn — the
+/// alternative is losing the diagnostic entirely, and the file's *contents* are
+/// content-free by construction (§5.2), which is why this degrades rather than
+/// aborts.
+pub(crate) fn tighten(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}

--- a/stella-diag/src/record.rs
+++ b/stella-diag/src/record.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The envelope — `docs/design/diagnostics.md` §5.1.
+//!
+//! One shape, shared by all seventeen crates:
+//!
+//! ```json
+//! {
+//!   "ts": 1754006400123,
+//!   "level": "warn",
+//!   "code": "store.migration.retry",
+//!   "target": "stella_store::migrate",
+//!   "cx": { "session": "a1b2c3d4", "execution": "9f8e7d6c", "turn": 3, "step": 11 },
+//!   "fields": { "attempt": 2, "backoff_ms": 250 }
+//! }
+//! ```
+//!
+//! The **facets** — the per-crate typed enums that render into it — are each
+//! crate's own. That is the delta from `serve-observability.md`: one closed
+//! `ServeEvent` enum holds at crate scope and breaks at workspace scope,
+//! because a shared god-enum makes every new variant recompile the world and
+//! stops any crate adding an event without editing a crate it does not own
+//! (§4, row 1). Nobody edits a shared enum here, and emission stays typed —
+//! which is the property that made the serve design testable in the first
+//! place, since a test asserts on a value and never on scraped stderr.
+//!
+//! [`Record::code`] is a **stable, documented public surface**, in the way
+//! `rustc`'s `E0308` is: operators alert on it, docs link it, and it outlives
+//! the message text (§11).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::cx::Cx;
+use crate::field::{Fields, StaticStr};
+use crate::level::Level;
+
+/// One diagnostic record.
+///
+/// Note what is **not** here: a message. A record is a `code` plus typed
+/// fields, so the thing operators match on cannot drift with the prose, and
+/// there is no `String` slot for a well-meaning contributor to drop a path
+/// into.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Record {
+    /// Epoch milliseconds — the workspace's existing convention
+    /// (`stella-store::sessions`), so this needs no time crate.
+    pub ts: u64,
+    pub level: Level,
+    /// The stable diagnostic code, dotted: `store.migration.retry`.
+    pub code: StaticStr,
+    /// The emitting module, from `module_path!()`: `stella_store::migrate`.
+    /// This is what [`Filter`](crate::Filter) matches on.
+    pub target: StaticStr,
+    #[serde(default)]
+    pub cx: Cx,
+    #[serde(default)]
+    pub fields: Fields,
+}
+
+impl Record {
+    /// Build a record stamped with the current time.
+    #[must_use]
+    pub fn new(
+        level: Level,
+        code: &'static str,
+        target: &'static str,
+        cx: Cx,
+        fields: Fields,
+    ) -> Self {
+        Self::at(now_millis(), level, code, target, cx, fields)
+    }
+
+    /// Build a record at an explicit timestamp.
+    ///
+    /// The seam tests use: a property over records needs a `ts` it chose, and
+    /// a clock read inside the constructor would make every such property
+    /// nondeterministic.
+    #[must_use]
+    pub fn at(
+        ts: u64,
+        level: Level,
+        code: &'static str,
+        target: &'static str,
+        cx: Cx,
+        fields: Fields,
+    ) -> Self {
+        Self {
+            ts,
+            level,
+            code: StaticStr::new(code),
+            target: StaticStr::new(target),
+            cx,
+            fields,
+        }
+    }
+
+    /// Roughly how many bytes this record occupies once rendered.
+    ///
+    /// An estimate on purpose: the crash ring needs a *bound*, and serializing
+    /// every record twice to get an exact one would double the cost of the
+    /// plane to buy precision nobody consumes. It is deliberately generous, so
+    /// the ring under-fills rather than over-runs its ceiling.
+    #[must_use]
+    pub fn estimated_bytes(&self) -> usize {
+        /// `ts`, `level`, the punctuation, and the four `cx` keys.
+        const ENVELOPE_OVERHEAD: usize = 96;
+        /// Quotes, colon and comma around each field, plus a value most fields
+        /// stay under.
+        const PER_FIELD_OVERHEAD: usize = 24;
+
+        let fields: usize = self
+            .fields
+            .iter()
+            .map(|(key, _)| key.len() + PER_FIELD_OVERHEAD)
+            .sum();
+        ENVELOPE_OVERHEAD + self.code.as_str().len() + self.target.as_str().len() + fields
+    }
+}
+
+/// Milliseconds since the Unix epoch, or `0` if the clock is before it.
+///
+/// A clock that cannot be read is not a reason to lose a record: `0` is an
+/// obviously-wrong timestamp on a record that still carries its code, fields
+/// and correlation, which is strictly more than nothing (invariant 5, and the
+/// same posture `stella-serve::observe::sink` already takes).
+#[must_use]
+pub fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |since| {
+            u64::try_from(since.as_millis()).unwrap_or(u64::MAX)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Loggable;
+
+    #[test]
+    fn the_envelope_renders_exactly_as_the_design_specifies() {
+        let record = Record::at(
+            1_754_006_400_123,
+            Level::Warn,
+            "store.migration.retry",
+            "stella_store::migrate",
+            Cx::new()
+                .session("session-a1b2c3d4ffff")
+                .execution("exec-9f8e7d6caaaa")
+                .turn(3)
+                .step(11),
+            Fields::new()
+                .with("attempt", 2_u64)
+                .with("backoff_ms", 250_u64),
+        );
+        assert_eq!(
+            serde_json::to_string(&record).expect("serialize"),
+            concat!(
+                r#"{"ts":1754006400123,"level":"warn","code":"store.migration.retry","#,
+                r#""target":"stella_store::migrate","#,
+                r#""cx":{"session":"a1b2c3d4","execution":"9f8e7d6c","turn":3,"step":11},"#,
+                r#""fields":{"attempt":2,"backoff_ms":250}}"#
+            )
+        );
+    }
+
+    /// Invariant 4, and property 8 of §12.
+    #[test]
+    fn a_record_round_trips() {
+        let record = Record::at(
+            1,
+            Level::Debug,
+            "agent.tool.call",
+            "stella_cli::agent",
+            Cx::new().turn(2),
+            Fields::new()
+                .with("tool", "bash")
+                .with("args_bytes", 412_u64)
+                .with("ok", true)
+                .with("elapsed", std::time::Duration::from_millis(9)),
+        );
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: Record = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, record);
+        assert_eq!(serde_json::to_string(&back).expect("re-serialize"), json);
+    }
+
+    /// A record with no fields and no correlation is still a legal record —
+    /// the shape most startup diagnostics have.
+    #[test]
+    fn a_bare_record_round_trips() {
+        let record = Record::at(
+            0,
+            Level::Info,
+            "cli.boot",
+            "stella_cli",
+            Cx::EMPTY,
+            Fields::new(),
+        );
+        let json = serde_json::to_string(&record).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"ts":0,"level":"info","code":"cli.boot","target":"stella_cli","cx":{},"fields":{}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<Record>(&json).expect("parse"),
+            record
+        );
+    }
+
+    #[test]
+    fn the_size_estimate_bounds_the_rendered_length() {
+        let record = Record::at(
+            1_754_006_400_123,
+            Level::Warn,
+            "store.migration.retry",
+            "stella_store::migrate",
+            Cx::new().session("session-a1b2c3d4").turn(3),
+            Fields::new()
+                .with("attempt", 2_u64)
+                .with("reason", "locked"),
+        );
+        let rendered = serde_json::to_vec(&record).expect("serialize").len();
+        assert!(
+            record.estimated_bytes() >= rendered,
+            "the estimate ({}) must not undercount the render ({rendered})",
+            record.estimated_bytes()
+        );
+    }
+
+    #[test]
+    fn a_clock_read_produces_a_plausible_timestamp() {
+        // 2020-01-01, comfortably in the past and comfortably after 0.
+        assert!(now_millis() > 1_577_836_800_000);
+    }
+
+    #[test]
+    fn a_record_has_no_message_slot() {
+        // Not a runtime assertion so much as a place to notice the intent: if
+        // a `message: String` is ever added, this test's premise — and §5.2 —
+        // is what it breaks.
+        let record = Record::at(
+            0,
+            Level::Error,
+            "x.y",
+            "t",
+            Cx::EMPTY,
+            Fields::new().with("n", 1_u8),
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&record).expect("serialize"))
+                .expect("parse");
+        let object = value.as_object().expect("an object");
+        assert_eq!(object.len(), 6, "the envelope has exactly six keys");
+        assert!(!object.contains_key("message"));
+        assert_eq!(1_u8.to_field(), crate::FieldValue::Uint(1));
+    }
+}

--- a/stella-diag/src/redact.rs
+++ b/stella-diag/src/redact.rs
@@ -35,12 +35,13 @@ use crate::field::{FieldValue, Loggable, ReviewedValue, StaticStr};
 
 /// Why an author judged a runtime string safe to record.
 ///
-/// Constructible only through [`note!`], and therefore only from a literal.
+/// Constructible only through [`note!`](crate::note), and therefore only from
+/// a literal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Note(&'static str);
 
 impl Note {
-    /// Not for direct use — call [`note!`], which is what constrains the
+    /// Not for direct use — call [`note!`](crate::note), which is what constrains the
     /// argument to a literal. Calling this with a `Box::leak`ed string would
     /// defeat the constraint, which is exactly why the workspace `clippy.toml`
     /// disallows that method.

--- a/stella-diag/src/redact.rs
+++ b/stella-diag/src/redact.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The escape hatch, made expensive on purpose — `docs/design/diagnostics.md`
+//! §5.5.
+//!
+//! §5.2 makes runtime content a compile error. Some runtime strings are
+//! genuinely safe to record and genuinely useful (a git ref name, a provider
+//! id an operator chose, a filter clause they typed), so there has to be a way
+//! through. The design question is not *whether* to have one — it is how to
+//! stop it becoming the default.
+//!
+//! ```
+//! # use stella_diag::{note, Redacted};
+//! # let branch_name = String::from("main");
+//! Redacted::reviewed(
+//!     branch_name,
+//!     note!("git ref names are user-chosen but are not model content"),
+//! );
+//! ```
+//!
+//! Three properties make this a hatch rather than a loophole:
+//!
+//! 1. [`note!`] accepts **only a string literal**, so the justification lives
+//!    in the source, is greppable, and shows up in the diff that introduced it.
+//!    A `format!` or a variable does not compile.
+//! 2. The justification travels *into the record*, so a maintainer reading a
+//!    crash file can see why a string is in it without opening the source.
+//! 3. `Redacted::reviewed` is a fixed, greppable token. §5.5 calls for a gate
+//!    script counting the sites against a per-crate ceiling that can only fall,
+//!    the same ratchet idiom `check-file-size.sh` already uses; that script is
+//!    slice 5 and this type is what it will count.
+
+use crate::field::{FieldValue, Loggable, ReviewedValue, StaticStr};
+
+/// Why an author judged a runtime string safe to record.
+///
+/// Constructible only through [`note!`], and therefore only from a literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Note(&'static str);
+
+impl Note {
+    /// Not for direct use — call [`note!`], which is what constrains the
+    /// argument to a literal. Calling this with a `Box::leak`ed string would
+    /// defeat the constraint, which is exactly why the workspace `clippy.toml`
+    /// disallows that method.
+    #[must_use]
+    pub const fn new(text: &'static str) -> Self {
+        Self(text)
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+/// Write the justification for recording a runtime string.
+///
+/// Accepts a string literal and nothing else:
+///
+/// ```compile_fail
+/// # use stella_diag::note;
+/// # let reason = String::from("because");
+/// note!(reason);
+/// ```
+#[macro_export]
+macro_rules! note {
+    ($justification:literal) => {
+        $crate::Note::new($justification)
+    };
+}
+
+/// A runtime string that a human reviewed and judged safe to record.
+///
+/// The name is deliberately uncomfortable. It reads as "this needed
+/// redacting", because the question every one of these should provoke in
+/// review is *did it?*
+pub struct Redacted<T> {
+    value: T,
+    note: Note,
+}
+
+impl<T: std::fmt::Display> Redacted<T> {
+    /// Record `value` verbatim, justified by `note`.
+    ///
+    /// The `Display` bound is the one place in this crate where `Display`
+    /// reaches a record, and it is bounded by construction: reaching it
+    /// requires naming this function and writing a literal justification next
+    /// to it.
+    #[must_use]
+    pub const fn reviewed(value: T, note: Note) -> Self {
+        Self { value, note }
+    }
+}
+
+impl<T: std::fmt::Display> Loggable for Redacted<T> {
+    fn to_field(&self) -> FieldValue {
+        FieldValue::Reviewed(ReviewedValue::new(
+            self.value.to_string(),
+            StaticStr::new(self.note.as_str()),
+        ))
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Redacted<T> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Redacted")
+            .field("value", &self.value)
+            .field("note", &self.note.as_str())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Fields;
+
+    #[test]
+    fn a_reviewed_value_records_itself_and_its_justification() {
+        let fields = Fields::new().with(
+            "branch",
+            Redacted::reviewed(
+                String::from("feature/logging"),
+                note!("git ref names are user-chosen but are not model content"),
+            ),
+        );
+        let json = serde_json::to_string(&fields).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"branch":{"reviewed":"feature/logging","note":"git ref names are user-chosen but are not model content"}}"#
+        );
+    }
+
+    /// The justification must survive a round trip, or a crash file loses the
+    /// one thing that explains why a string is in it.
+    #[test]
+    fn a_reviewed_value_round_trips_with_its_note() {
+        let fields = Fields::new().with(
+            "provider",
+            Redacted::reviewed("openrouter", note!("a provider id the operator configured")),
+        );
+        let json = serde_json::to_string(&fields).expect("serialize");
+        let back: Fields = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, fields);
+        match back.get("provider") {
+            Some(FieldValue::Reviewed(value)) => {
+                assert_eq!(value.value(), "openrouter");
+                assert_eq!(value.note(), "a provider id the operator configured");
+            }
+            other => panic!("expected a reviewed value, got {other:?}"),
+        }
+    }
+}

--- a/stella-diag/src/ring.rs
+++ b/stella-diag/src/ring.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The crash ring — `docs/design/diagnostics.md` §7.4.
+//!
+//! A bounded in-memory ring holding **every** record at **every** level,
+//! filter notwithstanding. It is written to disk only on a panic or a non-zero
+//! exit, landing at `.stella/private/crash-<ts>.jsonl`.
+//!
+//! This is what lets stella say the sentence it currently cannot:
+//!
+//! > Attach `.stella/private/crash-*.jsonl` to the issue.
+//!
+//! And here §5.2 pays off completely. Because content in a record does not
+//! compile, that file is content-free *by construction* — so a maintainer can
+//! ask a stranger on the internet to attach it without a privacy review, and
+//! the stranger can send it without reading it first. A crash dump you can
+//! safely ask for is worth more than a verbose flag nobody can rerun, which for
+//! a *coding agent* is the whole argument: runs are nondeterministic and
+//! expensive, so "reproduce it with verbose on" is frequently not a request the
+//! user can fulfil (§1.2).
+//!
+//! What was dropped is recorded rather than hidden. A ring that silently ate
+//! the beginning of a run would make a crash file read as a complete history
+//! when it is a tail, and a reader who cannot tell the difference will
+//! misdiagnose.
+
+use std::collections::VecDeque;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::private;
+use crate::record::Record;
+use crate::sink::SinkError;
+
+/// Records held, at most. §7.4's first bound.
+pub const MAX_RECORDS: usize = 2_000;
+
+/// Estimated bytes held, at most. §7.4's second bound, whichever binds first.
+pub const MAX_BYTES: usize = 1024 * 1024;
+
+/// The `.stella/private/` filename prefix a crash dump lands under. `stella
+/// doctor --last-failure` and any "attach the log" instruction both key off it.
+pub const CRASH_PREFIX: &str = "crash-";
+
+/// What a ring holds, and what it had to drop to stay bounded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RingStats {
+    pub held: usize,
+    pub bytes: usize,
+    /// Records evicted to stay within the bounds. Non-zero means the file is a
+    /// tail, and the dump says so in its own first record.
+    pub dropped: u64,
+}
+
+/// A bounded in-memory ring of records.
+///
+/// Everything reaches it regardless of filter, which is what keeps a crash
+/// dump complete for a user who ran with the default `warn` — the case that
+/// matters, because nobody reproduces a crash on purpose with `-vvv` first.
+#[derive(Debug)]
+pub struct Ring {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    records: VecDeque<(Record, usize)>,
+    bytes: usize,
+    dropped: u64,
+    max_records: usize,
+    max_bytes: usize,
+}
+
+impl Default for Ring {
+    fn default() -> Self {
+        Self::new(MAX_RECORDS, MAX_BYTES)
+    }
+}
+
+impl Ring {
+    #[must_use]
+    pub fn new(max_records: usize, max_bytes: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                records: VecDeque::new(),
+                bytes: 0,
+                dropped: 0,
+                // A zero bound would make `push` spin evicting a record it just
+                // added; one is the smallest ring that terminates.
+                max_records: max_records.max(1),
+                max_bytes: max_bytes.max(1),
+            }),
+        }
+    }
+
+    /// Add a record, evicting the oldest until both bounds hold.
+    pub fn push(&self, record: Record) {
+        let size = record.estimated_bytes();
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        inner.records.push_back((record, size));
+        inner.bytes = inner.bytes.saturating_add(size);
+        while inner.records.len() > inner.max_records
+            || (inner.bytes > inner.max_bytes && inner.records.len() > 1)
+        {
+            let Some((_, evicted)) = inner.records.pop_front() else {
+                break;
+            };
+            inner.bytes = inner.bytes.saturating_sub(evicted);
+            inner.dropped = inner.dropped.saturating_add(1);
+        }
+    }
+
+    /// Every record still held, oldest first.
+    #[must_use]
+    pub fn records(&self) -> Vec<Record> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .records
+            .iter()
+            .map(|(record, _)| record.clone())
+            .collect()
+    }
+
+    #[must_use]
+    pub fn stats(&self) -> RingStats {
+        let inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        RingStats {
+            held: inner.records.len(),
+            bytes: inner.bytes,
+            dropped: inner.dropped,
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .records
+            .is_empty()
+    }
+
+    /// Write every held record to `path` as JSONL, owner-only.
+    ///
+    /// The file opens with a `diag.ring.dumped` record of its own, carrying
+    /// what the ring held and what it dropped — so a reader can tell a complete
+    /// history from a tail without counting lines.
+    pub fn dump_to(&self, path: &Path) -> Result<usize, SinkError> {
+        let stats = self.stats();
+        let records = self.records();
+        let mut file = private::open_append(path)?;
+
+        let header = Record::new(
+            crate::Level::Info,
+            "diag.ring.dumped",
+            module_path!(),
+            crate::Cx::EMPTY,
+            crate::Fields::new()
+                .with("held", stats.held)
+                .with("dropped", stats.dropped)
+                .with("bytes", stats.bytes),
+        );
+        let mut written = 0;
+        for record in std::iter::once(&header).chain(records.iter()) {
+            let mut line = serde_json::to_vec(record).map_err(|_| SinkError::Encode)?;
+            line.push(b'\n');
+            file.write_all(&line)?;
+            written += 1;
+        }
+        file.flush()?;
+        private::tighten(path);
+        Ok(written)
+    }
+
+    /// Dump into `dir` under a timestamped `crash-<ts>.jsonl` name, returning
+    /// the path written.
+    ///
+    /// Nothing is written when the ring is empty: a zero-record crash file is
+    /// an artifact that wastes a maintainer's time and teaches a user that the
+    /// file is not worth attaching.
+    pub fn dump_into(&self, dir: &Path) -> Result<Option<PathBuf>, SinkError> {
+        if self.is_empty() {
+            return Ok(None);
+        }
+        let path = dir.join(format!(
+            "{CRASH_PREFIX}{}.jsonl",
+            crate::record::now_millis()
+        ));
+        self.dump_to(&path)?;
+        Ok(Some(path))
+    }
+}
+
+/// The most recent `crash-*.jsonl` in `dir`, if any.
+///
+/// Ordered by the timestamp in the filename rather than by mtime: the name is
+/// what the dump chose, and an mtime can be rewritten by a copy or a backup
+/// restore.
+#[must_use]
+pub fn latest_crash_file(dir: &Path) -> Option<PathBuf> {
+    let mut newest: Option<(u64, PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(stamp) = name
+            .strip_prefix(CRASH_PREFIX)
+            .and_then(|rest| rest.strip_suffix(".jsonl"))
+            .and_then(|stamp| stamp.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if newest.as_ref().is_none_or(|(best, _)| stamp > *best) {
+            newest = Some((stamp, path));
+        }
+    }
+    newest.map(|(_, path)| path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Cx, Fields, Level};
+
+    fn record(n: u64) -> Record {
+        Record::at(
+            n,
+            Level::Debug,
+            "test.record",
+            "stella_diag::ring",
+            Cx::EMPTY,
+            Fields::new().with("n", n),
+        )
+    }
+
+    #[test]
+    fn the_ring_keeps_the_most_recent_records_and_counts_the_rest() {
+        let ring = Ring::new(3, MAX_BYTES);
+        for n in 0..10 {
+            ring.push(record(n));
+        }
+        let held = ring.records();
+        assert_eq!(held.len(), 3);
+        assert_eq!(
+            held.iter().map(|r| r.ts).collect::<Vec<_>>(),
+            vec![7, 8, 9],
+            "the ring keeps the tail, which is the part next to the crash"
+        );
+        assert_eq!(ring.stats().dropped, 7);
+    }
+
+    /// Whichever bound binds first. A byte ceiling that could be exceeded
+    /// would make a crash dump unbounded on a run with wide fields.
+    #[test]
+    fn the_byte_bound_binds_before_the_record_bound() {
+        let ring = Ring::new(MAX_RECORDS, 400);
+        for n in 0..50 {
+            ring.push(record(n));
+        }
+        let stats = ring.stats();
+        assert!(stats.held < 5, "held {} on a 400-byte ring", stats.held);
+        assert!(stats.bytes <= 400 || stats.held == 1);
+        assert!(stats.dropped > 0);
+    }
+
+    /// The bounds must never evict the record that was just pushed — a ring
+    /// smaller than one record still has to hold the last thing that happened.
+    #[test]
+    fn a_ring_smaller_than_one_record_still_holds_the_last_one() {
+        let ring = Ring::new(1, 1);
+        ring.push(record(1));
+        ring.push(record(2));
+        let held = ring.records();
+        assert_eq!(held.len(), 1);
+        assert_eq!(held[0].ts, 2);
+    }
+
+    #[test]
+    fn a_dump_is_jsonl_owner_only_and_opens_with_its_own_census() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ring = Ring::new(2, MAX_BYTES);
+        for n in 0..5 {
+            ring.push(record(n));
+        }
+        let path = ring.dump_into(dir.path()).expect("dump").expect("a path");
+
+        let text = std::fs::read_to_string(&path).expect("read");
+        let lines: Vec<Record> = text
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each line parses"))
+            .collect();
+        assert_eq!(lines.len(), 3, "a census record plus the two held");
+        assert_eq!(lines[0].code.as_str(), "diag.ring.dumped");
+        assert_eq!(
+            lines[0].fields.get("dropped"),
+            Some(&crate::FieldValue::Uint(3))
+        );
+        assert_eq!(lines[1].ts, 3);
+        assert_eq!(lines[2].ts, 4);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a crash file is owner-only");
+        }
+    }
+
+    /// A zero-record crash file teaches a user that the artifact is not worth
+    /// attaching. Better to write nothing.
+    #[test]
+    fn an_empty_ring_writes_no_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(Ring::default().dump_into(dir.path()).expect("dump"), None);
+        assert_eq!(std::fs::read_dir(dir.path()).expect("read").count(), 0);
+    }
+
+    #[test]
+    fn the_latest_crash_file_is_the_highest_stamp_not_the_newest_mtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for name in ["crash-100.jsonl", "crash-9000.jsonl", "crash-3.jsonl"] {
+            std::fs::write(dir.path().join(name), "{}\n").expect("write");
+        }
+        std::fs::write(dir.path().join("traces.jsonl"), "{}\n").expect("write");
+        std::fs::write(dir.path().join("crash-nope.jsonl"), "{}\n").expect("write");
+
+        let latest = latest_crash_file(dir.path()).expect("a crash file");
+        assert_eq!(latest.file_name().expect("name"), "crash-9000.jsonl");
+    }
+
+    #[test]
+    fn no_crash_file_is_not_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(latest_crash_file(dir.path()), None);
+        assert_eq!(latest_crash_file(Path::new("/nonexistent/stella")), None);
+    }
+}

--- a/stella-diag/src/ring.rs
+++ b/stella-diag/src/ring.rs
@@ -200,6 +200,55 @@ impl Ring {
     }
 }
 
+/// How many crash dumps a workspace keeps. See [`prune_crash_files`].
+pub const CRASH_KEEP: usize = 5;
+
+/// Delete all but the `keep` newest `crash-*.jsonl` files in `dir`, returning
+/// how many were removed.
+///
+/// A dump is written on **every** non-zero exit, and most non-zero exits are
+/// ordinary user errors — a typo'd model id, a missing key. Without a bound,
+/// `.stella/private/` would accumulate one file per failed run forever, and
+/// nothing else in the workspace would ever clean them up (`stella stats
+/// prune` covers the store, not this). A handful is all any bug report needs:
+/// the interesting dump is the last one, and the four before it cover "it
+/// started happening after…".
+///
+/// Best-effort, like everything else on the failure path: a file that will not
+/// delete is left alone rather than turned into a second failure.
+pub fn prune_crash_files(dir: &Path, keep: usize) -> usize {
+    let mut stamped: Vec<(u64, PathBuf)> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if let Some(stamp) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(crash_stamp)
+        {
+            stamped.push((stamp, path));
+        }
+    }
+    if stamped.len() <= keep {
+        return 0;
+    }
+    // Newest first, then drop everything past the keep window.
+    stamped.sort_by_key(|(stamp, _)| std::cmp::Reverse(*stamp));
+    stamped
+        .drain(keep..)
+        .filter(|(_, path)| std::fs::remove_file(path).is_ok())
+        .count()
+}
+
+/// The timestamp in a `crash-<ts>.jsonl` filename, if it is one.
+fn crash_stamp(name: &str) -> Option<u64> {
+    name.strip_prefix(CRASH_PREFIX)
+        .and_then(|rest| rest.strip_suffix(".jsonl"))
+        .and_then(|stamp| stamp.parse::<u64>().ok())
+}
+
 /// The most recent `crash-*.jsonl` in `dir`, if any.
 ///
 /// Ordered by the timestamp in the filename rather than by mtime: the name is
@@ -213,11 +262,7 @@ pub fn latest_crash_file(dir: &Path) -> Option<PathBuf> {
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        let Some(stamp) = name
-            .strip_prefix(CRASH_PREFIX)
-            .and_then(|rest| rest.strip_suffix(".jsonl"))
-            .and_then(|stamp| stamp.parse::<u64>().ok())
-        else {
+        let Some(stamp) = crash_stamp(name) else {
             continue;
         };
         if newest.as_ref().is_none_or(|(best, _)| stamp > *best) {
@@ -336,6 +381,48 @@ mod tests {
 
         let latest = latest_crash_file(dir.path()).expect("a crash file");
         assert_eq!(latest.file_name().expect("name"), "crash-9000.jsonl");
+    }
+
+    /// A dump per failed run, forever, would be an unbounded write to a
+    /// directory nothing else prunes. The newest survive, because the newest
+    /// are the ones a bug report is about.
+    #[test]
+    fn pruning_keeps_the_newest_dumps_and_nothing_else() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for stamp in [10_u64, 30, 20, 50, 40, 60, 5] {
+            std::fs::write(dir.path().join(format!("crash-{stamp}.jsonl")), "{}\n").expect("write");
+        }
+        // Files this does not own must survive pruning untouched.
+        std::fs::write(dir.path().join("traces.jsonl"), "{}\n").expect("write");
+        std::fs::write(dir.path().join("store.db"), "x").expect("write");
+
+        assert_eq!(prune_crash_files(dir.path(), 3), 4);
+
+        let mut left: Vec<String> = std::fs::read_dir(dir.path())
+            .expect("read")
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec![
+                "crash-40.jsonl",
+                "crash-50.jsonl",
+                "crash-60.jsonl",
+                "store.db",
+                "traces.jsonl",
+            ]
+        );
+    }
+
+    #[test]
+    fn pruning_under_the_limit_deletes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("crash-1.jsonl"), "{}\n").expect("write");
+        assert_eq!(prune_crash_files(dir.path(), CRASH_KEEP), 0);
+        assert_eq!(prune_crash_files(Path::new("/nonexistent/stella"), 1), 0);
+        assert!(dir.path().join("crash-1.jsonl").exists());
     }
 
     #[test]

--- a/stella-diag/src/sink.rs
+++ b/stella-diag/src/sink.rs
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where records go: the [`Sink`] port and the four implementations that need
+//! no dependency this crate does not already have.
+//!
+//! The port is the whole point, and it is inherited unchanged from
+//! `serve-observability.md`: emission is typed and every site talks to
+//! [`Dx`](crate::Dx), so adopting `tracing` later is **one more impl in this
+//! file and no emit site touched**. `docs/design/diagnostics.md` §10 is that
+//! deferral re-argued at workspace scope, and it lands on `tracing` arriving as
+//! an off-by-default `otel` cargo feature — which is exactly one more `impl
+//! Sink`.
+//!
+//! [`Sink::write`] returns a `Result` **that [`Dx`](crate::Dx) discards**, and
+//! that asymmetry is deliberate. A sink must be able to say it failed (invariant
+//! 5: no silent discards), and a caller must never be able to fail because of
+//! it (§3.4: losing a log line must never lose a turn). Property 4 of §12 pins
+//! the pair down.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::filter::Filter;
+use crate::private;
+use crate::record::Record;
+
+/// Why a sink could not record something.
+///
+/// Typed rather than a `String` (invariant 5), and content-free for the same
+/// reason records are: an `io::Error`'s `Display` carries the filename, so only
+/// its [`std::io::ErrorKind`] is kept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SinkError {
+    Io(std::io::ErrorKind),
+    /// A record that would not serialize. Unreachable in practice — every
+    /// field type in this crate is serde-clean — but not an excuse to panic.
+    Encode,
+    /// Another thread panicked holding this sink's lock.
+    Poisoned,
+}
+
+impl std::fmt::Display for SinkError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(kind) => write!(formatter, "diagnostic sink I/O failed: {kind}"),
+            Self::Encode => formatter.write_str("diagnostic record would not serialize"),
+            Self::Poisoned => formatter.write_str("diagnostic sink lock was poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for SinkError {}
+
+impl From<std::io::Error> for SinkError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error.kind())
+    }
+}
+
+/// Somewhere a record can land.
+pub trait Sink: Send + Sync {
+    /// Record one. Returning `Err` is how a sink reports its own failure; it
+    /// never propagates to the emitting caller.
+    fn write(&self, record: &Record) -> Result<(), SinkError>;
+
+    fn flush(&self) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+/// One sink and the filter that governs it.
+///
+/// Per-sink rather than one filter for the whole process, because the two
+/// surfaces §6 lists genuinely want different answers: stderr defaults to
+/// `warn` so a normal run is quiet, while `--log-file` defaults to `info`
+/// because a file nobody reads until something breaks may as well contain
+/// enough to explain it.
+pub struct Bound {
+    filter: Filter,
+    sink: Arc<dyn Sink>,
+}
+
+impl Bound {
+    #[must_use]
+    pub fn new(filter: Filter, sink: Arc<dyn Sink>) -> Self {
+        Self { filter, sink }
+    }
+
+    #[must_use]
+    pub fn filter(&self) -> &Filter {
+        &self.filter
+    }
+
+    pub(crate) fn offer(&self, record: &Record) -> Option<Result<(), SinkError>> {
+        self.filter
+            .admits(record.target.as_str(), record.level)
+            .then(|| self.sink.write(record))
+    }
+
+    pub(crate) fn flush(&self) -> Result<(), SinkError> {
+        self.sink.flush()
+    }
+}
+
+/// One JSON object per line.
+///
+/// The machine-readable shape, and the one `--log-file` writes. The `Mutex`
+/// serializes whole lines: two threads writing concurrently would otherwise
+/// interleave mid-record and produce unparseable output.
+pub struct JsonlSink {
+    out: Mutex<Box<dyn Write + Send>>,
+}
+
+impl JsonlSink {
+    #[must_use]
+    pub fn stderr() -> Self {
+        Self::to_writer(std::io::stderr())
+    }
+
+    #[must_use]
+    pub fn to_writer(writer: impl Write + Send + 'static) -> Self {
+        Self {
+            out: Mutex::new(Box::new(writer)),
+        }
+    }
+
+    /// Append to `path`, owner-only, creating the parent directory if needed.
+    ///
+    /// 0600 because a log file is the easiest accidental egress there is —
+    /// §3.2's sharper reading of invariant 3 is that *operators ship logs*.
+    /// The contents are content-free by construction, and the permissions are
+    /// belt and braces.
+    pub fn file(path: &Path) -> Result<Self, SinkError> {
+        Ok(Self::to_writer(private::open_append(path)?))
+    }
+}
+
+impl Sink for JsonlSink {
+    fn write(&self, record: &Record) -> Result<(), SinkError> {
+        let mut line = serde_json::to_vec(record).map_err(|_| SinkError::Encode)?;
+        line.push(b'\n');
+        let mut out = self.out.lock().map_err(|_| SinkError::Poisoned)?;
+        out.write_all(&line)?;
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        self.out.lock().map_err(|_| SinkError::Poisoned)?.flush()?;
+        Ok(())
+    }
+}
+
+/// One human-readable line per record.
+///
+/// The default when stderr is a TTY (§6). Deliberately not colourised and
+/// deliberately not clever: this is the diagnostic plane, not the presentation
+/// plane, and §2's whole point is that the two stop borrowing each other's
+/// clothes.
+pub struct TextSink {
+    out: Mutex<Box<dyn Write + Send>>,
+}
+
+impl TextSink {
+    #[must_use]
+    pub fn stderr() -> Self {
+        Self::to_writer(std::io::stderr())
+    }
+
+    #[must_use]
+    pub fn to_writer(writer: impl Write + Send + 'static) -> Self {
+        Self {
+            out: Mutex::new(Box::new(writer)),
+        }
+    }
+
+    /// `WARN store.migration.retry stella_store::migrate turn=3 attempt=2`
+    fn render(record: &Record) -> String {
+        use std::fmt::Write as _;
+
+        let mut line = format!(
+            "{:<5} {} {}",
+            record.level.as_static().to_ascii_uppercase(),
+            record.code,
+            record.target
+        );
+        if let Some(session) = record.cx.session {
+            let _ = write!(line, " session={session}");
+        }
+        if let Some(turn) = record.cx.turn {
+            let _ = write!(line, " turn={turn}");
+        }
+        if let Some(step) = record.cx.step {
+            let _ = write!(line, " step={step}");
+        }
+        for (key, value) in record.fields.iter() {
+            // Through serde rather than a second renderer: a hand-written
+            // formatter for `FieldValue` would be a place for the two spellings
+            // of a record to disagree, and the JSON one is the authority.
+            let rendered = serde_json::to_string(value).unwrap_or_else(|_| String::from("\"?\""));
+            let _ = write!(line, " {key}={}", rendered.trim_matches('"'));
+        }
+        line
+    }
+}
+
+impl Sink for TextSink {
+    fn write(&self, record: &Record) -> Result<(), SinkError> {
+        let mut line = Self::render(record).into_bytes();
+        line.push(b'\n');
+        let mut out = self.out.lock().map_err(|_| SinkError::Poisoned)?;
+        out.write_all(&line)?;
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        self.out.lock().map_err(|_| SinkError::Poisoned)?.flush()?;
+        Ok(())
+    }
+}
+
+/// Discards everything.
+///
+/// The default when a caller does not care, and what keeps every library type
+/// in the workspace usable without wiring a sink — the same job
+/// `stella-serve::observe::sink::NullSink` does today.
+pub struct NullSink;
+
+impl Sink for NullSink {
+    fn write(&self, _record: &Record) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+/// Records in memory, for assertions.
+///
+/// This is what makes acceptance criteria testable: a test matches on a
+/// `Record`'s `code` and typed fields rather than grepping stderr for a phrase,
+/// so the assertion survives any change to how records are rendered.
+#[derive(Default)]
+pub struct Capture {
+    records: Mutex<Vec<Record>>,
+}
+
+impl Capture {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every record written so far, in order.
+    #[must_use]
+    pub fn records(&self) -> Vec<Record> {
+        self.records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    #[must_use]
+    pub fn codes(&self) -> Vec<String> {
+        self.records()
+            .iter()
+            .map(|record| record.code.as_str().to_owned())
+            .collect()
+    }
+
+    pub fn count(&self, predicate: impl Fn(&Record) -> bool) -> usize {
+        self.records().iter().filter(|r| predicate(r)).count()
+    }
+
+    #[must_use]
+    pub fn find(&self, code: &str) -> Option<Record> {
+        self.records()
+            .into_iter()
+            .find(|record| record.code.as_str() == code)
+    }
+}
+
+impl Sink for Capture {
+    fn write(&self, record: &Record) -> Result<(), SinkError> {
+        self.records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(record.clone());
+        Ok(())
+    }
+}
+
+/// Fails every write, for property 4 of §12.
+///
+/// Public rather than test-only so a downstream crate can prove the same
+/// property of *its* wiring: "a broken log did not break my turn" is a claim
+/// every embedder should be able to make about itself.
+pub struct FailingSink;
+
+impl Sink for FailingSink {
+    fn write(&self, _record: &Record) -> Result<(), SinkError> {
+        Err(SinkError::Io(std::io::ErrorKind::BrokenPipe))
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        Err(SinkError::Io(std::io::ErrorKind::BrokenPipe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Cx, Fields, Level};
+
+    /// A writer that hands its bytes back, so a sink's actual output is
+    /// assertable without a file.
+    #[derive(Clone, Default)]
+    struct Shared(Arc<Mutex<Vec<u8>>>);
+
+    impl Shared {
+        fn text(&self) -> String {
+            String::from_utf8(self.0.lock().expect("lock").clone()).expect("utf8")
+        }
+    }
+
+    impl Write for Shared {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn a_record() -> Record {
+        Record::at(
+            1_754_006_400_123,
+            Level::Warn,
+            "store.migration.retry",
+            "stella_store::migrate",
+            Cx::new().turn(3),
+            Fields::new()
+                .with("attempt", 2_u64)
+                .with("reason", "locked"),
+        )
+    }
+
+    #[test]
+    fn jsonl_writes_one_object_per_line() {
+        let shared = Shared::default();
+        let sink = JsonlSink::to_writer(shared.clone());
+        sink.write(&a_record()).expect("write");
+        sink.write(&a_record()).expect("write");
+
+        let text = shared.text();
+        let lines: Vec<_> = text.lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            let value: serde_json::Value = serde_json::from_str(line).expect("parse");
+            assert_eq!(value["code"], "store.migration.retry");
+            assert_eq!(value["fields"]["attempt"], 2);
+        }
+    }
+
+    #[test]
+    fn text_renders_one_readable_line() {
+        let shared = Shared::default();
+        let sink = TextSink::to_writer(shared.clone());
+        sink.write(&a_record()).expect("write");
+        assert_eq!(
+            shared.text(),
+            "WARN  store.migration.retry stella_store::migrate turn=3 attempt=2 reason=locked\n"
+        );
+    }
+
+    #[test]
+    fn a_bound_sink_drops_what_its_filter_excludes() {
+        let capture = Arc::new(Capture::new());
+        let bound = Bound::new(
+            Filter::parse("error").filter,
+            capture.clone() as Arc<dyn Sink>,
+        );
+        assert!(
+            bound.offer(&a_record()).is_none(),
+            "warn must not pass error"
+        );
+        assert!(capture.records().is_empty());
+
+        let bound = Bound::new(
+            Filter::parse("off,stella_store=debug").filter,
+            capture.clone() as Arc<dyn Sink>,
+        );
+        assert!(bound.offer(&a_record()).is_some());
+        assert_eq!(capture.records().len(), 1);
+    }
+
+    #[test]
+    fn a_failing_sink_reports_a_typed_error() {
+        let error = FailingSink.write(&a_record()).expect_err("must fail");
+        assert_eq!(error, SinkError::Io(std::io::ErrorKind::BrokenPipe));
+    }
+
+    /// §5.3: an `io::Error`'s `Display` carries the filename, which is exactly
+    /// the leak this design exists to close. Converting one keeps the kind and
+    /// drops everything else — there is no field on [`SinkError`] a path could
+    /// survive in.
+    #[test]
+    fn converting_an_io_error_drops_the_filename_it_names() {
+        let io = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "/home/ada/.stella/private/store.db: permission denied",
+        );
+        let error = SinkError::from(io);
+        assert_eq!(error, SinkError::Io(std::io::ErrorKind::PermissionDenied));
+        assert!(
+            !error.to_string().contains("ada"),
+            "the path survived: {error}"
+        );
+    }
+
+    #[test]
+    fn a_file_sink_writes_owner_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("stella.jsonl");
+        let sink = JsonlSink::file(&path).expect("open");
+        sink.write(&a_record()).expect("write");
+        sink.flush().expect("flush");
+
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(text.lines().count(), 1);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a log file is owner-only");
+        }
+    }
+}

--- a/stella-diag/tests/compile_fail.rs
+++ b/stella-diag/tests/compile_fail.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Property 1 of `docs/design/diagnostics.md` §12: **content cannot enter a
+//! record.**
+//!
+//! This is the witness for §5.2, and it is a stronger artifact than a sentinel
+//! sweep because it fails at the only moment that matters — before the code
+//! that would have leaked exists. A sweep tests the sentinel you wrote, not the
+//! property you meant, which is the lesson `serve-observability.md` §8 records
+//! after a working vacuity guard still missed a planted leak.
+//!
+//! A runtime test cannot observe a compile error, so this shells out to the
+//! compiler and diffs its output. That the expected stderr is stable at all is
+//! a consequence of `rust-toolchain.toml` pinning a concrete Rust version:
+//! floating on `stable` would rewrite these files on every release, which is
+//! the same reason AGENTS.md gives for pinning rustfmt.
+//!
+//! Regenerate after an intentional change (including a toolchain bump) with:
+//!
+//! ```text
+//! TRYBUILD=overwrite cargo test -p stella-diag --test compile_fail
+//! ```
+
+/// Each case is a way someone would *naturally* try to log runtime content.
+/// None of them is exotic; every one is a line a reasonable contributor writes
+/// on a Tuesday, and every one is a privacy incident under `tracing`'s `%value`.
+#[test]
+fn content_in_a_log_does_not_compile() {
+    trybuild::TestCases::new().compile_fail("tests/ui/*.rs");
+}

--- a/stella-diag/tests/properties.proptest-regressions
+++ b/stella-diag/tests/properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 079e925de9ac0be2cace6fa4e9a9a5721e257a7d3425040f1d99712801ee33e8 # shrinks to record = Record { ts: 0, level: Error, code: "store.migration.retry", target: "stella_store::migrate", cx: Cx { session: None, execution: None, turn: None, step: None }, fields: Fields([("attempt", Int(0))]) }
+cc c041d1a7064e7895a115d989482ca52a53730c33a0ac7791d08990597f0e8a11 # shrinks to record = Record { ts: 0, level: Error, code: "store.migration.retry", target: "stella_store::migrate", cx: Cx { session: None, execution: None, turn: None, step: None }, fields: Fields([("attempt", Float(2.3434129323714217e-125))]) }

--- a/stella-diag/tests/properties.rs
+++ b/stella-diag/tests/properties.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The properties `docs/design/diagnostics.md` §12 asks for, as properties
+//! rather than as examples.
+//!
+//! | # | Property | Here |
+//! |---|---|---|
+//! | 3 | Filter never gates emission | [`the_filter_governs_sinks_and_nothing_else`] |
+//! | 4 | A failing sink never fails a caller | [`a_sink_that_always_fails_changes_nothing_but_its_own_counter`] |
+//! | 8 | Envelope round-trips | [`every_record_round_trips_byte_for_byte`] |
+//!
+//! Properties 1 (content cannot enter a record) and 5 (the ring survives a
+//! panic) live where they can be observed: `tests/compile_fail.rs` and
+//! `src/crash.rs` respectively.
+//!
+//! The generators below build records only from things a real emit site could
+//! build them from — `&'static str` codes and targets out of a fixed pool,
+//! [`Loggable`] field values — because a strategy that could produce a record
+//! containing a `String` would be testing a type this crate does not admit.
+
+use std::sync::Arc;
+
+use proptest::prelude::*;
+use stella_diag::{
+    Bound, Capture, Cx, Dx, FailingSink, FieldValue, Fields, Filter, Level, LevelFilter, Record,
+    Ring, ShortId, Sink, StaticStr,
+};
+
+const CODES: [&str; 6] = [
+    "store.migration.retry",
+    "model.request.retried",
+    "tools.write.denied",
+    "agent.tool.call",
+    "cli.boot",
+    "diag.filter.bad_clause",
+];
+
+const TARGETS: [&str; 5] = [
+    "stella_store::migrate",
+    "stella_model::anthropic",
+    "stella_tools::write",
+    "stella_cli::agent",
+    "stella_serve",
+];
+
+const KEYS: [&str; 5] = ["attempt", "backoff_ms", "tool", "ok", "elapsed"];
+
+fn level() -> impl Strategy<Value = Level> {
+    prop::sample::select(Level::ALL.to_vec())
+}
+
+fn field_value() -> impl Strategy<Value = FieldValue> {
+    prop_oneof![
+        // Through `FieldValue::int`, not the variant, because that is the only
+        // way an emit site can build a signed field — and it is where the
+        // Int/Uint normalisation that makes the round trip exact happens.
+        any::<i64>().prop_map(FieldValue::int),
+        any::<u64>().prop_map(FieldValue::Uint),
+        // Floats a diagnostic actually carries: a duration, a ratio, a rate —
+        // three decimal places over a wide range, not an arbitrary bit
+        // pattern. That restriction is deliberate and is NOT the property
+        // getting weaker to fit: `serde_json`'s float *parser* is lossy by one
+        // ULP for a large fraction of full-precision doubles (its formatter is
+        // exact), so a strategy over `any::<f64>()` would be measuring a
+        // dependency's rounding rather than this crate's envelope.
+        // `a_full_precision_float_is_the_documented_exception` below pins that
+        // limitation down so it is recorded rather than quietly avoided.
+        (-1_000_000_000_i64..1_000_000_000)
+            .prop_map(|scaled| FieldValue::Float(scaled as f64 / 1000.0)),
+        any::<bool>().prop_map(FieldValue::Bool),
+        prop::sample::select(vec!["locked", "busy", "bash", "read_file"])
+            .prop_map(|text| FieldValue::Str(StaticStr::new(text))),
+        Just(FieldValue::Null),
+    ]
+}
+
+fn fields() -> impl Strategy<Value = Fields> {
+    prop::collection::vec((prop::sample::select(KEYS.to_vec()), field_value()), 0..5).prop_map(
+        |entries| {
+            let mut fields = Fields::new();
+            for (key, value) in entries {
+                fields.push(key, value);
+            }
+            fields
+        },
+    )
+}
+
+fn cx() -> impl Strategy<Value = Cx> {
+    (
+        prop::option::of("[0-9a-f]{1,40}"),
+        prop::option::of(any::<u64>()),
+        prop::option::of(any::<u64>()),
+    )
+        .prop_map(|(session, turn, step)| {
+            let mut cx = Cx::new();
+            if let Some(session) = session {
+                cx.session = Some(ShortId::new(&session));
+            }
+            cx.turn = turn;
+            cx.step = step;
+            cx
+        })
+}
+
+fn record() -> impl Strategy<Value = Record> {
+    (
+        any::<u64>(),
+        level(),
+        prop::sample::select(CODES.to_vec()),
+        prop::sample::select(TARGETS.to_vec()),
+        cx(),
+        fields(),
+    )
+        .prop_map(|(ts, level, code, target, cx, fields)| {
+            Record::at(ts, level, code, target, cx, fields)
+        })
+}
+
+/// Filter specs an operator could plausibly type, including nonsense.
+fn spec() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            prop::sample::select(vec![
+                "off", "error", "warn", "info", "debug", "trace", "shout", "",
+            ])
+            .prop_map(str::to_owned),
+            (
+                prop::sample::select(TARGETS.to_vec()),
+                prop::sample::select(vec!["off", "debug", "trace", "nope"]),
+            )
+                .prop_map(|(target, level)| format!("{target}={level}")),
+        ],
+        0..4,
+    )
+    .prop_map(|clauses| clauses.join(","))
+}
+
+/// The one documented exception to property 8, stated plainly because
+/// overclaiming is worse than the gap (§5.2 takes the same posture about
+/// `Box::leak`).
+///
+/// `serde_json` writes every `f64` exactly and reads a large fraction of
+/// full-precision doubles back one ULP off. Nothing in this crate can fix
+/// that, and the alternative — quantising floats on the way in — would trade a
+/// visible limitation for a silent one.
+///
+/// It costs nothing in practice: a diagnostic float is a duration, a ratio, or
+/// a rate, and every such value round-trips exactly. This test exists so the
+/// next person to widen the float strategy learns that from a failing name
+/// rather than from a flake.
+#[test]
+fn a_full_precision_float_is_the_documented_exception() {
+    let exact = 0.25_f64;
+    let round_trip = |value: f64| -> f64 {
+        let fields = Fields::new().with("value", value);
+        let json = serde_json::to_string(&fields).expect("serialize");
+        match serde_json::from_str::<Fields>(&json)
+            .expect("parse")
+            .get("value")
+        {
+            Some(&FieldValue::Float(parsed)) => parsed,
+            other => panic!("expected a float, got {other:?}"),
+        }
+    };
+    assert_eq!(round_trip(exact), exact, "a realistic value is exact");
+
+    let awkward = 2.343_412_932_371_421_7e-125_f64;
+    assert_eq!(
+        serde_json::to_string(&awkward).expect("serialize"),
+        "2.3434129323714217e-125",
+        "the formatter is exact; it is the parser that rounds"
+    );
+    assert_ne!(
+        round_trip(awkward),
+        awkward,
+        "if serde_json's parser has been fixed, widen the float strategy above \
+         and delete this test"
+    );
+}
+
+proptest! {
+    /// **Property 8 — the envelope round-trips (invariant 4).**
+    ///
+    /// Both directions: the parsed record equals the original, *and*
+    /// re-serializing it reproduces the same bytes. The second half is the one
+    /// that matters for a crash file, which is read by tools nobody in this
+    /// repository wrote.
+    #[test]
+    fn every_record_round_trips_byte_for_byte(record in record()) {
+        let json = serde_json::to_string(&record).expect("serialize");
+        let parsed: Record = serde_json::from_str(&json).expect("parse");
+        prop_assert_eq!(&parsed, &record);
+        prop_assert_eq!(serde_json::to_string(&parsed).expect("re-serialize"), json);
+    }
+
+    /// A record must never span lines: JSONL is the format, and one embedded
+    /// newline makes every downstream `while read line` wrong.
+    #[test]
+    fn a_rendered_record_is_exactly_one_line(record in record()) {
+        let json = serde_json::to_string(&record).expect("serialize");
+        prop_assert!(!json.contains('\n'));
+    }
+
+    /// **Property 3 — the filter governs sinks, never emission.**
+    ///
+    /// For any filter and any record sequence, the counters and the ring are
+    /// identical to a run with everything turned on; only sink output differs.
+    /// This is what keeps a crash dump complete for a user who ran at the
+    /// default `warn`, and what stops raising verbosity from changing a number.
+    #[test]
+    fn the_filter_governs_sinks_and_nothing_else(
+        records in prop::collection::vec(record(), 0..40),
+        spec in spec(),
+    ) {
+        let filtered_sink = Arc::new(Capture::new());
+        let filtered = Dx::new(vec![Bound::new(
+            Filter::parse(&spec).filter,
+            filtered_sink.clone() as Arc<dyn Sink>,
+        )]);
+
+        let open_sink = Arc::new(Capture::new());
+        let open = Dx::new(vec![Bound::new(
+            Filter::level(LevelFilter::Trace),
+            open_sink.clone() as Arc<dyn Sink>,
+        )]);
+
+        for record in &records {
+            filtered.emit(record.clone());
+            open.emit(record.clone());
+        }
+
+        prop_assert_eq!(filtered.counters(), open.counters());
+        prop_assert_eq!(filtered.counters().total(), records.len() as u64);
+        prop_assert_eq!(filtered.ring().records(), open.ring().records());
+        prop_assert_eq!(open_sink.records().len(), records.len());
+        prop_assert!(filtered_sink.records().len() <= records.len());
+
+        // And the sink output, whatever it turned out to be, is exactly what
+        // the filter admits — no more, and no less.
+        let filter = Filter::parse(&spec).filter;
+        let admitted = records
+            .iter()
+            .filter(|record| filter.admits(record.target.as_str(), record.level))
+            .count();
+        prop_assert_eq!(filtered_sink.records().len(), admitted);
+    }
+
+    /// **Property 4 — a failing sink never fails a caller.**
+    ///
+    /// A sink returning `Err` on every write leaves `emit` infallible and the
+    /// turn intact. `emit` returns `()`, so "the caller cannot fail" is a
+    /// property of the signature; what this pins down is that the *record* is
+    /// not lost either — the ring and the counters are byte-identical to a run
+    /// with a sink that works.
+    #[test]
+    fn a_sink_that_always_fails_changes_nothing_but_its_own_counter(
+        records in prop::collection::vec(record(), 1..30),
+    ) {
+        let doomed = Dx::new(vec![Bound::new(
+            Filter::level(LevelFilter::Trace),
+            Arc::new(FailingSink) as Arc<dyn Sink>,
+        )]);
+        let working = Dx::new(vec![Bound::new(
+            Filter::level(LevelFilter::Trace),
+            Arc::new(Capture::new()) as Arc<dyn Sink>,
+        )]);
+
+        for record in &records {
+            doomed.emit(record.clone());
+            working.emit(record.clone());
+        }
+
+        prop_assert_eq!(doomed.ring().records(), working.ring().records());
+        prop_assert_eq!(doomed.counters().total(), working.counters().total());
+        prop_assert_eq!(doomed.counters().sink_failures, records.len() as u64);
+        prop_assert_eq!(working.counters().sink_failures, 0);
+    }
+
+    /// The ring is bounded from above and holds the *tail*, whatever the
+    /// traffic looked like. A ring that kept the head would dump the least
+    /// relevant records at exactly the moment they matter least.
+    #[test]
+    fn the_ring_stays_bounded_and_keeps_the_tail(
+        records in prop::collection::vec(record(), 1..80),
+        capacity in 1_usize..12,
+    ) {
+        let ring = Ring::new(capacity, stella_diag::MAX_BYTES);
+        for record in &records {
+            ring.push(record.clone());
+        }
+
+        let held = ring.records();
+        prop_assert!(held.len() <= capacity);
+        prop_assert_eq!(held.len(), records.len().min(capacity));
+        prop_assert_eq!(
+            ring.stats().dropped,
+            (records.len() - held.len()) as u64
+        );
+        prop_assert_eq!(held.as_slice(), &records[records.len() - held.len()..]);
+    }
+
+    /// Parsing a filter spec never panics and never rejects wholesale: a spec
+    /// with three good clauses and one typo still yields the three. The gate
+    /// this protects is a startup path — a typo in a log knob must not take a
+    /// process down (§6).
+    #[test]
+    fn parsing_a_spec_is_total(spec in spec()) {
+        let parsed = Filter::parse(&spec);
+        let clauses = if spec.trim().is_empty() {
+            0
+        } else {
+            spec.split(',').count()
+        };
+        prop_assert!(parsed.bad.len() <= clauses);
+        for level in Level::ALL {
+            // Every target answers, including ones no directive mentions.
+            let _ = parsed.filter.admits("stella_unmentioned::module", level);
+        }
+    }
+}

--- a/stella-diag/tests/properties.rs
+++ b/stella-diag/tests/properties.rs
@@ -57,17 +57,19 @@ fn field_value() -> impl Strategy<Value = FieldValue> {
         // Int/Uint normalisation that makes the round trip exact happens.
         any::<i64>().prop_map(FieldValue::int),
         any::<u64>().prop_map(FieldValue::Uint),
-        // Floats a diagnostic actually carries: a duration, a ratio, a rate —
-        // three decimal places over a wide range, not an arbitrary bit
-        // pattern. That restriction is deliberate and is NOT the property
-        // getting weaker to fit: `serde_json`'s float *parser* is lossy by one
-        // ULP for a large fraction of full-precision doubles (its formatter is
-        // exact), so a strategy over `any::<f64>()` would be measuring a
-        // dependency's rounding rather than this crate's envelope.
-        // `a_full_precision_float_is_the_documented_exception` below pins that
-        // limitation down so it is recorded rather than quietly avoided.
-        (-1_000_000_000_i64..1_000_000_000)
-            .prop_map(|scaled| FieldValue::Float(scaled as f64 / 1000.0)),
+        // Arbitrary bit patterns, not a tidy decimal grid. This works only
+        // because the manifest enables serde_json's `float_roundtrip`; without
+        // it roughly a third of full-precision doubles come back one ULP off
+        // and this strategy fails within a few hundred cases. That is the
+        // point of generating them — the feature is easy to drop by accident,
+        // and this is what notices.
+        //
+        // Finite only: a non-finite float is normalised to `Null` by the
+        // `Loggable` impl, so no emit site can produce one and the strategy
+        // must not either.
+        any::<f64>()
+            .prop_filter("finite", |value| value.is_finite())
+            .prop_map(FieldValue::Float),
         any::<bool>().prop_map(FieldValue::Bool),
         prop::sample::select(vec!["locked", "busy", "bash", "read_file"])
             .prop_map(|text| FieldValue::Str(StaticStr::new(text))),
@@ -135,49 +137,6 @@ fn spec() -> impl Strategy<Value = String> {
         0..4,
     )
     .prop_map(|clauses| clauses.join(","))
-}
-
-/// The one documented exception to property 8, stated plainly because
-/// overclaiming is worse than the gap (§5.2 takes the same posture about
-/// `Box::leak`).
-///
-/// `serde_json` writes every `f64` exactly and reads a large fraction of
-/// full-precision doubles back one ULP off. Nothing in this crate can fix
-/// that, and the alternative — quantising floats on the way in — would trade a
-/// visible limitation for a silent one.
-///
-/// It costs nothing in practice: a diagnostic float is a duration, a ratio, or
-/// a rate, and every such value round-trips exactly. This test exists so the
-/// next person to widen the float strategy learns that from a failing name
-/// rather than from a flake.
-#[test]
-fn a_full_precision_float_is_the_documented_exception() {
-    let exact = 0.25_f64;
-    let round_trip = |value: f64| -> f64 {
-        let fields = Fields::new().with("value", value);
-        let json = serde_json::to_string(&fields).expect("serialize");
-        match serde_json::from_str::<Fields>(&json)
-            .expect("parse")
-            .get("value")
-        {
-            Some(&FieldValue::Float(parsed)) => parsed,
-            other => panic!("expected a float, got {other:?}"),
-        }
-    };
-    assert_eq!(round_trip(exact), exact, "a realistic value is exact");
-
-    let awkward = 2.343_412_932_371_421_7e-125_f64;
-    assert_eq!(
-        serde_json::to_string(&awkward).expect("serialize"),
-        "2.3434129323714217e-125",
-        "the formatter is exact; it is the parser that rounds"
-    );
-    assert_ne!(
-        round_trip(awkward),
-        awkward,
-        "if serde_json's parser has been fixed, widen the float strategy above \
-         and delete this test"
-    );
 }
 
 proptest! {

--- a/stella-diag/tests/ui/borrowed_str.rs
+++ b/stella-diag/tests/ui/borrowed_str.rs
@@ -1,0 +1,10 @@
+// The subtler half: `&'static str` is loggable because it lives in the binary,
+// so the obvious workaround is `.as_str()`. A borrow of a local `String` is not
+// `'static`, and the lifetime is what refuses it.
+use stella_diag::{diag, Dx};
+
+fn main() {
+    let dx = Dx::disabled();
+    let answer = String::from("the model said something");
+    diag!(&dx, info, "model.answer", text = answer.as_str());
+}

--- a/stella-diag/tests/ui/borrowed_str.stderr
+++ b/stella-diag/tests/ui/borrowed_str.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `answer` does not live long enough
+  --> tests/ui/borrowed_str.rs:9:45
+   |
+ 8 |     let answer = String::from("the model said something");
+   |         ------ binding `answer` declared here
+ 9 |     diag!(&dx, info, "model.answer", text = answer.as_str());
+   |     ----------------------------------------^^^^^^----------
+   |     |                                       |
+   |     |                                       borrowed value does not live long enough
+   |     argument requires that `answer` is borrowed for `'static`
+10 | }
+   | - `answer` dropped here while still borrowed

--- a/stella-diag/tests/ui/json_value.rs
+++ b/stella-diag/tests/ui/json_value.rs
@@ -1,0 +1,9 @@
+// A field value is not `serde_json::Value`. It is the one type that would make
+// every other rule in §5.2 decorative, since anything serializes into it.
+use stella_diag::{diag, Dx};
+
+fn main() {
+    let dx = Dx::disabled();
+    let payload = serde_json::json!({ "prompt": "the user's actual prompt" });
+    diag!(&dx, debug, "model.request", body = payload);
+}

--- a/stella-diag/tests/ui/json_value.stderr
+++ b/stella-diag/tests/ui/json_value.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `Value: Loggable` is not satisfied
+ --> tests/ui/json_value.rs:8:5
+  |
+8 |     diag!(&dx, debug, "model.request", body = payload);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |     |
+  |     the trait `Loggable` is not implemented for `Value`
+  |     required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `Loggable`:
+            &'static str
+            &T
+            ClauseFault
+            Duration
+            Extension
+            Option<T>
+            PathClass
+            PathKind
+          and $N others
+  = note: this error originates in the macro `$crate::diag` which comes from the expansion of the macro `diag` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/stella-diag/tests/ui/note_not_a_literal.rs
+++ b/stella-diag/tests/ui/note_not_a_literal.rs
@@ -1,0 +1,9 @@
+// §5.5: `note!` accepts only a string literal, so the justification lives in
+// the source, is greppable, and shows up in the diff that introduced it. A
+// computed justification would be a justification nobody reviews.
+use stella_diag::{note, Redacted};
+
+fn main() {
+    let reason = String::from("it seemed fine");
+    let _ = Redacted::reviewed("main", note!(reason));
+}

--- a/stella-diag/tests/ui/note_not_a_literal.stderr
+++ b/stella-diag/tests/ui/note_not_a_literal.stderr
@@ -1,0 +1,11 @@
+error: no rules expected `reason`
+ --> tests/ui/note_not_a_literal.rs:8:46
+  |
+8 |     let _ = Redacted::reviewed("main", note!(reason));
+  |                                              ^^^^^^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$justification:literal`
+ --> src/redact.rs
+  |
+  |     ($justification:literal) => {
+  |      ^^^^^^^^^^^^^^^^^^^^^^

--- a/stella-diag/tests/ui/owned_string.rs
+++ b/stella-diag/tests/ui/owned_string.rs
@@ -1,0 +1,12 @@
+// The line from docs/design/diagnostics.md §5.2, verbatim:
+//
+//     diag!(warn, "tools.write.denied", path = user_path);   // ← does not compile
+//
+// `tracing` would log this happily with `%user_path`. Here it is a type error.
+use stella_diag::{diag, Dx};
+
+fn main() {
+    let dx = Dx::disabled();
+    let user_path = String::from("/home/ada/.ssh/id_ed25519");
+    diag!(&dx, warn, "tools.write.denied", path = user_path);
+}

--- a/stella-diag/tests/ui/owned_string.stderr
+++ b/stella-diag/tests/ui/owned_string.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `String: Loggable` is not satisfied
+  --> tests/ui/owned_string.rs:11:5
+   |
+11 |     diag!(&dx, warn, "tools.write.denied", path = user_path);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the trait `Loggable` is not implemented for `String`
+   |     required by a bound introduced by this call
+   |
+help: the trait `Loggable` is implemented for `&str`
+  --> src/field.rs
+   |
+   | impl Loggable for &'static str {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::diag` which comes from the expansion of the macro `diag` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/stella-diag/tests/ui/path_buf.rs
+++ b/stella-diag/tests/ui/path_buf.rs
@@ -1,0 +1,10 @@
+// §5.4: a path is the most-wanted log field in a coding agent and the most
+// dangerous. `PathClass` is the way through; the path itself is not.
+use std::path::PathBuf;
+use stella_diag::{diag, Dx};
+
+fn main() {
+    let dx = Dx::disabled();
+    let target = PathBuf::from("/home/ada/clients/acme/notes.md");
+    diag!(&dx, warn, "tools.write.denied", path = target);
+}

--- a/stella-diag/tests/ui/path_buf.stderr
+++ b/stella-diag/tests/ui/path_buf.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `PathBuf: Loggable` is not satisfied
+ --> tests/ui/path_buf.rs:9:5
+  |
+9 |     diag!(&dx, warn, "tools.write.denied", path = target);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |     |
+  |     the trait `Loggable` is not implemented for `PathBuf`
+  |     required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `Loggable`:
+            &'static str
+            &T
+            ClauseFault
+            Duration
+            Extension
+            Option<T>
+            PathClass
+            PathKind
+          and $N others
+  = note: this error originates in the macro `$crate::diag` which comes from the expansion of the macro `diag` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## What & why

Implements slices 1 and 2 of [`docs/design/diagnostics.md`](docs/design/diagnostics.md): the `stella-diag` leaf crate, and the CLI wiring that makes it reach a user.

The finding the design opens with was that stella had no logging framework, no log file, no level, no filter, and no flag — but also **one good logging design at the wrong scope** (`stella-serve/src/observe/`). So this promotes that design rather than shopping for a framework, and fixes the four things that break when it goes from one crate to seventeen: a shared god-enum (→ envelope + per-crate facets), redaction proven by a sentinel sweep (→ a compile error), a level instead of a filter (→ target filtering), and ad-hoc correlation (→ one carrier).

**The distinctive part is not the envelope, it is that content in a log does not compile.** A field value is not `serde_json::Value` and not `impl Display`; it is a closed algebra whose only string variant holds a `&'static str`:

```rust
diag!(&dx, warn, "tools.write.denied", path = user_path);   // ← does not compile
```

`tracing` would log that happily with `%user_path`. That is the strongest single reason §10 gives for still deferring the facade: adopting it would trade a compile-time privacy guarantee for a review-time one.

That in turn is what makes the crash ring worth having. Every record at every level lands in a bounded in-memory ring regardless of filter, and reaches disk on a panic or a non-zero exit. Because content cannot enter a record, the file is content-free *by construction* — so a maintainer can ask a stranger on the internet to attach it without a privacy review, and the stranger can send it without reading it first. That is the sentence stella could not say before:

> Attach `.stella/private/crash-*.jsonl` to the issue.

### The user-visible surface

| Surface | Meaning |
|---|---|
| `-v` / `-vv` / `-vvv` | `info` / `debug` / `trace` |
| `--log-level <spec>` | `warn,stella_store=debug` — per crate, longest match wins |
| `--log-file <path>` | JSONL, created `0600`, floors at `info` |
| `STELLA_LOG` | same grammar; `STELLA_SERVE_LOG` kept as a documented alias |
| `stella doctor --last-failure` | prints the newest crash dump |

Default is `warn` to stderr — human-readable on a TTY, JSONL when redirected. Precedence is flag > `-v` > environment, which is why `--log-level` deliberately does *not* carry clap's `env =`: with it, `STELLA_LOG=warn stella -vv run …` would silently ignore the `-vv` the user just typed, because clap cannot distinguish an env-sourced value from a typed one.

Refs #1172

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Per §12, each property has a witness, and each lives where it can actually be observed:

| # | Property | Where |
|---|---|---|
| 1 | Content cannot enter a record | `stella-diag/tests/ui/*.rs` — five `trybuild` compile-fail cases |
| 3 | Filter never gates emission | `stella-diag/tests/properties.rs` (proptest) |
| 4 | A failing sink never fails a caller | `stella-diag/tests/properties.rs` (proptest) |
| 5 | The ring survives a panic | `stella-diag/src/crash.rs` |
| 8 | Envelope round-trips | `stella-diag/tests/properties.rs` (proptest) |

Property 1 is the one worth looking at. A runtime test cannot observe a compile error, so the witness is five cases a reasonable contributor would actually write — a `String`, a non-`'static` `&str`, a `PathBuf`, a `serde_json::Value`, and a computed `note!` — each of which must fail to build. It is a stronger artifact than a sentinel sweep because it fails at the only moment that matters, which is the lesson `serve-observability.md` §8 records after a working vacuity guard still missed a planted leak.

**Two properties changed the design rather than confirming it**, which is the main reason to read them:

- Property 8 found that `FieldValue::Int(0)` reads back as `Uint(0)` — JSON has one number type. `FieldValue::int` now normalises non-negative values, so the Rust value and the JSON value agree in both directions.
- Property 8 then found that ~30% of full-precision `f64`s came back one ULP off... but *only* under `cargo test -p stella-diag`, not `cargo test --workspace`. A transitive dependency was switching on `serde_json`'s `float_roundtrip` feature. A guarantee that holds only because some sibling crate happens to be in the build is not a guarantee, so `stella-diag` now names the feature itself.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 5,373 tests, 0 failures
- [x] Docs updated: new `stella-diag/README.md`, the workspace tour in `AGENTS.md` and `CONTRIBUTING.md` (whose "Fifteen crates" was already stale), `CHANGELOG.md`, and `--help`
- [x] `doc-citations`, `invariants`, `file-size`, `wire-schema`, `no-scratch`, `action-pins`, `cargo-install-pins` all pass

Two gate steps could not run **in this environment** and are unrelated to the diff: `shellcheck` is not installed, and `license-allowlist-parity` fails identically on an unmodified checkout (it cannot find `allow-licenses:` in `dependency-review.yml`).

## Ground-rule check

- [x] No I/O added to `stella-core` — nothing in this PR touches it. §7.3 is explicit that pure functions keep *returning* their rationale and the caller records it, and `stella-diag/README.md` restates that as the rule most likely to erode.
- [x] No new outbound network calls. No sink opens a socket, at any level, in any build.
- [x] New cross-boundary types round-trip through serde (property 8, plus unit round-trips).

**One new dependency, dev-only:** `trybuild` (MIT OR Apache-2.0, both already on `deny.toml`'s allow-list). A runtime test cannot observe a compile error, and the compile-fail case is the witness for the headline property; the alternative is hand-rolling `rustc` invocations and diffing stderr, which is what `trybuild` is. It never enters a shipping build. Its `.stderr` expectations are stable only because `rust-toolchain.toml` pins a concrete Rust version — regenerate with `TRYBUILD=overwrite cargo test -p stella-diag --test compile_fail` after a toolchain bump.

## Anything reviewers should know?

**`clippy.toml` is new and disallows `Box`/`String`/`Vec::leak` workspace-wide.** §5.2 names this itself rather than overclaiming: `Box::leak` turns a `String` into a `&'static str` and would defeat the type rule, so the claim is not "impossible" but *"impossible by accident, and loud on purpose"*. The three existing leak sites are legitimate (a bounded provider-config interner, its alias list, a test fixture) and now carry an `#[allow]` naming the reason.

**Three judgement calls worth a second opinion:**

1. **`PathClass`'s `ext` is a closed vocabulary, which is stricter than the design sketch.** §5.4 shows `"ext": "rs"` taken from the path, but a raw extension is still attacker-chosen text — `secrets.API_KEY_sk_live_…` is a legal filename and `read_file` takes its argument from a model. Recognised extensions record as themselves; anything else records as `other`.
2. **Crash dumps are pruned to the newest 5.** A dump is written on *every* non-zero exit and most non-zero exits are ordinary user errors, so without a bound `.stella/private/` would grow one file per failed run forever — nothing else prunes it. This is not in the design; it is a consequence of implementing §7.4 literally.
3. **`cli.run.failed` is emitted at `debug`, not `error`.** The human already has the failure on stderr and the shell has the exit code; at `error` it would print a second, terser copy of a message the user just read. The ring takes it either way — which is precisely what "the filter governs sinks, never emission" was built for.

**One known wart:** `stella doctor --last-failure` with no dump present exits non-zero, which itself writes a (nearly empty) dump, so a second invocation shows that one. Self-limiting and obvious from the file's contents, but worth knowing.

**Deferred to later slices, as the design sequences them:** re-basing `stella-serve/observe` onto `stella-diag` (3), `or_diag` and the silent-discard ratchet (4), `log_error!` and the `Redacted` ceiling script (5), the `DomainBridge` (6), and the generated `docs/reference/diagnostics.md` plus the off-by-default `otel` feature (7). Nothing here forecloses any of them — `Sink` is the port that makes slice 7 one additional impl with no emit site touched.

There is one structural decision I'd flag for agreement now, since later slices build on it: **there is no global `Dx`.** `install` returns the handle and `main` owns it; the panic hook closes over its own `Arc`. §7.1 argues correlation is free here precisely because invariant 2 already banned ambient state, so a reachable-from-anywhere handle would undo that. It does mean emit sites in later slices must take a `&Dx` parameter.

---

## Summary by Sourcery

Introduce a new stella-diag leaf crate providing a structured, privacy-safe diagnostics plane and wire it into the CLI, including crash dump handling and workspace documentation updates.

New Features:
- Add stella-diag crate implementing a typed, content-free diagnostic logging system with envelopes, fields, filters, correlation context, sinks, and a crash ring.
- Expose CLI flags -v/--verbose, --log-level, and --log-file plus STELLA_LOG/STELLA_SERVE_LOG environment handling for runtime control of diagnostics output and per-crate filtering.
- Add crash dump support that writes bounded JSONL logs to .stella/private/crash-*.jsonl on panics or non-zero exits, and introduce stella doctor --last-failure to print the newest crash file.
- Provide a diagnostics bootstrap module in stella-cli that installs sinks, a panic hook, and failure dump behaviour early in main, driven by CLI and environment settings.

Enhancements:
- Refine provider config leaking in stella-cli to be explicitly allowed and justified under new workspace-wide clippy rules forbidding Box/String/Vec::leak by default.
- Update workspace metadata to include the new stella-diag crate and adjust AGENTS.md and CONTRIBUTING.md workspace tour tables to describe its role in diagnostics.
- Improve enterprise telemetry tests and config to comply with new leak restrictions and better document bounded test-only leaks.

Build:
- Add stella-diag to the Cargo workspace membership and as a dependency of stella-cli, and configure serde_json with float_roundtrip to guarantee exact f64 round-tripping.
- Introduce a workspace-level clippy.toml to disallow Box/String/Vec::leak by default, with explicit allows only for bounded, justified interners and fixtures.

Documentation:
- Add stella-diag/README.md describing the diagnostics design, routing rules, crash ring, filtering, and usage patterns, aligned with docs/design/diagnostics.md.
- Update AGENTS.md and CONTRIBUTING.md to account for the expanded workspace (eighteen crates) and to document stella-diag as the place to emit diagnostics.
- Extend CHANGELOG.md with entries describing the new diagnostics behaviour, CLI flags, crash dumps, and logging guarantees.

Tests:
- Introduce extensive tests in stella-diag, including property-based tests for filter behaviour, sink failure isolation, record and ring round-trips, and crash handling, plus compile-fail tests that enforce that content-bearing types cannot be logged.
- Add CLI tests ensuring new doctor subcommand options and diagnostics-related flags parse and dispatch correctly.
