### PR TITLE
fix(pipeline): evidence gets the last word on the judge waiver; close the yaml config waiver

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2074 bench/harbor_adapter/stella_harbor/__init__.py
+2111 bench/harbor_adapter/stella_harbor/__init__.py
 4275 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1910 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py
@@ -27,8 +27,8 @@
 2060 stella-model/src/openai.rs
 1524 stella-model/src/zai.rs
 1773 stella-model/src/zai/tests.rs
-3336 stella-pipeline/src/pipeline.rs
-2474 stella-pipeline/src/pipeline/tests.rs
+3321 stella-pipeline/src/pipeline.rs
+2495 stella-pipeline/src/pipeline/tests.rs
 2784 stella-protocol/src/event.rs
 2078 stella-store/src/lib.rs
 2261 stella-store/src/tests.rs

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -2428,33 +2428,18 @@ impl<'a> Pipeline<'a> {
                         return CandidateResult::aborted(state.messages, reason);
                     }
                 }
-                // Triage judged this result not worth a separate reviewer.
-                // Record exactly that: a pass carrying no independent
-                // evidence. Falling through to `heuristic_fallback` would
-                // report "judge unavailable", which describes a judge that
-                // broke — not one that was deliberately waived — and would
-                // turn a task triage called simple into a verification
-                // failure. The summary states plainly what was not done.
-                LadderDecision::ModelJudge if !assessment.wants_judge() => {
-                    let evidence = JudgeEvidence {
-                        summary: "model review waived by triage; no independent \
-                                  verification was performed"
-                            .to_string(),
-                        deterministic: false,
-                        evidence_refs: vec![],
-                        ladder: Some(Box::new(snapshot.clone())),
-                    };
-                    self.emit(AgentEvent::JudgeVerdict {
-                        passed: true,
-                        evidence: evidence.clone(),
-                    });
-                    // Scored `Unverified`, NOT `DeterministicPass`: the run
-                    // passes, but no evidence was gathered for it. Claiming
-                    // the ladder's strongest score here would let a
-                    // review-waived candidate tie a genuinely flip-verified
-                    // sibling in best-of-N and then win the smaller-diff
-                    // tiebreak — selection would prefer the candidate that
-                    // proved the least.
+                // Triage judged this result not worth a separate reviewer,
+                // and the warrant AGREES from the change itself
+                // (`judge_waiver_stands`) — the guard is load-bearing, because
+                // this arm is only reached when the ladder came back
+                // inconclusive, which falsifies the waiver's own premise. A
+                // prompt-time `JUDGE: no` must not strip the last reviewer
+                // from a behavioral change nothing proved (§7.1:
+                // predict-then-commit is the bug).
+                LadderDecision::ModelJudge
+                    if !assessment.wants_judge() && Self::judge_waiver_stands(&state) =>
+                {
+                    let evidence = self.waived_completion(&snapshot);
                     return state.into_verified(
                         true,
                         &evidence,

--- a/stella-pipeline/src/pipeline/disclosure.rs
+++ b/stella-pipeline/src/pipeline/disclosure.rs
@@ -131,4 +131,48 @@ impl Pipeline<'_> {
         });
         Some(evidence)
     }
+
+    /// The verdict for a judge waiver that stands: triage said `JUDGE: no`
+    /// and the warrant agrees ([`Pipeline::judge_waiver_stands`]). A pass
+    /// carrying no independent evidence — the caller scores it `Unverified`,
+    /// never `DeterministicPass`, so a review-waived candidate cannot tie a
+    /// genuinely flip-verified sibling in best-of-N and then win the
+    /// smaller-diff tiebreak. The summary states plainly what was not done:
+    /// falling through to `heuristic_fallback` instead would report "judge
+    /// unavailable", which describes a judge that broke, not one that was
+    /// deliberately waived.
+    pub(super) fn waived_completion(
+        &self,
+        snapshot: &stella_protocol::LadderSnapshot,
+    ) -> JudgeEvidence {
+        let evidence = JudgeEvidence {
+            summary: "model review waived by triage; no independent verification was performed"
+                .to_string(),
+            deterministic: false,
+            evidence_refs: vec![],
+            ladder: Some(Box::new(snapshot.clone())),
+        };
+        self.emit(AgentEvent::JudgeVerdict {
+            passed: true,
+            evidence: evidence.clone(),
+        });
+        evidence
+    }
+
+    /// Whether triage's `JUDGE: no` waiver may stand, decided from the change
+    /// itself rather than the prompt.
+    ///
+    /// The waiver was answered before any work existed, and it is only ever
+    /// consulted once the ladder has come back inconclusive — the state in
+    /// which its own premise ("success is self-evident or a test proves it")
+    /// has been falsified. So the warrant gets the final word: the waiver
+    /// stands only where the diff shows nothing an independent reviewer could
+    /// catch (the same classes [`Pipeline::warranted_completion`] completes
+    /// without a judge). A behavioral diff, a deletion, or anything the diff
+    /// machinery could not read keeps its reviewer, whatever triage guessed.
+    pub(super) fn judge_waiver_stands(state: &CandidateState) -> bool {
+        warrant(&state.diff_text, state.file_changes)
+            .reason()
+            .is_some_and(|reason| !reason.warrants_independent_review())
+    }
 }

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1580,11 +1580,18 @@ async fn witness_authored_command_arms_the_flip_oracle_and_submits_fast() {
 /// bought a plan, an authored witness, and a judge no matter what triage said.
 /// An independent judge model IS available here, so a skipped witness proves
 /// triage's call was honored rather than independence being unavailable.
+///
+/// The judge is the one ceremony triage does NOT get to decline outright: its
+/// `JUDGE: no` was a prompt-time guess, this fixture's diff is behavioral, and
+/// nothing proved it — so the waiver does not stand (`judge_waiver_stands`)
+/// and the reviewer runs. Cheaper-than-the-floor still holds: no plan turn,
+/// no witness author, no baseline runs.
 #[tokio::test]
 async fn triage_can_route_work_onto_a_cheaper_path_than_the_keyword_floor() {
     let provider = ScriptedProvider::new(vec![
         text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
         text_result("done"),
+        text_result("PASS looks right"),
     ]);
     let (outcome, events, _) = run_unisolated_with_router(
         &provider,
@@ -1607,12 +1614,18 @@ async fn triage_can_route_work_onto_a_cheaper_path_than_the_keyword_floor() {
         !s.contains(&StageKind::Witness),
         "triage said no witness: {s:?}"
     );
-    // Two paid calls: triage and the worker. No witness author, no judge.
+    assert!(
+        s.contains(&StageKind::Judge),
+        "a behavioral diff keeps its reviewer, whatever triage guessed: {s:?}"
+    );
+    // Three paid calls: triage, the worker, and the judge the evidence
+    // demanded. The plan and witness-author ceremony triage declined is
+    // never bought.
     let calls = events
         .iter()
         .filter(|e| matches!(e, AgentEvent::StepUsage { .. }))
         .count();
-    assert_eq!(calls, 2, "ceremony triage declined is never bought: {s:?}");
+    assert_eq!(calls, 3, "no plan or witness-author call is bought: {s:?}");
 }
 
 /// The observed failure, end to end at the seam that actually decides it.
@@ -1628,6 +1641,9 @@ async fn a_chat_classification_on_a_files_request_still_reaches_execute() {
     let provider = ScriptedProvider::new(vec![
         text_result("CLASS: chat\nWITNESS: no\nJUDGE: no"),
         text_result("done"),
+        // The zero-diff guard revokes the lookup's judge-skip and the diff is
+        // behavioral, so the `JUDGE: no` waiver does not stand.
+        text_result("PASS looks right"),
     ]);
     let (outcome, events, _) = run_unisolated_with_router(
         &provider,
@@ -1659,6 +1675,8 @@ async fn headless_runs_ignore_a_model_chat_call_and_reach_execute() {
     let provider = ScriptedProvider::new(vec![
         text_result("CLASS: chat\nWITNESS: no\nJUDGE: no"),
         text_result("done"),
+        // Behavioral diff → the `JUDGE: no` waiver does not stand.
+        text_result("PASS looks right"),
     ]);
     let (outcome, events, _) = run_unisolated_with_router(
         &provider,
@@ -1927,11 +1945,14 @@ async fn run_isolated(
 /// execution on the working tree — not end the turn having done nothing.
 #[tokio::test]
 async fn a_setup_failure_degrades_to_a_bare_execution_instead_of_aborting() {
-    // triage → single; worker → done. No witness-author turn: the failure is
-    // pure isolation setup, and the bare fallback runs the worker once.
+    // triage → single; worker → done; judge → verdict. No witness-author
+    // turn: the failure is pure isolation setup, and the bare fallback runs
+    // the worker once. The judge runs despite `JUDGE: no` — the diff is
+    // behavioral, so the waiver does not stand (`judge_waiver_stands`).
     let provider = ScriptedProvider::new(vec![
         text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
         text_result("done"),
+        text_result("PASS looks right"),
     ]);
     let resolver = OneProvider(&provider);
     let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");

--- a/stella-pipeline/src/pipeline/tests/warrant.rs
+++ b/stella-pipeline/src/pipeline/tests/warrant.rs
@@ -91,6 +91,159 @@ async fn a_docs_only_change_completes_without_buying_a_judge_call() {
     );
 }
 
+const SOURCE_DIFF: &str = "\
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1,2 @@
+ fn a() {}
++fn b() { run(); }
+";
+
+/// Triage's `JUDGE: no` is a prompt-time guess, and this arm is only reached
+/// when the ladder came back inconclusive — the state that falsifies the
+/// waiver's own premise ("success is self-evident or a test already proves
+/// it"). On a behavioral diff nothing proved, the waiver must not stand: the
+/// third scripted call IS the judge, and the run must spend it.
+#[tokio::test]
+async fn a_judge_waiver_on_a_behavioral_diff_still_buys_the_judge() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
+        text_result("done"),
+        text_result("PASS — the change is sound"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], SOURCE_DIFF);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            witness_writer: false,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Add the b() helper", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    assert!(
+        provider.script.lock().await.is_empty(),
+        "the judge call must be spent: a waived judge here would leave the third result unserved"
+    );
+    assert!(
+        stages(&drain(&mut rx)).contains(&StageKind::Judge),
+        "a behavioral diff keeps its reviewer, whatever triage guessed"
+    );
+    let verdict = outcome.verdict.expect("a judged verdict");
+    assert!(
+        !verdict.summary.contains("waived"),
+        "the verdict must be the judge's, not the waiver's: {}",
+        verdict.summary
+    );
+}
+
+/// The half that keeps the waiver useful: where the warrant AGREES nothing
+/// needs a reviewer (a docs-only change), triage's `JUDGE: no` is honored
+/// exactly as before — two provider calls, no judge stage, and a verdict that
+/// says the review was deliberately waived rather than broken.
+#[tokio::test]
+async fn a_judge_waiver_stands_where_the_warrant_agrees() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
+        text_result("done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], DOCS_DIFF);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            witness_writer: false,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Rewrite the README opening", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert!(
+        provider.script.lock().await.is_empty(),
+        "exactly triage + worker were spent"
+    );
+    assert!(
+        !stages(&drain(&mut rx)).contains(&StageKind::Judge),
+        "the waiver stands where the warrant agrees there is nothing to review"
+    );
+    let verdict = outcome.verdict.expect("a reasoned verdict");
+    assert!(
+        verdict.summary.contains("waived"),
+        "the verdict must state the review was deliberately waived: {}",
+        verdict.summary
+    );
+}
+
 /// The witness: a diff probe that FAILED must never complete as "nothing
 /// changed".
 ///

--- a/stella-pipeline/src/triage.rs
+++ b/stella-pipeline/src/triage.rs
@@ -122,6 +122,15 @@ impl TaskAssessment {
     /// has to be an explicit call from triage — a class-derived default would
     /// silently drop the judge on exactly the path the zero-diff guard exists
     /// to catch (a "lookup" that turned out to touch files).
+    ///
+    /// An explicit `no` is a *request*, not a decision: by the time it is
+    /// consulted the ladder is inconclusive, which falsifies the premise the
+    /// triage prompt offered for saying no ("success is self-evident or a
+    /// test already proves it"). So the pipeline honors the waiver only when
+    /// the post-execution warrant agrees the change has nothing a reviewer
+    /// could catch (`Pipeline::judge_waiver_stands`) — the same
+    /// evidence-over-prediction rule `resolve_witness`'s ceiling applies in
+    /// the other direction.
     pub fn wants_judge(&self) -> bool {
         self.require_judge.unwrap_or(true)
     }

--- a/stella-pipeline/src/witness/warrant.rs
+++ b/stella-pipeline/src/witness/warrant.rs
@@ -346,19 +346,42 @@ fn is_test(path: &str) -> bool {
 }
 
 /// Build, CI, and dependency manifests: verified by the build and the gate.
+///
+/// A CLOSED list of names, on purpose. This used to also match every `*.yml`,
+/// `*.yaml`, and `*.lock` — but "yaml" is a syntax, not a category, and most
+/// yaml in the wild is behavior: a `docker-compose.yml`, a Helm values file,
+/// or an app's own config changes what runs, and each was completing with a
+/// PASS asserting "the build and gate verify these" while no build, gate, test
+/// or reviewer had seen it. A name this list has never heard of falls through
+/// to `Required`, exactly like every other rule here — when in doubt, the
+/// module buys the test.
 fn is_config(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
     let name = lower.rsplit('/').next().unwrap_or(&lower);
-    lower.starts_with(".github/")
-        || name == "cargo.lock"
-        || name == "cargo.toml"
-        || name == "package-lock.json"
-        || name == "pnpm-lock.yaml"
-        || name == "makefile"
-        || name == ".gitignore"
-        || lower.ends_with(".yml")
-        || lower.ends_with(".yaml")
-        || lower.ends_with(".lock")
+    // Dependency manifests and lockfiles (verified by the build), the build's
+    // own entry points, and CI pipeline definitions (verified by the gate
+    // itself running). Each entry names a file whose format has exactly one
+    // consumer; anything reusable-syntax lands on `Required`.
+    const MANIFESTS: &[&str] = &[
+        "cargo.toml",
+        "cargo.lock",
+        "go.mod",
+        "go.sum",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "bun.lock",
+        "bun.lockb",
+        "poetry.lock",
+        "uv.lock",
+        "gemfile.lock",
+        "composer.lock",
+        "makefile",
+        ".gitignore",
+        ".gitlab-ci.yml",
+        "azure-pipelines.yml",
+    ];
+    lower.starts_with(".github/") || MANIFESTS.contains(&name)
 }
 
 #[cfg(test)]

--- a/stella-pipeline/src/witness/warrant/tests.rs
+++ b/stella-pipeline/src/witness/warrant/tests.rs
@@ -48,11 +48,42 @@ fn tests_only_needs_no_test() {
 
 #[test]
 fn config_only_needs_no_test() {
-    let d = diff(&[".github/workflows/ci.yml"], "+  timeout-minutes: 30\n");
-    assert_eq!(
-        warrant(&d, 1),
-        WitnessWarrant::NotRequired(NoWitnessReason::ConfigOnly)
-    );
+    for path in [
+        ".github/workflows/ci.yml",
+        "Cargo.lock",
+        "web/yarn.lock",
+        "go.sum",
+        ".gitlab-ci.yml",
+    ] {
+        let d = diff(&[path], "+  timeout-minutes: 30\n");
+        assert_eq!(
+            warrant(&d, 1),
+            WitnessWarrant::NotRequired(NoWitnessReason::ConfigOnly),
+            "{path} is a build/CI/dependency manifest"
+        );
+    }
+}
+
+#[test]
+fn behavior_bearing_yaml_is_not_config() {
+    // The hole this closes: `is_config` matched every `*.yml`/`*.yaml`/`*.lock`
+    // by suffix, so a compose file, a Helm values file, or an app's own config
+    // completed with a PASS asserting "the build and gate verify these" while
+    // nothing had verified anything. Yaml is a syntax, not a category.
+    for path in [
+        "docker-compose.yml",
+        "deploy/values.yaml",
+        "config/database.yml",
+        "k8s/deployment.yaml",
+        "vendor/flock.lock",
+    ] {
+        let d = diff(&[path], "+  replicas: 3\n");
+        assert_eq!(
+            warrant(&d, 1),
+            WitnessWarrant::Required,
+            "{path} carries behavior and must keep its verification"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What &amp; why

The two approved follow-ups from the witness-protocol judge review (#1206). Both close paths where work could ship with **no witness and no reviewer** on the strength of a guess.

1. **Triage's `JUDGE: no` is honored only when the warrant agrees.** The waiver was answered from the prompt, before any work existed — and it is only ever consulted when the ladder came back inconclusive, the state that falsifies its own premise ("success is self-evident or a test already proves it"). A cheap prompt-time guess could strip the last reviewer from exactly the runs where nothing proved anything. `Pipeline::judge_waiver_stands` now gives the post-execution warrant the final word: the waiver stands only where the diff shows nothing a reviewer could catch (the same classes `warranted_completion` already completes without a judge); a behavioral diff keeps its reviewer, whatever triage guessed (witness-protocol §7.1: predict-then-commit is the bug). The waived-verdict construction moves beside its sibling in `disclosure.rs` as `waived_completion`.

2. **`is_config` no longer waives every `*.yml`/`*.yaml`/`*.lock`.** Yaml is a syntax, not a category: a `docker-compose.yml`, a Helm values file, or an app's own config changes what runs, and each completed with a deterministic PASS asserting "the build and gate verify these" while no build, gate, test, or reviewer had seen it. The rule is now a closed list of names with exactly one consumer — dependency manifests and lockfiles, the build's own entry points (`Makefile`, `.gitignore`), and CI pipeline definitions (`.github/`, `.gitlab-ci.yml`, `azure-pipelines.yml`) — and anything unrecognized falls through to `Required`, like every other rule in the module.

Four existing tests scripted `JUDGE: no` over a behavioral diff to save a fixture call; each now serves the judge result the new contract requires (the extra scripted call is itself the assertion that the reviewer runs).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`a_judge_waiver_on_a_behavioral_diff_still_buys_the_judge` and `a_judge_waiver_stands_where_the_warrant_agrees` (pipeline), `behavior_bearing_yaml_is_not_config` (warrant) — each fails on `main` and passes here.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (stella-pipeline clean; workspace check-compiles)
- [x] `cargo test --workspace` (stella-pipeline: 384 tests green)
- [x] `scripts/check-file-size.sh` green — the baseline diff records this PR's test growth, tightens `pipeline.rs` to its post-refactor size, **and covers `bench/harbor_adapter/stella_harbor/__init__.py` (+37), which grew on `main` without its baseline diff and has the gate red on the base branch**. Happy to drop that hunk if you'd rather fix it on `main` directly.
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Spend semantics change deliberately: a run where triage said `JUDGE: no` over a behavioral diff now buys one judge call it previously skipped — that is the point, per the review discussion. Where the warrant agrees there is nothing to review (docs/comments/manifests/no-op), the waiver is honored exactly as before: two calls, no judge stage, and a verdict stating the review was deliberately waived.

---

## Summary by Sourcery

Constrain judge waivers and config detection so behavioral changes always receive independent review and verification, while non-behavioral config/docs changes can still be safely waived.

Bug Fixes:
- Ensure a triage-specified `JUDGE: no` waiver does not suppress the judge for behavioral diffs or other changes that warrant independent review.
- Prevent behavior-bearing YAML and lockfiles (e.g., compose files, Helm values, app configs) from being treated as build/CI config that can skip witness verification.

Enhancements:
- Introduce warrant-based `judge_waiver_stands` and `waived_completion` handling so only changes the warrant classifies as not needing review can complete with an explicit, non-deterministic waived verdict.
- Narrow `is_config` to a closed list of dependency manifests, build entry points, and CI pipeline definitions, defaulting unknown YAML/lockfiles to required verification.
- Clarify triage semantics so `JUDGE: no` is treated as a request that is gated by post-execution warrant evidence rather than a standalone decision.

Build:
- Update the file-size baseline to reflect the new test additions and recent changes in the codebase.

Tests:
- Add pipeline and warrant tests covering judge waiver behavior on behavioral vs docs-only diffs and ensuring behavior-bearing YAML/lockfiles remain subject to verification.
- Update existing pipeline tests to assert that behavioral diffs still buy a judge call even when triage requested `JUDGE: no`, and adjust expected call counts accordingly.
