### PR TITLE
fix(bench): loop-bench reports a crash as a crash, and reconciles the trials it asked for

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -253,7 +253,18 @@ jobs:
           if [ -d loop-bench-jobs ]; then
             find loop-bench-jobs -name stella-events.jsonl -print0 \
               | while IFS= read -r -d '' stream; do
-                  trial="$(basename "$(dirname "$(dirname "$stream")")")"
+                  # `<trial>/agent/` for a single-step trial. A multi-step one
+                  # lives at `<trial>/steps/<step>/agent/`, where this alone
+                  # would name the file after the STEP — so several trials'
+                  # streams would overwrite each other and the evidence for a
+                  # verdict would be some other task's (#1299).
+                  owner="$(dirname "$(dirname "$stream")")"
+                  trial="$(basename "$owner")"
+                  case "$owner" in
+                    */steps/*)
+                      trial="$(basename "$(dirname "$(dirname "$owner")")").$trial"
+                      ;;
+                  esac
                   cp "$stream" "loop-bench-out/events/$trial.jsonl"
                 done
           fi
@@ -285,11 +296,13 @@ jobs:
             # than making a reader open bench/loop-bench/src/main.rs.
             case "${EXIT_CODE:-}" in
               0) echo "**PASS** — every trial that reported did real work." ;;
-              1) echo "**FAIL (loop)** — silent death, zero work, a stuck loop, or a task that never ran." ;;
+              1) echo "**FAIL (loop)** — silent death, zero work, a stuck loop, or a trial that never ran." ;;
               2) echo "**FAIL (invocation)** — the task list resolved to nothing, or the report path was unwritable." ;;
               3) echo "**FAIL (infrastructure)** — no trial artifacts at all; harbor never launched anything." ;;
               4) echo "**FAIL (pass floor)** — the loop was healthy but too few tasks passed." ;;
               5) echo "**FAIL (report)** — the run completed but the JSON report could not be written." ;;
+              6) echo "**FAIL (no winner)** — \`--require-winner\` was set and no arm cleared both bars." ;;
+              7) echo "**FAIL (reconciliation)** — the job directory held trials this run did not ask for, so every figure above covers a task set that is not the requested one." ;;
               "") echo "**FAIL** — loop-bench never ran; an earlier step failed." ;;
               *) echo "**FAIL** — exit $EXIT_CODE is outside the harness's contract: a build failure or a crash, not a verdict." ;;
             esac

--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -35,6 +35,19 @@ Defaults: 4 tasks from `DEFAULT_POOL`, `openrouter/z-ai/glm-4.7-flash`,
 the report for CI instead of the table, and `--json-out <path>` writes that same
 report to a file while the table still goes to stdout.
 
+A single run's JSON is an object — `{"trials": [...], "tally": {...},
+"reconciliation": {...}}` — where it used to be the bare `trials` array
+(#1299). The rows alone are not interpretable: `6 solved` means one thing over
+eight requested trials and another over six, and an artifact carrying the rows
+without the reconciliation is exactly the artifact that publishes the flattering
+number. `--compare` still emits `ComparisonReport` verbatim (see below).
+
+`stella tune effort` reads these files, and reads **both** shapes — A/Bing this
+month's arm against an artifact from last month is the ordinary use of that
+command, not an edge case. It also prints a note when the report's tally
+reports crashes, because those trials count as failures in the A/B and a
+promotion decided by them is a decision about the machine.
+
 ## Key concepts
 
 For each trial dir `<jobs-dir>/<job-name>/<task>__<id>/`, `distill_events` reads
@@ -44,32 +57,100 @@ calls (`write_file` / `edit_file` / `apply_edits` are writes — never
 `graph_query` are context queries), and a terminal event is `complete` or an
 `error` with `retryable: false`. The reward comes from `verifier/reward.txt`.
 
-`TrialReport::loop_verdict` collapses that into one word, in this order:
+Four more files in the same directory are read, each closing a hole where
+harbor knew something the harness did not (#1299) — see
+[`src/artifacts.rs`](src/artifacts.rs):
 
-| Verdict | Meaning |
+| File | What it settles |
 |---|---|
-| `solved` | reward `1.0` — a solved task did the work by definition, so reward beats every other signal |
-| `SILENT-DEATH` | zero tool calls *and* no terminal event — it vanished with no explanation, the worst mode |
-| `ZERO-WORK` | zero tool calls, but it said why |
-| `ran (unsolved)` | real work happened, the verifier said no — not a loop failure |
+| `result.json` | `exception_info` — harbor's own record that the trial *raised*, which is the crash signal. Also `task_name` (the untruncated one) and, for a multi-step trial, the aggregated reward |
+| `exception.txt` | the same message, for a trial that died before writing a structured record |
+| `agent/stella-exit-cause.json` | the adapter's SIGKILL post-mortem (#1178): `oom-kill` vs `external-teardown`. Both exit `137`, and which one it was decides whether the fix is a memory limit or a timeout |
+| `steps/<name>/agent/…` | a multi-step trial's per-step streams, folded into one row |
 
-**The gate is loop health, not pass rate.** `loop_broken()` is
-`zero_work && reward != Some(1.0)`; the process exits `1` if any trial matches,
-even when others passed.
+`TrialReport::loop_verdict` collapses all of that into one word, in this order:
+
+| Verdict | Meaning | Gates red |
+|---|---|---|
+| `solved` | reward `1.0` — a solved task did the work by definition, so reward beats every other signal | no |
+| `NOT-RUN` | requested, but harbor produced no trial dir for it | **yes** |
+| `UNREADABLE` | the stream had lines, none of them an event — plumbing, not loop evidence | no |
+| `STUCK-LOOP` | the engine's own `loop_detected` fired on a non-pass | **yes** |
+| `BUDGET-CAP` | `STELLA_BUDGET` denied the turn — a cost decision, not a loop defect | no |
+| `SILENT-DEATH` | zero tool calls *and* no terminal event — it vanished with no explanation, the worst mode | **yes** |
+| `ZERO-WORK` | zero tool calls, but it said why | **yes** |
+| `CRASHED` | real work happened, then harbor recorded the trial as having raised | no |
+| `ran (unsolved)` | real work happened, the verifier said no — not a loop failure | no |
+
+**The gate is loop health, not pass rate.** The process exits `1` if any trial's
+`loop_broken()` matches, even when others passed.
+
+`CRASHED` is the lowest-precedence verdict above `ran (unsolved)`, and that is
+the whole design. It never displaces a red verdict: a trial that did nothing and
+then died is still `SILENT-DEATH` and still red, with the crash printed on its
+row as the explanation it previously lacked. So `CRASHED` only ever replaces
+`ran (unsolved)` — which did not gate either, meaning the verdict costs the gate
+nothing and buys the table a true statement. Naming a failure better must not
+make the gate weaker.
+
+It is also read off harbor's `exception_info`, never inferred from the stream's
+shape: a turn that did its work and ended without a clean `complete` may simply
+have exited on a step cap, and treating that as a death would invent crashes.
 
 | Exit | Meaning |
 |---|---|
 | `0` | every trial that reported did real work (or passed) |
 | `1` | the loop misbehaved on at least one trial |
 | `2` | bad invocation: the task list resolved to nothing, or `--json-out` names an unwritable path (checked before anything is spent) |
-| `3` | no trial artifacts at all — infrastructure, not a loop regression |
+| `3` | no trial artifacts at all — infrastructure, not a loop regression. Also fires when *every* row is `NOT-RUN`: harbor launching nothing is that same infrastructure failure, and it used to report as `1` |
 | `4` | the loop was healthy but fewer than `--min-pass` trials passed |
 | `5` | the run finished and the `--json-out` report could not be written (the JSON is dumped on stdout instead) |
 | `6` | `--compare --require-winner` and no arm cleared both bars |
+| `7` | the job dir holds trials this run did not ask for, so every figure covers a task set that is not the requested one |
 
 `1` outranks `4`: when both fire, the loop failure is the actionable one, and a
-broken loop explains the missing passes anyway. `1` outranks `6` likewise — a
-broken loop makes an arm's numbers untrustworthy as a comparison.
+broken loop explains the missing passes anyway. `1` outranks `6` and `7`
+likewise — a broken loop makes an arm's numbers untrustworthy as a comparison.
+
+A crash is deliberately **not** an exit code. The gate is loop health, and a
+trial the machine killed is not evidence about the loop — the same reason
+`UNREADABLE` and `BUDGET-CAP` do not gate. What it must never again be is
+silent, or dressed as `ran (unsolved)`.
+
+## Requested vs reported (#1299)
+
+Harbor globs `-i` names and errors only when *nothing* matched, so a run that
+asked for eight tasks and matched six used to produce six healthy rows and exit
+`0`. Six of eight solved reads as 75% when it is 60%, and nothing on the page
+said which number you were looking at.
+
+Every run now reconciles what it asked harbor for against what came back, and
+prints the disagreement under the table
+([`src/reconcile.rs`](src/reconcile.rs)):
+
+- **Missing trials** become `NOT-RUN` rows, at *trial* granularity — three dirs
+  for a `--trials 5` task yields two `NOT-RUN` rows. The denominator is the
+  sample that was asked for, and the gate goes red (`1`).
+- **Surplus trials** — a second run's results sitting in the same job directory,
+  since harbor writes to `<jobs-dir>/<job-name>/` verbatim — exit `7`. They
+  render as ordinary healthy rows, so the reconciliation block is the only place
+  a reader would ever learn the figures cover two runs.
+- **Trial dirs no requested task claims** are still skipped, so a stale
+  directory cannot contaminate this run's gate — but the skip is now *counted
+  and named*, because a mistyped `--tasks` otherwise looks exactly like a run
+  harbor launched nothing for.
+- **A task name longer than 32 characters** reconciles. Harbor names a trial dir
+  `<task_name[:32] rstripped of _->__<shortuuid>`, so comparing the untruncated
+  name produced two wrong answers at once: every trial skipped as another run's,
+  and the task that really ran reported `NOT-RUN`. Harbor's own `task_name` off
+  `result.json` is preferred where it landed; the truncated prefix is the
+  fallback.
+
+Nothing here *adjusts* a count to make it consistent. It says what was asked
+for, what came back, and where the two disagree.
+
+`--analyze-only` reconciles nothing: it asked for nothing in particular, and
+reads whatever a finished jobs dir holds.
 
 ## `--compare`: A/B two configs over one task set (#876)
 
@@ -157,14 +238,23 @@ way.
   containers run. Unset, it warns, and the adapter then resolves `stella` on
   `PATH` before `target/release/stella` — on a dev machine the `PATH` hit is a
   host build the container cannot execute.
-- Requested tasks are **not reconciled** against reported rows. Harbor globs
-  `-i` names and only errors when *nothing* matched, so a run that asked for
-  eight tasks and matched six shows six healthy rows and exits `0`. Check the
-  row count against `--n`. Multi-step datasets are likewise unsupported: their
-  logs move to `steps/<name>/agent/` and every trial reads as "no event stream".
-- A crash *mid*-work is not a verdict of its own: `SILENT-DEATH` requires zero
-  tool calls, so a turn that did work and then vanished reports as
-  `ran (unsolved)`.
+- A multi-step trial's rows are **folded**, not listed. Harbor relocates each
+  step's logs into `steps/<name>/agent/` and removes the trial-root `agent/`,
+  and the harness sums the counters into one row per trial. Two fields do not
+  sum, and both choices are about not letting an early step vouch for a late
+  one: `terminal_event` is the *last* step's (a trial that completed step one
+  and vanished in step two ended by vanishing), and `zero_work` is recomputed
+  from the summed tool calls (a step that only reads is normal). Step order
+  comes from harbor's own `step_results`, not from sorting directory names.
+- A multi-step trial's reward is harbor's **aggregate** off `result.json`, since
+  there is no trial-root `verifier/` at all. Harbor folds the per-step rewards
+  by the task's `multi_step_reward_strategy` (`last` or `mean`); taking its
+  answer rather than inventing one here is what keeps the harness and the
+  dataset agreeing on what the task scored.
+- A crash is read from harbor's record, so a trial that died in a way harbor
+  never noticed still reports as whatever its stream showed. The harness reports
+  observations: "harbor recorded that this raised" is one, "the stream looks
+  short so it probably died" is not.
 
 ## Testing
 
@@ -180,6 +270,17 @@ shifted a whole row, a retryable warning read as terminal, a *solved* run with
 no `complete` event called silent, a stream of non-JSON stella output passing
 for an unexplained silent death. A new signal means a `TrialReport` field, an
 arm in `distill_events`, a `print_table` column (`TABLE_WIDTH`), and a test.
+
+The #1299 tests build real trial directories under a `tempfile::tempdir` and run
+`analyze` over them, because the defects they pin are about *files harbor wrote
+that nothing read* — a fixture that hands `distill_events` a string could not
+have caught any of them. They pin: a crash after real work reported as
+`ran (unsolved)`; a crash before any work quietly downgrading a red
+`SILENT-DEATH` to a green verdict (the regression the precedence order exists to
+prevent); a task measured over the trials that survived rather than the ones
+requested; a second run's trials folded into the first's figures; a 32-character
+task name reconciling as both `NOT-RUN` and somebody else's directory; and a
+multi-step trial read as empty.
 
 [`src/compare/tests.rs`](src/compare/tests.rs) covers the A/B fold at the same
 level: known outcomes producing the expected winner, a spend-bought win blocked

--- a/bench/loop-bench/src/artifacts.rs
+++ b/bench/loop-bench/src/artifacts.rs
@@ -1,0 +1,316 @@
+//! What harbor leaves in a trial directory *besides* the event stream (#1299).
+//!
+//! The harness used to read two files per trial —
+//! `agent/stella-events.jsonl` and `verifier/reward.txt` — and harbor writes
+//! more than that. Two of the three holes this module closes come from the
+//! same omission:
+//!
+//! * **A crash was invisible.** When the agent raises, harbor records an
+//!   [`ExceptionInfo`] on the trial's `result.json` (and its message alone in
+//!   `exception.txt`). A trial that died partway through therefore carried an
+//!   explicit "this did not finish" marker that nothing read, so it reported
+//!   as `ran (unsolved)` — indistinguishable from a turn that tried and was
+//!   wrong. An infrastructure failure reading as a capability failure sends
+//!   the operator hunting a reasoning bug that does not exist.
+//! * **A multi-step trial read as empty.** Harbor relocates each step's logs
+//!   into `steps/<name>/agent/` and *removes* the now-empty trial-root
+//!   `agent/` (`TrialPaths.cleanup_empty_mount_dirs`), so every multi-step
+//!   trial reported "no event stream" — a whole dataset shape scoring as
+//!   infrastructure failure.
+//!
+//! Everything here is a *read* of harbor's own record. The verdict this feeds
+//! is an observation ("harbor recorded an exception"), never an inference
+//! ("the stream looks short, it probably died") — the distinction the
+//! adapter's own `exit_cause.py` draws between an answered question and an
+//! unobserved one, and for the same reason: a guess presented as a finding
+//! erases the real cause from the record.
+//!
+//! [`ExceptionInfo`]: https://github.com/laude-institute/harbor
+//! (`harbor.models.trial.result.ExceptionInfo`)
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+/// The adapter's event stream, under the trial's `agent/` mount.
+pub const EVENTS_NAME: &str = "stella-events.jsonl";
+
+/// Harbor's own record of the trial (`harbor.models.trial.result.TrialResult`):
+/// `task_name`, `exception_info`, `step_results`, and — for a multi-step
+/// trial — the aggregated `verifier_result`.
+///
+/// `TrialPaths.result_path` names `result.json` while the class docstring
+/// directly above it says `results.json`. Harbor's code wins, but both are
+/// tried: reading the wrong one costs the crash signal entirely, and the cost
+/// of trying two names is one `stat`.
+const RESULT_NAMES: [&str; 2] = ["result.json", "results.json"];
+
+/// The exception message alone, at the trial root
+/// (`TrialPaths.exception_message_path`). Only read when `result.json` is
+/// missing or unparseable — the result file carries the same message *with*
+/// its exception type, which is the half that says whether a human should
+/// look at Stella or at Docker.
+const EXCEPTION_NAME: &str = "exception.txt";
+
+/// The adapter's post-mortem for a SIGKILL'd trial (`exit_cause.py`, #1178):
+/// OOM-kill vs an external teardown, decided from container evidence *while
+/// the container still existed*. It answers the question a bare exit 137
+/// cannot, so when it is present it is worth a line of its own.
+const EXIT_CAUSE_NAME: &str = "stella-exit-cause.json";
+
+/// One event stream, and which step produced it.
+#[derive(Debug, Clone)]
+pub struct StepStream {
+    /// `None` for a single-step trial; harbor's step name otherwise.
+    pub step: Option<String>,
+    /// The stream text, or the message that stands in for it when the file
+    /// could not be read. An unreadable stream is reported, never skipped.
+    pub raw: Result<String, String>,
+}
+
+/// Everything one trial directory says about itself.
+#[derive(Debug, Default, Clone)]
+pub struct TrialArtifacts {
+    /// One entry per event stream found, in the order the steps ran. Always
+    /// non-empty: a trial with no stream at all yields a single entry whose
+    /// `raw` is the error, so the trial still reaches the table.
+    pub streams: Vec<StepStream>,
+    /// The verifier's reward, or `None` when the trial never got that far.
+    pub reward: Option<f64>,
+    /// Set when a reward exists but cannot be used — a corrupt reward must
+    /// not silently downgrade a passing task to "never verified".
+    pub reward_problem: Option<String>,
+    /// `"<ExceptionType>: <message>"` when harbor recorded the trial as having
+    /// raised. This is the crash signal: an observation harbor made, not an
+    /// inference from the stream's shape.
+    pub crash: Option<String>,
+    /// The adapter's SIGKILL post-mortem verdict, when it wrote one.
+    pub exit_cause: Option<String>,
+    /// Harbor's own `task_name` for the trial. Authoritative where the
+    /// directory name is not: harbor truncates the task name to 32 characters
+    /// when naming the directory.
+    pub task_name: Option<String>,
+}
+
+/// Read one trial directory: its stream(s), its reward, and whether harbor
+/// recorded it as having crashed.
+#[must_use]
+pub fn read_trial(trial_dir: &Path) -> TrialArtifacts {
+    let result = read_result(trial_dir);
+    let agent_dirs = agent_dirs(trial_dir, result.as_ref());
+    let (reward, reward_problem) = read_reward(trial_dir, result.as_ref());
+    TrialArtifacts {
+        crash: read_crash(trial_dir, result.as_ref()),
+        exit_cause: read_exit_cause(&agent_dirs),
+        task_name: result
+            .as_ref()
+            .and_then(|v| v.get("task_name"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        streams: read_streams(&agent_dirs),
+        reward,
+        reward_problem,
+    }
+}
+
+/// The agent log directories to read, in step order.
+///
+/// A single-step trial has exactly one, `agent/`. A multi-step trial has one
+/// per step under `steps/<name>/agent/`, and its root `agent/` has been
+/// removed. When neither exists the root is returned anyway, so the caller
+/// reports the *expected* path in its "no event stream" message rather than a
+/// speculative per-step one.
+fn agent_dirs(trial_dir: &Path, result: Option<&Value>) -> Vec<(Option<String>, PathBuf)> {
+    let root = trial_dir.join("agent");
+    if root.join(EVENTS_NAME).is_file() {
+        return vec![(None, root)];
+    }
+    let mut steps: Vec<(Option<String>, PathBuf)> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(trial_dir.join("steps")) {
+        for entry in entries.flatten() {
+            let dir = entry.path().join("agent");
+            if dir.join(EVENTS_NAME).is_file() {
+                steps.push((Some(entry.file_name().to_string_lossy().into_owned()), dir));
+            }
+        }
+    }
+    if steps.is_empty() {
+        return vec![(None, root)];
+    }
+    // Order matters: the fold takes the *last* step's terminal event as the
+    // trial's, so a shuffled sequence would judge the wrong step's ending.
+    // `result.json` lists `step_results` in execution order, which is the only
+    // authoritative answer; a name sort is the fallback for a trial whose
+    // result file never landed (which is exactly the crashed case).
+    match step_order(result) {
+        Some(order) => steps.sort_by_key(|(name, _)| {
+            let position = name
+                .as_ref()
+                .and_then(|n| order.iter().position(|s| s == n));
+            // Steps harbor did not name sort after the ones it did, by name,
+            // rather than silently leading.
+            (position.unwrap_or(usize::MAX), name.clone())
+        }),
+        None => steps.sort_by(|a, b| a.0.cmp(&b.0)),
+    }
+    steps
+}
+
+/// The step names in execution order, from harbor's own `step_results`.
+fn step_order(result: Option<&Value>) -> Option<Vec<String>> {
+    let steps = result?.get("step_results")?.as_array()?;
+    let order: Vec<String> = steps
+        .iter()
+        .filter_map(|s| s.get("step_name").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    (!order.is_empty()).then_some(order)
+}
+
+/// Read every stream named by [`agent_dirs`].
+fn read_streams(agent_dirs: &[(Option<String>, PathBuf)]) -> Vec<StepStream> {
+    agent_dirs
+        .iter()
+        .map(|(step, dir)| {
+            let path = dir.join(EVENTS_NAME);
+            StepStream {
+                step: step.clone(),
+                // The message is unchanged from when this was inline in
+                // `analyze`: a trial with no readable stream is the worst
+                // outcome, and its row has to name the path that was missing.
+                raw: std::fs::read_to_string(&path)
+                    .map_err(|err| format!("no event stream ({}): {err}", path.display())),
+            }
+        })
+        .collect()
+}
+
+/// Read the verifier's reward, and any problem worth putting on the row.
+///
+/// Three sources, in descending directness:
+///
+/// 1. `verifier/reward.txt` — what the terminal-bench mapper writes for a
+///    single-step trial.
+/// 2. `result.json`'s `verifier_result.rewards.reward` — harbor's own
+///    aggregate. This is the *only* reward a multi-step trial has: harbor
+///    folds the per-step rewards by the task's `multi_step_reward_strategy`
+///    (last, or mean) and there is no trial-root `verifier/` at all. Taking
+///    harbor's aggregate rather than inventing a fold here means the harness
+///    and the dataset agree on what the task's score was.
+/// 3. Nothing — a quiet `None`. The trial never reached the verifier, which
+///    is not the same as scoring zero.
+///
+/// Harbor also accepts `verifier/reward.json`; it is deliberately not read,
+/// because the terminal-bench mapper writes the text form and a dataset that
+/// writes the JSON form should report `None` (under-crediting) rather than
+/// have this file guess at its key set.
+#[must_use]
+pub fn read_reward(trial_dir: &Path, result: Option<&Value>) -> (Option<f64>, Option<String>) {
+    let path = trial_dir.join("verifier").join("reward.txt");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => match content.trim().parse::<f64>() {
+            Ok(reward) => (Some(reward), None),
+            Err(_) => (
+                None,
+                Some(format!(
+                    "unreadable reward.txt: unparsable `{}`",
+                    crate::truncate(content.trim(), 20)
+                )),
+            ),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (aggregated_reward(result), None),
+        Err(err) => (None, Some(format!("unreadable reward.txt: {err}"))),
+    }
+}
+
+/// Harbor's aggregated reward off `result.json`, for a trial with no
+/// `verifier/reward.txt` of its own.
+fn aggregated_reward(result: Option<&Value>) -> Option<f64> {
+    result?
+        .get("verifier_result")?
+        .get("rewards")?
+        .get("reward")?
+        .as_f64()
+}
+
+/// Harbor's record of the trial, if it wrote one.
+fn read_result(trial_dir: &Path) -> Option<Value> {
+    RESULT_NAMES
+        .iter()
+        .filter_map(|name| std::fs::read_to_string(trial_dir.join(name)).ok())
+        .find_map(|raw| serde_json::from_str::<Value>(&raw).ok())
+}
+
+/// Whether harbor recorded this trial as having raised, and with what.
+///
+/// A multi-step trial can raise in one step and still write a clean
+/// trial-level record, so the per-step results are checked too. The *first*
+/// failing step is reported rather than the last: it is the one that explains
+/// everything after it.
+fn read_crash(trial_dir: &Path, result: Option<&Value>) -> Option<String> {
+    if let Some(crash) = result.and_then(|v| exception_label(v.get("exception_info"))) {
+        return Some(crash);
+    }
+    if let Some(steps) = result
+        .and_then(|v| v.get("step_results"))
+        .and_then(Value::as_array)
+        && let Some(crash) = steps.iter().find_map(|step| {
+            let label = exception_label(step.get("exception_info"))?;
+            let name = step.get("step_name").and_then(Value::as_str);
+            Some(match name {
+                Some(name) => format!("step `{name}` raised {label}"),
+                None => label,
+            })
+        })
+    {
+        return Some(crash);
+    }
+    // No result file (or an unparseable one) and an exception message at the
+    // root: harbor got far enough to name the failure but not to record it
+    // structurally. Worth strictly more than nothing.
+    let text = std::fs::read_to_string(trial_dir.join(EXCEPTION_NAME)).ok()?;
+    let line = text.lines().find(|line| !line.trim().is_empty())?;
+    Some(line.trim().to_string())
+}
+
+/// `"<type>: <message>"` from one `exception_info` object, or `None` when the
+/// field is absent or JSON `null` — which is what a trial that did *not* raise
+/// looks like, and must not be mistaken for a crash with an empty message.
+fn exception_label(info: Option<&Value>) -> Option<String> {
+    let info = info.filter(|value| !value.is_null())?;
+    let kind = info
+        .get("exception_type")
+        .and_then(Value::as_str)
+        .unwrap_or("exception");
+    let message = info
+        .get("exception_message")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    Some(if message.is_empty() {
+        kind.to_string()
+    } else {
+        format!("{kind}: {message}")
+    })
+}
+
+/// The adapter's SIGKILL post-mortem, when one was written next to a stream.
+///
+/// Only the verdict and its detail are lifted; the evidence stays in the file
+/// for whoever disputes the classification. A trial killed while the container
+/// was being torn down and one killed by the OOM killer both exit 137, and
+/// which of the two it was decides whether the fix is a memory limit or a
+/// timeout — so it is worth its own line on the row.
+fn read_exit_cause(agent_dirs: &[(Option<String>, PathBuf)]) -> Option<String> {
+    agent_dirs.iter().find_map(|(_, dir)| {
+        let raw = std::fs::read_to_string(dir.join(EXIT_CAUSE_NAME)).ok()?;
+        let value: Value = serde_json::from_str(&raw).ok()?;
+        let verdict = value.get("verdict").and_then(Value::as_str)?;
+        let detail = value.get("detail").and_then(Value::as_str).unwrap_or("");
+        Some(if detail.is_empty() {
+            verdict.to_string()
+        } else {
+            format!("{verdict} — {detail}")
+        })
+    })
+}

--- a/bench/loop-bench/src/lib.rs
+++ b/bench/loop-bench/src/lib.rs
@@ -9,12 +9,13 @@
 //! | Verdict | Meaning | In `loop_broken()`? |
 //! |---|---|---|
 //! | `solved` | the verifier passed it; reward wins | no |
-//! | `NOT-RUN` | the task was requested but harbor never produced a trial dir | **yes** |
+//! | `NOT-RUN` | the task (or one of its trials) was requested but harbor never produced a trial dir | **yes** |
 //! | `UNREADABLE` | the stream had lines but not one parsed as an event — schema drift or plumbing, not loop evidence | no |
 //! | `STUCK-LOOP` | the engine's own `loop_detected` fired and the task did not pass | **yes** |
 //! | `BUDGET-CAP` | the harness's `STELLA_BUDGET` denied the turn — a cost decision, not a loop defect | no |
 //! | `SILENT-DEATH` | zero tool calls and no terminal event: the loop vanished | **yes** |
 //! | `ZERO-WORK` | zero tool calls with a stated terminal event | **yes** |
+//! | `CRASHED` | work happened, then harbor recorded the trial as having raised | no |
 //! | `ran (unsolved)` | did real work, did not pass | no |
 //!
 //! The informational verdicts (`UNREADABLE`, `BUDGET-CAP`) are deliberately
@@ -26,6 +27,34 @@
 //! until the cap trips is exactly the defect this harness exists to catch —
 //! the cap firing is a symptom there, not the cause.
 //!
+//! # `CRASHED`, and why it sits where it does (#1299)
+//!
+//! A trial that dies partway through used to report `ran (unsolved)` — the
+//! same words as a turn that tried the task and got it wrong. An
+//! infrastructure failure wearing a capability failure's label sends the
+//! operator hunting a reasoning bug that does not exist, and the two are not
+//! even the same *kind* of fact: one says the agent was wrong, the other says
+//! the agent never finished being anything.
+//!
+//! It is the **lowest-precedence** verdict above `ran (unsolved)`, which is
+//! deliberate in both directions:
+//!
+//! * A crash never displaces a red verdict. A trial that did nothing and then
+//!   died is still `SILENT-DEATH`/`ZERO-WORK` and still gates red — the crash
+//!   record is added to its row as the explanation it previously lacked
+//!   ("vanished in stage `plan`" now comes with harbor's exception), rather
+//!   than replacing a gating verdict with a non-gating one. Naming a failure
+//!   better must never make the gate weaker.
+//! * `CRASHED` therefore only ever replaces `ran (unsolved)`, which does not
+//!   gate either. So it costs the gate nothing and buys the table a true
+//!   statement, which is exactly the trade this verdict is for.
+//!
+//! The signal is harbor's own `exception_info`, not an inference from the
+//! stream's shape. A turn that did its work and ended without a clean
+//! `complete` may simply have exited on a step cap; treating that as a death
+//! would invent crashes. "Harbor recorded that this raised" is an observation,
+//! and the harness reports observations.
+//!
 //! # The second gate: a pass-rate floor (#873)
 //!
 //! The nightly CI job also wants to notice the day the agent stops *solving*
@@ -36,12 +65,17 @@
 //! the pass rate this harness produces is a flash-tier model's under a cap:
 //! a floor is only meaningful once a job's own history has established one.
 
+pub mod artifacts;
 pub mod compare;
+pub mod reconcile;
 
 use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde_json::Value;
+
+use crate::artifacts::{StepStream, TrialArtifacts};
+use crate::reconcile::{Reconciliation, Requested, reported_task_name};
 
 /// The per-task loop + context signals, distilled from one trial's event
 /// stream and its verifier reward.
@@ -111,9 +145,27 @@ pub struct TrialReport {
     /// loop evidence (#611).
     pub unparsable_lines: u32,
     /// The task was requested this run but harbor produced no trial directory
-    /// at all. Synthesized by [`analyze`]; gates red — a task that never
-    /// launched must not read as a smaller, healthy run (#611).
+    /// for it. Synthesized by [`analyze`]; gates red — a task that never
+    /// launched must not read as a smaller, healthy run (#611). With
+    /// `--trials N` this covers a *partial* launch too: a task that produced
+    /// three of five trial dirs gets two `NOT-RUN` rows, so the denominator
+    /// is the sample that was asked for rather than the one that survived
+    /// (#1299).
     pub not_run: bool,
+    /// Harbor recorded this trial as having raised — `"<Type>: <message>"`
+    /// off its `result.json` (or `exception.txt`). The crash signal: an
+    /// observation harbor made, never an inference from the stream (#1299).
+    pub crash: Option<String>,
+    /// The adapter's SIGKILL post-mortem (#1178) when it wrote one: `oom-kill`
+    /// vs `external-teardown` vs `unattributed`, with its detail. Both 137s
+    /// look identical from the exit code, and which one it was decides whether
+    /// the fix is a memory limit or a timeout.
+    pub exit_cause: Option<String>,
+    /// Harbor step names this trial's stream(s) came from, in execution order.
+    /// Empty for an ordinary single-step trial. Distinct from `stages`, which
+    /// is Stella's own pipeline within one turn: these are harbor's steps,
+    /// each a separate agent invocation (#1299).
+    pub step_names: Vec<String>,
     /// The last `error` event's message, truncated for the table. Retryable
     /// warnings land here too — it is the most recent explanation, not a
     /// verdict.
@@ -139,6 +191,14 @@ impl TrialReport {
         self.parsed_lines == 0 && self.unparsable_lines > 0
     }
 
+    /// Harbor recorded this trial as having raised: it did not finish, whatever
+    /// its reward says. See the crate docs for why this is read off harbor's
+    /// record rather than inferred from the stream (#1299).
+    #[must_use]
+    pub fn crashed(&self) -> bool {
+        self.crash.is_some()
+    }
+
     /// The one-line loop verdict — the thing the reward number hides. See the
     /// crate docs for the ratified vocabulary and precedence.
     #[must_use]
@@ -159,6 +219,10 @@ impl TrialReport {
             } else {
                 "ZERO-WORK"
             }
+        } else if self.crashed() {
+            // Below every gating verdict on purpose: a crash explains a
+            // zero-work death, it does not excuse it. See the crate docs.
+            "CRASHED"
         } else {
             "ran (unsolved)"
         }
@@ -197,23 +261,60 @@ impl TrialReport {
     }
 }
 
+/// One run's distilled trials, and the requested-vs-reported check they were
+/// taken over.
+///
+/// The two travel together on purpose: a set of rows is only interpretable
+/// next to the question of whether it is all the rows there should be. Keeping
+/// the reconciliation in a second place a caller has to remember to consult is
+/// how a percentage over a shrunken denominator gets published (#1299).
+#[derive(Debug, Default, Clone)]
+pub struct Analysis {
+    /// The per-trial reports, sorted by task.
+    pub trials: Vec<TrialReport>,
+    /// Requested vs reported. `None` for `--analyze-only`, which asked for
+    /// nothing in particular and so has nothing to reconcile against.
+    pub reconciliation: Option<Reconciliation>,
+}
+
+impl Analysis {
+    /// The run-level counts both gates read.
+    #[must_use]
+    pub fn tally(&self) -> Tally {
+        tally(&self.trials)
+    }
+
+    /// No trial artifacts at all — infrastructure, not a loop regression.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.trials.is_empty()
+    }
+}
+
 /// Walk `<job_dir>/<task>__<id>/` trials and distill each into a report.
 ///
-/// `requested` is the task set this run resolved. When present it does two
-/// things (#611): trial dirs for tasks outside it are skipped — a stale job
-/// directory from an earlier run must not contaminate this one's gate — and
-/// requested tasks with no trial dir at all are synthesized as `NOT-RUN` rows
-/// that count toward the gate, so a task harbor never launched cannot read as
-/// a smaller, healthy run. Pass `None` for `--analyze-only`, which reads
-/// whatever a finished jobs dir holds.
+/// `requested` is what this run asked harbor for. When present it does three
+/// things:
 ///
-/// One known blind spot, which under-reports rather than inventing a signal:
-/// only single-step trials are found. A multi-step dataset relocates its logs
-/// to `steps/<name>/agent/` and removes the trial-root `agent/`, so every
-/// trial reports as "no event stream".
-pub fn analyze(job_dir: &Path, requested: Option<&[String]>) -> Vec<TrialReport> {
-    let mut reports = Vec::new();
-    let mut seen: Vec<String> = Vec::new();
+/// * trial dirs no requested task claims are skipped — a stale job directory
+///   from an earlier run must not contaminate this one's gate (#611) — and
+///   counted, so the skip is visible rather than silent (#1299);
+/// * requested trials with no directory become `NOT-RUN` rows that gate red,
+///   at *trial* granularity: three dirs for a five-trial task yields two
+///   `NOT-RUN` rows, so the denominator is the sample that was asked for
+///   (#611 for the task case, #1299 for the trial case);
+/// * every attribution is recorded in the returned [`Reconciliation`], which
+///   is what makes a mismatch loud.
+///
+/// Pass `None` for `--analyze-only`, which reads whatever a finished jobs dir
+/// holds and reconciles nothing.
+///
+/// Multi-step trials are read too (#1299): harbor relocates each step's logs
+/// into `steps/<name>/agent/` and removes the trial-root `agent/`, so those
+/// streams are found there and folded by [`fold_steps`].
+pub fn analyze(job_dir: &Path, requested: Option<Requested<'_>>) -> Analysis {
+    let mut trials = Vec::new();
+    let mut reconciliation = requested.map(|request| request.reconciliation());
     if let Ok(entries) = std::fs::read_dir(job_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
@@ -222,56 +323,143 @@ pub fn analyze(job_dir: &Path, requested: Option<&[String]>) -> Vec<TrialReport>
             }
             let name = entry.file_name().to_string_lossy().to_string();
             // Trial dirs are `<task>__<trialid>`; skip config.json etc.
-            let Some((task, _)) = name.split_once("__") else {
+            let Some((dir_prefix, _)) = name.split_once("__") else {
                 continue;
             };
-            if let Some(wanted) = requested
-                && !wanted.iter().any(|t| t == task)
-            {
-                continue;
-            }
-            seen.push(task.to_string());
-            let events_path = path.join("agent").join("stella-events.jsonl");
-            // A trial with no readable stream is the WORST outcome — the agent
-            // never started, or died before writing a line — so it must not be
-            // dropped from the table. Skipping it made a launch failure look
-            // like a clean run with fewer rows, and left the gate green.
-            let mut report = match std::fs::read_to_string(&events_path) {
-                Ok(raw) => distill_events(task, &raw),
-                Err(err) => TrialReport {
-                    task: task.to_string(),
-                    zero_work: true,
-                    last_error: Some(truncate(
-                        &format!("no event stream ({}): {err}", events_path.display()),
-                        90,
-                    )),
-                    ..Default::default()
-                },
+            let found = artifacts::read_trial(&path);
+            let task = match (requested, reconciliation.as_mut()) {
+                (Some(request), Some(record)) => {
+                    let (matched, ambiguous) =
+                        request.match_dir(dir_prefix, found.task_name.as_deref());
+                    let Some(task) = matched else {
+                        record.skipped(dir_prefix);
+                        continue;
+                    };
+                    record.saw(task, ambiguous.then_some(dir_prefix));
+                    task.to_string()
+                }
+                _ => reported_task_name(dir_prefix, found.task_name.as_deref()),
             };
-            let (reward, problem) = read_reward(&path);
-            report.reward = reward;
-            if let Some(problem) = problem {
-                report.last_error = Some(match report.last_error.take() {
-                    Some(existing) => truncate(&format!("{existing}; {problem}"), 90),
-                    None => truncate(&problem, 90),
-                });
-            }
-            reports.push(report);
+            trials.push(distill_trial(&task, &found));
         }
     }
-    if let Some(wanted) = requested {
-        for task in wanted {
-            if !seen.iter().any(|t| t == task) {
-                reports.push(TrialReport {
-                    task: task.clone(),
+    if let Some(record) = &reconciliation {
+        for (task, short) in record.missing() {
+            for _ in 0..short {
+                trials.push(TrialReport {
+                    task: task.to_string(),
                     not_run: true,
                     ..Default::default()
                 });
             }
         }
     }
-    reports.sort_by(|a, b| a.task.cmp(&b.task));
-    reports
+    trials.sort_by(|a, b| a.task.cmp(&b.task));
+    Analysis {
+        trials,
+        reconciliation,
+    }
+}
+
+/// Fold one trial directory's artifacts into its report.
+fn distill_trial(task: &str, found: &TrialArtifacts) -> TrialReport {
+    let mut report = distill_streams(task, &found.streams);
+    report.reward = found.reward;
+    // Truncated to the same width as `last_error`: both print as a `└` line
+    // under the row, and a longer one wraps the terminal rather than the cell.
+    report.crash = found.crash.as_deref().map(|crash| truncate(crash, 90));
+    report.exit_cause = found.exit_cause.as_deref().map(|cause| truncate(cause, 90));
+    if let Some(problem) = &found.reward_problem {
+        report.last_error = Some(match report.last_error.take() {
+            Some(existing) => truncate(&format!("{existing}; {problem}"), 90),
+            None => truncate(problem, 90),
+        });
+    }
+    report
+}
+
+/// Distill every stream a trial produced — one for a single-step trial, one
+/// per harbor step otherwise — and fold them into a single report.
+fn distill_streams(task: &str, streams: &[StepStream]) -> TrialReport {
+    let steps: Vec<TrialReport> = streams
+        .iter()
+        .map(|stream| match &stream.raw {
+            Ok(raw) => distill_events(task, raw),
+            // A trial with no readable stream is the WORST outcome — the agent
+            // never started, or died before writing a line — so it must not be
+            // dropped from the table. Skipping it made a launch failure look
+            // like a clean run with fewer rows, and left the gate green.
+            Err(problem) => TrialReport {
+                task: task.to_string(),
+                zero_work: true,
+                last_error: Some(truncate(problem, 90)),
+                ..Default::default()
+            },
+        })
+        .collect();
+    let mut report = fold_steps(&steps);
+    report.step_names = streams
+        .iter()
+        .filter_map(|stream| stream.step.clone())
+        .collect();
+    report
+}
+
+/// Fold a multi-step trial's per-step reports into one row.
+///
+/// Counters sum, because the trial did all of it. Two fields do not, and both
+/// choices are about not letting an early step vouch for a late one:
+///
+/// * `terminal_event` is the **last** step's. A trial that completed step one
+///   and then vanished in step two ended by vanishing, and an `any` fold would
+///   report it as having said goodbye.
+/// * `zero_work` is recomputed from the summed tool calls, so it means "this
+///   trial never did anything", not "some step didn't" — a step that only
+///   reads is a normal part of a multi-step task.
+///
+/// `budget_capped` *is* an `any`: the cap is per-trial, so once it fires the
+/// remaining steps were never given a fair chance either.
+#[must_use]
+pub fn fold_steps(steps: &[TrialReport]) -> TrialReport {
+    if let [single] = steps {
+        return single.clone();
+    }
+    let mut folded = TrialReport {
+        task: steps.first().map(|s| s.task.clone()).unwrap_or_default(),
+        ..Default::default()
+    };
+    let mut seen_stage = std::collections::BTreeSet::new();
+    for step in steps {
+        folded.model_calls = folded.model_calls.saturating_add(step.model_calls);
+        folded.tool_calls = folded.tool_calls.saturating_add(step.tool_calls);
+        folded.file_writes = folded.file_writes.saturating_add(step.file_writes);
+        folded.project_overview_calls = folded
+            .project_overview_calls
+            .saturating_add(step.project_overview_calls);
+        folded.graph_query_calls = folded
+            .graph_query_calls
+            .saturating_add(step.graph_query_calls);
+        folded.loop_detected = folded.loop_detected.saturating_add(step.loop_detected);
+        folded.retries = folded.retries.saturating_add(step.retries);
+        folded.parsed_lines = folded.parsed_lines.saturating_add(step.parsed_lines);
+        folded.unparsable_lines = folded
+            .unparsable_lines
+            .saturating_add(step.unparsable_lines);
+        folded.tokens = folded.tokens.saturating_add(step.tokens);
+        folded.spend_usd += step.spend_usd;
+        folded.budget_capped |= step.budget_capped;
+        folded.terminal_event = step.terminal_event;
+        for stage in &step.stages {
+            if seen_stage.insert(stage.clone()) {
+                folded.stages.push(stage.clone());
+            }
+        }
+        if step.last_error.is_some() {
+            folded.last_error.clone_from(&step.last_error);
+        }
+    }
+    folded.zero_work = folded.tool_calls == 0;
+    folded
 }
 
 /// Read the verifier's reward for one trial. Returns the reward and, when the
@@ -280,28 +468,11 @@ pub fn analyze(job_dir: &Path, requested: Option<&[String]>) -> Vec<TrialReport>
 /// (#611). A *missing* file stays a quiet `None`: the trial simply never
 /// reached the verifier.
 ///
-/// Harbor accepts EITHER `verifier/reward.txt` or `verifier/reward.json`
-/// (`harbor.models.trial.paths.TrialPaths`); only the text form is read here,
-/// because the terminal-bench mapper writes exactly that. A dataset passed via
-/// `--dataset` whose verifier emits the JSON form reports `None` for every
-/// trial, which reads as "never reached the verifier" — under-crediting, never
-/// over-crediting, so the loop gate stays honest.
+/// See [`artifacts::read_reward`] for the sources and their order; this is the
+/// path-only form, for a caller that has not already read `result.json`.
 pub fn read_reward(trial_dir: &Path) -> (Option<f64>, Option<String>) {
-    let path = trial_dir.join("verifier").join("reward.txt");
-    match std::fs::read_to_string(&path) {
-        Ok(content) => match content.trim().parse::<f64>() {
-            Ok(reward) => (Some(reward), None),
-            Err(_) => (
-                None,
-                Some(format!(
-                    "unreadable reward.txt: unparsable `{}`",
-                    truncate(content.trim(), 20)
-                )),
-            ),
-        },
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (None, None),
-        Err(err) => (None, Some(format!("unreadable reward.txt: {err}"))),
-    }
+    let found = artifacts::read_trial(trial_dir);
+    (found.reward, found.reward_problem)
 }
 
 /// The heart of the tool: turn one event stream into loop + context signals.
@@ -417,6 +588,12 @@ pub struct Tally {
     pub solved: usize,
     /// Trials whose loop misbehaved ([`TrialReport::loop_broken`]).
     pub loop_broken: usize,
+    /// Trials harbor recorded as having raised (#1299). Counted from the crash
+    /// record itself rather than from the `CRASHED` verdict, so it is the
+    /// number of trials that did not finish — including the ones whose verdict
+    /// a higher-precedence signal claimed (a crash that also died having done
+    /// nothing is `SILENT-DEATH`, and is still a crash).
+    pub crashed: usize,
 }
 
 /// Fold the per-trial reports into the run-level counts.
@@ -426,6 +603,7 @@ pub fn tally(reports: &[TrialReport]) -> Tally {
         total: reports.len(),
         solved: reports.iter().filter(|r| r.passed()).count(),
         loop_broken: reports.iter().filter(|r| r.loop_broken()).count(),
+        crashed: reports.iter().filter(|r| r.crashed()).count(),
     }
 }
 
@@ -448,12 +626,71 @@ pub fn below_pass_floor(reports: &[TrialReport], min_pass: usize) -> bool {
     min_pass > 0 && tally(reports).solved < min_pass
 }
 
+/// The JSON a CI consumer trends over time.
+///
+/// An object, where a single run used to emit a bare array of trials (#1299).
+/// The rows alone are not interpretable: `6 solved` means one thing over eight
+/// requested trials and another over six, and the artifact that carries the
+/// rows without the reconciliation is exactly the artifact that publishes the
+/// flattering number. The tally rides along for the same reason it is printed
+/// under the table — so a consumer trends the counts the exit code was decided
+/// from, rather than a second tally of its own that can drift from them.
+#[derive(Debug, serde::Serialize)]
+pub struct JsonReport<'a> {
+    /// The per-trial rows, sorted by task. What the array used to hold.
+    pub trials: &'a [TrialReport],
+    /// The run-level counts both gates read.
+    pub tally: Tally,
+    /// Requested vs reported; `null` for `--analyze-only`.
+    pub reconciliation: Option<&'a Reconciliation>,
+}
+
+/// Render an [`Analysis`] for a machine.
+#[must_use]
+pub fn json_report(analysis: &Analysis) -> JsonReport<'_> {
+    JsonReport {
+        trials: &analysis.trials,
+        tally: analysis.tally(),
+        reconciliation: analysis.reconciliation.as_ref(),
+    }
+}
+
 /// Width of the rendered table, in columns: 24 (task) + 14 (verdict) + 6 + 6 +
 /// 5 + 4 + 4 for the counters + 7 for `$`, plus the nine separator spaces and
 /// the six of `reward`. The verdict column is exactly as wide as the longest
 /// verdict string, `ran (unsolved)` — an 8-wide column overflowed it and
 /// shifted every counter on that row.
 const TABLE_WIDTH: usize = 85;
+
+pub fn print_analysis(analysis: &Analysis) {
+    print_table(&analysis.trials);
+    if let Some(record) = &analysis.reconciliation {
+        print_reconciliation(record);
+    }
+}
+
+/// The requested-vs-reported block. Printed only when the two disagree —
+/// a run whose accounting is exact should not have to be read to learn that.
+///
+/// It goes *after* the table because it is a statement about the table: these
+/// are the rows that should have been above and were not, and these are the
+/// rows above that this run did not ask for.
+pub fn print_reconciliation(record: &Reconciliation) {
+    let findings = record.findings();
+    if findings.is_empty() {
+        return;
+    }
+    println!("\nRECONCILIATION: requested and reported do not match");
+    for finding in findings {
+        println!("  ✗ {finding}");
+    }
+    if record.contaminated() {
+        println!(
+            "  ⚠ every figure above is computed over a task set that is not the one \
+             requested — treat the percentages as unsourced until this is resolved."
+        );
+    }
+}
 
 pub fn print_table(reports: &[TrialReport]) {
     println!(
@@ -495,6 +732,25 @@ pub fn print_table(reports: &[TrialReport]) {
                 ""
             );
         }
+        // The crash line prints even for a row whose verdict is something
+        // else, including `solved` (#1299). The verdict column holds one word
+        // and precedence already spent it; "harbor recorded this as having
+        // raised" is a separate fact, and the row is where an operator will
+        // look for it.
+        if let Some(crash) = &r.crash {
+            println!("{:>26}└ crashed: {crash}", "");
+        }
+        if let Some(cause) = &r.exit_cause {
+            println!("{:>26}└ exit cause: {cause}", "");
+        }
+        if !r.step_names.is_empty() {
+            println!(
+                "{:>26}└ folded from {} harbor step(s): {}",
+                "",
+                r.step_names.len(),
+                r.step_names.join(" → ")
+            );
+        }
         if r.project_overview_calls > 0 {
             overview_used += 1;
         }
@@ -510,6 +766,7 @@ pub fn print_table(reports: &[TrialReport]) {
         total: n,
         solved,
         loop_broken,
+        crashed,
     } = tally(reports);
     println!("{}", "─".repeat(TABLE_WIDTH));
     println!(
@@ -521,6 +778,17 @@ pub fn print_table(reports: &[TrialReport]) {
         println!(
             "  ⚠ {loop_broken} task(s) exercised the loop badly — that is a correctness \
              signal independent of the model or the reward."
+        );
+    }
+    // Said separately from the loop count, and in these words, because the
+    // conclusion to draw is the opposite one: a crash is the harness or the
+    // machine failing, and reading it as the agent being wrong is a week spent
+    // tuning prompts against an OOM (#1299).
+    if crashed > 0 {
+        println!(
+            "  ⚠ {crashed}/{n} trial(s) did not finish — harbor recorded an exception. \
+             Those are infrastructure outcomes, NOT the model getting the task wrong; \
+             the {solved}/{n} pass rate is over a run that partly did not happen."
         );
     }
     // A per-verdict tally, so a run is greppable at a glance.

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -38,7 +38,7 @@
 //!
 //! - `0` — every trial that reported did real work (or passed).
 //! - `1` — the loop misbehaved on at least one trial: silent death, zero
-//!   work, a stuck loop, or a requested task that never ran.
+//!   work, a stuck loop, or a requested trial that never ran.
 //! - `2` — bad invocation: the task list resolved to nothing, or
 //!   `--json-out` names a path that cannot be written.
 //! - `3` — no trial artifacts were found at all — an infrastructure failure
@@ -49,10 +49,18 @@
 //! - `6` — `--compare --require-winner` and no arm confidently beat the
 //!   baseline, or one did and a guard metric regressed. Opt-in, like `4`: a
 //!   comparison is a measurement, and "no winner" is a legitimate answer to it.
+//! - `7` — the job directory holds trials this run did not ask for, so every
+//!   figure was computed over a task set that is not the requested one (#1299).
 //!
 //! `1` outranks `4`: when both fire, the loop failure is the one a human can
 //! act on, and a broken loop explains the missing passes anyway. `1` outranks
-//! `6` for the same reason.
+//! `6` and `7` for the same reason.
+//!
+//! A crash is deliberately **not** an exit code. It is a verdict on the row
+//! and a count under the table, because the gate here is loop health and a
+//! trial the machine killed is not evidence about the loop — the same reason
+//! `UNREADABLE` and `BUDGET-CAP` do not gate. What it must never again be is
+//! silent, or dressed as `ran (unsolved)`.
 
 use std::path::Path;
 use std::process::Command;
@@ -61,7 +69,11 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 
 use loop_bench::compare::{arm_trials, default_guards, print_comparison};
-use loop_bench::{TrialReport, analyze, below_pass_floor, print_table, tally};
+use loop_bench::reconcile::Requested;
+use loop_bench::{
+    Analysis, TrialReport, analyze, below_pass_floor, json_report, print_analysis,
+    print_reconciliation, tally,
+};
 use stella_core::comparison::{ArmTrials, ComparisonConfig, Metric, compare};
 
 /// A small, representative default pool — mixed languages and difficulties, the
@@ -225,8 +237,13 @@ fn main() {
     // Prove the report path is writable BEFORE spending anything. A typo'd
     // artifact path discovered after a paid run costs the whole run; caught
     // here it costs one message and no API calls.
+    // `{}` and not `[]`: if the run dies before overwriting this, the leftover
+    // must not parse as a *valid, empty* report. An empty array does — a
+    // consumer would read it as a run of zero trials and say "insufficient
+    // samples", a statement about the experiment when the truth is that the
+    // file is a placeholder (#1299).
     if let Some(path) = &args.json_out
-        && let Err(err) = std::fs::write(path, "[]\n")
+        && let Err(err) = std::fs::write(path, "{}\n")
     {
         eprintln!("--json-out {path} is not writable: {err}");
         std::process::exit(2);
@@ -243,16 +260,25 @@ fn main() {
 /// The original one-config run: measure the loop, render the table, apply the
 /// loop gate and the opt-in pass floor.
 fn run_single(args: &Args, tasks: &[String]) -> i32 {
-    let reports = match collect_arm(args, tasks, &args.model, &args.job_name) {
-        Ok(reports) => reports,
+    let analysis = match collect_arm(args, tasks, &args.model, &args.job_name) {
+        Ok(analysis) => analysis,
         Err(code) => return code,
     };
+    let reports = &analysis.trials;
 
-    let json = serde_json::to_string_pretty(&reports).unwrap_or_else(|_| "[]".into());
+    let json =
+        serde_json::to_string_pretty(&json_report(&analysis)).unwrap_or_else(|_| "{}".into());
     if args.json {
         println!("{json}");
+        // The reconciliation is inside the JSON, but a mismatch has to reach
+        // the run log too: `--json` output is piped somewhere to be trended,
+        // and a mismatch nobody sees until they open the artifact is a
+        // mismatch that already did its damage.
+        if let Some(record) = &analysis.reconciliation {
+            print_reconciliation(record);
+        }
     } else {
-        print_table(&reports);
+        print_analysis(&analysis);
     }
     let report_lost = write_artifact(args, &json);
 
@@ -262,10 +288,13 @@ fn run_single(args: &Args, tasks: &[String]) -> i32 {
     if reports.iter().any(TrialReport::loop_broken) {
         return 1;
     }
+    if let Some(code) = contamination_exit(&analysis) {
+        return code;
+    }
     // The second, opt-in gate (#873). Checked after loop health so a run that
     // fails both reports the actionable half.
-    if below_pass_floor(&reports, args.min_pass) {
-        let solved = tally(&reports).solved;
+    if below_pass_floor(reports, args.min_pass) {
+        let solved = tally(reports).solved;
         eprintln!(
             "PASS FLOOR: {solved}/{} solved is below the required --min-pass {}",
             reports.len(),
@@ -274,6 +303,26 @@ fn run_single(args: &Args, tasks: &[String]) -> i32 {
         return 4;
     }
     if report_lost { 5 } else { 0 }
+}
+
+/// Exit `7` when the analysis covered trials this run did not ask for (#1299).
+///
+/// Missing trials need no code of their own: they become `NOT-RUN` rows that
+/// already gate red at `1` and are visible on the table. Surplus is the half
+/// with nowhere else to surface — an extra trial directory renders as an
+/// ordinary, healthy row, so without this the run reports a pass rate over a
+/// sample that includes an earlier run's results and looks entirely clean
+/// doing it.
+fn contamination_exit(analysis: &Analysis) -> Option<i32> {
+    let record = analysis.reconciliation.as_ref()?;
+    if !record.contaminated() {
+        return None;
+    }
+    eprintln!(
+        "RECONCILIATION: the reported trials are not the requested ones; \
+         the figures above are not this run's"
+    );
+    Some(7)
 }
 
 /// The `--compare` run (#876): the same task set under each named config, then
@@ -298,14 +347,22 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
 
     let mut arms: Vec<ArmTrials> = Vec::with_capacity(configs.len());
     let mut loop_broken = false;
+    let mut contaminated: Option<i32> = None;
     for (index, model) in configs.iter().enumerate() {
         let job_name = arm_job_name(&args.job_name, index, model);
-        let reports = match collect_arm(args, tasks, model, &job_name) {
-            Ok(reports) => reports,
+        let analysis = match collect_arm(args, tasks, model, &job_name) {
+            Ok(analysis) => analysis,
             Err(code) => return code,
         };
-        loop_broken |= reports.iter().any(TrialReport::loop_broken);
-        arms.push(arm_trials(model, model, &reports));
+        if let Some(record) = &analysis.reconciliation {
+            print_reconciliation(record);
+        }
+        loop_broken |= analysis.trials.iter().any(TrialReport::loop_broken);
+        // One arm's contaminated denominator is the whole comparison's
+        // problem: the arms are compared trial-for-trial, so a stale directory
+        // under one of them moves a lift that no model produced.
+        contaminated = contaminated.or_else(|| contamination_exit(&analysis));
+        arms.push(arm_trials(model, model, &analysis.trials));
     }
 
     // The first config named is the incumbent; every other is a candidate
@@ -328,6 +385,9 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
     if loop_broken {
         return 1;
     }
+    if let Some(code) = contaminated {
+        return code;
+    }
     if args.require_winner && !report.verdict.is_winner() {
         eprintln!("NO WINNER: --require-winner was set and no arm cleared both bars");
         return 6;
@@ -346,27 +406,39 @@ fn collect_arm(
     tasks: &[String],
     model: &str,
     job_name: &str,
-) -> Result<Vec<TrialReport>, i32> {
+) -> Result<Analysis, i32> {
     if !args.analyze_only
         && let Err(code) = run_harbor(args, tasks, model, job_name)
     {
         eprintln!("harbor run failed (exit {code}); analyzing whatever landed");
     }
-    // The resolved task set scopes the analysis (#611): stale trial dirs from
-    // an earlier run under the same job name are skipped, and requested tasks
-    // that never launched become NOT-RUN rows. `--analyze-only` reads
-    // whatever the finished jobs dir holds instead.
-    let requested = if args.analyze_only { None } else { Some(tasks) };
+    // The resolved request scopes the analysis (#611): stale trial dirs from
+    // an earlier run under the same job name are skipped, and requested trials
+    // that never launched become NOT-RUN rows. The trial count travels with
+    // the task list because `-k` is half the denominator — a task that ran
+    // two of five trials is as under-measured as one that ran none of one
+    // (#1299). `--analyze-only` reads whatever the finished jobs dir holds
+    // instead, and reconciles nothing.
+    let requested = (!args.analyze_only).then(|| Requested {
+        tasks,
+        trials_per_task: args.trials.max(1),
+    });
     let job_dir = Path::new(&args.jobs_dir).join(job_name);
-    let reports = analyze(&job_dir, requested);
-    if reports.is_empty() {
+    let analysis = analyze(&job_dir, requested);
+    // "Nothing landed" and "every row is a row we invented because nothing
+    // landed" are the same fact. Only the first used to reach here: once a
+    // requested set exists, `analyze` synthesizes a NOT-RUN row per missing
+    // trial, so a harbor that launched nothing at all produced a full table of
+    // them and exited `1` — the loop code — for a run in which the loop never
+    // ran. Exit `3` is the one that says infrastructure (#1299).
+    if analysis.is_empty() || analysis.trials.iter().all(|trial| trial.not_run) {
         eprintln!(
             "no trial artifacts found under {} — nothing to report",
             job_dir.display()
         );
         return Err(3);
     }
-    Ok(reports)
+    Ok(analysis)
 }
 
 /// Write `--json-out`, returning whether the artifact was lost.

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -477,7 +477,21 @@ fn arm_job_name(job_name: &str, index: usize, model: &str) -> String {
 
 fn resolve_tasks(args: &Args) -> Vec<String> {
     if !args.tasks.is_empty() {
-        return args.tasks.clone();
+        // Harbor's `-i` is a filter, so a name given twice still runs once —
+        // and the reconciliation counts it once too. Consistent, but an
+        // operator who typed it twice expected two, so say which it is rather
+        // than letting a `2/1 trials` line later read as a stale job dir
+        // (#1299). `--compare` rejects a repeated arm outright; a repeated task
+        // is harmless, so this only warns.
+        let mut deduped: Vec<String> = Vec::with_capacity(args.tasks.len());
+        for task in &args.tasks {
+            if deduped.contains(task) {
+                eprintln!("warning: --tasks names `{task}` twice; it is run and counted once");
+            } else {
+                deduped.push(task.clone());
+            }
+        }
+        return deduped;
     }
     // `--n 0` would measure nothing, so it floors at one task. Asking for more
     // than the pool holds silently under-measures the run — say so, because a

--- a/bench/loop-bench/src/reconcile.rs
+++ b/bench/loop-bench/src/reconcile.rs
@@ -1,0 +1,229 @@
+//! Requested tasks vs reported trials — the denominator check (#1299).
+//!
+//! Harbor takes `-i <name>` filters and errors only when *nothing* matched, so
+//! a run that asked for eight tasks and matched six produces six healthy rows
+//! and a clean exit. Six of eight solved reads as 75% when it is 60%, and
+//! nothing on the page says which number you are looking at. A wrong figure in
+//! the flattering direction with no marker on it is worse than no figure.
+//!
+//! #611 closed half of this: a requested task with no trial directory at all
+//! becomes a `NOT-RUN` row that counts in the denominator and gates red. Three
+//! ways past that check remained, and this module closes them:
+//!
+//! * **Missing *trials*, not tasks.** With `--trials 5`, a task that produced
+//!   two trial directories is present, healthy, and quietly measured over two
+//!   fifths of the sample it claimed.
+//! * **Surplus trials.** Harbor writes into `<jobs-dir>/<job-name>/`
+//!   verbatim. Running twice under the same job name leaves both runs' trial
+//!   directories side by side, and the second run scores itself over the union
+//!   — yesterday's binary folded into today's gate, invisibly.
+//! * **A name the directory cannot hold.** Harbor names a trial directory
+//!   `<task_name[:32] with trailing _- stripped>__<shortuuid>`
+//!   (`TrialConfig.generate_trial_name`). A requested task longer than 32
+//!   characters therefore never equals its own directory prefix: every one of
+//!   its trials was skipped as belonging to some other run, and the task it
+//!   really ran was reported `NOT-RUN`. Two failures from one truncation, both
+//!   pointing away from the cause.
+//!
+//! The rule throughout: reconciliation is *reported*, never *applied*. Nothing
+//! here adjusts a count to make it consistent — it says what was asked for,
+//! what came back, and where the two disagree.
+
+use std::collections::BTreeMap;
+
+/// Harbor truncates a task name to this many characters when naming a trial
+/// directory (`TrialConfig.generate_trial_name`).
+const TRIAL_DIR_TASK_LIMIT: usize = 32;
+
+/// What this run asked harbor for — the denominator every figure is taken
+/// over, carried separately from the results so the two can be compared.
+#[derive(Debug, Clone, Copy)]
+pub struct Requested<'a> {
+    /// The resolved task list, exactly as passed to harbor's `-i`.
+    pub tasks: &'a [String],
+    /// Trial directories expected per task (harbor's `-k`).
+    pub trials_per_task: usize,
+}
+
+impl<'a> Requested<'a> {
+    /// Which requested task a trial directory belongs to, or `None` when it
+    /// belongs to none of them.
+    ///
+    /// `task_name` is harbor's own record off `result.json` and is preferred
+    /// whenever it is present: the directory name is a *truncation* of it, and
+    /// only the untruncated form can tell two 40-character task names with the
+    /// same first 32 apart. The prefix comparison is the fallback for a trial
+    /// whose result file never landed — which is precisely the crashed trial,
+    /// the one it would be worst to lose.
+    ///
+    /// Returns the match plus whether the prefix was ambiguous, so the caller
+    /// can record a guess as a guess.
+    #[must_use]
+    pub fn match_dir(&self, dir_prefix: &str, task_name: Option<&str>) -> (Option<&'a str>, bool) {
+        if let Some(name) = task_name
+            && let Some(task) = self.tasks.iter().find(|t| t.as_str() == name)
+        {
+            return (Some(task.as_str()), false);
+        }
+        let matches: Vec<&str> = self
+            .tasks
+            .iter()
+            .filter(|t| trial_dir_prefix(t) == dir_prefix)
+            .map(String::as_str)
+            .collect();
+        (matches.first().copied(), matches.len() > 1)
+    }
+
+    /// A fresh, all-zero reconciliation over this request — every requested
+    /// task present with a count of nothing, so a task that never appears is
+    /// still in the table rather than absent from it.
+    #[must_use]
+    pub fn reconciliation(&self) -> Reconciliation {
+        Reconciliation {
+            trials_per_task: self.trials_per_task,
+            observed: self.tasks.iter().map(|t| (t.clone(), 0)).collect(),
+            unrequested: BTreeMap::new(),
+            ambiguous: Vec::new(),
+        }
+    }
+}
+
+/// The directory-name prefix harbor will give a task's trials.
+#[must_use]
+pub fn trial_dir_prefix(task: &str) -> String {
+    task.chars()
+        .take(TRIAL_DIR_TASK_LIMIT)
+        .collect::<String>()
+        .trim_end_matches(['_', '-'])
+        .to_string()
+}
+
+/// Requested vs reported, per task.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct Reconciliation {
+    /// Trial directories expected per requested task.
+    pub trials_per_task: usize,
+    /// Requested task → trial directories found for it. Every requested task
+    /// is a key, including the ones with a count of zero.
+    pub observed: BTreeMap<String, usize>,
+    /// Trial-directory prefix → directories skipped because no requested task
+    /// claims them. Skipping is right — a previous run's tasks must not
+    /// contaminate this run's gate — but doing it silently means a mistyped
+    /// `--tasks` looks like a run where harbor launched nothing.
+    pub unrequested: BTreeMap<String, usize>,
+    /// Directory prefixes that matched more than one requested task and could
+    /// not be resolved by harbor's own record. The attribution below is a
+    /// guess, and is labelled as one.
+    pub ambiguous: Vec<String>,
+}
+
+impl Reconciliation {
+    /// Record one trial directory against the task it was attributed to.
+    pub fn saw(&mut self, task: &str, ambiguous_prefix: Option<&str>) {
+        *self.observed.entry(task.to_string()).or_default() += 1;
+        if let Some(prefix) = ambiguous_prefix
+            && !self.ambiguous.iter().any(|p| p == prefix)
+        {
+            self.ambiguous.push(prefix.to_string());
+        }
+    }
+
+    /// Record one trial directory that no requested task claims.
+    pub fn skipped(&mut self, dir_prefix: &str) {
+        *self.unrequested.entry(dir_prefix.to_string()).or_default() += 1;
+    }
+
+    /// Requested trials that never produced a directory, per task. These
+    /// become `NOT-RUN` rows: the denominator stays the size that was asked
+    /// for, and the gate goes red.
+    #[must_use]
+    pub fn missing(&self) -> Vec<(&str, usize)> {
+        self.observed
+            .iter()
+            .filter_map(|(task, seen)| {
+                self.trials_per_task
+                    .checked_sub(*seen)
+                    .filter(|short| *short > 0)
+                    .map(|short| (task.as_str(), short))
+            })
+            .collect()
+    }
+
+    /// Trial directories beyond what this run asked for, per task — a second
+    /// run's results sitting in the first run's job directory.
+    #[must_use]
+    pub fn surplus(&self) -> Vec<(&str, usize)> {
+        self.observed
+            .iter()
+            .filter_map(|(task, seen)| {
+                seen.checked_sub(self.trials_per_task)
+                    .filter(|extra| *extra > 0)
+                    .map(|extra| (task.as_str(), extra))
+            })
+            .collect()
+    }
+
+    /// The report covers exactly the trials that were asked for, and each is
+    /// attributed to a task with certainty.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.missing().is_empty() && self.surplus().is_empty() && self.ambiguous.is_empty()
+    }
+
+    /// The denominator cannot be trusted: results this run did not ask for are
+    /// folded into it, or a directory could only be attributed by guessing.
+    ///
+    /// Deliberately *not* the same predicate as [`is_clean`](Self::is_clean).
+    /// A missing trial is already reported — it becomes a `NOT-RUN` row that
+    /// gates red and is visible on the table. Surplus has no row to become:
+    /// the extra trials look exactly like legitimate results, so this is the
+    /// only place a reader would ever learn of them.
+    #[must_use]
+    pub fn contaminated(&self) -> bool {
+        !self.surplus().is_empty() || !self.ambiguous.is_empty()
+    }
+
+    /// Every disagreement between what was asked for and what came back, as
+    /// lines for an operator. Empty when the two agree exactly.
+    #[must_use]
+    pub fn findings(&self) -> Vec<String> {
+        let mut findings = Vec::new();
+        let expected = self.trials_per_task;
+        for (task, short) in self.missing() {
+            let seen = self.observed.get(task).copied().unwrap_or(0);
+            findings.push(format!(
+                "{task}: {seen}/{expected} trial(s) reported — {short} missing, \
+                 counted as NOT-RUN so the denominator stays {expected}"
+            ));
+        }
+        for (task, extra) in self.surplus() {
+            let seen = self.observed.get(task).copied().unwrap_or(0);
+            findings.push(format!(
+                "{task}: {seen} trial dir(s) for {expected} requested — {extra} extra. \
+                 An earlier run's results are in this job directory; use a fresh \
+                 --job-name or delete it, or this run is scored over both"
+            ));
+        }
+        for prefix in &self.ambiguous {
+            findings.push(format!(
+                "`{prefix}…`: more than one requested task truncates to this directory \
+                 name and no result.json disambiguated it — its trials are attributed \
+                 to the first match, which may be the wrong task"
+            ));
+        }
+        for (prefix, count) in &self.unrequested {
+            findings.push(format!(
+                "`{prefix}`: {count} trial dir(s) excluded — no requested task matches. \
+                 They contribute to nothing here; check --tasks if that is a surprise"
+            ));
+        }
+        findings
+    }
+}
+
+/// The task name to show for a trial directory the requested set does not
+/// claim: harbor's own record when it landed, else the truncated prefix.
+#[must_use]
+pub fn reported_task_name(dir_prefix: &str, task_name: Option<&str>) -> String {
+    task_name.unwrap_or(dir_prefix).to_string()
+}

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -1,10 +1,63 @@
 //! The ratified verdict contract (#611): what makes a run red, and what is
 //! informational.
 
+use std::path::{Path, PathBuf};
+
 use super::*;
+use crate::reconcile::trial_dir_prefix;
 
 fn ev(events: &[&str]) -> String {
     events.join("\n")
+}
+
+/// The common single-trial request: one task, one trial.
+fn one_trial_each(tasks: &[String]) -> Requested<'_> {
+    Requested {
+        tasks,
+        trials_per_task: 1,
+    }
+}
+
+/// One trial directory with a single-step event stream, as harbor lays it out.
+fn trial_dir(job: &Path, name: &str, events: &[&str]) -> PathBuf {
+    let dir = job.join(name);
+    let agent = dir.join("agent");
+    std::fs::create_dir_all(&agent).expect("mkdir");
+    std::fs::write(agent.join("stella-events.jsonl"), ev(events)).expect("write");
+    dir
+}
+
+/// Harbor's own record of the trial.
+fn write_result(trial: &Path, result: serde_json::Value) {
+    std::fs::write(
+        trial.join("result.json"),
+        serde_json::to_string(&result).expect("serialize"),
+    )
+    .expect("write");
+}
+
+/// One `exception_info` object, as `harbor.models.trial.result` writes it.
+fn exception(kind: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "exception_type": kind,
+        "exception_message": message,
+        "exception_traceback": "Traceback (most recent call last): …",
+        "occurred_at": "2026-08-04T00:00:00",
+    })
+}
+
+fn write_reward(trial: &Path, reward: &str) {
+    let verifier = trial.join("verifier");
+    std::fs::create_dir_all(&verifier).expect("mkdir");
+    std::fs::write(verifier.join("reward.txt"), reward).expect("write");
+}
+
+/// The single row an analysis of one trial should hold.
+fn only(analysis: &Analysis) -> &TrialReport {
+    match &analysis.trials[..] {
+        [report] => report,
+        rows => panic!("expected exactly one row, got {}", rows.len()),
+    }
 }
 
 #[test]
@@ -237,14 +290,14 @@ fn analyze_reconciles_the_requested_task_set() {
     }
 
     let requested = vec!["wanted".to_string(), "missing".to_string()];
-    let reports = analyze(dir.path(), Some(&requested));
-    let tasks: Vec<&str> = reports.iter().map(|r| r.task.as_str()).collect();
+    let analysis = analyze(dir.path(), Some(one_trial_each(&requested)));
+    let tasks: Vec<&str> = analysis.trials.iter().map(|r| r.task.as_str()).collect();
     assert_eq!(
         tasks,
         vec!["missing", "wanted"],
         "stale dirs are skipped, missing tasks are synthesized"
     );
-    let missing = &reports[0];
+    let missing = &analysis.trials[0];
     assert!(missing.not_run);
     assert_eq!(missing.loop_verdict(), "NOT-RUN");
     assert!(
@@ -252,10 +305,30 @@ fn analyze_reconciles_the_requested_task_set() {
         "a task that never launched must not read as a smaller, healthy run"
     );
 
+    // #1299: the skip is recorded rather than silent — a mistyped --tasks
+    // otherwise looks exactly like a run harbor launched nothing for.
+    let record = analysis
+        .reconciliation
+        .as_ref()
+        .expect("a requested run reconciles");
+    assert_eq!(record.unrequested.get("stale"), Some(&1));
+    assert_eq!(record.missing(), vec![("missing", 1)]);
+    assert!(record.surplus().is_empty());
+    assert!(
+        !record.contaminated(),
+        "a skipped stale dir contributes to no figure, so it is a note, not a bad denominator"
+    );
+    assert!(
+        record.findings().iter().any(|f| f.contains("stale")),
+        "{:?}",
+        record.findings()
+    );
+
     // --analyze-only reads whatever is there: no filtering, no synthesis.
     let all = analyze(dir.path(), None);
-    let tasks: Vec<&str> = all.iter().map(|r| r.task.as_str()).collect();
+    let tasks: Vec<&str> = all.trials.iter().map(|r| r.task.as_str()).collect();
     assert_eq!(tasks, vec!["stale", "wanted"]);
+    assert!(all.reconciliation.is_none(), "nothing was requested");
 }
 
 /// #611: a present-but-corrupt reward file appends to `last_error` instead of
@@ -337,6 +410,402 @@ fn a_not_run_task_still_counts_against_the_floor() {
     assert_eq!(t.solved, 1);
     assert_eq!(t.loop_broken, 1, "NOT-RUN gates red on its own");
     assert!(below_pass_floor(&reports, 2), "1/2 is below a floor of 2");
+}
+
+/// #1299, hole 1: a trial that did real work and then died reports `CRASHED`,
+/// not `ran (unsolved)`. The old wording said the agent tried the task and got
+/// it wrong; what actually happened is that the machine killed it.
+#[test]
+fn a_crash_after_real_work_is_not_an_ordinary_failure() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = trial_dir(
+        job.path(),
+        "died__t1",
+        &[
+            r#"{"type":"stage","name":"execute"}"#,
+            r#"{"type":"tool_start","call":{"name":"edit_file"}}"#,
+            r#"{"type":"step_usage","cost_usd":0.02}"#,
+        ],
+    );
+    write_result(
+        &trial,
+        serde_json::json!({
+            "task_name": "died",
+            "exception_info": exception(
+                "NonZeroAgentExitCodeError",
+                "Stella exited with code 137; see stella-exit-cause.json",
+            ),
+        }),
+    );
+
+    let requested = vec!["died".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert_eq!(report.loop_verdict(), "CRASHED");
+    assert!(report.crashed());
+    assert!(
+        report
+            .crash
+            .as_deref()
+            .is_some_and(|crash| crash.starts_with("NonZeroAgentExitCodeError: Stella exited")),
+        "{:?}",
+        report.crash
+    );
+    assert!(
+        !report.loop_broken(),
+        "a trial the machine killed is not evidence about the loop"
+    );
+    assert_eq!(analysis.tally().crashed, 1);
+    assert_eq!(analysis.tally().solved, 0);
+}
+
+/// #1299: naming a failure better must never make the gate weaker. A crash
+/// that happened before any work is still `SILENT-DEATH` and still red — it
+/// simply now carries the explanation it never had.
+#[test]
+fn a_crash_before_any_work_stays_red_and_gains_its_explanation() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = trial_dir(
+        job.path(),
+        "vanished__t1",
+        &[
+            r#"{"type":"stage","name":"triage"}"#,
+            r#"{"type":"stage","name":"plan"}"#,
+        ],
+    );
+    write_result(
+        &trial,
+        serde_json::json!({
+            "task_name": "vanished",
+            "exception_info": exception("AgentTimeoutError", "agent exceeded its time limit"),
+        }),
+    );
+
+    let requested = vec!["vanished".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert_eq!(
+        report.loop_verdict(),
+        "SILENT-DEATH",
+        "a zero-work death keeps its gating verdict"
+    );
+    assert!(report.loop_broken());
+    assert!(
+        report.crash.is_some(),
+        "the crash is still on the row — the verdict column holds one word, \
+         and the explanation is a separate fact"
+    );
+    assert_eq!(
+        analysis.tally().crashed,
+        1,
+        "counted from the crash record, not from the verdict it lost"
+    );
+}
+
+/// #1299: `exception.txt` and the adapter's SIGKILL post-mortem (#1178) are
+/// read when `result.json` never landed — the trial that crashed hardest is
+/// the one least likely to have written a structured record.
+#[test]
+fn a_crash_is_read_from_the_files_a_dying_trial_manages_to_leave() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = trial_dir(
+        job.path(),
+        "oom__t1",
+        &[r#"{"type":"tool_start","call":{"name":"write_file"}}"#],
+    );
+    std::fs::write(
+        trial.join("exception.txt"),
+        "NonZeroAgentExitCodeError: Stella exited with code 137\n",
+    )
+    .expect("write");
+    std::fs::write(
+        trial.join("agent").join("stella-exit-cause.json"),
+        serde_json::json!({
+            "return_code": 137,
+            "verdict": "oom-kill",
+            "detail": "the container cgroup recorded oom_kill 1",
+        })
+        .to_string(),
+    )
+    .expect("write");
+
+    let requested = vec!["oom".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert_eq!(report.loop_verdict(), "CRASHED");
+    assert!(
+        report.crash.as_deref().is_some_and(|c| c.contains("137")),
+        "{:?}",
+        report.crash
+    );
+    assert!(
+        report
+            .exit_cause
+            .as_deref()
+            .is_some_and(|cause| cause.starts_with("oom-kill")),
+        "an OOM and a teardown both exit 137, and they have different fixes: {:?}",
+        report.exit_cause
+    );
+}
+
+/// #1299, hole 2: the denominator is the *trials* asked for, not the tasks. A
+/// task that produced two of three trial dirs is two-thirds measured, and the
+/// missing third is a row rather than a smaller divisor.
+#[test]
+fn a_partially_launched_task_is_still_measured_over_what_was_requested() {
+    let job = tempfile::tempdir().expect("job dir");
+    for name in ["half__t1", "half__t2"] {
+        let trial = trial_dir(
+            job.path(),
+            name,
+            &[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#],
+        );
+        write_reward(&trial, "1.0");
+    }
+
+    let requested = vec!["half".to_string()];
+    let analysis = analyze(
+        job.path(),
+        Some(Requested {
+            tasks: &requested,
+            trials_per_task: 3,
+        }),
+    );
+    let counts = analysis.tally();
+    assert_eq!(counts.total, 3, "the denominator is what was asked for");
+    assert_eq!(counts.solved, 2);
+    assert_eq!(
+        counts.loop_broken, 1,
+        "the trial that never launched gates red"
+    );
+    assert!(
+        below_pass_floor(&analysis.trials, 3),
+        "2 of 3 requested trials passed; over the 2 that ran it would read as all of them"
+    );
+
+    let record = analysis.reconciliation.expect("a requested run reconciles");
+    assert_eq!(record.missing(), vec![("half", 1)]);
+    assert!(!record.is_clean());
+    assert!(
+        !record.contaminated(),
+        "a missing trial already has a row and a red gate; it is not a bad denominator"
+    );
+}
+
+/// #1299, hole 2: a second run into the same job directory is reported, not
+/// folded in. The extra trials render as ordinary healthy rows, so this is the
+/// only place a reader would ever learn the figures cover two runs.
+#[test]
+fn a_second_run_in_one_job_dir_is_reported_rather_than_absorbed() {
+    let job = tempfile::tempdir().expect("job dir");
+    for name in ["twice__old", "twice__new"] {
+        trial_dir(
+            job.path(),
+            name,
+            &[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#],
+        );
+    }
+
+    let requested = vec!["twice".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let record = analysis
+        .reconciliation
+        .as_ref()
+        .expect("a requested run reconciles");
+    assert_eq!(record.surplus(), vec![("twice", 1)]);
+    assert!(
+        record.contaminated(),
+        "the run is scored over trials it did not ask for"
+    );
+    assert!(
+        record
+            .findings()
+            .iter()
+            .any(|finding| finding.contains("--job-name")),
+        "the finding says how to fix it: {:?}",
+        record.findings()
+    );
+}
+
+/// #1299, hole 2: harbor truncates a task name to 32 characters when it names
+/// the trial directory. Matching on the untruncated name produced *two* wrong
+/// answers at once — every trial skipped as another run's, and the task that
+/// really ran reported `NOT-RUN`.
+#[test]
+fn a_task_name_too_long_for_its_directory_still_reconciles() {
+    let task = "a-terminal-bench-task-with-a-really-quite-long-name";
+    let prefix = trial_dir_prefix(task);
+    assert_eq!(prefix.chars().count(), 32, "harbor's own truncation width");
+    assert_ne!(prefix, task);
+
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = trial_dir(
+        job.path(),
+        &format!("{prefix}__t1"),
+        &[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#],
+    );
+    write_reward(&trial, "1.0");
+
+    let requested = vec![task.to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert!(!report.not_run, "the task ran; only its name did not fit");
+    assert_eq!(
+        report.task, task,
+        "the row carries the name that was asked for"
+    );
+    assert_eq!(report.loop_verdict(), "solved");
+    let record = analysis.reconciliation.expect("a requested run reconciles");
+    assert!(record.is_clean(), "{:?}", record.findings());
+}
+
+/// #1299, hole 3: a multi-step trial is read. Harbor relocates each step's
+/// logs into `steps/<name>/agent/` and removes the trial-root `agent/`, which
+/// used to make every such trial report "no event stream".
+#[test]
+fn a_multi_step_trial_is_folded_from_its_step_logs() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = job.path().join("staged__t1");
+    for (step, events) in [
+        (
+            "01-setup",
+            ev(&[
+                r#"{"type":"stage","name":"triage"}"#,
+                r#"{"type":"tool_start","call":{"name":"read_file"}}"#,
+                r#"{"type":"step_usage","cost_usd":0.01}"#,
+                r#"{"type":"complete"}"#,
+            ]),
+        ),
+        (
+            "02-solve",
+            ev(&[
+                r#"{"type":"stage","name":"execute"}"#,
+                r#"{"type":"tool_start","call":{"name":"edit_file"}}"#,
+                r#"{"type":"step_usage","cost_usd":0.03}"#,
+                r#"{"type":"complete"}"#,
+            ]),
+        ),
+    ] {
+        let agent = trial.join("steps").join(step).join("agent");
+        std::fs::create_dir_all(&agent).expect("mkdir");
+        std::fs::write(agent.join("stella-events.jsonl"), events).expect("write");
+    }
+    // No trial-root `verifier/` either: harbor folds the per-step rewards by
+    // the task's strategy and records the result here. Taking its aggregate is
+    // what keeps the harness and the dataset agreeing on the score.
+    write_result(
+        &trial,
+        serde_json::json!({
+            "task_name": "staged",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "step_results": [{"step_name": "01-setup"}, {"step_name": "02-solve"}],
+        }),
+    );
+
+    let requested = vec!["staged".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert_eq!(report.step_names, vec!["01-setup", "02-solve"]);
+    assert_eq!(report.tool_calls, 2, "counters sum across steps");
+    assert_eq!(report.file_writes, 1);
+    assert_eq!(report.model_calls, 2);
+    assert!((report.spend_usd - 0.04).abs() < 1e-9);
+    assert_eq!(report.stages, vec!["triage", "execute"]);
+    assert!(
+        report.passed(),
+        "the reward came off harbor's own aggregate"
+    );
+    assert_eq!(report.loop_verdict(), "solved");
+    assert!(!report.zero_work);
+}
+
+/// #1299: the fold takes the **last** step's ending, not any step's. A trial
+/// that completed step one and vanished in step two ended by vanishing, and an
+/// `any` fold would report it as having said goodbye.
+#[test]
+fn a_multi_step_fold_ends_where_the_last_step_ended() {
+    let finished = distill_events(
+        "staged",
+        &ev(&[
+            r#"{"type":"tool_start","call":{"name":"edit_file"}}"#,
+            r#"{"type":"complete"}"#,
+        ]),
+    );
+    let vanished = distill_events("staged", &ev(&[r#"{"type":"stage","name":"plan"}"#]));
+
+    let folded = fold_steps(&[finished.clone(), vanished.clone()]);
+    assert!(
+        !folded.terminal_event,
+        "the trial ended in the step that vanished"
+    );
+    assert!(
+        !folded.zero_work,
+        "one step doing no work is normal in a multi-step task; the trial did work"
+    );
+    assert_eq!(folded.loop_verdict(), "ran (unsolved)");
+
+    // …and the other order is a trial that finished, however quiet its start.
+    let folded = fold_steps(&[vanished, finished]);
+    assert!(folded.terminal_event);
+}
+
+/// #1299: step order comes from harbor's `step_results`, not from sorting the
+/// directory names — the fold reads the last step's ending, so the wrong order
+/// judges the wrong step.
+#[test]
+fn step_order_follows_harbors_record_not_the_alphabet() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = job.path().join("ordered__t1");
+    for (step, events) in [
+        (
+            "zulu",
+            ev(&[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#]),
+        ),
+        ("alpha", ev(&[r#"{"type":"complete"}"#])),
+    ] {
+        let agent = trial.join("steps").join(step).join("agent");
+        std::fs::create_dir_all(&agent).expect("mkdir");
+        std::fs::write(agent.join("stella-events.jsonl"), events).expect("write");
+    }
+    write_result(
+        &trial,
+        serde_json::json!({
+            "task_name": "ordered",
+            "step_results": [{"step_name": "zulu"}, {"step_name": "alpha"}],
+        }),
+    );
+
+    let requested = vec!["ordered".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let report = only(&analysis);
+    assert_eq!(
+        report.step_names,
+        vec!["zulu", "alpha"],
+        "execution order, which a name sort would have reversed"
+    );
+    assert!(report.terminal_event, "`alpha` ran last and completed");
+}
+
+/// #1299: the JSON a CI job trends carries the reconciliation. An artifact
+/// with the rows but not the check is the artifact that publishes the
+/// flattering percentage.
+#[test]
+fn the_json_report_carries_the_denominator_check() {
+    let job = tempfile::tempdir().expect("job dir");
+    trial_dir(
+        job.path(),
+        "ran__t1",
+        &[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#],
+    );
+    let requested = vec!["ran".to_string(), "never".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+
+    let json = serde_json::to_value(json_report(&analysis)).expect("serialize");
+    assert_eq!(json["tally"]["total"], 2);
+    assert_eq!(json["tally"]["loop_broken"], 1);
+    assert_eq!(json["tally"]["crashed"], 0);
+    assert_eq!(json["reconciliation"]["observed"]["never"], 0);
+    assert_eq!(json["trials"].as_array().expect("rows").len(), 2);
 }
 
 /// `passed()` is exactly the reward test the verdict already made — a partial

--- a/stella-cli/src/memory/self_tuning.rs
+++ b/stella-cli/src/memory/self_tuning.rs
@@ -77,6 +77,66 @@ pub(crate) struct BenchTrial {
     pub loop_detected: u32,
 }
 
+/// The object form of a loop-bench `--json` report (#1299), where a single run
+/// used to emit the bare `trials` array. Both shapes are accepted: tuning
+/// against an artifact from an older run is an ordinary thing to do, and the
+/// trials inside are the same objects either way.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct BenchReport {
+    /// Deliberately **not** `#[serde(default)]`, unlike every other field
+    /// here: it is what makes this shape identifiable. Defaulted, any JSON
+    /// object at all would parse as a report of zero trials, and a wrong file
+    /// would reach the A/B as "insufficient samples" instead of "this is not a
+    /// loop-bench report".
+    pub trials: Vec<BenchTrial>,
+    #[serde(default)]
+    pub tally: BenchTally,
+}
+
+/// The run-level counts loop-bench folds its trials into. Only the ones this
+/// module has something to say about are read.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub(crate) struct BenchTally {
+    #[serde(default)]
+    pub total: usize,
+    /// Trials harbor recorded as having raised. They count as failures in the
+    /// A/B below — dropping them would let an arm improve by crashing — but a
+    /// tuning decision made largely out of crashed trials is a decision about
+    /// the machine, so it is worth saying out loud.
+    #[serde(default)]
+    pub crashed: usize,
+}
+
+/// Parse a loop-bench `--json` result file's contents.
+///
+/// Two shapes are accepted. Since #1299 a single run emits
+/// `{"trials": [...], "tally": {...}, "reconciliation": {...}}`; before that it
+/// was the bare `trials` array. Tuning against an artifact from an older run is
+/// an ordinary thing to do — the file exists to be trended — so the older shape
+/// stays readable rather than failing with a parse error that sounds like the
+/// file is corrupt.
+///
+/// The object is tried first. An array cannot deserialize into it, so the
+/// fallback is a genuine "not that shape" rather than a sniffing guess. An old
+/// file simply reports a zero tally: it carries no crash count, and no count is
+/// reported as no count rather than as an affirmative "nothing crashed".
+pub(crate) fn parse_bench_report(contents: &str) -> Result<BenchReport, String> {
+    if let Ok(report) = serde_json::from_str::<BenchReport>(contents) {
+        return Ok(report);
+    }
+    serde_json::from_str::<Vec<BenchTrial>>(contents)
+        .map(|trials| BenchReport {
+            trials,
+            tally: BenchTally::default(),
+        })
+        .map_err(|e| {
+            format!(
+                "expected a loop-bench --json report — an object with a `trials` array, \
+                 or the bare array older runs emitted: {e}"
+            )
+        })
+}
+
 /// The result of one A/B experiment: the decision plus each arm's stats, ready
 /// to print and to append to the ledger as a receipt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -415,6 +475,57 @@ mod tests {
         cfg.agent(EngineAgentKind::Worker)
             .and_then(|a| a.effort)
             .map(|e| effort_label(e).to_string())
+    }
+
+    /// #1299: loop-bench's single-run `--json` became an object where it was a
+    /// bare array. Both shapes must read, and to the same trials — an operator
+    /// A/Bing this month's arm against last month's artifact is the ordinary
+    /// use of this command, not an edge case.
+    #[test]
+    fn a_bench_report_reads_in_either_shape() {
+        let array = r#"[
+            {"task":"a","reward":1.0,"spend_usd":0.50,"loop_detected":0},
+            {"task":"b","reward":null,"spend_usd":0.10,"loop_detected":2}
+        ]"#;
+        let object = format!(
+            r#"{{"trials":{array},
+                 "tally":{{"total":2,"solved":1,"loop_broken":1,"crashed":1}},
+                 "reconciliation":null}}"#
+        );
+
+        let old = parse_bench_report(array).expect("the pre-#1299 array still reads");
+        let new = parse_bench_report(&object).expect("the object reads");
+        assert_eq!(old.trials.len(), 2);
+        assert_eq!(new.trials.len(), 2);
+        assert_eq!(new.trials[0].reward, Some(1.0));
+        assert_eq!(new.trials[1].reward, None, "never verified is not a zero");
+        assert_eq!(new.trials[1].loop_detected, 2);
+        assert_eq!(new.tally.crashed, 1);
+        assert_eq!(
+            old.tally.crashed, 0,
+            "an older file carries no crash count; that is silence, and the note \
+             it drives simply does not fire"
+        );
+
+        // The arithmetic must not depend on which shape the file was in.
+        let weights = RewardWeights::default();
+        let from_array = arm_from_trials("a", "high", &old.trials, &weights);
+        let from_object = arm_from_trials("a", "high", &new.trials, &weights);
+        assert_eq!(from_array.rewards, from_object.rewards);
+    }
+
+    /// A file that is neither shape stays an error. In particular a JSON object
+    /// that is not a report must not read as a report of zero trials, which
+    /// would reach the A/B as "insufficient samples" — a statement about the
+    /// experiment, when the truth is a statement about the file.
+    #[test]
+    fn a_file_that_is_not_a_bench_report_is_an_error() {
+        for contents in ["not json at all", r#"{"schema_version":3,"rows":[]}"#, "{}"] {
+            let err = parse_bench_report(contents)
+                .err()
+                .unwrap_or_else(|| panic!("{contents} must not parse as a report"));
+            assert!(err.contains("`trials`"), "{err}");
+        }
     }
 
     #[test]

--- a/stella-cli/src/tune_cmd.rs
+++ b/stella-cli/src/tune_cmd.rs
@@ -248,15 +248,29 @@ fn run_status(workspace_root: &Path) -> Result<(), String> {
 }
 
 /// Read a loop-bench `--json` result file into trials.
+///
+/// Two shapes are accepted. Since #1299 a single run emits
+/// `{"trials": [...], "tally": {...}, "reconciliation": {...}}`; before that it
+/// was the bare array. Reading an artifact from an older run is an ordinary
+/// thing to do here — the whole point of the file is to be trended — so the
+/// older shape stays readable rather than failing with a parse error that
+/// sounds like the file is corrupt.
 fn read_trials(path: &Path) -> Result<Vec<BenchTrial>, String> {
     let contents = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
-    serde_json::from_str::<Vec<BenchTrial>>(&contents).map_err(|e| {
-        format!(
-            "cannot parse {} as a loop-bench --json array of trial reports: {e}",
+    let report = engine::parse_bench_report(&contents)
+        .map_err(|problem| format!("cannot parse {}: {problem}", path.display()))?;
+    if report.tally.crashed > 0 {
+        eprintln!(
+            "note: {} of {} trials in {} did not finish — harbor recorded a crash. \
+             They count as failures below, which reads an infrastructure outcome as \
+             this knob's fault; re-run those trials before promoting on them.",
+            report.tally.crashed,
+            report.tally.total,
             path.display()
-        )
-    })
+        );
+    }
+    Ok(report.trials)
 }
 
 fn print_report(report: &ExperimentReport) {


### PR DESCRIPTION
## What & why

`loop-bench` read **two** files per trial — the event stream and the reward — and harbor writes five. All three holes in its own README came from that one omission.

Closes #1299

### 1. A crash was reported as an ordinary failure

Harbor records `exception_info` on each trial's `result.json` when the agent raises. So a trial that died partway through already carried an explicit "did not finish" marker that nothing read, and reported `ran (unsolved)` — the same words as a turn that tried the task and got it wrong. An infrastructure failure wearing a capability failure's label sends you hunting a reasoning bug that does not exist.

It now reports `CRASHED`, with harbor's exception and — for a SIGKILL — the adapter's own OOM-vs-teardown post-mortem (#1178) on the row.

**`CRASHED` is the lowest-precedence verdict above `ran (unsolved)`, and that is the whole design.** It never displaces a red verdict: a trial that did nothing and *then* died is still `SILENT-DEATH` and still gates red, with the crash added as the explanation it previously lacked. It only ever replaces `ran (unsolved)`, which did not gate either — so the verdict costs the gate nothing and buys the table a true statement. Naming a failure better must not make the gate weaker.

The signal is harbor's record, never an inference from the stream's shape: a turn that did its work and exited on a step cap is not a death, and treating it as one would invent crashes.

### 2. Requested tasks were never checked against reported ones

#611 closed the task-level half. Three ways past it remained:

- **Missing *trials*, not tasks** — a `--trials 5` task that produced two dirs was two-fifths measured, silently. Now `NOT-RUN` rows at trial granularity, so the denominator is the sample that was asked for.
- **Surplus trials** — harbor writes to `<jobs-dir>/<job-name>/` verbatim, so a second run scored itself over both runs' dirs and looked entirely clean doing it. Now exit `7`, since extra trials render as ordinary healthy rows and the reconciliation block is the only place a reader would ever learn.
- **A task name over 32 characters** — harbor truncates it when naming the trial dir, so comparing the untruncated name gave two wrong answers at once: every trial skipped as another run's, *and* the task that really ran reported `NOT-RUN`.

Nothing here adjusts a count to make it consistent. It says what was asked for, what came back, and where the two disagree.

Also: a run where harbor launched nothing now exits `3` (infrastructure) instead of `1` (loop). Once a requested set exists every row is a synthesized `NOT-RUN`, which is the same fact exit `3` already names.

### 3. Multi-step — built, not dropped

Harbor relocates each step's logs to `steps/<name>/agent/` and removes the trial-root `agent/`, so every such trial read as "no event stream". Their streams are now folded in harbor's own `step_results` order, with `terminal_event` taken from the **last** step (a trial that completed step one and vanished in step two ended by vanishing) and the reward taken from harbor's aggregate, so the harness and the dataset agree on what the task scored.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

13 new tests in `bench/loop-bench/src/tests.rs` build real trial directories under a `tempfile::tempdir` and run `analyze` over them — the defects are about *files harbor wrote that nothing read*, so a fixture handing `distill_events` a string could not have caught any of them. Plus 2 in `stella-cli` for the JSON shape contract.

Same two trial directories, `main` vs this branch:

```
=== BEFORE (main @ 252cb7eb) ===
kv-store-grpc            ran (unsolved)      1      1     1    0    0    0.11  0.0
polyglot-c-py              SILENT-DEATH      0      0     0    0    0    0.00  -
                          └ no event stream (…/polyglot-c-py__t1/agent/stella-events.jsonl)
LOOP: 1/2 broken   REWARD: 0/2 solved

=== AFTER ===
kv-store-grpc                   CRASHED      1      1     1    0    0    0.11  0.0
                          └ crashed: NonZeroAgentExitCodeError: Stella exited with code 137
polyglot-c-py                    solved      0      1     1    0    0    0.00  1.0
                          └ folded from 1 harbor step(s): 01-port
LOOP: 0/2 broken   REWARD: 1/2 solved
  ⚠ 1/2 trial(s) did not finish — harbor recorded an exception. Those are
    infrastructure outcomes, NOT the model getting the task wrong.
```

Note the multi-step row: `main` scored a **passing** task as a broken loop and lost the pass.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p loop-bench -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p loop-bench -p stella-cli` (34 + 1226 pass)
- [x] `make guards` (file-size, shellcheck, invariants, wire-schema, action-pins…)
- [x] `make doc-warnings` scoped to both crates
- [x] Docs updated — `bench/loop-bench/README.md` rewritten where it documented these as known holes
- [x] `Closes #1299` in the description **and** as a commit trailer
- [x] Rebased onto `252cb7eb` and re-tested green (kept unrebased on the branch, since updating it would need a force-push)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New cross-boundary type round-trips through serde (test included)

## Anything reviewers should know?

**A single run's `--json` is now an object**, `{"trials": [...], "tally": {...}, "reconciliation": {...}}`, where it was the bare `trials` array. The rows alone are not interpretable — `6 solved` means one thing over eight requested trials and another over six — and an artifact carrying the rows without the check is exactly the artifact that publishes the flattering number. `--compare` still emits `ComparisonReport` verbatim.

`stella tune effort` parses these files and **would have broken**. It now reads both shapes (A/Bing this month's arm against last month's artifact is the ordinary use of that command) and prints a note when its input's tally reports crashes, since those count as failures in the A/B and a promotion decided by them is a decision about the machine. Verified end-to-end: both shapes produce identical arithmetic, and a genuinely corrupt file still errors.

**A crash deliberately does not gate.** The gate here is loop health, and a trial the machine killed is not evidence about the loop — the same reason `UNREADABLE` and `BUDGET-CAP` do not gate. Given how often timeouts and OOMs show up on these runs, gating on them would make the nightly job red for a reason no loop fix can address, which is the failure mode the README already argues against for `--min-pass`. What a crash must never again be is silent, or dressed as `ran (unsolved)`.

The harbor layout facts here (32-char truncation, `steps/<name>/agent/`, the reward aggregation strategy, `exception_info`) were read out of the installed `harbor` package rather than inferred.

## Summary by Sourcery

Report harbor-recorded crashes explicitly in loop-bench, reconcile requested vs observed trials at trial granularity, and support multi-step trials and richer artifacts in analysis and JSON output.

New Features:
- Introduce explicit CRASHED verdicts and crash metadata on trial rows without changing loop gate behavior.
- Add trial-level requested-vs-reported reconciliation, including detection of missing and surplus trials and ambiguous task-directory mappings.
- Support multi-step harbor trials by reading per-step event logs and aggregated rewards, folding them into single trial reports.
- Change loop-bench single-run JSON output to an object including trials, tallies, and reconciliation metadata, and update stella-cli to consume both old and new shapes.

Bug Fixes:
- Ensure crashed trials are no longer reported as ordinary unsolved runs and that zero-work deaths remain gating.
- Treat runs where harbor launched nothing or only produced NOT-RUN trials as infrastructure failures instead of loop failures.
- Fix handling of long task names by matching trials using harbor’s recorded task_name and truncated directory prefixes.
- Preserve unique trial identification in CI when exporting multi-step event streams to artifacts.

Enhancements:
- Refactor artifact reading into a dedicated module that understands harbor’s result, exception, exit-cause, and multi-step layouts.
- Introduce an Analysis abstraction with tallies and reconciliation, plus helpers for printing and JSON emission.
- Extend loop-bench tallies and summaries to track crashed trials and print reconciliation and crash notes alongside the table.
- Improve documentation around verdict semantics, crash handling, reconciliation rules, and multi-step trial support, and expand tests to cover these behaviors.

CI:
- Enhance nightly bench workflow messaging for new exit code 7 and adjust event export to handle multi-step trials correctly.