### PR TITLE
chore: retighten the file-size ratchet baseline after #1203–#1209

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,26 +8,26 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 1998 bench/harbor_adapter/stella_harbor/__init__.py
-4271 bench/harbor_adapter/stella_harbor/secure_launcher.py
+4275 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1910 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py
-8166 bench/terminal_bench_analysis/tb21_analysis.py
+8211 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
-4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+4207 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
+2360 stella-cli/src/agent.rs
 1794 stella-cli/src/agent_tests.rs
-2350 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4503 stella-cli/src/command_deck.rs
+4508 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2579 stella-core/src/driver.rs
+2585 stella-core/src/driver.rs
 3543 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1628 stella-model/src/anthropic/tests.rs
 2060 stella-model/src/openai.rs
 1524 stella-model/src/zai.rs
 1773 stella-model/src/zai/tests.rs
-3403 stella-pipeline/src/pipeline.rs
+3336 stella-pipeline/src/pipeline.rs
 2474 stella-pipeline/src/pipeline/tests.rs
 2784 stella-protocol/src/event.rs
 2078 stella-store/src/lib.rs


### PR DESCRIPTION
## What & why

CI's `no new .rs file over the 1500-line ratchet` step is red on `main`: six grandfathered files grew past their recorded ceilings across the PRs that merged this morning — #1209's Python posture/parity work (`tb21_analysis.py` +45, its tests +34, `secure_launcher.py` +4) and the checkpoint/judge/triage work in #1203–#1207 (`agent.rs` +10, `command_deck.rs` +5, `driver.rs` +6). This is the baseline diff `check-file-size.sh` asks for, so the growth is justified in review rather than absorbed silently:

- the analyzer's posture body and v6 schema constants must live in the frozen, stdlib-only `tb21_analysis.py` (the secure launcher loads that exact file by path);
- the posture-parity witness belongs beside the analyzer tests it guards;
- the Rust growth shipped with its own reviewed PRs.

The update also **retightens** `stella-pipeline/src/pipeline.rs` from 3403 → 3336 (it shrank 67 lines in #1206), which is the ratchet working in the direction it exists for.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is the baseline file the file-size gate itself consumes; the gate is the test (`./scripts/check-file-size.sh` fails on `main`, passes here).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

One-file change. The alternative to a baseline bump would be splitting the three Python files, but `tb21_analysis.py` is deliberately one frozen, hash-identified artifact for the claim path, and the growth in the Rust files was already reviewed in its own PRs.

---

---

## Summary by Sourcery

Update file-size baseline thresholds so the ratchet gate reflects recent justified growth and shrinkage in tracked files.

Build:
- Adjust file-size baseline configuration used by CI size-check script to match current file sizes across Python and Rust sources.

CI:
- Realign the file-size ratchet gate input so the `check-file-size.sh` CI step passes on main while continuing to enforce the 1500-line limit.

Chores:
- Retighten baseline for `stella-pipeline/src/pipeline.rs` to capture its recent line-count reduction.
