### PR TITLE
feat(arenabench): fable 5 head-to-head match + OAuth-only seats in CLI mode

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -61,14 +61,15 @@ def _cmd_run(args: argparse.Namespace) -> int:
     missing: list[str] = []
     seated: list = []
     for contestant in spec.contestants:
+        candidates = needed.get(contestant.id, [])
         env = {
-            name: os.environ[name]
-            for name in needed.get(contestant.id, [])
-            if os.environ.get(name)
+            name: os.environ[name] for name in candidates if os.environ.get(name)
         }
-        absent = [n for n in needed.get(contestant.id, []) if n not in env]
-        if absent and not args.allow_missing_env:
-            missing.append(f"{contestant.name}: {', '.join(absent)}")
+        # The candidate names are alternatives, not a conjunction: a seat
+        # carrying any one of them is credentialled (a Claude subscription
+        # token authenticates a seat that has no ANTHROPIC_API_KEY at all).
+        if candidates and not env and not args.allow_missing_env:
+            missing.append(f"{contestant.name}: any of {', '.join(candidates)}")
         seated.append(replace(contestant, env=env))
     if missing:
         print("error: required environment variables are not set:", file=sys.stderr)

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -188,18 +188,30 @@ def load_match(path: Path, *, match_id: str | None = None) -> MatchSpec:
 
 
 def required_env(spec: MatchSpec, declared: dict[str, list[str]] | None = None) -> dict[str, list[str]]:
-    """Environment variables each seat needs, by contestant id.
+    """Environment variable *candidates* each seat accepts, by contestant id.
 
-    Derived from each seat's provider unless the template declared its own
-    list. This is what turns "no secrets in the file" from a restriction into
-    a contract: the template still says exactly what must be supplied.
+    Derived from each seat's provider and agent unless the template declared
+    its own list. The names are alternatives — the same "any one of these"
+    contract as :func:`.agents.missing_credentials` — because an agent that
+    reads its own token variable (or accepts a subscription token) is
+    legitimately credentialled without the provider-named key ever being set.
+    This is what turns "no secrets in the file" from a restriction into a
+    contract: the template still says exactly what must be supplied.
     """
-    from .agents import credential_env_for
+    from .agents import credential_env_for, resolve_agent
 
     out: dict[str, list[str]] = {}
     for contestant in spec.contestants:
         explicit = (declared or {}).get(contestant.id)
-        out[contestant.id] = list(explicit or credential_env_for(contestant.engine.api))
+        if explicit:
+            out[contestant.id] = list(explicit)
+            continue
+        candidates = list(credential_env_for(contestant.engine.api))
+        agent_spec = resolve_agent(contestant.agent)
+        for name in agent_spec.token_env + agent_spec.alt_credential_env:
+            if name not in candidates:
+                candidates.append(name)
+        out[contestant.id] = candidates
     return out
 
 

--- a/arenabench/matches/fable5-claude-code-vs-stella.toml
+++ b/arenabench/matches/fable5-claude-code-vs-stella.toml
@@ -1,0 +1,112 @@
+# arenabench match template
+#
+#   arenabench run matches/fable5-claude-code-vs-stella.toml --progress
+#
+# Claude Code vs Stella, both working on Fable 5 — the variable under test is
+# the agent architecture, not the model. The seats authenticate differently on
+# purpose:
+#
+#   Claude Code  Anthropic first-party, on a Claude subscription
+#                (CLAUDE_CODE_OAUTH_TOKEN — no metered spend at all)
+#   Stella       OpenRouter, metered (OPENROUTER_API_KEY), because Stella's
+#                pipeline makes ~3 calls per step and a subscription's shared
+#                requests-per-minute cap would measure the quota, not the agent
+#                (see the z-ai/glm-5.2 catalog row for the measured version of
+#                this argument).
+#
+# The upstream-routing confound (same model, different provider) documented in
+# openrouter-headhead-routing-confound does not apply in this shape: OpenRouter
+# serves Anthropic models from Anthropic, and the arms are not meant to share a
+# provider here — one is deliberately on the subscription.
+#
+# This file carries no secrets. Export CLAUDE_CODE_OAUTH_TOKEN and
+# OPENROUTER_API_KEY before running.
+
+[match]
+name = "fable 5: claude code vs stella"
+dataset = "terminal-bench-2.1"
+# Six small-to-medium tasks: one easy, five medium (task.toml difficulty is
+# the dataset's own tag; make-mips-interpreter from the GLM panel is tagged
+# hard and is deliberately NOT here). Four carry over from the measured GLM
+# panel so the effort observations below still have evidence behind them.
+tasks = [
+  "fix-git",
+  "regex-log",
+  "sqlite-with-gcov",
+  "large-scale-text-editing",
+  "openssl-selfsigned-cert",
+  "nginx-request-logging",
+]
+attempts = 1
+# 1 per contestant = 2 task containers (~2GB each) + 2 recorders. Colima is
+# 10GB; raising this to 2 needs ~13GB and will thrash.
+concurrency = 1
+record_video = true
+# Claude Code installs itself per trial: apt-get + the claude.ai installer
+# measured at 229s in an emulated amd64 container, against a 360s default.
+setup_timeout_multiplier = 4.0
+
+[[contestant]]
+id = "claude-code"
+name = "Claude Code (Fable 5)"
+agent = "claude-code"
+color = "#FF6B9D"
+
+  [contestant.engine]
+  api = "anthropic"
+  model = "claude-fable-5"
+  reasoning = true
+  # `medium` on both arms, so effort is not a confound. Measured 2026-08-03 on
+  # four of these six tasks: xhigh timed out on every step budget it was
+  # given; medium finished. Fable is slower per token than the model that
+  # produced that measurement — the wrong direction to raise effort in.
+  effort = "medium"
+  # No base_url: this seat runs at Anthropic itself, authenticated by the
+  # subscription token. No budget_usd either — Claude Code does not honour a
+  # spend cap, and on the plan the marginal spend is zero; the plan's own
+  # quota is the ceiling.
+
+  [contestant.env]
+  # Names only — never values. Any ONE of these credentials the seat;
+  # the subscription token is the intended one for this match.
+  required = ["CLAUDE_CODE_OAUTH_TOKEN"]
+
+[[contestant]]
+id = "stella"
+name = "Stella (Fable 5 pipeline)"
+agent = "stella"
+color = "#FFB000"
+
+  [contestant.engine]
+  api = "openrouter"
+  model = "anthropic/claude-fable-5"
+  reasoning = true
+  effort = "medium"
+  # Fable's real output ceiling, same number on both routes (#1211 §6.2).
+  max_tokens = 128000
+  # Per-trial cap (becomes STELLA_BUDGET). Six trials x $16 = $96, inside the
+  # $100-per-agent envelope for the run, with per-trial isolation: one
+  # runaway trial cannot eat the other five tasks' budget.
+  budget_usd = 16.0
+
+  # Per-role overrides — the "full pipeline" arm. Every model named here is in
+  # Stella's OFFLINE seed catalog under `openrouter`: the adapter pins
+  # STELLA_CATALOG_AUTO_REFRESH=0, and a role pinned to an unlisted slug
+  # refuses the run rather than silently falling back.
+    [contestant.engine.roles.verifier]
+    # Cross-lab on purpose: verification independent of the model family being
+    # verified, and of the worker in particular. Kimi K3 is the strongest
+    # non-Anthropic model in the seed catalog on this provider.
+    model = "moonshotai/kimi-k3"
+    effort = "high"
+    reasoning = "on"
+
+    [contestant.engine.roles.triage]
+    # Seeded in the catalog for exactly this seat: cheapest fast family
+    # member, classification only, never touches the workspace.
+    model = "anthropic/claude-haiku-4.5"
+    effort = "low"
+    reasoning = "off"
+
+  [contestant.env]
+  required = ["OPENROUTER_API_KEY"]

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -24,7 +24,7 @@ from arenabench.agents import (
     missing_credentials,
     resolve_agent,
 )
-from arenabench.config import match_from_toml, match_to_toml_dict
+from arenabench.config import match_from_toml, match_to_toml_dict, required_env
 from arenabench.harbor_agent import arena_posture
 from arenabench.model import (
     DIMENSIONS,
@@ -811,6 +811,22 @@ class TestSubscriptionCredential:
             "env": "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-x",
         })
         assert missing_credentials(seat) == []
+
+    def test_required_env_names_the_subscription_alternative(self):
+        """The CLI collects seat env against `required_env`. If that list
+        carries only the provider key, an OAuth-only seat aborts at preflight
+        and the token would never be forwarded — so the agent's own token
+        variables must appear as candidates alongside the provider's."""
+        spec = match_from_toml({
+            "match": {"dataset": "terminal-bench-2.1"},
+            "contestant": [{
+                "agent": "claude-code",
+                "engine": {"api": "anthropic", "model": "claude-fable-5"},
+            }],
+        })
+        candidates = required_env(spec)[spec.contestants[0].id]
+        assert "ANTHROPIC_API_KEY" in candidates
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in candidates
 
     def test_a_subscription_token_is_never_written_to(self, tmp_path: Path):
         """It is not a provider bearer token. Aliasing a provider key into it


### PR DESCRIPTION
## The match

`matches/fable5-claude-code-vs-stella.toml`: Claude Code and Stella both working on **Fable 5**, so the variable under test is the agent architecture, not the model.

- **Claude Code seat**: Anthropic first-party on a Claude subscription (`CLAUDE_CODE_OAUTH_TOKEN`) — no metered spend; the plan's quota is the ceiling.
- **Stella seat**: OpenRouter, metered, full pipeline — `anthropic/claude-fable-5` worker, `moonshotai/kimi-k3` verifier (cross-lab, so verification is independent of the family being verified), `anthropic/claude-haiku-4.5` triage. `budget_usd = 16.0` per trial → 6 × $16 = $96, inside a $100-per-agent envelope with per-trial isolation.
- **Six small-to-medium tasks** (dataset's own difficulty tags: 1 easy + 5 medium): fix-git, regex-log, sqlite-with-gcov, large-scale-text-editing, openssl-selfsigned-cert, nginx-request-logging. Four carry over from the measured GLM panel, so the `effort = "medium"` observations retain their evidence. make-mips-interpreter (tagged **hard**) is deliberately not here.

Every role model is present in the offline seed catalog under `openrouter`; all three answered a 1-token probe on the metered key before this was written.

## The fix it needs

`arenabench run` collected seat credentials against the provider's key name alone (`anthropic` → `ANTHROPIC_API_KEY`), so a seat carrying only `CLAUDE_CODE_OAUTH_TOKEN` aborted at preflight — and had it passed, the token would never have been forwarded into the seat's environment. Meanwhile `missing_credentials` already documents the any-one-of contract, and `AgentSpec.alt_credential_env` exists precisely so a subscription seat counts as credentialled.

- `required_env` now returns the candidate set `missing_credentials` describes: provider keys plus the agent's `token_env`/`alt_credential_env`.
- The CLI treats the list as alternatives, not a conjunction. This also unbreaks Google seats, where `GEMINI_API_KEY` set + `GOOGLE_API_KEY` absent previously aborted the run.

Tested: full `tests/test_arena.py` suite green locally, plus a new test pinning the CLI-facing seam.

## Summary by Sourcery

Allow arena CLI runs to treat multiple credential environment variables per seat as alternatives and add a new Fable 5 Claude Code vs Stella head-to-head match template.

New Features:
- Add a Fable 5 head-to-head match template comparing Claude Code and Stella with explicit task set and engine configuration.

Bug Fixes:
- Ensure seats authenticated only via agent-specific or subscription tokens (e.g. CLAUDE_CODE_OAUTH_TOKEN, GEMINI_API_KEY) are treated as properly credentialled without requiring the provider API key.
- Fix CLI preflight so it no longer aborts OAuth-only or alternative-credential seats when the provider-named key is unset.

Enhancements:
- Extend required_env to surface both provider-level and agent-specific credential environment variable names as valid candidates per seat.
- Improve CLI error messages by indicating that any of a set of candidate environment variables can satisfy seat credentials.

Tests:
- Add a test verifying that required_env includes agent subscription token variables alongside provider keys for CLI collection.