### PR TITLE
Restore main to green: raise command_deck.rs ceiling — #1356's growth is irreducible

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,7 +18,7 @@
 1749 stella-cli/src/agent_tests.rs
 2371 stella-cli/src/agent.rs
 1584 stella-cli/src/candidate_ws.rs
-4583 stella-cli/src/command_deck.rs
+4627 stella-cli/src/command_deck.rs
 1506 stella-cli/src/fleet_cmd.rs
 2129 stella-core/src/bus.rs
 2764 stella-core/src/driver.rs


### PR DESCRIPTION
`check-file-size` — a required step inside `fmt + clippy + test` — is red on `main` again, one commit after the last one was fixed.

`stella-cli/src/command_deck.rs` is at **4627 against a 4583 ceiling (+44)**, from #1356 (`318061f7`, "Never report a turn complete while it is still holding the user's input").

## Why a ceiling raise here, when the last one was a split

This is the distinction the gate exists to force, and the two breaks land on opposite sides of it:

| | #1351 → fixed by #1359 | #1356 → this PR |
|---|---|---|
| Shape | one self-contained 53-line method | +63/−19 across **5 hunks inside `run_deck_session`** |
| Somewhere to move it? | yes — `git_baseline.py`, purpose-built, same-shape API | no — the reusable half was **already extracted** |
| Remedy | **split** (ceiling +1, not +54) | **raise** |

#1356 did the right thing already: `settle` and `lead_control` are new modules in that same commit. What remains in `command_deck.rs` is call-site logic — a status send, an existing call wrapped in `settle::run_while_listening`, and the comments explaining why the ordering is load-bearing. The only way to "split" that further is to refactor the deck's main loop, which is not something an unbreak-main change should be attempting.

So this takes the gate's own documented path for irreducible growth: raise the ceiling, land it as a visible diff, justify it in review.

## One row, hand-edited

```
-4583 stella-cli/src/command_deck.rs
+4627 stella-cli/src/command_deck.rs
```

Deliberately **not** `make file-size-update`: it regenerates from the working tree and re-sorts the whole file under the invoking shell's locale collation, which reverts ceilings other branches tightened — it lowered three of them as recently as #1353. A one-row bump should be a one-row diff.

## The witness

- [x] The guard **is** the witness: `check-file-size.sh` fails on `main` (`7a6ce3ab`) and passes here.

## The gate

- [x] `make gate` — the full pre-push gate passed on push, no `SKIP_GATE`
- [x] Verified on `7a6ce3ab` that **file-size is the only failing guard**: `doc-links` ✓, `wire-schema` ✓, `invariants` ✓, `no-scratch` ✓, `cargo fmt --check` ✓

This should be the last thing between `main` and a green run.

## Context — third break on this gate in an hour

For whoever picks up the pattern rather than the incident: `main` has gone red on `check-file-size` three times in ~60 minutes (#1347's wire/parity set, then #1351, now #1356). The mechanism is that `--update` tightens a ceiling to a file's *exact* current length, which turns that file into a tripwire where any subsequent addition reds CI. `command_deck.rs` was tightened 4586 → 4583 by #1353; `harbor/__init__.py` was sitting at exactly 2301 when #1351 touched it. `docs/design/file-budget.md` (#1246) already argues this is structural rather than a tuning problem.

## Summary by Sourcery

Build:
- Update file-size-baseline.txt to increase the allowed size for stella-cli/src/command_deck.rs so check-file-size passes on main.