### PR TITLE
docs(parity): re-check the checkpoint rows against the tree (#1302)

### DIFF
--- a/docs/adr/0013-session-artifact-boundary.md
+++ b/docs/adr/0013-session-artifact-boundary.md
@@ -44,11 +44,27 @@ resume. The module says so itself: "local sessions are local"
 Meanwhile the engine already exports a portable turn snapshot.
 `stella_core::step::Checkpoint` (`step.rs:509`) is a versioned serde struct
 whose field order is the wire order, and `Engine::resume_turn`
-(`driver.rs:1108`) reconstitutes a `TurnState` from one. The cross-surface
-matrix records that this format has **no production writers**: the CLI replays
-its own `session_persist` journal and never calls `to_checkpoint`/`resume_turn`,
-and nothing behind `stella-serve` persists at all (the `turn.checkpoint_resume`
-row in `stella-parity/src/lib.rs`, deferred on both surfaces).
+(`driver.rs:1108`) reconstitutes a `TurnState` from one. When this ADR was
+written the cross-surface matrix recorded that this format had **no production
+writers**: the CLI replayed its own `session_persist` journal and never called
+`to_checkpoint`/`resume_turn`, and nothing behind `stella-serve` persisted at
+all (the `turn.checkpoint_resume` row in `stella-parity/src/lib.rs`, deferred
+on both surfaces).
+
+> **Update — 2026-08-03 (#1302).** That sentence is out of date, in the
+> pessimistic direction, and the argument below is unaffected by the
+> correction. `Checkpoint` has **two production writers**: the CLI deck writes
+> one into the work journal's `CHECKPOINT_BLOB` at every step boundary and its
+> resume path prefers it over `history.json`, and a served turn writes one into
+> an embedder-supplied `CheckpointStore`, read back at
+> `GET /v1/sessions/{id}/checkpoint` (#1198). What still has **no production
+> caller** is `Engine::resume_turn` — neither surface replays a snapshot into a
+> `TurnState`, so the format is written, stored, and handed back, but never fed
+> back in. The live statement of both halves is `stella-parity/src/lib.rs`
+> (`turn.checkpoint`, `turn.checkpoint_resume`); the paragraph above is kept as
+> the state this decision was taken against, because §4's version contract is
+> an obligation incurred *before* there were writers to bind — and now there
+> are.
 
 So the question this ADR answers is not "how do we build sync". It is: **when a
 session moves between machines, which half of that problem is Stella's?**
@@ -71,12 +87,14 @@ outright: the host assembles the turn and "every governed side effect — model
 calls and tool calls — is remoted back to the host"; "the engine never holds
 ambient authority" (`stella-serve/src/lib.rs:7`). A served turn is structurally
 incapable of reading a user's file, because reading a file is a request the
-host answers. The matrix already reasons from that line when it defers
-server-side checkpointing: "in the reverse-RPC model the workspace lives on the
-HOST side, so serve has no filesystem location it could honestly checkpoint
-against" (the `turn.checkpoint` row's API note in `stella-parity/src/lib.rs`).
-Applying the same line to durability is consistency, not a new concept to
-defend.
+host answers. The matrix reasoned from that line when it deferred server-side
+checkpointing — "in the reverse-RPC model the workspace lives on the HOST side,
+so serve has no filesystem location it could honestly checkpoint against" — and
+#1198 held the line while promoting that row: what a server may own is the
+engine's own turn state, not the work, and the location stays the embedder's
+(the `turn.checkpoint` row's API note in `stella-parity/src/lib.rs` is the
+current text). Applying the same line to durability is consistency, not a new
+concept to defend.
 
 **2. It deletes the hardest problem instead of solving it.** A portable
 workspace identity is the part of cross-machine resume with no good answer:
@@ -409,7 +427,10 @@ from anything above, and each would need its own decision:
   means the workspace is the host's (the `turn.checkpoint` row's API note in
   `stella-parity/src/lib.rs`). This ADR
   gives an embedder a defined artifact to persist; it does not give the server a
-  filesystem.
+  filesystem. (#1198 shipped a checkpoint *port* inside that line rather than
+  across it: `ServeConfig::checkpoints` is `None` by default, the crate names no
+  path, and the binary takes no `--checkpoint-dir` — so the embedder persists
+  the artifact and the server still chooses no location.)
 - **A stability promise on the *bundle* layout.** The `Checkpoint` version
   contract (§4) is a promise. The manifest and pack layout around it are not yet,
   and a first implementation should say so in its own docs.

--- a/docs/design/engine-embedding.md
+++ b/docs/design/engine-embedding.md
@@ -239,26 +239,36 @@ capabilities (`run_goal`, `run_sub_agent`) with wire-ready event
 vocabulary; serve simply never wires them. Judged multi-round autonomy is
 exactly what agent-app hosts want from an engine.
 
-**G5 — No durable turn over the API.** The CLI half of this closed: the
-deck attaches a `CheckpointSink` that writes the engine's versioned
-`Checkpoint` into the workspace's git-backed work journal at every step
-boundary, and its resume path prefers that checkpoint over the
-turn-boundary `history.json` whenever one exists — so an interrupted CLI
-turn reopens at its last step and does not re-run the completed ones.
+**G5 — A durable turn over the API, with no way to continue it.** Both
+halves of the *writing* closed. The CLI's deck attaches a `CheckpointSink`
+that writes the engine's versioned `Checkpoint` into the workspace's
+git-backed work journal at every step boundary, and its resume path prefers
+that checkpoint over the turn-boundary `history.json` whenever one exists —
+so an interrupted CLI turn reopens at its last step and does not re-run the
+completed ones. Serve's half landed too (#1198): `CheckpointStore` is a
+three-verb port an embedder fills, `SessionSpec::checkpoint` is the durable
+identity that keys it, and `GET|DELETE /v1/{sessions,turns}/{id}/checkpoint`
+read a resume point back or reclaim it. A served turn no longer dies with
+the process — given a store, which is `None` by default because the server
+never picks a location (ADR 0013).
 
-What remains is serve: it reaches both write seams (`persist_checkpoint`
-and `discard_checkpoint`, at the same boundaries the CLI driver uses) but
-nothing sets `checkpoint_sink`, and there is nowhere to read one back
-from — `SessionSpec` carries no session identity to key a store on. So a
-served turn still dies with the process. Fix shape: a checkpoint store
-behind serve, which the portable-session design gates.
+So the `Checkpoint` format has two production writers, and what remains is
+the *replay* direction: no route accepts a checkpoint, `Engine::resume_turn`
+has zero production callers, and serve deliberately does not re-drive a turn
+on restart — a resumed turn's first act is a reverse request only a host can
+answer. A host that reads back a resume point today must continue it by
+driving `stella-engine` in its own process. That is a real capability for a
+Mode-A host and no capability at all for a Mode-B one. Fix shape: a `resume`
+field on turn create that feeds a stored checkpoint into `Engine::resume_turn`
+— not a new `/v1/turns/{id}/resume`, which is already the pause gate's other
+half. Matrix row `turn.checkpoint_resume`, API side.
 
 The "two resume formats" framing was wrong and is retired. The sidecar and
 the work journal are not competing formats; they are canonical for
 different *instants* — the sidecar between turns, the checkpoint inside
 one, and a checkpoint exists only while a turn is in flight. See the table
 in `stella_store::journal`'s module docs. Converging the two stores is
-therefore not a goal; giving serve one at all is.
+therefore not a goal.
 
 **G6 — Wire types live in the server crate.** `ServerFrame` and the inbound
 bodies are `stella-serve` types, and schema export is split across two

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -1278,8 +1278,8 @@ impl<'a> Engine<'a> {
     ///   reopen the conversation at the checkpoint's step boundary, so the
     ///   completed steps' work is not re-run — see `stella-parity`'s
     ///   `turn.checkpoint_resume` row.
-    /// - **`stella-serve`** drives steps and would use this directly, but has
-    ///   no store to read a checkpoint back from (same row, API side).
+    /// - **`stella-serve`** stores one and hands it back on request but accepts
+    ///   none in return, so continuing is the host's call (same row, API side).
     ///
     /// So the production callers are embedders, and the in-tree exercise of it
     /// is `stella-engine`'s test suite. Anything that changes on either surface

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -307,15 +307,31 @@ pub static CAPABILITIES: &[Capability] = &[
             witness: "an_interrupted_turn_resumes_at_the_step_boundary_not_the_turn_boundary",
         },
         // Deliberately phrased to AGREE with `turn.checkpoint` above rather
-        // than restate it differently: serve does reach both write seams, so
-        // the gap here is not the seam and not the writing. It is that there is
-        // nowhere to read one back FROM, and nothing to key it on.
+        // than restate it differently. #1198 closed the two things this row
+        // used to name — serve had no store, and `SessionSpec` had no identity
+        // to key one on — so the gap is no longer the seam, the writing, the
+        // durability, or the read-back: a served turn writes the versioned
+        // `Checkpoint` at every step boundary and a host reads it back byte
+        // for byte. What is missing is the OTHER direction. Nothing accepts
+        // one: no route takes a checkpoint, and `Engine::resume_turn` still
+        // has zero production callers on either surface.
+        //
+        // That serve does not re-drive a turn itself is a decision, not an
+        // omission (`stella-serve/src/checkpoint.rs`, "Resume is
+        // host-initiated"): a resumed turn's first act is a reverse request
+        // only a host can answer, so a server that resumed on restart would
+        // park a thread on a request nobody is listening for. The declared gap
+        // is therefore the *verb*, not the mechanism — an API host holding a
+        // valid resume point today can only continue it by driving
+        // `stella-engine` in its own process.
         api: SurfacePosture::Deferred {
-            waiting_on: "somewhere for a served session to read a resume point back from: serve \
-                         reaches the write seams (see turn.checkpoint) but has no store, and \
-                         SessionSpec carries no session identity to key one on — so nothing \
-                         survives the process to resume. Note stella-serve/tests/resume.rs is SSE \
-                         stream resumption, a different resume entirely",
+            waiting_on: "a way to hand a resume point back: serve writes one and returns it (see \
+                         turn.checkpoint), and the artifact does reconstitute the turn it came \
+                         from — a_served_resume_point_reconstitutes_the_turn_it_came_from — but \
+                         no route accepts one and nothing calls Engine::resume_turn, so an API \
+                         host cannot ask the server to continue from where it crashed. Note \
+                         stella-serve/tests/resume.rs is SSE stream resumption, a different \
+                         resume entirely",
         },
     },
     Capability {
@@ -566,6 +582,39 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A `Deferred` row may name a test too, and when it does the name is
+    /// checked like a witness — because the risk it guards is the one this
+    /// row already realized once (#1302).
+    ///
+    /// `turn.checkpoint_resume`'s API deferral turns on a distinction that is
+    /// easy to state backwards: serve *does* write the versioned `Checkpoint`
+    /// and *does* hand it back, and the artifact really does reconstitute the
+    /// turn — the gap is that nothing accepts one. A reader who takes "not
+    /// shipped" to mean "nothing is written" rebuilds what exists, which is
+    /// exactly what a stale row costs. So the row cites the test that pins the
+    /// resumable half, and this keeps that citation from decaying into a name
+    /// nothing answers to.
+    #[test]
+    fn the_deferred_resume_row_cites_a_test_that_exists() {
+        let row = capability("turn.checkpoint_resume").expect("the row is declared");
+        let SurfacePosture::Deferred { waiting_on } = row.api else {
+            panic!(
+                "turn.checkpoint_resume's API posture moved — if serve now accepts a resume point \
+                 back, this row is Shipped and needs a witness, not a citation"
+            );
+        };
+        let cited = "a_served_resume_point_reconstitutes_the_turn_it_came_from";
+        assert!(
+            waiting_on.contains(cited),
+            "the deferral no longer cites {cited} — say what proves the artifact is resumable, or \
+             the row is back to asserting the gap without evidence"
+        );
+        assert!(
+            witness_exists(&api_sources(), cited),
+            "the deferral cites {cited}, which no swept serve source defines"
+        );
     }
 
     /// The unwitnessed-claims ratchet: exact equality, so witnessing a row

--- a/stella-serve/tests/checkpoint.rs
+++ b/stella-serve/tests/checkpoint.rs
@@ -15,6 +15,13 @@
 //!    **store**, not the session registry, which is the only version of the
 //!    feature a crashed server can benefit from;
 //! 3. a host can reclaim one, because nothing else ever will.
+//!
+//! And one claim about what those bytes are *worth* (#1302): what comes off
+//! the wire reconstitutes the turn it came from, transcript and money meter
+//! alike. A writer whose output nothing can read would be a different gap, not
+//! a closed one, so it is asserted rather than assumed — while the half that
+//! genuinely is missing, a wire verb that hands a resume point *back*, stays
+//! declared in `stella-parity`'s `turn.checkpoint_resume` row.
 
 mod common;
 
@@ -114,27 +121,24 @@ async fn next_frame(sse: &mut tokio::io::BufReader<tokio::net::TcpStream>) -> se
         .expect("the stream must not end early")
 }
 
-/// The witness for the `turn.checkpoint` API row: a served turn's resume point
-/// exists at the step boundary and is gone once the turn ends.
+/// Drive a turn across its first step boundary: answer the model with
+/// `first_result`, answer the tool call it asks for, and return the step-two
+/// `provider_request` frame.
 ///
-/// Two steps, not one, because a single-step turn never reaches
-/// `StepOutcome::Continue` and so never checkpoints — the seam under test only
-/// exists *between* steps. The model asks for a tool on step one; answering it
-/// commits the step, and the step-two provider request is proof the persist
-/// already ran (`drive_turn` persists before it loops).
-#[tokio::test]
-async fn a_served_turn_writes_a_resume_point_at_every_step_boundary() {
-    let (addr, store) = start_durable_server().await;
-    let session_id = create_session(addr).await;
-    let turn_id = create_session_turn(addr, &session_id).await;
-    let path = format!("/v1/sessions/{session_id}/checkpoint");
-
-    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
-
-    // Step one: the model calls a tool.
+/// That frame is the synchronization point these tests need. Two steps, not
+/// one, because a single-step turn never reaches `StepOutcome::Continue` and so
+/// never checkpoints — the seam under test only exists *between* steps — and
+/// seeing step two's request is proof the step-one persist already ran, since
+/// `drive_turn` persists before it loops.
+async fn cross_the_first_step_boundary(
+    addr: std::net::SocketAddr,
+    turn_id: &str,
+    sse: &mut tokio::io::BufReader<tokio::net::TcpStream>,
+    first_result: serde_json::Value,
+) -> serde_json::Value {
     let mut answered_provider = 0;
-    let second = loop {
-        let frame = next_frame(&mut sse).await;
+    loop {
+        let frame = next_frame(sse).await;
         match frame["type"].as_str() {
             Some("provider_request") if answered_provider == 0 => {
                 let (status, body) = post_json(
@@ -144,7 +148,7 @@ async fn a_served_turn_writes_a_resume_point_at_every_step_boundary() {
                     &json!({
                         "request_id": frame["request_id"],
                         "status": "ok",
-                        "result": model_wants_echo(),
+                        "result": first_result,
                     })
                     .to_string(),
                 )
@@ -170,7 +174,26 @@ async fn a_served_turn_writes_a_resume_point_at_every_step_boundary() {
             Some("provider_request") => break frame,
             _ => {}
         }
-    };
+    }
+}
+
+/// The witness for the `turn.checkpoint` API row: a served turn's resume point
+/// exists at the step boundary and is gone once the turn ends.
+///
+/// Why the turn has to run two steps is
+/// [`cross_the_first_step_boundary`]'s own doc — the seam under test exists
+/// only *between* steps.
+#[tokio::test]
+async fn a_served_turn_writes_a_resume_point_at_every_step_boundary() {
+    let (addr, store) = start_durable_server().await;
+    let session_id = create_session(addr).await;
+    let turn_id = create_session_turn(addr, &session_id).await;
+    let path = format!("/v1/sessions/{session_id}/checkpoint");
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    // Step one: the model calls a tool, the host answers, step two opens.
+    let second = cross_the_first_step_boundary(addr, &turn_id, &mut sse, model_wants_echo()).await;
 
     // The claim, over the wire.
     let (status, body) = get_checkpoint(addr, &path).await;
@@ -228,6 +251,75 @@ async fn a_served_turn_writes_a_resume_point_at_every_step_boundary() {
             .unwrap(),
         None,
         "and the store agrees with the route"
+    );
+}
+
+/// What the route hands back is a *resumable turn*, not merely bytes that
+/// parse: the transcript the engine left, the step to run next, and the money
+/// already spent (#1302).
+///
+/// This is the claim the `turn.checkpoint` row rests on and the one
+/// `turn.checkpoint_resume` is measured against. The rows have been wrong in
+/// this area before — in the pessimistic direction — because "serve writes a
+/// checkpoint" and "a host can do something with it" are separate facts and
+/// only the first one had a test. A writer whose output no reader can use is a
+/// different gap, not a closed one, so the reader half is asserted here
+/// against the same wire body a crashed host would fetch.
+///
+/// `TurnState::from_checkpoint` is exactly what `Engine::resume_turn`
+/// delegates to (`stella-core/src/driver.rs`); it is called directly because
+/// building an `Engine` would need a provider and a tool executor that
+/// reconstitution never reaches.
+///
+/// What this deliberately does **not** claim is that *serve* resumes. No route
+/// accepts a checkpoint back, on purpose — a resumed turn's first act is a
+/// reverse request only a host can answer (`crate::checkpoint`'s module docs)
+/// — so the continuing is the host's, in the host's process, and the missing
+/// wire verb stays declared in `stella-parity`.
+#[tokio::test]
+async fn a_served_resume_point_reconstitutes_the_turn_it_came_from() {
+    let (addr, _store) = start_durable_server().await;
+    let session_id = create_session(addr).await;
+    let turn_id = create_session_turn(addr, &session_id).await;
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    // A priced model call: a money meter that reads zero either way would
+    // prove nothing about whether spend survives the hop.
+    let mut first = model_wants_echo();
+    first["cost_usd"] = json!(0.25);
+    let _step_two = cross_the_first_step_boundary(addr, &turn_id, &mut sse, first).await;
+
+    let (status, body) =
+        get_checkpoint(addr, &format!("/v1/sessions/{session_id}/checkpoint")).await;
+    assert!(status.contains("200"), "{status} {body}");
+
+    // The host's side of the seam, over the bytes the host actually receives.
+    let resumed = stella_engine::TurnState::from_checkpoint(
+        stella_engine::decode_checkpoint(&body).expect("the wire body decodes as a Checkpoint"),
+        &stella_engine::EngineConfig::default(),
+    );
+
+    assert_eq!(
+        resumed.step(),
+        1,
+        "a resumed turn continues at the step that had not run, not from zero"
+    );
+    let transcript = serde_json::to_string(resumed.messages()).expect("the transcript serializes");
+    assert!(
+        transcript.contains("do the thing"),
+        "the request the turn was answering survives: {transcript}"
+    );
+    assert!(
+        transcript.contains("echoed"),
+        "so does the completed step's tool result — which is what makes resuming cheaper than \
+         restarting, since that work is not re-run: {transcript}"
+    );
+    assert!(
+        (resumed.total_cost_usd() - 0.25).abs() < 1e-9,
+        "and the money spent before the crash comes back with it, so a continued turn charges \
+         against what it already spent instead of starting the meter over: got {}",
+        resumed.total_cost_usd()
     );
 }
 


### PR DESCRIPTION
## What & why

The matrix said the engine's versioned `Checkpoint` had **no production writer**. It has two. The row that still said otherwise was wrong in the *pessimistic* direction, which costs the same credibility as an optimistic one and invites somebody to rebuild what already exists.

Closes #1302

### What the code actually does

| Surface | Writes a `Checkpoint`? | Reads one back? | Replays one? |
|---|---|---|---|
| CLI | yes — work journal `CHECKPOINT_BLOB`, every step boundary | yes — `restore_conversation` prefers it over `history.json` | no `resume_turn`; transcript granularity (already recorded) |
| serve | yes — `StoreSink` over an embedder-supplied `CheckpointStore`, keyed by `SessionSpec::checkpoint` | yes — `GET /v1/{sessions,turns}/{id}/checkpoint`, bytes verbatim | **no** |

`turn.checkpoint`'s API row was promoted when the store landed. `turn.checkpoint_resume` was not: it still waited on *"serve has no store, and `SessionSpec` carries no session identity to key one on"* — both closed in the same hour, by a branch cut before that sentence was written.

### Does resume work end to end

**Not on the API, and the gap moved rather than closed.** `Engine::resume_turn` still has zero production callers and no route accepts a checkpoint back, so a host can hold a valid resume point and have nowhere to hand it. That serve does not re-drive a turn itself is a decision, not an omission — a resumed turn's first act is a reverse request only a host can answer — so what is missing is the **verb**, not the mechanism. The row now says that instead of saying nothing survives.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, both of which fail on `main`:

- `a_served_resume_point_reconstitutes_the_turn_it_came_from` (`stella-serve/tests/checkpoint.rs`) — takes the body `GET …/checkpoint` returns and rebuilds a `TurnState` from it: the request the turn was answering, the completed step's tool result (so a continued turn does not re-run it), the step index, and the money already spent. "The artifact is resumable" was the load-bearing half nobody had checked; the priced model call is what makes the meter assertion mean something.
- `the_deferred_resume_row_cites_a_test_that_exists` (`stella-parity`) — a `Deferred` row that names a test now gets that name checked, the same way a `Shipped` witness is. Confirmed to fail when the citation is bent to a name nothing answers to.

The existing witness `a_served_turn_writes_a_resume_point_at_every_step_boundary` keeps its name and assertions; its two-step setup moved into a shared helper both tests drive.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed — `Engine::resume_turn`'s own docs, ADR 0013's context, and `engine-embedding.md` G5 each repeated the stale claim
- [x] `Closes #1302` appears above **and** as a commit trailer

Also run green: `rustdoc -D warnings`, `check-doc-citations.sh`, `check-invariants.sh`. `check-file-size.sh` reports `stella-graph/src/store.rs` at 1632 lines — reproduced with these changes stashed, so it predates this PR and is not touched here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**ADR 0013 is edited, and deliberately not rewritten.** It is `Proposed`, and its Context cites the matrix as evidence — the exact sentence that went stale. The original paragraph stays as the state the decision was taken against, marked as such, with a dated update beside it; §4's version contract reads *stronger* now, since the writers it binds exist. The one place the ADR quoted a matrix note verbatim that no longer exists in that file is corrected, because a quote a reader cannot find is worse than no quote.

**No behavior changed.** This is a documentation-accuracy PR plus the tests that keep it accurate — so no `CHANGELOG.md` entry (`Internal refactors, test-only changes … do not need a hand-written entry`).

**Deferred on purpose:** the replay verb itself. `engine-embedding.md` G5 now names the fix shape — a `resume` field on turn create, *not* a `POST /v1/turns/{id}/resume`, which is already the pause gate's other half — but building it is a wire-contract change and its own decision, not a row correction.

---

## Summary by Sourcery

Clarify checkpoint and resume behavior across CLI and serve surfaces and align documentation, parity matrix rows, and engine docs with current production writers and the remaining replay gap.

Enhancements:
- Add tests that verify served checkpoints reconstitute turn state, including transcript and cost, and ensure deferred parity rows cite existing tests.
- Refactor serve checkpoint tests to share a helper for driving turns across the first step boundary and tighten parity descriptions of the resume capability gap.

Documentation:
- Update ADR 0013, engine embedding design docs, and `Engine::resume_turn` documentation to accurately describe checkpoint writers, durability semantics, and the absence of a wire-level resume verb.

Tests:
- Introduce a new serve test that validates a checkpoint can reconstruct the interrupted turn, and a parity test that checks deferred rows reference real tests, alongside minor restructuring of existing checkpoint tests.
