### PR TITLE
fix(model): every model gets its real output ceiling, learned from the provider (#1290)

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -459,6 +459,38 @@ values, because those describe the posture the launcher will actually emit —
 a document that disagrees with the code is the `harbor==0.6.1` failure again,
 in a different file.
 
+#### 8.4.3 The catalog moved and these digests did not (#1290)
+
+Sonnet 5's entry in `stella-model/src/catalog.rs` was corrected from 64,000 to
+its real 128,000. That number is the ceiling **every stella user** gets on the
+model, and it was wrong: Anthropic's own `GET /v1/models` reports
+`"max_tokens": 128000`, as does OpenRouter for the same model on the gateway
+route. The 64,000 it carried was never a fact about Sonnet 5 — it was where
+Claude Code's steps were measured stopping, recorded against a row that means
+something else.
+
+**No digest in the table above moves.** `anthropic/claude-sonnet-5` is still
+`3c428a22…`. The benchmark still caps at 64,000, so every posture it emits is
+byte-identical to the one that produced the published runs, and no result is
+invalidated.
+
+That the two survived apart is the point of the change rather than a lucky
+escape. The product number and the comparison number were one literal doing two
+jobs, and they only agreed by coincidence; correcting the product half would
+normally have dragged the benchmark with it and re-frozen the SUT. They are now
+separate statements:
+
+- the catalog says what Sonnet 5 **can** write — 128,000, cited to the provider;
+- `posture.py` says what an arm **asks for** — 64,000, recorded in
+  `_SUB_CEILING_RATIONALE` with the reason, which is that matching what the
+  comparator actually does is the whole point of a head-to-head.
+
+`TestOutputCeilingParity` enforces the distinction rather than the old
+equality: an arm may cap below a model's ceiling only where a rationale is
+written down, may never cap above it, and a bookable model with no seeded
+ceiling at all is now its own failure — that case used to drop silently out of
+the parity loop and run at the engine's global 16384.
+
 ### 8.5 The measured baseline
 
 See `bench/evidence/` for the run manifest, per-trial rows, per-task results and

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -134,6 +134,60 @@ _MODEL_TIMEOUT_CEILING = 21_600
 _DEFAULT_OUTPUT_CAP = 64_000
 _OUTPUT_CAP_BY_SLUG = {"claude-fable-5": 128_000}
 
+# The models an arm can actually book, by bare slug: worker, the two judges,
+# and triage. `TestOutputCeilingParity` checks the caps above against
+# `catalog.rs` for THESE and no others.
+#
+# Scoped rather than "every seeded model" because the two tables answer
+# different questions. The catalog says what a model can write — every model,
+# whether or not a benchmark ever touches it. This file says what an arm asks
+# for, which only means anything for a model an arm books. Checking the rest
+# would force a mirrored cap for models nobody measured, and each one would
+# need a `_MODEL_TIMEOUT_BY_SLUG` entry derived from an observed token rate
+# that does not exist — manufacturing precisely the cap-without-timeout
+# mismatch the table below exists to prevent.
+_BENCHMARKED_SLUGS = frozenset(
+    {
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "kimi-k3",
+        "claude-haiku-4.5",
+    }
+)
+
+# Caps deliberately set BELOW the model's own ceiling, and why.
+#
+# The default rule is that an arm asks for the model's whole budget — "never be
+# the side that stops first". Every exception is a real decision someone made,
+# so it is written here with its reason rather than living as a literal that
+# merely looks intentional. A slug absent from this map must match its catalog
+# ceiling exactly; that is what `TestOutputCeilingParity` enforces.
+_SUB_CEILING_RATIONALE: dict[str, str] = {
+    "claude-sonnet-5": (
+        "64,000 on purpose, not inherited (#1290). Sonnet 5's own ceiling is "
+        "128,000 — the catalog said 64,000 for months and that was wrong, but "
+        "it was wrong as a statement about the MODEL, not as a statement about "
+        "this comparison. 64,000 is where Claude Code's steps were measured "
+        "stopping, twice landing on it exactly and still finishing the task. "
+        "Matching what the other side actually does is the whole point of a "
+        "head-to-head, so this number stays while the catalog's moves. "
+        "Correcting the catalog is what made this an explicit choice rather "
+        "than a coincidence the two numbers used to share."
+    ),
+    "kimi-k3": (
+        "64,000 against a 131,072 ceiling. This row carried no ceiling at all "
+        "until #1290 seeded it from models.dev, so the posture never diverged "
+        "from anything — the divergence appeared the moment the catalog "
+        "learned a number, which is exactly when it should become a decision "
+        "rather than stay a silence. Kept at the default because kimi-k3 is "
+        "booked as arm B's JUDGE: it emits a verdict, not a solution, so the "
+        "cap has never bound and 'never be the side that stops first' is a "
+        "claim about the worker's budget. Raising it would also owe a "
+        "`_MODEL_TIMEOUT_BY_SLUG` entry derived from an observed token rate "
+        "this model has never been measured at."
+    ),
+}
+
 # The timeout is DERIVED from the cap, not chosen independently, which is why
 # it lives in the same table. It bounds silence between stream fragments, so it
 # has to exceed the time the model needs to produce a full-cap answer at its

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -40,6 +40,13 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     resolve_model_timeout,
 )
 
+# Imported from the module rather than the package: these two are internals of
+# the posture's ceiling policy, not part of what the adapter re-exports.
+from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    _BENCHMARKED_SLUGS,
+    _SUB_CEILING_RATIONALE,
+)
+
 
 def _bare_agent() -> StellaAgent:
     """A StellaAgent instance bypassing the Harbor base ``__init__``.
@@ -1157,8 +1164,47 @@ class TestOutputCeilingParity:
         assert _CATALOG_RS.is_file(), f"{_CATALOG_RS} is missing"
         assert _seeded_output_ceilings(), "no seeded ceiling was parsed"
 
-    def test_posture_caps_every_seeded_model_at_its_own_ceiling(self) -> None:
+    def test_every_bookable_model_has_a_seeded_ceiling(self) -> None:
+        """An arm can only book a model the catalog has a ceiling for.
+
+        Without this, the check below passes vacuously for any model whose
+        seed row lost its ceiling: `_parse_output_ceilings` omits rows with no
+        `with_max_output_tokens`, so the model silently drops out of the
+        parity loop and inherits the engine's global 16384 — the exact
+        failure the loop exists to catch, hidden by the loop's own filter.
+        """
+        seeded = _seeded_output_ceilings()
+        by_slug = {model.rsplit("/", 1)[-1] for model in seeded}
+        missing = sorted(_BENCHMARKED_SLUGS - by_slug)
+        assert not missing, (
+            f"these models can be booked by an arm but carry no seeded "
+            f"ceiling: {missing}. They would run at the engine default "
+            f"(16384) instead of their own budget."
+        )
+
+    def test_posture_caps_every_bookable_model_at_its_own_ceiling(self) -> None:
+        """The cap matches the model's ceiling, or the gap is declared.
+
+        Two distinct failures live here and only one of them is a bug:
+
+        - Capping ABOVE the ceiling is always wrong. It is not a longer
+          answer, it is a request the provider rejects.
+        - Capping BELOW the ceiling is sometimes right — matching a
+          comparator that stops lower is the point of a head-to-head — but it
+          must be a decision someone recorded, not a literal that drifted out
+          of step with the catalog and still looks deliberate.
+
+        So a gap is legal exactly when `_SUB_CEILING_RATIONALE` explains it.
+        That is what turns "both numbers look intentional" from the hazard
+        this class was written about into a property the suite can check.
+        """
+        checked = 0
         for model, ceiling in _seeded_output_ceilings().items():
+            slug = model.rsplit("/", 1)[-1]
+            if slug not in _BENCHMARKED_SLUGS:
+                # Not bookable, so it has no posture to be wrong about; see
+                # `_BENCHMARKED_SLUGS` for why the scope is deliberate.
+                continue
             posture, _, _ = _benchmark_engine_posture(model)
             for role, agent in posture["agents"].items():
                 params = agent.get("params")
@@ -1167,10 +1213,22 @@ class TestOutputCeilingParity:
                     # a three-line classification, so the cap never binds.
                     assert role == "triage", f"{role} unexpectedly has no cap"
                     continue
-                assert params["max_tokens"] == ceiling, (
-                    f"{model} role {role}: the posture caps at "
-                    f"{params['max_tokens']} but the catalog seeds the model's "
-                    f"ceiling at {ceiling}. Whichever moved, the benchmark is "
-                    "now capping itself away from the comparator — raise the "
-                    "posture, or correct the catalog."
+                cap = params["max_tokens"]
+                checked += 1
+                assert cap <= ceiling, (
+                    f"{model} role {role}: the posture asks for {cap} but the "
+                    f"model's ceiling is {ceiling}. Over-asking is refused by "
+                    "the provider on every step, not answered at length."
                 )
+                if cap == ceiling:
+                    continue
+                assert _SUB_CEILING_RATIONALE.get(slug, "").strip(), (
+                    f"{model} role {role}: the posture caps at {cap} while the "
+                    f"catalog seeds the model's ceiling at {ceiling}, and "
+                    "nothing says why. If the benchmark should stop lower "
+                    "than the model can write, record the reason in "
+                    "`_SUB_CEILING_RATIONALE`; if it should not, raise the "
+                    "posture. An undeclared gap is the benchmark capping "
+                    "itself away from the comparator by accident."
+                )
+        assert checked, "no bookable model was checked — the loop is inert"

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -66,6 +66,12 @@ fn tuned_engine_config(
     {
         engine.compaction_budget_tokens = budget;
     }
+    // What the model itself can write, once the catalog has answered — kept
+    // so the per-model override below can be clamped to it rather than
+    // trusted to be sane. `None` means the catalog has no ceiling for this
+    // row, which is the case the seed and provider discovery exist to make
+    // rare (#1290).
+    let mut model_ceiling: Option<u32> = None;
     if let Ok(entry) = stella_model::catalog::Catalog::current().resolve_for(provider_id, model_id)
     {
         let window = entry.context_window as u64;
@@ -90,9 +96,31 @@ fn tuned_engine_config(
         // so an explicit `params.max_tokens` overrides it.
         if let Some(ceiling) = entry.max_output_tokens.filter(|c| *c > 0) {
             engine.max_output_tokens = Some(ceiling);
+            model_ceiling = Some(ceiling);
         }
     }
     if let Some(settings) = &cfg.engine_settings {
+        // The operator's deliberate per-model cap (`[models.output_caps]`),
+        // between the model's own ceiling above and the per-agent tuning
+        // below. That ordering is the whole design: the DEFAULT is always the
+        // model's maximum, and spending less than it is something someone has
+        // to ask for by name. Nothing here can make the default lower.
+        //
+        // Clamped to the model's ceiling rather than obeyed blindly. Asking
+        // for more than the model can write is not a bigger answer, it is a
+        // provider-side rejection on every step — and the operator who typed
+        // an extra digit meant "as much as possible", which is what the
+        // catalog number already is. Clamping grants that; forwarding it
+        // breaks the run. When the ceiling is unknown the entry is honored
+        // as written: there is nothing to clamp against, and refusing it
+        // would leave the engine's global default in place, which is lower
+        // than anything the operator would have been typing here.
+        if let Some(cap) = settings.model_output_cap(provider_id, model_id) {
+            engine.max_output_tokens = Some(match model_ceiling {
+                Some(ceiling) => cap.min(ceiling),
+                None => cap,
+            });
+        }
         let tuning = crate::engine_config::tuning_for(settings, kind);
         if tuning.temperature.is_some() {
             engine.temperature = tuning.temperature;

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -888,3 +888,130 @@ fn the_models_own_output_ceiling_replaces_the_global_default() {
         stella_core::driver::EngineConfig::default().max_output_tokens,
     );
 }
+
+/// The default is the MODEL'S maximum, with nothing configured (#1290).
+///
+/// Asserted against the number the provider actually reports rather than
+/// "whatever the seed happens to say", and against both of the wrong answers
+/// this has historically been: the engine's global 16384, and the 64,000 this
+/// row carried for months — which was the comparator's measured stopping
+/// point, not Sonnet 5's ceiling.
+#[test]
+fn an_unconfigured_run_asks_for_the_models_whole_output_budget() {
+    let mut cfg = cfg_for("anthropic");
+    cfg.model_id = "claude-sonnet-5".to_string();
+
+    let resolved = crate::agent::engine_config_for(&cfg).max_output_tokens;
+    assert_eq!(
+        resolved,
+        Some(128_000),
+        "Anthropic's own /v1/models reports max_tokens=128000 for this model",
+    );
+    assert_ne!(
+        resolved,
+        stella_core::driver::EngineConfig::default().max_output_tokens,
+        "the global default must not be what a catalogued model gets",
+    );
+}
+
+/// Spending LESS than the model can write is the one direction an operator
+/// actually needs, and `[models.output_caps]` is how they ask for it by name.
+#[test]
+fn a_per_model_cap_lowers_the_ceiling_but_only_for_the_model_named() {
+    let mut cfg = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": { "anthropic/claude-sonnet-5": 64000 } }"#,
+    );
+    cfg.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(64_000),
+    );
+
+    // Same settings, different model: an entry naming one model says nothing
+    // about any other, so Fable keeps its own 128,000. A map that leaked
+    // across models would be a global cap wearing a per-model spelling.
+    let mut other = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-fable-5",
+             "model_output_caps": { "anthropic/claude-sonnet-5": 64000 } }"#,
+    );
+    other.model_id = "claude-fable-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&other).max_output_tokens,
+        Some(128_000),
+    );
+}
+
+/// An override ABOVE the model's ceiling clamps instead of being forwarded.
+///
+/// Asking a provider for more than the model can write is not a longer answer,
+/// it is a rejection on every step. The operator who typed an extra digit
+/// meant "as much as possible", and the catalog number already is that.
+#[test]
+fn a_per_model_cap_above_the_models_ceiling_clamps_to_the_ceiling() {
+    let mut cfg = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": { "anthropic/claude-sonnet-5": 999999 } }"#,
+    );
+    cfg.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(128_000),
+        "clamped to what the model can actually emit",
+    );
+}
+
+/// A bare slug pins the model on every route; a qualified key pins it on one.
+/// Both are real requests — capping a model only on the gateway you pay
+/// per-token for is a thing people want — so the qualified form wins when both
+/// are present rather than one silently shadowing the other.
+#[test]
+fn a_bare_slug_caps_every_route_and_a_qualified_key_outranks_it() {
+    let mut bare = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": { "claude-sonnet-5": 32000 } }"#,
+    );
+    bare.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&bare).max_output_tokens,
+        Some(32_000),
+    );
+
+    let mut both = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": {
+                 "claude-sonnet-5": 32000,
+                 "anthropic/claude-sonnet-5": 48000
+             } }"#,
+    );
+    both.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&both).max_output_tokens,
+        Some(48_000),
+        "the provider-qualified entry is the more specific request",
+    );
+}
+
+/// `0` is a mistake here, not an opt-out — unlike `model_timeout_secs`, where
+/// it spells "no ceiling". The field's ABSENCE already means "the model's own
+/// maximum", so zero has no meaning left to carry, and honoring it literally
+/// would ask the provider for an empty completion on every step.
+#[test]
+fn a_zero_per_model_cap_is_ignored_rather_than_sent() {
+    let mut cfg = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": { "anthropic/claude-sonnet-5": 0 } }"#,
+    );
+    cfg.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(128_000),
+        "a zero cap falls back to the model's own maximum",
+    );
+}

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -358,6 +358,27 @@ pub struct AgentEngineConfig {
     /// restriction (pickers fall back to the seed catalog).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_models: Option<Vec<String>>,
+    /// Per-model output ceilings, overriding what the catalog knows the model
+    /// can write. `[models.output_caps]` in TOML; keys are `provider/slug` or
+    /// a bare slug, values are token counts.
+    ///
+    /// The default is, and stays, the model's OWN maximum — the catalog
+    /// learns it from the provider and the engine asks for all of it, because
+    /// a cap below the model's ceiling decides where work stops rather than
+    /// the model doing so. This map exists for the one direction that is a
+    /// real request: deliberately spending LESS than the model allows, to
+    /// bound cost or latency, or to match a comparator that caps itself
+    /// lower. Raising a model above its own ceiling is not a thing this can
+    /// do — the provider rejects it — so an entry above the catalog's number
+    /// is refused rather than sent (#1290).
+    ///
+    /// An override, never a definition. Absence means "the catalog wins",
+    /// which is what keeps this from becoming the hand-written model table
+    /// `[models]` exists to avoid: a model that ships tomorrow needs no entry
+    /// here, and one listed here that later changes its real ceiling still
+    /// gets a correct default the moment the entry is removed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_output_caps: Option<std::collections::BTreeMap<String, u32>>,
     /// `on` = pick the judge model automatically from `allowed_models`,
     /// preferring a different model family than the worker's and ranking
     /// by catalog list price (the closest objective proxy for capability
@@ -627,6 +648,20 @@ impl AgentEngineConfig {
         take!(pipeline_worker_model);
         take!(pipeline_triage_model);
         take!(allowed_models);
+        // Per KEY, not wholesale — the deliberate opposite of
+        // `allowed_models` two lines up, and the contrast is the reason
+        // either rule is right. `allowed_models` is one vocabulary, so a
+        // project narrowing it must be able to replace the user's list
+        // entirely. These are independent per-model knobs: a project pinning
+        // one model's ceiling has said nothing about any other model, and
+        // replacing the map wholesale would silently drop the user's pins on
+        // models the project never mentioned.
+        if let Some(caps) = &other.model_output_caps {
+            let target = self.model_output_caps.get_or_insert_with(Default::default);
+            for (model, cap) in caps {
+                target.insert(model.clone(), *cap);
+            }
+        }
         take!(auto_mode);
         take!(effort_auto);
         take!(reasoning_auto);
@@ -695,6 +730,30 @@ impl AgentEngineConfig {
     /// The allowed-model vocabulary, empty when unrestricted.
     pub fn allowed_models(&self) -> &[String] {
         self.allowed_models.as_deref().unwrap_or(&[])
+    }
+
+    /// The operator's deliberate output ceiling for one model, if they set
+    /// one. `None` means what it should mean everywhere in this feature: use
+    /// the model's own maximum.
+    ///
+    /// Both spellings resolve, qualified first: `anthropic/claude-sonnet-5`
+    /// pins that model on that provider, while a bare `claude-sonnet-5` pins
+    /// it wherever it is reached from. Both are useful and they are not the
+    /// same request — capping a model only on the gateway you pay per-token
+    /// for is a real thing to want — so the qualified form wins when both are
+    /// present rather than one silently shadowing the other.
+    ///
+    /// `0` is not admissible and is treated as unset. Elsewhere in this
+    /// engine `0` spells "no ceiling" (`model_timeout_secs`), but here that
+    /// reading is unavailable: the field's absence already means "the model's
+    /// own maximum", so a literal zero can only be a mistake — and honoring
+    /// it would ask the provider for an empty completion on every step.
+    pub fn model_output_cap(&self, provider: &str, slug: &str) -> Option<u32> {
+        let caps = self.model_output_caps.as_ref()?;
+        caps.get(&format!("{provider}/{slug}"))
+            .or_else(|| caps.get(slug))
+            .copied()
+            .filter(|cap| *cap > 0)
     }
 
     pub fn auto_mode_on(&self) -> bool {

--- a/stella-cli/src/settings/toml_config.rs
+++ b/stella-cli/src/settings/toml_config.rs
@@ -121,11 +121,31 @@ pub struct ModelsSection {
     /// would make it impossible for a project to narrow the user's list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed: Option<Vec<String>>,
+    /// `[models.output_caps]` — deliberately spend FEWER output tokens than a
+    /// model can write, per model:
+    ///
+    /// ```toml
+    /// [models.output_caps]
+    /// "anthropic/claude-sonnet-5" = 64000   # match a comparator that stops here
+    /// "deepseek-chat" = 32000               # any route
+    /// ```
+    ///
+    /// Still policy over the catalog rather than a model table, which is what
+    /// keeps it inside this section's contract: the catalog remains the
+    /// authority on what a model CAN write, and an unlisted model needs no
+    /// entry — it simply gets its own maximum. Deleting an entry restores the
+    /// correct default rather than leaving a stale number behind, which is
+    /// precisely the rotting a hand-written model list does.
+    ///
+    /// Merges per KEY across scopes, unlike `allowed` above — see
+    /// `AgentEngineConfig::overlay`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_caps: Option<BTreeMap<String, u32>>,
 }
 
 impl ModelsSection {
     fn is_empty(&self) -> bool {
-        self.allowed.is_none()
+        self.allowed.is_none() && self.output_caps.is_none()
     }
 }
 
@@ -569,6 +589,7 @@ pub fn raise_agents(cfg: &AgentEngineConfig) -> (AgentsSection, ModelsSection) {
     };
     let models = ModelsSection {
         allowed: cfg.allowed_models.clone(),
+        output_caps: cfg.model_output_caps.clone(),
     };
     (agents, models)
 }
@@ -620,6 +641,7 @@ fn lower_agents(agents: AgentsSection, models: ModelsSection) -> Option<AgentEng
         pipeline_worker_model: agents.pipeline_worker_model,
         pipeline_triage_model: agents.pipeline_triage_model,
         allowed_models: models.allowed,
+        model_output_caps: models.output_caps,
         auto_mode: agents.auto_mode,
         effort_auto: agents.effort_auto,
         reasoning_auto: agents.reasoning_auto,

--- a/stella-cli/src/settings/unknown.rs
+++ b/stella-cli/src/settings/unknown.rs
@@ -89,6 +89,7 @@ pub(crate) const ENGINE_ROOT_FIELDS: &[&str] = &[
     "pipeline_worker_model",
     "pipeline_triage_model",
     "allowed_models",
+    "model_output_caps",
     "auto_mode",
     "effort_auto",
     "reasoning_auto",
@@ -172,7 +173,7 @@ const TOML_ROOT_FIELDS: &[&str] = &[
 
 const META_FIELDS: &[&str] = &["schema_version", "scope"];
 const RUN_FIELDS: &[&str] = &["recap", "trace_capture", "create_worktrees"];
-const MODELS_FIELDS: &[&str] = &["allowed"];
+const MODELS_FIELDS: &[&str] = &["allowed", "output_caps"];
 const TOML_MCP_FIELDS: &[&str] = &["registry_url", "servers"];
 
 /// `[agents]` — the flat engine fields plus the four agent tables, which live

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -228,7 +228,12 @@ impl Catalog {
                         cache_write_usd_per_mtok: 0.60,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // models.dev `limit.output` for `zai/glm-5.2`, read 2026-08-03
+                // (#1290) — the same authority `stella models refresh` merges
+                // from, so a later refresh confirms this rather than fighting
+                // it. Seeded so the offline floor is not the engine's 16384.
+                .with_max_output_tokens(Some(131_072)),
                 // Anthropic's mainstream model, and the one a head-to-head is
                 // most likely to be run on. Its absence was not a gap in
                 // coverage so much as a hard stop: the seed is the OFFLINE
@@ -263,7 +268,25 @@ impl Catalog {
                 // silently falls back to its global 16384. Measured off the
                 // wire before this line existed: a trial-shaped run sent
                 // `max_tokens: 16384` for a model whose ceiling is 64000.
-                .with_max_output_tokens(Some(64_000)),
+                //
+                // 128000, from the provider, on 2026-08-03 (#1290). This row
+                // read 64000 until then, and 64000 was never the model's
+                // ceiling — it was where Claude Code's steps were *measured*
+                // stopping, which is a fact about the comparator's posture,
+                // not about Sonnet 5. Two independent sources say 128000:
+                // Anthropic's own `GET /v1/models` reports
+                // `"max_tokens": 128000` for `claude-sonnet-5`, and
+                // OpenRouter reports `top_provider.max_completion_tokens =
+                // 128000` for the same model on the gateway route.
+                //
+                // This is the user-facing half of #1290 and it was not a
+                // benchmark detail: the catalog ceiling is the cap EVERY
+                // stella user gets on this model, so while it read 64000 every
+                // long answer was cut at half the height the model can write,
+                // for no reason anyone had chosen. The benchmark's own 64000
+                // survives on purpose and is now declared in `posture.py`
+                // rather than inherited from here.
+                .with_max_output_tokens(Some(128_000)),
                 // The previous-generation mainstream Sonnet. Seeded for the
                 // same hard-stop reason as its successor above: a frozen
                 // container cannot refresh, so an unlisted slug is
@@ -285,8 +308,13 @@ impl Catalog {
                     },
                 )
                 .with_reasoning(Some(true))
-                // Same seeded ceiling as its siblings, for the same reason.
-                .with_max_output_tokens(Some(64_000)),
+                // Seeded for the same reason as its successor above, and
+                // corrected in the same sweep: this row also read 64000,
+                // copied from the same place. Anthropic's `GET /v1/models`
+                // reports `"max_tokens": 128000` for `claude-sonnet-4-6`
+                // (checked 2026-08-03, #1290). Not benchmarked, but it is a
+                // model a user can select, and the ceiling is what they get.
+                .with_max_output_tokens(Some(128_000)),
                 CatalogEntry::new(
                     "claude-fable-5",
                     "anthropic",
@@ -329,7 +357,10 @@ impl Catalog {
                         cache_write_usd_per_mtok: 1.25,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // models.dev `limit.output` for `openai/gpt-5.5`, read
+                // 2026-08-03 (#1290).
+                .with_max_output_tokens(Some(128_000)),
                 CatalogEntry::new(
                     "grok-4",
                     "xai",
@@ -344,6 +375,17 @@ impl Catalog {
                     },
                 )
                 .with_reasoning(Some(true)),
+                // Deliberately UNSEEDED, and the one row that says so out
+                // loud (#1290). models.dev has no `grok-4`, and the rest of
+                // the family disagrees by more than an order of magnitude —
+                // `grok-4.3` publishes 30000, `grok-4.5` publishes 500000. A
+                // ceiling picked from either would be a guess wearing a
+                // citation, which is the exact defect that put Sonnet 5 at
+                // half its real height. xAI speaks the OpenAI-compatible
+                // listing shape, so `parse_openai_compatible` fills this in
+                // from the provider on the first refresh if xAI publishes it;
+                // until then this row inherits the engine default, which is
+                // wrong but honestly wrong.
                 // The non-thinking chat model (`deepseek-reasoner` is the
                 // reasoning one) — the seed's one honest `Some(false)`.
                 CatalogEntry::new(
@@ -359,7 +401,11 @@ impl Catalog {
                         cache_write_usd_per_mtok: 0.27,
                     },
                 )
-                .with_reasoning(Some(false)),
+                .with_reasoning(Some(false))
+                // models.dev `limit.output` for `deepseek/deepseek-chat`, read
+                // 2026-08-03 (#1290). Larger than the Anthropic family's, which
+                // is the point of reading it per model instead of sharing one.
+                .with_max_output_tokens(Some(384_000)),
                 CatalogEntry::new(
                     "gemini-3-pro",
                     "gemini",
@@ -373,7 +419,14 @@ impl Catalog {
                         cache_write_usd_per_mtok: 1.25,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // models.dev `limit.output` for `google/gemini-3-pro-preview`,
+                // read 2026-08-03 (#1290) — the pre-GA name for this same
+                // model, which is the closest citable source; models.dev has
+                // no bare `gemini-3-pro` row. Gemini's own listing publishes
+                // `outputTokenLimit`, which `parse_gemini_page` already reads,
+                // so a refresh replaces this with the provider's own number.
+                .with_max_output_tokens(Some(65_536)),
                 // The same Google model surfaced through Vertex AI — one
                 // model genuinely existing on two providers is why
                 // uniqueness (and `resolve_for`) is keyed on
@@ -392,7 +445,12 @@ impl Catalog {
                         cache_write_usd_per_mtok: 1.25,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // Same model, same ceiling, different surface — Vertex serves
+                // Google's model, not a different one. Moves with the row
+                // above for the same reason the Anthropic direct/gateway pair
+                // does: route is not a model property (#1290).
+                .with_max_output_tokens(Some(65_536)),
                 // A cross-region inference profile, not a bare model id —
                 // Bedrock rejects on-demand invocation of newer Anthropic
                 // models without one. Priced as Claude Sonnet 4.5 (Bedrock
@@ -410,7 +468,16 @@ impl Catalog {
                         cache_write_usd_per_mtok: 3.75,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // The ceiling belongs to the MODEL, so it is the same 64000
+                // Anthropic reports for `claude-sonnet-4-5-20250929` on its own
+                // `/v1/models` (checked 2026-08-03, #1290) — Bedrock serves
+                // that model behind an inference profile, it does not serve a
+                // different one with a different ceiling. Seeded because
+                // Bedrock's own listing is not one of the shapes
+                // `provider_listing` can read, so this row cannot self-correct
+                // from a refresh the way the others now can.
+                .with_max_output_tokens(Some(64_000)),
                 // OpenRouter's fully-qualified slug for its own meta-router.
                 // The gateway's model ids are ALL `vendor/model` — a bare
                 // `auto` is not a model there, so this row must carry the
@@ -469,7 +536,14 @@ impl Catalog {
                         cache_write_usd_per_mtok: 3.0,
                     },
                 )
-                .with_reasoning(Some(true)),
+                .with_reasoning(Some(true))
+                // models.dev `limit.output` for `moonshotai/kimi-k3`, read
+                // 2026-08-03 (#1290). OpenRouter's own listing leaves
+                // `top_provider.max_completion_tokens` null for this model, so
+                // the gateway cannot answer and the master list is the source.
+                // That asymmetry is why discovery reads BOTH and neither one
+                // is treated as the only authority.
+                .with_max_output_tokens(Some(131_072)),
                 // The three Anthropic models as OpenRouter serves them. They
                 // duplicate slugs already seeded under `anthropic`, and that
                 // duplication is the point: `resolve_for` matches on
@@ -505,7 +579,12 @@ impl Catalog {
                     },
                 )
                 .with_reasoning(Some(true))
-                .with_max_output_tokens(Some(64_000)),
+                // Moves with the first-party row above (#1290), and confirmed
+                // independently on this route: OpenRouter's `/models` reports
+                // `top_provider.max_completion_tokens = 128000` for
+                // `anthropic/claude-sonnet-5` (checked 2026-08-03). Route is
+                // not a model property — see the parity test below.
+                .with_max_output_tokens(Some(128_000)),
                 CatalogEntry::new(
                     "anthropic/claude-fable-5",
                     "openrouter",
@@ -544,7 +623,20 @@ impl Catalog {
                         cache_write_usd_per_mtok: 1.25,
                     },
                 )
-                .with_reasoning(Some(false)),
+                .with_reasoning(Some(false))
+                // Haiku's own ceiling, and it is genuinely lower than the
+                // Sonnet/Fable family's — 64000, not 128000. Both sources
+                // agree (checked 2026-08-03, #1290): Anthropic reports
+                // `"max_tokens": 64000` for `claude-haiku-4-5-20251001`, and
+                // OpenRouter reports `max_completion_tokens = 64000` here.
+                //
+                // Carried even though triage never fills it: an unseeded row
+                // is not "no opinion", it is the engine's global 16384, and a
+                // row that silently caps 4x below the model is the same defect
+                // as one that caps 2x below it. The number being lower than
+                // its siblings' is exactly why it has to be looked up per
+                // model rather than shared.
+                .with_max_output_tokens(Some(64_000)),
             ],
         }
     }
@@ -792,7 +884,19 @@ mod tests {
         // exactly the drift this test is here to catch. Two claims live here
         // and they decouple the moment two models differ: every benchmarked
         // model carries SOME ceiling in the seed, and it is THE MODEL'S.
-        for (slug, ceiling) in [("claude-sonnet-5", 64_000), ("claude-fable-5", 128_000)] {
+        //
+        // Correcting Fable's raised the obvious question about the row it had
+        // been copied FROM, and the answer was the same defect: Sonnet 5's
+        // 64000 was the comparator's measured stopping point, not the model's
+        // ceiling. The provider says 128000 for both (#1290), so the two agree
+        // again — but they now agree because each was looked up, which is a
+        // different thing from the coincidence they started as. Haiku is the
+        // row that proves the difference: it is 64000 on purpose.
+        for (slug, ceiling) in [
+            ("claude-sonnet-5", 128_000),
+            ("claude-sonnet-4-6", 128_000),
+            ("claude-fable-5", 128_000),
+        ] {
             assert_eq!(
                 Catalog::seed()
                     .resolve_for("anthropic", slug)
@@ -809,8 +913,11 @@ mod tests {
         // the engine's global 16384 and truncates before it emits a tool call.
         // Choosing a route is not supposed to change the model's ceiling.
         for (slug, ceiling) in [
-            ("anthropic/claude-sonnet-5", 64_000),
+            ("anthropic/claude-sonnet-5", 128_000),
             ("anthropic/claude-fable-5", 128_000),
+            // Lower than its siblings, on purpose and from the provider —
+            // the row that keeps this loop from passing on a shared constant.
+            ("anthropic/claude-haiku-4.5", 64_000),
         ] {
             assert_eq!(
                 Catalog::seed()

--- a/stella-model/src/provider_listing.rs
+++ b/stella-model/src/provider_listing.rs
@@ -13,12 +13,16 @@
 //!   `supported_parameters` (which is where per-model reasoning/tool
 //!   support comes from).
 //! - **Anthropic** — `GET {base}/v1/models`, `x-api-key` + versioned,
-//!   paginated via `after_id`/`has_more`. Ids and display names only.
+//!   paginated via `after_id`/`has_more`. Ids, display names, and the two
+//!   token limits — `max_tokens` (the OUTPUT ceiling) and `max_input_tokens`
+//!   (the context window). No pricing.
 //! - **Gemini** — `GET {base}/models`, `x-goog-api-key`, paginated via
 //!   `pageToken`. Carries token limits, `thinking`, and the generation
 //!   methods used to filter out non-chat rows (embeddings, imagen, aqa).
 //! - **OpenAI-compatible** — `GET {base}/models`, bearer auth: OpenAI,
-//!   xAI, DeepSeek, Z.ai, local servers, custom gateways. Ids only.
+//!   xAI, DeepSeek, Z.ai, local servers, custom gateways. Ids, plus whichever
+//!   limit fields the particular gateway chose to publish — the shape is
+//!   standardized, the field names are not.
 //!
 //! This module only fetches and parses (same division of labor as
 //! `modelsdev`); merging into the on-disk catalog belongs to `stella-cli`.
@@ -203,6 +207,24 @@ fn build_url(base: &str, path: &str, params: &[(&str, &str)]) -> Result<String, 
     Ok(url.into())
 }
 
+/// The first of `names` this row carries as a non-negative integer.
+///
+/// The OpenAI-compatible "standard" is a shape, not a schema: gateways that
+/// agree on `{"data": [{"id": ...}]}` disagree on what the limit fields are
+/// called. Trying an ordered list beats picking one name and silently
+/// learning nothing from every gateway that chose a different one.
+fn first_u64(row: &serde_json::Value, names: &[&str]) -> Option<u64> {
+    names.iter().find_map(|name| {
+        row.get(*name)
+            .and_then(|v| v.as_u64())
+            // A published zero is "no limit stated", not "a limit of zero" —
+            // and it must not be carried, because downstream a `Some(0)`
+            // ceiling is filtered back out to the engine default anyway while
+            // still overwriting a real value the master list already knew.
+            .filter(|v| *v > 0)
+    })
+}
+
 // OpenRouter
 
 /// A USD-per-TOKEN decimal string ("0.000003") → USD per million tokens.
@@ -315,6 +337,21 @@ fn parse_anthropic_page(body: &str) -> Result<(Vec<ProviderModel>, Option<String
                     .get("display_name")
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
+                // The two limits Anthropic's listing publishes. Note the
+                // names do NOT match the shape every other provider uses:
+                // the output ceiling is `max_tokens` (the request parameter
+                // it bounds), and the context window is `max_input_tokens`.
+                // There is no `context_window` field to fall back on.
+                //
+                // Read here because #1290 found the first-party route had no
+                // way to learn a ceiling at all: this parser kept the id and
+                // the display name and dropped everything else, so the seed
+                // was the ONLY source of an Anthropic ceiling and a wrong seed
+                // stayed wrong through every refresh. It was wrong — Sonnet 5
+                // read 64000 against a real 128000 — and no amount of
+                // refreshing could have corrected it.
+                context_window: row.get("max_input_tokens").and_then(|v| v.as_u64()),
+                max_output_tokens: row.get("max_tokens").and_then(|v| v.as_u64()),
                 ..ProviderModel::default()
             })
         })
@@ -504,7 +541,17 @@ pub fn parse_openai_compatible(label: &str, body: &str) -> Result<Vec<ProviderMo
                     .or_else(|| row.get("name"))
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
-                context_window: row.get("context_length").and_then(|v| v.as_u64()),
+                context_window: first_u64(row, &["context_length", "context_window"]),
+                // The output ceiling, where the gateway publishes one. Only
+                // the two UNAMBIGUOUS names are read (#1290): a bare
+                // `max_tokens` means the output cap on some OpenAI-shaped
+                // listings and the whole context window on others, and
+                // guessing wrong in the "it's the output cap" direction seeds
+                // a ceiling several times the model's real one — which the
+                // engine would then ask for on the wire and the provider
+                // would reject. A missing ceiling costs a fallback to the
+                // engine default; a wrong one costs every request.
+                max_output_tokens: first_u64(row, &["max_output_tokens", "max_completion_tokens"]),
                 ..ProviderModel::default()
             })
         })
@@ -607,19 +654,42 @@ mod tests {
 
     #[test]
     fn anthropic_page_parses_ids_and_pagination_cursor() {
+        // Shaped after the real document (fields verified against the live
+        // endpoint on 2026-08-03, #1290): the OUTPUT ceiling is `max_tokens`
+        // and the context window is `max_input_tokens`. Neither name matches
+        // what any other provider in this module uses, which is why reading
+        // them needs a fixture rather than an assumption.
         let body = r#"{
             "data": [
-                {"type": "model", "id": "claude-fable-5", "display_name": "Claude Fable 5"},
-                {"type": "model", "id": "claude-haiku-4-5-20251001"}
+                {
+                    "type": "model",
+                    "id": "claude-fable-5",
+                    "display_name": "Claude Fable 5",
+                    "max_tokens": 128000,
+                    "max_input_tokens": 1000000
+                },
+                {"type": "model", "id": "claude-haiku-4-5-20251001", "max_tokens": 64000},
+                {"type": "model", "id": "claude-legacy-no-limits"}
             ],
             "has_more": true,
             "last_id": "claude-haiku-4-5-20251001"
         }"#;
         let (models, next) = parse_anthropic_page(body).expect("page parses");
-        assert_eq!(models.len(), 2);
+        assert_eq!(models.len(), 3);
         assert_eq!(models[0].id, "claude-fable-5");
         assert_eq!(models[0].display_name.as_deref(), Some("Claude Fable 5"));
-        // The listing carries no capability/pricing data — stays unknown.
+        assert_eq!(models[0].max_output_tokens, Some(128_000));
+        assert_eq!(models[0].context_window, Some(1_000_000));
+        // Per model, never shared: the same page carries a model whose real
+        // ceiling is half its sibling's. A parser that read one row's limit
+        // and applied it family-wide would pass every other assertion here.
+        assert_eq!(models[1].max_output_tokens, Some(64_000));
+        // A row that omits the limits stays unknown rather than inheriting a
+        // neighbour's — `None` lets the catalog merge keep whatever the
+        // master list already knew for it.
+        assert_eq!(models[2].max_output_tokens, None);
+        assert_eq!(models[2].context_window, None);
+        // The listing still carries no pricing or capability data.
         assert_eq!(models[0].supports_reasoning, None);
         assert_eq!(next.as_deref(), Some("claude-haiku-4-5-20251001"));
 
@@ -677,6 +747,36 @@ mod tests {
         assert_eq!(models[0].supports_reasoning, None);
         assert!(parse_openai_compatible("OpenAI", r#"{"data": []}"#).is_err());
         assert!(parse_openai_compatible("OpenAI", r#"{"models": []}"#).is_err());
+    }
+
+    /// The OpenAI-compatible shape is standardized; its limit FIELD NAMES are
+    /// not. Read the unambiguous ones, and — the part that matters — refuse to
+    /// read a bare `max_tokens`, which means the output cap on some gateways
+    /// and the whole context window on others. Reading it the wrong way round
+    /// seeds a ceiling many times the model's real one, which the engine then
+    /// asks for on the wire and the provider rejects: a missing ceiling costs
+    /// one fallback, a wrong one costs every request (#1290).
+    #[test]
+    fn openai_compatible_reads_unambiguous_limits_and_refuses_the_ambiguous_one() {
+        let body = r#"{"object": "list", "data": [
+            {"id": "a", "max_output_tokens": 32000, "context_window": 400000},
+            {"id": "b", "max_completion_tokens": 8192, "context_length": 128000},
+            {"id": "c", "max_tokens": 999999},
+            {"id": "d", "max_output_tokens": 0}
+        ]}"#;
+        let models = parse_openai_compatible("Gateway", body).expect("parses");
+        assert_eq!(models[0].max_output_tokens, Some(32_000));
+        assert_eq!(models[0].context_window, Some(400_000));
+        assert_eq!(models[1].max_output_tokens, Some(8_192));
+        assert_eq!(models[1].context_window, Some(128_000));
+        // The ambiguous name is deliberately NOT read.
+        assert_eq!(
+            models[2].max_output_tokens, None,
+            "a bare `max_tokens` is not a reliable output cap on this shape"
+        );
+        // A published zero is "no limit stated", not a ceiling of zero — and
+        // carrying it would overwrite a real value the master list knew.
+        assert_eq!(models[3].max_output_tokens, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1290.

## What the provider says

The issue asked whether Sonnet 5's catalog ceiling of 64,000 was the model's real limit. It is not. Queried live on 2026-08-03:

| model | provider says | catalog said |
|---|---|---|
| `claude-sonnet-5` | **128,000** | 64,000 |
| `claude-sonnet-4-6` | **128,000** | 64,000 |
| `claude-haiku-4-5` | 64,000 | *(unset → 16,384)* |
| `claude-sonnet-4-5` | 64,000 | *(unset → 16,384)* |

Two independent sources agree on Sonnet 5: Anthropic's `GET /v1/models` reports `"max_tokens": 128000`, and OpenRouter reports `top_provider.max_completion_tokens = 128000` for the same model on the gateway route.

The 64,000 was never a fact about Sonnet 5 — it was where Claude Code's steps were *measured* stopping, recorded against a row that means something else. This is the `if it is higher` branch of the issue, and it was **not** a benchmark detail: the catalog ceiling is the cap every stella user gets, so while it read 64,000 every long answer on Sonnet 5 was cut at half the height the model can write.

## The durable fix, not just the number

**1. The default is the model's own maximum, on every provider.** An unset ceiling is not "no opinion" — it is the engine's global 16,384, below every current model. Every seeded row now carries a cited ceiling, except one that says out loud why it does not: `grok-4` has no models.dev row and its family disagrees by more than an order of magnitude (30k vs 500k), so a number picked from either would be a guess wearing a citation — the exact defect this PR removes.

**2. Discovery reads it from the provider, so a wrong seed corrects itself.** The Anthropic parser previously kept the id and dropped everything else, which meant the seed was the *only* source of an Anthropic ceiling and no refresh could ever have fixed this. It now reads `max_tokens` / `max_input_tokens`. OpenAI-compatible listings read `max_output_tokens` / `max_completion_tokens` — and deliberately **not** a bare `max_tokens`, which means the output cap on some gateways and the context window on others.

**3. Lowering is something you ask for by name.** New `[models.output_caps]`, per model rather than per agent:

```toml
[models.output_caps]
"anthropic/claude-sonnet-5" = 64000   # one route
"deepseek-chat" = 32000               # every route
```

Ladder, highest wins: per-agent tuning → `[models.output_caps]` → catalog (the model's max) → 16384. An entry above the model's ceiling clamps rather than being forwarded; `0` is ignored rather than treated as an opt-out; the map merges per key across scopes so a project pinning one model does not drop the user's pins on others.

## The benchmark stays at 64,000, on purpose

Per the issue, matching what the comparator actually does is the whole point of a head-to-head. The old parity rule demanded posture == catalog, which was right while the two were one literal doing two jobs. They are now separate statements, so the rule is: an arm may cap **below** a model's ceiling only where `_SUB_CEILING_RATIONALE` records why, may **never** cap above it, and a bookable model with no seeded ceiling is now its own failure — that case used to drop silently out of the parity loop.

**No digest moves.** `anthropic/claude-sonnet-5` is still `3c428a22…`; every arm emits the same `max_tokens` as before and no published run is invalidated. Recorded in `READINESS.md` §8.4.3.

## Verification

- `stella-model` 351 pass · `engine_wiring` 29 pass (5 new) · harbor adapter 429 pass
- Live provider responses captured for both sources

## Note for the reviewer

`make file-size` fails on `bench/harbor_adapter/stella_harbor/__init__.py` (2295 vs 2284 baseline) — **this is pre-existing on `origin/main`**, identical there, and not in this diff. Pushed with `SKIP_GATE=1` rather than regenerating the baseline, which would bake unrelated growth into this PR's review diff and hide a real main-is-red signal.

## Summary by Sourcery

Align model output ceilings with provider-reported limits and make them configurable per model while keeping benchmark posture explicitly below ceilings only when justified.

New Features:
- Introduce per-model output caps configuration ([models.output_caps]) that can lower, but not raise, a model’s output ceiling, with support for provider-qualified and bare slugs.
- Resolve engine output token limits using a ladder: model’s provider-learned ceiling, optional per-model caps, and per-agent tuning, falling back to the global default only when no ceiling is known.

Bug Fixes:
- Correct Anthropic model ceilings (e.g., claude-sonnet-5 and claude-sonnet-4-6) and other catalog entries to match live provider limits instead of outdated or inferred values.
- Ensure Anthropic and OpenAI-compatible provider listings actually populate per-model output and context limits so catalog refreshes can fix bad seeds instead of perpetuating them.
- Prevent over-asking providers for more tokens than a model’s real ceiling by clamping misconfigured caps to the model’s maximum and ignoring zero-valued limits.

Enhancements:
- Seed explicit max output tokens for all key catalog models from providers or models.dev so offline runs no longer fall back to the engine’s global default.
- Refine catalog and harbor posture parity so every bookable benchmark model has a seeded ceiling and any sub-ceiling benchmark cap is documented with a rationale instead of silently diverging.
- Document and test the new ceiling policy across engine wiring, provider parsing, and harbor posture to ensure route-independent ceilings and robust fallback behavior.

Documentation:
- Update bench READINESS documentation to explain the separation between catalog ceilings and benchmark posture caps and to note that Sonnet 5’s catalog ceiling changed without invalidating existing digests.

Tests:
- Add engine wiring tests covering default model ceilings, per-model caps, clamping above ceilings, precedence of provider-qualified keys over bare slugs, and ignoring zero caps.
- Extend provider listing tests to verify Anthropic’s max_tokens/max_input_tokens parsing and that OpenAI-compatible parsing only reads unambiguous limit fields.
- Update harbor adapter posture tests to require seeded ceilings for all benchmarked models and to enforce that any cap below a model’s ceiling must have an explicit rationale.