### PR TITLE
fix(deps): relock stella-diag, which main's MSRV gate rejects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.6.62"
+version = "0.6.63"
 dependencies = [
  "proptest",
  "serde",


### PR DESCRIPTION
## What & why

`main` is currently red. `cargo check --workspace --locked` — the MSRV job — fails before it compiles anything:

```
error: the lock file /home/runner/work/stella/stella/Cargo.lock needs to be updated
       but --locked was passed to prevent this
```

`stella-diag`, the crate #1176 added, is recorded in `Cargo.lock` at `0.6.62` while every workspace manifest says `0.6.63`. #1176 was branched before the #1174 version sync and merged after it, so its new package entry carries the pre-sync version and nothing relocked it.

`--locked` is that job's entire purpose (restored deliberately in #1119), so this is not cosmetic — it fails on **every** pull request until the lockfile agrees with the manifests. It surfaced on #1177 and is not caused by it; it reproduces on `main` at `46b3abf` with no local changes.

One line. No dependency graph change: the diff is `stella-diag`'s version field and nothing else.

## The witness

- [x] No witness needed (lockfile only) — the gate is the witness:

```
$ git checkout main && cargo metadata --locked --format-version 1
error: cannot update the lock file ... because --locked was passed     # exit 101

$ git checkout this-branch && cargo metadata --locked --format-version 1
                                                                       # exit 0
```

## The gate

- [x] `cargo metadata --locked` — exits 0 here, 101 on `main`
- [x] `git diff --stat Cargo.lock` — 1 insertion, 1 deletion

## Ground-rule check

- [x] No new deps; no version changes beyond aligning the recorded one with the manifests
- [x] No new outbound network calls

## Anything reviewers should know?

Worth deciding separately: this is the third time a version-sync/branch-age interaction has produced a red gate (#1112/#1113, #1119, now this). The shape is always the same — a branch predating a `chore(release): sync versions` merge afterwards, and the lockfile is the only file that notices. A release-sync PR that also ran `cargo metadata` would close it, as would making the version-sync job relock.

Note also that neither #1175 nor #1177 got a CI run — no `ci.yml` run has ever been created for a `claude/*` branch, so this was not caught before those merged. That is worth looking at independently of this fix.

---

## Summary by Sourcery

Bug Fixes:
- Fix MSRV CI failures by updating the lockfile entry for stella-diag to match the workspace crate version.
