### PR TITLE
fix(candidate): tell a candidate what its snapshot left behind

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -93,6 +93,7 @@ use crate::agent::{
 };
 
 mod adopt;
+mod snapshot_gaps;
 mod witness_tools;
 use adopt::{attach_diffs, attach_numstat, conflict_paths_from_stderr, parse_name_status};
 use witness_tools::WitnessToolExecutor;
@@ -396,6 +397,7 @@ impl GitCandidateWorkspaces {
                 let tools: Box<dyn stella_core::ToolExecutor> = Box::new(
                     crate::agent::PolicyToolSet::new_owned(tools, self.policy.clone()),
                 );
+                let omitted = snapshot_gaps::omitted_ignored_paths(&toplevel, &root_rel).await;
                 Ok(GitCandidateWorkspace {
                     toplevel,
                     dir: dir.clone(),
@@ -415,6 +417,7 @@ impl GitCandidateWorkspaces {
                         ws_root,
                         overlay: overlay_untracked,
                     },
+                    omitted,
                 })
             }
             Err(reason) => {
@@ -606,6 +609,10 @@ pub(crate) struct GitCandidateWorkspace {
     diagnostics: GitDiagnosticRunner,
     tests: TypedTestRunner,
     repo_status: SnapshotRepoStatus,
+    /// Ignored paths present in the real tree and elided from this snapshot —
+    /// see [`snapshot_gaps`]. A display list for the candidate's context, not
+    /// a set anything branches on.
+    omitted: Vec<String>,
 }
 
 impl GitCandidateWorkspace {
@@ -827,6 +834,10 @@ impl CandidateWorkspace for GitCandidateWorkspace {
 
     fn repo_status(&self) -> &dyn RepoStatusPort {
         &self.repo_status
+    }
+
+    fn omitted_paths(&self) -> &[String] {
+        &self.omitted
     }
 
     async fn seal(&self) -> Result<(), WorkspaceError> {

--- a/crates/stella-cli/src/candidate_ws/snapshot_gaps.rs
+++ b/crates/stella-cli/src/candidate_ws/snapshot_gaps.rs
@@ -1,0 +1,183 @@
+//! What a candidate snapshot leaves behind.
+//!
+//! The snapshot is a *git view* of the tree, not a copy of it: `git worktree
+//! add` checks out HEAD, the uncommitted tracked delta is applied over that,
+//! and untracked files ride in from `git ls-files --others --exclude-standard`
+//! — which excludes ignored paths by construction. So everything matched by
+//! `.gitignore` is absent from every candidate: `node_modules/`, `.venv/`, a
+//! downloaded dataset, a compiled artifact the tests exec.
+//!
+//! For the tracked delta that is exactly right; ignored bytes are derived
+//! state, and copying `target/` N times to run N candidates would cost more
+//! than the fan-out. What is wrong is that the omission is *invisible from
+//! inside*. The candidate sees a plausible checkout, runs the project's own
+//! test command, and gets `Cannot find module` — a failure that reads as its
+//! own mistake, in a tree where the fix (reinstall) is not obviously available
+//! and the real cause is not observable at all.
+//!
+//! This module names the gap. It does not close it: closing it is a workspace
+//! substrate that copies whole trees instead of asking git what belongs in
+//! one, which is a different adapter behind the same port.
+
+use std::path::Path;
+
+/// How many entries a report may name. A diagnostic must not itself become a
+/// context-flooding wall of text on a tree that ignores ten thousand log
+/// files — but a cap that hides its own existence turns "here is what's
+/// missing" into a quiet lie, so truncation is stated in the list it
+/// truncates (see [`omitted_ignored_paths`]).
+const MAX_REPORTED: usize = 20;
+
+/// Ignored paths that exist in the real tree and are absent from every
+/// candidate snapshot, workspace-root-relative, as a **display list**.
+///
+/// `--directory` is what makes this affordable to report: a wholly-ignored
+/// directory collapses to one `dir/` entry instead of enumerating its
+/// contents, so `node_modules` costs one line rather than forty thousand.
+///
+/// Scoped to the workspace root the same way the untracked overlay is — a
+/// path above the session root is not in the candidate's tree under any
+/// substrate, so naming it would describe a gap the candidate cannot act on.
+///
+/// Best-effort by construction. This is a diagnostic about a snapshot that has
+/// already been built successfully; a tree we cannot describe is still a tree
+/// that works, so every failure path yields an empty list rather than
+/// propagating. Over [`MAX_REPORTED`] entries the list's final element says
+/// how many were withheld.
+pub(super) async fn omitted_ignored_paths(toplevel: &Path, root_rel: &Path) -> Vec<String> {
+    let listing = match super::git(
+        toplevel,
+        &[
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "-z",
+        ],
+    )
+    .await
+    {
+        Ok(listing) => listing,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut found: Vec<String> = Vec::new();
+    let mut withheld = 0usize;
+    for rel in listing.split('\0').filter(|p| !p.is_empty()) {
+        let Ok(ws_rel) = Path::new(rel).strip_prefix(root_rel) else {
+            continue;
+        };
+        let ws_rel = ws_rel.to_string_lossy();
+        if ws_rel.is_empty() {
+            continue;
+        }
+        if found.len() < MAX_REPORTED {
+            found.push(ws_rel.into_owned());
+        } else {
+            withheld += 1;
+        }
+    }
+    if withheld > 0 {
+        found.push(format!("… and {withheld} more ignored path(s)"));
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Build a real repo with one commit, a tracked file, and ignored state.
+    async fn repo_with_ignored_state() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.invalid"],
+            vec!["config", "user.name", "t"],
+        ] {
+            super::super::git(root, &args).await.expect("git setup");
+        }
+        std::fs::write(root.join(".gitignore"), "node_modules/\n*.log\n").expect("write ignore");
+        std::fs::write(root.join("src.rs"), "fn main() {}").expect("write src");
+        std::fs::create_dir_all(root.join("node_modules/left-pad")).expect("mkdir");
+        std::fs::write(root.join("node_modules/left-pad/index.js"), "x").expect("write dep");
+        std::fs::write(root.join("build.log"), "noise").expect("write log");
+        super::super::git(root, &["add", "-A"]).await.expect("add");
+        super::super::git(root, &["commit", "-q", "-m", "init", "--no-gpg-sign"])
+            .await
+            .expect("commit");
+        dir
+    }
+
+    /// The whole point: the dependency directory the tests need is reported,
+    /// and reported as ONE entry rather than one per vendored file.
+    #[tokio::test]
+    async fn an_ignored_dependency_directory_is_named_once() {
+        let repo = repo_with_ignored_state().await;
+        let found = omitted_ignored_paths(repo.path(), Path::new("")).await;
+
+        assert!(
+            found.iter().any(|p| p.starts_with("node_modules")),
+            "the dependency dir a candidate cannot build without: {found:?}"
+        );
+        assert_eq!(
+            found
+                .iter()
+                .filter(|p| p.starts_with("node_modules"))
+                .count(),
+            1,
+            "--directory must collapse it, not enumerate it: {found:?}"
+        );
+        assert!(
+            found.iter().any(|p| p == "build.log"),
+            "an ignored file is omitted too: {found:?}"
+        );
+    }
+
+    /// Tracked files are in the snapshot, so naming them would be false.
+    #[tokio::test]
+    async fn tracked_files_are_not_reported_as_missing() {
+        let repo = repo_with_ignored_state().await;
+        let found = omitted_ignored_paths(repo.path(), Path::new("")).await;
+        assert!(
+            !found.iter().any(|p| p == "src.rs" || p == ".gitignore"),
+            "tracked content is present in the snapshot: {found:?}"
+        );
+    }
+
+    /// A diagnostic must never be able to fail a snapshot that is otherwise
+    /// sound — the candidate can still run, it just runs uninformed.
+    #[tokio::test]
+    async fn a_non_repository_reports_nothing_instead_of_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            omitted_ignored_paths(dir.path(), Path::new(""))
+                .await
+                .is_empty()
+        );
+    }
+
+    /// Paths above the session root describe a gap the candidate could not act
+    /// on even if it knew, so they are not its business.
+    #[tokio::test]
+    async fn only_paths_under_the_session_root_are_reported() {
+        let repo = repo_with_ignored_state().await;
+        std::fs::create_dir_all(repo.path().join("sub")).expect("mkdir sub");
+        std::fs::write(repo.path().join("sub/inner.log"), "x").expect("write");
+
+        let found = omitted_ignored_paths(repo.path(), &PathBuf::from("sub")).await;
+        assert!(
+            found.iter().any(|p| p == "inner.log"),
+            "reported relative to the session root: {found:?}"
+        );
+        assert!(
+            !found.iter().any(|p| p.contains("node_modules")),
+            "a sibling of the session root is out of scope: {found:?}"
+        );
+    }
+}

--- a/crates/stella-pipeline/src/candidate_narration.rs
+++ b/crates/stella-pipeline/src/candidate_narration.rs
@@ -86,23 +86,43 @@ pub(crate) fn candidate_winner_notice(best_idx: usize, n: u32, ran: u32) -> Opti
 /// no longer byte-identical to its seal, which fails adoption for the whole
 /// candidate. Both halves of a split turn lose.
 ///
+/// It also names what the snapshot does NOT carry. A git-shaped snapshot
+/// elides every ignored path, so a candidate can be handed a tree whose
+/// `node_modules/` or `.venv/` is simply gone — and the only symptom is the
+/// project's own test command failing for a reason the tree does not explain.
+/// A candidate that knows can reinstall; a candidate that doesn't reports the
+/// project as broken.
+///
 /// Appended AFTER the shared prefix, never inside it: the candidates of a
 /// fan-out share one cached prefix, so the single message that differs between
 /// them has to be last (the prompt-cache stability invariant).
 pub(crate) fn messages_rooted_at(
     base: &[CompletionMessage],
-    root: Option<&str>,
+    workspace: Option<&dyn crate::ports::CandidateWorkspace>,
 ) -> Vec<CompletionMessage> {
     let mut messages = base.to_vec();
-    if let Some(root) = root {
-        messages.push(CompletionMessage::user(format!(
+    if let Some(ws) = workspace {
+        let root = ws.root();
+        let mut notice = format!(
             "Workspace: your tools and shell are rooted at `{root}`, an isolated \
              snapshot of the project. Only work inside this root is collected when \
              the turn finishes. Absolute paths in the task above name the original \
              tree; resolve them against this root instead (`/x/y` -> `{root}/x/y`). \
              Another copy of the project may be readable elsewhere on this machine — \
              editing it does not count, so do not `cd` out of this root."
-        )));
+        );
+        let omitted = ws.omitted_paths();
+        if !omitted.is_empty() {
+            notice.push_str(&format!(
+                "\n\nThis snapshot carries tracked and untracked files but NOT ignored \
+                 ones, so these exist in the original tree and are absent here: {}. \
+                 If a build or test fails on something they would have provided, \
+                 regenerate it inside this root (reinstall, rebuild) rather than \
+                 reaching outside for it.",
+                omitted.join(", ")
+            ));
+        }
+        messages.push(CompletionMessage::user(notice));
     }
     messages
 }
@@ -110,6 +130,73 @@ pub(crate) fn messages_rooted_at(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::{
+        AdoptedChange, CandidateWorkspace, DiagnosticRunner, RepoStatusPort, TestRunner,
+        WorkspaceError,
+    };
+
+    /// A workspace that answers only what the notice actually reads. The other
+    /// nine port methods are unreachable from this code path, and stubbing
+    /// them with plausible values would invite a future caller to depend on
+    /// something this fake never modelled.
+    struct NoticeOnlyWorkspace {
+        root: String,
+        omitted: Vec<String>,
+    }
+
+    impl NoticeOnlyWorkspace {
+        fn at(root: &str) -> Self {
+            Self {
+                root: root.into(),
+                omitted: Vec::new(),
+            }
+        }
+
+        fn missing(mut self, paths: &[&str]) -> Self {
+            self.omitted = paths.iter().map(|p| (*p).to_string()).collect();
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CandidateWorkspace for NoticeOnlyWorkspace {
+        fn root(&self) -> &str {
+            &self.root
+        }
+        fn omitted_paths(&self) -> &[String] {
+            &self.omitted
+        }
+        fn tools(&self) -> &dyn stella_core::ToolExecutor {
+            unimplemented!("the workspace notice dispatches no tool")
+        }
+        fn witness_tools(&self) -> &dyn stella_core::ToolExecutor {
+            unimplemented!("the workspace notice dispatches no tool")
+        }
+        fn diagnostics(&self) -> &dyn DiagnosticRunner {
+            unimplemented!("the workspace notice runs no diagnostics")
+        }
+        fn tests(&self) -> &dyn TestRunner {
+            unimplemented!("the workspace notice runs no tests")
+        }
+        fn repo_status(&self) -> &dyn RepoStatusPort {
+            unimplemented!("the workspace notice reads no repo status")
+        }
+        async fn seal(&self) -> Result<(), WorkspaceError> {
+            unimplemented!("the workspace notice seals nothing")
+        }
+        async fn sealed_is_unchanged(&self) -> Result<bool, WorkspaceError> {
+            unimplemented!("the workspace notice seals nothing")
+        }
+        async fn adopt(&self, _withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+            unimplemented!("the workspace notice adopts nothing")
+        }
+        async fn graft_witness(&self, _source: &str, _path: &str) -> Result<(), WorkspaceError> {
+            unimplemented!("the workspace notice grafts nothing")
+        }
+        async fn remove(&self) {
+            unimplemented!("the workspace notice removes nothing")
+        }
+    }
 
     #[test]
     fn a_fan_out_names_its_position_total_and_isolation() {
@@ -136,7 +223,8 @@ mod tests {
             CompletionMessage::system("prefix"),
             CompletionMessage::user("write vm.js to /app"),
         ];
-        let rooted = messages_rooted_at(&base, Some("/tmp/stella_candidate_64_0"));
+        let ws = NoticeOnlyWorkspace::at("/tmp/stella_candidate_64_0");
+        let rooted = messages_rooted_at(&base, Some(&ws));
 
         assert_eq!(
             rooted.len(),
@@ -167,6 +255,44 @@ mod tests {
     fn a_shared_tree_candidate_is_told_nothing() {
         let base = vec![CompletionMessage::user("goal")];
         assert_eq!(messages_rooted_at(&base, None), base);
+    }
+
+    /// The failure this prevents: `npm test` dies on a missing module, in a
+    /// tree that looks complete, for a reason the candidate cannot observe.
+    /// Naming the elision converts an inexplicable failure into a fixable one.
+    #[test]
+    fn a_candidate_is_told_what_the_snapshot_left_behind() {
+        let base = vec![CompletionMessage::user("run the tests")];
+        let ws = NoticeOnlyWorkspace::at("/tmp/stella_candidate_7_0")
+            .missing(&["node_modules/", ".venv/"]);
+
+        let notice = messages_rooted_at(&base, Some(&ws))
+            .pop()
+            .expect("a notice is appended")
+            .content;
+
+        assert!(notice.contains("node_modules/"), "{notice}");
+        assert!(notice.contains(".venv/"), "{notice}");
+        assert!(
+            notice.contains("regenerate it inside this root"),
+            "naming the gap without naming the remedy leaves the candidate stuck: {notice}"
+        );
+    }
+
+    /// A tree that ignores nothing must not be handed a paragraph about
+    /// nothing — the notice is paid for on every candidate of every fan-out.
+    #[test]
+    fn a_snapshot_that_elides_nothing_says_nothing_about_omissions() {
+        let base = vec![CompletionMessage::user("goal")];
+        let ws = NoticeOnlyWorkspace::at("/tmp/stella_candidate_7_1");
+
+        let notice = messages_rooted_at(&base, Some(&ws))
+            .pop()
+            .expect("a notice is appended")
+            .content;
+
+        assert!(notice.contains("/tmp/stella_candidate_7_1"), "{notice}");
+        assert!(!notice.contains("absent here"), "{notice}");
     }
 
     #[test]

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -64,7 +64,7 @@ use crate::candidate::{
 };
 use crate::candidate_fanout::fan_out_width;
 use crate::candidate_narration::{
-    candidate_fanout_notice, candidate_start_notice, candidate_winner_notice,
+    self, candidate_fanout_notice, candidate_start_notice, candidate_winner_notice,
 };
 use crate::candidate_steering::SteeringFanOut;
 use crate::plan::{PlanStep, build_planner_prompt, parse_plan, plan_repair_prompt};
@@ -2080,7 +2080,7 @@ impl<'a> Pipeline<'a> {
         let untracked_before = surface.repo_status.untracked_fingerprints().await;
 
         let mut state = CandidateState {
-            messages: crate::candidate_narration::messages_rooted_at(base_messages, surface.cwd),
+            messages: candidate_narration::messages_rooted_at(base_messages, surface.workspace),
             final_text: String::new(),
             file_changes: 0,
             mutating_actions: 0,

--- a/crates/stella-pipeline/src/ports.rs
+++ b/crates/stella-pipeline/src/ports.rs
@@ -757,6 +757,22 @@ pub trait CandidateWorkspace: Send + Sync {
     /// tree's semantics (the tamper watchlist and zero-diff guard must keep
     /// working unchanged inside a candidate).
     fn repo_status(&self) -> &dyn RepoStatusPort;
+    /// Workspace-relative paths that exist in the real tree but NOT in this
+    /// snapshot, as a display list for the candidate's own context.
+    ///
+    /// A git-shaped snapshot carries tracked content and untracked-but-not-
+    /// ignored files; everything in `.gitignore` is absent by construction.
+    /// That is defensible — ignored bytes are derived state, and copying them
+    /// per candidate can cost more than the fan-out — but it is invisible from
+    /// inside the snapshot, where a missing `node_modules/` surfaces only as a
+    /// test command failing for no stated reason.
+    ///
+    /// Empty by default: a substrate that copies whole trees omits nothing and
+    /// has nothing to declare. Only a snapshot that *elides* part of the tree
+    /// owes the candidate this list.
+    fn omitted_paths(&self) -> &[String] {
+        &[]
+    }
     /// Commit the current candidate bytes into its private immutable history
     /// immediately before a final verification observation.
     async fn seal(&self) -> Result<(), WorkspaceError>;

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2271 crates/stella-cli/src/agent.rs
 1750 crates/stella-cli/src/agent_tests.rs
-1585 crates/stella-cli/src/candidate_ws.rs
+1596 crates/stella-cli/src/candidate_ws.rs
 4754 crates/stella-cli/src/command_deck.rs
 1506 crates/stella-cli/src/fleet_cmd.rs
 2129 crates/stella-core/src/bus.rs


### PR DESCRIPTION
## What's wrong

A candidate snapshot is a **git view** of the tree, not a copy of it. `populate_snapshot` checks out HEAD, applies the tracked delta, and copies untracked files listed by `git ls-files --others --exclude-standard` — which excludes ignored paths by construction.

So everything matched by `.gitignore` is absent from **every** candidate: `node_modules/`, `.venv/`, a downloaded dataset, a compiled artifact the tests exec.

Eliding derived state is defensible — copying `target/` once per candidate would cost more than the fan-out buys. What is not defensible is that **the elision is invisible from inside**. The candidate sees a plausible checkout, runs the project's own test command, and gets `Cannot find module`: a failure that reads as its own mistake, in a tree where the cause is not observable and the remedy is not obviously available.

On that basis alone, best-of-N is unusable for most JS and Python projects.

## What this does

`snapshot_gaps` names the gap — `git ls-files --others --ignored --exclude-standard --directory`, with `--directory` collapsing a wholly-ignored directory to one entry so `node_modules` costs a line rather than forty thousand. Scoped to the session root like the untracked overlay, best-effort by construction (a snapshot we cannot describe is still a snapshot that runs), and truncation states itself in the list it truncates.

The candidate is told through the workspace notice it already receives, so a fan-out pays **nothing new in prefix cache**: same trailing message, one extra paragraph, only when there is something to report.

`CandidateWorkspace::omitted_paths` defaults to empty — no test fake moves, and a substrate that copies whole trees has nothing to declare, which is the shape #1383 will take.

## Scope

This makes the failure **diagnosable**, not absent. A candidate that knows `node_modules/` is missing can reinstall; one that doesn't reports the project as broken. Making the snapshot faithful is a different workspace substrate — #1383.

## Verification

- `cargo test -p stella-pipeline -p stella-cli` — exit 0, 1828 passed, 0 failed (re-running on the post-#1385 base)
- `cargo clippy -p stella-tools -p stella-pipeline -p stella-cli --all-targets -- -D warnings` — exit 0
- `cargo fmt --all -- --check` — exit 0
- `scripts/check-file-size.sh` — green

New tests: an ignored dependency directory is named once (not per-file); tracked files are never reported missing; a non-repository reports nothing rather than failing a sound snapshot; only paths under the session root are reported; the notice names both gap and remedy; a snapshot that elides nothing stays silent.

`crates/stella-cli/src/candidate_ws.rs` grew +11 (a `mod` declaration, a field, a trait method — the 183-line body is in its own module), so the baseline ceiling is raised per the gate's own instruction. That diff is one line, `1585 → 1596`, with no collateral tightening.

Rebased onto main after #1385 squash-merged.

Refs #1383, #1289

## Summary by Sourcery

Report omitted ignored paths in candidate workspace notices so candidates understand what the git-based snapshot left out and how to remedy resulting failures.

New Features:
- Expose omitted ignored paths from candidate workspaces and append them to the workspace notice when present.

Enhancements:
- Introduce snapshot gap detection that lists ignored paths missing from git-shaped candidate snapshots, with truncation and session-root scoping.
- Extend the CandidateWorkspace port with an optional omitted_paths accessor and implement it for git-backed candidate workspaces.
- Adjust pipeline wiring and tests to use workspace-aware rooted messages and validate the new omission notice behavior.

Build:
- Update file size baseline to account for the new snapshot_gaps module in the CLI.

Tests:
- Add tests for snapshot gap reporting around ignored directories, tracked files, non-repositories, session-root scoping, and workspace notices with and without omissions.