### PR TITLE
fix: close three open issues found stale or nearly-done in an issue sweep (#993, #1303, #1137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,16 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-file-size.sh
 
+      # Also toolchain-free. #928 found seven CLI surfaces documented nowhere,
+      # and the reason seven accumulated is that no gate related the `Command`
+      # enum to the reference pages — a new subcommand could ship undocumented
+      # and every check stayed green (#993). `doc-links` is a different
+      # property: it checks that citations resolve, so a command nobody cited
+      # was invisible to it.
+      - name: every subcommand has a reference page
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-command-docs.sh
+
       # Also toolchain-free (shellcheck ships preinstalled on ubuntu-latest).
       # install.sh is fetched over the network and piped into `sh` by
       # strangers before Stella is installed; the guard scripts are what the

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,8 +1,8 @@
 name: docs-guards
 
-# Two guards over prose. Neither needs a Rust toolchain, which is why they live
-# here rather than in ci.yml -- that workflow deliberately ignores `docs/**` and
-# `*.md`, and this one triggers on exactly those paths.
+# Three guards over prose. None needs a Rust toolchain, which is why they live
+# here rather than in ci.yml -- that workflow deliberately ignores `docs/**`,
+# `website/**` and `*.md`, and this one triggers on exactly those paths.
 #
 #  1. doc-links (scripts/check-doc-links.py): every citation resolves to a
 #     document that has declared an identity. Documents are addressed by a
@@ -19,8 +19,14 @@ name: docs-guards
 #     CONTRIBUTING.md and README.md each carried a drifted second copy before
 #     this existed.
 #
-# Rust sources are in the path filter because both read them: a citation added
-# to a .rs comment is exactly how one goes stale.
+#  3. command-docs (scripts/check-command-docs.sh): every `stella` subcommand
+#     has a reference page the sidebar lists, and every page names a command
+#     that still exists (#993). #928 found seven undocumented surfaces at once
+#     precisely because nothing related the two.
+#
+# Rust sources are in the path filter because all three read them: a citation
+# added to a .rs comment is exactly how one goes stale, and the subcommand list
+# the third guard checks is itself a Rust enum.
 on:
   pull_request:
     paths:
@@ -29,6 +35,8 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
+      - "website/content/docs/commands/**"
+      - "scripts/check-command-docs.sh"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -38,6 +46,8 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
+      - "website/content/docs/commands/**"
+      - "scripts/check-command-docs.sh"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -66,3 +76,12 @@ jobs:
       - name: the architectural invariants have one home and stable numbering
         if: ${{ !cancelled() }}
         run: bash scripts/check-invariants.sh
+
+      # Also runs in ci.yml, which is where the important half is caught: a new
+      # `Command` variant is a .rs change, so the required check sees it. This
+      # copy covers the other direction, which ci.yml structurally cannot —
+      # `paths-ignore: website/**` means a PR that only deletes a reference
+      # page or drops it from meta.json never starts that workflow.
+      - name: every subcommand has a reference page
+        if: ${{ !cancelled() }}
+        run: bash scripts/check-command-docs.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CARGO_SCOPE ?= --workspace
 # wire-schema is separated out because it runs the two schema exporters, which
 # is a cargo build.
 GATE_GUARDS_FAST := no-scratch action-pins cargo-install-pins license-allowlist-parity \
-                    repro-wiring shellcheck invariants doc-links file-size
+                    repro-wiring shellcheck invariants doc-links command-docs file-size
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 .PHONY: help
@@ -170,6 +170,10 @@ doc-report: ## Which documents are stale, superseded, or cited by nothing
 doc-adopt: ## Scaffold frontmatter onto a document so it can be cited: make doc-adopt DOC=path
 	@test -n "$(DOC)" || { echo "usage: make doc-adopt DOC=docs/design/thing.md"; exit 2; }
 	@python3 ./scripts/check-doc-links.py init $(DOC)
+
+.PHONY: command-docs
+command-docs: ## Assert every stella subcommand has a listed reference page (#993)
+	@./scripts/check-command-docs.sh
 
 .PHONY: wire-schema
 wire-schema: ## Assert docs/wire/ still describes the AgentEvent wire format (#971)

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -753,12 +753,19 @@ mod tests {
     /// pointed the tab at a `settings.json` the CLI never opens.
     #[test]
     fn user_config_dir_mirrors_the_cli_settings_loader() {
-        // SAFETY: env mutation in a test — nothing else in this crate (tests
-        // or production code) reads STELLA_CONFIG_DIR, so no parallel test
-        // can observe the transient value.
+        // The old note here reasoned that no parallel test could observe the
+        // transient value because nothing else reads STELLA_CONFIG_DIR. That
+        // is an argument about one variable, and the hazard is the shared
+        // environment: this test also reads HOME, which other crates' tests
+        // override, and stella-store's `any_override_set` reads
+        // STELLA_CONFIG_DIR. Take the crate-wide lock like every other
+        // env-mutating test here (#1137).
+        let _env = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&["STELLA_CONFIG_DIR"]);
+        // SAFETY: the lock is held for the whole test, and `_restore` undoes
+        // this on drop — including if `user_config_dir` panics.
         unsafe { std::env::set_var("STELLA_CONFIG_DIR", "/tmp/elsewhere") };
         let resolved = user_config_dir();
-        unsafe { std::env::remove_var("STELLA_CONFIG_DIR") };
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
             .expect("HOME set");

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -557,3 +557,6 @@ async fn respond_to_head(
 #[cfg(test)]
 #[path = "lib_tests.rs"]
 mod lib_tests;
+
+#[cfg(test)]
+mod test_env;

--- a/crates/stella-observatory/src/lib_tests.rs
+++ b/crates/stella-observatory/src/lib_tests.rs
@@ -703,15 +703,13 @@ fn memories_rules_and_reflections_come_from_disk_and_db() {
     assert_eq!(ratings[0]["what_to_improve"], "read the failing test first");
 }
 
-/// Serializes the tests that mutate `STELLA_DATA_DIR` — it is process-wide,
-/// so one test's `set_var` racing another's `respond` (which reads it via
-/// `usage_db_path`) would flake. Poison-tolerant: a panicking holder must
-/// not cascade into unrelated failures.
-static DATA_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 #[test]
 fn project_param_drills_into_another_registered_workspace() {
-    let _env = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // `crate::test_env::lock` rather than a mutex private to this file: the
+    // hazard is the shared process environment, and fsview.rs mutates it too
+    // (#1137). A second private lock would serialize nothing against that one.
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_DATA_DIR"]);
     // Two workspaces: `home` is empty, `other` is seeded. A usage.db in a
     // private STELLA_DATA_DIR registers `other`; ?project= must re-point
     // the request at it, and unknown ids must fall back to `home`.
@@ -741,13 +739,13 @@ fn project_param_drills_into_another_registered_workspace() {
             other.path().display()
         ))
         .unwrap();
-    // SAFETY: env mutation in tests — this is the only test that sets
-    // STELLA_DATA_DIR, and every assertion runs before it's removed.
+    // SAFETY: the env lock is held for the whole test, and `_restore` undoes
+    // this on drop — including if one of the `respond` calls below panics,
+    // which would otherwise leak a path into a TempDir about to be deleted.
     unsafe { std::env::set_var("STELLA_DATA_DIR", data.path()) };
     let drilled = respond(home.path(), "/api/overview?project=feedbeef00000001");
     let unknown = respond(home.path(), "/api/overview?project=doesnotexist");
     let listed = respond(home.path(), "/api/projects");
-    unsafe { std::env::remove_var("STELLA_DATA_DIR") };
     let v: serde_json::Value = serde_json::from_slice(&drilled.body).unwrap();
     assert_eq!(v["runs"], 2, "?project= reads the other workspace");
     let v: serde_json::Value = serde_json::from_slice(&unknown.body).unwrap();
@@ -760,11 +758,14 @@ fn project_param_drills_into_another_registered_workspace() {
 
 #[test]
 fn hub_telemetry_aggregates_scope_and_drills_to_project() {
-    let _env = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_DATA_DIR"]);
     let home = TempDir::new().unwrap();
 
     // A hub dir with no usage.db is an empty state, never an error.
     let empty = TempDir::new().unwrap();
+    // SAFETY: the env lock is held for the whole test, and `_restore` undoes
+    // this on drop — including if the fixture `unwrap`s below panic first.
     unsafe { std::env::set_var("STELLA_DATA_DIR", empty.path()) };
     let none = respond(home.path(), "/api/hub-telemetry");
 
@@ -819,7 +820,6 @@ fn hub_telemetry_aggregates_scope_and_drills_to_project() {
         home.path(),
         "/api/hub-telemetry?org=acme&workspace=ws1&repo=r1",
     );
-    unsafe { std::env::remove_var("STELLA_DATA_DIR") };
 
     // Empty hub: available:false, zeroed, 200 OK.
     assert_eq!(none.status, "200 OK");

--- a/crates/stella-observatory/src/test_env.rs
+++ b/crates/stella-observatory/src/test_env.rs
@@ -1,0 +1,93 @@
+//! Serialization and panic-safe restore for tests that mutate process
+//! environment variables.
+//!
+//! The environment is process-global and `cargo test` runs a crate's tests on
+//! a thread pool, so a test that sets `STELLA_DATA_DIR` is mutating state every
+//! concurrently-running test in the same binary can observe — `respond` reads
+//! it through `usage_db_path` on the hub-telemetry and project-drill paths.
+//!
+//! Two distinct hazards, and covering only one leaves the bug:
+//!
+//!   1. **Concurrency.** Take [`lock`] before touching the environment and
+//!      hold it for as long as the override must stay in place. One lock for
+//!      the whole crate, not one per variable: the hazard is the shared
+//!      environment, and a second private mutex elsewhere serializes nothing
+//!      against this one.
+//!   2. **Unwinding.** A "set, act, unset" sequence never reaches its unset
+//!      step when something panics first — an `unwrap` on a malformed fixture,
+//!      or `respond` itself — leaking the override into every test that runs
+//!      after it. Worse here than most: the leaked value points at a `TempDir`
+//!      that is about to be deleted, so later tests resolve a path that no
+//!      longer exists. [`EnvRestore`] restores from `Drop`, which runs while
+//!      unwinding.
+//!
+//! This mirrors `stella-cli`'s module of the same name, added by #911. See
+//! #1137, which is what this crate having no restore guard at all cost.
+
+/// Acquire the env lock, recovering from a poisoned mutex (a prior
+/// env-mutating test that panicked mid-hold must not cascade into unrelated
+/// failures).
+pub(crate) fn lock() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Captures the current value of each named env var and restores it on drop,
+/// including while unwinding from a failed assertion.
+///
+/// Callers must hold [`lock`] for the entire lifetime of the returned guard.
+#[must_use]
+pub(crate) struct EnvRestore(Vec<(String, Option<std::ffi::OsString>)>);
+
+impl EnvRestore {
+    pub(crate) fn capture(names: &[&str]) -> Self {
+        Self(
+            names
+                .iter()
+                .map(|name| ((*name).to_string(), std::env::var_os(name)))
+                .collect(),
+        )
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        // SAFETY: the caller holds `lock()` for this guard's whole lifetime,
+        // so no other test thread is reading or writing these vars.
+        unsafe {
+            for (name, value) in self.0.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}
+
+/// Witness for #1137: the "set, act, unset" sequence this replaces never
+/// reaches its unset step when something panics first. Fails on that pattern,
+/// passes on [`EnvRestore`], whose `Drop` runs during unwinding.
+#[test]
+fn restore_runs_on_unwind_not_just_normal_return() {
+    let _outer = lock();
+    let key = "STELLA_OBSERVATORY_TEST_ENV_RESTORE_WITNESS";
+    let original = std::env::var_os(key);
+    // SAFETY: the lock is held for the whole test.
+    unsafe { std::env::remove_var(key) };
+
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _restore = EnvRestore::capture(&[key]);
+        // SAFETY: as above.
+        unsafe { std::env::set_var(key, "mutated-by-panicking-test") };
+        panic!("simulated fixture failure mid-test");
+    }))
+    .is_err();
+
+    assert!(panicked, "the closure must have actually unwound");
+    assert_eq!(
+        std::env::var_os(key),
+        original,
+        "EnvRestore must undo the mutation even when the guarded body panics"
+    );
+}

--- a/crates/stella-pipeline/src/witness/airlock.rs
+++ b/crates/stella-pipeline/src/witness/airlock.rs
@@ -553,6 +553,25 @@ fn collapse_whitespace(text: &str) -> String {
         .to_ascii_lowercase()
 }
 
+/// Admit a field only if the grain actually reached still covers it.
+///
+/// Every field of a [`FailureBrief`] passes through here, gated on the *final*
+/// grain rather than on the branch that built it — so a brief can never report
+/// a grain lower than the content it carries.
+///
+/// Factored out of [`redact`] so the guard is reachable from a test. Two of
+/// the three call sites fire in normal operation; the `reproduction` one
+/// cannot be driven through `redact` at all today, because a reproduction
+/// candidate is the bare command wrapped in backticks — a strict superset, so
+/// it scrubs strictly harder, and a surviving reproduction therefore implies a
+/// surviving command. That makes the guard dormant rather than dead only if
+/// something exercises it: a check that cannot fire is indistinguishable from
+/// a check that has quietly broken, and there would be no history of it
+/// passing to compare against on the day the condition first occurs. See #1303.
+fn admit<T>(reached: DisclosureGrain, needs: DisclosureGrain, value: Option<T>) -> Option<T> {
+    (reached >= needs).then_some(value).flatten()
+}
+
 /// Build the brief the worker sees, at no more than `requested` grain.
 ///
 /// The scrubber runs on every field that could carry sealed material. A field
@@ -604,24 +623,16 @@ pub fn redact(sealed: &SealedFailure<'_>, requested: DisclosureGrain) -> Failure
 
     FailureBrief {
         grain,
-        // A grain that fell on a failed command scrub withholds the command;
-        // one that merely lost its reproduction keeps it.
-        command: (grain >= DisclosureGrain::Command)
-            .then_some(command)
-            .flatten(),
-        symptom: (grain >= DisclosureGrain::Symptom)
-            .then_some(symptom)
-            .flatten(),
-        // Gated by the *final* grain like its siblings, not just the branch
-        // that built it. `reproduction` can only be `Some` when the command
-        // scrubbed clean (the reproduction candidate is a superset of the bare
-        // command, so it scrubs strictly harder), which means `grain` never
-        // fell below `Reproduction` here — the guard is a no-op today. It exists
-        // so a future change to the reproduction candidate can never leave a
-        // brief reporting a low grain while still carrying a reproduction.
-        reproduction: (grain >= DisclosureGrain::Reproduction)
-            .then_some(reproduction)
-            .flatten(),
+        // Each field is gated on the *final* grain, not on the branch that
+        // built it: a grain that fell on a failed command scrub withholds the
+        // command, while one that merely lost its reproduction keeps it.
+        //
+        // The `reproduction` gate is a no-op today — see [`admit`] for why it
+        // cannot fire through this function, and why it is kept and tested
+        // anyway rather than deleted.
+        command: admit(grain, DisclosureGrain::Command, command),
+        symptom: admit(grain, DisclosureGrain::Symptom, symptom),
+        reproduction: admit(grain, DisclosureGrain::Reproduction, reproduction),
     }
 }
 

--- a/crates/stella-pipeline/src/witness/airlock/tests.rs
+++ b/crates/stella-pipeline/src/witness/airlock/tests.rs
@@ -247,6 +247,56 @@ fn grain_is_monotone_in_what_it_discloses() {
     assert!(full.reproduction.is_some());
 }
 
+/// The dormant half of the grain gate, driven directly. See #1303.
+///
+/// `redact` cannot reach this: a reproduction candidate is the bare command in
+/// backticks, so it scrubs strictly harder, and a reproduction that survived
+/// implies a command that survived — the grain never falls below
+/// `Reproduction` while a reproduction is still in hand. That is an argument
+/// about today's candidate construction, not a property of the type, so the
+/// guard stays and this test is what keeps it honest: if the gate were ever
+/// weakened to admit content above the grain it reports, this fails, whereas
+/// `redact`-level tests would stay green and say nothing.
+#[test]
+fn a_field_above_the_reached_grain_is_never_admitted() {
+    // The reachable half, for contrast: at or above the requirement, admitted.
+    assert_eq!(
+        admit(
+            DisclosureGrain::Reproduction,
+            DisclosureGrain::Reproduction,
+            Some("`cargo test -p stella-pipeline`"),
+        ),
+        Some("`cargo test -p stella-pipeline`"),
+    );
+
+    // The dormant half: a brief whose grain fell to `Symptom` must not carry a
+    // reproduction, however that combination arose.
+    assert_eq!(
+        admit(
+            DisclosureGrain::Symptom,
+            DisclosureGrain::Reproduction,
+            Some("`cargo test -p stella-pipeline`"),
+        ),
+        None,
+        "a reproduction outlived the grain that authorizes it",
+    );
+
+    // Every step down the ladder, so the gate is checked as an ordering rather
+    // than at one point on it.
+    for reached in [
+        DisclosureGrain::Outcome,
+        DisclosureGrain::Command,
+        DisclosureGrain::Symptom,
+    ] {
+        assert_eq!(
+            admit(reached, DisclosureGrain::Reproduction, Some("`pnpm test`")),
+            None,
+            "{} admitted a reproduction",
+            reached.label(),
+        );
+    }
+}
+
 #[test]
 fn the_same_failure_fingerprints_identically_across_runs() {
     let first = "\

--- a/crates/stella-store/src/home.rs
+++ b/crates/stella-store/src/home.rs
@@ -529,13 +529,17 @@ mod tests {
 
     #[test]
     fn stella_home_honors_the_override() {
-        // SAFETY: single-threaded test; set and read one process env var.
+        // The environment is process-global and cargo runs these tests on a
+        // thread pool — "single-threaded test", as this used to claim, was
+        // never true. A leaked `STELLA_HOME` also makes
+        // `migrate_legacy_global_dirs` no-op for every later test. See #1137.
+        let _lock = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&["STELLA_HOME"]);
+        // SAFETY: the lock is held for the whole test, and `_restore` undoes
+        // this on drop — including if the assertion below panics.
         unsafe {
             std::env::set_var("STELLA_HOME", "/tmp/stella-home-test");
         }
         assert_eq!(stella_home(), Some(PathBuf::from("/tmp/stella-home-test")));
-        unsafe {
-            std::env::remove_var("STELLA_HOME");
-        }
     }
 }

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -140,6 +140,8 @@ mod receipts;
 mod reconstruct;
 mod telemetry;
 #[cfg(test)]
+mod test_env;
+#[cfg(test)]
 mod tests;
 mod tool_calls;
 #[cfg(test)]

--- a/crates/stella-store/src/test_env.rs
+++ b/crates/stella-store/src/test_env.rs
@@ -1,0 +1,93 @@
+//! Serialization and panic-safe restore for tests that mutate process
+//! environment variables.
+//!
+//! The environment is process-global and `cargo test` runs a crate's tests on
+//! a thread pool, so a test that sets `STELLA_DATA_DIR` is mutating state that
+//! every concurrently-running test in the same binary can observe. That is not
+//! hypothetical here: [`crate::home::migrate_legacy_global_dirs`] silently
+//! no-ops whenever `STELLA_HOME`, `STELLA_DATA_DIR` or `STELLA_CONFIG_DIR` is
+//! set, and `UsageStore::open` calls it — so an unrelated test's override
+//! changes what a store-opening test does.
+//!
+//! Two distinct hazards, and both need covering:
+//!
+//!   1. **Concurrency.** Take [`lock`] before touching the environment, and
+//!      hold it for as long as the override must stay in place. Readers of
+//!      the same variables take it too, or the lock only serializes half the
+//!      race.
+//!   2. **Unwinding.** A hand-rolled "set, assert, unset" sequence never runs
+//!      its unset step when the assertion panics first, leaking the override
+//!      into every test that runs after it in this binary. [`EnvRestore`]
+//!      restores from `Drop`, which runs during unwinding too.
+//!
+//! This mirrors `stella-cli`'s module of the same name, added by #911. This
+//! crate had no serialization mechanism at all — strictly worse than the bug
+//! #911 fixed, which at least had a lock. See #1137.
+
+/// Acquire the env lock, recovering from a poisoned mutex (a prior
+/// env-mutating test that panicked mid-hold must not cascade into unrelated
+/// failures).
+pub(crate) fn lock() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Captures the current value of each named env var and restores it on drop,
+/// including while unwinding from a failed assertion.
+///
+/// Callers must hold [`lock`] for the entire lifetime of the returned guard.
+#[must_use]
+pub(crate) struct EnvRestore(Vec<(String, Option<std::ffi::OsString>)>);
+
+impl EnvRestore {
+    pub(crate) fn capture(names: &[&str]) -> Self {
+        Self(
+            names
+                .iter()
+                .map(|name| ((*name).to_string(), std::env::var_os(name)))
+                .collect(),
+        )
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        // SAFETY: the caller holds `lock()` for this guard's whole lifetime,
+        // so no other test thread is reading or writing these vars.
+        unsafe {
+            for (name, value) in self.0.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}
+
+/// Witness for #1137: the "set, assert, unset" sequence this replaces never
+/// reaches its unset step when the assertion panics first. Fails on that
+/// pattern, passes on [`EnvRestore`], whose `Drop` runs during unwinding.
+#[test]
+fn restore_runs_on_unwind_not_just_normal_return() {
+    let _outer = lock();
+    let key = "STELLA_STORE_TEST_ENV_RESTORE_WITNESS";
+    let original = std::env::var_os(key);
+    // SAFETY: the lock is held for the whole test.
+    unsafe { std::env::remove_var(key) };
+
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _restore = EnvRestore::capture(&[key]);
+        // SAFETY: as above.
+        unsafe { std::env::set_var(key, "mutated-by-panicking-test") };
+        panic!("simulated assertion failure mid-test");
+    }))
+    .is_err();
+
+    assert!(panicked, "the closure must have actually unwound");
+    assert_eq!(
+        std::env::var_os(key),
+        original,
+        "EnvRestore must undo the mutation even when the guarded body panics"
+    );
+}

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -1859,7 +1859,10 @@ mod tests {
 
     #[test]
     fn usage_db_path_honors_the_data_dir_override() {
-        // SAFETY: single-threaded test; we set and read one process env var.
+        // Not "single-threaded" as this used to claim — see crate::test_env.
+        let _lock = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&["STELLA_DATA_DIR"]);
+        // SAFETY: lock held for the whole test; `_restore` undoes this on drop.
         unsafe {
             std::env::set_var("STELLA_DATA_DIR", "/tmp/stella-usage-test");
         }
@@ -1867,9 +1870,6 @@ mod tests {
             usage_db_path(),
             PathBuf::from("/tmp/stella-usage-test/usage.db")
         );
-        unsafe {
-            std::env::remove_var("STELLA_DATA_DIR");
-        }
     }
 
     #[cfg(unix)]

--- a/scripts/check-command-docs.sh
+++ b/scripts/check-command-docs.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Guard: every `stella` subcommand has a reference page, and every reference
+# page names a subcommand that still exists. See #993 (residual of #928).
+#
+# #928 found seven undocumented CLI surfaces at once. Five gained pages in PR
+# #989 and two more later, but the half of #928 that explained *how seven
+# accumulated* — "and nothing in the gate would notice" — stayed true: no check
+# anywhere related the `Command` enum to website/content/docs/commands/. A new
+# subcommand could land with no page and every gate stayed green, which is
+# exactly how the original seven built up unnoticed.
+#
+# `make doc-links` is a different property: it asserts that docs paths *cited
+# from Rust* resolve. A command nobody ever cited is invisible to it.
+#
+# Three failures this catches:
+#
+#   1. **A new subcommand with no page.** The recurrence #928 documented.
+#   2. **A page that no sidebar lists.** meta.json is hand-maintained, so a
+#      page can exist on disk and be unreachable by navigation — undocumented
+#      in every sense that matters to a reader.
+#   3. **An orphan page.** A command renamed or removed leaves a page behind
+#      describing a surface that no longer ships. Stale reference docs are
+#      worse than absent ones: they read as current.
+#
+# Intentionally-undocumented surfaces go in scripts/command-docs-exempt.txt,
+# committed and visible in review like scripts/file-size-baseline.txt — so an
+# omission is a decision somebody signed off on rather than an oversight.
+#
+# Uses portable POSIX awk/sed/grep so it runs on a bare CI runner with no
+# toolchain, alongside the other early guards in ci.yml.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+# Where the top-level subcommand enum lives. It has moved twice already
+# (stella-cli/src/main.rs -> stella-cli/src/cli.rs, PR #999; then the whole
+# crate under crates/, PR #1385), which is why this fails loudly rather than
+# silently finding nothing.
+enum_file="crates/stella-cli/src/cli.rs"
+enum_decl="pub(crate) enum Command {"
+docs_dir="website/content/docs/commands"
+meta_file="$docs_dir/meta.json"
+exempt_file="scripts/command-docs-exempt.txt"
+
+status=0
+
+# Membership over a newline-delimited list, in pure shell.
+#
+# Deliberately NOT `printf ... | grep -qx`: under `set -o pipefail` that is a
+# race, not a test. `grep -q` exits the moment it matches, `printf` then dies
+# of SIGPIPE (141), and pipefail reports the pipeline as failed — so a slug
+# that IS present intermittently reads as absent, depending only on whether
+# printf had drained its buffer. It surfaced here as a different random subset
+# of commands being reported missing on every run.
+contains() {
+  case "
+$1
+" in
+  *"
+$2
+"*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+if [ ! -f "$enum_file" ]; then
+  echo "FAIL $enum_file not found." >&2
+  echo "     This guard reads the top-level subcommand list from that file. If" >&2
+  echo "     it moved, update \$enum_file in scripts/check-command-docs.sh in" >&2
+  echo "     the same PR." >&2
+  exit 1
+fi
+
+if [ ! -d "$docs_dir" ]; then
+  echo "FAIL $docs_dir not found." >&2
+  echo "     This guard expects the command reference pages to live there." >&2
+  exit 1
+fi
+
+# --- Parse the enum ---------------------------------------------------------
+# Variants sit at exactly four spaces of indent; their fields sit at eight,
+# doc comments open with `///`, and attributes with `#[`. Anchoring on the
+# four-space indent is what separates a variant from everything nested inside
+# one without needing to parse Rust. `$1` drops the indent, and the gsub
+# trims whatever follows the name (`{`, `(` or `,`).
+variants="$(awk -v decl="$enum_decl" '
+  index($0, decl) == 1 { inside = 1; next }
+  inside && /^\}/       { exit }
+  inside && /^    [A-Z][A-Za-z0-9]*[ ,{(]/ {
+    name = $1
+    gsub(/[,{(].*/, "", name)
+    if (name != "") { print name }
+  }
+' "$enum_file")"
+
+if [ -z "$variants" ]; then
+  echo "FAIL parsed zero variants from $enum_file." >&2
+  echo "     Expected a block opening with: $enum_decl" >&2
+  echo "     If the declaration changed, update \$enum_decl in" >&2
+  echo "     scripts/check-command-docs.sh in the same PR." >&2
+  exit 1
+fi
+
+# clap's derive renames variants to kebab-case by default, so `FooBar` is
+# invoked as `stella foo-bar` and its page is foo-bar.mdx.
+slugs="$(printf '%s\n' "$variants" \
+  | sed 's/\([a-z0-9]\)\([A-Z]\)/\1-\2/g' \
+  | tr '[:upper:]' '[:lower:]' \
+  | sort)"
+
+# --- Exemptions -------------------------------------------------------------
+# One slug per line; `#` opens a comment. An exempt command needs no page and
+# is not reported as missing, but an exempt slug that no longer names a real
+# command is still reported below so the list cannot rot.
+exempt=""
+if [ -f "$exempt_file" ]; then
+  exempt="$(sed 's/#.*//' "$exempt_file" | tr -d '[:blank:]' | grep -v '^$' | sort || true)"
+fi
+
+is_exempt() {
+  [ -n "$exempt" ] || return 1
+  contains "$exempt" "$1"
+}
+
+# --- The pages on disk ------------------------------------------------------
+# index.mdx is the section landing page, not a command reference.
+pages="$(find "$docs_dir" -maxdepth 1 -name '*.mdx' -exec basename {} .mdx \; \
+  | grep -vx 'index' | sort)"
+
+# --- The sidebar ------------------------------------------------------------
+# meta.json's "pages" array carries both page slugs and `---Group---` section
+# separators. Keys are on lines containing a colon; separators start with a
+# dash inside the quotes. What survives is the navigable slugs.
+sidebar=""
+if [ -f "$meta_file" ]; then
+  sidebar="$(grep -v ':' "$meta_file" \
+    | sed -n 's/.*"\([a-z][a-z0-9-]*\)".*/\1/p' | sort || true)"
+fi
+
+# --- 1. Every command has a page -------------------------------------------
+missing=0
+while IFS= read -r slug; do
+  [ -n "$slug" ] || continue
+  is_exempt "$slug" && continue
+  if [ ! -f "$docs_dir/$slug.mdx" ]; then
+    echo "FAIL \`stella $slug\` has no reference page: $docs_dir/$slug.mdx" >&2
+    missing=$((missing + 1))
+    status=1
+  fi
+done <<EOF
+$slugs
+EOF
+
+if [ "$missing" -ne 0 ]; then
+  echo "" >&2
+  echo "     Write the page, or add the slug to $exempt_file with a reason." >&2
+  echo "     An exemption is a decision on the record; a missing page is not." >&2
+fi
+
+# --- 2. Every page is reachable from the sidebar ----------------------------
+if [ -n "$sidebar" ]; then
+  unlisted=0
+  while IFS= read -r slug; do
+    [ -n "$slug" ] || continue
+    is_exempt "$slug" && continue
+    [ -f "$docs_dir/$slug.mdx" ] || continue
+    if ! contains "$sidebar" "$slug"; then
+      echo "FAIL $docs_dir/$slug.mdx is not listed in $meta_file." >&2
+      unlisted=$((unlisted + 1))
+      status=1
+    fi
+  done <<EOF
+$slugs
+EOF
+  if [ "$unlisted" -ne 0 ]; then
+    echo "" >&2
+    echo "     A page no sidebar lists is undocumented to anyone browsing." >&2
+    echo "     Add the slug to the \"pages\" array under the right group." >&2
+  fi
+fi
+
+# --- 3. No orphan pages -----------------------------------------------------
+orphans=0
+while IFS= read -r page; do
+  [ -n "$page" ] || continue
+  if ! contains "$slugs" "$page"; then
+    echo "FAIL $docs_dir/$page.mdx documents no \`Command\` variant." >&2
+    orphans=$((orphans + 1))
+    status=1
+  fi
+done <<EOF
+$pages
+EOF
+
+if [ "$orphans" -ne 0 ]; then
+  echo "" >&2
+  echo "     The command was renamed or removed and its page outlived it." >&2
+  echo "     Delete the page, or repoint it at the surface that replaced it." >&2
+fi
+
+# --- 4. No stale exemptions -------------------------------------------------
+if [ -n "$exempt" ]; then
+  while IFS= read -r slug; do
+    [ -n "$slug" ] || continue
+    if ! contains "$slugs" "$slug"; then
+      echo "FAIL $exempt_file exempts \"$slug\", which is not a subcommand." >&2
+      echo "     Remove the line: a stale exemption silently covers a future" >&2
+      echo "     command that happens to reuse the name." >&2
+      status=1
+    fi
+  done <<EOF
+$exempt
+EOF
+fi
+
+if [ "$status" -eq 0 ]; then
+  count="$(printf '%s\n' "$slugs" | wc -l | tr -d '[:blank:]')"
+  echo "check-command-docs: OK — $count subcommands, each with a listed reference page."
+fi
+exit "$status"

--- a/scripts/command-docs-exempt.txt
+++ b/scripts/command-docs-exempt.txt
@@ -1,0 +1,12 @@
+# Subcommands that intentionally ship without a reference page. See #993 and
+# scripts/check-command-docs.sh. Format: one command slug per line, with the
+# reason as a comment.
+#
+# Empty on purpose. Every `stella` subcommand is documented today, and the
+# guard exists to keep it that way. Adding a line here is allowed but is never
+# silent — it lands as a visible diff, to be justified in review like any other
+# change. Prefer writing the page.
+#
+# A slug listed here that is not a real subcommand fails the guard, so this
+# list cannot rot into a blanket exemption for a name some future command
+# reuses.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -30,7 +30,7 @@
 3691 crates/stella-pipeline/src/pipeline.rs
 2621 crates/stella-pipeline/src/pipeline/tests.rs
 2906 crates/stella-protocol/src/event.rs
-2080 crates/stella-store/src/lib.rs
+2082 crates/stella-store/src/lib.rs
 2264 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1569 crates/stella-tools/src/media.rs


### PR DESCRIPTION
## What & why

Output of an open-issue validity sweep: three tickets whose remaining work was small enough to finish outright. Each commit stands alone.

Closes #993
Closes #1303
Closes #1137

> **Supersedes #1389**, which was opened before #1385 moved every crate under `crates/` and could not be merged afterwards. Same three commits, re-landed on current `main` with the paths realigned — see *Rebase notes* at the bottom for exactly what changed and what did not.

**#993 — command↔page parity has no gate.** #928 found seven undocumented CLI surfaces at once. The pages were written, but the half of #928 that explained *how* seven accumulated — "and nothing in the gate would notice" — stayed true. `make doc-links` checks that docs paths cited from Rust resolve; a command nobody ever cited was invisible to it.

The docs half of #993 turned out to be done already (`arena.mdx` and `telemetry.mdx` both exist), and the enum has moved to `crates/stella-cli/src/cli.rs:268` since the issue was filed. So this adds the missing piece: `scripts/check-command-docs.sh`, checking parity in both directions plus sidebar reachability — a new subcommand with no page, a page `meta.json` does not list, an orphan page for a removed command, and a stale exemption naming no real command. The tree is at full parity today (36 variants, 36 pages, all 36 in the sidebar), so it lands green.

**#1303 — a safety check that has never fired.** `redact` gates every `FailureBrief` field on the grain actually reached. The `reproduction` arm cannot fire: a reproduction candidate is the bare command in backticks, a strict superset, so it scrubs strictly harder, and a surviving reproduction implies a surviving command. That is an argument about today's candidate construction, not a property of the type — so the guard is worth keeping, but a check that cannot fire is indistinguishable from one that has quietly broken. Lifted into a named `admit` so a test can drive it.

**#1137 — env-mutating tests with no lock at all.** `stella-store` and `stella-observatory` mutated process-global env vars in tests with no serialization mechanism whatsoever — the #911 bug class, but worse, since stella-cli at least had a lock. Both crates get the `test_env` module #911 introduced.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Three, one per commit:

- **#1303** — `a_field_above_the_reached_grain_is_never_admitted`. Verified by mutation: with the gate removed, it fails with its intended message and the other 17 airlock tests stay green. That green is the point — it is the first *evidence*, rather than assertion, that `redact` cannot reach the condition.
- **#1137** — `restore_runs_on_unwind_not_just_normal_return` in each new `test_env`. Fails on the "set, act, unset" pattern it replaces, passes on `EnvRestore`, whose `Drop` runs while unwinding.
- **#993** — the guard itself. All five branches (missing page, unlisted page, orphan page, stale exemption, honored exemption) were driven red before landing, and each was re-run three times to confirm determinism. That mattered: the first draft used `printf | grep -qx`, which under `set -o pipefail` is a race rather than a test — `grep -q` exits on match, `printf` dies of SIGPIPE, and pipefail reports the pipeline failed, so a documented command intermittently read as missing. Membership is now a pure-shell `case` glob.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` — `stella-pipeline`, `stella-store` and `stella-observatory` re-run in full on the rebased tree
- [x] `./scripts/check-command-docs.sh` — OK, 36 subcommands, each with a listed reference page
- [x] `./scripts/check-file-size.sh` — OK, none grew
- [x] Docs updated where behavior changed — the new guard is documented in `make help`, both workflows, and its own header
- [x] `Closes #N` appears both above and as a commit trailer

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] Test-only changes in two of the three commits

## Anything reviewers should know?

**The file-size baseline moves by 2 lines.** `crates/stella-store/src/lib.rs` gains a `#[cfg(test)] mod test_env;` declaration, which is the irreducible case `check-file-size.sh` names in its own failure message. The baseline line is hand-edited rather than regenerated, so the diff is exactly that one ceiling and nothing else could ride along. `usage.rs` grew too and was trimmed back to exactly its ceiling by moving the rationale into `test_env`'s module docs, where it belongs.

**The new guard is wired into two workflows on purpose, not by accident.** `ci.yml` is the required context and catches the important half — a new `Command` variant is a `.rs` change. It structurally cannot catch the other half: `paths-ignore: website/**` means a PR that only deletes a reference page never starts that workflow, so `docs-guards.yml` covers that direction.

**Each crate gets its own copy of `test_env`.** stella-cli's is crate-private and the workspace has no test-support crate. Extracting one is a bigger architectural call than #1137 authorizes; happy to file it as a follow-up if you'd rather have one home for it.

**stella-observatory's private `DATA_DIR_LOCK` is replaced, not kept alongside.** The hazard is the shared environment, not one variable — `fsview.rs` mutated `STELLA_CONFIG_DIR` under no lock at all, and a second private mutex serializes nothing against the first.

**A pre-existing flake surfaced once while validating this branch, and it is not from this PR.** `stella-store`'s `migrations::tests::concurrent_first_open_of_a_fresh_workspace_both_succeed` failed once under heavy machine load with `committable file …/.stella/.gitignore must be an owner-controlled single-link regular file` — four threads race `Store::open` on a fresh workspace behind a barrier, and one lost.

It is structurally impossible for this branch to have caused it: `crates/stella-store/src/migrations.rs`, which holds both the test and the racing path, is untouched here, and the only non-`#[cfg(test)]` line this PR adds anywhere in the crate is the `#[cfg(test)] mod test_env;` declaration itself. Measured after the fact: 0 failures in 12 consecutive full-suite runs on this branch, and 298/298 on re-run. Same shape as #454 (`concurrent_first_open_initializes_one_private_journal`, stella-media), which was filed and closed as a flaky-test class. Worth a fresh ticket against `Store::open`'s committable-file creation, but out of scope here.

## Rebase notes (what #1389 needed to become this)

#1385 moved every crate from `<crate>/` to `crates/<crate>/` after #1389 was written. Three things had to be realigned, and only three:

1. **File placement** — handled by git's directory-rename detection, so the two new `test_env.rs` files landed at `crates/stella-{store,observatory}/src/` on their own. No content changed.
2. **`scripts/file-size-baseline.txt`** — the one genuine conflict, because that file stores paths as *text*, which git cannot rename-detect. Resolved to `main`'s `crates/`-prefixed block carrying exactly one delta from the original commit: `crates/stella-store/src/lib.rs` `2080 → 2082`. The two sides were otherwise line-for-line identical.
3. **`enum_file` in `scripts/check-command-docs.sh`** — the only misalignment git could not see, since a filename spelled *inside* a file is not a tracked path. It pointed at `stella-cli/src/cli.rs`, which no longer exists; the guard would have exited 1 on the very check it introduces. Repointed to `crates/stella-cli/src/cli.rs`, and its comment now records the move it just survived — that comment exists precisely to explain why the guard fails loudly on a moved enum rather than silently finding nothing, and it has now been right twice.

That third fix is folded into the commit that introduces the script rather than added on top, so the guard is green at its own commit and `git bisect` never lands on a revision where it fails. Nothing else in the three commits changed.

## Summary by Sourcery

Add a new guard ensuring CLI subcommands have corresponding reference docs, and introduce shared test utilities to safely mutate environment variables in stella-store and stella-observatory tests while adding a targeted test for the failure brief grain gate.

New Features:
- Add a command-docs guard script and Makefile/CI targets to enforce parity between CLI subcommands and their documented pages.

Bug Fixes:
- Prevent env-related test flakiness in stella-store and stella-observatory by serializing environment mutation and restoring overrides on panic.
- Make the dormant failure-brief grain gate testable so regressions in its behavior are caught.

Enhancements:
- Refactor the airlock failure-brief grain gating logic into a reusable helper to clarify intent and support direct testing.

CI:
- Extend docs-guards and CI workflows to run the new command-docs guard when relevant files or docs change.

Documentation:
- Update workflow and Makefile help text to describe the new command-docs guard and its role alongside existing doc checks.

Tests:
- Add witness tests for env-restore behavior under panics in stella-store and stella-observatory, and for the failure brief grain admission invariant in stella-pipeline.

Chores:
- Register new test_env modules in stella-store and stella-observatory and adjust the file-size baseline to reflect their addition.