### PR TITLE
Restore main to green: re-record the file-size ceilings #1364 left stale

### DIFF
--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -81,7 +81,11 @@ if [ "${1:-}" = "--update" ]; then
     echo "# must be split instead. Raising an existing ceiling is allowed but is"
     echo "# never silent — it lands as a visible diff here, to be justified in"
     echo "# review like any other change."
-    current_sizes | awk -v limit="$LIMIT" '$1 > limit' | sort -k2
+    # LC_ALL=C: byte-order collation, so the baseline regenerates identically
+    # on every machine. A UTF-8 locale sorts punctuation differently (macOS
+    # orders agent_tests.rs before agent.rs), which reshuffles untouched lines
+    # and buries the one ceiling that actually moved.
+    current_sizes | awk -v limit="$LIMIT" '$1 > limit' | LC_ALL=C sort -k2
   } >"$baseline.tmp"
   mv "$baseline.tmp" "$baseline"
   echo "check-file-size: baseline updated — $(grep -cv '^#' "$baseline") grandfathered file(s) over $LIMIT lines."

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,8 +17,8 @@
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2371 stella-cli/src/agent.rs
 1749 stella-cli/src/agent_tests.rs
-1576 stella-cli/src/candidate_ws.rs
-4666 stella-cli/src/command_deck.rs
+1584 stella-cli/src/candidate_ws.rs
+4710 stella-cli/src/command_deck.rs
 1506 stella-cli/src/fleet_cmd.rs
 2129 stella-core/src/bus.rs
 2765 stella-core/src/driver.rs


### PR DESCRIPTION
## What & why

`main` is red, and has been since #1364. The `ci` run on `0f8da430` fails at
**"no new .rs file over the 1500-line ratchet"** — the *first* step of the
`fmt + clippy + test` job, so fmt, clippy and the tests never run at all.

#1364 regenerated `scripts/file-size-baseline.txt` partway through its branch
and then kept editing, so the ceilings it shipped describe an intermediate
state rather than the merge head:

| file | actual at HEAD | recorded ceiling | over by |
|---|---|---|---|
| `stella-cli/src/candidate_ws.rs` | 1584 | 1576 | +8 |
| `stella-cli/src/command_deck.rs` | 4710 | 4666 | +44 |

(It also *lowered* `candidate_ws.rs` from 1584 to 1576 without the file ever
shrinking — the branch had a smaller copy, the merge kept main's.)

This bites locally too, not just in CI: `check-file-size` is in
`GATE_GUARDS_FAST`, so `make check` — what the pre-push hook runs — fails for
everyone on a clean checkout of `main`.

Re-recording the two ceilings restores both. The growth is the deck
redesign's own and is irreducible in the same sense as #1360's.

### Second fix: pin the baseline's collation

`sort -k2` collates by locale. Under `LC_ALL=C` (CI) `agent.rs` sorts before
`agent_tests.rs`; under a UTF-8 locale (macOS default) the order flips,
because UTF-8 collation drops punctuation at the primary level and compares
`agentrs` against `agenttests`. The committed baseline was generated under C,
so `make file-size-update` on a Mac rewrote four untouched lines alongside
the two real ones, burying the ceiling that actually moved.

Pinning the sort to `LC_ALL=C` makes regeneration byte-identical on any
machine. Confirmed: with the pin, regenerating on macOS reproduces the
committed ordering exactly and the diff is the 2 ceiling lines and nothing
else.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here) — not a cargo
      test, because the guard *is* the assertion:

```
# on main            ./scripts/check-file-size.sh -> exit 1, "check-file-size: FAILED"
# on this branch     ./scripts/check-file-size.sh -> exit 0, "none grew"
```

The collation fix has its own witness: `make file-size-update` under
`LANG=en_US.UTF-8` produces a 4-line reorder before the change and a clean
tree after.

## The gate

- [x] `cargo fmt --check` — via `make guards`, exit 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo test --workspace` — exit 0, 118 suites, 6150 tests, 0 failures
- [x] `make shellcheck` — exit 0 (shellcheck 0.11.0)
- [x] `make guards` — all 9 guards OK, including `wire-schema`
- [x] Docs updated where behavior changed — n/a; the `LC_ALL=C` rationale is a
      comment at the change site

Worth noting the test suite was **never green on main** in CI, because CI
bailed at the ratchet before reaching it. It is green — I ran the full suite
to confirm nothing was hiding behind the guard. Nothing was.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Two files changed, both under `scripts/`. No Rust touched, so clippy/test
results carry over unchanged from `main`'s content.

The ratchet has now been re-recorded three times in recent history (#1356 via
#1360, and #1364 here). The recurring shape is the same: a PR runs
`file-size-update` mid-branch, grows the file further, and the stale ceiling
only surfaces after the merge. A guard that recomputed the ceiling at merge
time — or a pre-merge check on the merge head rather than the branch head —
would close it. Deliberately out of scope here; flagging it as a follow-up
rather than fixing it in an unbreak-main PR.

## Summary by Sourcery

Restore the file-size guard to green by updating stale baseline ceilings and making baseline regeneration deterministic across environments.

Bug Fixes:
- Update recorded file-size ceilings to match current sizes so the file-size ratchet passes on main.
- Force LC_ALL=C during baseline collation so file-size baseline regeneration is consistent across locales.