### PR TITLE
fix(gate): record the harbor adapter's growth in the size baseline

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2284 bench/harbor_adapter/stella_harbor/__init__.py
+2295 bench/harbor_adapter/stella_harbor/__init__.py
 4292 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2339 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
@@ -22,7 +22,7 @@
 1515 stella-cli/src/fleet_cmd.rs
 1526 stella-cli/src/memory/tests.rs
 2129 stella-core/src/bus.rs
-2767 stella-core/src/driver.rs
+2764 stella-core/src/driver.rs
 3661 stella-core/src/driver/tests.rs
 1677 stella-model/src/anthropic/tests.rs
 2072 stella-model/src/openai.rs


### PR DESCRIPTION
`main` is red on `check-file-size` again — a different file from the last two times.

## What broke

`bench/harbor_adapter/stella_harbor/__init__.py` grew to **2295 lines** when #1325 (`065e047c`) landed the Bedrock credential-set work, 11 over its recorded ceiling of 2284.

This is the guard's **grandfathered** branch, so unlike #1322's `store.rs` the remedy here *is* a baseline bump. That file is already an accepted exemption, and the guard explicitly asks for the raise to land as a visible diff rather than a split:

> These grandfathered files grew past their recorded ceiling. If the growth is irreducible ... run `make file-size-update` and commit the baseline diff so the increase is visible in review.

Three `check-file-size` failures landed on `main` today with three different remedies — worth keeping straight, because the red X looks identical:

| what happened | remedy |
|---|---|
| baseline drifted / duplicate row (#1310) | regenerate |
| new file crossed 1500, not grandfathered (#1322) | **split the file** |
| grandfathered file grew (this PR) | **raise its ceiling** |

Which paragraph the script prints is the whole diagnosis.

## The change

Two rows:

| file | before | after | |
|---|---:|---:|---|
| `bench/harbor_adapter/stella_harbor/__init__.py` | 2284 | 2295 | the actual growth |
| `stella-core/src/driver.rs` | 2767 | 2764 | **retightened** — it shrank |

Regenerating tightens as readily as it raises, which is the point of the ratchet.

## On `LC_ALL=C`

Generated under `LC_ALL=C` so the sort matches what a Linux run produces. Without it, macOS collation reorders `agent.rs` against `agent_tests.rs` and adds a no-op move to the diff. The checker builds a map and does not care, but the churn is noise in review and a needless conflict surface for any open branch touching this file — it already caused one rebase conflict earlier today.

Might be worth pinning `LC_ALL=C` inside `check-file-size.sh --update` so regeneration is reproducible regardless of who runs it. Left out of this PR to keep an unbreak-main change minimal.

## Verification

By exit code, not by reading output:

```
check-file-size          EXIT=0
cargo fmt --all --check  EXIT=0
shellcheck               EXIT=0
```

Baseline-only change, so nothing recompiles.

## Context

`main` has now been broken and repaired three times today, each by a merge that outran its own CI: #1306's baseline regeneration, #1313's oversized `store.rs`, and now #1325. Each looked unremarkable in review — that is exactly what the gate exists to catch, and it did, just after the merge rather than before it.

## Summary by Sourcery

Update file size baseline configuration to reflect recent changes in grandfathered files and keep the size gate passing.

Build:
- Adjust recorded line-count ceiling for bench/harbor_adapter/stella_harbor/__init__.py to match its new size.
- Retighten the recorded line-count ceiling for stella-core/src/driver.rs to reflect its reduced size.