### PR TITLE
fix(store): close the zero-length window that made a first-open report a planted ignore (#1410)

### DIFF
--- a/crates/stella-store/src/private.rs
+++ b/crates/stella-store/src/private.rs
@@ -21,7 +21,7 @@ pub(crate) const WORKSPACE_GENERATED_IGNORE: &[u8] =
     b"*.db\n*.db-wal\n*.db-shm\nreflections.jsonl\nprivate/\n";
 
 #[cfg(unix)]
-fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
+fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
     use std::io::Read as _;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
@@ -29,15 +29,36 @@ fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
     options
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
-    let mut file = options.open(path).map_err(|e| {
-        StoreError(format!(
-            "cannot open committable file {}: {e}",
-            path.display()
-        ))
-    })?;
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        // Unlinked between the caller's look and this open. Same benign
+        // publisher as the `nlink() == 0` arm below, seen one instant earlier.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(StoreError(format!(
+                "cannot open committable file {}: {e}",
+                path.display()
+            )));
+        }
+    };
     let metadata = file
         .metadata()
         .map_err(|e| StoreError(format!("cannot inspect {}: {e}", path.display())))?;
+    // `nlink() == 0` is the one benign member of this family, and it must be
+    // split out before the assertion below rather than folded into it: it says
+    // the inode we are holding open was unlinked while we held it, which is
+    // exactly what a concurrent `write_atomic` rename does to the file it
+    // replaces. Nothing planted it — there is nothing left at the path to have
+    // planted. An attacker's file always presents at least one link, so
+    // conceding this case costs the injection defense nothing, while folding
+    // it in reports a fabricated attack on a file that merely lost a race
+    // (#617 item 10, and the residual window #1410 closes).
+    //
+    // Ownership is still asserted first, so a *foreign* unlinked inode is
+    // reported rather than quietly retried.
+    if metadata.is_file() && metadata.uid() == unsafe { libc::geteuid() } && metadata.nlink() == 0 {
+        return Ok(None);
+    }
     if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
         return Err(StoreError(format!(
@@ -49,7 +70,7 @@ fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
         .map_err(|e| StoreError(format!("cannot read {}: {e}", path.display())))?;
-    Ok((bytes, mode))
+    Ok(Some((bytes, mode)))
 }
 
 /// Read a workspace file that is *meant* to be committed (the generated
@@ -63,9 +84,19 @@ fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
 /// `workspace_private_*` path resolution, so a non-unix build could not open
 /// its own store at all (#617).
 #[cfg(not(unix))]
-fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", path.display())))?;
+fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        // `None` carries the same meaning on both arms: no stable file to
+        // judge yet, so the caller settles rather than concluding anything.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(StoreError(format!(
+                "cannot inspect {}: {e}",
+                path.display()
+            )));
+        }
+    };
     if metadata.file_type().is_symlink() || !metadata.is_file() {
         return Err(StoreError(format!(
             "committable file {} must be a regular file",
@@ -74,7 +105,7 @@ fn read_committable_file(path: &Path) -> Result<(Vec<u8>, u32)> {
     }
     let bytes = std::fs::read(path)
         .map_err(|e| StoreError(format!("cannot read {}: {e}", path.display())))?;
-    Ok((bytes, MODE_SHARED))
+    Ok(Some((bytes, MODE_SHARED)))
 }
 
 /// Create the generated ignore exclusively, or report that someone else won.
@@ -131,32 +162,28 @@ fn create_generated_ignore_exclusively(path: &Path) -> Result<bool> {
     }
 }
 
+/// How long a loser waits for the winner's bytes before deciding a zero-length
+/// generated ignore is content of its own.
+///
+/// The window it covers is a single `write_all` of a 47-byte constant, so it
+/// shuts in microseconds and the budget is never spent in practice. It is
+/// generous anyway because the cost of the two mistakes is nothing alike:
+/// waiting a few milliseconds too long is invisible, while giving up too early
+/// puts the loser back on the rename path and resurrects the exact failure
+/// `create_generated_ignore_exclusively` was written to end.
+const IGNORE_SETTLE_ATTEMPTS: u32 = 50;
+const IGNORE_SETTLE_PAUSE: std::time::Duration = std::time::Duration::from_millis(1);
+
 pub(crate) fn ensure_workspace_generated_ignore(dot: &Path) -> Result<()> {
     let path = dot.join(".gitignore");
     // Try to be the one that creates it. Whoever wins writes content that
     // already contains `private/`, so every loser falls through to the read
     // below, finds the entry, and returns without writing — no rename races a
-    // reader in the common case.
+    // reader.
     if create_generated_ignore_exclusively(&path)? {
         return Ok(());
     }
-    let (mut bytes, mode) = match std::fs::symlink_metadata(&path) {
-        Ok(_) => read_committable_file(&path)?,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            // Created and then removed between the two calls. Rare enough to
-            // report rather than loop on.
-            return Err(StoreError(format!(
-                "generated ignore {} vanished while being inspected",
-                path.display()
-            )));
-        }
-        Err(error) => {
-            return Err(StoreError(format!(
-                "cannot inspect generated ignore {}: {error}",
-                path.display()
-            )));
-        }
-    };
+    let (mut bytes, mode) = settled_generated_ignore(&path)?;
     if bytes
         .split(|byte| *byte == b'\n')
         .any(|line| line == b"private/")
@@ -168,6 +195,55 @@ pub(crate) fn ensure_workspace_generated_ignore(dot: &Path) -> Result<()> {
     }
     bytes.extend_from_slice(b"private/\n");
     write_atomic(&path, &bytes, mode)
+}
+
+/// The generated ignore's contents once no publisher is still mid-flight.
+///
+/// Losing the exclusive create says a file exists; it does *not* say the
+/// winner has written to it yet. Between `create_new` returning and the
+/// winner's `write_all` landing, the path holds a zero-length file — and a
+/// loser that read it went on to treat it as a real ignore missing `private/`
+/// and repaired it with [`write_atomic`], whose rename unlinks the winner's
+/// inode. Any third opener holding that inode open for validation then saw
+/// `nlink() == 0` and reported the generated ignore as something planted.
+///
+/// That is the residual of #617 item 10 (#1410): the exclusive create removed
+/// the *common* rename-races-a-reader path, and this closes the window it
+/// left. Waiting is the whole fix — the winner's bytes contain `private/` by
+/// construction, so a loser that waits has nothing left to write.
+///
+/// A file that is still empty after the budget is a real empty file that
+/// nobody is writing, and it is repaired exactly as before. Skipping it
+/// instead would be a permanent skip, not a wait: the next open would find the
+/// same empty file and skip again, and `private/` would never be added.
+fn settled_generated_ignore(path: &Path) -> Result<(Vec<u8>, u32)> {
+    let mut last = None;
+    for attempt in 0..IGNORE_SETTLE_ATTEMPTS {
+        match read_committable_file(path)? {
+            // Settled and non-empty: the common case, and the only one that
+            // can be answered on the first look.
+            Some((bytes, mode)) if !bytes.is_empty() => return Ok((bytes, mode)),
+            // Present but empty — a winner mid-write, or a genuinely empty
+            // file. Indistinguishable in this instant, so keep it and look
+            // again; whichever it is declares itself by whether it changes.
+            Some(empty) => last = Some(empty),
+            // Unlinked under us mid-publication. Nothing to keep: the inode we
+            // looked at is gone and the replacement is not visible yet.
+            None => {}
+        }
+        if attempt + 1 < IGNORE_SETTLE_ATTEMPTS {
+            std::thread::sleep(IGNORE_SETTLE_PAUSE);
+        }
+    }
+    // The budget is spent. An empty file we saw the whole way through is one
+    // nobody is publishing, so it is ours to repair.
+    last.ok_or_else(|| {
+        StoreError(format!(
+            "generated ignore {} never settled: it was still being replaced \
+             after {IGNORE_SETTLE_ATTEMPTS} attempts",
+            path.display()
+        ))
+    })
 }
 
 pub(crate) fn ensure_workspace_state_dir(workspace_root: &Path) -> Result<(PathBuf, bool)> {
@@ -742,3 +818,6 @@ fn immutable_uri(path: &Path) -> Result<String> {
     uri.push_str("?immutable=1");
     Ok(uri)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-store/src/private/tests.rs
+++ b/crates/stella-store/src/private/tests.rs
@@ -1,0 +1,150 @@
+use std::path::Path;
+use std::sync::{Arc, Barrier};
+
+use super::*;
+
+/// Racers all calling [`ensure_workspace_generated_ignore`] on one fresh
+/// `.stella` must all succeed (#1410).
+///
+/// This is the fast path into the window that `Store::open`'s
+/// `concurrent_first_open_of_a_fresh_workspace_both_succeed` reaches only by
+/// luck: that test pays for SQLite migrations on every racer, so it lands in
+/// the few microseconds that matter perhaps once in a thousand runs. Calling
+/// the racing function directly buys thousands of attempts per second.
+fn race_generated_ignore(racers: usize, rounds: usize) -> Vec<String> {
+    let mut failures = Vec::new();
+    for _ in 0..rounds {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let dot = workspace.path().join(".stella");
+        std::fs::create_dir_all(&dot).expect("mkdir .stella");
+
+        let barrier = Arc::new(Barrier::new(racers));
+        let handles: Vec<_> = (0..racers)
+            .map(|_| {
+                let dot = dot.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ensure_workspace_generated_ignore(&dot)
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            if let Err(error) = handle.join().expect("racer panicked") {
+                failures.push(error.0);
+            }
+        }
+
+        // Whoever won, the invariant the function exists for must hold.
+        let settled = std::fs::read(dot.join(".gitignore")).expect("read settled ignore");
+        if !settled
+            .split(|byte| *byte == b'\n')
+            .any(|line| line == b"private/")
+        {
+            failures.push(format!(
+                "settled ignore lacks `private/`: {:?}",
+                String::from_utf8_lossy(&settled)
+            ));
+        }
+    }
+    failures
+}
+
+#[test]
+fn concurrent_first_open_never_reports_a_planted_ignore() {
+    const RACERS: usize = 16;
+    const ROUNDS: usize = 150;
+    let failures = race_generated_ignore(RACERS, ROUNDS);
+    assert!(
+        failures.is_empty(),
+        "{} of {} racers failed; first few: {:?}",
+        failures.len(),
+        RACERS * ROUNDS,
+        &failures[..failures.len().min(3)]
+    );
+}
+
+/// The window itself, driven rather than raced.
+///
+/// A zero-length `.gitignore` is exactly what a winner leaves visible between
+/// its `O_EXCL` create and its `write_all`. A loser that reads it must not
+/// conclude the file is real content missing `private/` and rename over it:
+/// that rename unlinks the winner's inode, and any third racer holding it open
+/// then sees `nlink() == 0` and reports a file nothing attacked.
+#[test]
+fn a_zero_length_ignore_is_not_treated_as_content_to_append_to() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let dot = workspace.path().join(".stella");
+    std::fs::create_dir_all(&dot).expect("mkdir .stella");
+    let path = dot.join(".gitignore");
+
+    // The winner's mid-write state: created, not yet written.
+    std::fs::write(&path, b"").expect("create empty");
+    let before = inode_of(&path);
+
+    // A winner finishing its write while the loser is in the settle window.
+    let writer_path = path.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Write in place, exactly as `create_generated_ignore_exclusively`
+        // does — the inode must survive.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&writer_path)
+            .expect("reopen")
+            .write_all(WORKSPACE_GENERATED_IGNORE)
+            .expect("write");
+    });
+
+    ensure_workspace_generated_ignore(&dot).expect("loser must not fail");
+    writer.join().expect("writer panicked");
+
+    assert_eq!(
+        inode_of(&path),
+        before,
+        "the loser replaced the winner's inode instead of waiting for it"
+    );
+    let settled = std::fs::read(&path).expect("read");
+    assert!(
+        settled
+            .split(|byte| *byte == b'\n')
+            .any(|line| line == b"private/"),
+        "settled ignore lacks `private/`"
+    );
+}
+
+/// A genuinely empty `.gitignore` — no winner ever arrives — must still be
+/// repaired, or the settle window would turn into a permanent skip.
+#[test]
+fn an_empty_ignore_with_no_writer_is_still_given_the_private_entry() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let dot = workspace.path().join(".stella");
+    std::fs::create_dir_all(&dot).expect("mkdir .stella");
+    let path = dot.join(".gitignore");
+    std::fs::write(&path, b"").expect("create empty");
+
+    ensure_workspace_generated_ignore(&dot).expect("must repair, not skip");
+
+    let settled = std::fs::read(&path).expect("read");
+    assert!(
+        settled
+            .split(|byte| *byte == b'\n')
+            .any(|line| line == b"private/"),
+        "an empty ignore nobody is writing must still gain `private/`, got {:?}",
+        String::from_utf8_lossy(&settled)
+    );
+}
+
+use std::io::Write as _;
+
+#[cfg(unix)]
+fn inode_of(path: &Path) -> u64 {
+    use std::os::unix::fs::MetadataExt as _;
+    std::fs::symlink_metadata(path).expect("stat").ino()
+}
+
+#[cfg(not(unix))]
+fn inode_of(_path: &Path) -> u64 {
+    0
+}


### PR DESCRIPTION
## What & why

Closes #1410

`Store::open` intermittently fails a concurrent first open with

```
committable file …/.stella/.gitignore must be an owner-controlled single-link regular file
```

for a file nothing has attacked. It shows up as `migrations::tests::concurrent_first_open_of_a_fresh_workspace_both_succeed` reddening a run and passing on rerun, which reads as a flaky test. **It is not.** The test is right and the code really can report an attack that did not happen.

I hit it while validating #1389, confirmed it was not from that PR, and traced it rather than filing it as another flaky-test ticket.

## The window #617 left

#617 item 10 fixed the obvious version of this. Before it, every concurrent first-opener saw `NotFound` and all of them renamed over the target; a rename unlinks the inode it replaces, so a racer holding the winner's file open for validation saw `nlink() == 0` and failed closed. `create_generated_ignore_exclusively` made the create `O_EXCL` so losers read instead of renaming.

Its docstring names the property it bought, and the qualifier turned out to be the surviving bug:

> …so every loser falls through to the read below, finds the entry, and returns without writing — no rename races a reader **in the common case**.

Winning the exclusive create and *having written* are two different instants. Between `create_new` returning and `write_all` landing, the path holds a **zero-length** file:

1. **A** wins the create, has not yet written.
2. **B** loses, reads the file, gets **zero bytes**.
3. B finds no `private/` line — there are no lines — so it treats the file as real content needing repair and calls `write_atomic`.
4. That rename unlinks A's inode.
5. **C**, holding that inode open to validate it, sees `nlink() == 0` and reports the ignore as planted.

The exclusive create removed the common rename-races-a-reader path and left a narrower one: a loser can still reach the rename, but only inside A's write window. A 47-byte `write_all` is why this fires roughly once in a thousand full-suite runs rather than every time.

## The fix

Two changes, because covering only the trigger leaves the class.

**The trigger.** A loser that reads a zero-length generated ignore waits for the winner's bytes instead of treating them as content to append to. Waiting is the whole fix — the winner's content contains `private/` by construction, so a loser that waits has nothing left to write.

**The class.** `nlink() == 0` becomes a benign race the caller settles, not a terminal "must be an owner-controlled single-link regular file". It means the inode we hold open was unlinked while we held it, which is exactly what a concurrent rename does. No planted file can present it — an attacker's file has at least one link. Ownership is still asserted **first**, so a *foreign* unlinked inode stays terminal.

Same shape as #513, which typed and retried this class for `stella-media` after #454.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Three tests, and the first two both fail before the fix:

- **`a_zero_length_ignore_is_not_treated_as_content_to_append_to`** — deterministic. It drives the window directly: create the ignore zero-length (exactly the winner's mid-write state) and assert the inode at the path survives the loser. On `main` it fails with *"the loser replaced the winner's inode instead of waiting for it"*.
- **`concurrent_first_open_never_reports_a_planted_ignore`** — 16 racers over 150 fresh workspaces. On `main` it reproduced the production message at **1 in 960 in under a second**. Going through `Store::open` reaches the window only by luck, because every racer pays for SQLite migrations first; calling the racing function directly buys thousands of attempts per second.
- **`an_empty_ignore_with_no_writer_is_still_given_the_private_entry`** — passes before *and* after, and is the point. It pins the thing the fix must not break: an empty `.gitignore` nobody is publishing must still gain `private/`. Without it, "wait instead of repairing" would quietly become a **permanent** skip — the next open finds the same empty file and skips again, forever.

## The gate

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p stella-store --all-targets -- -D warnings`
- [x] `cargo test -p stella-store` — 301 lib + 31 integration, zero failures
- [x] `./scripts/check-file-size.sh` — OK, none grew
- [x] ~60k stressed racers, zero failures (the bar #513 set for this class)
- [x] `Closes #N` appears both above and as a commit trailer

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] Security semantics unchanged — see below

## Anything reviewers should know?

**The security argument is the part worth reviewing, not the retry.** The guard exists to reject a file planted at the path. Conceding `nlink() == 0` costs it nothing, because an attacker who plants a file leaves at least one link to it; `nlink() == 0` says the thing we opened has *no* name any more, which only the unlink half of a rename produces. The uid check runs before the concession, so an unlinked inode we do not own is still reported. `nlink() >= 2`, a non-regular file, and a wrong owner all stay terminal exactly as before.

**The settle budget is 50 × 1 ms and is never spent in practice.** It covers a single `write_all` of a 47-byte constant. It is generous because the two mistakes are not symmetric: waiting a few milliseconds too long is invisible, while giving up early puts the loser back on the rename path and resurrects the failure `create_generated_ignore_exclusively` was written to end. The budget is only ever reached by a genuinely empty file, which is then repaired as before.

**`read_committable_file` changed signature** to `Result<Option<…>>`, where `None` means "no stable file to judge yet". It has one caller, and both the unix and non-unix arms were updated so the two keep the same meaning.

**I did not touch `migrations.rs`.** The flaky-looking test there is now correct-and-passing for the right reason, rather than retried or serialized into silence. If you would still prefer an outer retry on it as belt-and-braces, say so and I will add it — but I would rather it keep its ability to catch the next version of this.

## Summary by Sourcery

Handle races in creation and validation of the workspace-generated .gitignore to avoid falsely reporting planted ignores during concurrent first opens.

Bug Fixes:
- Treat zero-length generated .gitignore files as in-flight writes and wait for contents instead of rewriting them, preventing replacement of the winner's inode.
- Handle NotFound and nlink()==0 races when reading committable files as benign concurrent renames rather than security violations, while still enforcing ownership and file-type checks.

Enhancements:
- Introduce a settle loop for the generated .gitignore to wait for a stable, non-empty file before inspecting or repairing it, with a bounded wait budget.

Tests:
- Add concurrency and race-focused tests to stress ensure_workspace_generated_ignore, including deterministic and high-volume racers plus coverage for genuinely empty ignores.