### PR TITLE
fix(catalog): seed the output ceiling, or the engine never learns it

### DIFF
--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -254,7 +254,16 @@ impl Catalog {
                         cache_write_usd_per_mtok: 3.75,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // The model's own completion ceiling. Seeded, not left to a
+                // refresh: the runtime catalog only carries card data after
+                // `stella models refresh`, and a benchmark container runs
+                // frozen (`STELLA_CATALOG_AUTO_REFRESH=0`), so an unseeded
+                // ceiling is `None` everywhere it matters and the engine
+                // silently falls back to its global 16384. Measured off the
+                // wire before this line existed: a trial-shaped run sent
+                // `max_tokens: 16384` for a model whose ceiling is 64000.
+                .with_max_output_tokens(Some(64_000)),
                 CatalogEntry::new(
                     "claude-fable-5",
                     "anthropic",
@@ -273,7 +282,9 @@ impl Catalog {
                         cache_write_usd_per_mtok: 12.50,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // Same ceiling as Sonnet 5, and seeded for the same reason.
+                .with_max_output_tokens(Some(64_000)),
                 CatalogEntry::new(
                     "gpt-5.5",
                     "openai",
@@ -628,6 +639,31 @@ mod tests {
                 .max_output_tokens,
             Some(64_000),
         );
+    }
+
+    #[test]
+    fn the_seed_carries_a_ceiling_where_the_frozen_catalog_is_all_there_is() {
+        // A refreshed model card is not available everywhere the ceiling is
+        // needed. `stella models refresh` populates the card store, but a
+        // benchmark container runs frozen (`STELLA_CATALOG_AUTO_REFRESH=0`)
+        // and a fresh install has never refreshed at all — in both, the seed
+        // *is* the catalog. An unseeded ceiling is `None` there, and the
+        // engine falls back to its global default.
+        //
+        // That is not hypothetical: before these rows carried a ceiling, a
+        // trial-shaped run of the real binary against a recording endpoint
+        // put `max_tokens: 16384` on the wire for a model whose ceiling is
+        // 64000. Same run after: 64000.
+        for slug in ["claude-sonnet-5", "claude-fable-5"] {
+            assert_eq!(
+                Catalog::seed()
+                    .resolve_for("anthropic", slug)
+                    .unwrap()
+                    .max_output_tokens,
+                Some(64_000),
+                "{slug} must carry its ceiling in the seed, not only after a refresh",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What & why

#1175 taught the engine to read each model's completion ceiling from the catalog. **Measured against a recording endpoint, it does not** — because in the two places it matters, the catalog has no ceiling to read.

### What the wire said

The real release binary, run with a benchmark container's own environment (`STELLA_CATALOG_AUTO_REFRESH=0`, `STELLA_NO_SETTINGS=1`, `STELLA_NO_ENV_FILE=1`) against a local endpoint that records request bodies:

```
before:  {"model": "claude-sonnet-5", "max_tokens": 16384}
after:   {"model": "claude-sonnet-5", "max_tokens": 64000}
```

Identical invocation both times. The only change is these two seed rows.

### Why it was inert

`CatalogEntry::max_output_tokens` is populated when the runtime catalog is assembled from the model-card store, and that store is only filled by `stella models refresh`. A benchmark trial runs frozen, and a fresh install has never refreshed — in both, **the seed is the catalog**. No seed row carried a ceiling, so every lookup returned `None` and the engine kept its global 16,384.

The benchmark would not have surfaced this, and that is the part worth pausing on: the posture pins `params.max_tokens: 64000` explicitly, which overrides the catalog. A gate would have shown improvement, and the improvement would have been credited to the catalog wiring — which was doing nothing. Two changes, one of them dead, reported as one working change.

This is the defect shape this repository has been burned by three times — a value passed, assumed effective, never read back off the wire — reproduced inside the fix for it.

## Scope, deliberately narrow

Only the two Anthropic rows, and only at a number the repository already asserts elsewhere (`stella-store` and `model_catalog` fixtures both use `64_000` for the claude family).

Rows whose ceiling is not known here keep `None` and the previous default. Seeding a guess would be inventing catalog data — and `cost_usd` and compaction are computed from this table, so a wrong number there is worse than a missing one. A refresh still fills the rest.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_seed_carries_a_ceiling_where_the_frozen_catalog_is_all_there_is` asserts against `Catalog::seed()` specifically, because that is exactly what a frozen run resolves against.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-model -p stella-cli --all-targets -- -D warnings` — clean
- [x] `stella-model` (325) and `stella-cli` suites pass
- [x] `scripts/check-file-size.sh`
- [x] `--turn-budget 840` confirmed accepted end-to-end by the same binary (no clap rejection, turn completes)

## Anything reviewers should know?

**A second defect reproduced for free during this run, not fixed here.** A turn that completes and then fails verification exits nonzero:

```
{"type":"stage","name":"complete"}
{"type":"error","message":"verification failed: judge unavailable; heuristic fallback failed ...","retryable":false}
{"schema_version":1,"status":"error", ...}
```

`pipeline_status_result` maps both `Aborted` and `VerificationFailed` to `Err`, so Stella's own "did not verify" verdict reaches Harbor as `NonZeroAgentExitCodeError` — indistinguishable from a crash. #1173's handoff predicted exactly this and said to treat it as separate; here it is, reproducible at zero cost with a mock endpoint. It deserves its own issue and its own gate.

**Still unmeasured:** no paid trial has been run. This PR's evidence is a wire recording against a mock, not a Terminal-Bench result.

---

## Summary by Sourcery

Seed max output token ceilings for key Anthropic models in the runtime catalog to ensure the engine uses their true 64k completion limits, especially in frozen benchmark environments.

Bug Fixes:
- Ensure claude-sonnet-5 and claude-fable-5 carry a 64k max output token ceiling in the seeded catalog so runs without model-card refresh no longer fall back to the global 16,384 default.

Tests:
- Add a catalog seed test verifying that claude-sonnet-5 and claude-fable-5 resolve to a 64k max output token ceiling in frozen environments.
