### PR TITLE
fix(bench): a broken exit-cause probe is unattributed, not a teardown

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -1609,6 +1609,7 @@ class StellaAgent(BaseInstalledAgent):
             report = build_exit_cause_report(
                 return_code=SIGKILL_EXIT_CODE,
                 container_state=probe.get("container_state"),
+                container_absent=bool(probe.get("container_absent")),
                 memory_events_text=probe.get("memory_events_text"),
                 events=events,
                 probe_errors=list(probe.get("errors") or []),

--- a/bench/harbor_adapter/stella_harbor/exit_cause.py
+++ b/bench/harbor_adapter/stella_harbor/exit_cause.py
@@ -102,6 +102,7 @@ def sigkill_verdict(
     *,
     container_state: dict[str, Any] | None,
     memory_events: dict[str, int],
+    container_absent: bool = False,
 ) -> tuple[str, str]:
     """Return ``(verdict, detail)`` for a 137 exit.
 
@@ -114,9 +115,19 @@ def sigkill_verdict(
     * ``external-teardown`` — the container is exited, dead, or already gone,
       with no OOM evidence: something outside stopped it (a ``docker stop``,
       the harness reclaiming the trial).
-    * ``unattributed`` — the container is alive and healthy with zero OOM
-      events: the SIGKILL came from somewhere this probe cannot see. Still
-      recorded, because "we looked and found nothing" beats silence.
+    * ``unattributed`` — no evidence either way. Either the container is alive
+      and healthy with zero OOM events, or the probe could not observe it at
+      all. Still recorded, because "we looked and found nothing" beats silence.
+
+    ``container_state`` is ``None`` for two very different reasons, and only
+    the caller can tell them apart, so it must: ``container_absent=True`` means
+    *the probe looked and the container was genuinely gone* — that is
+    ``external-teardown``. ``container_absent=False`` with no state means *the
+    probe could not see* (the daemon refused, ``inspect`` failed, the enumerate
+    step errored). That is ``unattributed``, never a teardown: reporting a
+    failed measurement as an affirmative cause would erase a real OOM from the
+    record whenever Docker happens to be unwell, and the reader of the artifact
+    has no way to tell the guess from an observation.
     """
     state = container_state or {}
     if state.get("OOMKilled") is True:
@@ -132,11 +143,18 @@ def sigkill_verdict(
             "killed a process inside (the agent, as the largest resident) "
             "while the container itself kept running",
         )
-    if not state:
+    if container_absent:
         return (
             "external-teardown",
             "the task container no longer exists — it was removed while the "
             "agent was still running",
+        )
+    if not state:
+        return (
+            "unattributed",
+            "the probe could not observe the task container (see "
+            "probe_errors); with no observation there is no evidence of a "
+            "teardown or an OOM either way",
         )
     if state.get("Running") is not True:
         status = state.get("Status", "unknown")
@@ -195,6 +213,7 @@ async def probe_sigkill_cause(
 
     errors: list[str] = []
     container_state: dict[str, Any] | None = None
+    container_absent = False
     memory_events_text: str | None = None
     try:
         compose = compose_base_argv(environment)
@@ -212,6 +231,9 @@ async def probe_sigkill_cause(
         if return_code != 0:
             errors.append("could not enumerate the project's containers")
         elif not container_ids:
+            # An answered question, not a failed one: the project was
+            # enumerated and it is empty.
+            container_absent = True
             errors.append("the compose project lists no containers")
         else:
             return_code, output = await captured_process(
@@ -220,7 +242,7 @@ async def probe_sigkill_cause(
             if return_code != 0:
                 errors.append("docker inspect failed for the project containers")
             else:
-                container_state = _main_container_state(
+                container_state, container_absent = _main_container_state(
                     json.loads(output), service_label=service_label, errors=errors
                 )
         if container_state is not None and container_state.get("Running") is True:
@@ -239,6 +261,7 @@ async def probe_sigkill_cause(
         errors.append(f"exit-cause probe failed: {exc}")
     return {
         "container_state": container_state,
+        "container_absent": container_absent,
         "memory_events_text": memory_events_text,
         "errors": errors,
     }
@@ -246,11 +269,17 @@ async def probe_sigkill_cause(
 
 def _main_container_state(
     inspected: Any, *, service_label: str, errors: list[str]
-) -> dict[str, Any] | None:
-    """Pick the main service container's ``State`` out of ``docker inspect``."""
+) -> tuple[dict[str, Any] | None, bool]:
+    """Pick the main service container's ``State`` out of ``docker inspect``.
+
+    Returns ``(state, absent)``. ``absent`` is ``True`` only when the inspect
+    succeeded and genuinely showed no main container — an observation. A
+    malformed payload is a probe failure, not an absence, and leaves ``absent``
+    ``False`` so the verdict stays ``unattributed``.
+    """
     if not isinstance(inspected, Sequence):
         errors.append("docker inspect returned a non-list")
-        return None
+        return None, False
     for container in inspected:
         if not isinstance(container, dict):
             continue
@@ -258,9 +287,12 @@ def _main_container_state(
         labels = (config or {}).get("Labels") or {}
         if labels.get(service_label) == "main":
             state = container.get("State")
-            return state if isinstance(state, dict) else None
+            if isinstance(state, dict):
+                return state, False
+            errors.append("the main service container reported no State object")
+            return None, False
     errors.append("no main service container found to inspect")
-    return None
+    return None, True
 
 
 def build_exit_cause_report(
@@ -270,6 +302,7 @@ def build_exit_cause_report(
     memory_events_text: str | None,
     events: list[dict[str, Any]] | None,
     probe_errors: list[str],
+    container_absent: bool = False,
 ) -> dict[str, Any]:
     """Assemble the ``stella-exit-cause.json`` artifact for one 137 exit.
 
@@ -281,6 +314,7 @@ def build_exit_cause_report(
     verdict, detail = sigkill_verdict(
         container_state=container_state,
         memory_events=memory_events,
+        container_absent=container_absent,
     )
     return {
         "return_code": return_code,
@@ -288,6 +322,7 @@ def build_exit_cause_report(
         "verdict": verdict,
         "detail": detail,
         "container_state": container_state,
+        "container_absent": container_absent,
         "memory_events": memory_events or None,
         "stream_end": classify_stream_end(events),
         "probe_errors": probe_errors,

--- a/bench/harbor_adapter/tests/test_exit_cause.py
+++ b/bench/harbor_adapter/tests/test_exit_cause.py
@@ -119,8 +119,27 @@ class TestVerdict:
         assert "exited" in detail
 
     def test_a_missing_container_is_external_teardown(self) -> None:
-        verdict, _ = sigkill_verdict(container_state=None, memory_events={})
+        # "Missing" means the probe looked and found nothing there, which is
+        # what `container_absent` says. Absent that observation, a `None`
+        # state means only that the probe could not see — see below.
+        verdict, _ = sigkill_verdict(
+            container_state=None, memory_events={}, container_absent=True
+        )
         assert verdict == "external-teardown"
+
+    def test_an_unobservable_container_is_unattributed_not_teardown(self) -> None:
+        # A broken probe must never be reported as an affirmative cause: a
+        # Docker hiccup during the post-mortem of a real OOM would otherwise
+        # erase that OOM from the record and file it as infrastructure.
+        verdict, detail = sigkill_verdict(container_state=None, memory_events={})
+        assert verdict == "unattributed"
+        assert "could not observe" in detail
+
+    def test_oom_evidence_still_wins_over_an_unobservable_container(self) -> None:
+        verdict, _ = sigkill_verdict(
+            container_state=None, memory_events={"oom_kill": 1}
+        )
+        assert verdict == "oom-kill"
 
     def test_a_healthy_container_with_no_oom_events_is_unattributed(self) -> None:
         # "We looked and found nothing" is recorded, never guessed into a


### PR DESCRIPTION
## What & why

`sigkill_verdict` treated `container_state=None` as "the container is gone" and returned `external-teardown` — an affirmative causal claim about the trial. But `probe_sigkill_cause` leaves that field `None` on five paths that are probe **failures**, not observations:

- `compose ps -aq` exits non-zero → `"could not enumerate the project's containers"`
- `docker inspect` exits non-zero → `"docker inspect failed for the project containers"`
- inspect returns a non-list → `"docker inspect returned a non-list"`
- the main container carries no `State` object
- any exception at all → `"exit-cause probe failed: {exc}"`

So a Docker hiccup during the post-mortem of a **real OOM kill** recorded the trial as infrastructure teardown, erasing the OOM from the bench record. `verdict` is the field that gets aggregated; `probe_errors` sat beside it and was not consulted.

This is also inconsistent with the module's own stated posture. The `unattributed` verdict already exists for exactly this case, and the test next to the one being changed says why:

> `# "We looked and found nothing" is recorded, never guessed into a more satisfying answer.`

The fix distinguishes the two meanings of `None` at the only place that can tell them apart — the probe:

- `container_absent=True` — the probe looked and the container was genuinely gone (project enumerated empty, or inspect succeeded with no `main`-labelled container). Still `external-teardown`.
- `container_absent=False` with no state — the probe could not see. Now `unattributed`.
- OOM evidence still wins over both, unchanged.

`container_absent` is recorded in the artifact alongside the verdict, so a reader can re-derive the classification — consistent with the report's evidence-first contract.

Refs #1178

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_an_unobservable_container_is_unattributed_not_teardown` asserts `unattributed` for `container_state=None` with no absence observation. On `main` that path returns `external-teardown`, so the test fails there and passes here. `test_oom_evidence_still_wins_over_an_unobservable_container` pins the precedence that must not regress.

`test_a_missing_container_is_external_teardown` is updated rather than removed: its name and intent (a *missing* container is a teardown) are preserved, and the call is now explicit about which of the two meanings of `None` it exercises.

## The gate

- [x] `cargo fmt --check` — n/a, no Rust changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust changed
- [x] `cargo test --workspace` — n/a, no Rust changed
- [x] Docs updated where behavior changed — `sigkill_verdict` and `_main_container_state` docstrings now state the two-meanings-of-`None` rule
- [ ] CLA signed
- [ ] `Closes #N` — no issue closed; this refs #1178

Python gate actually run, from `bench/harbor_adapter`:

- `pytest tests/test_exit_cause.py -q` → **16 passed**
- `pytest -q` → **368 passed, 11 failed, 1 skipped**
- `ruff check` → All checks passed; `ruff format --check` → 2 files already formatted

The 11 failures are **pre-existing and environmental**, not from this change: on a stashed (clean) tree the same 11 fail with 366 passing. They come from ambient `STELLA_*` knobs in the dev container (`STELLA_JUDGE_*`, `STELLA_TRIAGE_*`, `STELLA_PIPELINE_ON`) tripping the adapter's unregistered-knob guard. This change accounts for the 366 → 368 delta.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`exit_cause.py` is in `_FIXED_ADAPTER_SOURCE_PATHS` (the frozen adapter roster in `secure_launcher.py`). That check compares the local adapter tree against the **published** commit, so a scored TB2.1 run cannot use this until it is merged and published — expected for any change to these files, but worth sequencing deliberately before the next scored run.

Scope note: this landed from an audit pass over `4f38a96..HEAD`. Coverage of that range was **partial** — see the summary in the session. `stella-serve/src/checkpoint.rs` and `engine_overrides.rs` were reviewed and found clean; `triage.rs`, `judge_stage.rs`, the SSE/pending surface, and the worker-agent lifecycle changes in `6184ac8` were **not** audited and should not be treated as cleared.

One low-severity item found but not fixed here, to keep this to one logical change: in `stella-serve/src/checkpoint.rs`, `StoreSink::discard()` shares the `reported` latch with `persist()`. The once-per-turn rationale is about `persist` running at every step boundary; `discard` runs once. A turn that reports a persist failure will then silently fail to remove a stale snapshot, leaving a resume point for a turn that actually completed — contrary to the module's "steady-state contents are exactly the turns that died without ending".

---

## Summary by Sourcery

Adjust exit-cause classification for SIGKILL trials to distinguish between genuinely absent containers and unobservable ones, preventing probe failures from being misreported as external teardowns and recording this distinction in artifacts.

Bug Fixes:
- Treat unobservable containers as unattributed instead of external teardowns when exit-cause probes cannot observe container state, avoiding loss of real OOM events.

Enhancements:
- Record an explicit container_absent flag in exit-cause probes and reports so readers can distinguish observed absence from probe failures.
- Clarify sigkill_verdict and _main_container_state docstrings to describe the two different meanings of a None container_state.

Tests:
- Extend exit-cause tests to cover unobservable containers, ensure OOM evidence still takes precedence, and update the missing-container teardown case to assert the new container_absent behavior.
