### PR TITLE
Make the harbor-adapter tests hermetic against the developer's shell

### DIFF
--- a/bench/harbor_adapter/tests/conftest.py
+++ b/bench/harbor_adapter/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Keep the adapter's tests independent of the developer's shell.
+
+`StellaAgent._forwarded_env` fails closed on any ambient `STELLA_*` key it
+does not recognize. That guard is deliberate and stays: a stray knob in
+someone's environment must never silently change what a benchmark measures.
+
+The cost is that the test suite inherits whatever the developer exports. A
+shell with `STELLA_JUDGE_MODEL` or `STELLA_TRIAGE_API` set — the posture
+variables `stella_harbor/posture.py` reads, which anyone running head-to-head
+arms has in their profile — turns 11 otherwise-unrelated tests red with
+`RuntimeError: claim benchmark environment contains unregistered STELLA_*
+knobs`. CI never sees it, because CI's environment is empty; it lands only on
+the person running `make bench-test` locally, in tests that have nothing to
+do with the variable that broke them.
+
+Clearing the inherited keys for the session makes the suite hermetic: every
+test starts from the same environment CI has, so a local run and a CI run
+agree. Tests that want a `STELLA_*` value still set it themselves with
+`monkeypatch`, which is the only way the value should ever get there.
+"""
+
+import os
+
+import pytest
+
+_ENV_PREFIX = "STELLA_"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _strip_ambient_stella_env():
+    """Remove inherited ``STELLA_*`` keys for the duration of the session."""
+    patcher = pytest.MonkeyPatch()
+    for key in [key for key in os.environ if key.startswith(_ENV_PREFIX)]:
+        patcher.delenv(key, raising=False)
+    yield
+    patcher.undo()

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -81,7 +81,11 @@ if [ "${1:-}" = "--update" ]; then
     echo "# must be split instead. Raising an existing ceiling is allowed but is"
     echo "# never silent — it lands as a visible diff here, to be justified in"
     echo "# review like any other change."
-    current_sizes | awk -v limit="$LIMIT" '$1 > limit' | sort -k2
+    # LC_ALL=C: byte-order collation, so the baseline regenerates identically
+    # on every machine. A UTF-8 locale sorts punctuation differently (macOS
+    # orders agent_tests.rs before agent.rs), which reshuffles untouched lines
+    # and buries the one ceiling that actually moved.
+    current_sizes | awk -v limit="$LIMIT" '$1 > limit' | LC_ALL=C sort -k2
   } >"$baseline.tmp"
   mv "$baseline.tmp" "$baseline"
   echo "check-file-size: baseline updated — $(grep -cv '^#' "$baseline") grandfathered file(s) over $LIMIT lines."

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,8 +17,8 @@
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2371 stella-cli/src/agent.rs
 1749 stella-cli/src/agent_tests.rs
-1576 stella-cli/src/candidate_ws.rs
-4666 stella-cli/src/command_deck.rs
+1584 stella-cli/src/candidate_ws.rs
+4710 stella-cli/src/command_deck.rs
 1506 stella-cli/src/fleet_cmd.rs
 2129 stella-core/src/bus.rs
 2765 stella-core/src/driver.rs


### PR DESCRIPTION
## What & why

> Stacked on #1365 — based on that branch so CI can go green. GitHub retargets
> this to `main` automatically when #1365 merges. Review that one first.

`make bench-test` fails on a clean checkout for anyone whose shell exports the
posture variables:

```
RuntimeError: claim benchmark environment contains unregistered STELLA_* knobs:
  STELLA_JUDGE_API, STELLA_JUDGE_EFFORT, STELLA_JUDGE_MODEL, ...
11 failed, 421 passed, 1 skipped
```

**The guard raising it is correct and is not touched here.**
`StellaAgent._forwarded_env` fails closed on any ambient `STELLA_*` key it does
not recognize, so a stray knob can never silently change what a benchmark
measures. That behavior stays exactly as it is.

What's wrong is that the *test suite* reads the developer's environment at
all. `stella_harbor/posture.py` reads `STELLA_JUDGE_*` and `STELLA_TRIAGE_*`,
so anyone who has run a head-to-head arm has those exported — and then 11
tests with nothing to do with those variables fail because of them.

### Why CI can't catch this

CI's environment is empty, so `harbor_adapter + analyzer pytest` is **green on
exactly the commit where the local run is red**. The failure exists only on
the machine of whoever runs the target, which is the worst place for it: it
reads as "the bench tooling is broken" rather than "your shell is set".

### The fix

A session-scoped autouse fixture in `tests/conftest.py` strips inherited
`STELLA_*` keys, so every test starts from the environment CI has.

This is not a new idea in this suite — it's the same fix the tests already
apply one key at a time, as each one bites:

| file | line | already clearing |
|---|---|---|
| `test_adapter.py` | 279-282 | `STELLA_MODEL`, `STELLA_BUDGET`, `STELLA_BASE_URL`, `STELLA_DISABLE_REFLECTION` |
| `test_log_writes.py` | 132-134 | `STELLA_BUDGET`, `STELLA_MODEL`, `STELLA_BASE_URL` |
| `test_exit_cause.py` | 44 | loops a list of names |

The fixture closes the whole class instead of the next key to bite.

## The witness

- [x] Fails on the parent commit, passes here — with the 11 posture variables
      exported:

```
# before:  make bench-test -> exit 2, "11 failed, 421 passed, 1 skipped"
# after:   make bench-test -> exit 0, "432 passed, 1 skipped" then "258 passed"
```

Run with `env | rg -c '^STELLA_'` reporting 11, i.e. the environment that
actually reproduces it — not a scrubbed one.

## The gate

- [x] `make bench-test` — exit 0 **with the 11 variables still set**
- [x] `ruff check` + `ruff format --check` — clean
- [x] `make guards` — all 9 OK
- [x] No Rust touched, so fmt/clippy/test carry over from the parent branch

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**Does this weaken the fail-closed guard?** No. The guard keeps direct
coverage at `test_adapter.py:437` and `:808`, both `pytest.raises` on the
`RuntimeError`, each setting the offending key explicitly. That is exactly the
pattern this change makes universal: a `STELLA_*` value reaches a test because
the test put it there, never because the developer's profile did.

The fixture clears *all* `STELLA_*` keys rather than only unregistered ones,
deliberately — "the environment CI has" is the one state that is reproducible
everywhere, and a partial clear would leave the registered keys as a second,
quieter source of local-only divergence.

Only the `harbor_adapter` suite needs this; `terminal_bench_analysis` reads no
`STELLA_*` variables and passed either way.

## Summary by Sourcery

Tests:
- Add a session-scoped autouse pytest fixture to clear STELLA_* environment variables during harbor-adapter tests, preventing developer shell configuration from interfering with test outcomes.