### PR TITLE
bench: make the authored-witness A/B runnable and measurable (#1284)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,7 +58,7 @@ jobs:
             exit 0
           fi
           if git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Eq '^(bench/harbor_adapter/|bench/terminal_bench_analysis/|bench/telemetry_store/|bench/evidence/frontier/|arenabench/|\.github/workflows/bench\.yml$)'; then
+            | grep -Eq '^(bench/harbor_adapter/|bench/terminal_bench_analysis/|bench/telemetry_store/|bench/evidence/|arenabench/|\.github/workflows/bench\.yml$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -92,6 +92,18 @@ jobs:
       - name: telemetry_store — pytest
         if: steps.scope.outputs.changed == 'true'
         run: uv run --with pytest --no-project pytest -q bench/telemetry_store/tests
+
+      # The development-baseline evidence tooling: the scorer, the manifest
+      # builder and the witness A/B comparison — the three scripts that decide
+      # what a published number *is*. Their tests existed and nothing ran them:
+      # the scope filter above named `bench/evidence/frontier/` and no other
+      # path under `bench/evidence/`, so this suite gated nothing at all. Same
+      # `--no-project` reasoning as the two below — the scripts are
+      # standard-library only, which is what makes recomputing a published
+      # score from committed evidence possible without the harness installed.
+      - name: evidence tooling — pytest
+        if: steps.scope.outputs.changed == 'true'
+        run: uv run --with pytest --no-project pytest -q bench/evidence/tests
 
       # The Frontier-Bench run planner. No project to sync and no Harbor to
       # install: plan.py imports nothing outside the standard library, which is

--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -505,6 +505,19 @@ SUT — that is intended. Two arms over the same 89 tasks on the same SUT is a
 direct, falsifiable test of whether the ladder's witness rung improves outcomes;
 one arm alone cannot answer it in either direction.
 
+**That test is now a procedure rather than a suggestion** ([#1284](https://github.com/macanderson/stella/issues/1284)):
+`bench/evidence/run/witness_ab.sh` runs one arm with the arm named as an
+argument and the task list pinned across both, and
+`bench/evidence/compare_arms.py` turns the two into the answer — tasks gained
+and lost, wrong "this passed" calls fixed and introduced, spend per additional
+task passed — under a decision rule fixed in
+[`bench/evidence/witness-ab/`](evidence/witness-ab/) before any data exists.
+The comparison refuses two runs that are not one experiment, and refuses a
+treatment arm whose trials authored no witness: the #1147 failure below is
+detectable only from the run's own proof stream, never from the posture that
+claims the tier. **The run has not been executed.** Everything up to the
+credential is in the tree.
+
 Constraints, each enforced fail-closed by `_validated_witness_author`:
 
 - The author must differ from the worker model (otherwise the tier is still off,

--- a/bench/evidence/README.md
+++ b/bench/evidence/README.md
@@ -13,7 +13,9 @@ about itself was therefore unfalsifiable. This directory is where that stops.
 ```
 score_dev_baseline.py     scoring: trials.jsonl -> pass@1 + two 95% intervals
 make_manifest.py          identity: freeze every input that can move the number
-tests/                    what keeps the two of them honest
+compare_arms.py           two arms of one experiment -> did the change pay?
+witness-ab/               the authored-witness A/B: protocol, plan, decision rule
+tests/                    what keeps the three of them honest
 <run-id>/
   run-manifest.json       the frozen inputs, and why the run is not a claim
   preregistration.json    what was fixed before the first trial
@@ -46,6 +48,29 @@ commit and Harbor version **the trial itself recorded**, so the manifest states
 the run's identity by collapsing 89 independent observations of it rather than by
 recomputing it from whatever checkout the manifest happened to be built in. Those
 are the same thing only while the run is still warm.
+
+Since #1284 a row also carries what the trial's own verification ladder did:
+which witness state it reached, and whether Stella itself claimed the work
+passed. That claim and the external grader's reward are two independent
+opinions of the same work, and their disagreement — a task failed while
+reporting success — is invisible to the score. It lived only in the uncommitted
+job tree, so it evaporated with it; carried here, the honesty of a published run
+is recomputable from the run directory like everything else.
+
+### Comparing two arms
+
+```bash
+python bench/evidence/compare_arms.py <control>/trials.jsonl <treatment>/trials.jsonl \
+  --tasks 89 --markdown <run-id>/results.md
+```
+
+Pairs two runs by task and reports what changed: tasks gained and lost with an
+exact McNemar test, wrong "this passed" calls fixed and introduced by name, and
+spend per additional task passed. It refuses — non-zero exit, `"verdict":
+"refused"`, numbers still printed — when the two files are not the two arms of
+one experiment, or when the treatment arm declared a verification tier it never
+exercised. See [`witness-ab/`](witness-ab/) for the experiment it was written
+for and the decision rule it applies.
 
 ### Reading a descriptive total
 

--- a/bench/evidence/compare_arms.py
+++ b/bench/evidence/compare_arms.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Compare a witness-off run against a witness-on run over the same tasks.
+
+`score_dev_baseline.py` answers "what did this run score". This answers the
+question #1284 exists for: **does an independent checker earn its cost?**
+
+Stella decides whether finished work is correct on a ladder. The strongest rung
+is the authored witness — a *second* model writes a test the worker must pass,
+so the model that did the work does not write its own exam. The weakest is the
+model judge, which reads the work and gives an opinion. Every Terminal-Bench
+number published before #1007 ran with the witness rung structurally off,
+because the posture pinned one model for every role and Stella refuses to let a
+worker author its own witness. Those numbers are a lower bound on the ladder,
+not a measurement of it.
+
+Turning the rung on is one environment variable (`STELLA_WITNESS_AUTHOR_MODEL`,
+#1007) over a workspace that now has a git baseline to compare against (#1225).
+What was missing is the arithmetic that turns two runs into an answer, and the
+evidence to run it over: the per-trial verdict and witness observations lived
+only in the multi-gigabyte Harbor job tree, which is never committed, so the
+comparison was computable only while the run was still on the disk that made
+it. `score_dev_baseline.py extract` now carries those fields into
+`trials.jsonl`, and this script reads two of them.
+
+Three properties, in the order they can invalidate a conclusion:
+
+1. **Identity.** Two runs of different SUTs, or two runs of the same arm, are
+   not an experiment. Mismatches refuse rather than produce a number.
+2. **The tier actually fired.** A posture that *declares* witness-on is not a
+   run that *authored* witnesses — #1147 is exactly that failure, where an
+   unresolvable author left the control arm executing under a treatment-arm
+   digest. A treatment arm that authored nothing measures nothing, and is
+   refused with that stated.
+3. **Both outcomes, paired by task.** How many more tasks pass, and how many
+   wrong "this passed" calls disappear. The second is the point of the rung and
+   is invisible to the score: a trial that fails the task and knows it costs the
+   same reward as one that fails and reports success, but only the second one
+   lies to a caller who then ships it.
+
+Usage::
+
+    python compare_arms.py <control-trials.jsonl> <treatment-trials.jsonl> \\
+        --tasks 89 [--markdown out.md]
+
+Exit status is 0 only for a comparison that is allowed to mean something. The
+report is printed either way — a refusal with the numbers withheld is a refusal
+nobody can check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Fixed by the preregistration in `witness-ab/README.md` before any paid call.
+# Changing any of them changes the answer and invalidates the comparison.
+BOOTSTRAP_SEED = 20260803
+BOOTSTRAP_DRAWS = 50_000
+SIGNIFICANCE_ALPHA = 0.05
+# The witness arm buys a second model's opinion on every candidate, so it is
+# expected to cost more; the question is how much more is worth paying. Half
+# again is the preregistered ceiling.
+COST_RATIO_CEILING = 1.5
+
+CONTROL_ARM = "witness-off"
+TREATMENT_ARM = "witness-on"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _number(value: Any) -> float | None:
+    return (
+        float(value)
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+        else None
+    )
+
+
+def _bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _passed(row: dict[str, Any]) -> bool:
+    """The external grader's answer, under the same rule as the scorer.
+
+    The verifier's reward is authoritative and the agent never sees it; a trial
+    that produced no reward at all — errored, timed out with nothing on disk,
+    never ran — is a failure and stays in the denominator.
+    """
+    accuracy = _number(row.get("accuracy"))
+    return accuracy is not None and accuracy >= 1.0
+
+
+def _seconds(row: dict[str, Any]) -> float | None:
+    """Agent wall clock for one trial, or ``None`` when it cannot be known."""
+    started, finished = row.get("agent_started_at"), row.get("agent_finished_at")
+    if not isinstance(started, str) or not isinstance(finished, str):
+        return None
+    try:
+        begin = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(finished.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (end - begin).total_seconds()
+
+
+def load_arm(path: Path) -> dict[str, dict[str, Any]]:
+    """Read one arm's ``trials.jsonl`` into a task-keyed map.
+
+    A task appearing twice is a resume or a rerun, both forbidden, and both
+    would silently double-weight that task in the pairing below.
+    """
+    rows: dict[str, dict[str, Any]] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        name = row.get("task_name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"{path}: a trial row has no task_name")
+        if name in rows:
+            raise ValueError(f"{path}: task {name!r} appears in more than one row")
+        rows[name] = row
+    return rows
+
+
+def _uniform(rows: list[dict[str, Any]], field: str) -> Any:
+    """The one value every row agrees on, or a stated disagreement."""
+    seen = sorted({json.dumps(row.get(field), sort_keys=True) for row in rows})
+    if not seen:
+        return None
+    if len(seen) == 1:
+        return json.loads(seen[0])
+    return {"DISAGREEMENT": [json.loads(value) for value in seen]}
+
+
+def check_identity(
+    control: dict[str, dict[str, Any]],
+    treatment: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[str]]:
+    """Confirm the two files are the two arms of one experiment.
+
+    Every check here fails closed. The alternative is a plausible number
+    computed over a pair of runs that never shared a SUT, a dataset or an arm —
+    and a plausible number is the failure mode this whole directory exists to
+    prevent.
+    """
+    refusals: list[str] = []
+    control_rows, treatment_rows = list(control.values()), list(treatment.values())
+    identity: dict[str, Any] = {}
+
+    for label, rows, expected in (
+        ("control", control_rows, CONTROL_ARM),
+        ("treatment", treatment_rows, TREATMENT_ARM),
+    ):
+        if not rows:
+            refusals.append(f"{label} arm has no trials")
+            continue
+        arms = {row.get("assurance_arm") for row in rows}
+        identity[f"{label}_arm"] = _uniform(rows, "assurance_arm")
+        identity[f"{label}_witness_author_model"] = _uniform(
+            rows, "witness_author_model"
+        )
+        identity[f"{label}_engine_posture_sha256"] = _uniform(
+            rows, "engine_posture_sha256"
+        )
+        if None in arms:
+            # v1 evidence predates the assurance block entirely (#1007). It
+            # cannot state which arm it ran, so it cannot be one.
+            refusals.append(
+                f"{label} arm: {sum(1 for r in rows if r.get('assurance_arm') is None)}"
+                " trial(s) do not record an assurance arm — pre-#1007 evidence"
+                " cannot be an arm of this experiment"
+            )
+        if arms - {None} != {expected}:
+            refusals.append(
+                f"{label} arm should be {expected!r}, trials say "
+                f"{sorted(str(a) for a in arms)}"
+            )
+
+    # One SUT, or it is two experiments. Recorded per trial by the adapter, so
+    # this reads what ran rather than what the current checkout would produce.
+    for field in ("source_commit", "binary_sha256"):
+        both = _uniform(control_rows + treatment_rows, field)
+        identity[field] = both
+        if isinstance(both, dict) and "DISAGREEMENT" in both:
+            refusals.append(
+                f"the two arms did not run the same {field}: {both['DISAGREEMENT']}"
+            )
+
+    if control and treatment:
+        only_control = sorted(set(control) - set(treatment))
+        only_treatment = sorted(set(treatment) - set(control))
+        identity["tasks_only_in_control"] = only_control
+        identity["tasks_only_in_treatment"] = only_treatment
+        if only_control or only_treatment:
+            # Not a refusal: a trial that never produced a row scores zero under
+            # the fixed denominator, which is the same rule the scorer applies.
+            # It is disclosed because an unpaired task is the one input a reader
+            # cannot recover from the totals.
+            identity["unpaired_tasks_note"] = (
+                "a task absent from an arm scores 0 in that arm, as it does in "
+                "`score_dev_baseline.py`; the pairing below counts it as a "
+                "failure rather than dropping it"
+            )
+    return identity, refusals
+
+
+def check_tier_fired(treatment: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], list[str]]:
+    """Did the treatment arm actually author witnesses, or only declare them?
+
+    #1147: a witness-arm posture whose author failed model validation dropped
+    the judge pin and executed the control arm — under a witness-arm digest.
+    The posture cannot answer this question about itself; only the run's own
+    proof stream can, and `witness_authored_state` is that stream folded into a
+    field (#1007).
+    """
+    states: dict[str, int] = {}
+    authored_total = 0
+    for row in treatment.values():
+        state = row.get("witness_authored_state") or "not_reported"
+        states[str(state)] = states.get(str(state), 0) + 1
+        authored_total += int(row.get("witness_authored_count") or 0)
+
+    fired = states.get("authored", 0)
+    summary = {
+        "trials_by_witness_state": states,
+        "trials_with_an_authored_witness": fired,
+        "witnesses_authored_total": authored_total,
+    }
+    refusals: list[str] = []
+    if not treatment:
+        return summary, refusals
+    if fired == 0:
+        refusals.append(
+            "the treatment arm authored no witness on any task: its trials report "
+            f"{states} — a run that declares the rung without exercising it "
+            "measures the control arm under a treatment-arm digest (#1147)"
+        )
+    return summary, refusals
+
+
+def mcnemar_exact_p(gained: int, lost: int) -> float | None:
+    """Two-sided exact McNemar over the discordant pairs.
+
+    The concordant pairs carry no information about a *change*, so the test is a
+    fair-coin binomial on the tasks that moved. Exact rather than the chi-square
+    approximation because the discordant count in a run this size is routinely
+    under ten, which is exactly where the approximation stops being one.
+    """
+    n = gained + lost
+    if n == 0:
+        return None
+    k = min(gained, lost)
+    tail = sum(math.comb(n, i) for i in range(k + 1)) / (2**n)
+    return min(1.0, 2 * tail)
+
+
+def bootstrap_delta(pairs: list[tuple[float, float]]) -> tuple[float, float]:
+    """Percentile bootstrap over per-task paired differences.
+
+    Resampling *tasks*, not trials, and keeping each task's pair together: the
+    two arms ran the same task set, and a bootstrap that broke the pairing would
+    report the interval of an unpaired comparison the run did not perform.
+    """
+    rng = random.Random(BOOTSTRAP_SEED)
+    n = len(pairs)
+    means = []
+    for _ in range(BOOTSTRAP_DRAWS):
+        total = 0.0
+        for _ in range(n):
+            treatment, control = pairs[rng.randrange(n)]
+            total += treatment - control
+        means.append(total / n)
+    means.sort()
+    return means[int(0.025 * BOOTSTRAP_DRAWS)], means[int(0.975 * BOOTSTRAP_DRAWS) - 1]
+
+
+def self_verdict_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """How often Stella's own verdict matched the external grader.
+
+    Two denominators, because they answer different questions. `reported_by` is
+    every trial that closed its ladder with a verdict at all — a trial killed
+    mid-turn made no claim and must not be scored as a wrong one. Inside that,
+    `model_judge_only` restricts to verdicts a model *opined*
+    (`deterministic: false`); a flip-oracle verdict is a different instrument
+    and averaging the two hides the one #1284 is about.
+    """
+
+    def summarize(subset: list[dict[str, Any]]) -> dict[str, Any]:
+        agree = sum(1 for row in subset if _bool(row["self_verdict_passed"]) == _passed(row))
+        false_pass = [
+            row["task_name"]
+            for row in subset
+            if row["self_verdict_passed"] is True and not _passed(row)
+        ]
+        false_fail = [
+            row["task_name"]
+            for row in subset
+            if row["self_verdict_passed"] is False and _passed(row)
+        ]
+        return {
+            "reported_by": len(subset),
+            "agreements": agree,
+            "agreement_rate": (agree / len(subset)) if subset else None,
+            "false_pass": len(false_pass),
+            "false_pass_tasks": sorted(false_pass),
+            "false_fail": len(false_fail),
+            "false_fail_tasks": sorted(false_fail),
+        }
+
+    reported = [row for row in rows if _bool(row.get("self_verdict_passed")) is not None]
+    judged = [row for row in reported if row.get("self_verdict_deterministic") is False]
+    stats = summarize(reported)
+    stats["silent_trials"] = len(rows) - len(reported)
+    stats["model_judge_only"] = summarize(judged)
+    return stats
+
+
+def _arm_totals(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Spend and time, each beside the number of trials that reported it.
+
+    Absent and zero are different answers — the discipline `score.json` already
+    applies to `usd_total`. A ratio built over two partially-reported totals is
+    the specific mistake this shape prevents.
+    """
+    usd = [value for row in rows if (value := _number(row.get("usd"))) is not None]
+    wall = [value for row in rows if (value := _seconds(row)) is not None]
+    return {
+        "trials": len(rows),
+        "usd_total": round(sum(usd), 4),
+        "usd_reported_by": len(usd),
+        "prompt_tokens": sum(row.get("n_input_tokens") or 0 for row in rows),
+        "completion_tokens": sum(row.get("n_output_tokens") or 0 for row in rows),
+        "agent_wall_s": round(sum(wall), 1),
+        "agent_wall_reported_by": len(wall),
+        "trials_with_an_exception": sum(1 for row in rows if row.get("exception_type")),
+        "trials_with_an_agent_timeout": sum(
+            1 for row in rows if row.get("exception_type") == "AgentTimeoutError"
+        ),
+    }
+
+
+def _cost(control: list[dict[str, Any]], treatment: list[dict[str, Any]], gained_net: int) -> dict[str, Any]:
+    left, right = _arm_totals(control), _arm_totals(treatment)
+    complete = (
+        left["usd_reported_by"] == left["trials"] > 0
+        and right["usd_reported_by"] == right["trials"] > 0
+    )
+    ratio = (
+        round(right["usd_total"] / left["usd_total"], 4)
+        if complete and left["usd_total"] > 0
+        else None
+    )
+    per_pass = (
+        round((right["usd_total"] - left["usd_total"]) / gained_net, 4)
+        if ratio is not None and gained_net > 0
+        else None
+    )
+    return {
+        "control": left,
+        "treatment": right,
+        "usd_ratio": ratio,
+        "usd_ratio_note": (
+            None
+            if complete
+            else "withheld: at least one arm reported spend on only part of its "
+            "trials, and a ratio of two partial sums is not a cost comparison"
+        ),
+        "usd_per_additional_task_passed": per_pass,
+        # Until #960 lands, Stella's headless process does not exit after its
+        # turn, so Harbor kills it at the agent timeout: those trials burn the
+        # full timeout regardless of how long the work took. Wall clock is
+        # reported because it is what the operator waits through, but it is not
+        # a measurement of the witness rung's time cost while this is true.
+        "wall_clock_note": (
+            "wall clock is timeout-bound on trials that raised AgentTimeoutError "
+            "(#960): "
+            f"{left['trials_with_an_agent_timeout']}/{left['trials']} control, "
+            f"{right['trials_with_an_agent_timeout']}/{right['trials']} treatment"
+        ),
+    }
+
+
+def decide(primary: dict[str, Any], verdicts: dict[str, Any], cost: dict[str, Any]) -> dict[str, Any]:
+    """Apply the preregistered rule. No thresholds are chosen after the data.
+
+    Stated in `bench/evidence/witness-ab/README.md` and fixed before the first
+    paid call, in this order:
+
+    * **Reject** if the arm loses more tasks than it gains at p < 0.05, or if it
+      increases wrong "this passed" calls. Either one makes the rung worse than
+      what already shipped.
+    * **Adopt** if it gains more tasks than it loses, that gain is either
+      significant or accompanied by fewer wrong "passed" calls, and it costs at
+      most `COST_RATIO_CEILING`x the control arm.
+    * **Inconclusive** otherwise — which changes nothing, and says so.
+    """
+    gained, lost = primary["gained"], primary["lost"]
+    p_value = primary["mcnemar_exact_p"]
+    false_pass_delta = verdicts["false_pass_delta"]
+    ratio = cost["usd_ratio"]
+    reasons: list[str] = []
+
+    if lost > gained and p_value is not None and p_value < SIGNIFICANCE_ALPHA:
+        reasons.append(
+            f"the witness arm lost {lost} tasks and gained {gained} "
+            f"(exact McNemar p={p_value:.4f})"
+        )
+    if false_pass_delta is not None and false_pass_delta > 0:
+        reasons.append(
+            f"wrong 'this passed' calls rose by {false_pass_delta}, which is the "
+            "failure the rung exists to remove"
+        )
+    if reasons:
+        return {"verdict": "reject", "reasons": reasons}
+
+    significant = p_value is not None and p_value < SIGNIFICANCE_ALPHA
+    fewer_false_passes = false_pass_delta is not None and false_pass_delta < 0
+    affordable = ratio is not None and ratio <= COST_RATIO_CEILING
+    if gained > lost and (significant or fewer_false_passes) and affordable:
+        return {
+            "verdict": "adopt",
+            "reasons": [
+                f"net +{gained - lost} tasks (gained {gained}, lost {lost}"
+                + (f", exact McNemar p={p_value:.4f}" if p_value is not None else "")
+                + ")",
+                f"wrong 'this passed' calls changed by {false_pass_delta}",
+                f"spend ratio {ratio}x ≤ {COST_RATIO_CEILING}x ceiling",
+            ],
+        }
+
+    unmet = []
+    if gained <= lost:
+        unmet.append(f"no net task gain (gained {gained}, lost {lost})")
+    if not significant and not fewer_false_passes:
+        unmet.append(
+            "the gain is neither significant at "
+            f"p<{SIGNIFICANCE_ALPHA} nor accompanied by fewer wrong 'passed' calls"
+        )
+    if not affordable:
+        unmet.append(
+            f"spend ratio {ratio} is above the {COST_RATIO_CEILING}x ceiling"
+            if ratio is not None
+            else "spend could not be compared (see usd_ratio_note)"
+        )
+    return {"verdict": "inconclusive", "reasons": unmet}
+
+
+def compare(
+    control: dict[str, dict[str, Any]],
+    treatment: dict[str, dict[str, Any]],
+    tasks: int,
+) -> dict[str, Any]:
+    """The whole comparison, as one JSON-serializable report."""
+    identity, refusals = check_identity(control, treatment)
+    tier, tier_refusals = check_tier_fired(treatment)
+    refusals = refusals + tier_refusals
+
+    universe = sorted(set(control) | set(treatment))
+    missing_everywhere = tasks - len(universe)
+    if missing_everywhere < 0:
+        refusals.append(
+            f"{len(universe)} tasks present, more than the declared denominator {tasks}"
+        )
+        missing_everywhere = 0
+
+    pairs: list[tuple[float, float]] = []
+    per_task: list[dict[str, Any]] = []
+    both_pass = gained = lost = both_fail = 0
+    for name in universe:
+        left, right = control.get(name), treatment.get(name)
+        control_pass = left is not None and _passed(left)
+        treatment_pass = right is not None and _passed(right)
+        pairs.append((float(treatment_pass), float(control_pass)))
+        if control_pass and treatment_pass:
+            both_pass += 1
+        elif treatment_pass:
+            gained += 1
+        elif control_pass:
+            lost += 1
+        else:
+            both_fail += 1
+        per_task.append(
+            {
+                "task": name,
+                "control_passed": control_pass,
+                "treatment_passed": treatment_pass,
+                "control_self_verdict": (left or {}).get("self_verdict_passed"),
+                "treatment_self_verdict": (right or {}).get("self_verdict_passed"),
+                "treatment_witness": (right or {}).get("witness_authored_state"),
+                "control_usd": (left or {}).get("usd"),
+                "treatment_usd": (right or {}).get("usd"),
+            }
+        )
+    # Tasks no trial covered in either arm are failures in both, by the fixed
+    # denominator, and they belong in the pairing so the interval is computed
+    # over the preregistered task count rather than the tasks that reported.
+    both_fail += missing_everywhere
+    pairs.extend([(0.0, 0.0)] * missing_everywhere)
+
+    control_passes = both_pass + lost
+    treatment_passes = both_pass + gained
+    low, high = bootstrap_delta(pairs) if pairs else (0.0, 0.0)
+    primary = {
+        "tasks_declared": tasks,
+        "tasks_with_a_trial_in_either_arm": len(universe),
+        "tasks_missing_from_both_arms": missing_everywhere,
+        "control_passes": control_passes,
+        "treatment_passes": treatment_passes,
+        "control_accuracy": control_passes / tasks if tasks else None,
+        "treatment_accuracy": treatment_passes / tasks if tasks else None,
+        "delta_passes": treatment_passes - control_passes,
+        "both_pass": both_pass,
+        "gained": gained,
+        "lost": lost,
+        "both_fail": both_fail,
+        "mcnemar_exact_p": mcnemar_exact_p(gained, lost),
+        "ci95_bootstrap_delta_accuracy": {
+            "low": low,
+            "high": high,
+            "seed": BOOTSTRAP_SEED,
+            "draws": BOOTSTRAP_DRAWS,
+            "method": "percentile over per-task paired differences",
+        },
+    }
+
+    control_stats = self_verdict_stats(list(control.values()))
+    treatment_stats = self_verdict_stats(list(treatment.values()))
+    control_false = set(control_stats["false_pass_tasks"])
+    treatment_false = set(treatment_stats["false_pass_tasks"])
+    verdicts = {
+        "control": control_stats,
+        "treatment": treatment_stats,
+        "false_pass_delta": treatment_stats["false_pass"] - control_stats["false_pass"],
+        # Named tasks, not just counts: "which five did it stop lying about" is
+        # the reviewable form of the claim, and the counts can cancel out.
+        "false_passes_fixed": sorted(control_false - treatment_false),
+        "false_passes_introduced": sorted(treatment_false - control_false),
+    }
+
+    cost = _cost(list(control.values()), list(treatment.values()), gained - lost)
+    decision = (
+        {"verdict": "refused", "reasons": refusals}
+        if refusals
+        else decide(primary, verdicts, cost)
+    )
+    return {
+        "schema": "stella-witness-ab-comparison-v1",
+        "comparable": not refusals,
+        "refusals": refusals,
+        "identity": identity,
+        "witness_tier": tier,
+        "primary_outcome": primary,
+        "self_verdict": verdicts,
+        "cost": cost,
+        "decision": decision,
+        "per_task": per_task,
+    }
+
+
+def _mark(value: Any) -> str:
+    return {True: "pass", False: "fail", None: "—"}.get(value, "—")
+
+
+def markdown(report: dict[str, Any]) -> str:
+    primary, verdicts = report["primary_outcome"], report["self_verdict"]
+    cost, decision = report["cost"], report["decision"]
+    lines = [
+        "# Authored witness on vs off — paired comparison",
+        "",
+        f"**{decision['verdict'].upper()}** — " + "; ".join(decision["reasons"] or ["—"]),
+        "",
+        f"- tasks passed: control {primary['control_passes']}/{primary['tasks_declared']} "
+        f"→ witness {primary['treatment_passes']}/{primary['tasks_declared']} "
+        f"({primary['delta_passes']:+d})",
+        f"- paired: gained {primary['gained']}, lost {primary['lost']}, "
+        f"both passed {primary['both_pass']}, both failed {primary['both_fail']}"
+        + (
+            f", exact McNemar p={primary['mcnemar_exact_p']:.4f}"
+            if primary["mcnemar_exact_p"] is not None
+            else ", no discordant pairs"
+        ),
+        f"- wrong \"this passed\" calls: control {verdicts['control']['false_pass']} "
+        f"→ witness {verdicts['treatment']['false_pass']} "
+        f"({verdicts['false_pass_delta']:+d})",
+        f"- spend: ${cost['control']['usd_total']:.2f} → "
+        f"${cost['treatment']['usd_total']:.2f}"
+        + (f" ({cost['usd_ratio']}x)" if cost["usd_ratio"] is not None else "")
+        + (
+            f" · ${cost['usd_per_additional_task_passed']:.2f} per additional task passed"
+            if cost["usd_per_additional_task_passed"] is not None
+            else ""
+        ),
+        f"- witness tier fired on {report['witness_tier']['trials_with_an_authored_witness']} "
+        f"treatment trials ({report['witness_tier']['witnesses_authored_total']} witnesses authored)",
+        "",
+    ]
+    if report["refusals"]:
+        lines += ["> **Refused.** " + " · ".join(report["refusals"]), ""]
+    lines += [
+        "| task | control | witness | control says | witness says | tier |",
+        "|---|---|---|---|---|---|",
+    ]
+    for row in report["per_task"]:
+        lines.append(
+            f"| `{row['task']}` | {_mark(row['control_passed'])} | "
+            f"{_mark(row['treatment_passed'])} | {_mark(row['control_self_verdict'])} | "
+            f"{_mark(row['treatment_self_verdict'])} | {row['treatment_witness'] or '—'} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("control", help="witness-off trials.jsonl")
+    parser.add_argument("treatment", help="witness-on trials.jsonl")
+    parser.add_argument(
+        "--tasks", type=int, required=True, help="preregistered denominator"
+    )
+    parser.add_argument("--markdown", help="also write the per-task table here")
+    args = parser.parse_args(argv)
+
+    try:
+        control = load_arm(Path(args.control))
+        treatment = load_arm(Path(args.treatment))
+    except (OSError, ValueError) as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 1
+
+    report = compare(control, treatment, args.tasks)
+    print(json.dumps(report, indent=2))
+    if args.markdown:
+        Path(args.markdown).write_text(markdown(report), encoding="utf-8")
+        print(f"\nwrote {args.markdown}", file=sys.stderr)
+    if report["refusals"]:
+        for refusal in report["refusals"]:
+            print(f"REFUSED: {refusal}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/evidence/make_manifest.py
+++ b/bench/evidence/make_manifest.py
@@ -304,6 +304,21 @@ def _recorded(run_dir: Path) -> dict[str, Any]:
     return out
 
 
+def _arm_mismatch(recorded_arm: Any, witness_author: str | None) -> bool:
+    """Does the operator's `--witness-author` contradict what the trials ran?
+
+    Only a recorded arm this script recognizes can contradict anything: v1
+    evidence records no arm at all (#1007 predates it) and a run whose trials
+    disagree is already reported as a `DISAGREEMENT` elsewhere. Both pass
+    through here rather than being refused for a question they cannot answer.
+    """
+    if recorded_arm == "witness-off":
+        return witness_author is not None
+    if recorded_arm == "witness-on":
+        return witness_author is None
+    return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
@@ -361,6 +376,21 @@ def main() -> int:
 
     trial_dirs = _trial_dirs(job_dir, run_dir)
     recorded = _recorded(run_dir)
+    if _arm_mismatch(recorded.get("assurance_arm"), witness_author):
+        # An A/B is run from one shell, and the author stays exported across
+        # both arms — so finalizing the control arm picks up the treatment's
+        # author unless the operator unsets it (#1284). The digests below would
+        # already disagree and `_drift` would withhold the body, but
+        # `engine.witness_author_model` is operator-supplied and would still
+        # name a model that arm never used. Refusing costs one rerun of a free
+        # script; recording it mislabels the arm of a paid run.
+        print(
+            f"FATAL: the trials recorded assurance arm {recorded['assurance_arm']!r}, "
+            f"but --witness-author says {witness_author!r}. Finalize the control "
+            "arm with `env -u STELLA_WITNESS_AUTHOR_MODEL`.",
+            file=sys.stderr,
+        )
+        return 1
     host = _host(Path(args.host_json) if args.host_json else None)
 
     manifest: dict[str, Any] = {

--- a/bench/evidence/run/README.md
+++ b/bench/evidence/run/README.md
@@ -49,6 +49,28 @@ bench/evidence/run/primary.sh A "<job-name>-phaseA"
 bench/evidence/run/finalize.sh "<run-id>" "<job-name>"
 ```
 
+## Running the two arms of an A/B instead
+
+`witness_ab.sh` replaces step 5 when the run is a paired experiment rather than
+a score — currently the authored-witness A/B (#1284), whose protocol,
+preregistered analysis plan and decision rule are in
+[`../witness-ab/`](../witness-ab/). It takes the arm as an argument rather than
+reading it out of the ambient environment, pins the task list so both arms
+cannot drift apart, and refuses an unusable witness author on the host before a
+container exists:
+
+```bash
+export STELLA_WITNESS_AUTHOR_MODEL=openrouter/deepseek/deepseek-v4-pro
+bench/evidence/run/witness_ab.sh off "<job>-off"
+bench/evidence/run/witness_ab.sh on  "<job>-on"
+```
+
+Finalize each arm into its own evidence directory, then compare them with
+`../compare_arms.py`. Finalize the control arm under
+`env -u STELLA_WITNESS_AUTHOR_MODEL`: the author stays exported across both
+arms, and a manifest that names one the arm did not run with is a mislabeled
+arm (`make_manifest.py` refuses it rather than recording it).
+
 ## The SUT binary must be the portable build
 
 `build_sut.sh` cross-compiles against `x86_64-unknown-linux-gnu.2.17` via

--- a/bench/evidence/run/sentinel.sh
+++ b/bench/evidence/run/sentinel.sh
@@ -36,6 +36,15 @@ print(f"reward={reward} stella_status={md.get('stella_status')} "
       f"binary_verified={md.get('stella_binary_sha256_verified_in_container')} "
       f"commit_verified={md.get('stella_source_commit_verified_in_binary')} "
       f"exception={(r.get('exception_info') or {}).get('exception_type')}")
+# Which verification arm this trial ran, and what its ladder actually reached.
+# Reported rather than gated: on a witness-arm sentinel `witness=authored` is
+# the cheapest possible proof that the tier fires before 89 trials depend on it
+# (#1284), but a warrant that decided this task needed no new test is a
+# legitimate `not_reported`, and failing on it would be a false gate.
+print(f"arm={md.get('stella_assurance_arm')} "
+      f"author={md.get('stella_witness_author_model')} "
+      f"witness={md.get('stella_witness_authored_state')} "
+      f"self_verdict={md.get('stella_self_verdict_state')}")
 # NOTE: while #960 stands, an AgentTimeoutError accompanies even a perfect
 # trial, so the gate is the reward and the in-container verifications — not the
 # absence of an exception, which the audited protocol additionally requires.

--- a/bench/evidence/run/witness_ab.sh
+++ b/bench/evidence/run/witness_ab.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# One arm of the authored-witness A/B (#1284).
+#
+# The experiment is two runs of the *same* task set on the *same* SUT, differing
+# in exactly one thing: whether a second model, independent of the worker,
+# authors the failing test that proves the work.
+#
+#   off — the control arm. Every role inherits TB_MODEL, so no author is
+#         independent of the worker and the authored-witness tier cannot run on
+#         any task. This is the arm every published Stella number came from.
+#   on  — the treatment arm. STELLA_WITNESS_AUTHOR_MODEL names a second model on
+#         the worker's provider; it reaches Stella only as `pipeline_judge_model`
+#         inside the hashed posture.
+#
+# Not `primary.sh`: that scores a preregistered phase of the whole frozen
+# dataset against a fixed denominator. This runs one arm of a paired experiment
+# over a task list the operator fixes once and uses for both arms. Not `tune.sh`
+# either: that moves two knobs at once by design and its task list is selected
+# on prior results, so nothing it produces is a measurement of anything.
+#
+# Usage:
+#   export STELLA_WITNESS_AUTHOR_MODEL=openrouter/deepseek/deepseek-v4-pro
+#   bench/evidence/run/witness_ab.sh off wab1-off  "$TB_ROOT/witness_ab.tasks"
+#   bench/evidence/run/witness_ab.sh on  wab1-on   "$TB_ROOT/witness_ab.tasks"
+#
+# then, once both arms are extracted into evidence directories:
+#   python3 bench/evidence/compare_arms.py <off>/trials.jsonl <on>/trials.jsonl \
+#       --tasks <denominator> --markdown <run>/results.md
+set -uo pipefail
+
+ARM="${1:?usage: witness_ab.sh <off|on> <job-name> [task-file]}"
+JOB="${2:?usage: witness_ab.sh <off|on> <job-name> [task-file]}"
+
+# The author is read here, before env.sh unsets an empty one, because the
+# control arm has to run with the variable *absent* while the operator keeps it
+# exported in their shell for the other arm. Selecting the arm by argument
+# rather than by what happens to be in the environment is the whole point: an
+# arm chosen by ambient state is an arm nobody can reproduce.
+AUTHOR="${STELLA_WITNESS_AUTHOR_MODEL:-}"
+case "$ARM" in
+  off) unset STELLA_WITNESS_AUTHOR_MODEL ;;
+  on)
+    test -n "$AUTHOR" || {
+      echo "FATAL: arm 'on' needs STELLA_WITNESS_AUTHOR_MODEL exported"
+      echo "       (a second provider/model on TB_MODEL's provider — one"
+      echo "       credential reaches the container, so it must be the same"
+      echo "       provider as the worker)"
+      exit 1
+    }
+    export STELLA_WITNESS_AUTHOR_MODEL="$AUTHOR"
+    ;;
+  *) echo "FATAL: arm must be 'off' or 'on'"; exit 1 ;;
+esac
+
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+
+TASKFILE="${3:-$TB_ROOT/witness_ab.tasks}"
+test -f "$TASKFILE" || {
+  echo "FATAL: no task file at $TASKFILE"
+  echo "       Create one first — both arms must read the same file:"
+  echo "         python3 -c \"import json;p=json.load(open('\$TB_ROOT/phases.json'));print('\\n'.join(sorted(p['phaseA']+p['phaseB'])))\" > $TASKFILE"
+  exit 1
+}
+test ! -e "$JOBS/$JOB" || { echo "FATAL: $JOBS/$JOB exists — a run never resumes"; exit 1; }
+
+N=$(grep -c . "$TASKFILE")
+test "$N" -gt 0 || { echo "FATAL: $TASKFILE lists no tasks"; exit 1; }
+
+# The task set is part of the experiment's identity, and the two arms are only
+# paired if they covered the same one. The first arm records the digest; the
+# second refuses if it differs. python3 rather than shasum/sha256sum because
+# preflight already requires python3 and the two commands are not both present
+# on both host platforms this runbook supports.
+TASKSET_SHA=$(sort "$TASKFILE" | python3 -c "import hashlib,sys;print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())")
+PIN="$TB_ROOT/witness_ab.taskset_sha256"
+if [ -f "$PIN" ]; then
+  test "$(cat "$PIN")" = "$TASKSET_SHA" || {
+    echo "FATAL: this experiment's first arm ran taskset $(cat "$PIN"),"
+    echo "       this one is $TASKSET_SHA — two arms over different task sets"
+    echo "       are not a paired comparison. Use a new TB_ROOT to start over."
+    exit 1
+  }
+else
+  printf '%s\n' "$TASKSET_SHA" > "$PIN"
+fi
+
+# Refuse an unusable author on the host, before any container is created. The
+# adapter validates it fail-closed anyway (#1147: an author Stella's offline
+# seed catalog does not carry drops the judge pin and runs the control arm), but
+# discovering that per trial costs the run instead of one message.
+if [ "$ARM" = "on" ]; then
+  python3 - "$TB_MODEL" "$AUTHOR" <<'PY' || exit 1
+import sys
+from stella_harbor.posture import _validated_witness_author
+
+try:
+    author = _validated_witness_author(sys.argv[1], sys.argv[2])
+except Exception as exc:  # noqa: BLE001 - the message is the whole output
+    print(f"FATAL: {exc}")
+    raise SystemExit(1)
+if author is None:
+    print("FATAL: the witness author resolved to nothing — this is the control arm")
+    raise SystemExit(1)
+print(f"witness author accepted: {author}")
+PY
+fi
+
+preflight || exit 1
+
+# macOS ships bash 3.2: no mapfile, no arrays from process substitution.
+INCLUDES=""
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  INCLUDES="$INCLUDES --include-task-name terminal-bench/$t"
+done < "$TASKFILE"
+
+CONC="${TB_CONCURRENCY:-3}"
+echo "arm=$ARM job=$JOB tasks=$N taskset_sha256=$TASKSET_SHA"
+echo "sut=$STELLA_SOURCE_COMMIT worker=$TB_MODEL"
+echo "witness_author=${STELLA_WITNESS_AUTHOR_MODEL:-<none: control arm>}"
+echo "budget/trial=${STELLA_BUDGET:-<uncapped>} concurrency=$CONC"
+echo "started=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cd "$TB_REPO" || exit 1
+# INCLUDES is deliberately unquoted: a pre-built flag list, one word per token,
+# every task name a fixed [a-z0-9-] slug from the frozen dataset.
+# shellcheck disable=SC2086
+harbor run \
+  --env docker \
+  --dataset "$TB_DATASET" \
+  $INCLUDES \
+  --agent-import-path stella_harbor:StellaAgent \
+  --model "$TB_MODEL" \
+  --job-name "$JOB" \
+  --jobs-dir "$JOBS" \
+  --n-attempts 1 --n-concurrent "$CONC" --max-retries 0
+rc=$?
+echo "harbor_exit=$rc finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+exit $rc

--- a/bench/evidence/score_dev_baseline.py
+++ b/bench/evidence/score_dev_baseline.py
@@ -66,6 +66,7 @@ def extract_trial(result_path: Path) -> dict[str, Any]:
     metadata = _dict(agent_result.get("metadata"))
     accounting = _dict(metadata.get("stella_accounting"))
     fields = _dict(accounting.get("fields"))
+    stream = _dict(metadata.get("stella_stream"))
 
     reward = _number(rewards.get("reward"))
     exception_type = exception_info.get("exception_type")
@@ -133,6 +134,30 @@ def extract_trial(result_path: Path) -> dict[str, Any]:
         "engine_posture_sha256": metadata.get("stella_engine_posture_sha256"),
         "assurance_arm": metadata.get("stella_assurance_arm"),
         "assurance_tiers_sha256": metadata.get("stella_assurance_tiers_sha256"),
+        # The verification-ladder A/B's whole input (#1284), and the reason it
+        # is here rather than derived later: the job tree these fields come from
+        # is not committed, so a comparison that reads it can only be run while
+        # the run is still on the disk that produced it. Four questions, four
+        # fields — which arm the posture *declared*, who the independent author
+        # was, whether the tier actually *fired* on this task, and what Stella
+        # itself claimed about the work the external reward then graded.
+        "witness_author_model": metadata.get("stella_witness_author_model"),
+        "witness_authored_state": metadata.get("stella_witness_authored_state"),
+        "witness_authored_count": _int(stream.get("witness_authored_count")),
+        "witness_warranted_count": _int(stream.get("witness_warranted_count")),
+        # Tri-state, and it must stay that way through the JSON round trip: a
+        # trial killed before the ladder closed made no claim, which is not the
+        # same datum as claiming failure.
+        "self_verdict_passed": (
+            stream.get("self_verdict_passed")
+            if isinstance(stream.get("self_verdict_passed"), bool)
+            else None
+        ),
+        "self_verdict_deterministic": (
+            stream.get("self_verdict_deterministic")
+            if isinstance(stream.get("self_verdict_deterministic"), bool)
+            else None
+        ),
         "binary_sha256": metadata.get("stella_binary_sha256"),
         "source_commit": metadata.get("stella_source_commit"),
         "harbor_version": metadata.get("stella_harbor_version"),

--- a/bench/evidence/tests/test_compare_arms.py
+++ b/bench/evidence/tests/test_compare_arms.py
@@ -1,0 +1,449 @@
+"""Tests for the authored-witness A/B comparison (#1284).
+
+This script decides whether the strongest rung of Stella's verification ladder
+becomes the default for every benchmark run. Two failure modes matter more than
+arithmetic bugs, and both produce a well-formed, confident report:
+
+* comparing two runs that are not the two arms of one experiment — different
+  SUTs, the same arm twice, or evidence too old to say which arm it ran;
+* comparing a treatment arm that *declared* the witness rung and never
+  exercised it, which is #1147 with the numbers still printing.
+
+Both refuse here. The rest is the pairing, the two outcomes, and the
+preregistered decision rule, which must not be reachable by any input that has
+not earned it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_EVIDENCE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _EVIDENCE / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+compare_arms = _load("compare_arms")
+
+
+def _row(task: str, *, arm: str, passed: bool, **extra) -> dict:
+    """One trial row in the shape `score_dev_baseline.py extract` writes."""
+    row = {
+        "task_name": task,
+        "trial_id": f"{task}__aaa",
+        "accuracy": 1.0 if passed else 0.0,
+        "reward": 1.0 if passed else 0.0,
+        "assurance_arm": arm,
+        "source_commit": "c" * 40,
+        "binary_sha256": "b" * 64,
+        "engine_posture_sha256": "off-digest" if arm == "witness-off" else "on-digest",
+        "witness_author_model": (
+            None if arm == "witness-off" else "openrouter/deepseek/deepseek-v4-pro"
+        ),
+        "witness_authored_state": (
+            "unavailable" if arm == "witness-off" else "authored"
+        ),
+        "witness_authored_count": 0 if arm == "witness-off" else 1,
+        "self_verdict_passed": passed,
+        "self_verdict_deterministic": False,
+        "usd": 1.0,
+    }
+    row.update(extra)
+    return row
+
+
+def _arms(control_rows: list[dict], treatment_rows: list[dict]):
+    return (
+        {row["task_name"]: row for row in control_rows},
+        {row["task_name"]: row for row in treatment_rows},
+    )
+
+
+# --------------------------------------------------------------------------
+# Refusals — before any number is allowed to mean something
+# --------------------------------------------------------------------------
+
+
+def test_two_runs_of_the_same_arm_are_not_an_experiment() -> None:
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=True)],
+        [_row("b", arm="witness-off", passed=True)],
+    )
+    report = compare_arms.compare(control, treatment, tasks=2)
+
+    assert report["comparable"] is False
+    assert report["decision"]["verdict"] == "refused"
+    assert any("treatment arm should be 'witness-on'" in r for r in report["refusals"])
+
+
+def test_evidence_that_cannot_say_which_arm_it_ran_is_refused() -> None:
+    """v1 evidence predates the assurance block, so it cannot be an arm."""
+    stale = _row("a", arm="witness-off", passed=True)
+    del stale["assurance_arm"]
+    control, treatment = _arms([stale], [_row("a", arm="witness-on", passed=True)])
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert report["comparable"] is False
+    assert any("pre-#1007 evidence" in r for r in report["refusals"])
+
+
+def test_two_different_suts_are_two_experiments() -> None:
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=False)],
+        [_row("a", arm="witness-on", passed=True, source_commit="d" * 40)],
+    )
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert report["comparable"] is False
+    assert any("same source_commit" in r for r in report["refusals"])
+
+
+def test_a_treatment_arm_that_never_authored_a_witness_is_refused() -> None:
+    """#1147: the posture declared the rung, model validation dropped the pin.
+
+    The digest said witness-on and the control arm executed. Nothing in the
+    posture can catch that — only the run's own proof stream can, so the
+    comparison reads the stream rather than the declaration.
+    """
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=False)],
+        [
+            _row(
+                "a",
+                arm="witness-on",
+                passed=True,
+                witness_authored_state="unavailable",
+                witness_authored_count=0,
+            )
+        ],
+    )
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert report["comparable"] is False
+    assert any("authored no witness on any task" in r for r in report["refusals"])
+    # The numbers are still printed: a refusal nobody can check is not one.
+    assert report["primary_outcome"]["gained"] == 1
+
+
+def test_a_refused_comparison_never_reaches_a_verdict() -> None:
+    """No input that fails a refusal may produce adopt/reject/inconclusive."""
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=False)],
+        [_row("a", arm="witness-off", passed=True)],
+    )
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert report["decision"]["verdict"] == "refused"
+
+
+# --------------------------------------------------------------------------
+# Pairing
+# --------------------------------------------------------------------------
+
+
+def test_pairing_splits_gained_from_lost() -> None:
+    control, treatment = _arms(
+        [
+            _row("both", arm="witness-off", passed=True),
+            _row("gained", arm="witness-off", passed=False),
+            _row("lost", arm="witness-off", passed=True),
+            _row("neither", arm="witness-off", passed=False),
+        ],
+        [
+            _row("both", arm="witness-on", passed=True),
+            _row("gained", arm="witness-on", passed=True),
+            _row("lost", arm="witness-on", passed=False),
+            _row("neither", arm="witness-on", passed=False),
+        ],
+    )
+    primary = compare_arms.compare(control, treatment, tasks=4)["primary_outcome"]
+
+    assert (primary["both_pass"], primary["gained"]) == (1, 1)
+    assert (primary["lost"], primary["both_fail"]) == (1, 1)
+    assert primary["delta_passes"] == 0
+    assert primary["control_passes"] == primary["treatment_passes"] == 2
+
+
+def test_a_task_missing_from_an_arm_scores_zero_there(capsys) -> None:
+    """Same rule as the scorer: a trial that never reported is a failure.
+
+    Dropping it instead would let an arm that crashed on its hardest tasks
+    compare its remaining ones against the other arm's full set.
+    """
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=True), _row("b", arm="witness-off", passed=True)],
+        [_row("a", arm="witness-on", passed=True)],
+    )
+    report = compare_arms.compare(control, treatment, tasks=2)
+    primary = report["primary_outcome"]
+
+    assert primary["lost"] == 1
+    assert primary["treatment_passes"] == 1
+    assert report["identity"]["tasks_only_in_control"] == ["b"]
+
+
+def test_a_task_no_arm_covered_still_counts_against_the_denominator() -> None:
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=True)],
+        [_row("a", arm="witness-on", passed=True)],
+    )
+    primary = compare_arms.compare(control, treatment, tasks=89)["primary_outcome"]
+
+    assert primary["tasks_missing_from_both_arms"] == 88
+    assert primary["both_fail"] == 88
+    assert primary["treatment_accuracy"] == 1 / 89
+
+
+def test_more_tasks_than_the_declared_denominator_is_refused() -> None:
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=True), _row("b", arm="witness-off", passed=True)],
+        [_row("a", arm="witness-on", passed=True), _row("b", arm="witness-on", passed=True)],
+    )
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert any("more than the declared denominator" in r for r in report["refusals"])
+
+
+def test_mcnemar_uses_only_the_discordant_pairs() -> None:
+    # Ten tasks moved one way and none the other: as one-sided as it gets.
+    assert compare_arms.mcnemar_exact_p(10, 0) < 0.01
+    # A wash, however large.
+    assert compare_arms.mcnemar_exact_p(5, 5) == 1.0
+    # Nothing moved: there is no test to run, and 1.0 would read as "measured".
+    assert compare_arms.mcnemar_exact_p(0, 0) is None
+
+
+# --------------------------------------------------------------------------
+# The secondary outcome: wrong "this passed" calls
+# --------------------------------------------------------------------------
+
+
+def test_a_wrong_this_passed_call_is_counted_and_named() -> None:
+    rows = [
+        # Claimed pass, graded zero — the failure the rung exists to remove.
+        _row("lied", arm="witness-off", passed=False, self_verdict_passed=True),
+        _row("honest-fail", arm="witness-off", passed=False, self_verdict_passed=False),
+        _row("honest-pass", arm="witness-off", passed=True, self_verdict_passed=True),
+    ]
+    stats = compare_arms.self_verdict_stats(rows)
+
+    assert stats["false_pass"] == 1
+    assert stats["false_pass_tasks"] == ["lied"]
+    assert stats["false_fail"] == 0
+    assert stats["reported_by"] == 3
+    assert stats["agreement_rate"] == 2 / 3
+
+
+def test_a_trial_that_made_no_claim_is_not_a_wrong_one() -> None:
+    """Tri-state through the whole chain: silence is not a verdict.
+
+    A trial killed before the ladder closed reports `self_verdict_passed: null`.
+    Reading that as "claimed failure" would credit the agent with honesty it
+    never displayed, on exactly the trials most likely to be re-read.
+    """
+    rows = [
+        _row("interrupted", arm="witness-off", passed=False, self_verdict_passed=None),
+        _row("judged", arm="witness-off", passed=True, self_verdict_passed=True),
+    ]
+    stats = compare_arms.self_verdict_stats(rows)
+
+    assert stats["reported_by"] == 1
+    assert stats["silent_trials"] == 1
+    assert stats["agreement_rate"] == 1.0
+
+
+def test_a_flip_oracle_verdict_is_not_counted_as_a_model_opinion() -> None:
+    """The deterministic rung and the model judge are different instruments.
+
+    #1284 quotes the *judge's* agreement rate. Averaging a flip-oracle verdict
+    into it reports the ladder's aggregate as the judge's reliability.
+    """
+    rows = [
+        _row(
+            "oracle",
+            arm="witness-off",
+            passed=False,
+            self_verdict_passed=True,
+            self_verdict_deterministic=True,
+        ),
+        _row(
+            "opinion",
+            arm="witness-off",
+            passed=False,
+            self_verdict_passed=True,
+            self_verdict_deterministic=False,
+        ),
+    ]
+    stats = compare_arms.self_verdict_stats(rows)
+
+    assert stats["false_pass"] == 2
+    assert stats["model_judge_only"]["reported_by"] == 1
+    assert stats["model_judge_only"]["false_pass_tasks"] == ["opinion"]
+
+
+def test_fixed_and_introduced_false_passes_are_named_not_netted() -> None:
+    """Two counts that cancel are not "no change" — they are two changes."""
+    control, treatment = _arms(
+        [
+            _row("was-lied-about", arm="witness-off", passed=False, self_verdict_passed=True),
+            _row("clean", arm="witness-off", passed=False, self_verdict_passed=False),
+        ],
+        [
+            _row("was-lied-about", arm="witness-on", passed=False, self_verdict_passed=False),
+            _row("clean", arm="witness-on", passed=False, self_verdict_passed=True),
+        ],
+    )
+    verdicts = compare_arms.compare(control, treatment, tasks=2)["self_verdict"]
+
+    assert verdicts["false_pass_delta"] == 0
+    assert verdicts["false_passes_fixed"] == ["was-lied-about"]
+    assert verdicts["false_passes_introduced"] == ["clean"]
+
+
+# --------------------------------------------------------------------------
+# Cost, and the preregistered decision rule
+# --------------------------------------------------------------------------
+
+
+def test_a_partial_spend_total_withholds_the_ratio() -> None:
+    """Two partial sums do not make a cost comparison — the same discipline
+    `score.json` applies to `usd_total`."""
+    silent = _row("b", arm="witness-on", passed=True)
+    del silent["usd"]
+    control, treatment = _arms(
+        [_row("a", arm="witness-off", passed=True), _row("b", arm="witness-off", passed=True)],
+        [_row("a", arm="witness-on", passed=True), silent],
+    )
+    cost = compare_arms.compare(control, treatment, tasks=2)["cost"]
+
+    assert cost["usd_ratio"] is None
+    assert "partial" in cost["usd_ratio_note"]
+    assert cost["treatment"]["usd_reported_by"] == 1
+
+
+def _decide(gained: int, lost: int, false_pass_delta: int, ratio: float | None) -> dict:
+    primary = {
+        "gained": gained,
+        "lost": lost,
+        "mcnemar_exact_p": compare_arms.mcnemar_exact_p(gained, lost),
+    }
+    return compare_arms.decide(
+        primary, {"false_pass_delta": false_pass_delta}, {"usd_ratio": ratio}
+    )
+
+
+def test_more_wrong_passed_calls_is_a_rejection_however_many_tasks_it_won() -> None:
+    """The rung's purpose is the honesty of the verdict, not only the score."""
+    decision = _decide(gained=8, lost=0, false_pass_delta=3, ratio=1.0)
+
+    assert decision["verdict"] == "reject"
+    assert any("wrong 'this passed'" in r for r in decision["reasons"])
+
+
+def test_losing_tasks_significantly_is_a_rejection() -> None:
+    decision = _decide(gained=0, lost=9, false_pass_delta=-2, ratio=1.0)
+
+    assert decision["verdict"] == "reject"
+
+
+def test_a_significant_gain_within_the_cost_ceiling_is_adopted() -> None:
+    decision = _decide(gained=9, lost=0, false_pass_delta=-4, ratio=1.4)
+
+    assert decision["verdict"] == "adopt"
+
+
+def test_a_gain_that_costs_too_much_is_not_adopted() -> None:
+    decision = _decide(gained=9, lost=0, false_pass_delta=-4, ratio=2.2)
+
+    assert decision["verdict"] == "inconclusive"
+    assert any("above the 1.5x ceiling" in r for r in decision["reasons"])
+
+
+def test_a_gain_whose_cost_could_not_be_compared_is_not_adopted() -> None:
+    """Unknown cost is not affordable cost."""
+    decision = _decide(gained=9, lost=0, false_pass_delta=-4, ratio=None)
+
+    assert decision["verdict"] == "inconclusive"
+
+
+def test_a_small_gain_with_no_honesty_improvement_is_inconclusive() -> None:
+    decision = _decide(gained=2, lost=1, false_pass_delta=0, ratio=1.1)
+
+    assert decision["verdict"] == "inconclusive"
+
+
+# --------------------------------------------------------------------------
+# End to end, through the CLI
+# --------------------------------------------------------------------------
+
+
+def _write(path: Path, rows: list[dict]) -> Path:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+def test_cli_reports_and_exits_nonzero_on_a_refusal(tmp_path: Path, capsys) -> None:
+    control = _write(tmp_path / "off.jsonl", [_row("a", arm="witness-off", passed=False)])
+    treatment = _write(tmp_path / "on.jsonl", [_row("a", arm="witness-off", passed=True)])
+
+    code = compare_arms.main([str(control), str(treatment), "--tasks", "1"])
+    out = json.loads(capsys.readouterr().out)
+
+    assert code == 1
+    assert out["comparable"] is False
+
+
+def test_cli_writes_a_table_that_names_every_task(tmp_path: Path, capsys) -> None:
+    control = _write(
+        tmp_path / "off.jsonl",
+        [
+            _row("alpha", arm="witness-off", passed=False, self_verdict_passed=True),
+            _row("beta", arm="witness-off", passed=True),
+        ],
+    )
+    treatment = _write(
+        tmp_path / "on.jsonl",
+        [
+            _row("alpha", arm="witness-on", passed=True),
+            _row("beta", arm="witness-on", passed=True),
+        ],
+    )
+    table = tmp_path / "results.md"
+
+    code = compare_arms.main(
+        [str(control), str(treatment), "--tasks", "2", "--markdown", str(table)]
+    )
+    report = json.loads(capsys.readouterr().out)
+    rendered = table.read_text()
+
+    assert code == 0
+    assert report["decision"]["verdict"] in {"adopt", "inconclusive"}
+    assert report["self_verdict"]["false_passes_fixed"] == ["alpha"]
+    assert "`alpha`" in rendered and "`beta`" in rendered
+
+
+def test_a_duplicated_task_in_one_arm_is_a_hard_error(tmp_path: Path) -> None:
+    """Two rows for one task means a resume or a rerun, both forbidden."""
+    path = _write(
+        tmp_path / "off.jsonl",
+        [
+            _row("a", arm="witness-off", passed=False),
+            _row("a", arm="witness-off", passed=True),
+        ],
+    )
+    try:
+        compare_arms.load_arm(path)
+    except ValueError as exc:
+        assert "more than one row" in str(exc)
+    else:  # pragma: no cover - the assertion is the test
+        raise AssertionError("a duplicated task must not load")

--- a/bench/evidence/tests/test_evidence_tooling.py
+++ b/bench/evidence/tests/test_evidence_tooling.py
@@ -267,6 +267,80 @@ def test_extract_carries_the_runs_own_identity(tmp_path: Path) -> None:
     assert row["reward"] == 1.0
 
 
+def test_extract_carries_the_verification_ladder_a_run_actually_exercised(
+    tmp_path: Path,
+) -> None:
+    """The A/B's whole input (#1284), and it only exists while the run does.
+
+    Stella's verdict on its own work and the witness observations behind it live
+    in the Harbor job tree, which is never committed. A comparison that reads
+    them from there can only run on the machine that produced the run; carried
+    into `trials.jsonl` they outlive it, like every other field the score
+    depends on.
+    """
+    path = _result(
+        tmp_path,
+        {
+            "task_name": "task",
+            "verifier_result": {"rewards": {"reward": 0.0}},
+            "agent_result": {
+                "metadata": {
+                    "stella_assurance_arm": "witness-on",
+                    "stella_witness_author_model": "openrouter/deepseek/deepseek-v4-pro",
+                    "stella_witness_authored_state": "authored",
+                    "stella_stream": {
+                        "witness_authored_count": 2,
+                        "witness_warranted_count": 3,
+                        "self_verdict_passed": True,
+                        "self_verdict_deterministic": False,
+                    },
+                }
+            },
+        },
+    )
+    row = scorer.extract_trial(path)
+
+    assert row["witness_author_model"] == "openrouter/deepseek/deepseek-v4-pro"
+    assert row["witness_authored_state"] == "authored"
+    assert row["witness_authored_count"] == 2
+    assert row["witness_warranted_count"] == 3
+    # Claimed pass, graded zero: one wrong "this passed" call, recomputable
+    # from the committed row alone.
+    assert row["self_verdict_passed"] is True
+    assert row["self_verdict_deterministic"] is False
+    assert row["accuracy"] == 0.0
+
+
+def test_a_trial_that_closed_no_verdict_extracts_null_not_false(tmp_path: Path) -> None:
+    """Tri-state, or "not measured" starts reading as "measured and honest"."""
+    path = _result(
+        tmp_path,
+        {
+            "task_name": "task",
+            "verifier_result": {"rewards": {"reward": 0.0}},
+            "agent_result": {"metadata": {"stella_stream": {}}},
+        },
+    )
+    row = scorer.extract_trial(path)
+
+    assert row["self_verdict_passed"] is None
+    assert row["self_verdict_deterministic"] is None
+
+
+def test_a_control_arm_manifest_refuses_an_author_it_did_not_run_with() -> None:
+    """An A/B is run from one shell, and the author stays exported (#1284).
+
+    Finalizing the control arm then records the treatment's author on a run
+    that never had one — a mislabeled arm, well-formed and confident.
+    """
+    assert manifest._arm_mismatch("witness-off", "openrouter/deepseek/deepseek-v4-pro")
+    assert manifest._arm_mismatch("witness-on", None)
+    assert not manifest._arm_mismatch("witness-off", None)
+    assert not manifest._arm_mismatch("witness-on", "openrouter/x-ai/grok-4.5")
+    # v1 evidence records no arm and cannot contradict anything.
+    assert not manifest._arm_mismatch(None, "openrouter/x-ai/grok-4.5")
+
+
 def test_reward_is_read_from_the_nested_rewards_object(tmp_path: Path) -> None:
     """`verifier_result.reward` is always None; the reward lives one level in.
 

--- a/bench/evidence/witness-ab/README.md
+++ b/bench/evidence/witness-ab/README.md
@@ -1,0 +1,198 @@
+# The authored-witness A/B
+
+Does an independent checker earn its cost? ([#1284](https://github.com/macanderson/stella/issues/1284))
+
+Stella decides whether finished work is correct on a ladder. Two of its rungs
+are model calls, and they are not equally strong:
+
+| rung | what it is | why it is stronger or weaker |
+|---|---|---|
+| **authored witness** | a *second* model writes a test that must fail on the old code and pass on the new | the model that did the work does not write its own exam |
+| **model judge** | a model reads the work and gives an opinion | the same model that did the work can grade it, and does |
+
+**Every Terminal-Bench number Stella has published ran with the authored
+witness structurally off.** Not by choice: the benchmark posture pinned one
+model for every role, Stella refuses to let a worker author the test that
+verifies it, and so each trial logged `continuing without an authored witness:
+no author independent of the worker` and carried on with the judge alone. Those
+numbers are a lower bound on the ladder, not a measurement of it
+([`../../READINESS.md`](../../READINESS.md) §9).
+
+Two things used to block turning it on, and both are fixed:
+
+* [#1007](https://github.com/macanderson/stella/issues/1007) added
+  `STELLA_WITNESS_AUTHOR_MODEL`, which names a second model on the worker's
+  provider and reaches Stella only as `pipeline_judge_model` inside the hashed
+  posture;
+* [#1225](https://github.com/macanderson/stella/issues/1225) gave each task
+  folder a git baseline, so a witness has something to be diffed against.
+
+This directory holds the protocol, the preregistered analysis plan and the
+decision rule for the run that answers the question. **The run itself has not
+happened yet** — it needs a spend-capable credential and a host that can run
+89 Docker task images, neither of which any amount of code in this repository
+can supply. Results land in a sibling `witness-ab-<YYYYMMDD>/` directory and
+this file gains a row pointing at them.
+
+## What gets measured
+
+Two runs, same SUT, same task set, same everything except one variable:
+
+| arm | `STELLA_WITNESS_AUTHOR_MODEL` | authored witness | model judge |
+|---|---|---|---|
+| control | unset | **off** — no author independent of the worker | on, *same model as the worker* |
+| treatment | a second model on the worker's provider | on | on, independent of the worker |
+
+The arm changes `stella_engine_posture_sha256`, and therefore the registered
+configuration. That is intended: two arms that hash the same are one arm run
+twice.
+
+### Outcomes, fixed before the first paid call
+
+1. **Primary — tasks passed.** Paired by task over the preregistered
+   denominator. Reported as gained / lost / both / neither, with an exact
+   McNemar test over the discordant pairs and a percentile bootstrap interval
+   on the paired difference (seed `20260803`, 50,000 draws).
+2. **Secondary — wrong "this passed" calls.** A trial where Stella's own
+   verdict said the work was done and the benchmark's external grader scored it
+   zero. This is what the rung exists to remove, and it is invisible to the
+   score: a task failed while claiming success costs the same reward as a task
+   failed honestly, but only the first one lies to whoever ships it. Counted
+   overall and restricted to verdicts a *model* opined
+   (`self_verdict_deterministic: false`) rather than ones the flip oracle
+   decided.
+3. **Cost.** Total spend, the treatment/control ratio, and spend per additional
+   task passed. Wall clock is reported but is not a time measurement while
+   [#960](https://github.com/macanderson/stella/issues/960) is open — Stella's
+   headless process does not exit after its turn, so Harbor kills it at the
+   agent timeout and every such trial burns the full timeout regardless of how
+   long the work took.
+
+### The decision rule
+
+Encoded in [`../compare_arms.py`](../compare_arms.py) (`decide()`), applied
+mechanically, and fixed here before any data exists:
+
+* **Reject** if the treatment arm loses more tasks than it gains at p < 0.05,
+  **or** if wrong "this passed" calls increase. Either makes the rung worse
+  than what already ships.
+* **Adopt** — the witness arm becomes the default for benchmark runs — if it
+  gains more tasks than it loses, that gain is either significant at p < 0.05
+  **or** accompanied by fewer wrong "passed" calls, **and** it costs at most
+  **1.5×** the control arm.
+* **Inconclusive** otherwise. Which changes nothing, and says so.
+
+Nothing above is chosen after the data arrives. A threshold moved once a number
+is in hand is not a decision rule, it is a preference with arithmetic attached.
+
+### Two refusals, before any of the above is computed
+
+`compare_arms.py` exits non-zero, and reports `"verdict": "refused"`, when:
+
+* **the arms are not one experiment** — a trial that does not record its
+  assurance arm (pre-#1007 evidence), an arm whose trials disagree about which
+  arm they ran, or two arms that ran different SUT commits or binaries;
+* **the treatment arm authored no witness on any task.** A posture that
+  *declares* the rung is not a run that *exercised* it. This is
+  [#1147](https://github.com/macanderson/stella/issues/1147) exactly: an author
+  Stella's offline seed catalog did not carry failed model validation, the
+  judge pin was dropped, and the control arm executed under a treatment-arm
+  digest. The run's own proof stream is the only thing that can answer it, and
+  every trial now carries that answer as a field.
+
+### Choosing the author
+
+Two hard constraints, both enforced fail-closed by `_validated_witness_author`:
+the author must differ from the worker (otherwise the tier is off with a hash
+saying otherwise), and it must sit on the **worker's provider** — a trial
+carries exactly one provider credential over the anonymous FD, resolved from
+the worker's provider, so a cross-provider author authenticates against
+nothing.
+
+One soft constraint, which is where the money is. `openrouter` is deliberately
+an *unseeded* provider (`stella-cli/src/config/providers.rs`): it fronts
+hundreds of `vendor/model` slugs that change weekly, so slug validation there
+is permissive by design and a typo is not caught before the call. What the
+seed catalog does carry for the `openrouter` route is the row that supplies a
+model's context window, output ceiling and prices —
+`moonshotai/kimi-k3`, `anthropic/claude-sonnet-5`, `anthropic/claude-fable-5`,
+`anthropic/claude-haiku-4.5` at the time of writing
+(`stella-model/src/catalog.rs`). An author without such a row runs against the
+engine's global defaults and reports spend only from the gateway's own usage
+accounting, which is a worse position to measure a cost question from. Prefer
+an author the seed carries; if the experiment needs one it does not, seed the
+row first.
+
+## Running it
+
+```bash
+export TB_REPO="$(git rev-parse --show-toplevel)"
+export TB_ROOT=/absolute/path/for/run/scratch
+
+# Steps 1–4 of ../run/README.md first: build_sut.sh, fetch_dataset.sh,
+# prepull.sh, sentinel.sh. Then fix the task list ONCE — both arms read it:
+python3 -c "import json;p=json.load(open('$TB_ROOT/phases.json'));print('\n'.join(sorted(p['phaseA']+p['phaseB'])))" \
+  > "$TB_ROOT/witness_ab.tasks"
+
+# The author must be a second model on the worker's provider, and one the
+# offline seed catalog carries. The script refuses an unusable one on the host,
+# before a container exists.
+export STELLA_WITNESS_AUTHOR_MODEL=openrouter/deepseek/deepseek-v4-pro
+
+# Run the sentinel once on the treatment arm too. It costs one trial and is the
+# cheapest possible check that the rung fires at all: its report line carries
+# `arm=witness-on witness=authored`. `witness=not_reported` there can still be
+# legitimate (the warrant may decide this task needs no new test), but
+# `arm=witness-off` on a run launched with the author exported is #1147 and
+# must be resolved before spending on 89 tasks.
+bench/evidence/run/sentinel.sh sentinel-witness-on
+
+bench/evidence/run/witness_ab.sh off wab1-off
+bench/evidence/run/witness_ab.sh on  wab1-on
+
+# Each arm becomes its own evidence directory, scored on its own terms. The
+# `env -u` is load-bearing: finalize.sh reads the author from the environment,
+# and the control arm's manifest must not name one it did not run with.
+# (make_manifest.py refuses that mismatch rather than recording it, but a
+# refusal at the end of a paid run is a worse place to learn it than here.)
+env -u STELLA_WITNESS_AUTHOR_MODEL \
+  bench/evidence/run/finalize.sh witness-ab-20260803/control wab1-off
+bench/evidence/run/finalize.sh witness-ab-20260803/treatment wab1-on
+
+# And then the comparison, which is the answer.
+python3 bench/evidence/compare_arms.py \
+  bench/evidence/witness-ab-20260803/control/trials.jsonl \
+  bench/evidence/witness-ab-20260803/treatment/trials.jsonl \
+  --tasks 89 --markdown bench/evidence/witness-ab-20260803/results.md \
+  > bench/evidence/witness-ab-20260803/comparison.json
+```
+
+Order matters in one direction only: run the **control** arm first if anything
+is still downloading, so a partially warm cache cannot advantage the arm under
+test. Neither arm may be re-run after seeing its score, and an operational
+abort relaunches under a new job name rather than resuming — the rules in
+[`../README.md`](../README.md) apply here unchanged.
+
+## Cost of the run
+
+89 tasks × 2 arms, one attempt each. The published `tb21-hh10-20260731` run
+spent **$88.29** over 89 Stella trials on `glm-5.2` with no per-trial cap, so
+the control arm is that order of magnitude and the treatment arm is that plus
+whatever the second model's authoring costs — which is the number this
+experiment exists to measure rather than predict. `STELLA_BUDGET` defaults to
+`0.60` per trial in `../run/env.sh`; a capped run measures a different agent, so
+decide the cap once and use the same one in both arms.
+
+## Why the tooling changed for this
+
+The comparison needs one field per trial that the committed evidence did not
+carry: what Stella itself claimed about the work the external grader then
+scored. It existed only as a `judge_verdict` event inside the multi-gigabyte
+Harbor job tree, which is never committed — so the agreement rate and the
+false-pass count were computable only while the run was still on the disk that
+produced it, and evaporated with it. The adapter now folds that verdict into
+trial metadata beside the witness observations it already recorded (#1007), and
+`score_dev_baseline.py extract` carries both into `trials.jsonl`. The evidence
+for this experiment is therefore reproducible from the run directory alone,
+which is the promise [`../README.md`](../README.md) makes about every number in
+here.

--- a/bench/evidence/witness-ab/preregistration.json
+++ b/bench/evidence/witness-ab/preregistration.json
@@ -1,0 +1,60 @@
+{
+  "schema": "stella-witness-ab-preregistration-v1",
+  "issue": "https://github.com/macanderson/stella/issues/1284",
+  "status": "plan_fixed_run_not_started",
+  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed: it needs a spend-capable credential and a host able to run the task images. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after.",
+  "plan_fixed_at": "2026-08-03",
+  "question": "Does an authored witness — a failing test written by a model independent of the worker — earn its cost, measured against the same task set run with that tier off?",
+  "design": "two arms, paired by task, one variable: STELLA_WITNESS_AUTHOR_MODEL unset (control) vs set to a second model on the worker's provider (treatment)",
+  "arms": {
+    "control": {
+      "assurance_arm": "witness-off",
+      "witness_author_model": null,
+      "authored_witness": "off — no author independent of the worker",
+      "model_judge": "on, same model as the worker"
+    },
+    "treatment": {
+      "assurance_arm": "witness-on",
+      "witness_author_model": "a second provider/model on the worker's provider, carried by Stella's offline seed catalog",
+      "authored_witness": "on",
+      "model_judge": "on, independent of the worker"
+    }
+  },
+  "shared": "same SUT commit and binary, same dataset digest, same task list, same budget cap, attempts=1, retries=0, same concurrency, same host",
+  "outcomes": {
+    "primary": "tasks passed, paired by task over the fixed denominator; reported as gained/lost/both/neither with an exact McNemar test over the discordant pairs",
+    "secondary": "trials whose own verdict claimed the work passed while the external grader scored it zero, overall and restricted to model-opined verdicts (self_verdict_deterministic=false)",
+    "cost": "total spend, treatment/control ratio, spend per additional task passed; wall clock reported but not treated as a time measurement while #960 keeps every trial at its agent timeout"
+  },
+  "analysis": {
+    "tool": "bench/evidence/compare_arms.py",
+    "reward_rule": "the external verifier's reward is authoritative; a trial that produced no reward scores 0 and stays in the denominator; a task absent from an arm scores 0 in that arm",
+    "bootstrap_seed": 20260803,
+    "bootstrap_draws": 50000,
+    "significance_alpha": 0.05,
+    "cost_ratio_ceiling": 1.5
+  },
+  "decision_rule": {
+    "reject": "the treatment arm loses more tasks than it gains at p < 0.05, OR wrong 'this passed' calls increase",
+    "adopt": "the treatment arm gains more tasks than it loses, AND that gain is significant at p < 0.05 or accompanied by fewer wrong 'this passed' calls, AND its spend is at most 1.5x the control arm",
+    "inconclusive": "anything else — the default does not change",
+    "adopted_means": "the witness arm becomes the default posture for benchmark runs"
+  },
+  "refusals": {
+    "not_one_experiment": "a trial that records no assurance arm, an arm whose trials disagree about which arm they ran, or two arms on different SUT commits or binaries",
+    "tier_never_fired": "the treatment arm authored no witness on any task — a posture that declares the rung is not a run that exercised it (#1147)"
+  },
+  "rules": "no reruns, no outcome-selected stops, no task excluded, no threshold moved after data; operational aborts are disclosed and relaunch under a new job name; failures published in the per-task table",
+  "to_be_recorded_before_the_first_paid_call": {
+    "prereg_url": null,
+    "registered_at": null,
+    "sut_commit": null,
+    "binary_sha256": null,
+    "dataset": null,
+    "worker_model": null,
+    "witness_author_model": null,
+    "taskset_sha256": null,
+    "denominator": null,
+    "budget_usd_per_trial": null
+  }
+}

--- a/bench/harbor_adapter/README.md
+++ b/bench/harbor_adapter/README.md
@@ -477,6 +477,16 @@ Every result exposes manifest-ready metadata keys:
   witness counters, which report what this trial's proof stream actually
   observed. Declared and observed are different claims, so both are recorded:
   a run must never disable a tier discoverably only by grepping trajectories.
+- `stella_self_verdict_state` (`passed` / `failed` / `not_reported`), plus
+  `self_verdict_passed`, `self_verdict_deterministic` and `self_verdict_count`
+  in `stella_stream` — **what Stella claimed about its own work** (#1284). The
+  trial is the only place that claim meets the verifier's reward, which the
+  agent never sees, and their disagreement (a task failed while reporting
+  success) is invisible to the score. `deterministic` distinguishes a verdict
+  the flip oracle decided from one a model opined; they are different
+  instruments and only the second is the judge's reliability.
+  `not_reported` is a third state on purpose: a trial killed before the ladder
+  closed made no claim, which is not the same datum as claiming failure.
 - `stella_workspace_git_baseline` — what the adapter did to the workspace
   before Stella started: `{"state": "created", "commit": <sha>}`,
   `preexisting`, `unavailable`, `failed`, `error`, or `not_attempted`. Also in

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -2067,6 +2067,16 @@ class StellaAgent(BaseInstalledAgent):
             if isinstance(stream_view, dict)
             else None
         ) or "not_reported"
+        # Stella's own verdict on its own work, as a top-level field for the
+        # same reason the witness state is one: the A/B this exists for (#1284)
+        # compares it against the external grader's reward, and a comparison
+        # that has to reach into a nested blob is one an analysis quietly skips.
+        # A trial with no stream made no claim — "not_reported", never "failed".
+        self_verdict_state = (
+            stream_view.get("self_verdict_state")
+            if isinstance(stream_view, dict)
+            else None
+        ) or "not_reported"
         # Absent (adapter predates install, or install never ran) is a real
         # state and must not be conflated with a step that ran and reported.
         workspace_git_baseline = getattr(
@@ -2125,6 +2135,7 @@ class StellaAgent(BaseInstalledAgent):
             "stella_assurance_tiers_sha256": assurance_tiers_sha256,
             "stella_witness_author_model": witness_author_model,
             "stella_witness_authored_state": witness_authored_state,
+            "stella_self_verdict_state": self_verdict_state,
             "stella_workspace_git_baseline": workspace_git_baseline,
         }
         if envelope is not None:

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -659,7 +659,8 @@ def fold_witness_observations(events: list[dict[str, Any]]) -> dict[str, Any]:
     warrant decided no test was warranted at all.
 
     Reads `{"type":"proof","step":{"kind":…}}` events, Stella's own account of
-    its verification ladder (`stella_protocol::ProofStep`). Before #1007 this
+    its verification ladder (`stella_protocol::ProofStep`), plus the
+    `{"type":"judge_verdict"}` event that closes the ladder. Before #1007 this
     lived only in the human-readable warning beside it, so "was the witness
     authored" was a question you answered by grepping trajectories.
 
@@ -667,13 +668,47 @@ def fold_witness_observations(events: list[dict[str, Any]]) -> dict[str, Any]:
     it could not author one; `None` means the stream never reached the question
     (an interrupted trial, or triage waiving assurance). Collapsing those into
     one boolean is how "not measured" starts reading as "measured and absent".
+
+    The verdict fields are the other half of the A/B question (#1284). A trial
+    carries two independent opinions about the same work — Stella's own
+    (`judge_verdict`) and the benchmark's external grader (`reward`, from the
+    verifier, which the agent never sees) — and the interesting number is how
+    often they disagree, in which direction. That comparison was only ever
+    computable from the multi-gigabyte job tree, which is never committed, so
+    it evaporated when the tree was deleted. Folding the verdict here puts it in
+    trial metadata, and `score_dev_baseline.py` carries it into the committed
+    `trials.jsonl` beside the reward it must be compared against.
+
+    `self_verdict_deterministic` is what keeps that comparison honest: a verdict
+    the flip oracle decided and a verdict a model opined are not the same claim,
+    and the model-judge-only rate is the one #1284 quotes.
     """
     proof_kinds: dict[str, int] = {}
     unavailable_reasons: list[str] = []
     warranted = 0
     assurance_planned: bool | None = None
+    verdict_count = 0
+    verdict_passed: bool | None = None
+    verdict_deterministic: bool | None = None
 
     for event in events:
+        if event.get("type") == "judge_verdict":
+            passed = event.get("passed")
+            if not isinstance(passed, bool):
+                continue  # a verdict that states no outcome is not one
+            verdict_count += 1
+            # Last verdict wins: a turn can revise a candidate and judge it
+            # again, and the claim the trial *ends* on is the one the external
+            # reward is a comment on.
+            verdict_passed = passed
+            evidence = event.get("evidence")
+            deterministic = (
+                evidence.get("deterministic") if isinstance(evidence, dict) else None
+            )
+            verdict_deterministic = (
+                deterministic if isinstance(deterministic, bool) else None
+            )
+            continue
         if event.get("type") != "proof":
             continue
         step = event.get("step")
@@ -720,4 +755,18 @@ def fold_witness_observations(events: list[dict[str, Any]]) -> dict[str, Any]:
         "witness_unavailable_reasons": unavailable_reasons,
         "witness_warranted_count": warranted,
         "assurance_witness_planned": assurance_planned,
+        # Same tri-state discipline as `witness_authored`: a trial that was
+        # killed before the ladder closed made no claim, and "made no claim"
+        # must not be scored as "claimed failure" in an agreement rate.
+        "self_verdict_passed": verdict_passed,
+        "self_verdict_state": (
+            "not_reported"
+            if verdict_passed is None
+            else ("passed" if verdict_passed else "failed")
+        ),
+        "self_verdict_deterministic": verdict_deterministic,
+        "self_verdict_count": verdict_count,
+        "verification_unavailable_count": proof_kinds.get(
+            "verification_unavailable", 0
+        ),
     }

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -728,6 +728,104 @@ class TestWitnessStreamObservation:
         assert envelope["_stella_stream"]["proof_step_counts"] == {}
 
 
+class TestSelfVerdictStreamObservation:
+    """What Stella claimed about its own work, beside what it was graded.
+
+    The A/B in #1284 turns on comparing the two. Stella's claim is a
+    `judge_verdict` event and the grade is the verifier's reward, which the
+    agent never sees — so a trial is the only place they meet, and the event
+    stream is the only place the claim exists.
+    """
+
+    @staticmethod
+    def _stream(*events: dict) -> dict:
+        envelope = _stream_to_envelope(
+            "\n".join(json.dumps(event) for event in events), process_returned=True
+        )
+        assert envelope is not None
+        return envelope["_stella_stream"]
+
+    def test_a_model_opinion_and_a_flip_oracle_are_told_apart(self) -> None:
+        """`deterministic` is the difference between two instruments.
+
+        #1284 measures the *judge's* agreement with the official grader.
+        Folding an oracle verdict in under the same name reports the ladder's
+        aggregate as the judge's reliability.
+        """
+        opinion = self._stream(
+            {
+                "type": "judge_verdict",
+                "passed": True,
+                "evidence": {"summary": "looks right", "deterministic": False},
+            },
+            {"type": "complete", "status": "completed", "cost_usd": 0.5},
+        )
+        assert opinion["self_verdict_passed"] is True
+        assert opinion["self_verdict_state"] == "passed"
+        assert opinion["self_verdict_deterministic"] is False
+
+        oracle = self._stream(
+            {
+                "type": "judge_verdict",
+                "passed": True,
+                "evidence": {
+                    "summary": "flip oracle: fail→pass on `pytest -q`",
+                    "deterministic": True,
+                },
+            },
+            {"type": "complete", "status": "completed", "cost_usd": 0.5},
+        )
+        assert oracle["self_verdict_deterministic"] is True
+
+    def test_the_last_verdict_is_the_one_the_trial_ended_on(self) -> None:
+        """A revised candidate is judged again; the reward grades the last one."""
+        stream = self._stream(
+            {
+                "type": "judge_verdict",
+                "passed": False,
+                "evidence": {"summary": "test still red", "deterministic": True},
+            },
+            {
+                "type": "judge_verdict",
+                "passed": True,
+                "evidence": {"summary": "flip observed", "deterministic": True},
+            },
+            {"type": "complete", "status": "completed", "cost_usd": 0.5},
+        )
+        assert stream["self_verdict_passed"] is True
+        assert stream["self_verdict_count"] == 2
+
+    def test_a_trial_that_closed_no_verdict_claimed_nothing(self) -> None:
+        """Silence is not a failed verdict.
+
+        An interrupted trial made no claim about its work, and scoring that as
+        a truthful "it failed" credits the agent with honesty it never showed —
+        on exactly the trials most likely to be re-read.
+        """
+        stream = self._stream(
+            {"type": "complete", "status": "completed", "cost_usd": 0.5}
+        )
+        assert stream["self_verdict_passed"] is None
+        assert stream["self_verdict_state"] == "not_reported"
+        assert stream["self_verdict_deterministic"] is None
+        assert stream["self_verdict_count"] == 0
+
+    def test_an_abstention_is_counted_and_is_not_a_verdict(self) -> None:
+        """#973: every evidence channel blind is a stated outcome of its own."""
+        stream = self._stream(
+            {
+                "type": "proof",
+                "step": {
+                    "kind": "verification_unavailable",
+                    "reason": "no oracle, no test result, unreadable tree",
+                },
+            },
+            {"type": "complete", "status": "completed", "cost_usd": 0.5},
+        )
+        assert stream["verification_unavailable_count"] == 1
+        assert stream["self_verdict_state"] == "not_reported"
+
+
 class TestWitnessArmEndToEnd:
     """Env knob -> posture -> container -> trial metadata."""
 
@@ -830,6 +928,11 @@ class TestWitnessArmEndToEnd:
                 "type": "proof",
                 "step": {"kind": "witness_unavailable", "reason": reason},
             },
+            {
+                "type": "judge_verdict",
+                "passed": True,
+                "evidence": {"summary": "reads correct", "deterministic": False},
+            },
             {"type": "complete", "status": "completed", "cost_usd": 0.42},
         ]
         (tmp_path / "stella-events.jsonl").write_text(
@@ -861,6 +964,12 @@ class TestWitnessArmEndToEnd:
         assert context.metadata["stella_stream"]["witness_unavailable_reasons"] == [
             reason
         ]
+        # The control arm's whole shape, in one trial: no witness could be
+        # authored, and a model judge — the worker's own model — declared the
+        # work done anyway. Whether the grader agreed is the comparison #1284
+        # runs, and it needs this field to be a field.
+        assert context.metadata["stella_self_verdict_state"] == "passed"
+        assert context.metadata["stella_stream"]["self_verdict_deterministic"] is False
 
 
 _CATALOG_RS = (

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2272 bench/harbor_adapter/stella_harbor/__init__.py
+2283 bench/harbor_adapter/stella_harbor/__init__.py
 4277 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2150 bench/harbor_adapter/tests/test_adapter.py
 3230 bench/harbor_adapter/tests/test_secure_launcher.py


### PR DESCRIPTION
## What & why

#1284 asks for two runs — the same task set with the independent checker off, then on — and a plain statement of whether the checker is worth its cost. It says nothing remains to build. That is true of the *run*: `STELLA_WITNESS_AUTHOR_MODEL` has existed since #1007 and task folders got a git baseline in #1225.

It was not true of the *measurement*. Two gaps, both of which would have been discovered after spending:

1. **The secondary outcome was not recoverable from committed evidence.** "How many wrong 'this passed' calls disappear" needs Stella's own verdict beside the external grader's reward. That verdict existed only as a `judge_verdict` event inside the multi-gigabyte Harbor job tree, which is never committed — so the false-pass count was computable only while the run was still on the disk that produced it, and evaporated with it.
2. **Nothing turned two runs into an answer.** No pairing, no decision rule, and nothing that could tell a treatment arm which *declared* the witness tier from one that *exercised* it — which is #1147 exactly, and is detectable only from the run's own proof stream.

This PR closes both, plus the runner and the preregistration, so the run is one command per arm and one command to score.

**The run itself has not been executed.** It needs a spend-capable credential and a host that can run 89 Docker task images; this environment has neither, and it costs real money on the maintainer's account. Everything up to the credential is in the tree. `Refs #1284` rather than `Closes` for that reason.

### Changes

| area | change |
|---|---|
| `stella_harbor/posture.py` | fold `judge_verdict` into the stream summary beside the witness observations #1007 already recorded: `self_verdict_passed`, `self_verdict_deterministic`, `self_verdict_count`, `verification_unavailable_count`. Tri-state — a trial killed before the ladder closed made no claim, which is not the same datum as claiming failure. `deterministic` separates a flip-oracle verdict from a model opinion; only the second is the judge's reliability |
| `stella_harbor/__init__.py` | surface `stella_self_verdict_state` as trial metadata, beside `stella_witness_authored_state` |
| `score_dev_baseline.py` | `extract` carries the verdict, the witness author and the witness observations into `trials.jsonl`, so a run's honesty is recomputable from the committed run directory like its score |
| `compare_arms.py` (new) | pair two arms by task; report gained/lost with an exact McNemar test, a paired bootstrap interval, false passes fixed and introduced **by name**, and spend per additional task passed; apply the preregistered decision rule |
| `run/witness_ab.sh` (new) | one arm per invocation, arm named as an argument rather than read from ambient state, task list digest pinned across both arms, unusable author refused on the host before a container exists |
| `make_manifest.py` | refuse a `--witness-author` that contradicts the arm the trials recorded |
| `run/sentinel.sh` | report the arm, author, witness state and self-verdict — one paid trial is the cheapest check that the rung fires before 89 depend on it |
| `witness-ab/` (new) | protocol, preregistered analysis plan, decision rule, and the exact commands |
| `bench.yml` | run `bench/evidence/tests` in CI |

### Two refusals, before any number is allowed to mean something

`compare_arms.py` exits non-zero with `"verdict": "refused"` (numbers still printed — a refusal nobody can check is not one) when the two files are not the two arms of one experiment (missing arm labels, the same arm twice, different SUT commits or binaries), or when the treatment arm authored no witness on any task.

### The decision rule, fixed before any data exists

* **Reject** if the arm loses more tasks than it gains at p < 0.05, or if wrong "this passed" calls increase.
* **Adopt** (the witness arm becomes the benchmark default) if it gains more tasks than it loses, that gain is significant or accompanied by fewer wrong "passed" calls, and it costs at most 1.5× the control arm.
* **Inconclusive** otherwise — which changes nothing, and says so.

Encoded in `decide()` and stated in `witness-ab/README.md` and `preregistration.json`.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`bench/evidence/tests/test_compare_arms.py` is new (28 tests) and fails on `main` — `compare_arms.py` does not exist there. The two that carry the most weight are `test_a_treatment_arm_that_never_authored_a_witness_is_refused` and `test_a_refused_comparison_never_reaches_a_verdict`: no input that fails a refusal may reach adopt/reject/inconclusive. `test_a_wrong_this_passed_call_is_counted_and_named` and `test_a_flip_oracle_verdict_is_not_counted_as_a_model_opinion` cover the secondary outcome; `TestSelfVerdictStreamObservation` (4 tests) covers the adapter-side fold, and both new `extract` tests fail on `main` because the fields are absent.

## The gate

- [x] `harbor_adapter` pytest — 413 passed, 1 skipped
- [x] `bench/evidence/tests` pytest — 56 passed (28 new)
- [x] `telemetry_store` + `frontier` pytest — 93 passed
- [x] Docs updated: `bench/evidence/README.md`, `bench/evidence/run/README.md`, `bench/harbor_adapter/README.md` (metadata contract), `bench/READINESS.md` §9
- [ ] Rust gates not run — this PR touches no Rust

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (both new Python files are standard-library only, which is what keeps a published score recomputable without the harness installed)
- [x] No new outbound network calls

## Anything reviewers should know?

**`make file-size` is red on `main`, independently of this PR.** `stella-graph/src/store.rs` is 1,632 lines against the 1,500-line limit and is not grandfathered — it crossed in #1313 (`4a0323f`), one commit before this branch's base. This PR does not touch it. The one baseline line it does change (`stella_harbor/__init__.py`, 2272 → 2283) is the visible, reviewable diff the guard asks for; the +11 lines are the new metadata field and its comment.

**Two judgement calls worth challenging:**

* *The cost ceiling is 1.5×.* Chosen before the data, which is the property that matters, but the number itself is a preference. If it should be 2×, change it now — changing it after the run is not a decision rule.
* *Wall clock is reported but not treated as a time measurement.* While #960 stands, Stella's headless process does not exit after its turn, so Harbor kills it at the agent timeout and every such trial burns the full timeout regardless of the work. The comparison says so in `wall_clock_note`, with the timeout count per arm.

**One thing the run must confirm that this PR cannot.** `openrouter` is a deliberately unseeded provider, so slug validation there is permissive and an author that does not resolve is not caught before the call. The seed catalog carries `moonshotai/kimi-k3` and the three `anthropic/*` gateway rows for that route — an author without a row runs against engine defaults for window, ceiling and pricing, which is a poor position to measure a cost question from. `witness-ab/README.md` says to prefer an author the seed carries and to confirm `arm=witness-on` on the sentinel before committing to 89 tasks.

---

## Summary by Sourcery

Add tooling, metadata, and documentation to support running and analyzing an authored-witness A/B experiment, including pairing control and treatment runs and enforcing correctness and reproducibility constraints.

New Features:
- Introduce a compare_arms tool to pair control and treatment runs and compute outcome, honesty, and cost metrics for the authored-witness A/B experiment.
- Add a witness_ab.sh runner and witness-ab protocol directory to run each A/B arm over a pinned task set with a preregistered analysis and decision rule.

Enhancements:
- Record Stella self-verdict and verification ladder observations in trial metadata and propagate them into trials.jsonl for reproducible honesty analysis.
- Tighten manifest creation by refusing mismatched assurance arms and witness authors, and extend sentinel output with assurance and witness state for cheap pre-run checks.
- Document the authored-witness A/B procedure, outcomes, and decision rule, and extend bench evidence documentation to cover the new comparison tooling.

CI:
- Update bench CI workflow to run bench/evidence tests when evidence tooling or configs change.

Tests:
- Add comprehensive tests for the compare_arms A/B comparison, self-verdict folding, evidence extraction, and manifest arm-author validation.
