### PR TITLE
feat(bench): one-gateway role routing, selectable worker effort and triage author

### DIFF
--- a/bench/evidence/run/tune.sh
+++ b/bench/evidence/run/tune.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# A Stella-only tuning run over a fixed task list.
+#
+# Not `primary.sh`. That script measures a preregistered phase of the whole
+# frozen dataset and exists to produce a publishable number. This one answers a
+# narrower and cheaper question — "did the change help?" — over tasks chosen
+# *because* Stella lost them, so its result is a tuning signal and never a
+# score. Nothing here is claim-eligible: the task list is selected on prior
+# results, which is exactly the selection bias a leaderboard row must not have.
+#
+# The comparator is historical. Claude Code already passed every task in the
+# list, on runs whose artifacts are on disk, so re-running it would spend money
+# to re-derive a number we hold. Only the Stella arm runs.
+#
+# Two arms, one variable each in principle and two in practice — the worker's
+# effort tier and the judge's author move together, which is what the operator
+# asked for. Read the result as "configuration A vs configuration B", not as an
+# attribution to either knob.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+
+ARM="${1:?usage: tune.sh <A|B> <job-name> [task-file]}"
+JOB="${2:?usage: tune.sh <A|B> <job-name> [task-file]}"
+TASKFILE="${3:-$TB_ROOT/tune5.tasks}"
+
+test -f "$TASKFILE" || { echo "FATAL: no task file at $TASKFILE"; exit 1; }
+test ! -e "$JOBS/$JOB" || { echo "FATAL: $JOBS/$JOB exists — a run never resumes"; exit 1; }
+
+# Every role on one provider. A trial carries exactly one credential over the
+# anonymous FD, so a judge or triage author on a second provider authenticates
+# against nothing — the adapter refuses such a posture rather than quietly
+# running the arm the digest does not describe.
+export TB_MODEL="${TB_MODEL:-openrouter/anthropic/claude-sonnet-5}"
+export STELLA_TRIAGE_MODEL="${STELLA_TRIAGE_MODEL:-openrouter/anthropic/claude-haiku-4.5}"
+
+case "$ARM" in
+  A)
+    export STELLA_WORKER_EFFORT=xhigh
+    export STELLA_WITNESS_AUTHOR_MODEL=openrouter/anthropic/claude-fable-5
+    ;;
+  B)
+    export STELLA_WORKER_EFFORT=high
+    export STELLA_WITNESS_AUTHOR_MODEL=openrouter/moonshotai/kimi-k3
+    ;;
+  *) echo "FATAL: arm must be A or B"; exit 1 ;;
+esac
+
+preflight || exit 1
+
+N=$(grep -c . "$TASKFILE")
+test "$N" -gt 0 || { echo "FATAL: $TASKFILE lists no tasks"; exit 1; }
+
+# macOS ships bash 3.2: no mapfile, no arrays from process substitution.
+INCLUDES=""
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  INCLUDES="$INCLUDES --include-task-name terminal-bench/$t"
+done < "$TASKFILE"
+
+# The task list is part of this run's identity: two runs that disagree about
+# which tasks they covered are not comparable, and the digest is how a later
+# reader checks that without trusting the job name.
+TASKSET_SHA=$(sort "$TASKFILE" | shasum -a 256 | awk '{print $1}')
+
+echo "arm=$ARM job=$JOB tasks=$N taskset_sha256=$TASKSET_SHA"
+echo "sut=$STELLA_SOURCE_COMMIT worker=$TB_MODEL effort=$STELLA_WORKER_EFFORT"
+echo "judge=$STELLA_WITNESS_AUTHOR_MODEL triage=$STELLA_TRIAGE_MODEL"
+echo "budget/trial=${STELLA_BUDGET:-<uncapped>} concurrency=${TB_CONCURRENCY:-5}"
+echo "started=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cd "$TB_REPO" || exit 1
+# INCLUDES is deliberately unquoted: a pre-built flag list, one word per token,
+# every task name a fixed [a-z0-9-] slug from the frozen dataset.
+# shellcheck disable=SC2086
+harbor run \
+  --env docker \
+  --dataset "$TB_DATASET" \
+  $INCLUDES \
+  --agent-import-path stella_harbor:StellaAgent \
+  --model "$TB_MODEL" \
+  --job-name "$JOB" \
+  --jobs-dir "$JOBS" \
+  --n-attempts 1 --n-concurrent "${TB_CONCURRENCY:-5}" --max-retries 0
+rc=$?
+echo "harbor_exit=$rc finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+exit $rc

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -79,10 +79,14 @@ from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
     _ENGINE_POSTURE_VERSION,
+    _TRIAGE_MODEL_ENV,
     _WITNESS_AUTHOR_ENV,
+    _WORKER_EFFORT_ENV,
     _benchmark_assurance_tiers,
     _benchmark_engine_posture,
     fold_witness_observations,
+    resolve_triage_model,
+    resolve_worker_effort,
 )
 from .turn_budget import (
     TURN_BUDGET_ENV as _TURN_BUDGET_ENV,
@@ -200,6 +204,12 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         # the run rather than enabling the policy. See `turn_budget`.
         _TURN_BUDGET_ENV,
         _WITNESS_AUTHOR_ENV,
+        # Worker effort and triage author: host-only like the witness author,
+        # reaching Stella only inside the hashed posture. Registering them is
+        # load-bearing, not tidy — the ambient check fails closed, and an
+        # unlisted `STELLA_TURN_BUDGET` killed all ten trials of a run.
+        _WORKER_EFFORT_ENV,
+        _TRIAGE_MODEL_ENV,
         # The portability target triple and glibc floor (#1018). `env.sh` exports
         # both so `build_sut.sh` builds to the same floor `preflight` asserts
         # against — keeping them apart is what let a glibc-2.35 binary reach five
@@ -1308,7 +1318,16 @@ class StellaAgent(BaseInstalledAgent):
             self._engine_posture,
             self._engine_posture_json,
             self._engine_posture_sha256,
-        ) = _benchmark_engine_posture(configured_model, witness_author=witness_author)
+        ) = _benchmark_engine_posture(
+            configured_model,
+            witness_author=witness_author,
+            worker_effort=resolve_worker_effort(
+                self._configured_value(_WORKER_EFFORT_ENV)
+            ),
+            triage_model=resolve_triage_model(
+                self._configured_value(_TRIAGE_MODEL_ENV)
+            ),
+        )
         (
             self._assurance_tiers,
             self._assurance_tiers_json,
@@ -1417,6 +1436,7 @@ class StellaAgent(BaseInstalledAgent):
             return None
         stripped = value.strip()
         return stripped or None
+
 
     def _effective_base_url(self, model: str) -> str | None:
         """Resolve and validate the authoritative provider endpoint."""

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -39,6 +39,92 @@ _ASSURANCE_TIERS_VERSION = "stella-tb21-assurance-tiers-v1"
 # trial ran cannot disagree with the arm its digest records (#1007).
 _WITNESS_AUTHOR_ENV = "STELLA_WITNESS_AUTHOR_MODEL"
 
+# Host-side selector for the worker's effort tier. The rule that sets it has
+# not changed — spend what the comparator spends — but the comparator is no
+# longer fixed, so the tier stops being a constant and becomes an arm. Both
+# admissible values are leaderboard-meaningful tiers rather than free text, and
+# the choice lands in the posture hash, so two runs at different efforts can
+# never share a digest.
+_WORKER_EFFORT_ENV = "STELLA_WORKER_EFFORT"
+_ADMISSIBLE_WORKER_EFFORTS = ("high", "xhigh", "max")
+
+# Host-side selector for the triage author. Triage classifies the request and
+# builds a prompt; it never edits the workspace and never decides the outcome,
+# so it is the one role where a cheaper, faster, non-reasoning model is a
+# design choice rather than a handicap. Unset keeps the historical behaviour
+# (triage inherits `default_model`), so every digest recorded before this
+# selector existed still describes the posture that produced it.
+_TRIAGE_MODEL_ENV = "STELLA_TRIAGE_MODEL"
+
+
+def resolve_worker_effort(value: str | None) -> str:
+    """Resolve the worker's effort tier from its host-side selector.
+
+    ``None`` (unset) reproduces every posture hash recorded before the tier
+    became selectable. An explicitly *empty* value is refused rather than
+    quietly treated as unset: it means an operator meant to select an arm and
+    the value was lost somewhere, which is exactly the case where inheriting
+    the frozen default would attribute the run to a tier nobody chose.
+    """
+    if value is None:
+        return "xhigh"
+    return _validated_worker_effort(value)
+
+
+def resolve_triage_model(value: str | None) -> str | None:
+    """Resolve the triage author pin, or ``None`` to inherit the worker.
+
+    Same shape as the witness author: the pin has to be asked for, so a tree
+    that merely carries this code keeps producing the historical posture.
+    Whitespace-only is treated as unset here because, unlike the effort tier,
+    "no pin" is a meaningful and previously-default configuration.
+    """
+    if value is None:
+        return None
+    return value.strip() or None
+
+
+def _validated_role_model(model: str, candidate: str, role: str) -> str:
+    """Return a validated per-role model pin, or refuse it with the reason.
+
+    The provider rule is the same one `_validated_witness_author` enforces and
+    it is enforced separately rather than shared, because the two roles fail
+    differently: an unreachable judge silently degrades the *claim* (the run
+    proceeds with the worker as its own author), while an unreachable triage
+    model fails the *call*. Both are refusals here, before anything is spent.
+    """
+    pin = candidate.strip()
+    if not pin or "/" not in pin:
+        raise ValueError(
+            f"benchmark {role} model must be a non-empty provider/model spec"
+        )
+    worker_provider = model.split("/", 1)[0].strip().lower()
+    pin_provider = pin.split("/", 1)[0].strip().lower()
+    if worker_provider != pin_provider:
+        raise ValueError(
+            f"benchmark {role} model must share the worker's provider "
+            f"(`{worker_provider}`): a trial carries exactly one provider "
+            f"credential over the anonymous FD, so a {role} model on "
+            f"`{pin_provider}` would authenticate against nothing"
+        )
+    return pin
+
+
+def _validated_worker_effort(worker_effort: str) -> str:
+    """Return the worker effort tier, or refuse an unrecognised one.
+
+    Fails closed rather than falling back to a default: a typo that silently
+    became `xhigh` would produce a number attributed to an effort the run never
+    used, and the digest would agree with the typo rather than with reality.
+    """
+    effort = worker_effort.strip().lower()
+    if effort not in _ADMISSIBLE_WORKER_EFFORTS:
+        raise ValueError(
+            f"benchmark worker effort must be one of "
+            f"{', '.join(_ADMISSIBLE_WORKER_EFFORTS)}; got `{worker_effort}`"
+        )
+    return effort
+
 
 def _validated_witness_author(model: str, witness_author: str) -> str:
     """Return the pinned witness/judge author, or refuse it with the reason.
@@ -82,6 +168,8 @@ def _benchmark_engine_posture(
     model: str,
     *,
     witness_author: str | None = None,
+    worker_effort: str = "xhigh",
+    triage_model: str | None = None,
 ) -> tuple[dict[str, Any], str, str]:
     """Return a canonical Terminal-Bench engine posture and its hash.
 
@@ -113,6 +201,7 @@ def _benchmark_engine_posture(
     selected_model = model.strip()
     if not selected_model or "/" not in selected_model:
         raise ValueError("benchmark model must be a non-empty provider/model spec")
+    selected_effort = _validated_worker_effort(worker_effort)
     posture: dict[str, Any] = {
         "default_model": selected_model,
         "allowed_models": [selected_model],
@@ -196,8 +285,13 @@ def _benchmark_engine_posture(
                 "reasoning": "on",
                 "params": {"max_tokens": 64000},
             },
+            # Only the worker's tier moves with the arm. `default` stays at
+            # `xhigh` deliberately: it governs roles with no explicit entry
+            # below, and letting it track the worker would silently retune
+            # those roles too — a second, undeclared variable inside a digest
+            # that claims to describe one.
             "worker": {
-                "effort": "xhigh",
+                "effort": selected_effort,
                 "reasoning": "on",
                 "params": {"max_tokens": 64000},
             },
@@ -235,6 +329,20 @@ def _benchmark_engine_posture(
         # number this digest misdescribes.
         posture["pipeline_judge_model"] = author
         posture["allowed_models"] = [selected_model, author]
+    if triage_model is not None:
+        # Same flat-key reasoning as the judge pin above: `settings_check` and
+        # `stella config` report the flat key as the role's origin, so the
+        # disclosed posture and the engine's own account of its wiring name the
+        # same field. `allowed_models` has to widen with it — the vocabulary is
+        # a whitelist, and a triage pin outside it is refused at resolve time,
+        # which would drop triage back onto the worker and bill the expensive
+        # model for the cheap role while the digest claimed otherwise.
+        triage = _validated_role_model(selected_model, triage_model, "triage")
+        posture["pipeline_triage_model"] = triage
+        allowed = list(posture["allowed_models"])
+        if triage not in allowed:
+            allowed.append(triage)
+        posture["allowed_models"] = allowed
     normalized = json.dumps(
         posture,
         sort_keys=True,

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -192,6 +192,119 @@ class TestBenchmarkPosture:
         assert on_digest != off_digest
 
 
+class TestWorkerEffortAndTriageArms:
+    """The two selectors a tuning run varies, and what they refuse."""
+
+    _MODEL = "openrouter/anthropic/claude-sonnet-5"
+
+    def test_unset_selectors_reproduce_the_frozen_posture(self) -> None:
+        """Carrying this code must not, by itself, change any recorded digest.
+
+        The selectors exist so a run can *ask* for a different arm. A tree that
+        merely contains them has asked for nothing, so the posture it produces
+        has to be byte-identical to the one produced before they existed —
+        otherwise every hash in `bench/READINESS.md` silently stops describing
+        the run it was recorded against.
+        """
+        explicit = _benchmark_engine_posture(
+            self._MODEL, worker_effort="xhigh", triage_model=None
+        )
+        default = _benchmark_engine_posture(self._MODEL)
+        assert default[1] == explicit[1]
+        assert default[2] == explicit[2]
+        assert default[0]["agents"]["worker"]["effort"] == "xhigh"
+        assert "pipeline_triage_model" not in default[0]
+
+    def test_worker_effort_moves_only_the_worker_and_the_digest(self) -> None:
+        """`high` and `xhigh` are two arms, and the hash has to say which."""
+        high, _high_json, high_digest = _benchmark_engine_posture(
+            self._MODEL, worker_effort="high"
+        )
+        xhigh, _xhigh_json, xhigh_digest = _benchmark_engine_posture(
+            self._MODEL, worker_effort="xhigh"
+        )
+        assert high["agents"]["worker"]["effort"] == "high"
+        assert xhigh["agents"]["worker"]["effort"] == "xhigh"
+        assert high_digest != xhigh_digest
+        # Only the worker moved. `default` governs roles with no entry of
+        # their own, and letting it track the worker would retune them as an
+        # undeclared second variable inside a one-variable comparison.
+        assert high["agents"]["default"]["effort"] == "xhigh"
+        assert high["agents"]["judge"]["effort"] == "xhigh"
+        assert high["agents"]["triage"] == xhigh["agents"]["triage"]
+
+    def test_unrecognised_worker_effort_is_refused_not_defaulted(self) -> None:
+        """A typo must not be silently promoted to the frozen default.
+
+        Falling back would attribute the run to a tier nobody selected, and the
+        digest would agree with the typo rather than with reality — the same
+        failure mode as a treatment arm degrading into the control arm.
+        """
+        with pytest.raises(ValueError, match="worker effort"):
+            _benchmark_engine_posture(self._MODEL, worker_effort="ultra")
+
+    def test_triage_pin_lands_in_the_flat_key_and_widens_the_vocabulary(
+        self,
+    ) -> None:
+        """A pinned triage author must also be an *allowed* model.
+
+        `allowed_models` is a whitelist. A triage pin outside it is refused at
+        resolve time, triage falls back to the worker, and the run bills the
+        expensive model for the cheap role while the digest claims otherwise.
+        """
+        triage = "openrouter/anthropic/claude-haiku-4.5"
+        posture, _normalized, digest = _benchmark_engine_posture(
+            self._MODEL, triage_model=triage
+        )
+        assert posture["pipeline_triage_model"] == triage
+        assert triage in posture["allowed_models"]
+        assert self._MODEL in posture["allowed_models"]
+        # Triage stays low/off regardless of who authors it: the role emits a
+        # short classification, and raising it would change what Stella is
+        # rather than what it was allowed to spend.
+        assert posture["agents"]["triage"] == {"effort": "low", "reasoning": "off"}
+        assert digest != _benchmark_engine_posture(self._MODEL)[2]
+
+    def test_triage_pin_must_share_the_workers_provider(self) -> None:
+        """One credential reaches the container, so a second provider is unusable."""
+        with pytest.raises(ValueError, match="triage model must share"):
+            _benchmark_engine_posture(
+                self._MODEL, triage_model="anthropic/claude-haiku-4.5"
+            )
+
+    def test_all_three_roles_coexist_inside_the_launcher_vocabulary(self) -> None:
+        """The full tuning posture must survive the fail-closed launcher seam.
+
+        `config::trusted_engine_config_shape_is_strict` rejects any root key
+        outside `ENGINE_ROOT_FIELDS`, so a posture that names a judge *and* a
+        triage author is the shape most likely to trip it — and it refuses the
+        run outright rather than dropping the unknown key.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            self._MODEL,
+            witness_author="openrouter/anthropic/claude-fable-5",
+            worker_effort="high",
+            triage_model="openrouter/anthropic/claude-haiku-4.5",
+        )
+        allowed_roots = {
+            "default_model",
+            "pipeline_judge_model",
+            "pipeline_worker_model",
+            "pipeline_triage_model",
+            "allowed_models",
+            "auto_mode",
+            "effort_auto",
+            "reasoning_auto",
+            "headless_scope_bypass",
+            "agents",
+        }
+        assert set(posture) <= allowed_roots
+        assert set(posture["agents"]) <= {"default", "worker", "judge", "triage"}
+        # Every pinned role is in the whitelist, or it cannot be resolved.
+        for role_key in ("pipeline_judge_model", "pipeline_triage_model"):
+            assert posture[role_key] in posture["allowed_models"]
+
+
 class TestWitnessStreamObservation:
     """Folding `AgentEvent::Proof` into a field an analysis can read."""
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1978 bench/harbor_adapter/stella_harbor/__init__.py
+1998 bench/harbor_adapter/stella_harbor/__init__.py
 4271 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1910 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py
@@ -15,8 +15,8 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-2350 stella-cli/src/agent.rs
 1794 stella-cli/src/agent_tests.rs
+2350 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
 4445 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
@@ -25,7 +25,7 @@
 1849 stella-fleet/src/fleet.rs
 1628 stella-model/src/anthropic/tests.rs
 2060 stella-model/src/openai.rs
-1520 stella-model/src/zai.rs
+1524 stella-model/src/zai.rs
 1773 stella-model/src/zai/tests.rs
 3381 stella-pipeline/src/pipeline.rs
 2440 stella-pipeline/src/pipeline/tests.rs

--- a/stella-cli/src/engine_config.rs
+++ b/stella-cli/src/engine_config.rs
@@ -949,9 +949,20 @@ mod tests {
         // Worker family anthropic → zai (2.20) beats deepseek (1.10).
         let spec = auto_judge_spec(&engine, "anthropic", &|_| true).unwrap();
         assert_eq!(spec.provider, "zai");
-        // Credentials filter: with anthropic unavailable, deepseek wins for
-        // a zai worker.
+        // Credentials filter: with anthropic unavailable, `anthropic/…` stops
+        // parsing as a qualified spec (the prefix is no longer a configured
+        // provider) and falls through to a bare-slug catalog lookup of the
+        // whole string. The gateway seeds that exact slug — it is OpenRouter's
+        // real wire name for the model — so the same model is still reachable
+        // over a provider we DO hold a credential for, and price still ranks
+        // it above deepseek. Losing the first-party key downgrades the route,
+        // not the judge.
         let spec = auto_judge_spec(&engine, "zai", &|id| id != "anthropic").unwrap();
+        assert_eq!(spec.provider, "openrouter");
+        assert_eq!(spec.model, "anthropic/claude-fable-5");
+        // With neither the vendor nor the gateway, deepseek is the fallback.
+        let spec =
+            auto_judge_spec(&engine, "zai", &|id| id != "anthropic" && id != "openrouter").unwrap();
         assert_eq!(spec.provider, "deepseek");
         // Nothing configured → None (caller falls back to normal routing).
         assert!(auto_judge_spec(&engine, "zai", &|_| false).is_none());

--- a/stella-cli/src/engine_config.rs
+++ b/stella-cli/src/engine_config.rs
@@ -961,8 +961,10 @@ mod tests {
         assert_eq!(spec.provider, "openrouter");
         assert_eq!(spec.model, "anthropic/claude-fable-5");
         // With neither the vendor nor the gateway, deepseek is the fallback.
-        let spec =
-            auto_judge_spec(&engine, "zai", &|id| id != "anthropic" && id != "openrouter").unwrap();
+        let spec = auto_judge_spec(&engine, "zai", &|id| {
+            id != "anthropic" && id != "openrouter"
+        })
+        .unwrap();
         assert_eq!(spec.provider, "deepseek");
         // Nothing configured → None (caller falls back to normal routing).
         assert!(auto_judge_spec(&engine, "zai", &|_| false).is_none());

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -439,6 +439,78 @@ impl Catalog {
                     },
                 )
                 .with_reasoning(Some(true)),
+                // The three Anthropic models as OpenRouter serves them. They
+                // duplicate slugs already seeded under `anthropic`, and that
+                // duplication is the point: `resolve_for` matches on
+                // (provider, id) exactly, so the first-party row is invisible
+                // to a run routed through the gateway. Without these, a
+                // benchmark trial on `openrouter/anthropic/claude-sonnet-5`
+                // resolves nothing, `max_output_tokens` is `None`, and the
+                // engine falls back to its global 16384 — the zero-tool
+                // truncation failure these ceilings exist to prevent,
+                // reintroduced by the choice of route alone.
+                //
+                // Routing matters now because the first-party Anthropic key is
+                // not always the one available; the gateway is. Prices are
+                // OpenRouter's own quotes, which differ from Anthropic list
+                // (Sonnet is $2/$10 here against $3/$15 direct), so a row that
+                // merely aliased the first-party pricing would misreport spend
+                // on every gateway turn.
+                CatalogEntry::new(
+                    "anthropic/claude-sonnet-5",
+                    "openrouter",
+                    "claude",
+                    1_000_000,
+                    // OpenRouter speaks its OpenAI-compatible dialect for every
+                    // upstream, including Anthropic's own models — the same
+                    // reason `moonshotai/kimi-k3` above is `OpenaiJson` rather
+                    // than the vendor's native shape.
+                    ToolDialect::OpenaiJson,
+                    Pricing {
+                        input_usd_per_mtok: 2.00,
+                        output_usd_per_mtok: 10.00,
+                        cached_input_usd_per_mtok: 0.20,
+                        cache_write_usd_per_mtok: 2.50,
+                    },
+                )
+                .with_reasoning(Some(true))
+                .with_max_output_tokens(Some(64_000)),
+                CatalogEntry::new(
+                    "anthropic/claude-fable-5",
+                    "openrouter",
+                    "claude",
+                    1_000_000,
+                    ToolDialect::OpenaiJson,
+                    Pricing {
+                        input_usd_per_mtok: 10.00,
+                        output_usd_per_mtok: 50.00,
+                        cached_input_usd_per_mtok: 1.00,
+                        cache_write_usd_per_mtok: 12.50,
+                    },
+                )
+                .with_reasoning(Some(true))
+                .with_max_output_tokens(Some(64_000)),
+                // Seeded for the `triage` role specifically: it classifies the
+                // request and builds a prompt, never edits the workspace, so
+                // the cheapest fast model in the family is the right one and
+                // its reasoning stays off. The 200k window is Haiku's own, not
+                // a trimmed copy of Sonnet's — `compaction_budget_tokens` is
+                // clamped off this number, so overstating it would let triage
+                // assemble a prompt the model cannot accept.
+                CatalogEntry::new(
+                    "anthropic/claude-haiku-4.5",
+                    "openrouter",
+                    "claude",
+                    200_000,
+                    ToolDialect::OpenaiJson,
+                    Pricing {
+                        input_usd_per_mtok: 1.00,
+                        output_usd_per_mtok: 5.00,
+                        cached_input_usd_per_mtok: 0.10,
+                        cache_write_usd_per_mtok: 1.25,
+                    },
+                )
+                .with_reasoning(Some(false)),
             ],
         }
     }
@@ -663,6 +735,42 @@ mod tests {
                 Some(64_000),
                 "{slug} must carry its ceiling in the seed, not only after a refresh",
             );
+        }
+        // The same models reached through the gateway are different rows, and
+        // the ceiling has to be on both. `resolve_for` matches (provider, id)
+        // exactly, so the first-party row above cannot answer for a run routed
+        // over OpenRouter: without its own ceiling that run silently drops to
+        // the engine's global 16384 and truncates before it emits a tool call.
+        // Choosing a route is not supposed to change the model's ceiling.
+        for slug in ["anthropic/claude-sonnet-5", "anthropic/claude-fable-5"] {
+            assert_eq!(
+                Catalog::seed()
+                    .resolve_for("openrouter", slug)
+                    .unwrap()
+                    .max_output_tokens,
+                Some(64_000),
+                "{slug} must carry its ceiling on the gateway route too",
+            );
+        }
+    }
+
+    /// The benchmark's roles must all resolve on one provider. A trial carries
+    /// exactly one credential, so a judge or triage model that only exists on
+    /// a second provider is unreachable at run time — and an unresolvable
+    /// judge pin silently degrades to "judge is the worker", which is the
+    /// weaker claim #1147 exists to refuse.
+    #[test]
+    fn every_benchmark_role_model_resolves_on_the_gateway_provider() {
+        let catalog = Catalog::seed();
+        for slug in [
+            "anthropic/claude-sonnet-5",  // worker
+            "anthropic/claude-fable-5",   // judge, arm A
+            "moonshotai/kimi-k3",         // judge, arm B
+            "anthropic/claude-haiku-4.5", // triage, both arms
+        ] {
+            catalog
+                .resolve_for("openrouter", slug)
+                .unwrap_or_else(|_| panic!("`{slug}` must be reachable on the openrouter route"));
         }
     }
 


### PR DESCRIPTION
Enables a Stella-only Terminal-Bench tuning run where the three engine roles sit on three different models. Two things blocked that, and both are fixed here.

## Why

**The catalog could not name Anthropic's models on the gateway route.** `resolve_for` matches `(provider, id)` exactly, so the seeded `anthropic` rows are invisible to a run routed through OpenRouter. A trial on `openrouter/anthropic/claude-sonnet-5` resolved nothing, `max_output_tokens` came back `None`, and the engine fell back to its global **16384** — the zero-tool truncation failure the seeded ceilings exist to prevent, reintroduced by the choice of route alone.

This is not hypothetical. In `gate1/gate2/gate3c` the worker burned whole steps hitting the 32000 cap with `tool_calls: 0`; `delta1` at 64000 shows `capped=0` and a single step reaching 46,686 output tokens. The ceiling is load-bearing, and it has to survive the route.

**The posture froze one model and `xhigh` for every role.** The only per-role override wired was `pipeline_judge_model`.

## What

**Catalog** — seed `anthropic/claude-sonnet-5`, `anthropic/claude-fable-5` and `anthropic/claude-haiku-4.5` under provider `openrouter`. They duplicate slugs already present under `anthropic`, and the duplication is the point. Prices are OpenRouter's own quotes (Sonnet is \$2/\$10 there against \$3/\$15 direct), so aliasing the first-party row would misreport spend on every gateway turn.

**Posture** — `worker_effort` and `triage_model` join `witness_author` as host-side selectors that land in the hashed posture, so two arms can never share a digest. Only the *worker's* tier moves; `default` stays `xhigh` so roles without an entry of their own are not retuned as an undeclared second variable. An unrecognised effort is refused rather than defaulted — a typo promoted to `xhigh` would attribute the run to a tier nobody chose.

Both knobs are registered host-only. The ambient check fails closed, and an unlisted `STELLA_TURN_BUDGET` already killed all ten trials of `gate3` at launch.

## Behaviour change worth reviewing

Seeding the gateway rows makes `anthropic/claude-fable-5` resolvable as a bare slug, which changes one branch of auto-judge selection: when `anthropic` is *not* a configured provider, the string stops parsing as a qualified spec and falls through to a catalog lookup of the whole string — which now exists on the gateway. The same model stays reachable over a provider we hold a credential for, so losing the vendor key downgrades the **route**, not the judge. Asserted explicitly in `engine_config.rs` rather than left to be discovered. The first-party path is unchanged: with `anthropic` configured the prefix split still wins.

The collision is intrinsic — OpenRouter's real wire slug for that model *is* `anthropic/claude-fable-5`, so it cannot be renamed around.

## Verification

- `stella-model` 326 passed; `stella-cli --bin stella` 1087 passed
- harbor adapter 343 passed, 1 skipped
- `check-file-size` OK; full pre-push gate green

Unset selectors reproduce the frozen posture byte-for-byte (asserted), so carrying this code changes no recorded digest.

**Note on the baseline:** `scripts/file-size-baseline.txt` records `zai.rs` 1520→1524, which is **inherited from #1202**, not from this change. `__init__.py` +20 is this change and is structural (imports, registry entries, the call).

## Summary by Sourcery

Enable benchmark runs to configure worker effort and triage author per role while ensuring Anthropic models remain correctly resolved and capped when routed via OpenRouter.

New Features:
- Add host-side selectors to configure worker effort tier and triage model for benchmark runs, with these choices embedded in the engine posture hash.
- Seed Anthropic Claude models under the OpenRouter provider in the catalog so benchmark roles can target gateway-routed variants with accurate ceilings and pricing.

Bug Fixes:
- Ensure Anthropic Claude models retain their max output token ceilings when accessed through the OpenRouter route to prevent unintended truncation.
- Guarantee benchmark role models (worker, judge, triage) are resolvable on the configured gateway provider so pins cannot silently degrade or fail at runtime.
- Adjust auto-judge selection so losing a first-party Anthropic credential prefers the OpenRouter route for the same model before falling back to deepseek.

Enhancements:
- Validate worker effort values strictly and fail closed on invalid tiers to keep posture digests aligned with the actual run configuration.
- Allow triage model pins while automatically widening the allowed model whitelist and enforcing provider matching between worker and triage roles.
- Extend posture hashing and launcher checks to cover the new worker and triage selectors without changing existing digests when unset.

Tests:
- Add posture tests covering worker effort selection, triage model pinning, provider validation, and compatibility with strict launcher config validation.
- Extend catalog tests to assert OpenRouter Anthropic models carry the correct max output token ceilings and are resolvable for all benchmark roles.