### PR TITLE
feat(pipeline): run isolated best-of-N candidates concurrently (#1215)

### DIFF
--- a/stella-pipeline/README.md
+++ b/stella-pipeline/README.md
@@ -37,6 +37,8 @@ which owns the port implementations and the `Router` itself. It builds no binary
 | [`src/witness/airlock.rs`](src/witness/airlock.rs) | The feedback airlock: `DisclosureGrain`, `SymptomClass`, `FailureFingerprint`, and the `scrub`/`redact` pair that decide what a failure may tell the worker. |
 | [`src/verify.rs`](src/verify.rs) | `FlipOracle`, `ladder_decision`, judge prompting/parsing, `heuristic_fallback`, `guidance_prompt`. |
 | [`src/candidate.rs`](src/candidate.rs) | `CandidateScore` and `select_best_candidate` — best-of-N selection, pure. |
+| [`src/candidate_fanout.rs`](src/candidate_fanout.rs) | `fan_out_width` and `FanOutBudget` — how wide a fan-out runs and how one turn's money is split between candidates spending at the same time. Pure; the normative statement of the overshoot window. |
+| [`src/pipeline/fanout_stage.rs`](src/pipeline/fanout_stage.rs) | The concurrent dispatch itself: workspace creation (serialized), `buffer_unordered` over the candidates, results re-ordered by index. |
 | [`src/mcp_prefetch.rs`](src/mcp_prefetch.rs) | `fold`: shared MCP context gathered once at the top of a fan-out instead of N times. |
 | [`src/replay.rs`](src/replay.rs), [`src/replay/golden.rs`](src/replay/golden.rs) | `validate_stream` / `structural_diff` / `parse_jsonl`, and the golden fixture format with its provenance manifest. |
 
@@ -112,6 +114,29 @@ same scrub, and a rejection emits `PolicyDecision { kind: Blocked }` carrying a 
 never content. Two audiences, two texts: the operator's `JudgeVerdict` event keeps the
 real output, because the human is not the adversary.
 
+**A best-of-N fan-out runs its isolated candidates at once**
+([`src/pipeline/fanout_stage.rs`](src/pipeline/fanout_stage.rs)). Isolation already
+guaranteed siblings never see each other's edits, so the only thing making
+`candidates = Some(n)` cost the *sum* of n runtimes rather than the slowest was the
+`&mut BudgetGuard` threaded through `run_candidate`. Three consequences worth knowing:
+
+- **Money is split, not shared.** Each candidate spends against a `BudgetGuard::carve` of
+  `headroom / width` and settles it back on the way out, gated before dispatch against the
+  shared parent. Aggregate spend stays at the cap plus one in-flight window — at most
+  `width` model calls, since the budget is consulted between steps and never mid-call.
+  `BudgetGuard::carve` puts its ceiling on the *session* axis by contract, so a candidate
+  that trips a turn cap now names the session axis in its abort text; the money is the same.
+- **Only the isolated path is concurrent.** The shared-tree degradation (`candidates > 1`
+  with no `CandidateWorkspacePort`) stays sequential — those candidates execute into one
+  working tree. `git worktree` creation is serialized too, including the second snapshot a
+  witness author needs: it costs milliseconds against a candidate's minutes.
+- **Live previews are muted while the lane is shared.** `TextDelta` and `Reasoning` are
+  the two events the wire contract already calls best-effort, and splicing three models'
+  fragments into one paragraph is worse than showing none. Every durable event — each
+  candidate's authoritative `Text`, its tool calls, file changes and proof steps — still
+  goes out live, and the fan-out narrates the mute so a quiet stream is not mistaken for a
+  stalled one. `candidate_concurrency: Some(1)` restores strictly sequential dispatch.
+
 **Degrade, never do nothing.** `WitnessAbort` splits reasons into `degradable` (no witness
 could be authored) and `rejected` (a budget limit, or an artifact-integrity violation), and
 `Pipeline::run` re-runs a bare worker turn when a candidate aborted before the worker ever
@@ -162,7 +187,8 @@ and port doubles — no API key, no network.
 
 - **Unit tests** sit beside the code ([`src/pipeline/tests.rs`](src/pipeline/tests.rs) and
   [`src/pipeline/tests/`](src/pipeline/tests)), split by concern: `witness_isolation`,
-  `best_of_n`, `terminal_outcomes`, `usage`, `telemetry`, `management_accounting`,
+  `best_of_n` (and its child `fanout_concurrency`), `terminal_outcomes`, `usage`,
+  `telemetry`, `management_accounting`,
   `mcp_prefetch`. They are child modules so they reach `CandidateSurface` and the other
   private surface via `super::*`; the shared fakes (`run_isolated`, `FakeWorkspacePort`)
   stay in the common ancestor `tests.rs`. `chaos.rs` enumerates the config × environment

--- a/stella-pipeline/src/candidate_fanout.rs
+++ b/stella-pipeline/src/candidate_fanout.rs
@@ -1,0 +1,278 @@
+//! What a best-of-N fan-out costs once its candidates stop taking turns.
+//!
+//! Fully-isolated candidates never see each other's edits — the module-doc
+//! guarantee `Pipeline::run_best_of_n` is built on, with `candidate_steering`
+//! already giving every candidate its own replay cursor over the user's
+//! steers. Nothing about the *work* required them to run one after another;
+//! the only thing that did was the `&mut BudgetGuard` threaded through
+//! `run_candidate` → `verify_candidate` → `judge`. So `--candidates 3` cost
+//! the **sum** of three candidate runtimes instead of the slowest, which on a
+//! wall-clock-bounded harness is the difference between finishing and being
+//! killed (#1215).
+//!
+//! This module owns the two decisions concurrency forces, kept synchronous
+//! and testable away from the I/O sequencing in `pipeline::fanout_stage`: how
+//! wide the fan-out runs, and how one turn's money is divided between
+//! candidates that spend at the same time.
+//!
+//! # The budget window
+//!
+//! A `&mut BudgetGuard` cannot be shared, so each candidate spends against a
+//! [`BudgetGuard::carve`] of the parent's headroom and folds its total back
+//! with [`BudgetGuard::settle_child`] when it settles — the same arrangement
+//! `stella_core::subagent` uses for a nested turn, and the same
+//! snapshot-not-reservation posture `stella-fleet` documents on its own
+//! dispatch gate.
+//!
+//! Two things bound the aggregate:
+//!
+//! 1. **A pre-dispatch gate.** A candidate claims its allowance from the
+//!    shared parent as it takes its concurrency slot, and a parent already
+//!    over an enforced cap hands out nothing — so a fan-out wider than the
+//!    money stops launching rather than launching everything and discovering
+//!    the cap N times.
+//! 2. **A per-candidate share.** The allowance is `headroom / width`, not the
+//!    whole headroom, so the candidates that are in flight *together* cannot
+//!    collectively promise more than the parent has. This is the same divisor
+//!    `fleet_cmd` applies before handing a child its guard, and for the same
+//!    reason.
+//!
+//! What is left is one window: the budget is consulted between steps, never
+//! mid-call (invariant 6), so each in-flight candidate can be one model call
+//! past its own allowance when it stops. **The documented overshoot is
+//! therefore at most `width` model calls beyond the cap** — at `width == 1`
+//! that is the one call the sequential path always allowed, and the whole
+//! guarantee degrades continuously from there.
+//!
+//! # What a carve changes, and what it does not
+//!
+//! [`BudgetGuard::carve`] lands its ceiling on the child's *session* axis by
+//! contract ("a child's whole life is one turn"), so a candidate that trips a
+//! cap now reports `BudgetAxis::Session` where a shared guard would have said
+//! `Turn`. The *money* is identical — both axes are consulted when the
+//! headroom is computed, so a turn limit still bounds the carve — and this is
+//! only ever a label on the abort message. It is called out here because it is
+//! the one observable difference between spending through a carve and spending
+//! through the parent directly.
+
+use std::sync::Mutex;
+
+use stella_core::{BudgetGuard, BudgetOutcome};
+
+/// How many isolated candidates may execute at once.
+///
+/// `None` — the default — runs the whole fan-out together, which is the point:
+/// `--candidates N` should cost the slowest candidate, not the sum. A
+/// configured width is clamped into `1..=n`, so `Some(1)` is the exact
+/// sequential behaviour that predates concurrency and a width past `n` is not
+/// an error, just unreachable.
+pub(crate) fn fan_out_width(n: u32, configured: Option<u32>) -> u32 {
+    let n = n.max(1);
+    configured.map_or(n, |w| w.clamp(1, n))
+}
+
+/// The fan-out's shared parent budget: the pre-dispatch gate, the per-
+/// candidate carve, and the settle that folds a finished candidate's spend
+/// back — see the module docs for the bound these three produce together.
+pub(crate) struct FanOutBudget {
+    /// A `Mutex` rather than a `RefCell` on purpose: every candidate future is
+    /// polled on one task today, but the guard travels inside futures the
+    /// caller may hand to a spawner tomorrow, and a `RefCell` would make that
+    /// a compile error at the wrong end of the codebase. Locks are held for a
+    /// single `Copy` read/write and never across an `await`.
+    parent: Mutex<BudgetGuard>,
+    width: u32,
+}
+
+impl FanOutBudget {
+    pub(crate) fn new(parent: BudgetGuard, width: u32) -> Self {
+        Self {
+            parent: Mutex::new(parent),
+            width: width.max(1),
+        }
+    }
+
+    /// Claim one candidate's allowance, or `None` when the fan-out has no
+    /// money left to give it.
+    ///
+    /// `None` is a *skip*, not a failure: the candidate never reaches a model,
+    /// so the caller scores it as a candidate that generated nothing rather
+    /// than as work that was attempted and aborted.
+    pub(crate) fn claim(&self) -> Option<BudgetGuard> {
+        let parent = self.lock();
+        if let BudgetOutcome::AbortTurn { .. } = parent.evaluate() {
+            return None;
+        }
+        let share = parent.headroom_usd().map(|h| h / f64::from(self.width));
+        let child = parent.carve(share);
+        child.is_viable_carve().then_some(child)
+    }
+
+    /// Fold one finished candidate's spend into the parent, so the next
+    /// candidate to claim a slot sees money that is already gone.
+    ///
+    /// Called in completion order — that is what makes the gate above live —
+    /// while the run's *reported* cost is summed by candidate index, so the
+    /// number the user sees does not depend on who finished first.
+    pub(crate) fn settle(&self, child: &BudgetGuard) {
+        self.lock().record_spend(child.session_spent_usd());
+    }
+
+    /// The parent guard, with every settled candidate's spend folded in.
+    pub(crate) fn into_parent(self) -> BudgetGuard {
+        self.parent
+            .into_inner()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BudgetGuard> {
+        self.parent
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::BudgetMode;
+
+    /// The default is the whole fan-out at once — the wall-clock lever the
+    /// concurrency exists for.
+    #[test]
+    fn an_unconfigured_width_runs_every_candidate_together() {
+        assert_eq!(fan_out_width(3, None), 3);
+        assert_eq!(fan_out_width(1, None), 1);
+    }
+
+    /// `Some(1)` is how an operator asks for the pre-concurrency behaviour
+    /// back, and it has to be exactly expressible.
+    #[test]
+    fn a_width_of_one_is_the_sequential_fan_out() {
+        assert_eq!(fan_out_width(4, Some(1)), 1);
+        assert_eq!(fan_out_width(4, Some(0)), 1, "0 is not a stalled fan-out");
+    }
+
+    /// A width past the candidate count is a wish, not an error.
+    #[test]
+    fn a_width_wider_than_the_fan_out_is_clamped_to_it() {
+        assert_eq!(fan_out_width(2, Some(9)), 2);
+    }
+
+    /// The whole point of dividing by the width: candidates that are in
+    /// flight together cannot each be promised the full headroom.
+    #[test]
+    fn concurrent_candidates_split_the_headroom_rather_than_each_taking_it() {
+        let parent = BudgetGuard::new(BudgetMode::Enforced, Some(6.0), None);
+        let budgets = FanOutBudget::new(parent, 3);
+
+        let shares: Vec<f64> = (0..3)
+            .map(|_| {
+                budgets
+                    .claim()
+                    .expect("a fresh cap funds every candidate")
+                    .session_limit_usd()
+                    .expect("an enforced cap carves a ceiling")
+            })
+            .collect();
+
+        assert_eq!(shares, vec![2.0, 2.0, 2.0]);
+        assert!(
+            shares.iter().sum::<f64>() <= 6.0,
+            "the in-flight window must never promise more than the cap: {shares:?}"
+        );
+    }
+
+    /// The aggregate bound the acceptance criterion names: with every
+    /// candidate spending its whole allowance, the parent lands at the cap
+    /// rather than at `width x cap`.
+    #[test]
+    fn settled_candidates_leave_the_parent_at_the_cap_not_a_multiple_of_it() {
+        let parent = BudgetGuard::new(BudgetMode::Enforced, Some(6.0), None);
+        let budgets = FanOutBudget::new(parent, 3);
+
+        for _ in 0..3 {
+            let mut child = budgets.claim().expect("a fresh cap funds every candidate");
+            child.record_spend(2.0);
+            budgets.settle(&child);
+        }
+
+        let settled = budgets.into_parent();
+        assert!(
+            (settled.spent_usd() - 6.0).abs() < 1e-9,
+            "aggregate spend must equal the cap, not 3x it: {}",
+            settled.spent_usd()
+        );
+    }
+
+    /// A fan-out wider than the money stops launching. Without the
+    /// pre-dispatch gate the later candidates would each buy one doomed model
+    /// call before discovering the cap.
+    #[test]
+    fn a_spent_parent_stops_funding_further_candidates() {
+        let parent = BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None);
+        let budgets = FanOutBudget::new(parent, 1);
+
+        let mut first = budgets.claim().expect("the first candidate is funded");
+        first.record_spend(1.5);
+        budgets.settle(&first);
+
+        assert!(
+            budgets.claim().is_none(),
+            "a breached cap must not fund another candidate"
+        );
+    }
+
+    /// Metering is not gating: an observed budget warns and keeps going, so
+    /// its candidates are always funded even past the limit. Escalating a
+    /// carve to a wall here would turn a stated warn-only posture into a hard
+    /// stop, one level down.
+    #[test]
+    fn an_observed_budget_keeps_funding_candidates_past_its_limit() {
+        let parent = BudgetGuard::new(BudgetMode::Observed, Some(1.0), None);
+        let budgets = FanOutBudget::new(parent, 2);
+
+        let mut first = budgets.claim().expect("the first candidate is funded");
+        first.record_spend(5.0);
+        budgets.settle(&first);
+
+        assert!(
+            budgets.claim().is_some(),
+            "observed mode warns; it never denies"
+        );
+    }
+
+    /// An unmetered run must not acquire a ceiling just by fanning out.
+    #[test]
+    fn an_unlimited_parent_carves_unlimited_candidates() {
+        let budgets = FanOutBudget::new(BudgetGuard::new(BudgetMode::Off, None, None), 4);
+        let child = budgets.claim().expect("no cap funds everything");
+        assert_eq!(child.session_limit_usd(), None);
+        assert_eq!(child.turn_limit_usd(), None);
+    }
+
+    /// Settling is order-independent in what it *accounts* — every
+    /// candidate's spend reaches the parent regardless of who finished first
+    /// — which is what lets the caller settle in completion order and still
+    /// report a total summed by index.
+    #[test]
+    fn every_candidate_settles_whatever_the_completion_order() {
+        let costs = [0.25f64, 1.5, 0.75];
+        let mut totals = Vec::new();
+        for order in [[0usize, 1, 2], [2, 1, 0], [1, 0, 2]] {
+            let budgets = FanOutBudget::new(BudgetGuard::new(BudgetMode::Off, None, None), 3);
+            let mut children: Vec<BudgetGuard> = (0..3)
+                .map(|_| budgets.claim().expect("unmetered"))
+                .collect();
+            for i in order {
+                children[i].record_spend(costs[i]);
+                budgets.settle(&children[i]);
+            }
+            totals.push(budgets.into_parent().spent_usd());
+        }
+        assert!(
+            totals.windows(2).all(|w| (w[0] - w[1]).abs() < 1e-9),
+            "completion order must not change what the parent accounts: {totals:?}"
+        );
+    }
+}

--- a/stella-pipeline/src/candidate_narration.rs
+++ b/stella-pipeline/src/candidate_narration.rs
@@ -10,6 +10,27 @@
 //! single candidate when a witness is being authored, and "candidate 1/1" there
 //! is noise rather than signal.
 
+/// Announce a fan-out whose candidates run *together* (#1215), before any of
+/// them starts.
+///
+/// Two facts the user cannot infer from the per-candidate lines that follow.
+/// The first is that the wall clock is now the slowest candidate rather than
+/// the sum, which is the whole reason to pay for N. The second is why their
+/// terminal stops streaming mid-thought: while N models share one event
+/// stream the live text preview is muted, and its absence would otherwise read
+/// as a stalled run. A sequential fan-out (`width <= 1`) says neither, because
+/// neither is true of it.
+pub(crate) fn candidate_fanout_notice(n: u32, width: u32) -> Option<String> {
+    if n <= 1 || width <= 1 {
+        return None;
+    }
+    Some(format!(
+        "\n▸ best-of-{n}: running {width} candidates at once — this turn costs the slowest \
+         candidate, not the sum. Live text previews are paused while they share the stream; \
+         each candidate's full answer still arrives.\n"
+    ))
+}
+
 /// Announce a candidate as it starts, naming its position and whether it is
 /// isolated — isolation is what decides whether a loser's edits survive, so it
 /// belongs in the line the user actually reads.
@@ -86,5 +107,28 @@ mod tests {
     fn a_single_candidate_never_narrates() {
         assert!(candidate_start_notice(0, 1, true).is_none());
         assert!(candidate_winner_notice(0, 1, 1).is_none());
+        assert!(candidate_fanout_notice(1, 1).is_none());
+    }
+
+    #[test]
+    fn a_concurrent_fan_out_names_its_width_and_the_muted_preview() {
+        let notice = candidate_fanout_notice(3, 3).expect("a wide fan-out narrates");
+        assert!(notice.contains("best-of-3"), "{notice}");
+        assert!(notice.contains("3 candidates at once"), "{notice}");
+        assert!(
+            notice.contains("not the sum"),
+            "the wall-clock claim is the reason to pay for N: {notice}"
+        );
+        assert!(
+            notice.contains("previews are paused"),
+            "a silent stream must be explained, not discovered: {notice}"
+        );
+    }
+
+    /// A fan-out that runs one candidate at a time streams exactly as it
+    /// always did, so it must not claim otherwise.
+    #[test]
+    fn a_sequential_fan_out_promises_no_concurrency() {
+        assert!(candidate_fanout_notice(3, 1).is_none());
     }
 }

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -94,6 +94,7 @@
 //! [`PipelinePorts`]: ports::PipelinePorts
 
 pub mod candidate;
+pub(crate) mod candidate_fanout;
 pub(crate) mod candidate_narration;
 pub(crate) mod candidate_steering;
 pub(crate) mod mcp_prefetch;

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -61,7 +61,10 @@ use stella_protocol::{
 use crate::candidate::{
     CandidateScore, CandidateSummary, score_from_verification, select_best_candidate,
 };
-use crate::candidate_narration::{candidate_start_notice, candidate_winner_notice};
+use crate::candidate_fanout::fan_out_width;
+use crate::candidate_narration::{
+    candidate_fanout_notice, candidate_start_notice, candidate_winner_notice,
+};
 use crate::candidate_steering::SteeringFanOut;
 use crate::plan::{PlanStep, build_planner_prompt, parse_plan, plan_repair_prompt};
 use crate::ports::{
@@ -94,6 +97,7 @@ use crate::witness::{
     witness_prompt, witness_repair_prompt,
 };
 mod disclosure;
+mod fanout_stage;
 mod judge_stage;
 mod raw_usage;
 mod run_error;
@@ -101,6 +105,7 @@ mod scope_stage;
 mod stage_budget;
 mod verify_probes;
 mod witness_stage;
+use fanout_stage::SerialCreates;
 use raw_usage::{RawCall, RawCallError};
 pub use run_error::{PipelineError, PipelineRunError};
 use run_error::{RoleResolveError, WitnessAuthorIndependence};
@@ -346,8 +351,27 @@ pub struct PipelineConfig {
     /// snapshot of the current tree state when a
     /// [`crate::ports::CandidateWorkspacePort`] is wired — and selects the
     /// best, adopting only the winner's changes into the real tree. Paid for
-    /// with n× the execution cost — opt-in only.
+    /// with n× the execution *cost* — opt-in only. Not n× the wall clock: see
+    /// [`Self::candidate_concurrency`].
     pub candidates: Option<u32>,
+    /// How many **isolated** candidates execute at once (#1215).
+    ///
+    /// `None` — the default — runs the whole fan-out together, so
+    /// `candidates = Some(n)` costs the slowest candidate in wall clock rather
+    /// than the sum of all n. `Some(1)` is the strictly sequential behaviour
+    /// that predates concurrency, and is the setting for a host that needs one
+    /// candidate's events to arrive without a sibling's interleaved on the
+    /// same stream.
+    ///
+    /// Only the isolated path is ever concurrent. The shared-tree degradation
+    /// (`candidates > 1` with no [`crate::ports::CandidateWorkspacePort`]
+    /// wired) stays sequential whatever this says: those candidates execute
+    /// into one working tree and would overwrite each other's files.
+    ///
+    /// The budget is divided rather than shared — see
+    /// `crate::candidate_fanout` for the aggregate bound this keeps and the
+    /// one-window overshoot it accepts.
+    pub candidate_concurrency: Option<u32>,
     /// Whether this run does its work in a throwaway worktree rather than the
     /// user's checkout. Consulted once — after planning, before execution,
     /// using the task class triage resolved — and only when the run is going
@@ -384,6 +408,7 @@ impl Default for PipelineConfig {
             max_revisions: 2,
             require_independent_witness: false,
             candidates: None,
+            candidate_concurrency: None,
             create_worktrees: crate::ports::WorktreePolicy::default(),
         }
     }
@@ -765,6 +790,17 @@ pub struct Pipeline<'a> {
     /// Whether the judge's same-family degradation caveat (L-M8) has been
     /// surfaced this run — see [`Pipeline::warn_judge_caveat`].
     judge_caveat_warned: AtomicBool,
+    /// Whether more than one candidate is currently writing to [`Self::events`]
+    /// — set for the duration of a concurrent best-of-N fan-out and false
+    /// everywhere else.
+    ///
+    /// Read only by [`Pipeline::run_engine_turn`], to mute the two event kinds
+    /// the wire contract already calls best-effort previews (`TextDelta`,
+    /// `Reasoning`). Interleaving those from N models produces one paragraph
+    /// of spliced sentences; every durable event — including each candidate's
+    /// authoritative `Text` — still goes out live. See
+    /// `pipeline::fanout_stage`'s module doc.
+    shared_event_lane: AtomicBool,
 }
 
 impl<'a> Pipeline<'a> {
@@ -803,6 +839,7 @@ impl<'a> Pipeline<'a> {
             configured_test,
             raw_call_seq: AtomicU64::new(RECEIPT_SEQ_ALLOCATED_BASE),
             judge_caveat_warned: AtomicBool::new(false),
+            shared_event_lane: AtomicBool::new(false),
         }
     }
 
@@ -1684,94 +1721,44 @@ impl<'a> Pipeline<'a> {
             }
         };
 
-        let mut candidates: Vec<CandidateResult> = Vec::with_capacity(n as usize);
-        // Index-aligned with `candidates` — every path below pushes to both, so
-        // adoption can pair a workspace with the result that produced it (and
-        // with the witness paths that result carries). `None` marks a candidate
-        // that never got a workspace.
-        let mut workspaces: Vec<Option<Box<dyn CandidateWorkspace>>> =
-            Vec::with_capacity(n as usize);
-        // One mirror, one cursor per candidate — see `candidate_steering`.
-        let fan = self.steering.map(SteeringFanOut::new);
-        for i in 0..n {
-            self.emit_text(candidate_start_notice(i, n, true));
-            let ws = match port.create().await {
-                Ok(ws) => ws,
-                Err(e) => {
-                    // Isolation was promised, so a candidate that cannot be
-                    // isolated is never run in the shared tree instead: it
-                    // scores as aborted and the remaining candidates go on.
-                    self.warn(format!("candidate {}/{n} skipped: {e}", i + 1));
-                    candidates.push(CandidateResult::setup_aborted(
-                        base_messages.to_vec(),
-                        format!("candidate isolation failed: {e}"),
-                    ));
-                    workspaces.push(None);
-                    continue;
-                }
-            };
-            let result = {
-                let bound_hook_runner = self.hooks.map(|(_, runner)| BoundHookRunner {
-                    inner: runner,
-                    cwd: ws.root(),
-                });
-                let surface = CandidateSurface {
-                    diagnostics: ws.diagnostics(),
-                    tests: ws.tests(),
-                    lint: self.lint,
-                    mutation: self.mutation,
-                    repo_status: ws.repo_status(),
-                    cwd: Some(ws.root()),
-                    hook_runner: bound_hook_runner
-                        .as_ref()
-                        .map(|runner| runner as &dyn HookRunner),
-                    workspace: Some(ws.as_ref()),
-                };
-                // Handed to the candidate rather than spent here: whether this
-                // run buys a witness is not knowable until the candidate has
-                // executed and its diff can be read.
-                let authoring = author_witness.then(|| WitnessAuthoring {
-                    port,
-                    author: witness_author
-                        .as_ref()
-                        .expect("authored witness identity is resolved before dispatch"),
-                    frames,
-                });
-                let mut engine = Engine::with_sleeper(
-                    worker.provider,
-                    ws.tools(),
-                    self.engine_config_for(surface),
-                    self.sleeper,
-                );
-                if let Some((hooks, runner)) = self.hooks {
-                    engine = engine.with_hooks(hooks, surface.hook_runner.unwrap_or(runner));
-                }
-                if let Some(gate) = self.turn_gate {
-                    engine = engine.with_gate(gate);
-                }
-                let view = fan.as_ref().map(|fan| fan.candidate());
-                if let Some(view) = view.as_ref() {
-                    engine = engine.with_steering(view);
-                }
-                self.run_candidate(
-                    goal,
-                    base_messages,
-                    plan,
-                    assessment,
-                    authoring,
-                    &engine,
-                    surface,
-                    budget,
-                    total,
-                )
-                .await
-            };
-            // Pushed together, always: adoption pairs `candidates[i]` with
-            // `workspaces[i]`, and the witness paths now ride on the result,
-            // so a candidate can never be matched to another one's artifact.
-            candidates.push(result);
-            workspaces.push(Some(ws));
-        }
+        // Isolation is created in index order even when the candidates then
+        // run together, and so is the second snapshot a witness author needs —
+        // `SerialCreates` is what makes the second one obey too. See
+        // `fanout_stage`'s module doc for why git, and not the model calls, is
+        // the thing worth serializing.
+        let serialized = SerialCreates::new(port);
+        let port: &dyn CandidateWorkspacePort = &serialized;
+        let width = fan_out_width(n, self.config.candidate_concurrency);
+        self.emit_text(candidate_fanout_notice(n, width));
+        // Index-aligned with the results below, so adoption can pair a
+        // workspace with the result that produced it (and with the witness
+        // paths that result carries). `Err` marks a candidate that never got a
+        // workspace, and carries the reason it will be scored with.
+        let workspaces = self.create_candidate_workspaces(port, n).await;
+        // Handed to the candidate rather than spent here: whether a run buys a
+        // witness is not knowable until the candidate has executed and its diff
+        // can be read.
+        let authoring = author_witness.then(|| WitnessAuthoring {
+            port,
+            author: witness_author
+                .as_ref()
+                .expect("authored witness identity is resolved before dispatch"),
+            frames,
+        });
+        let candidates = self
+            .dispatch_isolated_candidates(
+                goal,
+                base_messages,
+                plan,
+                assessment,
+                &worker,
+                authoring,
+                &workspaces,
+                width,
+                budget,
+                total,
+            )
+            .await;
 
         let best_idx = best_index(&candidates);
         // Counted before the winner is moved out — the report is about the
@@ -1782,7 +1769,7 @@ impl<'a> Pipeline<'a> {
         // aborted best-of-N run leaves the real tree untouched.
         let mut adopt_failure: Option<WorkspaceError> = None;
         for (i, slot) in workspaces.into_iter().enumerate() {
-            let Some(ws) = slot else {
+            let Ok(ws) = slot else {
                 continue;
             };
             if i == best_idx
@@ -2823,12 +2810,25 @@ impl<'a> Pipeline<'a> {
         let mutating = seen_mutating.clone();
         let read_only = self.read_only_tool_names();
         let consumer = self.events.clone();
+        // Read once per turn, not per event: a turn belongs to one candidate,
+        // and the fan-out sets this before dispatching any of them.
+        let shared_lane = self.shared_event_lane.load(Ordering::Relaxed);
         let filtered = EventSender::from_fn(move |event| {
             match &event {
                 // The pipeline is the sole authority for stage boundaries and
                 // the terminal event of an outcome-producing run — drop the
                 // engine's per-turn copies.
                 AgentEvent::Stage { .. } | AgentEvent::Complete { .. } => Ok(()),
+                // Concurrent candidates share this stream, and these two are
+                // the only events whose meaning depends on arriving
+                // uninterrupted: `TextDelta` is a preview its own `Text` event
+                // supersedes, and `Reasoning` is accumulated by the consumer.
+                // Three models' fragments spliced together is not a preview of
+                // anything. Everything durable still goes out live — see
+                // `Pipeline::shared_event_lane`.
+                AgentEvent::TextDelta { .. } | AgentEvent::Reasoning { .. } if shared_lane => {
+                    Ok(())
+                }
                 AgentEvent::FileChange { kind, .. } => {
                     // Reads ride the same event for the files panel but are
                     // not changes — counting them would defeat the zero-diff

--- a/stella-pipeline/src/pipeline/fanout_stage.rs
+++ b/stella-pipeline/src/pipeline/fanout_stage.rs
@@ -1,0 +1,312 @@
+//! Dispatching a best-of-N fan-out: `width` isolated candidates executing at
+//! once over one turn's budget and one event stream (#1215).
+//!
+//! Split out of `pipeline.rs` for the same reason `witness_stage` is — this is
+//! the one stage that runs several candidate pipelines against each other
+//! rather than one after the other, and its concurrency concerns (who creates
+//! worktrees, who narrates, who spends) do not belong inside the sequential
+//! read of `run_best_of_n`. The *decisions* it makes about width and money
+//! live in [`crate::candidate_fanout`]; this file is the I/O sequencing.
+//!
+//! # Three things had to be settled before candidates could overlap
+//!
+//! **Money.** [`FanOutBudget`] — a pre-dispatch gate plus a per-candidate
+//! carve, bounding the aggregate at the cap plus one in-flight window. Its
+//! module doc is the normative statement of that window.
+//!
+//! **Git.** Isolation is created in index order even when the candidates then
+//! run together, and a candidate's *second* `create` — the pristine snapshot
+//! its witness author works blind in — is funnelled through the same lock by
+//! [`SerialCreates`]. `create` is a `git worktree add` plus a snapshot commit
+//! against ONE repository; it costs milliseconds against a candidate's
+//! minutes, so serializing it keeps a whole class of concurrent-git failures
+//! out of the fan-out at no measurable wall-clock cost. Concurrency is worth
+//! having on the model calls, which is where the time actually goes.
+//!
+//! **The event stream.** N candidates share one [`stella_core::EventSender`],
+//! and the events that garble when they interleave are exactly the ones the
+//! wire contract already marks as droppable: `TextDelta` is "strictly a
+//! best-effort preview" whose authoritative twin is the `Text` event that
+//! follows it, and `Reasoning` is an accumulate-as-you-go display stream. A
+//! concurrent fan-out mutes those two and lets everything else through live,
+//! so the transcript keeps every durable event — each candidate's full `Text`,
+//! its tool calls, its file changes, its proof steps — and no consumer is
+//! handed three models' sentences spliced into one paragraph. A fan-out of
+//! width 1 mutes nothing, so the single-shot and authored-witness paths stream
+//! exactly as they always did.
+//!
+//! # Two shared surfaces this deliberately does not fence
+//!
+//! **The file-touch tally.** [`Pipeline::observed_mutations`] reads a delta off
+//! one session-wide [`crate::ports::FileTouchPort`], and concurrent candidates
+//! read overlapping windows of it. It is not cross-talk *here* because an
+//! isolated candidate executes against its workspace's own tool surface
+//! (`CandidateWorkspace::tools`), which the session recorder never sees — the
+//! delta stays at zero and the count falls through to the per-candidate
+//! `FileChange` tally, which is private to one turn's engine channel. A host
+//! that ever wires a recorder observing candidate workspaces too would need a
+//! per-candidate port, not a shared one.
+//!
+//! **`EngineConfig::turn_instance`.** Every candidate runs under the turn's
+//! one instance, so their step manifests key alike and the last writer wins.
+//! That was already true when candidates ran in sequence — concurrency only
+//! makes which one writes last unordered rather than "the highest index".
+//! Giving each candidate its own instance is the real fix and is not attempted
+//! here: the value is allocated by the caller (`stella-core::goal` walks it by
+//! round), so minting offsets inside the pipeline would collide with the next
+//! turn's.
+
+use super::*;
+
+use crate::candidate_fanout::FanOutBudget;
+
+/// One candidate's finished work, tagged with the index that produced it.
+///
+/// Completion order is not index order once candidates overlap, and three
+/// things downstream care about index: selection tie-breaks on it
+/// ([`select_best_candidate`]), adoption pairs `candidates[i]` with
+/// `workspaces[i]`, and the reported cost is summed in it so a run's total
+/// does not depend on who finished first.
+struct FinishedCandidate {
+    index: usize,
+    result: CandidateResult,
+    cost_usd: f64,
+}
+
+/// A [`CandidateWorkspacePort`] that lets exactly one `create` run at a time.
+///
+/// Wrapping the port rather than serializing at the call sites is what makes
+/// this cover the witness author's snapshot too: that `create` happens deep
+/// inside a candidate, at a point the fan-out has no visibility into, and it
+/// is a `git worktree add` against the same repository as everybody else's.
+pub(super) struct SerialCreates<'p> {
+    inner: &'p dyn CandidateWorkspacePort,
+    /// A `tokio` mutex, not a `std` one: the guard is held across the
+    /// `create().await` it exists to serialize.
+    gate: tokio::sync::Mutex<()>,
+}
+
+impl<'p> SerialCreates<'p> {
+    pub(super) fn new(inner: &'p dyn CandidateWorkspacePort) -> Self {
+        Self {
+            inner,
+            gate: tokio::sync::Mutex::new(()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CandidateWorkspacePort for SerialCreates<'_> {
+    async fn create(&self) -> Result<Box<dyn CandidateWorkspace>, WorkspaceError> {
+        let _serialized = self.gate.lock().await;
+        self.inner.create().await
+    }
+}
+
+impl<'a> Pipeline<'a> {
+    /// Snapshot one isolated workspace per candidate, in index order.
+    ///
+    /// `Err` is a slot, not an early return: isolation was *promised*, so a
+    /// candidate that cannot be isolated is never run in the shared tree
+    /// instead — it scores as a candidate that generated nothing and the rest
+    /// of the fan-out goes on. The reason travels with the slot so the
+    /// dispatcher can score it without re-deriving it.
+    pub(super) async fn create_candidate_workspaces(
+        &self,
+        port: &dyn CandidateWorkspacePort,
+        n: u32,
+    ) -> Vec<Result<Box<dyn CandidateWorkspace>, String>> {
+        let mut workspaces = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            self.emit_text(candidate_start_notice(i, n, true));
+            match port.create().await {
+                Ok(ws) => workspaces.push(Ok(ws)),
+                Err(e) => {
+                    self.warn(format!("candidate {}/{n} skipped: {e}", i + 1));
+                    workspaces.push(Err(format!("candidate isolation failed: {e}")));
+                }
+            }
+        }
+        workspaces
+    }
+
+    /// Execute one candidate per prepared workspace, `width` at a time, and
+    /// return the results **in index order**.
+    ///
+    /// The workspaces arrive already created (in index order, by the caller)
+    /// so that a slot which failed to isolate is a value here rather than a
+    /// branch: it scores as a candidate that generated nothing and the rest of
+    /// the fan-out goes on, exactly as it did when candidates ran in sequence.
+    ///
+    /// `budget` and `total` are the turn's, and both are settled before this
+    /// returns: `budget` gains every candidate's spend through
+    /// [`FanOutBudget`], `total` gains the same money summed by index.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn dispatch_isolated_candidates(
+        &self,
+        goal: &str,
+        base_messages: &[CompletionMessage],
+        plan: Option<&[PlanStep]>,
+        assessment: TaskAssessment,
+        worker: &ResolvedRole<'_>,
+        authoring: Option<WitnessAuthoring<'_>>,
+        workspaces: &[Result<Box<dyn CandidateWorkspace>, String>],
+        width: u32,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Vec<CandidateResult> {
+        // One mirror, one cursor per candidate — see `candidate_steering`.
+        // Every candidate observes every steer exactly once whether they run
+        // in sequence or together; the cursor is what makes that true, and it
+        // was already there.
+        let fan = self.steering.map(SteeringFanOut::new);
+        let budgets = FanOutBudget::new(*budget, width);
+        // Set for the whole fan-out rather than per candidate: the question a
+        // preview has to answer is "is anyone else writing to this stream",
+        // and while a wide fan-out is in flight the answer is yes for all of
+        // them. Cleared unconditionally below, including on the paths where a
+        // candidate aborted.
+        self.shared_event_lane.store(width > 1, Ordering::Relaxed);
+
+        let mut finished: Vec<FinishedCandidate> =
+            futures_util::stream::iter(workspaces.iter().enumerate().map(|(index, slot)| {
+                let fan = fan.as_ref();
+                let budgets = &budgets;
+                async move {
+                    let ws = match slot {
+                        Ok(ws) => ws.as_ref(),
+                        Err(reason) => {
+                            return FinishedCandidate {
+                                index,
+                                result: CandidateResult::setup_aborted(
+                                    base_messages.to_vec(),
+                                    reason.clone(),
+                                ),
+                                cost_usd: 0.0,
+                            };
+                        }
+                    };
+                    // A candidate the fan-out cannot fund never reaches a
+                    // model, so it is the same shape of result as one that
+                    // could not be isolated: nothing was generated, and the
+                    // siblings that were funded still decide the turn.
+                    let Some(mut allowance) = budgets.claim() else {
+                        return FinishedCandidate {
+                            index,
+                            result: CandidateResult::setup_aborted(
+                                base_messages.to_vec(),
+                                "candidate skipped: the turn's budget was already spent"
+                                    .to_string(),
+                            ),
+                            cost_usd: 0.0,
+                        };
+                    };
+                    let mut cost_usd = 0.0;
+                    let result = self
+                        .run_isolated_candidate(
+                            goal,
+                            base_messages,
+                            plan,
+                            assessment,
+                            worker,
+                            authoring,
+                            ws,
+                            fan,
+                            &mut allowance,
+                            &mut cost_usd,
+                        )
+                        .await;
+                    // Settled here, in completion order, so the next candidate
+                    // to claim a slot gates against money that is really gone.
+                    budgets.settle(&allowance);
+                    FinishedCandidate {
+                        index,
+                        result,
+                        cost_usd,
+                    }
+                }
+            }))
+            .buffer_unordered(width.max(1) as usize)
+            .collect()
+            .await;
+
+        self.shared_event_lane.store(false, Ordering::Relaxed);
+        finished.sort_by_key(|candidate| candidate.index);
+        *budget = budgets.into_parent();
+        // Summed in index order, not completion order: float addition is not
+        // associative, and a run's reported cost must not depend on which
+        // candidate happened to finish first.
+        for candidate in &finished {
+            *total += candidate.cost_usd;
+        }
+        finished
+            .into_iter()
+            .map(|candidate| candidate.result)
+            .collect()
+    }
+
+    /// Build one candidate's engine + surface over its own workspace and run
+    /// it. The body is what used to sit inside `run_best_of_n`'s loop; it is a
+    /// function now because every local in it — the engine, the steering view,
+    /// the bound hook runner — has to live in the candidate's own frame rather
+    /// than in a loop iteration shared with nobody.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_isolated_candidate(
+        &self,
+        goal: &str,
+        base_messages: &[CompletionMessage],
+        plan: Option<&[PlanStep]>,
+        assessment: TaskAssessment,
+        worker: &ResolvedRole<'_>,
+        authoring: Option<WitnessAuthoring<'_>>,
+        ws: &dyn CandidateWorkspace,
+        fan: Option<&SteeringFanOut<'_>>,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> CandidateResult {
+        let bound_hook_runner = self.hooks.map(|(_, runner)| BoundHookRunner {
+            inner: runner,
+            cwd: ws.root(),
+        });
+        let surface = CandidateSurface {
+            diagnostics: ws.diagnostics(),
+            tests: ws.tests(),
+            lint: self.lint,
+            mutation: self.mutation,
+            repo_status: ws.repo_status(),
+            cwd: Some(ws.root()),
+            hook_runner: bound_hook_runner
+                .as_ref()
+                .map(|runner| runner as &dyn HookRunner),
+            workspace: Some(ws),
+        };
+        let mut engine = Engine::with_sleeper(
+            worker.provider,
+            ws.tools(),
+            self.engine_config_for(surface),
+            self.sleeper,
+        );
+        if let Some((hooks, runner)) = self.hooks {
+            engine = engine.with_hooks(hooks, surface.hook_runner.unwrap_or(runner));
+        }
+        if let Some(gate) = self.turn_gate {
+            engine = engine.with_gate(gate);
+        }
+        let view = fan.map(SteeringFanOut::candidate);
+        if let Some(view) = view.as_ref() {
+            engine = engine.with_steering(view);
+        }
+        self.run_candidate(
+            goal,
+            base_messages,
+            plan,
+            assessment,
+            authoring,
+            &engine,
+            surface,
+            budget,
+            total,
+        )
+        .await
+    }
+}

--- a/stella-pipeline/src/pipeline/tests/best_of_n.rs
+++ b/stella-pipeline/src/pipeline/tests/best_of_n.rs
@@ -8,6 +8,13 @@
 
 use super::*;
 
+/// Candidates running *at the same time* (#1215) — the wall-clock half of the
+/// contract this module pins the correctness half of. A child module rather
+/// than a sibling of `best_of_n` so it reaches the shared fakes through this
+/// file's own `use super::*`, and so the already-oversized `tests.rs` does not
+/// grow another module declaration.
+mod fanout_concurrency;
+
 /// The core best-of-N isolation contract: every candidate runs against
 /// its own workspace surface (the session ports panic if touched), only
 /// the winner is adopted, and every workspace is removed.

--- a/stella-pipeline/src/pipeline/tests/best_of_n/fanout_concurrency.rs
+++ b/stella-pipeline/src/pipeline/tests/best_of_n/fanout_concurrency.rs
@@ -1,0 +1,450 @@
+//! Best-of-N candidates executing *at the same time* (#1215) — the wall-clock
+//! half of the isolation contract `best_of_n` pins the correctness half of.
+//!
+//! Every other test in this tree runs against doubles that resolve without
+//! ever returning `Pending`, so a concurrent fan-out and a sequential one are
+//! observationally identical there: `buffer_unordered` polls candidate 0 until
+//! it completes before it ever reaches candidate 1. That is a feature for
+//! those tests (they stay deterministic) and useless for this one, which has
+//! to prove candidates genuinely overlap.
+//!
+//! [`OverlapProbe`] is the instrument: a provider that yields to the runtime
+//! inside every completion and records how many completions were in flight at
+//! the peak. One candidate at a time can never move that number past 1,
+//! however much it yields — so the peak *is* the concurrency, and the scripted
+//! per-call yield counts let a test make candidates finish in an order other
+//! than their index.
+
+use super::*;
+
+use std::sync::atomic::AtomicU32;
+use stella_protocol::ToolCallObserver;
+
+/// A [`Provider`] that measures how many completions overlap.
+///
+/// Each call pops its scripted `(result, extra_yields)` pair on entry, so the
+/// response a candidate receives is fixed by the order candidates *reach* the
+/// model, while how long it stays there is scripted independently. That
+/// separation is what lets a test hold candidate 0 inside the model while its
+/// siblings run to completion.
+struct OverlapProbe {
+    script: std::sync::Mutex<VecDeque<(CompletionResult, usize)>>,
+    in_flight: AtomicU32,
+    peak: AtomicU32,
+    /// `enter:<text>` / `exit:<text>` in real order — the record of who
+    /// actually finished first.
+    trace: std::sync::Mutex<Vec<String>>,
+    /// A fragment streamed through the observer on every call, so a test can
+    /// see whether live previews reach the consumer.
+    stream_preview: bool,
+}
+
+impl OverlapProbe {
+    /// `script` pairs each completion with the number of EXTRA runtime yields
+    /// the call parks for. Every call yields at least once regardless: one
+    /// yield is what gives a sibling the chance to be polled into its own
+    /// call, which is the minimum any overlap needs.
+    fn new(script: Vec<(CompletionResult, usize)>) -> Self {
+        Self {
+            script: std::sync::Mutex::new(script.into_iter().collect()),
+            in_flight: AtomicU32::new(0),
+            peak: AtomicU32::new(0),
+            trace: std::sync::Mutex::new(Vec::new()),
+            stream_preview: false,
+        }
+    }
+
+    fn streaming(mut self) -> Self {
+        self.stream_preview = true;
+        self
+    }
+
+    /// The most completions that were ever in flight together.
+    fn peak(&self) -> u32 {
+        self.peak.load(Ordering::SeqCst)
+    }
+
+    fn trace(&self) -> Vec<String> {
+        self.trace.lock().unwrap().clone()
+    }
+
+    /// The order calls *returned*, by response text.
+    fn exit_order(&self) -> Vec<String> {
+        self.trace()
+            .into_iter()
+            .filter_map(|line| line.strip_prefix("exit:").map(str::to_string))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Provider for OverlapProbe {
+    fn id(&self) -> &str {
+        "overlap-probe"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        let (result, extra_yields) = {
+            let mut script = self.script.lock().unwrap();
+            script
+                .pop_front()
+                .ok_or_else(|| ProviderError::Terminal("overlap probe exhausted".into()))?
+        };
+        let live = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak.fetch_max(live, Ordering::SeqCst);
+        self.trace
+            .lock()
+            .unwrap()
+            .push(format!("enter:{}", result.text));
+        for _ in 0..=extra_yields {
+            tokio::task::yield_now().await;
+        }
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        self.trace
+            .lock()
+            .unwrap()
+            .push(format!("exit:{}", result.text));
+        Ok(result)
+    }
+
+    async fn complete_observed_ref(
+        &self,
+        req: CompletionRequestRef<'_>,
+        observer: &dyn ToolCallObserver,
+    ) -> Result<CompletionResult, ProviderError> {
+        if self.stream_preview {
+            // Two fragments, so an interleaved stream would visibly splice
+            // rather than merely reorder.
+            observer.text_delta("frag-a");
+            observer.reasoning_delta("thinking");
+        }
+        self.complete_ref(req).await
+    }
+}
+
+/// A resolver serving the probe for every role.
+struct OneProbe<'p>(&'p OverlapProbe);
+impl ProviderResolver for OneProbe<'_> {
+    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
+        Some(self.0)
+    }
+}
+
+/// [`super::run_isolated`] over the overlap probe, additionally returning the
+/// turn's budget guard so a test can assert what the fan-out actually spent.
+async fn run_probed(
+    provider: &OverlapProbe,
+    port: &FakeWorkspacePort,
+    config: PipelineConfig,
+    budget: BudgetGuard,
+) -> (PipelineOutcome, Vec<AgentEvent>, BudgetGuard) {
+    let resolver = OneProbe(provider);
+    let diagnostics = NeverRunner;
+    let repo_status = NeverRepoStatus;
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &diagnostics,
+            tests: &diagnostics,
+            lint: None,
+            mutation: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = budget;
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("a scripted fan-out completes");
+    (outcome, drain(&mut rx), budget)
+}
+
+/// One workspace per candidate, every one of them flipping fail→pass so the
+/// deterministic ladder submits without buying a judge call — which keeps the
+/// provider script to exactly one entry per candidate.
+fn flipping_workspaces(n: usize, log: &Arc<std::sync::Mutex<Vec<String>>>) -> FakeWorkspacePort {
+    FakeWorkspacePort::new(
+        (0..n)
+            .map(|id| {
+                Ok(FakeWorkspace::new(
+                    id,
+                    vec![false, true],
+                    Ok(vec![]),
+                    log.clone(),
+                ))
+            })
+            .collect(),
+        log.clone(),
+    )
+}
+
+/// `triage` plus one worker turn per candidate, each parking for `yields[i]`
+/// extra runtime yields.
+fn fanout_script(yields: &[usize]) -> Vec<(CompletionResult, usize)> {
+    let mut script = vec![(text_result("single"), 0)];
+    for (i, extra) in yields.iter().enumerate() {
+        script.push((text_result(&format!("cand{i} done")), *extra));
+    }
+    script
+}
+
+fn off_budget() -> BudgetGuard {
+    BudgetGuard::new(BudgetMode::Off, None, None)
+}
+
+/// The issue in one assertion: three isolated candidates are inside the model
+/// **together**, so the fan-out costs the slowest candidate rather than the
+/// sum of all three. Sequential dispatch pins the peak at one however long
+/// each candidate parks.
+#[tokio::test]
+async fn isolated_candidates_execute_concurrently() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0, 0]));
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(3, &log);
+
+    let (outcome, _events, _budget) =
+        run_probed(&provider, &port, isolated_config(3), off_budget()).await;
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert_eq!(outcome.candidates_run, 3);
+    assert_eq!(
+        provider.peak(),
+        3,
+        "all three candidates must be in flight together, not one at a time: {:?}",
+        provider.trace()
+    );
+}
+
+/// The knob an operator reaches for when they need one candidate's events to
+/// arrive without a sibling's spliced in: `Some(1)` is exactly the sequential
+/// dispatch that predates concurrency.
+#[tokio::test]
+async fn a_candidate_concurrency_of_one_restores_sequential_dispatch() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0, 0]));
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(3, &log);
+    let config = PipelineConfig {
+        candidate_concurrency: Some(1),
+        ..isolated_config(3)
+    };
+
+    let (outcome, _events, _budget) = run_probed(&provider, &port, config, off_budget()).await;
+
+    assert_eq!(outcome.candidates_run, 3);
+    assert_eq!(
+        provider.peak(),
+        1,
+        "width 1 must never overlap two candidates: {:?}",
+        provider.trace()
+    );
+    assert_eq!(
+        provider.exit_order(),
+        vec!["single", "cand0 done", "cand1 done", "cand2 done"],
+        "a sequential fan-out finishes in index order"
+    );
+}
+
+/// Selection must read the same whoever finishes first. Candidate 0 is held
+/// inside the model until both siblings have finished, and candidates 0 and 1
+/// tie on evidence and diff size — so the winner is decided by the earliest
+/// index, not by the earliest finish.
+#[tokio::test]
+async fn the_winner_does_not_depend_on_which_candidate_finishes_first() {
+    // Candidate 0 parks for a long stretch of yields; 1 and 2 run straight
+    // through, so the exit order is 1, 2, 0.
+    let provider = OverlapProbe::new(fanout_script(&[24, 0, 0]));
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = FakeWorkspacePort::new(
+        vec![
+            // 0 and 1 both flip fail→pass on identical diffs: a genuine tie.
+            Ok(FakeWorkspace::new(
+                0,
+                vec![false, true],
+                Ok(vec![]),
+                log.clone(),
+            )),
+            Ok(FakeWorkspace::new(
+                1,
+                vec![false, true],
+                Ok(vec![]),
+                log.clone(),
+            )),
+            // 2 never flips.
+            Ok(FakeWorkspace::new(
+                2,
+                vec![false, false],
+                Ok(vec![]),
+                log.clone(),
+            )),
+        ],
+        log.clone(),
+    );
+
+    let (outcome, _events, _budget) =
+        run_probed(&provider, &port, isolated_config(3), off_budget()).await;
+
+    let exits = provider.exit_order();
+    assert!(
+        exits.iter().position(|e| e == "cand1 done") < exits.iter().position(|e| e == "cand0 done"),
+        "the test is only meaningful if candidate 1 really finished first: {exits:?}"
+    );
+    assert_eq!(
+        outcome.final_text, "cand0 done",
+        "a tie is broken by the earliest INDEX, never by the earliest finish"
+    );
+    let log = log.lock().unwrap().clone();
+    assert_eq!(
+        log.iter()
+            .filter(|e| e.starts_with("adopt"))
+            .collect::<Vec<_>>(),
+        vec!["adopt:0"],
+        "the adopted workspace must be the winner's, whoever finished first: {log:?}"
+    );
+}
+
+/// Every candidate spends against a carve of the turn's budget and folds it
+/// back on the way out, so a concurrent fan-out is not a hole in the
+/// accounting: the guard and the reported total both see every candidate's
+/// money exactly once.
+#[tokio::test]
+async fn concurrent_candidates_settle_every_dollar_back_into_the_turn_budget() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0, 0]));
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(3, &log);
+
+    let (outcome, _events, budget) =
+        run_probed(&provider, &port, isolated_config(3), off_budget()).await;
+
+    // Triage plus one worker turn per candidate, at `text_result`'s cost.
+    let expected = 4.0 * 0.0001;
+    assert!(
+        (outcome.total_cost_usd - expected).abs() < 1e-9,
+        "the reported cost must be every candidate's spend, summed once: {}",
+        outcome.total_cost_usd
+    );
+    assert!(
+        (budget.spent_usd() - expected).abs() < 1e-9,
+        "the caller's guard must see the same money the outcome reports: {}",
+        budget.spent_usd()
+    );
+}
+
+/// A candidate the fan-out cannot fund never reaches a model. Without the
+/// pre-dispatch gate every remaining slot would buy one doomed call first and
+/// discover the enforced cap over again.
+///
+/// The cap here funds triage and the first in-flight window and nothing more:
+/// `width = 2`, so candidates 0 and 1 dispatch together, and by the time a
+/// slot frees for candidate 2 their settled spend has crossed it.
+#[tokio::test]
+async fn an_exhausted_enforced_budget_stops_dispatching_further_candidates() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0, 0]));
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(3, &log);
+    let config = PipelineConfig {
+        candidate_concurrency: Some(2),
+        ..isolated_config(3)
+    };
+    // Triage costs 0.0001 and leaves headroom; the first window's two
+    // candidates cost 0.0001 each and do not.
+    let budget = BudgetGuard::new(BudgetMode::Enforced, Some(0.00015), None);
+
+    let (_outcome, _events, _budget) = run_probed(&provider, &port, config, budget).await;
+
+    let entered: Vec<String> = provider
+        .trace()
+        .into_iter()
+        .filter_map(|line| line.strip_prefix("enter:").map(str::to_string))
+        .collect();
+    assert!(
+        entered.contains(&"cand0 done".to_string()),
+        "the funded window still runs: {entered:?}"
+    );
+    assert!(
+        !entered.contains(&"cand2 done".to_string()),
+        "a candidate dispatched after the cap was crossed must never reach the model: {entered:?}"
+    );
+}
+
+/// N models sharing one event stream mute the two event kinds the wire
+/// contract already calls best-effort previews. Everything durable — each
+/// candidate's authoritative `Text` — still arrives.
+#[tokio::test]
+async fn a_concurrent_fan_out_mutes_previews_but_never_the_authoritative_text() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0, 0])).streaming();
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(3, &log);
+
+    let (_outcome, events, _budget) =
+        run_probed(&provider, &port, isolated_config(3), off_budget()).await;
+
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            AgentEvent::TextDelta { .. } | AgentEvent::Reasoning { .. }
+        )),
+        "three models' fragments must not be spliced into one preview: {events:?}"
+    );
+    for i in 0..3 {
+        let expected = format!("cand{i} done");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Text { delta } if *delta == expected)),
+            "every candidate's authoritative text still reaches the consumer: {events:?}"
+        );
+    }
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Text { delta } if delta.contains("candidates at once")
+        )),
+        "the fan-out says why the stream went quiet: {events:?}"
+    );
+}
+
+/// A sequential fan-out has nobody to interleave with, so it streams exactly
+/// as it always did.
+#[tokio::test]
+async fn a_sequential_fan_out_still_streams_its_previews() {
+    let provider = OverlapProbe::new(fanout_script(&[0, 0])).streaming();
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = flipping_workspaces(2, &log);
+    let config = PipelineConfig {
+        candidate_concurrency: Some(1),
+        ..isolated_config(2)
+    };
+
+    let (_outcome, events, _budget) = run_probed(&provider, &port, config, off_budget()).await;
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { text } if text == "frag-a")),
+        "width 1 keeps the live preview: {events:?}"
+    );
+}

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -224,6 +224,16 @@ mid-run — and losing candidates leave no residue. Your index and stash are
 never touched. Outside a git repository, candidates degrade to sharing the
 working tree, with a loud warning.
 
+Isolated candidates run **concurrently**, so N candidates cost N× the money but
+roughly the wall clock of the slowest one rather than the sum of all N. The
+turn's budget is divided between the candidates in flight rather than handed to
+each of them, so a `--budget` still bounds the fan-out as a whole. While several
+models are writing to one event stream the live text preview is paused — each
+candidate's full answer, its tool calls and its file changes still arrive, and
+the run says so when it starts. Candidates sharing the working tree (the
+non-git degradation above) always run one at a time: they would otherwise
+overwrite each other's files.
+
 ## End to end: one verified run
 
 ```bash


### PR DESCRIPTION
## What & why

Fully-isolated best-of-N candidates ran strictly sequentially, so `--candidates N` cost the **sum** of N candidate runtimes rather than the slowest. Isolation already guaranteed siblings never see each other's edits and `SteeringFanOut` already gave every candidate its own replay cursor — the only thing forcing them to take turns was the `&mut BudgetGuard` threaded through `run_candidate` → `verify_candidate` → `judge`.

Isolated candidates now dispatch through `buffer_unordered(width)`. The three design questions the issue left open are settled explicitly:

**Budget — reservation, not a shared guard.** Each candidate spends against a `BudgetGuard::carve` of `headroom / width` and folds it back with `settle_child` on the way out, gated before dispatch against the shared parent. That is the same snapshot-not-reservation posture `stella-fleet` documents on its own dispatch gate, plus `fleet_cmd`'s per-child divisor. **Documented bound: aggregate spend never exceeds the cap by more than one in-flight window — at most `width` model calls**, since the budget is consulted between steps and never mid-call (invariant 6). At `width == 1` that is the single call the sequential path always allowed. `candidate_fanout`'s module doc is the normative statement.

**Event stream — mute the previews, keep everything durable.** A wide fan-out mutes `TextDelta` and `Reasoning`, the two kinds the wire contract already calls best-effort previews (`TextDelta`'s own docs: "strictly a best-effort preview… persistence layers may drop them"). Three models' fragments spliced into one paragraph is not a preview of anything. Every durable event still goes out live — each candidate's authoritative `Text`, its tool calls, file changes and proof steps — and the fan-out narrates the mute so a quiet stream is not read as a stalled run.

**Witness author turns — serialized on `create`, not on the model.** `git worktree add` plus a snapshot commit runs against one repository, and it is milliseconds against a candidate's minutes. `SerialCreates` wraps the `CandidateWorkspacePort` so both the up-front candidate workspaces *and* the second snapshot a witness author needs go through one lock; the model calls, where the time actually is, stay fully concurrent.

Results are re-ordered by index before selection and the reported cost is summed by index, so neither the winner nor the total depends on who finished first. Only the isolated path is ever concurrent — the shared-tree degradation (`candidates > 1` with no `CandidateWorkspacePort`) executes into one working tree and stays sequential. `PipelineConfig::candidate_concurrency: Some(1)` restores the previous strictly sequential dispatch.

Closes #1215

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-pipeline/src/pipeline/tests/best_of_n/fanout_concurrency.rs`. Every other test in the tree runs against doubles that never return `Pending`, so a concurrent fan-out and a sequential one are observationally identical there — `buffer_unordered` polls candidate 0 to completion before reaching candidate 1. `OverlapProbe` is a provider that yields inside every completion and records the peak number of completions in flight; one candidate at a time can never move that past 1 however much it yields.

Three of the seven tests are genuine witnesses (verified by forcing `fan_out_width` back to 1, which turns them red and leaves the rest green):

- `isolated_candidates_execute_concurrently` — peak in-flight is 3, not 1.
- `the_winner_does_not_depend_on_which_candidate_finishes_first` — candidate 0 is held inside the model until both siblings finish; the tie between 0 and 1 is still broken by earliest **index**, and `adopt:0` is what lands.
- `a_concurrent_fan_out_mutes_previews_but_never_the_authoritative_text`.

The rest pin the contract: `a_candidate_concurrency_of_one_restores_sequential_dispatch`, `concurrent_candidates_settle_every_dollar_back_into_the_turn_budget`, `an_exhausted_enforced_budget_stops_dispatching_further_candidates`, `a_sequential_fan_out_still_streams_its_previews`. `candidate_fanout.rs` adds eight unit tests over the width and budget arithmetic, including the aggregate-at-the-cap property.

Not covered here: the issue's "measured, e.g. loop-bench A/B" — that needs provider credentials this environment does not have. The peak-overlap assertion is the structural proof that the fan-out's duration is bounded by the slowest candidate rather than the sum.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 95 test targets green; **one pre-existing failure**, `verify::tests::both_judge_prompts_mark_the_diff_as_worker_authored_data`, which fails identically on this branch's base (confirmed with `git stash`) and is untouched by this change
- [x] Docs updated: `stella-pipeline/README.md` (file table, a Key-concepts section, the test-module list) and `website/content/docs/inference-pipeline.mdx`'s best-of-N section
- [x] `Closes #1215` appears both above and as a commit trailer

`make file-size` was already red on the base for three files (`bench/harbor_adapter/stella_harbor/__init__.py`, `bench/harbor_adapter/tests/test_adapter.py`, `stella-pipeline/src/pipeline/tests.rs`). This PR does not add to any of them: `pipeline.rs` is back to its exact pre-change line count, the new test module is declared inside `best_of_n.rs` rather than growing the already-over-ceiling `tests.rs`, and the baseline is untouched.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (`tokio`/`futures-util` were already this crate's)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**`BudgetGuard::carve` relabels the axis.** By contract a carve lands its ceiling on the child's *session* axis ("a child's whole life is one turn"), so a candidate that trips a **turn** cap now reports `BudgetAxis::Session` in its `BudgetDenied` event. The money is identical — headroom consults both axes, so a turn limit still bounds the carve — but it is an observable label change on the enforced path, called out in `candidate_fanout`'s module doc. Applied at every width rather than special-cased at 1, to keep one code path.

**A budget-skipped candidate is a `setup_aborted`.** It never reached a model, so `candidates_run` should not count it. That makes it degradable, so a fan-out where *every* candidate was skipped can still fall through to the bare-execution backstop and pay for one call. That is one call, versus the N the old shared-guard path paid (the first call always lands).

**Two shared surfaces deliberately not fenced**, both documented in `fanout_stage`'s module doc:

- `FileTouchPort` is one session-wide counter and concurrent candidates read overlapping windows of it. Not cross-talk today because an isolated candidate executes against `CandidateWorkspace::tools()`, which the session recorder never sees — the delta stays at zero and the count falls through to the per-candidate `FileChange` tally, which is private to one turn's engine channel. A host that ever wires a recorder observing candidate workspaces would need a per-candidate port.
- `EngineConfig::turn_instance` is shared across candidates, so their step manifests key alike and the last writer wins. Already true when candidates ran in sequence; concurrency only makes *which* one writes last unordered rather than "the highest index". The real fix is a per-candidate instance, which is not attempted here because the value is allocated by the caller (`stella-core::goal` walks it by round) and minting offsets inside the pipeline would collide with the next turn's. Worth its own issue.

**`candidate_concurrency` has no CLI surface**, matching `candidates` itself, which has never been flag-wired either — both are library-level config today. The default (`None` → full width) is what every current caller gets.

---

## Summary by Sourcery

Run best-of-N isolated candidates concurrently in the pipeline while keeping shared-tree candidates sequential, with serialized workspace creation and muted previews on shared event streams.

New Features:
- Add configurable candidate concurrency to isolated best-of-N runs so multiple candidates can execute in parallel within one turn.
- Introduce a dedicated candidate fan-out module to determine fan-out width and split turn budgets across concurrent candidates.

Enhancements:
- Refactor best-of-N execution into a separate fan-out stage that handles concurrent dispatch, budget gating, and index-stable result ordering.
- Serialize candidate workspace creation (including witness snapshots) to avoid concurrent git worktree issues while keeping model calls concurrent.
- Mute preview-only events when multiple candidates share an event stream, while still streaming all durable events and narrating the behavior to users.

Documentation:
- Document concurrent best-of-N fan-out behavior, budget splitting, and preview muting in the pipeline README and inference pipeline docs, including the new candidate fan-out and fan-out stage modules.

Tests:
- Add best-of-N fan-out concurrency tests and unit tests for fan-out width and budget behavior to verify concurrency, selection stability, budget accounting, and preview muting.
