### PR TITLE
test(bench): make all three catalog-parity tests fail legibly

### DIFF
--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1069,9 +1070,34 @@ def _parse_output_ceilings(source: str) -> dict[str, int]:
     return ceilings
 
 
+def _read_catalog_source() -> str:
+    """`_CATALOG_RS`'s text, or a reason instead of a bare `OSError`.
+
+    `_CATALOG_RS` is a literal assembled here, and the file it names lives in
+    the Rust tree — so a crate move retargets it with nothing on the Rust side
+    able to notice. That is not hypothetical: the move under `crates/` left
+    this pointing one segment short, and the two tests that read the catalog
+    without asserting on it first died with a bare `FileNotFoundError`. The
+    traceback named the stale path but not the thing a reader has to know,
+    which is that the path is hand-written *in this file* and is fixed here.
+
+    Raising `AssertionError` rather than letting the `OSError` through is what
+    makes all three failures legible: pytest renders it as a failed assertion
+    with the message, not as an unexpected exception in a `pathlib` frame.
+    """
+    try:
+        return _CATALOG_RS.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AssertionError(
+            f"cannot read the model catalog at {_CATALOG_RS}: {exc.strerror}. "
+            "That path is a literal in this file, not a resolved crate "
+            "location — if the crate moved, update `_CATALOG_RS` to match."
+        ) from exc
+
+
 def _seeded_output_ceilings() -> dict[str, int]:
     """`_parse_output_ceilings` over the real catalog this repo ships."""
-    return _parse_output_ceilings(_CATALOG_RS.read_text(encoding="utf-8"))
+    return _parse_output_ceilings(_read_catalog_source())
 
 
 class TestCatalogCeilingParser:
@@ -1202,6 +1228,28 @@ class TestOutputCeilingParity:
         # which is how a ratchet becomes decoration.
         assert _CATALOG_RS.is_file(), f"{_CATALOG_RS} is missing"
         assert _seeded_output_ceilings(), "no seeded ceiling was parsed"
+
+    def test_a_moved_catalog_says_where_the_path_is_fixed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A missing catalog must name the path *and* where to correct it.
+
+        The test above asserts `is_file()` and so fails legibly on its own;
+        the two below read the catalog through `_seeded_output_ceilings` and
+        used to surface a bare `FileNotFoundError` from inside `pathlib`. All
+        three now share one guarded read, and this pins that: the failure has
+        to point at `_CATALOG_RS` as the thing to edit, because the last time
+        this broke, the cause was a Rust crate move and the fix was a literal
+        in this file that no Rust check could have flagged.
+        """
+        monkeypatch.setattr(
+            sys.modules[__name__], "_CATALOG_RS", tmp_path / "gone" / "catalog.rs"
+        )
+        with pytest.raises(AssertionError) as caught:
+            _seeded_output_ceilings()
+        message = str(caught.value)
+        assert "catalog.rs" in message
+        assert "_CATALOG_RS" in message
 
     def test_every_bookable_model_has_a_seeded_ceiling(self) -> None:
         """An arm can only book a model the catalog has a ceiling for.


### PR DESCRIPTION
## What & why

Follow-up to #1385. That PR moved every crate under `crates/`, which broke three
tests in `TestOutputCeilingParity` because `_CATALOG_RS` is a hand-written path
into the Rust tree. Only one of the three said anything useful about it.

`test_catalog_is_readable_and_seeds_ceilings` asserts `is_file()` and failed
legibly. The other two read the catalog through `_seeded_output_ceilings()` and
surfaced a bare `FileNotFoundError` raised inside `pathlib`. That traceback names
the stale path but not the one thing a reader needs to know: the path is a
literal *in this test file*, and that is where it gets corrected. No Rust check
can flag it, because nothing in the Rust build knows the dependency exists.

All three now share one guarded read that raises `AssertionError` carrying that
instruction. The guard lives in the read, not in each test, so any future caller
inherits it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_a_moved_catalog_says_where_the_path_is_fixed` points `_CATALOG_RS` at a
missing file and asserts the resulting message names both `catalog.rs` and
`_CATALOG_RS`.

Verified it is a real witness rather than assumed: reverting just the
`_seeded_output_ceilings` wiring back to `main`'s `_CATALOG_RS.read_text(...)`
makes it fail with exactly the bare `FileNotFoundError` it exists to prevent.

Also verified end to end by pointing `_CATALOG_RS` at a non-existent directory
and reading the output. Before, two of three failed as `FileNotFoundError` from
a `pathlib` frame. After, all three report:

```
AssertionError: cannot read the model catalog at <path>: No such file or
directory. That path is a literal in this file, not a resolved crate location
— if the crate moved, update `_CATALOG_RS` to match.
```

## The gate

- [x] `bench/harbor_adapter` pytest — 433 passed, 1 skipped (432 before, +1 new test)
- [x] `./scripts/check-file-size.sh` — see below; this file is 1321 lines, under the 1500 ratchet
- [ ] `cargo fmt` / `clippy` / `test` — not applicable, no Rust changed
- [x] Docs updated where behavior changed — n/a, test-only

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The file-size gate is already red on `main`, unrelated to this PR.**
`crates/stella-cli/src/candidate_ws.rs` is 1629 lines against its recorded
ceiling of 1618 (+11), and `crates/stella-cli/src/agent_tests.rs` has a stale
baseline entry for a file that is no longer tracked. Both reproduce on a clean
`origin/main` checkout with no changes applied. I did not run
`make file-size-update`, because the baseline bump is meant to be a deliberate,
visible review decision about whether that growth is irreducible — not something
a passing PR absorbs silently.

Scope note: this is test-legibility only. It does not change what the parity
check verifies, only what it says when the wiring underneath it breaks.

## Summary by Sourcery

Improve failure messaging for catalog parity tests by centralizing a guarded catalog read and adding coverage for its error path.

New Features:
- Add a dedicated test ensuring catalog-path failures point to the literal `_CATALOG_RS` location.

Bug Fixes:
- Ensure all catalog parity tests fail with a clear assertion instead of propagating bare `FileNotFoundError` exceptions when the catalog path is stale.

Enhancements:
- Introduce a shared catalog read helper that wraps `OSError` in a descriptive `AssertionError` reused by all catalog parity tests.