### PR TITLE
docs+bench: pipeline-journey doc, fix stale posture copies, correct witness stage ordering

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -303,7 +303,7 @@ the relaunch is a fresh job name rather than a resume. The fix is to pre-pull al
 of the run instead of a term in the measurement. Any future runner on a
 consumer network should do the same.
 
-### 8.5 Effort was `high` against a `max` comparator (#1007)
+### 8.4 Effort was `high` against a `max` comparator (#1007)
 
 The posture froze `effort: high` for default/worker/judge. The comparator this
 benchmark is scored against is *"Claude Code using GLM-5.1 at **max effort**"*
@@ -330,7 +330,7 @@ the launcher emits:
 | x-ai/grok-4.5 | `3c7d6155…` | `ff61cb06…` |
 | z-ai/glm-5.1 | `55fdf342…` | `f15536e5…` |
 
-### 8.3.1 `max` → `xhigh`, for the Sonnet-5 comparator
+### 8.4.1 `max` → `xhigh`, for the Sonnet-5 comparator
 
 The rule that picked `max` above did not change; the comparator did. The rule
 is *spend what the other side spends*, because the leaderboard treats `high`,
@@ -345,7 +345,7 @@ Stella compute the comparator never receives. Anthropic separately documents
 `xhigh` — not `max` — as the setting for coding and agentic work, and warns
 `max` is prone to overthinking, so parity and the model's own guidance agree.
 
-### 8.3.2 The output cap moves with the effort tier
+### 8.4.2 The output cap moves with the effort tier
 
 Raising the tier alone was not enough, and the smoke run said so before the
 scored run could. Two of three Stella trials at xhigh died with:
@@ -390,7 +390,7 @@ because those arms were re-run. Runs published under the `max` posture remain
 described by the 8.3 table; a run states which posture it used in its own
 manifest, which is the point of hashing it.
 
-### 8.3.2 The output cap moves to the model's ceiling, and the two ceilings behind it
+### 8.4.3 The output cap moves to the model's ceiling, and the two ceilings behind it
 
 The `xhigh` posture above kept `params.max_tokens` at 32000. Arm B telemetry
 from the gate3c head-to-head falsified that number directly. Claude Code passed
@@ -429,23 +429,26 @@ head-to-head mean anything: **never be the side that stops first.** A ceiling
 below what the comparator is allowed is not a tuning choice, it is a handicap
 that the score then reports as a capability difference.
 
-Recomputed digests, via the adapter's own `_benchmark_engine_posture`:
+Recomputed digests, via the adapter's own `_benchmark_engine_posture`. (An
+earlier revision of this table mislabeled the `max`-era digests as the
+`xhigh`/32000 ones for three models; both prior generations are shown below,
+each re-verified by recomputing the exact posture variant.)
 
-| model | was (`xhigh`, 32000) | now (`xhigh`, 64000) |
-|---|---|---|
-| deepseek-v4-pro | `4249a1f9…` / `0de2116f…` | `9d7ad135…` |
-| z-ai/glm-5.2 | `a0ab8a75…` | `7e9da633…` |
-| x-ai/grok-4.5 | `ff61cb06…` | `19c4d345…` |
-| z-ai/glm-5.1 | `f15536e5…` | `8530a36f…` |
-| anthropic/claude-sonnet-5 | `55c6ef4c…` | `3c428a22…` |
+| model | was (`max`, uncapped) | was (`xhigh`, 32000) | now (`xhigh`, 64000) |
+|---|---|---|---|
+| deepseek-v4-pro | `0de2116f…` | `4249a1f9…` | `9d7ad135…` |
+| z-ai/glm-5.2 | `a0ab8a75…` | `b906090c…` | `7e9da633…` |
+| x-ai/grok-4.5 | `ff61cb06…` | `a1b0df58…` | `19c4d345…` |
+| z-ai/glm-5.1 | `f15536e5…` | `b80a9d06…` | `8530a36f…` |
+| anthropic/claude-sonnet-5 | `5176b46b…` | `55c6ef4c…` | `3c428a22…` |
 
-Runs published under the 32000 posture remain described by the 8.3.1 table.
+Runs published under the 32000 posture remain described by the 8.4.1 table.
 The registered tables in the protocol and the analyzer README carry the new
 values, because those describe the posture the launcher will actually emit —
 a document that disagrees with the code is the `harbor==0.6.1` failure again,
 in a different file.
 
-### 8.4 The measured baseline
+### 8.5 The measured baseline
 
 See `bench/evidence/` for the run manifest, per-trial rows, per-task results and
 the two scripts that recompute the number from them. Its preregistration is

--- a/bench/harbor_adapter/README.md
+++ b/bench/harbor_adapter/README.md
@@ -407,10 +407,11 @@ For every selected model, the normalized posture is:
   "auto_mode": "off",
   "effort_auto": "off",
   "reasoning_auto": "off",
+  "headless_scope_bypass": "on",
   "agents": {
-    "default": {"effort": "high", "reasoning": "on"},
-    "worker": {"effort": "high", "reasoning": "on"},
-    "judge": {"effort": "high", "reasoning": "on"},
+    "default": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+    "worker": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+    "judge": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
     "triage": {"effort": "low", "reasoning": "off"}
   }
 }

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -399,11 +399,15 @@ _ENGINE_POSTURE_FIELDS = frozenset(
         "auto_mode",
         "effort_auto",
         "reasoning_auto",
+        "headless_scope_bypass",
         "agents",
     }
 )
 _ENGINE_POSTURE_AGENT_ROLES = frozenset({"default", "worker", "judge", "triage"})
-_ENGINE_POSTURE_AGENT_FIELDS = frozenset({"effort", "reasoning"})
+# The outcome-bearing roles also carry `params` (`{"max_tokens": …}`); triage
+# keeps the engine default and has no `params` key. Kept in step with
+# `posture.py`, the normative home these sets describe.
+_ENGINE_POSTURE_AGENT_FIELDS = frozenset({"effort", "reasoning", "params"})
 RUNTIME_IDENTITY_FIELDS = frozenset(
     {
         "binary_sha256",

--- a/bench/terminal-bench-2.1-protocol.md
+++ b/bench/terminal-bench-2.1-protocol.md
@@ -141,9 +141,13 @@ raw trials, and disclosed comparator below.
 - Engine posture: the adapter atomically replaces merged repository/user
   `agent_engine_config` through the trusted `STELLA_ENGINE_CONFIG_JSON` seam
   after all Harbor extras. Every role inherits the exact selected model from
-  `default_model`; default/worker/judge use reasoning `on` at effort `high`,
-  triage uses reasoning `off` at effort `low`, all auto modes are `off`, and no
-  role has a provider/model/prompt/parameter override. The posture also sets
+  `default_model`; default/worker/judge use reasoning `on` at effort `xhigh`
+  with a raised `params.max_tokens` output cap of `64000` (retuned from the
+  original `high`/uncapped posture after the effort-parity and
+  output-truncation findings in `bench/READINESS.md` §8.4 — the digests in the
+  calibration manifest below are for this retuned posture), triage uses
+  reasoning `off` at effort `low`, all auto modes are `off`, and no
+  role has any other provider/model/prompt/parameter override. The posture also sets
   `headless_scope_bypass: on` (a string toggle) — a **deliberate,
   score-affecting** setting, disclosed here explicitly. A headless trial has no
   operator to approve an over-threshold plan; with this flag *off*, any plan

--- a/bench/terminal_bench_analysis/README.md
+++ b/bench/terminal_bench_analysis/README.md
@@ -81,14 +81,15 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
       "auto_mode": "off",
       "effort_auto": "off",
       "reasoning_auto": "off",
+      "headless_scope_bypass": "on",
       "agents": {
-        "default": {"effort": "high", "reasoning": "on"},
-        "worker": {"effort": "high", "reasoning": "on"},
-        "judge": {"effort": "high", "reasoning": "on"},
+        "default": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+        "worker": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+        "judge": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
         "triage": {"effort": "low", "reasoning": "off"}
       }
     },
-    "engine_posture_sha256": "98511188b8338637afe0f2ffde1998c26f048db2f9c936549f75bd222600cf76"
+    "engine_posture_sha256": "8530a36f8fe064d59a64b6b732d57d9e9d9613c0fee27da9b5a6f1501551ffe9"
   },
   "analysis": {
     "sha256": "REPLACE_AFTER_FINAL_ANALYZER_FREEZE_WITH_64_HEX",
@@ -202,9 +203,9 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
           "auto_mode": "off", "effort_auto": "off", "reasoning_auto": "off",
           "headless_scope_bypass": "on",
           "agents": {
-            "default": {"effort": "high", "reasoning": "on"},
-            "worker": {"effort": "high", "reasoning": "on"},
-            "judge": {"effort": "high", "reasoning": "on"},
+            "default": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "worker": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "judge": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
@@ -218,9 +219,9 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
           "auto_mode": "off", "effort_auto": "off", "reasoning_auto": "off",
           "headless_scope_bypass": "on",
           "agents": {
-            "default": {"effort": "high", "reasoning": "on"},
-            "worker": {"effort": "high", "reasoning": "on"},
-            "judge": {"effort": "high", "reasoning": "on"},
+            "default": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "worker": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "judge": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
@@ -234,9 +235,9 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
           "auto_mode": "off", "effort_auto": "off", "reasoning_auto": "off",
           "headless_scope_bypass": "on",
           "agents": {
-            "default": {"effort": "high", "reasoning": "on"},
-            "worker": {"effort": "high", "reasoning": "on"},
-            "judge": {"effort": "high", "reasoning": "on"},
+            "default": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "worker": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
+            "judge": {"effort": "xhigh", "reasoning": "on", "params": {"max_tokens": 64000}},
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },

--- a/bench/terminal_bench_analysis/tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tb21_analysis.py
@@ -55,7 +55,17 @@ CANONICAL_ENGINE_POSTURE_VERSION = "stella-tb21-engine-posture-v1"
 
 
 def canonical_engine_posture(model: str) -> tuple[dict[str, Any], str, str]:
-    """Return the registered launcher-owned engine config and byte hash."""
+    """Return the registered launcher-owned engine config and byte hash.
+
+    Mirrors ``bench/harbor_adapter/stella_harbor/posture.py`` — the normative
+    home for the posture (its module docs promise every consumer derives the
+    hash "from one implementation rather than from copies that can disagree").
+    This copy exists only because the analyzer is deliberately stdlib-only;
+    ``tests/test_tb21_analysis.py::test_posture_matches_the_adapters`` pins the
+    two byte-for-byte, so an edit to either without the other fails CI instead
+    of failing every trial's posture gate at claim time (which is what the
+    previous, silently stale copy of this function did).
+    """
     selected_model = model.strip()
     if not selected_model or "/" not in selected_model:
         raise ValueError("model must be a non-empty provider/model spec")
@@ -65,10 +75,23 @@ def canonical_engine_posture(model: str) -> tuple[dict[str, Any], str, str]:
         "auto_mode": "off",
         "effort_auto": "off",
         "reasoning_auto": "off",
+        "headless_scope_bypass": "on",
         "agents": {
-            "default": {"effort": "high", "reasoning": "on"},
-            "worker": {"effort": "high", "reasoning": "on"},
-            "judge": {"effort": "high", "reasoning": "on"},
+            "default": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 64000},
+            },
+            "worker": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 64000},
+            },
+            "judge": {
+                "effort": "xhigh",
+                "reasoning": "on",
+                "params": {"max_tokens": 64000},
+            },
             "triage": {"effort": "low", "reasoning": "off"},
         },
     }
@@ -612,13 +635,23 @@ STUDY_MANIFEST_ENGINE_POSTURE_FIELDS = frozenset(
         "auto_mode",
         "effort_auto",
         "reasoning_auto",
+        "headless_scope_bypass",
         "agents",
     }
 )
 STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES = frozenset(
     {"default", "worker", "judge", "triage"}
 )
-STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS = frozenset({"effort", "reasoning"})
+# Per-role field shapes: the outcome-bearing roles carry the raised output cap
+# (`params.max_tokens`); triage deliberately keeps the engine default, so its
+# exact shape has no `params` key. One flat set cannot express both.
+STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE: dict[str, frozenset[str]] = {
+    "default": frozenset({"effort", "reasoning", "params"}),
+    "worker": frozenset({"effort", "reasoning", "params"}),
+    "judge": frozenset({"effort", "reasoning", "params"}),
+    "triage": frozenset({"effort", "reasoning"}),
+}
+STUDY_MANIFEST_ENGINE_POSTURE_AGENT_PARAMS_FIELDS = frozenset({"max_tokens"})
 STUDY_MANIFEST_CONFIRMATORY_FIELDS = frozenset({"job_name", "n_concurrent_trials"})
 
 JOB_CONFIG_ALLOWED_FIELDS = frozenset(
@@ -2247,10 +2280,22 @@ def _validate_engine_posture_manifest_schema(
             continue
         _require_exact_manifest_fields(
             agents[role],
-            STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS,
+            STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE[role],
             f"{label}.agents.{role}",
             reasons,
         )
+        role_config = agents[role]
+        if (
+            isinstance(role_config, dict)
+            and "params" in STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE[role]
+            and "params" in role_config
+        ):
+            _require_exact_manifest_fields(
+                role_config["params"],
+                STUDY_MANIFEST_ENGINE_POSTURE_AGENT_PARAMS_FIELDS,
+                f"{label}.agents.{role}.params",
+                reasons,
+            )
 
 
 def _matches_setting(actual: Any, expected: Any) -> bool:

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -525,8 +525,42 @@ _POSTURE, _POSTURE_JSON, _POSTURE_SHA256 = analysis_module.canonical_engine_post
     _READINESS_POSTURE_SHA256,
 ) = analysis_module.canonical_engine_posture(_READINESS_MODEL)
 assert _POSTURE_SHA256 == (
-    "98511188b8338637afe0f2ffde1998c26f048db2f9c936549f75bd222600cf76"
+    "8530a36f8fe064d59a64b6b732d57d9e9d9613c0fee27da9b5a6f1501551ffe9"
 )
+
+
+def test_posture_matches_the_adapters() -> None:
+    """The analyzer's posture copy is byte-identical to the adapter's.
+
+    ``stella_harbor/posture.py`` is the normative home; the analyzer keeps a
+    stdlib-only copy so claim analysis has no package dependency. The copy has
+    drifted before — the adapter moved to xhigh/64000 + ``headless_scope_bypass``
+    while this module still hashed the effort-``high`` posture, which would have
+    failed every current trial's posture gate at claim time. Loading the adapter
+    module by path (it is pure stdlib) pins the two together so the next drift
+    fails here, in CI, instead.
+    """
+    import importlib.util
+
+    posture_path = (
+        Path(__file__).resolve().parents[2]
+        / "harbor_adapter"
+        / "stella_harbor"
+        / "posture.py"
+    )
+    spec = importlib.util.spec_from_file_location("stella_harbor_posture", posture_path)
+    assert spec is not None and spec.loader is not None
+    adapter_posture = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(adapter_posture)
+
+    for model in (analysis_module.PRIMARY_MODEL, *CALIBRATION_MODEL_ORDER):
+        ours, ours_json, ours_sha = analysis_module.canonical_engine_posture(model)
+        theirs, theirs_json, theirs_sha = adapter_posture._benchmark_engine_posture(
+            model
+        )
+        assert ours == theirs, f"posture body drifted for {model}"
+        assert ours_json == theirs_json, f"normalized JSON drifted for {model}"
+        assert ours_sha == theirs_sha, f"posture digest drifted for {model}"
 
 
 def _study_manifest(

--- a/docs/papers/deterministic-engine.md
+++ b/docs/papers/deterministic-engine.md
@@ -32,7 +32,7 @@ deterministic loop produces better outcomes than the flexibility of a swarm.
 4. [Stella's engine: deterministic by construction](#4-stellas-engine-deterministic-by-construction)
 5. [Why determinism is a feature, not a limitation](#5-why-determinism-is-a-feature-not-a-limitation)
 6. [When multi-agent is the wrong answer](#6-when-multi-agent-is-the-wrong-answer)
-7. [The deferred layer: stella-fleet](#7-the-deferred-layer-stella-fleet)
+7. [The parallel layer: stella-fleet](#7-the-parallel-layer-stella-fleet)
 8. [Conclusion](#8-conclusion)
 
 ---
@@ -270,11 +270,12 @@ trade-off, and the research supports it."
 
 ---
 
-## 7. The deferred layer: stella-fleet
+## 7. The parallel layer: stella-fleet
 
 Stella's workspace includes `stella-fleet` — a multi-agent fan-out system with
 a DAG planner, git-worktree isolation per task, and a SQLite lineage + spend
-ledger. It is complete and property-tested but **not wired into the CLI.**
+ledger. (When this paper was first written it was complete and property-tested
+but not yet wired into the CLI; it has since shipped as `stella fleet`.)
 
 This is not a contradiction. `stella-fleet` addresses a different problem:
 **multi-task parallelism**, not multi-agent-per-task coordination. When you

--- a/docs/pipeline-journey.md
+++ b/docs/pipeline-journey.md
@@ -1,0 +1,374 @@
+# The journey of a prompt — full pipeline mode, in plain language
+
+**Status:** Living document. Describes the staged pipeline as of 0.6.x.
+
+This is the maintainer's companion to the user-facing
+[Inference Pipeline](../website/content/docs/inference-pipeline.mdx) page. That
+page explains *what* the pipeline promises; this one walks a single prompt from
+the moment it enters `stella run` to the moment the run reports done, naming
+the module that owns each step so you can find the code in one hop. Everything
+here lives in `stella-pipeline` unless stated otherwise; the async orchestrator
+is `src/pipeline.rs`, and every *decision* it makes is a pure synchronous
+function in a sibling module (`triage`, `plan`, `scope`, `verify`, `witness`,
+`candidate`) — that split is the crate's core invariant.
+
+The one-line itinerary:
+
+> **prompt → triage (+ recall, concurrently) → [conversational fast path?] →
+> plan → scope review → execute → diff probe → witness warrant → witness
+> authoring (on demand) → evidence ladder → { submit fast | revise | judge |
+> abstain } → complete.**
+
+A detail worth calling out immediately, because older docs got it backwards:
+**the witness test is authored *after* execution, not before it.** Authoring
+waits until the warrant (`witness::warrant`) has read the actual diff, so a
+docs-only change never buys a test, and the author is kept *blind* to the diff
+(it works in a pristine snapshot of the pre-execution tree) so it cannot write
+a test that merely restates the patch.
+
+---
+
+## 0. What "full pipeline mode" is
+
+Stella has two ways to run a prompt:
+
+- **The raw step loop** (`stella run --no-pipeline`, and interactive chat):
+  `stella-core::Engine::run_turn` — the model proposes tool calls, tools run,
+  results feed back, repeat until the model stops or a budget/backstop fires.
+  No stages, no verification.
+- **The staged pipeline** (`stella run`, the default; per-turn in the Command
+  Deck while `/pipeline` is ON): the step loop wrapped in the stages below,
+  with deterministic verification and terminal-event ownership moved up into
+  `Pipeline::run`.
+
+"Full pipeline mode" is the second one. The engine still does all the actual
+work — reading files, editing, running commands — but the pipeline decides
+*when* the engine runs, *what evidence* is collected around it, and *whether
+the result may be called done*.
+
+The pipeline owns the terminal events. `Engine::run_turn` emits its own
+`Stage { Complete }` per turn, which is correct for one turn but wrong for a
+multi-step or revising run — so the pipeline gives each engine turn a private
+channel, forwards everything except the engine's stage/terminal events, and is
+the single authority for `Complete` / terminal `Error` (see the "Event
+ownership" section of the `pipeline.rs` module docs).
+
+## 1. Intake: triage and recall run side by side
+
+Entry point: `Pipeline::run` (`src/pipeline.rs`).
+
+Two things start at once, because neither depends on the other:
+
+- **Triage** (`Pipeline::triage` + the pure `triage` module): one cheap model
+  call, on the triage role's configured model, that classifies the prompt.
+  It answers two independent questions — *is this even a software task?*
+  (`conversational`), and *how much ceremony does it deserve?* (`TaskClass`:
+  `SimpleLookup` / `SingleTask` / `MultiStep`) — plus two optional opinions:
+  whether an authored witness is warranted and whether a judge review is
+  warranted. The call runs under a hard latency ceiling
+  (`triage_latency_ceiling`, default 10 s); if the model doesn't answer in
+  time the pipeline falls through to the full path rather than waiting.
+  A **deterministic floor** (`triage::resolve_task_class`) pattern-matches the
+  goal and can only *raise* the class toward more planning, never lower it —
+  a misclassified complex task must still complete, just with less
+  scaffolding, never fail outright.
+- **Context recall** (`ContextRecallPort`): advisory memory/graph recall over
+  the goal, bounded by its own latency ceiling (`recall_latency_ceiling`,
+  default 5 s) and degraded to "no frames" on expiry. Recalled frames are
+  bounded at the source (`bound_recalled_frames`) and ride as a **volatile
+  user message after the byte-stable system prefix** — never mutated into the
+  system block — so prompt-cache hits on the stable prefix survive across
+  turns (invariant 7, L-E8).
+
+## 2. The conversational fast path
+
+If triage said "this is chat, not work" — and the deterministic floor saw no
+task signal to overrule it — the pipeline answers in **one plain, tool-less
+completion** under a conversational system prompt and exits
+(`Pipeline::run_conversational`). This is the escape hatch that keeps a bare
+`hi` from being planned, executed, and witness-tested.
+
+## 3. Plan, then scope review (multi-step only)
+
+Only a `MultiStep` class plans (`TaskClass::plans`). The planner
+(`plan::build_planner_prompt` / `parse_plan`) turns the goal, the recalled
+frames, and a repository-structure summary into explicit steps. A plan that
+fails to parse gets one bounded repair attempt (`plan_repair_prompt`), then
+degrades to a single-step plan — a stubborn planner never blocks the work.
+
+If the plan's blast radius crosses any configured threshold
+(`scope::ScopeThresholds`: more than 5 steps, more than 8 estimated files, or
+estimated cost over $1 by default; all strict `>`), the run pauses for **scope
+review** (`pipeline/scope_stage.rs`). Interactively, you approve, trim to the
+largest under-threshold prefix, abort, or send the plan back to the planner
+with a note (bounded at `MAX_SCOPE_REVISIONS` re-plans). Headless runs must
+opt in to bypass the gate (`headless_bypass_scope_review` — the
+`headless_scope_bypass` engine-config toggle); without it, an over-threshold
+plan ends the run rather than silently auto-approving.
+
+## 4. Deciding where the work happens
+
+Before executing, the pipeline resolves *whose tree* the candidate works in
+(`worktree_decision_without_asking` + `Pipeline::isolate_in_worktree`):
+
+- **Best-of-N** (`candidates = Some(n)`) always isolates: each candidate runs
+  in a snapshot of the current tree (HEAD + uncommitted + untracked, via a
+  detached git worktree), and only the winner's changes are adopted.
+- **An authored witness** always requires a disposable candidate, even at
+  N = 1, so authoring can never mutate the session tree.
+- Otherwise the **worktree policy** (`create_worktrees`: always / never / ask)
+  decides — and it is consulted only when the run will actually change files,
+  and only when isolation is available (a plain directory can't offer it; a
+  configured `always` that can't be honoured says so out loud).
+
+There is a "never choose nothing" backstop: a candidate that aborts in *setup*
+(no isolation port, unsnapshottable tree, no independent witness author)
+degrades to a bare worker run on the working tree
+(`Pipeline::degrade_to_bare_execution`) — the fancy path being unavailable is
+a reason to do less, never a reason to do nothing. Genuine execution aborts
+(budget, loop detection, step caps) keep their stop.
+
+## 5. Baselines: the flip oracle arms before execution
+
+For any class that verifies, and only when the user supplied `--test-command`,
+the candidate runs that command **once before executing anything**
+(`Pipeline::run_candidate`) and records the result in the **flip oracle**
+(`verify::FlipOracle`). The oracle is a state machine keyed on the normalized
+command string: it locks onto the first *failure* it observes, and only a
+later *pass of that same command* moves it to `Flipped`. A suite that was
+already green can never produce a flip — which structurally excludes the
+"it passed, ship it" false positive.
+
+Details that keep the oracle honest:
+
+- **Typed outcomes (#860):** a baseline that timed out or never spawned
+  observed no assertion and does not lock the oracle — infra noise plus a
+  merely-faster candidate must not read as a verified flip.
+- **Failure fingerprints (#867):** a failing baseline contributes the *names*
+  of its failing tests; a later pass that names its tests without naming the
+  baseline's failures is no evidence — the fix-by-disappearance case (delete
+  the failing test, suite exits 0) is refused.
+
+Two other baselines are captured here: a lint/typecheck snapshot for the
+regression veto (#861), and content fingerprints of untracked files so the
+diff probe can tell this turn's new files from pre-existing dirt.
+
+## 6. Execute: the engine does the work
+
+`Pipeline::execute_plan` emits `Stage { Execute }` and runs the worker:
+
+- **Simple / single-task:** one engine turn against the goal.
+- **Multi-step:** one engine turn per plan step, each fed
+  `Step i/n: <description>` on top of the shared conversation.
+
+Each turn is `stella-core::Engine::run_turn` — the full tool loop with
+compaction, loop detection, and hooks — running on the **worker** role's
+model. The pipeline counts two things as the turn runs: `FileChange` events
+(observed file touches) and **mutating actions** (dispatched tool calls whose
+tool is not advertised read-only; unknown tools count as mutating, because
+`bash` is how most real work lands). The budget guard is consulted only at
+safe boundaries — between model calls, never mid-tool (invariant 6).
+
+## 7. The diff probe — engineered to be incapable of lying
+
+After execution the pipeline reads what changed (`Pipeline::gather_diff`):
+tracked changes via the configured diff diagnostic (default `git diff`), plus
+per-file `--no-index` numstats for created/modified untracked files (bounded
+concurrency). The probe's output is deliberately three-valued:
+
+- a real diff;
+- "the tree changed but the diff could not be captured" — when `FileChange`
+  events are positive but the diff came back empty
+  (`verification_honest_diff`), which downstream readers must treat as
+  *couldn't verify*, never *verified nothing*;
+- "the probe could not read the tree at all" (`DIFF_PROBE_FAILED`), with a
+  separately named case for "this is not a git repository, so `git diff` can
+  never answer here" (`DIFF_PROBE_NOT_A_REPO` — the permanent condition of a
+  Terminal-Bench task image, #973).
+
+The distinction exists because an ambiguous empty diff once convinced a judge
+that "no changes were made" — the archetypal verification lie.
+
+Simple lookups exit here if they touched nothing: a clean lookup has nothing
+to verify. A lookup that unexpectedly *did* touch files has its judge-skip
+revoked (the zero-diff guard) and continues into verification like any other
+change.
+
+## 8. The witness warrant, then on-demand authoring
+
+If no `--test-command` is armed, verification still wants a deterministic
+oracle — but only when the change *warrants* one. The **warrant**
+(`witness::warrant`) reads the diff and answers "does this change need a
+witness test, and if not, why not":
+
+- `NothingChanged`, `DocsOnly`, `TestsOnly`, `ConfigOnly`, `CommentsOnly`,
+  `PureRemoval` — each a *stated reason*, recorded in the verdict, mirroring
+  the contributor rule ("ship a witness test, or a stated reason there isn't
+  one"). Test-only changes and pure removals still warrant an independent
+  review even though no test is warranted.
+- Anything mixed, unrecognized, or unreadable **fails closed to Required**:
+  an unnecessary witness costs one model call; a missing one ships unverified
+  behavior.
+
+When a witness is required, the **witness author** — an independent model,
+resolved from the judge's slot and refused if it would be the same model as
+the worker — writes a minimal *failing* test (`pipeline/witness_stage.rs`).
+The author works in a **pristine snapshot of the pre-execution tree**, blind
+to the diff, so the test pins the *intended behavior* rather than restating
+the patch. The authored test must:
+
+- fail on the old code first (the fail-first gate — a test that passes before
+  the change proves nothing);
+- pass a static assertion-density screen (`witness::density`, #863): no
+  assertion-free tests, no constant-only assertions, no self-comparisons, no
+  bare `#[should_panic]`;
+- survive tamper checks every verify iteration: a worker (or revise turn)
+  that edits the witness files hard-fails the candidate
+  (`witness::airlock`).
+
+Its command then arms the same flip oracle. The witness is scaffolding for
+this one run — it lives and dies with the candidate workspace unless
+`--keep-witness` promotes it.
+
+If no independent author can be resolved, the run degrades to the unauthored
+ladder with a warning — unless `require_independent_witness` is set, in which
+case the run refuses up front (#1147: a benchmark arm whose manifest names an
+independent author must not silently produce a number without one).
+
+## 9. Verify: the evidence ladder
+
+`Pipeline::verify_candidate` re-runs the tracked command (the configured one,
+else the witness's), feeds every observation back to the oracle, and hands the
+pure `verify::ladder_decision` one `LadderInputs` snapshot: flip state,
+touched-test result, diff size and availability, file-touch count, mutating
+actions, new lint errors/warnings, and whether the witness proved
+tautological. The ladder answers **in this order**:
+
+1. **Touched tests red → `Revise`.** Already a deterministic failure; never
+   spend a judge call confirming it.
+2. **Nothing attempted → `NothingAttempted`.** The turn dispatched zero
+   mutating calls and nothing observed a change: the model narrated a solution
+   and wrote none of it down. This rung is *knowledge*, not abstention — the
+   revision turn gets a blunt nudge ("reasoning about a solution, or stating
+   one in prose, does not perform it"), and a run that never acts ends
+   `passed: false`. Before this rung existed, eleven untouched Terminal-Bench
+   tasks were reported as successes.
+3. **Every channel blind → `Unverifiable`.** No flip, no test result, an
+   unreadable tree, no recorded touch: the ladder *abstains*. No judge call —
+   a judge asked to rule on an empty record once answered with a confident
+   `FAIL` naming a file that existed. The run is scored unverified, never
+   passed or failed.
+4. **Flip + green + diff within budget (default ≤ 400 lines) + no new lint
+   errors + witness not tautological → `SubmitFast`.** The full deterministic
+   pass. The model judge is skipped entirely. Two audits run before the
+   submit is final: a **confirmation run** (#859 — one extra suite run; a
+   flake demotes the oracle to `Unstable` and escalates instead) and the
+   **mutation check** (#870 — break the changed lines one at a time; a
+   witness that stays green under every mutant is tautological and loses its
+   fast-submit).
+5. **Otherwise → `ModelJudge`.** Genuinely inconclusive, but at least one
+   channel saw something.
+
+## 10. Judge: asymmetric trust in a second opinion
+
+When the ladder escalates, the **judge** — a separate model call, by
+preference from a different model *family* than the worker — reviews the
+goal, the honest diff, and a compact structured evidence snapshot
+(`JudgeEvidence` carrying the full `LadderSnapshot`, #864: oracle trace in
+observation order, diagnostics delta, tamper result, audit findings), and
+answers with a leading `PASS` or `FAIL`. It never sees the worker's narration.
+A failed judge call degrades to a conservative heuristic verdict
+(`verify::heuristic_fallback`) rather than hanging.
+
+Trust in the judge is deliberately asymmetric, because its authority was
+measured and found wanting: across an 89-task Terminal-Bench run where the
+witness rung couldn't fire (single-model posture), the judge agreed with the
+benchmark's own grader 46% of the time, and its false passes cost tasks
+outright. So a judge "not yet" is always actionable (costs one revision), but
+a judge "done" **standing alone** — no flip, no green test behind it — is
+scored *unverified* rather than passed (`judge_pass_stands_alone`). The judge
+never overrides a deterministic failure.
+
+## 11. Revise: bounded retries with escalating candor
+
+A `Revise` decision (or a judge `FAIL`) sends the evidence back into a fresh
+worker turn (`Pipeline::revise_candidate`), up to `max_revisions` times
+(default 2). On the **second consecutive** deterministic failure, the pipeline
+spends one judge call on **distress guidance** (`verify::guidance_prompt`) —
+a course-correction note that rides with the next revision prompt instead of
+letting the worker dig the same hole. Repeated identical failures also widen
+what the revision prompt discloses about the failure
+(`witness::airlock::grain_for_repeats` — sealed failure output is scrubbed of
+secrets and disclosed at coarser or finer grain by repeat count). After every
+revise turn the tracked command is re-run and the ladder re-decides; the
+witness tamper check runs every iteration, so a revise turn that edits the
+witness is caught at the next check.
+
+## 12. Best-of-N selection and adoption
+
+With `candidates = Some(n)`, each candidate runs steps 5–11 in its own
+isolated snapshot (steered apart by `candidate_steering::SteeringFanOut`) and
+is scored (`candidate::score_from_verification`):
+
+> `DeterministicPass > JudgePass > Unverified > Failed`
+
+Ties break within a rank by mutation-survival, then fewer new diagnostics,
+then smaller diff (#869/#870). Only the winner's changes are adopted into the
+real tree — atomically, failing loudly with the conflicting paths named if
+you edited the same files mid-run. Losing candidates leave no residue.
+
+## 13. Complete: one terminal event, honest accounting
+
+`Pipeline::run` adopts the winning candidate's message trajectory and emits
+exactly one terminal signal:
+
+- **`Complete`** (with the worker model's label and the run's total spend)
+  when verification passed or was legitimately not needed;
+- a non-retryable **`Error`** when verification stayed red after the revision
+  budget (`PipelineStatus::VerificationFailed`) or the run aborted;
+- hard infrastructure failures return out of band as `PipelineRunError`.
+
+The `PipelineOutcome` records the task class, final text, total cost, revision
+count, how many candidates actually *ran* (not how many were configured), and
+the verdict — including `deterministic: true/false`, so a headless caller can
+tell a flip-oracle pass from a judge's opinion, and the frozen
+`LadderSnapshot` (#865), so `stella replay` can answer "why did this run
+fast-submit / revise / judge?" from the recording alone without re-deriving.
+
+Every stage boundary along the way emitted a `Stage` event, every model call
+was metered into the budget guard, and every proof-relevant step (oracle
+observations, warrant, tamper checks, audits) landed on the proof rail
+(`ProofStep`) — which is what makes a pipeline run *replayable* and its
+verdict *auditable* after the fact.
+
+---
+
+## Who runs on which model
+
+Four roles, all configured through `agent_engine_config` (see the README's
+"Agent engine config" section):
+
+| Role | What it does in the journey | Default resolution |
+|---|---|---|
+| **triage** | Stage 1 classification call | `pipeline_triage_model` → `default_model` |
+| **worker** | Execute turns, revise turns (plan and conversational ride this tier too) | `pipeline_worker_model` → `default_model` |
+| **judge** | Judge verdicts, distress guidance | `pipeline_judge_model` → `default_model`; prefers a different model *family* than the worker |
+| **witness author** | Authors the failing witness test | Resolves from the judge slot; **refused** if it would equal the worker's model — Stella will not let the worker write the test that proves the worker |
+
+A configured role model whose provider has no resolvable key degrades softly
+to the worker with a notice — configuration can never turn a runnable
+pipeline into an error. The one exception is deliberate:
+`require_independent_witness` makes a missing independent author a refusal
+instead of a degradation, for callers whose published posture claims one.
+
+## Where the knobs live
+
+`PipelineConfig` (`src/pipeline.rs`) is the single tuning surface: latency
+ceilings, scope thresholds, headless behavior, `test_command`,
+`witness_writer`, `keep_witness`, `distress_guidance`, `diff_budget_lines`
+(400), `diagnostics_veto_warnings`, `max_revisions` (2),
+`require_independent_witness`, `candidates`, and `create_worktrees`. The
+verification half's design history and remaining work are tracked in
+[`ROADMAP.md`](../ROADMAP.md); every decision and its spend is pinned by the
+per-PR degradation gate (`stella-pipeline/src/pipeline/tests/degradation_gate.rs`,
+`docs/verification-gate.md`).

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -36,11 +36,13 @@ in stages:
 
 <PipelineFlowDiagram />
 
-In full: triage → recall → plan → scope review → witness → execute → verify
+In full: triage → recall → plan → scope review → execute → witness → verify
 → judge, with a bounded revise loop. Recall runs concurrently with triage
 but emits after it; plan, scope review, and witness are conditional — a
 simple lookup skips them, scope review fires only above thresholds, and the
-witness is authored only without `--test-command`.
+witness is authored only without `--test-command`, on demand *after*
+execution, once the warrant has read the diff and confirmed the change
+needs a test at all.
 
 ### 1. Triage
 
@@ -97,12 +99,27 @@ typing — a note beginning "also do X" would have approved the plan it was
 arguing with. `Esc` is the one exception, because it cannot be mistaken for
 prose and it stops work rather than starting it.
 
-### 4. Witness
+### 4. Execute
+
+The worker runs the step loop against the plan — reading, editing, building,
+testing — with the full [toolbelt](/docs/agent-tools) and its
+[configured model, prompt, and parameters](/docs/configuration/agent-engine-config).
+If you passed `--test-command`, that command is run once *before* execution to
+record the failing baseline — the fail half of the flip oracle.
+
+### 5. Witness
 
 Verification needs something deterministic to check. If you passed
-`--test-command`, that command is the oracle. If not, an independent model —
+`--test-command`, that command is the oracle. If not, the **warrant** reads
+the diff the execute stage produced and decides whether the change needs a
+test at all — a docs-only edit, a pure removal, or a test-only change gets a
+stated reason instead of a test, and anything mixed or unreadable fails
+closed to "prove it". When a witness is warranted, an independent model —
 the **witness author**, never the worker — writes a minimal *failing* test
-that pins down the intended behavior. Witness files are watched for tampering:
+that pins down the intended behavior. The author works in a pristine snapshot
+of the *pre-execution* tree, blind to the diff, so it cannot write a test
+that merely restates the patch; its test must fail there first, and its
+command then arms the flip oracle. Witness files are watched for tampering:
 a worker that edits the witness test doesn't get credit for "passing" it.
 
 The witness is scaffolding for one run, not a test you inherit. It is written
@@ -114,19 +131,13 @@ nobody reviewed. Pass `--keep-witness` to promote it into your working tree
 when the test is worth keeping.
 
 ```bash
-# No oracle armed — an independent model authors the witness, and it is
-# discarded with the candidate workspace.
+# No oracle armed — an independent model authors the witness on demand, and
+# it is discarded with the candidate workspace.
 stella run "make Plan::validate reject a self-dependency by name"
 
 # Same run, but keep the authored test as a file you can review and commit.
 stella run --keep-witness "make Plan::validate reject a self-dependency by name"
 ```
-
-### 5. Execute
-
-The worker runs the step loop against the plan — reading, editing, building,
-testing — with the full [toolbelt](/docs/agent-tools) and its
-[configured model, prompt, and parameters](/docs/configuration/agent-engine-config).
 
 ### 6. Verify — the deterministic ladder
 

--- a/website/src/components/diagrams.tsx
+++ b/website/src/components/diagrams.tsx
@@ -221,8 +221,8 @@ export function PipelineFlowDiagram() {
   const stages: [string, string][] = [
     ["triage", "route it"],
     ["plan", "split context"],
-    ["witness", "failing test"],
     ["execute", "step loop"],
+    ["witness", "failing test"],
     ["verify", "flip oracle"],
     ["judge", "cross-family"],
   ];
@@ -231,7 +231,7 @@ export function PipelineFlowDiagram() {
       className="sdg"
       viewBox="0 0 720 150"
       role="img"
-      aria-label="The staged pipeline: triage, plan, witness, execute, verify, judge — with a revise loop back into execute."
+      aria-label="The staged pipeline: triage, plan, execute, witness, verify, judge — with a revise loop back into execute."
     >
       <title>The staged inference pipeline</title>
       <Defs />
@@ -253,8 +253,8 @@ export function PipelineFlowDiagram() {
         );
       })}
       {/* revise: judge back to execute */}
-      <Wire d="M672 96 C672 132 420 132 420 98" />
-      <text className="sdg-sub" x="546" y="142" textAnchor="middle">
+      <Wire d="M672 96 C672 132 302 132 302 98" />
+      <text className="sdg-sub" x="487" y="142" textAnchor="middle">
         revise — bounded, with evidence
       </text>
     </svg>


### PR DESCRIPTION
## What & why

Three strands, found while writing a plain-language walkthrough of the staged pipeline:

1. **New doc — `docs/pipeline-journey.md`.** A maintainer-oriented, plain-language narrative of a prompt's full journey through pipeline mode (triage+recall → conversational fast path → plan/scope → isolation decision → baselines → execute → diff probe → warrant → on-demand witness → evidence ladder → judge → revise → best-of-N selection → completion), with module pointers for every stage. Companion to the site's `inference-pipeline` page, which stays user-facing.

2. **Bench: the claim analyzer's posture copy had silently drifted three revisions behind the adapter.** `tb21_analysis.py::canonical_engine_posture` still hashed the effort-`high` posture with no `headless_scope_bypass` and no `params.max_tokens`, while `stella_harbor/posture.py` (the normative home) emits xhigh/64000 + `headless_scope_bypass: on`. As committed, **every trial produced by the current adapter would fail the analyzer's per-trial posture gate** — exactly the copy-drift `posture.py`'s module docs promise cannot happen. Synced the copy, extended the v6 schema field sets to the per-role shapes, updated the stale digest literal, and synced the launcher's (unconsumed but misleading) field sets.

3. **Doc corrections that fell out of verifying the above:**
   - Website `inference-pipeline.mdx` + `PipelineFlowDiagram` still showed witness → execute; the witness has been authored **after** execution (warrant-gated, diff-blind author) since the warrant landed. Reordered and documented the warrant.
   - Bench READMEs and the protocol prose showed effort-`high` posture JSON beside current xhigh-era digests; updated the bodies.
   - `READINESS.md` had two `### 8.3.2` sections and a digest table that mislabeled `max`-era digests as the xhigh/32000 generation for three models — renumbered (8.4.1–8.4.3, 8.5) and corrected the table, with every cell re-verified by recomputing the exact posture variant.
   - `docs/papers/deterministic-engine.md` still said stella-fleet is "not wired into the CLI"; it ships as `stella fleet`.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**

`tests/test_tb21_analysis.py::test_posture_matches_the_adapters` loads `stella_harbor/posture.py` by path and pins the analyzer's copy byte-for-byte against it, for the primary and all three calibration models. It fails on `main` (the copies disagree in body, normalized JSON, and digest) and passes here — and it makes the next drift a CI failure instead of a claim-time surprise.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)

No Rust code is touched; the workspace suite passes unchanged. The Python analyzer suite passes except the six ATIF-trajectory tests that require the pinned `harbor==0.6.1` package, which also fail identically on unmodified `main` in an environment without it — CI installs the pin.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

- `bench/terminal-bench-2.1-protocol.md` is a frozen preregistration; the edit follows the file's existing post-freeze-amendment practice and only brings the engine-posture *prose* in line with the digest table the same document already carries (which was recomputed for the retuned posture).
- The READINESS §8.4.3 digest-table correction was adjudicated by recomputation, not by guesswork — the `max`-uncapped and xhigh/32000 generations produce distinct digests for every roster model, and the corrected table shows both.

---

---

## Summary by Sourcery

Document the full staged inference pipeline journey, sync benchmark analyzer posture with the Harbor adapter, and correct documentation and diagrams around engine posture and witness stage ordering.

New Features:
- Add a maintainer-facing `docs/pipeline-journey.md` that narrates a prompt's full path through the staged pipeline with module pointers.

Bug Fixes:
- Update the benchmark analyzer's canonical engine posture to match the Harbor adapter (xhigh effort, raised max_tokens, headless_scope_bypass) and refresh its posture digest.
- Tighten engine posture manifest schema validation to reflect per-role field shapes and params fields, preventing configuration drift.
- Add a regression test that ensures the analyzer's posture copy stays byte-identical to the adapter implementation, catching future drift in CI.

Enhancements:
- Clarify website pipeline docs and flow diagram so execute precedes witness, expanding explanation of warrant-driven, on-demand witness authoring after execution.
- Align benchmark READMEs and protocol text with current xhigh/64000 posture, including corrected digest tables and section numbering.
- Update deterministic-engine paper to reflect that `stella-fleet` now ships on the CLI and reposition it as the parallel layer.
- Align Harbor secure launcher engine posture schema with the normative posture definition, including params for outcome-bearing roles.

Documentation:
- Introduce a detailed pipeline journey document describing each stage, decisions, and roles in full pipeline mode.
- Correct and expand user-facing documentation of the inference pipeline, witness warranting, and execution order.
- Fix outdated descriptions of engine posture, effort tiers, and digests in readiness and protocol docs, and update the description of `stella-fleet`'s CLI integration.

Tests:
- Add a test that loads the Harbor adapter posture module by path and asserts that its posture body, normalized JSON, and digest match the analyzer's for all benchmark models.
