### PR TITLE
feat(stella-serve): connect hooks and cost-drift reporting in the server (#1298)

### DIFF
--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -58,6 +58,7 @@ not in this table is a 404.
 | `GET` | `/healthz` | Unauthenticated. Liveness — is the process alive. `{"status":"ok"}` |
 | `GET` | `/readyz` | Unauthenticated. Readiness — is it safe to send new work. `200 {"state":"ready"}`, or `503` with `"starting"` / `"draining"` (#1131) |
 | `GET` | `/v1/metrics` | Counters as a flat JSON object of integers. Authenticated like every other route, and **pull-only** — see [serve-observability.md](./serve-observability.md) |
+| `GET` | `/v1/calibration` | Token-drift report (#1298): `{"models":[{provider_id, model, samples, estimated_input_tokens, actual_input_tokens, drift_ratio, applied_factor}]}` — what the engine estimated against what the provider billed. Read-only and authenticated, same reasoning as `/v1/metrics`. Empty `models` before any turn has committed a step. State is process memory keyed by `(provider_id, model)`; nothing is persisted, so a redeployed sidecar re-converges — which is why every row carries `samples` |
 | `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}`. Optional `engine` object (#1167) carries per-turn caller-policy knobs (`max_output_tokens`, `temperature`, `effort`, `reasoning`, `params`, `compaction_budget_tokens`, `summarize_overflow`, `summarize_keep_recent`) lowered onto the defaults — omitted/empty is a no-op; unusable values are 400s naming the knob; values past an operator ceiling are clamped and reported in the response's `clamped` array (`{knob, requested, effective}`, absent when nothing was lowered). `retry_policy`/`loop_detection` are operator policy and not settable |
 | `GET` | `/v1/turns/{id}/events` | SSE `id: <seq>` + `data: <ServerFrame>`. Resumable via `?after=<seq>` or `Last-Event-ID`. One concurrent subscriber; a second gets 409 |
 | `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |
@@ -128,6 +129,51 @@ replay the retained stream to rediscover what it owes.
 Also: the tool surface is selected by the `STELLA_SERVE_TOOLS=remote`
 environment variable, not a `--tools remote` flag — the binary parses no flags
 beyond `healthcheck`, `--version` and `--help`.
+
+## Hooks — who may register one (#1298)
+
+A served turn crosses the same boundaries a local one does, and an operator can
+now observe and intervene at them. **Only an operator can.**
+
+`stella-core` ships two hook systems and the sidecar attaches exactly one:
+
+- `stella_core::hooks`, the settings-declared **shell command** engine, is
+  deliberately unreachable from `stella-serve`. The containment posture below
+  is that the engine holds no ambient authority — every model and tool call is
+  remoted to the host. A hook system that spawned shells inside the sidecar
+  would hand back through a side door precisely the local execution the front
+  door refuses.
+- `stella_core::bus`, the **in-process** hook bus, is what a turn attaches, via
+  the `ServeExtension` trait.
+
+A `ServeExtension` is Rust code compiled into whatever binary calls
+`stella_serve::serve`, installed on `ServeConfig::extensions` before the
+listener binds. **No route registers, uploads, names or configures one**, and
+adding such a route would be a security change rather than a feature: the
+bearer token authenticates a *host*, not the operator, and a host that could
+install a handler could read every tool call's raw input — file contents and
+shell command lines included — and `Deny` its way into steering the engine.
+`stella-serve/tests/hooks.rs` pins that rule as a sweep over the route table,
+so the reversal fails a test rather than passing review.
+
+What an extension may do follows the bus's own split:
+
+| Kind | Registered with | Power |
+|---|---|---|
+| Observer | `HookBus::on` | Watches `agent.turn.*`, `agent.step.*`, `model.request.*`, `tool.call.*`, `policy.*`. Cannot veto, delay or fail the turn; a handler that errors is isolated, and one that keeps overrunning its latency budget is quarantined |
+| Policy | `HookBus::on_blocking` | Runs on `tool.call.requested` **before** the `tool_request` frame leaves. May `Deny` (the model sees a named error; the host is never asked), `RequireApproval`, or `Modify` the input the host is asked to run |
+
+The bus is minted per turn and dropped with it, keyed on the truncated
+`TurnRef` — so the hook plane inherits the record plane's posture: enough to
+correlate a turn, never enough to address one. A deployment that installs no
+extensions mints no bus at all, and every engine emit site stays behind its
+`if let Some(bus)`, so the shipping binary's behavior is unchanged.
+
+The turn boundaries are worth one note. `stella-serve` drives `run_step`
+itself rather than calling `run_turn`, so `agent.turn.started` /
+`agent.turn.completed` are framing this crate owns — it emits them through
+`run_turn`'s own payload shapers (`stella_core::driver::lifecycle`) so the two
+drivers cannot describe the same boundary differently.
 
 ## Durability — what a served turn survives (#1198)
 

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -89,7 +89,7 @@ use crate::compaction::compact_measured;
 use crate::receipts::TranscriptRevision;
 use lifecycle::{step_outcome_label, turn_outcome_payload};
 
-mod lifecycle;
+pub mod lifecycle;
 mod loop_evidence;
 mod truncation;
 use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
@@ -612,6 +612,19 @@ impl<'a> Engine<'a> {
 
     /// Attribute this engine's provider calls to a concrete pipeline role.
     /// Ordinary execution defaults to [`stella_protocol::ModelCallRole::Worker`].
+    /// The role this engine attributes its model calls to — the reader for
+    /// [`Engine::with_call_role`].
+    ///
+    /// Public because a host that drives [`Engine::run_step`] itself owns the
+    /// turn framing (`stella-serve`), and the `agent.turn.started` payload
+    /// names the role. Without this the host would have to keep its own copy
+    /// of the engine's default, which is a second source of truth for a value
+    /// it does not own.
+    #[must_use]
+    pub fn call_role(&self) -> stella_protocol::ModelCallRole {
+        self.call_role
+    }
+
     pub fn with_call_role(mut self, role: stella_protocol::ModelCallRole) -> Self {
         self.call_role = role;
         self
@@ -817,11 +830,7 @@ impl<'a> Engine<'a> {
             name: StageKind::Execute,
         });
         self.emit_lifecycle(bus::names::AGENT_TURN_STARTED, || {
-            serde_json::json!({
-                "message_count": messages.len(),
-                "max_steps": self.config.max_steps,
-                "role": self.call_role,
-            })
+            lifecycle::turn_started_payload(messages.len(), self.config.max_steps, self.call_role)
         });
         // The turn's state is OWNED for the duration and written back to the
         // caller's borrows when it drops — including on the hard-cancel path,
@@ -1139,17 +1148,12 @@ impl<'a> Engine<'a> {
         // than each attempt — a retried call is one request from an
         // observer's point of view, and the retries are already reported as
         // their own `AgentEvent`s.
-        //
-        // Payload hygiene: counts and identifiers, never transcript content.
-        // A message count says how large the request was without saying what
-        // was in it, which is what an observer applying policy at this
-        // boundary actually needs.
         self.emit_lifecycle(bus::names::MODEL_REQUEST_STARTED, || {
-            serde_json::json!({
-                "step": state.step,
-                "message_count": state.messages.len(),
-                "role": self.call_role,
-            })
+            lifecycle::model_request_started_payload(
+                state.step,
+                state.messages.len(),
+                self.call_role,
+            )
         });
         // Wall clock around the whole call including its retries, because that
         // is what a continuation would actually cost again — not the duration
@@ -1184,14 +1188,7 @@ impl<'a> Engine<'a> {
             }
         };
         self.emit_lifecycle(bus::names::MODEL_REQUEST_COMPLETED, || {
-            serde_json::json!({
-                "step": state.step,
-                "model": committed.result.model,
-                "cost_usd": committed.result.cost_usd,
-                "input_tokens": committed.result.usage.input_tokens,
-                "output_tokens": committed.result.usage.output_tokens,
-                "tool_calls": committed.result.tool_calls.len(),
-            })
+            lifecycle::model_request_completed_payload(state.step, &committed.result)
         });
         state.last_step = Some(step_started.elapsed());
         state.calibration_model = Some(committed.result.model.clone());

--- a/stella-core/src/driver/lifecycle.rs
+++ b/stella-core/src/driver/lifecycle.rs
@@ -21,8 +21,68 @@
 //! free-text field anywhere here is an abort `reason`, which is the engine's
 //! own diagnosis of why a turn ended and already reaches `AgentEvent::Error`
 //! and the transcript.
+//!
+//! # Why the turn-boundary shapers are public
+//!
+//! `Engine::run_turn_with_sender` is not the only turn driver: a durable host
+//! loops over [`Engine::run_step`](super::Engine::run_step) itself, and owns
+//! the turn framing that loop does not carry ("The step-scoped facade" in
+//! `stella-engine`). `stella-serve` is that host. Its turn therefore has to
+//! emit the same two boundary events with the same payload shape, or an
+//! extension watching the bus can tell a served turn from a local one — which
+//! is precisely the drift the shared `run_step` exists to prevent. Sharing the
+//! shaper is what keeps it one contract rather than two spellings of one.
 
 use super::{StepOutcome, TurnOutcome};
+
+/// What `agent.turn.started` carries: how much conversation the turn opened
+/// with, the loop bound it runs under, and which role is driving it. No
+/// message *content* — see the module docs.
+pub fn turn_started_payload(
+    message_count: usize,
+    max_steps: usize,
+    role: stella_protocol::ModelCallRole,
+) -> serde_json::Value {
+    serde_json::json!({
+        "message_count": message_count,
+        "max_steps": max_steps,
+        "role": role,
+    })
+}
+
+/// What `model.request.started` carries.
+///
+/// A message *count* says how large the request was without saying what was in
+/// it, which is what an observer applying policy at this boundary actually
+/// needs.
+pub(super) fn model_request_started_payload(
+    step: usize,
+    message_count: usize,
+    role: stella_protocol::ModelCallRole,
+) -> serde_json::Value {
+    serde_json::json!({
+        "step": step,
+        "message_count": message_count,
+        "role": role,
+    })
+}
+
+/// What `model.request.completed` carries: the model that served the call and
+/// what it cost, in tokens and dollars. Tool calls are *counted*, never named
+/// — the names and their arguments are the tool plane's own events.
+pub(super) fn model_request_completed_payload(
+    step: usize,
+    result: &stella_protocol::CompletionResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "step": step,
+        "model": result.model,
+        "cost_usd": result.cost_usd,
+        "input_tokens": result.usage.input_tokens,
+        "output_tokens": result.usage.output_tokens,
+        "tool_calls": result.tool_calls.len(),
+    })
+}
 
 /// What `agent.turn.completed` carries.
 ///
@@ -30,7 +90,7 @@ use super::{StepOutcome, TurnOutcome};
 /// text is transcript content and has no business on an observability event,
 /// while an abort reason is the engine's own diagnosis and is what an
 /// observer is watching this boundary for.
-pub(super) fn turn_outcome_payload(outcome: &TurnOutcome, steps: usize) -> serde_json::Value {
+pub fn turn_outcome_payload(outcome: &TurnOutcome, steps: usize) -> serde_json::Value {
     match outcome {
         TurnOutcome::Completed { cost_usd, .. } => serde_json::json!({
             "outcome": "completed",

--- a/stella-core/src/estimator.rs
+++ b/stella-core/src/estimator.rs
@@ -196,6 +196,17 @@ const CALIBRATION_SAMPLE_MAX_RATIO: f64 = CALIBRATION_MAX_FACTOR * 2.0;
 pub struct Calibration {
     ratio_ewma: f64,
     samples: u32,
+    /// Sum of the raw pre-call estimates behind `samples`, unclamped.
+    ///
+    /// Kept alongside the EWMA rather than derived from it because they answer
+    /// different questions. The EWMA is what *corrects* the next estimate, and
+    /// it is deliberately smoothed and clamped so one bad sample cannot steer
+    /// budgeting; these totals are what *reports* the gap, and a report that
+    /// inherited the clamp would understate exactly the drift it exists to
+    /// surface. See [`CalibrationMap::report`].
+    estimated_total: u64,
+    /// Sum of the provider-reported actuals behind `samples`, unclamped.
+    actual_total: u64,
 }
 
 impl Default for Calibration {
@@ -210,6 +221,8 @@ impl Calibration {
         Self {
             ratio_ewma: 1.0,
             samples: 0,
+            estimated_total: 0,
+            actual_total: 0,
         }
     }
 
@@ -235,11 +248,41 @@ impl Calibration {
                 CALIBRATION_ALPHA * ratio + (1.0 - CALIBRATION_ALPHA) * self.ratio_ewma;
         }
         self.samples += 1;
+        // The RAW pair, before the clamp above: the report's whole job is to
+        // say how far the estimate is from the bill, and a truncated sample
+        // would make a catastrophic tokenizer mismatch read as a mild one.
+        self.estimated_total = self.estimated_total.saturating_add(estimated);
+        self.actual_total = self.actual_total.saturating_add(actual);
     }
 
     /// How many samples have been recorded.
     pub fn samples(&self) -> u32 {
         self.samples
+    }
+
+    /// Total raw estimated input tokens across every recorded sample.
+    pub fn estimated_total(&self) -> u64 {
+        self.estimated_total
+    }
+
+    /// Total provider-reported input tokens across every recorded sample.
+    pub fn actual_total(&self) -> u64 {
+        self.actual_total
+    }
+
+    /// Observed drift over the whole sample history: `actual / estimated`,
+    /// unsmoothed and unclamped. `1.0` with no samples (nothing observed is
+    /// reported as no drift, never as a division by zero).
+    ///
+    /// Distinct from [`Calibration::factor`] on purpose. `factor` is the
+    /// number the engine multiplies by — smoothed, bounded, and exactly 1.0
+    /// until enough samples exist. This is the number a *human* reads: the
+    /// measured gap, whatever it is.
+    pub fn drift_ratio(&self) -> f64 {
+        if self.estimated_total == 0 {
+            return 1.0;
+        }
+        self.actual_total as f64 / self.estimated_total as f64
     }
 
     /// The correction factor to multiply a raw estimate by: exactly 1.0
@@ -322,6 +365,33 @@ impl CalibrationMap {
         }
     }
 
+    /// Every model's observed drift, sorted by model id.
+    ///
+    /// The read half of the loop `record` feeds: an operator (or a host
+    /// reading it through an API) can see how far Stella's own estimate is
+    /// from what the provider actually billed, per model, instead of
+    /// believing the estimate until the invoice disagrees.
+    ///
+    /// Sorted rather than in `HashMap` order so two consecutive reads of an
+    /// unchanged map are byte-identical — a report that reshuffles itself
+    /// every call is unusable for diffing and untestable.
+    pub fn report(&self) -> Vec<ModelDrift> {
+        let inner = self.lock();
+        let mut rows: Vec<ModelDrift> = inner
+            .iter()
+            .map(|(model, calibration)| ModelDrift {
+                model: model.clone(),
+                samples: calibration.samples(),
+                estimated_input_tokens: calibration.estimated_total(),
+                actual_input_tokens: calibration.actual_total(),
+                drift_ratio: calibration.drift_ratio(),
+                applied_factor: calibration.factor(),
+            })
+            .collect();
+        rows.sort_by(|a, b| a.model.cmp(&b.model));
+        rows
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, Calibration>> {
         // Poisoning means a panic mid-record; the state is a plain f64+u32
         // pair that cannot be left torn — keep calibrating.
@@ -329,6 +399,34 @@ impl CalibrationMap {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
+}
+
+/// One model's cost-drift row — what [`CalibrationMap::report`] hands back.
+///
+/// Counts and identifiers only. Nothing here is derived from transcript
+/// content, so a host may publish it (`stella-serve` does, at
+/// `GET /v1/calibration`) without opening a second exposure path for the
+/// conversation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelDrift {
+    /// The model string the provider reported on the results behind this row.
+    pub model: String,
+    /// Samples recorded. Below the minimum the correction needs (three),
+    /// `applied_factor` is still exactly 1.0 — the drift is measured but
+    /// deliberately not yet acted on.
+    pub samples: u32,
+    /// Raw estimated input tokens summed across those samples.
+    pub estimated_input_tokens: u64,
+    /// Provider-reported input tokens (fresh + cache reads + cache writes)
+    /// summed across the same samples.
+    pub actual_input_tokens: u64,
+    /// `actual / estimated` over the whole history — the gap itself.
+    /// Above 1.0 means Stella under-estimated what the provider billed.
+    pub drift_ratio: f64,
+    /// The bounded correction currently multiplied into estimates
+    /// ([`Calibration::factor`]), which is *not* `drift_ratio`: it is smoothed,
+    /// clamped, and 1.0 until enough samples exist.
+    pub applied_factor: f64,
 }
 
 #[cfg(test)]
@@ -587,5 +685,84 @@ mod tests {
             1.0,
             "two entries and no model named: never guess"
         );
+    }
+
+    // ---- Drift reporting ---------------------------------------------------
+
+    /// The report is the read half of the calibration loop: it must say what
+    /// was estimated, what was billed, and the gap — per model, sorted, and
+    /// from the RAW pairs rather than the clamped EWMA the engine budgets on.
+    #[test]
+    fn the_report_names_every_model_and_its_measured_gap() {
+        let map = CalibrationMap::new();
+        map.seed("zeta-1", &[(1000, 1500), (1000, 1500), (1000, 1500)]);
+        map.record("alpha-1", 2000, 1000);
+
+        let report = map.report();
+        assert_eq!(
+            report.iter().map(|r| r.model.as_str()).collect::<Vec<_>>(),
+            ["alpha-1", "zeta-1"],
+            "rows are sorted by model, so two reads of an unchanged map match"
+        );
+
+        let zeta = &report[1];
+        assert_eq!(zeta.samples, 3);
+        assert_eq!(zeta.estimated_input_tokens, 3000);
+        assert_eq!(zeta.actual_input_tokens, 4500);
+        assert!((zeta.drift_ratio - 1.5).abs() < 1e-9);
+        assert!(
+            (zeta.applied_factor - 1.5).abs() < 1e-9,
+            "three samples is the minimum, so the correction is live"
+        );
+
+        let alpha = &report[0];
+        assert_eq!(alpha.samples, 1);
+        assert!(
+            (alpha.drift_ratio - 0.5).abs() < 1e-9,
+            "the gap is measured…"
+        );
+        assert_eq!(
+            alpha.applied_factor, 1.0,
+            "…while one sample is still below the minimum to act on it"
+        );
+    }
+
+    /// The reported gap must not inherit the sample clamp. The clamp exists so
+    /// one absurd pair cannot steer budgeting; a *report* that hid the same
+    /// pair would understate exactly the tokenizer mismatch it exists to
+    /// surface.
+    #[test]
+    fn the_report_shows_the_raw_gap_not_the_clamped_one() {
+        let map = CalibrationMap::new();
+        // 100x drift — far past CALIBRATION_SAMPLE_MAX_RATIO (4.0).
+        map.record("wild-1", 1_000, 100_000);
+        let row = &map.report()[0];
+        assert_eq!(row.estimated_input_tokens, 1_000);
+        assert_eq!(row.actual_input_tokens, 100_000);
+        assert!(
+            (row.drift_ratio - 100.0).abs() < 1e-9,
+            "the report must show 100x, not the 4x the EWMA was allowed to see"
+        );
+        assert!(
+            row.applied_factor <= CALIBRATION_MAX_FACTOR,
+            "…while the applied correction stays bounded"
+        );
+    }
+
+    /// A model whose pairs were all zero-sided recorded nothing, so it must
+    /// not appear as a row claiming zero drift over zero tokens.
+    #[test]
+    fn an_empty_map_reports_nothing() {
+        let map = CalibrationMap::new();
+        assert!(map.report().is_empty());
+        map.record("silent-1", 0, 0);
+        assert_eq!(
+            map.report().len(),
+            1,
+            "the model was seen, so it is listed…"
+        );
+        let row = &map.report()[0];
+        assert_eq!(row.samples, 0);
+        assert_eq!(row.drift_ratio, 1.0, "…with no drift claimed from no data");
     }
 }

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -99,6 +99,11 @@ pub struct Capability {
 pub const COMPOSITION_SEAMS: &[&str] = &[
     "with_sleeper",
     "with_call_role",
+    // The reader for `with_call_role`, and an assembly detail for the same
+    // reason the setter is: a host that drives `run_step` itself owns the turn
+    // framing, and the `agent.turn.started` payload names the role — so it
+    // reads the engine's rather than keeping a second copy of the default.
+    "call_role",
     "with_turn_instance",
     "max_steps",
 ];
@@ -356,12 +361,14 @@ pub static CAPABILITIES: &[Capability] = &[
             missing: "a CLI-side test pinning that a configured workspace hook actually fires \
                       through agent wiring (core has hook tests; the CLI wiring has none)",
         },
-        api: SurfacePosture::Deferred {
-            waiting_on: "attaching the HookBus in serve's session assembly: shell hooks are \
-                         deliberately not run server-side (a host must not be able to make the \
-                         sidecar spawn shells), and with_bus is the server-shaped observer seam \
-                         built for exactly this — but serve never attaches it, so an API host \
-                         gets no lifecycle boundary events",
+        api: SurfacePosture::Shipped {
+            mechanism: "operator-installed ServeExtensions on a per-turn HookBus (#1298): \
+                        turn/step/model boundaries observable, tool.call.requested \
+                        interceptable before the reverse request leaves. Shell hooks stay \
+                        deliberately unreachable server-side (a host must not be able to make \
+                        the sidecar spawn shells) and NO route registers an extension — the \
+                        bearer token authenticates a host, which is not the operator",
+            witness: "operator_hooks_fire_across_a_served_turn",
         },
     },
     Capability {
@@ -388,9 +395,12 @@ pub static CAPABILITIES: &[Capability] = &[
                       calibration on session start (stella-core and stella-store each test their \
                       half; the CLI seam between them has no witness)",
         },
-        api: SurfacePosture::Deferred {
-            waiting_on: "serve attaching a CalibrationMap (and somewhere to persist samples — \
-                         serve deliberately has no store): every served turn estimates uncorrected",
+        api: SurfacePosture::Shipped {
+            mechanism: "a process-lifetime CalibrationMap per provider_id, fed by every \
+                        committed step and read at GET /v1/calibration (#1298). Samples are \
+                        not persisted — serve deliberately has no store — so a redeployed \
+                        sidecar re-converges, which is why the report carries `samples`",
+            witness: "the_drift_report_is_readable_through_the_api",
         },
     },
     Capability {
@@ -508,10 +518,12 @@ mod tests {
 
     /// API sources a witness may live in: the serve crate's unit tests plus
     /// its end-to-end suites.
-    fn api_sources() -> [&'static str; 10] {
+    fn api_sources() -> [&'static str; 12] {
         [
             include_str!("../../stella-serve/src/server.rs"),
+            include_str!("../../stella-serve/tests/calibration.rs"),
             include_str!("../../stella-serve/tests/checkpoint.rs"),
+            include_str!("../../stella-serve/tests/hooks.rs"),
             include_str!("../../stella-serve/tests/bridge.rs"),
             include_str!("../../stella-serve/tests/control.rs"),
             include_str!("../../stella-serve/tests/sessions.rs"),

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -56,7 +56,9 @@ host  ──POST /v1/turns──►  stella-serve  ──►  Session (dedicated
 | [`src/pending.rs`](src/pending.rs) | `Pending`, the `request_id` → one-shot registry shared across the two runtimes. Open it when a resolve POST returns 409. |
 | [`src/frame.rs`](src/frame.rs) | The wire vocabulary: `ServerFrame`, `TurnOutcomeWire`, `ToolResultIn`, `ProviderResultIn`, `ProviderErrorWire`. Every wire-shape change starts here. |
 | [`src/server.rs`](src/server.rs) | `serve` — accept loop, bearer auth, the connection fold (one record per connection), route classification, the turn registry, and a rustdoc list of the operational limits the deployment must supply. |
-| [`src/routes.rs`](src/routes.rs) | The endpoint handlers and the wire types they parse — the five `/v1/turns` routes (including `cancel`), `/healthz`, `/v1/metrics`, and the host-supplied ceilings (`max_steps`, `reverse_request_timeout_ms`). |
+| [`src/routes.rs`](src/routes.rs) | The endpoint handlers and the wire types they parse — the five `/v1/turns` routes (including `cancel`), `/healthz`, `/v1/metrics`, `/v1/calibration`, and the host-supplied ceilings (`max_steps`, `reverse_request_timeout_ms`). |
+| [`src/extensions.rs`](src/extensions.rs) | `ServeExtension` — the operator's per-turn hook plane (#1298), and the argument for why registration is operator-only and no route reaches it. |
+| [`src/calibration.rs`](src/calibration.rs) | The per-provider token-drift state and the `GET /v1/calibration` body: what the engine estimated against what the provider billed. |
 | [`src/observe/`](src/observe/) | Observability: `ServeEvent` (18 typed boundary events), the `Observer` port and its sinks, the request fold, the counters behind `/v1/metrics`, and the per-turn tally folded from the engine's own `AgentEvent` stream. Start at [`mod.rs`](src/observe/mod.rs); the design is [`docs/design/serve-observability.md`](../docs/design/serve-observability.md). |
 | [`src/accept.rs`](src/accept.rs) | The written `accept()` classification policy — transient vs fatal, the backoff, and the give-up streak. Byte-identical to [`stella-observatory/src/accept.rs`](../stella-observatory/src/accept.rs) (the observatory takes no `stella-*` dependency, so there is no shared crate to hold it); a drift-guard test in both crates fails if the two copies differ. Change one, change the other. |
 | [`src/http.rs`](src/http.rs) | A hand-rolled HTTP/1.1 + SSE layer following [`stella-observatory`](../stella-observatory)'s no-framework idiom, extended with request bodies, bearer auth, and long-lived responses. |
@@ -133,6 +135,29 @@ it will not send twice, and the engine step stays parked forever.
 rebuilds a real `ProviderError` from it so retry behaves exactly as with a local
 provider. Sending `terminal` where the host meant `rate_limited` silently disables
 the engine's backoff.
+
+**Hooks are the operator's, not the host's (#1298).** A `ServeExtension`
+installed on `ServeConfig::extensions` gets a per-turn `stella_core::bus::HookBus`
+and sees `agent.turn.*`, `agent.step.*`, `model.request.*` and `tool.call.*`; a
+policy handler registered with `on_blocking` can `Deny` or `Modify` a
+`tool.call.requested` **before** the `tool_request` frame leaves, so a refused
+tool is one the host is never asked to run. There is no route that registers an
+extension, deliberately: the bearer token authenticates a host, and a host that
+could install a handler could read every tool call's raw input and steer the
+engine with a `Deny`. The settings-declared *shell* hook engine
+(`stella_core::hooks`) stays unreachable here for the same reason the tool
+executor is remoted — the sidecar must not be makeable to spawn a shell.
+Installing nothing mints no bus, so a turn pays nothing for hooks nobody
+registered. [`src/extensions.rs`](src/extensions.rs) holds the argument.
+
+**Token drift is measured and readable (#1298).** Every committed step feeds the
+engine's pre-call estimate and the provider's reported usage into a
+`CalibrationMap` kept per `provider_id` for the process's life; `GET
+/v1/calibration` reports the gap per `(provider_id, model)`. It is process
+memory — this crate has no store — so a redeployed sidecar re-converges, which
+is why each row carries `samples`. `drift_ratio` is the raw measured gap;
+`applied_factor` is the bounded correction actually multiplied into estimates,
+and the two are deliberately different numbers.
 
 ## Gotchas
 
@@ -244,6 +269,15 @@ access are needed; the suites either bind `127.0.0.1:0` or use no socket at all.
 - [`tests/http.rs`](tests/http.rs) runs the same protocol end-to-end over a real
   socket: `POST /v1/turns`, SSE, the two result POSTs, and `cancel`, plus the
   auth, `max_steps` and deadline rejections.
+- [`tests/hooks.rs`](tests/hooks.rs) drives a `Session` with operator extensions
+  installed: that every boundary reaches an observer and pairs, that a policy
+  `Deny` lands before the host is asked, that a `Modify` rewrites what the host
+  receives, and — as a sweep over the route table — that no route lets a remote
+  caller register a hook.
+- [`tests/calibration.rs`](tests/calibration.rs) runs a turn whose provider
+  result reports real input usage and reads the gap back from
+  `GET /v1/calibration`, including that two providers sharing a model name keep
+  separate rows.
 - Unit tests live beside the code in [`src/frame.rs`](src/frame.rs) (wire
   round-trips, including that a legacy `aborted` payload without `cost_usd` still
   deserializes), [`src/server.rs`](src/server.rs) (the step-cap and deadline

--- a/stella-serve/src/calibration.rs
+++ b/stella-serve/src/calibration.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Token-drift calibration for served turns, and the read-only report behind
+//! `GET /v1/calibration` (#1298).
+//!
+//! The engine estimates a request's input tokens before it makes the call and
+//! compares that against what the provider says it actually billed
+//! (`stella_core::estimator`). Two things come out of the comparison: a
+//! bounded correction that feeds the compaction decision, and a *measurement*
+//! of how wrong the estimate was. Until now a served turn got neither — every
+//! served turn estimated uncorrected, and the gap was computed nowhere, so a
+//! host embedding Stella believed its own cost numbers with nothing able to
+//! contradict them.
+//!
+//! # Why the maps are keyed by provider
+//!
+//! [`CalibrationMap`] keys by the model string the provider reports, and says
+//! so: the provider dimension is handled "where samples are persisted", which
+//! for the CLI is `stella-store` keying telemetry by `(provider, model)`. This
+//! crate deliberately has no store, so that half has to live here — hence a
+//! map *per `provider_id`*, minted on first use. Without it two hosts pointing
+//! `openai` and `openai-compatible-proxy` at the same model name would blend
+//! their tokenizers' drift into one average that describes neither.
+//!
+//! # Lifetime, stated rather than discovered
+//!
+//! Process memory, for the process's life. There is nothing to seed from at
+//! boot and nothing written at shutdown, so a redeployed sidecar starts
+//! uncalibrated and re-converges — a handful of steps, since the EWMA weights
+//! recent samples heavily. That is the honest consequence of a crate with no
+//! persistence, and it is why the report carries `samples`: a row with three
+//! samples and a row with three thousand are not the same claim, and a reader
+//! must be able to tell them apart.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use stella_core::estimator::CalibrationMap;
+
+/// Every provider's drift state, keyed by the `provider_id` the turn declared.
+#[derive(Default)]
+pub(crate) struct CalibrationRegistry {
+    maps: Mutex<HashMap<String, Arc<CalibrationMap>>>,
+}
+
+impl CalibrationRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// The map this provider's turns calibrate against, minted on first use.
+    ///
+    /// Handed out as an `Arc` because the engine borrows it for the whole turn
+    /// on the session thread while `GET /v1/calibration` reads it from the
+    /// server runtime — the map's own `Mutex` (never held across an await)
+    /// makes that concurrent access sound.
+    pub(crate) fn for_provider(&self, provider_id: &str) -> Arc<CalibrationMap> {
+        Arc::clone(
+            self.lock()
+                .entry(provider_id.to_string())
+                .or_insert_with(|| Arc::new(CalibrationMap::new())),
+        )
+    }
+
+    /// The whole report, sorted by provider then model.
+    ///
+    /// Sorted for the same reason `CalibrationMap::report` sorts: two reads of
+    /// an unchanged registry must produce identical bytes, or the endpoint is
+    /// useless for diffing and awkward to test.
+    pub(crate) fn report(&self) -> DriftReport {
+        let snapshot: Vec<(String, Arc<CalibrationMap>)> = {
+            let maps = self.lock();
+            let mut pairs: Vec<(String, Arc<CalibrationMap>)> = maps
+                .iter()
+                .map(|(provider, map)| (provider.clone(), Arc::clone(map)))
+                .collect();
+            pairs.sort_by(|a, b| a.0.cmp(&b.0));
+            pairs
+        };
+        // The per-map reads happen with the registry lock released: a report
+        // takes each model map's own lock, and holding both would put a
+        // request handler on the inside of a lock a running turn takes on
+        // every committed step.
+        let models = snapshot
+            .into_iter()
+            .flat_map(|(provider_id, map)| {
+                map.report().into_iter().map(move |row| ModelDriftWire {
+                    provider_id: provider_id.clone(),
+                    model: row.model,
+                    samples: row.samples,
+                    estimated_input_tokens: row.estimated_input_tokens,
+                    actual_input_tokens: row.actual_input_tokens,
+                    drift_ratio: row.drift_ratio,
+                    applied_factor: row.applied_factor,
+                })
+            })
+            .collect();
+        DriftReport { models }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, Arc<CalibrationMap>>> {
+        // Poisoning means a panic while minting a map. The state is a
+        // `HashMap` of `Arc`s that cannot be left torn, and refusing to
+        // calibrate afterwards would turn one panic into a permanently blind
+        // server — the same call the map itself makes.
+        self.maps.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// The `GET /v1/calibration` body.
+///
+/// Counts and identifiers only — model ids, sample counts, token totals and
+/// two ratios. Nothing here is derived from transcript content, which is what
+/// makes a read-only endpoint the right shape for it: the report describes
+/// Stella's own estimator, not the conversation.
+#[derive(Debug, Serialize)]
+pub(crate) struct DriftReport {
+    /// One row per `(provider_id, model)` the process has seen. Empty before
+    /// any turn has committed a step — an honest "nothing measured yet",
+    /// which is not the same as "no drift".
+    pub(crate) models: Vec<ModelDriftWire>,
+}
+
+/// One `(provider_id, model)` row of [`DriftReport`].
+#[derive(Debug, Serialize)]
+pub(crate) struct ModelDriftWire {
+    provider_id: String,
+    model: String,
+    samples: u32,
+    estimated_input_tokens: u64,
+    actual_input_tokens: u64,
+    /// `actual / estimated` over this row's whole history — the gap itself,
+    /// unsmoothed and unclamped. Above 1.0 means Stella under-estimated what
+    /// the provider billed.
+    drift_ratio: f64,
+    /// The bounded correction actually multiplied into estimates, which is
+    /// deliberately *not* `drift_ratio`: it is smoothed and clamped, and stays
+    /// exactly 1.0 until the sample floor is cleared.
+    applied_factor: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two providers serving the same model name must not blend — the whole
+    /// reason the registry keys by provider before the map keys by model.
+    #[test]
+    fn providers_calibrate_independently_under_a_shared_model_name() {
+        let registry = CalibrationRegistry::new();
+        for _ in 0..3 {
+            registry
+                .for_provider("vendor-a")
+                .record("shared-1", 1_000, 2_000);
+            registry
+                .for_provider("vendor-b")
+                .record("shared-1", 1_000, 1_000);
+        }
+        let report = registry.report();
+        assert_eq!(report.models.len(), 2);
+        assert_eq!(report.models[0].provider_id, "vendor-a");
+        assert!((report.models[0].drift_ratio - 2.0).abs() < 1e-9);
+        assert_eq!(report.models[1].provider_id, "vendor-b");
+        assert!((report.models[1].drift_ratio - 1.0).abs() < 1e-9);
+    }
+
+    /// The same `provider_id` must reach the same state across turns, or a
+    /// session's calibration would reset every time a turn started.
+    #[test]
+    fn one_map_per_provider_is_shared_across_turns() {
+        let registry = CalibrationRegistry::new();
+        registry.for_provider("vendor-a").record("m", 1_000, 1_500);
+        registry.for_provider("vendor-a").record("m", 1_000, 1_500);
+        registry.for_provider("vendor-a").record("m", 1_000, 1_500);
+        let report = registry.report();
+        assert_eq!(report.models.len(), 1);
+        assert_eq!(report.models[0].samples, 3);
+        assert!((report.models[0].applied_factor - 1.5).abs() < 1e-9);
+    }
+
+    /// A server that has run nothing reports an empty list, not zeros that
+    /// would read as "measured, and perfect".
+    #[test]
+    fn a_fresh_registry_reports_no_rows() {
+        let json = serde_json::to_value(CalibrationRegistry::new().report()).unwrap();
+        assert_eq!(json, serde_json::json!({ "models": [] }));
+    }
+}

--- a/stella-serve/src/extensions.rs
+++ b/stella-serve/src/extensions.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Server-side hooks: the operator's seam into a served turn (#1298).
+//!
+//! `stella-core` ships two hook systems and this module attaches exactly one
+//! of them.
+//!
+//! - `stella_core::hooks` is the **settings-declared shell command** engine.
+//!   It runs operator-authored `bash -c` at lifecycle moments, and it is
+//!   deliberately **not** reachable from this crate. The sidecar's whole
+//!   containment story (ADR-033 Option B, `crate::remote`) is that the engine
+//!   holds no ambient authority: every model and tool call is remoted to the
+//!   host. A hook system that spawned shells here would hand back, through a
+//!   side door, precisely the local execution the front door refuses.
+//! - `stella_core::bus` is the **in-process** hook bus: typed handlers
+//!   registered against a catalog of dotted event names, observing the turn
+//!   and — on an explicit allowlist — intercepting it. That is what a served
+//!   turn attaches, through [`ServeExtension`].
+//!
+//! # Who may register a hook
+//!
+//! **The operator, in process, before the server starts. Nobody else, ever.**
+//!
+//! A [`ServeExtension`] is Rust code compiled into whatever binary calls
+//! [`serve`](crate::serve), installed on
+//! [`ServeConfig::extensions`](crate::ServeConfig::extensions) at construction
+//! time. There is no route that registers, uploads, names, or configures one,
+//! and adding one would be a security change, not a feature: a remote caller
+//! that could install a handler could read every tool call's raw input —
+//! including file contents and shell command lines — and `Deny` its way into
+//! controlling what the engine does. The bearer token authenticates *a host*,
+//! not the operator, and those are not the same principal.
+//!
+//! The shipping `stella-serve` binary registers none, so its behavior is
+//! unchanged; extensions exist for a host that embeds this crate and wants its
+//! own audit or policy plane inside the sidecar. See the module docs in
+//! `crate::server` for what the *transport* authenticates.
+//!
+//! # What an extension can and cannot do
+//!
+//! Registration is by kind, and the two kinds have different powers — the
+//! split is `stella_core::bus`'s, not this crate's:
+//!
+//! - `HookBus::on` — an **observer**. It watches; it can never veto, delay or
+//!   corrupt the turn. A handler that returns `Err` or overruns its latency
+//!   budget is isolated and, if it keeps overrunning, quarantined.
+//! - `HookBus::on_blocking` — a **policy hook** on the interceptable
+//!   allowlist. Server-side that is `tool.call.requested`: the chain runs
+//!   before the tool request frame reaches the host, and may `Deny` (the model
+//!   sees a named error instead of a result) or `Modify` (the input the host
+//!   is asked to run is rewritten). The file/command chains the CLI's
+//!   `ToolRegistry` also gates are absent here for the same reason the shell
+//!   engine is: the sidecar does not touch the filesystem, so it has no
+//!   file operation of its own to intercept.
+//!
+//! # Lifetime
+//!
+//! One [`HookBus`] per turn, minted on the session thread and dropped with it.
+//! [`ServeExtension::install`] is called once per turn with that bus, before
+//! the first step runs — so a subscription registered there sees the turn's
+//! opening event, and no subscription outlives the turn it was made for.
+
+use stella_core::bus::HookBus;
+
+/// An operator-installed hook plane for served turns.
+///
+/// Implementors register handlers in [`install`](ServeExtension::install) and
+/// keep them alive for the turn by calling
+/// `HookSubscription::detach` — the bus is per-turn, so a detached handler
+/// dies with it rather than leaking across turns.
+///
+/// ```no_run
+/// use stella_core::bus::{HookBus, HookDecision, names};
+/// use stella_serve::ServeExtension;
+///
+/// /// Refuse one tool outright, whatever the host advertised.
+/// struct NoDeploys;
+///
+/// impl ServeExtension for NoDeploys {
+///     fn name(&self) -> &str {
+///         "no-deploys"
+///     }
+///
+///     fn install(&self, bus: &HookBus) {
+///         bus.on_blocking(names::TOOL_CALL_REQUESTED, |event| {
+///             match event.payload["tool"].as_str() {
+///                 Some("deploy") => HookDecision::Deny {
+///                     reason: "deploys are not served from this sidecar".to_string(),
+///                 },
+///                 _ => HookDecision::Allow,
+///             }
+///         })
+///         .detach();
+///     }
+/// }
+/// ```
+pub trait ServeExtension: Send + Sync + 'static {
+    /// A stable, human-readable id. Used in the extension-error events an
+    /// isolated handler failure produces, so a broken extension is
+    /// identifiable rather than anonymous.
+    fn name(&self) -> &str;
+
+    /// Register this extension's handlers on one turn's bus.
+    ///
+    /// Called on the session thread, before the turn's first step. It must
+    /// not block: the turn does not start until it returns.
+    fn install(&self, bus: &HookBus);
+}
+
+/// Every extension the operator installed, in registration order.
+///
+/// A type alias rather than a wrapper struct: the ordering *is* the semantics
+/// (blocking handlers run in registration order and the first `Deny` wins), so
+/// a `Vec` says exactly what the bus will do with it.
+pub type Extensions = Vec<std::sync::Arc<dyn ServeExtension>>;
+
+/// Mint this turn's bus, install every extension on it, and announce the
+/// session — in that order, which is the order the bus's own contract
+/// requires: `HookBus::session_started` is documented as construct, subscribe,
+/// *then* announce, because an observer registered after the announcement
+/// would miss the one event that opens its fold.
+///
+/// Returns `None` when nothing is installed, so a turn on a serve deployment
+/// with no extensions never mints a bus and the engine's every emit site stays
+/// behind its `if let Some(bus)` — the "`None` adds zero work" contract
+/// `Engine::with_bus` is written to.
+pub(crate) fn install_for_turn(
+    extensions: &Extensions,
+    turn_id: impl Into<String>,
+) -> Option<HookBus> {
+    if extensions.is_empty() {
+        return None;
+    }
+    let bus = HookBus::new(turn_id);
+    for extension in extensions {
+        extension.install(&bus);
+    }
+    bus.session_started();
+    Some(bus)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use stella_core::bus::{HookEvent, names};
+
+    /// An extension that records every event it sees.
+    struct Recorder(Arc<Mutex<Vec<String>>>);
+
+    impl ServeExtension for Recorder {
+        fn name(&self) -> &str {
+            "recorder"
+        }
+
+        fn install(&self, bus: &HookBus) {
+            let seen = Arc::clone(&self.0);
+            bus.on("*", move |event: &HookEvent| {
+                seen.lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(event.name.clone());
+                Ok(())
+            })
+            .detach();
+        }
+    }
+
+    /// No extensions means no bus at all — not an empty one. The engine's
+    /// emit sites are all behind `if let Some(bus)`, so this is what keeps a
+    /// deployment that installed nothing from paying to build payloads
+    /// nobody reads.
+    #[test]
+    fn no_extensions_mints_no_bus() {
+        assert!(install_for_turn(&Extensions::new(), "turn-abc").is_none());
+    }
+
+    /// Ordering is the contract: an observer installed here must see
+    /// `session.started`, which is emitted after every install and would be
+    /// missed if the announcement came first.
+    #[test]
+    fn installed_extensions_see_the_opening_event() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let extensions: Extensions = vec![Arc::new(Recorder(Arc::clone(&seen)))];
+        let bus = install_for_turn(&extensions, "turn-abc").expect("a bus was minted");
+        assert_eq!(bus.session_id(), "turn-abc");
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            [names::SESSION_STARTED.to_string()]
+        );
+    }
+}

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -51,13 +51,29 @@
 //!
 //! See the module docs in `src/server.rs` for the HTTP shape of cancellation
 //! (the route table, and why `cancel` is a path segment rather than a `DELETE`).
+//!
+//! # Observing and intervening in a served turn
+//!
+//! Two seams, both added in #1298 and both deliberately shaped by who is
+//! allowed to use them:
+//!
+//! - [`ServeExtension`] is the **operator's** hook plane. Installed in
+//!   process on [`ServeConfig::extensions`], it observes the turn/step/model
+//!   boundaries and may intercept `tool.call.requested` before the request
+//!   frame reaches the host. No route registers one, on purpose —
+//!   `crate::extensions` is where that boundary is argued.
+//! - `GET /v1/calibration` is the **host's** read-only view of token-drift:
+//!   what the engine estimated against what the provider billed, per
+//!   `(provider_id, model)`. See `crate::calibration`.
 
 mod accept;
 mod backlog;
+mod calibration;
 pub mod checkpoint;
 mod controls;
 mod engine_overrides;
 mod error;
+pub mod extensions;
 mod frame;
 mod history;
 mod hostguard;
@@ -80,6 +96,7 @@ pub use checkpoint::{
     MAX_CHECKPOINT_KEY_LEN, MemoryCheckpointStore, TurnCheckpoint,
 };
 pub use error::ServeError;
+pub use extensions::{Extensions, ServeExtension};
 pub use frame::{
     ProviderDelta, ProviderDeltaIn, ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn,
     ServerFrame, ToolResultIn, TurnOutcomeWire,

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -96,6 +96,12 @@ pub enum Route {
     Readyz,
     #[serde(rename = "/v1/metrics")]
     Metrics,
+    /// The token-drift report (#1298): what the engine estimated against what
+    /// the provider billed, per `(provider_id, model)`. Read-only, and
+    /// authenticated like `/v1/metrics` for the same reason — it describes the
+    /// host's traffic.
+    #[serde(rename = "/v1/calibration")]
+    Calibration,
     #[serde(rename = "/v1/turns")]
     TurnsCreate,
     #[serde(rename = "/v1/turns/{id}/events")]
@@ -145,6 +151,7 @@ impl Route {
             Self::Healthz => "/healthz",
             Self::Readyz => "/readyz",
             Self::Metrics => "/v1/metrics",
+            Self::Calibration => "/v1/calibration",
             Self::TurnsCreate => "/v1/turns",
             Self::TurnEvents => "/v1/turns/{id}/events",
             Self::TurnToolResult => "/v1/turns/{id}/tool-result",
@@ -174,10 +181,11 @@ impl Route {
     /// method's exhaustive match until the author classifies it, and the
     /// tests assert `ALL` contains exactly the `is_real` variants it names —
     /// so the array cannot silently lag the enum.
-    pub const ALL: [Route; 17] = [
+    pub const ALL: [Route; 18] = [
         Route::Healthz,
         Route::Readyz,
         Route::Metrics,
+        Route::Calibration,
         Route::TurnsCreate,
         Route::TurnEvents,
         Route::TurnToolResult,
@@ -205,6 +213,7 @@ impl Route {
             Route::Healthz
             | Route::Readyz
             | Route::Metrics
+            | Route::Calibration
             | Route::TurnsCreate
             | Route::TurnEvents
             | Route::TurnToolResult

--- a/stella-serve/src/remote.rs
+++ b/stella-serve/src/remote.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::Value;
+use stella_core::bus::{self, HookBus, HookDecision, HookEventDraft, names as hook_names};
 use stella_core::ports::ToolExecutor;
 use stella_core::retry::Sleeper;
 use stella_protocol::{
@@ -290,6 +291,15 @@ pub(crate) struct RemoteToolExecutor {
     pending: Pending,
     counter: AtomicU64,
     timeout: Duration,
+    /// This turn's operator hook plane (#1298), `None` when the deployment
+    /// installed no extensions.
+    ///
+    /// The port owns it rather than the engine because the interception point
+    /// has to be *before the request frame leaves*: a `Deny` that arrived
+    /// after the host had already been asked to run the tool would be a veto
+    /// of the answer, not of the act. Same placement, and same reason, as
+    /// `ToolRegistry`'s gate on the CLI side.
+    bus: Option<HookBus>,
 }
 
 impl RemoteToolExecutor {
@@ -298,6 +308,7 @@ impl RemoteToolExecutor {
         frames: crate::backlog::FrameSink,
         pending: Pending,
         timeout: Duration,
+        bus: Option<HookBus>,
     ) -> Self {
         Self {
             schemas,
@@ -305,7 +316,80 @@ impl RemoteToolExecutor {
             pending,
             counter: AtomicU64::new(0),
             timeout,
+            bus,
         }
+    }
+
+    /// Run the `tool.call.requested` blocking chain before the request frame
+    /// is built.
+    ///
+    /// `Ok(None)`: allowed unchanged. `Ok(Some(input))`: allowed with a
+    /// policy-rewritten input, which is what the host is then asked to run.
+    /// `Err(output)`: refused — the model sees this error instead of a result,
+    /// and the host is never asked at all.
+    ///
+    /// The chain receives the RAW input: the blocking path is the explicitly
+    /// privileged interception point (`stella_core::bus`), and a policy that
+    /// cannot see the shell command it is judging cannot judge it. Observable
+    /// events below carry `sanitize_tool_input`'d copies instead.
+    ///
+    /// Deliberately the same decision handling as the CLI's `ToolRegistry`,
+    /// down to the dropped-`input` case: two surfaces answering one `Deny`
+    /// differently is exactly the drift `stella-parity` exists to catch.
+    fn gate_tool_call(
+        bus: &HookBus,
+        name: &str,
+        input: &Value,
+    ) -> Result<Option<Value>, ToolOutput> {
+        let outcome = bus.emit_blocking(HookEventDraft::new(
+            hook_names::TOOL_CALL_REQUESTED,
+            serde_json::json!({ "tool": name, "input": input }),
+        ));
+        match outcome.decision {
+            HookDecision::Deny { reason } => Err(ToolOutput::Error {
+                message: format!("`{name}` was denied by an extension policy: {reason}"),
+            }),
+            HookDecision::RequireApproval { reason } => Err(ToolOutput::Error {
+                message: format!("`{name}` requires approval before it can run: {reason}"),
+            }),
+            _ => {
+                if !outcome.modified {
+                    return Ok(None);
+                }
+                match outcome.event.payload.get("input") {
+                    Some(new_input) => Ok(Some(new_input.clone())),
+                    None => {
+                        // A `modify` that dropped `input` is a broken policy
+                        // handler. Surface it and keep the original rather
+                        // than asking the host to run garbage.
+                        bus.emit_named(
+                            hook_names::EXTENSION_ERROR,
+                            serde_json::json!({
+                                "failed_event": hook_names::TOOL_CALL_REQUESTED,
+                                "error": "modify decision dropped the `input` field; original input kept",
+                            }),
+                        );
+                        Ok(None)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Announce how the host answered, on the observable channel.
+    fn report_tool_outcome(bus: &HookBus, name: &str, output: &ToolOutput, duration_ms: u64) {
+        match output {
+            ToolOutput::Error { message } => bus.emit_named(
+                hook_names::TOOL_CALL_FAILED,
+                serde_json::json!({
+                    "tool": name, "error": message, "duration_ms": duration_ms,
+                }),
+            ),
+            ToolOutput::Ok { .. } => bus.emit_named(
+                hook_names::TOOL_CALL_COMPLETED,
+                serde_json::json!({ "tool": name, "duration_ms": duration_ms }),
+            ),
+        };
     }
 }
 
@@ -325,6 +409,25 @@ impl ToolExecutor for RemoteToolExecutor {
                 message: "turn cancelled before the tool call could be dispatched".to_string(),
             };
         }
+        // Operator policy, before anything is dispatched (#1298). A refusal
+        // returns here, so a denied tool costs the host nothing: no frame is
+        // sent, no reverse request is registered, and no deadline is armed.
+        let mut gated = None;
+        if let Some(bus) = &self.bus {
+            match Self::gate_tool_call(bus, name, input) {
+                Ok(replacement) => gated = replacement,
+                Err(refused) => return refused,
+            }
+            bus.emit_named(
+                hook_names::TOOL_CALL_STARTED,
+                serde_json::json!({
+                    "tool": name,
+                    "input": bus::sanitize_tool_input(gated.as_ref().unwrap_or(input)),
+                }),
+            );
+        }
+        let input = gated.as_ref().unwrap_or(input);
+        let started_at = Instant::now();
         let request_id = format!("tool-{}", self.counter.fetch_add(1, Ordering::Relaxed));
         let (tx, rx) = oneshot::channel();
         // Same refused-registration handling as the provider port: a cancel
@@ -351,7 +454,7 @@ impl ToolExecutor for RemoteToolExecutor {
             };
         }
         let started = dispatched(&self.pending, &request_id, ReverseKind::Tool);
-        match tokio::time::timeout(self.timeout, rx).await {
+        let output = match tokio::time::timeout(self.timeout, rx).await {
             Ok(Ok(output)) => {
                 answered(&self.pending, &request_id, ReverseKind::Tool, started);
                 output
@@ -373,6 +476,13 @@ impl ToolExecutor for RemoteToolExecutor {
                     ),
                 }
             }
+        };
+        // Reported on every exit above, including the ones the host never
+        // answered: an observer that pairs `started` with an outcome must not
+        // be left holding an open call precisely when the host wedged.
+        if let Some(bus) = &self.bus {
+            Self::report_tool_outcome(bus, name, &output, millis(started_at.elapsed()));
         }
+        output
     }
 }

--- a/stella-serve/src/router.rs
+++ b/stella-serve/src/router.rs
@@ -39,6 +39,7 @@ pub(crate) fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
         ["healthz"] => (Route::Healthz, None),
         ["readyz"] => (Route::Readyz, None),
         ["v1", "metrics"] => (Route::Metrics, None),
+        ["v1", "calibration"] => (Route::Calibration, None),
         ["v1", "turns"] => (Route::TurnsCreate, None),
         ["v1", "turns", id, "events"] => (Route::TurnEvents, Some(id)),
         ["v1", "turns", id, "tool-result"] => (Route::TurnToolResult, Some(id)),
@@ -93,7 +94,11 @@ pub(crate) fn resume_point(query: &str, req: &crate::http::Request) -> Option<u6
 /// The `Allow` header value for a known route.
 pub(crate) fn allowed(route: Route) -> &'static str {
     match route {
-        Route::Healthz | Route::Readyz | Route::Metrics | Route::TurnEvents => "GET",
+        Route::Healthz
+        | Route::Readyz
+        | Route::Metrics
+        | Route::Calibration
+        | Route::TurnEvents => "GET",
         Route::TurnsCreate
         | Route::TurnToolResult
         | Route::TurnProviderResult

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -192,6 +192,24 @@ pub(crate) async fn handle_metrics(
     res.json("200 OK", &body).await
 }
 
+/// `GET /v1/calibration` — the cost-drift report (#1298).
+///
+/// What the engine estimated a request's input tokens to be, against what the
+/// provider said it actually billed, per `(provider_id, model)`. A host that
+/// cannot read this believes its own cost numbers until the invoice disagrees.
+///
+/// Read-only and authenticated, like `/v1/metrics` and for the same reason:
+/// token volumes and model ids describe the host's traffic. It carries no
+/// transcript content — see `crate::calibration` for the shape and for what
+/// the numbers do and do not claim.
+pub(crate) async fn handle_calibration(
+    res: &mut Responder<'_>,
+    state: &ServerState,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(&state.calibration().report()).unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
 pub(crate) async fn handle_create(
     res: &mut Responder<'_>,
     state: &Arc<ServerState>,
@@ -254,6 +272,10 @@ pub(crate) async fn handle_create(
     // the closure because only `register_turn` — under the registry lock —
     // can mint it.
     let checkpoint_state = Arc::clone(state);
+    let extensions = state.extensions();
+    // Keyed on the declared provider so two providers serving the same model
+    // name never blend their drift — see `crate::calibration`.
+    let calibration = Some(state.calibration().for_provider(&turn.provider_id));
     let registered = state.register_turn(move |turn_id| {
         Session::start(SessionSpec {
             provider_id: turn.provider_id,
@@ -270,6 +292,8 @@ pub(crate) async fn handle_create(
             observer,
             on_settled: None,
             checkpoint: checkpoint_state.checkpoint_for(turn_id),
+            extensions,
+            calibration,
         })
     });
     let Some(id) = registered else {
@@ -1087,6 +1111,8 @@ pub(crate) async fn handle_session_turn(
     // path for a turn that never existed — miscounting an abort and racing
     // the `release` below.
     let hook_sess = Arc::clone(&sess);
+    let extensions = state.extensions();
+    let calibration = Some(state.calibration().for_provider(&request.provider_id));
     let registered = state.register_turn(move |turn_id| {
         Session::start(SessionSpec {
             provider_id: request.provider_id,
@@ -1099,6 +1125,8 @@ pub(crate) async fn handle_session_turn(
             observer,
             on_settled: Some(hook_sess.settle_hook(token)),
             checkpoint,
+            extensions,
+            calibration,
         })
     });
     let Some(turn_id) = registered else {

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -188,6 +188,19 @@ pub struct ServeConfig {
     /// deployment decision (a mounted volume, a replicated table) that this
     /// crate cannot guess and must not invent — see `crate::checkpoint`.
     pub checkpoints: Option<Arc<dyn crate::checkpoint::CheckpointStore>>,
+    /// The operator's hook extensions, installed on every served turn (#1298).
+    ///
+    /// Empty — the default, and what the shipping binary ships — is the
+    /// pre-#1298 behavior exactly: no bus is minted and no turn pays for a
+    /// boundary nobody observes.
+    ///
+    /// **Set here and nowhere else.** No route registers, names or configures
+    /// an extension, and that is a deliberate security boundary rather than an
+    /// unfinished one: the bearer token authenticates a *host*, and a host
+    /// that could install a handler could read every tool call's raw input and
+    /// `Deny` its way into steering the engine. `crate::extensions` states the
+    /// rule and what each hook kind may do.
+    pub extensions: crate::extensions::Extensions,
 }
 
 /// The default [`ServeConfig::resume_grace`]: thirty seconds.
@@ -244,7 +257,22 @@ impl ServeConfig {
             allowed_hosts: Vec::new(),
             shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
             checkpoints: None,
+            extensions: crate::extensions::Extensions::new(),
         }
+    }
+
+    /// Install an operator hook extension on every turn this server runs
+    /// (#1298).
+    ///
+    /// Order matters and is preserved: blocking policy handlers run in
+    /// registration order and the chain stops at the first `Deny`, so the
+    /// extension registered first is the one that gets to refuse first. See
+    /// [`ServeConfig::extensions`] for who may call this and why nobody else
+    /// can.
+    #[must_use]
+    pub fn with_extension(mut self, extension: Arc<dyn crate::extensions::ServeExtension>) -> Self {
+        self.extensions.push(extension);
+        self
     }
 
     /// Make served turns durable by writing their resume points to `store`.
@@ -391,6 +419,17 @@ pub(crate) struct ServerState {
     /// See [`ServeConfig::checkpoints`]. `None` leaves every turn's
     /// `checkpoint_sink` unset, which is exactly today's behavior.
     checkpoints: Option<Arc<dyn crate::checkpoint::CheckpointStore>>,
+    /// See [`ServeConfig::extensions`]. Cloned onto every `SessionSpec` — one
+    /// `Arc` bump per turn, and the same handler set for every turn, which is
+    /// what makes "the operator decides" checkable rather than per-request.
+    extensions: crate::extensions::Extensions,
+    /// Token-drift state, shared across every turn in the process (#1298).
+    ///
+    /// Server-owned rather than session-owned because calibration is only
+    /// useful across turns — a per-turn map would be discarded before it
+    /// cleared its sample floor — and because `GET /v1/calibration` has to
+    /// read it from outside any turn.
+    calibration: crate::calibration::CalibrationRegistry,
 }
 
 impl ServerState {
@@ -409,6 +448,18 @@ impl ServerState {
     /// The configured checkpoint store, if this deployment has one.
     pub(crate) fn checkpoints(&self) -> Option<&Arc<dyn crate::checkpoint::CheckpointStore>> {
         self.checkpoints.as_ref()
+    }
+
+    /// The operator's hook extensions, for the `SessionSpec` of a turn about
+    /// to start.
+    pub(crate) fn extensions(&self) -> crate::extensions::Extensions {
+        self.extensions.clone()
+    }
+
+    /// This process's token-drift state — read by `GET /v1/calibration`,
+    /// written by every committed step of every turn.
+    pub(crate) fn calibration(&self) -> &crate::calibration::CalibrationRegistry {
+        &self.calibration
     }
 
     /// This turn's or session's durable identity, or `None` when durability is
@@ -821,6 +872,8 @@ pub async fn serve_until(
         sessions: crate::sessions::SessionRegistry::new(),
         session_idle_ttl: config.session_idle_ttl,
         checkpoints: config.checkpoints.clone(),
+        extensions: config.extensions,
+        calibration: crate::calibration::CalibrationRegistry::new(),
         host_policy,
         lifecycle: Lifecycle::new(),
     });
@@ -1069,6 +1122,10 @@ async fn route(
             discard_body(res.stream_mut(), &mut req).await;
             return routes::handle_metrics(res, state).await;
         }
+        ("GET", Route::Calibration) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_calibration(res, state).await;
+        }
         ("GET", Route::TurnEvents) => {
             discard_body(res.stream_mut(), &mut req).await;
             return routes::handle_events(
@@ -1252,6 +1309,8 @@ mod tests {
                 lifecycle
             },
             checkpoints: None,
+            extensions: crate::extensions::Extensions::new(),
+            calibration: crate::calibration::CalibrationRegistry::new(),
         };
         (state, capture)
     }
@@ -1268,6 +1327,8 @@ mod tests {
             observer: crate::observe::null_observer(),
             on_settled: None,
             checkpoint: None,
+            extensions: crate::extensions::Extensions::new(),
+            calibration: None,
         }
     }
 

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -25,6 +25,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use stella_core::EngineConfig;
+use stella_core::bus::{HookBus, names as bus_names};
+use stella_core::driver::lifecycle::{turn_outcome_payload, turn_started_payload};
 use stella_engine::{
     BudgetGuard, CancelToken, Engine, EventSender, StepOutcome, TurnOutcome, step_cap_reason,
 };
@@ -105,6 +107,25 @@ pub struct SessionSpec {
     /// named a sink outright has said exactly where its checkpoints go, and
     /// this field is the server's convenience, not an override of it.
     pub checkpoint: Option<crate::checkpoint::TurnCheckpoint>,
+    /// The operator's hook plane for this turn (#1298), installed on a
+    /// freshly-minted `HookBus` before the first step runs.
+    ///
+    /// Empty — the default, and what the shipping binary uses — mints no bus
+    /// at all, so every engine emit site stays behind its `if let Some(bus)`
+    /// and a turn pays nothing for hooks nobody registered.
+    ///
+    /// **Operator-supplied only.** Nothing on the wire reaches this field;
+    /// see `crate::extensions` for why that boundary is where it is.
+    pub extensions: crate::extensions::Extensions,
+    /// Where this turn's `(estimated, actual)` token pairs are recorded, and
+    /// the correction it estimates under (#1298).
+    ///
+    /// Shared with the server's registry rather than owned per turn, because
+    /// calibration is only useful *across* turns: a map minted here would be
+    /// discarded before it cleared its three-sample floor. `None` is the
+    /// pre-#1298 behavior — the turn estimates uncorrected and contributes no
+    /// samples.
+    pub calibration: Option<Arc<stella_core::estimator::CalibrationMap>>,
 }
 
 /// The settlement callback a session owner installs on a turn — see
@@ -462,6 +483,7 @@ async fn drive_turn(
     budget: BudgetGuard,
     events: &mpsc::UnboundedSender<AgentEvent>,
     cancel: CancelToken,
+    bus: Option<&HookBus>,
 ) -> DrivenTurn {
     let events = EventSender::new(events.clone());
     // The stage marker `run_turn` opens with. Emitted here for the same
@@ -472,6 +494,18 @@ async fn drive_turn(
         name: StageKind::Execute,
     });
     let max_steps = engine.max_steps();
+    // The turn *boundary* on the hook bus, which `run_step` cannot emit — it
+    // is per-step, and a turn is what a host driving steps assembles itself
+    // (#1298). Same argument as the stage marker above and the step-cap exit
+    // below: this loop owns exactly the framing `run_turn_with_sender` owns,
+    // and it emits it through `run_turn`'s own payload shapers so the two
+    // drivers cannot say the same thing differently.
+    if let Some(bus) = bus {
+        bus.emit_named(
+            bus_names::AGENT_TURN_STARTED,
+            turn_started_payload(messages.len(), max_steps, engine.call_role()),
+        );
+    }
     let mut state = engine.new_turn(messages, budget).with_cancel_token(cancel);
 
     let outcome = loop {
@@ -519,6 +553,18 @@ async fn drive_turn(
         }
     };
 
+    // Every exit above lands here — including the step-cap backstop, whose
+    // turn is exactly the runaway an observer most wants paired with its
+    // `started`. Emitting from the individual breaks instead would be one
+    // added early return away from a silently unpaired boundary, which is the
+    // same reasoning that put `agent.step.completed` in a wrapper rather than
+    // at each of `run_step_inner`'s dozen exits.
+    if let Some(bus) = bus {
+        bus.emit_named(
+            bus_names::AGENT_TURN_COMPLETED,
+            turn_outcome_payload(&outcome, state.step()),
+        );
+    }
     let budget = *state.budget();
     DrivenTurn {
         outcome,
@@ -569,6 +615,17 @@ fn run_session(
     };
 
     runtime.block_on(async move {
+        // Minted before the ports, because the tool port carries it: the
+        // `tool.call.requested` chain has to run before a request frame
+        // leaves, and installing extensions afterwards would open a window in
+        // which a turn ran ungated. `None` when the operator installed
+        // nothing — see `crate::extensions`.
+        //
+        // Keyed on the `TurnRef`, which is the turn id already truncated for
+        // recording. Every sealed `HookEvent` embeds that key in its own id,
+        // so the hook plane inherits the same posture as the record plane —
+        // enough to correlate a turn, never enough to address one.
+        let bus = crate::extensions::install_for_turn(&spec.extensions, turn.to_string());
         let provider = RemoteProvider::new(
             spec.provider_id,
             frame_tx.clone(),
@@ -580,6 +637,7 @@ fn run_session(
             frame_tx.clone(),
             pending.clone(),
             spec.reverse_request_timeout,
+            bus.clone(),
         );
         let sleeper = TokioSleeper;
         // The controls' receiver half is lent to the engine for the turn: the
@@ -587,9 +645,18 @@ fn run_session(
         // drains `POST /steer` messages into the transcript at the same
         // boundary. The sender half stays on the registry entry.
         let (gate, steering) = control_ports.into_ports();
-        let engine = Engine::with_sleeper(&provider, &tools, spec.config, &sleeper)
+        let mut engine = Engine::with_sleeper(&provider, &tools, spec.config, &sleeper)
             .with_gate(&gate)
             .with_steering(&*steering);
+        // Both attachments are by reference for the engine's lifetime, so the
+        // owners have to outlive it — hence the bindings above rather than
+        // temporaries here.
+        if let Some(bus) = &bus {
+            engine = engine.with_bus(bus);
+        }
+        if let Some(calibration) = &spec.calibration {
+            engine = engine.with_calibration(calibration);
+        }
 
         // The engine emits `AgentEvent`s; wrap each as a frame for the host. The
         // reverse-RPC request frames bypass this and go straight to `frame_tx`
@@ -615,7 +682,15 @@ fn run_session(
             fold.finish()
         });
 
-        let outcome = drive_turn(&engine, spec.messages, spec.budget, &event_tx, cancel).await;
+        let outcome = drive_turn(
+            &engine,
+            spec.messages,
+            spec.budget,
+            &event_tx,
+            cancel,
+            bus.as_ref(),
+        )
+        .await;
         let messages = outcome.messages;
         let budget = outcome.budget;
         let outcome = outcome.outcome;

--- a/stella-serve/tests/bridge.rs
+++ b/stella-serve/tests/bridge.rs
@@ -71,6 +71,8 @@ fn spec_for(prompt: &str) -> SessionSpec {
         observer: stella_serve::observe::null_observer(),
         on_settled: None,
         checkpoint: None,
+        extensions: stella_serve::Extensions::new(),
+        calibration: None,
     }
 }
 

--- a/stella-serve/tests/calibration.rs
+++ b/stella-serve/tests/calibration.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `GET /v1/calibration` — the cost-drift report over the wire (#1298).
+//!
+//! The engine has always compared its own pre-call token estimate against what
+//! the provider reported; before this the comparison was unreachable from the
+//! API, so a host embedding Stella believed its own cost numbers with nothing
+//! able to contradict them. These tests drive a real turn over a real socket
+//! and then read the gap back out.
+
+mod common;
+
+use common::*;
+use serde_json::json;
+use stella_protocol::CompletionMessage;
+
+/// A model answer carrying provider-reported input usage — the "actual" half
+/// of the drift comparison. `common::model_result` reports zero, which the
+/// estimator ignores as carrying no signal, so this test needs its own.
+fn billed_answer(text: &str, input_tokens: u64) -> serde_json::Value {
+    json!({
+        "text": text,
+        "usage": {
+            "reported": true,
+            "input_tokens": input_tokens,
+            "output_tokens": 4,
+        },
+        "model": "mock-1",
+        "cost_usd": 0.0,
+    })
+}
+
+/// Run one turn to completion, answering its single provider request with a
+/// result that reports `input_tokens` billed.
+async fn run_billed_turn(addr: std::net::SocketAddr, provider_id: &str, input_tokens: u64) {
+    let create = json!({
+        "provider_id": provider_id,
+        "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+        "reverse_request_timeout_ms": 20_000,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    let turn_id = serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    while let Some(event) = next_event(&mut sse).await {
+        match event["type"].as_str().unwrap_or_default() {
+            "provider_request" => {
+                let answer = json!({
+                    "request_id": event["request_id"],
+                    "status": "ok",
+                    "result": billed_answer("done", input_tokens),
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &answer,
+                )
+                .await;
+                assert!(status.contains("200"), "provider-result: {status} {resp}");
+            }
+            "turn_complete" => break,
+            _ => {}
+        }
+    }
+}
+
+/// The witness for `calibration.drift` on the API surface: a turn's
+/// `(estimated, actual)` pair reaches the process's calibration state, and the
+/// gap is readable at `GET /v1/calibration`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_drift_report_is_readable_through_the_api() {
+    let addr = start_server().await;
+
+    // Before any turn: an empty list, which is an honest "nothing measured"
+    // rather than a zero that would read as "measured, and perfect".
+    let (status, body) = get_json_authed(addr, "/v1/calibration", TOKEN).await;
+    assert!(status.contains("200"), "calibration: {status} {body}");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&body).unwrap(),
+        json!({ "models": [] })
+    );
+
+    run_billed_turn(addr, "mock", 4_000).await;
+
+    let (status, body) = get_json_authed(addr, "/v1/calibration", TOKEN).await;
+    assert!(status.contains("200"), "calibration: {status} {body}");
+    let report: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let rows = report["models"].as_array().expect("models is a list");
+    assert_eq!(rows.len(), 1, "one provider, one model: {report}");
+
+    let row = &rows[0];
+    assert_eq!(row["provider_id"], "mock");
+    assert_eq!(row["model"], "mock-1");
+    assert_eq!(row["samples"], 1);
+    assert_eq!(
+        row["actual_input_tokens"], 4_000,
+        "the provider's own number, verbatim: {row}"
+    );
+    let estimated = row["estimated_input_tokens"].as_u64().unwrap();
+    assert!(
+        estimated > 0,
+        "the engine's pre-call estimate must be recorded, not just the bill: {row}"
+    );
+    let ratio = row["drift_ratio"].as_f64().unwrap();
+    assert!(
+        (ratio - 4_000.0 / estimated as f64).abs() < 1e-9,
+        "drift_ratio must be actual/estimated: {row}"
+    );
+    assert_eq!(
+        row["applied_factor"], 1.0,
+        "one sample is below the floor the correction needs, so nothing is \
+         applied yet — the gap is reported all the same: {row}"
+    );
+}
+
+/// Two providers must not blend. Keying only by model would average the
+/// tokenizers of anything a host chose to call the same thing, and the average
+/// would describe neither.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn drift_is_reported_per_provider_not_just_per_model() {
+    let addr = start_server().await;
+    run_billed_turn(addr, "vendor-a", 4_000).await;
+    run_billed_turn(addr, "vendor-b", 40).await;
+
+    let (_, body) = get_json_authed(addr, "/v1/calibration", TOKEN).await;
+    let report: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let rows = report["models"].as_array().unwrap();
+    assert_eq!(rows.len(), 2, "one row per (provider, model): {report}");
+    assert_eq!(rows[0]["provider_id"], "vendor-a");
+    assert_eq!(rows[1]["provider_id"], "vendor-b");
+    assert!(
+        rows[0]["drift_ratio"].as_f64().unwrap() > rows[1]["drift_ratio"].as_f64().unwrap(),
+        "the same model name under two providers must keep its own gap: {report}"
+    );
+}
+
+/// Read-only and authenticated, like `/v1/metrics` and for the same reason:
+/// token volumes and model ids describe the host's traffic, so an open
+/// endpoint would be free reconnaissance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_drift_report_is_authenticated_and_read_only() {
+    let addr = start_server().await;
+
+    let (status, _) = get_json(addr, "/v1/calibration").await;
+    assert!(status.contains("401"), "unauthenticated read: {status}");
+
+    let (status, body) = post_json(addr, "/v1/calibration", Some(TOKEN), "{}").await;
+    assert!(status.contains("405"), "write attempt: {status} {body}");
+}

--- a/stella-serve/tests/common/mod.rs
+++ b/stella-serve/tests/common/mod.rs
@@ -123,6 +123,9 @@ pub async fn start_drainable_server_with_checkpoints(
             allowed_hosts: Vec::new(),
             shutdown_grace,
             checkpoints,
+            // No operator hooks: the transport suite is about the transport,
+            // and `tests/hooks.rs` is where the hook plane is proved.
+            extensions: stella_serve::Extensions::new(),
         };
         let _ = serve_until(
             config,

--- a/stella-serve/tests/hooks.rs
+++ b/stella-serve/tests/hooks.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The operator hook plane on a served turn (#1298), proved against a live
+//! [`Session`] with a mock host — the same harness shape as `bridge.rs`, and
+//! for the same reason: the hook seam is inside the session thread, so testing
+//! it through HTTP would be testing the transport twice and the seam once.
+//!
+//! What these pin is the pair of claims `stella-parity` now makes for
+//! `hooks.lifecycle` on the API surface: that the boundaries a turn crosses
+//! reach a registered extension, and that a policy extension can refuse a tool
+//! **before** the host is asked to run it.
+
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+use stella_core::bus::{HookBus, HookDecision, HookEvent, names};
+use stella_core::{BudgetGuard, EngineConfig};
+use stella_protocol::{
+    BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, ToolCall, ToolOutput,
+    ToolSchema,
+};
+use stella_serve::observe::TurnRef;
+use stella_serve::{ServeExtension, ServerFrame, Session, SessionSpec};
+
+fn final_answer(text: &str) -> CompletionResult {
+    CompletionResult {
+        text: text.to_string(),
+        tool_calls: vec![],
+        usage: CompletionUsage::reported_zero(),
+        model: "mock".to_string(),
+        cost_usd: 0.0,
+        finish_reason: None,
+    }
+}
+
+fn wants_tool(call_id: &str, name: &str, input: serde_json::Value) -> CompletionResult {
+    CompletionResult {
+        text: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.to_string(),
+            name: name.to_string(),
+            input,
+        }],
+        usage: CompletionUsage::reported_zero(),
+        model: "mock".to_string(),
+        cost_usd: 0.0,
+        finish_reason: None,
+    }
+}
+
+fn echo_tool() -> ToolSchema {
+    ToolSchema {
+        name: "echo".to_string(),
+        description: "echo its input".to_string(),
+        input_schema: json!({ "type": "object" }),
+        read_only: false,
+        speculation_safe: false,
+    }
+}
+
+fn spec_with(extensions: Vec<Arc<dyn ServeExtension>>) -> SessionSpec {
+    SessionSpec {
+        provider_id: "mock".to_string(),
+        tools: vec![echo_tool()],
+        messages: vec![CompletionMessage::user("use the echo tool then answer")],
+        config: EngineConfig::default(),
+        budget: BudgetGuard::new(BudgetMode::Off, None, None),
+        reverse_request_timeout: SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT,
+        turn: TurnRef::new("turn-hooktest00"),
+        observer: stella_serve::observe::null_observer(),
+        on_settled: None,
+        checkpoint: None,
+        extensions,
+        calibration: None,
+    }
+}
+
+/// An observer extension that records the name of every event it sees.
+struct Recorder(Arc<Mutex<Vec<String>>>);
+
+impl ServeExtension for Recorder {
+    fn name(&self) -> &str {
+        "recorder"
+    }
+
+    fn install(&self, bus: &HookBus) {
+        let seen = Arc::clone(&self.0);
+        bus.on("*", move |event: &HookEvent| {
+            seen.lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(event.name.clone());
+            Ok(())
+        })
+        .detach();
+    }
+}
+
+/// A policy extension that refuses one named tool.
+struct RefuseTool(&'static str);
+
+impl ServeExtension for RefuseTool {
+    fn name(&self) -> &str {
+        "refuse-tool"
+    }
+
+    fn install(&self, bus: &HookBus) {
+        let refused = self.0;
+        bus.on_blocking(names::TOOL_CALL_REQUESTED, move |event| {
+            if event.payload["tool"].as_str() == Some(refused) {
+                return HookDecision::Deny {
+                    reason: format!("`{refused}` is not permitted on this deployment"),
+                };
+            }
+            HookDecision::Allow
+        })
+        .detach();
+    }
+}
+
+/// A policy extension that rewrites every tool input.
+struct RewriteInput;
+
+impl ServeExtension for RewriteInput {
+    fn name(&self) -> &str {
+        "rewrite-input"
+    }
+
+    fn install(&self, bus: &HookBus) {
+        bus.on_blocking(names::TOOL_CALL_REQUESTED, |event| HookDecision::Modify {
+            payload: json!({
+                "tool": event.payload["tool"],
+                "input": { "text": "rewritten by policy" },
+            }),
+        })
+        .detach();
+    }
+}
+
+/// Drive a turn to completion against a mock host, answering the first
+/// provider request with a tool call and the second with a final answer.
+/// Returns every tool request the host was asked to run.
+async fn run_turn(session: &mut Session) -> Vec<(String, serde_json::Value)> {
+    let mut provider_calls = 0usize;
+    let mut tool_requests = Vec::new();
+    while let Some(frame) = session.next_frame().await {
+        match frame {
+            ServerFrame::ProviderRequest { request_id, .. } => {
+                provider_calls += 1;
+                let result = if provider_calls == 1 {
+                    wants_tool("call-1", "echo", json!({ "text": "hi" }))
+                } else {
+                    final_answer("done")
+                };
+                session.resolve_provider(&request_id, result).unwrap();
+            }
+            ServerFrame::ToolRequest {
+                request_id,
+                name,
+                input,
+            } => {
+                tool_requests.push((name, input));
+                session
+                    .resolve_tool(
+                        &request_id,
+                        ToolOutput::Ok {
+                            content: "echoed".to_string(),
+                        },
+                    )
+                    .unwrap();
+            }
+            ServerFrame::TurnComplete { .. } => break,
+            // Nothing here pauses, so the control frames are inert; matched
+            // rather than wildcarded so a new frame kind lands as a compile
+            // error in a test that reads the stream.
+            ServerFrame::Event { .. }
+            | ServerFrame::TurnHeld { .. }
+            | ServerFrame::TurnReleased => {}
+        }
+    }
+    tool_requests
+}
+
+/// The witness for `hooks.lifecycle` on the API surface: an operator
+/// extension installed on the server sees the turn, step, model-call and
+/// tool-call boundaries of a turn the server ran.
+///
+/// The turn boundaries matter most here. `stella-serve` drives `run_step`
+/// itself rather than calling `run_turn`, so `agent.turn.started` /
+/// `agent.turn.completed` are framing this crate owns — they were absent for a
+/// served turn even once a bus was attached, and an observer would have seen
+/// steps with no turn around them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn operator_hooks_fire_across_a_served_turn() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let mut session = Session::start(spec_with(vec![Arc::new(Recorder(Arc::clone(&seen)))]));
+    let tool_requests = run_turn(&mut session).await;
+    assert_eq!(tool_requests.len(), 1, "the host ran the tool");
+
+    let seen = seen.lock().unwrap().clone();
+    for expected in [
+        names::SESSION_STARTED,
+        names::AGENT_TURN_STARTED,
+        names::AGENT_STEP_STARTED,
+        names::MODEL_REQUEST_STARTED,
+        names::MODEL_REQUEST_COMPLETED,
+        names::TOOL_CALL_STARTED,
+        names::TOOL_CALL_COMPLETED,
+        names::AGENT_STEP_COMPLETED,
+        names::AGENT_TURN_COMPLETED,
+    ] {
+        assert!(
+            seen.iter().any(|name| name == expected),
+            "a served turn never emitted `{expected}`; it emitted {seen:?}"
+        );
+    }
+    // The decision record for the allowed tool call. `tool.call.requested`
+    // itself is delivered only to blocking handlers — that is the bus's
+    // payload-hygiene boundary — so an observer's proof that a chain ran is
+    // the `policy.*` pair, not the raw event.
+    assert!(
+        seen.iter().any(|name| name == names::POLICY_EVALUATED)
+            && seen.iter().any(|name| name == names::POLICY_ALLOWED),
+        "the tool call ran without a recorded policy decision: {seen:?}"
+    );
+    assert!(
+        !seen.iter().any(|name| name == names::TOOL_CALL_REQUESTED),
+        "the raw request payload must never reach a plain observer: {seen:?}"
+    );
+    // Pairing, not just presence: an unpaired boundary is the failure mode
+    // that makes a lifecycle stream useless for accounting.
+    let count = |needle: &str| seen.iter().filter(|name| *name == needle).count();
+    assert_eq!(count(names::AGENT_TURN_STARTED), 1);
+    assert_eq!(count(names::AGENT_TURN_COMPLETED), 1);
+    assert_eq!(
+        count(names::AGENT_STEP_STARTED),
+        count(names::AGENT_STEP_COMPLETED),
+        "every step that started must have completed: {seen:?}"
+    );
+}
+
+/// A policy extension refuses the tool, and the refusal lands *before* the
+/// reverse request — the host is never asked to run it.
+///
+/// That ordering is the whole point of gating in the port rather than on the
+/// answer: a `Deny` evaluated after dispatch would be a veto of the result,
+/// by which time the host has already done the thing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_blocking_extension_refuses_a_tool_before_the_host_is_asked() {
+    let mut session = Session::start(spec_with(vec![Arc::new(RefuseTool("echo"))]));
+    let tool_requests = run_turn(&mut session).await;
+    assert!(
+        tool_requests.is_empty(),
+        "a denied tool must never reach the host, but it was asked to run {tool_requests:?}"
+    );
+}
+
+/// A `Modify` decision rewrites what the host is asked to run — the "adding
+/// context" half of the hook contract, as opposed to the refusing half.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_blocking_extension_rewrites_the_input_the_host_receives() {
+    let mut session = Session::start(spec_with(vec![Arc::new(RewriteInput)]));
+    let tool_requests = run_turn(&mut session).await;
+    assert_eq!(tool_requests.len(), 1);
+    assert_eq!(
+        tool_requests[0].1,
+        json!({ "text": "rewritten by policy" }),
+        "the host must receive the policy's input, not the model's"
+    );
+}
+
+/// A deployment that installed no extensions must behave exactly as it did
+/// before hooks existed: the turn runs, and nothing pays for a bus.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_turn_with_no_extensions_runs_unchanged() {
+    let mut session = Session::start(spec_with(Vec::new()));
+    let tool_requests = run_turn(&mut session).await;
+    assert_eq!(tool_requests.len(), 1);
+}
+
+/// The registration rule, structurally: **no route registers a hook.**
+///
+/// Written as a sweep over the real route table rather than as prose, because
+/// prose is what let the rule be quietly reversed. A future route that
+/// accepted an extension from a remote caller would hand a host the raw input
+/// of every tool call and a `Deny` it can steer the engine with — so adding
+/// one has to fail here first, and be argued rather than merged.
+#[test]
+fn no_route_lets_a_remote_caller_register_a_hook() {
+    for route in stella_serve::observe::Route::ALL {
+        let template = route.template();
+        assert!(
+            !template.contains("hook") && !template.contains("extension"),
+            "{template} looks like a hook-registration route — extensions are \
+             operator-installed only (see stella_serve::extensions)"
+        );
+    }
+}


### PR DESCRIPTION
## What & why

Two engine capabilities worked on the command line and were unreachable from the API. Both are now wired, with the rule about *who may use them* written where a test keeps it true.

**Hooks — operator-installed, never remote.** A served turn mints a per-turn `stella_core::bus::HookBus`, installs the operator's `ServeExtension`s on it, and attaches it to the engine via `Engine::with_bus`. Observers see `agent.turn.*`, `agent.step.*`, `model.request.*`, `tool.call.*` and `policy.*`; a handler registered with `on_blocking` gates `tool.call.requested` in `RemoteToolExecutor` — **before** the `tool_request` frame leaves — so a `Deny` means the host is never asked to run the tool at all, and a `Modify` rewrites the input it is asked to run.

Registration is `ServeConfig::extensions`: Rust code in whatever binary calls `serve`, set before the listener binds. No route registers, uploads, or names an extension. That boundary is argued in `src/extensions.rs` and pinned in `tests/hooks.rs` as a sweep over the real route table rather than as prose — the bearer token authenticates a *host*, not the operator, and a host that could install a handler could read every tool call's raw input and steer the engine with a `Deny`. The settings-declared **shell** hook engine (`stella_core::hooks`) stays deliberately unreachable server-side, for the same reason the tool executor is remoted: the sidecar must not be makeable to spawn a shell.

Because `stella-serve` drives `run_step` itself rather than calling `run_turn`, `agent.turn.started` / `agent.turn.completed` are framing this crate owns and had to be emitted here — they were absent for a served turn even with a bus attached, leaving an observer with steps and no turn around them. They now go through `run_turn`'s own payload shapers (`stella_core::driver::lifecycle`, made public), so the two drivers cannot describe one boundary differently. A deployment that installs nothing mints no bus, so every engine emit site stays behind its `if let Some(bus)` and behavior is unchanged.

**Cost drift — measured, and readable.** `Calibration` now keeps the raw `(estimated, actual)` totals alongside its EWMA, and `CalibrationMap::report()` returns them per model. Served turns attach a `CalibrationMap` kept per `provider_id` for the process's life, and `GET /v1/calibration` reports the gap:

```json
{"models":[{"provider_id":"anthropic","model":"…","samples":12,
            "estimated_input_tokens":41000,"actual_input_tokens":52000,
            "drift_ratio":1.268,"applied_factor":1.268}]}
```

`drift_ratio` is the measured gap, unsmoothed and unclamped; `applied_factor` is the bounded correction actually multiplied into estimates. Deliberately two numbers: a report that inherited the sample clamp would understate exactly the tokenizer mismatch it exists to surface. Keying by `provider_id` before the map keys by model is what stops two providers pointed at the same model name from blending into an average that describes neither. Nothing is persisted — this crate has no store — so a redeployed sidecar re-converges, which is why every row carries `samples`.

`stella-parity` moves `hooks.lifecycle` and `calibration.drift` from `Deferred` to `Shipped` on the API surface, each naming its witness, and the route sweep now claims `/v1/calibration`.

Closes #1298

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Verified by disabling each piece of wiring in turn and re-running:

| Wiring removed | Failure |
|---|---|
| `engine.with_bus(bus)` | `operator_hooks_fire_across_a_served_turn`: *a served turn never emitted `agent.step.started`* |
| the `agent.turn.*` emits in `drive_turn` | same test: *never emitted `agent.turn.started`* (steps fire, the turn around them does not) |
| `SessionSpec::calibration` attachment | `the_drift_report_is_readable_through_the_api` and `drift_is_reported_per_provider_not_just_per_model`: `{"models":[]}` |

New suites:

- `stella-serve/tests/hooks.rs` — boundaries reach an observer **and pair** (`step.started` count equals `step.completed`); a policy `Deny` lands before the host is asked; a `Modify` rewrites what the host receives; the raw `tool.call.requested` payload never reaches a plain observer; a turn with no extensions runs unchanged; and no route lets a remote caller register a hook.
- `stella-serve/tests/calibration.rs` — a real turn over a real socket, then the gap read back; per-provider separation; authenticated and read-only (401 unauthenticated, 405 on POST).
- `stella-core/src/estimator.rs` — the report names every model and its measured gap, shows the **raw** gap rather than the clamped one, and reports nothing for an empty map.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated — `docs/design/serve-surface.md` (route table row + a "Hooks — who may register one" section) and `stella-serve/README.md` (layout, gotchas, testing)
- [x] `Closes #1298` appears above and as a commit trailer
- [x] `check-file-size`, `check-wire-schema`, `check-doc-citations`, `check-invariants` all pass

## Ground-rule check

- [x] No I/O added to `stella-core` — the estimator change is two `u64` accumulators and a sorted read; no new dependencies in any crate
- [x] No new outbound network calls — `/v1/calibration` is pull-only, like `/v1/metrics`
- [x] `DriftReport` serializes one way (server → host) and is asserted against literal JSON in `tests/calibration.rs`

## Anything reviewers should know?

**The registration rule is the reviewable decision here.** The issue left it open ("probably operator-configured only, at least initially"); this takes that option and makes it structural. If a future PR wants remote registration, it has to delete a test that says why not.

**`stella-graph/src/store.rs` fails `check-file-size` at 1632 lines.** That is pre-existing on `main` — confirmed by running the gate against a stashed tree — and untouched here. I deliberately did not run `make file-size-update`, which regenerates the whole baseline and would have silently grandfathered it. Nothing in this PR grows a baselined file: `stella-core/src/driver.rs` comes out 3 lines *smaller*, because moving the model-call payload shapers into `driver/lifecycle.rs` more than paid for the new `Engine::call_role` accessor.

**Two engine-visible additions to `stella-core`, both small.** `driver/lifecycle.rs` becomes `pub` so serve can emit turn boundaries with the same payloads, and `Engine::call_role()` is the reader for the already-public `with_call_role` — added to `COMPOSITION_SEAMS` in the parity matrix, since a host driving steps needs the role for `agent.turn.started` and should not keep a second copy of the engine's default.

**Deferred, and stated rather than discovered:** calibration samples are not persisted, so drift resets on redeploy; giving serve a store is a separate decision. The `file.*` / `command.*` blocking chains the CLI's `ToolRegistry` gates have no server-side analogue, because the sidecar touches no filesystem and runs no commands of its own.

---

---

## Summary by Sourcery

Wire operator-installed hook extensions into served turns and expose per-provider token drift reporting via a new calibration API endpoint.

New Features:
- Add operator-configured ServeExtension hook plane to stella-serve turns, including turn lifecycle and tool-call events with policy gating.
- Expose token drift calibration data per provider and model through GET /v1/calibration, backed by shared in-process calibration maps.

Enhancements:
- Share lifecycle payload shapers from stella-core so locally and remotely driven turns emit consistent hook events.
- Extend calibration logic to track raw estimated vs actual token totals and derive a human-readable drift ratio separate from the applied correction factor.
- Document the hooks registration boundary and the calibration endpoint in serve design docs and README, and mark hooks.lifecycle and calibration.drift as shipped in the parity matrix.

Tests:
- Add hook-focused session tests ensuring lifecycle events fire, tool policies gate calls before dispatch, and no HTTP route allows remote hook registration.
- Add calibration tests that drive real turns over HTTP, validate `/v1/calibration` behavior, provider separation, auth, and read-only semantics, plus unit tests for estimator and registry behavior.
