### PR TITLE
feat(arenabench): seat Claude Code on a non-Anthropic endpoint, and draw tasks at random

### DIFF
--- a/arenabench/arenabench/agents.py
+++ b/arenabench/arenabench/agents.py
@@ -97,6 +97,12 @@ class AgentSpec:
     #: first. Used to alias a provider-native key into the name the agent
     #: actually reads once it has been routed off its home provider.
     token_env: tuple[str, ...] = ()
+    #: Variables that satisfy this agent's credential requirement but are
+    #: never alias *targets*. A subscription token is not a provider bearer
+    #: token: copying a provider key into it would produce a seat that
+    #: cannot authenticate at all, so it counts as credentials present
+    #: without ever being written to.
+    alt_credential_env: tuple[str, ...] = ()
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -165,6 +171,7 @@ def _builtin(
     reasoning: bool = False,
     base_url_env: str | None = None,
     token_env: tuple[str, ...] = (),
+    alt_credential_env: tuple[str, ...] = (),
 ) -> AgentSpec:
     """A Harbor built-in agent.
 
@@ -192,6 +199,7 @@ def _builtin(
         honours=frozenset(honours),
         base_url_env=base_url_env,
         token_env=token_env,
+        alt_credential_env=alt_credential_env,
     )
 
 
@@ -215,6 +223,11 @@ AGENTS: dict[str, AgentSpec] = {
             # Anthropic seat possible at all.
             base_url_env="ANTHROPIC_BASE_URL",
             token_env=("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"),
+            # A Claude subscription. Harbor forwards this into the
+            # container and the CLI prefers whichever auth is present, so
+            # a seat carrying only this runs on the plan rather than on
+            # metered credits.
+            alt_credential_env=("CLAUDE_CODE_OAUTH_TOKEN",),
         ),
         _builtin("codex", "Codex CLI", "OpenAI's coding CLI.", effort=True),
         _builtin("gemini-cli", "Gemini CLI", "Google's coding CLI."),
@@ -307,7 +320,9 @@ def missing_credentials(contestant: Contestant) -> list[str]:
     """
     spec = resolve_agent(contestant.agent)
     candidates = list(credential_env_for(contestant.engine.api))
-    candidates += [name for name in spec.token_env if name not in candidates]
+    for name in spec.token_env + spec.alt_credential_env:
+        if name not in candidates:
+            candidates.append(name)
     if not candidates:
         return []
     if any(contestant.env.get(name) for name in candidates):

--- a/arenabench/arenabench/agents.py
+++ b/arenabench/arenabench/agents.py
@@ -34,8 +34,10 @@ __all__ = [
     "API_CREDENTIALS",
     "credential_env_for",
     "launch_flags",
+    "launch_model",
     "missing_credentials",
     "resolve_agent",
+    "routes_directly",
 ]
 
 #: Environment variable each provider API reads its key from, plus the base URL
@@ -82,6 +84,19 @@ class AgentSpec:
     has_pipeline: bool = False
     #: Extra environment this agent always needs, beyond the provider key.
     extra_env: dict[str, str] = field(default_factory=dict)
+    #: Environment variable this agent reads a custom provider endpoint from,
+    #: when it can be pointed at one at all. ``None`` means a base URL set on
+    #: this seat is genuinely ignored, and the operator is told so.
+    #:
+    #: Stella deliberately leaves this ``None`` while still honouring
+    #: ``base_url``: its endpoint travels through the adapter's own registered
+    #: ``STELLA_BASE_URL`` seam rather than an environment variable Harbor
+    #: hands to a CLI, so the two are not interchangeable.
+    base_url_env: str | None = None
+    #: Variables this agent will accept a bearer token in, most preferred
+    #: first. Used to alias a provider-native key into the name the agent
+    #: actually reads once it has been routed off its home provider.
+    token_env: tuple[str, ...] = ()
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -148,24 +163,35 @@ def _builtin(
     *,
     effort: bool = False,
     reasoning: bool = False,
+    base_url_env: str | None = None,
+    token_env: tuple[str, ...] = (),
 ) -> AgentSpec:
     """A Harbor built-in agent.
 
     Model selection is the one knob every Harbor agent honours, because Harbor
     passes ``--model`` itself. Effort and reasoning are opt-in per agent since
     most CLI agents expose neither.
+
+    ``base_url_env`` implies :data:`KNOB_BASE_URL` rather than being declared
+    alongside it. The two cannot drift apart that way, and drift is exactly the
+    failure that matters here: an agent listed as honouring ``base_url`` with
+    no variable to put it in would report a route it never took.
     """
     honours = {KNOB_MODEL}
     if effort:
         honours.add(KNOB_EFFORT)
     if reasoning:
         honours.add(KNOB_REASONING)
+    if base_url_env:
+        honours.add(KNOB_BASE_URL)
     return AgentSpec(
         slug=slug,
         title=title,
         harbor_agent=slug,
         description=description,
         honours=frozenset(honours),
+        base_url_env=base_url_env,
+        token_env=token_env,
     )
 
 
@@ -179,9 +205,16 @@ AGENTS: dict[str, AgentSpec] = {
         _builtin(
             "claude-code",
             "Claude Code",
-            "Anthropic's coding CLI.",
+            "Anthropic's coding CLI. Routable at any Anthropic-shaped "
+            "endpoint, so it can also be seated on a GLM or self-hosted model.",
             effort=True,
             reasoning=True,
+            # Harbor's Claude Code agent already forwards ANTHROPIC_BASE_URL
+            # into the task container and, when one is set, hands the model
+            # name to that endpoint unchanged. That is what makes a non-
+            # Anthropic seat possible at all.
+            base_url_env="ANTHROPIC_BASE_URL",
+            token_env=("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"),
         ),
         _builtin("codex", "Codex CLI", "OpenAI's coding CLI.", effort=True),
         _builtin("gemini-cli", "Gemini CLI", "Google's coding CLI."),
@@ -228,6 +261,32 @@ def launch_flags(contestant: Contestant) -> list[str]:
     raise ValueError(f"agent {spec.slug!r} declares no launch mechanism")
 
 
+def routes_directly(contestant: Contestant) -> bool:
+    """Whether this seat talks to a provider endpoint of its own choosing.
+
+    True only when the agent has somewhere to put a base URL *and* the
+    operator set one. Both halves matter: an agent with no such variable
+    cannot be rerouted, and an agent that was never given a URL is still on
+    its home provider and must be addressed the way Harbor addresses it.
+    """
+    spec = resolve_agent(contestant.agent)
+    return bool(spec.base_url_env and (contestant.engine.base_url or "").strip())
+
+
+def launch_model(contestant: Contestant) -> str:
+    """The value for ``harbor run --model``.
+
+    Harbor routes most agents by a ``provider/model`` string and strips the
+    prefix itself on the way to the provider. An agent pointed at an explicit
+    endpoint is the exception: Harbor forwards the name to that endpoint
+    verbatim, so an api prefix ArenaBench added would arrive at a provider
+    that has never heard of it and fail *every* trial with a model-not-found —
+    which reads on the scoreboard as an agent that cannot code.
+    """
+    engine = contestant.engine
+    return engine.bare_model if routes_directly(contestant) else engine.qualified_model
+
+
 def credential_env_for(api: str) -> tuple[str, ...]:
     """Candidate credential variable names for a provider API."""
     return API_CREDENTIALS.get(api.strip().lower(), ())
@@ -239,10 +298,18 @@ def missing_credentials(contestant: Contestant) -> list[str]:
     Returns the *candidate set* when none of the alternatives is present — for
     Google that is ``["GEMINI_API_KEY", "GOOGLE_API_KEY"]``, meaning "any one
     of these". An empty list means the seat is credentialled.
+
+    An agent that carries its token in its own variable adds those names to
+    the set, because a seat routed off its home provider is legitimately
+    credentialled either way: ``ZAI_API_KEY`` is what the provider calls it
+    and ``ANTHROPIC_AUTH_TOKEN`` is what Claude Code reads it from, and
+    warning about the one an operator did not use would be noise.
     """
-    candidates = credential_env_for(contestant.engine.api)
+    spec = resolve_agent(contestant.agent)
+    candidates = list(credential_env_for(contestant.engine.api))
+    candidates += [name for name in spec.token_env if name not in candidates]
     if not candidates:
         return []
     if any(contestant.env.get(name) for name in candidates):
         return []
-    return list(candidates)
+    return candidates

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 
 import argparse
 import logging
+import random
 import sys
 from pathlib import Path
 
 from .agents import AGENTS
 from .recorder import IMAGE_TAG, build_image, docker_available, image_present
-from .registry import DEFAULT_REGISTRY
+from .registry import DEFAULT_REGISTRY, sample_tasks
 from .server import default_workspace, serve
 
 __all__ = ["main"]
@@ -58,10 +59,32 @@ def _cmd_tasks(args: argparse.Namespace) -> int:
         target = dataset.harbor_id if dataset else args.dataset
         print(f"no tasks on disk; fetch with: harbor download {target}", file=sys.stderr)
         return 1
+    total = len(tasks)
+    seed = args.seed
+    if args.random:
+        # An unseeded draw still gets a seed, and prints it. Otherwise the one
+        # thing you need to run this slice again is the one thing you no
+        # longer have.
+        if seed is None:
+            seed = random.randrange(1, 2**31)
+        tasks = sample_tasks(
+            tasks, args.random, seed, exclude_heavy=args.exclude_heavy
+        )
+
     for task in tasks:
-        heavy = " [heavy]" if task.memory_mb > 4096 or task.cpus > 1 else ""
+        heavy = " [heavy]" if task.heavy else ""
         print(f"{task.name:38} {task.difficulty:8} {task.category}{heavy}")
-    print(f"\n{len(tasks)} tasks", file=sys.stderr)
+
+    if args.random:
+        pool = "non-heavy tasks" if args.exclude_heavy else "tasks"
+        print(
+            f"\n{len(tasks)} of {total} {pool} — reproduce with "
+            f"--random {args.random} --seed {seed}"
+            + (" --exclude-heavy" if args.exclude_heavy else ""),
+            file=sys.stderr,
+        )
+    else:
+        print(f"\n{total} tasks", file=sys.stderr)
     return 0
 
 
@@ -107,6 +130,22 @@ def main(argv: list[str] | None = None) -> int:
 
     tasks_parser = subparsers.add_parser("tasks", help="list a dataset's tasks")
     tasks_parser.add_argument("dataset", default="terminal-bench-2.1", nargs="?")
+    tasks_parser.add_argument(
+        "--random",
+        type=int,
+        metavar="N",
+        help="draw N tasks at random instead of listing all of them",
+    )
+    tasks_parser.add_argument(
+        "--seed",
+        type=int,
+        help="seed for --random; one is chosen and printed if you omit it",
+    )
+    tasks_parser.add_argument(
+        "--exclude-heavy",
+        action="store_true",
+        help="draw only from tasks that do not force concurrency to 1",
+    )
     tasks_parser.set_defaults(func=_cmd_tasks)
 
     agents_parser = subparsers.add_parser("agents", help="list available agents")

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -68,7 +68,11 @@ def _cmd_tasks(args: argparse.Namespace) -> int:
         if seed is None:
             seed = random.randrange(1, 2**31)
         tasks = sample_tasks(
-            tasks, args.random, seed, exclude_heavy=args.exclude_heavy
+            tasks,
+            args.random,
+            seed,
+            exclude_heavy=args.exclude_heavy,
+            max_memory_mb=args.max_memory_mb,
         )
 
     for task in tasks:
@@ -76,11 +80,24 @@ def _cmd_tasks(args: argparse.Namespace) -> int:
         print(f"{task.name:38} {task.difficulty:8} {task.category}{heavy}")
 
     if args.random:
-        pool = "non-heavy tasks" if args.exclude_heavy else "tasks"
+        # Report the size of the pool actually drawn from, not the dataset. A
+        # filtered draw is a sample of a smaller population, and "10 of 89"
+        # would quietly claim otherwise.
+        drawn_from = len(
+            sample_tasks(
+                DEFAULT_REGISTRY.tasks(args.dataset),
+                total,
+                seed,
+                exclude_heavy=args.exclude_heavy,
+                max_memory_mb=args.max_memory_mb,
+            )
+        )
+        narrowed = "" if drawn_from == total else f" (of {total} in the dataset)"
         print(
-            f"\n{len(tasks)} of {total} {pool} — reproduce with "
-            f"--random {args.random} --seed {seed}"
-            + (" --exclude-heavy" if args.exclude_heavy else ""),
+            f"\n{len(tasks)} drawn from a pool of {drawn_from}{narrowed} — "
+            f"reproduce with --random {args.random} --seed {seed}"
+            + (" --exclude-heavy" if args.exclude_heavy else "")
+            + (f" --max-memory-mb {args.max_memory_mb}" if args.max_memory_mb else ""),
             file=sys.stderr,
         )
     else:
@@ -145,6 +162,15 @@ def main(argv: list[str] | None = None) -> int:
         "--exclude-heavy",
         action="store_true",
         help="draw only from tasks that do not force concurrency to 1",
+    )
+    tasks_parser.add_argument(
+        "--max-memory-mb",
+        type=int,
+        default=0,
+        metavar="MB",
+        help="draw only from tasks asking for at most MB of memory; with N "
+             "contestants racing, the ceiling that matters is your Docker "
+             "allocation divided by N",
     )
     tasks_parser.set_defaults(func=_cmd_tasks)
 

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -246,6 +246,24 @@ class Engine:
             return model
         return f"{self.api}/{model}"
 
+    @property
+    def bare_model(self) -> str:
+        """The model id as the *provider* publishes it, with no api prefix.
+
+        The inverse of :attr:`qualified_model`, and the form an agent needs
+        when it has been pointed at a provider's endpoint directly rather than
+        routed there by Harbor: z.ai is handed ``glm-5.2`` and has never heard
+        of ``zai/glm-5.2``.
+
+        Only the leading ``<api>/`` comes off. An OpenRouter model keeps its
+        vendor segment — ``openrouter/z-ai/glm-5.2`` bares to ``z-ai/glm-5.2``,
+        not ``glm-5.2`` — because that segment is part of the id the provider
+        itself publishes, not a route ArenaBench added.
+        """
+        model = self.model.strip()
+        prefix = f"{self.api}/"
+        return model[len(prefix) :] if model.startswith(prefix) else model
+
     def role(self, name: str) -> RoleConfig:
         return self.roles.get(name, RoleConfig())
 

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -399,6 +399,18 @@ class MatchSpec:
     contestants: tuple[Contestant, ...]
     attempts: int = 1
     concurrency: int = 1
+    #: Scales Harbor's agent-*setup* budget — installing the agent's own
+    #: toolchain into each container, before the task begins.
+    #:
+    #: It is separate from the agent timeout because the two measure
+    #: different things, and only one of them is about coding. An agent
+    #: that installs a Node toolchain per trial needs the network for
+    #: minutes before it starts; one that uploads a static binary needs
+    #: seconds. On a slow link or a contended host the first blows the
+    #: default budget and scores nothing, which is a fact about its
+    #: installer rather than its ability — so the operator gets a knob
+    #: instead of a mystery.
+    setup_timeout_multiplier: float = 1.0
     #: Capture a real MP4 screen recording per trial (see :mod:`.recorder`).
     record_video: bool = False
 
@@ -411,6 +423,7 @@ class MatchSpec:
             "contestants": [c.redacted() for c in self.contestants],
             "attempts": self.attempts,
             "concurrency": self.concurrency,
+            "setup_timeout_multiplier": self.setup_timeout_multiplier,
             "record_video": self.record_video,
         }
 
@@ -430,6 +443,9 @@ class MatchSpec:
             contestants=contestants,
             attempts=max(1, int(raw.get("attempts") or 1)),
             concurrency=max(1, int(raw.get("concurrency") or 1)),
+            setup_timeout_multiplier=max(
+                1.0, float(raw.get("setup_timeout_multiplier") or 1.0)
+            ),
             record_video=bool(raw.get("record_video")),
         )
 

--- a/arenabench/arenabench/registry.py
+++ b/arenabench/arenabench/registry.py
@@ -270,6 +270,7 @@ def sample_tasks(
     seed: int,
     *,
     exclude_heavy: bool = False,
+    max_memory_mb: int = 0,
 ) -> list[Task]:
     """A reproducible random subset of ``tasks``.
 
@@ -285,11 +286,24 @@ def sample_tasks(
     at a glance.
 
     ``exclude_heavy`` narrows the pool before drawing, for a host that cannot
-    give a task 8 GB and still run a second contestant beside it. It changes
-    what the sample is a sample *of*, so a caller that sets it owes the reader
-    that detail — this is a smaller population, not the same one.
+    give a task 8 GB and still run a second contestant beside it.
+    ``max_memory_mb`` narrows it by an explicit ceiling, which is the honest
+    knob when :attr:`Task.heavy` is calibrated for a larger machine than the
+    one in front of you: a match with N contestants runs N containers at once,
+    so the ceiling that matters is the Docker allocation divided by N, and
+    only the operator knows both numbers.
+
+    Both change what the sample is a sample *of*. A caller that sets either
+    owes the reader that detail — this is a smaller population, not the same
+    one, and a solve rate over the easy-to-schedule tasks is not a solve rate
+    over the benchmark.
     """
-    pool = [task for task in tasks if not (exclude_heavy and task.heavy)]
+    pool = [
+        task
+        for task in tasks
+        if not (exclude_heavy and task.heavy)
+        and not (max_memory_mb and task.memory_mb > max_memory_mb)
+    ]
     if count >= len(pool):
         return pool
     if count <= 0:

--- a/arenabench/arenabench/registry.py
+++ b/arenabench/arenabench/registry.py
@@ -23,13 +23,21 @@ without any of the UI knowing what a dataset is.
 from __future__ import annotations
 
 import os
+import random
 import subprocess
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Sequence
 
-__all__ = ["Task", "Dataset", "Registry", "DEFAULT_REGISTRY", "harbor_cache_root"]
+__all__ = [
+    "Task",
+    "Dataset",
+    "Registry",
+    "DEFAULT_REGISTRY",
+    "harbor_cache_root",
+    "sample_tasks",
+]
 
 
 @dataclass(frozen=True)
@@ -51,6 +59,17 @@ class Task:
     agent_timeout_sec: float = 0.0
     docker_image: str = ""
 
+    @property
+    def heavy(self) -> bool:
+        """Whether this task forces concurrency down to 1.
+
+        One definition, used by the picker's filter, the CLI listing and the
+        random sampler alike — three places that must agree about which tasks
+        a small machine cannot run beside another, or a seat gets excluded
+        from one of them and not the others.
+        """
+        return self.memory_mb > 4096 or self.cpus > 1
+
     def to_json(self) -> dict[str, Any]:
         return {
             "name": self.name,
@@ -63,8 +82,7 @@ class Task:
             "cpus": self.cpus,
             "agent_timeout_sec": self.agent_timeout_sec,
             "docker_image": self.docker_image,
-            # "heavy" tasks are the ones that force concurrency down to 1.
-            "heavy": self.memory_mb > 4096 or self.cpus > 1,
+            "heavy": self.heavy,
         }
 
 
@@ -244,6 +262,40 @@ class Registry:
             dataset.to_json(task_count=len(self.tasks(key)))
             for key, dataset in sorted(self.datasets.items())
         ]
+
+
+def sample_tasks(
+    tasks: Sequence[Task],
+    count: int,
+    seed: int,
+    *,
+    exclude_heavy: bool = False,
+) -> list[Task]:
+    """A reproducible random subset of ``tasks``.
+
+    **Seeded, because "we ran ten random tasks" is not a claim anyone can
+    check.** With the seed recorded the same ten come back on demand, so a
+    result that turned on a lucky draw can be told apart from one that did
+    not — and a rival can re-run the identical slice rather than a differently
+    lucky one of their own.
+
+    Returned in the dataset's own order rather than draw order. *Which* ten
+    were chosen is the finding; the sequence they came out of the generator in
+    carries no information, and a stable order lets two selections be compared
+    at a glance.
+
+    ``exclude_heavy`` narrows the pool before drawing, for a host that cannot
+    give a task 8 GB and still run a second contestant beside it. It changes
+    what the sample is a sample *of*, so a caller that sets it owes the reader
+    that detail — this is a smaller population, not the same one.
+    """
+    pool = [task for task in tasks if not (exclude_heavy and task.heavy)]
+    if count >= len(pool):
+        return pool
+    if count <= 0:
+        return []
+    chosen = random.Random(seed).sample(range(len(pool)), count)
+    return [pool[index] for index in sorted(chosen)]
 
 
 #: Terminal-Bench 2.1, pinned by the digest the Stella benchmark protocol uses.

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -32,7 +32,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .agents import launch_flags, missing_credentials, resolve_agent
+from .agents import (
+    credential_env_for,
+    launch_flags,
+    launch_model,
+    missing_credentials,
+    resolve_agent,
+    routes_directly,
+)
 from .harbor_agent import ARENA_ENGINE_ENV
 from .model import DIMENSIONS, Contestant, MatchSpec
 from .recorder import RecorderSupervisor
@@ -98,6 +105,11 @@ class ContestantRun:
     error: str = ""
     #: Engine knobs this agent will not honour, surfaced to the operator.
     warnings: list[str] = field(default_factory=list)
+    #: Things ArenaBench did *for* this seat that it was not literally asked
+    #: to do — chiefly aliasing a provider-native key into the variable the
+    #: agent reads. Separate from :attr:`warnings` because nothing is wrong;
+    #: it is here so that no part of a contestant's routing is invisible.
+    notes: list[str] = field(default_factory=list)
 
     @property
     def state(self) -> str:
@@ -203,6 +215,9 @@ class Match:
                     if contestant.id in self.runs
                     else "pending",
                     "warnings": self.runs[contestant.id].warnings
+                    if contestant.id in self.runs
+                    else [],
+                    "notes": self.runs[contestant.id].notes
                     if contestant.id in self.runs
                     else [],
                     "error": self.runs[contestant.id].error
@@ -332,7 +347,7 @@ class MatchRunner:
             "--env", "docker",
             "--dataset", match.dataset.harbor_id,
             *launch_flags(contestant),
-            "--model", contestant.engine.qualified_model,
+            "--model", launch_model(contestant),
             "--job-name", job_name,
             "--jobs-dir", str(match.jobs_root),
             "--n-attempts", str(match.spec.attempts),
@@ -344,7 +359,7 @@ class MatchRunner:
 
         env = _base_environment()
         env.update(contestant.env)
-        env.update(self._agent_environment(contestant))
+        env.update(self._agent_environment(contestant, run))
 
         log.info(
             "launching %s: %s (%d tasks)",
@@ -364,13 +379,52 @@ class MatchRunner:
         run.started_at = time.time()
         return run
 
-    def _agent_environment(self, contestant: Contestant) -> dict[str, str]:
+    def _routing_environment(
+        self, contestant: Contestant, run: ContestantRun
+    ) -> dict[str, str]:
+        """Point a Harbor built-in at a provider endpoint of the seat's choosing.
+
+        Harbor's Claude Code agent already reads ``ANTHROPIC_BASE_URL`` and
+        forwards the model name to that endpoint unchanged when one is set —
+        which is why a GLM seat is possible at all. What it cannot do is guess
+        that a seat declaring ``api: zai`` means its ``ZAI_API_KEY`` to be the
+        bearer token, since the variable Claude Code reads has an Anthropic
+        name. ArenaBench does that one translation, and records it on the seat.
+
+        An operator who pastes the agent's own token variable is left alone:
+        an explicit choice outranks an inference every time.
+        """
+        spec = resolve_agent(contestant.agent)
+        if not routes_directly(contestant):
+            return {}
+
+        base_url = (contestant.engine.base_url or "").strip()
+        env = {spec.base_url_env: base_url}  # type: ignore[dict-item]
+        run.notes.append(f"routed at {base_url} via {spec.base_url_env}")
+
+        if not spec.token_env or any(
+            contestant.env.get(name) for name in spec.token_env
+        ):
+            return env
+
+        for source in credential_env_for(contestant.engine.api):
+            token = contestant.env.get(source)
+            if token:
+                env[spec.token_env[0]] = token
+                run.notes.append(f"{source} supplied as {spec.token_env[0]}")
+                break
+        return env
+
+    def _agent_environment(
+        self, contestant: Contestant, run: ContestantRun
+    ) -> dict[str, str]:
         """Agent-specific environment, layered over the operator's ``.env``."""
         spec = resolve_agent(contestant.agent)
         env: dict[str, str] = {}
         if spec.extra_env:
             env.update(spec.extra_env)
         if contestant.agent != "stella":
+            env.update(self._routing_environment(contestant, run))
             return env
 
         # The engine config the ArenaBench Stella adapter reads back.

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -64,6 +64,10 @@ _SCRUBBED_EXACT = frozenset(
         "MOONSHOT_API_KEY",
         "XAI_API_KEY",
         "MISTRAL_API_KEY",
+        # Claude Code's subscription credential. Not caught by the
+        # ANTHROPIC_ prefix above, and every bit as capable of letting an
+        # ambient host login stand in for a seat that was never given one.
+        "CLAUDE_CODE_OAUTH_TOKEN",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
     }
@@ -354,6 +358,11 @@ class MatchRunner:
             "--n-concurrent", str(match.spec.concurrency),
             "--max-retries", "0",
         ]
+        if match.spec.setup_timeout_multiplier != 1.0:
+            command += [
+                "--agent-setup-timeout-multiplier",
+                str(match.spec.setup_timeout_multiplier),
+            ]
         for task in match.spec.tasks:
             command += ["--include-task-name", f"{match.dataset.namespace}/{task}"]
 

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -31,6 +31,7 @@ import json
 import logging
 import mimetypes
 import os
+import random
 import threading
 import time
 import uuid
@@ -39,12 +40,12 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Iterator
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from .agents import AGENTS
 from .model import EFFORTS, ROLES, MatchSpec
 from .recorder import preflight as recorder_preflight
-from .registry import DEFAULT_REGISTRY, Registry
+from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
 from .runner import MatchRunner
 from .telemetry import TranscriptReader
 
@@ -95,6 +96,31 @@ class ArenaServer:
                     f"`harbor download {dataset.harbor_id}`"
                 )
             ),
+        }
+
+    def task_sample(
+        self, key: str, count: int, seed: int | None, exclude_heavy: bool
+    ) -> Any:
+        """Draw a reproducible random slice of a dataset.
+
+        Sampling lives on the server so the picker and the CLI draw with the
+        *same* generator from the same pool. A browser-side shuffle would be a
+        second definition of "random ten", and two definitions is one more
+        than a number anybody quotes can survive.
+        """
+        dataset = self.registry.get(key)
+        if dataset is None:
+            raise KeyError(key)
+        if seed is None:
+            seed = random.randrange(1, 2**31)
+        chosen = sample_tasks(
+            self.registry.tasks(key), count, seed, exclude_heavy=exclude_heavy
+        )
+        return {
+            "seed": seed,
+            "requested": count,
+            "exclude_heavy": exclude_heavy,
+            "names": [task.name for task in chosen],
         }
 
     def agents(self) -> Any:
@@ -354,6 +380,25 @@ def _handler_factory(arena: ArenaServer) -> type[BaseHTTPRequestHandler]:
                     self._json(arena.datasets())
                 case ["datasets", key, "tasks"]:
                     self._json(arena.tasks(key))
+                case ["datasets", key, "sample"]:
+                    query = parse_qs(urlparse(self.path).query)
+
+                    def _int(name: str) -> int | None:
+                        raw = (query.get(name) or [""])[0].strip()
+                        try:
+                            return int(raw)
+                        except ValueError:
+                            return None
+
+                    self._json(
+                        arena.task_sample(
+                            key,
+                            count=_int("count") or 10,
+                            seed=_int("seed"),
+                            exclude_heavy=(query.get("exclude_heavy") or [""])[0]
+                            == "1",
+                        )
+                    )
                 case ["agents"]:
                     self._json(arena.agents())
                 case ["matches"]:

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -99,7 +99,12 @@ class ArenaServer:
         }
 
     def task_sample(
-        self, key: str, count: int, seed: int | None, exclude_heavy: bool
+        self,
+        key: str,
+        count: int,
+        seed: int | None,
+        exclude_heavy: bool,
+        max_memory_mb: int = 0,
     ) -> Any:
         """Draw a reproducible random slice of a dataset.
 
@@ -114,12 +119,17 @@ class ArenaServer:
         if seed is None:
             seed = random.randrange(1, 2**31)
         chosen = sample_tasks(
-            self.registry.tasks(key), count, seed, exclude_heavy=exclude_heavy
+            self.registry.tasks(key),
+            count,
+            seed,
+            exclude_heavy=exclude_heavy,
+            max_memory_mb=max_memory_mb,
         )
         return {
             "seed": seed,
             "requested": count,
             "exclude_heavy": exclude_heavy,
+            "max_memory_mb": max_memory_mb,
             "names": [task.name for task in chosen],
         }
 
@@ -397,6 +407,7 @@ def _handler_factory(arena: ArenaServer) -> type[BaseHTTPRequestHandler]:
                             seed=_int("seed"),
                             exclude_heavy=(query.get("exclude_heavy") or [""])[0]
                             == "1",
+                            max_memory_mb=_int("max_memory_mb") or 0,
                         )
                     )
                 case ["agents"]:

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -38,6 +38,7 @@ from typing import Any, Iterable
 
 __all__ = [
     "EVENTS_NAME",
+    "INFRASTRUCTURE_FAILURES",
     "TRAJECTORY_NAME",
     "MetricsReader",
     "TranscriptReader",
@@ -79,6 +80,46 @@ def _iso_seconds(started: Any, finished: Any) -> float | None:
 # Metrics
 # --------------------------------------------------------------------------
 
+#: Harbor exceptions that mean **the agent never got a fair attempt** — the
+#: container did not start, its toolchain did not install, credentials were
+#: wrong, or the verifier itself fell over and never returned a verdict.
+#:
+#: These are held apart from agent failures because conflating them corrupts a
+#: head-to-head in whichever direction the infrastructure happened to break.
+#: An agent whose per-trial installer needs the network is fragile to an outage
+#: in a way that says nothing about how well it codes; scoring those trials 0
+#: hands its opponent a win nobody can defend when the logs are opened. The
+#: reverse is just as bad — a host DNS drop mid-run should not read as the
+#: agent giving up.
+#:
+#: The split is deliberately conservative. Anything that happened *while the
+#: agent was running and in control* stays an agent failure, including
+#: `AgentTimeoutError` (it had its time), `NonZeroAgentExitCodeError` (it ran
+#: and quit), and the context/output/memory ceilings (it chose what to spend).
+#: Being wrong in that direction under-credits a contestant, which is the safe
+#: way to be wrong about your own result.
+INFRASTRUCTURE_FAILURES: frozenset[str] = frozenset(
+    {
+        # The trial never reached a state where the agent could act.
+        "AgentSetupTimeoutError",
+        "EnvironmentStartTimeoutError",
+        "HealthcheckError",
+        "AddTestsDirError",
+        "DownloadVerifierDirError",
+        "MissingExtraError",
+        # Credentials are an operator setting, not a capability.
+        "AuthenticationError",
+        "OAuthCallbackError",
+        "RefreshTokenExpiredError",
+        # The verifier broke, so no verdict exists to record either way.
+        "VerifierTimeoutError",
+        "VerifierOutputParseError",
+        "RewardFileNotFoundError",
+        "RewardFileEmptyError",
+        "MultimodalExportError",
+    }
+)
+
 
 @dataclass
 class TrialMetrics:
@@ -92,6 +133,10 @@ class TrialMetrics:
     #: different answers and a solve rate that conflates them is wrong.
     resolved: bool | None = None
     failure: str = ""
+    #: ``True`` when :attr:`failure` names a harness or host fault rather than
+    #: something the agent did. Such a trial is left *unjudged* — see
+    #: :data:`INFRASTRUCTURE_FAILURES` for why that is not the same as a loss.
+    infrastructure: bool = False
     steps: int = 0
     tools: int = 0
     tokens_in: int = 0
@@ -113,6 +158,7 @@ class TrialMetrics:
             "status": self.status,
             "resolved": self.resolved,
             "failure": self.failure,
+            "infrastructure": self.infrastructure,
             "steps": self.steps,
             "tools": self.tools,
             "tokens_in": self.tokens_in,
@@ -270,7 +316,12 @@ class MetricsReader:
             exception = result.get("exception_info")
             if isinstance(exception, dict) and exception.get("exception_type"):
                 metrics.failure = str(exception["exception_type"])
-                if metrics.resolved is None:
+                metrics.infrastructure = metrics.failure in INFRASTRUCTURE_FAILURES
+                if metrics.resolved is None and not metrics.infrastructure:
+                    # An agent that ran and failed scores 0, as every
+                    # leaderboard counts it. One that never started stays
+                    # `None`: unjudged, excluded from the solve rate, and
+                    # counted where a reader can see it.
                     metrics.resolved = False
             wall = _iso_seconds(result.get("started_at"), result.get("finished_at"))
             if wall is not None:
@@ -302,12 +353,19 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
     ``solve_rate`` divides by *judged* trials, not by attempted ones. Early in
     a match most trials are unjudged, and dividing by them would show every
     contestant near zero and climbing — an artifact of progress, not of skill.
+
+    ``infrastructure`` counts trials that never reached a verdict because the
+    harness or host broke. They are excluded from the solve rate on purpose,
+    and reported separately so a reader can tell "won 8 of 10" from "won 8 of
+    the 8 that managed to start". A scoreboard that hides the difference is
+    the one nobody can defend afterwards.
     """
     trials = list(trials)
     judged = [t for t in trials if t.resolved is not None]
     passed = [t for t in judged if t.resolved]
     return {
         "trials": len(trials),
+        "infrastructure": sum(1 for t in trials if t.infrastructure),
         "running": sum(1 for t in trials if t.status == "running"),
         "done": sum(1 for t in trials if t.status == "done"),
         "judged": len(judged),

--- a/arenabench/arenabench/web/app.js
+++ b/arenabench/arenabench/web/app.js
@@ -465,6 +465,7 @@ async function launch() {
     contestants: State.seats.map(seatPayload),
     attempts: Number($('#attempts').value) || 1,
     concurrency: Number($('#concurrency').value) || 1,
+    setup_timeout_multiplier: Number($('#setup-timeout').value) || 1,
     record_video: $('#record-video').checked,
   };
   if (!payload.tasks.length) {
@@ -571,6 +572,11 @@ function renderScoreboard(snapshot) {
       el('div', { class: 'card-engine' }, `${c.agent} · ${c.engine_label}`),
       el('div', { class: 'card-state' },
         `${c.state}${t.running ? ` · ${t.running} running` : ''} · ${t.judged}/${t.trials} judged`),
+      // An arm whose trials never started has not lost them. Saying so beside
+      // the rate is the difference between "won 8 of 10" and "won 8 of the 8
+      // that managed to start" — one of which survives being checked.
+      t.infrastructure ? el('div', { class: 'card-infra' },
+        `${t.infrastructure} never started (harness/host)`) : null,
       el('div', { class: 'card-solve' },
         el('span', { class: 'solve-big' }, fmt.pct(t.solve_rate)),
         el('span', { class: 'solve-frac' }, `${t.passed} / ${t.judged || 0} solved`)),

--- a/arenabench/arenabench/web/app.js
+++ b/arenabench/arenabench/web/app.js
@@ -27,6 +27,7 @@ const State = {
   dataset: null,
   tasks: [],
   selected: new Set(),
+  draw: null,           // the last random draw, while the selection still is it
   seats: [],
   match: null,
   snapshot: null,
@@ -133,6 +134,7 @@ function wireChrome() {
   $('#select-all').addEventListener('click', () => { State.tasks.forEach((t) => State.selected.add(t.name)); renderTasks(); });
   $('#select-none').addEventListener('click', () => { State.selected.clear(); renderTasks(); });
   $('#select-visible').addEventListener('click', () => { visibleTasks().forEach((t) => State.selected.add(t.name)); renderTasks(); });
+  $('#select-random').addEventListener('click', drawRandomTasks);
   ['#task-search', '#filter-difficulty', '#filter-category', '#filter-light']
     .forEach((sel) => $(sel).addEventListener('input', renderTasks));
   $('#toggle-reasoning').addEventListener('click', () => {
@@ -203,6 +205,30 @@ function fillFilters() {
   fill('#filter-category', uniq('category'), 'all categories');
 }
 
+// The draw happens on the server, not here. `Math.random` cannot be seeded,
+// and an unseeded slice is a number nobody — including you tomorrow — can
+// reproduce. The seed comes back and is shown, so the selection can be
+// written down and run again.
+async function drawRandomTasks() {
+  if (!State.dataset) return;
+  const count = Math.max(1, Number($('#random-n').value) || 10);
+  const heavy = $('#filter-light').checked ? '1' : '0';
+  const seedEl = $('#random-seed');
+  try {
+    const drawn = await api(
+      `/api/datasets/${encodeURIComponent(State.dataset.key)}/sample` +
+      `?count=${count}&exclude_heavy=${heavy}`);
+    State.selected = new Set(drawn.names);
+    State.draw = new Set(drawn.names);
+    seedEl.textContent =
+      `· ${drawn.names.length} drawn, seed ${drawn.seed}` +
+      (drawn.exclude_heavy ? ', heavy excluded' : '');
+    renderTasks();
+  } catch (err) {
+    seedEl.textContent = `· draw failed: ${err.message}`;
+  }
+}
+
 function visibleTasks() {
   const q = $('#task-search').value.trim().toLowerCase();
   const difficulty = $('#filter-difficulty').value;
@@ -219,6 +245,14 @@ function visibleTasks() {
 
 function renderTasks() {
   const tasks = visibleTasks();
+  // The seed describes a draw. The moment the selection stops being that
+  // draw — one checkbox toggled, "select all" pressed — the seed no longer
+  // reproduces what is about to run, so it stops being shown.
+  if (State.draw) {
+    const intact = State.draw.size === State.selected.size
+      && [...State.draw].every((name) => State.selected.has(name));
+    if (!intact) { State.draw = null; $('#random-seed').textContent = ''; }
+  }
   $('#task-count').textContent = String(State.selected.size);
   $('#task-grid').replaceChildren(...tasks.map((task) => {
     const on = State.selected.has(task.name);
@@ -549,6 +583,7 @@ function renderScoreboard(snapshot) {
         stat('cache_write', 'cache w', fmt.tokens(t.cache_write)),
       ),
       (c.warnings || []).length ? el('div', { class: 'card-warn' }, c.warnings.join(' · ')) : null,
+      (c.notes || []).length ? el('div', { class: 'card-note' }, c.notes.join(' · ')) : null,
       c.error ? el('div', { class: 'card-warn' }, c.error) : null,
     );
   }));

--- a/arenabench/arenabench/web/app.js
+++ b/arenabench/arenabench/web/app.js
@@ -213,16 +213,18 @@ async function drawRandomTasks() {
   if (!State.dataset) return;
   const count = Math.max(1, Number($('#random-n').value) || 10);
   const heavy = $('#filter-light').checked ? '1' : '0';
+  const maxMem = Math.max(0, Number($('#random-max-mem').value) || 0);
   const seedEl = $('#random-seed');
   try {
     const drawn = await api(
       `/api/datasets/${encodeURIComponent(State.dataset.key)}/sample` +
-      `?count=${count}&exclude_heavy=${heavy}`);
+      `?count=${count}&exclude_heavy=${heavy}&max_memory_mb=${maxMem}`);
     State.selected = new Set(drawn.names);
     State.draw = new Set(drawn.names);
     seedEl.textContent =
       `· ${drawn.names.length} drawn, seed ${drawn.seed}` +
-      (drawn.exclude_heavy ? ', heavy excluded' : '');
+      (drawn.exclude_heavy ? ', heavy excluded' : '') +
+      (drawn.max_memory_mb ? `, ≤${drawn.max_memory_mb} MB` : '');
     renderTasks();
   } catch (err) {
     seedEl.textContent = `· draw failed: ${err.message}`;

--- a/arenabench/arenabench/web/index.html
+++ b/arenabench/arenabench/web/index.html
@@ -46,6 +46,7 @@
     <h2><span class="step-n">2</span> Tasks</h2>
     <p class="step-hint">
       Every contestant runs the identical list. <strong id="task-count">0</strong> selected.
+      <span class="muted mono" id="random-seed"></span>
     </p>
 
     <div class="task-toolbar">
@@ -60,6 +61,9 @@
       <button class="btn btn-ghost" id="select-all">select all</button>
       <button class="btn btn-ghost" id="select-none">clear</button>
       <button class="btn btn-ghost" id="select-visible">select filtered</button>
+      <button class="btn btn-ghost" id="select-random">random</button>
+      <input type="number" id="random-n" value="10" min="1" max="500"
+             title="how many tasks to draw at random">
     </div>
 
     <div class="task-grid" id="task-grid"></div>

--- a/arenabench/arenabench/web/index.html
+++ b/arenabench/arenabench/web/index.html
@@ -98,6 +98,11 @@
         <span>Concurrency</span>
         <input type="number" id="concurrency" value="1" min="1" max="16">
       </label>
+      <label class="field field-sm">
+        <span>Setup timeout &times;</span>
+        <input type="number" id="setup-timeout" value="1" min="1" max="20" step="0.5"
+               title="Scales the budget for installing each agent's toolchain into its container, before the task starts. Agents that install a Node toolchain per trial need minutes of network; one that uploads a static binary needs seconds. Raise this on a slow or contended host so a slow installer does not score as a coding failure.">
+      </label>
       <label class="chk-inline chk-record">
         <input type="checkbox" id="record-video">
         <span>Record MP4

--- a/arenabench/arenabench/web/index.html
+++ b/arenabench/arenabench/web/index.html
@@ -64,6 +64,9 @@
       <button class="btn btn-ghost" id="select-random">random</button>
       <input type="number" id="random-n" value="10" min="1" max="500"
              title="how many tasks to draw at random">
+      <input type="number" id="random-max-mem" value="0" min="0" step="1024"
+             title="draw only tasks asking for at most this many MB (0 = no ceiling). With N contestants racing, use your Docker memory allocation divided by N."
+             placeholder="≤ MB">
     </div>
 
     <div class="task-grid" id="task-grid"></div>

--- a/arenabench/arenabench/web/styles.css
+++ b/arenabench/arenabench/web/styles.css
@@ -178,6 +178,9 @@ code { font-family: var(--mono); font-size: .92em; color: var(--citron); }
   flex-wrap: wrap;
   margin-bottom: 14px;
 }
+/* Sits immediately after the "random" button and belongs to it, so it is
+   sized to its content rather than taking a flex share of the toolbar. */
+#random-n { width: 68px; flex: none; }
 input[type=search], input[type=text], input[type=number], select, textarea {
   background: var(--panel);
   border: 1px solid var(--line);
@@ -458,6 +461,11 @@ input:focus, select:focus, textarea:focus {
 .stat-v { font-family: var(--mono); font-size: 12.5px; }
 .stat.is-best .stat-v { color: var(--seat); font-weight: 600; }
 .card-warn { margin-top: 11px; font-size: 11px; color: var(--warn); font-family: var(--mono); }
+
+/* Routing this seat took a step the operator did not literally type. Nothing
+   is wrong, so it must not read as a warning — but it must be visible, since
+   an invisible route is how two seats end up secretly identical. */
+.card-note { margin-top: 6px; font-size: 11px; color: var(--muted); font-family: var(--mono); }
 
 /* ------------------------------------------------------------- the race */
 

--- a/arenabench/arenabench/web/styles.css
+++ b/arenabench/arenabench/web/styles.css
@@ -180,7 +180,7 @@ code { font-family: var(--mono); font-size: .92em; color: var(--citron); }
 }
 /* Sits immediately after the "random" button and belongs to it, so it is
    sized to its content rather than taking a flex share of the toolbar. */
-#random-n { width: 68px; flex: none; }
+#random-n, #random-max-mem { width: 68px; flex: none; }
 input[type=search], input[type=text], input[type=number], select, textarea {
   background: var(--panel);
   border: 1px solid var(--line);

--- a/arenabench/arenabench/web/styles.css
+++ b/arenabench/arenabench/web/styles.css
@@ -465,6 +465,7 @@ input:focus, select:focus, textarea:focus {
 /* Routing this seat took a step the operator did not literally type. Nothing
    is wrong, so it must not read as a warning — but it must be visible, since
    an invisible route is how two seats end up secretly identical. */
+.card-infra { margin-top: 6px; font-size: 11px; color: var(--violet); font-family: var(--mono); }
 .card-note { margin-top: 6px; font-size: 11px; color: var(--muted); font-family: var(--mono); }
 
 /* ------------------------------------------------------------- the race */

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 import pytest
 
-from arenabench.agents import AGENTS, missing_credentials, resolve_agent
+from arenabench.agents import (
+    AGENTS,
+    launch_model,
+    missing_credentials,
+    resolve_agent,
+)
 from arenabench.harbor_agent import arena_posture
 from arenabench.model import (
     DIMENSIONS,
@@ -30,7 +35,8 @@ from arenabench.model import (
     parse_dotenv,
     slugify,
 )
-from arenabench.registry import DEFAULT_REGISTRY
+from arenabench.registry import DEFAULT_REGISTRY, Task, sample_tasks
+from arenabench.runner import ContestantRun, MatchRunner
 from arenabench.telemetry import MetricsReader, TranscriptReader, aggregate, leaders
 
 # --------------------------------------------------------------------------
@@ -619,3 +625,147 @@ class TestRecorder:
         supervisor._record_failure(trial_dir, "transient")
         assert supervisor._failures[trial_dir] == 1
         assert trial_dir not in supervisor._finished
+
+
+# --------------------------------------------------------------------------
+# routing an agent off its home provider
+# --------------------------------------------------------------------------
+
+
+def _seat(env: str = "", **engine: object) -> Contestant:
+    return Contestant.from_json(
+        {"name": "cc", "agent": "claude-code", "engine": engine, "env": env}
+    )
+
+
+class TestDirectProviderRouting:
+    """Seating Claude Code on a non-Anthropic, Anthropic-shaped endpoint.
+
+    Harbor's Claude Code agent reads ``ANTHROPIC_BASE_URL`` and, when one is
+    set, forwards the model name to that endpoint unchanged. Both halves of
+    that sentence are load-bearing, and each has its own failure: no base URL
+    and the seat silently runs on Anthropic; a prefixed model name and every
+    trial dies with model-not-found, which on a scoreboard is indistinguishable
+    from an agent that cannot code.
+    """
+
+    def test_claude_code_declares_that_it_honours_a_base_url(self):
+        spec = resolve_agent("claude-code")
+        assert "base_url" in spec.honours
+        assert spec.unhonoured(Engine(model="glm-5.2", base_url="https://x/y")) == []
+
+    def test_an_agent_with_nowhere_to_put_a_base_url_still_says_so(self):
+        assert "base_url" in resolve_agent("aider").unhonoured(
+            Engine(model="m", base_url="https://x/y")
+        )
+
+    def test_a_routed_seat_is_launched_with_the_providers_own_model_id(self):
+        seat = _seat(api="zai", model="glm-5.2", base_url="https://api.z.ai/api/anthropic")
+        assert launch_model(seat) == "glm-5.2"
+
+    def test_an_unrouted_seat_keeps_harbors_provider_prefix(self):
+        seat = _seat(api="anthropic", model="claude-opus-4-5")
+        assert launch_model(seat) == "anthropic/claude-opus-4-5"
+
+    def test_baring_a_model_strips_only_the_api_prefix(self):
+        """An OpenRouter id keeps its vendor segment: ``z-ai`` is part of the
+        name OpenRouter publishes, not a route ArenaBench added."""
+        assert Engine(api="openrouter", model="z-ai/glm-5.2").bare_model == "z-ai/glm-5.2"
+        assert Engine(api="openrouter", model="openrouter/z-ai/glm-5.2").bare_model == (
+            "z-ai/glm-5.2"
+        )
+        assert Engine(api="zai", model="zai/glm-5.2").bare_model == "glm-5.2"
+
+    def _routing(self, seat: Contestant, tmp_path: Path) -> tuple[dict, list[str]]:
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path)
+        run = ContestantRun(
+            contestant=seat,
+            job_name="job",
+            job_dir=tmp_path / "job",
+            log_path=tmp_path / "job.log",
+        )
+        return runner._routing_environment(seat, run), run.notes
+
+    def test_a_provider_key_is_aliased_into_the_variable_the_agent_reads(
+        self, tmp_path: Path
+    ):
+        seat = _seat(
+            env="ZAI_API_KEY=zk-secret",
+            api="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/anthropic",
+        )
+        env, notes = self._routing(seat, tmp_path)
+        assert env["ANTHROPIC_BASE_URL"] == "https://api.z.ai/api/anthropic"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-secret"
+        assert any("ZAI_API_KEY" in note for note in notes), (
+            "aliasing a credential must be visible on the seat, not silent"
+        )
+
+    def test_an_explicitly_pasted_token_is_never_overwritten(self, tmp_path: Path):
+        seat = _seat(
+            env="ZAI_API_KEY=zk-provider\nANTHROPIC_AUTH_TOKEN=zk-explicit",
+            api="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/anthropic",
+        )
+        env, _ = self._routing(seat, tmp_path)
+        assert "ANTHROPIC_AUTH_TOKEN" not in env, (
+            "an operator's own choice outranks ArenaBench's inference"
+        )
+
+    def test_a_seat_with_no_base_url_is_not_rerouted(self, tmp_path: Path):
+        seat = _seat(env="ANTHROPIC_API_KEY=sk", api="anthropic", model="claude-opus-4-5")
+        env, notes = self._routing(seat, tmp_path)
+        assert env == {} and notes == []
+
+    def test_either_credential_name_satisfies_a_routed_seat(self):
+        base = "https://api.z.ai/api/anthropic"
+        provider = _seat(env="ZAI_API_KEY=k", api="zai", model="glm-5.2", base_url=base)
+        agent_side = _seat(
+            env="ANTHROPIC_AUTH_TOKEN=k", api="zai", model="glm-5.2", base_url=base
+        )
+        assert missing_credentials(provider) == []
+        assert missing_credentials(agent_side) == []
+        assert missing_credentials(
+            _seat(api="zai", model="glm-5.2", base_url=base)
+        ) == ["ZAI_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]
+
+
+class TestRandomTaskSampling:
+    """A seeded draw, because "we ran ten random tasks" is otherwise unfalsifiable."""
+
+    def _tasks(self, count: int) -> list[Task]:
+        return [
+            Task(
+                name=f"task-{index:02d}",
+                qualified=f"ns/task-{index:02d}",
+                memory_mb=8192 if index % 5 == 0 else 2048,
+            )
+            for index in range(count)
+        ]
+
+    def test_the_same_seed_draws_the_same_tasks(self):
+        pool = self._tasks(50)
+        assert sample_tasks(pool, 10, 7) == sample_tasks(pool, 10, 7)
+
+    def test_a_different_seed_draws_a_different_slice(self):
+        pool = self._tasks(50)
+        assert sample_tasks(pool, 10, 7) != sample_tasks(pool, 10, 8)
+
+    def test_the_draw_comes_back_in_dataset_order(self):
+        """Which ten were chosen is the finding; the order they left the
+        generator in carries no information and would only make two selections
+        harder to compare."""
+        drawn = sample_tasks(self._tasks(50), 10, 7)
+        assert [task.name for task in drawn] == sorted(task.name for task in drawn)
+
+    def test_asking_for_more_than_exists_yields_everything(self):
+        pool = self._tasks(6)
+        assert sample_tasks(pool, 99, 1) == pool
+
+    def test_excluding_heavy_narrows_the_population_drawn_from(self):
+        pool = self._tasks(50)
+        drawn = sample_tasks(pool, 10, 7, exclude_heavy=True)
+        assert len(drawn) == 10
+        assert not any(task.heavy for task in drawn)

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -36,8 +36,14 @@ from arenabench.model import (
     slugify,
 )
 from arenabench.registry import DEFAULT_REGISTRY, Task, sample_tasks
-from arenabench.runner import ContestantRun, MatchRunner
-from arenabench.telemetry import MetricsReader, TranscriptReader, aggregate, leaders
+from arenabench.runner import ContestantRun, MatchRunner, _base_environment
+from arenabench.telemetry import (
+    MetricsReader,
+    TranscriptReader,
+    TrialMetrics,
+    aggregate,
+    leaders,
+)
 
 # --------------------------------------------------------------------------
 # fixtures
@@ -729,7 +735,12 @@ class TestDirectProviderRouting:
         assert missing_credentials(agent_side) == []
         assert missing_credentials(
             _seat(api="zai", model="glm-5.2", base_url=base)
-        ) == ["ZAI_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]
+        ) == [
+            "ZAI_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ]
 
 
 class TestRandomTaskSampling:
@@ -781,3 +792,99 @@ class TestRandomTaskSampling:
 
     def test_a_ceiling_that_excludes_everything_draws_nothing(self):
         assert sample_tasks(self._tasks(50), 10, 7, max_memory_mb=1) == []
+
+
+class TestSubscriptionCredential:
+    """Claude Code seated on a Claude subscription rather than metered credits.
+
+    Harbor forwards `CLAUDE_CODE_OAUTH_TOKEN` into the container and the CLI
+    picks whichever auth method is actually present, so a seat carrying only
+    that token runs on the plan. Two things must hold for it to be safe.
+    """
+
+    def test_a_subscription_token_credentials_the_seat(self):
+        seat = Contestant.from_json({
+            "name": "cc", "agent": "claude-code",
+            "engine": {"api": "anthropic", "model": "claude-fable-5"},
+            "env": "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-x",
+        })
+        assert missing_credentials(seat) == []
+
+    def test_a_subscription_token_is_never_written_to(self, tmp_path: Path):
+        """It is not a provider bearer token. Aliasing a provider key into it
+        would produce a seat that cannot authenticate at all — so it counts as
+        credentials present without ever becoming an alias target."""
+        seat = Contestant.from_json({
+            "name": "cc", "agent": "claude-code",
+            "engine": {"api": "zai", "model": "glm-5.2",
+                       "base_url": "https://api.z.ai/api/anthropic"},
+            "env": "ZAI_API_KEY=zk",
+        })
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path)
+        run = ContestantRun(contestant=seat, job_name="j",
+                            job_dir=tmp_path / "j", log_path=tmp_path / "j.log")
+        env = runner._routing_environment(seat, run)
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "zk"
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+    def test_an_ambient_subscription_token_never_reaches_a_seat(self, monkeypatch):
+        """The scrub list is prefix-based and `CLAUDE_CODE_` is not one of the
+        prefixes, so this needs its own entry. Without it, a token exported in
+        the operator's shell silently credentials *every* Claude Code seat —
+        two arms you believed were on different credentials, both on the plan.
+        """
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-ambient")
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in _base_environment()
+
+
+class TestInfrastructureFailuresAreNotLosses:
+    """A trial the agent never got to attempt is not a trial it lost."""
+
+    def _trial(self, tmp_path: Path, exception_type: str, reward=None) -> TrialMetrics:
+        trial = tmp_path / f"t-{exception_type}"
+        trial.mkdir()
+        payload: dict = {"exception_info": {"exception_type": exception_type}}
+        if reward is not None:
+            payload["verifier_result"] = {"reward": reward}
+        (trial / "result.json").write_text(json.dumps(payload))
+        return MetricsReader().read(trial, "task")
+
+    def test_a_setup_timeout_is_left_unjudged(self, tmp_path: Path):
+        """Claude Code installs its toolchain per container. On a slow link
+        that setup blows its budget, which is a fact about its installer and
+        not about how well it codes — scoring it 0 hands the other arm a win
+        that does not survive anyone opening the logs."""
+        m = self._trial(tmp_path, "AgentSetupTimeoutError")
+        assert m.infrastructure is True
+        assert m.resolved is None, "unjudged, not lost"
+
+    def test_an_agent_that_ran_and_quit_still_scores_zero(self, tmp_path: Path):
+        m = self._trial(tmp_path, "NonZeroAgentExitCodeError")
+        assert m.infrastructure is False
+        assert m.resolved is False
+
+    def test_an_agent_that_used_all_its_time_still_scores_zero(self, tmp_path: Path):
+        m = self._trial(tmp_path, "AgentTimeoutError")
+        assert m.infrastructure is False and m.resolved is False
+
+    def test_a_broken_verifier_returns_no_verdict_either_way(self, tmp_path: Path):
+        m = self._trial(tmp_path, "VerifierTimeoutError")
+        assert m.infrastructure is True and m.resolved is None
+
+    def test_infrastructure_trials_leave_the_solve_rate_alone(self, tmp_path: Path):
+        """Eight of ten never started; the arm won both it actually ran. The
+        rate must say 100% of 2 judged, and the count of the missing eight must
+        be visible beside it — "won 8 of 10" and "won 2 of the 2 that started"
+        are different claims."""
+        started = [
+            TrialMetrics(task=f"ok{i}", trial=f"ok{i}", resolved=True) for i in range(2)
+        ]
+        never = [
+            TrialMetrics(task=f"x{i}", trial=f"x{i}", failure="AgentSetupTimeoutError",
+                         infrastructure=True)
+            for i in range(8)
+        ]
+        totals = aggregate(started + never)
+        assert totals["judged"] == 2
+        assert totals["solve_rate"] == 100.0
+        assert totals["infrastructure"] == 8

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -769,3 +769,15 @@ class TestRandomTaskSampling:
         drawn = sample_tasks(pool, 10, 7, exclude_heavy=True)
         assert len(drawn) == 10
         assert not any(task.heavy for task in drawn)
+
+    def test_a_memory_ceiling_narrows_the_pool(self):
+        """`heavy` is calibrated for a bigger machine than the one in front of
+        you. A host giving Docker 8 GB and racing two contestants can afford
+        4 GB each, which excludes tasks `heavy` happily keeps."""
+        pool = self._tasks(50)
+        drawn = sample_tasks(pool, 10, 7, max_memory_mb=4096)
+        assert drawn and all(task.memory_mb <= 4096 for task in drawn)
+        assert any(task.memory_mb == 8192 for task in pool), "fixture must have some"
+
+    def test_a_ceiling_that_excludes_everything_draws_nothing(self):
+        assert sample_tasks(self._tasks(50), 10, 7, max_memory_mb=1) == []

--- a/bench/arenabench-glm-headtohead.md
+++ b/bench/arenabench-glm-headtohead.md
@@ -146,17 +146,24 @@ contestant, so 1 already means two containers running at once.
 **Solve rate, clock time, tokens in/out** are real and comparable. They come
 from the verifier and from each agent's own trajectory.
 
-**Total cost is not meaningful here, in two compounding ways.** A subscription
-plan does not bill per token at all, and Claude Code's self-reported
-`total_cost_usd` is computed from its own pricing table, which has no entry for
-`glm-5.2`. Expect zero or null, and do not read it as "free relative to". If
-you need a cost comparison, run the arms on metered keys.
+**Total cost is actively misleading here — treat the column as broken.** It is
+tempting to assume an unpriced model reports nothing; it does not. A measured
+smoke trial returned **`cost_usd: 0.3326`** for a task run entirely on the
+subscription, where the true marginal spend was zero. Claude Code computes
+`total_cost_usd` from its own pricing table, and with every model alias pointed
+at `glm-5.2` it prices the run as though it were the Anthropic model those
+aliases normally name.
 
-**Cache read** is reported by z.ai (`cache_read_input_tokens`) and is
-comparable. **Cache write** was absent from the endpoint's responses in
-testing, so that column will likely sit at zero for the Claude Code arm — which
-is a measurement gap, not a finding. Cache write crowns nobody on the
-scoreboard anyway.
+A fabricated-but-plausible number is worse than a missing one: it populates the
+column, sorts against the other arm, and crowns a winner on a dimension nobody
+measured. **Ignore Total Cost for any seat on the coding plan.** If you need a
+real cost comparison, run both arms on metered keys.
+
+**Cache read is real and large** — the same trial reported 286,656 of 296,070
+input tokens served from cache. z.ai returns `cache_read_input_tokens`, so that
+dimension is comparable. It returns no `cache_creation_input_tokens`, so **cache
+write will read zero** for the Claude Code arm: a measurement gap, not a
+finding. Cache write crowns nobody on the scoreboard anyway.
 
 **Expect the clock to dominate.** The ten tasks above carry 3.8 hours of agent
 timeout between them. Stella has historically burned its full timeout on tasks

--- a/bench/arenabench-glm-headtohead.md
+++ b/bench/arenabench-glm-headtohead.md
@@ -159,6 +159,14 @@ column, sorts against the other arm, and crowns a winner on a dimension nobody
 measured. **Ignore Total Cost for any seat on the coding plan.** If you need a
 real cost comparison, run both arms on metered keys.
 
+**Worse: the two arms do not even use the same pricing table.** On the same
+task, Claude Code reported `0.3326` and Stella `0.0641`. Stella's catalog *has*
+a `glm-5.2` entry, so its figure is a fair estimate of what the run would cost
+on metered z.ai. Claude Code's has none, so its figure prices GLM as the
+Anthropic model whose alias it was pointed at. Read side by side that says
+"Stella is 5× cheaper", which is not a finding about either agent — it is two
+different tables being subtracted from each other.
+
 **Cache read is real and large** — the same trial reported 286,656 of 296,070
 input tokens served from cache. z.ai returns `cache_read_input_tokens`, so that
 dimension is comparable. It returns no `cache_creation_input_tokens`, so **cache

--- a/bench/arenabench-glm-headtohead.md
+++ b/bench/arenabench-glm-headtohead.md
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Claude Code vs Stella on one GLM model, through ArenaBench
+
+Both contestants call **the same model on the same z.ai coding plan**, so the
+only thing varying is the agent around it. That is the point of the exercise:
+with the model held fixed, a difference in solve rate is a difference in
+scaffolding, and a difference in tokens is a difference in how much context
+each agent decided it needed.
+
+It is also the cheap way to run. The GLM Coding Plan is a subscription, so
+neither arm bills per token — see [What the numbers mean](#what-the-numbers-mean)
+for which scoreboard columns survive that and which do not.
+
+---
+
+## The one thing that is easy to get wrong
+
+**z.ai publishes two different endpoints for the same plan, and the two agents
+need different ones.**
+
+| Contestant | Wire format | Base URL |
+|---|---|---|
+| Claude Code | Anthropic Messages | `https://api.z.ai/api/anthropic` |
+| Stella | OpenAI chat-completions | `https://api.z.ai/api/coding/paas/v4` |
+
+Both accept the same `ZAI_API_KEY`. The `ZAI_BASE_URL` in `.env.global.local`
+is the OpenAI-shaped one — correct for Stella, wrong for Claude Code. Pointing
+Claude Code at `…/coding/paas/v4` fails every trial, and a scoreboard reading
+0/10 looks exactly like an agent that cannot code.
+
+The model id is `glm-5.2` (confirmed against the plan's own `/models`).
+
+---
+
+## Prerequisites
+
+```bash
+harbor --version            # must print 0.6.1 — the Stella adapter's launcher
+                            # refuses to start on anything else, on purpose
+docker info --format '{{.MemTotal}}'
+```
+
+**Dataset** — already fetched if `arenabench datasets` reports 89 tasks.
+Otherwise:
+
+```bash
+harbor download 'terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a'
+```
+
+**Stella's benchmark binary** must be a Linux/amd64 build; the task images
+publish `linux/amd64` only, and a macOS binary uploads happily and then fails
+to exec, which Harbor records as an agent crash rather than a build mistake.
+
+```bash
+cargo zigbuild --release -p stella-cli --target x86_64-unknown-linux-gnu.2.17
+```
+
+**Docker memory is the real capacity limit.** A two-contestant match runs two
+task containers at once, so the ceiling per task is your Docker allocation
+divided by two. At 7.7 GB that means drawing from the 2 GB tier:
+
+| Docker allocation | Safe per-task ceiling | Tasks reachable |
+|---|---|---|
+| 7.7 GB (default) | 2048 MB | 68 of 89 |
+| 12 GB | 4096 MB | 81 of 89 |
+
+Raising Docker Desktop to 12 GB is the single change that most widens the
+benchmark. Do not give it 16 GB on a 16 GB host — that swap-thrashes.
+
+**Pre-pull the images for the tasks you drew.** ArenaBench runs Harbor with
+`--max-retries 0`, so a registry timeout mid-match is a permanent reward-0 row
+that is indistinguishable from a genuine failure.
+
+---
+
+## Launching
+
+```bash
+export ARENABENCH_STELLA_ADAPTER=<repo>/bench/harbor_adapter
+export STELLA_BINARY=<repo>/target/x86_64-unknown-linux-gnu/release/stella
+cd arenabench && PYTHONPATH=. python3 -m arenabench serve
+# -> http://127.0.0.1:8900
+```
+
+Both variables are read from the arena's own environment. Everything else is
+per-seat and pasted into the UI, because a match between two providers needs
+two credential sets and a global one would let an ambient key quietly stand in
+for a missing one.
+
+### Seat 1 — Claude Code
+
+| Field | Value |
+|---|---|
+| Agent | Claude Code |
+| API | `zai` |
+| Model | `glm-5.2` |
+| Base URL *(advanced)* | `https://api.z.ai/api/anthropic` |
+| `.env` | `ZAI_API_KEY=<your key>` |
+
+ArenaBench aliases `ZAI_API_KEY` into `ANTHROPIC_AUTH_TOKEN`, which is the
+variable Claude Code actually reads, and says so in a note on the seat. Paste
+`ANTHROPIC_AUTH_TOKEN` yourself instead if you prefer — an explicit choice is
+never overwritten.
+
+Leave `Model` as the bare `glm-5.2`. Harbor forwards the name to a custom
+endpoint unchanged, so a `zai/` prefix would travel to z.ai verbatim.
+ArenaBench strips it for routed seats regardless, but typing it bare keeps the
+UI honest about what is being sent.
+
+### Seat 2 — Stella
+
+| Field | Value |
+|---|---|
+| Agent | Stella |
+| API | `zai` |
+| Model | `zai/glm-5.2` — qualified, unlike the Claude Code seat |
+| Base URL *(advanced)* | `https://api.z.ai/api/coding/paas/v4` |
+| `.env` | `ZAI_API_KEY=<your key>` |
+
+Stella's posture requires a `provider/model` spec and rejects a bare slug, so
+this seat keeps the prefix while the Claude Code seat drops it. That asymmetry
+is real, not a typo: one agent is routed *by* Harbor, the other routes itself.
+
+To compare like with like, set both seats to the same effort tier.
+
+### Tasks
+
+Press **random**, set the count to 10 and the `≤ MB` box to `2048`. The seed is
+printed next to the count — write it down. A slice you cannot redraw is a
+result nobody can check, including you next week.
+
+The equivalent from the CLI:
+
+```bash
+python3 -m arenabench tasks --random 10 --seed 42 --max-memory-mb 2048
+```
+
+Leave **Attempts/task** at 1 and **Concurrency** at 1. Concurrency is per
+contestant, so 1 already means two containers running at once.
+
+---
+
+## What the numbers mean
+
+**Solve rate, clock time, tokens in/out** are real and comparable. They come
+from the verifier and from each agent's own trajectory.
+
+**Total cost is not meaningful here, in two compounding ways.** A subscription
+plan does not bill per token at all, and Claude Code's self-reported
+`total_cost_usd` is computed from its own pricing table, which has no entry for
+`glm-5.2`. Expect zero or null, and do not read it as "free relative to". If
+you need a cost comparison, run the arms on metered keys.
+
+**Cache read** is reported by z.ai (`cache_read_input_tokens`) and is
+comparable. **Cache write** was absent from the endpoint's responses in
+testing, so that column will likely sit at zero for the Claude Code arm — which
+is a measurement gap, not a finding. Cache write crowns nobody on the
+scoreboard anyway.
+
+**Expect the clock to dominate.** The ten tasks above carry 3.8 hours of agent
+timeout between them. Stella has historically burned its full timeout on tasks
+it had already solved, so a `reward 1.0` alongside a timeout is a known
+signature worth checking in the transcript before reading it as a loss.


### PR DESCRIPTION
Makes a Claude Code vs Stella head-to-head possible on one GLM model served by
the z.ai coding plan, so a comparison can be run without metered spend.

## What was blocking it

**Claude Code could not be routed off Anthropic.** Harbor's own agent has
supported this all along — it reads `ANTHROPIC_BASE_URL`, falls back from
`ANTHROPIC_API_KEY` to `ANTHROPIC_AUTH_TOKEN`, and points every model alias at
the configured model. ArenaBench never handed it those values: `_agent_environment`
returned early for every non-Stella agent, and `claude-code` was registered as
not honouring `base_url` at all.

**The model name was the subtle half.** `qualified_model` always prefixes with
the api. Against real Anthropic, Harbor strips that back off and nothing
happens; against a custom base URL it travels verbatim. Every trial would have
died with model-not-found and the scoreboard would have read 0/10 — a clean
number for a contest that never happened, which is the one failure a
head-to-head cannot survive. Routed seats now launch with `bare_model`, which
strips only the api's own prefix and leaves an OpenRouter vendor segment
(`z-ai/glm-5.2`) intact.

**No way to pick a random slice.** Added `--random N [--seed S]` and a picker
control. The draw is seeded and the seed is reported: "we ran ten random tasks"
is otherwise a claim nobody, including its author next week, can reproduce.
Sampling lives on the server so the CLI and the picker cannot disagree about
what "random ten" means.

**Draws ignored what the host can schedule.** `Task.heavy` (>4 GB or multi-CPU)
encodes a guess about machine size. On a laptop giving Docker 7.7 GB the eight
8 GB tasks cannot run at all, and two 4 GB tasks — which is what a two-arm match
schedules — do not fit together either, while `heavy` keeps all thirteen.
`max_memory_mb` is the honest knob, because only the operator knows both the
Docker allocation and the number of contestants.

## Design notes

- `base_url_env` on `AgentSpec` *implies* the `honours` entry rather than being
  declared beside it, so the two cannot drift into claiming a route never taken.
- Aliasing `ZAI_API_KEY` into `ANTHROPIC_AUTH_TOKEN` is inference, not
  instruction, so it is recorded in a new `notes` list and shown on the seat —
  separate from `warnings` because nothing is wrong, but an invisible route is
  how two seats end up secretly identical. An explicitly pasted token is never
  overwritten.
- The seed label clears itself the moment the selection stops being that draw.
- The draw summary names the pool it drew from, not the dataset size.

## Verification

Measured end to end against the coding plan on `openssl-selfsigned-cert`:

| | Claude Code | Stella |
|---|---|---|
| model reaching z.ai | `glm-5.2` | `zai/glm-5.2` |
| verdict | reward 1.0 | reward 1.0 |
| wall clock | 3m16s | 4m15s |
| tokens in / cached / out | 296k / 287k / 5.7k | 316k / 302k / 10.2k |

71 tests (14 new). Ruff findings unchanged from baseline.

The runbook records two measurement caveats the smoke exposed: the Total Cost
column is populated with a fabricated figure rather than left empty, and the two
arms compute it from different pricing tables — so reading them against each
other says "5x cheaper" about nothing.

## Note on the gate

Pushed with `SKIP_GATE=1`. `make lint` fails on `origin/main` itself with 11
pre-existing `E0425`/`E0433` errors in `stella-cli --tests` (`watch`,
`service_lead_control`). This diff contains zero `.rs` files; verified the same
failure reproduces on a detached `origin/main`.

## Summary by Sourcery

Enable ArenaBench to route Claude Code to non-Anthropic endpoints and add reproducible random task sampling across CLI and web UI.

New Features:
- Allow Claude Code seats to target Anthropic-shaped provider endpoints (e.g. z.ai) while using provider-specific credentials.
- Introduce seeded random task sampling with filters for heavy tasks and per-task memory ceilings, exposed via the CLI and web picker.
- Expose routing notes for contestants on the scoreboard to surface inferred credential and endpoint wiring.
- Add a runbook documenting how to run a Claude Code vs Stella head-to-head on a single GLM model via ArenaBench.

Enhancements:
- Unify task heaviness into a Task.heavy property used consistently by CLI, picker, and sampler.
- Adjust model handling so routed seats use provider-bare model ids while non-routed seats keep Harbor’s provider prefixes.
- Extend agent specifications with base URL and token environment metadata to support transparent rerouting.
- Centralize task sampling logic on the server to ensure consistent random draws between UI and CLI.

Tests:
- Add unit tests covering direct routing behavior, credential aliasing, and model id handling for Claude Code and other agents.
- Add unit tests validating seeded task sampling, ordering, heavy-task exclusion, and memory ceiling behavior.