### PR TITLE
fix(candidate): tell an isolated candidate which tree is real

### DIFF
--- a/stella-pipeline/src/candidate_narration.rs
+++ b/stella-pipeline/src/candidate_narration.rs
@@ -9,6 +9,12 @@
 //! Both functions return `None` for `n <= 1`. `run_best_of_n` also serves a
 //! single candidate when a witness is being authored, and "candidate 1/1" there
 //! is noise rather than signal.
+//!
+//! [`messages_rooted_at`] narrates the same fan-out to its *other* audience.
+//! The user is told a candidate is isolated; until it was added, the candidate
+//! itself never was.
+
+use stella_protocol::CompletionMessage;
 
 /// Announce a fan-out whose candidates run *together* (#1215), before any of
 /// them starts.
@@ -67,6 +73,40 @@ pub(crate) fn candidate_winner_notice(best_idx: usize, n: u32, ran: u32) -> Opti
     ))
 }
 
+/// A candidate's own starting messages: the shared prefix, plus — when this
+/// candidate runs in a tree of its own — one line naming that tree.
+///
+/// The model is otherwise never told. Its tools are re-rooted silently, so
+/// `pwd` answers with a path the task statement never mentions, and a task that
+/// spells absolute paths (a benchmark's `/app`, a monorepo checkout) reads as a
+/// flat contradiction. Leaving it unsaid is not merely confusing: a candidate
+/// that resolves the contradiction the wrong way `cd`s to the original tree and
+/// works there, where its edits are outside the snapshot adoption diffs — so
+/// they are dropped — while the edits it did make inside can leave the snapshot
+/// no longer byte-identical to its seal, which fails adoption for the whole
+/// candidate. Both halves of a split turn lose.
+///
+/// Appended AFTER the shared prefix, never inside it: the candidates of a
+/// fan-out share one cached prefix, so the single message that differs between
+/// them has to be last (the prompt-cache stability invariant).
+pub(crate) fn messages_rooted_at(
+    base: &[CompletionMessage],
+    root: Option<&str>,
+) -> Vec<CompletionMessage> {
+    let mut messages = base.to_vec();
+    if let Some(root) = root {
+        messages.push(CompletionMessage::user(format!(
+            "Workspace: your tools and shell are rooted at `{root}`, an isolated \
+             snapshot of the project. Only work inside this root is collected when \
+             the turn finishes. Absolute paths in the task above name the original \
+             tree; resolve them against this root instead (`/x/y` -> `{root}/x/y`). \
+             Another copy of the project may be readable elsewhere on this machine — \
+             editing it does not count, so do not `cd` out of this root."
+        )));
+    }
+    messages
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,6 +124,49 @@ mod tests {
             shared.contains("shared working tree"),
             "a shared-tree fan-out must say so — a loser's edits stay on disk: {shared}"
         );
+    }
+
+    /// The fact the candidate could not otherwise get: which tree is real.
+    /// It must also say that the *other* copy is not collected — a candidate
+    /// that knows only its own path still has no reason to distrust the
+    /// absolute paths the task statement gave it.
+    #[test]
+    fn an_isolated_candidate_is_told_its_root_and_that_only_it_counts() {
+        let base = vec![
+            CompletionMessage::system("prefix"),
+            CompletionMessage::user("write vm.js to /app"),
+        ];
+        let rooted = messages_rooted_at(&base, Some("/tmp/stella_candidate_64_0"));
+
+        assert_eq!(
+            rooted.len(),
+            base.len() + 1,
+            "exactly one message is added: {rooted:?}"
+        );
+        // Byte-identical prefix, appended last: N candidates differ only in the
+        // tail, so the cached prefix is still shared across the fan-out.
+        assert_eq!(&rooted[..base.len()], &base[..], "prefix must not move");
+
+        let notice = &rooted[base.len()].content;
+        assert!(notice.contains("/tmp/stella_candidate_64_0"), "{notice}");
+        assert!(
+            notice.contains("do not `cd` out of this root"),
+            "the escape hatch that splits a turn across two trees: {notice}"
+        );
+        assert!(
+            notice.contains("Only work inside this root is collected"),
+            "naming the root is not enough — say the other copy does not count: {notice}"
+        );
+    }
+
+    /// A shared-tree candidate has no second tree to confuse, and the session
+    /// root is already the one the task text names. Saying anything here would
+    /// be a per-candidate message with nothing to report, paid for on a turn
+    /// that has no ambiguity to resolve.
+    #[test]
+    fn a_shared_tree_candidate_is_told_nothing() {
+        let base = vec![CompletionMessage::user("goal")];
+        assert_eq!(messages_rooted_at(&base, None), base);
     }
 
     #[test]

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -2079,7 +2079,7 @@ impl<'a> Pipeline<'a> {
         let untracked_before = surface.repo_status.untracked_fingerprints().await;
 
         let mut state = CandidateState {
-            messages: base_messages.to_vec(),
+            messages: crate::candidate_narration::messages_rooted_at(base_messages, surface.cwd),
             final_text: String::new(),
             file_changes: 0,
             mutating_actions: 0,

--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -106,10 +106,11 @@ fn shell_words(command: &str) -> Vec<String> {
 }
 
 /// If the command `cd`s somewhere outside the workspace `root`, return that
-/// target — the graph indexes only `root`, so a search or edit under a
-/// drifted tree is silently ungraphed (the cross-tree gap the telemetry
-/// showed). Targets we can't resolve (`$VAR`, `~`, `-`, a flag) are skipped:
-/// better a missed note than a wrong one.
+/// target — every other tool is confined to `root`, so an edit under a drifted
+/// tree is invisible to the file tools, the turn's diff, and verification (and
+/// ungraphed besides, the cross-tree gap the telemetry showed). Targets we
+/// can't resolve (`$VAR`, `~`, `-`, a flag) are skipped: better a missed note
+/// than a wrong one.
 fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
     let words = shell_words(command);
     for pair in words.windows(2) {
@@ -160,25 +161,40 @@ fn bash_grep_is_symbol_shaped(command: &str) -> bool {
     false
 }
 
-/// The advisory footer for a bash result, when the code graph exists (so its
-/// advice is actionable): a cross-root `cd` warning takes precedence — under a
-/// drifted tree graph_query can't help — otherwise a symbol-shaped grep gets
-/// the same `graph_query` pointer the native search tools carry.
+/// The advisory footer for a bash result: a cross-root `cd` warning takes
+/// precedence, otherwise a symbol-shaped grep gets the same `graph_query`
+/// pointer the native search tools carry.
+///
+/// Only the grep tip is conditioned on the code graph existing — it is advice
+/// about a tool that isn't there otherwise. The drift warning is NOT, and used
+/// to be: gating it on the index meant the one case that most needs it, a
+/// freshly-created tree with nothing indexed, was the one case that stayed
+/// silent. A best-of-N candidate is exactly that tree. Its shell starts in a
+/// snapshot under `/tmp` while the task text names the original checkout, so
+/// `cd`-ing back to the original is the natural misreading — and it used to
+/// draw no response at all, leaving the turn's work split across two trees with
+/// the half outside this root silently uncollected.
 fn graph_advisory(command: &str, root: &Path) -> Option<String> {
-    if !matches!(crate::graph::graph_available(root), Ok(true)) {
-        return None;
-    }
+    let graphed = matches!(crate::graph::graph_available(root), Ok(true));
     if let Some(target) = cd_escape_target(command, root) {
+        // Named only when the graph is real: pointing at graph_query as a
+        // reason to stay is noise on a tree that has no index to miss.
+        let graph_note = if graphed {
+            " graph_query and the grep/glob code-map footers index only this root, so \
+             it isn't covered by the code graph either."
+        } else {
+            ""
+        };
         return Some(format!(
-            "\n\nnote: this cd'd to `{target}`, outside the session root `{}` — \
-             graph_query and the grep/glob code-map footers index only this root, so \
-             work under `{target}` isn't covered by the code graph. To use the \
-             structural tools there, re-root the session on that tree (run stella from \
-             it).",
+            "\n\nnote: this cd'd to `{target}`, outside the session root `{}`. Only \
+             work under the session root is collected when the turn finishes — every \
+             other tool is confined to it, so edits under `{target}` are invisible to \
+             the file tools, to this turn's diff, and to verification.{graph_note} To \
+             work on that tree, re-root the session on it (run stella from it).",
             root.display()
         ));
     }
-    if bash_grep_is_symbol_shaped(command) {
+    if graphed && bash_grep_is_symbol_shaped(command) {
         return Some(format!("\n\n{}", crate::code_map::GRAPH_QUERY_TIP));
     }
     None
@@ -669,8 +685,11 @@ mod tests {
         assert!(!text.contains("outside the session root"), "{text}");
     }
 
+    /// An un-indexed tree still warns on drift — that is the case the warning
+    /// exists for. A best-of-N candidate's snapshot has no index, so gating the
+    /// warning on one let a candidate `cd` out of its own workspace in silence.
     #[tokio::test]
-    async fn no_index_means_no_advisory() {
+    async fn no_index_still_warns_on_a_cross_root_cd() {
         let dir = tempfile::tempdir().unwrap();
         let text = text_of(
             Bash.execute(
@@ -678,6 +697,42 @@ mod tests {
                 dir.path(),
             )
             .await,
+        );
+        assert!(
+            text.contains("outside the session root"),
+            "drift warns without an index: {text}"
+        );
+        // The grep tip stays index-gated: it points at a tool this tree hasn't
+        // got. The drift note must not smuggle it in by naming the graph.
+        assert!(
+            !text.contains("graph_query"),
+            "no index, so nothing may cite the graph: {text}"
+        );
+    }
+
+    /// The warning's load-bearing claim, on the tree with no index: work under
+    /// the drifted target is not collected. A candidate that read only "the
+    /// graph doesn't cover it" would reasonably `cd` anyway.
+    #[tokio::test]
+    async fn the_drift_warning_says_the_work_is_not_collected() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = text_of(
+            Bash.execute(&serde_json::json!({"command": "cd / && pwd"}), dir.path())
+                .await,
+        );
+        assert!(
+            text.contains("is collected when the turn finishes"),
+            "{text}"
+        );
+        assert!(text.contains("verification"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn a_plain_command_gets_no_advisory_without_an_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = text_of(
+            Bash.execute(&serde_json::json!({"command": "echo hi"}), dir.path())
+                .await,
         );
         assert!(!text.contains("graph_query"), "{text}");
         assert!(!text.contains("outside the session root"), "{text}");


### PR DESCRIPTION
## What broke

A best-of-N candidate's tools are re-rooted at a shadow worktree under `/tmp` — and nothing tells the model. Its shell answers `pwd` with a path the task statement never mentions, so a task that spells absolute paths (a benchmark's `/app`, a monorepo checkout) reads as a flat contradiction.

Observed on an arena-bench task. The candidate spent four turns running `stat`/`pwd`/`ls` against its own filesystem trying to decide which tree was real, concluded *"these are bind mounts pointing to different snapshots"*, and split its work across both.

The split is the actual damage, not the wasted turns:

- edits **outside** the snapshot are not in the diff adoption applies → silently dropped;
- edits **inside** can leave the snapshot no longer byte-identical to its seal → adoption fails for the whole candidate.

Both halves lose. A turn that looked productive lands nothing.

## Two causes

**1. The candidate was never told its root.** `candidate_start_notice` announces isolation to the *user*; there was no equivalent for the model. `messages_rooted_at` adds one: it names the snapshot as the only tree that is collected, and tells the model to resolve the task's absolute paths against it.

Appended **after** the shared prefix, never inside it — the candidates of a fan-out share one cached prefix, so the single message that differs between them has to be last. The call site is a one-for-one line swap because `pipeline.rs` sits exactly on its file-size ceiling (3672).

Gated on `surface.cwd == Some(_)`, which is precisely "runs in a tree that is not the session root" (all three construction sites checked). A shared-tree candidate is told nothing.

**2. bash's cross-root `cd` warning was inert where it mattered.** `graph_advisory` returned early unless a code graph existed at the root. A freshly-created snapshot has no index — so the one tree that most needs the warning was the one tree that never got it, and `cd /app` drew no response at all.

The index gate now covers only the grep tip, which is genuinely advice about a tool the graph provides. The drift warning always fires, and leads with the consequence that matters — *work outside the root is not collected by the file tools, the diff, or verification* — rather than graph coverage.

## Why now

Latent since candidate isolation was written. It surfaces now because `STELLA_CANDIDATES` only recently became selectable (#1211 §6.8); before that, `candidates` was written once, to `None`, so best-of-N had never run outside tests.

## Verification

- `cargo test -p stella-tools -p stella-pipeline` — exit 0, 1172 passed, 0 failed
- `cargo clippy -p stella-tools -p stella-pipeline --all-targets -- -D warnings` — exit 0
- `cargo check --workspace --all-targets` — exit 0
- `scripts/check-file-size.sh` — exit 0, `pipeline.rs` unchanged at 3672
- pre-push gate green

New tests: prefix stays byte-identical when the notice is appended; shared-tree candidates get nothing; an un-indexed tree still warns on a cross-root `cd` while the grep tip stays suppressed.

## Not addressed here

Whether best-of-N *should* run inside a benchmark container at all is a posture question, not a code one — adoption back into the graded tree is an extra failure surface a bench arm may not want. Flagging, not changing.

## Summary by Sourcery

Clarify workspace isolation for best-of-N candidates and ensure cross-root shell navigation warns about uncollected work, preventing edits from being split across trees.

Bug Fixes:
- Inform isolated candidates which workspace snapshot is real and that only work inside it is collected, avoiding edits in the wrong tree that are dropped or break adoption.
- Make bash cross-root `cd` warnings fire even when no code graph index exists so candidates are always warned that work outside the session root is not collected.

Enhancements:
- Add a candidate-facing workspace notice that explains how to resolve absolute task paths against the isolated snapshot and discourages `cd`-ing out of it.
- Refine bash advisory messaging to emphasize collection, diff, verification, and optional graph coverage, and keep grep-related tips gated on graph availability.
- Adjust pipeline candidate initialization to use the new rooted-message helper while preserving the shared cached prefix across fan-out candidates.

Tests:
- Add tests covering candidate workspace notices for isolated vs shared-tree runs and ensuring prefix stability in fan-outs.
- Add tests verifying drift warnings on unindexed trees, that they state work is not collected, and that plain commands without an index receive no advisory.