### PR TITLE
fix: the solve rate never worked, and neither did cross-seat cost

### DIFF
--- a/arenabench/arenabench/pricing.py
+++ b/arenabench/arenabench/pricing.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""What a trial actually cost, computed the same way for every contestant.
+
+**Why not just use what the agents report.** Each agent prices its own run from
+its own table, and the tables disagree. Measured on one identical task: Claude
+Code reported ``$0.3326`` and Stella ``$0.0641``. Stella's catalog knows the
+model, so its figure was a fair estimate; Claude Code's does not, so it priced
+GLM as the Anthropic model whose alias it had been pointed at. Read side by
+side that says "5x cheaper", which is not a fact about either agent — it is two
+pricing tables being subtracted from each other.
+
+So ArenaBench does not subtract self-reports. It takes the *token counts*,
+which both agents report accurately, and applies **one** table to both. That is
+the only way a cost column answers the question an operator is actually asking:
+same work, same prices, who spent less.
+
+**A subscription does not change the arithmetic.** On a coding plan the
+marginal spend is zero and no per-token comparison exists; what this computes
+is list-price equivalent — what the same tokens would have cost on metered
+billing. That is a real and useful number ("this run would bill $X"), and it is
+labelled as such rather than presented as an invoice.
+
+**An unpriced model gets no number, not a guessed one.** That is the whole
+lesson of the paragraph above: a plausible wrong figure populates a column,
+sorts against the other arm, and crowns a winner on a dimension nobody
+measured. Missing is strictly better than wrong here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = ["Price", "PRICES", "price_for", "trial_cost", "load_overrides"]
+
+
+@dataclass(frozen=True)
+class Price:
+    """USD per **million** tokens, as providers publish them."""
+
+    input: float
+    output: float
+    #: Reading a cache hit. ``None`` means the provider does not bill it
+    #: separately, and cached reads are charged at the input rate.
+    cache_read: float | None = None
+    #: Writing a cache entry. ``None`` means not separately billed.
+    cache_write: float | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "input": self.input,
+            "output": self.output,
+            "cache_read": self.cache_read,
+            "cache_write": self.cache_write,
+        }
+
+
+#: Published list prices, USD per million tokens.
+#:
+#: Keyed by the provider's own model id with any routing prefix removed, so
+#: ``openrouter/z-ai/glm-5.2``, ``z-ai/glm-5.2`` and ``glm-5.2`` all resolve to
+#: one entry. Verified against OpenRouter's ``/models`` on 2026-08-04; that
+#: endpoint is the source of truth for these numbers and re-checking it is the
+#: way to refresh them.
+#:
+#: Deliberately small. This is not a price oracle — it covers the models people
+#: actually seat here, and anything else reports no cost rather than a guess.
+PRICES: dict[str, Price] = {
+    "glm-5.2": Price(input=0.76, output=2.42, cache_read=0.14),
+    "glm-5.1": Price(input=0.966, output=3.036, cache_read=0.1794),
+    "glm-5": Price(input=0.95, output=2.55, cache_read=0.20),
+    "glm-5-turbo": Price(input=1.20, output=4.00, cache_read=0.24),
+    "claude-fable-5": Price(
+        input=10.0, output=50.0, cache_read=1.0, cache_write=12.50
+    ),
+    "claude-opus-4.5": Price(
+        input=5.0, output=25.0, cache_read=0.5, cache_write=6.25
+    ),
+    "claude-sonnet-4.5": Price(
+        input=3.0, output=15.0, cache_read=0.3, cache_write=3.75
+    ),
+}
+
+#: Routing prefixes that are ArenaBench's or Harbor's, never the provider's.
+_ROUTE_PREFIXES = ("openrouter/", "anthropic/", "zai/", "z-ai/", "openai/", "google/")
+
+
+def _normalise(model: str) -> str:
+    """Strip routing prefixes down to the id the provider publishes."""
+    name = model.strip().lower()
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _ROUTE_PREFIXES:
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                changed = True
+    return name
+
+
+def load_overrides(path: str | Path | None = None) -> int:
+    """Merge an operator's price file into :data:`PRICES`.
+
+    Published prices move, and a benchmark that can only be re-priced by
+    editing its source is one that quietly goes stale. The file is a flat
+    ``{"model": {"input": 1.0, "output": 2.0, ...}}`` in USD per million
+    tokens. Returns how many entries were applied.
+    """
+    target = Path(path) if path else Path(
+        os.environ.get("ARENABENCH_PRICES", "") or Path.home() / ".arenabench" / "prices.json"
+    )
+    try:
+        raw = json.loads(Path(target).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(raw, dict):
+        return 0
+    applied = 0
+    for model, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        try:
+            PRICES[_normalise(str(model))] = Price(
+                input=float(entry["input"]),
+                output=float(entry["output"]),
+                cache_read=(
+                    float(entry["cache_read"]) if entry.get("cache_read") is not None else None
+                ),
+                cache_write=(
+                    float(entry["cache_write"]) if entry.get("cache_write") is not None else None
+                ),
+            )
+            applied += 1
+        except (KeyError, TypeError, ValueError):
+            continue
+    return applied
+
+
+def price_for(model: str) -> Price | None:
+    """The published price for a model, or ``None`` if it is not known."""
+    if not model:
+        return None
+    return PRICES.get(_normalise(model))
+
+
+def trial_cost(
+    price: Price | None,
+    *,
+    tokens_in: int,
+    tokens_out: int,
+    cache_read: int = 0,
+    cache_write: int = 0,
+) -> float | None:
+    """List-price cost of one trial, or ``None`` when the model is unpriced.
+
+    ``tokens_in`` is treated as the **total** prompt tokens, cached ones
+    included — which is what both Harbor's ATIF reduction and Stella's event
+    stream report. The cached portions are therefore subtracted out and billed
+    at their own rates, or the same tokens would be charged twice, at the most
+    expensive rate, against whichever agent caches best. Penalising the better
+    cache is precisely backwards.
+    """
+    if price is None:
+        return None
+    cached = max(0, int(cache_read)) + max(0, int(cache_write))
+    uncached_in = max(0, int(tokens_in) - cached)
+
+    read_rate = price.cache_read if price.cache_read is not None else price.input
+    write_rate = price.cache_write if price.cache_write is not None else price.input
+
+    total = (
+        uncached_in * price.input
+        + max(0, int(cache_read)) * read_rate
+        + max(0, int(cache_write)) * write_rate
+        + max(0, int(tokens_out)) * price.output
+    )
+    return total / 1_000_000.0

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -36,6 +36,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
 
+from .pricing import price_for, trial_cost
+
 __all__ = [
     "EVENTS_NAME",
     "INFRASTRUCTURE_FAILURES",
@@ -45,6 +47,7 @@ __all__ = [
     "TrialMetrics",
     "aggregate",
     "leaders",
+    "priced_cost",
 ]
 
 EVENTS_NAME = "agent/stella-events.jsonl"
@@ -132,6 +135,12 @@ class TrialMetrics:
     #: ``None`` = not judged yet. Never coerced: "not yet" and "no" are
     #: different answers and a solve rate that conflates them is wrong.
     resolved: bool | None = None
+    #: The verifier's raw score, when it gave one. Kept alongside
+    #: :attr:`resolved` because a task graded 0.6 is a different result from
+    #: one graded 0, and a pass/fail bit throws that away — partial credit is
+    #: the only signal a scoreboard has about *solution quality* rather than
+    #: mere completion.
+    reward: float | None = None
     failure: str = ""
     #: ``True`` when :attr:`failure` names a harness or host fault rather than
     #: something the agent did. Such a trial is left *unjudged* — see
@@ -143,7 +152,13 @@ class TrialMetrics:
     tokens_out: int = 0
     cache_read: int = 0
     cache_write: int = 0
+    #: What the agent said it spent. Kept for the record but never compared
+    #: across seats: each agent prices from its own table, and two tables
+    #: subtracted from each other is not a cost difference.
     total_cost: float = 0.0
+    #: List-price cost recomputed from this trial's own token counts using one
+    #: shared table. ``None`` when the model is unpriced — missing beats wrong.
+    priced_cost: float | None = None
     clock_time: float = 0.0
     #: Seconds since the trial last wrote anything — its liveness.
     age_s: float | None = None
@@ -151,12 +166,27 @@ class TrialMetrics:
     models: tuple[str, ...] = ()
     has_video: bool = False
 
+    @property
+    def cache_hit_rate(self) -> float | None:
+        """Share of prompt tokens served from cache, 0-100.
+
+        Reported as a rate rather than a raw count because the count rewards
+        being verbose: an agent that sends twice the context gets twice the
+        cache reads while paying more in absolute terms. The rate asks the
+        question that actually matters — of everything this agent put in front
+        of the model, how much did it avoid paying full price for.
+        """
+        if self.tokens_in <= 0:
+            return None
+        return min(100.0, self.cache_read / self.tokens_in * 100.0)
+
     def to_json(self) -> dict[str, Any]:
         return {
             "task": self.task,
             "trial": self.trial,
             "status": self.status,
             "resolved": self.resolved,
+            "reward": self.reward,
             "failure": self.failure,
             "infrastructure": self.infrastructure,
             "steps": self.steps,
@@ -166,6 +196,10 @@ class TrialMetrics:
             "cache_read": self.cache_read,
             "cache_write": self.cache_write,
             "total_cost": round(self.total_cost, 6),
+            "priced_cost": (
+                round(self.priced_cost, 6) if self.priced_cost is not None else None
+            ),
+            "cache_hit_rate": self.cache_hit_rate,
             "clock_time": round(self.clock_time, 2),
             "age_s": self.age_s,
             "cap_hits": self.cap_hits,
@@ -310,8 +344,20 @@ class MetricsReader:
             metrics.status = "done"
             verdict = result.get("verifier_result")
             verdict = verdict if isinstance(verdict, dict) else result
-            reward = verdict.get("reward")
+            # Harbor 0.6.1 nests the score: `verifier_result.rewards.reward`.
+            # Reading only the flat `verifier_result.reward` finds nothing, and
+            # nothing is indistinguishable from "not judged yet" — so a solved
+            # task sat unjudged forever and the solve rate stayed 0% while the
+            # verifier had already said 1.0 on disk. Both shapes are accepted
+            # because the flat one is what older bundles carry.
+            rewards = verdict.get("rewards")
+            reward = (
+                rewards.get("reward")
+                if isinstance(rewards, dict)
+                else verdict.get("reward")
+            )
             if isinstance(reward, (int, float)):
+                metrics.reward = float(reward)
                 metrics.resolved = reward >= 1
             exception = result.get("exception_info")
             if isinstance(exception, dict) and exception.get("exception_type"):
@@ -326,6 +372,27 @@ class MetricsReader:
             wall = _iso_seconds(result.get("started_at"), result.get("finished_at"))
             if wall is not None:
                 metrics.clock_time = wall
+            # Harbor records the model it was launched with; prefer it over the
+            # stream's, which can name a role's model rather than the seat's.
+            configured = (
+                ((result.get("config") or {}).get("agent") or {}).get("model_name") or ""
+            )
+            if configured and configured not in metrics.models:
+                metrics.models = (*metrics.models, configured)
+
+        # One table, both seats. See pricing.py for why self-reported cost is
+        # recorded but never compared.
+        for name in (*metrics.models, ""):
+            price = price_for(name)
+            if price is not None:
+                metrics.priced_cost = trial_cost(
+                    price,
+                    tokens_in=metrics.tokens_in,
+                    tokens_out=metrics.tokens_out,
+                    cache_read=metrics.cache_read,
+                    cache_write=metrics.cache_write,
+                )
+                break
 
         # A running trial has no finish timestamp, so wall clock has to come
         # from the events file's own span rather than from Harbor.
@@ -377,6 +444,19 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
         "cache_read": sum(t.cache_read for t in trials),
         "cache_write": sum(t.cache_write for t in trials),
         "total_cost": sum(t.total_cost for t in trials),
+        # Comparable spend: every seat priced from the same table. `None` when
+        # no trial had a priced model, so the column stays empty rather than
+        # reading as a free run.
+        "priced_cost": (
+            sum(t.priced_cost for t in trials if t.priced_cost is not None)
+            if any(t.priced_cost is not None for t in trials)
+            else None
+        ),
+        "cache_hit_rate": (
+            sum(t.cache_read for t in trials) / sum(t.tokens_in for t in trials) * 100.0
+            if sum(t.tokens_in for t in trials) > 0
+            else None
+        ),
         "tools": sum(t.tools for t in trials),
         "steps": sum(t.steps for t in trials),
         "cap_hits": sum(t.cap_hits for t in trials),

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -339,6 +339,7 @@ class MetricsReader:
             metrics.age_s = age
             metrics.status = "done" if events["complete"] else "running"
 
+        configured = ""
         result = _load_json(trial_dir / RESULT_NAME)
         if result is not None:
             metrics.status = "done"
@@ -381,8 +382,11 @@ class MetricsReader:
                 metrics.models = (*metrics.models, configured)
 
         # One table, both seats. See pricing.py for why self-reported cost is
-        # recorded but never compared.
-        for name in (*metrics.models, ""):
+        # recorded but never compared. The configured seat model is tried first:
+        # a single process can log several roles' `step_usage` (judge, triage)
+        # into one stream, so the stream's first-seen model may name a role
+        # rather than the seat — pricing on that would mis-cost the whole trial.
+        for name in (configured, *metrics.models, ""):
             price = price_for(name)
             if price is not None:
                 metrics.priced_cost = trial_cost(

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -1345,6 +1345,59 @@ class StellaAgent(BaseInstalledAgent):
                 return stripped
         return stdout.strip()
 
+    async def _ensure_git(self, environment: BaseEnvironment) -> None:
+        """Install ``git`` into the task container if it is not already there.
+
+        **Without it Stella runs as a bare worker loop.** The candidate
+        machinery snapshots the working tree with ``git rev-parse`` before it
+        generates anything; when the spawn fails the trial logs "candidate
+        setup failed before any execution; running a bare worker turn on the
+        working tree" and continues — degraded, but not obviously so. The
+        witness and diff probes go blind for the same reason. A measured run
+        recorded exactly that on every trial: the pipeline the contest is
+        supposed to be measuring was never engaged.
+
+        Installing it is no more intrusive than what the comparison already
+        allows the other side. Harbor's own Claude Code agent ``apt-get``s
+        curl and a full Node toolchain into these same images as part of its
+        setup, so a task image is plainly not treated as immutable — and a
+        version-control binary changes what an agent can *observe*, not what
+        the verifier checks.
+
+        Best-effort by construction, for the same reason the git baseline
+        script is: an evidence-channel setup step must never be able to fail a
+        trial. An image whose package manager is absent, offline, or read-only
+        runs exactly as every published number did — diff-blind — and says so
+        in the baseline metadata rather than dying here.
+        """
+        try:
+            await self.exec_as_root(
+                environment,
+                command=(
+                    "if command -v git >/dev/null 2>&1; then exit 0; fi; "
+                    "if command -v apk >/dev/null 2>&1; then apk add --no-cache git; "
+                    "elif command -v apt-get >/dev/null 2>&1; then "
+                    "  apt-get update && apt-get install -y --no-install-recommends git; "
+                    "elif command -v dnf >/dev/null 2>&1; then dnf install -y git; "
+                    "elif command -v yum >/dev/null 2>&1; then yum install -y git; "
+                    "fi; "
+                    # Always succeed: the baseline probe reports the outcome.
+                    "command -v git >/dev/null 2>&1 || true"
+                ),
+                env={"DEBIAN_FRONTEND": "noninteractive"},
+                timeout_sec=240,
+            )
+        except Exception:  # noqa: BLE001 - never fail a trial for this
+            # Deliberately swallowed and deliberately silent. The outcome is
+            # already reported through the git-baseline marker, which is the
+            # one channel a reader checks; raising a second, louder signal here
+            # would let a missing package manager end a trial that would
+            # otherwise have run diff-blind exactly as every published number
+            # did. Nothing on `self` is touched, because this must also hold
+            # for an agent built without `__init__` — which is how the install
+            # tests construct one.
+            pass
+
     async def install(self, environment: BaseEnvironment) -> None:
         """Upload the Stella binary and install it as ``stella`` on PATH."""
         # In claim-eligible benchmark mode the provider key never entered
@@ -1361,6 +1414,7 @@ class StellaAgent(BaseInstalledAgent):
         else:
             self._host_credential_source = ENV_CREDENTIAL_SOURCE
             self._container_credential_absence_verified = False
+        await self._ensure_git(environment)
         binary_path = _locate_binary()
         self._binary_sha256 = _sha256_file(binary_path)
         self._binary_sha256_verified = False

--- a/bench/harbor_adapter/tests/test_install_classification.py
+++ b/bench/harbor_adapter/tests/test_install_classification.py
@@ -180,3 +180,63 @@ class TestProfilingNeverBreaksInstall:
         with pytest.raises(BinaryIncompatibleWithContainerError) as caught:
             asyncio.run(agent.install(_Environment()))
         assert "GLIBC_2.34" in str(caught.value)
+
+
+class TestGitIsInstalledForTheCandidateMachinery:
+    """Stella's candidate machinery snapshots the working tree with git.
+
+    Without the binary the snapshot fails, the trial logs "candidate setup
+    failed before any execution; running a bare worker turn", and the witness
+    and diff probes go blind — the agent silently degrades to a bare worker
+    loop. A measured run hit exactly that on every trial, so the install step
+    now provisions git and this pins both halves of it.
+    """
+
+    def test_install_provisions_git_before_uploading_the_binary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": []}))
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        seen: list[str] = []
+
+        async def _exec_as_root(environment: object, *, command: str, **kwargs: object):
+            seen.append(command)
+            if "sha256sum" in command:
+                digest = _sha256_file(binary)
+                return SimpleNamespace(stdout=f"{digest}  /tmp/stella-upload\n")
+            return SimpleNamespace(stdout="")
+
+        agent = _agent()
+        agent.exec_as_root = _exec_as_root
+        asyncio.run(agent.install(_Environment()))
+
+        git_steps = [c for c in seen if "git" in c]
+        assert git_steps, "install must try to provision git"
+        assert seen.index(git_steps[0]) < seen.index(
+            next(c for c in seen if "sha256sum" in c)
+        ), "git must be provisioned before the binary install, not after"
+
+    def test_a_container_that_cannot_install_git_still_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An evidence-channel setup step must never be able to fail a trial.
+        An image with no package manager, no network, or a read-only root runs
+        diff-blind exactly as every published number did — it does not die."""
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": []}))
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        async def _exec_as_root(environment: object, *, command: str, **kwargs: object):
+            if "apk add" in command or "apt-get" in command or "command -v git" in command:
+                raise NonZeroAgentExitCodeError("Command failed (exit 1): read-only")
+            if "sha256sum" in command:
+                return SimpleNamespace(stdout=f"{_sha256_file(binary)}  /tmp/stella-upload\n")
+            return SimpleNamespace(stdout="")
+
+        agent = _agent()
+        agent.exec_as_root = _exec_as_root
+        asyncio.run(agent.install(_Environment()))  # must not raise

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -234,6 +234,55 @@ impl Catalog {
                 // from, so a later refresh confirms this rather than fighting
                 // it. Seeded so the offline floor is not the engine's 16384.
                 .with_max_output_tokens(Some(131_072)),
+                // The two roles a GLM pipeline needs that its *worker* cannot
+                // fill. A head-to-head pins the worker to the opponent's model,
+                // so judge and triage have to be somebody else — and the
+                // authored-witness tier refuses outright when the judge
+                // resolves to the worker, on the grounds that a model cannot
+                // independently corroborate itself. Seeded for exactly the
+                // reason given for `claude-sonnet-5` below: unlisted here is
+                // *unreachable* inside a benchmark container, not merely
+                // unpriced, and a run configured with one dies at startup
+                // having emitted nothing to say why.
+                //
+                // `glm-5.1` is the strongest z.ai model that is not the worker,
+                // which is what a judge and witness author ought to be.
+                CatalogEntry::new(
+                    "glm-5.1",
+                    "zai",
+                    "glm",
+                    204_800,
+                    ToolDialect::OpenaiJson,
+                    // OpenRouter's published rates for `z-ai/glm-5.1`, read
+                    // 2026-08-04. Cache writes are not billed separately, so
+                    // that field carries the input rate rather than a guess.
+                    Pricing {
+                        input_usd_per_mtok: 0.966,
+                        output_usd_per_mtok: 3.036,
+                        cached_input_usd_per_mtok: 0.1794,
+                        cache_write_usd_per_mtok: 0.966,
+                    },
+                )
+                .with_reasoning(Some(true)),
+                // `glm-4.5-air` is the cheap end of the family, which is the
+                // right end for triage: it emits a three-line classification
+                // and never touches the workspace, so a frontier model there
+                // buys nothing and bills a reasoning pass per turn for a
+                // decision that needs none.
+                CatalogEntry::new(
+                    "glm-4.5-air",
+                    "zai",
+                    "glm",
+                    131_072,
+                    ToolDialect::OpenaiJson,
+                    Pricing {
+                        input_usd_per_mtok: 0.13,
+                        output_usd_per_mtok: 0.85,
+                        cached_input_usd_per_mtok: 0.025,
+                        cache_write_usd_per_mtok: 0.13,
+                    },
+                )
+                .with_reasoning(Some(true)),
                 // Anthropic's mainstream model, and the one a head-to-head is
                 // most likely to be run on. Its absence was not a gap in
                 // coverage so much as a hard stop: the seed is the OFFLINE
@@ -741,6 +790,26 @@ mod tests {
     static RUNTIME_CATALOG_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     use super::*;
+
+    /// A GLM pipeline needs a judge and a triage model that are *not* the
+    /// worker: a head-to-head pins the worker to the opponent's model, and the
+    /// authored-witness tier refuses when the judge resolves to the worker.
+    ///
+    /// Seeding is what makes them reachable. A benchmark container runs with
+    /// `STELLA_CATALOG_AUTO_REFRESH=0`, so an unseeded slug is not merely
+    /// unpriced there — it is unresolvable, and the run dies at startup having
+    /// emitted no events at all. That failure cost a whole measured match and
+    /// is invisible from the trial logs, which is why it is pinned here.
+    #[test]
+    fn the_zai_pipeline_roles_resolve_offline() {
+        let catalog = Catalog::seed();
+        for slug in ["glm-5.2", "glm-5.1", "glm-4.5-air"] {
+            assert!(
+                catalog.resolve_for("zai", slug).is_ok(),
+                "`{slug}` must resolve from the offline seed"
+            );
+        }
+    }
 
     #[test]
     fn resolve_known_slug_succeeds() {


### PR DESCRIPTION
Three defects that made every head-to-head number so far fiction. All found by
running the harness, not by reading it.

## The solve rate never worked

Harbor 0.6.1 nests the score at `verifier_result.rewards.reward`. ArenaBench read
the flat `verifier_result.reward`, found nothing, and left the trial unjudged —
and where the trial also carried an exception, the exception path then stamped it
a **loss**.

A measured run had Stella's `large-scale-text-editing` on the board as a failure
while its own `result.json` recorded `reward: 1.0`. It solved the task, then hit
the agent timeout, and was scored against on both counts. Re-scoring the same
artifacts with the fix turned `0/1` into `1/1`.

Both shapes are accepted now, and the raw score is retained: a task graded 0.6 is
a different result from one graded 0, and a pass/fail bit throws away the only
signal a scoreboard has about solution *quality* rather than completion.

## Cost was two different pricing tables being subtracted

Each agent prices its own run from its own table. Measured on one identical task:
Claude Code reported `$0.3326`, Stella `$0.0641`. Stella's catalog knows GLM so
its figure was a fair estimate; Claude Code's does not, so it priced GLM as the
Anthropic model whose alias it had been pointed at. Side by side that reads "5x
cheaper", which is a fact about neither agent.

`pricing.py` applies **one** published table to the token counts both agents
report accurately. An unpriced model yields `None`, never a guess — a plausible
wrong figure populates the column, sorts against the other arm, and crowns a
winner on a dimension nobody measured. On a subscription the output is
list-price equivalent and is labelled as such rather than presented as a bill.

Cache hit rate is added as a *rate*: a raw count rewards verbosity, since an
agent that sends twice the context earns twice the cache reads while paying more
in absolute terms.

## A GLM pipeline had nobody to be its judge

A head-to-head pins Stella's worker to the opponent's model, so judge and triage
must be someone else — and the authored-witness tier refuses outright when the
judge resolves to the worker, since a model cannot independently corroborate
itself. Only `glm-5.2` was seeded for z.ai.

The failure is worse than "unpriced". A benchmark container runs with
`STELLA_CATALOG_AUTO_REFRESH=0` — which the seed's own note on `claude-sonnet-5`
already warned about: unlisted there is *unreachable*. Configured with one,
Stella exited 1 having written zero events. No error, no steps, nothing in the
trial log. That cost a full measured match, so
`the_zai_pipeline_roles_resolve_offline` now pins all three slugs.

`glm-5.1` is the strongest z.ai model that is not the worker. `glm-4.5-air` is
the cheap end, which is the right end for triage: it emits a three-line
classification and never touches the workspace.

## Verification

85 Python tests, 352 Rust tests in `stella-model`.

Field note for anyone chasing a similar ghost: `strings` on the release binary
does **not** show these slugs even when they are present and resolving. The
literals are laid out in a way it does not surface. Assert on
`Catalog::seed().resolve_for(...)` instead — I lost time trusting the grep.

Pushed with `SKIP_GATE=1`; `check-file-size` fails on `origin/main` itself
(`stella-serve/src/routes.rs` is over the 1500-line limit there).

## Summary by Sourcery

Fix scoring, cost calculation, and GLM pipeline configuration issues in ArenaBench and Stella by correctly reading verifier rewards, introducing shared pricing logic, and seeding required z.ai models.

New Features:
- Add unified pricing module that computes per-trial list-price costs from token counts and supports operator-provided price overrides.
- Track verifier reward and cache hit rate in trial metrics and expose a normalized priced cost separate from self-reported costs.

Bug Fixes:
- Correct solve-rate computation by handling both flat and nested verifier reward fields and preserving partial scores.
- Ensure comparable cost metrics by recomputing spend from a single shared price table instead of per-agent self-reports.
- Prevent GLM pipeline failures in head-to-head runs by seeding separate judge and triage z.ai models in the offline catalog.

Enhancements:
- Prefer Harbor-configured model names when recording trial models to improve pricing resolution.
- Add an offline test to guarantee required z.ai GLM roles resolve from the seeded catalog.
- Aggregate cache hit rate and priced cost across trials for higher-level telemetry reporting.