### PR TITLE
bench: GLM-5.2 head-to-head post-mortem, Fable-class posture proposal, 5-task readiness probe

### DIFF
--- a/bench/evidence/glm52-h2h-postmortem/PROPOSAL-fable-128k-posture.md
+++ b/bench/evidence/glm52-h2h-postmortem/PROPOSAL-fable-128k-posture.md
@@ -1,0 +1,115 @@
+# Proposal: the Fable-class ceiling set — 128,000 output cap + scaled `model_timeout`
+
+**Status: PROPOSED — preregistration decision, maintainer sign-off required.
+Nothing in this PR changes the frozen posture, the engine constant, or any
+registered digest.** This memo exists so the decision can be made once,
+deliberately, before a paid Fable-class run — not discovered mid-run the way
+16384 → 32000 → 64000 each were (READINESS.md §8.4.2–§8.4.3).
+
+## The rule, restated
+
+The rule that set every previous ceiling is unchanged: **never be the side
+that stops first.** A ceiling below what the comparator is allowed is not a
+tuning choice; it is a handicap the score then reports as a capability
+difference. The frozen posture's `max_tokens: 64000` is correct *for the
+Sonnet-5 arm* because 64,000 is where the comparator's own steps stop —
+gate3c Arm B landed steps on exactly 64,000 twice and still emitted the tool
+call. It is **not** the model API ceiling: Sonnet 5's and Fable 5's output
+ceiling is 128,000 (`/v1/models` `max_tokens`; the engine's own catalog
+carries the same value).
+
+A Fable-class worker (`anthropic/claude-fable-5`) changes the comparator.
+Claude Code on the first-party API does not cap itself below the model
+ceiling, and Fable is documented to run minutes-long single steps on hard
+tasks at `xhigh`. Freezing a Fable arm at 64,000 would re-create the exact
+asymmetry §8.4.3 removed: Stella truncated at half the height the comparator
+is allowed to fill.
+
+The GLM-5.2 post-mortem beside this memo is the other half of the motive: the
+fatal cap-hit shape that survives the 64k posture is "first-step
+mega-reasoning" on golf/compression/assembly tasks — the class where the
+comparator's winning steps were already brushing its own ceiling.
+
+## The three ceilings, and what each change touches
+
+Same one-budget coupling as §8.4.3 — moving one alone relocates the cliff:
+
+| ceiling | Sonnet-5 arm (frozen) | Fable-class arm (proposed) | where it lives | what changes |
+|---|---|---|---|---|
+| `params.max_tokens` (default/worker/judge) | 64,000 | **128,000** (the model ceiling) | `bench/harbor_adapter/stella_harbor/posture.py::_benchmark_engine_posture` | the hashed posture → every posture digest |
+| `EngineConfig::model_timeout` | 816s | **1,572s** (provisional, see below) | `stella-core/src/driver.rs` (engine default) | the SUT binary → re-freeze of the SUT commit |
+| `--turn-budget` | per-trial, Harbor agent timeout − 60s | unchanged | adapter, per trial | nothing |
+
+`triage` stays at the engine default in both arms — low effort, three-line
+classification, the cap was never near binding (same reasoning as every
+prior generation).
+
+### On the `model_timeout` number
+
+816s was set 60s above the longest single step the comparator was ever
+rewarded for (756s, gate3c). No Fable-class comparator telemetry exists yet,
+so the honest derivation is the observed throughput scaled to the new cap:
+the comparator's 64,000-token rewarded step took 756s (~85 tok/s); a
+128,000-token step at the same rate is ~1,512s; the same +60s margin gives
+**1,572s**. Two qualifiers, both in the constant's own doc comment:
+
+* `model_timeout` bounds **idle silence between stream fragments**, not
+  elapsed time — a generation that keeps streaming is never cut by it. The
+  number is a margin against a provider that stopped answering, sized so it
+  can never bind before the output cap does.
+* If a Fable-class smoke run observes rewarded steps longer than 1,512s, the
+  rule says re-derive from the measurement (longest rewarded comparator step
+  + 60s), exactly as 816 was derived. The provisional number is registered as
+  provisional for that reason.
+
+## Reference digests for the proposed arm
+
+Computed with the adapter's own canonicalization (the posture dict from
+`_benchmark_engine_posture`, caps patched, normalized and hashed by the same
+`sort_keys`/compact-JSON/SHA-256 rule). **Reference only** — the
+authoritative values are whatever `_benchmark_engine_posture` emits after the
+constant actually moves, and the launcher manifest is the value of record; a
+hand value that disagrees with the machine manifest is the `harbor==0.6.1`
+failure in a new file.
+
+| model | frozen (`xhigh`, 64000) | proposed (`xhigh`, 128000) |
+|---|---|---|
+| anthropic/claude-fable-5 | `640b9469d5d3bc1394af20967915cca0f6841180648dec4daedbbd5f629ef510` | `b640fec3867ed632d742f8a78c5f899b222ce77422192a5c9ee395ceb2a004aa` |
+| anthropic/claude-sonnet-5 | `3c428a22435228b8b11731e7c90031f4b606a8ec8c96eadde9dd266a7ffdb104` | `29b57409d8448e565dadce0697cde353c6d84919a46a50467d7515522aba2848` |
+
+(The frozen Sonnet-5 value matches READINESS.md §8.4.3's registered table,
+which is the check that the reference machinery agrees with the launcher's.)
+The Sonnet-5 row's proposed column is listed because the constant is shared,
+**not** because this memo proposes changing the Sonnet-5 arm — under the
+parity rule the Sonnet-5 comparator stops at 64,000, so its frozen posture
+stays. If the maintainer instead prefers per-arm caps, the implementation
+should follow the existing arm pattern (a host-side selector that lands in
+the hash, like `STELLA_WORKER_EFFORT`), so that which cap a run used is a
+property of its digest rather than of its logs.
+
+## Why this is not automated away
+
+Three separate reasons, each sufficient:
+
+1. **It changes the frozen digest.** Registered thresholds and any published
+   number describe the posture that produced them; a silently moved constant
+   makes the digest describe a posture nobody registered. The change must
+   land as its own preregistration (or amendment) with the new digests in
+   the protocol tables — the same path §8.4.2 and §8.4.3 took.
+2. **Half of it is a SUT change.** `model_timeout` is an engine constant, so
+   the Fable arm requires a re-freeze of the SUT commit, which is
+   maintainer-only under the protocol ("design finalization before the audit
+   clock starts").
+3. **The number itself is provisional.** 1,572s is derived, not measured;
+   the preregistration should say which it is registering.
+
+## Decision asked of the maintainer
+
+* [ ] Approve the Fable-class arm shape: `max_tokens: 128000` for
+      default/worker/judge, `model_timeout: 1572s`, turn-budget wiring
+      unchanged, triage unchanged.
+* [ ] Choose global-constant vs per-arm-selector implementation.
+* [ ] Register it: apply the one-line posture change + engine constant on a
+      commit that becomes the new frozen SUT, recompute digests via
+      `_benchmark_engine_posture`, update the protocol/analyzer/READINESS
+      tables, and publish before any paid Fable-class trial.

--- a/bench/evidence/glm52-h2h-postmortem/README.md
+++ b/bench/evidence/glm52-h2h-postmortem/README.md
@@ -1,0 +1,191 @@
+# GLM-5.2 head-to-head post-mortem: the 106 cap hits and the 6.4× input gap
+
+A reading of the evidence from the 89-task Terminal-Bench 2.1 same-model
+head-to-head (`stella-docs/benchmarks/terminal-bench-2-1-glm-5-2.json` — the
+data behind the public "same model, different harness" page). Stella won the
+run, 58/89 against Claude Code's 44/89, and this document is about the two
+things the winning number hides: **106 output-cap hits** (Claude Code: 0) and
+**366M input tokens against 57M** (6.40×).
+
+Every figure below is recomputed by [`analyze.py`](analyze.py) beside this
+file, from the committed table alone — stdlib only, no network, no arguments.
+If this prose and that script disagree, the script wins.
+
+> **What survives of the raw evidence.** The per-trial `stella-events.jsonl`
+> streams (~900 MB/run) are not committed; the table is the durable reduction
+> (`bench/harbor_adapter/stella_harbor/live_feed.py::_reduce`, path+SHA
+> provenance in the telemetry store schema). `exit_cause.py` (#1213) now
+> captures the SIGKILL half of a death at the moment it happens; this
+> post-mortem is the reading half over what the run recorded. Where the table
+> cannot answer a question, that is said explicitly rather than guessed.
+
+## 1. Headline
+
+| | Stella | Claude Code |
+|---|---:|---:|
+| passed / 89 | **58** | 44 |
+| input tokens | 366,226,022 | 57,233,585 |
+| output tokens | 5.31M | 2.23M |
+| cost | $78.25 | $63.35 |
+| cap hits | **106** | 0 |
+
+`cap_hits` counts `step_usage` events with ≥16,384 output tokens **and zero
+tool calls** — a step that spent a huge output budget without acting. Under
+the frozen posture (`max_tokens: 64000`) a counted step may sit anywhere in
+[16,384, 64,000]; a literal truncation at the cap is the worst case of the
+class, not the whole class. Claude Code recorded zero because its steps
+either act or stay small — the failure shape is Stella-specific.
+
+## 2. The 106 cap hits
+
+### 2.1 Most cap hits were absorbed, not fatal
+
+The surprise: **tasks with cap hits passed at a *higher* rate (32/44 = 72.7%)
+than tasks without (26/45 = 57.8%)**, and 74 of the 106 hits happened inside
+passing trials. Cap hits cluster on the hard, long tasks — the ones Stella
+grinds out and Claude Code often doesn't attempt for long (regex-chess: 10
+hits, PASS; feal-linear-cryptanalysis: 6, PASS; llm-inference-batching:
+6, PASS). The loop demonstrably recovers from a burned step: it retries, the
+next step emits the tool call, the trial proceeds.
+
+So the cap-hit story is **not** "the cap loses tasks" at the margin — it is
+mostly a *spend and wall-clock* tax on tasks Stella wins anyway, plus a small
+fatal tail (§2.3).
+
+### 2.2 The tax is a third of all output
+
+Each hit burned ≥16,384 output tokens by definition, so the 106 hits burned
+**≥1.74M output tokens — 32.7% of everything Stella emitted in the run** —
+as reasoning that produced no action and was then thrown away. At GLM-5.2
+output pricing this is single-digit dollars; the real costs are wall-clock
+(each burned step is a full model call, and the biggest cap-hit tasks are the
+ones that also died at `AgentTimeoutError` with reward already earned) and
+context pollution (the truncated reasoning lands in history and is re-sent
+every subsequent step — see §3).
+
+### 2.3 The fatal tail: 12 failures with cap hits, 3 distinct shapes
+
+Lower-bound share of the trial's output burned in cap-hit steps
+(`cap_hits × 16384 / out_tokens`):
+
+| shape | tasks | signature |
+|---|---|---|
+| **FATAL-EARLY** | `write-compressor` (3 hits / 7 steps, ≥99.4% of output), `gpt2-codegolf` (3 / 11, ≥85.2%) | The trial essentially *was* its cap hits: a few giant zero-action reasoning dumps, near-zero input tokens, dead before doing anything. This is exactly the READINESS §8.4.2 shape ("budget spent on reasoning, no visible response") surviving the 64k raise — on tasks whose first step is one enormous think. |
+| **CAP-HEAVY** | `protein-assembly` (8 / 39, ≥75.8%), `financial-document-processor` (1 / 29, ≥57.8%), `path-tracing-reverse` (2 / 30, ≥52.0%) | Repeated burned steps dominating a short trial; the loop recovered each time but the budget/timeout ran out before the work did. |
+| **late/mixed** | `build-pov-ray`, `constraints-scheduling`, `dna-assembly`, `make-doom-for-mips`, `pytorch-model-recovery`, `raman-fitting`, `video-processing` | 1–4 hits inside long trials; the hits cost time but the failure has other co-causes (timeouts, verifier disagreement). |
+
+Two operational conclusions:
+
+1. **The recovery path works and should be kept** — it converted what would
+   have been ~30 additional failures into passes.
+2. **The remaining fatal shape is "first-step mega-reasoning"** on
+   code-golf/compression/assembly puzzles, i.e. exactly the class the
+   READINESS §8.4.3 head-to-head showed Claude Code winning with 45k–64k
+   token steps. The cap cannot be tuned away *under this model's 64k posture*
+   (both agents cap at 64k there); what changes it is the Fable-class arm —
+   see [`PROPOSAL-fable-128k-posture.md`](PROPOSAL-fable-128k-posture.md).
+   What *can* be fixed model-independently is the burned-step cost: a step
+   that returns with zero tool calls and ≥16k output should be retried with
+   a "act now, reason less" continuation rather than a plain retry, and its
+   truncated reasoning should not enter the standing context (§3 makes it a
+   compounding cost).
+
+### 2.4 What the evidence cannot say
+
+The table records *counts*, not per-step sizes, so it cannot distinguish a
+step that stopped at exactly 64,000 (a literal truncation) from a 20k
+zero-action step (model verbosity). It also cannot say what the reasoning
+was *about*. Both questions need the per-step `stella-events.jsonl`, which
+future runs keep and which `exit_cause.py` now annotates for the SIGKILL
+subset. The 5-task readiness run in [`../readiness-5task/`](../readiness-5task/)
+retains full streams for exactly this reason.
+
+## 3. The 6.4× input gap is context engineering, not configuration
+
+### 3.1 Decomposition
+
+**6.40× = 1.58× more steps × 4.06× more input per step.**
+
+Stella took 6,287 steps to Claude Code's 3,986 — more, but not wildly more,
+and partly *why it won* (it keeps grinding). The dominant factor is input per
+step: 58,251 tokens/step vs 14,359. No posture knob controls this; it is how
+the harness assembles context.
+
+### 3.2 The growth-rate signature
+
+Fitting per-task mean input-per-step against trial length:
+
+```
+stella: in/step ≈ 14,025 + 378·steps
+claude: in/step ≈  5,922 + 111·steps
+```
+
+Stella starts ~2.4× heavier *and grows 3.4× faster*. On short trials
+(<50 steps) Stella averages 23k/step to Claude Code's 10k; on long trials
+(≥100 steps) 70k/step to 20k. Since total input is per-step context summed
+over steps, Stella's total grows ~quadratically with a 3.4× larger
+coefficient — which is why the top-10 longest tasks alone carry 46% of the
+366M (regex-chess: 27.9M input over 247 steps at 113k/step; Claude Code
+solved... well, failed it, in 10 steps and 0.1M).
+
+The mechanism: every tool result, every recalled block, and every burned
+cap-hit reasoning dump accrues into the standing context and is re-sent on
+each subsequent call. Claude Code's curve says it holds the standing context
+roughly flat past ~20k via aggressive compaction/clearing; Stella's says its
+compaction (150k budget, keep-recent 8) engages too late and keeps too much.
+
+### 3.3 What it is worth
+
+Holding Stella's own step counts fixed and pricing them at Claude Code's
+context curve gives **119M input instead of 366M — a 3.1× reduction from
+recall/context engineering alone**, before touching step count, pass rate, or
+the posture. The levers, in expected order of yield:
+
+1. **Tool-result retention** — clear or summarize tool outputs older than
+   N steps (the single biggest divergence from Claude Code's curve).
+2. **Cap-hit debris** — never retain the truncated reasoning of a
+   zero-action step (§2.2's 1.74M output becomes recurring *input* every
+   step after it happens).
+3. **Compaction trigger** — the 150k `compaction_budget_tokens` roughly
+   matches where Stella's long-trial average lands (70k mean ≈ 140k tail),
+   i.e. it fires only at the very end of exactly the trials it should have
+   been shaping from the middle.
+
+### 3.4 Why cost didn't explode with it
+
+Blended input price: Stella $0.21/M vs Claude Code $1.11/M — provider-side
+prompt caching absorbs most of the re-sent prefix, which is why 6.4× tokens
+became only 1.24× cost. The gap is therefore *not* primarily a bill problem
+today; it is latency (105,237s wall vs 73,462s), timeout pressure on the
+exact tasks in §2.3's tail, and dependence on a provider discount that a
+different arm (first-party API, Fable-class pricing) does not extend at the
+same rate.
+
+## 4. The 8 tasks Stella failed and Claude Code passed
+
+The readiness question — "are we ready for the big one" — turns on these,
+because they are the asymmetric losses:
+
+| task | Stella's death | class |
+|---|---|---|
+| `fix-git` | 15 steps, 70s, clean exit, reward 0 | clean-fail |
+| `sanitize-git-repo` | 16 steps, 128s, clean exit, reward 0 | clean-fail |
+| `openssl-selfsigned-cert` | 25 steps, 195s, clean exit, reward 0 | clean-fail |
+| `kv-store-grpc` | 25 steps, 208s, clean exit, reward 0 | clean-fail |
+| `fix-code-vulnerability` | 98 steps, 287s, clean exit, reward 0 | clean-fail |
+| `constraints-scheduling` | 2 cap hits, NonZeroAgentExitCodeError | ceiling death |
+| `dna-assembly` | 4 cap hits, 20.6M input, AgentTimeoutError at 1913s | ceiling death |
+| `crack-7z-hash` | AgentTimeoutError at 2047s (compute-bound, 0 cap hits) | timeout death |
+
+The split matters. The three ceiling/timeout deaths are §2/§3's problems and
+the posture proposal's territory. The **five clean-fails are pure capability
+misses**: Stella finished quickly, said done, and the verifier said no — no
+caps, no timeouts, no infrastructure noise. Two are git-shaped (`fix-git`,
+`sanitize-git-repo` — the class #1212's pre-agent git baseline targets), and
+all five are exactly the class the worker-lifecycle work in #1213/#1214
+(judge-context sealing, single recall, persona parity) is meant to move.
+
+That makes them the correct 5-task readiness probe: cheap (all under 300s
+and 3.3M input in the failing run), verifier-decided, and each one a task
+Claude Code demonstrably passes. The run and its evidence live in
+[`../readiness-5task/`](../readiness-5task/).

--- a/bench/evidence/glm52-h2h-postmortem/analyze.py
+++ b/bench/evidence/glm52-h2h-postmortem/analyze.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Recompute every number in this directory's post-mortem from the committed
+head-to-head table.
+
+The input is the same per-task JSON the public docs page renders
+(`stella-docs/benchmarks/terminal-bench-2-1-glm-5-2.json`): one row per task,
+one cell per arm, produced by the live-feed reducer in
+`bench/harbor_adapter/stella_harbor/live_feed.py`. That reducer defines the
+`cap_hits` metric this post-mortem is about: a `step_usage` event with
+`output_tokens >= 16384` **and zero tool calls** — a step that spent a huge
+output budget and produced no action. Under the frozen 64000-token posture a
+step can sit anywhere in [16384, 64000] and still count, so the metric reads
+"large-output zero-action step", of which a literal cap truncation is the
+worst case.
+
+Stdlib only, no arguments; run it from anywhere:
+
+    python3 bench/evidence/glm52-h2h-postmortem/analyze.py
+
+Every figure quoted in README.md is printed here, labelled with the section
+that quotes it. If this script and the README disagree, the README is wrong —
+that is the point of committing the script (#909's rule: a number whose
+runner lives in someone's scratch directory is not reproducible).
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+CAP_HIT_MIN_OUTPUT = 16384  # mirrors live_feed._CAP_HIT_MIN_OUTPUT
+
+DATA = (
+    Path(__file__).resolve().parents[3]
+    / "stella-docs"
+    / "benchmarks"
+    / "terminal-bench-2-1-glm-5-2.json"
+)
+
+
+def fit_context_growth(rows: list[dict], arm: str) -> tuple[float, float]:
+    """Least-squares fit of per-task mean input-per-step against step count.
+
+    The slope is the marginal growth of the *average* context per additional
+    step; the marginal growth of the standing context itself is ~2x the slope
+    (for context C(k) ~ a + b*k, the mean over k steps grows at b/2 per step).
+    """
+    xs = [r[arm]["steps"] for r in rows if r[arm]["steps"] > 0]
+    ys = [r[arm]["in_tokens"] / r[arm]["steps"] for r in rows if r[arm]["steps"] > 0]
+    n = len(xs)
+    mx, my = sum(xs) / n, sum(ys) / n
+    slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / sum(
+        (x - mx) ** 2 for x in xs
+    )
+    return my - slope * mx, slope
+
+
+def main() -> None:
+    d = json.loads(DATA.read_text())
+    rows = d["rows"]
+    s_in = sum(r["stella"]["in_tokens"] for r in rows)
+    c_in = sum(r["claude"]["in_tokens"] for r in rows)
+    s_steps = sum(r["stella"]["steps"] for r in rows)
+    c_steps = sum(r["claude"]["steps"] for r in rows)
+    s_out = sum(r["stella"]["out_tokens"] for r in rows)
+
+    print(f"tasks: {len(rows)}")
+    print("== headline (README §1) ==")
+    print(
+        f"pass: stella {sum(1 for r in rows if r['stella']['pass'])}/89, "
+        f"claude {sum(1 for r in rows if r['claude']['pass'])}/89"
+    )
+    print(
+        f"input tokens: stella {s_in:,} claude {c_in:,} ratio {s_in / c_in:.2f}x"
+    )
+    print(
+        f"cap hits: stella {sum(r['stella']['cap_hits'] for r in rows)}, "
+        f"claude {sum(r['claude']['cap_hits'] for r in rows)}"
+    )
+
+    print("\n== cap-hit outcome split (README §2.1) ==")
+    with_cap = [r for r in rows if r["stella"]["cap_hits"] > 0]
+    without = [r for r in rows if r["stella"]["cap_hits"] == 0]
+    print(
+        f"tasks with >=1 cap hit: {len(with_cap)}; "
+        f"pass rate with: {sum(1 for r in with_cap if r['stella']['pass'])}/{len(with_cap)}"
+        f" = {sum(1 for r in with_cap if r['stella']['pass']) / len(with_cap):.1%}; "
+        f"without: {sum(1 for r in without if r['stella']['pass'])}/{len(without)}"
+        f" = {sum(1 for r in without if r['stella']['pass']) / len(without):.1%}"
+    )
+    print(
+        f"cap hits in passing trials: "
+        f"{sum(r['stella']['cap_hits'] for r in rows if r['stella']['pass'])}; "
+        f"in failing trials: "
+        f"{sum(r['stella']['cap_hits'] for r in rows if not r['stella']['pass'])}"
+    )
+
+    waste = sum(r["stella"]["cap_hits"] for r in rows) * CAP_HIT_MIN_OUTPUT
+    print("\n== wasted output floor (README §2.2) ==")
+    print(
+        f"cap-hit steps burned >= {waste:,} output tokens "
+        f"of {s_out:,} total = {waste / s_out:.1%} of all Stella output"
+    )
+
+    print("\n== fatal classes among the 12 cap-hit failures (README §2.3) ==")
+    for r in rows:
+        s = r["stella"]
+        if s["pass"] or s["cap_hits"] == 0:
+            continue
+        share = s["cap_hits"] * CAP_HIT_MIN_OUTPUT / max(1, s["out_tokens"])
+        cls = (
+            "FATAL-EARLY"
+            if s["steps"] < 20
+            else ("CAP-HEAVY" if share > 0.5 else "late/mixed")
+        )
+        print(
+            f"  {r['task']:35s} caps={s['cap_hits']} steps={s['steps']:3d} "
+            f"cap-share>={share:5.1%}  {cls}"
+        )
+
+    print("\n== token-efficiency decomposition (README §3.1) ==")
+    print(
+        f"6.40x = {s_steps / c_steps:.2f}x steps "
+        f"x {(s_in / s_steps) / (c_in / c_steps):.2f}x input-per-step "
+        f"(stella {s_in / s_steps:,.0f}/step, claude {c_in / c_steps:,.0f}/step)"
+    )
+
+    print("\n== context growth (README §3.2) ==")
+    for arm in ("stella", "claude"):
+        a, b = fit_context_growth(rows, arm)
+        print(f"  {arm:6s}: in/step ~= {a:,.0f} + {b:.1f} * steps")
+    hi = [r for r in rows if r["stella"]["steps"] >= 100]
+    lo = [r for r in rows if r["stella"]["steps"] < 50]
+    print(
+        f"  stella in/step: short trials {sum(r['stella']['in_tokens'] for r in lo) / sum(r['stella']['steps'] for r in lo):,.0f}, "
+        f"long trials {sum(r['stella']['in_tokens'] for r in hi) / sum(r['stella']['steps'] for r in hi):,.0f}"
+    )
+    chi = [r for r in rows if r["claude"]["steps"] >= 100]
+    clo = [r for r in rows if r["claude"]["steps"] < 50]
+    print(
+        f"  claude in/step: short trials {sum(r['claude']['in_tokens'] for r in clo) / sum(r['claude']['steps'] for r in clo):,.0f}, "
+        f"long trials {sum(r['claude']['in_tokens'] for r in chi) / sum(r['claude']['steps'] for r in chi):,.0f}"
+    )
+
+    _, b_c = fit_context_growth(rows, "claude")
+    a_c, b_c = fit_context_growth(rows, "claude")
+    whatif = sum(
+        (a_c + b_c * r["stella"]["steps"]) * r["stella"]["steps"] for r in rows
+    )
+    print("\n== counterfactual (README §3.3) ==")
+    print(
+        f"stella input at claude's context curve, stella's own step counts: "
+        f"{whatif / 1e6:.0f}M vs actual {s_in / 1e6:.0f}M "
+        f"-> {s_in / whatif:.1f}x reduction from context engineering alone"
+    )
+    top10 = sorted(rows, key=lambda r: -r["stella"]["in_tokens"])[:10]
+    print(
+        f"top-10 input tasks carry "
+        f"{sum(r['stella']['in_tokens'] for r in top10) / s_in:.1%} of stella input"
+    )
+
+    print("\n== cost (README §3.4) ==")
+    s_cost = sum(r["stella"]["cost_usd"] for r in rows)
+    c_cost = sum(r["claude"]["cost_usd"] for r in rows)
+    print(
+        f"stella ${s_cost:.2f} ({1e6 * s_cost / s_in:.3f} $/M-in blended), "
+        f"claude ${c_cost:.2f} ({1e6 * c_cost / c_in:.3f} $/M-in blended)"
+    )
+
+    print("\n== the 8 asymmetric failures (README §4) ==")
+    for r in rows:
+        s = r["stella"]
+        if not s["pass"] and r["claude"]["pass"]:
+            cls = (
+                "ceiling/timeout death"
+                if s["failure"] or s["cap_hits"]
+                else "clean-fail (verifier said no)"
+            )
+            print(
+                f"  {r['task']:28s} caps={s['cap_hits']} steps={s['steps']:3d} "
+                f"wall={s['wall_s']:5d}s fail={s['failure'] or '-':26s} {cls}"
+            )
+
+    print("\n== medians, for the curious ==")
+    print(
+        f"median in/step: stella "
+        f"{statistics.median(r['stella']['in_tokens'] / max(1, r['stella']['steps']) for r in rows):,.0f}, "
+        f"claude "
+        f"{statistics.median(r['claude']['in_tokens'] / max(1, r['claude']['steps']) for r in rows):,.0f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/evidence/readiness-5task/README.md
+++ b/bench/evidence/readiness-5task/README.md
@@ -1,0 +1,75 @@
+# Readiness probe: the 5 clean-fail tasks
+
+A development (non-claim) Harbor run of the five tasks the GLM-5.2
+head-to-head showed Stella failing cleanly while Claude Code passed —
+`fix-git`, `sanitize-git-repo`, `openssl-selfsigned-cert`, `kv-store-grpc`,
+`fix-code-vulnerability` (selection rationale:
+[`../glm52-h2h-postmortem/README.md`](../glm52-h2h-postmortem/README.md) §4).
+All five are verifier-decided capability misses with no ceiling or timeout
+confound, which makes them the cheapest honest probe of whether the
+post-head-to-head harness work (#1212 git baseline, #1213 exit-cause +
+provider streaming, #1214 worker lifecycle) moved the class.
+
+## Run design
+
+* SUT: `e5f9e07dee94b053021bbd262f8af2257b05dd8e` (this branch's base),
+  cross-built `x86_64-unknown-linux-gnu.2.17` via `cargo-zigbuild`,
+  offline smoke test 5/5.
+* Dataset: the pinned 89-task export
+  (`terminal-bench/terminal-bench-2-1@sha256:7d7bdc1c…`), five tasks staged
+  locally; images pre-pulled first (registry availability as a precondition,
+  per `bench/evidence/run/README.md`).
+* Plain `harbor run` + `stella_harbor:StellaAgent`, `--n-attempts 1`,
+  `--max-retries 0`, `--n-concurrent 2`. Ambient `STELLA_*` selectors are
+  scrubbed at launch so the trial executes the frozen control posture, not an
+  accidental triage/judge-pin arm (this sandbox exports
+  `STELLA_TRIAGE_MODEL`, which is a registered arm selector).
+* **Non-claim by construction**: no secure launcher, no intent ledger, and
+  the environment adaptations below.
+
+## Environment adaptations (disclosed, dev-only)
+
+The run executes inside a sandbox that re-signs **all** egress TLS at an
+upstream gateway with a private CA. The frozen binary verifies against its
+bundled webpki roots and correctly refuses that chain, so trial containers
+cannot reach any provider endpoint directly. Adaptations, none touching the
+frozen adapter or SUT:
+
+1. **Host-side TLS relay** — a plain-HTTP listener on the docker bridge that
+   rewrites `Host`, forwards over TLS to the real provider endpoint trusting
+   the gateway CA, and streams responses (SSE-safe). Stella reaches it via
+   `STELLA_BASE_URL`; the provider key still travels only
+   container → relay → provider on one VM.
+2. **HTTP/1.1 shim for Harbor's own tooling** — the gateway proxy cannot
+   carry HTTP/2 and harbor's supabase client stack hard-codes `http2=True`;
+   a venv-local `.pth` hook coerces httpx to HTTP/1.1. Dev venv only; the
+   secure claim launcher runs `python -S` and never loads it.
+3. **Provider route** — the canonical `openrouter/*` path pins
+   `https://openrouter.ai/api/v1` inside the adapter and therefore cannot
+   traverse the relay, so the run uses Stella's `local/` (OpenAI-compatible)
+   provider pointed at the relay with the OpenRouter key as
+   `LOCAL_API_KEY`. Model: `z-ai/glm-5.2` — the head-to-head's own model.
+
+## Status
+
+Infrastructure proven end-to-end; scored run pending credentials.
+
+* **Attempt 1 (anthropic/claude-sonnet-5, job
+  `stella-readiness-5task-20260803`):** all five trials launched, containers
+  built, binary verified in-container, triage fired, and every trial reached
+  the live Anthropic API through the relay — which answered
+  `"Your credit balance is too low to access the Anthropic API"` on the
+  worker's first paid call. Every Anthropic key provisioned in this
+  environment resolves to the same zero-credit account, so the attempt is an
+  operational abort (credentials), not an agent outcome: rewards were never
+  observed, and per the run rules the relaunch uses a fresh job name.
+* The AWS credentials in this environment can invoke
+  `us.anthropic.claude-sonnet-4-6` on Bedrock (verified with a 1-token
+  converse), but `stella_harbor` deliberately refuses Bedrock's multi-value
+  credential chain, so that route is out for Harbor trials.
+* The OpenRouter relaunch is staged turnkey
+  (`/home/user/tb-run/launch-openrouter.sh` in the run sandbox) and blocked
+  solely on an `OPENROUTER_API_KEY`.
+
+Per-task results, event streams, and the scored table land here when the
+run completes.


### PR DESCRIPTION
## What & why

Three pieces of readiness work ahead of the next preregistered Terminal-Bench run, all reading the evidence the 89-task GLM-5.2 head-to-head left behind:

1. **`bench/evidence/glm52-h2h-postmortem/`** — a post-mortem of the two numbers the winning 58/89 hides: the **106 output-cap hits** (Claude Code: 0) and the **366M-vs-57M input-token gap** (6.40×). Findings: 74 of the 106 cap hits were absorbed by passing trials (cap-hit tasks passed at 72.7% vs 57.8% without), but ≥32.7% of all Stella output was burned in zero-action steps, and the fatal tail is a distinct "first-step mega-reasoning" shape (`write-compressor`: ≥99.4% of its output in 3 cap-hit steps across a 7-step life). The input gap decomposes as 1.58× more steps × 4.06× more input per step; context-growth fits (378 vs 111 tokens/step) put a **3.1× input reduction** on the table from recall/context engineering alone, before touching step counts or posture. `analyze.py` recomputes every quoted figure from the committed head-to-head table.
2. **`PROPOSAL-fable-128k-posture.md`** — the Fable-class ceiling set (`max_tokens` 64,000 → 128,000 for default/worker/judge, `model_timeout` 816s → 1,572s provisional) written as a **preregistration decision memo with maintainer sign-off checkboxes**. Reference digests are computed through the adapter's own canonicalization (the frozen Sonnet-5 digest reproduces READINESS §8.4.3's registered `3c428a22…`). **No frozen posture, engine constant, or registered digest changes in this PR.**
3. **`bench/evidence/readiness-5task/`** — design, disclosed dev-environment adaptations, and status of a 5-task readiness probe over the five tasks Stella failed cleanly while Claude Code passed (`fix-git`, `sanitize-git-repo`, `openssl-selfsigned-cert`, `kv-store-grpc`, `fix-code-vulnerability`). Infrastructure is proven end-to-end (SUT cross-built at the glibc-2.17 floor, smoke 5/5, pinned dataset, pre-pulled images, containers → binary → live provider API); the first scored attempt aborted operationally on a zero-credit provider account and the relaunch is staged pending a credential. Scored results land on this branch when the run completes.

Refs #909, #1007, #1213

## The witness

- [x] No witness needed (pure docs/evidence — no executable behavior changes) — because: the PR adds analysis documents, a decision memo, and one stdlib-only analysis script whose output *is* the reproducibility check (it recomputes every figure in the prose from the committed JSON; a mismatch is visible by running it).

## The gate

- [x] `cargo fmt --check` — no Rust changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust changes
- [x] `cargo test --workspace` — no Rust changes
- [x] Docs updated where behavior/flags changed — n/a (no behavior/flags changed)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` — deliberately **not** used: this PR advances #909/#1007 without finishing them (`Refs` above)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls (the analysis script is offline/stdlib-only)

## Anything reviewers should know?

- The posture proposal is deliberately **not implemented** — changing the cap changes the frozen digest and half of it (`model_timeout`) is a SUT re-freeze, so it is presented as a decision memo per the run-ledger rules. The digests in its table are labelled reference values; the launcher manifest stays authoritative.
- The 5-task probe runs as a plain-`harbor` development run (non-claim by construction). Its README discloses every sandbox adaptation (TLS relay for the egress-gateway CA, an HTTP/1.1 shim for harbor's supabase client in the dev venv only) — none touch the frozen adapter, launcher, or SUT.
- The head-to-head evidence source is the committed docs table (`stella-docs/benchmarks/terminal-bench-2-1-glm-5-2.json`); per-trial event streams were not retained by that run, which the post-mortem calls out explicitly where it limits a conclusion.

---

## Summary by Sourcery

Add post-mortem evidence and readiness documentation for the GLM-5.2 head-to-head run, including a reproducible analysis script and a proposal for Fable-class posture, plus a 5-task readiness probe design.

Enhancements:
- Introduce a reproducible, stdlib-only analysis script that recomputes GLM-5.2 head-to-head metrics from the committed benchmark table.

Documentation:
- Document the GLM-5.2 head-to-head post-mortem, detailing cap-hit behavior, input-token gap analysis, and asymmetric failures.
- Add a preregistration decision memo proposing Fable-class ceiling settings (128k output cap and scaled model timeout) with maintainer approval checkpoints.
- Describe the design, environment adaptations, and status of a 5-task readiness probe targeting the clean-fail tasks from the GLM-5.2 benchmark.
