### PR TITLE
deck: view-only slash commands bypass the turn loop + live prompt-keyword highlighting

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -4005,9 +4005,11 @@ fn record_agent_invocation(
 /// printing to stdout (which the alternate screen owns) is never an option.
 ///
 /// Vocabulary: `/help`, `/clear`, `/models`, `/init`, `/agents`,
-/// `/pipeline`. `/files`, `/diff`, `/graph` are deck-local (tab switches) and
-/// consumed TUI-side; an unknown bare `/command` gets a hint rather than a
-/// wasted model call. Every productized command is no-argument, so the
+/// `/pipeline`. View-only commands (`/files`, `/diff`, `/graph`, the
+/// overlays and cards) are deck-local and consumed TUI-side at submission —
+/// see `stella_tui`'s `view_command`; an unknown bare `/command` gets a hint
+/// rather than a wasted model call. Every productized command is no-argument,
+/// so the
 /// *whole* trimmed input is matched — `/init do the thing` is a model prompt,
 /// not a silent reindex that discards the rest. Custom commands/skills (⚡)
 /// DO take arguments: `/fix-bug issue-42` expands the `fix-bug` template
@@ -4162,12 +4164,15 @@ async fn run_deck_command(
                  Thank you! 🙏"
                 .to_string());
         }
-        // Deck-local commands (tab switches, `/agents` opening the Agents
-        // tab, the transcript-page overlays) are normally consumed TUI-side,
-        // but a queued one reaches here — accept it as handled (a no-op)
-        // rather than calling it "unknown".
+        // Deck-local view commands (tab switches, `/agents` opening the
+        // Agents tab, the transcript-page overlays, the floating cards) are
+        // consumed TUI-side at submission — on every submission path, so a
+        // fresh one can no longer be enqueued at all. One can still reach
+        // here from a durable queue persisted by an older build — accept it
+        // as handled (a no-op) rather than calling it "unknown".
         "/files" | "/diff" | "/graph" | "/agents" | "/skills" | "/mcp" | "/mcp-search"
-        | "/settings" | "/sessions" | "/context" | "/inspect" | "/inbox" => {}
+        | "/settings" | "/sessions" | "/context" | "/inspect" | "/inbox" | "/tasks" | "/scope"
+        | "/witness" | "/budget" => {}
         _ => {
             // `/model <provider/slug>` — set the persistent default model.
             // Validation + the settings write live in `model_cmd` (parity

--- a/stella-tui/src/composer.rs
+++ b/stella-tui/src/composer.rs
@@ -510,6 +510,15 @@ pub fn handle_edit_key(key: KeyEvent, composer: &mut Composer) -> bool {
 pub struct ComposerLayout {
     /// The wrapped display rows (chips rendered as their `[pasted: …]` form).
     pub rows: Vec<String>,
+    /// Byte offset into [`Self::display`] where each row's text begins —
+    /// always `rows.len()` entries. What lets a renderer overlay
+    /// display-wide byte ranges (see [`crate::highlight`]) onto wrapped
+    /// rows exactly, soft wraps included.
+    pub row_starts: Vec<usize>,
+    /// The unwrapped display text the rows were cut from (chips + buffer) —
+    /// the one string prompt-keyword matching runs over, kept here so
+    /// matcher and rows can never disagree about what was laid out.
+    pub display: String,
     /// Row index the cursor sits on.
     pub cursor_row: usize,
     /// Display-width column of the cursor within `rows[cursor_row]`.
@@ -529,6 +538,7 @@ pub fn layout(composer: &Composer, width: usize) -> ComposerLayout {
     display.push_str(composer.buffer());
 
     let mut rows: Vec<String> = vec![String::new()];
+    let mut row_starts: Vec<usize> = vec![0];
     let mut col = 0usize;
     let (mut cursor_row, mut cursor_col) = (0usize, 0usize);
     for (idx, ch) in display.char_indices() {
@@ -538,12 +548,16 @@ pub fn layout(composer: &Composer, width: usize) -> ComposerLayout {
                 (cursor_row, cursor_col) = (rows.len() - 1, col);
             }
             rows.push(String::new());
+            // The `\n` itself is display text no row carries — the next row
+            // starts one byte past it.
+            row_starts.push(idx + 1);
             col = 0;
             continue;
         }
         let w = ch.width().unwrap_or(0);
         if col + w > width && col > 0 {
             rows.push(String::new());
+            row_starts.push(idx);
             col = 0;
         }
         if idx == cursor_at {
@@ -557,12 +571,15 @@ pub fn layout(composer: &Composer, width: usize) -> ComposerLayout {
         // insertion point visually lives on a fresh row.
         if col >= width {
             rows.push(String::new());
+            row_starts.push(display.len());
             col = 0;
         }
         (cursor_row, cursor_col) = (rows.len() - 1, col);
     }
     ComposerLayout {
         rows,
+        row_starts,
+        display,
         cursor_row,
         cursor_col,
     }
@@ -1073,6 +1090,29 @@ mod tests {
         let l = layout(&c, 4);
         assert_eq!(l.rows, vec!["日本", "語"]);
         assert_eq!((l.cursor_row, l.cursor_col), (1, 2));
+    }
+
+    #[test]
+    fn layout_reports_where_each_row_starts_in_the_display_text() {
+        // "abcdef\ngh" at width 4: "abcd" starts at 0 (soft wrap), "ef" at 4,
+        // and "gh" at 7 — one past the `\n` no row carries. The offsets are
+        // what lets display-wide keyword ranges land on wrapped rows exactly
+        // (see `crate::highlight`).
+        let c = typed("abcdef\ngh");
+        let l = layout(&c, 4);
+        assert_eq!(l.display, "abcdef\ngh");
+        assert_eq!(l.row_starts, vec![0, 4, 7]);
+        assert_eq!(l.rows.len(), l.row_starts.len(), "always in lockstep");
+        // The cursor-past-a-full-row fresh row starts at the display's end.
+        let full = layout(&typed("abcd"), 4);
+        assert_eq!(full.row_starts, vec![0, 4]);
+        // Chips are display text too — the buffer's rows start after them.
+        let mut chipped = Composer::with_paste_threshold(2);
+        chipped.paste("a\nb\nc");
+        chipped.insert_char('x');
+        let cl = layout(&chipped, 40);
+        assert_eq!(cl.display, "[pasted: 3 lines] x");
+        assert_eq!(cl.row_starts, vec![0]);
     }
 
     #[test]

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -21,6 +21,7 @@ use crate::cache_panel;
 use crate::composer::{ComposerLayout, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::deck_ui::{DeckUi, InstalledMode, IssuesMode};
+use crate::highlight;
 use crate::panel_guard::{guarded_band, guarded_overlay};
 use crate::render::{render_slash_popup, scroll_window_start, slash_popup_area};
 use crate::textline;
@@ -1165,6 +1166,11 @@ const DECK_COMPOSER_MAX_ROWS: usize = 4;
 /// Beyond [`DECK_COMPOSER_MAX_ROWS`] the box stops growing and scrolls, showing
 /// a slim thumb in the right gutter while keeping the caret in view.
 ///
+/// Prompt keywords are lit live as they are typed — the gold `/` and violet
+/// slug of a slash command, any future reserved word — via
+/// [`crate::highlight`] over the layout's display text, so the treatment
+/// follows the words across soft wraps and scrolling.
+///
 /// The caret is **steady**, not blinking: a blink carries no information the
 /// reversed cell doesn't already carry, and a terminal has no
 /// `prefers-reduced-motion` for a reader who needs it off.
@@ -1173,6 +1179,7 @@ fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer) {
     let total = layout.rows.len();
     let first = composer_scroll_first(layout.cursor_row, visible);
 
+    let keywords = highlight::prompt_keywords(&layout.display, highlight::RESERVED_WORDS);
     let cursor_style = theme::accent().add_modifier(Modifier::REVERSED);
     let mut lines: Vec<Line<'static>> = Vec::new();
     for (i, row) in layout.rows.iter().enumerate().skip(first).take(visible) {
@@ -1182,14 +1189,18 @@ fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer) {
             PROMPT_PREFIX,
             Style::default().fg(theme::ACCENT),
         )];
+        let row_start = layout.row_starts[i];
         if i == layout.cursor_row {
             let (before, under, after) = split_row_at(row, layout.cursor_col);
             let under_ch = under.map(String::from).unwrap_or_else(|| " ".into());
-            spans.push(Span::styled(before, theme::body()));
+            // The caret cell keeps its fixed reversed-accent look even over
+            // a keyword — the caret must read as the caret everywhere.
+            let after_at = row_start + before.len() + under.map_or(0, char::len_utf8);
+            push_keyword_spans(&mut spans, &before, row_start, &keywords);
             spans.push(Span::styled(under_ch, cursor_style));
-            spans.push(Span::styled(after, theme::body()));
+            push_keyword_spans(&mut spans, &after, after_at, &keywords);
         } else {
-            spans.push(Span::styled(row.clone(), theme::body()));
+            push_keyword_spans(&mut spans, row, row_start, &keywords);
         }
         lines.push(Line::from(spans));
     }
@@ -1204,6 +1215,22 @@ fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer) {
 
     if total > visible {
         render_scroll_gutter(first, visible, total, area, buf);
+    }
+}
+
+/// Push `text` — the fragment of the layout's display starting at byte
+/// `start` — as spans, plain prose in [`theme::body`] and each prompt
+/// keyword in its [`highlight::style`]. One call covers a whole row; the
+/// cursor row calls it once per side of the caret with the offsets shifted.
+fn push_keyword_spans(
+    spans: &mut Vec<Span<'static>>,
+    text: &str,
+    start: usize,
+    keywords: &[highlight::KeywordSpan],
+) {
+    for (kind, run) in highlight::segments(text, start, keywords) {
+        let style = kind.map_or_else(theme::body, highlight::style);
+        spans.push(Span::styled(run.to_string(), style));
     }
 }
 

--- a/stella-tui/src/deck_render/tests.rs
+++ b/stella-tui/src/deck_render/tests.rs
@@ -280,9 +280,51 @@ fn the_prompt_prefix_is_a_steady_uniform_accent() {
 }
 
 #[test]
+fn a_typed_slash_command_lights_gold_mark_and_violet_slug_live() {
+    // The prompt-keyword treatment (see `crate::highlight`): the moment
+    // `/files` sits in the composer, the dispatch `/` is gold and the slug
+    // violet — uniform for every slash command, live before ⏎.
+    let mut ui = DeckUi::default();
+    for c in "/files".chars() {
+        ui.composer.insert_char(c);
+    }
+    let layout = crate::composer::layout(&ui.composer, 40);
+    let area = Rect::new(0, 0, 40, 4);
+    let mut buf = Buffer::empty(area);
+    render_composer(&layout, area, &mut buf);
+    let text = buffer_text(&buf);
+    assert!(text.starts_with(">>> /files"), "typed row intact:\n{text}");
+    // Col 4 (after the `>>> ` prefix) is the mark; 5..10 are the slug.
+    assert_eq!(
+        buf.cell((4, 0)).unwrap().fg,
+        crate::theme::GOLD,
+        "the dispatch mark is gold"
+    );
+    assert!(
+        (5..10u16).all(|x| buf.cell((x, 0)).unwrap().fg == crate::theme::VIOLET),
+        "every slug cell is the deck's violet"
+    );
+    // The prose after the command keeps the body style: type an argument and
+    // the highlight must stop at the head token.
+    for c in " main".chars() {
+        ui.composer.insert_char(c);
+    }
+    let layout = crate::composer::layout(&ui.composer, 40);
+    let mut buf = Buffer::empty(area);
+    render_composer(&layout, area, &mut buf);
+    assert_ne!(
+        buf.cell((11, 0)).unwrap().fg,
+        crate::theme::VIOLET,
+        "'main' is prose, not part of the command"
+    );
+}
+
+#[test]
 fn composer_cursor_position_sits_right_after_the_prefix_on_an_empty_composer() {
     let layout = ComposerLayout {
         rows: vec![String::new()],
+        row_starts: vec![0],
+        display: String::new(),
         cursor_row: 0,
         cursor_col: 0,
     };
@@ -296,6 +338,8 @@ fn composer_cursor_position_sits_right_after_the_prefix_on_an_empty_composer() {
 fn composer_cursor_position_offsets_by_the_composer_areas_origin() {
     let layout = ComposerLayout {
         rows: vec!["hi".into()],
+        row_starts: vec![0],
+        display: "hi".into(),
         cursor_row: 0,
         cursor_col: 2,
     };
@@ -312,6 +356,12 @@ fn composer_cursor_position_tracks_the_caret_through_the_scroll_window() {
     // actually drawn.
     let layout = ComposerLayout {
         rows: (0..9).map(|i| format!("row{i}")).collect(),
+        // Hard-broken rows: each "rowN" is 4 bytes + the `\n` no row carries.
+        row_starts: (0..9).map(|i| i * 5).collect(),
+        display: (0..9)
+            .map(|i| format!("row{i}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
         cursor_row: 8,
         cursor_col: 4, // "row8" is 4 columns wide
     };
@@ -324,6 +374,8 @@ fn composer_cursor_position_tracks_the_caret_through_the_scroll_window() {
 fn composer_cursor_position_is_none_for_a_degenerate_area() {
     let layout = ComposerLayout {
         rows: vec![String::new()],
+        row_starts: vec![0],
+        display: String::new(),
         cursor_row: 0,
         cursor_col: 0,
     };

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -2011,9 +2011,14 @@ fn handle_help_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
-/// Route one submitted prompt. The first submission after a double-Esc hold
-/// goes to the FRONT of the queue (and is what releases the hold) so it runs
-/// before the returned prompt; everything else appends. This is an explicit
+/// Route one submitted prompt. A view-only slash command short-circuits
+/// first — see [`view_command`] — because it is not a prompt at all: it
+/// changes what the user is looking at, takes effect the moment ⏎ lands,
+/// and never touches the queue, the routing card, or a held dispatch.
+///
+/// Of what remains: the first submission after a double-Esc hold goes to the
+/// FRONT of the queue (and is what releases the hold) so it runs before the
+/// returned prompt; everything else appends. This is an explicit
 /// [`WorkspaceInput::EnqueueFront`] rather than a driver-side "held"
 /// reinterpretation of a plain Enqueue: the deck mirrors every queue edit
 /// locally at send time, and a message whose meaning depended on driver
@@ -2024,6 +2029,12 @@ fn handle_help_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
 /// where it belongs. A held dispatch skips the card: the double-Esc already
 /// *was* the user saying "run mine next".
 fn submit_prompt(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> DeckAction {
+    // Ahead of even the held check: a hold is about which PROMPT runs next,
+    // and a view switch is not a prompt — it must neither spend the hold's
+    // front slot nor release the hold.
+    if let Some(action) = view_command(ui, text.trim()) {
+        return action;
+    }
     if ui.dispatch_held {
         ui.dispatch_held = false;
         return DeckAction::Send(WorkspaceInput::EnqueueFront { text });
@@ -2047,9 +2058,11 @@ fn slash_matches(ui: &DeckUi) -> Vec<String> {
 /// single-session REPL (`crate::ui`) via `crate::composer` so both surfaces
 /// stay consistent by construction.
 ///
-/// Deck-local commands (tab switches, the help overlay) are intercepted here
-/// and act on the UI directly; everything else is enqueued for the driver,
-/// which owns the session-level vocabulary (`/clear`, `/models`, `/init`, …).
+/// The popup's ⏎ takes the same road every submission takes
+/// ([`submit_prompt`]), so selecting a command from the menu can never mean
+/// something different from typing the same text in full: view-only commands
+/// act on the UI immediately, everything else is enqueued for the driver,
+/// which owns the session-level vocabulary (`/clear`, `/init`, …).
 fn handle_slash_key(
     key: KeyEvent,
     matches: &[String],
@@ -2058,93 +2071,126 @@ fn handle_slash_key(
 ) -> Option<DeckAction> {
     match handle_slash_popup_key(key, matches, &mut ui.composer, &mut ui.slash_selected)? {
         SlashPopupOutcome::Handled => Some(DeckAction::Handled),
-        SlashPopupOutcome::Submit(text) => Some(match text.as_str() {
-            // Only the tab-switch commands are deck-local (they change view
-            // state the driver has no say over). `/diff` opens the diff
-            // viewer; `/files` shows the file tree, so it must also *close* a
-            // diff left open from a prior view.
-            "/files" | "/diff" => {
-                ui.set_tab(DeckTab::Files);
-                ui.files_diff_open = text == "/diff";
-                DeckAction::Handled
-            }
-            "/graph" => {
-                ui.set_tab(DeckTab::Graph);
-                DeckAction::Handled
-            }
-            // `/agents` opens the AGENTS tab directly, on the INSTALLED
-            // AGENTS pane (the configured-on-disk view the command has
-            // always been about) — and asks the driver, which owns the
-            // definitions on disk, for a fresh list.
-            "/agents" => {
-                ui.set_tab(DeckTab::Agents);
-                ui.agents_pane = AgentsPane::Installed;
-                ui.installed.busy = true;
-                DeckAction::Send(WorkspaceInput::AgentsRefresh)
-            }
-            // `/skills` opens the SKILLS tab directly and asks the driver —
-            // which owns the skills on disk — for a fresh installed list.
-            "/skills" => {
-                ui.set_tab(DeckTab::Skills);
-                ui.skills.status = Some("loading skills…".to_string());
-                DeckAction::Send(WorkspaceInput::Skill(SkillOp::List))
-            }
-            "/mcp" => {
-                ui.set_tab(DeckTab::Mcp);
-                DeckAction::Handled
-            }
-            // `/settings` opens the SETTINGS tab — the home of all config
-            // (deck-local view state, like the tab switches above).
-            "/settings" => {
-                ui.set_tab(DeckTab::Settings);
-                DeckAction::Handled
-            }
-            // The three transcript-page overlays are deck-local view state,
-            // exactly like the tab switches above (their keyboard shortcuts:
-            // empty-prompt `←` / `→`, and the footer's ✉ badge for the inbox).
-            "/sessions" => open_sessions_overlay(ui),
-            "/context" => open_context_overlay(ui),
-            "/inspect" => open_inspect_overlay(ui),
-            "/inbox" => open_inbox_overlay(ui),
-            // `/mcp-search` jumps straight into the MCP tab's registry
-            // search — THE way to begin looking for a server from anywhere
-            // (the old `/`-on-the-MCP-tab trigger collided with the command
-            // menu and is gone; `s` on the tab is the local equivalent).
-            "/mcp-search" => {
-                ui.set_tab(DeckTab::Mcp);
-                ui.mcp.mode = McpMode::Search;
-                ui.mcp.status = None;
-                DeckAction::Handled
-            }
-            // The floating cards: pure view state, so the driver has no say.
-            // `/budget` only *renders* locally — the edit it takes leaves as
-            // `WorkspaceInput::SetBudget` from the card's own key handler.
-            "/tasks" => {
-                ui.cards.raise(cards::Card::Tasks);
-                DeckAction::Handled
-            }
-            "/scope" => {
-                ui.cards.raise(cards::Card::Scope);
-                DeckAction::Handled
-            }
-            "/witness" => {
-                ui.cards.raise(cards::Card::Witness);
-                DeckAction::Handled
-            }
-            "/models" => {
-                ui.cards.raise(cards::Card::Models);
-                DeckAction::Handled
-            }
-            "/budget" => {
-                ui.cards.raise(cards::Card::Budget);
-                DeckAction::Handled
-            }
-            // Everything else — including `/help` — is enqueued for the
-            // driver, which owns the session vocabulary and answers into the
-            // transcript (a transient overlay would leave no record).
-            _ => submit_prompt(ui, model, text),
-        }),
+        SlashPopupOutcome::Submit(text) => Some(submit_prompt(ui, model, text)),
     }
+}
+
+/// Execute `text` as a **view-only** slash command, or `None` when it is not
+/// one.
+///
+/// These commands change what the user is *looking at* — a tab switch, an
+/// overlay, a floating card — never what any agent is doing. So they take
+/// effect the instant they are submitted, on every path a submission can
+/// arrive by: the slash popup's ⏎, a fully-typed ⏎ with the popup closed or
+/// filtered away, mid-turn while the lead is running, even during a
+/// double-Esc hold. None of them may enter the prompt queue: a view switch
+/// parked behind a running turn is a command that appears to do nothing until
+/// the agent finishes, and the driver could only answer it with a no-op
+/// anyway — the deck owns all of this state. (The refreshes some of them send
+/// — `AgentsRefresh`, `Skill(List)`, `SessionsRefresh`, `InspectRefresh` —
+/// are serviced at the driver's mid-turn recv site too, so "immediate" holds
+/// while a turn runs.)
+///
+/// Anything NOT in this table — driver commands (`/clear`, `/init`, `/model
+/// <id>`, …), custom ⚡ commands, unknown slashes — is prompt-shaped and
+/// keeps the normal routing: it *can* be steering or new work, the deck
+/// can't know, so it is treated exactly like a typed prompt.
+///
+/// Matched against the *whole* trimmed input, the same rule the driver's
+/// dispatcher applies: every view command is no-argument, so `/diff main` is
+/// a prompt, not a view switch discarding its arguments.
+fn view_command(ui: &mut DeckUi, text: &str) -> Option<DeckAction> {
+    Some(match text {
+        // `/diff` opens the diff viewer; `/files` shows the file tree, so it
+        // must also *close* a diff left open from a prior view.
+        "/files" | "/diff" => {
+            ui.set_tab(DeckTab::Files);
+            ui.files_diff_open = text == "/diff";
+            DeckAction::Handled
+        }
+        "/graph" => {
+            ui.set_tab(DeckTab::Graph);
+            DeckAction::Handled
+        }
+        // `/agents` opens the AGENTS tab directly, on the INSTALLED
+        // AGENTS pane (the configured-on-disk view the command has
+        // always been about) — and asks the driver, which owns the
+        // definitions on disk, for a fresh list.
+        "/agents" => {
+            ui.set_tab(DeckTab::Agents);
+            ui.agents_pane = AgentsPane::Installed;
+            ui.installed.busy = true;
+            DeckAction::Send(WorkspaceInput::AgentsRefresh)
+        }
+        // `/skills` opens the SKILLS tab directly and asks the driver —
+        // which owns the skills on disk — for a fresh installed list.
+        "/skills" => {
+            ui.set_tab(DeckTab::Skills);
+            ui.skills.status = Some("loading skills…".to_string());
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::List))
+        }
+        "/mcp" => {
+            ui.set_tab(DeckTab::Mcp);
+            DeckAction::Handled
+        }
+        // `/settings` opens the SETTINGS tab — the home of all config
+        // (deck-local view state, like the tab switches above).
+        "/settings" => {
+            ui.set_tab(DeckTab::Settings);
+            DeckAction::Handled
+        }
+        // The three transcript-page overlays are deck-local view state,
+        // exactly like the tab switches above (their keyboard shortcuts:
+        // empty-prompt `←` / `→`, and the footer's ✉ badge for the inbox).
+        "/sessions" => open_sessions_overlay(ui),
+        "/context" => open_context_overlay(ui),
+        "/inspect" => open_inspect_overlay(ui),
+        "/inbox" => open_inbox_overlay(ui),
+        // `/help` opens the same overlay the `?` key opens — identical to
+        // the driver's `Inbound::ShowHelp` ingest, minus the round trip
+        // (which used to park `/help` behind a running turn).
+        "/help" => {
+            ui.help_open = true;
+            ui.help_scroll = ScrollState::default();
+            ui.help_scroll.follow = false;
+            ui.help_scroll.top = 0;
+            DeckAction::Handled
+        }
+        // `/mcp-search` jumps straight into the MCP tab's registry
+        // search — THE way to begin looking for a server from anywhere
+        // (the old `/`-on-the-MCP-tab trigger collided with the command
+        // menu and is gone; `s` on the tab is the local equivalent).
+        "/mcp-search" => {
+            ui.set_tab(DeckTab::Mcp);
+            ui.mcp.mode = McpMode::Search;
+            ui.mcp.status = None;
+            DeckAction::Handled
+        }
+        // The floating cards: pure view state, so the driver has no say.
+        // `/budget` only *renders* locally — the edit it takes leaves as
+        // `WorkspaceInput::SetBudget` from the card's own key handler.
+        "/tasks" => {
+            ui.cards.raise(cards::Card::Tasks);
+            DeckAction::Handled
+        }
+        "/scope" => {
+            ui.cards.raise(cards::Card::Scope);
+            DeckAction::Handled
+        }
+        "/witness" => {
+            ui.cards.raise(cards::Card::Witness);
+            DeckAction::Handled
+        }
+        "/models" => {
+            ui.cards.raise(cards::Card::Models);
+            DeckAction::Handled
+        }
+        "/budget" => {
+            ui.cards.raise(cards::Card::Budget);
+            DeckAction::Handled
+        }
+        _ => return None,
+    })
 }
 
 /// The queue editor's modal keys. Everything the design doc promises for the

--- a/stella-tui/src/deck_ui/dispatch.rs
+++ b/stella-tui/src/deck_ui/dispatch.rs
@@ -64,8 +64,12 @@ impl DispatchRoute {
 /// Whether `text` states its own routing and must not be second-guessed.
 fn carries_its_own_intent(text: &str) -> bool {
     let head = text.trim_start();
-    // `!` never reaches here (shell dispatch precedes it), but listing it
-    // keeps the rule readable as "the three markers".
+    // `!` never reaches here (shell dispatch precedes it), and neither do
+    // view-only slash commands (`deck_ui::view_command` executes those at
+    // submission) — what `/` matches here is the prompt-shaped remainder:
+    // driver commands and custom ⚡ commands, which enqueue for the lead
+    // rather than raising the card. Listing all three markers keeps the
+    // rule readable.
     head.starts_with('>') || head.starts_with('/') || head.starts_with('!')
 }
 

--- a/stella-tui/src/deck_ui/tests/queue.rs
+++ b/stella-tui/src/deck_ui/tests/queue.rs
@@ -464,6 +464,132 @@ fn slash_diff_switches_to_files_and_opens_the_diff() {
     assert!(ui.files_diff_open, "/diff opens the viewer");
 }
 
+/// A model whose lead is mid-turn — the state whose queue/steering machinery
+/// view commands must never enter.
+fn model_with_running_lead() -> WorkspaceModel {
+    let mut m = model_with(&["lead"]);
+    m.apply_inbound(&Inbound::Status {
+        agent: "lead".into(),
+        status: AgentStatus::Running,
+    });
+    m
+}
+
+#[test]
+fn a_view_command_typed_past_the_popup_still_acts_immediately() {
+    // A trailing space closes the slash popup (the menu is a single-`/`-word
+    // view), so this submission takes the plain-Enter road — which used to
+    // enqueue the command for the driver, where it no-opped. The view switch
+    // must not depend on which road the ⏎ took.
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.slash_commands = vec![SlashCommand::new("/files", "files")];
+    ui.files_diff_open = true;
+    for c in "/files ".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    assert!(slash_matches(&ui).is_empty(), "the popup is closed");
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "/files is consumed locally");
+    assert_eq!(ui.tab, DeckTab::Files);
+    assert!(!ui.files_diff_open, "/files shows the tree, not a diff");
+    assert!(ui.composer.is_empty(), "the submission spent the buffer");
+}
+
+#[test]
+fn a_view_command_bypasses_a_running_turn_and_the_routing_card() {
+    // Submitted mid-turn (popup inactive: unknown-to-the-menu vocabulary), a
+    // view command must neither raise the dispatch card nor enqueue — it
+    // changes what the user is looking at, so it takes effect NOW.
+    let model = model_with_running_lead();
+    let mut ui = ready_ui();
+    ui.slash_commands = vec![]; // no menu — the bare typed text is submitted
+    for c in "/mcp".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "/mcp is consumed locally");
+    assert_eq!(ui.tab, DeckTab::Mcp);
+    assert!(
+        ui.pending_dispatch.is_none(),
+        "a view switch is never asked steer/next/parallel"
+    );
+}
+
+#[test]
+fn a_view_command_during_a_hold_neither_spends_nor_releases_it() {
+    // The double-Esc hold reserves the NEXT PROMPT's front-of-queue slot.
+    // Peeking at another tab while holding must not count as that prompt.
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.dispatch_held = true;
+    ui.slash_commands = vec![];
+    for c in "/graph".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled);
+    assert_eq!(ui.tab, DeckTab::Graph);
+    assert!(ui.dispatch_held, "the hold survives a view switch");
+}
+
+#[test]
+fn slash_help_opens_the_overlay_immediately_even_mid_turn() {
+    // `/help` used to round-trip through the driver's queue, so mid-turn it
+    // opened only when the turn finished. It is pure view state — the same
+    // overlay `?` opens — and must behave like one.
+    let model = model_with_running_lead();
+    let mut ui = ready_ui();
+    ui.slash_commands = vec![SlashCommand::new("/help", "help")];
+    for c in "/help".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "/help is consumed locally");
+    assert!(ui.help_open, "the overlay is up before the turn ends");
+}
+
+#[test]
+fn a_view_command_with_arguments_stays_a_prompt() {
+    // Every view command is no-argument (the driver's dispatcher applies the
+    // same whole-input rule), so `/diff main` is prompt-shaped — it enqueues
+    // rather than switching views and silently discarding "main".
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.slash_commands = vec![];
+    for c in "/diff main".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::Enqueue {
+            text: "/diff main".into()
+        })
+    );
+    assert_eq!(ui.tab, DeckTab::Session, "no view switch happened");
+}
+
+#[test]
+fn a_driver_command_still_enqueues_like_a_prompt() {
+    // `/clear` (and every non-view slash: driver commands, custom ⚡
+    // commands, unknowns) can be steering or new work — the deck can't know,
+    // so it keeps the normal prompt road to the driver.
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.slash_commands = vec![SlashCommand::new("/clear", "clear")];
+    for c in "/clear".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::Enqueue {
+            text: "/clear".into()
+        })
+    );
+}
+
 #[test]
 fn a_refreshed_graph_snapshot_updates_the_view_out_of_band() {
     use crate::graph::{GraphNode, GraphSnapshot};

--- a/stella-tui/src/highlight.rs
+++ b/stella-tui/src/highlight.rs
@@ -1,0 +1,376 @@
+//! Prompt-keyword highlighting for the composer.
+//!
+//! Certain words in a prompt are not prose — they *control what happens on
+//! submission*. A leading slash command picks a dispatch path before the
+//! driver ever sees the text; a future reserved word (say, `workflows`) may
+//! trigger an engine wherever it appears. Those words earn a distinctive,
+//! uniform treatment in the input itself, live as the user types, so the
+//! prompt telegraphs what it will *do* before ⏎ commits it.
+//!
+//! The architecture is two pure layers, both over the composer's **display
+//! text** (chips + buffer — the exact string [`crate::composer::layout`]
+//! wraps):
+//!
+//! 1. **Matching** — [`prompt_keywords`] runs every matcher and returns
+//!    non-overlapping [`KeywordSpan`]s in byte order. Matchers today: the
+//!    leading slash command (mark + name as two spans, so each can carry its
+//!    own colour) and reserved words from a vocabulary
+//!    ([`RESERVED_WORDS`] — empty until a feature claims one) matched
+//!    *anywhere* in the text. A new keyword family is one new matcher here;
+//!    no renderer changes.
+//! 2. **Segmentation** — [`segments`] intersects one wrapped row (or any
+//!    fragment of the display text) with those spans, yielding
+//!    `(Option<KeywordKind>, &str)` runs. Byte offsets make this exact
+//!    across soft wraps: a keyword split over two rows highlights on both,
+//!    because each row slices the same span table at its own offset.
+//!
+//! Styling is deliberately last and thin: [`style`] maps a kind to its
+//! [`crate::theme`] treatment, so every surface that draws a composer picks
+//! up the same look by construction.
+
+use ratatui::style::{Modifier, Style};
+
+use crate::theme;
+
+/// What a highlighted run of prompt text *is* — the vocabulary of prompt
+/// keywords. Styling maps from this, never from the matched text itself, so
+/// every keyword of a kind renders identically wherever it appears.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeywordKind {
+    /// The `/` of a leading slash command — the dispatch marker itself.
+    SlashMark,
+    /// The command slug right after the mark (`files` in `/files`).
+    SlashName,
+    /// A reserved word from the keyword vocabulary, anywhere in the prompt.
+    Reserved,
+}
+
+/// One matched keyword: a byte range over the composer's display text.
+/// Ranges from [`prompt_keywords`] are sorted and never overlap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeywordSpan {
+    /// Byte offset (inclusive) into the display text.
+    pub start: usize,
+    /// Byte offset (exclusive) into the display text.
+    pub end: usize,
+    pub kind: KeywordKind,
+}
+
+/// The reserved-word vocabulary shipped today: none. When a feature claims a
+/// word — a `workflows` engine wanting `workflows` lit up the moment it is
+/// typed, anywhere in the prompt — it is added here (or a caller passes its
+/// own slice) and the whole pipeline lights it with zero renderer changes.
+pub const RESERVED_WORDS: &[&str] = &[];
+
+/// Match every prompt keyword in `display`: the leading slash command first
+/// (it always wins overlaps — `/diff` is a command even if `diff` were also
+/// a reserved word), then `reserved` words anywhere. Returns byte-ordered,
+/// non-overlapping spans.
+pub fn prompt_keywords(display: &str, reserved: &[&str]) -> Vec<KeywordSpan> {
+    let mut spans = Vec::new();
+    leading_slash_command(display, &mut spans);
+    for word in reserved {
+        reserved_matches(display, word, &mut spans);
+    }
+    spans.sort_by_key(|s| s.start);
+    spans
+}
+
+/// The leading slash command, as the submission paths actually parse it: the
+/// first non-whitespace character must be `/` (mid-text slashes are paths,
+/// not commands), and the slug is the rest of that whitespace-delimited head
+/// token — the same head `split_once(char::is_whitespace)` gives the
+/// dispatcher. Every slash command gets the treatment, known or not: an
+/// unknown `/comand` still *dispatches* as a command (the driver answers it
+/// with a hint), so the highlight stays honest about what ⏎ will do.
+fn leading_slash_command(display: &str, spans: &mut Vec<KeywordSpan>) {
+    let head_at = display.len() - display.trim_start().len();
+    let head = &display[head_at..];
+    if !head.starts_with('/') {
+        return;
+    }
+    spans.push(KeywordSpan {
+        start: head_at,
+        end: head_at + 1,
+        kind: KeywordKind::SlashMark,
+    });
+    let name_len = head[1..]
+        .find(char::is_whitespace)
+        .unwrap_or(head.len() - 1);
+    if name_len > 0 {
+        spans.push(KeywordSpan {
+            start: head_at + 1,
+            end: head_at + 1 + name_len,
+            kind: KeywordKind::SlashName,
+        });
+    }
+}
+
+/// A character that can sit inside a keyword — the boundary test for
+/// whole-word matching. `-` and `_` count (a future `ci-status` keyword must
+/// not light inside `my-ci-status-page`).
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-'
+}
+
+/// Whole-word, ASCII-case-insensitive occurrences of `word` anywhere in
+/// `display`, skipping any that overlap a span already claimed (the slash
+/// command, or an earlier-listed reserved word).
+fn reserved_matches(display: &str, word: &str, spans: &mut Vec<KeywordSpan>) {
+    if word.is_empty() {
+        return;
+    }
+    let len = word.len();
+    let mut at = 0;
+    while at + len <= display.len() {
+        if !display.is_char_boundary(at)
+            || !display.is_char_boundary(at + len)
+            || !display[at..at + len].eq_ignore_ascii_case(word)
+        {
+            at += 1;
+            continue;
+        }
+        let free_standing = display[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_word_char(c))
+            && display[at + len..]
+                .chars()
+                .next()
+                .is_none_or(|c| !is_word_char(c));
+        let unclaimed = spans.iter().all(|s| s.end <= at || s.start >= at + len);
+        if free_standing && unclaimed {
+            spans.push(KeywordSpan {
+                start: at,
+                end: at + len,
+                kind: KeywordKind::Reserved,
+            });
+            at += len;
+        } else {
+            at += 1;
+        }
+    }
+}
+
+/// Slice `text` — a fragment of the display text beginning at byte `start`
+/// within it — into runs of uniform keyword kind (`None` = plain prose).
+/// Runs cover `text` exactly, in order; a keyword that begins before or ends
+/// after the fragment still colours the part that falls inside it, which is
+/// what keeps a soft-wrapped keyword lit on both of its rows.
+pub fn segments<'a>(
+    text: &'a str,
+    start: usize,
+    keywords: &[KeywordSpan],
+) -> Vec<(Option<KeywordKind>, &'a str)> {
+    let end = start + text.len();
+    let mut runs = Vec::new();
+    let mut at = start;
+    for span in keywords {
+        if span.end <= at {
+            continue;
+        }
+        if span.start >= end {
+            break;
+        }
+        let s = span.start.max(at);
+        let e = span.end.min(end);
+        if s > at {
+            runs.push((None, &text[at - start..s - start]));
+        }
+        runs.push((Some(span.kind), &text[s - start..e - start]));
+        at = e;
+    }
+    if at < end {
+        runs.push((None, &text[at - start..]));
+    }
+    runs
+}
+
+/// The one place a keyword kind becomes a look. Gold for the dispatch mark
+/// (the brand accent — it *is* chrome, like the `>>> ` prefix), the deck's
+/// violet for the command slug, both bold so a command reads as a command at
+/// a glance. Reserved words are amber italic — the same hue
+/// [`theme::SYNTAX_KEYWORD`] gives keywords in code, which is exactly what
+/// they are.
+pub fn style(kind: KeywordKind) -> Style {
+    match kind {
+        KeywordKind::SlashMark => Style::default()
+            .fg(theme::GOLD)
+            .add_modifier(Modifier::BOLD),
+        KeywordKind::SlashName => Style::default()
+            .fg(theme::VIOLET)
+            .add_modifier(Modifier::BOLD),
+        KeywordKind::Reserved => Style::default()
+            .fg(theme::AMBER)
+            .add_modifier(Modifier::ITALIC),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spans_of(display: &str, reserved: &[&str]) -> Vec<(usize, usize, KeywordKind)> {
+        prompt_keywords(display, reserved)
+            .into_iter()
+            .map(|s| (s.start, s.end, s.kind))
+            .collect()
+    }
+
+    #[test]
+    fn a_leading_slash_command_is_a_mark_plus_a_name() {
+        assert_eq!(
+            spans_of("/files", &[]),
+            vec![
+                (0, 1, KeywordKind::SlashMark),
+                (1, 6, KeywordKind::SlashName),
+            ]
+        );
+    }
+
+    #[test]
+    fn leading_whitespace_does_not_hide_the_command() {
+        // Submission trims before dispatching, so the highlight must agree.
+        assert_eq!(
+            spans_of("  /diff", &[]),
+            vec![
+                (2, 3, KeywordKind::SlashMark),
+                (3, 7, KeywordKind::SlashName),
+            ]
+        );
+    }
+
+    #[test]
+    fn only_the_head_token_is_the_command() {
+        // `/model zai/glm-5.2` — the argument is prose, including its slash.
+        assert_eq!(
+            spans_of("/model zai/glm-5.2", &[]),
+            vec![
+                (0, 1, KeywordKind::SlashMark),
+                (1, 6, KeywordKind::SlashName),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_mid_text_slash_is_a_path_not_a_command() {
+        assert!(spans_of("open src/main.rs", &[]).is_empty());
+    }
+
+    #[test]
+    fn a_bare_slash_lights_the_mark_alone() {
+        // The moment `/` is typed the treatment begins — the slug span
+        // appears with the first slug character.
+        assert_eq!(spans_of("/", &[]), vec![(0, 1, KeywordKind::SlashMark)]);
+    }
+
+    #[test]
+    fn a_reserved_word_lights_anywhere_case_insensitively() {
+        // The future the architecture is for: a `workflows` engine reserves
+        // its word, and it lights wherever it is typed.
+        assert_eq!(
+            spans_of("run my Workflows now", &["workflows"]),
+            vec![(7, 16, KeywordKind::Reserved)]
+        );
+    }
+
+    #[test]
+    fn a_reserved_word_inside_another_word_stays_dark() {
+        assert!(spans_of("reworkflows", &["workflows"]).is_empty());
+        assert!(spans_of("workflowsx", &["workflows"]).is_empty());
+        // `-` is a word character: this is one identifier, not the keyword.
+        assert!(spans_of("my-workflows", &["workflows"]).is_empty());
+        // …but plain punctuation is a boundary.
+        assert_eq!(
+            spans_of("workflows!", &["workflows"]),
+            vec![(0, 9, KeywordKind::Reserved)]
+        );
+    }
+
+    #[test]
+    fn the_slash_command_wins_an_overlap_with_a_reserved_word() {
+        // `/diff` is a command even if `diff` were also reserved — the
+        // command spans claim their bytes first.
+        assert_eq!(
+            spans_of("/diff", &["diff"]),
+            vec![
+                (0, 1, KeywordKind::SlashMark),
+                (1, 5, KeywordKind::SlashName),
+            ]
+        );
+        // Outside the command head the reserved word still lights.
+        assert_eq!(
+            spans_of("/show the diff", &["diff"]),
+            vec![
+                (0, 1, KeywordKind::SlashMark),
+                (1, 5, KeywordKind::SlashName),
+                (10, 14, KeywordKind::Reserved),
+            ]
+        );
+    }
+
+    #[test]
+    fn segments_cover_a_row_exactly_and_in_order() {
+        let keywords = prompt_keywords("/files now", &[]);
+        assert_eq!(
+            segments("/files now", 0, &keywords),
+            vec![
+                (Some(KeywordKind::SlashMark), "/"),
+                (Some(KeywordKind::SlashName), "files"),
+                (None, " now"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_keyword_split_by_a_soft_wrap_lights_on_both_rows() {
+        // Display "/inspect" wrapped at width 4 → rows "/ins" (offset 0) and
+        // "pect" (offset 4). The slug span [1,8) must colour its part of
+        // each row.
+        let keywords = prompt_keywords("/inspect", &[]);
+        assert_eq!(
+            segments("/ins", 0, &keywords),
+            vec![
+                (Some(KeywordKind::SlashMark), "/"),
+                (Some(KeywordKind::SlashName), "ins"),
+            ]
+        );
+        assert_eq!(
+            segments("pect", 4, &keywords),
+            vec![(Some(KeywordKind::SlashName), "pect")]
+        );
+    }
+
+    #[test]
+    fn an_empty_fragment_yields_no_segments() {
+        let keywords = prompt_keywords("/files", &[]);
+        assert_eq!(segments("", 6, &keywords), vec![]);
+    }
+
+    #[test]
+    fn a_wide_char_prompt_keeps_offsets_on_char_boundaries() {
+        // Multi-byte text around a reserved word: offsets are bytes, and the
+        // matcher must never split a char.
+        assert_eq!(
+            spans_of("日本語 workflows 日本語", &["workflows"]),
+            vec![(10, 19, KeywordKind::Reserved)]
+        );
+    }
+
+    #[test]
+    fn every_kind_has_a_distinct_uniform_style() {
+        // The treatment is part of the contract: gold mark, violet slug —
+        // distinct from each other and from body text.
+        assert_ne!(style(KeywordKind::SlashMark), style(KeywordKind::SlashName));
+        assert_eq!(
+            style(KeywordKind::SlashMark).fg,
+            Some(crate::theme::GOLD),
+            "the dispatch mark is gold"
+        );
+        assert_eq!(
+            style(KeywordKind::SlashName).fg,
+            Some(crate::theme::VIOLET),
+            "the slug rides the deck's violet"
+        );
+    }
+}

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -73,6 +73,7 @@ pub mod diff;
 pub mod envelope;
 pub mod fleet_dashboard;
 pub mod graph;
+pub mod highlight;
 pub mod markdown;
 pub mod notice;
 pub mod palette;


### PR DESCRIPTION
## What & why

Two composer-facing changes (one commit each):

**1. View-only slash commands take effect immediately, on every submission path.** A view-only command (`/files`, `/diff`, `/graph`, `/agents`, `/skills`, `/mcp`, `/mcp-search`, `/settings`, `/sessions`, `/context`, `/inspect`, `/inbox`, `/tasks`, `/scope`, `/witness`, `/models`, `/budget` — and now `/help`) changes what the user is *looking at*, never what an agent is doing, so it must never enter the prompt queue or the steering/simultaneous-work machinery. That was previously only true when the submission happened via the slash popup's ⏎; any other road (a trailing space or argument closing the popup, a vocabulary miss, mid-turn submit, a double-Esc hold) enqueued the command for the driver, where it waited out the running turn and then no-opped — a view switch that appeared to do nothing.

The view-command table now lives in one function (`view_command` in `stella-tui/src/deck_ui.rs`) consulted by `submit_prompt` itself, ahead of the held-dispatch check, so every submission path converges on one classification:
- view commands execute the instant ⏎ lands — no queue, no routing card, no steering assessment; a double-Esc hold is neither spent nor released by one. The refreshes some of them send (`AgentsRefresh`, `Skill(List)`, `SessionsRefresh`, `InspectRefresh`) are already serviced at the driver's mid-turn recv site, so "immediate" holds while a turn runs.
- everything else — driver commands (`/clear`, `/init`, `/model <id>`), custom ⚡ commands, unknown slashes — is prompt-shaped and keeps today's routing untouched: it *can* be steering, the deck can't know.
- `/help` joins the view table (it opens the same overlay `?` opens; the old driver round trip parked it behind a running turn).

**2. Prompt keywords are lit live in the composer.** New pure module `stella-tui/src/highlight.rs`: slash commands render with a gold `/` and the slug in the deck's violet, uniformly for every command (built-in, custom, or unknown — anything that will *dispatch* as a command is shown as one), following the text across soft wraps and around the caret. The architecture is matcher → byte-range spans → per-row segmentation → one kind→style mapping, designed so a future reserved word (e.g. `workflows` for a workflows engine) can be highlighted anywhere in the prompt by adding one matcher/vocabulary entry, with zero renderer changes. The reserved-word matcher (whole-word, case-insensitive, anywhere in the text) ships with an empty vocabulary but is fully implemented and tested.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Routing: `a_view_command_typed_past_the_popup_still_acts_immediately`, `a_view_command_bypasses_a_running_turn_and_the_routing_card`, `a_view_command_during_a_hold_neither_spends_nor_releases_it`, `slash_help_opens_the_overlay_immediately_even_mid_turn` (plus guards `a_view_command_with_arguments_stays_a_prompt`, `a_driver_command_still_enqueues_like_a_prompt`). Highlighting: the `highlight::tests` module, `layout_reports_where_each_row_starts_in_the_display_text`, and the cell-level render witness `a_typed_slash_command_lights_gold_mark_and_violet_slug_live`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (run for the two touched crates, `stella-tui` + `stella-cli`; nothing else depends on them)
- [x] `cargo test` for `stella-tui` (788 lib + integration) and `stella-cli` (1281 + integration), all green
- [x] Docs updated where behavior changed (doc comments on `view_command`, `submit_prompt`, `handle_slash_key`, `carries_its_own_intent`, `run_deck_command`, `ComposerLayout`, and the `highlight` module docs)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The template asks for one logical change per PR; this branch was designated for both requests, so they're kept as two clean, independently revertable commits.
- Deliberate scope call: non-view slash commands keep today's mid-turn treatment (enqueue for the lead, no routing card). An alternative reading of the ask is to raise the steer/next/parallel card for custom ⚡ commands mid-turn, since those expand to real prompts — happy to follow up if that's the intent.
- The driver keeps its no-op arm for view commands (now including the floating cards) as a fallback for durable queues persisted by older builds.
- Reserved-word style (amber italic) is defined but unused until a word is added to `RESERVED_WORDS`.

---

## Summary by Sourcery

Handle view-only slash commands as immediate UI-only actions across all submission paths and add live prompt keyword highlighting in the deck composer.

New Features:
- Treat view-only slash commands as instant view switches that bypass the prompt queue, routing card, and dispatch holds, including adding `/help` to this view-command set.
- Highlight prompt keywords live in the composer, rendering slash commands with a gold mark and violet slug that follow soft wraps and cursor movement.

Enhancements:
- Factor view-only slash command handling into a dedicated `view_command` helper so submission and slash-popup paths share consistent behavior.
- Extend composer layout to track display-wide text and per-row byte offsets, enabling accurate overlay of keyword highlights over wrapped rows.

Tests:
- Add queue-level tests covering view-command behavior across popup closure, mid-turn submission, dispatch holds, argument-bearing commands, and driver commands.
- Add render-level tests verifying live slash-command coloring and composer cursor position with the expanded layout metadata.
- Add unit tests for the new prompt keyword matching and segmentation logic, including reserved-word handling and style mapping.
