### PR TITLE
fix(files): a partial read must not license a whole-file overwrite

### DIFF
--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -878,24 +878,9 @@ impl ToolRegistry {
         // abort because it is a recoverable, model-actionable condition — the
         // message names the file and the fix, and re-reading is one cheap step
         // where a failed turn would be a whole one.
-        let clobbered = self.clobbered_paths(&pending_ops);
-        if !clobbered.is_empty() {
+        if let Some(refusal) = self.refused_mutation(name, &pending_ops) {
             return ToolOutput::Error {
-                message: format!(
-                    "refusing to write: {} changed since you last read {}. Another \
-                     agent (or a person) edited it after you looked, and this call \
-                     would overwrite their work with a plan formed against content \
-                     that no longer exists.\n\nRe-read {} and redo the change \
-                     against what is there now. Your edit is not lost — nothing was \
-                     written.",
-                    clobbered.join(", "),
-                    if clobbered.len() == 1 { "it" } else { "them" },
-                    if clobbered.len() == 1 {
-                        "the file"
-                    } else {
-                        "those files"
-                    },
-                ),
+                message: refusal.message(),
             };
         }
         // Updates need the pre-write content for the line diff; deletes need
@@ -1746,6 +1731,11 @@ impl ToolRegistry {
     ///
     /// An unreadable file is not a conflict either — the tool's own error
     /// path reports that far better than a staleness message would.
+    ///
+    /// This is the digest half of the guard only. A file whose bytes match but
+    /// which the agent has only ever glimpsed is the *other* half, decided by
+    /// coverage rather than by hashing — see
+    /// [`Self::refused_mutation`], which calls this one first.
     fn clobbered_paths(&self, pending: &[PendingTouch]) -> Vec<String> {
         let observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
         pending

--- a/crates/stella-tools/src/registry/belief.rs
+++ b/crates/stella-tools/src/registry/belief.rs
@@ -3,11 +3,14 @@
 //!
 //! One entry of [`ToolRegistry::observed`](super::ToolRegistry) — the whole of
 //! the no-clobber guarantee. This module owns what a belief is, the form it
-//! persists in, and the rule for updating one
-//! ([`ToolRegistry::remember_observed`](super::ToolRegistry::remember_observed)).
-//! The map itself and the comparison a mutation is checked against
-//! (`clobbered_paths`) stay on the registry, next to the touch that triggers
-//! them.
+//! persists in, the rule for updating one
+//! ([`ToolRegistry::remember_observed`](super::ToolRegistry::remember_observed))
+//! and the rule for acting on one
+//! ([`ToolRegistry::refused_mutation`](super::ToolRegistry::refused_mutation)).
+//! The map itself and the digest comparison (`clobbered_paths`) stay on the
+//! registry, next to the touch that triggers them.
+
+use super::{FileOp, PendingTouch};
 
 /// How much of a file's content the agent actually saw when it formed the
 /// belief.
@@ -81,7 +84,116 @@ impl Belief {
     }
 }
 
+/// Why a pending mutation is refused before it is allowed to run.
+///
+/// Both arms make the same claim at different strengths — "this call would
+/// destroy content the agent cannot account for" — and both are recoverable by
+/// reading, so each carries the message that names its own way out.
+pub(super) enum Refusal {
+    /// The bytes moved: something outside this session edited these paths
+    /// after the agent last looked at them.
+    Drifted(Vec<String>),
+    /// Nothing drifted, but the agent only ever saw part of this file and is
+    /// about to replace the whole of it. What would be lost is not another
+    /// agent's *edit* — it is every region the agent never read.
+    Unseen(String),
+}
+
+impl Refusal {
+    /// The model-facing refusal. Both arms name the file and the next action,
+    /// because this is returned as a tool error the agent is expected to
+    /// recover from in one step rather than as a failed turn.
+    pub(super) fn message(&self) -> String {
+        match self {
+            Self::Drifted(paths) => format!(
+                "refusing to write: {} changed since you last read {}. Another \
+                 agent (or a person) edited it after you looked, and this call \
+                 would overwrite their work with a plan formed against content \
+                 that no longer exists.\n\nRe-read {} and redo the change \
+                 against what is there now. Your edit is not lost — nothing was \
+                 written.",
+                paths.join(", "),
+                if paths.len() == 1 { "it" } else { "them" },
+                if paths.len() == 1 {
+                    "the file"
+                } else {
+                    "those files"
+                },
+            ),
+            Self::Unseen(path) => format!(
+                "refusing to write: you have only seen part of {path}. Every \
+                 read of it this session was windowed, clipped, or a single \
+                 span, so replacing the whole file would overwrite regions that \
+                 were never on your screen — including any work another agent \
+                 (or a person) left in them.\n\nRe-read {path} in full and \
+                 rewrite it against what is actually there, or use edit_file to \
+                 change only the region you did see. Your edit is not lost — \
+                 nothing was written.",
+            ),
+        }
+    }
+}
+
 impl super::ToolRegistry {
+    /// Whether this call must be refused before it runs, and why.
+    ///
+    /// Drift is checked first: when a file both drifted and is only partly
+    /// seen, "someone else changed this" is the more specific fact and the one
+    /// the agent has to act on.
+    pub(super) fn refused_mutation(&self, tool: &str, pending: &[PendingTouch]) -> Option<Refusal> {
+        let drifted = self.clobbered_paths(pending);
+        if !drifted.is_empty() {
+            return Some(Refusal::Drifted(drifted));
+        }
+        self.unseen_whole_file_rewrite(tool, pending)
+            .map(Refusal::Unseen)
+    }
+
+    /// The path this call would replace in full while holding only a partial
+    /// belief about it, if any.
+    ///
+    /// # Why this is not "refuse every mutation on a partial belief"
+    ///
+    /// What makes a partial belief dangerous is *whole-file replacement*, not
+    /// mutation as such. `write_file` substitutes the entire contents, so every
+    /// line the agent never read is destroyed whether or not it was the target
+    /// — and unlike drift, no digest comparison can catch it, because the bytes
+    /// the agent never saw are exactly the bytes it also never hashed a
+    /// disagreement about.
+    ///
+    /// `edit_file` and `apply_edits` replace a matched region and leave the
+    /// rest of the file byte-identical, so an unseen remainder is not at risk
+    /// and refusing them would buy nothing. It would also cost everything:
+    /// `read_file` windows at 2000 lines, so on any file above that ceiling
+    /// EVERY belief is partial and always will be. Refusing edits there would
+    /// make the largest files in a tree permanently unwritable — the deadlock
+    /// this guard is specifically built to avoid, since being told to look
+    /// again must cost a step, never the whole file.
+    ///
+    /// So the split is by what the tool destroys, not by how the belief was
+    /// earned: whole-file replacement is refused, targeted edits proceed, and
+    /// the agent's way back to a full rewrite is one honest whole-file read.
+    fn unseen_whole_file_rewrite(&self, tool: &str, pending: &[PendingTouch]) -> Option<String> {
+        // `web_download` lands a file exactly as `write_file` does — same
+        // classification, same total substitution of the contents — so it is
+        // the same hazard and takes the same rule.
+        if !matches!(tool, "write_file" | "web_download") {
+            return None;
+        }
+        let observed = self.observed.lock().unwrap_or_else(|p| p.into_inner());
+        pending
+            .iter()
+            // A `Create` replaces nothing: there is no prior content to be
+            // wrong about, and a path with no file has no belief either.
+            .filter(|p| matches!(p.op, FileOp::Update))
+            .find(|p| {
+                observed
+                    .get(&p.path)
+                    .is_some_and(|held| held.coverage == Coverage::Partial)
+            })
+            .map(|p| p.path.clone())
+    }
+
     /// Record what this session now knows `path` to hold, hashed from disk,
     /// and how much of that content the agent was actually shown.
     ///

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -808,6 +808,7 @@ mod chain;
 mod fence;
 mod file_change;
 mod gate_batch;
+mod partial_belief;
 #[cfg(unix)]
 mod private_state;
 mod schema_gate;
@@ -1257,9 +1258,15 @@ async fn a_span_read_cannot_launder_a_whole_file_belief() {
 ///
 /// Above `read_file`'s 2000-line ceiling a whole-file read is unreachable, so
 /// a rule of "only a whole-file read may refresh" would refuse the write, then
-/// refuse every re-read's attempt to clear it — the agent could never write
+/// refuse every re-read's attempt to clear it — the agent could never touch
 /// the file again. A partial belief is refreshable by the partial reads that
 /// are all such a file can offer.
+///
+/// What the re-read buys back is the right to *edit*, not the right to replace
+/// the file whole: clearing the drift says the bytes have not moved, and says
+/// nothing about the 100 lines past the window that A still has not read. Those
+/// are two separate refusals and this pins both — see the `partial_belief`
+/// submodule for the coverage rule itself.
 #[tokio::test]
 async fn a_windowed_re_read_recovers_a_file_too_big_to_read_whole() {
     let root = tempfile::tempdir().unwrap();
@@ -1296,7 +1303,7 @@ async fn a_windowed_re_read_recovers_a_file_too_big_to_read_whole() {
         .await;
     assert!(refused.is_error(), "the file is guarded: {refused:?}");
 
-    // The recovery the refusal asks for — the only one this file can give.
+    // The recovery the refusal asks for — the only read this file can give.
     let reread = agent_a
         .execute(
             "read_file",
@@ -1305,15 +1312,46 @@ async fn a_windowed_re_read_recovers_a_file_too_big_to_read_whole() {
         .await;
     assert!(!reread.is_error(), "A re-reads: {reread:?}");
 
-    let retry = agent_a
+    // The drift is now cleared: the bytes A holds are the bytes on disk. What
+    // the re-read could NOT buy back is the tail — a 2,100-line file windows at
+    // 2,000, so 100 lines have still never been on A's screen and replacing the
+    // file whole would take them out. Same call, different refusal.
+    let still_refused = agent_a
         .execute(
             "write_file",
             &serde_json::json!({ "path": "huge.txt", "content": "A's work, rebased\n", "reason": "redone" }),
         )
         .await;
+    match &still_refused {
+        ToolOutput::Error { message } => assert!(
+            message.contains("only seen part of"),
+            "B's edit is no longer the objection; the unseen tail is: {message}"
+        ),
+        other => panic!("a whole-file rewrite over an unread tail must be refused, got {other:?}"),
+    }
+
+    // And this is the step that proves it is not a deadlock: a targeted edit
+    // lands, because it leaves every line A never read exactly where it was.
+    let retry = agent_a
+        .execute(
+            "edit_file",
+            &serde_json::json!({
+                "path": "huge.txt",
+                "old_string": "line 7\n",
+                "new_string": "line 7 — rebased on B\n",
+                "reason": "redone against a region A actually read",
+            }),
+        )
+        .await;
     assert!(
         !retry.is_error(),
-        "after re-reading, A writes normally — no deadlock: {retry:?}"
+        "after re-reading, A edits normally — no deadlock: {retry:?}"
+    );
+    assert!(
+        std::fs::read_to_string(&file)
+            .unwrap()
+            .contains("B's careful work"),
+        "and B's work is still there — A changed only what it looked at"
     );
 }
 

--- a/crates/stella-tools/src/registry/tests/partial_belief.rs
+++ b/crates/stella-tools/src/registry/tests/partial_belief.rs
@@ -1,0 +1,218 @@
+//! Whole-file replacement against a belief the agent only ever glimpsed.
+//!
+//! The sibling tests in the parent module cover the *other* half of the
+//! no-clobber guarantee: someone else moved the bytes since you looked. This
+//! module covers the half that needs no second agent at all — the file is
+//! exactly as you left it, and replacing it whole still destroys every line
+//! outside the window you read.
+//!
+//! The three claims, in the order the guard has to hold them:
+//!
+//! 1. a whole-file replacement against a partial belief is refused;
+//! 2. a *targeted* edit against that same belief is not — `read_file` windows
+//!    at 2000 lines, so refusing those would make every file above that
+//!    ceiling unwritable;
+//! 3. a complete read still upgrades the belief, so the ordinary
+//!    read-then-write cycle never sees this guard at all.
+
+use super::*;
+
+/// `n` numbered lines — long enough that a windowed read is genuinely a
+/// window onto part of it.
+fn numbered_lines(n: usize) -> String {
+    (1..=n).map(|i| format!("line {i}\n")).collect()
+}
+
+/// **Witness.** A file this session has only ranged-read must not be
+/// replaceable whole.
+///
+/// No second agent, no concurrent edit, nothing stale: the agent saw 3 lines
+/// of 40 and then overwrites all 40. The 37 it never looked at are destroyed
+/// by its own hand, and the hash comparison cannot see it — the bytes on disk
+/// are exactly the bytes the belief recorded, so the only thing that can flag
+/// this call is the belief's *coverage*.
+///
+/// Before this guard, a file the agent had glimpsed was less protected than
+/// one it had never touched: the glimpse recorded a matching digest, which the
+/// clobber check reads as consent.
+#[tokio::test]
+async fn a_partial_read_cannot_authorize_a_blind_whole_file_overwrite() {
+    let (dir, agent) = telemetry_fixture();
+    let file = dir.path().join("notes.txt");
+    let original = numbered_lines(40);
+    std::fs::write(&file, &original).unwrap();
+
+    // The agent looks at the header. Lines 4-40 are never rendered.
+    let peek = agent
+        .execute(
+            "read_file",
+            &serde_json::json!({
+                "path": "notes.txt", "offset": 1, "limit": 3, "reason": "checking the header",
+            }),
+        )
+        .await;
+    assert!(!peek.is_error(), "the ranged read succeeds: {peek:?}");
+
+    // And then replaces the file with content formed against 3 of its 40 lines.
+    let wrote = agent
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "notes.txt",
+                "content": "line 1 — rewritten header\n",
+                "reason": "tidying the header",
+            }),
+        )
+        .await;
+
+    match &wrote {
+        ToolOutput::Error { message } => {
+            assert!(
+                message.contains("notes.txt"),
+                "the refusal names the file so the model can act on it: {message}"
+            );
+            assert!(
+                message.contains("edit_file"),
+                "the refusal names the tool that CAN do this safely: {message}"
+            );
+            assert!(
+                message.contains("nothing was written"),
+                "the refusal says the edit was not half-applied: {message}"
+            );
+        }
+        other => panic!("a whole-file write over 37 unseen lines must be refused, got {other:?}"),
+    }
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        original,
+        "the unseen lines are still there — this is the whole point"
+    );
+}
+
+/// **Pin.** A targeted edit against a partial belief still lands.
+///
+/// This is the reason the naive "refuse every mutation against a partial
+/// belief" version is wrong. `read_file` renders at most 2000 lines, so a file
+/// above that ceiling can NEVER be read whole and its belief can never be
+/// anything but partial — refusing targeted edits there would make every large
+/// file in the tree permanently unwritable. `edit_file` and `apply_edits`
+/// replace a matched region and leave the rest of the bytes exactly where they
+/// were, so there is no unseen remainder for them to destroy.
+#[tokio::test]
+async fn a_targeted_edit_against_a_partial_belief_still_lands() {
+    let (dir, agent) = telemetry_fixture();
+    let file = dir.path().join("huge.txt");
+    // Past `read_file`'s ceiling: every read of this file is a window, so the
+    // belief is partial and stays that way.
+    std::fs::write(&file, numbered_lines(2_100)).unwrap();
+
+    let read = agent
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "huge.txt", "reason": "reading what fits" }),
+        )
+        .await;
+    assert!(!read.is_error(), "the read succeeds: {read:?}");
+
+    let edited = agent
+        .execute(
+            "edit_file",
+            &serde_json::json!({
+                "path": "huge.txt",
+                "old_string": "line 7\n",
+                "new_string": "line 7 — edited in place\n",
+                "reason": "changing a region I actually read",
+            }),
+        )
+        .await;
+    assert!(
+        !edited.is_error(),
+        "a targeted edit destroys no unseen lines and must be allowed: {edited:?}"
+    );
+
+    let batched = agent
+        .execute(
+            "apply_edits",
+            &serde_json::json!({
+                "edits": [{
+                    "path": "huge.txt",
+                    "old_string": "line 9\n",
+                    "new_string": "line 9 — edited in a batch\n",
+                }],
+                "reason": "the transactional path is not a second policy",
+            }),
+        )
+        .await;
+    assert!(
+        !batched.is_error(),
+        "apply_edits is the same shape of change and must be allowed too: {batched:?}"
+    );
+
+    let on_disk = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("line 7 — edited in place"),
+        "{on_disk:.80}"
+    );
+    assert!(
+        on_disk.contains("line 9 — edited in a batch"),
+        "{on_disk:.80}"
+    );
+    assert!(
+        on_disk.contains("line 2100\n"),
+        "the tail the agent never saw is untouched — which is why this is safe"
+    );
+}
+
+/// **Pin.** A complete read still upgrades a partial belief to full, so the
+/// ordinary read-then-write cycle is untouched.
+///
+/// The recovery the refusal asks for has to actually work: an agent told "you
+/// have only seen part of this file" reads it whole and writes. If the upgrade
+/// did not happen, the guard would refuse the write, then refuse it again
+/// after the re-read, and the file would be permanently unwritable — the
+/// deadlock that makes a guard get deleted rather than fixed.
+#[tokio::test]
+async fn a_complete_read_upgrades_a_partial_belief_and_the_write_lands() {
+    let (dir, agent) = telemetry_fixture();
+    let file = dir.path().join("small.txt");
+    std::fs::write(&file, numbered_lines(40)).unwrap();
+
+    // A glimpse first, so the belief starts out partial.
+    let peek = agent
+        .execute(
+            "read_file",
+            &serde_json::json!({
+                "path": "small.txt", "offset": 1, "limit": 3, "reason": "checking the header",
+            }),
+        )
+        .await;
+    assert!(!peek.is_error(), "{peek:?}");
+
+    // Under the read ceiling, so this shows the model every line.
+    let whole = agent
+        .execute(
+            "read_file",
+            &serde_json::json!({ "path": "small.txt", "reason": "reading it in full" }),
+        )
+        .await;
+    assert!(!whole.is_error(), "{whole:?}");
+
+    let wrote = agent
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "small.txt",
+                "content": "rewritten against every line I read\n",
+                "reason": "the ordinary cycle",
+            }),
+        )
+        .await;
+    assert!(
+        !wrote.is_error(),
+        "a full read earns the whole-file belief a whole-file write needs: {wrote:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "rewritten against every line I read\n"
+    );
+}


### PR DESCRIPTION
## What & why

A belief the agent earned by glimpsing three lines of forty was treated, at write time, exactly like one it earned by reading the file whole. `clobbered_paths` only ever asked whether the bytes had **moved**, so a file the session had ranged-read and nobody else had touched passed clean — and `write_file` replaced thirty-seven lines that were never on the model's screen, with no refusal and no warning.

Nothing was missing from the recorded state. #1415 already stores the `Coverage` grade next to the digest; it just was not consulted on the way out. This PR wires it into the refusal.

The rule splits by **what the tool destroys**, not by how the belief was earned:

- **Whole-file replacement** (`write_file`, `web_download`) against a partial belief is refused. Every unread line goes, and no digest comparison can catch it — the bytes the agent never read are exactly the bytes it never formed a competing belief about.
- **`edit_file` / `apply_edits` are untouched.** They replace a matched region and leave the remainder byte-identical, so there is no unseen loss to prevent. This is load-bearing: `read_file` windows at 2000 lines, so above that ceiling *every* belief is partial and always will be. Refusing edits there would make the largest files in the tree permanently unwritable — the version of this fix that gets deleted rather than fixed.
- **A complete read still upgrades the belief to whole**, so the ordinary read-then-write cycle never meets this guard.

Drift is still checked first: when a file both drifted and is only partly seen, "someone else changed this" is the more specific fact and the one the agent has to act on.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The three required tests all live in `crates/stella-tools/src/registry/tests/partial_belief.rs`:

| | Test | Claim |
|---|---|---|
| **Witness** | `a_partial_read_cannot_authorize_a_blind_whole_file_overwrite` | 3 lines of 40 read, nothing drifted, whole-file rewrite → refused |
| **Pin** | `a_targeted_edit_against_a_partial_belief_still_lands` | `edit_file` **and** `apply_edits` on a windowed-read 2,100-line file still land |
| **Pin** | `a_complete_read_upgrades_a_partial_belief_and_the_write_lands` | glimpse → full read → `write_file` succeeds; the normal cycle is untouched |

Witness run against the **unfixed** implementation (tests present, `registry.rs` + `belief.rs` reverted to `main`):

```
running 4 tests
test registry::tests::partial_belief::a_complete_read_upgrades_a_partial_belief_and_the_write_lands ... ok
test registry::tests::partial_belief::a_partial_read_cannot_authorize_a_blind_whole_file_overwrite ... FAILED
test registry::tests::partial_belief::a_targeted_edit_against_a_partial_belief_still_lands ... ok

---- registry::tests::partial_belief::a_partial_read_cannot_authorize_a_blind_whole_file_overwrite stdout ----

thread '...' panicked at crates/stella-tools/src/registry/tests/partial_belief.rs:83:18:
a whole-file write over 37 unseen lines must be refused, got Ok { content: "wrote 28 bytes to notes.txt" }
```

`wrote 28 bytes` is the hole: the call succeeded, and the 37 unread lines were gone.

## The gate

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p stella-tools --lib --tests -- -D warnings`
- [x] `cargo test -p stella-tools` — 701 lib + 46 integration, 0 failed
- [x] `cargo test -p stella-engine -p stella-pipeline` — green (no downstream regression)
- [x] `scripts/check-file-size.sh` — OK, none grew
- [x] Docs updated: the rule and its rationale are doc comments on `unseen_whole_file_rewrite` / `Refusal`

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**One existing test changed behaviour — please look at this first.** `a_windowed_re_read_recovers_a_file_too_big_to_read_whole` asserted that a windowed re-read of a 2,100-line file restored the right to rewrite it *whole*. Under the new rule it does not, and should not: clearing the drift says the bytes have not moved, and says nothing about the 100 lines past the window the agent still has not read. The test now pins **both** refusals (drift first, then coverage) and proves the recovery that file can actually give — a targeted edit. Its original claim, "no deadlock", still holds; the way out is `edit_file` rather than `write_file`.

**Known residual, deliberately left for a separate change.** `record_touch` grades *any* mutation as `Coverage::Whole`, on the reasoning that the agent authored what it wrote. That is true for `write_file` and not quite true for `edit_file`: a partial read followed by a targeted edit upgrades the belief to whole, so a subsequent `write_file` is allowed even though the agent never saw the tail. Tightening it means changing what a mutation's coverage means, which touches drift detection and the "a session never conflicts with itself" property — a second logical change, not this one.

**Scope note.** `web_download` is included with `write_file` because it substitutes a file's entire contents and already shares its classification in `classify_file_op`. `delete_file` is not: deletion is not replacement, and gating it was not part of this change.

`registry.rs` shrinks 2318 → 2308 — the refusal text moved to `belief.rs` next to the rule that decides it — so no `file-size-baseline.txt` change is needed.

## Summary by Sourcery

Guard whole-file write and download operations from overwriting content based on partial file beliefs, and add tests documenting and enforcing the new partial-coverage refusal behavior.

Bug Fixes:
- Prevent whole-file write and web download operations from clobbering unseen file regions when only a partial read was performed in the current session.

Enhancements:
- Introduce a unified mutation-refusal mechanism that prioritizes drift detection and adds coverage-based protection for whole-file replacements.
- Clarify and restructure registry documentation and tests around partial beliefs, drift, and safe editing behavior.

Tests:
- Add a new partial_belief test module covering refusal of blind whole-file overwrites, allowance of targeted edits on partial reads, and upgrade of beliefs after full reads.
- Adjust the large-file re-read test to assert both drift and coverage refusals while confirming targeted edits remain possible.