### PR TITLE
docs(context): repair the blockquote broken by #1330's conflict resolution

### DIFF
--- a/docs/design/adaptive-context/context-frame-spec.md
+++ b/docs/design/adaptive-context/context-frame-spec.md
@@ -9,8 +9,8 @@
 > representation) and **all wire semantics** are defined normatively by the
 > **Context Graph Protocol (CGP)** — not by this document. Stella consumes the CGP
 > types directly (`contextgraph-types`, pinned in the root `Cargo.toml`'s
-`[workspace.dependencies]`; used by
-> `stella-graph` and `stella-context`). All three paths below are in the **CGP
+> `[workspace.dependencies]`; used by `stella-graph` and `stella-context`). All
+> three paths below are in the **CGP
 > repository**, not this one: `SPEC.md`, `docs/adr/0007-protocol-product-boundary.md`,
 > and the reconciliation delta table `docs/adaptive-context-reconciliation.md`.
 > The latter two are the outcome of


### PR DESCRIPTION
## What

One line in `docs/design/adaptive-context/context-frame-spec.md` lost its `>`
prefix, ending the "Normative home — read this first" callout mid-sentence.
Everything after it renders as body text instead of part of the callout.

```diff
  > types directly (`contextgraph-types`, pinned in the root `Cargo.toml`'s
- `[workspace.dependencies]`; used by
- > `stella-graph` and `stella-context`). All three paths below are in the **CGP
+ > `[workspace.dependencies]`; used by `stella-graph` and `stella-context`). All
+ > three paths below are in the **CGP
```

## Where it came from

#1330 carried a commit repairing the normative-home gate. main had already
retired that gate wholesale in #1324 — script and workflow deleted — so the two
sides conflicted across eight files, and that commit was the only one on the
branch touching any of them.

Resolving toward #1330 on this file was **right on the content**: since #819 the
`contextgraph-*` crates are exact-version registry pins declared once in the root
`Cargo.toml`'s `[workspace.dependencies]`, and `stella-cli/Cargo.toml` only
inherits them via `.workspace = true`. Naming `stella-cli/Cargo.toml` as the pin
site was stale. Only the line wrapping came across malformed.

## Scope

Prose is unchanged — this re-wraps two lines and restores one `>`. I swept all
three CGP-deferring docs (`context-frame-spec.md`, `context-reuse.md`,
`directive-schema.md`) for blockquote continuations missing their prefix; this
was the only one. No conflict markers survive anywhere in the tree.

The surviving `check-normative-home.sh` mentions in `AGENTS.md`, `docs/README.md`
and `context-reuse.md` are intentional past-tense prose explaining that the gate
was retired. Left alone.

## Verification

| Check | Result |
|---|---|
| `make invariants` | pass — 8 invariants, one normative home, 16 citations resolve |
| `make no-scratch` | pass |
| blockquote sweep, 3 CGP docs | no unprefixed continuations remain |
| `make file-size` | **fails — pre-existing.** Identical exit 2 on stock `origin/main`; see below |

## Heads-up: `make file-size` is red on main

Unrelated to this diff, and it blocks the pre-push gate for everyone:

```
Obsolete baseline entries (the file is now under the limit).
  stella-cli/src/memory/tests.rs is now 1498 lines (<= 1500) — drop its baseline entry
  stella-graph/src/store.rs     is now 1060 lines (<= 1500) — drop its baseline entry
```

Both files shrank below 1500, so their grandfather entries are stale and
`make file-size-update` should retire them. I confirmed this reproduces on a
clean `origin/main` checkout and left it out of this PR to keep the diff to the
docs fix. Pushed with `SKIP_GATE=1` for that reason.

## Summary by Sourcery

Documentation:
- Restore the missing blockquote prefix and rewrap lines in the adaptive context frame spec to keep the CGP normative callout intact.