### PR TITLE
test(bench): close the catalog parser's open last chunk, and pin both misreads

### DIFF
--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -665,15 +665,25 @@ _CATALOG_RS = (
 )
 
 
-def _seeded_output_ceilings() -> dict[str, int]:
-    """Read each seeded model's own completion ceiling from the Rust catalog.
+def _parse_output_ceilings(source: str) -> dict[str, int]:
+    """Collect each shipping model's completion ceiling out of catalog.rs text.
 
     Parsed rather than duplicated, because duplicating it is the defect this
     exists to catch. Entries with no `with_max_output_tokens` are omitted:
     the engine falls back to its global default for those, and the posture
     has no per-model ceiling to match.
+
+    Split out from the file read so the parser's own blind spots can be
+    tested against synthetic source — see `TestCatalogCeilingParser`.
     """
-    source = _CATALOG_RS.read_text(encoding="utf-8")
+    # Stop at the test module. Chunking on `CatalogEntry::new(` bounds every
+    # chunk by the *next* entry, but the seed table's last row has no next
+    # seeded entry — its chunk otherwise runs on into `#[cfg(test)]` and
+    # adopts the first ceiling it finds among the fixtures there. Skipping
+    # `test-only` slugs cannot prevent that: it filters an entry's own
+    # identity, not the extent of the chunk before it. The module boundary
+    # is what actually closes the region.
+    source = source.split("#[cfg(test)]")[0]
     ceilings: dict[str, int] = {}
     for chunk in source.split("CatalogEntry::new(")[1:]:
         head = re.match(r'\s*"([^"]+)"\s*,\s*"([^"]+)"', chunk)
@@ -682,9 +692,9 @@ def _seeded_output_ceilings() -> dict[str, int]:
         slug, provider = head.groups()
         if slug.startswith("test-only"):
             continue  # fixtures for the catalog's own tests, never benchmarked
-        # `split` already consumed the delimiter, so a chunk ends exactly
-        # where the next entry begins and the first ceiling in it is this
-        # entry's own.
+        # Within the seed table `split` already consumed the delimiter, so a
+        # chunk ends exactly where the next entry begins and the first
+        # ceiling in it is this entry's own.
         ceiling = re.search(r"with_max_output_tokens\(Some\(([\d_]+)\)\)", chunk)
         if ceiling is None:
             continue
@@ -699,6 +709,122 @@ def _seeded_output_ceilings() -> dict[str, int]:
         # row and finding this test still green.
         ceilings[f"{provider}/{slug}"] = int(ceiling.group(1).replace("_", ""))
     return ceilings
+
+
+def _seeded_output_ceilings() -> dict[str, int]:
+    """`_parse_output_ceilings` over the real catalog this repo ships."""
+    return _parse_output_ceilings(_CATALOG_RS.read_text(encoding="utf-8"))
+
+
+class TestCatalogCeilingParser:
+    """The parser's own blind spots, pinned against synthetic source.
+
+    The parity check below is only as trustworthy as what this reads out of
+    `catalog.rs`, and both ways it has been wrong so far were silent: a
+    number was still produced, just the wrong model's. Neither would have
+    reddened anything. So the two known misreads get fixtures rather than a
+    comment, because a comment does not fail.
+    """
+
+    _SHIPPING_ROW = """
+                CatalogEntry::new(
+                    "claude-sonnet-5",
+                    "anthropic",
+                    "claude",
+                    200_000,
+                )
+                .with_max_output_tokens(Some(64_000)),
+    """
+
+    # The seed table's *last* row, and — as in `catalog.rs` today — one that
+    # declares no ceiling of its own. That is what leaves its chunk open: with
+    # no ceiling to find first, the next one anywhere below becomes "its".
+    _UNCAPPED_LAST_ROW = """
+                CatalogEntry::new(
+                    "anthropic/claude-haiku-4.5",
+                    "openrouter",
+                    "claude",
+                    200_000,
+                ),
+    """
+
+    _TEST_MODULE_BARE_BUILDER = """
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn a_row_carries_its_own_ceiling() {
+        let entry = base.with_max_output_tokens(Some(8_000));
+        assert_eq!(entry.max_output_tokens, Some(8_000));
+    }
+}
+"""
+
+    def test_a_fixtures_ceiling_is_not_attributed_to_the_last_shipping_row(
+        self,
+    ) -> None:
+        """The seed table's last row must not adopt a number from the tests.
+
+        Nothing closes its chunk, and it has no ceiling of its own to be found
+        first. The bare builder call below is the shape `catalog.rs` actually
+        contains — a fixture asserting a ceiling round-trips, reached with no
+        `CatalogEntry::new(` in between — so an uncapped shipping row came back
+        capped at a number written to exercise the setter. Silent either way:
+        green if the posture happens to sit at 8000, otherwise red about a
+        model that never declared a ceiling at all.
+        """
+        source = (
+            self._SHIPPING_ROW
+            + self._UNCAPPED_LAST_ROW
+            + self._TEST_MODULE_BARE_BUILDER
+        )
+        assert _parse_output_ceilings(source) == {"anthropic/claude-sonnet-5": 64000}
+
+    def test_a_fixture_entry_does_not_become_a_benchmarked_model(self) -> None:
+        # The other way test source leaks: a fixture with its own
+        # `CatalogEntry::new(` becomes a chunk, and a phantom row the parity
+        # check then demands the posture cap at. Its slug is whatever the
+        # fixture author picked, so the `test-only` prefix is not a guarantee.
+        source = (
+            self._SHIPPING_ROW
+            + """
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn a_row_carries_its_own_ceiling() {
+        let entry = CatalogEntry::new(
+            "some-fixture",
+            "anthropic",
+            "claude",
+            200_000,
+        )
+        .with_max_output_tokens(Some(8_000));
+    }
+}
+"""
+        )
+        assert _parse_output_ceilings(source) == {"anthropic/claude-sonnet-5": 64000}
+
+    def test_a_gateway_slug_keeps_its_own_key(self) -> None:
+        # `anthropic/claude-sonnet-5` seeded under `openrouter` is a distinct
+        # row from the direct-Anthropic one. Reading the already-slashed slug
+        # as fully qualified collapses the two, and the later row wins — so
+        # one model's posture gets checked against the other's ceiling.
+        source = (
+            self._SHIPPING_ROW
+            + """
+                CatalogEntry::new(
+                    "anthropic/claude-sonnet-5",
+                    "openrouter",
+                    "claude",
+                    200_000,
+                )
+                .with_max_output_tokens(Some(48_000)),
+    """
+        )
+        assert _parse_output_ceilings(source) == {
+            "anthropic/claude-sonnet-5": 64000,
+            "openrouter/anthropic/claude-sonnet-5": 48000,
+        }
 
 
 class TestOutputCeilingParity:


### PR DESCRIPTION
## What & why

Follow-up to #1251, which landed the posture/ceiling ratchet. That check is only as
trustworthy as what it reads out of `catalog.rs`, and the parser had a hole at the one
place its stated invariant does not hold.

Refs #1211

The parser chunks the catalog by splitting on `CatalogEntry::new(`, so each chunk is
bounded by the *next* entry and "the first ceiling in the chunk is this entry's own".
True between entries — but the seed table's **last** row has no next seeded entry. Its
chunk runs on until the next `CatalogEntry::new(` anywhere in the file, which is inside
`#[cfg(test)]` (line 603).

Today that last row is `openrouter/anthropic/claude-haiku-4.5`, and it declares **no
ceiling of its own** — so there is nothing to be found first. Any bare
`with_max_output_tokens` added to a test between it and the next fixture entry becomes
"its" ceiling. `catalog.rs` already contains that exact shape at line 721 — a fixture
asserting the setter round-trips — shielded only by happening to sit behind a
`test-only`-prefixed entry.

Skipping `test-only` slugs cannot close this. It filters an entry's own *identity*, not
the *extent* of the chunk before it; a name-based filter cannot bound a region. Cutting
the source at the module boundary can, and does.

## What changed

- `_parse_output_ceilings(source)` split out of the file read, so synthetic source can be
  fed in. `_seeded_output_ceilings()` is now the one-line wrapper over the real catalog.
- The parser stops at `#[cfg(test)]`.
- Both leak modes get fixtures instead of comments, because a comment does not fail:
  - a fixture's ceiling attributed to an uncapped shipping row (reported as capped at 8000)
  - a fixture entry becoming a phantom benchmarked model the parity check then demands a
    posture for

No change to what the parity check reads from the real catalog: the same 5 seeded
ceilings, all 64000.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Mutation-tested. Removing the boundary line reddens **both** new fixtures:

```
AssertionError: assert {'openrouter/anthropic/claude-haiku-4.5': 8000} == {'anthropic/claude-sonnet-5': 64000}
AssertionError: assert {'anthropic/some-fixture': 8000}              == {'anthropic/claude-sonnet-5': 64000}
```

Worth recording because it caught a bad test on the way in: the first fixture originally
used a shipping row that *had* its own ceiling, so `re.search` found the right number
first and the test passed under mutation — decoration. Modeling the real hazard (an
uncapped last row, which is what `catalog.rs` actually has) is what made it bite.

The third fixture (gateway slug vs direct-provider key) is boundary-independent and
stayed green under the same mutation, as it should.

## The gate

- [x] `harbor_adapter` suite: **395 passed, 1 skipped** in a clean `env -i`
      (ambient `STELLA_*` makes the claim tests fail closed)
- [x] `ruff check` / `ruff format --check` clean on the touched file
- [x] `./scripts/check-file-size.sh` OK — 864 lines, under the 1500 ratchet
- [x] Full local pre-push gate (`fmt` + `clippy` + `test`) passed before push
- [ ] Docs — n/a, test-only change

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Test-only; no Rust touched and no production behavior changed. `Refs`, not `Closes` —
#1211 §6.2 was satisfied by #1251, this only makes that check trustworthy.

## Summary by Sourcery

Refine the harbor adapter posture tests’ catalog ceiling parsing to correctly ignore test-only Rust module code and validate parser behavior against known edge cases.

Enhancements:
- Extract output ceiling parsing into a reusable `_parse_output_ceilings` helper that can operate on arbitrary catalog source text.
- Limit catalog parsing to the main module content by stopping at the Rust `#[cfg(test)]` boundary to avoid leaking test fixtures into seeded model ceilings.

Tests:
- Add targeted tests for the catalog ceiling parser to pin previously silent misreads, including an uncapped last seeded row, a fixture-only catalog entry, and distinct gateway vs direct-provider slugs.