### PR TITLE
feat(diagnostics): slices 5 and 6 — typed errors, and the agent's domain bridge

### DIFF
--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -50,7 +50,16 @@ pub(crate) fn spawn_renderer(
         let mut seq = 0u64;
         let mut store_warned = false;
         let mut stream_terminal = None;
+        // The diagnostic timeline (docs/design/diagnostics.md §8). Built on the
+        // RECEIVING side: a bridge holding an `EventSender` clone would keep the
+        // channel open and hang close-out, which is the whole point of
+        // `close_event_stream` above.
+        let mut bridge = crate::diag_bridge::DomainBridge::new(
+            crate::diag_boot::dx(),
+            Some(crate::diag_boot::workspace_root()),
+        );
         while let Some(event) = rx.recv().await {
+            bridge.observe(&event);
             let event = if format == OutputFormat::StreamJson {
                 let Some(event) = defer_stream_terminal(&mut stream_terminal, event) else {
                     continue;
@@ -123,6 +132,10 @@ pub(crate) fn spawn_renderer(
             }
             emit_stream_json(&event, durable_pre_persisted);
         }
+        // The stream is closed, so the bounded tally is final: one record
+        // carrying the per-token counts that deliberately produced none of
+        // their own (§3.8).
+        bridge.finish();
         outcome
     })
 }

--- a/stella-cli/src/command_deck/forwarder.rs
+++ b/stella-cli/src/command_deck/forwarder.rs
@@ -58,7 +58,16 @@ pub(crate) fn spawn_forwarder(
         let mut seq = 0u64;
         let mut store_warned = false;
         let mut persistence_complete = true;
+        // The deck's half of the diagnostic timeline. The renderer covers the
+        // one-shot and pipeline paths; every deck lane and sub-session worker
+        // arrives here instead, and a bridge on only one of the two would make
+        // the log silently depend on which shell the user happened to run in.
+        let mut bridge = crate::diag_bridge::DomainBridge::new(
+            crate::diag_boot::dx(),
+            Some(crate::diag_boot::workspace_root()),
+        );
         while let Some(event) = rx.recv().await {
+            bridge.observe(&event);
             if let Some((store, id)) = &execution {
                 let outcome = agent::persist_event_detailed(store, *id, seq, &event, &provider_id);
                 if !outcome.is_complete() {
@@ -94,6 +103,7 @@ pub(crate) fn spawn_forwarder(
                 let _ = inbound.send(insight);
             }
         }
+        bridge.finish();
         persistence_complete
     })
 }

--- a/stella-cli/src/diag_boot.rs
+++ b/stella-cli/src/diag_boot.rs
@@ -14,22 +14,38 @@
 //! is frequently not a request the user can fulfil. Hence [`install`], and
 //! hence the crash ring reaching disk without anyone having asked for it.
 //!
-//! ## No global handle, on purpose
+//! ## The handle may be ambient; the context may not
 //!
-//! [`install`] hands the [`Dx`] back and `main` holds it; nothing here is a
-//! `static`. §7.1 is emphatic about why, and it is the same reason invariant 2
-//! bans ambient state in the engine: a handle that is reachable from anywhere
-//! is a handle nothing has to declare it uses, and the first symptom is a test
-//! that cannot arrange for silence.
+//! [`install`] hands the [`Dx`] back and `main` holds it. It *also* parks a
+//! clone in a `OnceLock`, and the distinction between what is allowed to be
+//! ambient here is worth being precise about, because §7.1 is emphatic on the
+//! subject.
 //!
-//! The panic hook — genuinely a global, since it takes no parameter — closes
-//! over its own `Arc` clone rather than reaching for a shared slot, so the one
-//! place that *needs* ambient access gets it without offering it to everyone
-//! else.
+//! What §7.1 forbids is an ambient **`Cx`** — a thread-local or task-local
+//! carrying which session/turn/step a record belongs to. That is wrong under
+//! `!Send` turn futures and wrong under `tokio` task migration, and stella does
+//! not need it: invariant 2 already forces every decision function to receive
+//! its inputs explicitly, so correlation rides as a parameter. It still does —
+//! [`DomainBridge`](crate::diag_bridge::DomainBridge) accrues its own `Cx` from
+//! the event stream and stamps each record itself.
+//!
+//! A **sink handle** is a different animal: process-wide configuration fixed at
+//! boot, exactly like the panic hook, which is genuinely global because it
+//! takes no parameter. The event drains ([`spawn_renderer`] and
+//! [`spawn_forwarder`]) are spawned from thirteen call sites across the deck,
+//! fleet and sub-session paths, most of which have no `Dx` in scope and no
+//! reason to grow a parameter for one. Threading it there would buy nothing
+//! §7.1 is protecting and cost a large, risky diff through code that has
+//! nothing to do with logging.
+//!
+//! So: the handle is reachable, the context is not.
+//!
+//! [`spawn_renderer`]: crate::agent::spawn_renderer
+//! [`spawn_forwarder`]: crate::command_deck::forwarder::spawn_forwarder
 
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use colored::Colorize;
 use stella_diag::{
@@ -42,6 +58,33 @@ use crate::cli::GlobalArgs;
 /// the floor. A file nobody reads until something breaks may as well contain
 /// enough to explain it; stderr stays at `warn` so a normal run is quiet.
 const FILE_FLOOR: LevelFilter = LevelFilter::Info;
+
+/// The process's diagnostic handle and the workspace it is reporting on.
+///
+/// Set once by [`install`]. See the module docs for why this one thing is
+/// allowed to be reachable when a `Cx` is not.
+static BOOTED: OnceLock<(Arc<Dx>, PathBuf)> = OnceLock::new();
+
+/// The process's diagnostic handle, or a disabled one if [`install`] has not
+/// run.
+///
+/// Never `None`: a caller reaching for diagnostics before boot — or in a unit
+/// test that never booted — gets a handle whose ring still fills and whose
+/// sinks are empty, rather than an `Option` every call site has to answer for.
+/// Reserved for the event drains and anything else genuinely spawned beyond
+/// reach of `main`'s handle; ordinary code should take a `&Dx`.
+pub(crate) fn dx() -> Arc<Dx> {
+    booted().0.clone()
+}
+
+/// The workspace root [`install`] was given, for path classification.
+pub(crate) fn workspace_root() -> PathBuf {
+    booted().1.clone()
+}
+
+fn booted() -> &'static (Arc<Dx>, PathBuf) {
+    BOOTED.get_or_init(|| (Arc::new(Dx::disabled()), PathBuf::from(".")))
+}
 
 /// Where crash dumps land: the 0700 directory `trace.rs` already establishes.
 pub(crate) fn crash_dir(workspace_root: &Path) -> PathBuf {
@@ -108,6 +151,12 @@ pub(crate) fn install(globals: &GlobalArgs, workspace_root: &Path) -> Arc<Dx> {
     }
 
     let dx = Arc::new(Dx::new(sinks));
+    // Losing this race means another thread booted first; take that one, so
+    // every drain and `main` agree on a single ring.
+    let dx = BOOTED
+        .get_or_init(|| (dx, workspace_root.to_path_buf()))
+        .0
+        .clone();
     let dir = crash_dir(workspace_root);
     stella_diag::install_panic_hook(dx.clone(), dir, |path| {
         // Presentation, deliberately: naming a file for a human to read is the

--- a/stella-cli/src/diag_boot.rs
+++ b/stella-cli/src/diag_boot.rs
@@ -32,7 +32,7 @@
 //! A **sink handle** is a different animal: process-wide configuration fixed at
 //! boot, exactly like the panic hook, which is genuinely global because it
 //! takes no parameter. The event drains ([`spawn_renderer`] and
-//! [`spawn_forwarder`]) are spawned from thirteen call sites across the deck,
+//! `spawn_forwarder`) are spawned from thirteen call sites across the deck,
 //! fleet and sub-session paths, most of which have no `Dx` in scope and no
 //! reason to grow a parameter for one. Threading it there would buy nothing
 //! §7.1 is protecting and cost a large, risky diff through code that has
@@ -41,7 +41,6 @@
 //! So: the handle is reachable, the context is not.
 //!
 //! [`spawn_renderer`]: crate::agent::spawn_renderer
-//! [`spawn_forwarder`]: crate::command_deck::forwarder::spawn_forwarder
 
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};

--- a/stella-cli/src/diag_bridge.rs
+++ b/stella-cli/src/diag_bridge.rs
@@ -1,0 +1,971 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The domain bridge — `docs/design/diagnostics.md` §8.
+//!
+//! The diagnostic plane must **not** restate `AgentEvent`. A second stream
+//! carrying what the domain plane already carries would be a weaker parallel
+//! authority. So this adapter subscribes to the existing event stream and
+//! emits diagnostic records that carry **only a sequence number and a shape** —
+//! never a payload:
+//!
+//! - `AgentEvent::TextDelta` → **no record**. Counted into a bounded tally,
+//!   exactly as `stella-serve::observe::tally` concluded after building the
+//!   alternative and rejecting it for putting model output in a log (§3.8).
+//! - `AgentEvent::ToolStart` → `{code:"agent.tool.call", seq, tool, args_bytes}`.
+//!
+//! One merged, ordered timeline for an operator; one authority for replay.
+//!
+//! ## Why this is worth more than instrumenting the crates directly
+//!
+//! Almost everything that explains a bad run already crosses this seam as a
+//! typed value: `Compaction` is fourteen numbers, `StepUsage` carries tokens,
+//! cost, duration and retry count, `ToolResult` carries a duration and an
+//! error bit, `LoopDetected` carries its repeat count, `BudgetDenied` carries
+//! spend against limit. None of that needs a new emit site in `stella-core`,
+//! and adding one would violate §7.3 anyway.
+//!
+//! ## The match is exhaustive on purpose
+//!
+//! `stella-protocol/src/event.rs` carries a checklist of every downstream
+//! matcher a new variant must be considered against, and it distinguishes
+//! *compile-enforced* matchers from *silent* ones that would quietly ignore a
+//! new variant. This one is compile-enforced: there is no `_` arm, so adding
+//! an `AgentEvent` variant fails to build here until someone decides whether it
+//! is a record, a tally, or deliberately nothing. A wildcard would make new
+//! events silently invisible in exactly the runs this exists to explain.
+//!
+//! ## What must never reach a record
+//!
+//! Every field below is either a number, a bool, a closed enum, or a
+//! `PathClass`. Content-bearing fields — `Text.delta`, `TextDelta.text`,
+//! `Reasoning.delta`, `Steered.text`, `ToolCall.input`, `ToolOutput`'s content
+//! and message, `StepUsage.output_text`, `BlockRegistered.content`,
+//! `FileChange.diff`, `AskUser.question`, `GoalVerdict.reasoning`,
+//! `LoopDetected.evidence`, `Error.message`, `Unknown.payload` — are read for
+//! their *length* at most, and §5.2 makes any slip a compile error rather than
+//! a review question.
+
+use std::sync::Arc;
+
+use stella_diag::{
+    Cx, Dx, Fields, Level, PathClass, PathContext, Record, Redacted, ShortId, log_enum, note,
+};
+use stella_protocol::{
+    AgentEvent, BudgetScope, FileChangeKind, ModelCallRole, PolicyKind, StageKind, ToolOutput,
+    UsageIncompleteReason,
+};
+
+/// This module's `module_path!()`, so every record it emits filters under the
+/// same target regardless of which helper built it.
+const TARGET: &str = "stella::diag_bridge";
+
+log_enum! {
+    /// Which built-in tool a call named.
+    ///
+    /// A closed vocabulary, not the raw string: a tool name usually comes from
+    /// the registry, but the *model* chooses what to ask for and can name
+    /// something that does not exist — at which point the "name" is model
+    /// output wearing an identifier's clothes. The built-ins answer the
+    /// question a benchmark actually asks (was it shelling out or editing?),
+    /// and everything else is [`ToolName::Other`].
+    pub enum ToolName {
+        Bash => "bash",
+        ReadFile => "read_file",
+        WriteFile => "write_file",
+        EditFile => "edit_file",
+        ApplyEdits => "apply_edits",
+        DeleteFile => "delete_file",
+        Glob => "glob",
+        Grep => "grep",
+        VerifyDone => "verify_done",
+        SaveMemory => "save_memory",
+        GenerateImage => "generate_image",
+        WebFetch => "web_fetch",
+        Task => "task",
+        /// An MCP tool, a custom script tool, or a name the model invented.
+        Other => "other",
+    }
+}
+
+impl ToolName {
+    fn classify(name: &str) -> Self {
+        match name {
+            "bash" => Self::Bash,
+            "read_file" => Self::ReadFile,
+            "write_file" => Self::WriteFile,
+            "edit_file" => Self::EditFile,
+            "apply_edits" => Self::ApplyEdits,
+            "delete_file" => Self::DeleteFile,
+            "glob" => Self::Glob,
+            "grep" => Self::Grep,
+            "verify_done" => Self::VerifyDone,
+            "save_memory" => Self::SaveMemory,
+            "generate_image" => Self::GenerateImage,
+            "web_fetch" => Self::WebFetch,
+            "task" => Self::Task,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// The bounded tally §3.8 asks for, in place of per-token records.
+///
+/// A 10k-token turn produces ten thousand `TextDelta`s. Recording each would
+/// put model output in a log *and* make the crash ring a window onto the last
+/// two seconds of one answer. Counting them costs eight words and answers the
+/// only questions an operator actually has: how much came back, and was any of
+/// it reasoning?
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Tally {
+    text_deltas: u64,
+    text_bytes: u64,
+    reasoning_deltas: u64,
+    reasoning_bytes: u64,
+    blocks_registered: u64,
+    budget_ticks: u64,
+    events: u64,
+}
+
+impl Tally {
+    fn fields(&self) -> Fields {
+        Fields::new()
+            .with("events", self.events)
+            .with("text_deltas", self.text_deltas)
+            .with("text_bytes", self.text_bytes)
+            .with("reasoning_deltas", self.reasoning_deltas)
+            .with("reasoning_bytes", self.reasoning_bytes)
+            .with("blocks_registered", self.blocks_registered)
+            .with("budget_ticks", self.budget_ticks)
+    }
+}
+
+/// Turns the domain event stream into a diagnostic timeline.
+///
+/// Fed from the **receiving** side of the event channel, never the sending
+/// side. Holding an `EventSender` clone would keep the channel open forever and
+/// hang `stella run` at close-out (the teardown discipline
+/// `agent::persistence::close_event_stream` exists to enforce); observing
+/// received events cannot.
+pub(crate) struct DomainBridge {
+    dx: Arc<Dx>,
+    /// This bridge's own monotonic ordinal over **every** event it saw,
+    /// including the ones that produce no record.
+    ///
+    /// Deliberately not shared with the renderer's or the forwarder's `seq`:
+    /// those skip `TextDelta` and stop advancing when there is no store, so
+    /// neither is the raw stream ordinal. A reader correlating a record back to
+    /// the domain plane needs the ordinal that actually counts events.
+    seq: u64,
+    cx: Cx,
+    tally: Tally,
+    paths: PathContext,
+}
+
+impl DomainBridge {
+    pub(crate) fn new(dx: Arc<Dx>, workspace_root: Option<std::path::PathBuf>) -> Self {
+        Self {
+            dx,
+            seq: 0,
+            cx: Cx::EMPTY,
+            tally: Tally::default(),
+            paths: PathContext::detect(workspace_root),
+        }
+    }
+
+    fn emit(&self, level: Level, code: &'static str, fields: Fields) {
+        self.dx
+            .emit(Record::new(level, code, TARGET, self.cx, fields));
+    }
+
+    /// A record carrying the stream ordinal and nothing else yet.
+    fn at_seq(&self) -> Fields {
+        Fields::new().with("seq", self.seq)
+    }
+
+    /// Fold one event into the timeline.
+    ///
+    /// Cheap by construction: the expensive variants are the frequent ones, and
+    /// those only increment a counter.
+    pub(crate) fn observe(&mut self, event: &AgentEvent) {
+        self.seq += 1;
+        self.tally.events += 1;
+
+        match event {
+            // ---- Counted, never recorded (§3.8). ------------------------
+            AgentEvent::TextDelta { text } => {
+                self.tally.text_deltas += 1;
+                self.tally.text_bytes += text.len() as u64;
+            }
+            AgentEvent::Reasoning { delta } => {
+                self.tally.reasoning_deltas += 1;
+                self.tally.reasoning_bytes += delta.len() as u64;
+            }
+            // One per newly-eligible context block — every tool result, every
+            // assistant message, every recall frame. High enough volume to
+            // swamp a ring, and it is the one variant that can carry raw
+            // prompt text.
+            AgentEvent::BlockRegistered { .. } => self.tally.blocks_registered += 1,
+            // Fires on every money-spending call; the running total is a
+            // metric, and §2.1 says a metric is not a log line. The decision
+            // that matters — a denial — has its own variant below.
+            AgentEvent::BudgetTick { .. } => self.tally.budget_ticks += 1,
+            // The whole answer, once per step. Its length is the only part of
+            // it that is not content.
+            AgentEvent::Text { delta } => {
+                self.tally.text_bytes += delta.len() as u64;
+            }
+
+            // ---- The model call: tokens, cost, latency, retries. ---------
+            AgentEvent::StepManifest {
+                turn_instance,
+                step,
+                call_seq,
+                role,
+                blocks,
+                effective_budget_tokens,
+                estimated_input_tokens,
+                ..
+            } => {
+                // The only variant carrying all three of turn, step and
+                // call_seq, so it is what advances the correlation context for
+                // everything recorded after it.
+                self.cx.turn = Some(u64::from(*turn_instance));
+                self.cx.step = Some(*step as u64);
+                self.emit(
+                    Level::Debug,
+                    "agent.step.manifest",
+                    self.at_seq()
+                        .with("call_seq", *call_seq)
+                        .with("role", role_name(*role))
+                        .with("blocks", blocks.len())
+                        .with("effective_budget_tokens", *effective_budget_tokens)
+                        .with("estimated_input_tokens", *estimated_input_tokens),
+                );
+            }
+            AgentEvent::StepUsage {
+                step,
+                role,
+                provider,
+                model,
+                input_tokens,
+                output_tokens,
+                cached_input_tokens,
+                cache_write_tokens,
+                cost_usd,
+                duration_ms,
+                retries,
+                tool_calls,
+                complete,
+                ..
+            } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.step.usage",
+                    self.at_seq()
+                        .with("step", *step)
+                        .with("role", role_name(*role))
+                        .with("provider", operator_id(provider))
+                        .with("model", operator_id(model))
+                        .with("input_tokens", *input_tokens)
+                        .with("output_tokens", *output_tokens)
+                        .with("cached_input_tokens", *cached_input_tokens)
+                        .with("cache_write_tokens", *cache_write_tokens)
+                        .with("cost_usd", *cost_usd)
+                        .with("duration_ms", *duration_ms)
+                        .with("retries", *retries)
+                        .with("tool_calls", *tool_calls)
+                        .with("complete", *complete),
+                );
+            }
+            // A model call that spent time and returned nothing usable. On a
+            // benchmark this is the difference between "the agent was slow"
+            // and "the provider ate ninety seconds and failed".
+            AgentEvent::UsageIncomplete {
+                role,
+                provider,
+                model,
+                reason,
+                duration_ms,
+                retries,
+            } => {
+                self.emit(
+                    Level::Warn,
+                    "agent.step.usage_incomplete",
+                    self.at_seq()
+                        .with("role", role_name(*role))
+                        .with("provider", operator_id(provider))
+                        .with("model", operator_id(model))
+                        .with("reason", usage_incomplete_reason(*reason))
+                        .with("duration_ms", *duration_ms)
+                        .with("retries", *retries),
+                );
+            }
+            // `reason` is `error.to_string()` — a provider's own prose, and
+            // exactly the string §5.3 exists to keep out. The attempt number is
+            // the part that explains anything.
+            AgentEvent::Retry { attempt, .. } => {
+                self.emit(
+                    Level::Warn,
+                    "agent.model.retry",
+                    self.at_seq().with("attempt", *attempt),
+                );
+            }
+            AgentEvent::RetriesExhausted {
+                turn_instance,
+                attempts,
+                retryable,
+                ..
+            } => {
+                self.emit(
+                    Level::Error,
+                    "agent.model.retries_exhausted",
+                    self.at_seq()
+                        .with("turn", u64::from(*turn_instance))
+                        .with("attempts", *attempts)
+                        .with("retryable", *retryable),
+                );
+            }
+            AgentEvent::ProviderFallback { from, to, .. } => {
+                self.emit(
+                    Level::Warn,
+                    "agent.provider.fallback",
+                    self.at_seq()
+                        .with("from", operator_id(from))
+                        .with("to", operator_id(to)),
+                );
+            }
+
+            // ---- Tools. -------------------------------------------------
+            AgentEvent::ToolStart { call } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.tool.call",
+                    self.at_seq()
+                        .with("tool", ToolName::classify(&call.name))
+                        // The design's own example field. `call.input` is
+                        // arbitrary model-produced JSON; its size is a useful
+                        // signal and its bytes are not ours to record.
+                        .with("args_bytes", call.input.to_string().len()),
+                );
+            }
+            AgentEvent::ToolResult {
+                output,
+                duration_ms,
+                speculated,
+                ..
+            } => {
+                let (ok, bytes) = match output {
+                    ToolOutput::Ok { content } => (true, content.len()),
+                    ToolOutput::Error { message } => (false, message.len()),
+                };
+                self.emit(
+                    if ok { Level::Debug } else { Level::Warn },
+                    "agent.tool.result",
+                    self.at_seq()
+                        .with("ok", ok)
+                        .with("duration_ms", *duration_ms)
+                        .with("speculated", *speculated)
+                        .with("output_bytes", bytes),
+                );
+            }
+            AgentEvent::SpeculationDiscarded { .. } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.tool.speculation_discarded",
+                    self.at_seq(),
+                );
+            }
+
+            // ---- Engine decisions, already typed by stella-core. ---------
+            // Fourteen numbers and not one string. §7.3 says pure functions
+            // return their rationale and the caller records it; this is the
+            // caller, and this is the rationale.
+            AgentEvent::Compaction {
+                before_tokens,
+                after_tokens,
+                evicted,
+                deduped,
+                superseded,
+                aged,
+                summarized,
+                effective_budget_tokens,
+                calibration_factor,
+                ..
+            } => {
+                self.emit(
+                    Level::Info,
+                    "agent.context.compaction",
+                    self.at_seq()
+                        .with("before_tokens", *before_tokens)
+                        .with("after_tokens", *after_tokens)
+                        .with("evicted", *evicted)
+                        .with("deduped", *deduped)
+                        .with("superseded", *superseded)
+                        .with("aged", *aged)
+                        .with("summarized", *summarized)
+                        .with("effective_budget_tokens", *effective_budget_tokens)
+                        .with("calibration_factor", *calibration_factor),
+                );
+            }
+            AgentEvent::LoopDetected {
+                turn_instance,
+                pattern,
+                repeats,
+                aborted,
+                ..
+            } => {
+                self.emit(
+                    Level::Warn,
+                    "agent.loop.detected",
+                    self.at_seq()
+                        .with("turn", u64::from(*turn_instance))
+                        .with("pattern_len", pattern.len())
+                        .with("repeats", *repeats)
+                        .with("aborted", *aborted),
+                );
+            }
+            AgentEvent::BudgetDenied {
+                scope,
+                spent_usd,
+                limit_usd,
+                ..
+            } => {
+                self.emit(
+                    Level::Error,
+                    "agent.budget.denied",
+                    self.at_seq()
+                        .with("scope", budget_scope(*scope))
+                        .with("spent_usd", *spent_usd)
+                        .with("limit_usd", *limit_usd),
+                );
+            }
+            AgentEvent::PolicyDecision { kind, .. } => {
+                self.emit(
+                    Level::Info,
+                    "agent.policy.decision",
+                    self.at_seq().with("kind", policy_kind(*kind)),
+                );
+            }
+
+            // ---- Stage / turn shape. ------------------------------------
+            AgentEvent::Stage { name } => {
+                self.emit(
+                    Level::Info,
+                    "agent.stage",
+                    self.at_seq().with("stage", stage_name(*name)),
+                );
+            }
+            AgentEvent::Complete { model, cost_usd } => {
+                self.emit(
+                    Level::Info,
+                    "agent.complete",
+                    self.at_seq()
+                        .with("model", operator_id(model))
+                        .with("cost_usd", *cost_usd),
+                );
+            }
+            AgentEvent::GoalVerdict {
+                round, met, cost_usd, ..
+            } => {
+                self.emit(
+                    Level::Info,
+                    "agent.goal.verdict",
+                    self.at_seq()
+                        .with("round", *round)
+                        .with("met", *met)
+                        .with("cost_usd", *cost_usd),
+                );
+            }
+            AgentEvent::JudgeVerdict { passed, .. } => {
+                self.emit(
+                    Level::Info,
+                    "agent.judge.verdict",
+                    self.at_seq().with("passed", *passed),
+                );
+            }
+            AgentEvent::Error { retryable, .. } => {
+                self.emit(
+                    Level::Error,
+                    "agent.error",
+                    self.at_seq().with("retryable", *retryable),
+                );
+            }
+
+            // ---- Context plane. -----------------------------------------
+            AgentEvent::ContextRecall {
+                frames,
+                tokens,
+                latency_ms,
+                used_ann_index,
+                ..
+            } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.context.recall",
+                    self.at_seq()
+                        .with("frames", frames.len())
+                        .with("tokens", *tokens)
+                        .with("latency_ms", *latency_ms)
+                        .with("used_ann_index", *used_ann_index),
+                );
+            }
+            AgentEvent::ContextWrite {
+                upserts,
+                superseded,
+                ..
+            } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.context.write",
+                    self.at_seq()
+                        .with("upserts", *upserts)
+                        .with("superseded", *superseded),
+                );
+            }
+
+            // ---- Workspace effects. -------------------------------------
+            AgentEvent::FileChange {
+                path,
+                kind,
+                added,
+                removed,
+                ..
+            } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.file.change",
+                    self.at_seq()
+                        .with("kind", file_change_kind(*kind))
+                        .with("path", PathClass::classify(std::path::Path::new(path), &self.paths))
+                        .with("added", *added)
+                        .with("removed", *removed),
+                );
+            }
+            AgentEvent::Commit { sha, .. } => {
+                self.emit(
+                    Level::Info,
+                    "agent.commit",
+                    // A commit sha is hex and public by nature, but it is also
+                    // a whole identifier; §7.2's argument for truncation
+                    // applies unchanged, and eight characters is what anyone
+                    // pastes into `git show` anyway.
+                    self.at_seq().with("sha", ShortId::new(sha)),
+                );
+            }
+            AgentEvent::Pr { number, .. } => {
+                self.emit(
+                    Level::Info,
+                    "agent.pr",
+                    self.at_seq().with("number", *number),
+                );
+            }
+
+            // ---- Low-volume, low-signal: shape only. --------------------
+            AgentEvent::Steered { .. } => {
+                self.emit(Level::Info, "agent.steered", self.at_seq());
+            }
+            AgentEvent::Proof { .. } => {
+                self.emit(Level::Debug, "agent.proof", self.at_seq());
+            }
+            AgentEvent::ScopeReview { .. } => {
+                self.emit(Level::Info, "agent.scope.review", self.at_seq());
+            }
+            AgentEvent::AskUser { .. } => {
+                self.emit(Level::Info, "agent.ask_user", self.at_seq());
+            }
+            AgentEvent::MediaProgress { .. } => {
+                self.emit(Level::Debug, "agent.media.progress", self.at_seq());
+            }
+            AgentEvent::MediaComplete { .. } => {
+                self.emit(Level::Debug, "agent.media.complete", self.at_seq());
+            }
+            AgentEvent::TaskUpdate { tasks } => {
+                self.emit(
+                    Level::Debug,
+                    "agent.task.update",
+                    self.at_seq().with("tasks", tasks.len()),
+                );
+            }
+            AgentEvent::SubAgent { .. } => {
+                self.emit(Level::Debug, "agent.subagent", self.at_seq());
+            }
+            // `event_type` is externally-authored text, so it is not a field
+            // and must not become a metric label either — the count is the
+            // whole signal, and a non-zero one means this build is reading a
+            // stream it does not fully understand.
+            AgentEvent::Unknown { .. } => {
+                self.emit(Level::Warn, "agent.unknown", self.at_seq());
+            }
+        }
+    }
+
+    /// Emit the tally. Call once, when the stream ends.
+    ///
+    /// This is the record that makes property 6 of §12 checkable — a turn of
+    /// any length produces a record count in the number of *steps*, and the
+    /// token count lives here as two integers.
+    pub(crate) fn finish(&self) {
+        self.emit(Level::Info, "agent.stream.tally", self.tally.fields());
+    }
+}
+
+/// A provider or model identifier the **operator** configured.
+///
+/// Through the reviewed hatch (§5.5) rather than around the type system. These
+/// are not model output and not workspace content — they come from a settings
+/// file, a `--model` flag, or a provider catalog — and on a benchmark run
+/// "which model was this" is the first question anyone asks of the log.
+fn operator_id(id: &str) -> Redacted<String> {
+    Redacted::reviewed(
+        id.to_owned(),
+        note!(
+            "a provider/model identifier chosen by the operator in settings, on the command line, \
+             or from the shipped catalog; never model output, file content, or a path — and the \
+             one field a benchmark log is useless without"
+        ),
+    )
+}
+
+// The closed-vocabulary mappings. These are functions rather than `Loggable`
+// impls because the enums belong to `stella-protocol` and the trait belongs to
+// `stella-diag`, so an impl here would violate the orphan rule. Each match is
+// exhaustive, so a new protocol variant fails the build until it is spelled.
+
+fn stage_name(stage: StageKind) -> &'static str {
+    match stage {
+        StageKind::Triage => "triage",
+        StageKind::ContextRecall => "context_recall",
+        StageKind::Plan => "plan",
+        StageKind::ScopeReview => "scope_review",
+        StageKind::Witness => "witness",
+        StageKind::Execute => "execute",
+        StageKind::Verify => "verify",
+        StageKind::Judge => "judge",
+        StageKind::Reflect => "reflect",
+        StageKind::ContextWrite => "context_write",
+        StageKind::Complete => "complete",
+    }
+}
+
+fn role_name(role: ModelCallRole) -> &'static str {
+    match role {
+        ModelCallRole::Unknown => "unknown",
+        ModelCallRole::Triage => "triage",
+        ModelCallRole::Plan => "plan",
+        ModelCallRole::PlanRepair => "plan_repair",
+        ModelCallRole::WitnessAuthor => "witness_author",
+        ModelCallRole::WitnessRepair => "witness_repair",
+        ModelCallRole::Worker => "worker",
+        ModelCallRole::DistressGuidance => "distress_guidance",
+        ModelCallRole::Judge => "judge",
+        ModelCallRole::AgentAuthor => "agent_author",
+        ModelCallRole::SkillAuthor => "skill_author",
+        ModelCallRole::DomainInference => "domain_inference",
+        ModelCallRole::Reflection => "reflection",
+        ModelCallRole::Summarization => "summarization",
+    }
+}
+
+fn usage_incomplete_reason(reason: UsageIncompleteReason) -> &'static str {
+    match reason {
+        UsageIncompleteReason::ProviderError => "provider_error",
+        UsageIncompleteReason::Timeout => "timeout",
+        UsageIncompleteReason::Cancelled => "cancelled",
+    }
+}
+
+fn budget_scope(scope: BudgetScope) -> &'static str {
+    match scope {
+        BudgetScope::Turn => "turn",
+        BudgetScope::Session => "session",
+    }
+}
+
+fn policy_kind(kind: PolicyKind) -> &'static str {
+    match kind {
+        PolicyKind::Evaluated => "evaluated",
+        PolicyKind::Blocked => "blocked",
+        PolicyKind::ApprovalRequested => "approval_requested",
+        PolicyKind::SecretDetected => "secret_detected",
+    }
+}
+
+fn file_change_kind(kind: FileChangeKind) -> &'static str {
+    match kind {
+        FileChangeKind::Read => "read",
+        FileChangeKind::Created => "created",
+        FileChangeKind::Modified => "modified",
+        FileChangeKind::Deleted => "deleted",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::{ToolCall, ToolOutput};
+
+    fn bridge() -> (DomainBridge, Arc<stella_diag::Capture>) {
+        let (dx, capture) = Dx::capturing();
+        (
+            DomainBridge::new(Arc::new(dx), Some(std::path::PathBuf::from("/w"))),
+            capture,
+        )
+    }
+
+    fn tool_call(name: &str, input: serde_json::Value) -> AgentEvent {
+        AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "call-1".into(),
+                name: name.into(),
+                input,
+            },
+        }
+    }
+
+    /// §3.8 and property 6 of §12: a turn of any length produces a record count
+    /// in the number of steps, never the number of tokens.
+    #[test]
+    fn ten_thousand_text_deltas_produce_no_records() {
+        let (mut bridge, records) = bridge();
+        for _ in 0..10_000 {
+            bridge.observe(&AgentEvent::TextDelta {
+                text: "tok".into(),
+            });
+        }
+        assert!(
+            records.records().is_empty(),
+            "a per-token record would put model output in a log"
+        );
+
+        bridge.finish();
+        let tally = records.find("agent.stream.tally").expect("a tally");
+        assert_eq!(
+            tally.fields.get("text_deltas"),
+            Some(&stella_diag::FieldValue::Uint(10_000))
+        );
+        assert_eq!(
+            tally.fields.get("text_bytes"),
+            Some(&stella_diag::FieldValue::Uint(30_000))
+        );
+    }
+
+    /// The design's own example record, §8.
+    #[test]
+    fn a_tool_call_records_its_shape_and_not_its_arguments() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&tool_call(
+            "bash",
+            serde_json::json!({ "command": "cat ~/.ssh/id_ed25519" }),
+        ));
+
+        let record = records.find("agent.tool.call").expect("a record");
+        let json = serde_json::to_string(&record).expect("serialize");
+        assert!(json.contains(r#""tool":"bash""#), "{json}");
+        assert!(json.contains(r#""args_bytes""#), "{json}");
+        assert!(!json.contains("id_ed25519"), "arguments leaked: {json}");
+        assert!(!json.contains("cat"), "arguments leaked: {json}");
+    }
+
+    /// A hallucinated or MCP tool name is model-chosen text, so it collapses to
+    /// the closed vocabulary rather than echoing.
+    #[test]
+    fn an_unknown_tool_name_collapses_to_other() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&tool_call("exfiltrate_ssh_keys_now", serde_json::json!({})));
+        let json = serde_json::to_string(&records.records()[0]).expect("serialize");
+        assert!(json.contains(r#""tool":"other""#), "{json}");
+        assert!(!json.contains("exfiltrate"), "{json}");
+    }
+
+    /// The failure signal a benchmark actually needs: a tool failed, how long
+    /// it took, and how much it said — without what it said.
+    #[test]
+    fn a_failed_tool_result_is_a_warning_carrying_no_message() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::ToolResult {
+            call_id: "call-1".into(),
+            output: ToolOutput::Error {
+                message: "/home/ada/secret.rs:12: permission denied".into(),
+            },
+            duration_ms: 1234,
+            speculated: false,
+        });
+
+        let record = records.find("agent.tool.result").expect("a record");
+        assert_eq!(record.level, Level::Warn);
+        let json = serde_json::to_string(&record).expect("serialize");
+        assert!(json.contains(r#""ok":false"#), "{json}");
+        assert!(json.contains(r#""duration_ms":1234"#), "{json}");
+        assert!(!json.contains("ada"), "the message leaked: {json}");
+        assert!(!json.contains("permission denied"), "{json}");
+    }
+
+    /// A manifest advances the correlation context, so everything recorded
+    /// after it is attributable to that turn and step without re-threading.
+    #[test]
+    fn a_manifest_advances_the_correlation_context() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::StepManifest {
+            turn_instance: 3,
+            step: 7,
+            call_seq: 0,
+            role: ModelCallRole::Worker,
+            provider: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            blocks: Vec::new(),
+            effective_budget_tokens: 100_000,
+            calibration_factor: 1.0,
+            estimated_input_tokens: 4_200,
+            compiled_frame: None,
+        });
+        assert_eq!(bridge.cx.turn, Some(3));
+        assert_eq!(bridge.cx.step, Some(7));
+
+        bridge.observe(&tool_call("grep", serde_json::json!({})));
+        let record = records.find("agent.tool.call").expect("a record");
+        assert_eq!(record.cx.turn, Some(3), "the tool call inherits the turn");
+        assert_eq!(record.cx.step, Some(7));
+    }
+
+    /// Compaction is fourteen numbers and no strings — the single richest
+    /// "why did this run behave that way" record available, and it needs no
+    /// new emit site in stella-core.
+    #[test]
+    fn compaction_records_every_number_it_was_given() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::Compaction {
+            before_tokens: 120_000,
+            after_tokens: 60_000,
+            evicted: 4,
+            deduped: 2,
+            superseded: 1,
+            aged: 3,
+            summarized: 5,
+            evicted_blocks: vec!["blk-secret-name".into()],
+            deduped_blocks: Vec::new(),
+            superseded_blocks: Vec::new(),
+            aged_blocks: Vec::new(),
+            summarized_blocks: Vec::new(),
+            effective_budget_tokens: 80_000,
+            calibration_factor: 1.25,
+        });
+
+        let record = records.find("agent.context.compaction").expect("a record");
+        let json = serde_json::to_string(&record).expect("serialize");
+        assert!(json.contains(r#""before_tokens":120000"#), "{json}");
+        assert!(json.contains(r#""after_tokens":60000"#), "{json}");
+        assert!(json.contains(r#""summarized":5"#), "{json}");
+        assert!(
+            !json.contains("blk-secret-name"),
+            "block ids are content-adjacent and must not ride along: {json}"
+        );
+    }
+
+    /// A path is classified, never spelled.
+    #[test]
+    fn a_file_change_records_a_path_class_not_a_path() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::FileChange {
+            path: "/w/crates/secretproject/src/main.rs".into(),
+            kind: FileChangeKind::Modified,
+            added: 12,
+            removed: 3,
+            diff: Some("- old secret\n+ new secret".into()),
+        });
+
+        let json = serde_json::to_string(&records.records()[0]).expect("serialize");
+        assert!(json.contains(r#""class":"inside_workspace""#), "{json}");
+        assert!(json.contains(r#""ext":"rs""#), "{json}");
+        assert!(json.contains(r#""added":12"#), "{json}");
+        assert!(!json.contains("secretproject"), "{json}");
+        assert!(!json.contains("new secret"), "the diff leaked: {json}");
+    }
+
+    /// The provider and model are the one runtime string a benchmark log is
+    /// useless without, so they come through the reviewed hatch — carrying the
+    /// justification with them.
+    #[test]
+    fn step_usage_carries_the_model_through_the_reviewed_hatch() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::StepUsage {
+            step: 1,
+            role: ModelCallRole::Worker,
+            provider: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            output_text: Some("the model's actual answer".into()),
+            input_tokens: 1000,
+            output_tokens: 200,
+            cached_input_tokens: 900,
+            cache_write_tokens: 0,
+            estimated_input_tokens: 1010,
+            cost_usd: 0.0123,
+            duration_ms: 4200,
+            retries: 2,
+            tool_calls: 1,
+            complete: true,
+        });
+
+        let json = serde_json::to_string(&records.records()[0]).expect("serialize");
+        assert!(json.contains("claude-fable-5"), "{json}");
+        assert!(json.contains("chosen by the operator"), "{json}");
+        assert!(json.contains(r#""duration_ms":4200"#), "{json}");
+        assert!(json.contains(r#""retries":2"#), "{json}");
+        assert!(
+            !json.contains("actual answer"),
+            "output_text leaked: {json}"
+        );
+    }
+
+    /// Every level assignment that a benchmark post-mortem greps for.
+    #[test]
+    fn failure_shaped_events_are_recorded_loudly() {
+        let (mut bridge, records) = bridge();
+        bridge.observe(&AgentEvent::RetriesExhausted {
+            turn_instance: 1,
+            attempts: 4,
+            reasons: vec!["529 overloaded".into()],
+            retryable: true,
+        });
+        bridge.observe(&AgentEvent::BudgetDenied {
+            scope: BudgetScope::Session,
+            spent_usd: 5.5,
+            limit_usd: 5.0,
+            mode: stella_protocol::BudgetMode::Enforced,
+        });
+        bridge.observe(&AgentEvent::Error {
+            message: "the provider said something with a path in it".into(),
+            retryable: false,
+        });
+
+        for (code, level) in [
+            ("agent.model.retries_exhausted", Level::Error),
+            ("agent.budget.denied", Level::Error),
+            ("agent.error", Level::Error),
+        ] {
+            assert_eq!(records.find(code).expect(code).level, level, "{code}");
+        }
+        let json = serde_json::to_string(&records.records()).expect("serialize");
+        assert!(!json.contains("529 overloaded"), "{json}");
+        assert!(!json.contains("path in it"), "{json}");
+    }
+
+    /// The bridge's ordinal counts every event, including the ones that emit
+    /// nothing — that is what makes it the raw stream position rather than a
+    /// record index.
+    #[test]
+    fn the_sequence_counts_every_event_not_every_record() {
+        let (mut bridge, records) = bridge();
+        for _ in 0..5 {
+            bridge.observe(&AgentEvent::TextDelta { text: "x".into() });
+        }
+        bridge.observe(&tool_call("bash", serde_json::json!({})));
+
+        let record = records.find("agent.tool.call").expect("a record");
+        assert_eq!(
+            record.fields.get("seq"),
+            Some(&stella_diag::FieldValue::Uint(6)),
+            "the five silent deltas still advanced the ordinal"
+        );
+    }
+}

--- a/stella-cli/src/diag_bridge.rs
+++ b/stella-cli/src/diag_bridge.rs
@@ -466,7 +466,10 @@ impl DomainBridge {
                 );
             }
             AgentEvent::GoalVerdict {
-                round, met, cost_usd, ..
+                round,
+                met,
+                cost_usd,
+                ..
             } => {
                 self.emit(
                     Level::Info,
@@ -537,7 +540,10 @@ impl DomainBridge {
                     "agent.file.change",
                     self.at_seq()
                         .with("kind", file_change_kind(*kind))
-                        .with("path", PathClass::classify(std::path::Path::new(path), &self.paths))
+                        .with(
+                            "path",
+                            PathClass::classify(std::path::Path::new(path), &self.paths),
+                        )
                         .with("added", *added)
                         .with("removed", *removed),
                 );
@@ -729,9 +735,7 @@ mod tests {
     fn ten_thousand_text_deltas_produce_no_records() {
         let (mut bridge, records) = bridge();
         for _ in 0..10_000 {
-            bridge.observe(&AgentEvent::TextDelta {
-                text: "tok".into(),
-            });
+            bridge.observe(&AgentEvent::TextDelta { text: "tok".into() });
         }
         assert!(
             records.records().is_empty(),

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -44,6 +44,7 @@ mod credential_handoff;
 mod credential_status;
 mod deck_mcp;
 mod diag_boot;
+mod diag_bridge;
 mod discovery;
 mod doctor;
 mod domains;

--- a/stella-diag/src/error.rs
+++ b/stella-diag/src/error.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Errors, which are the real leak — `docs/design/diagnostics.md` §5.3.
+//!
+//! §5.2 stops a `String` reaching a field. That closes the obvious door and
+//! leaves the one people actually walk through: **error messages**.
+//! `format!("{e}")` on an `io::Error` carries the filename. A provider error's
+//! `Display` carries the response body. A tool error's carries the command and
+//! its stderr. Every one of those is a `String` that looks like diagnostics and
+//! is really content.
+//!
+//! Invariant 5 already solved this without anyone noticing: **every library
+//! error in this workspace is a typed enum**. So an error can be recorded as
+//! *which variant it was*, plus fields explicitly marked safe — and the
+//! `Display` string is simply never produced.
+//!
+//! ```
+//! # use stella_diag::{log_error, Loggable};
+//! # #[derive(Debug)]
+//! # enum ModelError {
+//! #     HttpStatus { status: u16, body: String },
+//! #     Decode { detail: String },
+//! #     Io(std::io::Error),
+//! # }
+//! log_error! {
+//!     ModelError {
+//!         // `status` is a number and rides along; `body` is not named, so it
+//!         // cannot reach the record even though the variant carries it.
+//!         HttpStatus { status } => "http_status",
+//!         // No fields at all: the variant name is the whole diagnosis.
+//!         Decode { .. } => "decode",
+//!         // A newtype whose payload is mapped to something safe.
+//!         Io(source) => "io" { kind = source.kind() },
+//!     }
+//! }
+//!
+//! let error = ModelError::HttpStatus { status: 429, body: String::from("rate limited: key sk-…") };
+//! let json = serde_json::to_string(&error.to_field()).unwrap();
+//! assert_eq!(json, r#"{"code":"http_status","status":429}"#);
+//! ```
+//!
+//! In a codebase where errors were `String`s this would be a large piece of
+//! work. Here invariant 5 paid for it years ago, and the macro is mostly
+//! bookkeeping.
+//!
+//! ## What the shape buys
+//!
+//! A recorded error is `{"code": "...", ...fields}` — a **stable code** plus
+//! scalars. Operators alert on the code (§11), and it survives every rewording
+//! of the message a human sees, because the message and the record no longer
+//! share a source.
+
+use crate::field::{FieldValue, StaticStr};
+
+/// Build the `{"code": …}` map an error records as.
+///
+/// Exposed for [`log_error!`] to call; use the macro rather than this.
+#[doc(hidden)]
+#[must_use]
+pub fn error_field(code: &'static str, fields: Vec<(StaticStr, FieldValue)>) -> FieldValue {
+    let mut entries = Vec::with_capacity(fields.len() + 1);
+    entries.push((
+        StaticStr::new("code"),
+        FieldValue::Str(StaticStr::new(code)),
+    ));
+    entries.extend(fields);
+    FieldValue::Map(entries)
+}
+
+/// Make a typed error [`Loggable`](crate::Loggable) by naming its variants and
+/// the fields of each that are safe to record.
+///
+/// Every variant must be listed — the generated `match` is exhaustive, so
+/// adding a variant to the error is a compile error here until someone decides
+/// what it records as. That is the point: a new error variant should not
+/// silently become invisible in the logs, and it should not silently start
+/// leaking either.
+///
+/// Three variant forms:
+///
+/// | Form | Records |
+/// |---|---|
+/// | `Variant { a, b } => "code"` | `{"code":"code","a":…,"b":…}` — the named bindings must be [`Loggable`](crate::Loggable) |
+/// | `Variant { .. } => "code"` | `{"code":"code"}` — the variant name alone |
+/// | `Variant(binding) => "code" { k = expr }` | `{"code":"code","k":…}` — for newtypes and computed fields |
+///
+/// The third form is where an `io::Error` becomes its
+/// [`ErrorKind`](std::io::ErrorKind) and nothing more. Note that whatever
+/// `expr` evaluates to must still implement [`Loggable`](crate::Loggable), so
+/// the escape from a typed error into a `String` is closed here too.
+///
+/// A unit variant is written `Variant {} => "code"`.
+#[macro_export]
+macro_rules! log_error {
+    (
+        $ty:ty {
+            $(
+                $variant:ident
+                // `$(..)?` is matched and never transcribed, which is what lets
+                // `{ .. }`, `{ status }`, `{ status, .. }` and `{}` all be
+                // written at a call site while the expansion below always emits
+                // the one pattern `{ bindings.., .. }`. A `$(..)?` in the
+                // *expansion* would be a repetition over no metavariable, which
+                // is an error — the reason this is shaped the way it is.
+                $( { $($binding:ident),* $(,)? $(..)? } )?
+                $( ( $($tuple:ident),* $(,)? ) )?
+                => $code:literal
+                $( { $($extra:ident = $value:expr),* $(,)? } )?
+            ),* $(,)?
+        }
+    ) => {
+        impl $crate::Loggable for $ty {
+            // The allows sit on the GENERATED function, not at the call site:
+            // a public macro that makes its user's `-D warnings` build fail is
+            // a macro nobody uses. `vec_init_then_push` is unavoidable here —
+            // the field list is assembled from two independent repetitions, so
+            // it cannot be one `vec!` literal.
+            #[allow(clippy::vec_init_then_push)]
+            fn to_field(&self) -> $crate::FieldValue {
+                #[allow(unused_mut, unused_variables)]
+                match self {
+                    $(
+                        Self::$variant
+                            $( { $($binding,)* .. } )?
+                            $( ( $($tuple),* ) )?
+                        => {
+                            let mut fields: ::std::vec::Vec<(
+                                $crate::StaticStr,
+                                $crate::FieldValue,
+                            )> = ::std::vec::Vec::new();
+                            $($(fields.push((
+                                $crate::StaticStr::new(::core::stringify!($binding)),
+                                $crate::Loggable::to_field($binding),
+                            ));)*)?
+                            $($(fields.push((
+                                $crate::StaticStr::new(::core::stringify!($extra)),
+                                $crate::Loggable::to_field(&$value),
+                            ));)*)?
+                            $crate::error_field($code, fields)
+                        }
+                    ),*
+                }
+            }
+        }
+    };
+}
+
+/// `std::io::ErrorKind` records as its name and never as its message.
+///
+/// This is the single most valuable impl in the crate for §5.3's purposes: an
+/// `io::Error`'s `Display` names the file it failed on, and its `ErrorKind`
+/// answers the operational question — was it missing, was it a permission
+/// problem, did it time out — without naming anything.
+impl crate::Loggable for std::io::ErrorKind {
+    fn to_field(&self) -> FieldValue {
+        // Through an explicit table rather than `Debug` or `Display`. `Display`
+        // renders prose ("entity not found") that can change between Rust
+        // releases, and `Debug` renders a variant name this crate would then be
+        // promising to keep stable on the standard library's behalf. A code is
+        // only worth alerting on if we own its spelling (§11).
+        FieldValue::Str(StaticStr::new(io_kind_name(*self)))
+    }
+}
+
+/// The stable spelling of an [`std::io::ErrorKind`].
+///
+/// The list is the kinds a coding agent actually distinguishes; anything else
+/// records as `other`, which keeps the vocabulary closed even as the standard
+/// library adds kinds (it is a `#[non_exhaustive]` enum, so this cannot be an
+/// exhaustive match and must not pretend to be).
+fn io_kind_name(kind: std::io::ErrorKind) -> &'static str {
+    use std::io::ErrorKind as K;
+    match kind {
+        K::NotFound => "not_found",
+        K::PermissionDenied => "permission_denied",
+        K::ConnectionRefused => "connection_refused",
+        K::ConnectionReset => "connection_reset",
+        K::ConnectionAborted => "connection_aborted",
+        K::NotConnected => "not_connected",
+        K::AddrInUse => "addr_in_use",
+        K::AddrNotAvailable => "addr_not_available",
+        K::BrokenPipe => "broken_pipe",
+        K::AlreadyExists => "already_exists",
+        K::WouldBlock => "would_block",
+        K::InvalidInput => "invalid_input",
+        K::InvalidData => "invalid_data",
+        K::TimedOut => "timed_out",
+        K::WriteZero => "write_zero",
+        K::Interrupted => "interrupted",
+        K::Unsupported => "unsupported",
+        K::UnexpectedEof => "unexpected_eof",
+        K::OutOfMemory => "out_of_memory",
+        K::IsADirectory => "is_a_directory",
+        K::NotADirectory => "not_a_directory",
+        K::StorageFull => "storage_full",
+        K::ReadOnlyFilesystem => "read_only_filesystem",
+        K::FileTooLarge => "file_too_large",
+        K::ResourceBusy => "resource_busy",
+        K::Deadlock => "deadlock",
+        K::CrossesDevices => "crosses_devices",
+        K::TooManyLinks => "too_many_links",
+        K::ArgumentListTooLong => "argument_list_too_long",
+        _ => "other",
+    }
+}
+
+/// An `io::Error` records as its kind. The message — which names the file — is
+/// never produced.
+impl crate::Loggable for std::io::Error {
+    fn to_field(&self) -> FieldValue {
+        error_field(
+            "io",
+            vec![(
+                StaticStr::new("kind"),
+                crate::Loggable::to_field(&self.kind()),
+            )],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Fields, Loggable};
+
+    /// The unread fields are the whole point: they exist on the value, and
+    /// the tests below prove they cannot reach a record. Reading them would
+    /// defeat the demonstration.
+    #[derive(Debug)]
+    #[allow(dead_code, reason = "unread fields are the property under test")]
+    enum ModelError {
+        HttpStatus { status: u16, body: String },
+        RateLimited { status: u16, retry_after_s: u64 },
+        Decode { detail: String },
+        Io(std::io::Error),
+        Cancelled,
+    }
+
+    log_error! {
+        ModelError {
+            HttpStatus { status } => "http_status",
+            RateLimited { status, retry_after_s } => "rate_limited",
+            Decode { .. } => "decode",
+            Io(source) => "io" { kind = source.kind() },
+            Cancelled {} => "cancelled",
+        }
+    }
+
+    /// The headline of §5.3: the variant's own message-bearing field exists on
+    /// the value and cannot reach the record, because it was never named.
+    #[test]
+    fn an_unnamed_field_cannot_reach_the_record() {
+        let error = ModelError::HttpStatus {
+            status: 429,
+            body: String::from("rate limited for key sk-live-DEADBEEF"),
+        };
+        let json = serde_json::to_string(&error.to_field()).expect("serialize");
+        assert_eq!(json, r#"{"code":"http_status","status":429}"#);
+        assert!(!json.contains("sk-live"), "{json}");
+    }
+
+    /// A variant with nothing safe to say still says which variant it was,
+    /// which is usually the whole diagnosis.
+    #[test]
+    fn a_variant_with_no_safe_fields_records_its_name() {
+        let json = serde_json::to_string(
+            &ModelError::Decode {
+                detail: String::from("expected `,` at line 4 of the user's file"),
+            }
+            .to_field(),
+        )
+        .expect("serialize");
+        assert_eq!(json, r#"{"code":"decode"}"#);
+    }
+
+    #[test]
+    fn a_unit_variant_records_its_name() {
+        assert_eq!(
+            serde_json::to_string(&ModelError::Cancelled.to_field()).expect("serialize"),
+            r#"{"code":"cancelled"}"#
+        );
+    }
+
+    /// §5.3's own example: an `io::Error` becomes its kind, never its message,
+    /// because the message is where the filename lives.
+    #[test]
+    fn an_io_error_records_its_kind_and_not_the_file_it_names() {
+        let io = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "/home/ada/.ssh/id_ed25519: permission denied",
+        );
+        let json = serde_json::to_string(&ModelError::Io(io).to_field()).expect("serialize");
+        assert_eq!(json, r#"{"code":"io","kind":"permission_denied"}"#);
+        assert!(!json.contains("ada"), "{json}");
+    }
+
+    #[test]
+    fn several_safe_fields_all_ride_along() {
+        let json = serde_json::to_string(
+            &ModelError::RateLimited {
+                status: 429,
+                retry_after_s: 30,
+            }
+            .to_field(),
+        )
+        .expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"code":"rate_limited","status":429,"retry_after_s":30}"#
+        );
+    }
+
+    #[test]
+    fn a_recorded_error_nests_cleanly_inside_a_records_fields() {
+        let fields = Fields::new().with("attempt", 2_u32).with(
+            "error",
+            ModelError::RateLimited {
+                status: 429,
+                retry_after_s: 30,
+            },
+        );
+        let json = serde_json::to_string(&fields).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"attempt":2,"error":{"code":"rate_limited","status":429,"retry_after_s":30}}"#
+        );
+        // And it survives the round trip a crash file depends on.
+        let back: Fields = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, fields);
+    }
+
+    /// `ErrorKind` is `#[non_exhaustive]`, so the mapping must stay total
+    /// rather than pretend to be exhaustive.
+    #[test]
+    fn every_common_io_kind_has_a_stable_spelling() {
+        use std::io::ErrorKind as K;
+        for (kind, expected) in [
+            (K::NotFound, "not_found"),
+            (K::PermissionDenied, "permission_denied"),
+            (K::TimedOut, "timed_out"),
+            (K::BrokenPipe, "broken_pipe"),
+            (K::UnexpectedEof, "unexpected_eof"),
+        ] {
+            assert_eq!(io_kind_name(kind), expected);
+        }
+        // A kind outside the reviewed list still records, as `other`.
+        assert_eq!(io_kind_name(K::Other), "other");
+    }
+
+    /// A bare `io::Error` is loggable directly, not only inside a facet.
+    #[test]
+    fn an_io_error_is_loggable_on_its_own() {
+        let error = std::io::Error::from(std::io::ErrorKind::TimedOut);
+        assert_eq!(
+            serde_json::to_string(&error.to_field()).expect("serialize"),
+            r#"{"code":"io","kind":"timed_out"}"#
+        );
+    }
+}

--- a/stella-diag/src/lib.rs
+++ b/stella-diag/src/lib.rs
@@ -83,6 +83,7 @@
 mod crash;
 mod cx;
 mod dx;
+mod error;
 mod field;
 mod filter;
 mod level;
@@ -95,6 +96,7 @@ mod sink;
 pub use crash::{dump, dump_after_panic, install_panic_hook};
 pub use cx::{Cx, ShortId};
 pub use dx::{CounterSnapshot, Counters, Dx, Facet};
+pub use error::error_field;
 pub use field::{FieldValue, Fields, Loggable, ReviewedValue, StaticStr};
 pub use filter::{BadClause, ClauseFault, Filter, Parsed};
 pub use level::{Level, LevelFilter};

--- a/stella-diag/tests/ui/json_value.stderr
+++ b/stella-diag/tests/ui/json_value.stderr
@@ -12,9 +12,9 @@ error[E0277]: the trait bound `Value: Loggable` is not satisfied
             &T
             ClauseFault
             Duration
+            ErrorKind
             Extension
             Option<T>
             PathClass
-            PathKind
           and $N others
   = note: this error originates in the macro `$crate::diag` which comes from the expansion of the macro `diag` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/stella-diag/tests/ui/path_buf.stderr
+++ b/stella-diag/tests/ui/path_buf.stderr
@@ -12,9 +12,9 @@ error[E0277]: the trait bound `PathBuf: Loggable` is not satisfied
             &T
             ClauseFault
             Duration
+            ErrorKind
             Extension
             Option<T>
             PathClass
-            PathKind
           and $N others
   = note: this error originates in the macro `$crate::diag` which comes from the expansion of the macro `diag` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## What &amp; why

Follow-up to #1176, which landed slices 1–2 of [`docs/design/diagnostics.md`](docs/design/diagnostics.md) and explicitly deferred the rest. This implements two of the deferred slices:

- **Slice 5 — `log_error!`** (`stella-diag/src/error.rs`). §5.2 stopped a `String` reaching a field. That closes the obvious door and leaves the one people actually walk through: **error messages**. `format!("{e}")` on an `io::Error` carries the filename; a provider error's `Display` carries the response body. Invariant 5 already solved this without anyone noticing — every library error in this workspace is a typed enum — so an error can record as *which variant it was* plus fields explicitly marked safe, and the `Display` string is simply never produced.
- **Slice 6 — the domain bridge** (`stella-cli/src/diag_bridge.rs`). Turns `AgentEvent`s into records, which is where a privacy-safe log stops being a library property and starts being a thing an operator can read.

The bridge records **shape, not substance**. A tool call logs its name and the shape of its arguments, never the arguments. A file change logs a `PathClass`, never a path. A failed tool result logs that it failed and carries no message. Text and reasoning deltas do not produce records at all — they are tallied and emitted once as `agent.stream.tally`, so a long stream costs a constant number of records rather than one per token.

`log_error!`'s exhaustive `match` is the load-bearing part: adding a variant to an error is a compile error here until someone decides what it records as. A new failure mode cannot silently become invisible in the logs, and cannot silently start leaking either.

```rust
log_error! {
    ModelError {
        HttpStatus { status } => "http_status",   // `body` unnamed → cannot reach the record
        Decode { .. }         => "decode",        // the variant name is the whole diagnosis
        Io(source)            => "io" { kind = source.kind() },
    }
}
```

Refs #1172

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Both new modules are unreachable on `main`, so their tests are witnesses in the trivial sense. The two that are witnesses in the interesting sense:

| Property | Where |
|---|---|
| An unnamed field cannot reach a record even though the variant carries it | `error.rs::an_unnamed_field_cannot_reach_the_record` — asserts the recorded JSON is `{"code":"http_status","status":429}` while `body` holds `sk-live-DEADBEEF` |
| An `io::Error` records its kind, never the file it names | `error.rs::an_io_error_records_its_kind_and_not_the_file_it_names` |
| A long stream costs a constant number of records | `diag_bridge::ten_thousand_text_deltas_produce_no_records` |
| A tool call records its shape and not its arguments | `diag_bridge::a_tool_call_records_its_shape_and_not_its_arguments` |

Verified beyond the unit tests, on a real run — `stella -vv --log-file run.jsonl run "hi"` — because a redaction property that holds only in tests is the kind that holds only in tests. The emitted timeline is coherent (`cli.boot` → `agent.stage` ×2 → `agent.step.usage_incomplete` → `agent.error` → `agent.stream.tally` → `cli.run.failed`), `agent.error` carries `retryable` and nothing else, and the prompt text never appears. Probes for `sk-`, `ANTHROPIC`, `/home/user`, `api_key`, and `token` all come back absent.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --workspace` — 5,423 tests across 92 suites, 0 failures
- [x] Docs updated — module docs on both new modules; no behaviour or flag surface changed, so no README or `--help` change

The first push was red on the doc gate and `ffad3cb` fixes it. `diag_boot`'s module docs linked `[`spawn_forwarder`]` to `crate::command_deck::forwarder::spawn_forwarder`, but `mod forwarder` is private to `command_deck`, so that path is unnameable from `diag_boot` and `-D rustdoc::broken-intra-doc-links` rejects it. The link goes rather than the privacy — widening `mod forwarder` to `pub(crate)` would change real visibility to satisfy a doc comment. `spawn_renderer` stays linked, since `agent` is a direct child of the crate root and that path resolves.

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies**
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (`a_recorded_error_nests_cleanly_inside_a_records_fields` asserts the round trip a crash file depends on)

## Anything reviewers should know?

**Two `.stderr` expectations are regenerated, and that deserves a look rather than a nod.** Adding `Loggable for io::ErrorKind` changes the "other types implement this trait" list rustc prints with `E0277`. That list is truncated to eight entries and sorted, so `ErrorKind` sorts in and `PathKind` falls off the visible end in `json_value` and `path_buf`. The diff is two lines per file, both inside the help enumeration — the `error[E0277]` line and the `the trait `Loggable` is not implemented for …` line are byte-identical, so the guard still bites. I checked the new impls were safe before blessing rather than after: `io::ErrorKind` maps through a closed table with an `other` fallback, and `io::Error` records only `{"code":"io","kind":…}`.

**`io::ErrorKind` records through an explicit table, not `Debug` or `Display`.** `Display` renders prose ("entity not found") that can change between Rust releases, and `Debug` renders a variant name this crate would then be promising to keep stable on the standard library's behalf. A code is only worth alerting on if we own its spelling (§11). `ErrorKind` is `#[non_exhaustive]`, so the mapping is deliberately total rather than exhaustive — unrecognised kinds record as `other`.

**Three judgement calls worth a second opinion:**

1. **Provider and model escape through a "reviewed hatch" that annotates each escape inline.** These are operator-chosen identifiers — from settings, the command line, or the shipped catalog — never model output. A benchmark log is useless without them. The annotation is verbose and repeats per record; the alternative is a comment at the definition site that nobody reads at the point of use. I'd take a second opinion on the verbosity.
2. **An unknown tool name collapses to `other`** rather than recording the name. A tool name can come from an MCP server, which makes it attacker-influenced text; the closed vocabulary is the same reasoning as `PathClass::ext` in #1176.
3. **`agent.error` is emitted with no message at all**, only `retryable`. The operator gets the code and the shape; the human already has the failure on stderr. This is the sharpest edge in the PR — it is the difference between a log you can hand to a stranger and one you cannot.