### PR TITLE
Restore main to green: regenerate docs/wire/ after #1361's LoopDetected doc edits

### DIFF
--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -888,19 +888,19 @@ export type AgentEvent = {
    */
   evidence: string;
   /**
-   * `"exact_repeat"` | `"short_cycle"` — mirrors
+   * `"exact_repeat"` | `"short_cycle"` | `"stagnation"` — mirrors
    * `stella-core::loop_detect::LoopVerdict` (kept as a string here so
    * `stella-protocol` never depends on `stella-core`).
    */
   kind: string;
   /**
    * Tool names of the repeated signature, in cycle order (one entry
-   * for an exact repeat).
+   * for an exact repeat or a stagnating tool).
    */
   pattern: string[];
   /**
-   * Consecutive identical calls (exact repeat) or full cycles (short
-   * cycle) observed.
+   * Consecutive identical calls (exact repeat), full cycles (short
+   * cycle), or consecutive no-progress calls (stagnation) observed.
    */
   repeats: number;
   turn_instance: number;

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1638,18 +1638,18 @@
           "type": "string"
         },
         "kind": {
-          "description": "`\"exact_repeat\"` | `\"short_cycle\"` — mirrors\n`stella-core::loop_detect::LoopVerdict` (kept as a string here so\n`stella-protocol` never depends on `stella-core`).",
+          "description": "`\"exact_repeat\"` | `\"short_cycle\"` | `\"stagnation\"` — mirrors\n`stella-core::loop_detect::LoopVerdict` (kept as a string here so\n`stella-protocol` never depends on `stella-core`).",
           "type": "string"
         },
         "pattern": {
-          "description": "Tool names of the repeated signature, in cycle order (one entry\nfor an exact repeat).",
+          "description": "Tool names of the repeated signature, in cycle order (one entry\nfor an exact repeat or a stagnating tool).",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "repeats": {
-          "description": "Consecutive identical calls (exact repeat) or full cycles (short\ncycle) observed.",
+          "description": "Consecutive identical calls (exact repeat), full cycles (short\ncycle), or consecutive no-progress calls (stagnation) observed.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -78,19 +78,19 @@ export type AgentEvent = {
    */
   evidence: string;
   /**
-   * `"exact_repeat"` | `"short_cycle"` — mirrors
+   * `"exact_repeat"` | `"short_cycle"` | `"stagnation"` — mirrors
    * `stella-core::loop_detect::LoopVerdict` (kept as a string here so
    * `stella-protocol` never depends on `stella-core`).
    */
   kind: string;
   /**
    * Tool names of the repeated signature, in cycle order (one entry
-   * for an exact repeat).
+   * for an exact repeat or a stagnating tool).
    */
   pattern: string[];
   /**
-   * Consecutive identical calls (exact repeat) or full cycles (short
-   * cycle) observed.
+   * Consecutive identical calls (exact repeat), full cycles (short
+   * cycle), or consecutive no-progress calls (stagnation) observed.
    */
   repeats: number;
   turn_instance: number;

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -198,18 +198,18 @@
               "type": "string"
             },
             "kind": {
-              "description": "`\"exact_repeat\"` | `\"short_cycle\"` — mirrors\n`stella-core::loop_detect::LoopVerdict` (kept as a string here so\n`stella-protocol` never depends on `stella-core`).",
+              "description": "`\"exact_repeat\"` | `\"short_cycle\"` | `\"stagnation\"` — mirrors\n`stella-core::loop_detect::LoopVerdict` (kept as a string here so\n`stella-protocol` never depends on `stella-core`).",
               "type": "string"
             },
             "pattern": {
-              "description": "Tool names of the repeated signature, in cycle order (one entry\nfor an exact repeat).",
+              "description": "Tool names of the repeated signature, in cycle order (one entry\nfor an exact repeat or a stagnating tool).",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "repeats": {
-              "description": "Consecutive identical calls (exact repeat) or full cycles (short\ncycle) observed.",
+              "description": "Consecutive identical calls (exact repeat), full cycles (short\ncycle), or consecutive no-progress calls (stagnation) observed.",
               "format": "uint",
               "minimum": 0,
               "type": "integer"


### PR DESCRIPTION
`check-wire-schema` — a required step inside `fmt + clippy + test` — is red on `main` (`706c5649`).

#1361 taught `loop_detect` a third verdict and updated the doc comments on `AgentEvent::LoopDetected`'s `kind`, `pattern` and `repeats` to mention it. The exported contract is generated **from those doc comments**, so editing the prose alone leaves `docs/wire/` stale. Fix is `make wire-schema-update` and nothing else.

## The contract does not move

This is the part worth checking rather than taking on trust, so I checked it mechanically. Every changed line across all four artifacts is a `description` string or its `.d.ts` comment twin:

```
-   * `"exact_repeat"` | `"short_cycle"` — mirrors
+   * `"exact_repeat"` | `"short_cycle"` | `"stagnation"` — mirrors
```

Filtering the diff for `"type"`, `"const"`, `"required"`, `"properties"`, `"items"`, `"format"`, `"minimum"`, `"$ref"` returns **nothing**. No field is added, removed, renamed, or made required.

So this is not even the *additive* case the wire rule is written to permit — it is structurally a no-op. No `--output-format stream-json` consumer, SSE consumer, or `agentevent.d.ts` user can observe it.

## The witness

- [x] The guard **is** the witness: `check-wire-schema.sh` fails on `main` and passes here.

## The gate

- [x] `make gate` — full pre-push gate passed on push, no `SKIP_GATE`
- [x] Verified on `706c5649` that **wire-schema is the only failing guard**: `file-size` ✓ (fixed by #1360), `doc-links` ✓, `invariants` ✓, `cargo fmt --check` ✓

## Worth noting: a wire artifact can rot with no type change at all

Second wire staleness in two hours, and the two have *different* causes: #1347 went stale by adding a `ServerFrame` variant, #1361 by editing a sentence. Because the artifacts are generated from doc comments, "I only touched a comment" is not a safe assumption — which is exactly why it slips through.

`wire-schema` also runs only in `make gate` and the pre-push hook. Anyone merging with an admin override or a stale local hook lands this without seeing it, which AGENTS.md already records happening at #1185.

## Summary by Sourcery

Regenerate wire artifacts to reflect the new loop-detection verdict without changing the wire contract structure.

CI:
- Restore the wire-schema check to green on main by syncing generated wire artifacts with the updated doc comments.

Documentation:
- Update AgentEvent loop-detection descriptions in generated wire TypeScript and schema docs to include the stagnation verdict and its behavior.