### PR TITLE
Make CI the sole author of CHANGELOG.md entries

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -171,10 +171,13 @@ jobs:
       # Draft CHANGELOG entries from the diff this tag is about to release,
       # once, into a file both sync-versions.sh call sites read (the tagged
       # release commit below and the bot/version-sync PR after it), so the tag
-      # and main roll identical text. The script prints nothing when it can't
-      # draft (no key, API failure) and sync-versions.sh skips injection when
-      # a contributor already wrote [Unreleased] entries by hand — either way
-      # the release proceeds exactly as it did before this step existed.
+      # and main roll identical text. This is the sole author of CHANGELOG.md
+      # entries — sync-versions.sh overwrites [Unreleased] with this draft
+      # regardless of what (if anything) a PR put there, so changelog
+      # authorship lives entirely in this CI job and never in a coding agent
+      # or contributor hand-editing the file. The script prints nothing when
+      # it can't draft (no key, API failure), and sync-versions.sh then rolls
+      # [Unreleased] as-is rather than blocking the release on it.
       - name: Draft changelog entries from the release diff
         if: steps.ver.outputs.skip != 'true'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,26 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## How this file works
 
-**Every merge to main cuts a release** (see [`RELEASING.md`](RELEASING.md)).
-Hand-written entries still come first: add a bullet under `## [Unreleased]` in
-the same PR as your change whenever that change is something a user would
-notice — a new flag, a changed default, a fixed bug, a breaking rename — and
-the release rolls your words verbatim.
+**Every merge to main cuts a release** (see [`RELEASING.md`](RELEASING.md)),
+and **CI writes this file, not contributors or coding agents.** Don't add a
+bullet under `## [Unreleased]` in your PR — leave the section alone. The
+release job drafts the entries itself from the **released diff**
+(`scripts/changelog-ai.sh`, the same AI Gateway that writes the GitHub
+Release notes) and rolls those beneath the new version heading, replacing
+whatever was under `[Unreleased]` (normally nothing). A release whose diff
+has nothing user-facing gets a one-line `_Internal: …_` note instead of
+bullets.
 
-When a release arrives with `## [Unreleased]` empty — which is most releases,
-at one release per merge — the release job drafts the entries itself from the
-**released diff** (`scripts/changelog-ai.sh`, the same AI Gateway that writes
-the GitHub Release notes) and rolls those beneath the new version heading. A
-release whose diff has nothing user-facing gets a one-line
-`_Internal: …_` note instead of bullets. Hand-written entries always win: the
-drafted text is only injected when the section is empty, and the draft is
-grounded in the diff, not the commit messages.
+Changelog authorship used to be split between hand-written PR entries and
+this drafter, with hand-written text winning whenever present. That produced
+inconsistent, sometimes-mangled entries, so the drafter is now the only
+author: one voice, always grounded in the diff rather than in whatever a PR
+happened to say about itself. If your change needs context the diff alone
+won't convey, put it in the PR description — `changelog-ai.sh` reads commit
+bodies (squash-merge PR descriptions) too, not just the code.
 
-Internal refactors, test-only changes, and CI work do not need a hand-written
-entry — the drafter files those under the `_Internal_` line on its own.
+Internal refactors, test-only changes, and CI work need no action from
+you — the drafter files those under the `_Internal_` line on its own.
 
 Each GitHub Release additionally carries per-release notes generated at publish
 time from the same diff. Those are release-note prose; this file is the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,18 +44,19 @@ Manual version bumps are therefore only needed for the hand-cut flows below.
 Two things, and they are not the same thing:
 
 - **[`CHANGELOG.md`](CHANGELOG.md)** — the durable record, one section per
-  version. Contributors still write the best entries: add a bullet under
-  `## [Unreleased]` in the PR whenever a user would notice the change, and
-  the release rolls your words verbatim. When a release arrives with
-  `[Unreleased]` empty — most releases, at one release per merge —
-  `auto-tag.yml` drafts the section from the **released diff** instead
+  version, and **CI writes it, not PRs.** `auto-tag.yml` drafts the section
+  for every release from the **released diff**
   ([`scripts/changelog-ai.sh`](scripts/changelog-ai.sh), the same AI Gateway
   key and model as the release notes) and injects it before the roll, at both
   roll sites (the tagged release commit and the version-sync PR), so the tag
-  and main record identical text. A release whose diff has nothing
-  user-facing gets a one-line `_Internal: …_` note. If the key is unset or
-  the call fails, the roll proceeds with an empty section exactly as before —
-  drafting is best-effort, never release-blocking.
+  and main record identical text. The draft **replaces** whatever sits under
+  `[Unreleased]` — contributors and coding agents should leave that section
+  alone rather than hand-write entries in a PR; a split between hand-written
+  and drafted entries is what used to make this file inconsistent. A release
+  whose diff has nothing user-facing gets a one-line `_Internal: …_` note. If
+  the AI Gateway key is unset or the call fails, the roll proceeds with
+  whatever was already under `[Unreleased]` (normally nothing) exactly as
+  before — drafting is best-effort, never release-blocking.
 - **GitHub Release notes** — generated at publish time by `release.yml` from
   the commit range. Release-note prose, not a curated record, and not
   something to edit by hand.

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -38,34 +38,35 @@ perl -pi -e 's/tag: "v[^"]*"/tag: "v$ENV{NEW_VERSION}"/; s/^  version "[^"]*"/  
   packaging/homebrew/stella.rb
 
 if [ -f CHANGELOG.md ] && grep -q '^## \[Unreleased\]' CHANGELOG.md; then
-  # If the release arrived with an empty [Unreleased] and auto-tag.yml drafted
-  # entries from the release diff (scripts/changelog-ai.sh), inject them under
-  # the heading before rolling — so the roll below carries them down instead
-  # of minting yet another blank version heading. Hand-written entries always
-  # win: a non-empty section is left exactly as the contributor wrote it.
-  # Injection lives here, not in the workflow, because this script runs at two
-  # call sites (the tagged release commit and the bot/version-sync PR) and the
-  # tag and main must roll identical text — one script, two call sites, no
-  # drift (#786).
+  # CI drafts every release's changelog section from the release diff
+  # (scripts/changelog-ai.sh, invoked once by auto-tag.yml and handed to both
+  # sync-versions.sh call sites via CHANGELOG_ENTRIES_FILE, so the tag and
+  # main roll identical text). The draft is authoritative: it REPLACES
+  # whatever already sits under [Unreleased], hand-written or not — changelog
+  # authorship lives in the release job, not in feature PRs, so entries stay
+  # in one consistent voice instead of whatever a contributor or coding agent
+  # happened to type. Injection lives here, not in the workflow, because this
+  # script runs at two call sites (the tagged release commit and the
+  # bot/version-sync PR) and the tag and main must roll identical text — one
+  # script, two call sites, no drift (#786).
   if [ -n "${CHANGELOG_ENTRIES_FILE:-}" ] && [ -s "${CHANGELOG_ENTRIES_FILE}" ]; then
-    if awk '/^## \[Unreleased\]/{inside=1; next}
-            inside && /^## \[/{exit}
-            inside && NF{found=1; exit}
-            END{exit found ? 1 : 0}' CHANGELOG.md; then
-      ENTRIES_FILE="${CHANGELOG_ENTRIES_FILE}" perl -pi -e '
-        if (/^## \[Unreleased\]$/) {
-          open my $fh, "<", $ENV{ENTRIES_FILE} or next;
-          my $e = do { local $/; <$fh> };
-          $e =~ s/\s+\z//;
-          $_ .= "\n" . $e . "\n";
-        }' CHANGELOG.md
-      echo "sync-versions: injected drafted changelog entries for ${version}."
-    else
-      echo "sync-versions: [Unreleased] already has entries; drafted entries not injected."
-    fi
+    # An explicit lexical filehandle, not `local @ARGV; <>`: -pi's own
+    # in-place magic already drives @ARGV/<> to iterate CHANGELOG.md, and
+    # reassigning @ARGV mid-script (even locally) to slurp a second file
+    # collides with that and corrupts the edit.
+    ENTRIES_FILE="${CHANGELOG_ENTRIES_FILE}" perl -0777 -pi -e '
+      open my $fh, "<", $ENV{ENTRIES_FILE} or die "cannot open $ENV{ENTRIES_FILE}: $!";
+      my $entries = do { local $/; <$fh> };
+      close $fh;
+      $entries =~ s/\s+\z//;
+      s/^## \[Unreleased\]\n.*?(?=^## \[|\z)/"## [Unreleased]\n\n" . $entries . "\n\n"/mse;
+    ' CHANGELOG.md
+    echo "sync-versions: CI-drafted changelog entries written for ${version}."
+  else
+    echo "::warning::no changelog entries drafted (AI Gateway unset or the call failed); rolling [Unreleased] as-is."
   fi
   # Inserting *after* the heading (rather than renaming it) is what carries
-  # the existing bullets down into the new version's section.
+  # the section's content down into the new version's section.
   RELEASE_DATE="${RELEASE_DATE:-$(date -u +%F)}" \
     perl -pi -e 's/^## \[Unreleased\]$/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] — $ENV{RELEASE_DATE}/' CHANGELOG.md
   grep -q "^## \[${version}\] " CHANGELOG.md \


### PR DESCRIPTION
## What & why

Changelog management was split between the release CI job and hand-written PR
entries: contributors (including coding agents) were asked to add a bullet
under `## [Unreleased]` in the same PR as their change, and that hand-written
text always won over the CI-drafted entries (`scripts/changelog-ai.sh`,
already wired into `auto-tag.yml`) whenever the section wasn't empty. That
split is what produced inconsistent, sometimes-mangled entries — different
PRs writing changelog prose in different voices and formats, with no drift
protection.

This moves changelog authorship entirely into the CI/version-bump process:

- `scripts/sync-versions.sh` now **always overwrites** `[Unreleased]` with the
  CI-drafted entries from the release diff, regardless of what (if anything)
  a PR already put there — instead of only injecting when the section was
  empty.
- `CHANGELOG.md` and `RELEASING.md` docs updated to tell contributors and
  agents to leave `[Unreleased]` alone; context that isn't obvious from the
  diff should go in the PR description, which `changelog-ai.sh` already reads
  (commit bodies / squash-merge PR descriptions).
- `auto-tag.yml` comments updated to match the new behavior.

No issue tracks this — closes nothing.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this only
      changes CI/release tooling (a bash+perl script and workflow comments,
      no application code) and doc prose. Verified by hand: rewrote the
      `[Unreleased]`-replacement `perl` invocation to use an explicit lexical
      filehandle instead of `local @ARGV`/`<>` (the original draft collided
      with `-pi`'s own use of `@ARGV` for in-place editing and corrupted the
      file), then round-tripped it against sample `CHANGELOG.md` fixtures
      covering both a non-empty (hand-written) and an empty `[Unreleased]`
      section, confirming the CI draft always replaces the section content
      and the subsequent version roll still lands correctly.

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (`CHANGELOG.md`, `RELEASING.md`)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [ ] `Closes #N` appears both above and as a commit trailer — n/a, no issue

No Rust source changed, so `fmt`/`clippy`/`cargo test` are not applicable;
`bash -n` and a YAML parse check were run against the changed
script/workflow instead.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home) — the AI
      Gateway call in `changelog-ai.sh` already existed and is unchanged

## Anything reviewers should know?

The behavior change is deliberate and directly requested: `[Unreleased]` is no
longer a place contributors or agents should write to — CI (`auto-tag.yml` →
`scripts/changelog-ai.sh` → `scripts/sync-versions.sh`) is now the only writer
of `CHANGELOG.md`, on every release, unconditionally (short of the AI Gateway
key being unset or the call failing, in which case the section rolls as-is,
same degrade-open behavior as before).

---

## Summary by Sourcery

Centralize CHANGELOG.md authorship in the CI release pipeline so [Unreleased] is always populated from CI-drafted entries and never hand-edited in PRs.

Enhancements:
- Change sync-versions.sh to always replace the [Unreleased] section with CI-drafted changelog entries, regardless of existing manual content, and adjust behavior when no draft is available.
- Clarify in CHANGELOG.md and RELEASING.md that CI is the sole writer of changelog entries and contributors should no longer edit the [Unreleased] section in PRs.
- Update the auto-tag.yml workflow comments to describe the new authoritative CI-based changelog drafting behavior and fallback semantics.
