### PR TITLE
refactor(stella-core): one home for the goal-loop wording and receipt slot math

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -53,6 +53,7 @@ mod graph;
 mod outcome;
 mod output;
 mod persistence;
+mod presence;
 mod prompt;
 mod tools;
 
@@ -72,6 +73,7 @@ pub(crate) use persistence::{
     close_event_stream, persist_event, persist_event_detailed, record_execution_end,
     spawn_renderer, warn_store_write_failed,
 };
+pub(crate) use presence::SessionPresence;
 pub(crate) use prompt::*;
 // `tool_policy` is a top-level module (`main.rs`); the re-export keeps every
 // session driver's `agent::PolicyToolSet` reading as "the agent's tool stack".
@@ -606,19 +608,7 @@ async fn run_pipeline_one_shot(
     // notification (or the SESSIONS overlay) replays the journal.
     let run_ok = matches!(&result, Ok(o) if matches!(o.status, PipelineStatus::Completed));
     let run_secs = turn_start.elapsed().as_secs();
-    let notify = if !run_ok {
-        Some((
-            format!("{}: run FAILED", presence.name()),
-            crate::command_deck::prompt_line(prompt, 160),
-        ))
-    } else if run_secs >= 60 {
-        Some((
-            format!("{}: run finished ({run_secs}s)", presence.name()),
-            crate::command_deck::prompt_line(prompt, 160),
-        ))
-    } else {
-        None
-    };
+    let notify = presence.one_shot_notification(run_ok, run_secs, prompt);
     presence.finish(run_ok, notify);
 
     match &result {
@@ -1036,27 +1026,16 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             if let Err(e) = &result {
                 eprintln!("  {} {}\n", "Error:".red().bold(), e);
             }
-            // Failures reflect too (minus the user's own soft stop) — the
-            // one-shot pipeline path has always treated a failed run as a
-            // high-value learning signal; interactive paths now match
-            // (issue #373, item 7).
-            if should_reflect_on(&result)
-                && turn_warrants_reflection(&messages[turn_start..])
-                && let Some(m) = &mut memory
-            {
-                let mut report = m
-                    .reflect_and_record(
-                        &*provider,
-                        &cfg.model_id,
-                        &messages,
-                        false,
-                        result.is_ok(),
-                        remaining_budget(&budget),
-                    )
-                    .await;
-                settle_reflection_budget(&mut report, &mut budget);
-                surface_reflection(&report, OutputFormat::Text);
-            }
+            reflect_on_interactive_turn(
+                &*provider,
+                cfg,
+                &mut memory,
+                &messages,
+                turn_start,
+                &result,
+                &mut budget,
+            )
+            .await;
             continue;
         }
 
@@ -1129,26 +1108,16 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         if let Err(e) = &result {
             eprintln!("  {} {}\n", "Error:".red().bold(), e);
         }
-        // Same reflect-on-failure policy as the `/goal` block above and the
-        // one-shot pipeline path (issue #373, item 7): a soft stop is a user
-        // choice and stays excluded; a real failure is a learning signal.
-        if should_reflect_on(&result)
-            && turn_warrants_reflection(&messages[turn_start..])
-            && let Some(m) = &mut memory
-        {
-            let mut report = m
-                .reflect_and_record(
-                    &*provider,
-                    &cfg.model_id,
-                    &messages,
-                    false,
-                    result.is_ok(),
-                    remaining_budget(&budget),
-                )
-                .await;
-            settle_reflection_budget(&mut report, &mut budget);
-            surface_reflection(&report, OutputFormat::Text);
-        }
+        reflect_on_interactive_turn(
+            &*provider,
+            cfg,
+            &mut memory,
+            &messages,
+            turn_start,
+            &result,
+            &mut budget,
+        )
+        .await;
     }
 
     if let Some(set) = &mcp {
@@ -1194,6 +1163,43 @@ pub(crate) async fn record_turn_episode(
     // all.
     m.record_episode(prompt, episode_outcome, &turn_files, started_unix, None)
         .await;
+}
+
+/// Post-turn reflection for one interactive REPL turn, shared by the plain
+/// prompt handler and `/goal` — the two carried byte-identical copies of
+/// this block, which is exactly the drift this helper removes.
+///
+/// Failures reflect too (the one-shot pipeline path has always treated a
+/// failed run as a high-value learning signal); only a user-chosen soft stop
+/// is excluded (`should_reflect_on`, issue #373 item 7). The gate reads only
+/// this turn's message slice (`turn_start..`) so a conversational turn never
+/// spends a model call.
+async fn reflect_on_interactive_turn(
+    provider: &dyn Provider,
+    cfg: &Config,
+    memory: &mut Option<SessionMemory>,
+    messages: &[CompletionMessage],
+    turn_start: usize,
+    result: &Result<(), String>,
+    budget: &mut BudgetGuard,
+) {
+    if should_reflect_on(result)
+        && turn_warrants_reflection(&messages[turn_start..])
+        && let Some(m) = memory
+    {
+        let mut report = m
+            .reflect_and_record(
+                provider,
+                &cfg.model_id,
+                messages,
+                false,
+                result.is_ok(),
+                remaining_budget(budget),
+            )
+            .await;
+        settle_reflection_budget(&mut report, budget);
+        surface_reflection(&report, OutputFormat::Text);
+    }
 }
 
 /// Surface a post-turn [`ReflectionReport`] for human text output. Machine
@@ -2016,117 +2022,6 @@ pub(crate) fn begin_execution(
             Some((store.clone(), id))
         }
         Err(_) => None,
-    }
-}
-
-/// A headless/plain session's presence in the machine-wide registry: the
-/// deck's SESSIONS overlay finds it live and — because every execution links
-/// back via [`begin_execution`]'s `session` — can replay it long after it
-/// ended. Registration is best-effort throughout: a failed registry write
-/// never disturbs the run.
-pub(crate) struct SessionPresence {
-    registry: stella_store::SessionRegistry,
-    record: stella_store::SessionRecord,
-    name: String,
-    /// This session's durable record, carried so [`Self::finish`] can compact
-    /// it. Cloning the handle rather than re-opening the record keeps the
-    /// compaction pointed at the session that was actually bound, whatever the
-    /// driver did in between.
-    durability: crate::durability::SessionDurability,
-}
-
-impl SessionPresence {
-    /// Announce the session (status In Progress), titled from the workspace
-    /// and the prompt/goal that started it, and bind this session's durability
-    /// to `tools`.
-    ///
-    /// The binding is done HERE, rather than left to each headless driver,
-    /// because this is the moment the session acquires the identity durability
-    /// is keyed on. A driver that announced without binding would run a whole
-    /// session whose turns checkpoint nowhere — and the failure would be
-    /// silent, because an unbound sink is indistinguishable from a session
-    /// that simply never crashed.
-    pub(crate) fn announce(cfg: &Config, prompt: &str, tools: &Arc<ToolRegistry>) -> Self {
-        let name = cfg
-            .workspace_root
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| cfg.workspace_root.display().to_string());
-        let mut record = stella_store::SessionRecord::new(
-            cfg.workspace_root.display().to_string(),
-            name.clone(),
-        );
-        record.title = format!("{name}: {}", crate::command_deck::prompt_line(prompt, 48));
-        record.summary = crate::command_deck::prompt_line(prompt, 240);
-        let registry = stella_store::SessionRegistry::open_default();
-        let _ = registry.upsert(&record);
-        // stderr, not stdout: `--output-format json` owns stdout, and a
-        // durability advisory must never land inside a machine-readable
-        // document.
-        if let Some(warning) =
-            crate::durability::bind_session(&cfg.durability, tools, &cfg.workspace_root, &record.id)
-        {
-            eprintln!("  {warning}");
-        }
-        Self {
-            registry,
-            record,
-            name,
-            durability: cfg.durability.clone(),
-        }
-    }
-
-    /// The registry id — what executions link to and notifications carry.
-    pub(crate) fn id(&self) -> &str {
-        &self.record.id
-    }
-
-    /// The workspace's display name (notification titles).
-    pub(crate) fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// A new prompt is running: refresh the summary (and the title, if the
-    /// session was announced before its first real prompt).
-    pub(crate) fn update_prompt(&mut self, prompt: &str) {
-        self.record.summary = crate::command_deck::prompt_line(prompt, 240);
-        self.record.status = stella_store::SessionStatus::InProgress;
-        self.record.title = format!(
-            "{}: {}",
-            self.name,
-            crate::command_deck::prompt_line(prompt, 48)
-        );
-        let _ = self.registry.upsert(&self.record);
-    }
-
-    /// Between turns an interactive session waits on the human.
-    pub(crate) fn needs_input(&mut self) {
-        self.record.status = stella_store::SessionStatus::NeedsInput;
-        let _ = self.registry.upsert(&self.record);
-    }
-
-    /// Terminal status, plus an optional persist-until-read inbox
-    /// notification linked to this session — the headless → `/inbox` flow:
-    /// a finished `stella run` surfaces in every deck's inbox, and `Enter`
-    /// replays it.
-    pub(crate) fn finish(&mut self, ok: bool, notify: Option<(String, String)>) {
-        self.record.status = if ok {
-            stella_store::SessionStatus::Complete
-        } else {
-            stella_store::SessionStatus::Error
-        };
-        let _ = self.registry.upsert(&self.record);
-        // The headless counterpart of the deck's exit compaction. A one-shot
-        // run writes fewer objects than a long deck session, but it is also the
-        // shape that runs a hundred times in a loop from a script — which is
-        // exactly how a workspace accumulates loose objects nobody is watching.
-        self.durability.compact();
-        if let Some((title, body)) = notify {
-            let _ = stella_store::NotificationStore::open_default().push(
-                &stella_store::Notification::new(title, body, self.record.id.clone())
-                    .with_session_id(self.record.id.clone()),
-            );
-        }
     }
 }
 

--- a/stella-cli/src/agent/goal.rs
+++ b/stella-cli/src/agent/goal.rs
@@ -178,21 +178,11 @@ pub(crate) async fn run_raw_one_shot(
         set.close_all().await;
     }
     // Terminal registry status + the headless → `/inbox` flow (failure
-    // always notifies; success only past the looked-away threshold).
-    let run_secs = crate::memory::unix_now_secs().saturating_sub(started_unix);
-    let notify = if outcome.is_err() {
-        Some((
-            format!("{}: run FAILED", presence.name()),
-            crate::command_deck::prompt_line(prompt, 160),
-        ))
-    } else if run_secs >= 60 {
-        Some((
-            format!("{}: run finished ({run_secs}s)", presence.name()),
-            crate::command_deck::prompt_line(prompt, 160),
-        ))
-    } else {
-        None
-    };
+    // always notifies; success only past the looked-away threshold —
+    // `SessionPresence::one_shot_notification`, shared with the pipeline path).
+    let run_secs =
+        u64::try_from(crate::memory::unix_now_secs().saturating_sub(started_unix)).unwrap_or(0);
+    let notify = presence.one_shot_notification(outcome.is_ok(), run_secs, prompt);
     presence.finish(outcome.is_ok(), notify);
     outcome
 }
@@ -714,9 +704,9 @@ async fn run_goal_pipeline_turn(
             // the even slot, the round's judge the odd slot beside it (the
             // `+ 1` lives in `Engine::assess`). All rounds share one
             // execution_id, and receipts key on `(turn_instance, step,
-            // call_seq)` with steps restarting per turn — without this,
-            // every round overwrites the previous round's step manifests.
-            let round_turn = u32::try_from(2 * round.saturating_sub(1)).unwrap_or(u32::MAX);
+            // call_seq)` with steps restarting per turn — the slot math is
+            // `stella_core::goal`'s, shared with the raw and served loops.
+            let round_turn = stella_core::goal::goal_round_turn_offset(round);
             let pipeline_config = PipelineConfig {
                 engine: EngineConfig {
                     turn_instance: round_turn,
@@ -755,11 +745,9 @@ async fn run_goal_pipeline_turn(
                 steering: None,
             };
             let pipeline = Pipeline::new(ports, tx.clone(), pipeline_config);
-            let round_goal = format!(
-                "GOAL: {goal}\n\nWork toward this goal. An independent judge will assess the \
-                 result after each working round from the transcript evidence; keep your work \
-                 verifiable (run tests, show outputs)."
-            );
+            // The same kickoff wording as the raw goal loop and the served
+            // one — `stella_core::goal` owns the bytes for all three.
+            let round_goal = stella_core::goal::goal_kickoff_text(goal);
             match pipeline.run(&round_goal, messages, budget).await {
                 Ok(outcome) => {
                     total_cost_usd += outcome.total_cost_usd;
@@ -827,15 +815,9 @@ async fn run_goal_pipeline_turn(
                 break;
             }
 
-            let feedback = if verdict.feedback.trim().is_empty() {
-                verdict.reasoning.clone()
-            } else {
-                verdict.feedback.clone()
-            };
-            messages.push(CompletionMessage::user(format!(
-                "The judge assessed the goal as NOT yet met.\nJudge feedback: {feedback}\n\n\
-                 Continue working toward the goal: {goal}"
-            )));
+            messages.push(CompletionMessage::user(
+                stella_core::goal::judge_feedback_text(goal, &verdict),
+            ));
         }
 
         // An explicit break result (abort/error/judge-down) stands. If the goal

--- a/stella-cli/src/agent/presence.rs
+++ b/stella-cli/src/agent/presence.rs
@@ -1,0 +1,134 @@
+//! A headless/plain session's presence in the machine-wide session registry.
+
+use super::*;
+
+/// A headless/plain session's presence in the machine-wide registry: the
+/// deck's SESSIONS overlay finds it live and — because every execution links
+/// back via [`super::begin_execution`]'s `session` — can replay it long after
+/// it ended. Registration is best-effort throughout: a failed registry write
+/// never disturbs the run.
+pub(crate) struct SessionPresence {
+    registry: stella_store::SessionRegistry,
+    record: stella_store::SessionRecord,
+    name: String,
+    /// This session's durable record, carried so [`Self::finish`] can compact
+    /// it. Cloning the handle rather than re-opening the record keeps the
+    /// compaction pointed at the session that was actually bound, whatever the
+    /// driver did in between.
+    durability: crate::durability::SessionDurability,
+}
+
+impl SessionPresence {
+    /// Announce the session (status In Progress), titled from the workspace
+    /// and the prompt/goal that started it, and bind this session's durability
+    /// to `tools`.
+    ///
+    /// The binding is done HERE, rather than left to each headless driver,
+    /// because this is the moment the session acquires the identity durability
+    /// is keyed on. A driver that announced without binding would run a whole
+    /// session whose turns checkpoint nowhere — and the failure would be
+    /// silent, because an unbound sink is indistinguishable from a session
+    /// that simply never crashed.
+    pub(crate) fn announce(cfg: &Config, prompt: &str, tools: &Arc<ToolRegistry>) -> Self {
+        let name = cfg
+            .workspace_root
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| cfg.workspace_root.display().to_string());
+        let mut record = stella_store::SessionRecord::new(
+            cfg.workspace_root.display().to_string(),
+            name.clone(),
+        );
+        record.title = format!("{name}: {}", crate::command_deck::prompt_line(prompt, 48));
+        record.summary = crate::command_deck::prompt_line(prompt, 240);
+        let registry = stella_store::SessionRegistry::open_default();
+        let _ = registry.upsert(&record);
+        // stderr, not stdout: `--output-format json` owns stdout, and a
+        // durability advisory must never land inside a machine-readable
+        // document.
+        if let Some(warning) =
+            crate::durability::bind_session(&cfg.durability, tools, &cfg.workspace_root, &record.id)
+        {
+            eprintln!("  {warning}");
+        }
+        Self {
+            registry,
+            record,
+            name,
+            durability: cfg.durability.clone(),
+        }
+    }
+
+    /// The registry id — what executions link to and notifications carry.
+    pub(crate) fn id(&self) -> &str {
+        &self.record.id
+    }
+
+    /// The workspace's display name (notification titles).
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The headless one-shot → `/inbox` notification decision, shared by the
+    /// pipeline and raw (`--no-pipeline`) paths so the two cannot drift: a
+    /// failed run always lands a notification; a successful one only when it
+    /// ran long enough (60s) that the user has plausibly looked away.
+    pub(crate) fn one_shot_notification(
+        &self,
+        run_ok: bool,
+        run_secs: u64,
+        prompt: &str,
+    ) -> Option<(String, String)> {
+        let title = if !run_ok {
+            format!("{}: run FAILED", self.name())
+        } else if run_secs >= 60 {
+            format!("{}: run finished ({run_secs}s)", self.name())
+        } else {
+            return None;
+        };
+        Some((title, crate::command_deck::prompt_line(prompt, 160)))
+    }
+
+    /// A new prompt is running: refresh the summary (and the title, if the
+    /// session was announced before its first real prompt).
+    pub(crate) fn update_prompt(&mut self, prompt: &str) {
+        self.record.summary = crate::command_deck::prompt_line(prompt, 240);
+        self.record.status = stella_store::SessionStatus::InProgress;
+        self.record.title = format!(
+            "{}: {}",
+            self.name,
+            crate::command_deck::prompt_line(prompt, 48)
+        );
+        let _ = self.registry.upsert(&self.record);
+    }
+
+    /// Between turns an interactive session waits on the human.
+    pub(crate) fn needs_input(&mut self) {
+        self.record.status = stella_store::SessionStatus::NeedsInput;
+        let _ = self.registry.upsert(&self.record);
+    }
+
+    /// Terminal status, plus an optional persist-until-read inbox
+    /// notification linked to this session — the headless → `/inbox` flow:
+    /// a finished `stella run` surfaces in every deck's inbox, and `Enter`
+    /// replays it.
+    pub(crate) fn finish(&mut self, ok: bool, notify: Option<(String, String)>) {
+        self.record.status = if ok {
+            stella_store::SessionStatus::Complete
+        } else {
+            stella_store::SessionStatus::Error
+        };
+        let _ = self.registry.upsert(&self.record);
+        // The headless counterpart of the deck's exit compaction. A one-shot
+        // run writes fewer objects than a long deck session, but it is also the
+        // shape that runs a hundred times in a loop from a script — which is
+        // exactly how a workspace accumulates loose objects nobody is watching.
+        self.durability.compact();
+        if let Some((title, body)) = notify {
+            let _ = stella_store::NotificationStore::open_default().push(
+                &stella_store::Notification::new(title, body, self.record.id.clone())
+                    .with_session_id(self.record.id.clone()),
+            );
+        }
+    }
+}

--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -149,7 +149,7 @@ impl RepoStatusPort for GitRepoStatus {
     async fn tracked_fingerprints(&self) -> std::collections::HashMap<String, String> {
         let mut out = std::collections::HashMap::new();
         let mut cmd = tokio::process::Command::new("git");
-        stella_tools::exec::scrub_sensitive_env(&mut cmd);
+        scrub_model_subprocess(&mut cmd);
         cmd.args([
             "-c",
             "core.quotePath=false",
@@ -598,6 +598,9 @@ fn resolve_head(root: &std::path::Path) -> Option<String> {
     for var in stella_tools::exec::GIT_REPO_ENV_VARS {
         cmd.env_remove(var);
     }
+    // Same credential-scrub policy as every other git spawn in this file —
+    // this was the one site that skipped it (sync `Command`, so the std form).
+    stella_tools::exec::scrub_sensitive_std_env(&mut cmd);
     let out = cmd.output().ok()?;
     if !out.status.success() {
         return None;
@@ -632,7 +635,7 @@ fn test_process(invocation: &TestInvocation, root: &std::path::Path) -> tokio::p
     for var in stella_tools::exec::GIT_REPO_ENV_VARS {
         cmd.env_remove(var);
     }
-    stella_tools::exec::scrub_sensitive_env(&mut cmd);
+    scrub_model_subprocess(&mut cmd);
     cmd
 }
 
@@ -640,7 +643,7 @@ fn test_process(invocation: &TestInvocation, root: &std::path::Path) -> tokio::p
 impl DiagnosticRunner for GitDiagnosticRunner {
     async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
         let mut cmd = tokio::process::Command::new("git");
-        stella_tools::exec::scrub_sensitive_env(&mut cmd);
+        scrub_model_subprocess(&mut cmd);
         match invocation {
             DiagnosticInvocation::GitDiff => match self.baseline_commit() {
                 Some(baseline) => {

--- a/stella-core/src/goal.rs
+++ b/stella-core/src/goal.rs
@@ -104,6 +104,57 @@ pub struct GoalJudgeVerdict {
     pub feedback: String,
 }
 
+/// The kickoff message every goal loop opens with.
+///
+/// Shared by [`Engine::run_goal`], the CLI's staged-pipeline goal loop, and
+/// `stella-serve`'s `drive_goal`: a served goal round and a CLI goal round
+/// must put byte-identical words in front of the model or they are two
+/// features wearing one name. All three surfaces used to carry their own
+/// copy of this string with a comment promising exactly that — this function
+/// is the promise made structural.
+#[must_use]
+pub fn goal_kickoff_text(goal: &str) -> String {
+    format!(
+        "GOAL: {goal}\n\nWork toward this goal. An independent judge will assess the \
+         result after each working round from the transcript evidence; keep your work \
+         verifiable (run tests, show outputs)."
+    )
+}
+
+/// The message that carries a judge's "not yet" back to the worker — the
+/// other half of the [`goal_kickoff_text`] contract, shared by the same
+/// three goal loops.
+///
+/// An empty `feedback` field falls back to the verdict's `reasoning` (the
+/// judge explained *why* even when it offered no next action); the fallback
+/// lives here so no surface re-implements it differently.
+#[must_use]
+pub fn judge_feedback_text(goal: &str, verdict: &GoalJudgeVerdict) -> String {
+    let feedback = if verdict.feedback.trim().is_empty() {
+        &verdict.reasoning
+    } else {
+        &verdict.feedback
+    };
+    format!(
+        "The judge assessed the goal as NOT yet met.\nJudge feedback: {feedback}\n\n\
+         Continue working toward the goal: {goal}"
+    )
+}
+
+/// The receipt turn-slot offset of `round`'s worker calls: worker rounds
+/// take even slots (0, 2, 4, …) and each round's judge takes the odd slot
+/// beside them ([`Engine::assess`] adds the `+ 1`), so no two model calls in
+/// a goal arc share a `(turn_instance, step, call_seq)` receipt key within
+/// one execution.
+///
+/// Shared by the same three goal loops as [`goal_kickoff_text`] — a surface
+/// that re-derived the slot math differently would silently overwrite a
+/// sibling round's step manifests in the store.
+#[must_use]
+pub fn goal_round_turn_offset(round: usize) -> u32 {
+    u32::try_from(round.saturating_sub(1).saturating_mul(2)).unwrap_or(u32::MAX)
+}
+
 const JUDGE_SYSTEM_PROMPT: &str = "You are an impartial judge assessing whether a coding agent \
      has fully met a stated goal. Judge from EVIDENCE, never from claims: use your read-only \
      tools (read_file, grep, glob, explorations, ci_status, search_issues) to verify the work \
@@ -135,20 +186,13 @@ impl Engine<'_> {
         goal_config: &GoalConfig,
     ) -> GoalOutcome {
         let starting_cost_usd = budget.session_spent_usd();
-        messages.push(CompletionMessage::user(format!(
-            "GOAL: {goal}\n\nWork toward this goal. An independent judge will assess the \
-             result after each working round from the transcript evidence; keep your work \
-             verifiable (run tests, show outputs)."
-        )));
+        messages.push(CompletionMessage::user(goal_kickoff_text(goal)));
 
         for round in 1..=goal_config.max_rounds {
             budget.begin_turn();
-            // Each round is its own turn for receipt purposes: worker rounds
-            // take even slots above the caller's base and each round's judge
-            // takes the odd slot beside it (see `assess`), so no two model
-            // calls in the goal arc share a `(turn_instance, step, call_seq)`
-            // receipt key within the execution.
-            let round_offset = u32::try_from(2 * round.saturating_sub(1)).unwrap_or(u32::MAX);
+            // Each round is its own turn for receipt purposes — see
+            // `goal_round_turn_offset` for the even/odd slot rule.
+            let round_offset = goal_round_turn_offset(round);
             let round_engine =
                 self.with_turn_instance(self.config.turn_instance.saturating_add(round_offset));
             match round_engine.run_turn(messages, budget, events).await {
@@ -202,15 +246,7 @@ impl Engine<'_> {
                 };
             }
 
-            let feedback = if verdict.feedback.trim().is_empty() {
-                verdict.reasoning.clone()
-            } else {
-                verdict.feedback.clone()
-            };
-            messages.push(CompletionMessage::user(format!(
-                "The judge assessed the goal as NOT yet met.\nJudge feedback: {feedback}\n\n\
-                 Continue working toward the goal: {goal}"
-            )));
+            messages.push(CompletionMessage::user(judge_feedback_text(goal, &verdict)));
         }
 
         GoalOutcome::Unmet {
@@ -1170,5 +1206,40 @@ mod tests {
         let cut = truncate_chars(s, 4);
         assert_eq!(cut, "héll…");
         assert_eq!(truncate_chars("short", 10), "short");
+    }
+
+    /// The three goal loops (core, CLI pipeline, serve) share these helpers so
+    /// their prompts and receipt slots cannot drift — pin the exact wording
+    /// and slot math the shared functions promise.
+    #[test]
+    fn shared_goal_loop_helpers_pin_wording_and_slot_math() {
+        assert_eq!(
+            goal_kickoff_text("ship it"),
+            "GOAL: ship it\n\nWork toward this goal. An independent judge will assess the \
+             result after each working round from the transcript evidence; keep your work \
+             verifiable (run tests, show outputs)."
+        );
+        let verdict = GoalJudgeVerdict {
+            met: false,
+            reasoning: "tests missing".into(),
+            feedback: "add a test".into(),
+        };
+        assert_eq!(
+            judge_feedback_text("ship it", &verdict),
+            "The judge assessed the goal as NOT yet met.\nJudge feedback: add a test\n\n\
+             Continue working toward the goal: ship it"
+        );
+        // Whitespace-only feedback falls back to the reasoning.
+        let bare = GoalJudgeVerdict {
+            met: false,
+            reasoning: "tests missing".into(),
+            feedback: "  ".into(),
+        };
+        assert!(judge_feedback_text("ship it", &bare).contains("Judge feedback: tests missing"));
+        // Worker rounds take even slots; `Engine::assess` adds the judge's +1.
+        assert_eq!(goal_round_turn_offset(1), 0);
+        assert_eq!(goal_round_turn_offset(2), 2);
+        assert_eq!(goal_round_turn_offset(3), 4);
+        assert_eq!(goal_round_turn_offset(usize::MAX), u32::MAX);
     }
 }

--- a/stella-serve/src/goal.rs
+++ b/stella-serve/src/goal.rs
@@ -61,26 +61,11 @@ pub struct GoalRun {
     pub judge_provider_id: Option<String>,
 }
 
-/// The seed message a goal run opens with — byte-identical to
-/// [`Engine::run_goal`]'s, because a served goal round and a CLI goal round
-/// must put the same words in front of the model or they are two features
-/// wearing one name.
-fn seed_message(goal: &str) -> CompletionMessage {
-    CompletionMessage::user(format!(
-        "GOAL: {goal}\n\nWork toward this goal. An independent judge will assess the \
-         result after each working round from the transcript evidence; keep your work \
-         verifiable (run tests, show outputs)."
-    ))
-}
-
-/// The message that carries a judge's "not yet" back to the worker — again
-/// byte-identical to the CLI's.
-fn feedback_message(goal: &str, feedback: &str) -> CompletionMessage {
-    CompletionMessage::user(format!(
-        "The judge assessed the goal as NOT yet met.\nJudge feedback: {feedback}\n\n\
-         Continue working toward the goal: {goal}"
-    ))
-}
+// The seed and feedback wording is `stella_core::goal`'s
+// (`goal_kickoff_text` / `judge_feedback_text`): a served goal round and a
+// CLI goal round must put the same words in front of the model or they are
+// two features wearing one name — this file used to carry its own copies
+// with a comment promising byte-identity that nothing enforced.
 
 /// Drive a judged goal run to its outcome (#1297).
 ///
@@ -121,11 +106,13 @@ pub(crate) async fn drive_goal(
     bus: Option<&HookBus>,
 ) -> DrivenTurn {
     let sender = EventSender::new(events.clone());
-    messages.push(seed_message(&run.goal));
+    messages.push(CompletionMessage::user(
+        stella_core::goal::goal_kickoff_text(&run.goal),
+    ));
 
     for round in 1..=run.config.max_rounds {
         budget.begin_turn();
-        let offset = u32::try_from(2 * round.saturating_sub(1)).unwrap_or(u32::MAX);
+        let offset = stella_core::goal::goal_round_turn_offset(round);
         let round_engine = engine.with_turn_instance(base_turn.saturating_add(offset));
         let driven = crate::session::drive_turn(
             &round_engine,
@@ -198,12 +185,9 @@ pub(crate) async fn drive_goal(
                 budget,
             };
         }
-        let feedback = if verdict.feedback.trim().is_empty() {
-            verdict.reasoning
-        } else {
-            verdict.feedback
-        };
-        messages.push(feedback_message(&run.goal, &feedback));
+        messages.push(CompletionMessage::user(
+            stella_core::goal::judge_feedback_text(&run.goal, &verdict),
+        ));
     }
 
     DrivenTurn {


### PR DESCRIPTION
## What & why

A line-by-line review of the turn loop and every path that invokes the agent (`stella run` / `goal` / `monitor` / `chat` / `resume`, the deck, the plain REPL, sub-sessions, fleet workers, `stella-serve`, and the pipeline's execute turns), looking for multiple paths that do the same thing and near-duplicate implementations. The core loop itself is sound — `run_turn` is exactly a loop over `run_step`, and the deck/fleet/serve drivers all route through the shared `agent::` wiring helpers — but the review found one real unenforced duplication and a handful of smaller ones, all fixed here:

- **Goal-loop wording + receipt slot math, copied across three crates.** The goal kickoff message, the judge "not yet" feedback message (including its empty-feedback→reasoning fallback), and the even/odd receipt turn-slot offset existed as verbatim copies in `stella_core::Engine::run_goal`, the CLI's staged-pipeline goal loop (`run_goal_pipeline_turn`), and `stella-serve::drive_goal` — the serve copy carried a doc comment *promising* byte-identity that nothing enforced. They now live once in `stella_core::goal` (`goal_kickoff_text`, `judge_feedback_text`, `goal_round_turn_offset`) and all three surfaces consume them.
- **REPL reflection blocks.** `run_interactive`'s plain-prompt handler and its `/goal` handler carried byte-identical 20-line post-turn reflection blocks; they now share `reflect_on_interactive_turn`.
- **One-shot inbox notification decision.** The "failure always notifies; success only past 60s" rule was written twice (pipeline path in `agent.rs`, raw path in `agent/goal.rs`); it now lives on `SessionPresence::one_shot_notification`.
- **Subprocess credential scrub in `agent/tools.rs`.** Three git spawns bypassed the file's named scrub seam (`scrub_model_subprocess`) and called the compat facade directly; they now go through the seam. `resolve_head` — the one git spawn in the file that scrubbed nothing — now scrubs like its siblings.
- `SessionPresence` moved to its own `agent/presence.rs` module (the file-size ratchet flagged `agent.rs` growing past its recorded ceiling; the extraction puts it 105 lines under).

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is behavior-preserving deduplication. The new `shared_goal_loop_helpers_pin_wording_and_slot_math` unit test in `stella-core` pins the exact wording, the empty-feedback fallback, and the slot math the three goal loops now share, so a future drift is a test failure rather than a silent divergence. (`goal_round_turn_offset` also swaps `2 *` for `saturating_mul(2)`, removing a theoretical debug-mode overflow — unreachable at real round counts.)

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

Reviewed but deliberately **not** changed: the four per-driver `PipelinePorts` assemblies (one-shot, goal, deck, fleet) already share `WorkspacePorts`, `resolve_engine_wiring`, `pipeline_engine_config_for`, and `apply_pipeline_tuning` — their remaining differences (approval gate, steering tap, recall port) are intentional per-surface behavior, and collapsing them further would trade documented explicitness for a config-object with per-driver branches. Similarly, `stella-serve`'s `drive_turn` is a deliberate second *loop* over the one shared `run_step` (cancel + checkpoint seams), not a second implementation of a step.

---

## Summary by Sourcery

Deduplicate goal-loop messaging and receipt slot math across core, CLI, and serve, and centralize session presence and reflection behavior for headless and interactive runs.

Enhancements:
- Introduce shared helpers in stella-core for goal kickoff messaging, judge feedback text, and goal round receipt slot calculation used by all goal drivers.
- Extract SessionPresence into its own module and add a shared one-shot notification helper to keep CLI pipeline and raw runs consistent.
- Factor interactive REPL post-turn reflection into a single helper shared by plain prompt and /goal handlers.
- Route all git subprocesses in CLI tooling through the common credential-scrub seam and align resolve_head with the same policy.

Tests:
- Add a unit test in stella-core to pin the shared goal text wording, empty-feedback fallback behavior, and receipt slot math.
