### PR TITLE
Feat/agent durability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.6.67"
+version = "0.6.69"
 dependencies = [
  "stella-serve",
 ]

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,13 +15,13 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-2316 stella-cli/src/agent.rs
 1792 stella-cli/src/agent_tests.rs
+2316 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2493 stella-core/src/driver.rs
-3420 stella-core/src/driver/tests.rs
+2552 stella-core/src/driver.rs
+3543 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1628 stella-model/src/anthropic/tests.rs
 2042 stella-model/src/openai.rs
@@ -34,7 +34,7 @@
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2015 stella-tools/src/registry.rs
+2119 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1829 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -16,9 +16,9 @@
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 1793 stella-cli/src/agent_tests.rs
-2336 stella-cli/src/agent.rs
+2332 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4442 stella-cli/src/command_deck.rs
+4440 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
 2557 stella-core/src/driver.rs
 3543 stella-core/src/driver/tests.rs
@@ -34,7 +34,7 @@
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2192 stella-tools/src/registry.rs
+2236 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1829 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,10 +15,10 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-1793 stella-cli/src/agent_tests.rs
+1794 stella-cli/src/agent_tests.rs
 2332 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4440 stella-cli/src/command_deck.rs
+4445 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
 2557 stella-core/src/driver.rs
 3543 stella-core/src/driver/tests.rs
@@ -27,8 +27,8 @@
 2042 stella-model/src/openai.rs
 1507 stella-model/src/zai.rs
 1773 stella-model/src/zai/tests.rs
-3249 stella-pipeline/src/pipeline.rs
-2393 stella-pipeline/src/pipeline/tests.rs
+3361 stella-pipeline/src/pipeline.rs
+2440 stella-pipeline/src/pipeline/tests.rs
 2782 stella-protocol/src/event.rs
 2076 stella-store/src/lib.rs
 2261 stella-store/src/tests.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,10 +15,10 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-1792 stella-cli/src/agent_tests.rs
-2316 stella-cli/src/agent.rs
+1793 stella-cli/src/agent_tests.rs
+2336 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4413 stella-cli/src/command_deck.rs
+4442 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
 2557 stella-core/src/driver.rs
 3543 stella-core/src/driver/tests.rs
@@ -34,7 +34,7 @@
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2170 stella-tools/src/registry.rs
+2192 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1829 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,14 +27,14 @@
 2042 stella-model/src/openai.rs
 1507 stella-model/src/zai.rs
 1773 stella-model/src/zai/tests.rs
-3361 stella-pipeline/src/pipeline.rs
+3371 stella-pipeline/src/pipeline.rs
 2440 stella-pipeline/src/pipeline/tests.rs
 2782 stella-protocol/src/event.rs
 2076 stella-store/src/lib.rs
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2236 stella-tools/src/registry.rs
+2241 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1829 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -30,7 +30,7 @@
 3249 stella-pipeline/src/pipeline.rs
 2393 stella-pipeline/src/pipeline/tests.rs
 2782 stella-protocol/src/event.rs
-2074 stella-store/src/lib.rs
+2076 stella-store/src/lib.rs
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -34,7 +34,7 @@
 2261 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2119 stella-tools/src/registry.rs
+2170 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1829 stella-tui/src/deck_render.rs
 3889 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4413 stella-cli/src/command_deck.rs
 2129 stella-core/src/bus.rs
-2552 stella-core/src/driver.rs
+2557 stella-core/src/driver.rs
 3543 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1628 stella-model/src/anthropic/tests.rs

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -276,7 +276,7 @@ async fn run_pipeline_one_shot(
     let started_unix = crate::memory::unix_now_secs();
     // Machine-wide presence: the deck's SESSIONS overlay sees this run live
     // and can replay its journal after it ends.
-    let mut presence = SessionPresence::announce(cfg, prompt);
+    let mut presence = SessionPresence::announce(cfg, prompt, &registry);
     let execution = begin_execution(&store, "pipeline", prompt, cfg, Some(presence.id()));
     let files_before = registry.files_touched().len();
 
@@ -788,7 +788,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     // Machine-wide presence: the plain REPL registers like the deck does,
     // so its sessions are findable in every SESSIONS overlay and replayable
     // from their journals. No inbox notifications — the user is right here.
-    let mut presence = SessionPresence::announce(cfg, "interactive session");
+    let mut presence = SessionPresence::announce(cfg, "interactive session", &registry);
 
     // Session-scoped lean-mode activation state: the tool stack is rebuilt
     // every turn, but a tool the model surfaced via tool_search must stay
@@ -2007,8 +2007,16 @@ pub(crate) struct SessionPresence {
 
 impl SessionPresence {
     /// Announce the session (status In Progress), titled from the workspace
-    /// and the prompt/goal that started it.
-    pub(crate) fn announce(cfg: &Config, prompt: &str) -> Self {
+    /// and the prompt/goal that started it, and bind this session's durability
+    /// to `tools`.
+    ///
+    /// The binding is done HERE, rather than left to each headless driver,
+    /// because this is the moment the session acquires the identity durability
+    /// is keyed on. A driver that announced without binding would run a whole
+    /// session whose turns checkpoint nowhere — and the failure would be
+    /// silent, because an unbound sink is indistinguishable from a session
+    /// that simply never crashed.
+    pub(crate) fn announce(cfg: &Config, prompt: &str, tools: &ToolRegistry) -> Self {
         let name = cfg
             .workspace_root
             .file_name()
@@ -2022,6 +2030,18 @@ impl SessionPresence {
         record.summary = crate::command_deck::prompt_line(prompt, 240);
         let registry = stella_store::SessionRegistry::open_default();
         let _ = registry.upsert(&record);
+        // stderr, not stdout: `--output-format json` owns stdout, and a
+        // durability advisory must never land inside a machine-readable
+        // document.
+        if let Some(warning) = crate::durability::bind_session(
+            &cfg.durability,
+            tools,
+            &cfg.workspace_root,
+            registry.sidecar_dir(&record.id),
+            &record.id,
+        ) {
+            eprintln!("  {warning}");
+        }
         Self {
             registry,
             record,

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -2016,7 +2016,7 @@ impl SessionPresence {
     /// session whose turns checkpoint nowhere — and the failure would be
     /// silent, because an unbound sink is indistinguishable from a session
     /// that simply never crashed.
-    pub(crate) fn announce(cfg: &Config, prompt: &str, tools: &ToolRegistry) -> Self {
+    pub(crate) fn announce(cfg: &Config, prompt: &str, tools: &Arc<ToolRegistry>) -> Self {
         let name = cfg
             .workspace_root
             .file_name()

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -2033,13 +2033,9 @@ impl SessionPresence {
         // stderr, not stdout: `--output-format json` owns stdout, and a
         // durability advisory must never land inside a machine-readable
         // document.
-        if let Some(warning) = crate::durability::bind_session(
-            &cfg.durability,
-            tools,
-            &cfg.workspace_root,
-            registry.sidecar_dir(&record.id),
-            &record.id,
-        ) {
+        if let Some(warning) =
+            crate::durability::bind_session(&cfg.durability, tools, &cfg.workspace_root, &record.id)
+        {
             eprintln!("  {warning}");
         }
         Self {

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -236,6 +236,9 @@ pub(crate) fn pipeline_config_for_approval_capability(
             cfg,
             worker_model,
         ),
+        // Where this run's work happens. Resolved from settings here and asked
+        // at triage, once the class says whether anything is going to change.
+        create_worktrees: cfg.create_worktrees.policy(),
         ..Default::default()
     }
 }

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -40,6 +40,17 @@ fn tuned_engine_config(
         // default. Read here rather than at each receipt site so every engine
         // this session builds — default, worker, judge — agrees on it.
         lifecycle_enabled: crate::memory::session_lifecycle_enabled(&cfg.workspace_root),
+        // Durability, for every role at once. This is the single place an
+        // engine is tuned in this crate, so attaching the sink here covers the
+        // deck's lead turn and its pipeline, sub-agents, sub-sessions and the
+        // fleet without six chances to forget one.
+        //
+        // `None` while the session has not bound its durable location — a
+        // command with no turn to checkpoint, or a driver that has not yet
+        // resolved its session record. That is not a silent downgrade: it is
+        // what stops `persist_checkpoint` from serializing a whole transcript
+        // per step only to discard it.
+        checkpoint_sink: cfg.durability.sink(),
         ..EngineConfig::default()
     };
     // Compaction must fire BEFORE the provider's context window overflows:

--- a/stella-cli/src/agent/goal.rs
+++ b/stella-cli/src/agent/goal.rs
@@ -104,7 +104,7 @@ pub(crate) async fn run_raw_one_shot(
     let started_unix = crate::memory::unix_now_secs();
     // Machine-wide presence: findable in the deck's SESSIONS overlay and
     // replayable from its journal after this process exits.
-    let mut presence = SessionPresence::announce(cfg, prompt);
+    let mut presence = SessionPresence::announce(cfg, prompt, &registry);
     let outcome = run_turn(
         &*provider,
         base_tools,
@@ -270,7 +270,7 @@ pub async fn run_goal_cmd(
     let started_unix = crate::memory::unix_now_secs();
     // Machine-wide presence: a goal run is exactly the long-lived headless
     // session the SESSIONS overlay + replay exist for.
-    let mut presence = SessionPresence::announce(cfg, goal);
+    let mut presence = SessionPresence::announce(cfg, goal, &registry);
     let outcome = if use_pipeline {
         run_goal_pipeline_turn(
             &*provider,

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -818,6 +818,7 @@ fn cfg_for(provider_id: &str) -> Config {
         // settings-driven wiring under test is the thing exercised. The
         // flag-pinned case sets this explicitly.
         model_pinned_by_flag: false,
+        durability: Default::default(),
         api_key: ApiKey::new("dummy-key-unused-offline"),
         credential_source: None,
         workspace_root: std::path::PathBuf::from("/tmp"),

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -819,6 +819,7 @@ fn cfg_for(provider_id: &str) -> Config {
         // flag-pinned case sets this explicitly.
         model_pinned_by_flag: false,
         durability: Default::default(),
+        create_worktrees: Default::default(),
         api_key: ApiKey::new("dummy-key-unused-offline"),
         credential_source: None,
         workspace_root: std::path::PathBuf::from("/tmp"),

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -51,6 +51,54 @@ fn the_turn_budget_flag_reaches_every_role_that_can_continue() {
 }
 
 #[test]
+fn a_bound_session_checkpoints_from_every_role() {
+    // The same argument as the turn budget above, for the same reason: the
+    // sink is attached at ONE place (`tuned_engine_config`) precisely so no
+    // role can be left out, and "left out" is invisible from inside the engine
+    // crate — an unbound sink is indistinguishable from a session that simply
+    // never crashed. This is the wire.
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = cfg_for("zai");
+
+    // Unbound: no sink, so `persist_checkpoint` does not serialize a whole
+    // transcript per step only to drop it.
+    assert!(
+        crate::agent::engine_config_for(&cfg)
+            .checkpoint_sink
+            .is_none(),
+        "a session with no durable location attaches nothing",
+    );
+
+    cfg.durability.bind(dir.path().to_path_buf());
+
+    let worker = ModelRef::new("zai", "glm-5.2".to_string());
+    for (role, engine) in [
+        ("default", crate::agent::engine_config_for(&cfg)),
+        ("judge", crate::agent::judge_engine_config_for(&cfg)),
+        (
+            "worker",
+            crate::agent::pipeline_engine_config_for(&cfg, &worker),
+        ),
+    ] {
+        assert!(
+            engine.checkpoint_sink.is_some(),
+            "the {role} engine must carry the session's checkpoint sink",
+        );
+    }
+
+    // And it reaches the file the store will read back — the binding is live,
+    // not merely present.
+    crate::agent::engine_config_for(&cfg)
+        .checkpoint_sink
+        .expect("bound")
+        .persist("{\"version\":1}");
+    assert_eq!(
+        stella_store::journal::read_checkpoint(dir.path()).as_deref(),
+        Some("{\"version\":1}"),
+    );
+}
+
+#[test]
 fn pipeline_worker_model_is_inert_without_the_fix_but_routes_with_it() {
     // Issue #276: `pipeline_worker_model` (and `agents.worker.*`) must
     // actually change what `Role::Worker` resolves to — previously the

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -78,7 +78,13 @@ fn a_bound_session_checkpoints_from_every_role() {
         "ses-engine-wiring",
     )
     .unwrap();
-    cfg.durability.bind(record.clone());
+    cfg.durability.bind(
+        record.clone(),
+        std::sync::Arc::new(stella_tools::ToolRegistry::new(
+            ws.path().to_path_buf(),
+            stella_tools::RegistryOptions::default(),
+        )),
+    );
 
     let worker = ModelRef::new("zai", "glm-5.2".to_string());
     for (role, engine) in [

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -57,7 +57,8 @@ fn a_bound_session_checkpoints_from_every_role() {
     // role can be left out, and "left out" is invisible from inside the engine
     // crate — an unbound sink is indistinguishable from a session that simply
     // never crashed. This is the wire.
-    let dir = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+    let ws = tempfile::tempdir().unwrap();
     let cfg = cfg_for("zai");
 
     // Unbound: no sink, so `persist_checkpoint` does not serialize a whole
@@ -66,10 +67,18 @@ fn a_bound_session_checkpoints_from_every_role() {
         crate::agent::engine_config_for(&cfg)
             .checkpoint_sink
             .is_none(),
-        "a session with no durable location attaches nothing",
+        "a session with no durable record attaches nothing",
     );
 
-    cfg.durability.bind(dir.path().to_path_buf());
+    // `open_in`, never `open`: the latter reads `STELLA_HOME`, and a test that
+    // touched a process-global would race its siblings.
+    let record = stella_store::work_journal::WorkJournal::open_in(
+        store.path(),
+        ws.path(),
+        "ses-engine-wiring",
+    )
+    .unwrap();
+    cfg.durability.bind(record.clone());
 
     let worker = ModelRef::new("zai", "glm-5.2".to_string());
     for (role, engine) in [
@@ -86,16 +95,13 @@ fn a_bound_session_checkpoints_from_every_role() {
         );
     }
 
-    // And it reaches the file the store will read back — the binding is live,
+    // And it reaches the record the store reads back — the binding is live,
     // not merely present.
     crate::agent::engine_config_for(&cfg)
         .checkpoint_sink
         .expect("bound")
         .persist("{\"version\":1}");
-    assert_eq!(
-        stella_store::journal::read_checkpoint(dir.path()).as_deref(),
-        Some("{\"version\":1}"),
-    );
+    assert_eq!(record.checkpoint().as_deref(), Some("{\"version\":1}"));
 }
 
 #[test]

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -445,7 +445,6 @@ pub async fn run_deck_session(
         &cfg.durability,
         &registry,
         &cfg.workspace_root,
-        sidecar_dir.clone(),
         &session_record.id,
     ) {
         let _ = deck_tx.send(system_notice(warning));
@@ -1043,7 +1042,6 @@ pub async fn run_deck_session(
                                     &cfg.durability,
                                     &registry,
                                     &cfg.workspace_root,
-                                    sidecar_dir.clone(),
                                     &session_record.id,
                                 ) {
                                     let _ = deck_tx.send(chrome_note(warning));

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -436,6 +436,20 @@ pub async fn run_deck_session(
             }
         },
     );
+    // The other two halves of the same promise, bound beside the journal
+    // because all three name the session and all three must name the SAME one:
+    // every turn from here checkpoints into this record's sidecar, and every
+    // file the agent touches commits to this session's ref in stella's own git
+    // store. Re-bound on an in-deck session switch, below.
+    if let Some(warning) = crate::durability::bind_session(
+        &cfg.durability,
+        &registry,
+        &cfg.workspace_root,
+        sidecar_dir.clone(),
+        &session_record.id,
+    ) {
+        let _ = deck_tx.send(system_notice(warning));
+    }
     // A release-build panic aborts before any `Drop` or `catch_unwind` runs
     // (the workers' panic catch included), so this hook is the journal's
     // only flush point on that path — the terminal is restored by
@@ -1018,6 +1032,21 @@ pub async fn run_deck_session(
                                             )));
                                         }
                                     }
+                                }
+                                // Durability re-keys with everything else. The
+                                // next turn's engine reads the sink afresh, so
+                                // the checkpoint lands in the session the user
+                                // just switched TO; the departing session's
+                                // resume point and commits are left as they
+                                // stood.
+                                if let Some(warning) = crate::durability::bind_session(
+                                    &cfg.durability,
+                                    &registry,
+                                    &cfg.workspace_root,
+                                    sidecar_dir.clone(),
+                                    &session_record.id,
+                                ) {
+                                    let _ = deck_tx.send(chrome_note(warning));
                                 }
 
                                 // Blank the lead pane, replay the adopted

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -592,7 +592,12 @@ pub async fn run_deck_session(
         inbound: in_tx.clone(),
         answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
     };
-    let scope_gate = DeckApprovalGate::new(LEAD.to_string(), in_tx.clone(), scope_rx);
+    let scope_gate = DeckApprovalGate::new(
+        LEAD.to_string(),
+        in_tx.clone(),
+        scope_rx,
+        Arc::new(ask_io.clone()),
+    );
 
     // The deck drives turns through the staged pipeline by default (triage →
     // recall → plan → scope → witness → execute → verify → judge); `/pipeline`

--- a/stella-cli/src/command_deck/model_cmd.rs
+++ b/stella-cli/src/command_deck/model_cmd.rs
@@ -214,6 +214,7 @@ mod tests {
             turn_budget: None,
             model_pinned_by_flag: false,
             durability: Default::default(),
+            create_worktrees: Default::default(),
             api_key: stella_model::ApiKey::new("dummy-key-unused-offline"),
             workspace_root,
             base_url_override: None,

--- a/stella-cli/src/command_deck/model_cmd.rs
+++ b/stella-cli/src/command_deck/model_cmd.rs
@@ -213,6 +213,7 @@ mod tests {
             provider,
             turn_budget: None,
             model_pinned_by_flag: false,
+            durability: Default::default(),
             api_key: stella_model::ApiKey::new("dummy-key-unused-offline"),
             workspace_root,
             base_url_override: None,

--- a/stella-cli/src/command_deck/scope_gate.rs
+++ b/stella-cli/src/command_deck/scope_gate.rs
@@ -32,6 +32,14 @@ pub(crate) struct DeckApprovalGate {
     /// picker, so "trim" means "keep the largest prefix that would not have
     /// tripped review in the first place".
     pub(crate) max_steps: usize,
+    /// How [`ApprovalGate::confirm`] reaches the human.
+    ///
+    /// A separate surface from `decisions` because the two are different
+    /// questions. The decision channel is fed by the scope card's keys, and
+    /// that card is raised by the pipeline's own `ScopeReview` event — so a
+    /// plain yes/no parked on it would wait for a card nobody was going to
+    /// draw. `ask_user`'s io raises its own.
+    pub(crate) ask: Arc<dyn crate::interactive::AskUserIo>,
 }
 
 impl DeckApprovalGate {
@@ -44,6 +52,7 @@ impl DeckApprovalGate {
         agent: String,
         inbound: UnboundedSender<Inbound>,
         decisions: UnboundedReceiver<DeckScopeDecision>,
+        ask: Arc<dyn crate::interactive::AskUserIo>,
     ) -> Self {
         Self {
             agent,
@@ -52,6 +61,7 @@ impl DeckApprovalGate {
             max_steps: stella_pipeline::scope::ScopeThresholds::default()
                 .max_steps
                 .unwrap_or(5),
+            ask,
         }
     }
 
@@ -109,6 +119,20 @@ impl ApprovalGate for DeckApprovalGate {
         }
         resolved
     }
+
+    /// Yes/no through `ask_user`'s card. Fail-closed: a closed deck, an io
+    /// error, or anything that is not an affirmative leaves the run doing what
+    /// it would have done unasked.
+    async fn confirm(&self, question: &str) -> bool {
+        let options = ["yes".to_string(), "no".to_string()];
+        match self.ask.prompt(question, &options).await {
+            Ok(answer) => matches!(
+                answer.trim().to_ascii_lowercase().as_str(),
+                "1" | "y" | "yes"
+            ),
+            Err(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -124,6 +148,7 @@ mod tests {
             inbound: tx,
             decisions: Arc::new(tokio::sync::Mutex::new(drx)),
             max_steps,
+            ask: Arc::new(crate::interactive::HeadlessAskUserIo),
         }
     }
 
@@ -191,6 +216,7 @@ mod tests {
             inbound: tx,
             decisions: Arc::new(tokio::sync::Mutex::new(drx)),
             max_steps: 5,
+            ask: Arc::new(crate::interactive::HeadlessAskUserIo),
         };
         let proposal = ScopeProposal {
             summary: "big".into(),

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -396,6 +396,10 @@ pub struct Config {
     /// Trajectory trace capture after each finished execution (settings
     /// `trace_capture`, #1042). Default off.
     pub trace_capture: bool,
+    /// Whether a run does its work in a throwaway git worktree instead of this
+    /// checkout (settings `create_worktrees`). Default `ask`, put once at
+    /// triage and only when the run is going to change files.
+    pub create_worktrees: crate::settings::CreateWorktrees,
     /// Monotonic authority computed while loading the scope chain. Runtime
     /// adapters consume this instead of reinterpreting trust environment
     /// variables or repository settings independently.
@@ -577,6 +581,7 @@ impl Config {
         cfg.tool_policy = settings.tool_policy();
         cfg.enable_recap = settings.recap_enabled();
         cfg.trace_capture = settings.trace_capture_enabled();
+        cfg.create_worktrees = settings.create_worktrees();
         Ok(cfg)
     }
 
@@ -720,6 +725,7 @@ impl Config {
                     tool_policy: Default::default(),
                     enable_recap: false,
                     trace_capture: false,
+                    create_worktrees: Default::default(),
                     authority: crate::settings::AuthorityPolicy::default(),
                     credential_source,
                     credential_advisories: credentials_file.advisories().to_vec(),
@@ -917,6 +923,7 @@ impl Config {
             tool_policy: Default::default(),
             enable_recap: false,
             trace_capture: false,
+            create_worktrees: Default::default(),
             authority: crate::settings::AuthorityPolicy::default(),
             credential_source: Some(source),
             credential_advisories: credentials_file.advisories().to_vec(),

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -344,6 +344,17 @@ pub struct Config {
     /// with a truthful partial instead of being destroyed mid-flight.
     pub turn_budget: Option<std::time::Duration>,
     pub workspace_root: std::path::PathBuf,
+    /// Where this session's turns write their resume point — the handle every
+    /// engine this session builds reads its `checkpoint_sink` from.
+    ///
+    /// A shared cell rather than a session id or a path because neither exists
+    /// yet when a `Config` is built: the drivers resolve their
+    /// [`stella_store::SessionRecord`] afterwards, and the deck re-points it on
+    /// every in-deck session switch. Empty until a driver binds it, which is
+    /// also what keeps the non-session commands (`stella config`, `stella
+    /// tools`) from carrying durability they have no turn to use. See
+    /// [`crate::durability`].
+    pub durability: crate::durability::SessionDurability,
     /// `--base-url`: required for the `local` provider (it IS the server
     /// address), an optional proxy/override for every other provider.
     pub base_url_override: Option<String>,
@@ -696,6 +707,10 @@ impl Config {
                     // Stamped by the caller that holds the parsed CLI; see the
                     // field's doc comment.
                     turn_budget: None,
+                    // Unbound: the session whose sidecar this points at is
+                    // resolved by the driver, after config load. See the
+                    // field's doc comment.
+                    durability: crate::durability::SessionDurability::default(),
                     api_key: ApiKey::new(api_key),
                     workspace_root,
                     base_url_override: Some(base_url),
@@ -887,6 +902,9 @@ impl Config {
             model_pinned_by_flag: false,
             // Likewise stamped by the caller that holds the parsed CLI.
             turn_budget: None,
+            // Unbound until a driver resolves this run's session record — see
+            // the field's doc comment.
+            durability: crate::durability::SessionDurability::default(),
             api_key: key,
             workspace_root: workspace_root.to_path_buf(),
             base_url_override: base_url_override.map(str::to_string),

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -212,6 +212,7 @@ fn config_debug_never_leaks_the_api_key() {
         model_id: "glm-5.2".to_string(),
         turn_budget: None,
         model_pinned_by_flag: false,
+        durability: Default::default(),
         api_key: ApiKey::new(secret),
         workspace_root: std::path::PathBuf::from("/tmp/ws"),
         base_url_override: None,

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -213,6 +213,7 @@ fn config_debug_never_leaks_the_api_key() {
         turn_budget: None,
         model_pinned_by_flag: false,
         durability: Default::default(),
+        create_worktrees: Default::default(),
         api_key: ApiKey::new(secret),
         workspace_root: std::path::PathBuf::from("/tmp/ws"),
         base_url_override: None,

--- a/stella-cli/src/durability.rs
+++ b/stella-cli/src/durability.rs
@@ -5,21 +5,31 @@
 //! and deliberately says nothing about where. This module is the CLI's answer
 //! to *where*, and it has to live in a crate that depends on both
 //! `stella-core` (which declares the trait) and `stella-store` (which owns the
-//! session sidecar). `stella-store` cannot implement it: it depends only on
+//! durable record). `stella-store` cannot implement it: it depends only on
 //! `stella-protocol` and has never heard of the engine.
+//!
+//! # One store, not two
+//!
+//! The resume point goes into the work journal's
+//! [`stella_store::work_journal::CHECKPOINT_BLOB`], the same commit graph as
+//! the file changes it is a resume point *for* — not into a transient file
+//! beside it. Two stores would need a recovery path that decides which to
+//! believe when they disagree, and they would disagree, because nothing can
+//! update both atomically. A crash between two such writes is not a rare case
+//! here; it is the exact case the whole feature exists to survive.
 //!
 //! # Why a shared cell rather than a plain field
 //!
-//! A session's durable identity does not exist when its [`crate::config::Config`] is
-//! built. The deck receives `&Config` and only then resolves — or mints — the
-//! [`stella_store::SessionRecord`] whose sidecar the checkpoint belongs in, and
-//! it re-points that sidecar mid-run every time the user switches sessions. A
-//! `PathBuf` field could be filled in by neither of those moments.
+//! A session's durable identity does not exist when its
+//! [`crate::config::Config`] is built. The deck receives `&Config` and only
+//! then resolves — or mints — the [`stella_store::SessionRecord`] the record is
+//! keyed on, and it re-keys that on every in-deck session switch. A plain field
+//! could be filled in by neither of those moments.
 //!
 //! So `Config` carries a [`SessionDurability`] handle instead: cheap to clone,
 //! empty until a driver binds it, and read afresh by every engine the session
-//! builds. `agent::engine_config_for` runs per turn, so an in-deck session
-//! switch is picked up by the next turn with nothing to re-thread.
+//! builds. `agent::engine_config_for` runs per turn, so a session switch is
+//! picked up by the next turn with nothing to re-thread.
 //!
 //! # Why `sink()` may answer `None`
 //!
@@ -29,80 +39,86 @@
 //! step of every turn to throw the bytes away. An unbound handle yields `None`
 //! and the engine skips the encode entirely.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use stella_core::step::CheckpointSink;
+use stella_store::work_journal::WorkJournal;
 
-/// A handle on where this session's resume point is written.
+/// A handle on this session's durable record.
 ///
 /// Cloned into [`crate::config::Config`] and shared by every engine the session
 /// builds. Empty until a driver calls [`Self::bind`]; binding again re-points
 /// it, which is what an in-deck session switch needs.
 #[derive(Clone, Debug, Default)]
 pub struct SessionDurability {
-    /// The bound session's sidecar directory. `RwLock` rather than `OnceLock`
-    /// because a deck session can be switched, and the *next* turn's checkpoint
-    /// must land in the session it actually belongs to.
-    sidecar: Arc<RwLock<Option<PathBuf>>>,
+    /// `RwLock` rather than `OnceLock` because a deck session can be switched,
+    /// and the *next* turn's checkpoint must land in the session it actually
+    /// belongs to. `Arc<WorkJournal>` so `sink()` hands out a cheap share
+    /// rather than re-opening the record per engine.
+    journal: Arc<RwLock<Option<Arc<WorkJournal>>>>,
 }
 
 impl SessionDurability {
-    /// Point this handle at `sidecar_dir` — the directory
-    /// [`stella_store::SessionRegistry::sidecar_dir`] gives for the session
-    /// that is now running.
-    pub fn bind(&self, sidecar_dir: PathBuf) {
-        let mut slot = self.sidecar.write().unwrap_or_else(|p| p.into_inner());
-        *slot = Some(sidecar_dir);
+    /// Point this handle at `journal` — the durable record of the session that
+    /// is now running.
+    pub fn bind(&self, journal: WorkJournal) {
+        let mut slot = self.journal.write().unwrap_or_else(|p| p.into_inner());
+        *slot = Some(Arc::new(journal));
+    }
+
+    /// This session's durable record, if one is bound.
+    pub fn journal(&self) -> Option<Arc<WorkJournal>> {
+        self.journal
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// The sink to hand [`stella_core::EngineConfig::checkpoint_sink`], or
     /// `None` while this handle is unbound.
     ///
-    /// The bound path is read out *here*, once per engine, rather than on every
+    /// The record is read out *here*, once per engine, rather than on every
     /// `persist` — the lock stays off the per-step hot path, and a session
     /// switch is picked up because the next turn builds a new engine.
     pub fn sink(&self) -> Option<Arc<dyn CheckpointSink>> {
-        let dir = self
-            .sidecar
-            .read()
-            .unwrap_or_else(|p| p.into_inner())
-            .clone()?;
-        Some(Arc::new(SidecarCheckpointSink { dir }))
+        let journal = self.journal()?;
+        Some(Arc::new(JournalCheckpointSink { journal }))
     }
 }
 
-/// A [`CheckpointSink`] over the session sidecar's `checkpoint.json`.
+/// A [`CheckpointSink`] over the work journal's checkpoint blob.
 #[derive(Debug)]
-struct SidecarCheckpointSink {
-    dir: PathBuf,
+struct JournalCheckpointSink {
+    journal: Arc<WorkJournal>,
 }
 
-impl CheckpointSink for SidecarCheckpointSink {
-    /// One atomic write (temp + fsync + rename), as the trait's cost note
-    /// requires — this runs on the turn's own task and blocks it.
+impl CheckpointSink for JournalCheckpointSink {
+    /// One commit on this session's ref. Dearer than an atomic file write and
+    /// still cheap against what a step costs — see
+    /// [`WorkJournal::record_checkpoint`].
     ///
     /// The error is dropped, not logged: this is called on every step of every
     /// turn, so a failing sink would emit one line per step, and the trait's
     /// contract is that a checkpoint which cannot be written leaves the turn
     /// exactly as recoverable as it was before the sink existed.
     fn persist(&self, json: &str) {
-        let _ = stella_store::journal::write_checkpoint(&self.dir, json);
+        let _ = self.journal.record_checkpoint(json);
     }
 
-    /// Idempotent by [`stella_store::journal::clear_checkpoint`]'s own
-    /// contract — a missing file is success, which is what lets every terminal
+    /// Idempotent by [`WorkJournal::clear_checkpoint`]'s own contract, and free
+    /// when there is nothing to retract — which is what lets every terminal
     /// path discard unconditionally.
     fn discard(&self) {
-        let _ = stella_store::journal::clear_checkpoint(&self.dir);
+        let _ = self.journal.clear_checkpoint();
     }
 }
 
 /// The label a session's durable commits carry, derived from the workspace.
 ///
-/// Not the session id: the id answers *which run*, and the work journal is
-/// already keyed on it. This answers *whose work*, and a human reading
-/// `git log` on the durable record wants the workspace name.
+/// Not the session id: the id answers *which run*, and the record is already
+/// keyed on it. This answers *whose work*, and a human reading `git log` on the
+/// durable record wants the workspace name.
 pub fn agent_label(workspace_root: &Path) -> String {
     workspace_root
         .file_name()
@@ -113,33 +129,32 @@ pub fn agent_label(workspace_root: &Path) -> String {
 /// Bind both halves of this session's durability: where its turns write a
 /// resume point, and where its file mutations commit.
 ///
-/// One call rather than two because the halves answer one question — *which
-/// session owns the work happening now* — and a driver that re-keyed only one
-/// of them would checkpoint into the session it just left, or commit there.
-/// The deck calls this at startup and again on every in-deck session switch;
-/// the one-shot drivers call it once.
+/// One call, and one opened record shared by both, because the halves answer
+/// one question — *which session owns the work happening now* — and a driver
+/// that re-keyed only one of them would checkpoint into the session it just
+/// left, or commit there. The deck calls this at startup and again on every
+/// in-deck session switch; the one-shot drivers call it once.
 ///
-/// Returns a message to show the operator when the durable record could not be
-/// opened, and `None` on success. Best-effort throughout, by the same reasoning
-/// as the sink contract: a session with no durable record is exactly as
-/// recoverable as every session was before this existed, so refusing to start
-/// over it would trade a working session for none.
+/// Returns a message to show the operator when the record could not be opened,
+/// and `None` on success. Best-effort throughout, by the same reasoning as the
+/// sink contract: a session with no durable record is exactly as recoverable as
+/// every session was before this existed, so refusing to start over it would
+/// trade a working session for none.
 pub fn bind_session(
     durability: &SessionDurability,
     registry: &stella_tools::ToolRegistry,
     workspace_root: &Path,
-    sidecar_dir: PathBuf,
     session_id: &str,
 ) -> Option<String> {
-    durability.bind(sidecar_dir);
-    match stella_store::work_journal::WorkJournal::open(workspace_root, session_id) {
+    match WorkJournal::open(workspace_root, session_id) {
         Ok(journal) => {
-            registry.attach_work_journal(journal, agent_label(workspace_root));
+            registry.attach_work_journal(journal.clone(), agent_label(workspace_root));
+            durability.bind(journal);
             None
         }
         Err(e) => Some(format!(
-            "durable work record unavailable ({e}) — this session's file changes will not be \
-             recoverable from stella's own history"
+            "durable work record unavailable ({e}) — this session's turns and file changes will \
+             not be recoverable from stella's own history"
         )),
     }
 }
@@ -148,6 +163,13 @@ pub fn bind_session(
 mod tests {
     use super::*;
 
+    /// A record rooted in two temp dirs — never [`WorkJournal::open`], which
+    /// reads `STELLA_HOME` and would make these tests fight their siblings over
+    /// one process-global.
+    fn journal(store: &Path, workspace: &Path, session: &str) -> WorkJournal {
+        WorkJournal::open_in(store, workspace, session).unwrap()
+    }
+
     #[test]
     fn an_unbound_handle_offers_no_sink() {
         assert!(SessionDurability::default().sink().is_none());
@@ -155,61 +177,107 @@ mod tests {
 
     #[test]
     fn a_bound_handle_round_trips_a_checkpoint() {
-        let dir = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-round-trip");
         let durability = SessionDurability::default();
-        durability.bind(dir.path().to_path_buf());
+        durability.bind(record.clone());
 
         let sink = durability.sink().expect("bound");
         sink.persist("{\"version\":1}");
-        assert_eq!(
-            stella_store::journal::read_checkpoint(dir.path()).as_deref(),
-            Some("{\"version\":1}"),
-        );
+        assert_eq!(record.checkpoint().as_deref(), Some("{\"version\":1}"));
 
         sink.discard();
-        assert!(stella_store::journal::read_checkpoint(dir.path()).is_none());
+        assert!(
+            record.checkpoint().is_none(),
+            "a turn that ended leaves no resume point behind"
+        );
     }
 
     #[test]
-    fn discard_is_idempotent_on_a_turn_that_never_checkpointed() {
-        let dir = tempfile::tempdir().unwrap();
+    fn a_later_checkpoint_supersedes_the_earlier_one() {
+        // The sink contract: `persist` is a complete snapshot, never a delta,
+        // and replaces any earlier one. In a commit graph "replaces" has to be
+        // proved — the earlier blob is still reachable from an older commit.
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-supersede");
         let durability = SessionDurability::default();
-        durability.bind(dir.path().to_path_buf());
+        durability.bind(record.clone());
         let sink = durability.sink().expect("bound");
-        // Twice, having never persisted: both must be silent.
+
+        sink.persist("{\"step\":1}");
+        sink.persist("{\"step\":2}");
+        assert_eq!(record.checkpoint().as_deref(), Some("{\"step\":2}"));
+    }
+
+    #[test]
+    fn discard_is_free_and_silent_on_a_turn_that_never_checkpointed() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-never");
+        let durability = SessionDurability::default();
+        durability.bind(record.clone());
+        let sink = durability.sink().expect("bound");
+
         sink.discard();
         sink.discard();
-        assert!(stella_store::journal::read_checkpoint(dir.path()).is_none());
+        assert!(record.checkpoint().is_none());
+        // And it cost nothing: a turn ending before its first step boundary is
+        // the common case, so it must not write a commit.
+        assert!(
+            record.session_tip().is_none(),
+            "discarding nothing writes nothing"
+        );
     }
 
     #[test]
     fn rebinding_re_points_the_next_sink() {
-        let first = tempfile::tempdir().unwrap();
-        let second = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let first = journal(store.path(), ws.path(), "ses-first");
+        let second = journal(store.path(), ws.path(), "ses-second");
         let durability = SessionDurability::default();
 
-        durability.bind(first.path().to_path_buf());
+        durability.bind(first.clone());
         durability
             .sink()
             .expect("bound")
             .persist("{\"first\":true}");
 
         // The in-deck session switch: the next engine's sink writes to the
-        // session that is now running, and the previous session's resume point
-        // is left exactly as it stood.
-        durability.bind(second.path().to_path_buf());
+        // session that is now running, and the session the user left keeps its
+        // resume point exactly as it stood.
+        durability.bind(second.clone());
         durability
             .sink()
             .expect("bound")
             .persist("{\"second\":true}");
 
-        assert_eq!(
-            stella_store::journal::read_checkpoint(first.path()).as_deref(),
-            Some("{\"first\":true}"),
-        );
-        assert_eq!(
-            stella_store::journal::read_checkpoint(second.path()).as_deref(),
-            Some("{\"second\":true}"),
-        );
+        assert_eq!(first.checkpoint().as_deref(), Some("{\"first\":true}"));
+        assert_eq!(second.checkpoint().as_deref(), Some("{\"second\":true}"));
+    }
+
+    #[test]
+    fn a_checkpoint_and_the_work_it_describes_share_one_commit_graph() {
+        // The reason there is one store and not two: a resume point is only
+        // useful alongside the file state it resumes INTO, and here both are
+        // reachable from the same ref rather than needing to be reconciled.
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-together");
+        std::fs::write(ws.path().join("work.txt"), "half-done\n").unwrap();
+        record
+            .record(&["work.txt".to_string()], &[], "the agent's write")
+            .unwrap();
+
+        let durability = SessionDurability::default();
+        durability.bind(record.clone());
+        durability.sink().expect("bound").persist("{\"step\":7}");
+
+        let tip = record.session_tip().expect("recorded");
+        record.mark_turn(1, &tip).unwrap();
+        assert_eq!(record.read_at_turn(1, "work.txt").unwrap(), "half-done\n");
+        assert_eq!(record.checkpoint().as_deref(), Some("{\"step\":7}"));
     }
 }

--- a/stella-cli/src/durability.rs
+++ b/stella-cli/src/durability.rs
@@ -54,25 +54,40 @@ use stella_store::work_journal::WorkJournal;
 pub struct SessionDurability {
     /// `RwLock` rather than `OnceLock` because a deck session can be switched,
     /// and the *next* turn's checkpoint must land in the session it actually
-    /// belongs to. `Arc<WorkJournal>` so `sink()` hands out a cheap share
-    /// rather than re-opening the record per engine.
-    journal: Arc<RwLock<Option<Arc<WorkJournal>>>>,
+    /// belongs to. `Arc` so `sink()` hands out cheap shares rather than
+    /// re-opening the record per engine.
+    bound: Arc<RwLock<Option<Bound>>>,
+}
+
+/// What a bound session writes through: its durable record, and the registry
+/// holding the staleness map that rides along with each checkpoint.
+#[derive(Clone)]
+struct Bound {
+    journal: Arc<WorkJournal>,
+    registry: Arc<stella_tools::ToolRegistry>,
+}
+
+/// `ToolRegistry` is not `Debug` (it holds trait objects), and
+/// [`CheckpointSink`] requires it of every implementor. The record is the part
+/// worth printing anyway — it names the session and the store — so the registry
+/// is elided rather than the whole handle losing its `Debug`.
+impl std::fmt::Debug for Bound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Bound")
+            .field("journal", &self.journal)
+            .finish_non_exhaustive()
+    }
 }
 
 impl SessionDurability {
-    /// Point this handle at `journal` — the durable record of the session that
-    /// is now running.
-    pub fn bind(&self, journal: WorkJournal) {
-        let mut slot = self.journal.write().unwrap_or_else(|p| p.into_inner());
-        *slot = Some(Arc::new(journal));
-    }
-
-    /// This session's durable record, if one is bound.
-    pub fn journal(&self) -> Option<Arc<WorkJournal>> {
-        self.journal
-            .read()
-            .unwrap_or_else(|p| p.into_inner())
-            .clone()
+    /// Point this handle at the durable record of the session that is now
+    /// running, and at the registry whose staleness map belongs with it.
+    pub fn bind(&self, journal: WorkJournal, registry: Arc<stella_tools::ToolRegistry>) {
+        let mut slot = self.bound.write().unwrap_or_else(|p| p.into_inner());
+        *slot = Some(Bound {
+            journal: Arc::new(journal),
+            registry,
+        });
     }
 
     /// The sink to hand [`stella_core::EngineConfig::checkpoint_sink`], or
@@ -82,35 +97,54 @@ impl SessionDurability {
     /// `persist` — the lock stays off the per-step hot path, and a session
     /// switch is picked up because the next turn builds a new engine.
     pub fn sink(&self) -> Option<Arc<dyn CheckpointSink>> {
-        let journal = self.journal()?;
-        Some(Arc::new(JournalCheckpointSink { journal }))
+        let bound = self
+            .bound
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()?;
+        Some(Arc::new(JournalCheckpointSink { bound }))
     }
 }
 
-/// A [`CheckpointSink`] over the work journal's checkpoint blob.
+/// A [`CheckpointSink`] over the work journal's reserved blobs.
 #[derive(Debug)]
 struct JournalCheckpointSink {
-    journal: Arc<WorkJournal>,
+    bound: Bound,
 }
 
 impl CheckpointSink for JournalCheckpointSink {
-    /// One commit on this session's ref. Dearer than an atomic file write and
-    /// still cheap against what a step costs — see
-    /// [`WorkJournal::record_checkpoint`].
+    /// One commit on this session's ref, carrying the resume point and the
+    /// staleness map together. Dearer than an atomic file write and still cheap
+    /// against what a step costs — see [`WorkJournal::record_checkpoint`].
+    ///
+    /// The staleness map is snapshotted *here*, at the step boundary, rather
+    /// than when a file changes: it is updated by reads too, and saving it only
+    /// on mutation would drop every read since the last write. That is the loss
+    /// that matters, because a resumed session's transcript still says the agent
+    /// read those files.
     ///
     /// The error is dropped, not logged: this is called on every step of every
     /// turn, so a failing sink would emit one line per step, and the trait's
     /// contract is that a checkpoint which cannot be written leaves the turn
     /// exactly as recoverable as it was before the sink existed.
     fn persist(&self, json: &str) {
-        let _ = self.journal.record_checkpoint(json);
+        let observed = self.bound.registry.observed_snapshot();
+        let _ = self
+            .bound
+            .journal
+            .record_checkpoint(json, observed.as_deref());
     }
 
     /// Idempotent by [`WorkJournal::clear_checkpoint`]'s own contract, and free
     /// when there is nothing to retract — which is what lets every terminal
     /// path discard unconditionally.
+    ///
+    /// The staleness map is deliberately NOT retracted with the checkpoint. It
+    /// describes what this *session* has seen, and the session's next turn is
+    /// exactly as entitled to the no-clobber guarantee as the one that just
+    /// ended.
     fn discard(&self) {
-        let _ = self.journal.clear_checkpoint();
+        let _ = self.bound.journal.clear_checkpoint();
     }
 }
 
@@ -135,6 +169,9 @@ pub fn agent_label(workspace_root: &Path) -> String {
 /// left, or commit there. The deck calls this at startup and again on every
 /// in-deck session switch; the one-shot drivers call it once.
 ///
+/// Resuming a session also restores its staleness map, which is what carries
+/// the no-clobber guarantee across the interruption.
+///
 /// Returns a message to show the operator when the record could not be opened,
 /// and `None` on success. Best-effort throughout, by the same reasoning as the
 /// sink contract: a session with no durable record is exactly as recoverable as
@@ -142,14 +179,20 @@ pub fn agent_label(workspace_root: &Path) -> String {
 /// trade a working session for none.
 pub fn bind_session(
     durability: &SessionDurability,
-    registry: &stella_tools::ToolRegistry,
+    registry: &Arc<stella_tools::ToolRegistry>,
     workspace_root: &Path,
     session_id: &str,
 ) -> Option<String> {
     match WorkJournal::open(workspace_root, session_id) {
         Ok(journal) => {
+            // Before anything else can touch a file: a resumed session that
+            // wrote before restoring would be unguarded for exactly the writes
+            // its restored transcript most encourages it to make.
+            if let Some(observed) = journal.observed() {
+                registry.restore_observed(&observed);
+            }
             registry.attach_work_journal(journal.clone(), agent_label(workspace_root));
-            durability.bind(journal);
+            durability.bind(journal, registry.clone());
             None
         }
         Err(e) => Some(format!(
@@ -170,6 +213,14 @@ mod tests {
         WorkJournal::open_in(store, workspace, session).unwrap()
     }
 
+    /// A registry over `workspace`, for the staleness map the sink snapshots.
+    fn registry(workspace: &Path) -> Arc<stella_tools::ToolRegistry> {
+        Arc::new(stella_tools::ToolRegistry::new(
+            workspace.to_path_buf(),
+            stella_tools::RegistryOptions::default(),
+        ))
+    }
+
     #[test]
     fn an_unbound_handle_offers_no_sink() {
         assert!(SessionDurability::default().sink().is_none());
@@ -181,7 +232,7 @@ mod tests {
         let ws = tempfile::tempdir().unwrap();
         let record = journal(store.path(), ws.path(), "ses-round-trip");
         let durability = SessionDurability::default();
-        durability.bind(record.clone());
+        durability.bind(record.clone(), registry(ws.path()));
 
         let sink = durability.sink().expect("bound");
         sink.persist("{\"version\":1}");
@@ -203,7 +254,7 @@ mod tests {
         let ws = tempfile::tempdir().unwrap();
         let record = journal(store.path(), ws.path(), "ses-supersede");
         let durability = SessionDurability::default();
-        durability.bind(record.clone());
+        durability.bind(record.clone(), registry(ws.path()));
         let sink = durability.sink().expect("bound");
 
         sink.persist("{\"step\":1}");
@@ -217,7 +268,7 @@ mod tests {
         let ws = tempfile::tempdir().unwrap();
         let record = journal(store.path(), ws.path(), "ses-never");
         let durability = SessionDurability::default();
-        durability.bind(record.clone());
+        durability.bind(record.clone(), registry(ws.path()));
         let sink = durability.sink().expect("bound");
 
         sink.discard();
@@ -239,7 +290,7 @@ mod tests {
         let second = journal(store.path(), ws.path(), "ses-second");
         let durability = SessionDurability::default();
 
-        durability.bind(first.clone());
+        durability.bind(first.clone(), registry(ws.path()));
         durability
             .sink()
             .expect("bound")
@@ -248,7 +299,7 @@ mod tests {
         // The in-deck session switch: the next engine's sink writes to the
         // session that is now running, and the session the user left keeps its
         // resume point exactly as it stood.
-        durability.bind(second.clone());
+        durability.bind(second.clone(), registry(ws.path()));
         durability
             .sink()
             .expect("bound")
@@ -272,12 +323,68 @@ mod tests {
             .unwrap();
 
         let durability = SessionDurability::default();
-        durability.bind(record.clone());
+        durability.bind(record.clone(), registry(ws.path()));
         durability.sink().expect("bound").persist("{\"step\":7}");
 
         let tip = record.session_tip().expect("recorded");
         record.mark_turn(1, &tip).unwrap();
         assert_eq!(record.read_at_turn(1, "work.txt").unwrap(), "half-done\n");
         assert_eq!(record.checkpoint().as_deref(), Some("{\"step\":7}"));
+    }
+
+    #[tokio::test]
+    async fn the_no_clobber_guard_survives_a_crash() {
+        // The whole point of persisting the staleness map. Without it a resumed
+        // session is *less* safe than a fresh one is honest: its restored
+        // transcript still says the agent read the file, so the model acts on
+        // content it believes it knows, while a forgetful guard waves the
+        // overwrite through.
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::write(ws.path().join("shared.txt"), "original\n").unwrap();
+
+        // Session one reads the file, then checkpoints — which is where the
+        // map it built gets written down.
+        let first_registry = registry(ws.path());
+        let out = first_registry
+            .execute(
+                "read_file",
+                &serde_json::json!({ "path": "shared.txt", "reason": "planning" }),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        let record = journal(store.path(), ws.path(), "ses-crash");
+        let durability = SessionDurability::default();
+        durability.bind(record.clone(), first_registry);
+        durability.sink().expect("bound").persist("{\"step\":1}");
+
+        // …and dies. Meanwhile something else edits the file.
+        std::fs::write(ws.path().join("shared.txt"), "somebody else's work\n").unwrap();
+
+        // Session two resumes: same durable record, a brand-new registry that
+        // has never seen a thing.
+        let resumed = registry(ws.path());
+        resumed.restore_observed(&record.observed().expect("the map was persisted"));
+
+        let out = resumed
+            .execute(
+                "write_file",
+                &serde_json::json!({
+                    "path": "shared.txt",
+                    "content": "what session one intended\n",
+                    "reason": "acting on what I read before the crash",
+                }),
+            )
+            .await;
+
+        assert!(
+            out.is_error(),
+            "the resumed session must be told the file moved, not silently overwrite it: {out:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(ws.path().join("shared.txt")).unwrap(),
+            "somebody else's work\n",
+            "and the other party's work is still there"
+        );
     }
 }

--- a/stella-cli/src/durability.rs
+++ b/stella-cli/src/durability.rs
@@ -1,0 +1,215 @@
+//! Where this session's turns write their resume point.
+//!
+//! [`stella_core::step::CheckpointSink`] says *when* a checkpoint is written —
+//! at the one step boundary where the transcript is guaranteed well-paired —
+//! and deliberately says nothing about where. This module is the CLI's answer
+//! to *where*, and it has to live in a crate that depends on both
+//! `stella-core` (which declares the trait) and `stella-store` (which owns the
+//! session sidecar). `stella-store` cannot implement it: it depends only on
+//! `stella-protocol` and has never heard of the engine.
+//!
+//! # Why a shared cell rather than a plain field
+//!
+//! A session's durable identity does not exist when its [`crate::config::Config`] is
+//! built. The deck receives `&Config` and only then resolves — or mints — the
+//! [`stella_store::SessionRecord`] whose sidecar the checkpoint belongs in, and
+//! it re-points that sidecar mid-run every time the user switches sessions. A
+//! `PathBuf` field could be filled in by neither of those moments.
+//!
+//! So `Config` carries a [`SessionDurability`] handle instead: cheap to clone,
+//! empty until a driver binds it, and read afresh by every engine the session
+//! builds. `agent::engine_config_for` runs per turn, so an in-deck session
+//! switch is picked up by the next turn with nothing to re-thread.
+//!
+//! # Why `sink()` may answer `None`
+//!
+//! [`stella_core::Engine::persist_checkpoint`] serializes the whole transcript
+//! *before* it hands anything to the sink. An always-attached sink that happens
+//! to have nowhere to write would therefore pay full JSON encoding on every
+//! step of every turn to throw the bytes away. An unbound handle yields `None`
+//! and the engine skips the encode entirely.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use stella_core::step::CheckpointSink;
+
+/// A handle on where this session's resume point is written.
+///
+/// Cloned into [`crate::config::Config`] and shared by every engine the session
+/// builds. Empty until a driver calls [`Self::bind`]; binding again re-points
+/// it, which is what an in-deck session switch needs.
+#[derive(Clone, Debug, Default)]
+pub struct SessionDurability {
+    /// The bound session's sidecar directory. `RwLock` rather than `OnceLock`
+    /// because a deck session can be switched, and the *next* turn's checkpoint
+    /// must land in the session it actually belongs to.
+    sidecar: Arc<RwLock<Option<PathBuf>>>,
+}
+
+impl SessionDurability {
+    /// Point this handle at `sidecar_dir` — the directory
+    /// [`stella_store::SessionRegistry::sidecar_dir`] gives for the session
+    /// that is now running.
+    pub fn bind(&self, sidecar_dir: PathBuf) {
+        let mut slot = self.sidecar.write().unwrap_or_else(|p| p.into_inner());
+        *slot = Some(sidecar_dir);
+    }
+
+    /// The sink to hand [`stella_core::EngineConfig::checkpoint_sink`], or
+    /// `None` while this handle is unbound.
+    ///
+    /// The bound path is read out *here*, once per engine, rather than on every
+    /// `persist` — the lock stays off the per-step hot path, and a session
+    /// switch is picked up because the next turn builds a new engine.
+    pub fn sink(&self) -> Option<Arc<dyn CheckpointSink>> {
+        let dir = self
+            .sidecar
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()?;
+        Some(Arc::new(SidecarCheckpointSink { dir }))
+    }
+}
+
+/// A [`CheckpointSink`] over the session sidecar's `checkpoint.json`.
+#[derive(Debug)]
+struct SidecarCheckpointSink {
+    dir: PathBuf,
+}
+
+impl CheckpointSink for SidecarCheckpointSink {
+    /// One atomic write (temp + fsync + rename), as the trait's cost note
+    /// requires — this runs on the turn's own task and blocks it.
+    ///
+    /// The error is dropped, not logged: this is called on every step of every
+    /// turn, so a failing sink would emit one line per step, and the trait's
+    /// contract is that a checkpoint which cannot be written leaves the turn
+    /// exactly as recoverable as it was before the sink existed.
+    fn persist(&self, json: &str) {
+        let _ = stella_store::journal::write_checkpoint(&self.dir, json);
+    }
+
+    /// Idempotent by [`stella_store::journal::clear_checkpoint`]'s own
+    /// contract — a missing file is success, which is what lets every terminal
+    /// path discard unconditionally.
+    fn discard(&self) {
+        let _ = stella_store::journal::clear_checkpoint(&self.dir);
+    }
+}
+
+/// The label a session's durable commits carry, derived from the workspace.
+///
+/// Not the session id: the id answers *which run*, and the work journal is
+/// already keyed on it. This answers *whose work*, and a human reading
+/// `git log` on the durable record wants the workspace name.
+pub fn agent_label(workspace_root: &Path) -> String {
+    workspace_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| workspace_root.display().to_string())
+}
+
+/// Bind both halves of this session's durability: where its turns write a
+/// resume point, and where its file mutations commit.
+///
+/// One call rather than two because the halves answer one question — *which
+/// session owns the work happening now* — and a driver that re-keyed only one
+/// of them would checkpoint into the session it just left, or commit there.
+/// The deck calls this at startup and again on every in-deck session switch;
+/// the one-shot drivers call it once.
+///
+/// Returns a message to show the operator when the durable record could not be
+/// opened, and `None` on success. Best-effort throughout, by the same reasoning
+/// as the sink contract: a session with no durable record is exactly as
+/// recoverable as every session was before this existed, so refusing to start
+/// over it would trade a working session for none.
+pub fn bind_session(
+    durability: &SessionDurability,
+    registry: &stella_tools::ToolRegistry,
+    workspace_root: &Path,
+    sidecar_dir: PathBuf,
+    session_id: &str,
+) -> Option<String> {
+    durability.bind(sidecar_dir);
+    match stella_store::work_journal::WorkJournal::open(workspace_root, session_id) {
+        Ok(journal) => {
+            registry.attach_work_journal(journal, agent_label(workspace_root));
+            None
+        }
+        Err(e) => Some(format!(
+            "durable work record unavailable ({e}) — this session's file changes will not be \
+             recoverable from stella's own history"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unbound_handle_offers_no_sink() {
+        assert!(SessionDurability::default().sink().is_none());
+    }
+
+    #[test]
+    fn a_bound_handle_round_trips_a_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let durability = SessionDurability::default();
+        durability.bind(dir.path().to_path_buf());
+
+        let sink = durability.sink().expect("bound");
+        sink.persist("{\"version\":1}");
+        assert_eq!(
+            stella_store::journal::read_checkpoint(dir.path()).as_deref(),
+            Some("{\"version\":1}"),
+        );
+
+        sink.discard();
+        assert!(stella_store::journal::read_checkpoint(dir.path()).is_none());
+    }
+
+    #[test]
+    fn discard_is_idempotent_on_a_turn_that_never_checkpointed() {
+        let dir = tempfile::tempdir().unwrap();
+        let durability = SessionDurability::default();
+        durability.bind(dir.path().to_path_buf());
+        let sink = durability.sink().expect("bound");
+        // Twice, having never persisted: both must be silent.
+        sink.discard();
+        sink.discard();
+        assert!(stella_store::journal::read_checkpoint(dir.path()).is_none());
+    }
+
+    #[test]
+    fn rebinding_re_points_the_next_sink() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let durability = SessionDurability::default();
+
+        durability.bind(first.path().to_path_buf());
+        durability
+            .sink()
+            .expect("bound")
+            .persist("{\"first\":true}");
+
+        // The in-deck session switch: the next engine's sink writes to the
+        // session that is now running, and the previous session's resume point
+        // is left exactly as it stood.
+        durability.bind(second.path().to_path_buf());
+        durability
+            .sink()
+            .expect("bound")
+            .persist("{\"second\":true}");
+
+        assert_eq!(
+            stella_store::journal::read_checkpoint(first.path()).as_deref(),
+            Some("{\"first\":true}"),
+        );
+        assert_eq!(
+            stella_store::journal::read_checkpoint(second.path()).as_deref(),
+            Some("{\"second\":true}"),
+        );
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -48,6 +48,7 @@ mod diag_bridge;
 mod discovery;
 mod doctor;
 mod domains;
+mod durability;
 mod engine_config;
 mod enterprise_telemetry;
 #[cfg(test)]

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -162,6 +162,12 @@ pub struct Settings {
     /// run's episode. Local-only by construction. Default off.
     #[serde(default)]
     pub trace_capture: Option<Toggle>,
+    /// `always` / `ask` / `never` — whether a run does its work in a throwaway
+    /// git worktree instead of the working tree. Absent, null, or empty means
+    /// `ask`, and the question is put once, at triage, only when the run is
+    /// actually going to change files. See [`CreateWorktrees`].
+    #[serde(default)]
+    pub create_worktrees: Option<CreateWorktrees>,
     /// Appearance preferences — currently just the TUI colour theme
     /// (`/theme`). Whole-block last-wins across scopes; carries no authority.
     #[serde(default)]
@@ -198,6 +204,63 @@ pub struct Settings {
     /// when parsing individual scopes so repository text cannot supply it.
     #[serde(skip)]
     pub authority_policy: AuthorityPolicy,
+}
+
+/// `create_worktrees`: whether a run does its work in a throwaway git worktree
+/// instead of the user's checkout.
+///
+/// `"always"`, `"ask"`, `"never"` — and `""`, null, or the key being absent all
+/// mean `"ask"`, so a scope that wants to say "no opinion" can write the key
+/// empty rather than having to delete it. Anything else is a loud parse error;
+/// a typo here would otherwise silently pick a side on where somebody's work
+/// happens.
+///
+/// The policy is consumed at triage (`Pipeline::isolate_in_worktree`), which is
+/// the first moment it is both answerable and worth asking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CreateWorktrees {
+    Always,
+    #[default]
+    Ask,
+    Never,
+}
+
+impl CreateWorktrees {
+    /// The pipeline's spelling of the same decision.
+    pub fn policy(self) -> stella_pipeline::ports::WorktreePolicy {
+        match self {
+            Self::Always => stella_pipeline::ports::WorktreePolicy::Always,
+            Self::Ask => stella_pipeline::ports::WorktreePolicy::Ask,
+            Self::Never => stella_pipeline::ports::WorktreePolicy::Never,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CreateWorktrees {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Through `Option<String>` so an explicit `null` lands here rather than
+        // being rejected before this function sees it.
+        let raw = Option::<String>::deserialize(deserializer)?;
+        match raw.as_deref().map(str::trim).unwrap_or("") {
+            "" | "ask" => Ok(Self::Ask),
+            "always" => Ok(Self::Always),
+            "never" => Ok(Self::Never),
+            other => Err(serde::de::Error::custom(format!(
+                "\"create_worktrees\": {other:?} is not one of \"always\", \"ask\", \"never\" \
+                 (empty or absent means \"ask\")"
+            ))),
+        }
+    }
+}
+
+impl Serialize for CreateWorktrees {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(match self {
+            Self::Always => "always",
+            Self::Ask => "ask",
+            Self::Never => "never",
+        })
+    }
 }
 
 /// An `on`/`off` switch. A dedicated enum rather than `bool` because the
@@ -905,6 +968,12 @@ impl Settings {
     /// on (a later `"off"` turns it back off — project wins per field).
     pub fn trace_capture_enabled(&self) -> bool {
         self.trace_capture.is_some_and(Toggle::is_on)
+    }
+
+    /// The resolved `create_worktrees` policy. An absent key means `ask`, the
+    /// same as an empty or null one — see [`CreateWorktrees`].
+    pub fn create_worktrees(&self) -> CreateWorktrees {
+        self.create_worktrees.unwrap_or_default()
     }
 
     /// The persisted TUI colour-theme slug (`ui.theme`), if any. `None` means

--- a/stella-cli/src/settings/tests.rs
+++ b/stella-cli/src/settings/tests.rs
@@ -1086,3 +1086,41 @@ fn enable_recap_defaults_off_when_no_scope_sets_it() {
     let merged = Settings::load(workspace).expect("settings load");
     assert!(!merged.recap_enabled(), "recap defaults off");
 }
+
+/// Every spelling of "no opinion" resolves to `ask`, and a typo is loud.
+///
+/// The three quiet spellings matter because they are how a scope says "I have
+/// nothing to say about this": absent, explicitly null, and present-but-empty.
+/// A parser that accepted only the first would make `"create_worktrees": ""`
+/// either an error or — far worse — a silent `always`, deciding on its own
+/// where somebody's work happens.
+#[test]
+fn create_worktrees_reads_every_spelling_of_no_opinion_as_ask() {
+    for json in [
+        r#"{}"#,
+        r#"{"create_worktrees": null}"#,
+        r#"{"create_worktrees": ""}"#,
+        r#"{"create_worktrees": "  "}"#,
+        r#"{"create_worktrees": "ask"}"#,
+    ] {
+        let parsed: Settings = serde_json::from_str(json).unwrap_or_else(|e| panic!("{json}: {e}"));
+        assert_eq!(
+            parsed.create_worktrees(),
+            CreateWorktrees::Ask,
+            "{json} must mean ask"
+        );
+    }
+
+    let always: Settings = serde_json::from_str(r#"{"create_worktrees": "always"}"#).unwrap();
+    assert_eq!(always.create_worktrees(), CreateWorktrees::Always);
+    let never: Settings = serde_json::from_str(r#"{"create_worktrees": "never"}"#).unwrap();
+    assert_eq!(never.create_worktrees(), CreateWorktrees::Never);
+
+    // A typo must not silently pick a side.
+    let err = serde_json::from_str::<Settings>(r#"{"create_worktrees": "alwyas"}"#)
+        .expect_err("a misspelling is a parse error");
+    assert!(
+        err.to_string().contains("always"),
+        "the error should name the accepted values: {err}"
+    );
+}

--- a/stella-cli/src/settings/toml_config.rs
+++ b/stella-cli/src/settings/toml_config.rs
@@ -100,6 +100,10 @@ pub struct RunSection {
     /// (#1042). Same name in JSON (`trace_capture`).
     #[serde(default)]
     pub trace_capture: Option<Toggle>,
+    /// `always` / `ask` / `never` — whether a run works in a throwaway git
+    /// worktree instead of the checkout. Same name in JSON.
+    #[serde(default)]
+    pub create_worktrees: Option<super::CreateWorktrees>,
 }
 
 /// `[models]` — policy over the model catalog, not a model table.
@@ -340,6 +344,7 @@ impl TomlConfig {
             tools,
             enable_recap: run.recap,
             trace_capture: run.trace_capture,
+            create_worktrees: run.create_worktrees,
             ui,
             context,
             context_providers,

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -756,11 +756,16 @@ impl<'a> Engine<'a> {
     /// Write `state`'s resume point through the configured
     /// [`crate::step::CheckpointSink`], if the host attached one.
     ///
+    /// Public because a host that drives [`Self::run_step`] itself — as
+    /// `stella-serve` does — owns its own loop and must reach the same seam.
+    /// Sharing this method rather than letting each driver write its own is
+    /// what keeps a served turn and a CLI turn equally recoverable.
+    ///
     /// Silent on every failure path, by the sink contract: an unwritable
     /// checkpoint leaves the turn exactly as recoverable as it was before the
     /// sink existed, and failing a live turn to report a durability
     /// *improvement* would be strictly worse than not offering one.
-    fn persist_checkpoint(&self, state: &crate::step::TurnState) {
+    pub fn persist_checkpoint(&self, state: &crate::step::TurnState) {
         let Some(sink) = self.config.checkpoint_sink.as_ref() else {
             return;
         };
@@ -774,7 +779,7 @@ impl<'a> Engine<'a> {
     /// Called on every terminal path — completion, abort, and the step cap —
     /// because a checkpoint that outlives its turn is worse than none: it
     /// invites a resume that re-runs work the caller already saw finish.
-    fn discard_checkpoint(&self) {
+    pub fn discard_checkpoint(&self) {
         if let Some(sink) = self.config.checkpoint_sink.as_ref() {
             sink.discard();
         }

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -73,6 +73,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::StreamExt;
@@ -261,6 +262,19 @@ pub struct EngineConfig {
     /// field still defaults `false` so a programmatically-built config opts in
     /// deliberately rather than inheriting a product default it never read.
     pub lifecycle_enabled: bool,
+    /// Where this engine's turns write their resume point, if anywhere.
+    ///
+    /// `None` — the default — is the behaviour every caller had before: a turn
+    /// interrupted mid-flight is gone, and the host recovers by re-dispatching
+    /// the prompt and paying for the work again. Attaching a sink makes the
+    /// turn itself recoverable; see [`crate::step::CheckpointSink`] for the failure
+    /// contract, and [`Engine::resume_turn`] for the other half.
+    ///
+    /// Kept here rather than passed to `run_turn` because it is a property of
+    /// the host's durability arrangement, not of any one turn — the same
+    /// reasoning that puts [`Self::cwd`] here rather than making the engine
+    /// sniff it.
+    pub checkpoint_sink: Option<Arc<dyn crate::step::CheckpointSink>>,
 }
 
 impl Default for EngineConfig {
@@ -291,6 +305,11 @@ impl Default for EngineConfig {
             cwd: ".".to_string(),
             turn_instance: 0,
             lifecycle_enabled: false,
+            // Off by default for the same reason `turn_budget` is: only a
+            // caller that owns durable storage can say where a resume point
+            // belongs, and a default location invented here would write one
+            // process's turns into another's session.
+            checkpoint_sink: None,
         }
     }
 }
@@ -699,8 +718,17 @@ impl<'a> Engine<'a> {
                 self.emit_lifecycle(bus::names::AGENT_TURN_COMPLETED, || {
                     turn_outcome_payload(&outcome, turn.state.step)
                 });
+                self.discard_checkpoint();
                 return outcome;
             }
+            // The checkpoint seam (#971). `StepOutcome::Continue` is the one
+            // moment the transcript is guaranteed well-paired — no `tool_use`
+            // without its `tool_result` — and `state.step` has already been
+            // advanced by `run_step`, so the snapshot names the step that runs
+            // NEXT rather than the one that just finished. Writing here and
+            // nowhere else is what makes a resumed turn indistinguishable from
+            // one that was never interrupted.
+            self.persist_checkpoint(&turn.state);
         }
 
         let reason = step_cap_reason(self.config.max_steps);
@@ -718,7 +746,38 @@ impl<'a> Engine<'a> {
         self.emit_lifecycle(bus::names::AGENT_TURN_COMPLETED, || {
             turn_outcome_payload(&outcome, turn.state.step)
         });
+        // A turn that ran into the step cap is over, however unhappily. Leaving
+        // its checkpoint behind would offer a resume that replays a turn whose
+        // whole problem was that it would not stop.
+        self.discard_checkpoint();
         outcome
+    }
+
+    /// Write `state`'s resume point through the configured
+    /// [`crate::step::CheckpointSink`], if the host attached one.
+    ///
+    /// Silent on every failure path, by the sink contract: an unwritable
+    /// checkpoint leaves the turn exactly as recoverable as it was before the
+    /// sink existed, and failing a live turn to report a durability
+    /// *improvement* would be strictly worse than not offering one.
+    fn persist_checkpoint(&self, state: &crate::step::TurnState) {
+        let Some(sink) = self.config.checkpoint_sink.as_ref() else {
+            return;
+        };
+        if let Ok(json) = state.to_checkpoint().to_json() {
+            sink.persist(&json);
+        }
+    }
+
+    /// Drop any resume point for the turn that just ended.
+    ///
+    /// Called on every terminal path — completion, abort, and the step cap —
+    /// because a checkpoint that outlives its turn is worse than none: it
+    /// invites a resume that re-runs work the caller already saw finish.
+    fn discard_checkpoint(&self) {
+        if let Some(sink) = self.config.checkpoint_sink.as_ref() {
+            sink.discard();
+        }
     }
 
     /// Run exactly ONE committed step against `state`, the unit a durable host

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -3418,3 +3418,126 @@ async fn a_call_only_stream_outlives_the_deadline_because_it_is_not_stalled() {
     );
     drain_events(&mut rx);
 }
+
+/// A [`CheckpointSink`] that records what a turn wrote and how often it
+/// cleared, so a test can assert both halves of the durability contract.
+#[derive(Debug, Default)]
+struct RecordingSink {
+    persisted: std::sync::Mutex<Vec<String>>,
+    discards: AtomicU32,
+}
+
+impl crate::step::CheckpointSink for RecordingSink {
+    fn persist(&self, json: &str) {
+        self.persisted
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(json.to_string());
+    }
+    fn discard(&self) {
+        self.discards.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn a_turn_checkpoints_at_every_step_boundary_and_clears_when_it_ends() {
+    // The durability contract in one test. Script: a tool call (step 0
+    // continues) then text (step 1 completes), so the turn crosses exactly
+    // one step boundary.
+    //
+    // What must hold:
+    //   * exactly one checkpoint, written at the one `Continue`;
+    //   * it decodes, so what a resume would read is what this build writes;
+    //   * `step` is 1 — the index that runs NEXT, not the one that just ran,
+    //     because a resume that replayed the finished step would re-execute
+    //     its tool call;
+    //   * exactly one discard, so a completed turn leaves nothing behind for
+    //     a later resume to replay.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("call_1", "bash")),
+            Ok(text_result("done")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let sink = Arc::new(RecordingSink::default());
+    let config = EngineConfig {
+        checkpoint_sink: Some(sink.clone() as Arc<dyn crate::step::CheckpointSink>),
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("go"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "the scripted turn completes: {outcome:?}"
+    );
+
+    let persisted = sink.persisted.lock().unwrap_or_else(|p| p.into_inner());
+    assert_eq!(
+        persisted.len(),
+        1,
+        "one step boundary means one checkpoint, not one per model call"
+    );
+    let checkpoint =
+        crate::step::Checkpoint::from_json(&persisted[0]).expect("a written checkpoint decodes");
+    assert_eq!(
+        checkpoint.step, 1,
+        "the checkpoint names the step that runs next, so a resume does not \
+         re-execute the tool call the snapshotted step already ran"
+    );
+    assert!(
+        checkpoint.messages.len() > 2,
+        "the transcript rides along and has grown past the seed system+user \
+         pair — the assistant's tool call and its result are exactly what a \
+         resumed turn must not have to re-derive: {} messages",
+        checkpoint.messages.len()
+    );
+    assert_eq!(
+        sink.discards.load(Ordering::SeqCst),
+        1,
+        "a turn that ended clears its resume point exactly once"
+    );
+    drain_events(&mut rx);
+}
+
+#[tokio::test]
+async fn a_turn_without_a_sink_is_unchanged() {
+    // The default config attaches no sink, and that path must stay entirely
+    // free of checkpoint work — this is what keeps durability opt-in for
+    // embedders that own their own persistence.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("done"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    assert!(
+        EngineConfig::default().checkpoint_sink.is_none(),
+        "durability is opt-in: a default engine writes no checkpoints"
+    );
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("go"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+    drain_events(&mut rx);
+}

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -505,6 +505,18 @@ pub const CHECKPOINT_VERSION: u32 = 1;
 /// back with its keys sorted and the round-trip would not be byte-identical.
 /// Field order here IS the wire order, and
 /// `checkpoint_round_trips_byte_identically` pins it.
+///
+/// # What is in one
+///
+/// [`Self::messages`] is the whole conversation, verbatim — which means the
+/// full content of every file the agent read, including whatever was in those
+/// files. That is deliberate (the engine's next model call needs the bytes),
+/// but it makes a checkpoint as sensitive as the workspace it was taken from.
+///
+/// Anything that moves one somewhere the workspace is not — a host, a server, a
+/// support bundle, a log — is making an egress decision, and should make it
+/// knowing that. Stated here rather than left to be discovered, because this is
+/// the type someone reads before writing the code that moves it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Checkpoint {
     /// [`CHECKPOINT_VERSION`] at the time of writing.
@@ -595,6 +607,12 @@ pub enum CheckpointError {
 ///
 /// Implementations are invoked on the turn's own task and block it, so
 /// `persist` must be cheap. The file-backed sink is one temp+fsync+rename.
+///
+/// # What a sink is being handed
+///
+/// The bytes are a whole conversation, so they carry the full content of every
+/// file the agent read — see [`Checkpoint`]. Choosing where a sink puts them is
+/// choosing where that content lives.
 pub trait CheckpointSink: Send + Sync + std::fmt::Debug {
     /// Record `json` as the resume point for this turn, replacing any earlier
     /// one. `json` is [`Checkpoint::to_json`] output and is a complete

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -573,6 +573,43 @@ pub enum CheckpointError {
     },
 }
 
+/// Where a durable host puts the [`Checkpoint`] a turn writes at each step
+/// boundary.
+///
+/// The engine owns *when*: a checkpoint is written at the one moment the
+/// transcript is guaranteed well-paired (no `tool_use` without its
+/// `tool_result`), and discarded the moment the turn reaches a terminal
+/// outcome, because resuming a turn that already ended would replay it. The
+/// host owns *where* — this crate does no file I/O, and a sink can just as
+/// well be a database row or an HTTP call.
+///
+/// # Failures are the sink's to absorb
+///
+/// Neither method returns a `Result`, and that is deliberate. A checkpoint
+/// that cannot be written must never fail the turn that produced it: without
+/// one the turn is exactly as durable as it was before (its prompt is
+/// re-queued and the work is re-run), so a full disk would be trading a
+/// recoverable turn for a dead one. Sinks that want the failure seen should
+/// report it out of band — once, not per step, since this is called on every
+/// step of every turn.
+///
+/// Implementations are invoked on the turn's own task and block it, so
+/// `persist` must be cheap. The file-backed sink is one temp+fsync+rename.
+pub trait CheckpointSink: Send + Sync + std::fmt::Debug {
+    /// Record `json` as the resume point for this turn, replacing any earlier
+    /// one. `json` is [`Checkpoint::to_json`] output and is a complete
+    /// snapshot, never a delta.
+    fn persist(&self, json: &str);
+
+    /// Drop the resume point — the turn reached a terminal outcome.
+    ///
+    /// Must be idempotent: a turn that never checkpointed (it ended on its
+    /// first step) still discards on the way out, and a crash between
+    /// `persist` and `discard` leaves a stale point that the next `discard`
+    /// clears.
+    fn discard(&self);
+}
+
 /// [`BudgetGuard`]'s state as data.
 ///
 /// The guard keeps its fields private (it is a meter, not a record) and is not

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -126,6 +126,31 @@ pub static CAPABILITIES: &[Capability] = &[
         },
     },
     Capability {
+        id: "turn.checkpoint",
+        engine_home: "stella-core step: the CheckpointSink seam, written at the one step boundary \
+                      where the transcript is guaranteed well-paired",
+        engine_entries: &["persist_checkpoint", "discard_checkpoint"],
+        cli: SurfacePosture::Shipped {
+            mechanism: "Config's SessionDurability handle, attached at agent::tuned_engine_config \
+                        so every role gets it; the sink writes the work journal's CHECKPOINT_BLOB",
+            witness: "a_bound_session_checkpoints_from_every_role",
+        },
+        // The plumbing is present and correct on this surface — `drive_turn`
+        // calls both entry points at the same seams the CLI driver does — but
+        // nothing sets `checkpoint_sink`, so a served turn is not durable.
+        // That is a design decision, not an omission: in the reverse-RPC model
+        // the workspace lives on the HOST side, so serve has no filesystem
+        // location it could honestly checkpoint against (and no `stella-store`
+        // dependency, and no workspace root or session id in `SessionSpec`).
+        // `SessionSpec::config` is `pub`, so an embedder that owns a workspace
+        // supplies its own sink today.
+        api: SurfacePosture::Deferred {
+            waiting_on: "who owns the workspace for a served session — the host supplies a sink \
+                         through the public EngineConfig today; a server-side one needs the \
+                         portable-session design (transportable state between machines) first",
+        },
+    },
+    Capability {
         id: "turn.stream_events",
         engine_home: "stella-protocol AgentEvent over the engine's EventSender",
         engine_entries: &[],
@@ -394,9 +419,14 @@ mod tests {
     /// the same trade `provider_parity` documents: a witness that moves to a
     /// file outside this list fails loudly (a false alarm to fix by extending
     /// the list), never silently (the rotted proof this exists to catch).
-    fn cli_sources() -> [&'static str; 7] {
+    fn cli_sources() -> [&'static str; 8] {
         [
             include_str!("../../stella-cli/src/agent_tests.rs"),
+            // `agent_tests.rs` is split into submodules by the file-size
+            // ratchet, so its children have to be listed too — a witness that
+            // moved into one of them is not missing, it is one `include_str!`
+            // away from being invisible to this sweep.
+            include_str!("../../stella-cli/src/agent_tests/engine_wiring.rs"),
             include_str!("../../stella-cli/src/subagent/tests.rs"),
             include_str!("../../stella-cli/src/subsession.rs"),
             include_str!("../../stella-cli/src/command_deck/tests.rs"),

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -347,6 +347,14 @@ pub struct PipelineConfig {
     /// best, adopting only the winner's changes into the real tree. Paid for
     /// with n× the execution cost — opt-in only.
     pub candidates: Option<u32>,
+    /// Whether this run does its work in a throwaway worktree rather than the
+    /// user's checkout. Consulted once, at triage, and only when the run is
+    /// going to change files.
+    ///
+    /// The precedence is: a run that changes nothing is never isolated; a
+    /// workspace with no candidate isolation cannot offer it (and an `Always`
+    /// that cannot be honoured says so); only then does this policy decide.
+    pub create_worktrees: crate::ports::WorktreePolicy,
 }
 
 impl Default for PipelineConfig {
@@ -374,6 +382,7 @@ impl Default for PipelineConfig {
             max_revisions: 2,
             require_independent_witness: false,
             candidates: None,
+            create_worktrees: crate::ports::WorktreePolicy::default(),
         }
     }
 }
@@ -382,6 +391,65 @@ impl PipelineConfig {
     /// The effective candidate count (`candidates`, floored at 1).
     fn candidate_count(&self) -> u32 {
         self.candidates.unwrap_or(1).max(1)
+    }
+}
+
+/// What the operator is asked under [`crate::ports::WorktreePolicy::Ask`].
+///
+/// Phrased as what changes for *them*, not as what the implementation does:
+/// the cost of isolation is that `git status` stays quiet while the run works,
+/// and the benefit is that an abandoned run leaves nothing behind.
+const WORKTREE_QUESTION: &str = "Do this run's work in a throwaway git worktree? Nothing reaches your checkout until the run \
+     finishes and adopts it.";
+
+/// The worktree decision, before anyone is asked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Decided {
+    Yes,
+    No,
+    /// No, and the operator configured something they are not getting.
+    NoAndSayWhy(&'static str),
+    /// The policy defers to the human.
+    MustAsk,
+}
+
+/// The half of the worktree decision that needs no gate — split out so the
+/// precedence is testable without a live approval port, exactly as
+/// `DeckApprovalGate::decide` splits the keypress mapping out of its channel.
+///
+/// Order matters and is not arbitrary:
+///
+/// 1. A run that changes nothing is never isolated, whatever the policy says.
+///    There is nothing to protect, and asking would put a prompt in front of
+///    the commonest thing anyone does — a question about relocating work that
+///    is not going to happen.
+/// 2. Without isolation available there is nothing to offer. Silent under
+///    `ask`/`never` (neither wanted it), but `always` is told, because that
+///    operator configured something this workspace cannot give them.
+/// 3. Only then does the policy speak.
+fn worktree_decision_without_asking(
+    policy: crate::ports::WorktreePolicy,
+    run_changes_files: bool,
+    isolation_available: bool,
+) -> Decided {
+    use crate::ports::WorktreePolicy;
+    if !run_changes_files {
+        return Decided::No;
+    }
+    if !isolation_available {
+        return match policy {
+            WorktreePolicy::Always => Decided::NoAndSayWhy(
+                "\"create_worktrees\": \"always\" is configured, but this workspace offers no \
+                 candidate isolation (it is not a git working tree) — this run's changes will \
+                 land in the working tree",
+            ),
+            _ => Decided::No,
+        };
+    }
+    match policy {
+        WorktreePolicy::Always => Decided::Yes,
+        WorktreePolicy::Never => Decided::No,
+        WorktreePolicy::Ask => Decided::MustAsk,
     }
 }
 
@@ -847,6 +915,11 @@ impl<'a> Pipeline<'a> {
             && assessment.wants_witness()
             && task_class.verifies_unconditionally()
             && self.can_author_independent_witness();
+        // The third reason a single candidate needs isolation: the operator
+        // asked for this run's work to happen in a worktree rather than in
+        // their checkout. Resolved here, beside the other two, so all three
+        // reach the same one decision.
+        let isolate = self.isolate_in_worktree(task_class).await;
         // Single-shot (the default) runs directly over the session ports —
         // zero snapshot/adoption machinery only when the user supplied the
         // test invocation (or witness authoring is otherwise disabled).
@@ -854,7 +927,8 @@ impl<'a> Pipeline<'a> {
         // N=1, so authoring can never mutate the session tree.
         // Best-of-N runs every candidate in an isolated snapshot of the
         // current tree state and adopts only the winner's changes (L-E7).
-        let (best, worker_model_label, candidates_run) = if n == 1 && !authored_witness {
+        let (best, worker_model_label, candidates_run) = if n == 1 && !authored_witness && !isolate
+        {
             let worker = match self.resolve_provider(Role::Worker) {
                 Ok(worker) => worker,
                 Err(error) => {
@@ -3048,6 +3122,44 @@ impl<'a> Pipeline<'a> {
             // A worker that won't resolve fails later, on its own terms —
             // not here, disguised as a witness-independence verdict.
             WitnessAuthorIndependence::WorkerUnresolvable => false,
+        }
+    }
+
+    /// Whether this run does its work in a throwaway worktree, per
+    /// [`PipelineConfig::create_worktrees`].
+    ///
+    /// Asked at triage and nowhere else, because triage is the first moment the
+    /// question is answerable *and* worth asking. Earlier — at launch, say —
+    /// every `stella "what does this do"` would raise a prompt about relocating
+    /// work it is never going to do. Later, the run has already started
+    /// changing the checkout, and the answer could not be honoured.
+    ///
+    /// Three conditions come before the policy, in order of how little they owe
+    /// the user an explanation:
+    ///
+    /// - A class that does not change files is never isolated. There is nothing
+    ///   to protect, and the prompt would be pure noise on the commonest path.
+    /// - Without a [`crate::ports::CandidateWorkspacePort`] there is no
+    ///   isolation to offer — a plain directory, or a caller that wired none.
+    ///   Under `Always` that IS worth saying, because the operator configured
+    ///   something they are not getting.
+    /// - `Never` and `Always` answer without asking. Only `Ask` reaches the
+    ///   gate, and a gate with nobody behind it declines (see
+    ///   [`crate::ports::ApprovalGate::confirm`]).
+    async fn isolate_in_worktree(&self, task_class: TaskClass) -> bool {
+        let isolation_available = self.candidate_workspaces.is_some();
+        match worktree_decision_without_asking(
+            self.config.create_worktrees,
+            task_class.verifies_unconditionally(),
+            isolation_available,
+        ) {
+            Decided::Yes => true,
+            Decided::No => false,
+            Decided::NoAndSayWhy(reason) => {
+                self.warn(reason.to_string());
+                false
+            }
+            Decided::MustAsk => self.approvals.confirm(WORKTREE_QUESTION).await,
         }
     }
 

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -919,7 +919,17 @@ impl<'a> Pipeline<'a> {
         // asked for this run's work to happen in a worktree rather than in
         // their checkout. Resolved here, beside the other two, so all three
         // reach the same one decision.
-        let isolate = self.isolate_in_worktree(task_class).await;
+        // Asked ONLY when the answer can change what happens. Best-of-N and an
+        // authored witness already require a disposable candidate, so the
+        // branch below is taken regardless of this value — prompting there
+        // would put a question to the operator whose answer is then discarded,
+        // which teaches them their choices do not matter. `false` is the safe
+        // value in that case precisely because it is unreachable.
+        let isolate = if n == 1 && !authored_witness {
+            self.isolate_in_worktree(task_class).await
+        } else {
+            false
+        };
         // Single-shot (the default) runs directly over the session ports —
         // zero snapshot/adoption machinery only when the user supplied the
         // test invocation (or witness authoring is otherwise disabled).

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -2391,3 +2391,50 @@ fn recalled_frames_are_bounded_with_visible_markers() {
     assert_eq!(small.len(), 1);
     assert_eq!(small[0].content, "ok");
 }
+
+/// `create_worktrees` precedence, without a gate in the way.
+///
+/// The case that matters most is the first one: a lookup never raises the
+/// question. `ask` is the default, so a policy that asked before knowing the
+/// class would put a prompt in front of every `stella "what does this do"` —
+/// about relocating work the run is never going to do.
+#[test]
+fn the_worktree_policy_defers_to_the_class_then_to_what_is_available() {
+    use crate::pipeline::{Decided, worktree_decision_without_asking as decide};
+    use crate::ports::WorktreePolicy::{Always, Ask, Never};
+
+    // A run that changes nothing is never isolated and never asks — not even
+    // under `always`.
+    for policy in [Always, Ask, Never] {
+        assert_eq!(
+            decide(policy, false, true),
+            Decided::No,
+            "{policy:?} must not isolate a run that changes nothing"
+        );
+    }
+
+    // No isolation available: silent for the two policies that did not ask for
+    // it, and told for the one that did.
+    assert_eq!(decide(Ask, true, false), Decided::No);
+    assert_eq!(decide(Never, true, false), Decided::No);
+    assert!(
+        matches!(decide(Always, true, false), Decided::NoAndSayWhy(_)),
+        "an operator who configured `always` and cannot have it must be told"
+    );
+
+    // And with everything available, the policy decides.
+    assert_eq!(decide(Always, true, true), Decided::Yes);
+    assert_eq!(decide(Never, true, true), Decided::No);
+    assert_eq!(decide(Ask, true, true), Decided::MustAsk);
+}
+
+/// An approval gate that cannot ask answers "no", so an unwired or headless
+/// host keeps doing exactly what it did before the question existed.
+#[tokio::test]
+async fn a_gate_with_nobody_behind_it_declines_to_relocate_the_work() {
+    use crate::ports::{AlwaysAbortGate, ApprovalGate};
+    assert!(
+        !AlwaysAbortGate.confirm("anything at all").await,
+        "a headless run must not silently relocate somebody's work"
+    );
+}

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -763,6 +763,40 @@ pub enum ScopeDecision {
 pub trait ApprovalGate: Send + Sync {
     /// Present `proposal` and await the user's decision.
     async fn review(&self, proposal: &ScopeProposal) -> ScopeDecision;
+
+    /// Ask a plain yes/no question and await the answer — today, whether to
+    /// isolate this run in a worktree ([`WorktreePolicy::Ask`]).
+    ///
+    /// Defaulted to `false` rather than left abstract, and that default is the
+    /// answer, not a placeholder: a gate that cannot ask has nobody to ask, and
+    /// declining leaves the run doing exactly what it did before the question
+    /// existed. Silently answering *yes* would relocate somebody's work on the
+    /// strength of an unwired port.
+    async fn confirm(&self, _question: &str) -> bool {
+        false
+    }
+}
+
+/// Whether a run does its work in a throwaway git worktree instead of the
+/// user's own checkout.
+///
+/// The two are not equivalent, which is why this is a policy and not a
+/// preference. Working in the tree is what the user sees happening and can
+/// interrupt; working in a worktree means nothing lands until the run adopts
+/// it, so a half-finished run leaves the checkout untouched — at the cost that
+/// `git status` shows nothing while it runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WorktreePolicy {
+    /// Isolate whenever the run is going to change files and isolation is
+    /// available.
+    Always,
+    /// Ask, once, at triage — after the class is known, so a lookup that will
+    /// not touch anything never raises the question. The default, and what an
+    /// absent, null, or empty setting means.
+    #[default]
+    Ask,
+    /// Never isolate; work in the checkout.
+    Never,
 }
 
 // No-op / default port implementations
@@ -874,6 +908,24 @@ impl ApprovalGate for StdioApprovalGate {
                 note: answer.to_string(),
             },
         }
+    }
+
+    /// `[y/N]` on stdin. Fail-closed on EOF and read errors, and on a bare
+    /// Enter, matching [`Self::review`] — an unanswered question must not
+    /// relocate where somebody's work happens.
+    async fn confirm(&self, question: &str) -> bool {
+        use std::io::{self, BufRead, Write};
+
+        println!();
+        println!("  {question}");
+        print!("  [y/N]: ");
+        let _ = io::stdout().flush();
+
+        let mut line = String::new();
+        if io::stdin().lock().read_line(&mut line).is_err() {
+            return false;
+        }
+        matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
     }
 }
 

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -12,8 +12,10 @@
 //!
 //! Scope note: one [`Session`] drives one turn. Multi-turn sessions (retaining
 //! the message history across turns) layer on top of this without changing the
-//! transport; per-step checkpointing now has its seam here (see
-//! [`drive_turn`]) but nothing is persisted yet.
+//! transport; per-step checkpointing happens here (see [`drive_turn`]) through
+//! the `CheckpointSink` the host attaches to `EngineConfig`, so a served turn
+//! interrupted mid-flight resumes from its last step boundary rather than
+//! being re-run from the prompt.
 
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -381,9 +383,11 @@ struct DrivenTurn {
 /// - **A checkpoint seam.** `StepOutcome::Continue` is the one moment the
 ///   transcript is guaranteed well-paired (no `tool_use` without its
 ///   `tool_result`), which is exactly where a durable runner would persist
-///   `state.to_checkpoint()`. This server does not persist one yet — there is
-///   nowhere to put it — but the seam is now here rather than one refactor
-///   away.
+///   `state.to_checkpoint()`. It does: when the host attaches a
+///   `CheckpointSink` to `EngineConfig`, every step boundary of a served turn
+///   writes a resume point, exactly as a CLI turn does — the two drivers call
+///   the same `Engine::persist_checkpoint`, so an HTTP turn and a local turn
+///   are equally recoverable rather than merely similar.
 async fn drive_turn(
     engine: &Engine<'_>,
     messages: Vec<CompletionMessage>,
@@ -413,18 +417,26 @@ async fn drive_turn(
                 message: reason.clone(),
                 retryable: false,
             });
+            engine.discard_checkpoint();
             break TurnOutcome::Aborted {
                 reason,
                 cost_usd: state.total_cost_usd(),
             };
         }
         match engine.run_step(&mut state, &events).await {
-            // The checkpoint seam. Nothing is persisted yet; the comment is
-            // here so the next person looking for where a checkpoint would go
-            // finds the answer rather than the question.
-            StepOutcome::Continue => continue,
+            // The checkpoint seam: the one moment the transcript is
+            // guaranteed well-paired. A served turn that dies here — a dropped
+            // connection, a killed process — resumes from this point instead
+            // of re-running the prompt and paying for the work twice.
+            StepOutcome::Continue => {
+                engine.persist_checkpoint(&state);
+                continue;
+            }
             terminal => {
                 if let Some(outcome) = terminal.into_turn_outcome() {
+                    // The turn ended; a resume point that outlives it would
+                    // offer to replay work the client already saw finish.
+                    engine.discard_checkpoint();
                     break outcome;
                 }
                 // Unreachable: `into_turn_outcome` is `None` only for

--- a/stella-store/src/journal.rs
+++ b/stella-store/src/journal.rs
@@ -19,6 +19,10 @@
 //! - **`queue.json`** — the pending prompt backlog, rewritten atomically on
 //!   every queue mutation. A prompt the user queued is durable the moment it
 //!   is queued.
+//! - **`checkpoint.json`** — the in-flight turn's resume point, rewritten
+//!   atomically at every step boundary and removed when the turn ends. Unlike
+//!   the three above it describes work that is *still happening*, so its mere
+//!   presence after a restart means a turn was interrupted mid-flight.
 //!
 //! ## Crash-safety contract
 //!
@@ -48,6 +52,12 @@ pub const JOURNAL_FILE: &str = "journal.jsonl";
 pub const HISTORY_FILE: &str = "history.json";
 /// The pending prompt backlog snapshot inside a session's sidecar dir.
 pub const QUEUE_FILE: &str = "queue.json";
+/// The in-flight turn's resume point inside a session's sidecar dir.
+///
+/// Present only while a turn is actually running: written at every step
+/// boundary and removed when the turn reaches a terminal outcome. Its presence
+/// after a restart therefore *means* "a turn was interrupted here".
+pub const CHECKPOINT_FILE: &str = "checkpoint.json";
 
 /// Flush the coalescing buffer once it holds this many bytes even if the
 /// delta run hasn't ended — bounds journal-write latency on very long
@@ -318,6 +328,42 @@ pub fn read_queue(dir: &Path) -> Vec<String> {
         .ok()
         .and_then(|text| serde_json::from_str(&text).ok())
         .unwrap_or_default()
+}
+
+/// Atomically record the in-flight turn's resume point (`checkpoint.json`).
+///
+/// `json` is written verbatim rather than through this module's private
+/// `write_snapshot` helper: it is
+/// already `stella_core::step::Checkpoint::to_json` output, and re-serializing
+/// a `String` would store a JSON *string literal* containing escaped JSON.
+/// Storing the bytes as given also keeps this crate free of any dependency on
+/// the engine's types — the checkpoint is opaque here, and the version gate
+/// that decides whether these bytes are usable lives with the type that wrote
+/// them.
+pub fn write_checkpoint(dir: &Path, json: &str) -> Result<()> {
+    crate::ensure_private_dir(dir)?;
+    crate::private::write_private_atomic(&dir.join(CHECKPOINT_FILE), json.as_bytes())
+}
+
+/// The in-flight turn's resume point, verbatim; `None` when no turn was
+/// interrupted (or the file is unreadable, which is the same recovery path:
+/// fall back to re-dispatching the prompt).
+pub fn read_checkpoint(dir: &Path) -> Option<String> {
+    crate::read_private_to_string(&dir.join(CHECKPOINT_FILE)).ok()
+}
+
+/// Drop the resume point — the turn it described reached a terminal outcome.
+///
+/// Idempotent: a turn that ended before its first step boundary never wrote
+/// one, and clearing an absent checkpoint is success, not an error. Any other
+/// I/O failure IS reported, because a checkpoint that survives its own turn
+/// would offer to resume work the caller already watched finish.
+pub fn clear_checkpoint(dir: &Path) -> Result<()> {
+    match std::fs::remove_file(dir.join(CHECKPOINT_FILE)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(StoreError(format!("cannot clear {CHECKPOINT_FILE}: {e}"))),
+    }
 }
 
 /// Whether a sidecar dir holds anything to restore — the resumability test.
@@ -680,6 +726,45 @@ mod tests {
             unsettled_prompts(&worker_done),
             vec![(lead.clone(), "refactor the fold".to_string())]
         );
+    }
+
+    #[test]
+    fn a_checkpoint_survives_verbatim_and_clearing_is_idempotent() {
+        // The bytes must come back EXACTLY as written: they are a
+        // `Checkpoint::to_json` payload whose version gate lives in
+        // stella-core, and any re-encoding here (storing the `String` through
+        // a serializer, say) would hand that gate an escaped JSON string
+        // literal instead of a checkpoint.
+        let dir = temp_dir("checkpoint");
+        assert_eq!(
+            read_checkpoint(&dir),
+            None,
+            "no interrupted turn means no resume point"
+        );
+        // Clearing before anything was ever written is success: a turn that
+        // ended on its first step discards without having persisted.
+        clear_checkpoint(&dir).expect("clearing an absent checkpoint is not an error");
+
+        let json = r#"{"version":1,"step":3,"messages":[],"nested":{"quote":"\"x\""}}"#;
+        write_checkpoint(&dir, json).unwrap();
+        assert_eq!(
+            read_checkpoint(&dir).as_deref(),
+            Some(json),
+            "stored verbatim — not re-serialized"
+        );
+
+        // Rewriting replaces rather than appends: one live turn, one point.
+        let second = r#"{"version":1,"step":4}"#;
+        write_checkpoint(&dir, second).unwrap();
+        assert_eq!(read_checkpoint(&dir).as_deref(), Some(second));
+
+        clear_checkpoint(&dir).unwrap();
+        assert_eq!(
+            read_checkpoint(&dir),
+            None,
+            "a finished turn leaves nothing for a later resume to replay"
+        );
+        clear_checkpoint(&dir).expect("clearing twice is still success");
     }
 
     #[test]

--- a/stella-store/src/journal.rs
+++ b/stella-store/src/journal.rs
@@ -52,13 +52,6 @@ pub const JOURNAL_FILE: &str = "journal.jsonl";
 pub const HISTORY_FILE: &str = "history.json";
 /// The pending prompt backlog snapshot inside a session's sidecar dir.
 pub const QUEUE_FILE: &str = "queue.json";
-/// The in-flight turn's resume point inside a session's sidecar dir.
-///
-/// Present only while a turn is actually running: written at every step
-/// boundary and removed when the turn reaches a terminal outcome. Its presence
-/// after a restart therefore *means* "a turn was interrupted here".
-pub const CHECKPOINT_FILE: &str = "checkpoint.json";
-
 /// Flush the coalescing buffer once it holds this many bytes even if the
 /// delta run hasn't ended — bounds journal-write latency on very long
 /// uninterrupted streams without fsyncing per token.
@@ -330,41 +323,14 @@ pub fn read_queue(dir: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Atomically record the in-flight turn's resume point (`checkpoint.json`).
-///
-/// `json` is written verbatim rather than through this module's private
-/// `write_snapshot` helper: it is
-/// already `stella_core::step::Checkpoint::to_json` output, and re-serializing
-/// a `String` would store a JSON *string literal* containing escaped JSON.
-/// Storing the bytes as given also keeps this crate free of any dependency on
-/// the engine's types — the checkpoint is opaque here, and the version gate
-/// that decides whether these bytes are usable lives with the type that wrote
-/// them.
-pub fn write_checkpoint(dir: &Path, json: &str) -> Result<()> {
-    crate::ensure_private_dir(dir)?;
-    crate::private::write_private_atomic(&dir.join(CHECKPOINT_FILE), json.as_bytes())
-}
-
-/// The in-flight turn's resume point, verbatim; `None` when no turn was
-/// interrupted (or the file is unreadable, which is the same recovery path:
-/// fall back to re-dispatching the prompt).
-pub fn read_checkpoint(dir: &Path) -> Option<String> {
-    crate::read_private_to_string(&dir.join(CHECKPOINT_FILE)).ok()
-}
-
-/// Drop the resume point — the turn it described reached a terminal outcome.
-///
-/// Idempotent: a turn that ended before its first step boundary never wrote
-/// one, and clearing an absent checkpoint is success, not an error. Any other
-/// I/O failure IS reported, because a checkpoint that survives its own turn
-/// would offer to resume work the caller already watched finish.
-pub fn clear_checkpoint(dir: &Path) -> Result<()> {
-    match std::fs::remove_file(dir.join(CHECKPOINT_FILE)) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(StoreError(format!("cannot clear {CHECKPOINT_FILE}: {e}"))),
-    }
-}
+// The in-flight turn's resume point used to live here, as a `checkpoint.json`
+// beside the history and the queue. It now lives in the work journal's
+// `CHECKPOINT_BLOB` (`crate::work_journal`), for one reason: a resume point and
+// the file changes it is a resume point *for* are one fact, and keeping them in
+// two stores means a recovery path has to decide which to believe when they
+// disagree. Nothing can update both atomically, so they eventually would — and
+// a crash between the two writes is precisely the case the feature exists to
+// survive.
 
 /// Whether a sidecar dir holds anything to restore — the resumability test.
 pub fn has_state(dir: &Path) -> bool {
@@ -728,44 +694,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_checkpoint_survives_verbatim_and_clearing_is_idempotent() {
-        // The bytes must come back EXACTLY as written: they are a
-        // `Checkpoint::to_json` payload whose version gate lives in
-        // stella-core, and any re-encoding here (storing the `String` through
-        // a serializer, say) would hand that gate an escaped JSON string
-        // literal instead of a checkpoint.
-        let dir = temp_dir("checkpoint");
-        assert_eq!(
-            read_checkpoint(&dir),
-            None,
-            "no interrupted turn means no resume point"
-        );
-        // Clearing before anything was ever written is success: a turn that
-        // ended on its first step discards without having persisted.
-        clear_checkpoint(&dir).expect("clearing an absent checkpoint is not an error");
-
-        let json = r#"{"version":1,"step":3,"messages":[],"nested":{"quote":"\"x\""}}"#;
-        write_checkpoint(&dir, json).unwrap();
-        assert_eq!(
-            read_checkpoint(&dir).as_deref(),
-            Some(json),
-            "stored verbatim — not re-serialized"
-        );
-
-        // Rewriting replaces rather than appends: one live turn, one point.
-        let second = r#"{"version":1,"step":4}"#;
-        write_checkpoint(&dir, second).unwrap();
-        assert_eq!(read_checkpoint(&dir).as_deref(), Some(second));
-
-        clear_checkpoint(&dir).unwrap();
-        assert_eq!(
-            read_checkpoint(&dir),
-            None,
-            "a finished turn leaves nothing for a later resume to replay"
-        );
-        clear_checkpoint(&dir).expect("clearing twice is still success");
-    }
+    // The checkpoint round-trip moved with the checkpoint itself — see
+    // `crate::work_journal::tests::a_checkpoint_survives_verbatim_and_clearing_is_idempotent`.
 
     #[test]
     fn history_and_queue_snapshots_roundtrip_and_default_empty() {

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -164,6 +164,7 @@ pub mod reflection;
 pub mod scoreboard;
 pub mod sessions;
 pub mod usage;
+pub mod work_journal;
 pub mod workspace_local;
 
 use ddl::TABLES;

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -164,6 +164,7 @@ pub mod reflection;
 pub mod scoreboard;
 pub mod sessions;
 pub mod usage;
+pub mod workspace_local;
 
 use ddl::TABLES;
 // Corruption classification and its actionable wording live with the tooling

--- a/stella-store/src/work_journal.rs
+++ b/stella-store/src/work_journal.rs
@@ -1,0 +1,413 @@
+//! The durable record of everything an agent did to a workspace, kept in a
+//! git repository that lives in stella's own directory.
+//!
+//! # Why git, and why not the user's git
+//!
+//! Every requirement durability has, git already implements: content-addressed
+//! storage, automatic dedup of unchanged files, zlib compression, `gc` as an
+//! end-of-session compaction step, and `show`/`checkout` as replay. Rolling a
+//! directory of JSON snapshots instead would duplicate the whole transcript per
+//! step and dedup nothing.
+//!
+//! What is NOT reused is the *user's* repository. The git dir lives at
+//! `data_dir()/work/<local-workspace-id>.git` and the workspace is attached as
+//! a work tree (`--git-dir` + `--work-tree`). That buys three things at once:
+//!
+//! - **The workspace need not be a git repo.** Durability stops being a
+//!   property of how the user set up their directory.
+//! - **The user's repository is never touched.** No shared object store, no
+//!   ref namespace collision, no interaction with their `gc`. Their index,
+//!   `HEAD`, branch, and staged changes are all untouched, and stella's edits
+//!   appear to them as ordinary unstaged changes — which is what they are.
+//! - **`.gitignore` still applies**, because it is read from the work tree. A
+//!   build directory the agent wrote into does not bloat the store.
+//!
+//! # Never `HEAD`, never a shared index
+//!
+//! Two sessions may work one workspace at once, so nothing here touches `HEAD`
+//! or the default index. Each session commits with plumbing —
+//! `read-tree` → `add` → `write-tree` → `commit-tree` → `update-ref` — onto
+//! its own `refs/stella/<session>/head`, using its own `GIT_INDEX_FILE`. Two
+//! sessions therefore share the object store (which is what gives cross-session
+//! dedup) and contend over nothing.
+//!
+//! # Keyed on identity, not path
+//!
+//! The store is named by [`crate::workspace_local`]'s id, so moving or renaming
+//! the workspace keeps its history. Keying on the canonical path — the obvious
+//! choice — would orphan everything on the first `mv`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::{Result, StoreError};
+
+/// A session's handle on the workspace's durable history.
+#[derive(Debug, Clone)]
+pub struct WorkJournal {
+    git_dir: PathBuf,
+    work_tree: PathBuf,
+    index_file: PathBuf,
+    session: String,
+}
+
+/// Where a session's commits accumulate. Per-session so concurrent sessions
+/// never contend on a ref.
+fn session_ref(session: &str) -> String {
+    format!("refs/stella/{session}/head")
+}
+
+/// The marker a caller can replay from: `refs/stella/<session>/turn/<n>`.
+fn turn_ref(session: &str, turn: u32) -> String {
+    format!("refs/stella/{session}/turn/{turn}")
+}
+
+impl WorkJournal {
+    /// Open (creating on first use) the durable history for `workspace_root`.
+    ///
+    /// `session` must be filesystem- and ref-safe; session ids (`ses-…`) are.
+    pub fn open(workspace_root: &Path, session: &str) -> Result<Self> {
+        Self::open_in(
+            &crate::usage::data_dir().join("work"),
+            workspace_root,
+            session,
+        )
+    }
+
+    /// [`Self::open`] against an explicit store root.
+    ///
+    /// The root is a parameter rather than always `data_dir()` so this type
+    /// has no dependency on process-global state. That is not only for tests:
+    /// `data_dir()` reads `STELLA_HOME`, and a type that reads it internally
+    /// cannot be exercised by two concurrent callers wanting different stores.
+    pub fn open_in(store_root: &Path, workspace_root: &Path, session: &str) -> Result<Self> {
+        let identity = crate::workspace_local::resolve(workspace_root)?;
+        let root = store_root.to_path_buf();
+        std::fs::create_dir_all(&root)
+            .map_err(|e| StoreError(format!("cannot create work-journal root: {e}")))?;
+        let git_dir = root.join(format!("{}.git", identity.id));
+        let journal = Self {
+            git_dir,
+            work_tree: identity.path,
+            index_file: root.join(format!("{}.{session}.index", identity.id)),
+            session: session.to_string(),
+        };
+        journal.ensure_repo()?;
+        Ok(journal)
+    }
+
+    fn ensure_repo(&self) -> Result<()> {
+        if self.git_dir.join("HEAD").exists() {
+            return Ok(());
+        }
+        run(Command::new("git").args(["init", "-q", "--bare", &self.git_dir.to_string_lossy()]))?;
+        // A bare repo refuses a work tree. Everything else about bare — no
+        // checkout of its own, no branch to confuse — is exactly what is
+        // wanted, so flip only this one bit.
+        self.git(&["config", "core.bare", "false"])?;
+        // The store is stella's own; it must never depend on whether the user
+        // has configured a git identity.
+        self.git(&["config", "user.name", "stella"])?;
+        self.git(&["config", "user.email", "stella@localhost"])?;
+        Ok(())
+    }
+
+    fn git(&self, args: &[&str]) -> Result<String> {
+        let mut cmd = Command::new("git");
+        cmd.arg("--git-dir")
+            .arg(&self.git_dir)
+            .arg("--work-tree")
+            .arg(&self.work_tree)
+            .args(args)
+            .env("GIT_INDEX_FILE", &self.index_file)
+            // The work tree is the user's; a hook or config of theirs must
+            // never run as a side effect of stella recording history.
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", &self.git_dir);
+        run(&mut cmd)
+    }
+
+    /// The commit this session last recorded, if any.
+    fn tip(&self) -> Option<String> {
+        self.git(&[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &session_ref(&self.session),
+        ])
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    }
+
+    /// Record `paths` as they stand on disk, plus any `blobs` (in-memory
+    /// content that has no file — the turn checkpoint, the staleness map),
+    /// as one commit on this session's ref.
+    ///
+    /// Returns the new commit id. Paths are workspace-relative and are staged
+    /// individually — never `git add -A`, which would sweep in the user's own
+    /// unrelated work and make the history a lie about what the agent did.
+    pub fn record(
+        &self,
+        paths: &[String],
+        blobs: &[(&str, &str)],
+        message: &str,
+    ) -> Result<String> {
+        let parent = self.tip();
+
+        // Seed the index from the parent so this commit is the parent's tree
+        // plus these changes, not just these changes.
+        match &parent {
+            Some(p) => self.git(&["read-tree", p])?,
+            None => self.git(&["read-tree", "--empty"])?,
+        };
+
+        for path in paths {
+            // `git add` on an ignored path is a hard error, not a skip. An
+            // agent that writes into a build directory would otherwise fail
+            // the whole record — so ignored paths are filtered deliberately
+            // rather than discovered by exception.
+            if self.is_ignored(path) {
+                continue;
+            }
+            // A path that vanished (the agent deleted it) is staged as a
+            // removal; `--ignore-unmatch` keeps that from being an error.
+            if self.work_tree.join(path).exists() {
+                self.git(&["add", "--", path])?;
+            } else {
+                self.git(&["rm", "--cached", "--ignore-unmatch", "-q", "--", path])?;
+            }
+        }
+
+        for (name, content) in blobs {
+            let oid = self.hash_blob(content)?;
+            // 100644 = a regular file. These are stella's own records, kept
+            // under a reserved prefix so they can never collide with a real
+            // workspace path.
+            self.git(&[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("100644,{oid},.stella-journal/{name}"),
+            ])?;
+        }
+
+        let tree = self.git(&["write-tree"])?.trim().to_string();
+        let mut args: Vec<String> = vec!["commit-tree".into(), tree, "-m".into(), message.into()];
+        if let Some(p) = &parent {
+            args.push("-p".into());
+            args.push(p.clone());
+        }
+        let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let commit = self.git(&refs)?.trim().to_string();
+        self.git(&["update-ref", &session_ref(&self.session), &commit])?;
+        Ok(commit)
+    }
+
+    /// Whether the work tree's own ignore rules exclude `path`.
+    ///
+    /// `check-ignore` exits 1 for "not ignored", which [`run`] reports as an
+    /// error — so this reads the exit status directly rather than going
+    /// through it. Unreadable or ambiguous cases answer "not ignored": the
+    /// cost of storing one extra file is trivial next to silently dropping a
+    /// real one from the durable record.
+    fn is_ignored(&self, path: &str) -> bool {
+        Command::new("git")
+            .arg("--git-dir")
+            .arg(&self.git_dir)
+            .arg("--work-tree")
+            .arg(&self.work_tree)
+            .args(["check-ignore", "-q", "--", path])
+            .env("GIT_INDEX_FILE", &self.index_file)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", &self.git_dir)
+            .current_dir(&self.work_tree)
+            .status()
+            .is_ok_and(|s| s.success())
+    }
+
+    fn hash_blob(&self, content: &str) -> Result<String> {
+        let mut cmd = Command::new("git");
+        cmd.arg("--git-dir")
+            .arg(&self.git_dir)
+            .args(["hash-object", "-w", "--stdin"])
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| StoreError(format!("cannot run git hash-object: {e}")))?;
+        {
+            use std::io::Write as _;
+            let stdin = child.stdin.as_mut().expect("piped");
+            stdin
+                .write_all(content.as_bytes())
+                .map_err(|e| StoreError(format!("cannot write blob: {e}")))?;
+        }
+        let out = child
+            .wait_with_output()
+            .map_err(|e| StoreError(format!("git hash-object failed: {e}")))?;
+        if !out.status.success() {
+            return Err(StoreError(format!(
+                "git hash-object failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Mark `commit` as the state at the end of `turn`, so it can be replayed
+    /// by turn number rather than by commit id.
+    pub fn mark_turn(&self, turn: u32, commit: &str) -> Result<()> {
+        self.git(&["update-ref", &turn_ref(&self.session, turn), commit])?;
+        Ok(())
+    }
+
+    /// The content of `path` as it stood at the end of `turn`.
+    pub fn read_at_turn(&self, turn: u32, path: &str) -> Result<String> {
+        self.git(&["show", &format!("{}:{path}", turn_ref(&self.session, turn))])
+    }
+
+    /// One of the reserved journal blobs as it stood at the end of `turn`.
+    pub fn blob_at_turn(&self, turn: u32, name: &str) -> Result<String> {
+        self.read_at_turn(turn, &format!(".stella-journal/{name}"))
+    }
+
+    /// Compact the object store. The end-of-session step: everything stays
+    /// replayable, it simply stops being loose objects.
+    pub fn compact(&self) -> Result<()> {
+        self.git(&["gc", "--quiet", "--auto"])?;
+        Ok(())
+    }
+}
+
+fn run(cmd: &mut Command) -> Result<String> {
+    let out = cmd
+        .output()
+        .map_err(|e| StoreError(format!("cannot run git: {e}")))?;
+    if !out.status.success() {
+        return Err(StoreError(format!(
+            "git {:?} failed: {}",
+            cmd.get_args().collect::<Vec<_>>(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch workspace and its own store root. No environment variable
+    /// is touched, so these run correctly in parallel with everything else —
+    /// an earlier version set `STELLA_HOME` and the tests raced each other.
+    fn scratch() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let guard = tempfile::tempdir().unwrap();
+        let ws = guard.path().join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+        let store = guard.path().join("store");
+        (guard, ws, store)
+    }
+
+    #[test]
+    fn a_non_git_workspace_still_gets_durable_replayable_history() {
+        // The whole point: durability must not depend on the user having run
+        // `git init`.
+        let (_guard, ws, store) = scratch();
+        assert!(!ws.join(".git").exists(), "the workspace is not a git repo");
+        std::fs::write(ws.join("a.txt"), "v1\n").unwrap();
+
+        let journal = WorkJournal::open_in(&store, &ws, "ses-test").unwrap();
+        let c1 = journal
+            .record(&["a.txt".into()], &[], "stella(lead): create a.txt")
+            .unwrap();
+        journal.mark_turn(1, &c1).unwrap();
+
+        std::fs::write(ws.join("a.txt"), "v2\n").unwrap();
+        let c2 = journal
+            .record(&["a.txt".into()], &[], "stella(lead): update a.txt")
+            .unwrap();
+        journal.mark_turn(2, &c2).unwrap();
+
+        assert_eq!(journal.read_at_turn(1, "a.txt").unwrap(), "v1\n");
+        assert_eq!(journal.read_at_turn(2, "a.txt").unwrap(), "v2\n");
+        assert!(
+            !ws.join(".git").exists(),
+            "and stella still created no repo in the user's workspace"
+        );
+    }
+
+    #[test]
+    fn a_checkpoint_blob_rides_along_and_replays_per_turn() {
+        // Turn state and workspace state land in ONE object, so "restart turn
+        // 7" restores both halves from a single consistent point rather than
+        // two stores that can disagree.
+        let (_guard, ws, store) = scratch();
+        std::fs::write(ws.join("a.txt"), "code\n").unwrap();
+        let journal = WorkJournal::open_in(&store, &ws, "ses-blob").unwrap();
+
+        let c1 = journal
+            .record(
+                &["a.txt".into()],
+                &[("checkpoint.json", r#"{"version":1,"step":3}"#)],
+                "turn 7 step 3",
+            )
+            .unwrap();
+        journal.mark_turn(7, &c1).unwrap();
+
+        assert_eq!(
+            journal.blob_at_turn(7, "checkpoint.json").unwrap(),
+            r#"{"version":1,"step":3}"#
+        );
+    }
+
+    #[test]
+    fn history_accumulates_rather_than_replacing() {
+        // Each commit is the parent's tree plus this change — a file touched
+        // in turn 1 and never again must still be present at turn 2.
+        let (_guard, ws, store) = scratch();
+        std::fs::write(ws.join("first.txt"), "one\n").unwrap();
+        let journal = WorkJournal::open_in(&store, &ws, "ses-acc").unwrap();
+        let c1 = journal.record(&["first.txt".into()], &[], "first").unwrap();
+        journal.mark_turn(1, &c1).unwrap();
+
+        std::fs::write(ws.join("second.txt"), "two\n").unwrap();
+        let c2 = journal
+            .record(&["second.txt".into()], &[], "second")
+            .unwrap();
+        journal.mark_turn(2, &c2).unwrap();
+
+        assert_eq!(journal.read_at_turn(2, "first.txt").unwrap(), "one\n");
+        assert_eq!(journal.read_at_turn(2, "second.txt").unwrap(), "two\n");
+    }
+
+    #[test]
+    fn gitignored_paths_never_enter_the_store() {
+        // An agent that writes build output must not bloat durable history
+        // with it. `.gitignore` is read from the work tree, so this works even
+        // though the git dir lives elsewhere.
+        let (_guard, ws, store) = scratch();
+        std::fs::write(ws.join(".gitignore"), "build/\n").unwrap();
+        std::fs::create_dir_all(ws.join("build")).unwrap();
+        std::fs::write(ws.join("build/out.o"), "junk\n").unwrap();
+        std::fs::write(ws.join("kept.txt"), "real\n").unwrap();
+
+        let journal = WorkJournal::open_in(&store, &ws, "ses-ignore").unwrap();
+        let c = journal
+            .record(
+                &["kept.txt".into(), "build/out.o".into()],
+                &[],
+                "one real file, one ignored",
+            )
+            .unwrap();
+        journal.mark_turn(1, &c).unwrap();
+
+        assert_eq!(journal.read_at_turn(1, "kept.txt").unwrap(), "real\n");
+        assert!(
+            journal.read_at_turn(1, "build/out.o").is_err(),
+            "the ignored artifact must not be stored"
+        );
+    }
+}

--- a/stella-store/src/work_journal.rs
+++ b/stella-store/src/work_journal.rs
@@ -77,6 +77,17 @@ fn journal_blob_path(name: &str) -> String {
 /// they disagree — and they will, because nothing can update both atomically.
 pub const CHECKPOINT_BLOB: &str = "checkpoint.json";
 
+/// The reserved blob holding the session's staleness map — `path → digest this
+/// session last saw`, the state behind the no-clobber guarantee.
+///
+/// Written in the same commit as [`CHECKPOINT_BLOB`] and **not** retracted with
+/// it. The two have different lifetimes, and confusing them would quietly
+/// disarm the guard: a checkpoint describes one turn and must not outlive it,
+/// while the staleness map describes what this *session* has seen and has to
+/// outlive every turn in it. A session's second turn is exactly as entitled to
+/// the guarantee as its first.
+pub const OBSERVED_BLOB: &str = "observed.json";
+
 impl WorkJournal {
     /// Open (creating on first use) the durable history for `workspace_root`.
     ///
@@ -291,7 +302,8 @@ impl WorkJournal {
         Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
     }
 
-    /// Write the in-flight turn's resume point, replacing any earlier one.
+    /// Write the in-flight turn's resume point, replacing any earlier one, and
+    /// the staleness map that belongs with it.
     ///
     /// One commit per step boundary. Measurably dearer than an atomic file
     /// write — about 27ms against 8ms for a transcript-sized snapshot — and
@@ -299,12 +311,27 @@ impl WorkJournal {
     /// noise beside it, and what it buys is that the resume point and the file
     /// changes it describes share one commit graph instead of needing to be
     /// reconciled across two stores.
-    pub fn record_checkpoint(&self, json: &str) -> Result<String> {
-        self.record(
-            &[],
-            &[(CHECKPOINT_BLOB, Some(json))],
-            "stella: turn checkpoint",
-        )
+    ///
+    /// `observed` rides along rather than getting a commit of its own, which is
+    /// what makes persisting it free. A step boundary is also the *right*
+    /// moment for it: the map is updated by reads as well as writes, and a
+    /// scheme that saved it only when a file changed would drop every read
+    /// since the last mutation — the exact loss that leaves a resumed session
+    /// acting on content it believes it knows with the guard no longer watching
+    /// (see `ToolRegistry::restore_observed`). `None` leaves whatever was last
+    /// written in place.
+    pub fn record_checkpoint(&self, json: &str, observed: Option<&str>) -> Result<String> {
+        let mut blobs: Vec<(&str, Option<&str>)> = vec![(CHECKPOINT_BLOB, Some(json))];
+        if let Some(observed) = observed {
+            blobs.push((OBSERVED_BLOB, Some(observed)));
+        }
+        self.record(&[], &blobs, "stella: turn checkpoint")
+    }
+
+    /// The session's staleness map as of this session's tip, or `None` when
+    /// this session never observed a file.
+    pub fn observed(&self) -> Option<String> {
+        self.blob_at_tip(OBSERVED_BLOB)
     }
 
     /// Retract the resume point — the turn it described reached a terminal
@@ -334,12 +361,14 @@ impl WorkJournal {
     /// does: both mean "nothing to resume from", and the recovery path is
     /// identical — re-run the prompt.
     pub fn checkpoint(&self) -> Option<String> {
+        self.blob_at_tip(CHECKPOINT_BLOB)
+    }
+
+    /// One reserved blob as of this session's tip.
+    fn blob_at_tip(&self, name: &str) -> Option<String> {
         let tip = self.session_tip()?;
-        self.git(&[
-            "show",
-            &format!("{tip}:{}", journal_blob_path(CHECKPOINT_BLOB)),
-        ])
-        .ok()
+        self.git(&["show", &format!("{tip}:{}", journal_blob_path(name))])
+            .ok()
     }
 
     /// Mark `commit` as the state at the end of `turn`, so it can be replayed
@@ -471,7 +500,7 @@ mod tests {
             .expect("clearing an absent checkpoint is not an error");
 
         let json = r#"{"version":1,"step":3,"messages":[],"nested":{"quote":"\"x\""}}"#;
-        journal.record_checkpoint(json).unwrap();
+        journal.record_checkpoint(json, None).unwrap();
         assert_eq!(
             journal.checkpoint().as_deref(),
             Some(json),
@@ -480,7 +509,7 @@ mod tests {
 
         // Rewriting replaces rather than appends: one live turn, one point.
         let second = r#"{"version":1,"step":4}"#;
-        journal.record_checkpoint(second).unwrap();
+        journal.record_checkpoint(second, None).unwrap();
         assert_eq!(journal.checkpoint().as_deref(), Some(second));
 
         journal.clear_checkpoint().unwrap();
@@ -506,7 +535,7 @@ mod tests {
         journal
             .record(&["kept.txt".into()], &[], "the agent's write")
             .unwrap();
-        journal.record_checkpoint(r#"{"step":2}"#).unwrap();
+        journal.record_checkpoint(r#"{"step":2}"#, None).unwrap();
 
         journal.clear_checkpoint().unwrap();
 

--- a/stella-store/src/work_journal.rs
+++ b/stella-store/src/work_journal.rs
@@ -62,6 +62,21 @@ fn turn_ref(session: &str, turn: u32) -> String {
     format!("refs/stella/{session}/turn/{turn}")
 }
 
+/// Stella's own records live under a reserved prefix, so a blob can never
+/// collide with a real workspace path.
+fn journal_blob_path(name: &str) -> String {
+    format!(".stella-journal/{name}")
+}
+
+/// The reserved blob holding the in-flight turn's resume point.
+///
+/// The checkpoint lives *here*, in the same commit graph as the work it
+/// describes, and not in a transient file beside it. A resume point and the
+/// file changes it is a resume point *for* are one fact; splitting them across
+/// two stores means a recovery path has to decide which one to believe when
+/// they disagree — and they will, because nothing can update both atomically.
+pub const CHECKPOINT_BLOB: &str = "checkpoint.json";
+
 impl WorkJournal {
     /// Open (creating on first use) the durable history for `workspace_root`.
     ///
@@ -148,13 +163,17 @@ impl WorkJournal {
     /// content that has no file — the turn checkpoint, the staleness map),
     /// as one commit on this session's ref.
     ///
+    /// A blob whose content is `None` is *removed* from the record. That is
+    /// what lets a turn ending retract its resume point in the same substrate
+    /// that wrote it, rather than needing a second store with its own delete.
+    ///
     /// Returns the new commit id. Paths are workspace-relative and are staged
     /// individually — never `git add -A`, which would sweep in the user's own
     /// unrelated work and make the history a lie about what the agent did.
     pub fn record(
         &self,
         paths: &[String],
-        blobs: &[(&str, &str)],
+        blobs: &[(&str, Option<&str>)],
         message: &str,
     ) -> Result<String> {
         let parent = self.session_tip();
@@ -184,16 +203,27 @@ impl WorkJournal {
         }
 
         for (name, content) in blobs {
-            let oid = self.hash_blob(content)?;
-            // 100644 = a regular file. These are stella's own records, kept
-            // under a reserved prefix so they can never collide with a real
-            // workspace path.
-            self.git(&[
-                "update-index",
-                "--add",
-                "--cacheinfo",
-                &format!("100644,{oid},.stella-journal/{name}"),
-            ])?;
+            let entry = journal_blob_path(name);
+            match content {
+                Some(content) => {
+                    let oid = self.hash_blob(content)?;
+                    // 100644 = a regular file. These are stella's own records,
+                    // kept under a reserved prefix so they can never collide
+                    // with a real workspace path.
+                    self.git(&[
+                        "update-index",
+                        "--add",
+                        "--cacheinfo",
+                        &format!("100644,{oid},{entry}"),
+                    ])?;
+                }
+                // `--force-remove` drops the entry whether or not the file
+                // exists in the work tree — and it never does for these, which
+                // is the whole point of a blob: it has no file.
+                None => {
+                    self.git(&["update-index", "--force-remove", "--", &entry])?;
+                }
+            }
         }
 
         let tree = self.git(&["write-tree"])?.trim().to_string();
@@ -259,6 +289,57 @@ impl WorkJournal {
             )));
         }
         Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Write the in-flight turn's resume point, replacing any earlier one.
+    ///
+    /// One commit per step boundary. Measurably dearer than an atomic file
+    /// write — about 27ms against 8ms for a transcript-sized snapshot — and
+    /// the right trade anyway: a step is a model call, so the difference is
+    /// noise beside it, and what it buys is that the resume point and the file
+    /// changes it describes share one commit graph instead of needing to be
+    /// reconciled across two stores.
+    pub fn record_checkpoint(&self, json: &str) -> Result<String> {
+        self.record(
+            &[],
+            &[(CHECKPOINT_BLOB, Some(json))],
+            "stella: turn checkpoint",
+        )
+    }
+
+    /// Retract the resume point — the turn it described reached a terminal
+    /// outcome, and a checkpoint that outlives its turn invites a resume that
+    /// replays work the caller already saw finish.
+    ///
+    /// Idempotent, and cheap when there is nothing to retract: every terminal
+    /// path discards unconditionally, including turns that ended before their
+    /// first step boundary, so the common case must not cost a commit. One
+    /// `cat-file -e` answers that.
+    pub fn clear_checkpoint(&self) -> Result<()> {
+        if self.checkpoint().is_none() {
+            return Ok(());
+        }
+        self.record(
+            &[],
+            &[(CHECKPOINT_BLOB, None)],
+            "stella: turn checkpoint retired",
+        )?;
+        Ok(())
+    }
+
+    /// The in-flight turn's resume point as of this session's tip, or `None`
+    /// when no turn was interrupted.
+    ///
+    /// An unreadable record answers `None` for the same reason a missing one
+    /// does: both mean "nothing to resume from", and the recovery path is
+    /// identical — re-run the prompt.
+    pub fn checkpoint(&self) -> Option<String> {
+        let tip = self.session_tip()?;
+        self.git(&[
+            "show",
+            &format!("{tip}:{}", journal_blob_path(CHECKPOINT_BLOB)),
+        ])
+        .ok()
     }
 
     /// Mark `commit` as the state at the end of `turn`, so it can be replayed
@@ -355,15 +436,86 @@ mod tests {
         let c1 = journal
             .record(
                 &["a.txt".into()],
-                &[("checkpoint.json", r#"{"version":1,"step":3}"#)],
+                &[(CHECKPOINT_BLOB, Some(r#"{"version":1,"step":3}"#))],
                 "turn 7 step 3",
             )
             .unwrap();
         journal.mark_turn(7, &c1).unwrap();
 
         assert_eq!(
-            journal.blob_at_turn(7, "checkpoint.json").unwrap(),
+            journal.blob_at_turn(7, CHECKPOINT_BLOB).unwrap(),
             r#"{"version":1,"step":3}"#
+        );
+    }
+
+    #[test]
+    fn a_checkpoint_survives_verbatim_and_clearing_is_idempotent() {
+        // Moved here from the sidecar journal when the checkpoint folded into
+        // this store. The bytes must come back EXACTLY as written: they are a
+        // `Checkpoint::to_json` payload whose version gate lives in
+        // stella-core, and any re-encoding (storing the `String` through a
+        // serializer, say) would hand that gate an escaped JSON string literal
+        // instead of a checkpoint.
+        let (_guard, ws, store) = scratch();
+        let journal = WorkJournal::open_in(&store, &ws, "ses-verbatim").unwrap();
+
+        assert_eq!(
+            journal.checkpoint(),
+            None,
+            "no interrupted turn means no resume point"
+        );
+        // Clearing before anything was ever written is success: a turn that
+        // ended on its first step discards without having persisted.
+        journal
+            .clear_checkpoint()
+            .expect("clearing an absent checkpoint is not an error");
+
+        let json = r#"{"version":1,"step":3,"messages":[],"nested":{"quote":"\"x\""}}"#;
+        journal.record_checkpoint(json).unwrap();
+        assert_eq!(
+            journal.checkpoint().as_deref(),
+            Some(json),
+            "stored verbatim — not re-serialized"
+        );
+
+        // Rewriting replaces rather than appends: one live turn, one point.
+        let second = r#"{"version":1,"step":4}"#;
+        journal.record_checkpoint(second).unwrap();
+        assert_eq!(journal.checkpoint().as_deref(), Some(second));
+
+        journal.clear_checkpoint().unwrap();
+        assert_eq!(
+            journal.checkpoint(),
+            None,
+            "a finished turn leaves nothing for a later resume to replay"
+        );
+        journal
+            .clear_checkpoint()
+            .expect("clearing twice is still success");
+    }
+
+    #[test]
+    fn retracting_a_checkpoint_leaves_the_workspace_files_alone() {
+        // `--force-remove` drops an index entry; the fear it raises is that it
+        // reaches the work tree too. It must not: the agent's files are the
+        // whole point of the record, and a turn ending is not a reason to
+        // forget them.
+        let (_guard, ws, store) = scratch();
+        std::fs::write(ws.join("kept.txt"), "real work\n").unwrap();
+        let journal = WorkJournal::open_in(&store, &ws, "ses-retract").unwrap();
+        journal
+            .record(&["kept.txt".into()], &[], "the agent's write")
+            .unwrap();
+        journal.record_checkpoint(r#"{"step":2}"#).unwrap();
+
+        journal.clear_checkpoint().unwrap();
+
+        let tip = journal.session_tip().unwrap();
+        journal.mark_turn(1, &tip).unwrap();
+        assert_eq!(journal.read_at_turn(1, "kept.txt").unwrap(), "real work\n");
+        assert!(
+            ws.join("kept.txt").exists(),
+            "the file on disk is untouched by a checkpoint retraction"
         );
     }
 

--- a/stella-store/src/work_journal.rs
+++ b/stella-store/src/work_journal.rs
@@ -128,7 +128,11 @@ impl WorkJournal {
     }
 
     /// The commit this session last recorded, if any.
-    fn tip(&self) -> Option<String> {
+    ///
+    /// Public because marking a turn needs it: a caller that records several
+    /// mutations in a turn marks the turn from wherever the session ended up,
+    /// rather than threading the last commit id back out of every write.
+    pub fn session_tip(&self) -> Option<String> {
         self.git(&[
             "rev-parse",
             "--verify",
@@ -153,7 +157,7 @@ impl WorkJournal {
         blobs: &[(&str, &str)],
         message: &str,
     ) -> Result<String> {
-        let parent = self.tip();
+        let parent = self.session_tip();
 
         // Seed the index from the parent so this commit is the parent's tree
         // plus these changes, not just these changes.

--- a/stella-store/src/workspace_local.rs
+++ b/stella-store/src/workspace_local.rs
@@ -1,0 +1,280 @@
+//! Machine-local workspace identity — the key that survives a `mv`.
+//!
+//! Stella already had two identities and neither answers "is this the same
+//! working copy I saw last time?":
+//!
+//! - [`crate::identity::workspace_id`] is the *cloud* identity. It is minted
+//!   only by explicit registration and lives at `<root>/.stella/workspace.json`
+//!   *outside* `private/`, deliberately, so committing it gives one workspace
+//!   identity across clones and machines. Keying local state on it would make
+//!   every clone of a repository share one store.
+//! - `project_id` ([`crate::usage::project_id_for`]) is a hash of the
+//!   canonical path. Always present, machine-local — and it changes the moment
+//!   the directory is renamed or moved, which is exactly the failure this
+//!   module exists to remove.
+//!
+//! So this is a third identity, and its properties are the complement of both:
+//! machine-local, minted implicitly on first sight, durable across a move, and
+//! **not** shared with a clone. It lives at
+//! `<root>/.stella/private/local-id.json`, and `private/` is gitignored by
+//! construction (`WORKSPACE_GENERATED_IGNORE`), so a `git clone` never carries
+//! it — a fresh clone correctly gets a fresh identity, because local sessions
+//! are local.
+//!
+//! # Move versus copy
+//!
+//! The marker alone cannot tell a moved workspace from a copied one: both show
+//! up as "my id, at a path that is not where I last was". The record of where
+//! it last lived is what separates them.
+//!
+//! - The old path is gone, or no longer carries this id → the workspace
+//!   **moved**. Adopt the new path and keep the identity.
+//! - The old path still exists and still carries the *same* id → this is a
+//!   **copy**. Mint a fresh identity for it, so a duplicated project cannot
+//!   silently write into the original's history.
+//!
+//! Guessing wrong in the copy direction is the expensive mistake — it merges
+//! two projects' state — so the ambiguous case resolves to "copy".
+//!
+//! # What is deliberately not solved
+//!
+//! Delete `.stella/private/` *and* move the directory and nothing links the
+//! two ends; no scheme can recover that, because nothing survived that both
+//! sides share. The data is not lost (session listings are not scoped by
+//! workspace), it is only no longer auto-discovered. A heuristic that guessed
+//! here would eventually bind two unrelated projects together, which is worse
+//! than an honest miss.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+/// The marker filename inside `<root>/.stella/private/`.
+pub const LOCAL_ID_FILE: &str = "local-id.json";
+
+/// How [`resolve`] arrived at the identity it returned. Callers that own
+/// path-keyed state use this to migrate it; everyone else can ignore it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Origin {
+    /// The marker was already there and the workspace has not moved.
+    Existing,
+    /// No marker: minted one. `path_key` names the pre-move key any legacy
+    /// path-keyed state would be filed under, so a caller can adopt it.
+    Minted,
+    /// The marker was there but the workspace has moved since. The identity is
+    /// unchanged; the recorded path was updated.
+    Moved,
+    /// A copy of a workspace that still exists elsewhere. A fresh identity was
+    /// minted so the two do not share state.
+    Copied,
+}
+
+/// A workspace's machine-local identity, and how it was reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalWorkspace {
+    /// The durable id. Stable across renames and moves.
+    pub id: String,
+    /// The canonical path this identity is currently bound to.
+    pub path: PathBuf,
+    /// The path-hash key this workspace would have had before this module
+    /// existed — the lookup key for legacy path-keyed state.
+    pub path_key: String,
+    /// How the identity was resolved.
+    pub origin: Origin,
+}
+
+/// The on-disk marker. A struct rather than an ad-hoc `Value` so the field
+/// order is the wire order and an unknown shape fails to parse instead of
+/// half-parsing into a wrong identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Marker {
+    id: String,
+    /// Where this marker last resolved. The move/copy discriminator.
+    path: String,
+}
+
+fn marker_path(workspace_root: &Path) -> PathBuf {
+    workspace_root
+        .join(".stella")
+        .join(crate::private::WORKSPACE_PRIVATE_DIR)
+        .join(LOCAL_ID_FILE)
+}
+
+fn canonical(workspace_root: &Path) -> PathBuf {
+    workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf())
+}
+
+fn read_marker(workspace_root: &Path) -> Option<Marker> {
+    let text = crate::read_private_to_string(&marker_path(workspace_root)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_marker(workspace_root: &Path, marker: &Marker) -> Result<()> {
+    let dir = workspace_root
+        .join(".stella")
+        .join(crate::private::WORKSPACE_PRIVATE_DIR);
+    crate::ensure_private_dir(&dir)?;
+    let body = serde_json::to_string(marker)
+        .map_err(|e| crate::StoreError(format!("cannot serialize {LOCAL_ID_FILE}: {e}")))?;
+    crate::private::write_private_atomic(&dir.join(LOCAL_ID_FILE), body.as_bytes())
+}
+
+/// Resolve (and, when absent, mint) this workspace's machine-local identity.
+///
+/// Infallible in spirit — the only errors are "cannot write into your own
+/// `.stella/private/`", which every other durable path reports too. A caller
+/// that cannot tolerate failure can fall back to [`crate::usage::project_id_for`]
+/// and behave exactly as it did before this existed.
+pub fn resolve(workspace_root: &Path) -> Result<LocalWorkspace> {
+    let here = canonical(workspace_root);
+    let path_key = crate::usage::project_id_for(&here);
+
+    let Some(marker) = read_marker(workspace_root) else {
+        let minted = Marker {
+            id: crate::enterprise_telemetry::random_uuid_v4(),
+            path: here.to_string_lossy().into_owned(),
+        };
+        write_marker(workspace_root, &minted)?;
+        return Ok(LocalWorkspace {
+            id: minted.id,
+            path: here,
+            path_key,
+            origin: Origin::Minted,
+        });
+    };
+
+    if marker.path == here.to_string_lossy() {
+        return Ok(LocalWorkspace {
+            id: marker.id,
+            path: here,
+            path_key,
+            origin: Origin::Existing,
+        });
+    }
+
+    // The recorded path differs. If the workspace it names still exists AND
+    // still claims this same id, both are live and this one is a copy.
+    let previous = PathBuf::from(&marker.path);
+    let previous_still_claims_id = read_marker(&previous).is_some_and(|m| m.id == marker.id);
+
+    if previous_still_claims_id {
+        let minted = Marker {
+            id: crate::enterprise_telemetry::random_uuid_v4(),
+            path: here.to_string_lossy().into_owned(),
+        };
+        write_marker(workspace_root, &minted)?;
+        return Ok(LocalWorkspace {
+            id: minted.id,
+            path: here,
+            path_key,
+            origin: Origin::Copied,
+        });
+    }
+
+    let moved = Marker {
+        id: marker.id,
+        path: here.to_string_lossy().into_owned(),
+    };
+    write_marker(workspace_root, &moved)?;
+    Ok(LocalWorkspace {
+        id: moved.id,
+        path: here,
+        path_key,
+        origin: Origin::Moved,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ws(name: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join(name);
+        std::fs::create_dir_all(&root).unwrap();
+        (dir, root)
+    }
+
+    #[test]
+    fn first_sight_mints_and_is_stable_afterwards() {
+        let (_guard, root) = ws("proj");
+        let first = resolve(&root).unwrap();
+        assert_eq!(first.origin, Origin::Minted);
+        assert!(!first.id.is_empty());
+
+        let again = resolve(&root).unwrap();
+        assert_eq!(again.origin, Origin::Existing);
+        assert_eq!(again.id, first.id, "identity must not fork on re-resolve");
+    }
+
+    #[test]
+    fn a_moved_workspace_keeps_its_identity() {
+        // The whole point: `stella resume` keys on this, and today it keys on
+        // the path string, so renaming a project orphans every session.
+        let guard = tempfile::tempdir().unwrap();
+        let before = guard.path().join("old-name");
+        std::fs::create_dir_all(&before).unwrap();
+        let original = resolve(&before).unwrap();
+
+        let after = guard.path().join("new-name");
+        std::fs::rename(&before, &after).unwrap();
+
+        let moved = resolve(&after).unwrap();
+        assert_eq!(moved.origin, Origin::Moved);
+        assert_eq!(
+            moved.id, original.id,
+            "a rename is not a new workspace — the identity survives it"
+        );
+        assert_ne!(
+            moved.path_key, original.path_key,
+            "the path hash DID change, which is exactly why it cannot be the key"
+        );
+    }
+
+    #[test]
+    fn a_copy_gets_its_own_identity_so_histories_never_merge() {
+        // Both copies are live. Sharing an id would let one project's agents
+        // write into the other's durable history — the expensive mistake, so
+        // the ambiguous case must resolve this way.
+        let guard = tempfile::tempdir().unwrap();
+        let original_root = guard.path().join("original");
+        std::fs::create_dir_all(&original_root).unwrap();
+        let original = resolve(&original_root).unwrap();
+
+        let copy_root = guard.path().join("copy");
+        std::fs::create_dir_all(copy_root.join(".stella").join("private")).unwrap();
+        std::fs::copy(marker_path(&original_root), marker_path(&copy_root)).unwrap();
+
+        let copied = resolve(&copy_root).unwrap();
+        assert_eq!(copied.origin, Origin::Copied);
+        assert_ne!(
+            copied.id, original.id,
+            "a copy must not inherit the original's identity"
+        );
+        assert_eq!(
+            resolve(&original_root).unwrap().id,
+            original.id,
+            "and the original is undisturbed by having been copied"
+        );
+    }
+
+    #[test]
+    fn the_marker_lives_where_git_will_not_carry_it() {
+        // `private/` is in WORKSPACE_GENERATED_IGNORE, so a clone gets a fresh
+        // identity rather than sharing the origin's. If this path ever moves
+        // out of `private/`, clones start fighting over one store.
+        let (_guard, root) = ws("proj");
+        resolve(&root).unwrap();
+        let path = marker_path(&root);
+        assert!(path.exists());
+        assert!(
+            path.components()
+                .any(|c| c.as_os_str() == crate::private::WORKSPACE_PRIVATE_DIR),
+            "the local id must live under the gitignored private dir: {path:?}"
+        );
+    }
+}

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -102,6 +102,13 @@ pub struct ToolRegistry {
     /// also the wrong cost model for an agent — being told "that moved, read
     /// it again" is a cheap retry, where blocking burns a turn.
     observed: std::sync::Mutex<HashMap<String, String>>,
+    /// The session's durable record, once a host attaches one.
+    ///
+    /// `OnceLock` because a session binds exactly one journal, at start, and
+    /// never rebinds: a registry whose journal changed mid-session would split
+    /// one agent's history across two stores. Absent — the default — leaves
+    /// every existing caller behaving exactly as before.
+    work_journal: std::sync::OnceLock<(stella_store::work_journal::WorkJournal, String)>,
     /// Paths `read_symbol` resolved and read, shared with the registered
     /// tool instance and drained once per execution into the file-touch
     /// ledger — the symbol's file is resolved through the code graph
@@ -486,6 +493,7 @@ impl ToolRegistry {
             root,
             touched: std::sync::Mutex::new(FileTouchLedger::default()),
             observed: std::sync::Mutex::new(HashMap::new()),
+            work_journal: std::sync::OnceLock::new(),
             span_reads,
             workspace_probe: std::sync::Mutex::new(None),
             turn_bracketing: std::sync::atomic::AtomicBool::new(false),
@@ -1664,6 +1672,44 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// Bind this session's durable record. Idempotent by construction: a
+    /// second call is ignored, because one session owns one history.
+    ///
+    /// `agent` labels the commits, so a workspace worked by several agents
+    /// reads back as an attributable log rather than an anonymous one.
+    pub fn attach_work_journal(
+        &self,
+        journal: stella_store::work_journal::WorkJournal,
+        agent: impl Into<String>,
+    ) {
+        let _ = self.work_journal.set((journal, agent.into()));
+    }
+
+    /// Commit one mutation to the session's durable record.
+    ///
+    /// Best-effort by the same reasoning as the checkpoint sink: a journal
+    /// that cannot be written leaves the agent exactly as recoverable as it
+    /// was before durability existed, so failing a live tool call to report
+    /// the loss of a *safety net* would be strictly worse than not having one.
+    /// Reads are skipped — nothing changed, and a commit per read would bury
+    /// the record of real work.
+    fn journal_mutation(&self, pending: &PendingTouch, reason: &str) {
+        let Some((journal, agent)) = self.work_journal.get() else {
+            return;
+        };
+        let verb = match pending.op {
+            FileOp::Read => return,
+            FileOp::Create => "create",
+            FileOp::Update => "update",
+            FileOp::Delete => "delete",
+        };
+        let _ = journal.record(
+            std::slice::from_ref(&pending.path),
+            &[],
+            &format!("stella({agent}): {verb} {} — {reason}", pending.path),
+        );
+    }
+
     fn record_touch(
         &self,
         pending: PendingTouch,
@@ -1684,6 +1730,11 @@ impl ToolRegistry {
             .filter(|s| !s.is_empty())
             .map(String::from)
             .unwrap_or_else(|| default_reason(pending.op).to_string());
+        // The durable record, written from the same choke point as the ledger
+        // and the staleness map, so all three describe one reality. Before the
+        // diff work below, which is presentation: if anything here is going to
+        // be expensive, the commit that makes the work recoverable goes first.
+        self.journal_mutation(&pending, &reason);
         // Counts and rendered diff come out of the SAME pre/post pair, so the
         // ledger, the telemetry payload and the TUI describe one reality.
         let pre = pre_content.as_deref().unwrap_or("");

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -77,6 +77,31 @@ pub struct ToolRegistry {
     late_tools: std::sync::RwLock<HashMap<String, Arc<dyn Tool>>>,
     root: PathBuf,
     touched: std::sync::Mutex<FileTouchLedger>,
+    /// `normalized workspace path → sha256 of the content THIS session last
+    /// observed`, and the whole of the no-clobber guarantee.
+    ///
+    /// Every successful touch records what the file looked like when this
+    /// agent was done with it — a read records what it read, a write records
+    /// what it wrote. Before a later mutation of the same path, the on-disk
+    /// content is re-hashed and compared: a mismatch means something outside
+    /// this session changed the file since this agent last looked, so the
+    /// mutation would silently overwrite work the agent never saw.
+    ///
+    /// # Why this needs no shared state
+    ///
+    /// It is deliberately NOT a lock, and there is no registry, daemon, or
+    /// lease anywhere. Each agent remembers only what it saw itself, which is
+    /// exactly enough: agent B's write is what makes agent A's memory stale,
+    /// so A detects it locally with no channel to B and no knowledge that B
+    /// exists. Two processes, two containers, or a human editing in an editor
+    /// are all the same case.
+    ///
+    /// A lock would be strictly weaker. It serializes writers but does nothing
+    /// about staleness: B waits, takes the lock, and overwrites the file A
+    /// just changed using a plan A's content no longer justifies. Waiting is
+    /// also the wrong cost model for an agent — being told "that moved, read
+    /// it again" is a cheap retry, where blocking burns a turn.
+    observed: std::sync::Mutex<HashMap<String, String>>,
     /// Paths `read_symbol` resolved and read, shared with the registered
     /// tool instance and drained once per execution into the file-touch
     /// ledger — the symbol's file is resolved through the code graph
@@ -460,6 +485,7 @@ impl ToolRegistry {
             late_tools: std::sync::RwLock::new(HashMap::new()),
             root,
             touched: std::sync::Mutex::new(FileTouchLedger::default()),
+            observed: std::sync::Mutex::new(HashMap::new()),
             span_reads,
             workspace_probe: std::sync::Mutex::new(None),
             turn_bracketing: std::sync::atomic::AtomicBool::new(false),
@@ -767,6 +793,32 @@ impl ToolRegistry {
         // tools yield zero or one op; `apply_edits` yields one Update per
         // distinct file in its batch.
         let pending_ops = self.classify_file_ops(name, input);
+        // The no-clobber guard. Refuse BEFORE executing: once a write lands,
+        // the other agent's work is already gone and the best this could do is
+        // narrate the loss. Returned as a tool `Error` rather than a turn
+        // abort because it is a recoverable, model-actionable condition — the
+        // message names the file and the fix, and re-reading is one cheap step
+        // where a failed turn would be a whole one.
+        let clobbered = self.clobbered_paths(&pending_ops);
+        if !clobbered.is_empty() {
+            return ToolOutput::Error {
+                message: format!(
+                    "refusing to write: {} changed since you last read {}. Another \
+                     agent (or a person) edited it after you looked, and this call \
+                     would overwrite their work with a plan formed against content \
+                     that no longer exists.\n\nRe-read {} and redo the change \
+                     against what is there now. Your edit is not lost — nothing was \
+                     written.",
+                    clobbered.join(", "),
+                    if clobbered.len() == 1 { "it" } else { "them" },
+                    if clobbered.len() == 1 {
+                        "the file"
+                    } else {
+                        "those files"
+                    },
+                ),
+            };
+        }
         // Updates need the pre-write content for the line diff; deletes need
         // it for the pre-deletion line count. Lossy UTF-8 so a binary file
         // still yields a deterministic (if approximate) line count.
@@ -1565,6 +1617,53 @@ impl ToolRegistry {
     /// `revision` assigned under the lock — concurrent touches may deliver
     /// out of order, but consumers keep the highest revision and stay
     /// consistent.
+    /// Record what this session now knows `path` to hold, hashed from disk.
+    ///
+    /// Called for every successful touch, reads included: a read is how an
+    /// agent acquires the belief a later write acts on, so it is exactly as
+    /// load-bearing here as a write. A path that no longer exists drops its
+    /// entry — after a delete there is nothing left to clobber, and the next
+    /// agent to create the file is starting fresh rather than overwriting.
+    fn remember_observed(&self, path: &str, full: &std::path::Path) {
+        let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        match std::fs::read(full) {
+            Ok(bytes) => {
+                observed.insert(path.to_string(), crate::staleness::hex_sha256(&bytes));
+            }
+            Err(_) => {
+                observed.remove(path);
+            }
+        }
+    }
+
+    /// The paths in `pending` this call would clobber — ones this session has
+    /// seen before whose bytes on disk no longer match what it saw.
+    ///
+    /// Only `Update` and `Delete` can clobber. A `Create` is checked by the
+    /// filesystem itself, and a `Read` changes nothing. A path this session
+    /// has never observed is NOT flagged: this guard's claim is "you are about
+    /// to overwrite a change you never saw", and it can only make that claim
+    /// about a file it watched the agent look at. Blind writes to never-read
+    /// files are a separate policy question and are deliberately left alone
+    /// here, so this check has no false positives.
+    ///
+    /// An unreadable file is not a conflict either — the tool's own error
+    /// path reports that far better than a staleness message would.
+    fn clobbered_paths(&self, pending: &[PendingTouch]) -> Vec<String> {
+        let observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        pending
+            .iter()
+            .filter(|p| matches!(p.op, FileOp::Update | FileOp::Delete))
+            .filter(|p| {
+                observed.get(&p.path).is_some_and(|seen| {
+                    std::fs::read(&p.full)
+                        .is_ok_and(|bytes| crate::staleness::hex_sha256(&bytes) != *seen)
+                })
+            })
+            .map(|p| p.path.clone())
+            .collect()
+    }
+
     fn record_touch(
         &self,
         pending: PendingTouch,
@@ -1573,6 +1672,11 @@ impl ToolRegistry {
         input: &Value,
         bus: Option<&HookBus>,
     ) {
+        // Refresh this session's belief about the file before anything else in
+        // here can fail or return early: the ledger is telemetry, but this is
+        // the guarantee, and a touch whose digest went unrecorded would leave
+        // the NEXT write to this path unguarded.
+        self.remember_observed(&pending.path, &pending.full);
         let reason = input
             .get("reason")
             .and_then(|v| v.as_str())

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -102,13 +102,18 @@ pub struct ToolRegistry {
     /// also the wrong cost model for an agent — being told "that moved, read
     /// it again" is a cheap retry, where blocking burns a turn.
     observed: std::sync::Mutex<HashMap<String, String>>,
-    /// The session's durable record, once a host attaches one.
+    /// The session's durable record, once a host attaches one. Absent — the
+    /// default — leaves every existing caller behaving exactly as before.
     ///
-    /// `OnceLock` because a session binds exactly one journal, at start, and
-    /// never rebinds: a registry whose journal changed mid-session would split
-    /// one agent's history across two stores. Absent — the default — leaves
-    /// every existing caller behaving exactly as before.
-    work_journal: std::sync::OnceLock<(stella_store::work_journal::WorkJournal, String)>,
+    /// `RwLock`, not `OnceLock`, because a registry can outlive the session it
+    /// was built for. The deck builds one registry and then lets the user
+    /// switch sessions under it, re-keying everything that names the session —
+    /// claim holder, notification attribution, journal sidecar. The durable
+    /// record has to follow, or work done after the switch commits to the ref
+    /// of the session the user left. Splitting one *registry's* history across
+    /// two stores is not the hazard it first looks like: they are two
+    /// sessions, and two histories is the correct answer.
+    work_journal: std::sync::RwLock<Option<(stella_store::work_journal::WorkJournal, String)>>,
     /// Paths `read_symbol` resolved and read, shared with the registered
     /// tool instance and drained once per execution into the file-touch
     /// ledger — the symbol's file is resolved through the code graph
@@ -493,7 +498,7 @@ impl ToolRegistry {
             root,
             touched: std::sync::Mutex::new(FileTouchLedger::default()),
             observed: std::sync::Mutex::new(HashMap::new()),
-            work_journal: std::sync::OnceLock::new(),
+            work_journal: std::sync::RwLock::new(None),
             span_reads,
             workspace_probe: std::sync::Mutex::new(None),
             turn_bracketing: std::sync::atomic::AtomicBool::new(false),
@@ -1672,8 +1677,12 @@ impl ToolRegistry {
             .collect()
     }
 
-    /// Bind this session's durable record. Idempotent by construction: a
-    /// second call is ignored, because one session owns one history.
+    /// Bind this session's durable record, replacing any earlier binding.
+    ///
+    /// Re-binding is how a host whose registry outlives one session — the deck,
+    /// across a session switch — keeps the record attributed to the session
+    /// that is actually running. Mutations before the call land on the previous
+    /// session's ref and stay there; nothing already committed moves.
     ///
     /// `agent` labels the commits, so a workspace worked by several agents
     /// reads back as an attributable log rather than an anonymous one.
@@ -1682,7 +1691,8 @@ impl ToolRegistry {
         journal: stella_store::work_journal::WorkJournal,
         agent: impl Into<String>,
     ) {
-        let _ = self.work_journal.set((journal, agent.into()));
+        let mut slot = self.work_journal.write().unwrap_or_else(|p| p.into_inner());
+        *slot = Some((journal, agent.into()));
     }
 
     /// Commit one mutation to the session's durable record.
@@ -1694,7 +1704,16 @@ impl ToolRegistry {
     /// Reads are skipped — nothing changed, and a commit per read would bury
     /// the record of real work.
     fn journal_mutation(&self, pending: &PendingTouch, reason: &str) {
-        let Some((journal, agent)) = self.work_journal.get() else {
+        // Cloned out from under the lock rather than held across the commit:
+        // `record` spawns git, and a read guard held across a subprocess would
+        // park a concurrent re-bind for the length of it. The clone is three
+        // paths and a string.
+        let Some((journal, agent)) = self
+            .work_journal
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+        else {
             return;
         };
         let verb = match pending.op {

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -1688,11 +1688,16 @@ impl ToolRegistry {
             return 0;
         };
         let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
-        let mut count = 0;
-        for (path, digest) in restored {
-            observed.entry(path).or_insert(digest);
-            count += 1;
-        }
+        // REPLACE, never merge. The restored map is this session's complete
+        // belief about the tree, and the deck reuses one registry across a
+        // session switch — so merging would leave the departing session's
+        // observations in place and refuse the arriving session's writes to
+        // files it never read. `or_insert` compounded it by preferring the
+        // stale entry when both sessions had seen the same path, making a
+        // disagreement unresolvable in the wrong direction. A guard built to
+        // have no false positives cannot inherit another session's memory.
+        let count = restored.len();
+        *observed = restored;
         count
     }
 

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -1649,6 +1649,53 @@ impl ToolRegistry {
         }
     }
 
+    /// This session's staleness map as JSON, for a durable host to persist.
+    ///
+    /// `BTreeMap`, so the bytes are a pure function of the contents: this is
+    /// written into a content-addressed store on every step boundary, and a
+    /// `HashMap`'s iteration order would mint a fresh object each time for a
+    /// map that had not changed.
+    ///
+    /// `None` when nothing has been observed yet — there is no state to write,
+    /// and an empty object would still cost a commit.
+    #[must_use]
+    pub fn observed_snapshot(&self) -> Option<String> {
+        let observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        if observed.is_empty() {
+            return None;
+        }
+        let ordered: std::collections::BTreeMap<&str, &str> = observed
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        serde_json::to_string(&ordered).ok()
+    }
+
+    /// Restore a staleness map persisted by [`Self::observed_snapshot`],
+    /// returning how many paths came back.
+    ///
+    /// Restoring is what makes the no-clobber guarantee survive a crash. Without
+    /// it a resumed session is *less* safe than a fresh one is honest: the
+    /// restored transcript still says the agent read a file, so the model acts
+    /// on content it believes it knows, while the guard — having forgotten it
+    /// was ever read — waves the overwrite through. That is the one combination
+    /// the guard exists to prevent.
+    ///
+    /// Merges rather than replaces. Anything this session has already seen is
+    /// newer than the snapshot by construction, so it wins.
+    pub fn restore_observed(&self, json: &str) -> usize {
+        let Ok(restored) = serde_json::from_str::<HashMap<String, String>>(json) else {
+            return 0;
+        };
+        let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        let mut count = 0;
+        for (path, digest) in restored {
+            observed.entry(path).or_insert(digest);
+            count += 1;
+        }
+        count
+    }
+
     /// The paths in `pending` this call would clobber — ones this session has
     /// seen before whose bytes on disk no longer match what it saw.
     ///

--- a/stella-tools/src/registry/tests.rs
+++ b/stella-tools/src/registry/tests.rs
@@ -932,3 +932,68 @@ async fn a_session_never_conflicts_with_itself() {
         "revision 2\n"
     );
 }
+
+/// Every mutation is durably recorded without the agent deciding to commit.
+///
+/// This is the answer to work lost when a turn dies before its commit: the
+/// hook is the tool, not the model's judgement, so there is no window in which
+/// a write exists only in the working tree.
+#[tokio::test]
+async fn every_mutation_is_committed_without_the_agent_choosing_to() {
+    let root = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+    let reg = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    let journal = stella_store::work_journal::WorkJournal::open_in(
+        store.path(),
+        root.path(),
+        "ses-autocommit",
+    )
+    .unwrap();
+    reg.attach_work_journal(journal.clone(), "lead");
+
+    // One ordinary write. The agent never asks for a commit.
+    let out = reg
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "work.txt",
+                "content": "the work\n",
+                "reason": "doing the job",
+            }),
+        )
+        .await;
+    assert!(!out.is_error(), "the write succeeds: {out:?}");
+
+    journal.mark_turn(1, &journal_tip(&journal)).unwrap();
+    assert_eq!(
+        journal.read_at_turn(1, "work.txt").unwrap(),
+        "the work\n",
+        "the mutation is durable the instant it lands, with no commit step"
+    );
+
+    // A second write supersedes it in the record rather than appending noise.
+    let out = reg
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "work.txt",
+                "content": "revised\n",
+                "reason": "revising",
+            }),
+        )
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+    journal.mark_turn(2, &journal_tip(&journal)).unwrap();
+    assert_eq!(journal.read_at_turn(2, "work.txt").unwrap(), "revised\n");
+    assert_eq!(
+        journal.read_at_turn(1, "work.txt").unwrap(),
+        "the work\n",
+        "and turn 1 still replays its own version — history, not a snapshot"
+    );
+}
+
+/// The session ref's current commit. A test affordance: production callers
+/// mark turns from the commit `record` returns.
+fn journal_tip(journal: &stella_store::work_journal::WorkJournal) -> String {
+    journal.session_tip().expect("a mutation was recorded")
+}

--- a/stella-tools/src/registry/tests.rs
+++ b/stella-tools/src/registry/tests.rs
@@ -997,3 +997,39 @@ async fn every_mutation_is_committed_without_the_agent_choosing_to() {
 fn journal_tip(journal: &stella_store::work_journal::WorkJournal) -> String {
     journal.session_tip().expect("a mutation was recorded")
 }
+
+/// Switching sessions must not inherit the previous session's beliefs.
+///
+/// The deck reuses one registry across a session switch, so a merging restore
+/// left the departing session's observations in place — and the arriving
+/// session was then refused writes to files it had never read. A guard built
+/// to have no false positives cannot carry another session's memory.
+#[test]
+fn restoring_a_session_replaces_rather_than_inherits() {
+    let root = tempfile::tempdir().unwrap();
+    let reg = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    // Session A saw two files, one of which B never touches.
+    let a = serde_json::json!({ "shared.rs": "aaa", "only-a-saw-this.rs": "bbb" }).to_string();
+    assert_eq!(reg.restore_observed(&a), 2);
+
+    // Session B's record disagrees about the shared file and never mentions
+    // the other one at all.
+    let b = serde_json::json!({ "shared.rs": "ccc" }).to_string();
+    assert_eq!(reg.restore_observed(&b), 1);
+
+    let json = reg
+        .observed_snapshot()
+        .expect("a restored session has a snapshot");
+    let observed: std::collections::HashMap<String, String> =
+        serde_json::from_str(&json).expect("the snapshot round-trips");
+    assert_eq!(
+        observed.get("shared.rs").map(String::as_str),
+        Some("ccc"),
+        "the arriving session's digest wins — `or_insert` used to keep the stale one"
+    );
+    assert!(
+        !observed.contains_key("only-a-saw-this.rs"),
+        "a file only the departing session read must not guard the arriving one"
+    );
+}

--- a/stella-tools/src/registry/tests.rs
+++ b/stella-tools/src/registry/tests.rs
@@ -807,3 +807,128 @@ async fn exec_ok(reg: &ToolRegistry, name: &str, input: serde_json::Value) {
 mod chain;
 mod schema_gate;
 mod touch;
+
+/// The no-clobber guarantee, end to end and across two independent sessions.
+///
+/// Two registries over one workspace stand in for two agents: they share no
+/// state, no lock and no channel, exactly as two processes would. The claim is
+/// that A cannot silently overwrite B's edit — not that A is made to wait for
+/// it.
+#[tokio::test]
+async fn one_agent_cannot_clobber_another_agents_edit() {
+    let root = tempfile::tempdir().unwrap();
+    let file = root.path().join("shared.txt");
+    std::fs::write(&file, "original\n").unwrap();
+
+    let agent_a = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    let agent_b = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    // A reads the file — this is the belief its later write will act on.
+    let read = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "shared.txt", "reason": "planning an edit" }),
+        )
+        .await;
+    assert!(!read.is_error(), "A can read the file: {read:?}");
+
+    // B edits it. B has never heard of A and takes no lock.
+    let b_wrote = agent_b
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "shared.txt",
+                "content": "B's careful work\n",
+                "reason": "B does its job",
+            }),
+        )
+        .await;
+    assert!(!b_wrote.is_error(), "B's write lands: {b_wrote:?}");
+
+    // A now writes against content that no longer exists. This is the exact
+    // moment work gets destroyed in a lock-based design — B has released, so
+    // A proceeds and B's edit is gone.
+    let a_wrote = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "shared.txt",
+                "content": "A's stale work\n",
+                "reason": "A does its job",
+            }),
+        )
+        .await;
+    match &a_wrote {
+        ToolOutput::Error { message } => {
+            assert!(
+                message.contains("shared.txt"),
+                "the refusal names the file so the model can act on it: {message}"
+            );
+            assert!(
+                message.contains("nothing was written"),
+                "the refusal says the edit was not half-applied: {message}"
+            );
+        }
+        other => panic!("A's stale write must be refused, got {other:?}"),
+    }
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "B's careful work\n",
+        "B's work survives untouched — this is the whole guarantee"
+    );
+
+    // And the recovery is one cheap step, not a failed turn: re-read, then
+    // write. This is why staleness beats a lock for an agent — being told to
+    // look again costs a step; blocking costs a turn.
+    let reread = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "shared.txt", "reason": "re-reading after the refusal" }),
+        )
+        .await;
+    assert!(!reread.is_error(), "A re-reads: {reread:?}");
+    let retry = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "shared.txt",
+                "content": "A's work, rebased on B's\n",
+                "reason": "redone against current content",
+            }),
+        )
+        .await;
+    assert!(
+        !retry.is_error(),
+        "after re-reading, A writes normally: {retry:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "A's work, rebased on B's\n"
+    );
+}
+
+/// A session writing its own file repeatedly must never trip the guard — the
+/// digest it remembers after each write is the one it finds on the next.
+/// Without this, the guarantee would make ordinary single-agent work fail.
+#[tokio::test]
+async fn a_session_never_conflicts_with_itself() {
+    let root = tempfile::tempdir().unwrap();
+    let agent = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    for i in 0..3 {
+        let out = agent
+            .execute(
+                "write_file",
+                &serde_json::json!({
+                    "path": "mine.txt",
+                    "content": format!("revision {i}\n"),
+                    "reason": "iterating",
+                }),
+            )
+            .await;
+        assert!(!out.is_error(), "write {i} succeeds: {out:?}");
+    }
+    assert_eq!(
+        std::fs::read_to_string(root.path().join("mine.txt")).unwrap(),
+        "revision 2\n"
+    );
+}

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -126,3 +126,4 @@ witness verification onto an engine that can't replay deterministically.
   content-free and governed by org-managed enrollment.
 
 Continue: [Why single-thread beats the swarm →](/docs/principles/determinism)
+· [No agent silently overwrites another's work →](/docs/principles/no-clobber)

--- a/website/content/docs/principles/meta.json
+++ b/website/content/docs/principles/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Engineering Principles",
-  "pages": ["determinism"]
+  "pages": ["determinism", "no-clobber"]
 }

--- a/website/content/docs/principles/no-clobber.mdx
+++ b/website/content/docs/principles/no-clobber.mdx
@@ -1,0 +1,118 @@
+---
+title: No agent silently overwrites another's work
+description: Stella refuses a write that would land on top of a change it never saw — without a lock, a daemon, or any knowledge that the other party exists. How the guarantee works, what it deliberately does not claim, and why it survives a crash.
+---
+
+Point two agents at one repository and the failure is not a corrupted file.
+It is a *quiet* one. Agent A reads `handler.rs`, spends four minutes forming a
+plan against what it read, and writes the result. In between, agent B — or a
+person in an editor — changed the same file. A's write succeeds. Nothing
+errors. B's work is gone, and the only record that it existed is a diff
+nobody is going to read.
+
+Stella refuses that write.
+
+## The guarantee
+
+**A mutation is refused when the file changed since this session last looked
+at it.** Not deferred, not merged, not warned about afterwards — refused
+before anything is written, with a message naming the file and the fix:
+
+```
+refusing to write: src/handler.rs changed since you last read it. Another
+agent (or a person) edited it after you looked, and this call would
+overwrite their work with a plan formed against content that no longer
+exists.
+
+Re-read the file and redo the change against what is there now. Your edit
+is not lost — nothing was written.
+```
+
+That is returned as a tool error, not a turn abort, and the distinction is
+deliberate. The condition is recoverable and the model can act on it: re-read
+the file, redo the edit. One cheap step, where aborting would throw away a
+whole turn.
+
+## Why not a lock
+
+A lock is the obvious answer and it is strictly weaker.
+
+Locks serialize *writers*. They do nothing about *staleness*. Agent B waits,
+takes the lock, and then overwrites the file A just changed — using a plan
+that A's content no longer justifies. B did everything right and still
+destroyed the work. Serializing the writes never addressed the problem,
+because the problem was never simultaneity; it was acting on a belief that
+had expired.
+
+Waiting is also the wrong cost model for an agent. Being told "that moved,
+read it again" is a cheap retry. Blocking burns a turn.
+
+## How it works: no shared state at all
+
+Each session keeps one map: **the path it touched, and the digest of what it
+saw there.** Before any update or delete, the bytes on disk are re-hashed and
+compared with what this session remembers.
+
+There is no registry, no daemon, no lease, and no channel between agents.
+That is not a simplification — it is the point. *Agent B's write is what makes
+agent A's memory stale*, so A detects it locally, with no knowledge that B
+exists. Two processes, two containers, a CI job, and a human typing in Vim are
+all the same case, and none of them has to be running Stella.
+
+Reads count. A read is how an agent acquires the belief a later write acts on,
+so it is recorded exactly as a write is. A delete drops the entry — after a
+delete there is nothing left to clobber, and the next agent to create the file
+is starting fresh rather than overwriting.
+
+## What it deliberately does not claim
+
+The guard's claim is precise: *you are about to overwrite a change you never
+saw*. It can only make that claim about a file it watched this session look
+at. So:
+
+- **A path this session never touched is not flagged.** Blind writes to
+  never-read files are a separate policy question, left alone here. The result
+  is a guard with no false positives — every refusal names a real conflict.
+- **Creates are not checked by the guard.** The filesystem itself already
+  answers "does this exist".
+- **An unreadable file is not a conflict.** The tool's own error path reports
+  that far better than a staleness message would.
+
+A guard that cried wolf would be turned off, and then it would protect
+nothing.
+
+## It survives a crash
+
+The map used to live only in memory, which left a gap worth naming plainly: a
+session that died took the whole guarantee with it.
+
+That is worse than it sounds. The resumed session was not merely back to
+square one — it was *less safe than an honest fresh start*. Its restored
+transcript still said the agent had read the file, so the model went on acting
+on content it believed it knew, while the guard, having forgotten the read
+ever happened, waved the overwrite through. Precisely the combination the
+guard exists to prevent.
+
+So the map is now written down. It lives in Stella's durable work record — a
+git store kept in Stella's own directory, never in your repository — and is
+restored when the session [resumes](/docs/commands/resume), before anything can
+touch a file. A resumed session is exactly as guarded as the one that died.
+
+Two details of that are load-bearing:
+
+- **It is written at each step boundary, not at each file change.** The map is
+  updated by reads as well as writes, so saving it only when a file changed
+  would drop every read since the last write — which is exactly the loss
+  described above.
+- **It outlives the turn.** A turn's resume point is retracted when that turn
+  ends; the staleness map is not. It describes what the *session* has seen, and
+  a session's second turn is as entitled to the guarantee as its first.
+
+## Where this sits
+
+The guard is enforced in the tool registry, above every file-touching tool at
+once — built-ins, MCP-server tools, and custom tools alike. It is not
+something a tool opts into, and not something the model can decide to skip.
+That is the same reasoning as
+[determinism over intelligence](/docs/principles/determinism): where a
+mechanism can decide something, the mechanism decides it.


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? -->

<!--
  Replace the N below with the issue number, or delete the line if there is no
  issue. A number in the PR *title* does NOT close anything — GitHub only reads
  closing keywords from this description and from commit messages.
  Use `Refs #N` instead if this PR advances the issue without finishing it.
-->

Closes #N

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

## Ground-rule check

<!-- Delete lines that don't apply. -->

- [ ] No I/O added to `stella-core`; no new deps without justification below
- [ ] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

## Summary by Sourcery

Add durable session and workspace history for agents, including per-step turn checkpoints, a no-clobber file safety guarantee across concurrent sessions, and configurable worktree isolation for pipeline runs.

Enhancements:
- Track per-session observed file hashes in the tool registry to prevent overwriting external changes and support restoring staleness state after crashes.
- Integrate a git-backed work journal for recording workspace mutations, checkpoints, and staleness maps keyed by machine-local workspace identity.
- Extend engine and server execution to emit and clear checkpoints through a configurable CheckpointSink so interrupted turns can resume from the last step boundary.
- Wire session durability through CLI config and engine wiring so all agent roles share the same checkpoint sink and work journal.
- Introduce a machine-local workspace identity that survives moves and is used to key durable work history independently of the user's git repo.
- Add pipeline support for running in throwaway git worktrees with an operator-controlled policy and interactive confirmation when needed.

Documentation:
- Document the no-clobber guarantee and crash-survivable staleness map in the principles docs and link it from the principles index.

Tests:
- Add end-to-end tests for the no-clobber guard across multiple agents, durability of mutations via the work journal, checkpointing behavior at step boundaries, workspace identity behavior across moves and copies, and worktree isolation policy precedence.
- Extend CLI and pipeline tests to cover checkpoint sink wiring across roles and create_worktrees configuration parsing and behavior.