### PR TITLE
fix(bench): enroll git_baseline.py and exit_cause.py in the frozen adapter roster

### DIFF
--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -74,6 +74,8 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/__init__.py",
     "bench/harbor_adapter/stella_harbor/atif.py",
     "bench/harbor_adapter/stella_harbor/credential_bundle.py",
+    "bench/harbor_adapter/stella_harbor/exit_cause.py",
+    "bench/harbor_adapter/stella_harbor/git_baseline.py",
     "bench/harbor_adapter/stella_harbor/host_attestation.py",
     "bench/harbor_adapter/stella_harbor/live_feed.py",
     "bench/harbor_adapter/stella_harbor/portability.py",

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2074 bench/harbor_adapter/stella_harbor/__init__.py
-4275 bench/harbor_adapter/stella_harbor/secure_launcher.py
+2111 bench/harbor_adapter/stella_harbor/__init__.py
+4277 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1910 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py
 8211 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
## What & why

Main's "harbor_adapter + analyzer pytest" job is red: 31 launcher tests fail with `RuntimeError: public adapter tree hash differs from runtime identity`. That is the fail-closed mismatch `_FIXED_ADAPTER_SOURCE_PATHS` exists to force — the runtime digest rglobs every `*.py` under `stella_harbor/`, while the public-tree check walks the hand-written tuple, so any module present on disk but absent from the tuple makes the two disagree and everything downstream fails closed.

Two modules were added without enrollment:

- `stella_harbor/git_baseline.py` (#1212, pre-agent git baseline)
- `stella_harbor/exit_cause.py` (#1213, SIGKILL post-mortem)

This PR adds both to the tuple in their alphabetical positions. It also regenerates the file-size ratchet baseline: `secure_launcher.py` +2 lines (the roster entries), and `__init__.py` 2074 → 2111 — growth #1213 landed on main without a baseline update, so the ratchet check on main is red as well and this absorbs it.

Refs #1211

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

The witness already exists on main: `test_frozen_adapter_source_paths_match_the_package_on_disk` compares the tuple against an rglob of the package and currently fails (along with 30 downstream launcher tests) — it names exactly this fix in its assertion message. Verified locally by replicating its comparison byte-for-byte: roster == on-disk set, no missing, no stale, alphabetical order preserved. The launcher suite itself needs the pinned `harbor` package, which isn't installable in this environment.

## The gate

- [x] `cargo fmt --check` — no Rust touched
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust touched
- [x] `cargo test --workspace` — no Rust touched
- [x] Docs updated where behavior/flags changed — none changed (a constant tuple and a generated baseline)
- [x] CLA signed
- [x] `Closes #N` — intentionally `Refs #1211` only; this advances the bench-readiness item without finishing the issue

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The two-line baseline diff is the visible-justification path the ratchet requires: one line is this PR's own +2 in `secure_launcher.py`, the other records `__init__.py`'s already-merged #1213 growth. Nothing is loosened beyond what is already on main.

---

## Summary by Sourcery

Enroll newly added harbor adapter modules in the frozen adapter roster and update the file-size baseline to match current sources.

Bug Fixes:
- Include exit_cause.py and git_baseline.py in the secure launcher frozen adapter source list so runtime and public adapter trees stay in sync.

Build:
- Refresh file-size baseline to reflect the updated harbor adapter sources.
