### PR TITLE
feat(deck): wire the lead lane's Control verbs onto the turn gate (#1219)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,7 +18,7 @@
 1743 stella-cli/src/agent_tests.rs
 2359 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4551 stella-cli/src/command_deck.rs
+4667 stella-cli/src/command_deck.rs
 1515 stella-cli/src/fleet_cmd.rs
 1526 stella-cli/src/memory/tests.rs
 2129 stella-core/src/bus.rs
@@ -38,6 +38,6 @@
 2234 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1870 stella-tui/src/deck_render.rs
-3902 stella-tui/src/deck_ui.rs
+3905 stella-tui/src/deck_ui.rs
 1665 stella-tui/src/views/engine.rs
 1608 stella-tui/src/views/session.rs

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -102,6 +102,7 @@ use stella_tui::{
     SlashCommand, SplashCue, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::watch;
 
 use crate::agent;
 use crate::claims::ClaimTap;
@@ -1465,6 +1466,18 @@ pub async fn run_deck_session(
         // registry, so sub-agents this turn dispatches stop when it does
         // (`crate::subagent`). The engine still takes it by reference.
         let steering: Arc<subsession::SteeringTap> = Arc::default();
+        // The lead lane's pause gate (#1219), per-turn for the same reason
+        // `steering` is: a pause cannot leak into the next turn, because the
+        // next iteration builds a fresh channel that starts `false`.
+        //
+        // `Arc` because it goes three places — the pipeline (which attaches it
+        // to every engine it builds and parks its management calls behind it),
+        // the step-loop engine, and the registry, so sub-agents this turn
+        // dispatches park with it rather than spending on behind a paused lead.
+        let (pause_tx, pause_rx) = watch::channel(false);
+        let gate: Arc<subsession::WatchGate> = Arc::new(subsession::WatchGate(pause_rx));
+        // The lane's latched dashboard state — see `service_lead_control`.
+        let mut lead_paused = false;
         let end = {
             // Both arms return `Result<(), String>`, so one pinned future
             // drives either path through the same select loop.
@@ -1491,6 +1504,7 @@ pub async fn run_deck_session(
                         &lead_holder,
                         &discovery_activation,
                         &steering,
+                        &gate,
                         mcp.clone(),
                     )
                     .await
@@ -1512,6 +1526,7 @@ pub async fn run_deck_session(
                         &lead_holder,
                         &discovery_activation,
                         &steering,
+                        &gate,
                         recall_event,
                     )
                     .await
@@ -1630,6 +1645,19 @@ pub async fn run_deck_session(
                                 // pair's second press (StopAndHold below)
                                 // stays the immediate hard cancel.
                                 steering.request_soft_stop();
+                                // A soft stop ends the turn at its NEXT step
+                                // boundary — and a paused turn is exactly one
+                                // that cannot reach a boundary, because the
+                                // gate parks it just before the stop flag is
+                                // read. Release the gate so it wakes, sees the
+                                // latched stop, and ends keeping its completed
+                                // work; otherwise Esc on a paused lead reads
+                                // as doing nothing until the user happens to
+                                // resume (#1219). `lead_paused` is deliberately
+                                // NOT cleared: the row is still painted paused,
+                                // and the turn-end unlatch below is what owes
+                                // it a status.
+                                let _ = pause_tx.send(false);
                                 let _ = in_tx.send(Inbound::Event {
                                     agent: LEAD.to_string(),
                                     event: AgentEvent::Text {
@@ -1853,19 +1881,34 @@ pub async fn run_deck_session(
                         }) => {
                             let _ = scope_tx.send(decision);
                         }
-                        // Lead-lane pause/resume/restart: the boundary gate
-                        // now EXISTS (`Pipeline::with_turn_gate` — the fleet's
-                        // pipeline workers park on it), but the deck's lead
-                        // turn does not yet build a watch channel and thread
-                        // it through `run_lead_turn`'s pipeline construction —
-                        // that wiring (and fleet tasks as deck lanes) is the
-                        // remaining follow-up. No-op here until then.
-                        Some(WorkspaceInput::Control { .. }) => {}
+                        // Lead-lane pause/resume (#1219). Everything above has
+                        // peeled off `Stop` (either lane) and every worker
+                        // lane, so what lands here is the LEAD's own
+                        // pause/resume/restart — see `service_lead_control`.
+                        Some(WorkspaceInput::Control { control, .. }) => {
+                            lead_paused =
+                                service_lead_control(control, &pause_tx, &in_tx, lead_paused);
+                        }
                     },
                 }
             }
             // `turn` (and the channel senders it holds) drops here.
         };
+
+        // The turn is over, so the lane is not paused any more — whether it ran
+        // past its last boundary to completion or was hard-cancelled while
+        // parked. Said explicitly because the fold will not move a row off
+        // `Paused` from the event stream: without this the cancel path's
+        // terminal `Error` — and every event of the NEXT turn — would be
+        // swallowed and the row would read paused for the rest of the session.
+        // `WaitingInput`, not a terminal state: the arms below emit the turn's
+        // own outcome and this must not pre-empt them.
+        if lead_paused {
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::WaitingInput,
+            });
+        }
 
         match end {
             TurnEnd::Finished(outcome) => {
@@ -2654,6 +2697,60 @@ fn service_worker_control(
                 );
             }
         }
+    }
+}
+
+/// The LEAD lane's `Control` verbs (#1219) — the lead twin of
+/// [`service_worker_control`], and deliberately much smaller: a worker lane is
+/// a spawned thread with a retained spec, while the lead IS the session.
+///
+/// `paused` is the lane's currently latched state and the return is what it
+/// becomes, so the caller can tell at turn end whether it still owes the
+/// dashboard a status (the deck's fold will not move a row off `Paused` from
+/// the event stream, by design — streaming output must not silently un-pause
+/// a lane the user parked).
+///
+/// The status sent here is load-bearing, not decoration: `p` is a *toggle*
+/// resolved against the row's current status, so a pause that parked the turn
+/// without painting the row would leave the next `p` sending Pause again — a
+/// lane the user could park and never release.
+///
+/// Pause/Resume flip the turn's watch channel, which the pipeline, the
+/// step-loop engine, and the registry's sub-agent dispatcher all hold: the
+/// turn parks at its next step boundary, never mid-tool (L-E6). A `send` that
+/// fails means every receiver is gone — the turn is already over — which is
+/// exactly the stale control that must read as a no-op, so it is dropped
+/// rather than reported.
+///
+/// `Restart` is not a lead verb, by the fleet's own rule: a restart is the
+/// caller re-dispatching, which the deck already offers (stop, then submit
+/// again). There is no retained lead spec to respawn from. `Stop` never
+/// arrives here — the driver's own arm claims it, for both lanes — and is
+/// matched only so a newly added control cannot be silently swallowed.
+fn service_lead_control(
+    control: stella_tui::AgentControl,
+    pause_tx: &watch::Sender<bool>,
+    in_tx: &UnboundedSender<Inbound>,
+    paused: bool,
+) -> bool {
+    match control {
+        stella_tui::AgentControl::Pause => {
+            let _ = pause_tx.send(true);
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::Paused,
+            });
+            true
+        }
+        stella_tui::AgentControl::Resume => {
+            let _ = pause_tx.send(false);
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::Running,
+            });
+            false
+        }
+        stella_tui::AgentControl::Restart | stella_tui::AgentControl::Stop => paused,
     }
 }
 
@@ -4103,6 +4200,9 @@ async fn run_lead_turn(
     claim_holder: &str,
     activated: &crate::discovery::ActivatedTools,
     steering: &Arc<subsession::SteeringTap>,
+    // This turn's pause gate (#1219), owned by the driver loop so its input
+    // arms can flip it while this future runs.
+    gate: &Arc<subsession::WatchGate>,
     // Phase 2 (#713): this turn's `ContextRecall`, carried from the caller
     // because recall runs before this channel exists.
     recall_event: Option<AgentEvent>,
@@ -4134,11 +4234,14 @@ async fn run_lead_turn(
     );
     // This turn's file changes ride this turn's channel.
     registry.attach_events(stella_core::EventSender::new(tx.clone()));
-    // ...and this turn's soft stop reaches the sub-agents it dispatches. The
-    // lead turn has no pause gate (Pause is a worker-lane verb), so steering
-    // is all there is to publish; the guard takes it down on return.
+    // ...and this turn's soft stop AND pause reach the sub-agents it
+    // dispatches: a paused lead must not keep spending inside a child it
+    // dispatched, which is only reachable because the dispatcher reads both
+    // seams off the registry. The guard takes them down on return.
     let _controls = registry.attach_turn_controls(
-        stella_core::ports::TurnControls::none().with_steering(steering.clone()),
+        stella_core::ports::TurnControls::none()
+            .with_steering(steering.clone())
+            .with_gate(gate.clone()),
     );
 
     // Same structural drop-order rule as `agent::run_turn`: every tx clone
@@ -4173,7 +4276,10 @@ async fn run_lead_turn(
             &TokioSleeper,
         )
         .with_calibration(calibration)
-        .with_steering(steering.as_ref());
+        .with_steering(steering.as_ref())
+        // Polled once per step, at the same boundary as the budget abort and
+        // the soft stop — so a pause parks between model calls, never mid-tool.
+        .with_gate(gate.as_ref());
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }
@@ -4263,6 +4369,9 @@ async fn run_lead_pipeline_turn(
     claim_holder: &str,
     activated: &crate::discovery::ActivatedTools,
     steering: &Arc<subsession::SteeringTap>,
+    // As in `run_lead_turn` — the driver loop owns it and flips it from its
+    // input arms while this future runs (#1219).
+    gate: &Arc<subsession::WatchGate>,
     mcp: Option<Arc<stella_mcp::McpToolSet>>,
 ) -> Result<(), String> {
     budget.begin_turn();
@@ -4287,11 +4396,13 @@ async fn run_lead_pipeline_turn(
     // Candidate registries are deliberately left unattached — a candidate's
     // edits live in a shadow worktree and are only the user's once adopted.
     registry.attach_events(stella_core::EventSender::new(tx.clone()));
-    // As in `run_lead_turn`: Esc reaches this turn's sub-agents. The same tap
-    // goes to the pipeline's execute engine below, so one stop lands on the
-    // stage, its tool calls, and their children alike.
+    // As in `run_lead_turn`: Esc and Pause reach this turn's sub-agents. The
+    // same tap and gate go to the pipeline below, so one stop — or one pause —
+    // lands on the stage, its tool calls, and their children alike.
     let _controls = registry.attach_turn_controls(
-        stella_core::ports::TurnControls::none().with_steering(steering.clone()),
+        stella_core::ports::TurnControls::none()
+            .with_steering(steering.clone())
+            .with_gate(gate.clone()),
     );
 
     let result = {
@@ -4379,7 +4490,12 @@ async fn run_lead_pipeline_turn(
             headless_bypass_scope_review: false,
             ..agent::apply_pipeline_tuning(cfg, PipelineConfig::default())
         };
-        let pipeline = Pipeline::new(ports, tx.clone(), config);
+        // #1214's seam, now driven from the deck: the pipeline attaches this
+        // gate to every engine it builds (execute/revise turns, the witness
+        // author) and parks its own management calls pre-spend behind it, so a
+        // lead pause reaches a staged turn at the same safe step boundary the
+        // step-loop path gets — and no further `StepUsage` lands until resume.
+        let pipeline = Pipeline::new(ports, tx.clone(), config).with_turn_gate(gate.as_ref());
         pipeline.run(prompt, messages, budget).await
     };
     // Same settle window as `run_lead_turn` — see `SteeringTap::mark_settling`.

--- a/stella-cli/src/command_deck/tests.rs
+++ b/stella-cli/src/command_deck/tests.rs
@@ -614,3 +614,158 @@ fn requeue_front_mirrors_each_front_insert_to_the_deck() {
     }
     assert!(rx.try_recv().is_err(), "exactly one mirror per insert");
 }
+
+/// #1219: `p` on the lead row must reach the gate the driver hands to
+/// `Pipeline::with_turn_gate` and `Engine::with_gate`, so this asserts on the
+/// real adapter's parking behavior rather than on the flag behind it. Parking
+/// IS the acceptance criterion — the engine polls the gate once per step, so a
+/// gate that never parks is a pause that buys another model call.
+#[tokio::test]
+async fn pausing_the_lead_lane_parks_its_turn_gate_until_resume() {
+    use stella_core::ports::TurnGate;
+
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let gate: Arc<subsession::WatchGate> = Arc::new(subsession::WatchGate(pause_rx));
+    let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+
+    // Unpaused, a step boundary costs nothing: the turn runs straight through.
+    tokio::time::timeout(std::time::Duration::from_secs(5), gate.wait_if_paused())
+        .await
+        .expect("an unpaused gate must not park the turn");
+
+    let paused = service_lead_control(stella_tui::AgentControl::Pause, &pause_tx, &in_tx, false);
+    assert!(
+        paused,
+        "the lane latches paused — the driver owes the dashboard a status at \
+         turn end because the fold will not clear it from the event stream"
+    );
+    match in_rx.try_recv() {
+        Ok(Inbound::Status { agent, status }) => {
+            assert_eq!(agent, LEAD);
+            assert_eq!(status, AgentStatus::Paused);
+        }
+        other => panic!("expected the lead row to flip to paused, got {other:?}"),
+    }
+
+    // Park a real waiter — this is the await the engine's next step takes.
+    let waiter = tokio::spawn({
+        let gate = gate.clone();
+        async move { gate.wait_if_paused().await }
+    });
+    let mut waiter = std::pin::pin!(waiter);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(150), &mut waiter)
+            .await
+            .is_err(),
+        "a paused gate must hold the turn at its step boundary"
+    );
+
+    let paused = service_lead_control(stella_tui::AgentControl::Resume, &pause_tx, &in_tx, paused);
+    assert!(
+        !paused,
+        "resume clears the latch — nothing owed at turn end"
+    );
+    match in_rx.try_recv() {
+        Ok(Inbound::Status { agent, status }) => {
+            assert_eq!(agent, LEAD);
+            assert_eq!(status, AgentStatus::Running);
+        }
+        other => panic!("expected the lead row to flip back to running, got {other:?}"),
+    }
+    tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+        .await
+        .expect("resume must release the turn parked at the boundary")
+        .expect("the waiter task completes");
+}
+
+/// Restart is not a lead verb (#1219 leaves it out of scope, by the fleet's
+/// own rule): the lead IS the session, so there is no retained spec to respawn
+/// from and re-dispatching is just submitting the prompt again. It must leave
+/// the turn exactly as it found it — in particular it must not tell the
+/// dashboard about a respawn that never happened.
+#[test]
+fn restart_is_not_a_lead_verb_and_leaves_the_turn_untouched() {
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+
+    assert!(
+        service_lead_control(stella_tui::AgentControl::Restart, &pause_tx, &in_tx, true),
+        "a paused lane stays paused"
+    );
+    assert!(
+        !service_lead_control(stella_tui::AgentControl::Restart, &pause_tx, &in_tx, false),
+        "a running lane stays running"
+    );
+    assert!(!*pause_rx.borrow(), "and the gate is never touched");
+    assert!(
+        in_rx.try_recv().is_err(),
+        "restart emits no status — the row must not claim a respawn"
+    );
+}
+
+/// Acceptance (#1219): a stale pause/resume is a no-op, never an error. The
+/// keystroke can land after every gate receiver is gone — the turn it aimed at
+/// has ended — and the failed `send` is dropped rather than reported, because
+/// there is nothing left to pause and nothing the user did wrong.
+#[test]
+fn a_stale_lead_control_is_a_no_op_not_an_error() {
+    let (pause_tx, pause_rx) = watch::channel(false);
+    drop(pause_rx);
+    let (in_tx, _in_rx) = mpsc::unbounded_channel();
+
+    assert!(service_lead_control(
+        stella_tui::AgentControl::Pause,
+        &pause_tx,
+        &in_tx,
+        false
+    ));
+    assert!(!service_lead_control(
+        stella_tui::AgentControl::Resume,
+        &pause_tx,
+        &in_tx,
+        true
+    ));
+}
+
+/// Pause and the soft stop are polled at the SAME step boundary, and the gate
+/// parks the turn just before the stop flag is read — so a stop latched behind
+/// a pause would sit unobserved, and Esc on a paused lead would read as doing
+/// nothing. The driver releases the gate when it latches a soft stop; this pins
+/// the release, which is what lets the parked turn wake and end (#1219).
+#[tokio::test]
+async fn a_soft_stop_releases_a_paused_lead_so_the_turn_can_reach_its_boundary() {
+    use stella_core::ports::TurnGate;
+
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let gate: Arc<subsession::WatchGate> = Arc::new(subsession::WatchGate(pause_rx));
+    let (in_tx, _in_rx) = mpsc::unbounded_channel();
+    let steering: Arc<subsession::SteeringTap> = Arc::default();
+
+    service_lead_control(stella_tui::AgentControl::Pause, &pause_tx, &in_tx, false);
+    let waiter = tokio::spawn({
+        let gate = gate.clone();
+        async move { gate.wait_if_paused().await }
+    });
+    let mut waiter = std::pin::pin!(waiter);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(150), &mut waiter)
+            .await
+            .is_err(),
+        "parked, as a paused turn must be"
+    );
+
+    // What the driver's lead-Stop arm does: latch the stop, then release the
+    // gate so the turn can reach the boundary that observes it.
+    steering.request_soft_stop();
+    let _ = pause_tx.send(false);
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+        .await
+        .expect("the soft stop must release the parked turn, not deadlock it")
+        .expect("the waiter task completes");
+    assert!(
+        stella_core::ports::TurnSteering::soft_stop_requested(steering.as_ref()),
+        "and the stop is still latched when the woken turn reads it — the \
+         release must not consume the request it exists to deliver"
+    );
+}

--- a/stella-cli/src/subagent.rs
+++ b/stella-cli/src/subagent.rs
@@ -113,11 +113,12 @@
 //!   message the user addressed to the parent.
 //!
 //! Every driver that runs turns installs a dispatcher and publishes what it
-//! has: the deck's lead and pipeline turns publish a steering tap (Pause is a
-//! worker-lane verb, so the lead has no gate), and deck worker lanes and fleet
-//! workers publish their `WatchGate`. A driver that publishes nothing is still
-//! not a failure state — a child then runs bounded by its step cap and its
-//! carve, exactly as before.
+//! has: the deck's lead and pipeline turns publish both a steering tap and a
+//! `WatchGate` (#1219 — `p` on the lead row parks the turn and, through this
+//! dispatcher, every child it dispatched), and deck worker lanes and fleet
+//! workers publish their own `WatchGate`. A driver that publishes nothing is
+//! still not a failure state — a child then runs bounded by its step cap and
+//! its carve, exactly as before.
 //!
 //! # A cancelled parent: cascade the intent, not the mechanism
 //!

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -354,11 +354,18 @@ pub(crate) fn route_mid_turn(text: String, settling: bool) -> MidTurnRoute {
     }
 }
 
-/// `stella_core::ports::TurnGate` over a watch channel: the worker's turn
-/// parks at its next step boundary while the driver holds `true` (Pause)
-/// and continues on `false` (Resume). A dropped sender (driver gone) reads
-/// as resumed — a worker must never park forever on teardown.
-struct WatchGate(watch::Receiver<bool>);
+/// `stella_core::ports::TurnGate` over a watch channel: the turn parks at
+/// its next step boundary while the driver holds `true` (Pause) and
+/// continues on `false` (Resume). A dropped sender (driver gone) reads
+/// as resumed — a turn must never park forever on teardown.
+///
+/// `pub(crate)` for one caller beyond this module: the deck's LEAD lane
+/// (#1219), which builds the same adapter over its own per-turn channel and
+/// hands it to `Pipeline::with_turn_gate` / `Engine::with_gate`. Deck worker
+/// lanes and the deck lead sit on the same side of the deck/fleet boundary,
+/// so they share this item rather than duplicating it; `fleet_cmd.rs` keeps
+/// its own co-located twin precisely because it does not.
+pub(crate) struct WatchGate(pub(crate) watch::Receiver<bool>);
 
 #[async_trait::async_trait]
 impl stella_core::ports::TurnGate for WatchGate {

--- a/stella-core/src/ports.rs
+++ b/stella-core/src/ports.rs
@@ -167,9 +167,11 @@ pub trait TurnSteering: Send + Sync {
 /// every turn of the session and cannot name a single turn's lifetime, so it
 /// needs `Arc`s it can clone onto a child's thread instead.
 ///
-/// Both fields are `Option` because no driver has both. The deck's lead turn
-/// steers but does not pause (pause is a worker-lane verb); a worker lane
-/// pauses but does not steer. A driver publishes what it has.
+/// Both fields are `Option` because not every driver has both: a worker lane
+/// pauses but does not steer, and a headless run does neither. The deck's
+/// lead turn has both — it steers (`>`), and since #1219 it pauses (`p`) —
+/// so a driver publishes what it has, which may be one, the other, or the
+/// pair.
 ///
 /// # Empty is a real state, not an error
 ///

--- a/stella-core/src/subagent/tests.rs
+++ b/stella-core/src/subagent/tests.rs
@@ -990,6 +990,36 @@ async fn owned_turn_controls_stop_a_child_without_clobbering_an_attached_gate() 
     );
 }
 
+/// Every driver used to publish exactly one seam — worker lanes a gate, the
+/// deck's lead a steering tap — so the both-at-once case had no caller and no
+/// test. The deck's lead lane is that caller now (#1219): it steers with `>`
+/// and pauses with `p`, and hands the pair to its sub-agent dispatcher in one
+/// [`TurnControls`]. A `with_gate` that displaced the steering it was given
+/// would turn the lead's Esc into a no-op the moment pause was wired up —
+/// silently, since both are `Option` and neither absence is an error.
+#[test]
+fn turn_controls_carrying_both_seams_give_a_child_both() {
+    let provider = ScriptedProvider::new(vec![]);
+    let tools = MixedTools::default();
+    let both = TurnControls::none()
+        .with_gate(Arc::new(CountingGate(AtomicUsize::new(0))))
+        .with_steering(Arc::new(SpySteering {
+            drained: AtomicUsize::new(0),
+            stop: false,
+        }));
+    assert!(!both.is_empty());
+
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep)
+        .with_turn_controls(&both);
+
+    assert!(engine.gate.is_some(), "the pause must survive the steering");
+    assert!(
+        engine.steering.is_some(),
+        "and the steering must survive the pause — the two seams are \
+         independent, not a slot the last writer wins"
+    );
+}
+
 #[test]
 fn empty_turn_controls_leave_an_engine_exactly_as_it_was() {
     let provider = ScriptedProvider::new(vec![]);

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -249,7 +249,9 @@ pub static CAPABILITIES: &[Capability] = &[
         engine_home: "stella-core TurnGate port — park at a step boundary, never mid-tool",
         engine_entries: &["with_gate"],
         cli: SurfacePosture::Shipped {
-            mechanism: "deck pause/resume controls; a paused turn parks its sub-agent children too",
+            mechanism: "deck pause/resume controls (`p`), on worker lanes and on the lead's own \
+                        turn alike (#1219 — raw and pipeline paths); a paused turn parks its \
+                        sub-agent children too",
             witness: "a_paused_turn_parks_its_children_and_resume_releases_them",
         },
         api: SurfacePosture::Shipped {

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -3397,7 +3397,10 @@ fn handle_agents_key(
         // `r` restart. The driver honors all three on worker lanes
         // (`req:`/`sub:`): pause parks the worker at its next step boundary
         // (never mid-tool), restart respawns the lane from its retained
-        // spec. On the lead they are no-ops (Esc is the lead's interrupt).
+        // spec. On the lead, `s` is the interrupt (as Esc is) and `p` parks
+        // the live turn at the same step boundary — sub-agents included
+        // (#1219); only `r` stays a no-op there, because restarting the lead
+        // is just re-submitting the prompt and there is no spec to respawn.
         KeyCode::Char('s') if composer_empty => model.agents.get(ui.focused).map(|entry| {
             DeckAction::Send(WorkspaceInput::Control {
                 agent: entry.meta.id.clone(),


### PR DESCRIPTION
Closes #1219.

The deck's `WorkspaceInput::Control { .. }` arm was a no-op for the lead lane, so `p` on the lead row did nothing. The gate seam it needed landed in #1214 (`Pipeline::with_turn_gate`); this is the deck-side plumbing the issue scoped.

## What's wired

`command_deck/lead_control.rs` owns a `LeadPause` — one watch channel per turn, the `WatchGate` over it, and the dashboard latch. The driver loop builds one per turn and hands the gate to **both** paths:

| path | seam |
|---|---|
| pipeline (`run_lead_pipeline_turn`) | `Pipeline::with_turn_gate(...)` |
| step loop (`run_lead_turn`) | `Engine::with_gate(...)` |

…plus `attach_turn_controls`, so sub-agents the lead dispatched park with it rather than a paused lead redirecting its spend into its own children.

Per-turn by construction: the next iteration builds a fresh channel starting `false`, so a pause cannot leak into the next turn, and a stale pause/resume aimed at a turn that already ended is a no-op rather than a state the next prompt inherits.

**Restart stays out of scope**, per the issue and the fleet's own rule: a restart is the caller re-dispatching, and there is no retained lead spec to respawn from — the lead *is* the session.

## Why one type instead of three locals

The channel and the latch are **not the same fact**, which is the part that is easy to get half-right:

- A soft stop reopens the channel while the row is still painted paused.
- The row must be repaid at turn end whether or not the turn ever actually parked.

Keeping them in one type makes both cases hard to miss. Every method takes `&self` and the latch is an `AtomicBool` — the driver's turn future borrows the seam for as long as it runs while the input pump writes to it, the same shape `watch::Sender` already has. A `&mut self` API would have been more restrictive than the channel it wraps.

## Two interactions this exposed

Neither was named in the issue; both are fixed here, with tests.

1. **Esc on a paused lead would have done nothing.** Pause and the soft stop are polled at the *same* step boundary, and the gate parks the turn *just before* the stop flag is read — so a latched stop sat unobserved. Latching a soft stop now reopens the gate; the turn wakes, sees the stop, and ends keeping its completed work.

2. **A paused row would have stuck for the rest of the session.** The deck's fold deliberately won't move a lane off `Paused` from the event stream (streaming output must not silently un-pause a lane the user parked). So a turn hard-cancelled *while paused* left the row reading ⏸, swallowing every later event's status.

Related: the status emission is load-bearing, not decoration — `p` is a *toggle* resolved against the row's current status, so a pause that parked the turn without painting the row would leave the next `p` sending Pause again.

## Acceptance

- [x] Pausing the lead mid-turn parks at the next safe boundary (no further `StepUsage` until resume) on **both** paths
- [x] Sub-agents dispatched by the lead park with it
- [x] A stale pause/resume with no live turn is a no-op, never an error

## Notes for review

- `subsession::WatchGate` becomes `pub(crate)` rather than gaining a third copy. Deck worker lanes and the deck lead sit on the same side of the deck/fleet boundary — which is exactly why `fleet_cmd.rs` keeps its own co-located twin and this does not.
- Three comments this falsifies are corrected: `TurnControls`' *"no driver has both"* (the lead is now the first driver with both seams), the subagent module's *"the lead has no gate"*, and the TUI keymap's *"on the lead they are no-ops"*.
- `stella-parity`'s `turn.pause_resume` entry claimed CLI pause/resume parity the lead lane did not actually have; its `mechanism` string is now accurate. Witness unchanged.
- **File-size ratchet:** `deck_ui.rs` needs no baseline entry (back to 3902 exactly). `command_deck.rs` is +7 over its ceiling — a module declaration, one local, two parameters, four call sites: the irreducible cost of threading a port through both turn paths. One-line baseline diff.

## Tests

`lead_control`, 6 new:
- `pausing_the_lead_lane_parks_its_turn_gate_until_resume` — asserts on the real adapter's parking/release, not the flag behind it
- `a_soft_stop_releases_a_paused_lead_so_the_turn_can_reach_its_boundary`
- `settle_repays_a_row_left_painted_paused_by_a_soft_stop`
- `settle_is_silent_when_the_turn_was_never_paused`
- `restart_is_not_a_lead_verb_and_leaves_the_turn_untouched`
- `a_stale_lead_control_is_a_no_op_not_an_error`

`stella-core`, 1 new:
- `turn_controls_carrying_both_seams_give_a_child_both` — pins the invariant the deck's transitive pause newly depends on

Existing `a_paused_turn_parks_its_children_and_resume_releases_them` already covers registry-gate ⇒ children-park; this change is what publishes the gate from the deck.

`make gate` green end to end (exit 0, 102 suites, 0 failures).
