### PR TITLE
feat(cli): --max-output-tokens, and a real ceiling for grok-4 (#1290)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -16,7 +16,7 @@
 4207 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2370 stella-cli/src/agent.rs
-1748 stella-cli/src/agent_tests.rs
+1749 stella-cli/src/agent_tests.rs
 1576 stella-cli/src/candidate_ws.rs
 4582 stella-cli/src/command_deck.rs
 1516 stella-cli/src/fleet_cmd.rs

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -151,6 +151,29 @@ fn tuned_engine_config(
             engine.tool_result_horizon_steps = (steps > 0).then_some(steps as usize);
         }
     }
+    // `--max-output-tokens`, last and therefore highest (#1290). It outranks
+    // both settings surfaces because it is the most specific thing anyone can
+    // say — this invocation, right now — and because it is what an operator
+    // reaches for when a CONFIGURED value is the thing going wrong. A flag
+    // that a settings file could quietly beat would be useless in exactly
+    // that moment.
+    //
+    // Applies to every role for the same reason the turn budget does: what it
+    // bounds is the process's spend, not one agent's. Capping the worker while
+    // a judge kept the model's full ceiling would move the cost rather than
+    // reduce it.
+    //
+    // Clamped to the model's own ceiling, like the per-model setting. The flag
+    // is the likeliest of the three to carry a fat-fingered digit — it is
+    // typed fresh each run, with no file to review it — and over-asking is not
+    // a longer answer, it is a rejection on every step that bills the round
+    // trip and needs another call to retry.
+    if let Some(cap) = cfg.max_output_tokens {
+        engine.max_output_tokens = Some(match model_ceiling {
+            Some(ceiling) => cap.min(ceiling),
+            None => cap,
+        });
+    }
     // Capability clamp: a catalog-confirmed non-reasoning model must not
     // carry effort/reasoning onto the wire — providers reject or silently
     // ignore them, and both outcomes are worse than omitting the fields

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -815,6 +815,7 @@ fn cfg_for(provider_id: &str) -> Config {
         provider,
         model_id,
         turn_budget: None,
+        max_output_tokens: None,
         plan_mode: false,
         // The default posture for these tests is "no --model given", so the
         // settings-driven wiring under test is the thing exercised. The

--- a/stella-cli/src/agent_tests/engine_wiring.rs
+++ b/stella-cli/src/agent_tests/engine_wiring.rs
@@ -997,6 +997,68 @@ fn a_bare_slug_caps_every_route_and_a_qualified_key_outranks_it() {
     );
 }
 
+/// `--max-output-tokens` outranks BOTH settings surfaces, on every role.
+///
+/// It is the most specific statement available — this invocation, right now —
+/// and it is what an operator reaches for when a configured value is the thing
+/// going wrong. A flag a settings file could quietly beat would be useless in
+/// exactly that moment.
+#[test]
+fn the_max_output_tokens_flag_outranks_every_configured_cap() {
+    // Both settings surfaces set, and disagreeing with each other.
+    let mut cfg = cfg_with_engine(
+        "anthropic",
+        r#"{ "default_model": "anthropic/claude-sonnet-5",
+             "model_output_caps": { "anthropic/claude-sonnet-5": 64000 },
+             "agents": { "default": { "params": { "max_tokens": 48000 } },
+                         "judge":   { "params": { "max_tokens": 48000 } } } }"#,
+    );
+    cfg.model_id = "claude-sonnet-5".to_string();
+    cfg.max_output_tokens = Some(24_000);
+
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(24_000),
+        "the flag must beat both the per-model cap and the per-agent tuning",
+    );
+    // Every role, for the reason the turn budget is every-role: what it bounds
+    // is the process's spend. Capping the worker while the judge kept the
+    // model's whole ceiling would move the cost rather than reduce it.
+    assert_eq!(
+        crate::agent::judge_engine_config_for(&cfg).max_output_tokens,
+        Some(24_000),
+    );
+}
+
+/// The flag clamps too. It is the likeliest of the three to carry a
+/// fat-fingered digit — typed fresh each run, with no file to review it — and
+/// over-asking is a rejection on every step, not a longer answer.
+#[test]
+fn the_max_output_tokens_flag_clamps_to_the_models_ceiling() {
+    let mut cfg = cfg_for("anthropic");
+    cfg.model_id = "claude-sonnet-5".to_string();
+    cfg.max_output_tokens = Some(900_000);
+
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(128_000),
+    );
+}
+
+/// Absent flag changes nothing — the model's own maximum still stands. Without
+/// this the two tests above would pass just as well if the flag were applied
+/// unconditionally with some default.
+#[test]
+fn no_flag_leaves_the_models_own_ceiling_in_place() {
+    let mut cfg = cfg_for("anthropic");
+    cfg.model_id = "claude-sonnet-5".to_string();
+    assert_eq!(cfg.max_output_tokens, None, "fixture must not set the flag");
+    assert_eq!(
+        crate::agent::engine_config_for(&cfg).max_output_tokens,
+        Some(128_000),
+    );
+}
+
 /// `0` is a mistake here, not an opt-out — unlike `model_timeout_secs`, where
 /// it spells "no ceiling". The field's ABSENCE already means "the model's own
 /// maximum", so zero has no meaning left to carry, and honoring it literally

--- a/stella-cli/src/cli.rs
+++ b/stella-cli/src/cli.rs
@@ -138,6 +138,24 @@ pub(crate) struct GlobalArgs {
     #[arg(long, global = true, env = "STELLA_TURN_BUDGET", value_parser = parse_turn_budget)]
     pub(crate) turn_budget: Option<std::time::Duration>,
 
+    /// Cap output tokens per step, below what the model can write
+    ///
+    /// The default is the model's OWN maximum, which the catalog learns from
+    /// the provider — so you never need this to get a full-length answer. Use
+    /// it to deliberately spend LESS: bound cost on a long unattended run, cut
+    /// latency, or match a comparator that stops lower.
+    ///
+    /// Clamped to the model's real ceiling rather than sent as written.
+    /// Over-asking is not a longer answer, it is a provider-side rejection on
+    /// every step — one that costs the round trip and then needs another call
+    /// to retry.
+    ///
+    /// Wins over `[models.output_caps]` and per-agent `params.max_tokens`, and
+    /// applies to every role. Omit for the model's own ceiling.
+    /// Env: STELLA_MAX_OUTPUT_TOKENS.
+    #[arg(long, global = true, env = "STELLA_MAX_OUTPUT_TOKENS", value_parser = parse_max_output_tokens)]
+    pub(crate) max_output_tokens: Option<u32>,
+
     /// Use the plain line REPL instead of the Command Deck
     ///
     /// The deck (the tabbed TUI) also steps aside automatically when stdin or
@@ -995,4 +1013,28 @@ fn parse_turn_budget(raw: &str) -> Result<std::time::Duration, String> {
         ));
     }
     Ok(std::time::Duration::from_secs_f64(value))
+}
+
+/// `--max-output-tokens`: a positive step ceiling, refused rather than
+/// reinterpreted when it is anything else.
+///
+/// Zero is rejected by name instead of being read as "no limit". Elsewhere in
+/// this engine `0` does spell "no ceiling" (`model_timeout_secs`), but here
+/// the flag's ABSENCE already means "the model's own maximum", so zero has no
+/// second meaning left to carry — and taking it literally would ask the
+/// provider for an empty completion on every step, which fails a run in a way
+/// that looks like the model refusing to work.
+fn parse_max_output_tokens(raw: &str) -> Result<u32, String> {
+    let value: u32 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("`{raw}` is not a whole number of output tokens"))?;
+    if value == 0 {
+        return Err(
+            "max output tokens must be greater than 0 — omit the flag to use \
+             the model's own maximum"
+                .to_string(),
+        );
+    }
+    Ok(value)
 }

--- a/stella-cli/src/command_deck/model_cmd.rs
+++ b/stella-cli/src/command_deck/model_cmd.rs
@@ -237,6 +237,7 @@ mod tests {
             model_id: provider.default_model.to_string(),
             provider,
             turn_budget: None,
+            max_output_tokens: None,
             plan_mode: false,
             model_pinned_by_flag: false,
             durability: Default::default(),

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -345,6 +345,19 @@ pub struct Config {
     /// the engine decline to start a continuation it cannot finish, ending
     /// with a truthful partial instead of being destroyed mid-flight.
     pub turn_budget: Option<std::time::Duration>,
+    /// `--max-output-tokens`: a per-invocation ceiling on what one step may
+    /// write, always BELOW what the model can (#1290). `None` — the normal
+    /// case — leaves every role asking for the model's own maximum.
+    ///
+    /// Stamped from the flag in `main` like [`Self::turn_budget`], for the
+    /// same reason: `Config::load` never consults it, and threading a
+    /// straight-through value into that signature would widen it for nothing.
+    ///
+    /// Outranks both settings surfaces (`[models.output_caps]` and per-agent
+    /// `params.max_tokens`) because it is the most specific statement anyone
+    /// can make — this invocation, right now — and it is the one an operator
+    /// reaches for when a configured value is the thing going wrong.
+    pub max_output_tokens: Option<u32>,
     /// User-invoked plan mode (#1264): force the scope-review gate for this
     /// run whatever the plan's size. Stamped from `--plan` in `main`, like
     /// [`Self::turn_budget`], because `Config::load` has no view of the
@@ -733,6 +746,7 @@ impl Config {
                     // Stamped by the caller that holds the parsed CLI; see the
                     // field's doc comment.
                     turn_budget: None,
+                    max_output_tokens: None,
                     plan_mode: false,
                     // Unbound: the session whose sidecar this points at is
                     // resolved by the driver, after config load. See the
@@ -944,6 +958,7 @@ impl Config {
             model_pinned_by_flag: false,
             // Likewise stamped by the caller that holds the parsed CLI.
             turn_budget: None,
+            max_output_tokens: None,
             plan_mode: false,
             // Unbound until a driver resolves this run's session record — see
             // the field's doc comment.

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -211,6 +211,7 @@ fn config_debug_never_leaks_the_api_key() {
         provider: PROVIDERS[0].clone(),
         model_id: "glm-5.2".to_string(),
         turn_budget: None,
+        max_output_tokens: None,
         plan_mode: false,
         model_pinned_by_flag: false,
         durability: Default::default(),

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -773,6 +773,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
     // carry something straight through. `main` is where the flag and the config
     // are both in hand.
     cfg.turn_budget = cli.globals.turn_budget;
+    cfg.max_output_tokens = cli.globals.max_output_tokens;
     cfg.plan_mode = cli.globals.plan_mode;
     // `--tools` is the lowest-authority scope (#1263): folded in AFTER
     // settings so it can only narrow what they already allowed. `narrow_with`

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -374,18 +374,34 @@ impl Catalog {
                         cache_write_usd_per_mtok: 3.00,
                     },
                 )
-                .with_reasoning(Some(true)),
-                // Deliberately UNSEEDED, and the one row that says so out
-                // loud (#1290). models.dev has no `grok-4`, and the rest of
-                // the family disagrees by more than an order of magnitude —
-                // `grok-4.3` publishes 30000, `grok-4.5` publishes 500000. A
-                // ceiling picked from either would be a guess wearing a
-                // citation, which is the exact defect that put Sonnet 5 at
-                // half its real height. xAI speaks the OpenAI-compatible
-                // listing shape, so `parse_openai_compatible` fills this in
-                // from the provider on the first refresh if xAI publishes it;
-                // until then this row inherits the engine default, which is
-                // wrong but honestly wrong.
+                .with_reasoning(Some(true))
+                // 30000 — the highest cap reported for ANY grok-4-generation
+                // model, and deliberately not the highest number in the wider
+                // family (#1290).
+                //
+                // models.dev carries no bare `grok-4` row. Its generation
+                // siblings agree at 30000 (`grok-4.3`, and all three
+                // `grok-4.20-*` variants); `grok-4.5` reports 500000, but that
+                // is a later generation and taking its number would be reading
+                // a different model's ceiling.
+                //
+                // The two directions of being wrong here are NOT symmetric,
+                // which is what decides the value. Guessing LOW costs some
+                // unused headroom on long answers. Guessing HIGH costs a
+                // provider-side rejection on every single request — the model
+                // never runs, the developer pays for the round trip, and the
+                // work needs another call to retry. So where the family
+                // disagrees, the ceiling has to be the one no member of the
+                // generation would refuse.
+                //
+                // Left unseeded this row inherited the engine's global 16384,
+                // which truncates real work — so "no number" was never the
+                // safe option it looks like. xAI speaks the OpenAI-compatible
+                // listing shape, so `parse_openai_compatible` raises this to
+                // the provider's own figure on the first refresh that finds
+                // one; this is the offline floor, not a claim to have looked
+                // it up.
+                .with_max_output_tokens(Some(30_000)),
                 // The non-thinking chat model (`deepseek-reasoner` is the
                 // reasoning one) — the seed's one honest `Some(false)`.
                 CatalogEntry::new(

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -279,6 +279,97 @@ cross-family as your lineup changes:
 }
 ```
 
+## Output token ceilings
+
+**By default every model is asked for its own maximum.** Stella reads that
+ceiling from the model catalog, which learns it from the provider's own
+`/models` endpoint, so you never have to configure anything to get a
+full-length answer. A cap set below the model's ceiling decides where work
+stops instead of the model doing so — and a step cut off mid-reasoning emits
+no tool call and does no work at all.
+
+So the only thing worth configuring here is spending **less** than the model
+allows: bounding cost on a long unattended run, cutting latency, or matching a
+comparator that stops lower. Two ways to say it.
+
+### `--max-output-tokens` — this run
+
+```bash
+stella run "audit the auth module" --max-output-tokens 32000
+```
+
+Global flag, applies to every role, also readable as
+`STELLA_MAX_OUTPUT_TOKENS`. Use it when you want one invocation to behave
+differently, or when a configured value is the thing you are debugging — it
+outranks both settings surfaces below for exactly that reason.
+
+### `[models.output_caps]` — this workspace
+
+```toml
+[models.output_caps]
+"anthropic/claude-sonnet-5" = 64000   # this model on this provider
+"deepseek-chat" = 32000               # this model on any route
+```
+
+Keys are `provider/slug` or a bare slug; the provider-qualified form wins when
+both match, so you can cap a model only on the gateway you pay per-token for.
+Entries merge per model across settings scopes, so a project pinning one model
+never drops your pins on others.
+
+This is an **override, never a definition**. A model absent from the table
+simply gets its own maximum, so a model that ships tomorrow needs no entry —
+and deleting an entry restores a correct default rather than leaving a stale
+number behind.
+
+### Precedence, and two rules worth knowing
+
+Highest wins:
+
+1. `--max-output-tokens` (this invocation)
+2. `[models.output_caps]` (per model)
+3. per-agent `params.max_tokens` under `agent_engine_config`
+4. the model's own ceiling, from the catalog — **the default**
+
+<Callout type="warn">
+**A value above the model's real ceiling is clamped, not sent.** Asking a
+provider for more than the model can write is not a longer answer — it is a
+rejection on every request, which bills the round trip and then needs another
+call to retry. Clamping gives you what an over-large number was asking for
+anyway.
+
+**`0` is refused, not read as "unlimited".** Absence already means "the
+model's own maximum", so zero has no second meaning left to carry. (This
+differs from `model_timeout_secs`, where `0` *does* mean "no ceiling".)
+</Callout>
+
+### Where the ceiling comes from
+
+| provider | field read from its `/models` |
+| --- | --- |
+| Anthropic | `max_tokens` (output) and `max_input_tokens` (context) |
+| OpenRouter | `top_provider.max_completion_tokens` |
+| Gemini | `outputTokenLimit` |
+| OpenAI-compatible | `max_output_tokens` or `max_completion_tokens` |
+
+A bare `max_tokens` on an OpenAI-compatible listing is deliberately **not**
+read: it means the output cap on some gateways and the whole context window on
+others, and reading it the wrong way round would seed a ceiling several times
+the model's real one.
+
+Bedrock and Vertex publish no listing Stella can read, so those rows carry a
+seeded value instead. `stella models refresh` (and the startup sync) replaces
+seeded numbers with the provider's own wherever one is published.
+
+<Callout type="info">
+**One model is a documented estimate: `grok-4`.** No catalog source publishes a
+cap for that exact slug. Its generation siblings — `grok-4.3` and the
+`grok-4.20-*` variants — all report 30,000, so that is what ships. The later
+`grok-4.5` reports 500,000, but taking a different generation's number would
+risk a rejection on every request rather than merely leaving headroom unused.
+It is corrected automatically the first time xAI's listing publishes a real
+figure.
+</Callout>
+
 ## Generation parameters
 
 Every entry under `params` follows **include-when-set** semantics: an absent


### PR DESCRIPTION
Follow-up to #1332, which made the model's own maximum the default everywhere and added `[models.output_caps]`. Two gaps were left.

## 1. The flag

`[models.output_caps]` covers a workspace. But the thing an operator reaches for when a **configured value is the problem** is a flag — and a flag a settings file could quietly beat would be useless in exactly that moment. So `--max-output-tokens` (env `STELLA_MAX_OUTPUT_TOKENS`) sits at the top of the ladder:

```
--max-output-tokens  >  [models.output_caps]  >  agents.<role>.params.max_tokens
                     >  catalog (the model's max)  >  16384
```

It applies to **every role**, for the reason `--turn-budget` does: what it bounds is the process's spend, not one agent's. Capping the worker while the judge kept the model's whole ceiling would move cost rather than reduce it.

Two guards, both tested:

- **Clamped to the model's ceiling.** It's the likeliest of the three surfaces to carry a fat-fingered digit — typed fresh each run, with no file to review it.
- **`0` refused at parse time**, not read as "unlimited". Absence already means "the model's own maximum", so zero has no second meaning left; taking it literally would request an empty completion every step.

```
$ stella --max-output-tokens 0 run "x"
error: invalid value '0' for '--max-output-tokens <MAX_OUTPUT_TOKENS>':
       max output tokens must be greater than 0 — omit the flag to use the model's own maximum
```

## 2. grok-4 gets a real ceiling: 30,000

#1332 left this row deliberately unseeded because no source publishes a cap for that exact slug. That reasoning was half right and the conclusion was wrong: **unseeded is not "no number", it is the engine's global 16,384**, which truncates real work.

The two ways of being wrong here are not symmetric, and that decides the value:

| direction | cost |
|---|---|
| guess **low** | some unused headroom on long answers |
| guess **high** | provider rejection on **every** request — the model never runs, the dev pays the round trip, and the work needs another call to retry |

So where a family disagrees, the ceiling must be one no member of the generation would refuse. `grok-4.3` and all three `grok-4.20-*` variants report **30,000**. `grok-4.5` reports 500,000, but that is a later generation — taking its number would be reading a different model's ceiling.

Documented in the docs as an estimate rather than left looking like a lookup, and corrected automatically the first time xAI's listing publishes a real figure.

## Docs

New **"Output token ceilings"** section in `configuration/agent-engine-config.mdx` covering both surfaces, the precedence order, the clamp and zero rules, which field is read from each provider's `/models`, why a bare `max_tokens` is deliberately never read on OpenAI-compatible listings, and the grok-4 estimate stated plainly.

## Verification

- `stella-cli` **1226** pass (3 new ladder tests) · `stella-model` **368** pass
- Flag smoke-tested end to end: help text renders, `0` and non-numeric refused with actionable messages
- Full pre-push gate green (fmt, clippy, file-size, invariants)

`file-size` baseline regenerated rather than hand-merged — it is generated and the gate refuses an edited copy. Exactly one line moves: `agent_tests.rs` 1748 → 1749, the single `Config` field this flag adds to a test fixture.

## Summary by Sourcery

Add a global CLI flag and config plumbing to cap per-step output tokens with clear precedence over existing caps, and seed a conservative default output ceiling for grok-4 while documenting how output token limits are derived and applied.

New Features:
- Introduce a global `--max-output-tokens` / `STELLA_MAX_OUTPUT_TOKENS` flag that caps per-step output tokens across all roles and overrides configuration-based caps.

Enhancements:
- Clamp user-specified output caps to each model's real ceiling to avoid provider rejections from over-large requests.
- Seed a 30,000-token default output ceiling for the `grok-4` model based on its generation siblings, pending provider-published values.
- Propagate the new max-output-tokens flag through CLI configuration and engine wiring, ensuring consistent behavior across roles.

Documentation:
- Document output token ceiling behavior, including precedence between flags and config, clamping rules, provider model listing fields, and the estimated grok-4 ceiling.

Tests:
- Add tests covering precedence of the max-output-tokens flag, clamping behavior to model ceilings, and default behavior when the flag is absent.