### PR TITLE
fix(catalog): an out-of-range output ceiling is unknown, not u32::MAX

### DIFF
--- a/stella-cli/src/model_catalog.rs
+++ b/stella-cli/src/model_catalog.rs
@@ -742,12 +742,15 @@ fn install_runtime_catalog(store: &CatalogStore) {
                 // consequence: the engine fell back to one global 16384 for
                 // every model, and truncated steps that the model had room to
                 // finish. Saturating rather than wrapping, so an absurd card
-                // value cannot silently become a small one.
+                // value cannot silently become a plausible one: `try_from`
+                // fails to `None` ("no ceiling known", keep the default)
+                // rather than clamping to `u32::MAX`, which would read as a
+                // real 4-billion-token ceiling and be asked for on the wire.
                 .with_max_output_tokens(
                     listing
                         .pricing
                         .max_output_tokens
-                        .map(|v| v.min(u32::MAX as u64) as u32),
+                        .and_then(|v| u32::try_from(v).ok()),
                 ),
             );
             known.insert(key);

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -129,23 +129,18 @@ pub struct CatalogEntry {
     /// The model's own maximum completion length, from `limit.output` on the
     /// model card. `None` is "unknown" and leaves the engine default standing.
     ///
-    /// This exists because the engine had no way to ask. `EngineConfig`
-    /// carried one global `max_output_tokens` (16384) for every model on
-    /// every provider, and its comment named per-model caps as "the eventual
-    /// refinement" — while the value was already being parsed from
-    /// models.dev, written to the `max_output_tokens` column of the model
-    /// card, read back out, and then dropped at the runtime-catalog assembly
-    /// in `stella-cli`. Exactly the shape of the cache-write rate before #97,
-    /// at exactly the same site.
+    /// This exists because the engine had no way to ask: `EngineConfig`
+    /// carried one global `max_output_tokens` for every model on every
+    /// provider, and its comment named per-model caps as "the eventual
+    /// refinement" — while the value was already parsed from models.dev,
+    /// stored on the model card, read back, and then dropped at the
+    /// runtime-catalog assembly in `stella-cli`. The same shape as the
+    /// cache-write rate before #97, at the same site.
     ///
-    /// The cost was not theoretical. On the Terminal-Bench 2.1 gate, four
-    /// trials ended on a step that emitted the cap exactly and made no tool
-    /// call, against a comparator that spent 45,001–64,000 output tokens on
-    /// those same four tasks and finished each with its tool call, reward
-    /// `1.0`. Two of the comparator's winning steps landed on precisely
-    /// 64,000 — its own ceiling — so the model fills whatever budget it is
-    /// given and the only question is whose number stops it first. Ours did,
-    /// at half the height, on data we already had.
+    /// A model spends whatever budget it is given, so a cap below the
+    /// model's own ceiling decides where work stops rather than the model
+    /// doing so — and a step cut off mid-reasoning emits no tool call and
+    /// does no work. `bench/READINESS.md` §8.3.2 carries the measurement.
     pub max_output_tokens: Option<u32>,
 }
 


### PR DESCRIPTION
## What & why

Follow-up to #1175, addressing the review feedback left on it after it merged.

`install_runtime_catalog` clamped the model card's `max_output_tokens` (a `u64`) into `u32` with `.min(u32::MAX as u64) as u32`. A card carrying an out-of-range value would land as a real-looking **4-billion-token ceiling** and be asked for on the wire — a worse failure than the one #1175 fixed, because the engine would request something no provider serves, on every call, silently.

`u32::try_from(..).ok()` fails to `None` instead — "no ceiling known" — which the engine already handles by keeping its default. Clamping invents data; `None` says we do not have it.

Also trims the benchmark narrative on `CatalogEntry::max_output_tokens`. `stella-model` is a shared library and the gate story does not belong in it at that length; the invariant and a pointer to `bench/READINESS.md` §8.3.2 do. (Both points raised by Sourcery on #1175. The third — making `TEARDOWN_SEC` configurable — is declined: it is a fixed teardown reserve, and a knob nobody asked for is a knob that can be set wrong.)

## The witness

- [x] No witness needed (behaviour is unreachable from committed data — no seeded or model-card row carries an output ceiling above `u32::MAX`) — because the change is a narrowing of an impossible-today input from "invent a plausible number" to "report unknown". The existing `a_row_carries_the_models_own_output_ceiling_and_defaults_to_unknown` covers the `None` path the new code routes into.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-model --all-targets -- -D warnings` — clean
- [x] `stella-model` + `stella-cli` suites pass (1,058 unit + integration targets)
- [x] `scripts/check-file-size.sh`

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

**CI did not run on #1175 and will not run here either without your help.** No `ci.yml` run has ever been created for a `claude/*` branch in this repo — pushes and PR events originating from this integration do not start `pull_request` workflows, `workflow_dispatch` returns 403 for it, and neither `ready_for_review` nor a close/reopen cycle triggered one. The gate results above are from running the same commands locally. One push to this branch from your own credentials, or a re-run from the Actions UI, is enough to get the required contexts to report.

---

## Summary by Sourcery

Clarify handling of per-model output token ceilings in the runtime catalog to treat out-of-range values as unknown rather than inventing a large ceiling, and update catalog documentation to reflect the invariant and external benchmark reference.

Bug Fixes:
- Ensure model cards with out-of-range max_output_tokens values are treated as having no known ceiling instead of being clamped to a 4-billion-token limit.

Enhancements:
- Simplify and refocus the CatalogEntry::max_output_tokens documentation on the per-model cap invariant and point to the relevant benchmark documentation section.
