### PR TITLE
perf(gate): scope the pre-push compile tiers to the crates a diff can reach (#1135)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,20 +2,56 @@
 #
 # Stella pre-push gate.
 #
-# Runs the exact fmt + clippy + test gate CI would run — locally, on every
-# push — because the org's GitHub Actions is billing-locked: every required
-# check (`fmt + clippy + test`, `cargo deny + cargo audit`) fast-fails in
-# seconds without ever executing, and `enforce_admins` is off, so gate-failing
-# code otherwise reaches `main` through admin/auto merges (exactly how the
-# clippy errors and the E0061 compile break landed and had to be hand-repaired).
+# Runs the fmt + clippy + test gate CI would run — locally, on every push —
+# scoped to the crates the pushed diff can actually reach (#1135).
 #
-# This is the enforcement point that still works while Actions is down: it
-# catches the break on the author's push, before the PR is merged. It is
-# advisory, not a server-side guarantee — it must be installed per clone and is
-# bypassable — but it makes the gate run automatically again.
+# WHY A LOCAL GATE AT ALL
+#
+# Not because Actions is down. It was, and this file used to say so: "the org's
+# GitHub Actions is billing-locked: every required check fast-fails in seconds
+# without ever executing". That stopped being true — Actions executed real
+# checks on PR #1098 on 2026-08-01, ran for minutes, and failed on genuine
+# findings — and a hook justified by a false premise is one correction away
+# from being deleted along with the premise. The reasons that outlive the
+# billing hold:
+#
+#   - `enforce_admins` is off, so gate-failing code can still reach `main`
+#     through an admin or auto merge. That is exactly how the clippy errors and
+#     the E0061 compile break landed and had to be hand-repaired.
+#   - CI is a round trip. Learning about a rustfmt diff ten minutes after the
+#     push, on a branch you have already moved on from, costs more than the
+#     seconds it takes to learn about it here.
+#   - Some guards run nowhere else for months at a time. `wire-schema` lived
+#     only in `make gate`, so a branch pushed server-side never met it — which
+#     is how #1185 merged with stale generated artifacts.
+#
+# It is advisory, not a server-side guarantee — it must be installed per clone
+# and is bypassable — but it makes the gate run automatically again.
+#
+# WHAT IT COSTS
+#
+# `make gate` compiles, documents and tests all 21 workspace members. Running
+# that unconditionally meant a test-only change confined to one crate paid the
+# full workspace, twice, once per push (observed on #911: the push blew a
+# two-minute timeout and had to be re-run detached). So the compile tiers —
+# clippy, rustdoc, test — are scoped to the crates the diff reaches, computed
+# by scripts/impacted-crates.sh, which answers `--workspace` for anything it
+# cannot narrow with confidence. The cheap global guards are never scoped: a
+# 1500-line file or an unpinned action is a fact about the repository, not
+# about a crate.
+#
+# Pushes to `main` and pushes of tags always run the full workspace. So does
+# any diff touching a workspace-root manifest, `Cargo.lock`, a build script, or
+# this gate's own machinery.
 #
 #   Install once per clone:  make hooks           (sets core.hooksPath=.githooks)
+#   Reduced gate:            GATE=fast git push   (guards + fmt + clippy, no tests)
+#   Force the full sweep:    GATE=full git push
 #   Bypass (emergencies):    SKIP_GATE=1 git push     or     git push --no-verify
+#
+# The GATE=fast rung exists because the choice under time pressure used to be
+# binary — the whole gate, or `SKIP_GATE=1` — and under a deadline people pick
+# the second. A reduced gate that runs beats a full gate that gets skipped.
 #
 set -uo pipefail
 
@@ -23,6 +59,8 @@ if [ "${SKIP_GATE:-}" = "1" ]; then
   printf '\033[33m⚠ SKIP_GATE=1 — skipping the pre-push gate\033[0m\n' >&2
   exit 0
 fi
+
+remote_name="${1:-origin}"
 
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
@@ -32,14 +70,129 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 # committer identity, seed commits, fleet/* branches). Pushes from linked
 # worktrees are the worst case: there GIT_DIR is absolute, so it follows the
 # tests into every temp cwd. Scrub the env so the suite sees a clean world.
+#
+# Scrubbed AFTER the `cd` above, which needs GIT_DIR to resolve the worktree it
+# was invoked from, and before any diff below — those run against the checkout
+# this hook has already cd'd into.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_PREFIX
 
-printf '\033[36m▸ pre-push gate — make gate (fmt-check · clippy -D warnings · test)\033[0m\n' >&2
-if make gate; then
+zero='0000000000000000000000000000000000000000'
+
+# ── What is being pushed ─────────────────────────────────────────────────────
+#
+# Git feeds the hook one line per ref on stdin: `<local ref> <local sha>
+# <remote ref> <remote sha>`. Accumulate the diff of every ref in the push,
+# because one `git push` can carry several branches and the gate must cover all
+# of them.
+
+changed="$(mktemp)"
+trap 'rm -f "$changed"' EXIT
+scope_reason=""
+force_full=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+
+  # Deleting a remote ref pushes no content to check.
+  [ "$local_sha" = "$zero" ] && continue
+
+  # Tags are releases: a tag is what a published binary gets built from, so it
+  # gets the unscoped run no matter how small the diff looks.
+  case "$local_ref" in
+  refs/tags/*)
+    force_full=1
+    scope_reason="pushing a tag"
+    break
+    ;;
+  esac
+
+  # Same for the trunk itself — the branch every other branch is measured
+  # against, and the one place a narrow answer has nothing behind it.
+  case "$remote_ref" in
+  refs/heads/main | refs/heads/master)
+    force_full=1
+    scope_reason="pushing to ${remote_ref#refs/heads/}"
+    break
+    ;;
+  esac
+
+  if [ "$remote_sha" = "$zero" ]; then
+    # A branch the remote does not have yet: measure against the remote's
+    # default branch, which is what the eventual PR will be diffed against.
+    base="$(git symbolic-ref --quiet "refs/remotes/$remote_name/HEAD" 2>/dev/null)"
+    if [ -z "$base" ]; then
+      for candidate in main master; do
+        if git rev-parse --verify --quiet "refs/remotes/$remote_name/$candidate" >/dev/null; then
+          base="refs/remotes/$remote_name/$candidate"
+          break
+        fi
+      done
+    fi
+    if [ -z "$base" ]; then
+      force_full=1
+      scope_reason="no $remote_name default branch to diff a new branch against"
+      break
+    fi
+  else
+    # The remote tip has to be an object we actually hold. If someone else
+    # pushed it and this clone has not fetched, there is no diff to compute.
+    if ! git cat-file -e "$remote_sha^{commit}" 2>/dev/null; then
+      force_full=1
+      scope_reason="$remote_name is at a commit this clone has not fetched"
+      break
+    fi
+    base="$remote_sha"
+  fi
+
+  # Three-dot: what this push ADDS since the common ancestor. Two-dot would
+  # also report, in reverse, every commit the remote has and this branch does
+  # not — a branch that is merely behind would look like it had changed the
+  # world, and would be gated as if it had.
+  if ! git diff --name-only "$base...$local_sha" >>"$changed" 2>/dev/null; then
+    force_full=1
+    scope_reason="cannot diff $base...$local_sha"
+    break
+  fi
+done
+
+# ── The scope ────────────────────────────────────────────────────────────────
+
+if [ "${GATE:-}" = "full" ]; then
+  force_full=1
+  scope_reason="GATE=full"
+fi
+
+if [ "$force_full" = "1" ]; then
+  scope="--workspace"
+  printf '\033[36m▸ scope: full workspace (%s)\033[0m\n' "$scope_reason" >&2
+else
+  scope="$(sort -u "$changed" | ./scripts/impacted-crates.sh)"
+fi
+
+# ── The tier ─────────────────────────────────────────────────────────────────
+#
+# An empty scope means no crate in the workspace can be reached by this diff —
+# a website-only or workflow-only push. The global guards still run; there is
+# simply nothing to compile.
+
+if [ -z "$scope" ]; then
+  target="guards"
+  label="make guards (no crate reachable — global guards + fmt only)"
+elif [ "${GATE:-}" = "fast" ]; then
+  target="check"
+  label="make check (guards + fmt + clippy; GATE=fast, no rustdoc and no tests)"
+else
+  target="gate"
+  label="make gate (guards + fmt-check · clippy -D warnings · rustdoc · test)"
+fi
+
+printf '\033[36m▸ pre-push gate — %s\033[0m\n' "$label" >&2
+if make "$target" CARGO_SCOPE="$scope"; then
   printf '\033[32m✔ gate green — pushing\033[0m\n' >&2
   exit 0
 fi
 
 printf '\033[31m✖ gate failed — push aborted.\033[0m\n' >&2
-printf '  Fix the errors above, or bypass in an emergency: SKIP_GATE=1 git push (or git push --no-verify).\n' >&2
+printf '  Fix the errors above, or step down a rung: GATE=fast git push (reduced gate),\n' >&2
+printf '  GATE=full git push (whole workspace), SKIP_GATE=1 git push (bypass entirely).\n' >&2
 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,24 @@ jobs:
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo fmt --check
 
+      # DELIBERATELY UNSCOPED, and it must stay that way (#1135).
+      #
+      # The pre-push hook narrows these same three tiers — clippy, rustdoc,
+      # test — to the crates a diff can reach, via scripts/impacted-crates.sh.
+      # That is safe precisely because THIS job does not: the local gate can
+      # afford to be clever because something unclever still compiles the whole
+      # tree before anything merges.
+      #
+      # Scoping here too would leave no run anywhere that builds every member
+      # pre-merge, and would make a bug in the impact graph invisible until
+      # `main` goes red — the failure mode this repo pays for most often. The
+      # graph has real escape hatches to get wrong: `include_str!` across crate
+      # boundaries, and tests that climb out of CARGO_MANIFEST_DIR to read
+      # `website/` or `docs/wire/` at run time.
+      #
+      # The cost argument does not apply here either. Runner time is parallel
+      # and rust-cache keeps it warm, so it is not what blocks an author; the
+      # two minutes the hook used to burn on every push is.
       - name: cargo clippy -D warnings
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,24 @@ after touching a `NORMATIVE-HOME:` document.
 `docs/**.md` path — or a `§N` inside one — that does not exist (#652). Adding
 a citation to a document you have not written yet fails the build, by design.
 
-For a faster pre-push sanity check (no tests): `make check` — scratch + pins +
-license parity + shellcheck + invariants + file-size + fmt + clippy.
+Three rungs, each a superset of the one above:
+
+| Target | Runs | Honours `CARGO_SCOPE` |
+| --- | --- | --- |
+| `make guards` | global guards + `fmt --check` — nothing compiles | — |
+| `make check` | ...plus clippy | clippy |
+| `make gate` | ...plus rustdoc and the test suite | clippy, rustdoc, test |
+
+`CARGO_SCOPE` narrows only the compile tiers, and defaults to `--workspace`, so
+`make gate` and CI are unchanged unless a caller asks for less (#1135):
+
+```bash
+make gate CARGO_SCOPE="-p stella-cli"   # that crate and its dependents
+make impacted RANGE=origin/main..HEAD   # what the hook would pick for your branch
+```
+
+The global guards are never scoped: a 1500-line file or an unpinned action is a
+fact about the repository, not about a crate.
 
 `no-scratch` runs first because it costs milliseconds: it asserts no tracked
 file matches a `.gitignore` rule. **Session scratch must never reach the
@@ -98,9 +114,29 @@ It is advisory and per-clone (bypassable with `SKIP_GATE=1 git push` or
 `git push --no-verify`), so it complements the required server-side checks
 rather than replacing them — with `enforce_admins` off, an admin or auto-merge
 can still land gate-failing code, and the hook is what catches that on the
-author's push. When Actions is unavailable entirely (an org billing hold has
+author's push. It is also the only place some guards run for long stretches:
+`wire-schema` lived only in `make gate` until #1185 merged with stale generated
+artifacts. When Actions is unavailable entirely (an org billing hold has
 happened before — see RELEASING.md's local-release path), it is the only gate
 running at all.
+
+The hook derives `CARGO_SCOPE` from the pushed diff via
+`scripts/impacted-crates.sh`, so a change confined to one crate compiles and
+tests that crate and its dependents rather than all 21 members (#1135). It
+widens to the whole workspace for a push to `main`, a tag, a diff touching a
+workspace-root manifest / `Cargo.lock` / a build script / the gate machinery,
+and for anything it cannot narrow with confidence. Two escape hatches sit
+*above* `SKIP_GATE`, because the choice under time pressure should not be
+binary:
+
+```bash
+GATE=fast git push       # make check — guards + fmt + clippy, no rustdoc, no tests
+GATE=full git push       # the whole workspace, whatever the diff says
+SKIP_GATE=1 git push     # nothing at all (emergencies)
+```
+
+`make impacted-test` covers the scoping rules; it is hermetic and deliberately
+not part of `gate`.
 
 Supply-chain checks run as a separate CI job: `make supply-chain` (or
 `cargo deny check advisories bans sources licenses`). All four are real

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,20 @@ red gate costs you thirty seconds locally instead of a review round-trip. It is
 advisory and per-clone (`SKIP_GATE=1 git push` bypasses it), not a substitute
 for the server-side checks.
 
+The hook scopes the three compile tiers — clippy, rustdoc, test — to the crates
+your diff can actually reach, so a change confined to one crate no longer pays
+for all 21 members (#1135). It falls back to the whole workspace for a push to
+`main`, a tag, a diff touching a workspace-root manifest / `Cargo.lock` / a
+build script / the gate machinery, and for anything it cannot narrow with
+confidence. See what it would choose with `make impacted`. Under time pressure,
+step down a rung rather than switching the gate off:
+
+```bash
+GATE=fast git push       # guards + fmt + clippy — no rustdoc, no tests
+GATE=full git push       # the whole workspace, whatever the diff says
+SKIP_GATE=1 git push     # nothing at all (emergencies)
+```
+
 `check-no-scratch.sh` asserts that no tracked file matches a `.gitignore` rule —
 agent-session scratch (repro trees, plans, memory files) must never reach the
 remote (#448). If it fails, either untrack the path with

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,30 @@ BUMP ?= patch
 LIMIT ?= 0
 TARGET ?= 60
 
+# Which cargo packages the three *compile* tiers of the gate cover — clippy,
+# rustdoc and test (#1135). The default is the whole workspace, so `make gate`
+# and CI behave exactly as they always have; nothing narrows unless a caller
+# asks it to:
+#
+#   make gate                                  every member (CI, `main`, releases)
+#   make gate CARGO_SCOPE="-p stella-cli"      one member and its dependents
+#
+# `.githooks/pre-push` fills this in from the pushed diff via
+# scripts/impacted-crates.sh, which answers `--workspace` for anything it
+# cannot narrow with confidence. The cheap global guards below are deliberately
+# NOT scoped — a 1500-line file or an unpinned action is a fact about the
+# repository, not about a crate.
+CARGO_SCOPE ?= --workspace
+
+# The guard tiers, named so the gate, the fast check and the hook can compose
+# them instead of restating the list three times and drifting apart.
+# GATE_GUARDS_FAST needs no toolchain at all (shell scripts over the tree);
+# doc-citations and wire-schema are separated out because wire-schema runs the
+# two schema exporters, which is a cargo build.
+GATE_GUARDS_FAST := no-scratch action-pins cargo-install-pins license-allowlist-parity \
+                    repro-wiring shellcheck invariants file-size
+GATE_GUARDS := $(GATE_GUARDS_FAST) doc-citations wire-schema
+
 .PHONY: help
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' Makefile | \
@@ -44,8 +68,8 @@ format-check: ## Check formatting without modifying (CI gate)
 	cargo fmt --check
 
 .PHONY: lint
-lint: ## Run clippy with -D warnings (CI gate)
-	cargo clippy --workspace --all-targets -- -D warnings
+lint: ## Run clippy with -D warnings (CI gate; CARGO_SCOPE to narrow)
+	cargo clippy $(CARGO_SCOPE) --all-targets -- -D warnings
 
 .PHONY: fix
 fix: ## Auto-fix clippy lints + format
@@ -53,8 +77,8 @@ fix: ## Auto-fix clippy lints + format
 	cargo fmt
 
 .PHONY: test
-test: ## Run the full test suite (all crates)
-	cargo test --workspace
+test: ## Run the test suite (all crates; CARGO_SCOPE to narrow)
+	cargo test $(CARGO_SCOPE)
 
 .PHONY: test-core
 test-core: ## Test stella-core only (fast engine iteration)
@@ -147,8 +171,8 @@ file-size-update: ## Retighten the 1500-line ratchet baseline (run after splitti
 	@./scripts/check-file-size.sh --update
 
 .PHONY: doc-warnings
-doc-warnings: ## Assert rustdoc is clean workspace-wide (#634)
-	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+doc-warnings: ## Assert rustdoc is clean workspace-wide (#634; CARGO_SCOPE to narrow)
+	RUSTDOCFLAGS="-D warnings" cargo doc $(CARGO_SCOPE) --no-deps
 
 .PHONY: shellcheck
 shellcheck: ## Lint install.sh, scripts/*.sh, and .githooks/* (#916)
@@ -161,20 +185,40 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 	docker build -f packaging/docker/Dockerfile.serve -t stella-serve:ci .
 	@./scripts/smoke-serve-image.sh stella-serve:ci
 
+# The three tiers of the gate, from cheapest to dearest. Each is a superset of
+# the one above it, and only the compile tiers honour CARGO_SCOPE.
+#
+#   guards  every global guard + rustfmt. No crate compiles, so nothing to scope.
+#   check   ...plus clippy. The graduated fallback: a reduced gate, not no gate.
+#   gate    ...plus rustdoc and the test suite. What CI runs, unscoped.
+
+.PHONY: guards
+guards: $(GATE_GUARDS) format-check ## Global guards + fmt only (no crate compiles; nothing to scope)
+
 .PHONY: gate
-gate: no-scratch action-pins cargo-install-pins license-allowlist-parity repro-wiring shellcheck doc-citations invariants file-size wire-schema doc-warnings format-check lint test ## Full CI gate: no-scratch + action-pins + cargo-install-pins + license-allowlist-parity + repro-wiring + shellcheck + doc-citations + invariants + file-size + wire-schema + rustdoc + fmt-check + clippy + test
+gate: $(GATE_GUARDS) doc-warnings format-check lint test ## Full CI gate: guards + rustdoc + fmt-check + clippy + test
 
 .PHONY: check
-check: no-scratch action-pins cargo-install-pins license-allowlist-parity repro-wiring shellcheck invariants file-size format-check lint ## Fast pre-push check (scratch + pins + license parity + repro wiring + shellcheck + invariants + file-size + fmt + clippy, no tests)
+check: $(GATE_GUARDS_FAST) format-check lint ## Fast pre-push check: toolchain-free guards + fmt + clippy, no rustdoc and no tests
+
+.PHONY: impacted
+impacted: ## Print the cargo scope for a diff (RANGE=origin/main..HEAD)
+	@./scripts/impacted-crates.sh $(if $(RANGE),--range $(RANGE),--range origin/main..HEAD)
+
+.PHONY: impacted-test
+impacted-test: ## Test the gate-scoping script (hermetic; not part of `gate`)
+	./scripts/test-impacted-crates.sh
 
 .PHONY: hooks
-hooks: ## Install the pre-push gate hook (runs `make gate` on every push)
+hooks: ## Install the pre-push gate hook (runs `make gate`, scoped to the diff, on every push)
 	git config core.hooksPath .githooks
 	@chmod +x .githooks/* 2>/dev/null || true
-	@printf '\033[32m✔ hooks installed\033[0m — pre-push now runs the fmt+clippy+test gate.\n'
-	@printf '  Catches a red gate on your machine, and is the only gate running when\n'
-	@printf '  Actions is unavailable (an org billing hold has happened before).\n'
-	@printf '  Bypass in emergencies: \033[36mSKIP_GATE=1 git push\033[0m (or \033[36mgit push --no-verify\033[0m).\n'
+	@printf '\033[32m✔ hooks installed\033[0m — pre-push now runs the fmt+clippy+rustdoc+test gate.\n'
+	@printf '  Catches a red gate on your machine instead of ten minutes later in CI.\n'
+	@printf '  Compile tiers are scoped to the crates your diff reaches (#1135); pushes to\n'
+	@printf '  main and tag pushes always run the whole workspace.\n'
+	@printf '  Step down a rung: \033[36mGATE=fast git push\033[0m (guards+fmt+clippy, no tests),\n'
+	@printf '  \033[36mGATE=full git push\033[0m (whole workspace), \033[36mSKIP_GATE=1 git push\033[0m (bypass).\n'
 
 .PHONY: dev-env
 dev-env: ## Set this worktree up for development (per-worktree STELLA_HOME + target dir, tool check)

--- a/scripts/impacted-crates.sh
+++ b/scripts/impacted-crates.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+#
+# Narrow the gate's compile/test tiers to the crates a diff can actually break
+# (#1135).
+#
+# `make gate` compiled, documented and tested all 21 workspace members on every
+# invocation, and `.githooks/pre-push` ran it unconditionally. A 13-file
+# test-only change confined to `stella-cli` therefore paid a full-workspace
+# `cargo doc` + `clippy --all-targets` + `cargo test` — twice, once per push
+# (observed while shipping #911). With no tier between "everything" and
+# `SKIP_GATE=1`, the honest choice under time pressure was to skip the gate
+# entirely, which is the worst possible default for a repo whose stated culture
+# is that the gate must be believable.
+#
+# This script prints the cargo package scope for those tiers to stdout, on one
+# line, in one of three shapes:
+#
+#   --workspace           every member — the safe answer, and the default
+#   -p stella-cli ...     only the members the diff can reach
+#   (empty)               no member can be reached; skip the compile tiers
+#
+# Its reasoning goes to stderr so a caller can show its work.
+#
+#   scripts/impacted-crates.sh --range <base>..<head>
+#   git diff --name-only A B | scripts/impacted-crates.sh
+#
+# WHY THIS IS MORE THAN A REVERSE-DEPENDENCY WALK
+#
+# Cargo's dependency graph is not the whole build graph here. Three kinds of
+# edge exist in this tree, and a scoper that knows only the first is wrong in a
+# way that is invisible until CI disagrees with the local gate:
+#
+#   1. Ownership + reverse dependencies. A changed file under `stella-core/`
+#      belongs to `stella-core`, and every member that depends on it —
+#      through normal, dev OR build dependencies — must be re-checked. Dev
+#      dependencies count: crate A's *tests* can depend on B even when A's
+#      library does not.
+#
+#   2. Compile-time escapes. `stella-parity/src/lib.rs` does
+#      `include_str!("../../stella-cli/src/subsession.rs")`, and
+#      `stella-tools/tests/doc_truth.rs` does `include_str!("../../README.md")`.
+#      No cargo edge names either one. These are resolved literally below, so
+#      touching that prompt file re-tests `stella-parity` even though nothing
+#      depends on `stella-cli`.
+#
+#   3. Run-time escapes. `stella-tools/tests/docs_in_sync.rs` walks
+#      `website/content/docs/agent-tools/*.mdx`; `stella-cli/src/main_tests.rs`
+#      reads `website/content/docs/commands/meta.json`; and
+#      `stella-protocol/tests/wire_contract.rs` reads `docs/wire/`. These open
+#      files by path at run time, so no static scan can resolve their targets.
+#      They are detected — not enumerated in a hand-kept table that would rot —
+#      by the shape they all share: `env!("CARGO_MANIFEST_DIR")` climbed with
+#      `.parent()` or `".."`. Any crate matching that shape is re-checked
+#      whenever the diff touches anything outside every crate directory.
+#
+# Escape edges (2 and 3) add the *reading* crate, and deliberately do not drag
+# in its reverse dependents: a stale `README.md` can fail `stella-tools`'s own
+# doc test, but it cannot change the code that `stella-tools`'s dependents
+# compile against.
+#
+# EVERY UNCERTAIN ANSWER IS `--workspace`
+#
+# A wrong narrow answer is a gate that lies. Missing jq, missing cargo, a
+# `cargo metadata` that will not resolve, an unreadable diff, a path this
+# script cannot place, or a change to the scoping machinery itself all print
+# `--workspace` and say why. The cheap global guards (`no-scratch`,
+# `action-pins`, `file-size`, `invariants`, `wire-schema`, `doc-citations`, …)
+# are unscoped by construction — they are not this script's business, and
+# `make gate` runs them on every push regardless of what is printed here.
+#
+# Uses portable POSIX tooling and no bash-4 features: macOS ships bash 3.2, so
+# no associative arrays (same constraint as scripts/check-file-size.sh).
+set -euo pipefail
+
+full() {
+	printf '%s\n' "--workspace"
+	printf 'impacted-crates: full workspace — %s\n' "$1" >&2
+	exit 0
+}
+
+range=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--range)
+		[ $# -ge 2 ] || {
+			echo "impacted-crates: --range needs an argument" >&2
+			exit 2
+		}
+		range="$2"
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,30p' "$0"
+		exit 0
+		;;
+	*)
+		echo "impacted-crates: unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+	full "not a git repository"
+fi
+cd "$repo_root"
+
+# ---------------------------------------------------------------------------
+# 1. The changed paths.
+# ---------------------------------------------------------------------------
+
+if [ -n "$range" ]; then
+	if ! changed="$(git diff --name-only "$range" 2>/dev/null)"; then
+		full "cannot diff $range"
+	fi
+else
+	changed="$(cat)"
+fi
+
+# Drop blanks so an empty stdin does not read as one empty path.
+changed="$(printf '%s\n' "$changed" | sed '/^[[:space:]]*$/d')"
+
+if [ -z "$changed" ]; then
+	printf '\n'
+	printf 'impacted-crates: nothing changed — no compile tiers needed\n' >&2
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Global build inputs — any of these and the answer is the whole workspace.
+#
+# The first group changes how *every* crate compiles (feature resolution, the
+# lock, the toolchain, lint config, a build script's output). The second group
+# is the gate machinery itself: if you are editing the thing that decides what
+# gets tested, the only believable proof is the unscoped run. That rule makes
+# this change's own push pay full price, which is the point.
+# ---------------------------------------------------------------------------
+
+global_re='^(Cargo\.toml|Cargo\.lock|rust-toolchain(\.toml)?|clippy\.toml|rustfmt\.toml|deny\.toml|\.cargo/.*|(.*/)?build\.rs)$'
+machinery_re='^(Makefile|scripts/impacted-crates\.sh|\.githooks/pre-push)$'
+
+hit="$(printf '%s\n' "$changed" | grep -E -m1 "$global_re" || true)"
+[ -z "$hit" ] || full "$hit is a global build input"
+
+hit="$(printf '%s\n' "$changed" | grep -E -m1 "$machinery_re" || true)"
+[ -z "$hit" ] || full "$hit changes the gate machinery itself"
+
+# ---------------------------------------------------------------------------
+# 3. The workspace map, from cargo itself.
+# ---------------------------------------------------------------------------
+
+command -v jq >/dev/null 2>&1 || full "jq is not installed"
+command -v cargo >/dev/null 2>&1 || full "cargo is not installed"
+command -v rg >/dev/null 2>&1 || full "ripgrep (rg) is not installed"
+
+if ! meta="$(cargo metadata --no-deps --format-version 1 2>/dev/null)"; then
+	full "cargo metadata failed (a manifest or the lock may be broken)"
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# `<crate dir>\t<package name>`. The checkout prefix is stripped in shell
+# rather than in jq: jq would need the absolute path spliced into a regex, and
+# a checkout path containing a regex metacharacter (`.claude/worktrees/…` has
+# one on the very first component) would silently mis-anchor it.
+jq -r '.packages[] | (.manifest_path | sub("/Cargo\\.toml$"; "")) + "\t" + .name' \
+	<<<"$meta" >"$work/dirs.abs" || full "cannot read package directories from cargo metadata"
+
+: >"$work/dirs.rel"
+while IFS=$'\t' read -r dir name; do
+	rel="${dir#"$repo_root"/}"
+	# Unstripped (a member outside the checkout) or empty (a package rooted at
+	# the checkout itself) both make prefix matching meaningless.
+	[ "$rel" != "$dir" ] && [ -n "$rel" ] || full "package $name is not inside the checkout"
+	printf '%s\t%s\n' "$rel" "$name" >>"$work/dirs.rel"
+done <"$work/dirs.abs"
+
+# Longest directory first, so the deepest enclosing crate wins: a nested member
+# must claim its own files rather than losing them to a shorter prefix.
+awk -F'\t' '{ print length($1) "\t" $0 }' "$work/dirs.rel" |
+	sort -rn | cut -f2- >"$work/dirs"
+
+cut -f2 "$work/dirs" | sort -u >"$work/members"
+
+# `<dependency>\t<dependent>` for workspace-internal edges only, all dependency
+# kinds included (a dev-dependency is a real edge for `cargo test`).
+jq -r '.packages[] as $p | $p.dependencies[] | .name + "\t" + $p.name' <<<"$meta" |
+	sort -u >"$work/edges.raw"
+awk -F'\t' 'NR==FNR { member[$0]=1; next } member[$1] { print }' \
+	"$work/members" "$work/edges.raw" >"$work/edges"
+
+# ---------------------------------------------------------------------------
+# 4. Place every changed path.
+# ---------------------------------------------------------------------------
+
+: >"$work/seed"    # crates that own a changed file — these get the closure
+: >"$work/extra"   # crates reached by an escape edge — no closure (see header)
+outside=0
+
+crate_for() {
+	# Longest-prefix match against the crate directories.
+	local path="$1" dir name
+	while IFS=$'\t' read -r dir name; do
+		case "$path" in
+		"$dir"/*) printf '%s\n' "$name"; return 0 ;;
+		esac
+	done <"$work/dirs"
+	return 1
+}
+
+while IFS= read -r path; do
+	if owner="$(crate_for "$path")"; then
+		printf '%s\n' "$owner" >>"$work/seed"
+	else
+		outside=1
+	fi
+done <<<"$changed"
+
+# ---------------------------------------------------------------------------
+# 5. Escape edges.
+# ---------------------------------------------------------------------------
+
+# 5a. Compile-time: resolve every `include_str!`/`include_bytes!`/`include!`
+#     literal against the including file, and record the ones that land outside
+#     the including crate.
+normalize() {
+	# Collapse `.` and `..` in a relative path without touching the disk (the
+	# target may have just been deleted, and macOS has no `realpath
+	# --relative-to`).
+	local path="$1" part out=""
+	local IFS=/
+	for part in $path; do
+		case "$part" in
+		'' | .) ;;
+		..) out="${out%/*}" ;;
+		*) out="$out/$part" ;;
+		esac
+	done
+	printf '%s\n' "${out#/}"
+}
+
+# The explicit `.` and `</dev/null` are both load-bearing. Given no path
+# argument and a non-TTY stdin, ripgrep searches STDIN rather than the working
+# directory — and this script's stdin is a pipe that `cat` has already drained,
+# so the scan would match nothing, exit 0, and silently drop every escape edge.
+: >"$work/includes" # `<target path>\t<including crate>`
+while IFS= read -r line; do
+	src="${line%%:*}"
+	src="${src#./}"
+	lit="${line#*:}"
+	lit="${lit#*\"}"
+	lit="${lit%\"*}"
+	[ -n "$lit" ] || continue
+	case "$lit" in /*) continue ;; esac # absolute literals are not repo paths
+	target="$(normalize "${src%/*}/$lit")"
+	src_crate="$(crate_for "$src")" || continue
+	tgt_crate="$(crate_for "$target" || true)"
+	[ "$tgt_crate" = "$src_crate" ] && continue
+	printf '%s\t%s\n' "$target" "$src_crate" >>"$work/includes"
+done < <(rg --no-heading -H -o -g '*.rs' \
+	'include(_str|_bytes)?!\("[^"]+"' . </dev/null 2>/dev/null || true)
+
+if [ -s "$work/includes" ]; then
+	awk -F'\t' 'NR==FNR { changed[$0]=1; next } changed[$1] { print $2 }' \
+		<(printf '%s\n' "$changed") "$work/includes" >>"$work/extra"
+fi
+
+# 5b. Run-time: crates whose sources climb out of their own manifest directory.
+#     Detected by shape rather than listed by name, so a new one cannot quietly
+#     fall outside the gate's reach.
+if [ "$outside" -eq 1 ]; then
+	while IFS= read -r src; do
+		src="${src#./}"
+		[ -n "$src" ] || continue
+		rg -q '\.parent\(\)|"\.\."' "$src" </dev/null 2>/dev/null || continue
+		crate_for "$src" >>"$work/extra" || true
+	done < <(rg -l -g '*.rs' 'CARGO_MANIFEST_DIR' . </dev/null 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Reverse-dependency closure over the owned crates.
+# ---------------------------------------------------------------------------
+
+sort -u "$work/seed" >"$work/impacted"
+frontier="$work/impacted"
+while [ -s "$frontier" ]; do
+	awk -F'\t' 'NR==FNR { f[$0]=1; next } f[$1] { print $2 }' \
+		"$frontier" "$work/edges" | sort -u >"$work/next.raw"
+	comm -23 "$work/next.raw" "$work/impacted" >"$work/next"
+	[ -s "$work/next" ] || break
+	sort -u "$work/impacted" "$work/next" >"$work/merged"
+	mv "$work/merged" "$work/impacted"
+	mv "$work/next" "$work/frontier"
+	frontier="$work/frontier"
+done
+
+sort -u "$work/impacted" "$work/extra" >"$work/final.raw"
+# Only ever name real members: an escape edge in a stale path, or a crate
+# renamed out from under this script, must not become `-p <nonexistent>`.
+comm -12 "$work/final.raw" "$work/members" >"$work/final"
+
+# ---------------------------------------------------------------------------
+# 7. Answer.
+# ---------------------------------------------------------------------------
+
+count="$(wc -l <"$work/final" | tr -d ' ')"
+total="$(wc -l <"$work/members" | tr -d ' ')"
+
+if [ "$count" -eq 0 ]; then
+	printf '\n'
+	printf 'impacted-crates: no crate is reachable from this diff — skipping the compile tiers\n' >&2
+	exit 0
+fi
+
+# Scoping the whole workspace with 21 `-p` flags is slower than `--workspace`
+# and reads worse in the log; collapse it.
+if [ "$count" -ge "$total" ]; then
+	full "the diff reaches every member"
+fi
+
+scope=""
+while IFS= read -r name; do
+	scope="$scope -p $name"
+done <"$work/final"
+printf '%s\n' "${scope# }"
+printf 'impacted-crates: %s of %s members —%s\n' "$count" "$total" "$scope" >&2

--- a/scripts/test-impacted-crates.sh
+++ b/scripts/test-impacted-crates.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Tests for impacted-crates.sh (#1135).
+#
+#   ./scripts/test-impacted-crates.sh
+#
+# Run it after touching that script. Not part of `make gate`: it runs
+# `cargo metadata` against a synthetic workspace a dozen times, which is a
+# couple of seconds not worth adding to every push — the same call `make
+# dev-env-test` makes.
+#
+# ── Why a fixture instead of the real checkout ───────────────────────────────
+#
+# Asserting against this repository's own crate graph would make the suite a
+# transcript of today's membership list: adding a crate, or moving one file
+# between two of them, would turn cases red without anything being wrong. The
+# fixture is a five-crate workspace with each edge kind built in exactly once,
+# so a case fails only when the *scoping rule* it names has broken.
+#
+# It also lets the escape-edge cases be real. The fixture's `reader` crate
+# genuinely contains `include_str!` pointing outside itself and its `rt` crate
+# genuinely climbs out of `CARGO_MANIFEST_DIR`, so the two scans under test run
+# against real source rather than a mock.
+#
+# ── What "tested" means here ─────────────────────────────────────────────────
+#
+# The script's whole job is deciding what NOT to compile, so a bug that always
+# answers `--workspace` is invisible to a suite that only checks safety, and a
+# bug that always answers "nothing" is invisible to one that only checks
+# narrowing. Every case therefore asserts the exact scope line, and the cases
+# come in pairs that straddle each rule: E1/E2 straddle the reverse-dependency
+# closure, G1/G3 straddle the global-build-input list, X1/X2 straddle the
+# compile-time escape, R1/R2 straddle the run-time escape.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/impacted-crates.sh"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# One assertion form: feed paths on stdin, compare the scope line exactly.
+# Exact rather than substring, because "-p base" is a substring of the wrong
+# answer "-p base -p mid" and the difference between them is the whole point.
+want() { # want <name> <expected-stdout> <changed-path>...
+	local name="$1" expect="$2"
+	shift 2
+	local got
+	got="$(printf '%s\n' "$@" | (cd "$FIX" && "$SCRIPT" 2>/dev/null))"
+	if [ "$got" = "$expect" ]; then
+		printf 'ok    %s\n' "$name"
+		pass=$((pass + 1))
+	else
+		printf 'FAIL  %-44s want=[%s] got=[%s]\n' "$name" "$expect" "$got"
+		fail=$((fail + 1))
+	fi
+}
+
+want_empty() { # want_empty <name> <changed-path>...
+	local name="$1"
+	shift
+	want "$name" "" "$@"
+}
+
+# ── the fixture ──────────────────────────────────────────────────────────────
+#
+#   base  ← mid ← leaf        a three-link chain, for the closure
+#   base  ← devdep            via [dev-dependencies] only
+#   reader                    include_str!s ../README.md and base's source
+#   rt                        climbs out of CARGO_MANIFEST_DIR at run time
+#
+# `reader` and `rt` deliberately depend on nothing: it must be the escape scans
+# that pull them in, not a dependency edge standing in for them.
+
+mkcrate() { # mkcrate <dir> <name> [manifest-tail]
+	mkdir -p "$FIX/$1/src"
+	{
+		printf '[package]\nname = "%s"\nversion = "0.0.0"\nedition = "2021"\npublish = false\n' "$2"
+		printf '%s\n' "${3:-}"
+	} >"$FIX/$1/Cargo.toml"
+	printf 'pub fn %s() {}\n' "$(printf '%s' "$2" | tr '-' '_')" >"$FIX/$1/src/lib.rs"
+}
+
+mkdir -p "$FIX/docs" "$FIX/site"
+cat >"$FIX/Cargo.toml" <<'EOF'
+[workspace]
+resolver = "2"
+members = ["crates/base", "crates/mid", "crates/leaf", "crates/devdep", "crates/reader", "crates/rt"]
+EOF
+printf 'readme\n' >"$FIX/README.md"
+printf 'note\n' >"$FIX/docs/note.md"
+printf 'page\n' >"$FIX/site/page.mdx"
+
+mkcrate crates/base base
+mkcrate crates/mid mid '[dependencies]
+base = { path = "../base" }'
+mkcrate crates/leaf leaf '[dependencies]
+mid = { path = "../mid" }'
+# Dev-dependency only: `cargo test -p devdep` compiles base, so a change to
+# base must re-test devdep even though its library does not link base.
+mkcrate crates/devdep devdep '[dev-dependencies]
+base = { path = "../base" }'
+mkcrate crates/reader reader
+mkcrate crates/rt rt
+
+cat >>"$FIX/crates/reader/src/lib.rs" <<'EOF'
+const README: &str = include_str!("../../../README.md");
+const BASE_SRC: &str = include_str!("../../base/src/lib.rs");
+EOF
+cat >>"$FIX/crates/rt/src/lib.rs" <<'EOF'
+pub fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("has a parent")
+        .to_path_buf()
+}
+EOF
+
+# `leaf` carries the build script, so the "a build script forces the full
+# workspace" rule is tested on a real member rather than a bare path.
+printf 'fn main() {}\n' >"$FIX/crates/leaf/build.rs"
+
+git -C "$FIX" init -q
+git -C "$FIX" add -A >/dev/null 2>&1
+
+if ! (cd "$FIX" && cargo metadata --no-deps --format-version 1 >/dev/null 2>&1); then
+	echo "test-impacted-crates: cargo metadata will not resolve the fixture; aborting" >&2
+	exit 2
+fi
+
+# ── ownership and the reverse-dependency closure ─────────────────────────────
+
+want "E1  a leaf crate impacts only itself" \
+	"-p leaf" "crates/leaf/src/lib.rs"
+want "E2  a base crate impacts its dependents" \
+	"-p base -p devdep -p leaf -p mid -p reader" "crates/base/src/lib.rs"
+want "E3  mid impacts leaf but not base" \
+	"-p leaf -p mid" "crates/mid/src/lib.rs"
+want "E4  a dev-dependency is a real edge" \
+	"-p devdep" "crates/devdep/src/lib.rs"
+want "E5  two crates union, not intersect" \
+	"-p leaf -p mid -p rt" "crates/mid/src/lib.rs" "crates/rt/src/lib.rs"
+want "E6  a crate's tests belong to that crate" \
+	"-p leaf" "crates/leaf/tests/smoke.rs"
+
+# ── global build inputs and the machinery rule ───────────────────────────────
+
+want "G1  the workspace manifest is global" \
+	"--workspace" "Cargo.toml"
+want "G2  the lock is global" \
+	"--workspace" "Cargo.lock"
+want "G3  a crate's own manifest is NOT global" \
+	"-p leaf" "crates/leaf/Cargo.toml"
+want "G4  a build script is global" \
+	"--workspace" "crates/leaf/build.rs"
+want "G5  the toolchain pin is global" \
+	"--workspace" "rust-toolchain.toml"
+want "G6  lint config is global" \
+	"--workspace" "clippy.toml"
+want "G7  one global input outweighs a narrow one" \
+	"--workspace" "crates/leaf/src/lib.rs" "Cargo.lock"
+want "M1  the Makefile is machinery" \
+	"--workspace" "Makefile"
+want "M2  the scoper itself is machinery" \
+	"--workspace" "scripts/impacted-crates.sh"
+want "M3  the hook is machinery" \
+	"--workspace" ".githooks/pre-push"
+
+# ── compile-time escapes: include_str! reaching out of the crate ─────────────
+
+want "X1  base's source re-tests the crate that include_str!s it" \
+	"-p base -p devdep -p leaf -p mid -p reader" "crates/base/src/lib.rs"
+want "X2  a sibling source with no include edge does not" \
+	"-p leaf" "crates/leaf/src/lib.rs"
+want "X3  an include target outside every crate names the reader" \
+	"-p reader -p rt" "README.md"
+
+# ── run-time escapes: CARGO_MANIFEST_DIR climbed with .parent() ──────────────
+
+want "R1  an unreferenced repo file still re-tests the run-time reader" \
+	"-p rt" "docs/note.md"
+want "R2  ...and so does a file under a directory no crate names" \
+	"-p rt" "site/page.mdx"
+want "R3  an in-crate change does not wake the run-time reader" \
+	"-p leaf" "crates/leaf/src/lib.rs"
+
+# ── degenerate answers ───────────────────────────────────────────────────────
+
+want_empty "N1  an empty diff needs no compile tiers"
+want "N2  reaching every member collapses to --workspace" \
+	"--workspace" "crates/base/src/lib.rs" "crates/rt/src/lib.rs"
+
+# ── fail safe: an unusable workspace must widen, never narrow ────────────────
+
+printf 'this is not toml [[[\n' >"$FIX/crates/base/Cargo.toml"
+want "S1  a broken manifest falls back to the full workspace" \
+	"--workspace" "crates/leaf/src/lib.rs"
+
+echo
+printf 'passed=%d failed=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`make gate` compiles, documents and tests all 21 workspace members, and `.githooks/pre-push` ran it unconditionally. A 13-file test-only change confined to `stella-cli` therefore paid a full-workspace `cargo doc` + `clippy --all-targets` + `cargo test` — twice, once per push (observed shipping #911, where the push blew a two-minute timeout and had to be re-run detached).

With no rung between "everything" and `SKIP_GATE=1`, the honest choice under time pressure was to skip the gate entirely — the worst possible default for a repo whose culture is that the gate must be believable.

This scopes the three **compile** tiers — clippy, rustdoc, test — to the crates the pushed diff can actually reach. The cheap global guards stay unscoped.

Closes #1135

### Measured, warm cache, test-only edit to `stella-cli/src/main_tests.rs`

| | clippy + rustdoc + test | scope |
| --- | --- | --- |
| before | **126s** | `--workspace` (21 members) |
| after | **60s** | `-p stella-cli -p stella-parity` |

2.1x, and the gap widens with the workspace. `stella-parity` is in scope because it `include_str!`s `stella-cli`'s sources — see below.

### It is not just a reverse-dependency walk

Cargo's dependency graph is not the whole build graph here, and a scoper that knows only that graph is wrong in a way that is invisible until CI disagrees with the local gate. `scripts/impacted-crates.sh` walks three edge kinds:

1. **Ownership + reverse dependencies**, over all dependency kinds — a dev-dependency is a real edge for `cargo test`.
2. **Compile-time escapes.** `stella-parity/src/lib.rs` does `include_str!("../../stella-cli/src/subsession.rs")`; `stella-tools/tests/doc_truth.rs` does `include_str!("../../README.md")`. No cargo edge names either. These are resolved literally.
3. **Run-time escapes.** `stella-tools/tests/docs_in_sync.rs` walks `website/content/docs/agent-tools/*.mdx`, `stella-cli/src/main_tests.rs` reads `website/content/docs/commands/meta.json`, `stella-protocol/tests/wire_contract.rs` reads `docs/wire/`. No static scan can resolve those, so they are detected **by shape** — `env!("CARGO_MANIFEST_DIR")` climbed with `.parent()` or `".."` — rather than listed in a table that would rot. A new one cannot quietly fall outside the gate's reach.

Escape edges add the *reading* crate and deliberately not its dependents: a stale `README.md` can fail `stella-tools`'s own doc test, but cannot change the code its dependents compile against.

### Every uncertain answer is `--workspace`

Missing jq/cargo/rg, an unresolvable `cargo metadata`, an unfetched remote tip, an unplaceable path, a workspace-root manifest, `Cargo.lock`, a build script, a push to `main`, a tag, or a change to the gate machinery itself (`Makefile`, the hook, the scoper). That last rule makes **this PR's own pushes run the full workspace**, which is the point.

### A graduated fallback

```bash
GATE=fast git push     # make check — guards + fmt + clippy, no rustdoc, no tests
GATE=full git push     # the whole workspace, whatever the diff says
SKIP_GATE=1 git push   # nothing at all (emergencies)
```

A reduced gate that runs beats a full gate that gets skipped.

### The stale rationale

The hook's header justified itself on the grounds that "the org's GitHub Actions is billing-locked: every required check fast-fails in seconds without ever executing". That stopped being true — Actions ran real checks on PR #1098 on 2026-08-01, for minutes, failing on genuine findings. Replaced with the reasons that outlive the billing hold: `enforce_admins` is off, CI is a round trip, and some guards run nowhere else for months (`wire-schema` lived only in `make gate`, which is how #1185 merged with stale artifacts).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-impacted-crates.sh` — 25 cases, hermetic, against a synthetic six-crate workspace with each edge kind built in exactly once. It cannot run on `main` because the script under test does not exist there; every case is a new assertion about behavior `main` does not have.

Cases come in pairs that straddle each rule, because a bug that always answers `--workspace` is invisible to a suite that only checks safety and a bug that always answers "nothing" is invisible to one that only checks narrowing: E1/E2 straddle the closure, G1/G3 the global-input list, X1/X2 the compile-time escape, R1/R2 the run-time escape, S1 the fail-safe. Every case asserts the **exact** scope line — `-p base` is a substring of the wrong answer `-p base -p mid`.

The ten hook paths (feature branch, `GATE=fast`, website-only, push to main, tag, `GATE=full`, unfetched remote tip, branch deletion, `SKIP_GATE`, new branch) were exercised end to end against real commits with a shimmed `make` that records its arguments.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `make guards` — all nine toolchain-free guards + `wire-schema`, green
- [x] `shellcheck install.sh scripts/*.sh .githooks/*` — clean
- [x] Docs updated: AGENTS.md, CONTRIBUTING.md, `make help`, the `make hooks` banner
- [x] `Closes #1135` appears both above and as a commit trailer

## Anything reviewers should know?

**CI stays unscoped, deliberately — and that is a decision to push back on if you disagree.** The issue title names CI, and the same `CARGO_SCOPE` plumbing would work there. I did not wire it, and recorded why in `ci.yml` at the clippy step: the hook can afford to be clever precisely because something unclever still compiles the whole tree before anything merges. Scope both and no run anywhere builds every member pre-merge, so a bug in the impact graph stays invisible until `main` goes red — the failure mode this repo pays for most often. Runner time is parallel and rust-cache keeps it warm, so CI is not what blocks an author; the two minutes the hook burned on every push is. The issue's five acceptance criteria are all local and all met.

**`make gate` and CI are byte-identical by default.** `CARGO_SCOPE` defaults to `--workspace`, and the `gate`/`check` prerequisite lists were refactored into `GATE_GUARDS`/`GATE_GUARDS_FAST` variables that expand to exactly the same targets as before.

**One subtle bug worth knowing about, since it nearly shipped silently:** given no path argument and a non-TTY stdin, ripgrep searches *stdin* rather than the working directory. The escape-edge scans run inside a script whose stdin is a pipe already drained by `cat`, so they matched nothing, exited 0, and dropped every escape edge — a scoper that looked correct and was quietly unsound. Both call sites now pass an explicit `.` and `</dev/null`, with a comment saying why.

**`scripts/test-impacted-crates.sh` is not in `make gate`**, matching the `make dev-env-test` precedent: it runs `cargo metadata` against a fixture a dozen times, which is a couple of seconds not worth adding to every push. Run it after touching the scoper.

## Summary by Sourcery

Scope the pre-push gate’s compile tiers to only the crates affected by a diff while keeping global guards and CI unscoped, and introduce clearer gate tiers and tooling around this behavior.

Enhancements:
- Introduce a CARGO_SCOPE parameter to allow clippy, rustdoc, and tests to run on only impacted crates instead of the whole workspace by default.
- Refactor gate-related Makefile targets into named guard tiers (guards, check, gate) so pre-push and CI workflows compose them consistently.
- Add the impacted and impacted-test Makefile targets to surface and validate the crate-scoping logic for a given diff.
- Document the new graduated gate workflow, scoped compile behavior, and escape-hatch options in AGENTS.md and CONTRIBUTING.md.
- Clarify in CI configuration that clippy remains deliberately unscoped, explaining the rationale and interaction with the local gate.

Tests:
- Add scripts/test-impacted-crates.sh to validate impacted-crates.sh against a synthetic workspace that exercises ownership, escape edges, and failure modes of the scoping logic.

Chores:
- Add scripts/impacted-crates.sh to compute the cargo package scope for a diff, including dependency closures and escape edges, to drive pre-push gate scoping.