### PR TITLE
serve: make the verification pipeline reachable over the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,6 +3342,7 @@ dependencies = [
  "serde_json",
  "stella-core",
  "stella-engine",
+ "stella-pipeline",
  "stella-protocol",
  "tempfile",
  "thiserror 2.0.19",

--- a/stella-parity/src/lib.rs
+++ b/stella-parity/src/lib.rs
@@ -458,11 +458,39 @@ pub static CAPABILITIES: &[Capability] = &[
             mechanism: "`stella run` (default pipeline path) with the scope-review approval gate",
             witness: "non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review",
         },
-        api: SurfacePosture::Deferred {
-            waiting_on: "a runs resource (or moving the approval boundary into the engine): serve \
-                         does not link stella-pipeline, so the product's defining verification \
-                         ladder — and the approval gate with it — is structurally unreachable \
-                         from the API",
+        // Shipped in #1288, as the mode flag this row's `waiting_on` named as
+        // the alternative to a `/v1/runs` resource: `pipeline` on `POST
+        // /v1/turns` (and `POST /v1/sessions/{id}/turns`) drives the turn
+        // through `Pipeline::run` instead of a bare engine step loop, over
+        // the SAME transport every other turn already uses — the SSE
+        // stream, `POST /v1/turns/{id}/cancel`, and the settlement hook all
+        // work unchanged, exactly as `goal.loop` (#1297) established for its
+        // own mode flag. The one genuinely new wire primitive is the
+        // approval gate: `ServerFrame::ScopeReviewRequest` and `POST
+        // /v1/turns/{id}/approve`, symmetric with `tool-result` /
+        // `provider-result` (`stella-serve/src/pipeline_run.rs`,
+        // `stella-serve/src/remote.rs::RemoteApprovalGate`). Verification's
+        // process-launching ports (`TestRunner`, `DiagnosticRunner`) are
+        // remoted through the SAME `ToolRequest`/`ToolResultIn` frames every
+        // tool call already crosses (`RemoteVerificationRunner`) — not a new
+        // containment decision, `tools.local_execution`'s posture below
+        // applied to two more typed callers.
+        //
+        // Declared, not silent, follow-up (`pipeline_run.rs`'s own module
+        // docs carry the full list): context recall, repo structure, lint,
+        // mutation, coverage, and candidate-workspace isolation are not
+        // wired yet (every one of those ports is designed to degrade open
+        // when absent, so a served run still verifies — it just cannot
+        // isolate best-of-N candidates or measure diff coverage yet); the
+        // witness-author role rides the worker's provider rather than
+        // getting its own id the way judge does; and `pipeline` is refused
+        // alongside `goal`/`sub_agents` on the same turn rather than
+        // composed with them.
+        api: SurfacePosture::Shipped {
+            mechanism: "a `pipeline` block on POST /v1/turns and POST /v1/sessions/{id}/turns \
+                        drives the turn through Pipeline::run; POST /v1/turns/{id}/approve \
+                        resolves the scope-review gate",
+            witness: "a_pipeline_run_is_requestable_over_the_wire_and_its_approval_gate_round_trips",
         },
     },
     Capability {

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -31,6 +31,10 @@ stella-core = { path = "../stella-core" }
 # rather than `Engine::run_turn` so a turn can be cancelled at a step
 # boundary and checkpointed between steps (#1129).
 stella-engine = { path = "../stella-engine" }
+# The verification pipeline (#1288): `pipeline` on `POST /v1/turns` drives a
+# turn through `stella_pipeline::Pipeline::run` instead of a bare engine step
+# loop, over the same remoted ports every other turn uses.
+stella-pipeline = { path = "../stella-pipeline" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/stella-serve/src/backlog.rs
+++ b/stella-serve/src/backlog.rs
@@ -143,6 +143,7 @@ fn droppable(frame: &ServerFrame) -> bool {
         ServerFrame::Event { .. } => true,
         ServerFrame::ToolRequest { .. }
         | ServerFrame::ProviderRequest { .. }
+        | ServerFrame::ScopeReviewRequest { .. }
         | ServerFrame::TurnHeld { .. }
         | ServerFrame::TurnReleased
         | ServerFrame::TurnComplete { .. } => false,

--- a/stella-serve/src/frame.rs
+++ b/stella-serve/src/frame.rs
@@ -18,8 +18,10 @@
 
 use serde::{Deserialize, Serialize};
 use stella_core::TurnOutcome;
+use stella_pipeline::ports::ScopeDecision;
 use stella_protocol::{
-    AgentEvent, CompletionRequest, CompletionResult, ModelCallRole, ProviderError, ToolOutput,
+    AgentEvent, CompletionRequest, CompletionResult, ModelCallRole, ProviderError, ScopeProposal,
+    ToolOutput,
 };
 
 /// One frame emitted by the engine toward the host over the outbound stream.
@@ -85,6 +87,22 @@ pub enum ServerFrame {
     /// `null` when it wrote none: the client that reconnects need not be the
     /// process that paused.
     TurnHeld { reason: Option<String> },
+    /// A pipeline-driven turn (`pipeline` on `POST /v1/turns`, #1288) reached
+    /// its scope-review gate and is parked on the host's decision, keyed by
+    /// `request_id` exactly like [`ServerFrame::ToolRequest`] /
+    /// [`ServerFrame::ProviderRequest`]. The host answers with
+    /// [`ScopeReviewResultIn`] on `POST /v1/turns/{id}/approve`.
+    ///
+    /// This is the pipeline's `ApprovalGate::review` (L-E5), remoted rather
+    /// than answered in-process — the API's counterpart to the CLI's
+    /// interactive scope-review card. Nothing else about a served turn
+    /// changes: the same `AgentEvent::ScopeReview` the pipeline already
+    /// emits still carries the human-readable proposal on the ordinary event
+    /// stream, so this frame is only the request half of the round trip.
+    ScopeReviewRequest {
+        request_id: String,
+        proposal: ScopeProposal,
+    },
     /// The hold announced by [`ServerFrame::TurnHeld`] is over and the turn is
     /// proceeding (#932). Emitted once, paired with the `TurnHeld` before it.
     ///
@@ -134,6 +152,47 @@ impl From<TurnOutcome> for TurnOutcomeWire {
 pub struct ToolResultIn {
     pub request_id: String,
     pub output: ToolOutput,
+}
+
+/// Host → engine: the human's decision on a [`ServerFrame::ScopeReviewRequest`].
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeReviewResultIn {
+    pub request_id: String,
+    pub decision: ScopeDecisionWire,
+}
+
+/// Wire mirror of [`stella_pipeline::ports::ScopeDecision`]. That type lives in
+/// `stella-pipeline` and is not itself `Serialize`/`Deserialize` — this crate
+/// owns the wire mapping, exactly as [`TurnOutcomeWire`] owns `TurnOutcome`'s.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum ScopeDecisionWire {
+    /// Execute the plan as proposed.
+    Approve,
+    /// Execute only the steps at these indices into the proposed step list.
+    Trim {
+        keep_steps: Vec<usize>,
+    },
+    /// Re-plan with the reviewer's own words folded into the next attempt. An
+    /// empty `note` reads as [`ScopeDecision::Abort`] — the same collapse
+    /// [`stella_pipeline::ports::StdioApprovalGate`] makes for a bare "no".
+    Revise {
+        note: String,
+    },
+    Abort,
+}
+
+impl From<ScopeDecisionWire> for ScopeDecision {
+    fn from(wire: ScopeDecisionWire) -> Self {
+        match wire {
+            ScopeDecisionWire::Approve => ScopeDecision::Approve,
+            ScopeDecisionWire::Trim { keep_steps } => ScopeDecision::Trim { keep_steps },
+            ScopeDecisionWire::Revise { note } => ScopeDecision::Revise { note },
+            ScopeDecisionWire::Abort => ScopeDecision::Abort,
+        }
+    }
 }
 
 /// Host → engine: the result of a [`ServerFrame::ProviderRequest`] — either a
@@ -526,5 +585,56 @@ mod tests {
                 cost_usd: 0.0,
             }
         );
+    }
+
+    /// The scope-review request/result pair (#1288), in the exact shape a
+    /// client parses/posts — same discipline as
+    /// `the_outbound_frame_tags_and_field_names_are_the_wire_contract`.
+    #[test]
+    fn the_scope_review_frame_and_its_result_keep_their_wire_shape() {
+        let request = serde_json::to_value(ServerFrame::ScopeReviewRequest {
+            request_id: "scope-0".to_string(),
+            proposal: ScopeProposal {
+                summary: "add a widget".to_string(),
+                steps: vec!["write the widget".to_string()],
+                estimated_files: 1,
+                estimated_cost_usd: Some(0.02),
+            },
+        })
+        .unwrap();
+        assert_eq!(request["type"], "scope_review_request");
+        assert_eq!(request["request_id"], "scope-0");
+        assert_eq!(request["proposal"]["summary"], "add a widget");
+
+        let approve: ScopeReviewResultIn = serde_json::from_value(serde_json::json!({
+            "request_id": "scope-0",
+            "decision": { "decision": "approve" },
+        }))
+        .expect("an approve body parses");
+        assert!(matches!(approve.decision, ScopeDecisionWire::Approve));
+
+        let trim: ScopeReviewResultIn = serde_json::from_value(serde_json::json!({
+            "request_id": "scope-0",
+            "decision": { "decision": "trim", "keep_steps": [0, 2] },
+        }))
+        .expect("a trim body parses");
+        assert!(matches!(
+            trim.decision,
+            ScopeDecisionWire::Trim { ref keep_steps } if keep_steps == &[0, 2]
+        ));
+
+        let revise: ScopeDecision = ScopeDecisionWire::Revise {
+            note: "smaller, please".to_string(),
+        }
+        .into();
+        assert_eq!(
+            revise,
+            ScopeDecision::Revise {
+                note: "smaller, please".to_string()
+            }
+        );
+
+        let abort: ScopeDecision = ScopeDecisionWire::Abort.into();
+        assert_eq!(abort, ScopeDecision::Abort);
     }
 }

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -82,6 +82,7 @@ mod http;
 mod lifecycle;
 pub mod observe;
 mod pending;
+mod pipeline_run;
 mod remote;
 mod router;
 mod routes;
@@ -101,12 +102,13 @@ pub use error::ServeError;
 pub use extensions::{Extensions, ServeExtension};
 pub use frame::{
     ProviderDelta, ProviderDeltaIn, ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn,
-    ServerFrame, ToolResultIn, TurnOutcomeWire,
+    ScopeDecisionWire, ScopeReviewResultIn, ServerFrame, ToolResultIn, TurnOutcomeWire,
 };
 pub use goal::GoalRun;
 pub use hostguard::HostMode;
 pub use observe::{Metrics, Observer, ServeEvent, SharedObserver};
 pub use pending::Pending;
+pub use pipeline_run::PipelineRun;
 pub use server::{
     DEFAULT_RESUME_GRACE, DEFAULT_SESSION_IDLE_TTL, DEFAULT_SHUTDOWN_GRACE, MAX_RESUME_GRACE,
     MAX_SHUTDOWN_GRACE, ServeConfig, serve, serve_until,

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -122,6 +122,12 @@ pub enum Route {
     TurnPause,
     #[serde(rename = "/v1/turns/{id}/resume")]
     TurnResume,
+    /// Resolve a pipeline-driven turn's scope-review gate (#1288) — the
+    /// reverse-RPC counterpart to [`Route::TurnToolResult`] /
+    /// [`Route::TurnProviderResult`], for the one decision a pipeline run
+    /// asks a human rather than a model or a tool.
+    #[serde(rename = "/v1/turns/{id}/approve")]
+    TurnApprove,
     /// `GET` (read back) and `DELETE` (reclaim) share the member path, the
     /// same one-resource-two-verbs shape as [`Route::Session`].
     #[serde(rename = "/v1/turns/{id}/checkpoint")]
@@ -161,6 +167,7 @@ impl Route {
             Self::TurnSteer => "/v1/turns/{id}/steer",
             Self::TurnPause => "/v1/turns/{id}/pause",
             Self::TurnResume => "/v1/turns/{id}/resume",
+            Self::TurnApprove => "/v1/turns/{id}/approve",
             Self::TurnCheckpoint => "/v1/turns/{id}/checkpoint",
             Self::SessionsCreate => "/v1/sessions",
             Self::Session => "/v1/sessions/{id}",
@@ -181,7 +188,7 @@ impl Route {
     /// method's exhaustive match until the author classifies it, and the
     /// tests assert `ALL` contains exactly the `is_real` variants it names —
     /// so the array cannot silently lag the enum.
-    pub const ALL: [Route; 18] = [
+    pub const ALL: [Route; 19] = [
         Route::Healthz,
         Route::Readyz,
         Route::Metrics,
@@ -195,6 +202,7 @@ impl Route {
         Route::TurnSteer,
         Route::TurnPause,
         Route::TurnResume,
+        Route::TurnApprove,
         Route::TurnCheckpoint,
         Route::SessionsCreate,
         Route::Session,
@@ -223,6 +231,7 @@ impl Route {
             | Route::TurnSteer
             | Route::TurnPause
             | Route::TurnResume
+            | Route::TurnApprove
             | Route::TurnCheckpoint
             | Route::SessionsCreate
             | Route::Session
@@ -452,6 +461,10 @@ impl StreamEndReason {
 pub enum ReverseKind {
     Provider,
     Tool,
+    /// A pipeline scope-review gate reached over the wire (#1288): the
+    /// pipeline-driven turn's `ApprovalGate::review` call, remoted the same
+    /// way a tool or provider call is.
+    ScopeReview,
 }
 
 /// Which half of the checkpoint sink failed.

--- a/stella-serve/src/observe/metrics.rs
+++ b/stella-serve/src/observe/metrics.rs
@@ -77,6 +77,9 @@ pub struct Metrics {
 
     reverse_dispatched_provider_total: AtomicU64,
     reverse_dispatched_tool_total: AtomicU64,
+    /// A pipeline-driven turn's scope-review gate, dispatched over the wire
+    /// exactly like a tool or provider request (#1288).
+    reverse_dispatched_scope_review_total: AtomicU64,
     reverse_answered_total: AtomicU64,
     reverse_wait_ms_total: AtomicU64,
     reverse_timed_out_total: AtomicU64,
@@ -139,6 +142,7 @@ pub struct Snapshot {
 
     pub reverse_dispatched_provider_total: u64,
     pub reverse_dispatched_tool_total: u64,
+    pub reverse_dispatched_scope_review_total: u64,
     pub reverse_answered_total: u64,
     pub reverse_wait_ms_total: u64,
     pub reverse_timed_out_total: u64,
@@ -210,6 +214,9 @@ impl Metrics {
 
             reverse_dispatched_provider_total: self.reverse_dispatched_provider_total.load(ORDER),
             reverse_dispatched_tool_total: self.reverse_dispatched_tool_total.load(ORDER),
+            reverse_dispatched_scope_review_total: self
+                .reverse_dispatched_scope_review_total
+                .load(ORDER),
             reverse_answered_total: self.reverse_answered_total.load(ORDER),
             reverse_wait_ms_total: self.reverse_wait_ms_total.load(ORDER),
             reverse_timed_out_total: self.reverse_timed_out_total.load(ORDER),
@@ -334,6 +341,7 @@ impl Observer for Metrics {
                 match kind {
                     ReverseKind::Provider => &self.reverse_dispatched_provider_total,
                     ReverseKind::Tool => &self.reverse_dispatched_tool_total,
+                    ReverseKind::ScopeReview => &self.reverse_dispatched_scope_review_total,
                 }
                 .fetch_add(1, ORDER);
                 self.reverse_in_flight.fetch_add(1, ORDER);

--- a/stella-serve/src/pending.rs
+++ b/stella-serve/src/pending.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use stella_pipeline::ports::ScopeDecision;
 use stella_protocol::{CompletionResult, ProviderError, ToolOutput};
 use tokio::sync::{mpsc, oneshot};
 
@@ -45,6 +46,12 @@ enum PendingReply {
         /// is how the step learns the fragment stream is over.
         deltas: ProviderDeltaFeed,
     },
+    /// A pipeline-driven turn's scope-review gate, parked on the host's
+    /// decision (#1288). Same shape as `Tool`, kept as its own variant rather
+    /// than reusing it: a scope review answers with a typed `ScopeDecision`,
+    /// not a `ToolOutput`, and the kind-mismatch check below is what keeps a
+    /// host from resolving one as the other.
+    ScopeReview(oneshot::Sender<ScopeDecision>),
 }
 
 /// A cloneable handle to the shared registry. Cloning shares the same map.
@@ -106,6 +113,23 @@ impl Pending {
         true
     }
 
+    /// Register a scope-review reply channel under `id`. Same contract as
+    /// [`Pending::register_tool`], for the one pipeline decision a served
+    /// turn asks a human rather than a model or a tool (#1288).
+    #[must_use]
+    pub(crate) fn register_scope_review(
+        &self,
+        id: String,
+        reply: oneshot::Sender<ScopeDecision>,
+    ) -> bool {
+        let mut map = self.lock();
+        if self.is_cancelled() {
+            return false;
+        }
+        map.insert(id, PendingReply::ScopeReview(reply));
+        true
+    }
+
     /// Register a provider reply channel under `id`, together with the feed
     /// any streamed fragments for that request are delivered on. Same
     /// contract — and the same locked cancellation check — as
@@ -131,6 +155,15 @@ impl Pending {
         // A receive-side drop (the engine step was cancelled) is not an error to
         // the host: the request is simply gone.
         let _ = self.report_misroute(id, self.take_tool(id))?.send(output);
+        Ok(())
+    }
+
+    /// Resolve a pipeline turn's scope-review gate with the host's decision.
+    /// Errors if `id` is unknown or names a tool/provider request (#1288).
+    pub fn resolve_scope_review(&self, id: &str, decision: ScopeDecision) -> Result<(), ServeError> {
+        let _ = self
+            .report_misroute(id, self.take_scope_review(id))?
+            .send(decision);
         Ok(())
     }
 
@@ -171,7 +204,7 @@ impl Pending {
                     }
                     Ok(())
                 }
-                Some(PendingReply::Tool(_)) => {
+                Some(PendingReply::Tool(_) | PendingReply::ScopeReview(_)) => {
                     Err(ServeError::RequestKindMismatch(id.to_string(), "provider"))
                 }
                 None => Err(ServeError::UnknownRequest(id.to_string())),
@@ -289,6 +322,20 @@ impl Pending {
             Some(other) => {
                 map.insert(id.to_string(), other);
                 Err(ServeError::RequestKindMismatch(id.to_string(), "tool"))
+            }
+            None => Err(ServeError::UnknownRequest(id.to_string())),
+        }
+    }
+
+    /// Take the scope-review reply channel registered under `id`. Same
+    /// single-lock discipline as [`Pending::take_tool`].
+    fn take_scope_review(&self, id: &str) -> Result<oneshot::Sender<ScopeDecision>, ServeError> {
+        let mut map = self.lock();
+        match map.remove(id) {
+            Some(PendingReply::ScopeReview(tx)) => Ok(tx),
+            Some(other) => {
+                map.insert(id.to_string(), other);
+                Err(ServeError::RequestKindMismatch(id.to_string(), "scope_review"))
             }
             None => Err(ServeError::UnknownRequest(id.to_string())),
         }
@@ -584,6 +631,39 @@ mod tests {
                 MisrouteFault::KindMismatch,
                 MisrouteFault::UnknownRequest,
             ],
+        );
+    }
+
+    /// A pipeline turn's scope review registers and resolves exactly like a
+    /// tool request — same round trip, different reply type (#1288) — and a
+    /// host that answers it with the wrong kind gets the same `KindMismatch`
+    /// a tool/provider mix-up gets.
+    #[test]
+    fn a_scope_review_registers_and_resolves_like_any_other_reverse_request() {
+        let pending = test_pending();
+        let (tx, rx) = oneshot::channel();
+        assert!(pending.register_scope_review("scope-0".to_string(), tx));
+
+        pending
+            .resolve_scope_review("scope-0", ScopeDecision::Approve)
+            .expect("a registered scope review resolves");
+        assert_eq!(rx.blocking_recv(), Ok(ScopeDecision::Approve));
+
+        // Resolving again finds nothing — the entry was taken, not merely read.
+        assert!(
+            pending
+                .resolve_scope_review("scope-0", ScopeDecision::Abort)
+                .is_err()
+        );
+
+        // Answering a tool request as a scope review (or vice versa) is a
+        // kind mismatch, not a silent success.
+        let (tool_tx, _tool_rx) = oneshot::channel();
+        assert!(pending.register_tool("tool-0".to_string(), tool_tx));
+        assert!(
+            pending
+                .resolve_scope_review("tool-0", ScopeDecision::Abort)
+                .is_err()
         );
     }
 }

--- a/stella-serve/src/pipeline_run.rs
+++ b/stella-serve/src/pipeline_run.rs
@@ -1,0 +1,420 @@
+//! The verification pipeline over the wire (#1288): `pipeline` on
+//! `POST /v1/turns` (and `POST /v1/sessions/{id}/turns`) drives a turn through
+//! `stella_pipeline::Pipeline::run` — plan, scope review, execute, witness,
+//! verify, judge — instead of a bare engine step loop.
+//!
+//! # Why a mode on a turn, not a `/v1/runs` resource
+//!
+//! Everything a pipeline run needs from the transport already exists on a
+//! turn and is already witnessed, exactly as `goal` (#1297) found before it:
+//! `GET /v1/turns/{id}/events` streams its progress (the pipeline already
+//! emits `AgentEvent::Stage`, `AgentEvent::ScopeReview`, `AgentEvent::
+//! JudgeVerdict`, and the rest of its own vocabulary — this module adds no
+//! new event types), `POST /v1/turns/{id}/cancel` stops it, and the
+//! settlement hook writes the transcript back. A `/v1/runs` resource would
+//! restate every one of those with its own id space and its own bugs — the
+//! same argument `crate::goal`'s module docs make, word for word. The ONE
+//! genuinely new interaction a pipeline run introduces is the scope-review
+//! gate, which is why that (and only that) gets a new wire primitive:
+//! [`crate::frame::ServerFrame::ScopeReviewRequest`] and
+//! `POST /v1/turns/{id}/approve` — see `crate::remote::RemoteApprovalGate`.
+//!
+//! # The three questions #1288 asked, answered
+//!
+//! 1. **Verification can take a long time.** Same answer as every other
+//!    turn: the caller subscribes to the SSE stream (resumable via
+//!    `?after=`), and `POST /v1/turns/{id}/cancel` stops the run at its next
+//!    reverse-RPC boundary. No new streaming model — the pipeline already
+//!    reports its stage transitions as ordinary events.
+//! 2. **The approval step needs a human.** The human is whoever the host's
+//!    bearer token belongs to — the same party that already answers
+//!    `tool-result` / `provider-result`. `POST /v1/turns/{id}/approve`
+//!    resolves it, fail-closed ([`ScopeDecision::Abort`]) on cancellation,
+//!    disconnection, or the same reverse-request deadline every other call
+//!    obeys. A caller that wants to run unattended sets `auto_approve` and
+//!    gets a local gate that says yes without a round trip — an explicit
+//!    request, never a silent default.
+//! 3. **Verification runs commands from the repository.** Nothing runs on
+//!    this server. `TestRunner`/`DiagnosticRunner` — the pipeline's only
+//!    process-launching ports — are remoted through the exact same
+//!    `ToolRequest`/`ToolResultIn` frames every tool call already crosses
+//!    (`crate::remote::RemoteVerificationRunner`), under two reserved names
+//!    the host recognizes. This is not a new containment decision: it is
+//!    `stella-parity`'s existing `tools.local_execution: NotApplicable`
+//!    posture ("the sidecar never executes tools itself") applied to two
+//!    more typed callers. A host that has not implemented the two reserved
+//!    tool names answers as it would any unknown tool, which the ladder
+//!    already reads as "no toolchain" — a first-class, honestly-degrading
+//!    outcome, not a crash.
+//!
+//! # What is deliberately not wired yet
+//!
+//! Declared, not silent — the same discipline `stella-parity` enforces on
+//! every other capability row:
+//!
+//! - **Context recall, repo structure, lint, mutation, coverage, candidate
+//!   isolation** ([`NoContextRecall`], [`NoRepoStructure`], [`NoRepoStatus`],
+//!   [`NoFileTouches`], and `lint`/`mutation`/`coverage`/
+//!   `candidate_workspaces` left `None`). Every one of these ports is
+//!   designed to degrade open when absent (their own doc comments say so:
+//!   "a caller with nothing to offer supplies `NoContextRecall`"), so a
+//!   served run still verifies — it just cannot isolate best-of-N candidates
+//!   or measure diff coverage yet. Wiring them is additive follow-up work,
+//!   not a redesign.
+//! - **Per-role provider routing.** Worker, triage, and judge each get their
+//!   own [`crate::remote::RemoteProvider`] (so the host can route a judge to
+//!   a different model, mirroring `goal.judge_provider_id`), but a served
+//!   run's `witness_writer` role rides the worker's — an independent witness
+//!   author needs its own provider id the same way judge does, and is a
+//!   small, additive follow-up.
+//! - **Mid-run steering and sub-agents.** `goal`/`sub_agents` blocks are not
+//!   accepted together with `pipeline` — the pipeline already loops
+//!   internally (revisions, best-of-N) and drives its own judge, so layering
+//!   the turn-level judge/delegation modes on top would be two competing
+//!   control loops. Refused with a named 400, not silently ignored.
+//! - **Cancellation is reverse-RPC-boundary, not step-boundary.** Exactly the
+//!   limitation `docs/design/serve-surface.md` already states for the plain
+//!   engine driver ("does not interrupt CPU-bound work between reverse
+//!   requests") — a pipeline run has no CPU-bound stretch longer than the
+//!   engine's own, so this is the same bound, not a new one.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use stella_core::router::{CircuitBreaker, ProviderProfile};
+use stella_core::{BudgetGuard, EngineConfig, RoleTable, Router, TurnOutcome};
+use stella_pipeline::ports::{
+    ApprovalGate, NoContextRecall, NoFileTouches, NoRepoStatus, NoRepoStructure, PipelinePorts,
+    ProviderResolver, ScopeDecision,
+};
+use stella_pipeline::{Pipeline, PipelineConfig};
+use stella_protocol::{AgentEvent, CompletionMessage, ModelRef, Provider, ScopeProposal};
+use tokio::sync::mpsc;
+
+use crate::pending::Pending;
+use crate::remote::{RemoteApprovalGate, RemoteProvider, RemoteVerificationRunner, TokioSleeper};
+use crate::session::DrivenTurn;
+
+/// A pipeline-driven turn, as the host asked for it — the `pipeline` block on
+/// `POST /v1/turns`.
+pub struct PipelineRun {
+    /// The task, exactly as `stella run "<goal>"` takes it on the CLI. Not the
+    /// turn's `messages`: those carry only the stable system prefix (if any),
+    /// and the pipeline appends its own recall+goal message from this field —
+    /// the same split `stella-cli` already keeps.
+    pub goal: String,
+    /// Skip the scope-review gate entirely rather than asking the host,
+    /// using a local gate that approves every plan without a round trip.
+    /// `false` — the default — asks the host over `POST
+    /// /v1/turns/{id}/approve` for any plan that crosses the operator's
+    /// scope thresholds; this is an explicit opt into unattended execution,
+    /// never an implicit one.
+    pub auto_approve: bool,
+    /// The test command the flip oracle tracks. `None` (the default) hands
+    /// the flip oracle to the witness author when `witness_writer` is on.
+    pub test_command: Option<String>,
+    /// Witness authoring (L-E11): an independent model authors a failing
+    /// test to arm the flip oracle when no `test_command` is configured.
+    /// Defaults to [`PipelineConfig::default`]'s `true`.
+    pub witness_writer: bool,
+    /// Maximum revision turns per candidate when verification fails.
+    /// `None` keeps [`PipelineConfig::default`]'s value.
+    pub max_revisions: Option<u32>,
+    /// Best-of-N candidate count. `None`/`Some(1)` is single-shot.
+    ///
+    /// Isolated (worktree-snapshotted) fan-out needs
+    /// [`stella_pipeline::ports::CandidateWorkspacePort`], which this served
+    /// posture does not wire yet (see the module docs) — a served run with
+    /// `candidates > 1` therefore executes candidates into the shared
+    /// remoted workspace sequentially, exactly as the pipeline's own
+    /// documented degradation says a candidate count with no isolation port
+    /// does. Left as the caller's choice rather than silently clamped to 1,
+    /// so the behavior is legible from the pipeline's own contract instead
+    /// of a serve-specific carve-out.
+    pub candidates: Option<u32>,
+    /// The provider id the triage call announces, when the caller wants it
+    /// on a different account/model than the worker. `None` runs it on the
+    /// turn's own provider id.
+    pub triage_provider_id: Option<String>,
+    /// The provider id the judge call announces — the same knob
+    /// `goal.judge_provider_id` already exposes, generalized to the
+    /// pipeline's own internal judge.
+    pub judge_provider_id: Option<String>,
+}
+
+/// A time source for the single-profile [`CircuitBreaker`] a served pipeline
+/// run constructs. The breaker only matters when a role fails over between
+/// multiple profiles; a served run has exactly one, so nothing here ever
+/// trips it — but `CircuitBreaker::new` still wants a real clock rather than
+/// a stub that could misreport `now_ms`.
+struct WallClock;
+
+impl stella_core::ports::Clock for WallClock {
+    fn now_ms(&self) -> u64 {
+        u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+        )
+        .unwrap_or(u64::MAX)
+    }
+}
+
+/// Tags the dummy [`ModelRef`]s a served run's single-provider [`Router`]
+/// resolves roles to — never a real model slug, just a key
+/// [`ServedProviderResolver`] switches on to pick which remoted provider
+/// instance serves a role.
+mod role_tag {
+    pub(super) const WORKER: &str = "worker";
+    pub(super) const TRIAGE: &str = "triage";
+    pub(super) const JUDGE: &str = "judge";
+}
+
+/// Resolves the pipeline's role-tagged [`ModelRef`]s to one of three
+/// [`RemoteProvider`]s, each announcing its own `provider_id` and
+/// [`stella_protocol::ModelCallRole`] on the wire — so a host can route a
+/// served run's judge to a different model than its worker, the same
+/// property `goal.judge_provider_id` already buys a turn-level judge.
+struct ServedProviderResolver {
+    worker: RemoteProvider,
+    triage: RemoteProvider,
+    judge: RemoteProvider,
+}
+
+impl ProviderResolver for ServedProviderResolver {
+    fn provider_for(&self, model: &ModelRef) -> Option<&dyn Provider> {
+        match model.model_id.as_str() {
+            role_tag::WORKER => Some(&self.worker),
+            role_tag::TRIAGE => Some(&self.triage),
+            role_tag::JUDGE => Some(&self.judge),
+            _ => None,
+        }
+    }
+}
+
+/// An [`ApprovalGate`] that approves every plan without a round trip — the
+/// explicit `auto_approve` opt-in, never the default. Distinct from
+/// [`stella_pipeline::ports::AlwaysAbortGate`], which exists for exactly the
+/// opposite posture (a headless run with nobody to ask, conservative by
+/// refusing); this one is for a caller who has already decided to run
+/// unattended and said so.
+struct AutoApproveGate;
+
+#[async_trait]
+impl ApprovalGate for AutoApproveGate {
+    async fn review(&self, _proposal: &ScopeProposal) -> ScopeDecision {
+        ScopeDecision::Approve
+    }
+}
+
+/// Lower a [`PipelineRun`] plus the turn's own engine config into a full
+/// [`PipelineConfig`]. `headless` is always `false`: a served run always has
+/// *some* [`ApprovalGate`] behind it — [`AutoApproveGate`] or
+/// [`RemoteApprovalGate`] — never [`stella_pipeline::ports::AlwaysAbortGate`],
+/// so the CLI's "headless means nobody to ask" branch never applies here.
+/// `headless_bypass_scope_review` is therefore inert (only read inside the
+/// `headless` arm) and left at its default.
+fn pipeline_config(run: &PipelineRun, engine: EngineConfig) -> PipelineConfig {
+    let mut config = PipelineConfig {
+        engine,
+        headless: false,
+        test_command: run.test_command.clone(),
+        witness_writer: run.witness_writer,
+        candidates: run.candidates,
+        ..PipelineConfig::default()
+    };
+    if let Some(max_revisions) = run.max_revisions {
+        config.max_revisions = max_revisions;
+    }
+    config
+}
+
+/// Drive one pipeline-driven turn to its outcome (#1288).
+///
+/// Structurally the pipeline's counterpart to [`crate::session::drive_turn`]
+/// / [`crate::goal::drive_goal`]: it builds the pipeline's own port set over
+/// the same reverse-RPC primitives every turn already uses, runs
+/// [`Pipeline::run`], and maps the result back to the shared [`DrivenTurn`]
+/// shape so `run_session`'s three modes (plain turn, goal, pipeline) settle
+/// identically.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn drive_pipeline(
+    run: &PipelineRun,
+    provider_id: String,
+    // The turn's already-constructed, already-hook-gated tool executor
+    // (`crate::session::run_session`'s `tools`, or its sub-agent-delegating
+    // view) — reused rather than rebuilt, so a pipeline-driven turn's
+    // execute-stage tool calls go through the same operator
+    // `tool.call.requested` policy as an ordinary turn's. The verification
+    // ladder's own process launches (`RemoteVerificationRunner`) are
+    // deliberately NOT gated the same way: they are the pipeline's own
+    // deterministic diagnostics, not model-initiated tool calls, exactly as
+    // `verify_done`'s local runner bypasses `ToolRegistry` in the CLI.
+    tools: &dyn stella_core::ToolExecutor,
+    engine_config: EngineConfig,
+    messages: Vec<CompletionMessage>,
+    mut budget: BudgetGuard,
+    frame_tx: crate::backlog::FrameSink,
+    pending: Pending,
+    reverse_request_timeout: Duration,
+    events: &mpsc::UnboundedSender<AgentEvent>,
+    gate: &dyn stella_core::ports::TurnGate,
+) -> DrivenTurn {
+    let worker_id = provider_id;
+    let triage_id = run.triage_provider_id.clone().unwrap_or_else(|| worker_id.clone());
+    let judge_id = run.judge_provider_id.clone().unwrap_or_else(|| worker_id.clone());
+
+    let resolver = ServedProviderResolver {
+        worker: RemoteProvider::new(
+            worker_id.clone(),
+            frame_tx.clone(),
+            pending.clone(),
+            reverse_request_timeout,
+        ),
+        triage: RemoteProvider::new(
+            triage_id,
+            frame_tx.clone(),
+            pending.clone(),
+            reverse_request_timeout,
+        )
+        .with_role(stella_protocol::ModelCallRole::Triage),
+        judge: RemoteProvider::new(
+            judge_id,
+            frame_tx.clone(),
+            pending.clone(),
+            reverse_request_timeout,
+        )
+        .with_role(stella_protocol::ModelCallRole::Judge),
+    };
+
+    let router = Router::new(
+        RoleTable::new(),
+        vec![ProviderProfile::new(
+            worker_id,
+            ModelRef::new(role_tag::WORKER, role_tag::WORKER),
+            ModelRef::new(role_tag::TRIAGE, role_tag::TRIAGE),
+            ModelRef::new(role_tag::JUDGE, role_tag::JUDGE),
+        )],
+        CircuitBreaker::new(Box::new(WallClock)),
+    );
+
+    let verify = RemoteVerificationRunner::new(frame_tx.clone(), pending.clone(), reverse_request_timeout);
+    let auto_approve_gate = AutoApproveGate;
+    let remote_approval_gate = RemoteApprovalGate::new(frame_tx, pending, reverse_request_timeout);
+    let sleeper = TokioSleeper;
+
+    let ports = PipelinePorts {
+        router: &router,
+        providers: &resolver,
+        tools,
+        recall: &NoContextRecall,
+        repo: &NoRepoStructure,
+        repo_status: &NoRepoStatus,
+        touches: &NoFileTouches,
+        diagnostics: &verify,
+        tests: &verify,
+        lint: None,
+        mutation: None,
+        coverage: None,
+        approvals: if run.auto_approve {
+            &auto_approve_gate as &dyn ApprovalGate
+        } else {
+            &remote_approval_gate as &dyn ApprovalGate
+        },
+        sleeper: &sleeper,
+        hooks: None,
+        candidate_workspaces: None,
+        mcp_prefetch: None,
+        steering: None,
+    };
+
+    let config = pipeline_config(run, engine_config);
+    let pipeline = Pipeline::new(ports, events.clone(), config).with_turn_gate(gate);
+
+    let mut messages = messages;
+    let outcome = match pipeline.run(&run.goal, &mut messages, &mut budget).await {
+        Ok(outcome) => {
+            use stella_pipeline::PipelineStatus;
+            match outcome.status {
+                PipelineStatus::Completed | PipelineStatus::VerificationFailed { .. } => {
+                    TurnOutcome::Completed {
+                        text: outcome.final_text,
+                        cost_usd: outcome.total_cost_usd,
+                    }
+                }
+                PipelineStatus::Aborted { reason } => TurnOutcome::Aborted {
+                    reason,
+                    cost_usd: outcome.total_cost_usd,
+                },
+            }
+        }
+        Err(err) => TurnOutcome::Aborted {
+            reason: err.cause.to_string(),
+            cost_usd: err.total_cost_usd,
+        },
+    };
+
+    DrivenTurn {
+        outcome,
+        messages,
+        budget,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_run() -> PipelineRun {
+        PipelineRun {
+            goal: "add a widget".to_string(),
+            auto_approve: false,
+            test_command: None,
+            witness_writer: true,
+            max_revisions: None,
+            candidates: None,
+            triage_provider_id: None,
+            judge_provider_id: None,
+        }
+    }
+
+    /// A served run is never the CLI's "nobody to ask" headless posture — it
+    /// always has a real `ApprovalGate` behind it, so the pipeline's own
+    /// headless-without-bypass refusal must never fire for one.
+    #[test]
+    fn a_served_pipeline_run_is_never_headless() {
+        let config = pipeline_config(&base_run(), EngineConfig::default());
+        assert!(!config.headless);
+    }
+
+    /// The caller's knobs land on the right `PipelineConfig` fields, and
+    /// anything left unset keeps the pipeline's own default rather than a
+    /// serve-specific one.
+    #[test]
+    fn caller_knobs_lower_onto_pipeline_config_field_by_field() {
+        let mut run = base_run();
+        run.test_command = Some("cargo test -p widget".to_string());
+        run.witness_writer = false;
+        run.max_revisions = Some(5);
+        run.candidates = Some(3);
+        let config = pipeline_config(&run, EngineConfig::default());
+        assert_eq!(config.test_command.as_deref(), Some("cargo test -p widget"));
+        assert!(!config.witness_writer);
+        assert_eq!(config.max_revisions, 5);
+        assert_eq!(config.candidates, Some(3));
+        // Left unset by `PipelineRun` — the pipeline's own default survives.
+        assert_eq!(
+            config.diff_budget_lines,
+            PipelineConfig::default().diff_budget_lines
+        );
+    }
+
+    /// `max_revisions: None` must not zero out the pipeline's own default —
+    /// only an explicit caller value may move it.
+    #[test]
+    fn an_unset_max_revisions_keeps_the_pipelines_own_default() {
+        let config = pipeline_config(&base_run(), EngineConfig::default());
+        assert_eq!(config.max_revisions, PipelineConfig::default().max_revisions);
+    }
+}

--- a/stella-serve/src/remote.rs
+++ b/stella-serve/src/remote.rs
@@ -16,13 +16,18 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_core::bus::{self, HookBus, HookDecision, HookEventDraft, names as hook_names};
 use stella_core::ports::ToolExecutor;
 use stella_core::retry::Sleeper;
+use stella_pipeline::ports::{
+    ApprovalGate, CmdKind, CmdOutcome, DiagnosticInvocation, DiagnosticRunner, ScopeDecision,
+    TestInvocation, TestRunner,
+};
 use stella_protocol::{
-    CompletionRequestRef, CompletionResult, Provider, ProviderError, ToolCallObserver, ToolOutput,
-    ToolSchema,
+    CompletionRequestRef, CompletionResult, Provider, ProviderError, ScopeProposal,
+    ToolCallObserver, ToolOutput, ToolSchema,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -550,15 +555,297 @@ impl RemoteToolExecutor {
     }
 }
 
+/// The `ApprovalGate` port as a reverse-RPC to the host (#1288): a
+/// pipeline-driven turn's scope-review gate, remoted exactly like a tool or
+/// provider call. `review` emits a [`ServerFrame::ScopeReviewRequest`] and
+/// blocks the pipeline stage on the host's [`ScopeDecision`].
+///
+/// [`ApprovalGate::confirm`] is left at its default (`false`, i.e. "never
+/// isolate in a worktree") — a served run has no
+/// `CandidateWorkspacePort` wired yet ([`crate::pipeline_run`]'s module docs
+/// name this as a declared follow-up), so the question this method answers
+/// never has a workspace to say yes to.
+pub(crate) struct RemoteApprovalGate {
+    frames: crate::backlog::FrameSink,
+    pending: Pending,
+    counter: AtomicU64,
+    timeout: Duration,
+}
+
+impl RemoteApprovalGate {
+    pub(crate) fn new(frames: crate::backlog::FrameSink, pending: Pending, timeout: Duration) -> Self {
+        Self {
+            frames,
+            pending,
+            counter: AtomicU64::new(0),
+            timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl ApprovalGate for RemoteApprovalGate {
+    /// Fail-closed on every exit that is not an explicit host decision —
+    /// cancellation, a disconnected host, a wedged one — matching
+    /// [`stella_pipeline::ports::AlwaysAbortGate`] and the fail-closed EOF
+    /// handling in [`stella_pipeline::ports::StdioApprovalGate`]: an
+    /// unanswered scope review must never relocate into "run it anyway".
+    async fn review(&self, proposal: &ScopeProposal) -> ScopeDecision {
+        if self.pending.is_cancelled() {
+            return ScopeDecision::Abort;
+        }
+        let request_id = format!("scope-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let (tx, rx) = oneshot::channel();
+        if !self.pending.register_scope_review(request_id.clone(), tx) {
+            return ScopeDecision::Abort;
+        }
+        if self
+            .frames
+            .send(ServerFrame::ScopeReviewRequest {
+                request_id: request_id.clone(),
+                proposal: proposal.clone(),
+            })
+            .is_err()
+        {
+            self.pending.abandon(&request_id);
+            return ScopeDecision::Abort;
+        }
+        let started = dispatched(&self.pending, &request_id, ReverseKind::ScopeReview);
+        match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(decision)) => {
+                answered(&self.pending, &request_id, ReverseKind::ScopeReview, started);
+                decision
+            }
+            // The sender was dropped: cancellation or teardown already
+            // reported itself through `Pending::clear`/`cancel`, so nothing
+            // further is recorded here — same reasoning as
+            // `RemoteProvider::complete_remoted`'s cancelled-sender arm.
+            Ok(Err(_)) => ScopeDecision::Abort,
+            Err(_) => {
+                self.pending.abandon(&request_id);
+                timed_out(&self.pending, &request_id, ReverseKind::ScopeReview, started);
+                ScopeDecision::Abort
+            }
+        }
+    }
+}
+
+/// The typed process-outcome ports (`TestRunner`, `DiagnosticRunner`) as a
+/// reverse-RPC to the host (#1288), reusing the exact `ToolRequest` /
+/// `ToolResultIn` wire vocabulary every other tool call already goes
+/// through — the verification ladder's process launches are not a new
+/// containment decision, they are the existing bring-your-own-tools
+/// boundary ([`ToolExecutor`]'s doc, and `stella-parity`'s
+/// `tools.local_execution` row) applied to two more typed callers. See
+/// [`crate::pipeline_run`] for why this is the answer rather than a new
+/// wire primitive.
+///
+/// Reserved names, in a `stella.verify.*` namespace no real tool schema may
+/// occupy: the host recognizes them and answers with a JSON-encoded
+/// [`CmdOutcomeWire`] as the tool's `content`; a host that has not
+/// implemented them answers as it would any unknown tool (an error), which
+/// this type reads as [`CmdKind::Infra`] — "no toolchain for this", already
+/// a first-class, gracefully-handled outcome on the typed ladder.
+pub(crate) const PIPELINE_TEST_TOOL: &str = "stella.verify.run_test";
+pub(crate) const PIPELINE_DIAGNOSTIC_TOOL: &str = "stella.verify.run_diagnostic";
+
+/// Wire projection of [`CmdOutcome`]. Carried as a JSON string inside a
+/// [`ToolOutput::Ok`]'s `content` — the same "structured payload inside a
+/// tool's string content" shape several production tools already use — so
+/// answering a verification call costs the host no new response envelope,
+/// only a documented `content` shape for these two reserved names.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum CmdOutcomeWire {
+    Completed {
+        exit_code: i32,
+        #[serde(default)]
+        stdout_tail: String,
+        #[serde(default)]
+        stderr_tail: String,
+    },
+    TimedOut,
+    OutOfMemory,
+    Infra,
+}
+
+impl From<CmdOutcomeWire> for CmdOutcome {
+    fn from(wire: CmdOutcomeWire) -> Self {
+        match wire {
+            CmdOutcomeWire::Completed {
+                exit_code,
+                stdout_tail,
+                stderr_tail,
+            } => CmdOutcome {
+                exit_code,
+                stdout_tail,
+                stderr_tail,
+                kind: CmdKind::Completed,
+            },
+            CmdOutcomeWire::TimedOut => infra_outcome(CmdKind::TimedOut),
+            CmdOutcomeWire::OutOfMemory => infra_outcome(CmdKind::OutOfMemory),
+            CmdOutcomeWire::Infra => infra_outcome(CmdKind::Infra),
+        }
+    }
+}
+
+fn infra_outcome(kind: CmdKind) -> CmdOutcome {
+    CmdOutcome {
+        exit_code: -1,
+        stdout_tail: String::new(),
+        stderr_tail: String::new(),
+        kind,
+    }
+}
+
+/// A `CmdOutcome` reporting that the host never answered, or answered with
+/// something this crate cannot read as a [`CmdOutcomeWire`] — never a
+/// fabricated pass or a fabricated assertion failure, per
+/// [`CmdOutcome::assertion_result`]'s contract: infrastructure noise must
+/// read as unobserved, not as failing.
+fn unreachable_outcome() -> CmdOutcome {
+    infra_outcome(CmdKind::Infra)
+}
+
+/// Ask the host to run one reserved verification call and wait for its
+/// answer, exactly like [`RemoteToolExecutor::dispatch`] — a free function
+/// rather than a shared base, because the two callers ([`RemoteVerificationRunner`]'s
+/// two trait methods) differ only in the tool name and the input they send.
+async fn dispatch_verification_call(
+    frames: &crate::backlog::FrameSink,
+    pending: &Pending,
+    timeout: Duration,
+    name: &str,
+    input: Value,
+) -> CmdOutcome {
+    if pending.is_cancelled() {
+        return unreachable_outcome();
+    }
+    let request_id = format!("verify-{}", next_verify_call_id());
+    let (tx, rx) = oneshot::channel();
+    if !pending.register_tool(request_id.clone(), tx) {
+        return unreachable_outcome();
+    }
+    if frames
+        .send(ServerFrame::ToolRequest {
+            request_id: request_id.clone(),
+            name: name.to_string(),
+            input,
+        })
+        .is_err()
+    {
+        pending.abandon(&request_id);
+        return unreachable_outcome();
+    }
+    let started = dispatched(pending, &request_id, ReverseKind::Tool);
+    let output = match tokio::time::timeout(timeout, rx).await {
+        Ok(Ok(output)) => {
+            answered(pending, &request_id, ReverseKind::Tool, started);
+            output
+        }
+        Ok(Err(_)) => return unreachable_outcome(),
+        Err(_) => {
+            pending.abandon(&request_id);
+            timed_out(pending, &request_id, ReverseKind::Tool, started);
+            return unreachable_outcome();
+        }
+    };
+    match output {
+        ToolOutput::Ok { content } => serde_json::from_str::<CmdOutcomeWire>(&content)
+            .map(CmdOutcome::from)
+            .unwrap_or_else(|_| unreachable_outcome()),
+        ToolOutput::Error { .. } => unreachable_outcome(),
+    }
+}
+
+/// A per-request-id counter for [`dispatch_verification_call`]. Process-wide
+/// rather than per-runner: [`RemoteVerificationRunner`] answers both
+/// `TestRunner` and `DiagnosticRunner` from one shared `&self`, so a
+/// per-instance counter would need its own synchronization anyway, and a
+/// pipeline run mints a fresh runner per turn — the same tradeoff
+/// [`PROVIDER_INSTANCES`] makes for [`RemoteProvider`].
+static VERIFY_CALL_INSTANCES: AtomicU64 = AtomicU64::new(0);
+
+fn next_verify_call_id() -> u64 {
+    VERIFY_CALL_INSTANCES.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Both typed process-launching ports the verification ladder needs
+/// (#1288), sharing one reverse-RPC dispatch. See [`PIPELINE_TEST_TOOL`] /
+/// [`PIPELINE_DIAGNOSTIC_TOOL`] for the wire contract.
+pub(crate) struct RemoteVerificationRunner {
+    frames: crate::backlog::FrameSink,
+    pending: Pending,
+    timeout: Duration,
+}
+
+impl RemoteVerificationRunner {
+    pub(crate) fn new(frames: crate::backlog::FrameSink, pending: Pending, timeout: Duration) -> Self {
+        Self {
+            frames,
+            pending,
+            timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl TestRunner for RemoteVerificationRunner {
+    async fn run_test(&self, invocation: &TestInvocation) -> CmdOutcome {
+        dispatch_verification_call(
+            &self.frames,
+            &self.pending,
+            self.timeout,
+            PIPELINE_TEST_TOOL,
+            serde_json::json!({
+                "program": invocation.program,
+                "args": invocation.args,
+            }),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl DiagnosticRunner for RemoteVerificationRunner {
+    async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
+        let input = match invocation {
+            DiagnosticInvocation::GitDiff => serde_json::json!({ "invocation": "git_diff" }),
+            DiagnosticInvocation::UntrackedNumstat { path } => serde_json::json!({
+                "invocation": "untracked_numstat",
+                "path": path,
+            }),
+        };
+        dispatch_verification_call(
+            &self.frames,
+            &self.pending,
+            self.timeout,
+            PIPELINE_DIAGNOSTIC_TOOL,
+            input,
+        )
+        .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use stella_core::bus::{HookBus, HookEvent, names as hook_names};
     use stella_core::ports::ToolExecutor;
-    use stella_protocol::ToolOutput;
+    use stella_pipeline::ports::{
+        ApprovalGate, CmdKind, DiagnosticInvocation, DiagnosticRunner, ScopeDecision,
+        TestInvocation, TestRunner,
+    };
+    use stella_protocol::{ScopeProposal, ToolOutput};
 
-    use super::RemoteToolExecutor;
+    use super::{
+        CmdOutcomeWire, PIPELINE_DIAGNOSTIC_TOOL, PIPELINE_TEST_TOOL, RemoteApprovalGate,
+        RemoteToolExecutor, RemoteVerificationRunner,
+    };
+    use crate::frame::ServerFrame;
     use crate::observe::event::TurnRef;
     use crate::pending::Pending;
 
@@ -666,6 +953,160 @@ mod tests {
                 hook_names::TOOL_CALL_FAILED.to_string(),
             ],
             "a wedged host is exactly when an observer must not be left waiting"
+        );
+    }
+
+    /// A fresh, connected reverse-RPC channel triple: the pending registry, a
+    /// frame receiver a test can drain, and the sink both new ports
+    /// (#1288) are constructed over.
+    fn live_channel() -> (
+        crate::backlog::FrameSink,
+        tokio::sync::mpsc::UnboundedReceiver<ServerFrame>,
+        Pending,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = crate::backlog::FrameSink::new(
+            tx,
+            crate::backlog::FrameBacklog::new(crate::backlog::DEFAULT_MAX_QUEUED_FRAMES),
+        );
+        let pending = Pending::new(
+            crate::observe::null_observer(),
+            TurnRef::new("turn-remotetest"),
+        );
+        (sink, rx, pending)
+    }
+
+    /// A scope review the host approves round-trips into
+    /// [`ScopeDecision::Approve`] — the pipeline's `ApprovalGate::review`,
+    /// remoted (#1288).
+    #[tokio::test]
+    async fn a_host_answered_scope_review_reaches_the_pipeline_as_the_hosts_decision() {
+        let (sink, mut rx, pending) = live_channel();
+        let gate = RemoteApprovalGate::new(sink, pending.clone(), Duration::from_secs(5));
+        let proposal = ScopeProposal {
+            summary: "do the thing".to_string(),
+            steps: vec!["step one".to_string()],
+            estimated_files: 1,
+            estimated_cost_usd: None,
+        };
+
+        let review = tokio::spawn(async move { gate.review(&proposal).await });
+
+        let ServerFrame::ScopeReviewRequest { request_id, .. } = rx.recv().await.unwrap() else {
+            panic!("expected a scope review request frame");
+        };
+        assert!(
+            pending
+                .resolve_scope_review(&request_id, ScopeDecision::Approve)
+                .is_ok()
+        );
+        assert_eq!(review.await.unwrap(), ScopeDecision::Approve);
+    }
+
+    /// A scope review the host never answers fails closed
+    /// ([`ScopeDecision::Abort`]) rather than defaulting to running the plan
+    /// unattended — the same fail-closed contract
+    /// [`stella_pipeline::ports::StdioApprovalGate`] gives a read error.
+    #[tokio::test]
+    async fn an_unanswered_scope_review_fails_closed() {
+        let (sink, _rx, pending) = live_channel();
+        let gate = RemoteApprovalGate::new(sink, pending, Duration::from_millis(20));
+        let proposal = ScopeProposal {
+            summary: "do the thing".to_string(),
+            steps: vec!["step one".to_string()],
+            estimated_files: 1,
+            estimated_cost_usd: None,
+        };
+        assert_eq!(gate.review(&proposal).await, ScopeDecision::Abort);
+    }
+
+    /// A well-formed [`CmdOutcomeWire`] the host answers with round-trips into
+    /// the matching [`CmdOutcome`], for both the test-runner and the
+    /// diagnostic-runner traits [`RemoteVerificationRunner`] answers (#1288).
+    #[tokio::test]
+    async fn a_hosts_cmd_outcome_reaches_the_ladder_as_the_matching_typed_result() {
+        let (sink, mut rx, pending) = live_channel();
+        let runner = RemoteVerificationRunner::new(sink, pending.clone(), Duration::from_secs(5));
+
+        let call = tokio::spawn(async move {
+            runner
+                .run_test(&TestInvocation {
+                    program: "cargo".to_string(),
+                    args: vec!["test".to_string()],
+                })
+                .await
+        });
+
+        let ServerFrame::ToolRequest {
+            request_id,
+            name,
+            input,
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("expected a tool request frame");
+        };
+        assert_eq!(name, PIPELINE_TEST_TOOL);
+        assert_eq!(input["program"], "cargo");
+
+        let content = serde_json::to_string(&CmdOutcomeWire::Completed {
+            exit_code: 1,
+            stdout_tail: "FAILED".to_string(),
+            stderr_tail: String::new(),
+        })
+        .unwrap();
+        assert!(
+            pending
+                .resolve_tool(&request_id, ToolOutput::Ok { content })
+                .is_ok()
+        );
+
+        let outcome = call.await.unwrap();
+        assert_eq!(outcome.kind, CmdKind::Completed);
+        assert_eq!(outcome.exit_code, 1);
+        assert_eq!(outcome.stdout_tail, "FAILED");
+        assert_eq!(outcome.assertion_result(), Some(false));
+    }
+
+    /// A host that has not implemented the reserved verification tool names
+    /// answers as it would any unknown tool — an error — and the ladder must
+    /// read that as "no toolchain" ([`CmdKind::Infra`]), never as a failing
+    /// assertion: an infra outcome and a genuine test failure must not be
+    /// confused, per [`CmdOutcome::assertion_result`]'s own contract.
+    #[tokio::test]
+    async fn a_host_that_does_not_implement_verification_degrades_to_infra_not_a_failure() {
+        let (sink, mut rx, pending) = live_channel();
+        let runner = RemoteVerificationRunner::new(sink, pending.clone(), Duration::from_secs(5));
+
+        let call = tokio::spawn(async move {
+            runner
+                .run_diagnostic(&DiagnosticInvocation::GitDiff)
+                .await
+        });
+
+        let ServerFrame::ToolRequest {
+            request_id, name, ..
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("expected a tool request frame");
+        };
+        assert_eq!(name, PIPELINE_DIAGNOSTIC_TOOL);
+        assert!(
+            pending
+                .resolve_tool(
+                    &request_id,
+                    ToolOutput::Error {
+                        message: "unknown tool".to_string(),
+                    },
+                )
+                .is_ok()
+        );
+
+        let outcome = call.await.unwrap();
+        assert_eq!(outcome.kind, CmdKind::Infra);
+        assert_eq!(
+            outcome.assertion_result(),
+            None,
+            "an unimplemented verification call observed no assertion either way"
         );
     }
 }

--- a/stella-serve/src/router.rs
+++ b/stella-serve/src/router.rs
@@ -24,6 +24,7 @@ pub(crate) fn route_addresses_a_turn(route: Route) -> bool {
             | Route::TurnSteer
             | Route::TurnPause
             | Route::TurnResume
+            | Route::TurnApprove
             | Route::TurnCheckpoint
     )
 }
@@ -49,6 +50,7 @@ pub(crate) fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
         ["v1", "turns", id, "steer"] => (Route::TurnSteer, Some(id)),
         ["v1", "turns", id, "pause"] => (Route::TurnPause, Some(id)),
         ["v1", "turns", id, "resume"] => (Route::TurnResume, Some(id)),
+        ["v1", "turns", id, "approve"] => (Route::TurnApprove, Some(id)),
         ["v1", "turns", id, "checkpoint"] => (Route::TurnCheckpoint, Some(id)),
         ["v1", "sessions"] => (Route::SessionsCreate, None),
         ["v1", "sessions", id] => (Route::Session, Some(id)),
@@ -107,6 +109,7 @@ pub(crate) fn allowed(route: Route) -> &'static str {
         | Route::TurnSteer
         | Route::TurnPause
         | Route::TurnResume
+        | Route::TurnApprove
         | Route::SessionsCreate
         | Route::SessionTurns => "POST",
         Route::Session | Route::TurnCheckpoint | Route::SessionCheckpoint => "GET, DELETE",

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -69,6 +69,71 @@ struct TurnRequest {
     /// `task` tool, so the model never learns children exist.
     #[serde(default)]
     sub_agents: Option<SubAgentsSpec>,
+    /// Drive this turn through the verification pipeline (#1288) — plan,
+    /// scope review, execute, witness, verify, judge — instead of a bare
+    /// engine step loop. Mutually exclusive with `goal` and `sub_agents`:
+    /// the pipeline already loops internally and drives its own judge, so a
+    /// request naming more than one of the three is refused with a 400
+    /// rather than silently picking one.
+    #[serde(default)]
+    pipeline: Option<PipelineSpec>,
+}
+
+/// `pipeline` on `POST /v1/turns` (#1288). See [`crate::PipelineRun`] for
+/// what each field means to the pipeline itself; this is only the wire
+/// shape and its defaults.
+#[derive(Debug, Deserialize)]
+struct PipelineSpec {
+    /// The task, exactly as `stella run "<goal>"` takes it on the CLI.
+    goal: String,
+    /// Skip the scope-review gate and approve every plan without asking the
+    /// host — an explicit opt into unattended execution. `false` (the
+    /// default) asks over `POST /v1/turns/{id}/approve` for any plan that
+    /// crosses the operator's scope thresholds.
+    #[serde(default)]
+    auto_approve: bool,
+    /// The test command the flip oracle tracks. Omitted hands the flip
+    /// oracle to the witness author when `witness_writer` is on.
+    #[serde(default)]
+    test_command: Option<String>,
+    /// Witness authoring (L-E11). Defaults to on, matching the pipeline's
+    /// own default.
+    #[serde(default = "default_true")]
+    witness_writer: bool,
+    /// Maximum revision turns per candidate when verification fails.
+    /// Omitted keeps the pipeline's own default.
+    #[serde(default)]
+    max_revisions: Option<u32>,
+    /// Best-of-N candidate count. Omitted or `1` is single-shot.
+    #[serde(default)]
+    candidates: Option<u32>,
+    /// The provider id the triage call announces. Omitted runs it on the
+    /// turn's own provider id.
+    #[serde(default)]
+    triage_provider_id: Option<String>,
+    /// The provider id the judge call announces — the pipeline's own
+    /// counterpart to `goal.judge_provider_id`.
+    #[serde(default)]
+    judge_provider_id: Option<String>,
+}
+
+/// Lower a caller's `pipeline` block into [`crate::PipelineRun`]. `None`
+/// when the goal text is blank — the same "nothing stated, nothing invented"
+/// rule [`goal_run`] applies.
+fn pipeline_run(spec: PipelineSpec) -> Option<crate::PipelineRun> {
+    if spec.goal.trim().is_empty() {
+        return None;
+    }
+    Some(crate::PipelineRun {
+        goal: spec.goal,
+        auto_approve: spec.auto_approve,
+        test_command: spec.test_command,
+        witness_writer: spec.witness_writer,
+        max_revisions: spec.max_revisions,
+        candidates: spec.candidates,
+        triage_provider_id: spec.triage_provider_id,
+        judge_provider_id: spec.judge_provider_id,
+    })
 }
 
 /// `goal` on `POST /v1/turns` — a judged multi-round run (#1297).
@@ -337,6 +402,17 @@ pub(crate) async fn handle_create(
                 .await;
         }
     };
+    if turn.pipeline.is_some() && (turn.goal.is_some() || turn.sub_agents.is_some()) {
+        return res
+            .json(
+                "400 Bad Request",
+                &error_body(
+                    "`pipeline` cannot be combined with `goal` or `sub_agents` — the pipeline \
+                     drives its own internal judge and does not support delegation yet",
+                ),
+            )
+            .await;
+    }
 
     let mut config = EngineConfig::default();
     let clamped = match &turn.engine {
@@ -391,6 +467,7 @@ pub(crate) async fn handle_create(
     let sub_agents = turn
         .sub_agents
         .and_then(|spec| state.sub_agent_policy().clamp(spec.into()));
+    let pipeline = turn.pipeline.and_then(pipeline_run);
     let extensions = state.extensions();
     // Keyed on the declared provider so two providers serving the same model
     // name never blend their drift — see `crate::calibration`.
@@ -412,6 +489,7 @@ pub(crate) async fn handle_create(
             on_settled: None,
             checkpoint: checkpoint_state.checkpoint_for(turn_id),
             goal,
+            pipeline,
             sub_agents,
             extensions,
             calibration,
@@ -736,6 +814,44 @@ pub(crate) async fn handle_tool_result(
     match entry
         .pending
         .resolve_tool(&result.request_id, result.output)
+    {
+        Ok(()) => res.json("200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => {
+            res.json("409 Conflict", &error_body(&err.to_string()))
+                .await
+        }
+    }
+}
+
+/// `POST /v1/turns/{id}/approve` — resolve a pipeline-driven turn's
+/// scope-review gate (#1288). Same shape as [`handle_tool_result`]: a 404
+/// for an unknown turn, a 409 for an unknown/mismatched/already-answered
+/// `request_id` (including one raised by a turn that was never running the
+/// pipeline mode, which has nothing registered under any `scope-*` id and so
+/// answers exactly the same honest 409 a stray tool-result would).
+pub(crate) async fn handle_approve(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    let result: crate::frame::ScopeReviewResultIn = match serde_json::from_slice(body) {
+        Ok(result) => result,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid scope review result: {err}")),
+                )
+                .await;
+        }
+    };
+    match entry
+        .pending
+        .resolve_scope_review(&result.request_id, result.decision.into())
     {
         Ok(()) => res.json("200 OK", br#"{"status":"ok"}"#).await,
         Err(err) => {

--- a/stella-serve/src/routes/sessions.rs
+++ b/stella-serve/src/routes/sessions.rs
@@ -266,6 +266,7 @@ pub(crate) async fn handle_session_turn(
             on_settled: Some(hook_sess.settle_hook(token)),
             checkpoint,
             goal,
+            pipeline: None,
             sub_agents,
             extensions,
             calibration,

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -1227,6 +1227,7 @@ async fn route(
             // Body-bearing but not body-*requiring*: an empty pause is the
             // shape the route shipped with and stays valid (#932).
             | Route::TurnPause
+            | Route::TurnApprove
             | Route::SessionsCreate
             | Route::SessionTurns,
         ) => {}
@@ -1261,6 +1262,7 @@ async fn route(
         Route::TurnProviderDelta => routes::handle_provider_delta(res, state, id, &req.body).await,
         Route::TurnSteer => routes::handle_steer(res, state, id, &req.body).await,
         Route::TurnPause => routes::handle_pause(res, state, id, &req.body).await,
+        Route::TurnApprove => routes::handle_approve(res, state, id, &req.body).await,
         Route::SessionsCreate => routes::handle_session_create(res, state, &req.body).await,
         Route::SessionTurns => routes::handle_session_turn(res, state, id, &req.body).await,
         // Unreachable: the match above admits exactly the body-bearing
@@ -1358,6 +1360,7 @@ mod tests {
             observer: crate::observe::null_observer(),
             on_settled: None,
             goal: None,
+            pipeline: None,
             sub_agents: None,
             checkpoint: None,
             extensions: crate::extensions::Extensions::new(),

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -117,6 +117,13 @@ pub struct SessionSpec {
     /// boundary, and the settlement hook writes its transcript back. See
     /// [`GoalRun`](crate::GoalRun)'s own module for the full argument.
     pub goal: Option<crate::goal::GoalRun>,
+    /// Drive this turn through the verification pipeline (#1288) instead of
+    /// a bare engine step loop or a judged goal run. Mutually exclusive with
+    /// [`SessionSpec::goal`] and [`SessionSpec::sub_agents`] — the route
+    /// layer refuses a request naming more than one, since the pipeline
+    /// already loops internally (revisions, best-of-N) and drives its own
+    /// judge. `None` — the default — is the pre-#1288 behavior exactly.
+    pub pipeline: Option<crate::pipeline_run::PipelineRun>,
     /// What this turn's sub-agents may do (#1297), after the operator's
     /// [`crate::SubAgentPolicy`] has clamped the caller's request. `None`
     /// advertises no `task` tool at all, so the model never learns children
@@ -758,45 +765,76 @@ fn run_session(
             engine = engine.with_calibration(calibration);
         }
 
-        let outcome = match &spec.goal {
-            // A judged multi-round run (#1297). Its judge announces its own
-            // provider id and `role: judge` on every frame, so a host can
-            // route it to a different family than the worker — the property
-            // the goal loop exists for, and the one the engine cannot enforce
-            // because the host owns the model calls.
-            Some(run) => {
-                let judge_provider = crate::remote::RemoteProvider::new(
-                    run.judge_provider_id
-                        .clone()
-                        .unwrap_or_else(|| provider.id_string()),
-                    frame_tx.clone(),
-                    pending.clone(),
-                    spec.reverse_request_timeout,
-                )
-                .with_role(stella_protocol::ModelCallRole::Judge);
-                crate::goal::drive_goal(
-                    &engine,
-                    &judge_provider,
-                    run,
-                    spec.config.turn_instance,
-                    spec.messages,
-                    spec.budget,
-                    &event_tx,
-                    cancel,
-                    bus.as_ref(),
-                )
-                .await
-            }
-            None => {
-                drive_turn(
-                    &engine,
-                    spec.messages,
-                    spec.budget,
-                    &event_tx,
-                    cancel,
-                    bus.as_ref(),
-                )
-                .await
+        // Three mutually exclusive modes, in the order they were added:
+        // plain turn, judged goal run (#1297), pipeline-driven turn (#1288).
+        // `spec.pipeline` and `spec.goal` never both hold — the route layer
+        // refuses a request naming both (see `routes::handle_create`) — so
+        // this reads top-to-bottom as a priority list rather than a real
+        // ambiguity.
+        let outcome = if let Some(run) = &spec.pipeline {
+            // The pipeline drives its own internal engine turns and its own
+            // judge; it does not ride the `engine`/`tool_view` built above
+            // through the goal loop's step machinery. It DOES reuse
+            // `tool_view` itself (the turn's hook-gated tool executor,
+            // sub-agent-delegating or not) so its execute-stage tool calls
+            // are governed identically to an ordinary turn's — see
+            // `pipeline_run::drive_pipeline`'s own docs for the full account
+            // of what is and is not shared with the plain turn/goal paths.
+            crate::pipeline_run::drive_pipeline(
+                run,
+                provider.id_string(),
+                tool_view,
+                spec.config.clone(),
+                spec.messages,
+                spec.budget,
+                frame_tx.clone(),
+                pending.clone(),
+                spec.reverse_request_timeout,
+                &event_tx,
+                &gate,
+            )
+            .await
+        } else {
+            match &spec.goal {
+                // A judged multi-round run (#1297). Its judge announces its
+                // own provider id and `role: judge` on every frame, so a host
+                // can route it to a different family than the worker — the
+                // property the goal loop exists for, and the one the engine
+                // cannot enforce because the host owns the model calls.
+                Some(run) => {
+                    let judge_provider = crate::remote::RemoteProvider::new(
+                        run.judge_provider_id
+                            .clone()
+                            .unwrap_or_else(|| provider.id_string()),
+                        frame_tx.clone(),
+                        pending.clone(),
+                        spec.reverse_request_timeout,
+                    )
+                    .with_role(stella_protocol::ModelCallRole::Judge);
+                    crate::goal::drive_goal(
+                        &engine,
+                        &judge_provider,
+                        run,
+                        spec.config.turn_instance,
+                        spec.messages,
+                        spec.budget,
+                        &event_tx,
+                        cancel,
+                        bus.as_ref(),
+                    )
+                    .await
+                }
+                None => {
+                    drive_turn(
+                        &engine,
+                        spec.messages,
+                        spec.budget,
+                        &event_tx,
+                        cancel,
+                        bus.as_ref(),
+                    )
+                    .await
+                }
             }
         };
         let messages = outcome.messages;

--- a/stella-serve/tests/bridge.rs
+++ b/stella-serve/tests/bridge.rs
@@ -72,6 +72,7 @@ fn spec_for(prompt: &str) -> SessionSpec {
         on_settled: None,
         checkpoint: None,
         goal: None,
+        pipeline: None,
         sub_agents: None,
         extensions: stella_serve::Extensions::new(),
         calibration: None,
@@ -157,6 +158,11 @@ async fn tool_round_trip_completes_the_turn() {
             ServerFrame::TurnHeld { .. } | ServerFrame::TurnReleased => {
                 panic!("an unpaused turn must not announce a hold")
             }
+            // This turn does not run the pipeline, so it must never reach a
+            // scope-review gate.
+            ServerFrame::ScopeReviewRequest { .. } => {
+                panic!("a plain turn must not raise a scope review")
+            }
         }
     }
 
@@ -198,6 +204,11 @@ async fn immediate_completion_needs_no_tools() {
             // be a frame every host has to learn to ignore.
             ServerFrame::TurnHeld { .. } | ServerFrame::TurnReleased => {
                 panic!("an unpaused turn must not announce a hold")
+            }
+            // This turn does not run the pipeline, so it must never reach a
+            // scope-review gate.
+            ServerFrame::ScopeReviewRequest { .. } => {
+                panic!("a plain turn must not raise a scope review")
             }
         }
     }
@@ -440,6 +451,11 @@ async fn streamed_provider_deltas_surface_as_events_before_the_completion() {
                 panic!("an unpaused turn must not announce a hold")
             }
             ServerFrame::ToolRequest { .. } => {}
+            // This turn does not run the pipeline, so it must never reach a
+            // scope-review gate.
+            ServerFrame::ScopeReviewRequest { .. } => {
+                panic!("a plain turn must not raise a scope review")
+            }
         }
     }
 

--- a/stella-serve/tests/goal_and_subagents.rs
+++ b/stella-serve/tests/goal_and_subagents.rs
@@ -73,6 +73,7 @@ fn base_spec(prompt: &str) -> SessionSpec {
         on_settled: None,
         checkpoint: None,
         goal: None,
+        pipeline: None,
         sub_agents: None,
         // No operator hooks and no calibration map: these scenarios are about
         // the goal loop and delegation, and an empty extension list is the
@@ -165,6 +166,10 @@ async fn a_goal_run_is_requestable_over_the_wire_and_streams_its_rounds() {
             }
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
             ServerFrame::TurnHeld { .. } | ServerFrame::TurnReleased => {}
+            // These scenarios drive goal/sub-agent turns, not the pipeline.
+            ServerFrame::ScopeReviewRequest { .. } => {
+                panic!("a goal/sub-agent turn must not raise a scope review")
+            }
         }
     }
 

--- a/stella-serve/tests/hooks.rs
+++ b/stella-serve/tests/hooks.rs
@@ -77,6 +77,7 @@ fn spec_with(extensions: Vec<Arc<dyn ServeExtension>>) -> SessionSpec {
         // assert on what the hook plane saw, so the goal loop and sub-agents
         // stay off — their own acceptance lives in `goal_and_subagents.rs`.
         goal: None,
+        pipeline: None,
         sub_agents: None,
     }
 }
@@ -175,12 +176,14 @@ async fn run_turn(session: &mut Session) -> Vec<(String, serde_json::Value)> {
                     .unwrap();
             }
             ServerFrame::TurnComplete { .. } => break,
-            // Nothing here pauses, so the control frames are inert; matched
-            // rather than wildcarded so a new frame kind lands as a compile
-            // error in a test that reads the stream.
+            // Nothing here pauses or runs the pipeline, so the control frames
+            // and the scope-review request are inert; matched rather than
+            // wildcarded so a new frame kind lands as a compile error in a
+            // test that reads the stream.
             ServerFrame::Event { .. }
             | ServerFrame::TurnHeld { .. }
-            | ServerFrame::TurnReleased => {}
+            | ServerFrame::TurnReleased
+            | ServerFrame::ScopeReviewRequest { .. } => {}
         }
     }
     tool_requests

--- a/stella-serve/tests/pipeline.rs
+++ b/stella-serve/tests/pipeline.rs
@@ -1,0 +1,215 @@
+//! The witness for `pipeline.verified_run` on the API surface (#1288): a
+//! caller can request a verified run over `POST /v1/turns`, watch it plan and
+//! reach a scope-review gate, answer that gate over `POST
+//! /v1/turns/{id}/approve`, and see the verification ladder's own diagnostic
+//! run cross the wire as an ordinary tool call — exactly the reverse-RPC
+//! boundary every other tool call already goes through.
+//!
+//! The scripted sequence mirrors `stella-pipeline`'s own
+//! `interactive_scope_review_approve_proceeds_past_the_gate` (a `"multi"`
+//! triage classification, a six-step plan, which is what reliably crosses
+//! `ScopeThresholds::default()`), so this test is not re-proving the
+//! pipeline's internal planning/scope logic — that is `stella-pipeline`'s
+//! job, and it is exhaustively tested there. What this test proves is
+//! narrower and is what `stella-parity`'s row is about: that the same
+//! pipeline is *reachable at all* from an HTTP client, that its approval
+//! gate is a real round trip rather than an unreachable route, and that its
+//! verification commands cross the wire rather than running on this server.
+
+mod common;
+
+use common::*;
+use serde_json::json;
+
+/// An API caller can request a verified run, answer its scope-review gate
+/// over the wire, see the verification ladder's diagnostic call cross the
+/// same reverse-RPC boundary every tool call uses, and watch the turn settle
+/// — the three "Done when" bullets on #1288, exercised end to end over a
+/// real socket.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_pipeline_run_is_requestable_over_the_wire_and_its_approval_gate_round_trips() {
+    let addr = start_server().await;
+
+    let create = json!({
+        "provider_id": "scripted",
+        "messages": [],
+        "pipeline": {
+            "goal": "Refactor across the codebase and then update all callers"
+        }
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(
+        status.contains("200"),
+        "create status: {status}, body: {body}"
+    );
+    let created: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let turn_id = created["turn_id"].as_str().unwrap().to_string();
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let mut provider_calls = 0u32;
+    let mut saw_scope_review_event = false;
+    let mut saw_scope_review_request = false;
+    let mut saw_diagnostic_tool_request = false;
+    let mut saw_stage_execute = false;
+    let mut outcome = None;
+
+    while let Some(event) = next_event(&mut sse).await {
+        match event["type"].as_str().unwrap_or_default() {
+            "event" => match event["event"]["type"].as_str().unwrap_or_default() {
+                "scope_review" => saw_scope_review_event = true,
+                "stage" if event["event"]["name"].as_str() == Some("execute") => {
+                    saw_stage_execute = true;
+                }
+                _ => {}
+            },
+            "provider_request" => {
+                provider_calls += 1;
+                let request_id = event["request_id"].as_str().unwrap();
+                // 1: triage → a plan-worthy classification. 2: the plan
+                // itself — six steps, the same count
+                // `interactive_scope_review_approve_proceeds_past_the_gate`
+                // uses to reliably cross the default scope thresholds.
+                // 3+: whatever the execute/witness/judge stages ask for; a
+                // plain "done" is not a meaningful answer to every one of
+                // them, but this test is not pinning the pipeline's internal
+                // verdict logic — only that the turn can be driven to a
+                // terminal frame at all.
+                let text = match provider_calls {
+                    1 => "multi",
+                    2 => r#"["s1","s2","s3","s4","s5","s6"]"#,
+                    _ => "done",
+                };
+                let result = model_result(text);
+                let resolve = json!({
+                    "request_id": request_id,
+                    "status": "ok",
+                    "result": result,
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &resolve,
+                )
+                .await;
+                assert!(status.contains("200"), "provider-result: {status} {resp}");
+            }
+            "tool_request" => {
+                // The only tool calls a served pipeline run raises that this
+                // test never advertised a schema for are its own
+                // verification ports — `RemoteVerificationRunner`'s reserved
+                // names. Answered with an empty-but-well-formed
+                // `CmdOutcomeWire`, matching an empty `git diff` (nothing to
+                // verify) so the run does not need a witness author scripted
+                // too.
+                let name = event["name"].as_str().unwrap_or_default();
+                if name == "stella.verify.run_diagnostic" {
+                    saw_diagnostic_tool_request = true;
+                }
+                assert!(
+                    name == "stella.verify.run_diagnostic" || name == "stella.verify.run_test",
+                    "a served pipeline run must never ask the host to run anything but its own \
+                     reserved verification calls: got `{name}`"
+                );
+                let request_id = event["request_id"].as_str().unwrap();
+                let cmd_outcome = json!({
+                    "kind": "completed",
+                    "exit_code": 0,
+                    "stdout_tail": "",
+                    "stderr_tail": "",
+                })
+                .to_string();
+                let resolve = json!({
+                    "request_id": request_id,
+                    "output": { "ok": { "content": cmd_outcome } },
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/tool-result"),
+                    Some(TOKEN),
+                    &resolve,
+                )
+                .await;
+                assert!(status.contains("200"), "tool-result: {status} {resp}");
+            }
+            "scope_review_request" => {
+                saw_scope_review_request = true;
+                assert!(
+                    event["proposal"]["steps"].as_array().map(Vec::len) == Some(6),
+                    "the card the host approves must be the plan the pipeline actually built: {event}"
+                );
+                let request_id = event["request_id"].as_str().unwrap();
+                let approve = json!({
+                    "request_id": request_id,
+                    "decision": { "decision": "approve" },
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/approve"),
+                    Some(TOKEN),
+                    &approve,
+                )
+                .await;
+                assert!(status.contains("200"), "approve: {status} {resp}");
+            }
+            "turn_complete" => {
+                outcome = Some(event["outcome"].clone());
+                break;
+            }
+            other => panic!("unexpected frame on a served pipeline run: {other} ({event})"),
+        }
+    }
+
+    assert!(
+        saw_scope_review_event,
+        "the plan's card must be visible on the ordinary event stream, not only in the \
+         reverse-RPC request"
+    );
+    assert!(
+        saw_scope_review_request,
+        "the approval gate must be reachable over the wire, not merely emitted as an event"
+    );
+    assert!(
+        saw_diagnostic_tool_request,
+        "the verification ladder's diagnostic call must cross the same reverse-RPC boundary \
+         every tool call does"
+    );
+    assert!(
+        saw_stage_execute,
+        "an approved plan must proceed into execution"
+    );
+    assert!(
+        outcome.is_some(),
+        "a served pipeline run must reach a terminal frame"
+    );
+}
+
+/// `pipeline` and `goal` are two different ways of driving a turn — the
+/// pipeline already loops internally and drives its own judge — so a request
+/// naming both is refused at the route rather than silently picking one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipeline_combined_with_goal_is_refused_at_the_route() {
+    let addr = start_server().await;
+
+    let create = json!({
+        "provider_id": "scripted",
+        "messages": [],
+        "pipeline": { "goal": "do the thing" },
+        "goal": { "goal": "also judge it" },
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(
+        status.contains("400"),
+        "create status: {status}, body: {body}"
+    );
+    assert!(
+        body.contains("pipeline"),
+        "the refusal must name the field that conflicted: {body}"
+    );
+}


### PR DESCRIPTION
## What & why

`stella-serve` never linked `stella-pipeline`, so an API caller got the raw agent loop but not the verification ladder (plan → scope review → execute → witness → verify → judge), and the scope-review approval gate was structurally unreachable from the wire — the biggest gap `docs/design/engine-embedding.md` names (G3).

This connects it, following the same "mode flag on a turn, not a new resource" shape `goal` (#1297) already established:

- `pipeline` is a new optional block on `POST /v1/turns`, driving the turn through `Pipeline::run` instead of a bare engine step loop, over the existing SSE stream, cancel route, and settlement machinery. No new streaming primitive.
- The one genuinely new wire primitive is the approval gate: `ServerFrame::ScopeReviewRequest` + `POST /v1/turns/{id}/approve`, symmetric with the existing `tool-result`/`provider-result` reverse RPC (`RemoteApprovalGate`). A caller may opt into `auto_approve` for unattended runs; the default asks the host and fails closed (`ScopeDecision::Abort`) on timeout or disconnect.
- The pipeline's process-launching ports (`TestRunner`, `DiagnosticRunner`) are remoted through the same `ToolRequest`/`ToolResultIn` frames every tool call already crosses, under two reserved `stella.verify.*` names (`RemoteVerificationRunner`) — not a new containment decision, the existing bring-your-own-tools posture (`tools.local_execution: NotApplicable`) applied to two more typed callers.

Declared, not silent, follow-up (see `pipeline_run.rs`'s module docs): context recall, repo structure, lint, mutation, coverage, and candidate-workspace isolation aren't wired yet — every one of those ports degrades open by design, so a served run still verifies, just without best-of-N isolation or diff-coverage measurement yet. `pipeline` on `POST /v1/sessions/{id}/turns` is also still open — currently declined at the route.

Closes #1288

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here) — `stella-serve/tests/pipeline.rs`'s `a_pipeline_run_is_requestable_over_the_wire_and_its_approval_gate_round_trips`: drives a real served run over HTTP through triage → plan → scope review → `POST /approve` → execute → a remoted diagnostic call → `turn_complete`.

## The gate

- [x] `cargo fmt --check` (stella-serve, stella-pipeline, stella-parity)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not yet run workspace-wide
- [ ] `cargo test --workspace` — `cargo test -p stella-serve` is green (all pre-existing + new tests); full workspace run (including `stella-parity`'s route/witness sweep) still pending
- [ ] Docs updated where behavior/flags changed — `docs/design/serve-surface.md` / `docs/design/engine-embedding.md` still describe the old "blocked" state; not yet revised
- [ ] CLA signed
- [x] `Closes #1288` appears above

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (`ScopeReviewResultIn`/`ScopeDecisionWire` wire tests in `frame.rs`, `CmdOutcomeWire` exercised in `remote.rs`'s new tests)

## Anything reviewers should know?

**This is a draft — still in progress.** Currently getting a second design opinion (in progress) on two open questions before I consider this ready:

1. Whether "mode flag on `/v1/turns`" is right given the pipeline's much longer, internally-looping lifecycle, vs. a dedicated resource.
2. Whether reusing `ToolRequest`/`ToolResultIn` for the two verification calls (a JSON-encoded `CmdOutcomeWire` inside an ordinary tool `content` string) is sound, or whether it should be its own typed frame in the wire schema instead.

Also still open: the `stella-parity` capability row's mechanism text currently mentions `POST /v1/sessions/{id}/turns`, but that route doesn't actually accept `pipeline` yet (hardcoded to `None` in `routes/sessions.rs`) — I'll either wire it in or correct the claim before marking this ready.

Design docs (`docs/design/serve-surface.md`, `docs/design/engine-embedding.md`) haven't been updated yet to state the decision — that's next.

---

## Summary by Sourcery

Expose the verification pipeline as an optional mode on API turns, including a remote scope-review approval gate and remoted verification runners.

New Features:
- Add a `pipeline` block on POST /v1/turns to run turns through the verification pipeline instead of the base engine loop.
- Introduce POST /v1/turns/{id}/approve and a new ScopeReviewRequest server frame to support an interactive scope-review approval gate over the API.
- Remote the pipeline's test and diagnostic runners via reserved verification tool calls using the existing reverse-RPC tool infrastructure.

Enhancements:
- Wire pipeline-driven turns into the existing session/turn lifecycle, metrics, routing, backlog, and observer systems.
- Extend pending reverse-request tracking to handle typed scope-review decisions alongside provider and tool replies.
- Document the shipped API posture for pipeline verification in stella-parity capabilities and add tests covering pipeline behavior and routing constraints.

Tests:
- Add end-to-end tests that drive a pipeline run over HTTP, exercise the approval gate round-trip, and ensure verification diagnostics cross the wire as tool calls.
- Add unit tests for new scope-review frames, pending registry behavior, and remote verification runners' CmdOutcome handling.
