### PR TITLE
fix(files): a windowed read is still a read the no-clobber guard watched

### DIFF
--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -17,7 +17,10 @@ use crate::file_touch::{
     normalize_workspace_path,
 };
 
+mod belief;
 mod process_tools;
+
+use belief::{Belief, Coverage};
 
 /// One tool the agent can call. Input arrives as the model-produced JSON;
 /// output is always a typed `ToolOutput` (never a bare string).
@@ -105,7 +108,11 @@ pub struct ToolRegistry {
     /// just changed using a plan A's content no longer justifies. Waiting is
     /// also the wrong cost model for an agent — being told "that moved, read
     /// it again" is a cheap retry, where blocking burns a turn.
-    observed: std::sync::Mutex<HashMap<String, String>>,
+    ///
+    /// Each entry also carries HOW MUCH of that content the agent actually
+    /// saw ([`Coverage`]), which decides what a later partial read is allowed
+    /// to do to it — see [`Self::remember_observed`].
+    observed: std::sync::Mutex<HashMap<String, Belief>>,
     /// The session's durable record, once a host attaches one. Absent — the
     /// default — leaves every existing caller behaving exactly as before.
     ///
@@ -126,8 +133,9 @@ pub struct ToolRegistry {
     span_reads: crate::read_symbol::SpanReadLedger,
     /// The read-state ledger shared with `read_file`/`read_symbol`/`edit_file`/
     /// `write_file`, held here for one question only: did a read actually show
-    /// the model the whole file? [`Self::remember_observed`] may not act on a
-    /// read that did not — see the gate in [`Self::record_touch`].
+    /// the model the whole file? That answer is the [`Coverage`] grade
+    /// [`Self::record_touch`] hands to [`Self::remember_observed`], which
+    /// decides what the read may do to an existing belief.
     read_ledger: Arc<crate::read::ReadLedger>,
     /// The workspace before-image for the turn in flight, when one was taken
     /// ([`ToolRegistry::begin_workspace_probe`]). `None` before the first
@@ -1668,25 +1676,6 @@ impl ToolRegistry {
         Some(PendingTouch { path, op })
     }
 
-    /// Record what this session now knows `path` to hold, hashed from disk.
-    ///
-    /// Called for every successful touch, reads included: a read is how an
-    /// agent acquires the belief a later write acts on, so it is exactly as
-    /// load-bearing here as a write. A path that no longer exists drops its
-    /// entry — after a delete there is nothing left to clobber, and the next
-    /// agent to create the file is starting fresh rather than overwriting.
-    fn remember_observed(&self, path: &str) {
-        let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
-        match crate::rootfd::read_confined_bytes(&self.root, path) {
-            Some(bytes) => {
-                observed.insert(path.to_string(), crate::staleness::hex_sha256(&bytes));
-            }
-            None => {
-                observed.remove(path);
-            }
-        }
-    }
-
     /// This session's staleness map as JSON, for a durable host to persist.
     ///
     /// `BTreeMap`, so the bytes are a pure function of the contents: this is
@@ -1702,9 +1691,9 @@ impl ToolRegistry {
         if observed.is_empty() {
             return None;
         }
-        let ordered: std::collections::BTreeMap<&str, &str> = observed
+        let ordered: std::collections::BTreeMap<&str, String> = observed
             .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .map(|(k, v)| (k.as_str(), v.encode()))
             .collect();
         serde_json::to_string(&ordered).ok()
     }
@@ -1726,6 +1715,10 @@ impl ToolRegistry {
         let Ok(restored) = serde_json::from_str::<HashMap<String, String>>(json) else {
             return 0;
         };
+        let restored: HashMap<String, Belief> = restored
+            .into_iter()
+            .map(|(path, encoded)| (path, Belief::decode(&encoded)))
+            .collect();
         let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
         // REPLACE, never merge. The restored map is this session's complete
         // belief about the tree, and the deck reuses one registry across a
@@ -1761,7 +1754,7 @@ impl ToolRegistry {
             .filter(|p| {
                 observed.get(&p.path).is_some_and(|seen| {
                     crate::rootfd::read_confined_bytes(&self.root, &p.path)
-                        .is_some_and(|bytes| crate::staleness::hex_sha256(&bytes) != *seen)
+                        .is_some_and(|bytes| crate::staleness::hex_sha256(&bytes) != seen.sha256)
                 })
             })
             .map(|p| p.path.clone())
@@ -1846,22 +1839,20 @@ impl ToolRegistry {
         // the guarantee, and a touch whose digest went unrecorded would leave
         // the NEXT write to this path unguarded.
         //
-        // A read only earns that belief if it showed the model the whole file.
-        // `remember_observed` hashes what is on DISK, so a ranged read — or one
-        // clipped by the per-line or payload cap — would otherwise record the
-        // agent as having seen bytes it was never shown, and a later write over
-        // that unseen tail would sail past `clobbered_paths` clean. `read_file`
-        // defaults to a 2000-line window and `read_symbol` reads a span, so the
-        // partial case is the common one, not the exotic one.
-        //
-        // Skipping is not the same as forgetting: an earlier complete read's
-        // digest stays, so the guard keeps whatever real belief it had rather
-        // than downgrading to "never looked".
-        let establishes_belief = !matches!(pending.op, FileOp::Read)
-            || self.read_ledger.saw_whole_file(&self.root, &pending.path);
-        if establishes_belief {
-            self.remember_observed(&pending.path);
-        }
+        // A read earns the WHOLE-file grade only if it showed the model every
+        // line: `read_file` defaults to a 2000-line window and `read_symbol`
+        // reads a span, so the partial case is the common one. A mutation
+        // always earns it — the agent authored what it just wrote, so there is
+        // no unseen remainder to be wrong about. What a partial read may then
+        // do to an existing belief is `remember_observed`'s rule.
+        let coverage = if !matches!(pending.op, FileOp::Read)
+            || self.read_ledger.saw_whole_file(&self.root, &pending.path)
+        {
+            Coverage::Whole
+        } else {
+            Coverage::Partial
+        };
+        self.remember_observed(&pending.path, coverage);
         let reason = input
             .get("reason")
             .and_then(|v| v.as_str())

--- a/crates/stella-tools/src/registry/belief.rs
+++ b/crates/stella-tools/src/registry/belief.rs
@@ -1,0 +1,180 @@
+//! What this session believes a file holds, and how much of it the agent was
+//! actually shown.
+//!
+//! One entry of [`ToolRegistry::observed`](super::ToolRegistry) — the whole of
+//! the no-clobber guarantee. This module owns what a belief is, the form it
+//! persists in, and the rule for updating one
+//! ([`ToolRegistry::remember_observed`](super::ToolRegistry::remember_observed)).
+//! The map itself and the comparison a mutation is checked against
+//! (`clobbered_paths`) stay on the registry, next to the touch that triggers
+//! them.
+
+/// How much of a file's content the agent actually saw when it formed the
+/// belief.
+///
+/// The no-clobber guard needs three states, not two, and this is the third.
+/// "No belief" and "a belief" alone force a choice between two failures:
+/// letting a windowed read overwrite a whole-file belief (which launders a
+/// concurrent edit into it), or letting no windowed read record anything
+/// (which leaves the file unguarded). Recording *how* the belief was earned
+/// keeps both closed — see
+/// [`ToolRegistry::remember_observed`](super::ToolRegistry::remember_observed)
+/// for the rule itself.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum Coverage {
+    /// Every byte was seen or written by this agent: a read that rendered the
+    /// whole file unclipped and uncapped, or any create/update/delete, since
+    /// the agent authored the content it just wrote.
+    Whole,
+    /// Only part of it was seen — a windowed `read_file`, a `read_symbol`
+    /// span, or a read clipped by the per-line or payload cap.
+    Partial,
+}
+
+/// What this session last observed a file to hold, and how much of that
+/// content the agent was actually shown.
+#[derive(Clone, Debug)]
+pub(super) struct Belief {
+    pub(super) sha256: String,
+    pub(super) coverage: Coverage,
+}
+
+/// Marks a partial belief in the persisted staleness map.
+///
+/// A whole-file belief is written as a bare hex digest, exactly as before
+/// coverage was tracked, so a snapshot of a session that only ever read whole
+/// files is byte-identical to the one the previous version wrote — and an
+/// older map restores as [`Coverage::Whole`], which is the truth for it: only
+/// a whole-file read could establish belief in the version that wrote it.
+const PARTIAL_BELIEF_PREFIX: &str = "partial:";
+
+impl Belief {
+    /// The persisted form: bare digest for a whole-file belief, prefixed for a
+    /// partial one. See [`PARTIAL_BELIEF_PREFIX`] on why the whole-file case
+    /// stays bare.
+    pub(super) fn encode(&self) -> String {
+        match self.coverage {
+            Coverage::Whole => self.sha256.clone(),
+            Coverage::Partial => format!("{PARTIAL_BELIEF_PREFIX}{}", self.sha256),
+        }
+    }
+
+    /// Inverse of [`Self::encode`]. An unprefixed value is a whole-file belief
+    /// — including every map written before partial beliefs were recorded at
+    /// all, for which that is the correct reading.
+    ///
+    /// A map written by a NEWER version and restored here would read the
+    /// prefix as part of the digest, which can only ever fail to match disk —
+    /// so the guard over-refuses and asks for a re-read. That is the direction
+    /// a no-clobber guard is allowed to be wrong in.
+    pub(super) fn decode(encoded: &str) -> Self {
+        match encoded.strip_prefix(PARTIAL_BELIEF_PREFIX) {
+            Some(sha256) => Self {
+                sha256: sha256.to_string(),
+                coverage: Coverage::Partial,
+            },
+            None => Self {
+                sha256: encoded.to_string(),
+                coverage: Coverage::Whole,
+            },
+        }
+    }
+}
+
+impl super::ToolRegistry {
+    /// Record what this session now knows `path` to hold, hashed from disk,
+    /// and how much of that content the agent was actually shown.
+    ///
+    /// Called for every successful touch, reads included: a read is how an
+    /// agent acquires the belief a later write acts on, so it is exactly as
+    /// load-bearing here as a write. A path that no longer exists drops its
+    /// entry — after a delete there is nothing left to clobber, and the next
+    /// agent to create the file is starting fresh rather than overwriting.
+    ///
+    /// # Why a partial read may establish but not overwrite
+    ///
+    /// This hashes what is on DISK, not what was rendered, so what a partial
+    /// read may do to an existing belief is the whole question — and both
+    /// extremes fail, in opposite directions:
+    ///
+    /// - **Always overwrite** launders a concurrent edit into belief. A reads
+    ///   the file whole, B edits the tail, A peeks at the head and learns
+    ///   nothing about B's edit — but the refreshed hash now says A has seen
+    ///   B's content, so A's next write compares B's work against itself,
+    ///   passes clean, and destroys it.
+    /// - **Never record** leaves the file unguarded: `clobbered_paths` cannot
+    ///   flag a path it has no entry for. Not the exotic case — `read_file`
+    ///   windows at 2000 lines, so above that ceiling *every* read is partial
+    ///   and none can ever be whole.
+    ///
+    /// So a partial read establishes a belief where there is none and
+    /// refreshes one that was itself partial, but never overwrites a
+    /// whole-file belief. That closes both holes without deadlocking the
+    /// agent: a file holding a whole-file belief is small enough to be read
+    /// whole again — the recovery the refusal asks for — while one too big for
+    /// that only ever holds a partial belief, so the windowed reads that are
+    /// all it can offer still refresh it.
+    pub(super) fn remember_observed(&self, path: &str, coverage: Coverage) {
+        let mut observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(bytes) = crate::rootfd::read_confined_bytes(&self.root, path) else {
+            observed.remove(path);
+            return;
+        };
+        if coverage == Coverage::Partial
+            && observed
+                .get(path)
+                .is_some_and(|held| held.coverage == Coverage::Whole)
+        {
+            return;
+        }
+        observed.insert(
+            path.to_string(),
+            Belief {
+                sha256: crate::staleness::hex_sha256(&bytes),
+                coverage,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A whole-file belief must persist as a bare digest: the pre-coverage
+    /// format, so a map written by the version before this one and a map
+    /// written by this one are the same bytes for the same beliefs.
+    #[test]
+    fn a_whole_file_belief_persists_as_a_bare_digest() {
+        let belief = Belief {
+            sha256: "abc123".into(),
+            coverage: Coverage::Whole,
+        };
+        assert_eq!(belief.encode(), "abc123");
+    }
+
+    /// And an old map — every value a bare digest — restores as whole-file,
+    /// which is the truth for it.
+    #[test]
+    fn an_unprefixed_value_decodes_as_a_whole_file_belief() {
+        let belief = Belief::decode("abc123");
+        assert_eq!(belief.sha256, "abc123");
+        assert_eq!(belief.coverage, Coverage::Whole);
+    }
+
+    #[test]
+    fn a_partial_belief_round_trips_through_its_prefix() {
+        let belief = Belief {
+            sha256: "def456".into(),
+            coverage: Coverage::Partial,
+        };
+        let decoded = Belief::decode(&belief.encode());
+        assert_eq!(decoded.sha256, "def456");
+        assert_eq!(
+            decoded.coverage,
+            Coverage::Partial,
+            "a partial belief that decoded as whole-file would regain the \
+             power to be laundered by the next windowed read"
+        );
+    }
+}

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -1124,3 +1124,219 @@ fn restoring_a_session_replaces_rather_than_inherits() {
         "a file only the departing session read must not guard the arriving one"
     );
 }
+
+/// A windowed read is still a read the guard watched, so the file it looked at
+/// must stay guarded.
+///
+/// `read_file` renders at most 2000 lines, so on a file above that ceiling
+/// EVERY read is partial. Grading a partial read as "no belief at all" left
+/// exactly those files — the big ones, the ones several agents are most likely
+/// to be in at once — outside the no-clobber guarantee entirely: no entry in
+/// the staleness map means `clobbered_paths` has nothing to compare and the
+/// overwrite lands with no refusal.
+#[tokio::test]
+async fn a_windowed_read_still_guards_against_a_concurrent_edit() {
+    let root = tempfile::tempdir().unwrap();
+    let file = root.path().join("big.txt");
+    let original: String = (1..=50).map(|i| format!("line {i}\n")).collect();
+    std::fs::write(&file, &original).unwrap();
+
+    let agent_a = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    let agent_b = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    // A reads a WINDOW — what every read of an over-ceiling file looks like.
+    let read = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({
+                "path": "big.txt", "offset": 1, "limit": 10, "reason": "reading the head",
+            }),
+        )
+        .await;
+    assert!(!read.is_error(), "A's windowed read: {read:?}");
+
+    // B appends work A was never shown.
+    let mut edited = original.clone();
+    edited.push_str("B's careful work\n");
+    let b_wrote = agent_b
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "big.txt", "content": edited, "reason": "B does its job" }),
+        )
+        .await;
+    assert!(!b_wrote.is_error(), "B's write lands: {b_wrote:?}");
+
+    let a_wrote = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "big.txt", "content": "A's stale work\n", "reason": "A does its job" }),
+        )
+        .await;
+    match &a_wrote {
+        ToolOutput::Error { message } => assert!(
+            message.contains("big.txt"),
+            "the refusal names the file: {message}"
+        ),
+        other => panic!("a write over an unseen edit must be refused, got {other:?}"),
+    }
+    assert!(
+        std::fs::read_to_string(&file)
+            .unwrap()
+            .contains("B's careful work"),
+        "B's work survives — a windowed reader is still a guarded one"
+    );
+}
+
+/// The other direction: a partial read must not overwrite a whole-file belief.
+///
+/// A saw the file whole, B edited a region A never looked at again, and A's
+/// `read_symbol` span learns nothing about B's edit. Refreshing the belief on
+/// that span would compare B's content against itself and wave A's write
+/// through — the laundering this grade exists to prevent.
+#[tokio::test]
+async fn a_span_read_cannot_launder_a_whole_file_belief() {
+    // `target_fn` is lines 5-8 in both versions; only `alpha`'s body differs,
+    // so the span A re-reads is byte-identical and tells it nothing.
+    const BEFORE: &str = "fn alpha() {\n    let a = 1;\n}\n\nfn target_fn() {\n    let x = 1;\n    let y = 2;\n}\n\nfn omega() {}\n";
+    const AFTER: &str = "fn alpha() {\n    let a = 999;\n}\n\nfn target_fn() {\n    let x = 1;\n    let y = 2;\n}\n\nfn omega() {}\n";
+
+    let root = tempfile::tempdir().unwrap();
+    let file = root.path().join("lib.rs");
+    std::fs::write(&file, BEFORE).unwrap();
+    let db = crate::graph::graph_db_path(root.path());
+    std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+    let graph = stella_graph::CodeGraph::open(root.path(), &db).unwrap();
+    graph.index_all().unwrap();
+    graph.shutdown();
+
+    let agent_a = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    let agent_b = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    let read = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "lib.rs", "reason": "reading it whole" }),
+        )
+        .await;
+    assert!(!read.is_error(), "A's whole-file read: {read:?}");
+
+    let b_wrote = agent_b
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "lib.rs", "content": AFTER, "reason": "B edits alpha" }),
+        )
+        .await;
+    assert!(!b_wrote.is_error(), "B's write lands: {b_wrote:?}");
+
+    let span = agent_a
+        .execute(
+            "read_symbol",
+            &serde_json::json!({ "name": "target_fn", "reason": "peeking at one symbol" }),
+        )
+        .await;
+    assert!(!span.is_error(), "A's span read: {span:?}");
+
+    let a_wrote = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "lib.rs", "content": "A's stale work\n", "reason": "A does its job" }),
+        )
+        .await;
+    assert!(
+        a_wrote.is_error(),
+        "a span read must not refresh a whole-file belief, got {a_wrote:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        AFTER,
+        "B's edit survives the peek"
+    );
+}
+
+/// The refusal has to be recoverable on a file too big to read whole.
+///
+/// Above `read_file`'s 2000-line ceiling a whole-file read is unreachable, so
+/// a rule of "only a whole-file read may refresh" would refuse the write, then
+/// refuse every re-read's attempt to clear it — the agent could never write
+/// the file again. A partial belief is refreshable by the partial reads that
+/// are all such a file can offer.
+#[tokio::test]
+async fn a_windowed_re_read_recovers_a_file_too_big_to_read_whole() {
+    let root = tempfile::tempdir().unwrap();
+    let file = root.path().join("huge.txt");
+    let original: String = (1..=2_100).map(|i| format!("line {i}\n")).collect();
+    std::fs::write(&file, &original).unwrap();
+
+    let agent_a = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+    let agent_b = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    let read = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "huge.txt", "reason": "first look" }),
+        )
+        .await;
+    assert!(!read.is_error(), "A's read: {read:?}");
+
+    let mut edited = original.clone();
+    edited.push_str("B's careful work\n");
+    let b_wrote = agent_b
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "huge.txt", "content": edited, "reason": "B does its job" }),
+        )
+        .await;
+    assert!(!b_wrote.is_error(), "B's write lands: {b_wrote:?}");
+
+    let refused = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "huge.txt", "content": "A's stale work\n", "reason": "A does its job" }),
+        )
+        .await;
+    assert!(refused.is_error(), "the file is guarded: {refused:?}");
+
+    // The recovery the refusal asks for — the only one this file can give.
+    let reread = agent_a
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "huge.txt", "reason": "re-reading after the refusal" }),
+        )
+        .await;
+    assert!(!reread.is_error(), "A re-reads: {reread:?}");
+
+    let retry = agent_a
+        .execute(
+            "write_file",
+            &serde_json::json!({ "path": "huge.txt", "content": "A's work, rebased\n", "reason": "redone" }),
+        )
+        .await;
+    assert!(
+        !retry.is_error(),
+        "after re-reading, A writes normally — no deadlock: {retry:?}"
+    );
+}
+
+/// The coverage grade has to survive a crash, or a resumed session silently
+/// regains the power to launder the belief it restored.
+#[test]
+fn a_beliefs_coverage_survives_the_snapshot_round_trip() {
+    let root = tempfile::tempdir().unwrap();
+    let reg = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+
+    let stored = serde_json::json!({ "whole.rs": "aaa", "windowed.rs": "partial:bbb" }).to_string();
+    assert_eq!(reg.restore_observed(&stored), 2);
+
+    let json = reg.observed_snapshot().expect("a snapshot");
+    let observed: std::collections::HashMap<String, String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        observed.get("whole.rs").map(String::as_str),
+        Some("aaa"),
+        "a whole-file belief stays a bare digest — the pre-coverage format, unchanged"
+    );
+    assert_eq!(
+        observed.get("windowed.rs").map(String::as_str),
+        Some("partial:bbb"),
+        "a partial belief is still partial after a resume"
+    );
+}


### PR DESCRIPTION
## What & why

Follow-up to a Vercel review comment on **#1397** (`registry.rs:1860-1861`), which
flagged that the new `establishes_belief` gate could let "a later blind write
silently clobber an unseen edit."

The comment's stated mechanism — a `read_symbol` span read laundering *stale*
whole-file coverage — does **not** reproduce. `read_symbol` reads through the same
`ReadFile` instance, so `record_read` clears the coverage flag and `record_coverage`
re-derives it from the span. #1397's fix holds there, and this PR pins it with a test
at exactly that seam.

The consequence it named is real, via the opposite path.

`clobbered_paths` only ever flags when `observed[path] != disk`, so **removing** an
entry can only ever *reduce* flagging — a gate that skips `remember_observed` cannot
fix a false negative there by construction, it can only create new ones. #1397 closed
the laundering hole by opening its mirror image: a file whose only reads were windowed
now has **no entry at all**, and the guard cannot flag a path it has never observed.

`read_file` renders at most 2000 lines, so above that ceiling *every* read is partial.
The files left outside the no-clobber guarantee were the big ones — the ones most
likely to have two agents in them at once.

Verified against `d3c2a3b1`: A windows a file, B appends, A overwrites. No refusal,
B's work gone, disk reads `A's stale work`.

### The fix

The guard needs three states, not two. `observed` now stores a `Belief` carrying the
`Coverage` its digest was earned at:

| | belief absent | belief `Partial` | belief `Whole` |
|---|---|---|---|
| whole-file read / any mutation | establish `Whole` | overwrite → `Whole` | refresh |
| partial read | establish `Partial` | refresh | **leave alone** |

That last cell is #1397's fix; the first column is this one. Both holes closed.

It also cannot deadlock, which is why "only a whole-file read may refresh" is not the
answer: a file holding a whole-file belief is small enough to be read whole *again* —
the recovery the refusal asks for — while one too big for that only ever holds a
partial belief, so the windowed reads that are all it can offer still refresh it.

Whole-file beliefs persist as a bare digest exactly as before, so a snapshot is
byte-identical for a session that only read whole files, and an older map restores as
whole-file — the truth for it, since only a whole-file read could establish belief in
the version that wrote it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four tests in `registry/tests.rs` plus three in the new `registry/belief.rs`:

- `a_windowed_read_still_guards_against_a_concurrent_edit` — **fails on `d3c2a3b1`**
- `a_windowed_re_read_recovers_a_file_too_big_to_read_whole` (2100 lines) — **fails on `d3c2a3b1`**
- `a_span_read_cannot_launder_a_whole_file_belief` — passes on both; pins #1397's fix
  at the `read_symbol` seam the review comment named
- `a_beliefs_coverage_survives_the_snapshot_round_trip` — coverage survives a resume

Confirmed by reverting the rule to `if coverage == Coverage::Whole` in place: the first
two fail, the other two pass.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (118 test binaries, 0 failures)
- [x] Docs updated — the rule is stated in full on `remember_observed`
- [x] `scripts/check-file-size.sh` clean for every file this PR touches

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] The persisted staleness map round-trips, with a test, in both directions and
      across the pre-coverage format

## Anything reviewers should know?

**No baseline churn.** The belief type, its persisted form and the update rule move to
a new `crates/stella-tools/src/registry/belief.rs`, so `registry.rs` ends **9 lines
shorter** than before this change (2318 vs 2327) rather than 53 longer — it stays under
its 2348 ceiling and needs no `file-size-update`.

`scripts/check-file-size.sh` is already red on `main` for three untouched `stella-cli`
files (`agent/tests.rs` 1747 lines and unbaselined, `candidate_ws.rs` +11, a stale
`agent_tests.rs` entry — fallout from #1393/#1385). Deliberately left alone: fixing
them here would sweep someone else's growth into this PR's baseline diff, which is the
one thing that gate exists to make visible.

`remember_observed` is an `impl super::ToolRegistry` block in the child module. Legal,
and it keeps "what a belief is, how it persists, how it updates" in one file — but it
is a split inherent impl, so flag it if you'd rather it stayed on the registry.

**Still deliberately out of scope:** a blind write to a file this session never read at
all remains unflagged, per the guard's no-false-positives rule. And coverage is one bit,
not a set of ranges — an agent that windows lines 1-10 and writes the whole file still
overwrites 11-2000 unseen. This PR only restores the "someone else changed it" signal
for those files; per-region coverage is a larger design question.

## Summary by Sourcery

Track read coverage in the registry’s staleness map so windowed reads participate in no-clobber protections without laundering whole-file beliefs, and persist this state across snapshots.

New Features:
- Introduce a Belief model with coverage grading (whole vs partial) for file contents observed by a session.
- Allow partial reads to establish and refresh guarded state for large files while preventing them from overwriting whole-file beliefs.

Enhancements:
- Refactor staleness tracking into a dedicated belief module that owns the belief data model, persistence format, and update rules.
- Extend the registry snapshot/restore logic to round-trip belief coverage while remaining compatible with the previous bare-digest format.

Tests:
- Add integration tests around windowed reads, span reads, and recovery flows to prove concurrent-edit protection and avoid deadlocks for large files.
- Add unit tests for belief encoding/decoding to verify prefix handling and backward compatibility of the persisted staleness map.