### PR TITLE
Restore main to green: move _ensure_git to the module that exists for it

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -85,7 +85,7 @@ from .exit_cause import (
     build_exit_cause_report,
     probe_sigkill_cause,
 )
-from .git_baseline import run_git_baseline
+from .git_baseline import ensure_git, run_git_baseline
 from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
@@ -1345,59 +1345,6 @@ class StellaAgent(BaseInstalledAgent):
                 return stripped
         return stdout.strip()
 
-    async def _ensure_git(self, environment: BaseEnvironment) -> None:
-        """Install ``git`` into the task container if it is not already there.
-
-        **Without it Stella runs as a bare worker loop.** The candidate
-        machinery snapshots the working tree with ``git rev-parse`` before it
-        generates anything; when the spawn fails the trial logs "candidate
-        setup failed before any execution; running a bare worker turn on the
-        working tree" and continues — degraded, but not obviously so. The
-        witness and diff probes go blind for the same reason. A measured run
-        recorded exactly that on every trial: the pipeline the contest is
-        supposed to be measuring was never engaged.
-
-        Installing it is no more intrusive than what the comparison already
-        allows the other side. Harbor's own Claude Code agent ``apt-get``s
-        curl and a full Node toolchain into these same images as part of its
-        setup, so a task image is plainly not treated as immutable — and a
-        version-control binary changes what an agent can *observe*, not what
-        the verifier checks.
-
-        Best-effort by construction, for the same reason the git baseline
-        script is: an evidence-channel setup step must never be able to fail a
-        trial. An image whose package manager is absent, offline, or read-only
-        runs exactly as every published number did — diff-blind — and says so
-        in the baseline metadata rather than dying here.
-        """
-        try:
-            await self.exec_as_root(
-                environment,
-                command=(
-                    "if command -v git >/dev/null 2>&1; then exit 0; fi; "
-                    "if command -v apk >/dev/null 2>&1; then apk add --no-cache git; "
-                    "elif command -v apt-get >/dev/null 2>&1; then "
-                    "  apt-get update && apt-get install -y --no-install-recommends git; "
-                    "elif command -v dnf >/dev/null 2>&1; then dnf install -y git; "
-                    "elif command -v yum >/dev/null 2>&1; then yum install -y git; "
-                    "fi; "
-                    # Always succeed: the baseline probe reports the outcome.
-                    "command -v git >/dev/null 2>&1 || true"
-                ),
-                env={"DEBIAN_FRONTEND": "noninteractive"},
-                timeout_sec=240,
-            )
-        except Exception:  # noqa: BLE001 - never fail a trial for this
-            # Deliberately swallowed and deliberately silent. The outcome is
-            # already reported through the git-baseline marker, which is the
-            # one channel a reader checks; raising a second, louder signal here
-            # would let a missing package manager end a trial that would
-            # otherwise have run diff-blind exactly as every published number
-            # did. Nothing on `self` is touched, because this must also hold
-            # for an agent built without `__init__` — which is how the install
-            # tests construct one.
-            pass
-
     async def install(self, environment: BaseEnvironment) -> None:
         """Upload the Stella binary and install it as ``stella`` on PATH."""
         # In claim-eligible benchmark mode the provider key never entered
@@ -1414,7 +1361,7 @@ class StellaAgent(BaseInstalledAgent):
         else:
             self._host_credential_source = ENV_CREDENTIAL_SOURCE
             self._container_credential_absence_verified = False
-        await self._ensure_git(environment)
+        await ensure_git(self, environment)
         binary_path = _locate_binary()
         self._binary_sha256 = _sha256_file(binary_path)
         self._binary_sha256_verified = False

--- a/bench/harbor_adapter/stella_harbor/git_baseline.py
+++ b/bench/harbor_adapter/stella_harbor/git_baseline.py
@@ -70,6 +70,63 @@ def git_baseline_script(workdir: str | None) -> str:
     )
 
 
+async def ensure_git(agent: Any, environment: Any) -> None:
+    """Install ``git`` into the task container if it is not already there.
+
+    **Without it Stella runs as a bare worker loop.** The candidate machinery
+    snapshots the working tree with ``git rev-parse`` before it generates
+    anything; when the spawn fails the trial logs "candidate setup failed
+    before any execution; running a bare worker turn on the working tree" and
+    continues — degraded, but not obviously so. The witness and diff probes go
+    blind for the same reason. A measured run recorded exactly that on every
+    trial: the pipeline the contest is supposed to be measuring was never
+    engaged. It is also the first branch ``git_baseline_script`` gives up on,
+    which is what makes this module the place it belongs.
+
+    Installing it is no more intrusive than what the comparison already allows
+    the other side. Harbor's own Claude Code agent ``apt-get``s curl and a full
+    Node toolchain into these same images as part of its setup, so a task image
+    is plainly not treated as immutable — and a version-control binary changes
+    what an agent can *observe*, not what the verifier checks.
+
+    Best-effort by construction, for the same reason the baseline script is: an
+    evidence-channel setup step must never be able to fail a trial. An image
+    whose package manager is absent, offline, or read-only runs exactly as
+    every published number did — diff-blind — and says so in the baseline
+    metadata rather than dying here.
+
+    A free function taking the agent, matching `run_git_baseline` below: it
+    reads nothing off ``self`` but ``exec_as_root``, so binding it to the class
+    bought nothing and cost the package root fifty lines.
+    """
+    try:
+        await agent.exec_as_root(
+            environment,
+            command=(
+                "if command -v git >/dev/null 2>&1; then exit 0; fi; "
+                "if command -v apk >/dev/null 2>&1; then apk add --no-cache git; "
+                "elif command -v apt-get >/dev/null 2>&1; then "
+                "  apt-get update && apt-get install -y --no-install-recommends git; "
+                "elif command -v dnf >/dev/null 2>&1; then dnf install -y git; "
+                "elif command -v yum >/dev/null 2>&1; then yum install -y git; "
+                "fi; "
+                # Always succeed: the baseline probe reports the outcome.
+                "command -v git >/dev/null 2>&1 || true"
+            ),
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+            timeout_sec=240,
+        )
+    except Exception:  # noqa: BLE001 - never fail a trial for this
+        # Deliberately swallowed and deliberately silent. The outcome is
+        # already reported through the git-baseline marker, which is the one
+        # channel a reader checks; raising a second, louder signal here would
+        # let a missing package manager end a trial that would otherwise have
+        # run diff-blind exactly as every published number did. Nothing on the
+        # agent is touched, because this must also hold for one built without
+        # `__init__` — which is how the install tests construct one.
+        pass
+
+
 async def run_git_baseline(agent: Any, environment: Any) -> None:
     """Give a bare task workspace a git baseline before the agent starts.
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2301 bench/harbor_adapter/stella_harbor/__init__.py
+2302 bench/harbor_adapter/stella_harbor/__init__.py
 4292 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2339 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
@@ -17,7 +17,6 @@
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 1749 stella-cli/src/agent_tests.rs
 2371 stella-cli/src/agent.rs
-1749 stella-cli/src/agent_tests.rs
 1576 stella-cli/src/candidate_ws.rs
 4583 stella-cli/src/command_deck.rs
 1506 stella-cli/src/fleet_cmd.rs


### PR DESCRIPTION
`check-file-size` — a required job in `ci.yml` (line 141) — is **red on `main` right now**.

#1351 added `_ensure_git` (53 lines, mostly docstring) to `stella_harbor/__init__.py`, which was sitting at *exactly* its 2301-line ceiling. The file landed at 2355, 54 over.

## Why a split and not a higher ceiling

The guard's own message draws the line: irreducible growth gets `make file-size-update`, reducible growth gets split. This is the textbook reducible case, and the destination already exists and says so in its own module docstring:

> *"Its own module rather than more length on the adapter package root, per the repository's file-size ratchet rule: separable new code becomes a module."* — `git_baseline.py`

`git_baseline.py` already exports `run_git_baseline(agent, environment)` with exactly this shape, and `__init__.py` already imports from it. `_ensure_git` reads nothing off `self` but `exec_as_root`, so binding it to the class bought nothing. It also removes the *first branch `git_baseline_script` gives up on* — "git is not installed" — which is what makes this module where it belonged to begin with.

## The one line that stays

That returns 53 of the 54 lines. The 54th is the call site, which is irreducible — you cannot call a function without a line — so **the ceiling moves by 1 instead of by 54**. Regenerating the baseline also drops a duplicate `stella-cli/src/agent_tests.rs` entry that was listed twice.

```
-2301 bench/harbor_adapter/stella_harbor/__init__.py
+2302 bench/harbor_adapter/stella_harbor/__init__.py
 ...
-1749 stella-cli/src/agent_tests.rs      # listed twice
```

## The witness

- [x] The guard **is** the witness: `check-file-size.sh` fails on `main` and passes here. Reproduced red before the change and green after.

Behaviour is covered rather than merely compiled: #1351's own `test_install_classification.py` stubs `agent.exec_as_root` — the one call `ensure_git` makes — and passes unchanged. **432 harbor-adapter tests pass, 1 skipped.**

## The gate

- [x] `make gate` — the full pre-push gate passed on push, no `SKIP_GATE`
- [x] Guards: `file-size`, `doc-links`, `wire-schema`, `invariants`, `no-scratch`
- [x] `cargo fmt --check`
- [x] Independently verified on `e35bab70` that the rest of `ci` is already green there — `cargo fmt` ✓, `cargo clippy --workspace --all-targets -D warnings` ✓, `cargo test --workspace` ✓ (111 suites). **`file-size` was the only remaining break.**

## Not bundled, deliberately

`__init__.py` also carries `_git_baseline_script` and `_parse_git_baseline_report` — a *second* git-baseline implementation running parallel to this module's. Moving those would collide with `git_baseline_script`'s name and means rewriting imports in `tests/test_adapter.py`. That is a real refactor and wants its own PR, not an unbreak-main change.

## Ground-rule check

- [x] No new dependencies, no new outbound network calls
- [x] Pure move — the shell command, timeout, env, and swallow-everything semantics are byte-identical

## Summary by Sourcery

Move the git installation helper from the harbor adapter package root into the dedicated git_baseline module to restore compliance with the file-size guard while preserving behavior.

Enhancements:
- Refactor the git ensure helper into a standalone function in git_baseline and adjust the harbor adapter to call it.
- Align git baseline utilities in a single module to match existing abstractions and reduce __init__ size.

Build:
- Update file-size baseline metadata to reflect the reduced __init__ length and remove a duplicate entry.