### PR TITLE
feat(parity): cross-surface capability matrix + embedding architecture doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.6.66"
+version = "0.6.67"
 dependencies = [
  "stella-serve",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stella-parity"
+version = "0.6.66"
+dependencies = [
+ "stella-serve",
+]
+
+[[package]]
 name = "stella-pipeline"
 version = "0.6.66"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "stella-fleet",
   "stella-observatory",
   "stella-serve",
+  "stella-parity",
   "stella-tui",
   "stella-cli",
   "bench/loop-bench",

--- a/docs/design/engine-embedding.md
+++ b/docs/design/engine-embedding.md
@@ -1,0 +1,291 @@
+# Stella as an embeddable gen-AI engine — architecture, surfaces, and the parity contract
+
+**Status:** descriptive of the tree as of 2026-08, plus a gap register. The
+enforcement half — the cross-surface capability matrix — ships with this
+document as the `stella-parity` crate and runs in `cargo test --workspace`.
+**Companion docs:** `docs/design/serve-surface.md` (the API surface in
+detail), `AGENTS.md` (the numbered architectural invariants this document
+assumes).
+
+Stella is heading three places at once, and all three consume the same
+engine:
+
+1. **An embeddable engine** for companies building AI-agent applications —
+   Stella supplies the turn loop, verification, budgeting, and context
+   discipline; the host supplies keys, tools, and product.
+2. **A CLI that grows an API surface** — `stella` the tool and `stella-serve`
+   the sidecar are two front doors to one machine.
+3. **A community edition of a commercial product** — which raises the bar on
+   inspectability: every layer has to be readable, testable, and integrable
+   on its own.
+
+The risk in that plan is not building the engine — it exists — it is the two
+front doors drifting apart. This document maps the machine, the three ways a
+host can drop it into an application, the parity system that keeps the doors
+honest, and the gaps between today's tree and the embedding story.
+
+---
+
+## 1. The machine: one engine, layered ports, two front doors
+
+Every arrow points at a dependency. The load-bearing property (AGENTS.md
+invariant 1) is that arrows only ever point *down*: the decision core is
+plain synchronous logic over owned data, and everything that touches the
+world — models, processes, files, sockets — arrives through a port trait
+implemented above it.
+
+```mermaid
+flowchart TB
+    subgraph surfaces["Surfaces — the front doors"]
+        CLI["stella-cli<br/>community CLI + Command Deck TUI"]
+        SERVE["stella-serve<br/>HTTP/SSE sidecar (BYOK reverse-RPC)"]
+    end
+
+    subgraph assembly["Assembly — how a stack is composed"]
+        RUNTIME["stella-runtime<br/>resource assembly: provider, store,<br/>budget, calibration, tool registry"]
+        ENGINE["stella-engine<br/>execution facade: run_step,<br/>TurnState, Checkpoint, CancelToken"]
+    end
+
+    subgraph capability["Capability crates — ports implemented"]
+        MODEL["stella-model<br/>provider adapters + parity matrix"]
+        TOOLS["stella-tools<br/>sandboxed tool registry"]
+        STORE["stella-store<br/>sessions, telemetry, drift samples"]
+        PIPE["stella-pipeline<br/>plan → witness → verify → judge"]
+        MCP["stella-mcp"]
+        CTX["stella-context / stella-graph"]
+    end
+
+    subgraph core["The decision core — no I/O, property-tested"]
+        CORE["stella-core<br/>turn loop, budget, compaction, loop detection,<br/>goal loop, sub-agents, hooks, calibration"]
+        PROTO["stella-protocol<br/>wire types: AgentEvent, CompletionMessage,<br/>Provider + ToolCallObserver ports"]
+    end
+
+    CLI --> RUNTIME
+    CLI --> PIPE
+    CLI --> CORE
+    SERVE --> ENGINE
+    RUNTIME --> MODEL & TOOLS & STORE & MCP & CTX & PIPE
+    ENGINE --> CORE
+    RUNTIME --> CORE
+    MODEL & TOOLS & STORE & PIPE & MCP & CTX --> PROTO
+    CORE --> PROTO
+```
+
+Read the assembly layer carefully, because it is where the current tree is
+weakest: **the two halves of issue #971 never converged.** `stella-runtime`
+(resource assembly) is consumed only by the CLI — and only its `parts::*`
+free functions; its `RuntimeBuilder`/`SessionRuntime` composite has zero
+production call sites. `stella-engine` (execution facade) is consumed only by
+serve; the CLI still drives `stella-core` directly. So the diagram above is
+the *intended* shape; today each surface uses one assembly crate and
+re-implements the other's half by hand. Gap G1 below.
+
+---
+
+## 2. Three ways to drop Stella into an application
+
+### Mode A — in-process Rust library (deepest integration)
+
+For a Rust host (or anything that can FFI into one): link `stella-engine`
+and drive steps yourself. You own the loop, the persistence, and both ports.
+
+```mermaid
+sequenceDiagram
+    participant Host as Host application
+    participant Engine as stella-engine (in-process)
+    participant P as your Provider impl
+    participant T as your ToolExecutor impl
+
+    Host->>Engine: new_turn(messages, budget) [+ gate, steering, hooks, calibration]
+    loop until Done / Aborted / your step cap
+        Host->>Engine: run_step(&mut state, events)
+        Engine->>P: complete_observed_ref(request)
+        P-->>Engine: streamed completion
+        Engine->>T: execute(tool, input)
+        T-->>Engine: ToolOutput
+        Engine-->>Host: StepOutcome + AgentEvents
+        Host->>Host: state.to_checkpoint() → your store
+    end
+```
+
+What you get for free at this layer: the step-boundary contract (cancel,
+pause, steer — never mid-tool), compaction and prompt-cache discipline,
+loop detection, budget enforcement, drift calibration, the goal loop and
+sub-agents, and a serde `Checkpoint` that resumes in another process.
+What you owe: the loop bound (`engine.max_steps()` — see the crate docs'
+canonical example), event handling, and persistence.
+
+Licensing note for this mode: linking the AGPL-3.0-only crates in-process
+carries AGPL obligations for the combined work; the commercial track exists
+for hosts who need different terms. Mode B is the arms-length alternative.
+
+### Mode B — sidecar API (`stella-serve`, language-agnostic)
+
+The host runs the `stella-serve` binary and talks HTTP/SSE. The defining
+property is **bring-your-own-everything via reverse RPC**: the sidecar never
+holds provider keys and never executes tools — it emits `provider_request` /
+`tool_request` frames and the *host* answers them. Stella supplies the turn
+discipline; the host keeps custody of secrets and side effects.
+
+```mermaid
+sequenceDiagram
+    participant App as Host app (any language)
+    participant Serve as stella-serve sidecar
+    participant LLM as Host's model vendor
+
+    App->>Serve: POST /v1/sessions {system_prompt, budget}
+    App->>Serve: POST /v1/sessions/{id}/turns {input, tools}
+    App->>Serve: GET /v1/turns/{id}/events (SSE, resumable via seq)
+    Serve-->>App: provider_request {request_id, request}
+    App->>LLM: the actual model call (host's key)
+    App->>Serve: POST /v1/turns/{id}/provider-result
+    Serve-->>App: tool_request {request_id, name, input}
+    App->>App: execute the tool (host's sandbox)
+    App->>Serve: POST /v1/turns/{id}/tool-result
+    Serve-->>App: event frames … turn_complete {outcome}
+    Note over App,Serve: steer / pause / resume / cancel land at step boundaries
+```
+
+Wire contract artifacts already exist: `docs/wire/serveframe.schema.json`,
+`serveinbound.schema.json`, and `serveframe.d.ts`, drift-gated by
+`scripts/check-wire-schema.sh`.
+
+### Mode C — the community CLI (the reference host)
+
+`stella` itself is Mode A taken to its richest conclusion: the CLI is the
+one host that wires *everything* — pipeline verification, memory, skills,
+MCP, fleet, the deck. Treat it as the living reference implementation for
+what a full embedding looks like; the parity matrix below is what keeps the
+API surface from quietly falling behind it.
+
+---
+
+## 3. The parity contract: features ship on both surfaces, or the absence is declared
+
+The failure mode this repo already solved once for providers —
+"per-provider divergence nothing enforced" (`stella-model/src/provider_parity.rs`)
+— exists one level up, between surfaces. Measured on the tree at the time of
+writing: the API could set exactly **one** of `EngineConfig`'s ~15 tuning
+knobs (`max_steps`); the goal loop, sub-agents, hooks, and calibration were
+CLI-only; and serve's own route tests hand-listed 7 of its 14 routes.
+
+The fix is the same instrument, promoted a level: **`stella-parity`**, a
+workspace crate holding one `Capability` row per engine capability, each row
+declaring a posture on every surface:
+
+| Posture | Meaning | What the tests check |
+|---|---|---|
+| `Shipped { mechanism, witness }` | wired on this surface | the named witness test exists in that surface's sources |
+| `ShippedUnwitnessed { mechanism, missing }` | wired, but no test pins the wiring | counted against `UNWITNESSED_BASELINE`, a ratchet pinned by exact equality |
+| `Deferred { waiting_on }` | not there yet, deliberately | the reason is written down where review can see it |
+| `NotApplicable { reason }` | never meant to be there | the design reason is written down |
+
+Completeness is enforced **from both ends**, so the matrix cannot silently
+lag reality:
+
+- every real API route (`Route::ALL`, added to `stella-serve` with a
+  compile-enforced classifier) must be claimed by a row — a new route
+  without a matrix decision fails `cargo test --workspace` in the PR that
+  adds it;
+- every public `Engine` entry point in the driver/goal modules must be
+  claimed by a row or by the composition-seam allowlist — a new engine
+  capability without a matrix decision fails the same way.
+
+**The law** (mirroring the provider matrix's): adding an engine capability,
+an API route, or an agent-facing CLI behavior means updating the matrix in
+the same PR. `Deferred` is an honest and expected answer. The matrix's job
+is to make sure a human wrote the answer down where a test keeps it true.
+
+What this deliberately does **not** do yet: sweep the CLI's clap tree into
+the matrix (the CLI's 34 commands are mostly offline introspection; mapping
+them all is noise), or verify *behavioral* equivalence between surfaces
+(that needs the harness described in G8). Both are declared follow-ups, not
+silent omissions.
+
+---
+
+## 4. Gap register — between today's tree and the embedding story
+
+Ordered by how much they matter to an embedding customer. Each is verified
+against the tree, not aspirational.
+
+**G1 — The split-brain assembly layer.** `stella-runtime` is CLI-only (and
+only its `parts::*`; `RuntimeBuilder` has zero call sites), `stella-engine`
+is serve-only, and the CLI drives `stella-core` directly. Consequence: there
+is no single "construct a Stella" path a Mode-A host can copy, and every
+capability serve lacks (G3–G5) is a re-implementation away rather than a
+builder call away. Convergence direction: serve adopts `stella-runtime` for
+its resource half (its `with_provider` seam was built for exactly the
+`RemoteProvider` case), and the CLI adopts `stella-engine`'s step loop —
+after which `RuntimeBuilder → Engine` *is* the Mode-A quickstart.
+
+**G2 — The API cannot tune the engine.** One knob (`max_steps`) of ~15 is
+wire-settable; effort, reasoning, output caps, model/tool timeouts,
+compaction budget, retry policy, and turn wall-clock are all default-only
+over serve. An embedding host cannot even express "low effort, 8k output"
+today. Fix shape: an `engine` block on turn/session create mapping onto
+`EngineConfig`, matrix row `config.tuning` flipping to `Shipped`.
+
+**G3 — "Verified done" is unreachable from the API.** The pipeline (plan →
+witness → verify → judge), and with it the approval gate, is structurally
+absent from serve — the crate is not even linked. The product's defining
+contract is CLI-only, which for customer segment #1 is the single biggest
+gap. This needs the deferred design decision recorded in
+`docs/design/serve-surface.md`: a `/v1/runs` pipeline resource vs. moving
+the approval boundary into the engine.
+
+**G4 — Goal loop and sub-agents are CLI-only.** Both are engine
+capabilities (`run_goal`, `run_sub_agent`) with wire-ready event
+vocabulary; serve simply never wires them. Judged multi-round autonomy is
+exactly what agent-app hosts want from an engine.
+
+**G5 — No durable turn anywhere, and two resume formats.** The engine's
+versioned `Checkpoint` has zero production writers: serve marks the
+persistence seam but persists nothing (a served turn dies with the
+process), and the CLI resumes from its own `session_persist` journal
+instead. Convergence: serve gets a checkpoint store; the deck's journal
+either adopts or wraps `Checkpoint`.
+
+**G6 — Wire types live in the server crate.** `ServerFrame` and the inbound
+bodies are `stella-serve` types, and schema export is split across two
+crates. An SDK author should depend on a protocol crate (or the generated
+schemas alone), never on a server implementation. Move the wire types to
+`stella-protocol` (or a `stella-wire` crate) and unify the export.
+
+**G7 — Versioning is a path literal.** `/v1` is hardcoded in the
+classifier; compatibility is additive-serde plus schema drift-gates, which
+is solid, but there is no version negotiation and no stated deprecation
+policy — table stakes for a commercial API. Cheap first step: serve
+version + supported-contract range on `/readyz` and a documented
+additive-only policy.
+
+**G8 — No behavioral-parity harness.** The matrix (this PR) guarantees
+*presence* parity. The next instrument is *behavior* parity: a scripted
+provider + tool fixture run through both `Engine::run_turn` in-process and
+a live `stella-serve` over HTTP, asserting the two `AgentEvent` streams
+fold to the same transcript, cost, and outcome. The serve test suite
+already has every building block (scripted reverse-RPC hosts, event
+folding); this is composition work, and it belongs in `stella-parity` as
+integration tests.
+
+**G9 — Smaller, still real.** No soft stop on the wire (only hard cancel);
+no `GET /v1/turns/{id}` status-without-streaming; no list endpoints; no
+official client SDKs beyond the generated `.d.ts`; serve's `Route` dispatch
+matches carry catch-alls (partially mitigated by the `Route::ALL`
+round-trip test added with this document); `hooks.lifecycle` over the API
+should ship as bus-event frames, not shell hooks.
+
+---
+
+## 5. What to build next, in order
+
+1. **Land the ratchet** (this PR): matrix + route registry + the law in
+   review culture.
+2. **Converge the assembly layer** (G1) — it makes G2–G5 each a small PR
+   instead of a re-plumbing.
+3. **Engine-config block on the wire** (G2) — highest value-to-effort for
+   embedding customers.
+4. **Behavioral-parity harness** (G8) — after which "same feature, same
+   behavior, both doors" is a test, not a review comment.
+5. **`/v1/runs` or engine-level approvals** (G3) — the decision that
+   unlocks the flagship contract for hosts.

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -989,13 +989,17 @@ export type AgentEvent = {
   duration_ms: number;
   /**
    * The engine's RAW (uncalibrated) pre-call estimate of the input it
-   * sent — paired with `input_tokens` this is one drift sample, the
-   * feedback that calibrates future estimates per model
-   * (`stella-core::estimator::Calibration`). Raw by contract:
+   * sent — paired with `input_tokens` (plus cache-write tokens, which
+   * are real prompt tokens split out only for pricing) this is one
+   * drift sample, the feedback that calibrates future estimates per
+   * model (`stella-core::estimator::Calibration`). Raw by contract:
    * consumers rebuild the correction from these pairs, and a
    * corrected estimate here would compound the correction on every
-   * round trip. `0` means no estimate was taken (pre-drift emitters —
-   * hence `serde(default)`, so old streams still parse).
+   * round trip. Attachment weight is excluded — the media estimate is
+   * a deliberate ~80× over-estimate of billed tokens, right for
+   * context pressure and poison as a drift sample. `0` means no
+   * estimate was taken (pre-drift emitters — hence `serde(default)`,
+   * so old streams still parse).
    */
   estimated_input_tokens?: number;
   input_tokens: number;

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1871,7 +1871,7 @@
         },
         "estimated_input_tokens": {
           "default": 0,
-          "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` this is one drift sample, the\nfeedback that calibrates future estimates per model\n(`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. `0` means no estimate was taken (pre-drift emitters —\nhence `serde(default)`, so old streams still parse).",
+          "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` (plus cache-write tokens, which\nare real prompt tokens split out only for pricing) this is one\ndrift sample, the feedback that calibrates future estimates per\nmodel (`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. Attachment weight is excluded — the media estimate is\na deliberate ~80× over-estimate of billed tokens, right for\ncontext pressure and poison as a drift sample. `0` means no\nestimate was taken (pre-drift emitters — hence `serde(default)`,\nso old streams still parse).",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -247,13 +247,17 @@ export type AgentEvent = {
   duration_ms: number;
   /**
    * The engine's RAW (uncalibrated) pre-call estimate of the input it
-   * sent — paired with `input_tokens` this is one drift sample, the
-   * feedback that calibrates future estimates per model
-   * (`stella-core::estimator::Calibration`). Raw by contract:
+   * sent — paired with `input_tokens` (plus cache-write tokens, which
+   * are real prompt tokens split out only for pricing) this is one
+   * drift sample, the feedback that calibrates future estimates per
+   * model (`stella-core::estimator::Calibration`). Raw by contract:
    * consumers rebuild the correction from these pairs, and a
    * corrected estimate here would compound the correction on every
-   * round trip. `0` means no estimate was taken (pre-drift emitters —
-   * hence `serde(default)`, so old streams still parse).
+   * round trip. Attachment weight is excluded — the media estimate is
+   * a deliberate ~80× over-estimate of billed tokens, right for
+   * context pressure and poison as a drift sample. `0` means no
+   * estimate was taken (pre-drift emitters — hence `serde(default)`,
+   * so old streams still parse).
    */
   estimated_input_tokens?: number;
   input_tokens: number;

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -514,7 +514,7 @@
             },
             "estimated_input_tokens": {
               "default": 0,
-              "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` this is one drift sample, the\nfeedback that calibrates future estimates per model\n(`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. `0` means no estimate was taken (pre-drift emitters —\nhence `serde(default)`, so old streams still parse).",
+              "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` (plus cache-write tokens, which\nare real prompt tokens split out only for pricing) this is one\ndrift sample, the feedback that calibrates future estimates per\nmodel (`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. Attachment weight is excluded — the media estimate is\na deliberate ~80× over-estimate of billed tokens, right for\ncontext pressure and poison as a drift sample. `0` means no\nestimate was taken (pre-drift emitters — hence `serde(default)`,\nso old streams still parse).",
               "format": "uint64",
               "minimum": 0,
               "type": "integer"

--- a/scripts/check-license-allowlist-parity.sh
+++ b/scripts/check-license-allowlist-parity.sh
@@ -11,7 +11,11 @@
 # permits.
 #
 # Uses portable POSIX tools so it runs on a bare CI runner (no ripgrep, no
-# yq — neither is a dependency of this repo).
+# yq — neither is a dependency of this repo). "Portable" includes mawk,
+# Debian's default awk: mawk's brace intervals are broken (`{2,}` matches
+# exactly two, not two-or-more), which once made this script parse an empty
+# allow-licenses list on any mawk machine — green in CI (gawk), red locally —
+# so no regex here may use `{n,}`/`{n,m}` repetition.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
@@ -46,7 +50,7 @@ fi
 review_list="$(
   awk '
     /^[[:space:]]*allow-licenses:/{flag=1; sub(/^[[:space:]]*allow-licenses:[[:space:]]*>-?[[:space:]]*$/, ""); if (length($0)) print; next}
-    flag && /^[[:space:]]{2,}[A-Za-z0-9]/{print; next}
+    flag && /^[[:space:]][[:space:]]+[A-Za-z0-9]/{print; next}
     flag {flag=0}
   ' "$workflow" \
     | tr ',' '\n' \

--- a/stella-parity/Cargo.toml
+++ b/stella-parity/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stella-parity"
+description = "The cross-surface capability matrix: every engine capability declares how it ships on the CLI and the API, with witness tests checked for existence — so a feature landing on one surface without the other is a red test, not a roadmap footnote."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+# For `Route::ALL` — the enumerable API surface this matrix sweeps. Nothing
+# else: the CLI is a binary crate, so its surface is checked against source
+# text (the same discipline provider_parity.rs uses for adapter witnesses).
+stella-serve = { path = "../stella-serve" }

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The cross-surface capability matrix — the structural guard against a
+//! feature shipping on one of Stella's surfaces and silently not the other.
+//!
+//! Stella is one engine behind (today) two customer-facing surfaces: the CLI
+//! (`stella-cli`, the community tool) and the API (`stella-serve`, the
+//! embeddable sidecar). Nothing used to enforce that a capability landing on
+//! one surface landed on — or was *deliberately declared absent from* — the
+//! other, and the two drifted exactly the way per-provider features drifted
+//! before `stella-model/src/provider_parity.rs`: at the time this matrix was
+//! written, the API could set precisely ONE of `EngineConfig`'s ~15 tuning
+//! knobs, the goal loop and sub-agents were CLI-only, and the serve crate's
+//! own route tests covered 7 of its 14 routes. This module makes that class
+//! of gap structural instead of tribal, with the same three instruments the
+//! provider matrix proved out:
+//!
+//! - **A declared row per capability**, with a posture on every surface. An
+//!   absence is legal only as a [`SurfacePosture::Deferred`] (with what it is
+//!   waiting on) or a [`SurfacePosture::NotApplicable`] (with the design
+//!   reason) — never as silence.
+//! - **Witness tests named and checked.** A `Shipped` posture names the test
+//!   that proves the wiring on that surface, and this crate's tests fail when
+//!   the named function no longer exists in the surface's sources.
+//! - **Completeness enforced from both ends.** Every real API route
+//!   ([`stella_serve::observe::Route::ALL`]) must be claimed by a row, and
+//!   every public `Engine` entry point in `stella-core`'s driver/goal modules
+//!   must be claimed by a row or by the composition-seam allowlist — so
+//!   adding a route or an engine capability without a matrix decision fails
+//!   `cargo test --workspace`, in the same PR that added it.
+//!
+//! **The law for new features:** adding an engine capability, an API route,
+//! or an agent-facing CLI behavior means updating this matrix in the same
+//! PR. `Deferred` is an honest and expected answer — the point is that a
+//! human wrote the answer down where a test can keep it true, not that every
+//! feature ships everywhere at once.
+//!
+//! The embedding story this matrix serves — what "the API surface ships with
+//! parity" means for hosts dropping Stella into their own applications — is
+//! `docs/design/engine-embedding.md`.
+
+/// How one capability ships on one surface.
+#[derive(Debug)]
+pub enum SurfacePosture {
+    /// Wired on this surface, with the named witness test proving it —
+    /// checked for existence by this crate's tests, exactly as
+    /// `provider_parity` checks adapter witnesses.
+    Shipped {
+        /// The surface mechanism, for humans reading the matrix. For API
+        /// rows this names the route template(s) verbatim — the route sweep
+        /// matches [`stella_serve::observe::Route::ALL`] against these
+        /// strings, so a claimed route must be spelled exactly.
+        mechanism: &'static str,
+        /// Name of the test function proving the wiring on this surface.
+        witness: &'static str,
+    },
+    /// Wired on this surface, but no test pins the wiring — a debt this
+    /// matrix counts rather than hides. Bounded by
+    /// [`UNWITNESSED_BASELINE`], a ratchet that only goes down: writing the
+    /// missing witness promotes the row to `Shipped` and lowers the
+    /// baseline in the same PR.
+    ShippedUnwitnessed {
+        mechanism: &'static str,
+        /// What a witness for this wiring would pin.
+        missing: &'static str,
+    },
+    /// Not on this surface yet, deliberately and visibly — the surface-level
+    /// sibling of `stella-store`'s declared-gap `DRAIN_FORMATS`. `waiting_on`
+    /// names the decision or dependency, so a reviewer can tell a parked
+    /// feature from a forgotten one.
+    Deferred { waiting_on: &'static str },
+    /// This capability is not meant to exist on this surface, with the
+    /// design reason a reviewer can check.
+    NotApplicable { reason: &'static str },
+}
+
+/// One engine capability and how it ships on each surface.
+#[derive(Debug)]
+pub struct Capability {
+    /// Stable id, `area.name`.
+    pub id: &'static str,
+    /// Where the capability lives in the engine, as prose for the reader.
+    pub engine_home: &'static str,
+    /// The public `Engine` function names this row claims — the engine-side
+    /// completeness sweep requires every swept entry point to be claimed by
+    /// exactly this field (or the [`COMPOSITION_SEAMS`] allowlist).
+    pub engine_entries: &'static [&'static str],
+    /// How the community CLI ships it.
+    pub cli: SurfacePosture,
+    /// How the embeddable API ships it.
+    pub api: SurfacePosture,
+}
+
+/// Public `Engine` methods that are composition seams, not customer-facing
+/// capabilities: hosts use them to assemble a stack, and no surface would
+/// ever expose them directly. Anything swept from the engine sources that is
+/// neither claimed by a row nor listed here fails the completeness test.
+pub const COMPOSITION_SEAMS: &[&str] = &[
+    "with_sleeper",
+    "with_call_role",
+    "with_turn_instance",
+    "max_steps",
+];
+
+/// How many `ShippedUnwitnessed` postures the matrix currently carries. A
+/// ratchet, not a budget: the test pins exact equality, so witnessing a row
+/// forces this DOWN in the same PR (the win is recorded), and adding a new
+/// unwitnessed claim forces it UP — a visible review decision instead of a
+/// silent one.
+pub const UNWITNESSED_BASELINE: usize = 2;
+
+/// The matrix. Ordered by area; ids are stable and unique.
+pub static CAPABILITIES: &[Capability] = &[
+    Capability {
+        id: "turn.run",
+        engine_home: "stella-core driver: one bounded agent turn (run_turn as a loop over run_step)",
+        engine_entries: &["run_turn", "run_turn_with_sender", "run_step", "new_turn"],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella run` / deck turns via agent::run_turn and the pipeline drivers",
+            witness: "non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "POST /v1/turns — a stateless turn driven as a step loop on a session thread",
+            witness: "full_turn_round_trips_over_http",
+        },
+    },
+    Capability {
+        id: "turn.stream_events",
+        engine_home: "stella-protocol AgentEvent over the engine's EventSender",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "TUI transcript rendering and --output-format json event stream",
+            witness: "non_tty_text_output_is_headless_without_losing_text_rendering",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "GET /v1/turns/{id}/events — SSE ServerFrames with monotonic seq, \
+                        resumable via ?after= / Last-Event-ID",
+            witness: "every_frame_carries_a_monotonic_seq_in_the_payload_and_the_sse_id",
+        },
+    },
+    Capability {
+        id: "turn.cancel",
+        engine_home: "stella-engine CancelToken — clean stop at the next step boundary",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "deck turn controls and signal handling; parent cancel reaches children",
+            witness: "cancelling_the_parent_stops_the_child_at_its_next_boundary",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "POST /v1/turns/{id}/cancel — unwinds at the next step boundary, \
+                        completed steps kept",
+            witness: "a_cancel_unwinds_at_the_next_step_boundary",
+        },
+    },
+    Capability {
+        id: "turn.soft_stop",
+        engine_home: "stella-core SOFT_STOP_REASON via the TurnSteering port — user-initiated, keeps history valid",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "deck Esc soft stop through the SteeringTap; propagates to dispatched children",
+            witness: "a_turns_soft_stop_reaches_the_children_it_dispatched",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "a soft flag on POST /v1/turns/{id}/cancel (or a distinct verb): only the \
+                         hard step-boundary cancel is on the wire, so an API host cannot express \
+                         'stop but keep this turn's completed work as an ordinary result'",
+        },
+    },
+    Capability {
+        id: "turn.steer",
+        engine_home: "stella-core TurnSteering port — mid-turn user messages at step boundaries",
+        engine_entries: &["with_steering"],
+        cli: SurfacePosture::Shipped {
+            mechanism: "deck mid-turn input via the SteeringTap",
+            witness: "a_live_turn_still_steers_on_the_marker_and_spawns_otherwise",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "POST /v1/turns/{id}/steer — injected at the next step boundary, echoed as \
+                        a steered event",
+            witness: "a_steer_lands_in_the_next_model_request_and_echoes_on_the_stream",
+        },
+    },
+    Capability {
+        id: "turn.pause_resume",
+        engine_home: "stella-core TurnGate port — park at a step boundary, never mid-tool",
+        engine_entries: &["with_gate"],
+        cli: SurfacePosture::Shipped {
+            mechanism: "deck pause/resume controls; a paused turn parks its sub-agent children too",
+            witness: "a_paused_turn_parks_its_children_and_resume_releases_them",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "POST /v1/turns/{id}/pause and POST /v1/turns/{id}/resume — idempotent, \
+                        held at the boundary",
+            witness: "a_paused_turn_holds_at_the_boundary_until_resumed",
+        },
+    },
+    Capability {
+        id: "session.persistent",
+        engine_home: "caller-owned message history and budget across turns (the engine borrows, never owns)",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella chat` / `stella resume` over the session_persist journal",
+            witness: "journal_then_replay_is_identity_on_the_fold_relevant_stream",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "POST /v1/sessions, GET|DELETE /v1/sessions/{id}, \
+                        POST /v1/sessions/{id}/turns — server-owned history on a byte-stable \
+                        prompt prefix",
+            witness: "a_session_threads_history_across_turns_on_a_stable_prefix",
+        },
+    },
+    Capability {
+        id: "turn.checkpoint_resume",
+        engine_home: "stella-engine Checkpoint — versioned serde snapshot at a step boundary, resumable in another process",
+        engine_entries: &["resume_turn"],
+        cli: SurfacePosture::Deferred {
+            waiting_on: "converging the deck's session_persist journal with the engine Checkpoint: \
+                         the CLI replays its own journal format and never calls \
+                         to_checkpoint/resume_turn, so the one durable-resume format the engine \
+                         exports has zero production writers",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "a checkpoint store behind serve: session.rs marks StepOutcome::Continue \
+                         as the persistence seam but nothing persists, so a served turn does not \
+                         survive the process",
+        },
+    },
+    Capability {
+        id: "goal.loop",
+        engine_home: "stella-core goal: judged rounds until an independent judge assesses the goal met",
+        engine_entries: &["run_goal", "assess"],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella goal` / `stella monitor`, with a cross-family judge resolved by \
+                        default",
+            witness: "distinct_families_route_a_cross_family_judge",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "a goals resource (or a mode flag on turns): judged multi-round runs — a \
+                         defining capability for agent-app hosts — cannot be requested over the \
+                         wire at all",
+        },
+    },
+    Capability {
+        id: "agent.subagents",
+        engine_home: "stella-core subagent: bounded child turns with carved budgets and forwarded metering",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "the task tool via SessionSubAgents; deck lanes; fleet workers",
+            witness: "the_production_tool_stack_forwards_sub_agent_spend",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "sub-agent wiring in serve's session assembly: the engine machinery and \
+                         the SubAgent event vocabulary are wire-ready, but a served turn's tool \
+                         stack installs no task tool, so children cannot exist",
+        },
+    },
+    Capability {
+        id: "hooks.lifecycle",
+        engine_home: "stella-core hooks (PreToolUse/PostToolUse/SessionStart) and the observer-only HookBus",
+        engine_entries: &["with_hooks", "run_session_start_hooks", "with_bus"],
+        cli: SurfacePosture::ShippedUnwitnessed {
+            mechanism: "workspace hooks wired via with_session_hook_context on every driver path",
+            missing: "a CLI-side test pinning that a configured workspace hook actually fires \
+                      through agent wiring (core has hook tests; the CLI wiring has none)",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "attaching the HookBus in serve's session assembly: shell hooks are \
+                         deliberately not run server-side (a host must not be able to make the \
+                         sidecar spawn shells), and with_bus is the server-shaped observer seam \
+                         built for exactly this — but serve never attaches it, so an API host \
+                         gets no lifecycle boundary events",
+        },
+    },
+    Capability {
+        id: "budget.enforce",
+        engine_home: "stella-core BudgetGuard: turn and session USD axes, enforced at step boundaries",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "--budget / --turn-budget on the session axis, surviving across turns",
+            witness: "budget_cap_holds_across_turns_rather_than_resetting_each_one",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "budget {mode, turn_limit_usd, session_limit_usd} on turn and session \
+                        create; aborted turns report incurred cost",
+            witness: "aborted_outcome_preserves_incurred_cost_on_wire",
+        },
+    },
+    Capability {
+        id: "calibration.drift",
+        engine_home: "stella-core estimator CalibrationMap: per-model token-drift correction feeding compaction",
+        engine_entries: &["with_calibration"],
+        cli: SurfacePosture::ShippedUnwitnessed {
+            mechanism: "seed_calibration from the store plus with_calibration on every driver path",
+            missing: "a CLI-side test pinning that persisted drift samples reach the engine's \
+                      calibration on session start (stella-core and stella-store each test their \
+                      half; the CLI seam between them has no witness)",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "serve attaching a CalibrationMap (and somewhere to persist samples — \
+                         serve deliberately has no store): every served turn estimates uncorrected",
+        },
+    },
+    Capability {
+        id: "config.tuning",
+        engine_home: "stella-core EngineConfig: effort, reasoning, output caps, timeouts, loop/compaction tuning",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "settings + flags resolved field-by-field into EngineConfig",
+            witness: "configured_settings_beat_the_baseline_field_by_field",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "an engine-config block on turn/session create: of EngineConfig's ~15 \
+                         knobs only max_steps is settable over the wire — an embedding host \
+                         cannot pin effort, reasoning, output caps, timeouts, or budgets-in-time \
+                         from the API",
+        },
+    },
+    Capability {
+        id: "pipeline.verified_run",
+        engine_home: "stella-pipeline: the plan/witness/verify/judge ladder behind `verified done, not claimed done`",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella run` (default pipeline path) with the scope-review approval gate",
+            witness: "non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review",
+        },
+        api: SurfacePosture::Deferred {
+            waiting_on: "a runs resource (or moving the approval boundary into the engine): serve \
+                         does not link stella-pipeline, so the product's defining verification \
+                         ladder — and the approval gate with it — is structurally unreachable \
+                         from the API",
+        },
+    },
+    Capability {
+        id: "tools.local_execution",
+        engine_home: "stella-core ToolExecutor port over stella-tools' sandboxed registry",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "the full local registry (bash, edit, read, MCP, skills) under policy \
+                        layering",
+            witness: "a_settings_entry_hides_and_refuses_bash_in_the_real_stack",
+        },
+        api: SurfacePosture::NotApplicable {
+            reason: "deliberate bring-your-own-tools posture: serve remotes every tool call to \
+                     the host (STELLA_SERVE_TOOLS=remote is the only mode) so the sidecar never \
+                     executes host-supplied work itself. A server-side tool mode would be a new \
+                     capability row, not a change to this one",
+        },
+    },
+    Capability {
+        id: "provider.calls",
+        engine_home: "stella-protocol Provider port — model calls, streamed and observed",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "BYOK adapters resolved from config (stella-model), one per provider id",
+            witness: "existing_providers_still_route_to_their_current_adapter",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "reverse RPC: provider_request frames answered on \
+                        POST /v1/turns/{id}/provider-result, tool_request frames on \
+                        POST /v1/turns/{id}/tool-result — the host owns keys and execution",
+            witness: "an_unanswered_provider_request_fails_on_the_deadline",
+        },
+    },
+    Capability {
+        id: "ops.health",
+        engine_home: "surface-level operability: liveness, readiness, counters",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella doctor` plus --log-level/--log-file diagnostics",
+            witness: "doctor_parses_bare_and_with_repair",
+        },
+        api: SurfacePosture::Shipped {
+            mechanism: "GET /healthz, GET /readyz (unauthenticated), GET /v1/metrics \
+                        (authenticated, pull-only)",
+            witness: "readyz_reports_ready_while_serving",
+        },
+    },
+];
+
+/// The row for `id`, or `None` — unknown ids are the caller's bug, and the
+/// tests below guarantee every declared id resolves.
+#[must_use]
+pub fn capability(id: &str) -> Option<&'static Capability> {
+    CAPABILITIES.iter().find(|c| c.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_serve::observe::Route;
+
+    /// CLI sources a witness may live in. Source text, not the module tree —
+    /// the same trade `provider_parity` documents: a witness that moves to a
+    /// file outside this list fails loudly (a false alarm to fix by extending
+    /// the list), never silently (the rotted proof this exists to catch).
+    fn cli_sources() -> [&'static str; 7] {
+        [
+            include_str!("../../stella-cli/src/agent_tests.rs"),
+            include_str!("../../stella-cli/src/subagent/tests.rs"),
+            include_str!("../../stella-cli/src/subsession.rs"),
+            include_str!("../../stella-cli/src/command_deck/tests.rs"),
+            include_str!("../../stella-cli/src/session_persist.rs"),
+            include_str!("../../stella-cli/src/engine_config.rs"),
+            include_str!("../../stella-cli/src/main_tests.rs"),
+        ]
+    }
+
+    /// API sources a witness may live in: the serve crate's unit tests plus
+    /// its end-to-end suites.
+    fn api_sources() -> [&'static str; 9] {
+        [
+            include_str!("../../stella-serve/src/server.rs"),
+            include_str!("../../stella-serve/tests/bridge.rs"),
+            include_str!("../../stella-serve/tests/control.rs"),
+            include_str!("../../stella-serve/tests/sessions.rs"),
+            include_str!("../../stella-serve/tests/resume.rs"),
+            include_str!("../../stella-serve/tests/shutdown.rs"),
+            include_str!("../../stella-serve/tests/step_cancel.rs"),
+            include_str!("../../stella-serve/tests/http.rs"),
+            include_str!("../../stella-serve/tests/hostguard.rs"),
+        ]
+    }
+
+    fn witness_exists(sources: &[&str], witness: &str) -> bool {
+        let needle = format!("fn {witness}(");
+        sources.iter().any(|source| source.contains(&needle))
+    }
+
+    #[test]
+    fn capability_ids_are_unique_and_resolvable() {
+        let mut seen = std::collections::BTreeSet::new();
+        for row in CAPABILITIES {
+            assert!(seen.insert(row.id), "duplicate capability row: {}", row.id);
+            assert!(capability(row.id).is_some());
+        }
+        assert!(capability("no.such.capability").is_none());
+    }
+
+    /// Every `Shipped` CLI posture's witness must exist in the CLI sources.
+    #[test]
+    fn every_cli_witness_exists() {
+        let sources = cli_sources();
+        for row in CAPABILITIES {
+            if let SurfacePosture::Shipped { witness, .. } = row.cli {
+                assert!(
+                    witness_exists(&sources, witness),
+                    "cli witness for `{}` not found: {witness}",
+                    row.id
+                );
+            }
+        }
+    }
+
+    /// Every `Shipped` API posture's witness must exist in the serve sources.
+    #[test]
+    fn every_api_witness_exists() {
+        let sources = api_sources();
+        for row in CAPABILITIES {
+            if let SurfacePosture::Shipped { witness, .. } = row.api {
+                assert!(
+                    witness_exists(&sources, witness),
+                    "api witness for `{}` not found: {witness}",
+                    row.id
+                );
+            }
+        }
+    }
+
+    /// The unwitnessed-claims ratchet: exact equality, so witnessing a row
+    /// forces the baseline DOWN in the same PR and a new unwitnessed claim
+    /// forces it UP — both visible review decisions.
+    #[test]
+    fn unwitnessed_claims_match_the_declared_baseline_exactly() {
+        let count = CAPABILITIES
+            .iter()
+            .flat_map(|row| [&row.cli, &row.api])
+            .filter(|posture| matches!(posture, SurfacePosture::ShippedUnwitnessed { .. }))
+            .count();
+        assert_eq!(
+            count, UNWITNESSED_BASELINE,
+            "ShippedUnwitnessed count moved: promote rows (baseline down) or declare the new \
+             debt (baseline up) — in this same change"
+        );
+    }
+
+    /// API-side completeness: every real route the server dispatches must be
+    /// claimed by some row's API mechanism, spelled as its exact template. A
+    /// new route added to `stella-serve` without a matrix decision fails
+    /// here, in the adding PR.
+    #[test]
+    fn every_api_route_is_claimed_by_a_capability_row() {
+        for route in Route::ALL {
+            let template = route.template();
+            let claimed = CAPABILITIES.iter().any(|row| match row.api {
+                SurfacePosture::Shipped { mechanism, .. }
+                | SurfacePosture::ShippedUnwitnessed { mechanism, .. } => {
+                    mechanism.contains(template)
+                }
+                _ => false,
+            });
+            assert!(
+                claimed,
+                "route {template} is not claimed by any capability row — add it to an existing \
+                 row's mechanism or declare a new capability"
+            );
+        }
+    }
+
+    /// Engine-side completeness: every public `Engine` entry point in the
+    /// driver and goal modules must be claimed by a row's `engine_entries`
+    /// or by [`COMPOSITION_SEAMS`]. A new engine capability added without a
+    /// matrix decision fails here, in the adding PR.
+    ///
+    /// The sweep reads source text for four-space-indented `pub fn` /
+    /// `pub async fn` lines — `impl` items — which deliberately skips
+    /// `pub(crate)` internals and module-level free functions.
+    #[test]
+    fn every_public_engine_entry_point_is_claimed() {
+        let sources = [
+            include_str!("../../stella-core/src/driver.rs"),
+            include_str!("../../stella-core/src/goal.rs"),
+        ];
+        let mut swept: Vec<&str> = Vec::new();
+        for source in sources {
+            for line in source.lines() {
+                let Some(rest) = line
+                    .strip_prefix("    pub fn ")
+                    .or_else(|| line.strip_prefix("    pub async fn "))
+                else {
+                    continue;
+                };
+                let name = rest.split(['(', '<']).next().unwrap_or("").trim();
+                if !name.is_empty() {
+                    swept.push(name);
+                }
+            }
+        }
+        assert!(
+            swept.len() >= 10,
+            "the sweep found implausibly few entry points ({}) — did the driver sources move?",
+            swept.len()
+        );
+        for name in swept {
+            let claimed = COMPOSITION_SEAMS.contains(&name)
+                || CAPABILITIES
+                    .iter()
+                    .any(|row| row.engine_entries.contains(&name));
+            assert!(
+                claimed,
+                "public Engine entry point `{name}` is not claimed by any capability row or by \
+                 COMPOSITION_SEAMS — decide where it ships (Deferred is a legal answer) and \
+                 record it"
+            );
+        }
+    }
+
+    /// Every claimed engine entry actually exists in the swept sources —
+    /// the mirror of the sweep, so a renamed engine method cannot leave a
+    /// row pointing at nothing.
+    #[test]
+    fn every_claimed_engine_entry_exists() {
+        let sources = [
+            include_str!("../../stella-core/src/driver.rs"),
+            include_str!("../../stella-core/src/goal.rs"),
+        ];
+        for row in CAPABILITIES {
+            for entry in row.engine_entries {
+                let plain = format!("pub fn {entry}");
+                let asynk = format!("pub async fn {entry}");
+                assert!(
+                    sources
+                        .iter()
+                        .any(|s| s.contains(&plain) || s.contains(&asynk)),
+                    "row `{}` claims engine entry `{entry}` which no swept source defines",
+                    row.id
+                );
+            }
+        }
+    }
+}

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -148,6 +148,60 @@ impl Route {
             Self::Unrouted => "<unrouted>",
         }
     }
+
+    /// Every real route, for exhaustive iteration — the server's own route
+    /// tests walk this instead of hand-listed subsets that rot (they covered
+    /// 7 of 14 before this existed), and the cross-surface capability matrix
+    /// (`stella-parity`) sweeps it so a route added here without a matrix row
+    /// fails the workspace tests. [`Route::Unrouted`] is the 404 sentinel,
+    /// not a route, and is deliberately absent.
+    ///
+    /// Kept honest by [`Route::is_real`]: adding a `Route` variant fails that
+    /// method's exhaustive match until the author classifies it, and the
+    /// tests assert `ALL` contains exactly the `is_real` variants it names —
+    /// so the array cannot silently lag the enum.
+    pub const ALL: [Route; 14] = [
+        Route::Healthz,
+        Route::Readyz,
+        Route::Metrics,
+        Route::TurnsCreate,
+        Route::TurnEvents,
+        Route::TurnToolResult,
+        Route::TurnProviderResult,
+        Route::TurnCancel,
+        Route::TurnSteer,
+        Route::TurnPause,
+        Route::TurnResume,
+        Route::SessionsCreate,
+        Route::Session,
+        Route::SessionTurns,
+    ];
+
+    /// Whether this is a real, dispatchable route rather than the 404
+    /// sentinel. Deliberately an exhaustive match with no wildcard: adding a
+    /// `Route` variant is a compile error here until the author classifies
+    /// it — and classifying it real without adding it to [`Route::ALL`]
+    /// fails `all_lists_every_real_route_exactly_once`.
+    #[must_use]
+    pub fn is_real(self) -> bool {
+        match self {
+            Route::Healthz
+            | Route::Readyz
+            | Route::Metrics
+            | Route::TurnsCreate
+            | Route::TurnEvents
+            | Route::TurnToolResult
+            | Route::TurnProviderResult
+            | Route::TurnCancel
+            | Route::TurnSteer
+            | Route::TurnPause
+            | Route::TurnResume
+            | Route::SessionsCreate
+            | Route::Session
+            | Route::SessionTurns => true,
+            Route::Unrouted => false,
+        }
+    }
 }
 
 /// How many characters of a turn id reach a record.
@@ -685,6 +739,30 @@ pub fn host_for_record(host: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The registry is honest in both directions: `ALL` names exactly the
+    /// `is_real` routes (adding a variant trips `is_real`'s exhaustive match,
+    /// and classifying it real without joining `ALL` fails here), with no
+    /// duplicates. The dispatch-side half — every template classifies back to
+    /// its own variant — lives beside `classify` in `server.rs`.
+    #[test]
+    fn all_lists_every_real_route_exactly_once() {
+        let mut seen = std::collections::BTreeSet::new();
+        for route in Route::ALL {
+            assert!(
+                route.is_real(),
+                "{} is in ALL but not real",
+                route.template()
+            );
+            assert!(
+                seen.insert(route.template()),
+                "duplicate ALL entry: {}",
+                route.template()
+            );
+        }
+        assert!(!Route::Unrouted.is_real());
+        assert_eq!(seen.len(), Route::ALL.len());
+    }
 
     /// Invariant 4: every type crossing a crate boundary round-trips through
     /// `serde_json` byte-for-byte.

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -1453,21 +1453,41 @@ mod tests {
     }
 
     /// Every routable path must name a verb in its `Allow` header, or a 405 is
-    /// half an answer.
+    /// half an answer. Iterates [`Route::ALL`], not a hand-listed subset —
+    /// the previous list covered 7 of 14 routes, which is exactly the rot an
+    /// enumerable registry exists to end.
     #[test]
     fn every_known_route_names_an_allowed_method() {
-        for route in [
-            Route::Healthz,
-            Route::Metrics,
-            Route::TurnsCreate,
-            Route::TurnEvents,
-            Route::TurnToolResult,
-            Route::TurnProviderResult,
-            Route::TurnCancel,
-        ] {
+        for route in Route::ALL {
             assert!(
-                matches!(allowed(route), "GET" | "POST"),
+                !allowed(route).is_empty(),
                 "{} has no allowed method",
+                route.template()
+            );
+        }
+        assert!(allowed(Route::Unrouted).is_empty(), "404s carry no Allow");
+    }
+
+    /// Every real route's template classifies back to the same variant — the
+    /// structural guard against adding a `Route` variant whose path the
+    /// dispatcher never learned (both dispatch matches carry catch-alls, so
+    /// that mistake compiles).
+    #[test]
+    fn every_real_routes_template_classifies_back_to_itself() {
+        for route in Route::ALL {
+            let path = route.template().replace("{id}", "member-x");
+            let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+            let (classified, member) = classify(&segs);
+            assert_eq!(
+                classified,
+                route,
+                "template {} did not classify to its own route",
+                route.template()
+            );
+            assert_eq!(
+                member.is_some(),
+                route.template().contains("{id}"),
+                "member-id capture must match the template shape for {}",
                 route.template()
             );
         }


### PR DESCRIPTION
## What & why

Stella is one engine behind two customer-facing surfaces — the community CLI and the embeddable `stella-serve` API — and nothing enforced that a feature landing on one landed on (or was *deliberately declared absent from*) the other. Measured drift at the time of writing: the API can set exactly **one** of `EngineConfig`'s ~15 knobs (`max_steps`); the goal loop, sub-agents, hooks, and calibration are CLI-only; serve's own route tests hand-listed 7 of its 14 routes.

This PR promotes the `provider_parity.rs` instrument one level up:

**New crate `stella-parity`** — one `Capability` row per engine capability, each declaring a posture per surface: `Shipped {mechanism, witness}` (witness checked for existence in that surface's sources), `ShippedUnwitnessed` (counted under an exact-equality ratchet, `UNWITNESSED_BASELINE`), `Deferred {waiting_on}`, or `NotApplicable {reason}`. Completeness is enforced from **both ends**: every real API route must be claimed by a row, and every public `Engine` entry point in driver/goal must be claimed by a row or the composition-seam allowlist. Net effect: adding an engine capability or an API route without a parity decision fails `cargo test --workspace` in the adding PR. The law mirrors the provider matrix's: update the matrix in the same PR; `Deferred` is an honest, expected answer.

**`stella-serve` route registry** — `Route::ALL` plus a no-wildcard `Route::is_real()` (adding a variant is a compile error until classified). Route tests now iterate `ALL` instead of 7-of-14 hand lists, and every template must classify back to its own variant — the guard against a `Route` variant the dispatcher never learned, which used to compile because both dispatch matches carry catch-alls.

**`docs/design/engine-embedding.md`** — the architecture (mermaid), the three embedding modes (in-process Rust via `stella-engine`; BYOK reverse-RPC sidecar via `stella-serve`; the CLI as reference host), the parity law, and a verified gap register **G1–G9** — led by the split-brain assembly layer (`stella-runtime` is CLI-only with a zero-call-site `RuntimeBuilder`; `stella-engine` is serve-only) and the API's structural inability to reach the pipeline verification ladder.

**Two gate repairs**, both pre-existing red:
- `check-license-allowlist-parity.sh` failed on every mawk machine (Debian's default awk): mawk's brace intervals are broken — `{2,}` matches *exactly two* — so the parser saw an empty `allow-licenses` list and reported a misleading "could not find". CI's gawk masked it. The regex is now interval-free with a comment banning `{n,}` in this script. **No licensing decision was involved: both allow-lists agreed on all 17 licenses all along.**
- `docs/wire/` schemas regenerated: the `estimated_input_tokens` doc-comment change from #1185 flows into the generated schema descriptions (description-only, no wire-shape change); the drift gate rightly caught it.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here): `every_api_route_is_claimed_by_a_capability_row`, `every_public_engine_entry_point_is_claimed`, `every_cli_witness_exists`, `every_api_witness_exists`, `every_claimed_engine_entry_exists`, `unwitnessed_claims_match_the_declared_baseline_exactly`, `all_lists_every_real_route_exactly_once`, `every_real_routes_template_classifies_back_to_itself`, plus `every_known_route_names_an_allowed_method` upgraded from 7 routes to `Route::ALL`. The script fix's witness is `make gate` itself going green on a mawk machine.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (5425 passed, 0 failed)
- [x] Docs updated (new design doc; matrix rustdoc cites it)
- [x] Full `make gate` green end-to-end for the first time on a mawk machine (license-parity + shellcheck + wire-schema included)

## Ground-rule check

- [x] No I/O added to `stella-core` (untouched); no new deps (`stella-parity` depends only on `stella-serve`)
- [x] No new outbound network calls

## Anything reviewers should know?

- `UNWITNESSED_BASELINE = 2`: the CLI's hooks wiring and calibration seeding are shipped but have no CLI-side witness tests — the matrix records that as counted debt rather than pretending. Writing those two witnesses lowers the baseline.
- Deliberately out of scope, declared in the doc: sweeping the CLI's 34-command clap tree into the matrix, and a behavioral-parity harness (same scripted fixture through in-process `run_turn` and live serve, asserting identical folded transcripts) — that's G8, the natural next PR.
- The matrix rows for API `Deferred` postures double as a machine-checked roadmap: `turn.soft_stop`, `turn.checkpoint_resume`, `goal.loop`, `agent.subagents`, `hooks.lifecycle` (as bus frames), `calibration.drift`, `config.tuning`, `pipeline.verified_run`.

---

## Summary by Sourcery

Introduce a cross-surface capability matrix crate to enforce feature parity between the CLI and API, strengthen route coverage and classification in the server, update wire schema docs, and fix a portability issue in the license allowlist parity script.

New Features:
- Add the stella-parity crate that declares engine capabilities with CLI and API postures, backed by witness and completeness checks across routes and engine entry points.

Bug Fixes:
- Fix the check-license-allowlist-parity.sh script to avoid non-portable awk brace intervals so license lists are parsed consistently across environments.

Enhancements:
- Add a complete Route registry and real-route classifier in stella-serve, and update tests to exhaustively validate routes, allowed methods, and template classification.
- Refine documentation on token drift and media attachment estimation in generated wire schemas, and add a new engine embedding design document describing architecture, embedding modes, and parity expectations.

Build:
- Register the new stella-parity crate in the workspace manifest.

Documentation:
- Add docs/design/engine-embedding.md to describe Stella’s embedding architecture, surfaces, and the parity contract, and propagate updated comments into wire schema docs.

Tests:
- Add parity-oriented tests ensuring all real routes are listed and classified correctly, all capability witnesses exist, unwitnessed capabilities match a declared baseline, and engine entry points and routes are fully claimed by the matrix.
