### PR TITLE
Stop the diagnostic stderr sink writing into a frame the deck owns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ changing code inside a crate you don't already know.
 | Change REPL rendering / panels / keybindings | [`stella-tui`](stella-tui/README.md) | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
 | Touch shared types crossing a crate boundary | [`stella-protocol`](stella-protocol/README.md) | **Zero logic, zero I/O — types only.** |
 | Resolve where `~/.stella` is — home dir, stella home, the user-tier data dir | [`stella-home`](stella-home/README.md) | **A leaf with NO dependencies at all**, which is what lets `stella-store` and `stella-observatory` share it (the observatory must not link the store). Every resolver has a pure `resolve_*` half that reads no environment. |
-| Emit a diagnostic — a record explaining *why* the program did something | [`stella-diag`](stella-diag/README.md) | **A leaf: `serde` only, so anything may depend on it.** Field values cannot hold a `String`, a `Path`, or model output — that is a compile error, not a review question. Design: [`docs/design/diagnostics.md`](docs/design/diagnostics.md). |
+| Emit a diagnostic — a record explaining *why* the program did something | [`stella-diag`](stella-diag/README.md) | **A leaf: `serde` only, so anything may depend on it.** Field values cannot hold a `String`, a `Path`, or model output — that is a compile error, not a review question. Design: `doc:diagnostics`. |
 | Persistence: executions, events, telemetry (SQLite) | [`stella-store`](stella-store/README.md) | |
 | Retrieval: graph, embeddings, episodic memory | [`stella-context`](stella-context/README.md) | |
 | Tree-sitter code indexing | [`stella-graph`](stella-graph/README.md) | |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,7 @@ dependencies = [
  "proptest",
  "ratatui",
  "serde_json",
+ "stella-diag",
  "stella-protocol",
  "stella-tools",
  "sysinfo",

--- a/docs/design/diagnostics/diagnostics.md
+++ b/docs/design/diagnostics/diagnostics.md
@@ -301,6 +301,26 @@ JSONL when it is not. Everything at every level, always, goes to the ring (§7.4
 regardless of filter — the filter governs *sinks*, never *emission*, which is
 what keeps counters correct at any verbosity.
 
+**The TTY sink yields to the presentation plane.** §2.1 routes each plane to its
+own destination, and the one collision that rule does not describe is that
+"stderr" and "the deck" are the same terminal. `ratatui` paints stdout through a
+diff-based buffer it assumes owns the screen, so a record written straight to
+stderr does not scroll past — it lands at the hardware cursor and wedges itself
+into the frame, which is how a routine `agent.tool.result ok=false` (a `warn` by
+design; §8 wants the failure signal) ended up printed through the middle of the
+composer. So the TTY sink is wrapped in `TerminalGated` and a renderer takes a
+`TerminalHold` for exactly as long as it owns the screen — `TerminalGuard` in
+`stella-tui`, which is the workspace's only caller of `enable_raw_mode`.
+
+This is a routing decision, not a discard, and it costs an operator nothing: the
+ring still takes every record at every level, and `--log-file` is not a terminal
+and is not gated, so *attach the log* keeps working through a deck session. Only
+the copy that would have corrupted the frame is dropped. The redirected branch is
+never gated — a pipe is not a frame, and whoever is reading it wants everything.
+Human-facing messages are unaffected either way: those are the presentation
+plane's `eprintln!`s, including the one naming a crash dump, and they never went
+through a sink.
+
 ---
 
 ## 7. Correlation without spans

--- a/stella-cli/src/diag_boot.rs
+++ b/stella-cli/src/diag_boot.rs
@@ -48,7 +48,8 @@ use std::sync::{Arc, OnceLock};
 
 use colored::Colorize;
 use stella_diag::{
-    Bound, Cx, Dx, Filter, JsonlSink, Level, LevelFilter, Parsed, Record, Sink, TextSink, diag,
+    Bound, Cx, Dx, Filter, JsonlSink, Level, LevelFilter, Parsed, Record, Sink, TerminalGated,
+    TextSink, diag,
 };
 
 use crate::cli::GlobalArgs;
@@ -122,16 +123,9 @@ pub(crate) fn install(globals: &GlobalArgs, workspace_root: &Path) -> Arc<Dx> {
     let Parsed { filter, bad } = resolve_filter(globals);
     let mut sinks = Vec::new();
 
-    // Human-readable on a TTY, JSONL when redirected — §6. A person watching a
-    // terminal and a program parsing a pipe want different things, and which
-    // one is present is knowable without asking.
     if !filter.is_off() {
-        let stderr_sink: Arc<dyn Sink> = if std::io::stderr().is_terminal() {
-            Arc::new(TextSink::stderr())
-        } else {
-            Arc::new(JsonlSink::stderr())
-        };
-        sinks.push(Bound::new(filter.clone(), stderr_sink));
+        let sink = stderr_sink(std::io::stderr().is_terminal(), std::io::stderr());
+        sinks.push(Bound::new(filter.clone(), sink));
     }
 
     // A failed `--log-file` is reported and then dropped, never fatal: the
@@ -203,6 +197,35 @@ pub(crate) fn install(globals: &GlobalArgs, workspace_root: &Path) -> Arc<Dx> {
         verbosity = globals.verbose,
     );
     dx
+}
+
+/// The stderr sink §6 describes, and the one place the TTY question is asked.
+///
+/// Human-readable on a terminal, JSONL when redirected: a person watching a
+/// screen and a program parsing a pipe want different things, and which one is
+/// present is knowable without asking.
+///
+/// The terminal branch is additionally **gated**, and that is the half §6 did
+/// not anticipate. On a TTY this sink and the deck are aimed at the same
+/// screen, and `ratatui` paints through a buffer it assumes owns it — so a
+/// `warn` written straight to stderr does not scroll past, it lands at the
+/// hardware cursor and wedges itself into the frame. `TerminalGated` declines
+/// to write while a renderer holds the screen; the crash ring and any
+/// `--log-file` still take those records, so nothing an operator would attach
+/// is lost (see [`stella_diag::TerminalHold`]).
+///
+/// The redirected branch is deliberately **not** gated. A pipe is not the
+/// terminal, no frame can be corrupted through it, and whatever is reading the
+/// other end is entitled to every record even mid-deck.
+///
+/// `writer` is a parameter rather than `TextSink::stderr()` inline so a test
+/// can ask both branches what they do without owning the process's stderr.
+fn stderr_sink(is_terminal: bool, writer: impl std::io::Write + Send + 'static) -> Arc<dyn Sink> {
+    if is_terminal {
+        Arc::new(TerminalGated::new(TextSink::to_writer(writer)))
+    } else {
+        Arc::new(JsonlSink::to_writer(writer))
+    }
 }
 
 /// A sink error as a closed vocabulary rather than a message.
@@ -351,6 +374,78 @@ mod tests {
             crash_dir(Path::new("/w")),
             Path::new("/w/.stella/private"),
             "a crash dump must land in the 0700 directory trace.rs establishes"
+        );
+    }
+
+    /// A writer that hands its bytes back, so a sink's real output is
+    /// assertable without owning the process's stderr.
+    #[derive(Clone, Default)]
+    struct Shared(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl Shared {
+        fn text(&self) -> String {
+            String::from_utf8(self.0.lock().expect("lock").clone()).expect("utf8")
+        }
+    }
+
+    impl std::io::Write for Shared {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn a_warning() -> Record {
+        Record::new(
+            Level::Warn,
+            "agent.tool.result",
+            "stella::diag_bridge",
+            Cx::EMPTY,
+            stella_diag::Fields::new().with("ok", false),
+        )
+    }
+
+    /// The regression this gate exists for: a `warn` record reaching a live
+    /// terminal while the deck is drawing on it lands at the cursor and wedges
+    /// itself through the frame. `agent.tool.result ok=false` is a `warn` by
+    /// design — a benchmark needs the failure signal — so the fix has to be
+    /// that the terminal sink stays quiet, not that the record stops existing.
+    ///
+    /// Both branches are asserted in one test on purpose: the hold is a
+    /// process-wide static, so a second test function holding it concurrently
+    /// would silence this one's sink at random.
+    #[test]
+    fn only_the_terminal_branch_goes_quiet_while_the_deck_owns_the_screen() {
+        let on_tty = Shared::default();
+        let redirected = Shared::default();
+        let tty_sink = stderr_sink(true, on_tty.clone());
+        let pipe_sink = stderr_sink(false, redirected.clone());
+
+        let hold = stella_diag::TerminalHold::acquire();
+        tty_sink.write(&a_warning()).expect("write");
+        pipe_sink.write(&a_warning()).expect("write");
+
+        assert_eq!(
+            on_tty.text(),
+            "",
+            "this is the byte that painted `WARN agent.tool.result` over the composer"
+        );
+        assert!(
+            redirected.text().contains("agent.tool.result"),
+            "a pipe is not a frame and must still get every record: {:?}",
+            redirected.text()
+        );
+
+        drop(hold);
+        tty_sink.write(&a_warning()).expect("write");
+        assert!(
+            on_tty.text().contains("agent.tool.result"),
+            "a terminal with no renderer on it is an ordinary stderr: {:?}",
+            on_tty.text()
         );
     }
 

--- a/stella-diag/src/lib.rs
+++ b/stella-diag/src/lib.rs
@@ -106,7 +106,10 @@ pub use ring::{
     CRASH_KEEP, CRASH_PREFIX, MAX_BYTES, MAX_RECORDS, Ring, RingStats, latest_crash_file,
     prune_crash_files,
 };
-pub use sink::{Bound, Capture, FailingSink, JsonlSink, NullSink, Sink, SinkError, TextSink};
+pub use sink::{
+    Bound, Capture, FailingSink, JsonlSink, NullSink, Sink, SinkError, TerminalGated, TerminalHold,
+    TextSink,
+};
 
 mod redact;
 pub use redact::{Note, Redacted};

--- a/stella-diag/src/sink.rs
+++ b/stella-diag/src/sink.rs
@@ -20,6 +20,7 @@
 
 use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::filter::Filter;
@@ -220,6 +221,93 @@ impl Sink for TextSink {
     }
 }
 
+/// How many live [`TerminalHold`]s there are.
+///
+/// A count rather than a flag, because the holds genuinely nest: the deck can
+/// hand the terminal to the fleet dashboard and take it back, and a flag would
+/// let whichever one exited first un-silence stderr underneath the other.
+static TERMINAL_HOLDS: AtomicUsize = AtomicUsize::new(0);
+
+/// Claims the terminal for a full-screen renderer until it is dropped.
+///
+/// §2.1 routes each plane to its own destination and §6 sends the diagnostic
+/// plane's default to stderr — but "stderr" and "the deck" are the same
+/// terminal, which is the one collision the routing rule does not describe.
+/// `ratatui` paints stdout through a diff-based buffer it believes it owns
+/// exclusively; a record written straight to stderr lands at the hardware
+/// cursor instead, so the frame acquires bytes the buffer has no cell for and
+/// will not repaint until something else dirties that row. The user sees a
+/// `WARN …` line wedged through the middle of the composer.
+///
+/// So a renderer takes a hold for exactly as long as it owns the screen, and
+/// [`TerminalGated`] declines to write while one is live.
+///
+/// This is a routing decision, not a discard: the filter already declines
+/// records per-sink without that counting as a loss, and the same records still
+/// reach the crash ring — which takes everything at every level regardless of
+/// filter (§7.4) — and any `--log-file`, which is not a terminal and is not
+/// gated. "Attach the log" keeps working through a deck session; it is only
+/// the copy that would have corrupted the frame that is dropped.
+#[derive(Debug)]
+#[must_use = "the terminal is released the instant this is dropped"]
+pub struct TerminalHold(());
+
+impl TerminalHold {
+    /// Take a hold. Release is [`Drop`], so a renderer that panics or bails
+    /// part-way through setup un-silences stderr on the way out.
+    pub fn acquire() -> Self {
+        TERMINAL_HOLDS.fetch_add(1, Ordering::AcqRel);
+        Self(())
+    }
+
+    /// Whether any renderer currently owns the terminal.
+    #[must_use]
+    pub fn is_active() -> bool {
+        TERMINAL_HOLDS.load(Ordering::Acquire) > 0
+    }
+}
+
+impl Drop for TerminalHold {
+    fn drop(&mut self) {
+        TERMINAL_HOLDS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// A sink whose bytes land on the terminal, silenced while a [`TerminalHold`]
+/// is live.
+///
+/// Wrap the stderr sink in this **only when stderr is a TTY**. When it has been
+/// redirected to a file or a pipe it is not the terminal any renderer is
+/// drawing on, nothing can be corrupted, and a consumer on the other end of
+/// that pipe is entitled to every record.
+pub struct TerminalGated {
+    inner: Arc<dyn Sink>,
+}
+
+impl TerminalGated {
+    pub fn new(inner: impl Sink + 'static) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl Sink for TerminalGated {
+    fn write(&self, record: &Record) -> Result<(), SinkError> {
+        if TerminalHold::is_active() {
+            return Ok(());
+        }
+        self.inner.write(record)
+    }
+
+    /// Forwarded unconditionally: a flush moves bytes already accepted and
+    /// paints nothing new, and skipping it would strand whatever was written
+    /// before the renderer took the screen.
+    fn flush(&self) -> Result<(), SinkError> {
+        self.inner.flush()
+    }
+}
+
 /// Discards everything.
 ///
 /// The default when a caller does not care, and what keeps every library type
@@ -370,6 +458,53 @@ mod tests {
         assert_eq!(
             shared.text(),
             "WARN  store.migration.retry stella_store::migrate turn=3 attempt=2 reason=locked\n"
+        );
+    }
+
+    /// The whole gate in one test, deliberately: `TERMINAL_HOLDS` is a
+    /// process-wide static and the test binary is threaded, so splitting these
+    /// assertions into separate `#[test]`s would let one function's hold
+    /// silence another function's sink and fail at random.
+    #[test]
+    fn a_gated_sink_goes_quiet_exactly_while_a_renderer_owns_the_terminal() {
+        let shared = Shared::default();
+        let sink = TerminalGated::new(TextSink::to_writer(shared.clone()));
+
+        assert!(!TerminalHold::is_active(), "nothing should hold by default");
+        sink.write(&a_record()).expect("write");
+        assert!(
+            shared.text().contains("store.migration.retry"),
+            "an unheld terminal must still get its records: {:?}",
+            shared.text()
+        );
+
+        let before = shared.text();
+        let outer = TerminalHold::acquire();
+        sink.write(&a_record()).expect("write");
+        assert_eq!(
+            shared.text(),
+            before,
+            "a record written while the deck owns the screen lands mid-frame"
+        );
+
+        // Nested, because the deck can hand the screen to the fleet dashboard
+        // and take it back. The inner release must not un-silence the outer.
+        let inner = TerminalHold::acquire();
+        drop(inner);
+        assert!(TerminalHold::is_active(), "the outer hold is still live");
+        sink.write(&a_record()).expect("write");
+        assert_eq!(shared.text(), before, "the inner drop released too much");
+
+        // A flush is still forwarded — it moves bytes already accepted and
+        // paints nothing new.
+        sink.flush().expect("flush");
+
+        drop(outer);
+        assert!(!TerminalHold::is_active(), "the screen is back");
+        sink.write(&a_record()).expect("write");
+        assert!(
+            shared.text().len() > before.len(),
+            "a restored terminal must get records again"
         );
     }
 

--- a/stella-tui/Cargo.toml
+++ b/stella-tui/Cargo.toml
@@ -11,6 +11,10 @@ publish.workspace = true
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
 stella-tools = { path = "../stella-tools" }
+# Only for `TerminalHold` — while this crate owns the screen, the diagnostic
+# plane's stderr sink must not write to it (see `term::TerminalGuard`).
+# stella-diag is a leaf crate by construction, so this adds no cycle.
+stella-diag = { path = "../stella-diag" }
 arboard.workspace = true
 png.workspace = true
 serde_json.workspace = true

--- a/stella-tui/src/term.rs
+++ b/stella-tui/src/term.rs
@@ -158,12 +158,28 @@ pub(crate) enum Screen {
 /// terminal in raw mode.
 pub(crate) struct TerminalGuard {
     state: Arc<TermState>,
+    /// Silences the diagnostic plane's terminal sink for exactly as long as
+    /// this guard owns the screen.
+    ///
+    /// The lifetimes have to be the same one, which is why the hold lives here
+    /// rather than around each `run_deck`/`fleet_dashboard` call: those are two
+    /// call sites today and every future renderer is a third. `ratatui` paints
+    /// stdout through a buffer it assumes nothing else writes to, so a `warn`
+    /// record going straight to stderr lands at the cursor and wedges itself
+    /// into the frame — which is what put `WARN agent.tool.result …` through
+    /// the middle of the composer. Records still reach the crash ring and any
+    /// `--log-file`; see `stella_diag::TerminalHold`.
+    _diag_hold: stella_diag::TerminalHold,
 }
 
 impl TerminalGuard {
     pub(crate) fn enter(mouse: bool, screen: Screen) -> io::Result<Self> {
         let guard = Self {
             state: Arc::new(TermState::default()),
+            // Taken with the guard, before the first `execute!` below: an
+            // `enter` that fails part-way still drops the guard, and the hold
+            // has to have covered the writes that already happened.
+            _diag_hold: stella_diag::TerminalHold::acquire(),
         };
         let mut out = io::stdout();
         enable_raw_mode()?;


### PR DESCRIPTION
A `WARN agent.tool.result …` line has been printing through the middle of the composer, several times a turn:

```
>>> WARN  agent.tool.result stella::diag_bridge turn=0 step=3 seq=1372 ok=false duration_ms=1 …
```

## What was wrong

Two planes aimed at one terminal. §2.1 routes the diagnostic plane to stderr and the presentation plane to the deck, and never notices those are the same screen. `ratatui` paints stdout through a diff-based buffer it assumes it owns exclusively, so a record written straight to stderr does not scroll past — it lands at the hardware cursor and wedges itself into the frame, which the buffer has no cell for and will not repaint until something else dirties that row.

`agent.tool.result ok=false` is a `warn` **on purpose** — §8 wants the failure signal a benchmark reads, and `diag_bridge.rs` has a test pinning it. A tool erroring is routine (a symbol not found, a glob that matched nothing, a non-zero exit), so this fired constantly. **The level is not the bug and is left alone:** any `warn` would have corrupted the frame, so lowering it would only have made a structural defect rarer.

## The fix

`Dx.sinks` is fixed at construction with no mutation API, so this cannot be fixed at the call site. Instead:

- `stella-diag` gains `TerminalHold` (a nesting-safe process-wide claim) and `TerminalGated`, a sink decorator that declines to write while a hold is live.
- `TerminalGuard` in `stella-tui` takes a hold for exactly as long as it owns the screen. The hold lives *in the guard* rather than around each `run_deck` / `fleet_dashboard` call because its lifetime must be precisely terminal ownership — and that guard is the workspace's **only** caller of `enable_raw_mode`, so there is no way to own the screen without holding it.
- `diag_boot` wraps the TTY stderr branch in the gate. The redirected branch is deliberately *not* gated — a pipe is not a frame, and whoever reads it is entitled to every record.

`stella-tui → stella-diag` is a new edge, and the intended direction: stella-diag is a leaf by construction so anything may depend on it.

## This costs an operator nothing

The crash ring still takes every record at every level regardless of filter (§7.4), and `--log-file` is not a terminal and is not gated — so *attach the log* keeps working through a deck session. Only the copy that would have corrupted the frame is dropped. Human-facing `eprintln!`s, including the one naming a crash dump, never went through a sink and are unaffected.

## Verification

- `cargo test -p stella-diag --lib` — 80 pass, incl. a new test covering the unheld / held / nested / released state machine in one function (the hold is a process-wide static, so splitting it across `#[test]`s would let one function silence another's sink at random).
- `cargo test -p stella-cli --bin stella diag_boot` — 9 pass, incl. a new test that the TTY branch goes quiet under a hold while the redirected branch does not. `stderr_sink` was extracted taking its writer so both branches are assertable without owning the process's stderr.
- `cargo test -p stella-tui` — all pass, incl. the pty smoke test.
- `cargo clippy -D warnings` on stella-diag, stella-tui, stella-cli `--all-targets`; `cargo check --workspace --all-targets`; `cargo fmt --check`; file-size and invariants guards.

Also updates `doc:diagnostics` §6 to describe the gate.

## ⚠️ `check-doc-links` is red on this branch, and that is not this branch's break

`AGENTS.md`'s citation of the diagnostics design went stale when the doc was split into a directory. **#1353 owns that fix** as part of restoring main to green, so this branch deliberately does not carry a second copy — an earlier revision of this PR did, and it was reverted rather than leave two branches rewriting the same table row into a guaranteed conflict. This branch goes green on that guard the moment #1353 lands.

(Worth considering on #1353: that row has now rotted twice — at #1344 and again when #1350's merge took the pre-#1344 side of the hunk. `check-doc-links` itself suggests `doc:<id>`, and `doc:diagnostics` would end it permanently. Not blocking, and not this PR's call to make.)
