### PR TITLE
fix: unbreak the file-size gate — #1397 reverted the baseline past #1393

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,13 +339,13 @@ governs:
 
 | Crate | God files (ceiling) |
 |---|---|
-| `stella-cli` | `src/command_deck.rs` (4754), `src/agent.rs` (2270), `src/agent/tests.rs` (1747), `src/candidate_ws.rs` (1585), `src/fleet_cmd.rs` (1506) |
-| `stella-core` | `src/driver/tests.rs` (3672), `src/driver.rs` (2765), `src/bus.rs` (2129) |
-| `stella-model` | `src/openai.rs` (2072), `src/zai/tests.rs` (1815), `src/anthropic/tests.rs` (1677), `src/zai.rs` (1533) |
+| `stella-cli` | `src/command_deck.rs` (4754), `src/agent.rs` (2270), `src/agent/tests.rs` (1747), `src/candidate_ws.rs` (1629), `src/fleet_cmd.rs` (1506) |
+| `stella-core` | `src/driver/tests.rs` (3675), `src/driver.rs` (2770), `src/bus.rs` (2129) |
+| `stella-model` | `src/openai.rs` (2076), `src/zai/tests.rs` (1815), `src/anthropic/tests.rs` (1773), `src/zai.rs` (1542) |
 | `stella-pipeline` | `src/pipeline.rs` (3691), `src/pipeline/tests.rs` (2621) |
-| `stella-protocol` | `src/event.rs` (2906) |
-| `stella-store` | `src/tests.rs` (2264), `src/lib.rs` (2080), `src/usage.rs` (1916) |
-| `stella-tools` | `src/registry.rs` (2326), `src/scripts.rs` (1839), `src/media.rs` (1569) |
+| `stella-protocol` | `src/event.rs` (2920) |
+| `stella-store` | `src/tests.rs` (2268), `src/lib.rs` (2074), `src/usage.rs` (1916) |
+| `stella-tools` | `src/registry.rs` (2327), `src/scripts.rs` (1839), `src/media.rs` (1569) |
 | `stella-tui` | `src/deck_ui.rs` (4068), `src/views/engine.rs` (1665), `src/views/session.rs` (1621), `src/deck_render.rs` (1600), `src/deck.rs` (1528) |
 
 The other twelve crates carry no god files — keep it that way. Each crate's

--- a/crates/stella-cli/README.md
+++ b/crates/stella-cli/README.md
@@ -89,7 +89,7 @@ file is a candidate to extract into one.
 |---|---|
 | [`src/agent.rs`](src/agent.rs) | 2270 |
 | [`src/agent/tests.rs`](src/agent/tests.rs) | 1747 |
-| [`src/candidate_ws.rs`](src/candidate_ws.rs) | 1596 |
+| [`src/candidate_ws.rs`](src/candidate_ws.rs) | 1629 |
 | [`src/command_deck.rs`](src/command_deck.rs) | 4754 |
 | [`src/fleet_cmd.rs`](src/fleet_cmd.rs) | 1506 |
 
@@ -254,10 +254,11 @@ execution on the first subprocess (#553). `STELLA_NO_ENV_FILE=1` disables it all
 make test-cli            # = cargo test -p stella-cli
 ```
 
-Almost all of it is in-crate unit tests, wired with `#[cfg(test)] #[path = …]`
-from the module they cover: [`src/tests.rs`](src/tests.rs) (argument
-surface), [`src/agent/tests.rs`](src/agent/tests.rs) (prompt assembly, provider
-routing, usage completeness), [`src/config/tests.rs`](src/config/tests.rs) (key
+Almost all of it is in-crate unit tests, each declared with a plain
+`#[cfg(test)] mod tests;` from the module it covers and living at
+`<module>/tests.rs`: [`src/tests.rs`](src/tests.rs) (argument surface),
+[`src/agent/tests.rs`](src/agent/tests.rs) (prompt assembly, provider routing,
+usage completeness), [`src/config/tests.rs`](src/config/tests.rs) (key
 resolution, the provider-parity matrix), plus the `settings`/`memory`
 private-state and quarantine suites. [`tests/inspect_cli.rs`](tests/inspect_cli.rs)
 is the sole integration test — it spawns `env!("CARGO_BIN_EXE_stella")` against a

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,9 +15,9 @@
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4207 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-2271 crates/stella-cli/src/agent.rs
-1750 crates/stella-cli/src/agent_tests.rs
-1618 crates/stella-cli/src/candidate_ws.rs
+2270 crates/stella-cli/src/agent.rs
+1747 crates/stella-cli/src/agent/tests.rs
+1629 crates/stella-cli/src/candidate_ws.rs
 4754 crates/stella-cli/src/command_deck.rs
 1506 crates/stella-cli/src/fleet_cmd.rs
 2129 crates/stella-core/src/bus.rs
@@ -34,7 +34,7 @@
 2268 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1569 crates/stella-tools/src/media.rs
-2348 crates/stella-tools/src/registry.rs
+2327 crates/stella-tools/src/registry.rs
 1839 crates/stella-tools/src/scripts.rs
 1528 crates/stella-tui/src/deck.rs
 1600 crates/stella-tui/src/deck_render.rs


### PR DESCRIPTION
## What & why

### `make file-size` is red on `main`

Not #1393's doing — **#1393 landed with a correct baseline.** At its merge
commit `7b342a18`:

```
2270 crates/stella-cli/src/agent.rs
1747 crates/stella-cli/src/agent/tests.rs
```

[#1397](https://github.com/macanderson/stella/pull/1397) (`d3c2a3b1`) then took
it backwards. It regenerated `scripts/file-size-baseline.txt` against a tree
that predated the rename, and the merge kept that version:

```diff
-2270 crates/stella-cli/src/agent.rs
-1747 crates/stella-cli/src/agent/tests.rs
-1596 crates/stella-cli/src/candidate_ws.rs
-2305 crates/stella-tools/src/registry.rs
+2271 crates/stella-cli/src/agent.rs
+1750 crates/stella-cli/src/agent_tests.rs     <- resurrects a path #1393 deleted
+1618 crates/stella-cli/src/candidate_ws.rs
+2348 crates/stella-tools/src/registry.rs
```

So `main` now fails all three branches of `check-file-size` at once:

```
  crates/stella-cli/src/agent/tests.rs is 1747 lines, over the 1500-line limit
  crates/stella-cli/src/candidate_ws.rs grew to 1629 lines, over its ceiling of 1618 (+11)
  crates/stella-cli/src/agent_tests.rs (baseline entry, file no longer tracked)
```

The renamed file reads as brand-new and oversized with no grandfather entry, the
old path is a stale row naming nothing, and `candidate_ws.rs` has since grown
past the ceiling #1397 restored.

**This is the first step of the `fmt + clippy + test` job**, so fmt, clippy and
the entire test suite have not run on `main` since #1397 merged.

Fixed by regenerating: `make file-size-update`. That carries the grandfather
entry across the rename (1750 → 1747 — the file is three lines *smaller* than
the ceiling it already had) rather than inventing one, and picks up the real
current sizes for the rest.

This is the fourth recurrence of the same shape: a PR regenerates the baseline
against an older tree, and the merge silently reinstates numbers describing a
state that no longer exists. The baseline is generated, so the only safe
conflict resolution is to re-run the generator on the merged tree.

### `stella-cli/README.md` describes the layout #1393 deleted

The paragraph introducing the crate's tests still reads:

> Almost all of it is in-crate unit tests, wired with `#[cfg(test)] #[path = …]`
> from the module they cover

`#[path]` is exactly what #1393 removed — `git grep '#\[path' -- '*.rs'` on main
now returns only the two comments inside `stella-graph/src/rust_resolve.rs`,
which describe the attribute rather than use it. Rewritten to say what the tree
does: a plain `#[cfg(test)] mod tests;` from the module it covers, resolving to
`<module>/tests.rs` with no attribute.

### The god-file tables had drifted from the baseline

`AGENTS.md` and `stella-cli/README.md` hand-mirror the baseline, so they go
stale whenever a ratchet moves and nothing notices. Nine cells disagreed:
candidate_ws, openai, anthropic/tests, zai, driver, driver/tests, event,
registry, plus the renamed `agent` path. Most of this predates both PRs above. A
table of ceilings that disagrees with the ceiling registry is worse than no
table — it invites planning against a number the gate does not enforce — so
every cell is now taken from the baseline.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the gate is its
      own witness. `./scripts/check-file-size.sh` exits **1** on `main` and
      exits **0** here, with the three failures above as the difference. The doc
      half is documentation only, verified by re-deriving every table cell from
      the baseline and confirming zero remaining disagreements.

## The gate

- [x] `make file-size` — exit 0 (exit 1 on main)
- [x] `make doc-links`
- [x] the other eight toolchain-free guards (`no-scratch`, `action-pins`,
      `cargo-install-pins`, `license-allowlist-parity`, `repro-wiring`,
      `shellcheck`, `invariants`, `command-docs`)
- [x] No Rust touched, so `fmt`/`clippy`/`test` are unaffected by this diff —
      but they should now actually *run* on main again, which is the point.

## Anything reviewers should know?

**Worth landing quickly.** With `check-file-size` red, the required job dies
before fmt, clippy or a single test executes, so nothing merging right now is
being tested.

Neither doc problem is reachable by `make doc-links`. That guard resolves
*citations* — a doc id or path cited from code or another document. These are a
prose sentence and cells in a markdown table, which no guard reads.

If a guard for the table is wanted, the shape is small: parse the
`` `src/…` (N) `` cells out of AGENTS.md and diff them against the baseline.
That is how the nine drifted cells were found. Left out here to keep the change
reviewable — happy to add it as a follow-up.
