### PR TITLE
feat(bench): give Terminal-Bench task dirs a git baseline before Stella starts (#1211 §6.4)

### DIFF
--- a/bench/harbor_adapter/README.md
+++ b/bench/harbor_adapter/README.md
@@ -318,7 +318,19 @@ claim analyzer requires these exact values.
    `STELLA_SOURCE_COMMIT` is only an assertion and a mismatch aborts setup.
    Deterministic hashes of the executable adapter and Harbor Python source trees
    are recorded separately from their human-readable versions.
-4. **Holds** exactly one provider key in an unlinked, owner-only, seekable host
+4. **Baselines** the task workspace in git before Stella starts (#1211). After
+   `stella init` indexes the workspace for the code graph, the adapter runs one
+   in-container `git init && git add -A && git commit` as the task user —
+   Terminal-Bench images are plain directories, and without a repository the
+   diff probe, candidate isolation, the witness author's snapshot, and the
+   mutation audit are all structurally blind (#973). Stella's `.stella/` state
+   is excluded via `.git/info/exclude` (never a tracked file), an already-
+   versioned workspace is left untouched, and the outcome — `created` (with
+   the baseline commit), `preexisting`, `unavailable`, `failed`, or `error` —
+   is disclosed in trial metadata and the public ATIF trajectory. The step can
+   never fail a trial: a workspace it could not baseline runs exactly as the
+   witness-off control arm always did, and says so.
+5. **Holds** exactly one provider key in an unlinked, owner-only, seekable host
    temporary-file descriptor, then execs Harbor with every named or aliased
    copy of either OpenRouter credential removed from its environment. The
    distinct management key is used only by the host launcher's control-plane
@@ -329,20 +341,20 @@ claim analyzer requires these exact values.
    Docker `Config` before binary upload and again before handing that one key to
    Stella through Compose exec's anonymous stdin pipe. The key is never put in
    container argv/environment or a benchmark log.
-5. **Runs** Stella one-shot as a direct Compose argv: `main`,
+6. **Runs** Stella one-shot as a direct Compose argv: `main`,
    `/usr/local/bin/stella`, global
    flags, `run`, and the complete task instruction as one final argument.
    Stella itself appends and flushes every completed event to
    `/logs/agent/stella-events.jsonl`; no launcher shell or `tee` process exists.
-6. **Reports** cost, tokens, model, status, and accounting completeness back to
+7. **Reports** cost, tokens, model, status, and accounting completeness back to
    Harbor. It reconstructs a strict envelope from JSONL even when diagnostics
    are interleaved. On timeout/cancellation it recovers only durable events and
    marks the stream/accounting incomplete rather than inventing terminal data.
-7. **Classifies** a real nonzero Stella exit as Harbor's
+8. **Classifies** a real nonzero Stella exit as Harbor's
    `NonZeroAgentExitCodeError`, but only after output, metrics, and ATIF have
    been persisted. Harbor still runs the canonical benchmark verifier, which
    independently determines task correctness.
-8. **Writes** a validated ATIF-v1.7 trace to
+9. **Writes** a validated ATIF-v1.7 trace to
    `<trial>/agent/trajectory.json` for later post-scan publication.
 
 ## Public trajectory (ATIF v1.7)
@@ -453,6 +465,11 @@ Every result exposes manifest-ready metadata keys:
   witness counters, which report what this trial's proof stream actually
   observed. Declared and observed are different claims, so both are recorded:
   a run must never disable a tier discoverably only by grepping trajectories.
+- `stella_workspace_git_baseline` — what the adapter did to the workspace
+  before Stella started: `{"state": "created", "commit": <sha>}`,
+  `preexisting`, `unavailable`, `failed`, `error`, or `not_attempted`. Also in
+  ATIF `agent.extra.workspace_git_baseline`, unconditionally, so a trajectory
+  reviewer sees the in-container baseline action (or its absence) first-hand.
 
 ## Configuration
 

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -130,6 +130,23 @@ _TRAJECTORY_NAME = "trajectory.json"
 # zero bytes lost), which trained readers to ignore it.
 _TELEMETRY_INCOMPLETE = "stella-adapter: TELEMETRY-INCOMPLETE"
 
+# Workspace git baseline (#1211 §6 item 4; blindness documented in #973).
+# Terminal-Bench task images are plain directories, so on exactly this
+# benchmark the diff probe can never read a tree, candidate isolation is
+# unavailable, the witness author has nothing to snapshot, and the mutation
+# audit cannot restore. One repository with one commit, created before Stella
+# starts, turns all of those channels on. The marker line is the whole
+# contract between the in-container script and the host-side parser; the
+# parsed report is disclosed verbatim in trial metadata and the public ATIF
+# trajectory, so a reviewer sees exactly what the adapter did to the
+# workspace. A workspace that is already a repository is left untouched —
+# committing on top of task-owned history would change the task.
+_GIT_BASELINE_MARKER = "stella-git-baseline:"
+_GIT_BASELINE_TIMEOUT_SEC = 180
+_GIT_BASELINE_COMMIT_MESSAGE = "stella-harbor: task workspace baseline"
+_GIT_BASELINE_IDENT = "stella-harbor"
+_GIT_BASELINE_EMAIL = "stella-harbor@bench.invalid"
+
 # Defaults when neither Harbor nor the environment specify a value.
 _DEFAULT_MODEL = "anthropic/claude-fable-5"
 _DEFAULT_BUDGET = "5.0"
@@ -1096,6 +1113,86 @@ def _stream_to_envelope(
     }
 
 
+def _git_baseline_script(workdir: str | None) -> str:
+    """Build the POSIX-sh script that establishes the workspace git baseline.
+
+    Always exits 0 and reports through one greppable marker line, because an
+    evidence-channel setup step must never be able to fail a trial — a
+    workspace it could not baseline runs exactly as every published number
+    did (diff-blind), it just says so in metadata instead of silently.
+
+    Branch order is load-bearing:
+
+    - ``[ -e .git ]`` runs before ``rev-parse`` so a repository git refuses
+      to read (dubious ownership) still reads as *preexisting* rather than
+      falling through to ``git init`` — reinitializing and committing inside
+      a task-owned repository would rewrite task state.
+    - ``rev-parse`` runs under ``safe.directory='*'`` for the same reason:
+      a false "not a repository" is the one probe result that must not
+      happen, and it covers the workspace-nested-inside-a-parent-repo case
+      ``[ -e .git ]`` cannot see.
+    - ``.stella/`` is excluded via ``.git/info/exclude``, never a tracked
+      ``.gitignore`` — the exclude file lives inside ``.git``, so the
+      baseline adds zero entries to the tree a verifier might enumerate.
+    - ``--allow-empty`` guarantees a baseline commit exists even for an
+      empty task directory, so "repository with no HEAD" is not a state the
+      diff probe can encounter.
+    """
+    prologue = ""
+    if workdir:
+        prologue = (
+            f"cd {shlex.quote(workdir)} || {{ "
+            f"echo '{_GIT_BASELINE_MARKER} state=error detail=workdir-unavailable'; "
+            "exit 0; }; "
+        )
+    ident = (
+        f"-c user.name={shlex.quote(_GIT_BASELINE_IDENT)} "
+        f"-c user.email={shlex.quote(_GIT_BASELINE_EMAIL)}"
+    )
+    return (
+        f"{prologue}"
+        "if ! command -v git >/dev/null 2>&1; then "
+        f"echo '{_GIT_BASELINE_MARKER} state=unavailable detail=git-not-installed'; "
+        "elif [ -e .git ] || git -c safe.directory='*' rev-parse "
+        "--is-inside-work-tree >/dev/null 2>&1; then "
+        f"echo '{_GIT_BASELINE_MARKER} state=preexisting'; "
+        "elif git init -q >/dev/null 2>&1 "
+        "&& mkdir -p .git/info "
+        "&& printf '%s\\n' '.stella/' >> .git/info/exclude "
+        "&& git add -A >/dev/null 2>&1 "
+        f"&& git {ident} commit -q --allow-empty --no-verify "
+        f"-m {shlex.quote(_GIT_BASELINE_COMMIT_MESSAGE)} >/dev/null 2>&1; then "
+        f'echo "{_GIT_BASELINE_MARKER} state=created '
+        'commit=$(git rev-parse HEAD 2>/dev/null)"; '
+        "else "
+        f"echo '{_GIT_BASELINE_MARKER} state=failed detail=git-command-failed'; "
+        "fi"
+    )
+
+
+def _parse_git_baseline_report(stdout: str | None) -> dict[str, str]:
+    """Parse the marker line into a report; absence is itself a finding.
+
+    The last marker line wins (a retried step reports its final state), and
+    only non-empty ``key=value`` tokens are kept, so a failed
+    ``git rev-parse HEAD`` yields no ``commit`` key rather than an empty one.
+    """
+    if stdout:
+        for line in reversed(stdout.splitlines()):
+            stripped = line.strip()
+            if not stripped.startswith(_GIT_BASELINE_MARKER):
+                continue
+            report: dict[str, str] = {}
+            for token in stripped[len(_GIT_BASELINE_MARKER) :].split():
+                key, sep, value = token.partition("=")
+                if sep and key and value:
+                    report[key] = value
+            if report.get("state"):
+                return report
+            break
+    return {"state": "unreported"}
+
+
 class StellaAgent(BaseInstalledAgent):
     """Run the Stella coding CLI as a Harbor installed agent."""
 
@@ -1131,6 +1228,7 @@ class StellaAgent(BaseInstalledAgent):
     _assurance_tiers: dict[str, Any]
     _assurance_tiers_json: str
     _assurance_tiers_sha256: str
+    _workspace_git_baseline: dict[str, str]
 
     def __init__(self, *args: Any, agent_timeout_sec: Any = None, **kwargs: Any):
         """Accept Harbor's per-trial agent deadline, and keep it off the base.
@@ -1256,6 +1354,7 @@ class StellaAgent(BaseInstalledAgent):
             self._version = version_line
 
         await self._build_code_graph(environment)
+        await self._establish_workspace_git_baseline(environment)
 
     async def _build_code_graph(self, environment: BaseEnvironment) -> None:
         """Index the task workspace so ``graph_query`` is offered at all.
@@ -1287,6 +1386,37 @@ class StellaAgent(BaseInstalledAgent):
             if "code graph:" in line:
                 self._code_graph_summary = line.strip()
                 break
+
+    async def _establish_workspace_git_baseline(
+        self, environment: BaseEnvironment
+    ) -> None:
+        """Give the task workspace a git baseline before Stella starts.
+
+        Runs once per task environment, after ``stella init`` (whose
+        ``.stella/`` state directory the script excludes from the baseline),
+        as the same in-container user the turn runs as — so the repository
+        the diff probe later reads is owned by the user reading it.
+        Best-effort by construction: every outcome, including "could not
+        even exec", lands in ``self._workspace_git_baseline`` and from there
+        in trial metadata and the ATIF trajectory, never in a raised error.
+        """
+        task_env_config = getattr(environment, "task_env_config", None)
+        cwd = getattr(task_env_config, "workdir", None)
+        script = _git_baseline_script(str(cwd) if cwd else None)
+        try:
+            result = await self.exec_as_agent(
+                environment, command=script, timeout_sec=_GIT_BASELINE_TIMEOUT_SEC
+            )
+        except Exception as exc:  # noqa: BLE001 - evidence setup, never fatal
+            self._workspace_git_baseline = {"state": "error", "detail": str(exc)}
+            print(
+                f"stella-adapter: workspace git baseline unavailable: {exc}",
+                file=sys.stderr,
+            )
+            return
+        self._workspace_git_baseline = _parse_git_baseline_report(
+            getattr(result, "stdout", None)
+        )
 
     @with_prompt_template
     async def run(
@@ -1833,6 +1963,11 @@ class StellaAgent(BaseInstalledAgent):
             if isinstance(stream_view, dict)
             else None
         ) or "not_reported"
+        # Absent (adapter predates install, or install never ran) is a real
+        # state and must not be conflated with a step that ran and reported.
+        workspace_git_baseline = getattr(
+            self, "_workspace_git_baseline", {"state": "not_attempted"}
+        )
 
         extra: dict[str, Any] = {
             "stella_status": metrics.get("status"),
@@ -1886,6 +2021,7 @@ class StellaAgent(BaseInstalledAgent):
             "stella_assurance_tiers_sha256": assurance_tiers_sha256,
             "stella_witness_author_model": witness_author_model,
             "stella_witness_authored_state": witness_authored_state,
+            "stella_workspace_git_baseline": workspace_git_baseline,
         }
         if envelope is not None:
             extra["stella_accounting"] = envelope_accounting(envelope)
@@ -1945,6 +2081,7 @@ class StellaAgent(BaseInstalledAgent):
                 assurance_tiers_sha256=assurance_tiers_sha256,
                 witness_author_model=witness_author_model,
                 witness_authored_state=witness_authored_state,
+                workspace_git_baseline=workspace_git_baseline,
             )
             self._write_log(
                 _TRAJECTORY_NAME,

--- a/bench/harbor_adapter/stella_harbor/atif.py
+++ b/bench/harbor_adapter/stella_harbor/atif.py
@@ -480,6 +480,7 @@ def envelope_to_trajectory(
     assurance_tiers_sha256: str | None = None,
     witness_author_model: str | None = None,
     witness_authored_state: str | None = None,
+    workspace_git_baseline: dict[str, str] | None = None,
 ) -> Trajectory:
     """Build and validate an ATIF-v1.7 trajectory from a Stella envelope."""
     events = envelope.get("events")
@@ -653,6 +654,12 @@ def envelope_to_trajectory(
     # (It shipped guarded like its neighbours once — exactly the ambiguity
     # this comment promised away.)
     agent_extra["witness_authored_state"] = witness_authored_state or "not_reported"
+    # Also unconditional, and for the same reason: the workspace baseline is
+    # an in-container action a public trajectory reviewer must be able to see
+    # (or see was not attempted), never infer from a missing key.
+    agent_extra["workspace_git_baseline"] = dict(
+        workspace_git_baseline or {"state": "not_attempted"}
+    )
 
     return Trajectory(
         schema_version="ATIF-v1.7",

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -31,14 +33,17 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     _ADAPTER_VERSION,
     _ENGINE_CONFIG_ENV,
     _ENGINE_POSTURE_VERSION,
+    _GIT_BASELINE_MARKER,
     _INSTALL_PATH,
     HOST_CREDENTIAL_BUNDLE_FD_ENV,
     StellaAgent,
     _benchmark_engine_posture,
     _cached_binary,
     _extract_metrics,
+    _git_baseline_script,
     _is_truthy,
     _load_json_object,
+    _parse_git_baseline_report,
     _secure_exec_with_credential_fd,
     _sha256_file,
     _source_tree_sha256,
@@ -1904,6 +1909,241 @@ class TestAtifTrajectory:
         assert validated.agent.extra["host_credential_name"] == ("OPENROUTER_API_KEY")
         assert validated.agent.extra["host_credential_bundle_count"] == 1
         assert validated.agent.extra["container_credential_absence_verified"] is True
+
+
+_GIT_AVAILABLE = shutil.which("git") is not None
+
+
+def _run_baseline_script(workdir: Path, env: dict[str, str] | None = None) -> str:
+    """Execute the generated baseline script exactly as the container would."""
+    result = subprocess.run(
+        ["/bin/sh", "-c", _git_baseline_script(str(workdir))],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    # The script's contract: it never fails the exec, whatever it found.
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _git(workdir: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(workdir), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+class TestWorkspaceGitBaseline:
+    """#1211 §6 item 4: task dirs get a git baseline before Stella starts."""
+
+    @pytest.mark.skipif(not _GIT_AVAILABLE, reason="requires git on the host")
+    def test_creates_baseline_commit_and_excludes_stella_state(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "task.py").write_text("def solve(): ...\n")
+        (tmp_path / ".stella" / "private").mkdir(parents=True)
+        (tmp_path / ".stella" / "private" / "codegraph.db").write_bytes(b"db")
+
+        report = _parse_git_baseline_report(_run_baseline_script(tmp_path))
+
+        assert report["state"] == "created"
+        assert report["commit"] == _git(tmp_path, "rev-parse", "HEAD")
+        # Every task file is in the baseline; Stella's own state is not, and
+        # the tree the verifier enumerates gained no entries (the exclusion
+        # lives in .git/info/exclude, not a tracked .gitignore).
+        tracked = _git(tmp_path, "ls-files").splitlines()
+        assert "task.py" in tracked
+        assert not any(entry.startswith(".stella") for entry in tracked)
+        assert not (tmp_path / ".gitignore").exists()
+        assert _git(tmp_path, "status", "--porcelain") == ""
+        subject = _git(tmp_path, "log", "-1", "--format=%s")
+        assert subject == "stella-harbor: task workspace baseline"
+
+    @pytest.mark.skipif(not _GIT_AVAILABLE, reason="requires git on the host")
+    def test_empty_workspace_still_gets_a_baseline_commit(
+        self, tmp_path: Path
+    ) -> None:
+        report = _parse_git_baseline_report(_run_baseline_script(tmp_path))
+        assert report["state"] == "created"
+        # --allow-empty: "repository with no HEAD" is not a reachable state.
+        assert report["commit"] == _git(tmp_path, "rev-parse", "HEAD")
+
+    @pytest.mark.skipif(not _GIT_AVAILABLE, reason="requires git on the host")
+    def test_preexisting_repository_is_left_untouched(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("app\n")
+        _git(tmp_path, "init", "-q")
+        _git(tmp_path, "add", "-A")
+        _git(
+            tmp_path,
+            "-c",
+            "user.name=task",
+            "-c",
+            "user.email=task@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "task-owned history",
+        )
+        head_before = _git(tmp_path, "rev-parse", "HEAD")
+        (tmp_path / "untracked.txt").write_text("dirty\n")
+
+        report = _parse_git_baseline_report(_run_baseline_script(tmp_path))
+
+        # Committing on top of task-owned history would change the task, so
+        # HEAD and the dirty working tree must both survive verbatim.
+        assert report == {"state": "preexisting"}
+        assert _git(tmp_path, "rev-parse", "HEAD") == head_before
+        assert "untracked.txt" in _git(tmp_path, "status", "--porcelain")
+
+    def test_missing_git_reports_unavailable_and_exits_zero(
+        self, tmp_path: Path
+    ) -> None:
+        stdout = _run_baseline_script(tmp_path, env={"PATH": "/nonexistent"})
+        assert _parse_git_baseline_report(stdout) == {
+            "state": "unavailable",
+            "detail": "git-not-installed",
+        }
+
+    def test_missing_workdir_reports_error_and_exits_zero(
+        self, tmp_path: Path
+    ) -> None:
+        stdout = _run_baseline_script(tmp_path / "gone")
+        assert _parse_git_baseline_report(stdout) == {
+            "state": "error",
+            "detail": "workdir-unavailable",
+        }
+
+    def test_report_parser_takes_last_marker_and_drops_empty_values(self) -> None:
+        stdout = (
+            "unrelated diagnostics\n"
+            f"{_GIT_BASELINE_MARKER} state=failed detail=git-command-failed\n"
+            f"{_GIT_BASELINE_MARKER} state=created commit=\n"
+        )
+        # Last marker wins; the empty commit= token (a failed rev-parse) must
+        # yield no key rather than an empty string a reader could mistake for
+        # a digest.
+        assert _parse_git_baseline_report(stdout) == {"state": "created"}
+        assert _parse_git_baseline_report("no marker here") == {"state": "unreported"}
+        assert _parse_git_baseline_report(None) == {"state": "unreported"}
+        assert _parse_git_baseline_report("") == {"state": "unreported"}
+
+    def test_establish_runs_in_task_workdir_and_records_report(self) -> None:
+        agent = _bare_agent()
+        commands: list[tuple[str, int]] = []
+
+        class _Environment:
+            task_env_config = SimpleNamespace(workdir="/app")
+
+        async def _exec_as_agent(
+            environment: object, *, command: str, timeout_sec: int
+        ) -> SimpleNamespace:
+            commands.append((command, timeout_sec))
+            return SimpleNamespace(
+                return_code=0,
+                stdout=f"{_GIT_BASELINE_MARKER} state=created commit={'a' * 40}\n",
+            )
+
+        agent.exec_as_agent = _exec_as_agent
+        asyncio.run(agent._establish_workspace_git_baseline(_Environment()))
+
+        assert agent._workspace_git_baseline == {
+            "state": "created",
+            "commit": "a" * 40,
+        }
+        assert len(commands) == 1
+        command, timeout_sec = commands[0]
+        assert command.startswith("cd /app || ")
+        assert "git init" in command
+        assert "git add -A" in command
+        assert "--allow-empty" in command
+        assert ".git/info/exclude" in command
+        assert timeout_sec == 180
+
+    def test_establish_never_raises_and_records_exec_failure(self) -> None:
+        agent = _bare_agent()
+
+        class _Environment:
+            task_env_config = SimpleNamespace(workdir="/app")
+
+        async def _exec_as_agent(
+            environment: object, *, command: str, timeout_sec: int
+        ) -> SimpleNamespace:
+            raise RuntimeError("compose exec unavailable")
+
+        agent.exec_as_agent = _exec_as_agent
+        asyncio.run(agent._establish_workspace_git_baseline(_Environment()))
+
+        assert agent._workspace_git_baseline == {
+            "state": "error",
+            "detail": "compose exec unavailable",
+        }
+
+    def test_metadata_and_trajectory_disclose_the_baseline_state(
+        self, tmp_path: Path
+    ) -> None:
+        agent = _bare_agent()
+        agent.logs_dir = tmp_path
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent._version = "stella 0.4.43"
+        agent._instruction = "Fix the benchmark task."
+        agent._session_id = "session-baseline"
+        agent._return_code = 0
+        agent._envelope = _trajectory_envelope()
+        agent._metrics = _extract_metrics(json.dumps(agent._envelope))
+        agent._workspace_git_baseline = {"state": "created", "commit": "b" * 40}
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+
+        assert ctx.metadata["stella_workspace_git_baseline"] == {
+            "state": "created",
+            "commit": "b" * 40,
+        }
+        validated = Trajectory.model_validate_json(
+            (tmp_path / "trajectory.json").read_text(encoding="utf-8")
+        )
+        assert validated.agent.extra["workspace_git_baseline"] == {
+            "state": "created",
+            "commit": "b" * 40,
+        }
+
+    def test_absent_baseline_is_disclosed_as_not_attempted(self) -> None:
+        agent = _bare_agent()
+        agent._metrics = {
+            "cost_usd": None,
+            "n_input_tokens": None,
+            "n_output_tokens": None,
+            "n_cache_tokens": None,
+            "status": "completed",
+            "model": None,
+            "steps": None,
+        }
+        agent._return_code = 0
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+
+        assert ctx.metadata["stella_workspace_git_baseline"] == {
+            "state": "not_attempted"
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Implements the top unimplemented change from the #1211 tracking issue's "beat Claude Code + Fable 5" list (§6 item 4): the harbor adapter now gives every Terminal-Bench task workspace a git baseline before Stella starts.

Terminal-Bench task images are plain directories, so on exactly this benchmark all of the verification ladder's tree-level evidence channels are structurally blind (#973): the diff probe can never read a tree, candidate isolation is unavailable, the witness author has nothing to snapshot, and the mutation audit cannot restore. One adapter-side `git init && git add -A && git commit` inside the container — before Stella starts — turns those channels on per task.

Behavior details, each load-bearing:

- Runs during `install()`, after `stella init`, as the task user — so the repository the diff probe later reads is owned by the user reading it, and it covers every task step of a multi-step trial.
- A workspace that is already a repository (SWE-bench, git-flavored TB tasks) is **left untouched**: the `[ -e .git ]` check runs before `rev-parse` so even a repo git refuses to read (dubious ownership) reads as `preexisting` rather than being re-initialized and committed over.
- `.stella/` is excluded via `.git/info/exclude`, never a tracked `.gitignore` — the tree a verifier enumerates gains zero entries.
- `--allow-empty` guarantees a baseline commit exists even for an empty task dir, so "repository with no HEAD" is unreachable.
- The step can never fail a trial. Every outcome — `created` (with the baseline commit sha), `preexisting`, `unavailable`, `failed`, `error`, `not_attempted` — is disclosed in trial metadata (`stella_workspace_git_baseline`) and written **unconditionally** into the public ATIF trajectory (`agent.extra.workspace_git_baseline`), so leaderboard trajectory reviewers see the in-container action first-hand (the disclosure #1211 §6.4 asks to confirm).

Scope note: #1211 is a broad tracking index. §2's `#960` item (process never exits) is already fixed in-tree — `stella-cli/tests/run_exits_cli.rs` is the regression witness and the double-`complete` remnant is handled in `stella-cli/src/agent/output.rs` — so this PR takes the next item down the §6 points-per-effort ordering.

Refs #1211

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here) — `TestWorkspaceGitBaseline` in `bench/harbor_adapter/tests/test_adapter.py` (10 tests): real-git execution of the generated script (baseline created, `.stella` excluded, task files committed), preexisting-repo untouched (HEAD and dirty tree survive), git-missing/workdir-missing report-and-exit-0 paths, marker parsing (last marker wins, empty `commit=` dropped), install-path wiring, exec-failure never raises, and metadata + ATIF disclosure including the `not_attempted` default.

## The gate

- [x] `cargo fmt --check` — no Rust touched (Python bench tooling only)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust touched
- [x] `cargo test --workspace` — no Rust touched; the relevant gates are the bench suites: adapter **353 passed** and analyzer **258 passed**, run with CI's exact invocations (`uv sync --locked --extra dev && uv run --no-sync pytest -q`)
- [x] Docs updated where behavior changed (`bench/harbor_adapter/README.md`: new "Baselines" step in *What it does*, new `stella_workspace_git_baseline` metadata key in *Disclosed benchmark configuration*)
- [x] CLA signed
- [x] `Refs #1211` appears above and the commit message carries the issue number (advances the tracking issue without finishing it, so no closing keyword)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls (the baseline is one in-container `git` invocation against the task's own tree)

## Anything reviewers should know?

- The adapter version stays `0.6.0` deliberately: `secure_launcher._CANONICAL_ADAPTER_VERSION` pins it, `uv.lock` carries it, and behavior identity is already captured by `stella_adapter_sha256`, which moves with this change automatically.
- The claim analyzer reads trajectory `agent.extra` permissively (`extra.get(...)`), so the new unconditional key cannot fail existing claim validation; the exact-field manifest checks apply to the study manifest, not to trajectories.
- Not done here, per #1211 §6.4's parenthetical: confirming the Terminal-Bench leaderboard's trajectory-review rules are comfortable with the in-container baseline is an owner/maintainer conversation. The unconditional ATIF disclosure is designed to make that review trivial.

---

## Summary by Sourcery

Add a best-effort git baseline step for Terminal-Bench task workspaces in the Stella Harbor adapter and expose its outcome in benchmark metadata and ATIF trajectories.

New Features:
- Establish a git baseline for Terminal-Bench task workspaces during Stella agent installation, including handling preexisting repositories and diff-blind workspaces.

Enhancements:
- Record workspace git baseline reports in trial metadata and ATIF trajectories so benchmark reviewers can see exactly what the adapter did to the task workspace.

Documentation:
- Document the new workspace git baseline step and the `stella_workspace_git_baseline` metadata key in the Harbor adapter README.

Tests:
- Add Harbor adapter tests covering git baseline script behavior, error and unavailability paths, install-time wiring, and metadata/trajectory disclosure including the not-attempted default.
