### PR TITLE
Add stagnation detection to loop_detect for non-repeating arguments

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -22,8 +22,8 @@
 4583 stella-cli/src/command_deck.rs
 1506 stella-cli/src/fleet_cmd.rs
 2129 stella-core/src/bus.rs
-2764 stella-core/src/driver.rs
-3661 stella-core/src/driver/tests.rs
+2765 stella-core/src/driver.rs
+3672 stella-core/src/driver/tests.rs
 1677 stella-model/src/anthropic/tests.rs
 2072 stella-model/src/openai.rs
 1572 stella-model/src/zai.rs

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -1673,6 +1673,7 @@ impl<'a> Engine<'a> {
                 pattern.iter().map(|c| c.name.clone()).collect(),
                 *repeats,
             ),
+            LoopVerdict::Stagnant { tool, count } => ("stagnation", vec![tool.clone()], *count),
         };
         let reason = verdict
             .evidence()

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -2002,6 +2002,7 @@ async fn period_three_cycle_with_no_progress_steers_then_aborts() {
         loop_detection: LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 2,
+            stagnation_threshold: 0, // disabled: this test isolates the cycle check
         },
         ..EngineConfig::default()
     };
@@ -2137,8 +2138,8 @@ async fn run_synthetic_survival_turn(dialect: &str, id_style: fn(u32) -> String)
         script: TokioMutex::new(script),
         calls: Arc::new(AtomicU32::new(0)),
     };
-    // A tool executor returning a constant 600-char output — the context
-    // pressure half of the exit criterion.
+    // A tool executor returning a 600-char output — the context pressure
+    // half of the exit criterion.
     struct GrowingTools;
     #[async_trait]
     impl ToolExecutor for GrowingTools {
@@ -2151,9 +2152,18 @@ async fn run_synthetic_survival_turn(dialect: &str, id_style: fn(u32) -> String)
                 speculation_safe: false,
             }]
         }
-        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        async fn execute(&self, _name: &str, input: &Value) -> ToolOutput {
+            // Consistently "large" per compaction's threshold, and DISTINCT
+            // per call. Distinctness is not cosmetic: 200 commands that all
+            // answer with the same bytes is a stagnant turn by
+            // `loop_detect`'s definition and would be aborted on the
+            // evidence — correctly, but this test is about surviving
+            // context pressure across provider dialects, not about loop
+            // detection. Real work answers differently each step; the
+            // fixture has to as well or it tests the wrong thing.
+            let tag = input.get("cmd").and_then(|v| v.as_str()).unwrap_or("?");
             ToolOutput::Ok {
-                content: "x".repeat(600), // consistently "large" per compaction's threshold
+                content: format!("{tag}: {}", "x".repeat(600)),
             }
         }
     }
@@ -3358,6 +3368,7 @@ mod budget_boundaries;
 mod compute_passes;
 mod context_efficiency;
 mod lifecycle_bus;
+mod loop_abort;
 mod steer_midturn;
 mod usage_completeness;
 mod zero_copy_request;

--- a/stella-core/src/driver/tests/compute_passes.rs
+++ b/stella-core/src/driver/tests/compute_passes.rs
@@ -170,9 +170,30 @@ async fn per_step_hashing_grows_with_the_turn_not_with_its_square() {
             script: TokioMutex::new(script),
             calls: Arc::new(AtomicU32::new(0)),
         };
-        let tools = CountingTools {
-            calls: Arc::new(AtomicU32::new(0)),
-        };
+        // Answers each command differently. `CountingTools` replies "ok" to
+        // everything, which — with the distinct inputs above — is the
+        // stagnation signature `loop_detect` aborts on: the arguments moved
+        // and the answer never did. This test is about hashing, so the
+        // fixture has to make progress the way real work does.
+        struct EchoingTools;
+        #[async_trait]
+        impl ToolExecutor for EchoingTools {
+            fn schemas(&self) -> Vec<ToolSchema> {
+                vec![ToolSchema {
+                    name: "bash".into(),
+                    description: "run a command".into(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    read_only: false,
+                    speculation_safe: false,
+                }]
+            }
+            async fn execute(&self, _name: &str, input: &Value) -> ToolOutput {
+                ToolOutput::Ok {
+                    content: format!("ran {input}"),
+                }
+            }
+        }
+        let tools = EchoingTools;
         let sleeper = NoopSleeper;
         let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
         let mut messages = vec![

--- a/stella-core/src/driver/tests/loop_abort.rs
+++ b/stella-core/src/driver/tests/loop_abort.rs
@@ -1,0 +1,243 @@
+//! The steer→abort ladder across a *recovery*: the shape a real stuck turn
+//! actually takes.
+//!
+//! `stuck_loop_steers_once_then_aborts_on_re_detection` pins the ladder when
+//! the model ignores the warning immediately — three identical calls, then a
+//! fourth. That is the easy half. The half seen in the field is the one where
+//! the steer WORKS: the model breaks the streak, does one different thing, and
+//! then falls into a second loop on a different tool. The turn's steer is
+//! already spent at that point, so the very next detection is supposed to be
+//! the kill.
+
+use super::*;
+
+/// A tool executor that answers with a constant per tool name, so two calls
+/// with the same name AND the same input are byte-identical — the condition
+/// `loop_detect` requires before it will call anything a loop. Real `grep` is
+/// deterministic in exactly this way: same pattern, same path, unchanged tree,
+/// same bytes out.
+struct ConstantTools {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl ToolExecutor for ConstantTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![
+            ToolSchema {
+                name: "grep".into(),
+                description: "search".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                speculation_safe: true,
+            },
+            ToolSchema {
+                name: "read_file".into(),
+                description: "read".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                speculation_safe: true,
+            },
+        ]
+    }
+    async fn execute(&self, name: &str, _input: &Value) -> ToolOutput {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ToolOutput::Ok {
+            content: match name {
+                "grep" => "stella-tui/src/deck.rs:118: /// Cumulative prompt-cache".into(),
+                other => format!("contents of {other}"),
+            },
+        }
+    }
+}
+
+fn call_of(call_id: &str, name: &str, input: Value) -> CompletionResultAlias {
+    CompletionResultAlias {
+        text: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.into(),
+            name: name.into(),
+            input,
+        }],
+        usage: CompletionUsage::reported_zero(),
+        model: "scripted".into(),
+        cost_usd: 0.0001,
+        finish_reason: None,
+    }
+}
+
+fn grep_call() -> CompletionResultAlias {
+    call_of(
+        "c_grep",
+        "grep",
+        serde_json::json!({"pattern": "cache_write_tokens", "path": "stella-tui/src/deck.rs"}),
+    )
+}
+
+/// THE field repro. The model loops, gets steered, actually course-corrects
+/// with one different call — and then falls straight into a second loop. The
+/// turn already spent its one warning, so the second loop's first detection
+/// must abort rather than grind to the step cap.
+#[tokio::test]
+async fn a_loop_that_resumes_after_a_successful_course_correction_still_aborts() {
+    // grep ×3 (detect + steer) → read_file (the course correction) → grep
+    // forever (ScriptedProvider repeats its last entry).
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(grep_call()),
+            Ok(grep_call()),
+            Ok(grep_call()),
+            Ok(call_of(
+                "c_read",
+                "read_file",
+                serde_json::json!({"path": "stella-tui/src/deck.rs"}),
+            )),
+            Ok(grep_call()),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tool_calls = Arc::new(AtomicU32::new(0));
+    let tools = ConstantTools {
+        calls: tool_calls.clone(),
+    };
+    let sleeper = NoopSleeper;
+    // A low cap so a broken ladder shows up as "ground to the cap" in a
+    // second rather than 200 steps of grinding.
+    let config = EngineConfig {
+        max_steps: 30,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("why is the cache write count wrong?"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    let events = drain_events(&mut rx);
+    let detections: Vec<bool> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::LoopDetected { aborted, .. } => Some(*aborted),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { ref reason, .. } if reason.contains("stuck-loop")),
+        "the second loop must abort the turn, got {outcome:?} after \
+         {} tool calls and detections {detections:?}",
+        tool_calls.load(Ordering::SeqCst),
+    );
+    assert!(
+        tool_calls.load(Ordering::SeqCst) <= 8,
+        "the second loop must die on its FIRST detection (3 + 1 + 3 calls), \
+         not grind to the cap: {} calls, detections {detections:?}",
+        tool_calls.load(Ordering::SeqCst),
+    );
+    assert_eq!(
+        detections,
+        vec![false, true],
+        "one steer, then the kill — the spent warning is not re-earned"
+    );
+}
+
+/// A provider that never repeats an argument: every call is `grep` with a
+/// freshly mutated pattern, exactly as the field transcript showed (a regex
+/// alternation the model kept reshuffling). The tool answers identically
+/// every time, so not one of these calls learns anything.
+struct MutatingGrepProvider {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl Provider for MutatingGrepProvider {
+    fn id(&self) -> &str {
+        "mutating-grep"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        // A different alternation every call — and, like the real provider
+        // (Moonshot mints `<tool>:<n>`), a different call_id too.
+        let pattern = (0..=n)
+            .map(|i| format!("cache_write_{i}"))
+            .collect::<Vec<_>>()
+            .join("|");
+        Ok(call_of(
+            &format!("grep:{n}"),
+            "grep",
+            serde_json::json!({"pattern": pattern, "path": "stella-tui/src/deck.rs"}),
+        ))
+    }
+}
+
+/// THE bug this change exists for. Before stagnation detection, this turn
+/// ran to the step cap: every `input` differed, so `detect_exact_repeat`
+/// never matched two records, and the arguments never settled into a period
+/// so `detect_short_cycle` never matched either — while every single call
+/// returned the same bytes. On the live turn that produced this shape the
+/// tool ran 38 times before an accidental exact triple finally tripped the
+/// old detector.
+#[tokio::test]
+async fn a_tool_answering_identically_to_every_new_argument_is_steered_then_killed() {
+    let provider = MutatingGrepProvider {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tool_calls = Arc::new(AtomicU32::new(0));
+    let tools = ConstantTools {
+        calls: tool_calls.clone(),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        max_steps: 60,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("where is the cache write count summed?"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    let calls = tool_calls.load(Ordering::SeqCst);
+
+    let events = drain_events(&mut rx);
+    let detections: Vec<(String, usize, bool)> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::LoopDetected {
+                kind,
+                repeats,
+                aborted,
+                ..
+            } => Some((kind.clone(), *repeats, *aborted)),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { ref reason, .. } if reason.contains("stuck-loop")),
+        "a tool that answers every new argument identically must end the turn, \
+         got {outcome:?} after {calls} calls, detections {detections:?}"
+    );
+    assert_eq!(detections.len(), 2, "steer then kill: {detections:?}");
+    assert_eq!(detections[0].0, "stagnation", "classified by the new rung");
+    assert!(!detections[0].2, "first detection steers");
+    assert!(detections[1].2, "second detection aborts");
+    // The default threshold is 6, so the steer lands around the 7th call
+    // (detection runs at the top of a step, on the PREVIOUS step's results)
+    // and the kill one threshold later. The old detector needed 38.
+    assert!(
+        calls <= 16,
+        "must die within a couple of thresholds, not grind to the cap: {calls} calls"
+    );
+}

--- a/stella-core/src/loop_detect.rs
+++ b/stella-core/src/loop_detect.rs
@@ -9,7 +9,7 @@
 //! drives) a real, typed verdict it can act on early: steer or abort with
 //! a clear reason instead of grinding to the cap.
 //!
-//! Two failure modes are detected, matching real agent stuck-loop
+//! Three failure modes are detected, matching real agent stuck-loop
 //! signatures:
 //!
 //! 1. **Exact repeat** — the same tool called with byte-identical input,
@@ -21,6 +21,16 @@
 //!    `read_file` again; or the period-3 read → failing edit → failing
 //!    test grind). Invisible to exact-repeat detection because no single
 //!    call repeats consecutively.
+//! 3. **Stagnation** — the same tool called over and over with arguments
+//!    that keep *changing*, every call still returning byte-identical
+//!    output. Invisible to both checks above: no input repeats, so there is
+//!    no exact repeat, and the arguments never settle into a fixed cycle
+//!    either. This is the shape a model falls into when it is fiddling with
+//!    one call's parameters instead of changing strategy — the observed
+//!    case was `grep` on one file with a regex alternation the model kept
+//!    reshuffling (`a|b|c|a|b` → `a|b|c|a`), 38 consecutive calls returning
+//!    the same 906 bytes. Varying the arguments is not progress; learning
+//!    something is, and byte-identical output proves nothing was learned.
 //!
 //! **Progress is part of the loop definition.** A repeat or cycle only
 //! counts when the *outputs* are byte-identical too: identical input with
@@ -111,6 +121,16 @@ pub struct LoopDetectionConfig {
     /// cycle is only evidence once it has actually recurred, so the lowest
     /// meaningful value is `2`.
     pub short_cycle_repeats: usize,
+    /// Consecutive calls to the SAME tool that all produced byte-identical
+    /// output — whatever their arguments — required to flag stagnation.
+    /// `0` or `1` disable the check.
+    ///
+    /// Deliberately looser than [`Self::exact_repeat_threshold`]: an
+    /// identical input repeated is unambiguous evidence, while a *varying*
+    /// input is weaker on its own, so it takes more of it before the
+    /// detector will speak. Six consecutive searches that each came back
+    /// with the same bytes is a model turning knobs, not one exploring.
+    pub stagnation_threshold: usize,
 }
 
 impl Default for LoopDetectionConfig {
@@ -122,10 +142,17 @@ impl Default for LoopDetectionConfig {
     /// step-driver's belt-and-suspenders backstop
     /// (`EngineConfig::max_steps`, 200 by default), so a stuck turn costs
     /// a handful of wasted calls, never a whole cap's worth.
+    ///
+    /// Stagnation sits at double the exact-repeat threshold. It is the
+    /// backstop for the two above rather than a peer of them: it asks only
+    /// "did this tool tell us anything new", which is true of *every*
+    /// stuck shape, so it must be the slowest to fire or it would preempt
+    /// the tighter, better-described verdicts.
     fn default() -> Self {
         Self {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 3,
+            stagnation_threshold: 6,
         }
     }
 }
@@ -160,6 +187,15 @@ pub enum LoopVerdict {
         pattern: Vec<ToolCall>,
         repeats: usize,
     },
+    /// `count` consecutive calls to `tool` at the end of the inspected
+    /// history all produced byte-identical output, at or above
+    /// `LoopDetectionConfig::stagnation_threshold`, while their inputs did
+    /// NOT all match — the arguments moved and the answer did not.
+    ///
+    /// The weakest of the three verdicts and the last one checked: it makes
+    /// no claim about the *shape* of the repetition, only that the tool
+    /// stopped being informative.
+    Stagnant { tool: String, count: usize },
 }
 
 impl LoopVerdict {
@@ -185,6 +221,11 @@ impl LoopVerdict {
                     names.join(" → ")
                 ))
             }
+            LoopVerdict::Stagnant { tool, count } => Some(format!(
+                "the last {count} `{tool}` calls used DIFFERENT arguments but every one \
+                 returned byte-identical output — varying the arguments is not learning \
+                 anything, so this tool has nothing left to tell you here"
+            )),
         }
     }
 }
@@ -207,15 +248,23 @@ impl LoopVerdict {
 /// unresolved output still matches nothing — an identity is evidence about
 /// an output that was observed, never a substitute for observing one.
 fn same_record(a: &CallRecord<'_>, b: &CallRecord<'_>) -> bool {
-    a.call.name == b.call.name
-        && a.call.input == b.call.input
-        && match (&a.output, &b.output) {
-            (Some(a_out), Some(b_out)) => match (&a.identity, &b.identity) {
-                (Some(a_id), Some(b_id)) => a_id == b_id,
-                _ => a_out == b_out,
-            },
-            _ => false,
-        }
+    a.call.name == b.call.name && a.call.input == b.call.input && same_output(a, b)
+}
+
+/// Whether two records produced the same *information*, ignoring what was
+/// asked. Split out of [`same_record`] because [`detect_stagnation`] needs
+/// exactly this half: it asks "did the tool tell us anything new" without
+/// asking whether the arguments matched. Every rule stated in `same_record`'s
+/// docs about identities and unresolved outputs lives here, so the two checks
+/// can never drift apart on what "the same output" means.
+fn same_output(a: &CallRecord<'_>, b: &CallRecord<'_>) -> bool {
+    match (&a.output, &b.output) {
+        (Some(a_out), Some(b_out)) => match (&a.identity, &b.identity) {
+            (Some(a_id), Some(b_id)) => a_id == b_id,
+            _ => a_out == b_out,
+        },
+        _ => false,
+    }
 }
 
 /// Inspect the tail of recent tool calls for a non-progress loop.
@@ -233,15 +282,22 @@ fn same_record(a: &CallRecord<'_>, b: &CallRecord<'_>) -> bool {
 /// 2. **Short cycle** (see the module docs), shortest period first so the
 ///    tightest description of the evidence wins (a period-2 loop is never
 ///    reported as the period-4 loop it also technically is).
+/// 3. **Stagnation** (see the module docs), checked LAST because it is the
+///    weakest claim: "this tool stopped being informative" is true of every
+///    exact repeat and every same-tool cycle too, so checking it earlier
+///    would swallow both of the better-described verdicts above.
 ///
 /// Never panics on any input — empty history, a single call, history
 /// shorter than every threshold, and a zeroed-out `config` (which disables
-/// both checks) all return `NoLoop` rather than indexing out of bounds.
+/// every check) all return `NoLoop` rather than indexing out of bounds.
 pub fn detect_loop(records: &[CallRecord<'_>], config: LoopDetectionConfig) -> LoopVerdict {
     if let Some(verdict) = detect_exact_repeat(records, config.exact_repeat_threshold) {
         return verdict;
     }
     if let Some(verdict) = detect_short_cycle(records, config.short_cycle_repeats) {
+        return verdict;
+    }
+    if let Some(verdict) = detect_stagnation(records, config.stagnation_threshold) {
         return verdict;
     }
     LoopVerdict::NoLoop
@@ -326,6 +382,51 @@ fn detect_short_cycle(records: &[CallRecord<'_>], repeats_threshold: usize) -> O
         }
     }
     None
+}
+
+/// Count the trailing run of records that call the same tool as the last
+/// record AND produced the same output as it ([`same_output`]); report
+/// `Stagnant` if that run is `>= threshold` and its inputs are not all
+/// identical. `threshold < 2` and empty `records` both return `None`.
+///
+/// The all-same-input guard hands a run of byte-identical calls back to
+/// [`detect_exact_repeat`], which describes it far better — mirroring
+/// [`detect_short_cycle`]'s all-same guard, and for the same reason: with
+/// exact-repeat detection disabled (`threshold < 2`) this check would
+/// otherwise start reporting exact repeats under a vaguer name.
+///
+/// Note what is deliberately NOT required: that the inputs differ from each
+/// other pairwise, or differ in any particular way. A run of `a, a, b, b, c`
+/// stagnates just as a run of `a, b, c, d, e` does — what makes it stagnation
+/// is that none of them moved the answer.
+fn detect_stagnation(records: &[CallRecord<'_>], threshold: usize) -> Option<LoopVerdict> {
+    if threshold < 2 {
+        return None;
+    }
+    let last = records.last()?;
+    // `same_output(last, last)` is false for an unresolved output, so a
+    // trailing call whose result is not in the window yields a count of 0 and
+    // never fires — the same "a loop can only be PROVEN by observed outputs"
+    // rule the other two checks follow.
+    let count = records
+        .iter()
+        .rev()
+        .take_while(|record| record.call.name == last.call.name && same_output(record, last))
+        .count();
+    if count < threshold {
+        return None;
+    }
+    let run = &records[records.len() - count..];
+    if run
+        .iter()
+        .all(|record| record.call.input == last.call.input)
+    {
+        return None;
+    }
+    Some(LoopVerdict::Stagnant {
+        tool: last.call.name.clone(),
+        count,
+    })
 }
 
 #[cfg(test)]
@@ -418,6 +519,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100, // disable short-cycle for this test
+            stagnation_threshold: 0,  // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -428,6 +530,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         let verdict = detect_loop(&records, config);
         assert_eq!(
@@ -449,6 +552,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         match detect_loop(&records, config) {
             LoopVerdict::ExactRepeat { count, .. } => assert_eq!(count, 5),
@@ -499,6 +603,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -516,6 +621,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert!(detect_loop(&records, config).is_loop());
     }
@@ -543,6 +649,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert!(
             detect_loop(&records, config).is_loop(),
@@ -569,6 +676,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -587,6 +695,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -604,6 +713,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 100,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert!(detect_loop(&records, config).is_loop());
     }
@@ -615,6 +725,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100, // disable exact-repeat for this test
             short_cycle_repeats: 3,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -634,6 +745,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 3,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         let verdict = detect_loop(&records, config);
         match &verdict {
@@ -657,6 +769,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 3,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         match detect_loop(&records, config) {
             LoopVerdict::ShortCycle { repeats, .. } => assert_eq!(repeats, 5),
@@ -703,6 +816,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 3,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         let verdict = detect_loop(&records, config);
         match &verdict {
@@ -735,6 +849,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 2,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -757,6 +872,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 2,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         match detect_loop(&records, config) {
             LoopVerdict::ShortCycle { pattern, repeats } => {
@@ -788,6 +904,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 100,
             short_cycle_repeats: 2,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -802,6 +919,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 0, // disabled
             short_cycle_repeats: 1,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -894,7 +1012,8 @@ mod tests {
         for threshold in [0, 1] {
             let config = LoopDetectionConfig {
                 exact_repeat_threshold: threshold,
-                short_cycle_repeats: 0, // also disabled, so overall NoLoop
+                short_cycle_repeats: 0,  // also disabled, so overall NoLoop
+                stagnation_threshold: 0, // ditto
             };
             assert_eq!(
                 detect_loop(&records, config),
@@ -917,6 +1036,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: 0,
             short_cycle_repeats: 0,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -930,6 +1050,7 @@ mod tests {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: usize::MAX,
             short_cycle_repeats: usize::MAX,
+            stagnation_threshold: 0, // disabled: this test isolates another check
         };
         assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
@@ -964,6 +1085,167 @@ mod tests {
         assert!(evidence.contains("read_file"));
         assert!(evidence.contains("edit_file"));
         assert!(evidence.contains('3'));
+    }
+
+    // ---- stagnation: same tool, moving arguments, unmoving answer --------
+
+    /// One `grep` whose pattern differs from every other, over one file,
+    /// always finding the same thing — the field shape from the journal of
+    /// the turn that motivated this check.
+    fn grep_variant(pattern: &str) -> CallRecord<'static> {
+        call(
+            "grep",
+            serde_json::json!({ "pattern": pattern, "path": "stella-tui/src/deck.rs" }),
+            "118:    /// Cumulative prompt-cache *write* tokens",
+        )
+    }
+
+    /// THE regression. A model reshuffling one regex alternation gets a
+    /// different `input` every call and byte-identical output every call.
+    /// Neither exact-repeat (inputs never match) nor short-cycle (the
+    /// arguments never settle into a period) can see it; before stagnation
+    /// existed this ran 38 calls deep on a live turn.
+    #[test]
+    fn a_tool_whose_arguments_move_but_whose_answer_never_does_is_a_loop() {
+        let records: Vec<CallRecord<'static>> = (0..6)
+            .map(|i| grep_variant(&format!("cache_write|total_cache|savings_{i}")))
+            .collect();
+        let verdict = detect_loop(&records, LoopDetectionConfig::default());
+        match &verdict {
+            LoopVerdict::Stagnant { tool, count } => {
+                assert_eq!(tool, "grep");
+                assert_eq!(*count, 6);
+            }
+            other => panic!("expected Stagnant, got {other:?}"),
+        }
+        assert!(verdict.is_loop());
+        let evidence = verdict.evidence().expect("stagnation has evidence");
+        assert!(evidence.contains("grep"), "evidence names the tool");
+        assert!(
+            evidence.contains("DIFFERENT arguments"),
+            "evidence must say why this is not an exact repeat: {evidence}"
+        );
+    }
+
+    #[test]
+    fn stagnation_below_the_threshold_is_not_a_loop() {
+        // Five is exploration; the default only speaks at six.
+        let records: Vec<CallRecord<'static>> = (0..5)
+            .map(|i| grep_variant(&format!("pattern_{i}")))
+            .collect();
+        assert_eq!(
+            detect_loop(&records, LoopDetectionConfig::default()),
+            LoopVerdict::NoLoop
+        );
+    }
+
+    #[test]
+    fn a_tool_that_keeps_answering_differently_never_stagnates() {
+        // Six searches, six different answers: the arguments moved AND the
+        // answer moved. That is exactly what productive searching looks
+        // like, and it must survive however long it goes on.
+        let records: Vec<CallRecord<'static>> = (0..6)
+            .map(|i| {
+                call(
+                    "grep",
+                    serde_json::json!({ "pattern": format!("p{i}") }),
+                    &format!("src/lib.rs:{i}: hit"),
+                )
+            })
+            .collect();
+        assert_eq!(
+            detect_loop(&records, LoopDetectionConfig::default()),
+            LoopVerdict::NoLoop
+        );
+    }
+
+    #[test]
+    fn another_tool_interleaved_breaks_the_stagnation_run() {
+        // A model that greps, reads what it found, then greps again is
+        // acting on the results. Only an UNBROKEN run of one tool telling
+        // us nothing counts, so the run is measured from the tail.
+        let mut records: Vec<CallRecord<'static>> =
+            (0..5).map(|i| grep_variant(&format!("p{i}"))).collect();
+        records.push(read("src/deck.rs"));
+        records.extend((5..9).map(|i| grep_variant(&format!("p{i}"))));
+        assert_eq!(
+            detect_loop(&records, LoopDetectionConfig::default()),
+            LoopVerdict::NoLoop,
+            "the trailing grep run is 4 — the read reset it"
+        );
+    }
+
+    #[test]
+    fn identical_calls_are_reported_as_an_exact_repeat_not_stagnation() {
+        // Stagnation is the vaguer description of the same evidence, so it
+        // must never claim a run exact-repeat describes precisely.
+        let records = vec![grep_variant("same"); 8];
+        match detect_loop(&records, LoopDetectionConfig::default()) {
+            LoopVerdict::ExactRepeat { count, .. } => assert_eq!(count, 8),
+            other => panic!("expected ExactRepeat to win, got {other:?}"),
+        }
+        // And with exact-repeat disabled it still refuses to relabel them:
+        // the all-same-input guard holds on its own, not by ordering luck.
+        let config = LoopDetectionConfig {
+            exact_repeat_threshold: 0,
+            short_cycle_repeats: 0,
+            stagnation_threshold: 3,
+        };
+        assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
+    }
+
+    #[test]
+    fn stagnation_needs_observed_outputs_like_every_other_check() {
+        // Unresolved results prove nothing, however many there are.
+        let records: Vec<CallRecord<'static>> = (0..8)
+            .map(|i| record("grep", serde_json::json!({ "pattern": i }), None))
+            .collect();
+        assert_eq!(
+            detect_loop(&records, LoopDetectionConfig::default()),
+            LoopVerdict::NoLoop
+        );
+    }
+
+    #[test]
+    fn zero_or_one_stagnation_threshold_disables_that_check() {
+        let records: Vec<CallRecord<'static>> =
+            (0..10).map(|i| grep_variant(&format!("p{i}"))).collect();
+        for threshold in [0, 1] {
+            let config = LoopDetectionConfig {
+                exact_repeat_threshold: 0,
+                short_cycle_repeats: 0,
+                stagnation_threshold: threshold,
+            };
+            assert_eq!(
+                detect_loop(&records, config),
+                LoopVerdict::NoLoop,
+                "threshold {threshold} should disable stagnation detection"
+            );
+        }
+    }
+
+    #[test]
+    fn stagnation_compares_identities_when_compaction_rewrote_the_outputs() {
+        // The #554 rule applies here too: the older results were stubbed in
+        // place, but their pre-compaction identities still match, so the run
+        // is still evidence.
+        let records: Vec<CallRecord<'static>> = (0..6)
+            .map(|i| {
+                let stubbed = i < 4;
+                with_identity(
+                    call(
+                        "grep",
+                        serde_json::json!({ "pattern": format!("p{i}") }),
+                        if stubbed { "[evicted]" } else { "118: hit" },
+                    ),
+                    "blk_same",
+                )
+            })
+            .collect();
+        assert!(
+            detect_loop(&records, LoopDetectionConfig::default()).is_loop(),
+            "matching identities must survive an in-place rewrite here too"
+        );
     }
 
     /// Small, deliberately overlapping alphabet of names/inputs/outputs so
@@ -1004,25 +1286,30 @@ mod tests {
             records in proptest::collection::vec(arb_call_record(), 0..16),
             exact_repeat_threshold in 0usize..8,
             short_cycle_repeats in 0usize..8,
+            stagnation_threshold in 0usize..8,
         ) {
-            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats };
+            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
             let verdict = detect_loop(&records, config);
             // Whatever the verdict, `is_loop`/`evidence` must not panic either.
             let _ = verdict.is_loop();
             let _ = verdict.evidence();
         }
 
-        /// Property: history shorter than both thresholds is always
-        /// `NoLoop` — there's no way for either check to have enough
-        /// evidence (the shortest cycle period is 2).
+        /// Property: history shorter than EVERY threshold is always
+        /// `NoLoop` — there's no way for any check to have enough evidence
+        /// (the shortest cycle period is 2).
         #[test]
         fn short_history_is_always_no_loop(
             records in proptest::collection::vec(arb_call_record(), 0..12),
             exact_repeat_threshold in 2usize..8,
             short_cycle_repeats in 1usize..8,
+            stagnation_threshold in 2usize..8,
         ) {
-            if records.len() < exact_repeat_threshold && records.len() < 2 * short_cycle_repeats {
-                let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats };
+            if records.len() < exact_repeat_threshold
+                && records.len() < 2 * short_cycle_repeats
+                && records.len() < stagnation_threshold
+            {
+                let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
                 prop_assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
             }
         }
@@ -1038,6 +1325,7 @@ mod tests {
             records in proptest::collection::vec(arb_call_record(), 0..16),
             exact_repeat_threshold in 2usize..8,
             short_cycle_repeats in 2usize..8,
+            stagnation_threshold in 2usize..8,
         ) {
             let records: Vec<CallRecord<'static>> = records
                 .into_iter()
@@ -1047,7 +1335,7 @@ mod tests {
                     record
                 })
                 .collect();
-            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats };
+            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
             prop_assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
         }
     }

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -355,15 +355,15 @@ pub enum AgentEvent {
     /// Additive to the wire contract: older consumers never see it.
     LoopDetected {
         turn_instance: u32,
-        /// `"exact_repeat"` | `"short_cycle"` — mirrors
+        /// `"exact_repeat"` | `"short_cycle"` | `"stagnation"` — mirrors
         /// `stella-core::loop_detect::LoopVerdict` (kept as a string here so
         /// `stella-protocol` never depends on `stella-core`).
         kind: String,
         /// Tool names of the repeated signature, in cycle order (one entry
-        /// for an exact repeat).
+        /// for an exact repeat or a stagnating tool).
         pattern: Vec<String>,
-        /// Consecutive identical calls (exact repeat) or full cycles (short
-        /// cycle) observed.
+        /// Consecutive identical calls (exact repeat), full cycles (short
+        /// cycle), or consecutive no-progress calls (stagnation) observed.
         repeats: usize,
         /// The human-readable evidence — same text the paired
         /// `Steered`/`Error` carries.

--- a/stella-tools/src/glob.rs
+++ b/stella-tools/src/glob.rs
@@ -213,6 +213,16 @@ fn fd_command(search_dir: &std::path::Path, pattern: &str) -> Command {
     fd.arg("--exclude").arg(".git");
     fd.arg("--type").arg("f");
     fd.arg("--color").arg("never");
+    // Single-threaded, for the same reason `grep` passes `--sort path`: `fd`
+    // walks in PARALLEL, so the same glob over the same unchanged tree
+    // answers in a different order every call — and because `--max-results`
+    // stops the walk early, a capped search returns a different SET too.
+    // `stella_core::loop_detect` proves a turn is stuck by finding
+    // byte-identical tool output, so a search that never repeats itself is a
+    // search it can never catch looping. Sorting the lines afterwards would
+    // fix the order and quietly leave the set arbitrary, which reads as a fix
+    // and is not one — the walk itself has to be deterministic.
+    fd.arg("--threads").arg("1");
     fd.arg("--max-results").arg(MAX_RESULTS.to_string());
     fd.arg("--").arg(pattern).arg(search_dir);
     crate::subprocess_env::scrub_sensitive_env(&mut fd);

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -423,6 +423,29 @@ impl Tool for Grep {
         rg.arg("--max-columns")
             .arg(MAX_COLUMNS.to_string())
             .arg("--max-columns-preview");
+        // Deterministic file order, and it is load-bearing rather than a
+        // nicety. `rg` walks directories in PARALLEL, so the same search over
+        // the same unchanged tree emits its matching files in a different
+        // order on every call. Three things break on that:
+        //
+        // - `stella_core::loop_detect` decides a turn is making progress by
+        //   comparing tool output BYTES. A reordered result is a different
+        //   result, so a model re-running one search forever looks like a
+        //   model learning something new every time, and no rung of the
+        //   detector can fire. That is not hypothetical: it is why a live
+        //   turn ran one `grep` dozens of times before anything stopped it.
+        // - `stella_core::compaction`'s dedup pass collapses byte-identical
+        //   tool results. Reordered duplicates each keep a full copy.
+        // - The agent re-reads its own earlier search and sees the answer
+        //   move, which invites the re-search that started the loop.
+        //
+        // Sorting AFTER capture cannot fix it: `truncate_middle` below caps
+        // the raw bytes before anything is parsed into lines, so an unordered
+        // walk drops a different set of files each call and no later sort can
+        // put back what was already cut. The order has to be right at the
+        // source. `--sort path` costs `rg`'s parallelism, which is the price
+        // of a search tool that answers the same question the same way.
+        rg.arg("--sort").arg("path");
         // `rg` skips dot-prefixed entries by default, so a search under
         // `.github/`, `.cargo/` or any dotfile came back "(no matches)" —
         // which an agent reads as "that code does not exist". The `grep`

--- a/stella-tools/tests/search_determinism.rs
+++ b/stella-tools/tests/search_determinism.rs
@@ -1,0 +1,121 @@
+//! The search tools must answer byte-identically to byte-identical input.
+//!
+//! This is not a property of `grep` alone — it is the precondition
+//! `stella_core::loop_detect` runs on. That module decides whether a turn is
+//! making progress by comparing tool output bytes, so a tool with any per-call
+//! variation (a timestamp, a counter, an unordered walk) is invisible to loop
+//! detection and can thrash until the step cap. `read_file` already needs
+//! `driver::comparable_output` to strip its volatile session-tally footer;
+//! this test is what keeps `grep` from ever quietly needing the same exemption.
+
+use std::path::PathBuf;
+
+use stella_tools::registry::Tool;
+
+/// A small tree with several matching files, so the result spans more than one
+/// path — multi-file output is where an unordered walk would show up.
+fn fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["alpha.rs", "beta.rs", "gamma.rs", "delta.rs"] {
+        std::fs::write(
+            dir.path().join(name),
+            "pub struct Deck;\nfn cache_write_tokens() -> u64 { 0 }\n// cache_write_tokens\n",
+        )
+        .expect("write fixture");
+    }
+    dir
+}
+
+#[tokio::test]
+async fn repeated_identical_grep_calls_return_identical_bytes() {
+    let dir = fixture();
+    let root: PathBuf = dir.path().to_path_buf();
+    let tool = stella_tools::grep::Grep::default();
+    let input = serde_json::json!({ "pattern": "cache_write_tokens" });
+
+    let mut outputs = Vec::new();
+    for _ in 0..8 {
+        outputs.push(format!("{:?}", tool.execute(&input, &root).await));
+    }
+
+    for (i, out) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            &outputs[0], out,
+            "grep call {i} differed from call 0 — loop detection compares output \
+             bytes, so any per-call variation blinds it to a thrashing turn"
+        );
+    }
+    assert!(
+        outputs[0].contains("alpha.rs"),
+        "fixture sanity: the search must actually match: {}",
+        outputs[0]
+    );
+}
+
+/// `glob` shells to `fd`, which walks in parallel exactly as `rg` does — and
+/// caps the walk with `--max-results`, so an unpinned walk varies the SET it
+/// returns, not merely the order.
+///
+/// The fixture shape matters, and finding one that witnesses anything took
+/// measuring: a FLAT tree of 750 files reproduces nothing, because the walk
+/// drains before the threads can diverge. It takes a DEEP one, past the
+/// 500-result cap, before the early stop starts landing in different places —
+/// at which point it is blatant (five `fd` runs over this repo, five different
+/// answers; the same tree at depth 5 below, five runs, five answers).
+#[tokio::test]
+async fn repeated_identical_glob_calls_return_identical_bytes() {
+    /// Depth-5, fan-out-3, three files per directory: 363 directories and
+    /// 1089 files, which is both well past the cap and cheap to build.
+    fn build(path: &std::path::Path, depth: usize) {
+        if depth == 0 {
+            return;
+        }
+        for i in 0..3 {
+            let child = path.join(format!("d{i}_{depth}"));
+            std::fs::create_dir_all(&child).expect("mkdir");
+            for f in 0..3 {
+                std::fs::write(child.join(format!("f{f}.rs")), "fn x() {}\n").expect("write");
+            }
+            build(&child, depth - 1);
+        }
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    build(dir.path(), 5);
+    let root: PathBuf = dir.path().to_path_buf();
+    let tool = stella_tools::glob::Glob::with_code_map();
+    let input = serde_json::json!({ "pattern": "**/*.rs" });
+
+    let first = format!("{:?}", tool.execute(&input, &root).await);
+    for i in 1..8 {
+        let again = format!("{:?}", tool.execute(&input, &root).await);
+        assert_eq!(
+            first, again,
+            "glob call {i} differed — an unpinned parallel walk makes a \
+             repeated search look like new information, which is exactly what \
+             loop detection reads as progress"
+        );
+    }
+    assert!(first.contains(".rs"), "fixture sanity: {first}");
+}
+
+/// The same guarantee for the modes added in #1260 — a footer, a truncation
+/// note or a count that varied per call would defeat detection just as surely.
+#[tokio::test]
+async fn every_grep_output_mode_is_deterministic() {
+    let dir = fixture();
+    let root: PathBuf = dir.path().to_path_buf();
+    let tool = stella_tools::grep::Grep::default();
+
+    for mode in ["content", "files_with_matches", "count"] {
+        let input = serde_json::json!({
+            "pattern": "cache_write_tokens",
+            "output_mode": mode,
+            "context": 1,
+        });
+        let first = format!("{:?}", tool.execute(&input, &root).await);
+        for i in 1..4 {
+            let again = format!("{:?}", tool.execute(&input, &root).await);
+            assert_eq!(first, again, "output_mode={mode} varied on call {i}");
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Adds a third loop detection mode to catch when a tool is called repeatedly with *changing* arguments but returns *identical* output every time — a pattern invisible to both exact-repeat and short-cycle detection.

This solves a real field issue where a model reshuffled a regex alternation in `grep` calls 38 times, each with different input but identical output, before the old detector finally caught it by accident. The new "stagnation" check fires when the same tool is called 6+ consecutive times (configurable) with varying inputs but byte-identical outputs, proving the tool has stopped being informative.

The three detection rungs now form a ladder:
1. **Exact repeat** — same input, same output (tightest description)
2. **Short cycle** — periodic input/output pattern (medium description)  
3. **Stagnation** — varying input, identical output (weakest description, checked last to avoid preempting better verdicts)

## The witness

- [x] Witness tests included:
  - `a_tool_whose_arguments_move_but_whose_answer_never_does_is_a_loop()` — demonstrates the regression case
  - `a_tool_that_keeps_answering_differently_never_stagnates()` — ensures progress isn't blocked
  - `identical_calls_are_reported_as_an_exact_repeat_not_stagnation()` — ensures exact repeats aren't relabeled
  - `a_loop_that_resumes_after_a_successful_course_correction_still_aborts()` — integration test showing the steer→abort ladder works across recovery
  - `a_tool_answering_identically_to_every_new_argument_is_steered_then_killed()` — field reproduction showing 38-call thrash now dies in ~7 calls
  - Determinism tests in `stella-tools` ensure `grep` and `glob` output is byte-identical across repeated calls (load-bearing for loop detection)

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated: module docs, config struct, verdict enum, and tool implementations all document the determinism requirement
- [x] `LoopDetectionConfig::stagnation_threshold` added with sensible default (6, double the exact-repeat threshold)
- [x] `LoopVerdict::Stagnant` variant added with clear evidence message
- [x] Protocol event updated to include `"stagnation"` as a loop kind

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new network calls
- [x] No serde surface added: `LoopDetectionConfig` and `LoopVerdict` are internal to `stella-core` and derive no serde at all, so there is nothing to round-trip. The only wire-facing change is the new `"stagnation"` value of `AgentEvent::LoopDetected.kind`, which is a plain `String`.

## Notes for reviewers

**Load-bearing changes:**
- `grep.rs` and `glob.rs` now pass `--sort path` and `--threads 1` respectively. These are **not** cosmetic — parallel walks make identical searches return different byte sequences, which blinds loop detection. The determinism tests in `stella-tools` prove this is necessary.
- `same_output()` extracted from `same_record()` so stagnation detection can check output identity without requiring input identity.
- Detection order matters: stagnation is checked *last* because it's the weakest claim (true of every exact repeat and cycle too), so it must not preempt the tighter verdicts.

**Test fixture changes:**
- `compute_passes.rs` switched from `CountingTools` (constant output) to `EchoingTools` (varying output per input) to avoid triggering stagnation detection in an unrelated test.
- All existing loop-detection tests now explicitly disable stagnation (`stagnation_threshold: 0`) to isolate the check they're testing.

## Summary by Sourcery

Introduce a stagnation-based loop detection mode and ensure search tools are deterministic so loop detection can reliably detect non-progress loops.

New Features:
- Add stagnation-based loop detection for repeated same-tool calls with varying inputs but identical outputs, exposed via LoopDetectionConfig and LoopVerdict::Stagnant.
- Extend loop detection protocol events to report a new "stagnation" loop kind to downstream consumers.

Enhancements:
- Refine loop detection logic to separate output comparison from input matching and to order exact-repeat, short-cycle, and stagnation checks by evidential strength.
- Update grep and glob tools to enforce deterministic output ordering and threading so identical inputs produce byte-identical outputs across calls.
- Adjust driver tests and fixtures to use non-constant tool outputs where needed to avoid unintended stagnation detection and to cover steer-then-abort behavior across loop recoveries.

Tests:
- Add targeted tests for stagnation detection behavior, including regression and integration scenarios covering steering, recovery, and eventual abort.
- Add determinism tests for grep and glob to verify repeated identical calls return byte-identical outputs in all modes.
- Extend property-based tests to account for the new stagnation threshold and ensure short histories and disabled thresholds behave as expected.
