### PR TITLE
fix(wire): regenerate the stale wire contract, and make CI run the guard that would have caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,18 @@ jobs:
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # docs/wire/ is generated from the types and committed, so it drifts the
+      # moment `AgentEvent` changes — including its doc comments, which the
+      # exporters carry into the schema verbatim (#971). This guard was the one
+      # check-*.sh that no workflow ran: it lived only in `make gate`, so it
+      # was enforced by the local pre-push hook and nothing else. A branch
+      # pushed server-side never met it, which is how #1185 merged with a
+      # rewritten `estimated_input_tokens` comment and stale artifacts. Needs
+      # the toolchain — it runs the two exporters under `--features schema`.
+      - name: docs/wire/ still matches the types
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: ./scripts/check-wire-schema.sh
+
       # Nothing gated rustdoc, so its warning count only grew — one crate's doc
       # link to a private fn had made `cargo doc` a hard failure, unnoticed
       # (#634). Gating is what stops it regrowing.

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -989,13 +989,17 @@ export type AgentEvent = {
   duration_ms: number;
   /**
    * The engine's RAW (uncalibrated) pre-call estimate of the input it
-   * sent — paired with `input_tokens` this is one drift sample, the
-   * feedback that calibrates future estimates per model
-   * (`stella-core::estimator::Calibration`). Raw by contract:
+   * sent — paired with `input_tokens` (plus cache-write tokens, which
+   * are real prompt tokens split out only for pricing) this is one
+   * drift sample, the feedback that calibrates future estimates per
+   * model (`stella-core::estimator::Calibration`). Raw by contract:
    * consumers rebuild the correction from these pairs, and a
    * corrected estimate here would compound the correction on every
-   * round trip. `0` means no estimate was taken (pre-drift emitters —
-   * hence `serde(default)`, so old streams still parse).
+   * round trip. Attachment weight is excluded — the media estimate is
+   * a deliberate ~80× over-estimate of billed tokens, right for
+   * context pressure and poison as a drift sample. `0` means no
+   * estimate was taken (pre-drift emitters — hence `serde(default)`,
+   * so old streams still parse).
    */
   estimated_input_tokens?: number;
   input_tokens: number;

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1871,7 +1871,7 @@
         },
         "estimated_input_tokens": {
           "default": 0,
-          "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` this is one drift sample, the\nfeedback that calibrates future estimates per model\n(`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. `0` means no estimate was taken (pre-drift emitters —\nhence `serde(default)`, so old streams still parse).",
+          "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` (plus cache-write tokens, which\nare real prompt tokens split out only for pricing) this is one\ndrift sample, the feedback that calibrates future estimates per\nmodel (`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. Attachment weight is excluded — the media estimate is\na deliberate ~80× over-estimate of billed tokens, right for\ncontext pressure and poison as a drift sample. `0` means no\nestimate was taken (pre-drift emitters — hence `serde(default)`,\nso old streams still parse).",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -247,13 +247,17 @@ export type AgentEvent = {
   duration_ms: number;
   /**
    * The engine's RAW (uncalibrated) pre-call estimate of the input it
-   * sent — paired with `input_tokens` this is one drift sample, the
-   * feedback that calibrates future estimates per model
-   * (`stella-core::estimator::Calibration`). Raw by contract:
+   * sent — paired with `input_tokens` (plus cache-write tokens, which
+   * are real prompt tokens split out only for pricing) this is one
+   * drift sample, the feedback that calibrates future estimates per
+   * model (`stella-core::estimator::Calibration`). Raw by contract:
    * consumers rebuild the correction from these pairs, and a
    * corrected estimate here would compound the correction on every
-   * round trip. `0` means no estimate was taken (pre-drift emitters —
-   * hence `serde(default)`, so old streams still parse).
+   * round trip. Attachment weight is excluded — the media estimate is
+   * a deliberate ~80× over-estimate of billed tokens, right for
+   * context pressure and poison as a drift sample. `0` means no
+   * estimate was taken (pre-drift emitters — hence `serde(default)`,
+   * so old streams still parse).
    */
   estimated_input_tokens?: number;
   input_tokens: number;

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -514,7 +514,7 @@
             },
             "estimated_input_tokens": {
               "default": 0,
-              "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` this is one drift sample, the\nfeedback that calibrates future estimates per model\n(`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. `0` means no estimate was taken (pre-drift emitters —\nhence `serde(default)`, so old streams still parse).",
+              "description": "The engine's RAW (uncalibrated) pre-call estimate of the input it\nsent — paired with `input_tokens` (plus cache-write tokens, which\nare real prompt tokens split out only for pricing) this is one\ndrift sample, the feedback that calibrates future estimates per\nmodel (`stella-core::estimator::Calibration`). Raw by contract:\nconsumers rebuild the correction from these pairs, and a\ncorrected estimate here would compound the correction on every\nround trip. Attachment weight is excluded — the media estimate is\na deliberate ~80× over-estimate of billed tokens, right for\ncontext pressure and poison as a drift sample. `0` means no\nestimate was taken (pre-drift emitters — hence `serde(default)`,\nso old streams still parse).",
               "format": "uint64",
               "minimum": 0,
               "type": "integer"


### PR DESCRIPTION
`main` is currently red on `make wire-schema`, and has been since #1185.

## What broke

#1185 (`94f68d8b`) rewrote the doc comment on `estimated_input_tokens` to
record that cache-write tokens count toward the drift sample and that
attachment weight is deliberately excluded. That comment is part of the
*exported* wire contract — the exporters carry it into `docs/wire/`
verbatim — so the committed artifacts went stale the moment it merged.

Because `.githooks/pre-push` runs the full `make gate`, this is not
cosmetic: anyone with hooks installed is currently blocked from pushing
**any** branch based on current `main`, whatever they changed.

## Commit 1 — regenerate the artifacts

`scripts/export-agentevent-schema.sh`. Four files move, because
`AgentEvent` is exported through two roots: its own schema and the
`stella-serve` frame that embeds it.

The diff is **prose only** — every hunk is a `description` string or a
`/** */` block. No field is added, removed, renamed or re-typed, and no
optional field became required, so the additive-only wire contract is
untouched and no consumer of `--output-format stream-json`, the SSE
stream, or `docs/wire/agentevent.d.ts` is affected.

## Commit 2 — close the hole that let it merge

`scripts/check-wire-schema.sh` was the only `check-*.sh` in the repo that
no workflow ran. Every other one is covered — five in `ci.yml`, three in
`normative-home.yml` — leaving this one enforced solely by the local
pre-push hook, i.e. only for people pushing from a clone with hooks
installed. A branch pushed server-side never met it, which is exactly how
#1185 went green through review.

This looks like an oversight rather than a decision: the `gate` target
describes itself as the "Full CI gate: ... + wire-schema + ...", and the
script's own header says it uses portable POSIX tools "so it runs on a
bare CI runner". It needs the toolchain (it runs the two exporters under
`--features schema`), so the step sits after clippy rather than in the
toolchain-free block at the top of the job.

Drop this commit if you'd rather land the regenerate alone.

## Verification

- `make gate` on commit 1: **exit 0**, no failures.
- `check-wire-schema: OK — docs/wire/ matches the types.`
- After the `ci.yml` edit, the four gate checks that parse workflow YAML
  re-pass, including `check-action-pins: OK — all 45 'uses:' references
  are pinned to a commit SHA`.
- Pre-push gate green on the pushed tip.

## Summary by Sourcery

Refresh the wire contract artifacts to align with the updated AgentEvent comments and integrate the wire-schema check into CI so future schema changes cannot drift from the committed docs.

Bug Fixes:
- Regenerate the committed wire schema artifacts so AgentEvent documentation matches the current type definitions.
- Add a CI job step to enforce that docs/wire artifacts stay in sync with the Rust wire schema, preventing stale contracts from merging.

CI:
- Extend the main CI workflow to run scripts/check-wire-schema.sh after clippy as part of the gate.

Documentation:
- Update exported AgentEvent wire documentation to clarify how cache-write tokens and attachment weight factor into drift sampling and token estimation.