### PR TITLE
fix(#940): five audit findings — symlink deletes, rollback ownership, rg config scrub, size-skip reporting, HTTP-date Retry-After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,34 @@ skip the roll) were re-inserted the same way.
 
 ## [Unreleased]
 
+### Fixed
+
+- `delete_file` now removes a **symlink itself** instead of the file it points
+  at. The path resolver canonicalizes, so deleting an in-tree symlink (a
+  vendored config, a `node_modules/.bin` entry) silently destroyed the target
+  and left the link dangling, reported as an ordinary deletion. A dangling
+  symlink is now deletable too, and the tool says which of the two it removed.
+- `apply_edits` no longer reverts a write that arrived from outside the batch.
+  When a mid-batch write failed, the rollback restored the bytes captured
+  during validation unconditionally — destroying any change a formatter,
+  watcher, or editor had made in between while still reporting a clean
+  all-or-nothing abort. Files whose bytes are no longer the batch's are left
+  alone and named in the error.
+- `RIPGREP_CONFIG_PATH` is scrubbed from tool subprocesses, alongside the
+  `GIT_CONFIG_*` family it matches. A planted `rg` config (`--max-count=1`, a
+  hiding `--glob`) silently truncated what the `grep` tool returned, and the
+  agent read the shortfall as fact.
+- `Retry-After` is honored in its HTTP-date form, not only as delta-seconds.
+  A provider behind a CDN — the deployments that actually rate-limit — had its
+  stated backoff window dropped, and the retry landed back inside it.
+
+### Changed
+
+- `stella init`'s code-graph summary reports files skipped for exceeding the
+  indexer's size ceiling, beside the existing generated-file count. The
+  exclusion was counted and surfaced nowhere, so a large file leaving the index
+  looked like a file with no symbols in it.
+
 ## [0.6.72] — 2026-08-03
 
 ## [0.6.71] — 2026-08-02

--- a/stella-cli/src/agent/graph.rs
+++ b/stella-cli/src/agent/graph.rs
@@ -63,6 +63,7 @@ pub(super) fn index_workspace_graph_blocking(
         files_parsed: stats.files_parsed,
         files_unchanged: stats.files_skipped_unchanged,
         files_skipped_generated: stats.files_skipped_generated,
+        files_skipped_too_large: stats.files_skipped_too_large,
     };
     graph.shutdown();
     Ok(summary)
@@ -81,14 +82,21 @@ pub(super) struct GraphSummary {
     /// separately from `total_files` so the exclusion is visible, not just
     /// silently absent from the count.
     pub(super) files_skipped_generated: usize,
+    /// Files this pass excluded for exceeding the indexer's 4 MiB ceiling (a
+    /// memory bound on tree-sitter, whose syntax tree runs several times the
+    /// size of its source). Same reason the generated count is here: a user
+    /// whose file left the index otherwise gets no signal at all, and reads
+    /// the graph's silence about it as the file having no symbols.
+    pub(super) files_skipped_too_large: usize,
 }
 
 /// The `✓ code graph: N symbols, M imports…` summary line, shared by `stella
 /// init` and the session auto-builder so both surfaces read identically.
 /// Reports index totals; the parenthetical is this pass's parse/skip split.
-/// When this pass excluded any generated/minified files, an explicit
-/// "skipped N generated files" clause makes that visible rather than letting
-/// them silently vanish from the file count (issue #272).
+/// Each exclusion this pass made gets its own trailing clause — "skipped N
+/// generated files" (issue #272), "skipped N files over the size limit" — so
+/// a file that left the index says so, instead of silently vanishing from the
+/// count and reading as a file with no symbols in it.
 pub(super) fn format_graph_stats(summary: &GraphSummary) -> String {
     let base = format!(
         "✓ code graph: {} symbols, {} imports across {} file{} ({} re-parsed, {} unchanged this pass)",
@@ -99,18 +107,25 @@ pub(super) fn format_graph_stats(summary: &GraphSummary) -> String {
         summary.files_parsed,
         summary.files_unchanged,
     );
-    if summary.files_skipped_generated == 0 {
+    let clauses: Vec<String> = [
+        (summary.files_skipped_generated, "generated file"),
+        (summary.files_skipped_too_large, "file over the size limit"),
+    ]
+    .into_iter()
+    .filter(|(count, _)| *count > 0)
+    .map(|(count, noun)| {
+        // "file over the size limit" pluralizes on the noun, not the tail.
+        let plural = noun.replacen("file", "files", 1);
+        format!(
+            "skipped {count} {}",
+            if count == 1 { noun } else { &plural }
+        )
+    })
+    .collect();
+    if clauses.is_empty() {
         return base;
     }
-    format!(
-        "{base} — skipped {} generated file{}",
-        summary.files_skipped_generated,
-        if summary.files_skipped_generated == 1 {
-            ""
-        } else {
-            "s"
-        }
-    )
+    format!("{base} — {}", clauses.join(", "))
 }
 
 /// A session-lifetime holder for the live code graph. It keeps the in-process

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -1464,79 +1464,8 @@ mod usage_completeness;
 #[path = "agent_tests/engine_wiring.rs"]
 mod engine_wiring;
 
-/// Issue #272: `stella init`'s summary line must surface generated/minified
-/// exclusion count, not let excluded files silently vanish from the totals.
-/// Tested on the pure builder/output functions, never a live TTY.
-#[test]
-fn format_graph_stats_reports_generated_skip_count_when_nonzero() {
-    let summary = GraphSummary {
-        total_symbols: 12,
-        total_imports: 4,
-        total_files: 3,
-        files_parsed: 2,
-        files_unchanged: 1,
-        files_skipped_generated: 5,
-    };
-    let line = format_graph_stats(&summary);
-    assert!(
-        line.contains("skipped 5 generated files"),
-        "line should surface the skip count: {line}"
-    );
-    assert!(line.contains("12 symbols"), "{line}");
-}
-
-#[test]
-fn format_graph_stats_omits_the_skip_clause_when_nothing_was_skipped() {
-    let summary = GraphSummary {
-        total_symbols: 1,
-        total_imports: 0,
-        total_files: 1,
-        files_parsed: 1,
-        files_unchanged: 0,
-        files_skipped_generated: 0,
-    };
-    let line = format_graph_stats(&summary);
-    assert!(
-        !line.contains("skipped"),
-        "no skip clause when nothing was excluded: {line}"
-    );
-}
-
-#[test]
-fn format_graph_stats_uses_singular_file_for_a_count_of_one() {
-    let summary = GraphSummary {
-        total_symbols: 0,
-        total_imports: 0,
-        total_files: 0,
-        files_parsed: 0,
-        files_unchanged: 0,
-        files_skipped_generated: 1,
-    };
-    let line = format_graph_stats(&summary);
-    assert!(line.contains("skipped 1 generated file"), "{line}");
-    assert!(
-        !line.contains("generated files"),
-        "singular, not plural, for a count of one: {line}"
-    );
-}
-
-/// End-to-end through the real builder `stella init` calls
-/// ([`index_workspace_graph_blocking`]): a `*.min.*` file sitting at the
-/// workspace root (no denied directory involved) must be excluded and
-/// counted, while an ordinary file alongside it indexes normally.
-#[test]
-fn index_workspace_graph_blocking_reports_generated_skips_end_to_end() {
-    let ws = tempfile::tempdir().unwrap();
-    std::fs::write(ws.path().join("app.min.js"), "function refresh(){}\n").unwrap();
-    std::fs::write(ws.path().join("main.rs"), "pub fn run() {}\n").unwrap();
-
-    let summary = index_workspace_graph_blocking(ws.path()).expect("index build succeeds");
-    assert_eq!(summary.total_files, 1, "the minified file is never indexed");
-    assert_eq!(summary.files_skipped_generated, 1);
-
-    let line = format_graph_stats(&summary);
-    assert!(line.contains("skipped 1 generated file"), "{line}");
-}
+#[path = "agent_tests/code_graph.rs"]
+mod code_graph;
 
 /// Issue #644: the machine-readable envelope declares its contract version, and
 /// declares the *same* one on both arms. A version present on the success shape

--- a/stella-cli/src/agent_tests/code_graph.rs
+++ b/stella-cli/src/agent_tests/code_graph.rs
@@ -1,0 +1,153 @@
+//! The code-graph build cluster's reporting surface: what `stella init`'s
+//! summary line says about the files the indexer left out.
+//!
+//! Split out of `agent_tests.rs` when it grew past its file-size ceiling
+//! (#629) — the guard's rule is that new code goes in its own module rather
+//! than onto the end of an already-oversized file, and the issue #940
+//! size-limit tests below were the growth that tripped it. The whole
+//! `format_graph_stats` / `index_workspace_graph_blocking` group moves
+//! together: every exclusion the indexer counts is one subject, and splitting
+//! the generated case from the size-limit case would leave two half-stories.
+//!
+//! `GraphSummary`, `format_graph_stats` and `index_workspace_graph_blocking`
+//! come through the parent's `use super::*`, exactly as `engine_wiring` does.
+
+use super::*;
+
+/// Issue #272: `stella init`'s summary line must surface generated/minified
+/// exclusion count, not let excluded files silently vanish from the totals.
+/// Tested on the pure builder/output functions, never a live TTY.
+#[test]
+fn format_graph_stats_reports_generated_skip_count_when_nonzero() {
+    let summary = GraphSummary {
+        total_symbols: 12,
+        total_imports: 4,
+        total_files: 3,
+        files_parsed: 2,
+        files_unchanged: 1,
+        files_skipped_generated: 5,
+        files_skipped_too_large: 0,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(
+        line.contains("skipped 5 generated files"),
+        "line should surface the skip count: {line}"
+    );
+    assert!(line.contains("12 symbols"), "{line}");
+}
+
+#[test]
+fn format_graph_stats_omits_the_skip_clause_when_nothing_was_skipped() {
+    let summary = GraphSummary {
+        total_symbols: 1,
+        total_imports: 0,
+        total_files: 1,
+        files_parsed: 1,
+        files_unchanged: 0,
+        files_skipped_generated: 0,
+        files_skipped_too_large: 0,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(
+        !line.contains("skipped"),
+        "no skip clause when nothing was excluded: {line}"
+    );
+}
+
+#[test]
+fn format_graph_stats_uses_singular_file_for_a_count_of_one() {
+    let summary = GraphSummary {
+        total_symbols: 0,
+        total_imports: 0,
+        total_files: 0,
+        files_parsed: 0,
+        files_unchanged: 0,
+        files_skipped_generated: 1,
+        files_skipped_too_large: 0,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(line.contains("skipped 1 generated file"), "{line}");
+    assert!(
+        !line.contains("generated files"),
+        "singular, not plural, for a count of one: {line}"
+    );
+}
+
+/// End-to-end through the real builder `stella init` calls
+/// ([`index_workspace_graph_blocking`]): a `*.min.*` file sitting at the
+/// workspace root (no denied directory involved) must be excluded and
+/// counted, while an ordinary file alongside it indexes normally.
+#[test]
+fn index_workspace_graph_blocking_reports_generated_skips_end_to_end() {
+    let ws = tempfile::tempdir().unwrap();
+    std::fs::write(ws.path().join("app.min.js"), "function refresh(){}\n").unwrap();
+    std::fs::write(ws.path().join("main.rs"), "pub fn run() {}\n").unwrap();
+
+    let summary = index_workspace_graph_blocking(ws.path()).expect("index build succeeds");
+    assert_eq!(summary.total_files, 1, "the minified file is never indexed");
+    assert_eq!(summary.files_skipped_generated, 1);
+
+    let line = format_graph_stats(&summary);
+    assert!(line.contains("skipped 1 generated file"), "{line}");
+}
+
+/// Issue #940: `files_skipped_too_large` was counted by the indexer and
+/// surfaced nowhere, so a user whose large file left the index got no signal
+/// at all — the graph simply answered as if the file held no symbols. It rides
+/// beside the generated count, and both clauses appear when both fired.
+#[test]
+fn format_graph_stats_reports_the_size_limit_skip_count() {
+    let summary = GraphSummary {
+        total_symbols: 9,
+        total_imports: 2,
+        total_files: 4,
+        files_parsed: 4,
+        files_unchanged: 0,
+        files_skipped_generated: 0,
+        files_skipped_too_large: 3,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(
+        line.contains("skipped 3 files over the size limit"),
+        "the size-cap exclusion must be visible: {line}"
+    );
+
+    let both = format_graph_stats(&GraphSummary {
+        files_skipped_generated: 2,
+        files_skipped_too_large: 1,
+        ..summary
+    });
+    assert!(both.contains("skipped 2 generated files"), "{both}");
+    assert!(
+        both.contains("skipped 1 file over the size limit"),
+        "singular, not plural, for a count of one: {both}"
+    );
+}
+
+/// End-to-end through the real builder `stella init` calls: a file past the
+/// indexer's size ceiling is excluded, counted, and named on the summary line,
+/// while an ordinary file alongside it indexes normally.
+#[test]
+fn index_workspace_graph_blocking_reports_size_limit_skips_end_to_end() {
+    let ws = tempfile::tempdir().unwrap();
+    // Short lines of real syntax — indistinguishable from hand-written source
+    // to every filter except the size cap (which stella-graph keeps private).
+    let mut huge = String::new();
+    let mut n = 0u32;
+    while huge.len() <= 4 * 1024 * 1024 {
+        huge.push_str(&format!("function generated_{n}() {{ return {n}; }}\n"));
+        n += 1;
+    }
+    std::fs::write(ws.path().join("huge.js"), &huge).unwrap();
+    std::fs::write(ws.path().join("main.rs"), "pub fn run() {}\n").unwrap();
+
+    let summary = index_workspace_graph_blocking(ws.path()).expect("index build succeeds");
+    assert_eq!(summary.files_skipped_too_large, 1);
+    assert_eq!(summary.total_files, 1, "the oversize file is never indexed");
+
+    let line = format_graph_stats(&summary);
+    assert!(
+        line.contains("skipped 1 file over the size limit"),
+        "{line}"
+    );
+}

--- a/stella-model/src/http.rs
+++ b/stella-model/src/http.rs
@@ -119,15 +119,99 @@ pub(crate) fn classify_unary_dispatch_error(label: &str, error: &reqwest::Error)
     ProviderError::Transport(error.to_string())
 }
 
-/// Parse a `Retry-After` header (delta-seconds form, RFC 9110 §10.2.3) into
-/// a millisecond hint for the retry policy — `stella-core/src/retry.rs`
-/// honors `RateLimited.retry_after_ms` when present. The HTTP-date form is
-/// not handled (providers send seconds on 429s); an absent or unparseable
-/// value yields `None` rather than an error.
+/// Parse a `Retry-After` header (RFC 9110 §10.2.3) into a millisecond hint
+/// for the retry policy — `stella-core/src/retry.rs` honors
+/// `RateLimited.retry_after_ms` when present. An absent or unparseable value
+/// yields `None` rather than an error.
 pub(crate) fn parse_retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
-    let value = headers.get(reqwest::header::RETRY_AFTER)?;
-    let seconds: u64 = value.to_str().ok()?.trim().parse().ok()?;
-    Some(seconds.saturating_mul(1000))
+    let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    retry_after_ms_at(value, unix_epoch_secs_now())
+}
+
+/// Seconds since the Unix epoch, or 0 if the system clock is set before it.
+/// Split out so [`retry_after_ms_at`] stays a pure function of its inputs and
+/// the HTTP-date arm is testable without a fixed system clock.
+fn unix_epoch_secs_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// The pure half of [`parse_retry_after_ms`]: `value` interpreted against a
+/// caller-supplied clock.
+///
+/// Both RFC 9110 forms are accepted. Delta-seconds is what every major API
+/// sends directly; the HTTP-date form is what a CDN or reverse proxy in front
+/// of one emits — and a deployment fronted by a CDN is exactly the deployment
+/// that rate-limits. Ignoring the date form did not fail loudly: the hint came
+/// back `None`, the driver fell back to its computed backoff, and the retry
+/// landed back inside the window the server had just named.
+///
+/// A date already in the past yields `Some(0)`; the retry policy floors a zero
+/// hint at its own base delay, so "retry now" is expressed rather than
+/// discarded. The two obsolete formats RFC 9110 §5.6.7 lists (RFC 850 and
+/// asctime) are deliberately not parsed — nothing observed emits them, and
+/// they degrade to `None` exactly as the date form used to.
+fn retry_after_ms_at(value: &str, now_epoch_secs: i64) -> Option<u64> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(seconds.saturating_mul(1000));
+    }
+    let deadline = imf_fixdate_epoch_secs(value)?;
+    Some((deadline - now_epoch_secs).max(0).saturating_mul(1000) as u64)
+}
+
+const MONTHS: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/// Seconds since the Unix epoch for an IMF-fixdate — `Sun, 06 Nov 1994
+/// 08:49:37 GMT`, the one form RFC 9110 §5.6.7 allows a sender to generate.
+/// Strict by design: a header this function cannot read exactly is a header
+/// whose meaning we would be guessing at, and `None` costs only the fallback
+/// to computed backoff.
+fn imf_fixdate_epoch_secs(value: &str) -> Option<i64> {
+    // The day-of-week is redundant with the date and is not cross-checked;
+    // a sender that disagrees with itself is not a reason to drop the hint.
+    let (_weekday, rest) = value.split_once(", ")?;
+    let mut fields = rest.split(' ');
+    let day: i64 = fields.next()?.parse().ok()?;
+    let month_name = fields.next()?;
+    let month = MONTHS.iter().position(|name| *name == month_name)? as i64 + 1;
+    let year: i64 = fields.next()?.parse().ok()?;
+    let mut clock = fields.next()?.split(':');
+    // GMT is the only zone the grammar permits, so anything else is a
+    // malformed header rather than another time zone to convert from.
+    if fields.next()? != "GMT" || fields.next().is_some() {
+        return None;
+    }
+    let hour: i64 = clock.next()?.parse().ok()?;
+    let minute: i64 = clock.next()?.parse().ok()?;
+    let second: i64 = clock.next()?.parse().ok()?;
+    if clock.next().is_some() {
+        return None;
+    }
+    // A leap second is spelled `:60`; it maps onto the same POSIX epoch
+    // second as `:59`, which is the closest a Unix timestamp can represent.
+    if !(1..=31).contains(&day) || hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    Some(days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second.min(59))
+}
+
+/// Days between 1970-01-01 and a proleptic-Gregorian `y-m-d`, by Howard
+/// Hinnant's `days_from_civil`. Written out rather than pulling in a date
+/// crate for one header: this is the whole of the calendar arithmetic an
+/// IMF-fixdate needs, and it handles the leap rules exactly. `m` is 1-based
+/// and assumed in range (its caller validates).
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400; // [0, 399]
+    let day_of_year = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
 }
 
 /// Best-effort extraction of the human `message` from a provider's
@@ -410,6 +494,98 @@ mod tests {
     fn client_builds_without_panicking() {
         // Smoke test: the connect-timeout client constructs on this platform.
         let _ = client();
+    }
+
+    /// The reference epoch every date case below is stated against:
+    /// `Sun, 06 Nov 1994 08:49:37 GMT`, RFC 9110 §5.6.7's own example.
+    const RFC_EXAMPLE_EPOCH: i64 = 784_111_777;
+
+    #[test]
+    fn delta_seconds_is_still_the_common_form() {
+        assert_eq!(retry_after_ms_at("120", 0), Some(120_000));
+        assert_eq!(retry_after_ms_at("  30 ", 0), Some(30_000));
+        assert_eq!(retry_after_ms_at("0", 0), Some(0));
+    }
+
+    /// Issue #940: the HTTP-date form was ignored, so a provider fronted by a
+    /// CDN — the deployments that actually rate-limit — had its stated window
+    /// dropped and the driver retried back inside it on computed backoff.
+    #[test]
+    fn an_http_date_becomes_the_remaining_wait() {
+        assert_eq!(
+            imf_fixdate_epoch_secs("Sun, 06 Nov 1994 08:49:37 GMT"),
+            Some(RFC_EXAMPLE_EPOCH),
+            "the RFC's own example must land on its own epoch second"
+        );
+        assert_eq!(
+            retry_after_ms_at("Sun, 06 Nov 1994 08:49:37 GMT", RFC_EXAMPLE_EPOCH - 90),
+            Some(90_000),
+            "the hint is the wait remaining, not the timestamp"
+        );
+    }
+
+    /// A window that has already closed means "retry now" — expressed as a
+    /// zero hint (which the retry policy floors at its own base delay), never
+    /// as a negative wait and never as a dropped hint.
+    #[test]
+    fn an_elapsed_http_date_is_zero_not_negative_and_not_dropped() {
+        assert_eq!(
+            retry_after_ms_at("Sun, 06 Nov 1994 08:49:37 GMT", RFC_EXAMPLE_EPOCH + 600),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn the_calendar_arithmetic_handles_leap_years_and_epoch_boundaries() {
+        for (header, epoch) in [
+            ("Thu, 01 Jan 1970 00:00:00 GMT", 0),
+            ("Wed, 31 Dec 1969 23:59:59 GMT", -1),
+            // 2000 is a leap year (divisible by 400); 1900 was not.
+            ("Tue, 29 Feb 2000 12:00:00 GMT", 951_825_600),
+            ("Mon, 01 Mar 2100 00:00:00 GMT", 4_107_542_400),
+            // A leap second collapses onto the same POSIX second as :59.
+            ("Sat, 31 Dec 2016 23:59:60 GMT", 1_483_228_799),
+        ] {
+            assert_eq!(imf_fixdate_epoch_secs(header), Some(epoch), "{header}");
+        }
+    }
+
+    /// Strictness is the point: a header we cannot read exactly is one whose
+    /// meaning we would be guessing at, and `None` only costs the fallback to
+    /// computed backoff. The two obsolete RFC 9110 §5.6.7 formats are among
+    /// these deliberately.
+    #[test]
+    fn a_malformed_or_obsolete_date_yields_no_hint_rather_than_a_wrong_one() {
+        for header in [
+            "",
+            "soon",
+            "-30",
+            "1.5",
+            "Sun, 06 Nov 1994 08:49:37 PST", // only GMT is in the grammar
+            "Sun, 06 Nov 1994 08:49:37 GMT extra", // trailing junk
+            "Sun, 06 Nov 1994 08:49 GMT",    // no seconds
+            "Sun, 06 Xyz 1994 08:49:37 GMT", // not a month
+            "Sun, 06 Nov 1994 25:49:37 GMT", // hour out of range
+            "Sun, 32 Nov 1994 08:49:37 GMT", // day out of range
+            "Sunday, 06-Nov-94 08:49:37 GMT", // obsolete RFC 850 form
+            "Sun Nov  6 08:49:37 1994",      // obsolete asctime form
+        ] {
+            assert_eq!(retry_after_ms_at(header, 0), None, "{header:?}");
+        }
+    }
+
+    #[test]
+    fn the_header_map_path_reads_both_forms() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        assert_eq!(parse_retry_after_ms(&headers), None);
+        headers.insert(reqwest::header::RETRY_AFTER, "45".parse().unwrap());
+        assert_eq!(parse_retry_after_ms(&headers), Some(45_000));
+        // Long past, so the answer is deterministic against the real clock.
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "Sun, 06 Nov 1994 08:49:37 GMT".parse().unwrap(),
+        );
+        assert_eq!(parse_retry_after_ms(&headers), Some(0));
     }
 
     #[test]

--- a/stella-tools/src/apply_edits.rs
+++ b/stella-tools/src/apply_edits.rs
@@ -13,7 +13,10 @@
 //!    full, permissions), every touched file — the one that failed included —
 //!    is **rolled back** to its original bytes so the tree is never left
 //!    half-applied; a file that cannot be restored is named loudly in the
-//!    error instead of being reported clean.
+//!    error instead of being reported clean. The rollback restores only what
+//!    the batch still owns: a file whose bytes no longer match what this batch
+//!    wrote belongs to whoever wrote it last, and is reported rather than
+//!    reverted (see `roll_back_prior_writes`).
 //!
 //! One transactional call also fits the engine's concurrency model better
 //! than N serial `edit_file` barriers: mutating tools are never
@@ -114,6 +117,52 @@ fn parse_edits(input: &Value) -> Result<Vec<ParsedEdit>, String> {
             Ok(parsed)
         })
         .collect()
+}
+
+/// One touched file: (display path, full path, original bytes, final bytes).
+type TouchedFile = (String, std::path::PathBuf, String, String);
+
+/// Restore every file this batch already wrote back to its pre-batch bytes,
+/// returning the lines the caller appends to its error.
+///
+/// A file is rolled back only while the batch still owns it. Between our write
+/// and the failure that triggered this, something else — a formatter, a
+/// watcher, the user's editor — may have rewritten the file; restoring the
+/// pre-batch bytes over that silently reverts THEIR change under the banner of
+/// a clean abort. Ownership is decided by comparing the bytes on disk to the
+/// bytes we wrote, which are already in memory, so an exact comparison costs no
+/// more than a hash and cannot collide. A file we cannot read is not evidence
+/// of foreign ownership, so it still rolls back.
+///
+/// An empty return means every already-written file is back to its original
+/// content.
+async fn roll_back_prior_writes(
+    files: &HashMap<String, TouchedFile>,
+    written: &[String],
+) -> String {
+    let mut note = String::new();
+    for key in written {
+        let (path, full, original, ours) = &files[key];
+        if matches!(tokio::fs::read(full).await, Ok(now) if now != ours.as_bytes()) {
+            note.push_str(&format!(
+                "\n  NOT ROLLED BACK: `{path}` was changed by something else after this batch \
+                 wrote it — its current content was left alone; reconcile it by hand"
+            ));
+            continue;
+        }
+        // The rollback especially must not truncate: a failed rollback with a
+        // truncating write turns a partial batch into a destroyed file.
+        if crate::durable_write::write_file_durably(full.clone(), original.as_bytes().to_vec())
+            .await
+            .is_err()
+        {
+            note.push_str(&format!(
+                "\n  ROLLBACK FAILED for `{path}` — restore it manually from the content you \
+                 last read"
+            ));
+        }
+    }
+    note
 }
 
 /// The batch's composed post-edit content for one `path` — the SAME
@@ -329,7 +378,7 @@ impl Tool for ApplyEdits {
         // ---- Phase 2: apply — one write per touched file, in first-touch
         // order. On a mid-batch write failure, roll back every file already
         // written to its original bytes so the tree never stays half-applied.
-        let mut written: Vec<&String> = Vec::new();
+        let mut written: Vec<String> = Vec::new();
         for key in &order {
             let (path, full, _, simulated) = &files[key];
             if let Err(e) = crate::durable_write::write_file_durably(
@@ -364,24 +413,7 @@ impl Tool for ApplyEdits {
                          the content you last read"
                     ));
                 }
-                for prior in &written {
-                    let (prior_path, prior_full, original, _) = &files[*prior];
-                    // The rollback especially must not truncate: a failed
-                    // rollback with a truncating write turns a partial batch
-                    // into a destroyed file.
-                    if crate::durable_write::write_file_durably(
-                        prior_full.clone(),
-                        original.as_bytes().to_vec(),
-                    )
-                    .await
-                    .is_err()
-                    {
-                        rollback_note.push_str(&format!(
-                            "\n  ROLLBACK FAILED for `{prior_path}` — restore it manually from \
-                             the content you last read"
-                        ));
-                    }
-                }
+                rollback_note.push_str(&roll_back_prior_writes(&files, &written).await);
                 if rollback_note.is_empty() {
                     rollback_note = format!(
                         "\n  every touched file (including `{path}`) holds its original \
@@ -395,7 +427,7 @@ impl Tool for ApplyEdits {
                     ),
                 };
             }
-            written.push(key);
+            written.push(key.clone());
         }
         // The model knows the bytes it just produced (#331) — record every
         // final content so these writes are never misattributed as drift.
@@ -784,6 +816,98 @@ mod tests {
         assert!(
             !message.contains("ROLLBACK FAILED"),
             "an intact failing file must not raise a manual-restore alarm: {message}"
+        );
+    }
+
+    /// One entry of the rollback's view of a touched file: the bytes it found
+    /// before the batch, and the bytes the batch wrote.
+    fn touched(
+        key: &str,
+        full: &std::path::Path,
+        original: &str,
+        ours: &str,
+    ) -> (String, TouchedFile) {
+        (
+            key.to_string(),
+            (
+                key.to_string(),
+                full.to_path_buf(),
+                original.to_string(),
+                ours.to_string(),
+            ),
+        )
+    }
+
+    /// The audit witness. The rollback restored the bytes captured during
+    /// validation unconditionally, so a write that landed from ANOTHER process
+    /// between our write and the abort was silently reverted — a third party's
+    /// change destroyed, and the error still read as a clean all-or-nothing
+    /// abort. A file whose bytes are no longer ours is left alone and named.
+    #[tokio::test]
+    async fn a_foreign_write_after_ours_is_reported_not_reverted() {
+        let dir = tempfile::tempdir().unwrap();
+        let full = dir.path().join("a.rs");
+        std::fs::write(&full, "someone else wrote this\n").unwrap();
+
+        let files: HashMap<String, TouchedFile> = HashMap::from([touched(
+            "a.rs",
+            &full,
+            "before the batch\n",
+            "the batch wrote this\n",
+        )]);
+        let note = roll_back_prior_writes(&files, &["a.rs".to_string()]).await;
+
+        assert!(note.contains("NOT ROLLED BACK"), "{note}");
+        assert!(note.contains("a.rs"), "{note}");
+        assert_eq!(
+            std::fs::read_to_string(&full).unwrap(),
+            "someone else wrote this\n",
+            "the rollback must not revert a write this batch does not own"
+        );
+    }
+
+    /// The other side of the same rule: bytes still matching what the batch
+    /// wrote are the batch's to undo, and the note stays empty.
+    #[tokio::test]
+    async fn the_rollback_restores_a_file_the_batch_still_owns() {
+        let dir = tempfile::tempdir().unwrap();
+        let full = dir.path().join("a.rs");
+        std::fs::write(&full, "the batch wrote this\n").unwrap();
+
+        let files: HashMap<String, TouchedFile> = HashMap::from([touched(
+            "a.rs",
+            &full,
+            "before the batch\n",
+            "the batch wrote this\n",
+        )]);
+        let note = roll_back_prior_writes(&files, &["a.rs".to_string()]).await;
+
+        assert!(note.is_empty(), "{note}");
+        assert_eq!(
+            std::fs::read_to_string(&full).unwrap(),
+            "before the batch\n"
+        );
+    }
+
+    /// A file we cannot read tells us nothing about who owns it, so the
+    /// all-or-nothing contract wins and it is restored.
+    #[tokio::test]
+    async fn an_unreadable_file_is_still_rolled_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let full = dir.path().join("vanished.rs");
+
+        let files: HashMap<String, TouchedFile> = HashMap::from([touched(
+            "vanished.rs",
+            &full,
+            "before the batch\n",
+            "the batch wrote this\n",
+        )]);
+        let note = roll_back_prior_writes(&files, &["vanished.rs".to_string()]).await;
+
+        assert!(note.is_empty(), "{note}");
+        assert_eq!(
+            std::fs::read_to_string(&full).unwrap(),
+            "before the batch\n"
         );
     }
 }

--- a/stella-tools/src/delete.rs
+++ b/stella-tools/src/delete.rs
@@ -2,6 +2,17 @@
 //! set (create/read/update/delete) so file lifecycle is fully visible to
 //! the Files Touched tracker; agents should prefer this over `bash rm`
 //! (which the tracker cannot attribute).
+//!
+//! A **symlink is removed as the link**, never as its target. That takes its
+//! own resolver (`resolve_entry_within_root`) because
+//! [`crate::resolve_within_root`] canonicalizes, which is right for every
+//! other tool — read/edit/write all want the real file — and exactly wrong
+//! here: canonicalizing `vendor/config.toml → ../../real/config.toml` and
+//! then `remove_file`-ing the result deletes the real file and leaves the
+//! link dangling. Silent data loss on any repository carrying in-tree
+//! symlinks (vendored configs, `node_modules/.bin`).
+
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -11,12 +22,36 @@ use crate::registry::Tool;
 
 pub struct DeleteFile;
 
+/// Resolve `path` to the entry to remove **without following a final
+/// symlink**.
+///
+/// The parent goes through [`crate::resolve_within_root`], so containment is
+/// enforced exactly as everywhere else (including through intermediate
+/// symlinked directories); only the last component is re-joined verbatim.
+/// `file_name` returns `None` for `""`, `.`, and any path ending in `..`, so
+/// those are rejected here rather than resolving to a directory.
+///
+/// `None` means the path escapes the workspace root. A path whose parent does
+/// not exist resolves fine and then fails the caller's own existence check
+/// with the missing-path message.
+fn resolve_entry_within_root(root: &Path, path: &str) -> Option<PathBuf> {
+    let relative = Path::new(path);
+    let name = relative.file_name()?;
+    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+    let parent_full = if parent.as_os_str().is_empty() {
+        root.canonicalize().ok()?
+    } else {
+        crate::resolve_within_root(root, parent.to_str()?)?
+    };
+    Some(parent_full.join(name))
+}
+
 #[async_trait]
 impl Tool for DeleteFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "delete_file".into(),
-            description: "Delete a file in the workspace. Prefer this over `bash rm`.".into(),
+            description: "Delete a file in the workspace. Prefer this over `bash rm`. A symlink is removed as the link; its target is left alone.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -36,12 +71,25 @@ impl Tool for DeleteFile {
                 message: "missing required field `path`".into(),
             };
         };
-        let Some(full) = crate::resolve_within_root(root, path) else {
+        let Some(full) = resolve_entry_within_root(root, path) else {
             return ToolOutput::Error {
                 message: format!("path `{path}` escapes the workspace root"),
             };
         };
-        if !full.is_file() {
+        // lstat, not `is_file()`: the whole point is to see the link rather
+        // than what it points at.
+        let file_type = match tokio::fs::symlink_metadata(&full).await {
+            Ok(meta) => meta.file_type(),
+            Err(_) => {
+                return ToolOutput::Error {
+                    message: format!(
+                        "`{path}` is not a file (directories and missing paths are not deletable \
+                         with this tool)"
+                    ),
+                };
+            }
+        };
+        if !file_type.is_file() && !file_type.is_symlink() {
             return ToolOutput::Error {
                 message: format!(
                     "`{path}` is not a file (directories and missing paths are not deletable \
@@ -49,9 +97,23 @@ impl Tool for DeleteFile {
                 ),
             };
         }
+        // Read the target BEFORE unlinking so the report can name what was
+        // spared — the model otherwise cannot tell a link deletion from a
+        // file deletion, which is the whole ambiguity this fixes.
+        let target = if file_type.is_symlink() {
+            tokio::fs::read_link(&full).await.ok()
+        } else {
+            None
+        };
         match tokio::fs::remove_file(&full).await {
             Ok(()) => ToolOutput::Ok {
-                content: format!("deleted {path}"),
+                content: match target {
+                    Some(target) => format!(
+                        "deleted symlink {path} — the link only; its target `{}` is untouched",
+                        target.display()
+                    ),
+                    None => format!("deleted {path}"),
+                },
             },
             Err(e) => ToolOutput::Error {
                 message: format!("could not delete `{path}`: {e}"),
@@ -86,5 +148,95 @@ mod tests {
             assert!(out.is_error(), "{why} must be rejected: {out:?}");
         }
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The audit witness: deleting a symlink must unlink the LINK, leaving its
+    /// target intact. Before this, the resolver canonicalized first and the
+    /// tool removed the target — silent data loss in any tree with in-tree
+    /// symlinks, reported as an ordinary `deleted <path>`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deleting_a_symlink_removes_the_link_not_its_target() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("vendor")).unwrap();
+        std::fs::write(dir.path().join("real.toml"), "keep me").unwrap();
+        std::os::unix::fs::symlink("../real.toml", dir.path().join("vendor/config.toml")).unwrap();
+
+        let out = DeleteFile
+            .execute(
+                &serde_json::json!({"path": "vendor/config.toml"}),
+                dir.path(),
+            )
+            .await;
+        match out {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("symlink"), "{content}");
+                assert!(content.contains("real.toml"), "{content}");
+            }
+            ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
+        }
+        assert!(
+            !dir.path()
+                .join("vendor/config.toml")
+                .symlink_metadata()
+                .is_ok(),
+            "the link itself must be gone"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("real.toml")).unwrap(),
+            "keep me",
+            "the symlink's target must survive"
+        );
+    }
+
+    /// A dangling symlink is still a link the agent may want gone; before the
+    /// fix it resolved to nothing and the tool reported it as missing.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_dangling_symlink_is_deletable() {
+        let dir = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink("nowhere.txt", dir.path().join("ghost-link")).unwrap();
+
+        let out = DeleteFile
+            .execute(&serde_json::json!({"path": "ghost-link"}), dir.path())
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert!(dir.path().join("ghost-link").symlink_metadata().is_err());
+    }
+
+    /// The last component is re-joined verbatim, so containment has to come
+    /// from the parent's own resolution — including through a symlinked
+    /// directory that points outside the workspace.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlinked_directory_leading_outside_the_root_still_rejects() {
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "private").unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("escape")).unwrap();
+
+        let out = DeleteFile
+            .execute(
+                &serde_json::json!({"path": "escape/secret.txt"}),
+                dir.path(),
+            )
+            .await;
+        assert!(out.is_error(), "{out:?}");
+        assert!(outside.path().join("secret.txt").exists());
+    }
+
+    /// `file_name()` is `None` for these, so they can never resolve to the
+    /// directory they name.
+    #[tokio::test]
+    async fn dot_and_dotdot_tails_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        for tail in ["sub/.", "sub/..", "."] {
+            let out = DeleteFile
+                .execute(&serde_json::json!({"path": tail}), dir.path())
+                .await;
+            assert!(out.is_error(), "`{tail}` must be rejected: {out:?}");
+        }
+        assert!(dir.path().join("sub").is_dir());
     }
 }

--- a/stella-tools/src/subprocess_env.rs
+++ b/stella-tools/src/subprocess_env.rs
@@ -18,15 +18,17 @@
 //! * **Ambient authority** ([`crate::subprocess_env::is_ambient_authority_env_name`]) — the value is
 //!   not a secret, but possessing the variable hands the child authority it
 //!   should not inherit, or redirects what a program it runs will execute.
-//!   `SSH_AUTH_SOCK` (a live agent socket signs for the user's keys) and the
+//!   `SSH_AUTH_SOCK` (a live agent socket signs for the user's keys), the
 //!   git config/command-injection family (`GIT_CONFIG_COUNT` +
 //!   `GIT_CONFIG_KEY_0` + `GIT_CONFIG_VALUE_0` sets *any* git config key for
 //!   every `git` the subprocess runs; `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`
-//!   and `GIT_PROXY_COMMAND` each name a program git execs) live here. This
-//!   is the same family `stella-cli`'s `.env`-file loader refuses to import,
-//!   applied at the other end of the pipe. It lives here rather than in
-//!   `stella-fleet`'s `SystemGitCli` so `stella-tools`' and `stella-cli`'s
-//!   own git invocations get identical treatment from one list.
+//!   and `GIT_PROXY_COMMAND` each name a program git execs), and
+//!   `RIPGREP_CONFIG_PATH` (a file of default `rg` arguments that silently
+//!   redacts what the `grep` tool returns) live here. This is the same family
+//!   `stella-cli`'s `.env`-file loader refuses to import, applied at the other
+//!   end of the pipe. It lives here rather than in `stella-fleet`'s
+//!   `SystemGitCli` so `stella-tools`' and `stella-cli`'s own git invocations
+//!   get identical treatment from one list.
 //!
 //! # Re-admitting one variable: `STELLA_SUBPROCESS_ENV_ALLOW`
 //!
@@ -137,6 +139,13 @@ const CREDENTIAL_ENV_SUFFIXES: &[&str] = &[
 /// `GIT_CONFIG_SYSTEM` repoint git at an attacker-written config file, and
 /// `GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF` / `GIT_PROXY_COMMAND` name a
 /// program git will exec.
+///
+/// `RIPGREP_CONFIG_PATH` is the same shape as `GIT_CONFIG_GLOBAL`, one layer
+/// out: it repoints `rg` at a file of default arguments. The `grep` tool
+/// shells out to `rg`, so a planted config (`--max-count=1`, a `--glob`
+/// hiding a directory, `--fixed-strings` defeating a regex) silently changes
+/// what a search returns — and the agent reads the difference as fact rather
+/// than as a redacted result. Scrubbed for the same reason git's is.
 const AMBIENT_AUTHORITY_ENV_VARS: &[&str] = &[
     "SSH_AUTH_SOCK",
     "GIT_CONFIG_COUNT",
@@ -146,6 +155,7 @@ const AMBIENT_AUTHORITY_ENV_VARS: &[&str] = &[
     "GIT_EXTERNAL_DIFF",
     "GIT_PROXY_COMMAND",
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "RIPGREP_CONFIG_PATH",
 ];
 
 /// The numbered halves of git's `GIT_CONFIG_COUNT` protocol
@@ -628,7 +638,7 @@ mod tests {
     }
 
     #[test]
-    fn git_injection_family_and_agent_socket_are_ambient_authority_not_credentials() {
+    fn config_injection_family_and_agent_socket_are_ambient_authority_not_credentials() {
         for name in [
             "GIT_CONFIG_COUNT",
             "GIT_CONFIG_KEY_0",
@@ -639,6 +649,7 @@ mod tests {
             "GIT_EXTERNAL_DIFF",
             "GIT_PROXY_COMMAND",
             "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "RIPGREP_CONFIG_PATH",
             "SSH_AUTH_SOCK",
         ] {
             assert!(
@@ -668,6 +679,23 @@ mod tests {
                 "{benign} must remain available to task subprocesses"
             );
         }
+    }
+
+    /// The `grep` tool shells out to `rg`, which reads default arguments from
+    /// the file `RIPGREP_CONFIG_PATH` names. A planted config (`--max-count=1`,
+    /// a `--glob` hiding a directory) silently truncates what a search returns
+    /// and the agent reads the shortfall as fact — the `GIT_CONFIG_GLOBAL`
+    /// hazard, one layer out. An INHERITED value must not reach the child.
+    #[tokio::test]
+    async fn an_inherited_ripgrep_config_path_never_reaches_a_scrubbed_child() {
+        let _planted = test_support::ScopedEnvVar::set("RIPGREP_CONFIG_PATH", "/tmp/planted-rgrc");
+        let mut command = tokio::process::Command::new("sh");
+        command.args(["-c", "printf '%s' \"${RIPGREP_CONFIG_PATH-unset}\""]);
+        scrub_sensitive_env(&mut command);
+
+        let output = command.output().await.expect("spawn shell");
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "unset");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why

The five findings from [#940](https://github.com/macanderson/stella/issues/940)'s backlog that have data-loss or wrong-answer consequences. The issue is a grab-bag of ~35 items; this takes the correctness half and leaves the rest (see "Anything reviewers should know?" below).

**`stella-tools` — `delete_file` deleted a symlink's target, not the link.** `resolve_within_root` canonicalizes, which is right for read/edit/write and exactly wrong here: deleting `vendor/config.toml → ../../real/config.toml` removed `real/config.toml` and left the link dangling, reported as an ordinary `deleted vendor/config.toml`. Silent data loss on any repository with in-tree symlinks. A dedicated resolver runs the *parent* through `resolve_within_root` — so containment is enforced exactly as everywhere else, including through symlinked directories — and re-joins the last component verbatim before `lstat`ing it. Side effects: a dangling symlink is now deletable (it used to resolve to nothing and report as missing), and the output names which of link or target was removed.

**`stella-tools` — `apply_edits` rollback reverted third-party writes.** On a mid-batch write failure the rollback restored the bytes captured during validation, unconditionally. A write that landed from another process (a formatter, a watcher, the user's editor) between our write and the abort was destroyed — and the error still read as a clean all-or-nothing abort. The rollback now restores only files whose bytes are still the ones this batch wrote, and reports the rest as `NOT ROLLED BACK`. A file that cannot be read is not evidence of foreign ownership, so it still rolls back.

**`stella-tools` — `RIPGREP_CONFIG_PATH` is scrubbed from tool subprocesses.** Same class as `GIT_CONFIG_GLOBAL`, which was already on the ambient-authority list, one layer out: the `grep` tool shells out to `rg`, and a planted config (`--max-count=1`, a `--glob` hiding a directory) silently changes what a search returns. The agent reads the shortfall as fact rather than as a redacted result.

**`stella-cli` — `stella init` reports files skipped for size.** `IndexStats::files_skipped_too_large` was counted by the indexer and reached no surface, so a user whose large file left the index got no signal at all — the graph simply answered as though the file held no symbols. It now rides beside the `files_skipped_generated` clause that was already there, and both appear when both fired.

**`stella-model` — `Retry-After` honors the RFC 9110 HTTP-date form.** Major APIs send delta-seconds directly, but a CDN in front of one emits the date form, and those deployments are exactly the ones that rate-limit. The hint came back `None`, the driver fell back to computed backoff, and the retry landed back inside the window the server had just named. The IMF-fixdate parse is written out (≈20 lines of calendar arithmetic) rather than adding a date dependency for one header, and is deliberately strict — the two obsolete RFC 9110 §5.6.7 formats still degrade to `None`, exactly as the date form used to.

Refs #940

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)
- [ ] No witness needed (pure refactor / docs / CI) — because:

Each of the five was verified the artisanal way — production change reverted in place, tests re-run:

| Witness | Crate |
|---|---|
| `delete::tests::deleting_a_symlink_removes_the_link_not_its_target` | `stella-tools` |
| `delete::tests::a_dangling_symlink_is_deletable` | `stella-tools` |
| `apply_edits::tests::a_foreign_write_after_ours_is_reported_not_reverted` | `stella-tools` |
| `subprocess_env::tests::an_inherited_ripgrep_config_path_never_reaches_a_scrubbed_child` | `stella-tools` |
| `agent::tests::code_graph::format_graph_stats_reports_the_size_limit_skip_count` | `stella-cli` |
| `agent::tests::code_graph::index_workspace_graph_blocking_reports_size_limit_skips_end_to_end` | `stella-cli` |
| `http::tests::an_http_date_becomes_the_remaining_wait` | `stella-model` |
| `http::tests::the_header_map_path_reads_both_forms` | `stella-model` |

The `apply_edits` witness runs against the extracted `roll_back_prior_writes` rather than through `execute`. Racing a real concurrent writer against a mid-batch write failure has no deterministic scheduling point, and the extraction is what makes the ownership rule assertable at all — the alternative was a sleep-and-hope test.

Guardrails that pass on both sides, added alongside the symlink fix because the new resolver re-joins the last path component verbatim and containment has to come entirely from the parent's own resolution: `a_symlinked_directory_leading_outside_the_root_still_rejects` and `dot_and_dotdot_tails_are_rejected`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (see the pre-existing failure noted below)
- [x] Docs updated where behavior/flags changed — `delete_file`'s tool description now states the symlink rule (it is model-facing), and the four module doc comments carry the reasoning. No `docs/**` page asserted the old behavior for any of the five.
- [x] CLA signed
- [x] `Refs #940` appears both above and as a commit trailer

Also green: `no-scratch`, `action-pins`, `cargo-install-pins`, `license-allowlist-parity`, `invariants`, `doc-citations`, `wire-schema`, `rustdoc -D warnings`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**Two pre-existing gate failures on `main`, reproduced on a clean checkout of the parent commit and untouched here.** Neither involves a file this PR edits:

1. `stella-pipeline`'s `verify::tests::both_judge_prompts_mark_the_diff_as_worker_authored_data` fails on `cargo test --workspace`.
2. `check-file-size` is red on three baseline entries — `bench/harbor_adapter/stella_harbor/__init__.py` (+137), `bench/harbor_adapter/tests/test_adapter.py` (+240), `stella-pipeline/src/pipeline/tests.rs` (+21).

`stella-cli/src/agent_tests.rs` was heading for a fourth entry on that list, so the whole `format_graph_stats` / `index_workspace_graph_blocking` group moved to `agent_tests/code_graph.rs` — the same split `engine_wiring` took for the same reason. That file now *shrinks*. The move is why the `agent_tests.rs` diff looks larger than the change; nothing in the moved tests was edited beyond the new `files_skipped_too_large` field.

**Deliberately left for follow-up:**

- `stella-media/src/http.rs` has its own `parse_retry_after_ms` with the same delta-seconds-only limitation. It is a separate crate that does not depend on `stella-model`, so fixing it means either duplicating the calendar arithmetic or adding a crate dependency for one header — neither belongs in this PR.
- Everything else on #940: the three dead-code rulings (`HookBus::set_agent`, `compaction::compact`, the `late_tools` overlay), schema-driven tool-input validation, the retention-engine caller, the cache-multiplier cross-check, the `diagnose_cache` extraction, and the whole server / CLI / docs / testing sections. The issue stays open.

---

## Summary by Sourcery

Address multiple correctness and reporting issues across tools, CLI, and HTTP handling, focusing on safe file operations, accurate rollback behavior, reliable search, clearer index summaries, and proper rate-limit honoring.

New Features:
- Expose size-limit skip counts in the `stella init` code-graph summary line so users can see when large files are excluded from indexing.

Bug Fixes:
- Ensure `delete_file` removes symlink entries themselves rather than deleting their targets, and make dangling symlinks deletable while clearly reporting what was removed.
- Prevent `apply_edits` rollback from overwriting changes made by external processes by only restoring files whose contents still match the batch’s writes and reporting non-owned files as not rolled back.
- Scrub `RIPGREP_CONFIG_PATH` from tool subprocess environments so ripgrep configs cannot silently alter search results returned by the `grep` tool.
- Honor `Retry-After` headers in both delta-seconds and HTTP-date form, using strict IMF-fixdate parsing so CDN-fronted deployments’ rate-limit windows are respected instead of ignored.

Enhancements:
- Extend code-graph summary formatting to pluralize and combine multiple exclusion clauses (generated and size-limited) for clearer reporting of index coverage.
- Refine delete-file error handling to distinguish non-file entries via `symlink_metadata` and add more robust containment checks around symlinked directories and special path tails (`.`/`..`).

Documentation:
- Update tool and module documentation to describe symlink deletion semantics, rollback ownership rules, ripgrep config scrubbing, size-limit reporting, and HTTP-date handling for `Retry-After`.
