### PR TITLE
feat(verify): give the judge the diff the agent actually authored

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,7 +15,7 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4207 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-2376 stella-cli/src/agent.rs
+2271 stella-cli/src/agent.rs
 1750 stella-cli/src/agent_tests.rs
 1585 stella-cli/src/candidate_ws.rs
 4754 stella-cli/src/command_deck.rs
@@ -27,14 +27,14 @@
 2072 stella-model/src/openai.rs
 1572 stella-model/src/zai.rs
 1843 stella-model/src/zai/tests.rs
-3672 stella-pipeline/src/pipeline.rs
+3691 stella-pipeline/src/pipeline.rs
 2621 stella-pipeline/src/pipeline/tests.rs
 2906 stella-protocol/src/event.rs
 2080 stella-store/src/lib.rs
 2264 stella-store/src/tests.rs
 1916 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-2284 stella-tools/src/registry.rs
+2326 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1528 stella-tui/src/deck.rs
 1600 stella-tui/src/deck_render.rs

--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -381,6 +381,18 @@ impl stella_pipeline::FileTouchPort for RegistryTouches<'_> {
         self.0.mutations_recorded()
     }
 
+    /// Rendered here rather than borrowed, because the two crates on either
+    /// side of this bridge do not depend on each other: the tool crate owns the
+    /// ledger, the pipeline crate owns the question, and this is the only place
+    /// that can see both.
+    fn authored_diff(&self) -> stella_pipeline::AuthoredChange {
+        let rendered = self.0.authored_diff();
+        stella_pipeline::AuthoredChange {
+            text: rendered.text,
+            lines: rendered.lines,
+        }
+    }
+
     fn begin_workspace_probe(&self) {
         self.0.begin_workspace_probe();
     }

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -116,7 +116,7 @@ pub use pipeline::{
     PipelineRunError, PipelineStatus, RoleCallOverrides, Verdict,
 };
 pub use ports::{
-    AdoptedChange, AlwaysAbortGate, ApprovalGate, ArtifactIdentity, ArtifactKind,
+    AdoptedChange, AlwaysAbortGate, ApprovalGate, ArtifactIdentity, ArtifactKind, AuthoredChange,
     CandidateWorkspace, CandidateWorkspacePort, CmdKind, CmdOutcome, ContextRecallPort,
     CoverageProbe, DiagnosticInvocation, DiagnosticRunner, FileTouchPort, LineMutation, LintProbe,
     LintRecord, McpPrefetchPort, MutantOutcome, MutationProbe, NoContextRecall, NoFileTouches,

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -103,6 +103,7 @@ use crate::witness::{
     validate_witness_identity, validate_witness_invocation, witness_identity_matches,
     witness_prompt, witness_repair_prompt,
 };
+mod authored;
 mod disclosure;
 mod fanout_stage;
 mod judge_stage;
@@ -3331,9 +3332,27 @@ impl<'a> Pipeline<'a> {
         // second walk of an identical tree.
         self.touches.settle_workspace_probe();
         state.file_changes = self.observed_mutations(state);
-        state.diff_lines = probe.lines;
+        // The authored channel is read AFTER settling, for the same reason the
+        // count is: the probe's attributions are recorded through the same
+        // emitter, so reading first would describe the turn before its opaque
+        // calls had been accounted for.
+        let authored = self.touches.authored_diff();
+        // `max`, not a sum — these are two independent LOWER BOUNDS on one
+        // number, not two disjoint tallies. A tracked file edited through
+        // `write_file` is counted by both, and adding them would double it.
+        // (The same reasoning as `observed_mutations` above.)
+        state.diff_lines = probe.lines.max(authored.lines);
+        // Deliberately NOT widened by the authored channel. `diff_available`
+        // means "the configured probe could read the working tree", and the
+        // ladder's blind-evidence rung is built on that exact claim. An
+        // authored diff proves what was written, never what survived to sit on
+        // disk at the end of the turn — so it informs the judge without
+        // asserting that the tree was successfully re-read.
         state.diff_available = probe.available;
-        state.diff_text = verification_honest_diff(probe.text, state.file_changes);
+        state.diff_text = verification_honest_diff(
+            authored::splice_authored(probe.text, &authored),
+            state.file_changes,
+        );
     }
 
     /// Emit this recall's telemetry. The projection itself lives on

--- a/stella-pipeline/src/pipeline/authored.rs
+++ b/stella-pipeline/src/pipeline/authored.rs
@@ -1,0 +1,159 @@
+//! Joining the two diff channels.
+//!
+//! The pipeline reads two descriptions of what a turn did, and they answer
+//! different questions. The configured diff diagnostic (`git diff`) reports how
+//! the tree now differs from a commit — authoritative about what SURVIVED, and
+//! structurally blind to an untracked file or to a workspace with no repository
+//! at all. The authored channel reports what the file tools were asked to
+//! write — authoritative about INTENT, and silent about whether a later step
+//! clobbered it.
+//!
+//! Neither subsumes the other, so this module concatenates them rather than
+//! choosing. The whole reason that is legal is that both halves are unified-diff
+//! shaped: every consumer downstream parses the joined string with one parser
+//! and cannot tell which half a hunk came from.
+
+/// Labels the authored section when it is appended to a tree-state diff.
+///
+/// Starts with `#` on purpose. `witness::warrant::changed_paths` treats the
+/// remainder of any `--- ` or `+++ ` line as a file path, and
+/// `verify::mutation` reads `+`-prefixed lines as mutable content — a header in
+/// either shape would be parsed as a bogus path or a bogus mutation target. A
+/// comment prefix is inert to every parser that reads this text.
+const AUTHORED_SECTION_HEADER: &str =
+    "# --- changes recorded by the file tools at write time (authorship, not tree state) ---";
+
+/// Join what the tree says with what the tools recorded.
+///
+/// The two answer different questions and neither subsumes the other: the probe
+/// reports how the tree now differs from a commit (authoritative about what
+/// SURVIVED, blind to untracked files and to workspaces with no repository),
+/// while the authored channel reports what the agent asked to be written
+/// (authoritative about INTENT, silent about whether a later step clobbered
+/// it). Concatenating them — probe first, since on-disk state is the stronger
+/// claim where it exists — is what lets a judge see both.
+///
+/// The authored text is unified-diff shaped precisely so this concatenation is
+/// legal: every consumer downstream (`changed_paths`, `changed_lines`,
+/// `mutants_from_diff`) parses the joined string with one parser and cannot
+/// tell which half a hunk came from, which is the point.
+pub(super) fn splice_authored(
+    probe_text: String,
+    authored: &crate::ports::AuthoredChange,
+) -> String {
+    if authored.is_empty() {
+        return probe_text;
+    }
+    if probe_text.trim().is_empty() {
+        return authored.text.clone();
+    }
+    format!("{probe_text}\n{AUTHORED_SECTION_HEADER}\n{}", authored.text)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::ports::AuthoredChange;
+
+    /// A created file, as the ledger renders it.
+    ///
+    /// The body carries a comparison on purpose: `verify::mutation` swaps
+    /// operators, so a fixture with no operator would pass
+    /// [`an_authored_create_yields_mutants_where_a_marker_yielded_none`] for the
+    /// wrong reason — proving only that the content was unmutatable, not that the
+    /// header was parsed.
+    fn authored_create() -> AuthoredChange {
+        AuthoredChange {
+            text:
+                "--- /dev/null\n+++ b/solution.py\n@@ -1,0 +1,2 @@\n+def ok(n):\n+    return n >= 2\n"
+                    .to_string(),
+            lines: 2,
+        }
+    }
+
+    #[test]
+    fn an_empty_authored_change_leaves_the_probe_text_untouched() {
+        let probe = "diff --git a/x b/x\n".to_string();
+        assert_eq!(
+            splice_authored(probe.clone(), &AuthoredChange::default()),
+            probe
+        );
+    }
+
+    /// The Terminal-Bench case: the probe could not look, so the authored diff is
+    /// the entire answer and must not be buried under a joining header.
+    #[test]
+    fn a_blank_probe_yields_the_authored_diff_alone() {
+        let spliced = splice_authored(String::new(), &authored_create());
+        assert!(spliced.starts_with("--- /dev/null"), "{spliced}");
+        assert!(!spliced.contains(AUTHORED_SECTION_HEADER), "{spliced}");
+    }
+
+    /// Where both channels have something to say, the tree comes first — on-disk
+    /// state is the stronger claim about what survived — and the authored section
+    /// is labelled so a reader knows which question each half answers.
+    #[test]
+    fn both_channels_are_joined_with_the_tree_first() {
+        let probe = "diff --git a/lib.rs b/lib.rs\n--- a/lib.rs\n+++ b/lib.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n";
+        let spliced = splice_authored(probe.to_string(), &authored_create());
+        let tree = spliced.find("a/lib.rs").expect("tree half");
+        let header = spliced.find(AUTHORED_SECTION_HEADER).expect("the label");
+        let authored = spliced.find("b/solution.py").expect("authored half");
+        assert!(tree < header && header < authored, "{spliced}");
+    }
+
+    /// The header must be inert to every parser that reads this text. A `--- ` or
+    /// `+++ ` prefix would be read as a file path by `warrant::changed_paths`, and
+    /// a `+` prefix as mutable content by `verify::mutation`.
+    #[test]
+    fn the_section_header_cannot_be_parsed_as_a_path_or_a_change() {
+        assert!(AUTHORED_SECTION_HEADER.starts_with('#'));
+        let paths = crate::witness::warrant::changed_paths(AUTHORED_SECTION_HEADER);
+        assert!(paths.is_empty(), "{paths:?}");
+        let mutants = crate::verify::mutation::mutants_from_diff(AUTHORED_SECTION_HEADER, &[]);
+        assert!(mutants.is_empty(), "{mutants:?}");
+    }
+
+    /// The knock-on this channel repairs, part one: the mutation audit.
+    ///
+    /// A marker line carries no `+++` header, so `current_path` never binds and the
+    /// audit emits nothing — passing vacuously on exactly the workspaces where it
+    /// is the only check left. The authored render restores it.
+    #[test]
+    fn an_authored_create_yields_mutants_where_a_marker_yielded_none() {
+        let marker = "+ untracked change: solution.py (+2 lines)";
+        assert!(
+            crate::verify::mutation::mutants_from_diff(marker, &[]).is_empty(),
+            "the old shape audits nothing — this is the defect being fixed"
+        );
+        let mutants = crate::verify::mutation::mutants_from_diff(&authored_create().text, &[]);
+        assert!(!mutants.is_empty(), "the authored shape is auditable");
+        assert!(
+            mutants.iter().all(|m| m.path == "solution.py"),
+            "{mutants:?}"
+        );
+    }
+
+    /// The knock-on this channel repairs, part two: the warrant's path rules.
+    #[test]
+    fn an_authored_create_names_its_path_to_the_warrant() {
+        let paths = crate::witness::warrant::changed_paths(&authored_create().text);
+        assert_eq!(paths, vec!["solution.py".to_string()]);
+    }
+
+    /// A deletion points its right side at `/dev/null`, which the mutant builder
+    /// reads as "there is nothing here to mutate" rather than trying to break lines
+    /// that are gone.
+    #[test]
+    fn an_authored_delete_is_not_mutated() {
+        let deleted = AuthoredChange {
+            text: "--- a/gone.rs\n+++ /dev/null\n@@ -1,1 +1,0 @@\n-fn main() {}\n".to_string(),
+            lines: 1,
+        };
+        assert!(
+            crate::verify::mutation::mutants_from_diff(&deleted.text, &[]).is_empty(),
+            "a removed line is not a mutation target"
+        );
+    }
+}

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -286,6 +286,27 @@ pub trait FileTouchPort: Send + Sync {
     /// decides for the event.
     fn mutations_recorded(&self) -> u64;
 
+    /// The change the agent **authored**, rendered as a unified diff by the
+    /// file tools themselves at the moment they wrote it.
+    ///
+    /// This is the companion channel to the configured diff diagnostic, and it
+    /// exists because that diagnostic is `git diff`, which answers a question
+    /// about *tree state* when verification needs one about *authorship*. Git
+    /// is structurally unable to answer twice over:
+    ///
+    /// * a task directory that is not a repository (every Terminal-Bench
+    ///   image), where the probe can only report that it could not look; and
+    /// * a newly created file, which git cannot see until it is staged — so
+    ///   the commonest shape of agent work reached the judge as a bare path
+    ///   and a line count, with none of its content.
+    ///
+    /// The recorder holds both images of every write it performed, so it can
+    /// answer both. Default empty, so a host with no recorder — and every test
+    /// double — behaves exactly as it did before this existed.
+    fn authored_diff(&self) -> AuthoredChange {
+        AuthoredChange::default()
+    }
+
     /// Take a before-image of the workspace for the turn about to run.
     ///
     /// The pair with [`Self::settle_workspace_probe`] exists because a tool's
@@ -315,6 +336,34 @@ pub trait FileTouchPort: Send + Sync {
     /// Records through the same emitter as every other touch, so the ledger
     /// keeps exactly one birthplace for a `FileChange`.
     fn settle_workspace_probe(&self) {}
+}
+
+/// What the file recorder authored this session, as reported by
+/// [`FileTouchPort::authored_diff`].
+///
+/// Deliberately plain data rather than a borrowed view of the recorder's
+/// ledger: this crate does not depend on the tool crate that owns it, and the
+/// host bridging the two must be free to render once and hand the result over.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthoredChange {
+    /// Unified-diff text for changes a file tool declared by path, plus
+    /// bounded marker lines for paths that were merely observed changing.
+    /// Empty when the session authored nothing.
+    pub text: String,
+    /// Net lines changed by **declared** writes only.
+    ///
+    /// Paths that were merely observed (a `tar` extraction, a build) are
+    /// excluded on purpose: this number is compared against a size budget, and
+    /// unpacking a source tree must not be able to spend it.
+    pub lines: u32,
+}
+
+impl AuthoredChange {
+    /// Whether this carries anything a reader could act on.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty()
+    }
 }
 
 /// A [`FileTouchPort`] that never observes anything, for hosts with no file

--- a/stella-pipeline/src/witness/warrant.rs
+++ b/stella-pipeline/src/witness/warrant.rs
@@ -228,7 +228,12 @@ pub fn warrant(diff: &str, file_changes: u32) -> WitnessWarrant {
 /// stripped — a deletion still reports what it removed, and a rename
 /// contributes both its old and new path to the "every path must agree"
 /// rules.
-fn changed_paths(diff: &str) -> Vec<String> {
+/// `pub(crate)` so the authored-diff channel can assert, at its own seam, that
+/// what it renders is parsed here as real paths. That property is invisible
+/// from inside this module and silent when it breaks — the parser simply
+/// returns nothing — so the test that guards it has to live next to the
+/// producer.
+pub(crate) fn changed_paths(diff: &str) -> Vec<String> {
     let mut paths = Vec::new();
     for line in diff.lines() {
         let raw = if let Some(rest) = line.strip_prefix("+++ ") {

--- a/stella-tools/src/authored_diff.rs
+++ b/stella-tools/src/authored_diff.rs
@@ -1,0 +1,602 @@
+//! The diff of what the agent *meant* to change.
+//!
+//! `git diff` answers "how does the tree differ from a commit". That is the
+//! wrong question in two workspaces the agent is routinely run in, and the
+//! judge has been paying for it in both:
+//!
+//! * **No repository at all.** A Terminal-Bench task directory is a plain
+//!   directory, so the diff probe can only ever report that it could not look.
+//!   Every judge call on that benchmark has been handed a sentence of English
+//!   where a diff belongs.
+//! * **A new file.** `git diff` cannot see an untracked path, so the single
+//!   most common shape of agent work — *create the file that solves the task* —
+//!   reaches the judge as a one-line marker naming the path and its length,
+//!   carrying none of its content.
+//!
+//! Neither gap is a defect in git. They are the same category error twice:
+//! asking a tool that reports **tree state** to answer a question about
+//! **authorship**. This module answers the authorship question from the one
+//! place that already knows it — every CRUD tool in this registry funnels
+//! through `ToolRegistry::record_touch`, which holds the pre-image and
+//! the post-image of a write at the instant it happens, and then throws both
+//! away after rendering a single event.
+//!
+//! # Why the two provenances are not interchangeable
+//!
+//! A touch reaches the ledger by one of two routes, and they carry very
+//! different confidence:
+//!
+//! * [`Provenance::Declared`] — a CRUD tool **named this path in its input**.
+//!   The agent asked for this write, by path, through a schema we own. That is
+//!   as close to intent as this process can observe.
+//! * [`Provenance::Observed`] — [`crate::shell_touch`] saw the path change
+//!   across an opaque call. Something changed it; *the agent* may not have
+//!   meant it. A `tar xzf`, a `./configure`, a `make` and a deliberate
+//!   `sed -i` are indistinguishable at this layer.
+//!
+//! The distinction is not academic. A single extraction of the SQLite source
+//! tree produced ~1,200 `Observed` creations in one turn, every one recorded
+//! as a full-content authored file. Rendering those as authored diff would
+//! bury the agent's actual three-line fix under a megabyte of upstream test
+//! fixtures, and would tell a judge that the turn wrote SQLite.
+//!
+//! So the two render differently, on purpose: `Declared` entries render as a
+//! real unified diff with their content, and `Observed` entries render as
+//! bounded marker lines that name the path and its size and nothing else. The
+//! tree-state channel still reports them; this channel declines to call them
+//! authorship.
+//!
+//! # Cumulative, like the tool it replaces
+//!
+//! Entries fold by path and hold the **first** pre-image against the **latest**
+//! post-image, so ten edits to one file render as one hunk describing the net
+//! change. This matches what `git diff` would have shown against the session
+//! baseline. Rendering only the last edit would be the more obvious
+//! implementation and would quietly understate every iterated fix.
+
+use std::collections::BTreeMap;
+
+use crate::file_touch::{FileOp, changed_region_diff, line_diff};
+
+/// The marker line shape for a change this ledger will not render in full.
+///
+/// Mirrors `stella_pipeline::witness::warrant::untracked_change_line`
+/// **exactly**, and must keep mirroring it: the warrant parses this prefix back
+/// out to hold marker-only paths to the same path rules as tracked ones, and a
+/// hand-rolled variant here would silently blind it — the same defect that once
+/// let a turn creating a new source file classify as docs-only. The two crates
+/// cannot share a constant (neither depends on the other), so
+/// [`tests::marker_line_matches_the_pipeline_contract`] pins the literal
+/// instead.
+const MARKER_PREFIX: &str = "+ untracked change: ";
+
+/// Paths whose content this ledger will hold. Past this the ledger keeps
+/// counting but stops retaining, so a runaway turn cannot grow it without
+/// bound. Chosen well above any plausible authored change: an agent that
+/// declares writes to more than 512 distinct paths in one session is not doing
+/// the thing this channel exists to describe.
+const MAX_TRACKED_PATHS: usize = 512;
+
+/// Largest pre/post image held for one path. Matches
+/// [`crate::shell_touch`]'s per-file content ceiling so the two channels agree
+/// about what "too big to describe" means. A file over this is still recorded —
+/// as a marker, never as silence.
+const MAX_RETAINED_BYTES: usize = 256 * 1024;
+
+/// Ceiling on the rendered text. The judge's context is finite and this is one
+/// of several things competing for it; past this the render stops and says how
+/// many files it did not reach.
+const MAX_RENDER_BYTES: usize = 128 * 1024;
+
+/// Ceiling on marker lines for [`Provenance::Observed`] paths. Fifty names
+/// enough to see a pattern; the remainder is reported as a count. Without this
+/// the SQLite extraction above would contribute 1,200 lines of noise.
+const MAX_OBSERVED_MARKERS: usize = 50;
+
+/// How a touch came to be known — see the module docs for why this is load
+/// bearing rather than bookkeeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// A CRUD tool named this path in its input.
+    Declared,
+    /// The workspace probe saw the path change across an opaque call.
+    Observed,
+}
+
+impl Provenance {
+    /// Classify by the `tool` label `ToolRegistry::record_touch` already
+    /// carries.
+    ///
+    /// Defaults to [`Self::Declared`] for anything unrecognized, because every
+    /// route into `record_touch` except the probe *is* a tool that named its
+    /// path. A future emitter that observes rather than declares must be added
+    /// here — and the failure mode of forgetting is over-reporting authorship
+    /// for one tool, which is visible in the rendered diff, rather than
+    /// dropping a real change silently.
+    #[must_use]
+    pub fn for_tool(tool: &str) -> Self {
+        if tool == crate::shell_touch::PROBE_TOOL_LABEL {
+            Self::Observed
+        } else {
+            Self::Declared
+        }
+    }
+}
+
+/// One path's cumulative story across the session.
+#[derive(Debug, Clone)]
+struct Entry {
+    /// The op of the FIRST touch — decides whether the left side of the render
+    /// is the file or `/dev/null`.
+    first_op: FileOp,
+    /// The op of the LATEST touch — decides the right side the same way.
+    last_op: FileOp,
+    provenance: Provenance,
+    /// Content before the first touch. `None` when it was never measurable.
+    origin: Option<String>,
+    /// Content after the latest touch. `None` when it was never measurable.
+    latest: Option<String>,
+    /// Set when either image was too large to hold, so the render can say so
+    /// instead of implying the file is empty.
+    oversized: bool,
+}
+
+impl Entry {
+    /// Whether this entry can render a real hunk, as opposed to a marker.
+    fn renderable(&self) -> bool {
+        self.provenance == Provenance::Declared && !self.oversized
+    }
+
+    /// The net line delta, computed from the SAME pair the hunk renders from.
+    fn counts(&self) -> (u64, u64) {
+        match (&self.origin, &self.latest) {
+            (Some(origin), Some(latest)) => line_diff(origin, latest),
+            _ => (0, 0),
+        }
+    }
+}
+
+/// What one render produced.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthoredDiff {
+    /// Unified-diff text for declared changes, plus bounded markers for the
+    /// rest. Empty when the session declared nothing.
+    pub text: String,
+    /// Net lines changed by **declared** touches only. Observed paths are
+    /// deliberately excluded: this number feeds a size budget, and a tarball
+    /// must not be able to spend it.
+    pub lines: u32,
+    /// Declared paths rendered.
+    pub declared_files: usize,
+    /// Observed paths seen (whether or not a marker was rendered for each).
+    pub observed_files: usize,
+}
+
+impl AuthoredDiff {
+    /// Whether this carries anything a reader could act on.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty()
+    }
+}
+
+/// Per-session ledger of authored changes, folded by path.
+#[derive(Debug, Clone, Default)]
+pub struct AuthoredDiffLedger {
+    entries: BTreeMap<String, Entry>,
+    /// Paths dropped for exceeding [`MAX_TRACKED_PATHS`]. Reported, never
+    /// hidden — a bound that goes unmentioned reads as a complete answer.
+    dropped: usize,
+}
+
+impl AuthoredDiffLedger {
+    /// Fold one touch into the ledger.
+    ///
+    /// `pre`/`post` are the two images `record_touch` already computed for its
+    /// own event; passing them here costs nothing beyond the retention bound
+    /// above and is what makes a cumulative render possible.
+    ///
+    /// Reads are rejected here rather than at the call site, deliberately. A
+    /// read is not a change, and the caller that forgets to filter one is the
+    /// bug this guard exists to survive — the ledger must not depend on every
+    /// future emitter remembering.
+    pub fn record(
+        &mut self,
+        path: &str,
+        op: FileOp,
+        provenance: Provenance,
+        pre: &str,
+        post: &str,
+    ) {
+        if matches!(op, FileOp::Read) {
+            return;
+        }
+        let oversized = pre.len() > MAX_RETAINED_BYTES || post.len() > MAX_RETAINED_BYTES;
+        if let Some(entry) = self.entries.get_mut(path) {
+            entry.last_op = op;
+            entry.latest = (!oversized).then(|| post.to_string());
+            entry.oversized |= oversized;
+            // A path a CRUD tool declared stays declared even if the probe
+            // later observes it again: the probe re-reports every declared
+            // write it can see, and letting that downgrade the provenance
+            // would erase authorship from exactly the files that have it.
+            if provenance == Provenance::Declared {
+                entry.provenance = Provenance::Declared;
+            }
+            return;
+        }
+        if self.entries.len() >= MAX_TRACKED_PATHS {
+            self.dropped += 1;
+            return;
+        }
+        self.entries.insert(
+            path.to_string(),
+            Entry {
+                first_op: op,
+                last_op: op,
+                provenance,
+                origin: (!oversized).then(|| pre.to_string()),
+                latest: (!oversized).then(|| post.to_string()),
+                oversized,
+            },
+        );
+    }
+
+    /// Render the session's authored change.
+    ///
+    /// Declared paths render as a real unified diff — `---`/`+++` headers and
+    /// `@@` hunks — because every downstream consumer already parses that
+    /// shape. That is not a formatting preference: `verify::mutation`'s mutant
+    /// builder requires a `+++` header before it will emit anything, and the
+    /// warrant reads the same headers for its path rules. A bespoke format
+    /// here would leave both no-ops on precisely the workspaces this module
+    /// exists to serve.
+    #[must_use]
+    pub fn render(&self) -> AuthoredDiff {
+        let mut out = AuthoredDiff::default();
+        let mut text = String::new();
+        let mut lines_added = 0u64;
+        let mut lines_removed = 0u64;
+        let mut observed_rendered = 0usize;
+        let mut observed_elided = 0usize;
+        let mut truncated = 0usize;
+
+        for (path, entry) in &self.entries {
+            if entry.provenance == Provenance::Observed {
+                out.observed_files += 1;
+            }
+            if text.len() >= MAX_RENDER_BYTES {
+                truncated += 1;
+                continue;
+            }
+            if !entry.renderable() {
+                // Everything that is not a declared, measurable change gets a
+                // marker: the path is real evidence even when its content is
+                // not ours to claim or too large to carry.
+                if observed_rendered >= MAX_OBSERVED_MARKERS {
+                    observed_elided += 1;
+                    continue;
+                }
+                let (added, _) = entry.counts();
+                text.push_str(&marker_line(path, added));
+                text.push('\n');
+                observed_rendered += 1;
+                continue;
+            }
+            let (origin, latest) = match (&entry.origin, &entry.latest) {
+                (Some(origin), Some(latest)) => (origin, latest),
+                _ => continue,
+            };
+            // A file written back byte-identical is not a change, whatever the
+            // ledger recorded on the way there.
+            let Some(hunk) = changed_region_diff(origin, latest) else {
+                continue;
+            };
+            let (added, removed) = line_diff(origin, latest);
+            lines_added += added;
+            lines_removed += removed;
+            out.declared_files += 1;
+            // `/dev/null` on the side that did not exist, exactly as git renders
+            // it — and exactly what the mutant builder keys on to skip a
+            // deletion rather than trying to mutate lines that are gone.
+            let left = if matches!(entry.first_op, FileOp::Create) {
+                "/dev/null".to_string()
+            } else {
+                format!("a/{path}")
+            };
+            let right = if matches!(entry.last_op, FileOp::Delete) {
+                "/dev/null".to_string()
+            } else {
+                format!("b/{path}")
+            };
+            text.push_str(&format!("--- {left}\n+++ {right}\n{hunk}"));
+        }
+
+        // Every bound this render hit, stated. A truncated diff that does not
+        // say it was truncated is read as a complete one, and a judge acting on
+        // that is the failure this whole channel exists to prevent.
+        if observed_elided > 0 {
+            text.push_str(&format!(
+                " … and {observed_elided} further path(s) changed by opaque calls, not listed\n"
+            ));
+        }
+        if truncated > 0 {
+            text.push_str(&format!(
+                " … and {truncated} further changed file(s) omitted — the rendered diff hit its \
+                 {MAX_RENDER_BYTES}-byte ceiling\n"
+            ));
+        }
+        if self.dropped > 0 {
+            text.push_str(&format!(
+                " … and {} further path(s) not tracked — the ledger hit its {MAX_TRACKED_PATHS}-path \
+                 ceiling\n",
+                self.dropped
+            ));
+        }
+
+        out.lines = u32::try_from(lines_added + lines_removed).unwrap_or(u32::MAX);
+        out.text = text;
+        out
+    }
+}
+
+/// One marker line, in the shape the pipeline's warrant already parses.
+fn marker_line(path: &str, added_lines: u64) -> String {
+    format!("{MARKER_PREFIX}{path} (+{added_lines} lines)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ledger() -> AuthoredDiffLedger {
+        AuthoredDiffLedger::default()
+    }
+
+    /// The coupling this module cannot express in the type system: the marker
+    /// shape is mirrored from the pipeline's warrant, which parses it back out.
+    /// If that format moves, this test is the thing that notices.
+    #[test]
+    fn marker_line_matches_the_pipeline_contract() {
+        assert_eq!(
+            marker_line("src/main.rs", 12),
+            "+ untracked change: src/main.rs (+12 lines)"
+        );
+    }
+
+    /// The defect this module exists for: a created file reaches the render
+    /// with its CONTENT, not merely its name and length.
+    #[test]
+    fn a_declared_create_renders_its_content() {
+        let mut led = ledger();
+        led.record(
+            "solution.py",
+            FileOp::Create,
+            Provenance::Declared,
+            "",
+            "print(1)\nprint(2)\n",
+        );
+        let out = led.render();
+        assert!(out.text.contains("+++ b/solution.py"), "{}", out.text);
+        assert!(out.text.contains("--- /dev/null"), "{}", out.text);
+        assert!(out.text.contains("+print(1)"), "{}", out.text);
+        assert!(out.text.contains("+print(2)"), "{}", out.text);
+        assert_eq!(out.lines, 2);
+        assert_eq!(out.declared_files, 1);
+    }
+
+    /// The render must be parseable by the mutant builder, which is a no-op
+    /// without a `+++` header. This is the shape contract, asserted directly.
+    #[test]
+    fn a_declared_render_carries_a_header_before_its_hunk() {
+        let mut led = ledger();
+        led.record(
+            "a.rs",
+            FileOp::Create,
+            Provenance::Declared,
+            "",
+            "let x=1;\n",
+        );
+        let text = led.render().text;
+        let header = text.find("+++ ").expect("a header");
+        let hunk = text.find("@@").expect("a hunk");
+        assert!(header < hunk, "header must precede its hunk: {text}");
+    }
+
+    /// Ten edits to one file are one net change, not ten — and not just the
+    /// last one.
+    #[test]
+    fn repeated_edits_fold_into_one_cumulative_hunk() {
+        let mut led = ledger();
+        led.record("f.txt", FileOp::Create, Provenance::Declared, "", "v1\n");
+        led.record(
+            "f.txt",
+            FileOp::Update,
+            Provenance::Declared,
+            "v1\n",
+            "v2\n",
+        );
+        led.record(
+            "f.txt",
+            FileOp::Update,
+            Provenance::Declared,
+            "v2\n",
+            "v3\n",
+        );
+        let out = led.render();
+        assert_eq!(out.declared_files, 1, "one file, one entry");
+        assert!(out.text.contains("+v3"), "the net post-image: {}", out.text);
+        assert!(
+            !out.text.contains("+v2"),
+            "intermediate states are not the net change: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("--- /dev/null"),
+            "created first, so the left side never existed: {}",
+            out.text
+        );
+    }
+
+    /// The SQLite-extraction case: observed paths are named and counted, never
+    /// rendered as authored content.
+    #[test]
+    fn observed_paths_render_as_markers_not_content() {
+        let mut led = ledger();
+        led.record(
+            "sqlite/test/tkt1435.test",
+            FileOp::Create,
+            Provenance::Observed,
+            "",
+            "a\nb\nc\n",
+        );
+        let out = led.render();
+        assert!(
+            out.text
+                .contains("+ untracked change: sqlite/test/tkt1435.test"),
+            "{}",
+            out.text
+        );
+        assert!(!out.text.contains("+a"), "no content: {}", out.text);
+        assert_eq!(out.observed_files, 1);
+        assert_eq!(out.declared_files, 0);
+        assert_eq!(out.lines, 0, "an observed path must not spend the budget");
+    }
+
+    /// A bulk materialization is bounded and says how much it withheld.
+    #[test]
+    fn a_bulk_observation_is_bounded_and_reports_the_bound() {
+        let mut led = ledger();
+        for i in 0..300 {
+            led.record(
+                &format!("vendor/f{i:04}.c"),
+                FileOp::Create,
+                Provenance::Observed,
+                "",
+                "x\n",
+            );
+        }
+        let out = led.render();
+        let markers = out
+            .text
+            .lines()
+            .filter(|l| l.starts_with(MARKER_PREFIX))
+            .count();
+        assert_eq!(markers, MAX_OBSERVED_MARKERS);
+        assert!(
+            out.text.contains("further path(s) changed by opaque calls"),
+            "the bound is stated: {}",
+            out.text
+        );
+        assert_eq!(out.observed_files, 300, "all of them are still counted");
+        assert_eq!(out.lines, 0);
+    }
+
+    /// A declared write that the probe re-observes stays declared. Otherwise
+    /// the turn-end probe would strip authorship from every file the agent
+    /// actually wrote.
+    #[test]
+    fn a_probe_re_observation_cannot_downgrade_a_declared_path() {
+        let mut led = ledger();
+        led.record("fix.rs", FileOp::Create, Provenance::Declared, "", "ok\n");
+        led.record(
+            "fix.rs",
+            FileOp::Update,
+            Provenance::Observed,
+            "ok\n",
+            "ok\n",
+        );
+        let out = led.render();
+        assert_eq!(out.declared_files, 1, "still authored: {}", out.text);
+    }
+
+    /// Reads are not changes, and the ledger refuses them itself rather than
+    /// trusting every caller to filter.
+    #[test]
+    fn reads_are_refused_at_the_ledger() {
+        let mut led = ledger();
+        led.record("seen.rs", FileOp::Read, Provenance::Declared, "x\n", "x\n");
+        assert!(led.render().is_empty());
+    }
+
+    /// A file written back byte-identical is not a change.
+    #[test]
+    fn an_identical_rewrite_renders_nothing() {
+        let mut led = ledger();
+        led.record(
+            "same.rs",
+            FileOp::Update,
+            Provenance::Declared,
+            "x\n",
+            "x\n",
+        );
+        assert!(led.render().is_empty());
+    }
+
+    /// A deletion renders what went, and points its right side at `/dev/null`
+    /// so the mutant builder skips it instead of mutating absent lines.
+    #[test]
+    fn a_delete_renders_to_dev_null() {
+        let mut led = ledger();
+        led.record(
+            "gone.rs",
+            FileOp::Delete,
+            Provenance::Declared,
+            "a\nb\n",
+            "",
+        );
+        let out = led.render();
+        assert!(out.text.contains("--- a/gone.rs"), "{}", out.text);
+        assert!(out.text.contains("+++ /dev/null"), "{}", out.text);
+        assert!(out.text.contains("-a"), "{}", out.text);
+        assert_eq!(out.lines, 2);
+    }
+
+    /// An oversized file is recorded as a marker, never as silence and never
+    /// as an empty-file rewrite.
+    #[test]
+    fn an_oversized_file_degrades_to_a_marker() {
+        let mut led = ledger();
+        let big = "x\n".repeat(MAX_RETAINED_BYTES);
+        led.record("huge.bin", FileOp::Create, Provenance::Declared, "", &big);
+        let out = led.render();
+        assert!(
+            out.text.contains("+ untracked change: huge.bin"),
+            "{}",
+            out.text
+        );
+        assert!(!out.text.contains("+x"), "content withheld: {}", out.text);
+    }
+
+    /// The path ceiling is a bound that gets reported, not a silent cap.
+    #[test]
+    fn the_path_ceiling_is_reported() {
+        let mut led = ledger();
+        for i in 0..(MAX_TRACKED_PATHS + 10) {
+            led.record(
+                &format!("f{i:05}.rs"),
+                FileOp::Create,
+                Provenance::Declared,
+                "",
+                "x\n",
+            );
+        }
+        let out = led.render();
+        assert!(
+            out.text.contains("further path(s) not tracked"),
+            "the bound is stated: {}",
+            out.text
+        );
+    }
+
+    /// The probe's label is the one thing that makes a touch observed.
+    #[test]
+    fn provenance_is_read_from_the_tool_label() {
+        assert_eq!(
+            Provenance::for_tool(crate::shell_touch::PROBE_TOOL_LABEL),
+            Provenance::Observed
+        );
+        assert_eq!(Provenance::for_tool("write_file"), Provenance::Declared);
+        assert_eq!(Provenance::for_tool("edit_file"), Provenance::Declared);
+    }
+}

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod agent_use;
 pub mod apply_edits;
+pub mod authored_diff;
 pub mod bash;
 pub mod catalog;
 pub mod ci;

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -130,6 +130,13 @@ pub struct ToolRegistry {
     /// why an unbracketed session behaves exactly as it did before this
     /// existed.
     workspace_probe: std::sync::Mutex<Option<crate::shell_touch::WorkspaceProbe>>,
+    /// The session's authored-change ledger — what the agent *meant* to change,
+    /// as opposed to how the tree now differs from a commit. Fed from
+    /// [`Self::record_touch`] because that is the one place holding both images
+    /// of a write, and read by the verification pipeline wherever `git diff`
+    /// structurally cannot answer (an untracked file, or no repository at all).
+    /// See [`crate::authored_diff`] for why the two are different questions.
+    authored: std::sync::Mutex<crate::authored_diff::AuthoredDiffLedger>,
     /// Whether this session brackets turns at all, latched by the first
     /// [`ToolRegistry::begin_workspace_probe`] and never cleared.
     ///
@@ -518,6 +525,7 @@ impl ToolRegistry {
             work_journal: std::sync::RwLock::new(None),
             span_reads,
             workspace_probe: std::sync::Mutex::new(None),
+            authored: std::sync::Mutex::new(crate::authored_diff::AuthoredDiffLedger::default()),
             turn_bracketing: std::sync::atomic::AtomicBool::new(false),
             citations,
             agent_uses: std::sync::Mutex::new(crate::agent_use::AgentUseLedger::default()),
@@ -1847,8 +1855,13 @@ impl ToolRegistry {
         // Counts and rendered diff come out of the SAME pre/post pair, so the
         // ledger, the telemetry payload and the TUI describe one reality.
         let pre = pre_content.as_deref().unwrap_or("");
-        let (lines_added, lines_removed, diff) = match pending.op {
-            FileOp::Read => (0, 0, None),
+        // `post` rides alongside the counts so the authored-change ledger can
+        // keep BOTH images of this write. It costs nothing extra to produce —
+        // every arm below already computes it to render its own diff — and it
+        // is the difference between a judge that can read the agent's change
+        // and one that is handed a filename (see [`crate::authored_diff`]).
+        let (lines_added, lines_removed, diff, post) = match pending.op {
+            FileOp::Read => (0, 0, None, None),
             FileOp::Create => {
                 // `write_file` carries the new content in its input. A file
                 // created by an opaque call (a shell redirect, a compiler
@@ -1867,6 +1880,7 @@ impl ToolRegistry {
                     count_lines(content),
                     0,
                     crate::file_touch::changed_region_diff("", content),
+                    Some(content.to_string()),
                 )
             }
             FileOp::Update => {
@@ -1884,18 +1898,31 @@ impl ToolRegistry {
                         .unwrap_or_default(),
                 };
                 let (added, removed) = line_diff(pre, &post);
-                (
-                    added,
-                    removed,
-                    crate::file_touch::changed_region_diff(pre, &post),
-                )
+                let diff = crate::file_touch::changed_region_diff(pre, &post);
+                (added, removed, diff, Some(post))
             }
             FileOp::Delete => (
                 0,
                 count_lines(pre),
                 crate::file_touch::changed_region_diff(pre, ""),
+                Some(String::new()),
             ),
         };
+        // Reads yield `None` above and the ledger refuses them again on its own
+        // account — two guards, because this caller has already been the place
+        // a read leaked into a change count once.
+        if let Some(post) = &post {
+            self.authored
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .record(
+                    &pending.path,
+                    pending.op,
+                    crate::authored_diff::Provenance::for_tool(tool),
+                    pre,
+                    post,
+                );
+        }
         let path = pending.path;
         let (revision, record, total_files) = {
             let mut touched = self.touched.lock().unwrap_or_else(|p| p.into_inner());
@@ -1992,6 +2019,21 @@ impl ToolRegistry {
         self.mutations.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// The session's authored change, rendered as a unified diff.
+    ///
+    /// The companion to [`Self::mutations_recorded`]: that answers *how many*
+    /// changes happened, this answers *what they were*. Both are read by the
+    /// verification pipeline, and this one exists because the channel it
+    /// previously read — `git diff` — cannot answer at all in the two
+    /// workspaces that matter most (no repository; a newly created file).
+    #[must_use]
+    pub fn authored_diff(&self) -> crate::authored_diff::AuthoredDiff {
+        self.authored
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .render()
+    }
+
     /// Take a before-image of the workspace for the turn about to run.
     ///
     /// Paired with [`Self::settle_workspace_probe`]. `classify_file_op` reads
@@ -2069,7 +2111,7 @@ impl ToolRegistry {
                     op: touch.op,
                 },
                 pre_content,
-                "workspace_probe",
+                crate::shell_touch::PROBE_TOOL_LABEL,
                 &serde_json::json!({ "reason": "observed in the workspace" }),
                 None,
             );

--- a/stella-tools/src/shell_touch.rs
+++ b/stella-tools/src/shell_touch.rs
@@ -50,6 +50,14 @@ const SKIP_DIRS: &[&str] = &[
     ".tox",
 ];
 
+/// The `tool` label every touch this module attributes is recorded under.
+///
+/// A constant rather than a literal at the call site because it is now read
+/// back: [`crate::authored_diff::Provenance::for_tool`] uses it to tell a
+/// change the agent *declared* from one this module merely *observed*, and
+/// those two must never be compared through two copies of a string.
+pub const PROBE_TOOL_LABEL: &str = "workspace_probe";
+
 /// Entry ceiling for one walk. Past this the probe stops and says so.
 const MAX_ENTRIES: usize = 20_000;
 /// Depth ceiling, so a symlink cycle or a pathological tree cannot hang a turn.


### PR DESCRIPTION
## The problem

`state.diff_text` — the diff every judge call, guidance call and mutation audit reads — had exactly one producer: `Pipeline::gather_diff`, which is `git diff`. Git cannot answer the question verification is asking in the two workspaces that matter most.

**No repository.** A Terminal-Bench task directory is a plain directory, so the probe returns `DIFF_PROBE_NOT_A_REPO` — a sentence of English where a diff belongs. Every judge call on that benchmark has been ruling with zero information about the change.

**A new file.** `git diff` cannot see an untracked path, so the commonest shape of agent work — *create the file that solves the task* — reached the judge as:

```
+ untracked change: solution.py (+129 lines)
```

A path and a number. Not one line of content.

`verify.rs` already records that the judge "agreed with the benchmark's grader 46% of the time" while "reasoning from a diff and its own opinion." On Terminal-Bench there was no diff — it was reasoning from its own opinion alone, and 46% is what that looks like.

### Two audits were silently no-oping

Both `verify::mutation::mutants_from_diff` and `witness::warrant::changed_paths` require a `+++` header before they emit anything. A marker line has none, and `DIFF_PROBE_NOT_A_REPO` matches nothing at all — so the tautology audit passed vacuously and the warrant's path rules never saw the file. The diff-size budget was inert too: `diff_lines` is always `0` without git, so `diff_lines <= diff_budget` always held.

## The fix

Neither gap is a defect in git. It is the same category error twice: asking a tool that reports **tree state** to answer a question about **authorship**. The answer was already in hand and being thrown away — `record_touch` holds the pre-image and post-image of every write.

`stella_tools::authored_diff` retains both, folds by path (first pre-image against latest post-image, so ten edits render as one net hunk, matching what `git diff` against the session baseline would show), and renders unified-diff text. `pipeline::authored::splice_authored` joins it to the probe's output — tree first, since on-disk state is the stronger claim about what *survived*, then the authored section, which is the only claim about *intent*.

Because both halves are unified-diff shaped, every downstream consumer parses the joined string with one parser and cannot tell which half a hunk came from. That is what restores the two dead audits.

### Provenance is load-bearing

A touch a CRUD tool **declared** by path renders with its content. One the workspace probe merely **observed** across an opaque call renders as a bounded marker line.

This is not fussiness. Extracting the SQLite source tree produces ~1,200 observed creations in a single turn. Rendering those as authorship would bury a three-line fix under a megabyte of upstream test fixtures and tell the judge the turn wrote SQLite.

### Deliberate non-changes

- **`diff_available` is not widened.** It means "the configured probe could read the working tree", and the ladder's blind-evidence rung is built on that exact claim. An authored diff proves what was *written*, never what *survived* to sit on disk.
- **`diff_lines` takes `max`, not a sum** — two independent lower bounds on one number, not disjoint tallies. Same reasoning as `observed_mutations`.
- **Reads are refused twice** — at the call site and again inside the ledger, so a future emitter that forgets cannot leak a read into a change count.

Every bound reports itself: per-file retention, total render size, marker count and tracked-path count each emit a line saying what was withheld.

## Verification

- `make gate` — exit 0, 6,273 tests, all 9 guards OK
- 13 new unit tests in `stella_tools::authored_diff`, 7 new seam tests in `pipeline::authored`
- The two repaired knock-ons are pinned directly: a test asserts the old marker shape yields zero mutants and the authored shape yields mutants for the right path, so a regression fails loudly instead of returning to silence
- `scripts/file-size-baseline.txt`: `splice_authored` was moved into its own module to minimise growth; the irreducible remainder (a struct field, a method, the `absorb_probe` fold) raises two ceilings by +19 and +42, as the gate prescribes. The third baseline line is a retightening where `agent.rs` had shrunk.

## Summary by Sourcery

Introduce an authored-diff channel that captures the agent’s actual file edits and splice it into verification’s diff so judges and audits see real content even for new files and non-repo workspaces.

New Features:
- Track authored file changes in a per-session ledger and expose them as unified-diff text and line counts via the file touch registry and pipeline ports.
- Add pipeline logic to combine git-based tree diffs with authored diffs into a single unified stream consumed by verification and warrant logic.

Enhancements:
- Bound and report authored-diff retention (per-file size, tracked-path count, rendered size, and observed marker count) to keep verification context manageable and transparent.
- Differentiate declared writes from probe-observed changes so authored diffs represent agent intent while bulk extractions and builds are rendered as lightweight markers.
- Ensure downstream consumers like mutation audits and warrant path analysis recognize and act on authored diffs by aligning marker formats and exporting changed-path parsing for tests.

Documentation:
- Document the semantics of authored vs tree-state diffs, their provenance, and how they are joined in the pipeline to inform verification.

Tests:
- Add extensive unit tests for the authored-diff ledger, including provenance handling, folding of repeated edits, bounds behavior, and render shape contracts.
- Add seam tests around diff splicing to confirm authored diffs repair mutation and warrant behavior and that the authored section header is inert to existing parsers.