### PR TITLE
fix(tui): clamp a typed hunk range before walking it

### DIFF
--- a/stella-tui/src/input.rs
+++ b/stella-tui/src/input.rs
@@ -74,7 +74,12 @@ pub fn hunk_selection_from_typed(text: &str, total: usize) -> Option<Vec<usize>>
         if from == 0 || from > to {
             return None;
         }
-        out.extend((from..=to).filter(|i| *i <= total).map(|i| i - 1));
+        // Clamp the range before walking it, never after. This parse runs
+        // inline in the key handler, so a typed `1-9999999999` filtered
+        // one value at a time would stop the deck redrawing and reading
+        // keys for as long as it counted. Bounding the range costs the
+        // same answer in as many steps as the card has hunks.
+        out.extend((from..=to.min(total)).map(|i| i - 1));
     }
     out.sort_unstable();
     out.dedup();
@@ -276,6 +281,27 @@ mod tests {
         assert_eq!(hunk_selection_from_typed("99", 2), Some(vec![]));
         for prose in ["", "  ", "keep the first one", "1 or 2", "-1", "3-1", "0"] {
             assert_eq!(hunk_selection_from_typed(prose, 4), None, "{prose:?}");
+        }
+    }
+
+    /// A typed upper bound is a bound, not a work list. `1-99` on a 2-hunk card
+    /// already had to answer `[0, 1]`; what this pins is the *cost* of getting
+    /// there, because the parse runs inline in the key handler and a range
+    /// walked one value at a time would stop the deck redrawing and reading
+    /// keys. Answered on a worker so reintroducing the walk fails in seconds
+    /// rather than hanging the suite until CI's timeout kills it.
+    #[test]
+    fn a_typed_upper_bound_costs_the_card_not_the_number() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(hunk_selection_from_typed(&format!("1-{}", usize::MAX), 3));
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(selection) => assert_eq!(selection, Some(vec![0, 1, 2])),
+            Err(_) => panic!(
+                "`1-{}` walked the typed range instead of clamping it",
+                usize::MAX
+            ),
         }
     }
 }


### PR DESCRIPTION
Applies the [`vercel[bot]` review comment on #1372](https://github.com/macanderson/stella/pull/1372) that landed unaddressed — the finding is real.

## The bug

`hunk_selection_from_typed` built the reviewer's full inclusive range and *then* filtered it down to the card's hunk count:

```rust
out.extend((from..=to).filter(|i| *i <= total).map(|i| i - 1));
```

`.filter()` doesn't shrink a range — the iterator still steps through every value to reject it. So the loop's trip count comes from the number typed, not from the data. On a three-hunk card, `1-9999999999` costs ten billion iterations to answer `[0, 1, 2]`, and `1-18446744073709551615` never finishes.

## Why it's worse than a slow parse

The call site is `stella-tui/src/deck_ui/gates.rs:194` — inline in the crossterm key handler, no yield point. The deck stops redrawing and stops reading keys, including the cancel key, until the count completes. And this is the per-hunk approval gate (#1265), i.e. the one whose answer edits somebody's files: the worst place in the deck to become unresponsive.

## The fix

```rust
out.extend((from..=to.min(total)).map(|i| i - 1));
```

Identical output. `from` is already known to be `>= 1` and `<= to` by the guard two lines up, so for an ascending range `to.min(total)` yields exactly the values `*i <= total` kept. A wholly out-of-range token (`from > total`) collapses to an empty range instead of an empty filter — same "drop it rather than fail the line" behaviour the doc comment promises, and already covered by the existing `hunk_selection_drops_out_of_range_and_refuses_prose` test.

Cost is now `O(hunks on the card)` regardless of what was typed.

## Test

`a_typed_upper_bound_costs_the_card_not_the_number` parses `1-{usize::MAX}` on a worker thread with a five-second budget, so reintroducing the walk fails in seconds rather than hanging the suite until CI's timeout kills it.

Verified both directions:
- old line restored → fails at 5.01s with `` `1-18446744073709551615` walked the typed range instead of clamping it ``
- clamp in place → passes instantly

## Checks

| gate | result |
| --- | --- |
| `cargo test -p stella-tui` | exit 0 — 825 passed, 0 failed |
| `cargo clippy -p stella-tui --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --all -- --check` | exit 0 |
| `scripts/check-file-size.sh` | exit 0 — none grew |

## Summary by Sourcery

Clamp typed hunk selection ranges to the card’s hunk count to prevent unbounded iteration in the TUI key handler.

Bug Fixes:
- Prevent the hunk selection parser from hanging the TUI when users type extremely large upper bounds in range expressions.

Enhancements:
- Add a concurrency-based regression test that ensures typed hunk ranges are clamped and complete within a bounded time budget.
