### PR TITLE
docs: restore the old name in the section that exists to record it

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -493,12 +493,12 @@ the parity loop and run at the engine's global 16384.
 
 #### 8.4.4 The verifier rename moved every digest in the table above
 
-The non-worker verification model was called `verifier` in five places and
+The non-worker verification model was called `judge` in five places and
 `witness author` / `test author` / `author` in the rest. It is now `verifier`
 everywhere, and the posture key it is pinned with went with it:
 
-    pipeline_verifier_model  ->  pipeline_verifier_model
-    agents.verifier          ->  agents.verifier
+    pipeline_judge_model  ->  pipeline_verifier_model
+    agents.judge          ->  agents.verifier
 
 **Every digest in 8.4.2 moved, and none of the postures behind them changed.**
 The digest is a hash over the posture dict *including its key names*, so a
@@ -506,22 +506,34 @@ rename with no behavioral content still re-hashes. This is the one case 8.4.3
 was careful to avoid and could not be avoided here: the key name *is* the
 vocabulary being fixed.
 
-| model | published as (`verifier`) | now (`verifier`) |
+Both columns below are keyed by the **exact** model string the posture was built
+from, `openrouter/` prefix and all. The prefix is part of the hashed dict, so
+`z-ai/glm-5.1` and `openrouter/z-ai/glm-5.1` are two different postures with two
+different digests; an abbreviated label here is what let three rows pair a
+prefixed left column with a bare right one.
+
+| model | published as (`judge`) | now (`verifier`) |
 |---|---|---|
-| deepseek-v4-pro | `9d7ad135…` | `0d732c3e…` |
-| z-ai/glm-5.2 | `7e9da633…` | `ce79d6b9…` |
-| x-ai/grok-4.5 | `19c4d345…` | `0a59db13…` |
-| z-ai/glm-5.1 | `8530a36f…` | `9242ff5a…` |
-| anthropic/claude-sonnet-5 | `3c428a22…` | `c8536200…` |
-| anthropic/claude-fable-5 | `5d42e236…` | `642746e4…` |
-| openrouter/anthropic/claude-fable-5 | `18a1ba22…` | `e5059092…` |
+| `openrouter/deepseek/deepseek-v4-pro` | `9d7ad135…` | `0d732c3e…` |
+| `openrouter/z-ai/glm-5.2` | `7e9da633…` | `41f9be3b…` |
+| `openrouter/x-ai/grok-4.5` | `19c4d345…` | `4505a9f8…` |
+| `openrouter/z-ai/glm-5.1` | `8530a36f…` | `8ce2e820…` |
+| `anthropic/claude-sonnet-5` | `3c428a22…` | `c8536200…` |
+| `anthropic/claude-fable-5` | `5d42e236…` | `642746e4…` |
+| `openrouter/anthropic/claude-fable-5` | `18a1ba22…` | `e5059092…` |
+
+Every left-column value reproduces from the pre-rename `_benchmark_engine_posture`
+for the model string on its row, and every right-column value from the current
+one. `bench/terminal-bench-2.1-protocol.md` records the same model strings for
+the first three.
 
 What this does and does not invalidate:
 
 - **No published number is wrong.** Every run recorded under the left column
   ran the posture that column describes. `bench/evidence/` is untouched — the
-  run manifests, per-trial rows, and the `verifier-evidence-demand-1295` record
-  keep their original digests and their original vocabulary.
+  run manifests, per-trial rows, and the `judge-evidence-demand-1295` record
+  keep their original digests and their original vocabulary, which is why that
+  directory name still says `judge`.
 - **What is lost is cross-boundary digest equality.** A post-rename run of an
   arm that is behaviorally identical to a pre-rename one will not produce a
   matching digest, so "same posture as #950" can no longer be shown by

--- a/docs/design/config-system/stella.next.toml
+++ b/docs/design/config-system/stella.next.toml
@@ -132,7 +132,7 @@ track_latest = ["anthropic/claude-opus"]
 # =============================================================================
 # AGENTS  ── RESHAPED (closed set -> open set) + EXTENDED
 # =============================================================================
-# Today the agent set is CLOSED: four struct fields — default, worker, judge,
+# Today the agent set is CLOSED: four struct fields — default, worker, verifier,
 # triage. A misspelled agent key in JSON is silently ignored.
 #
 # Opening it is what makes the `task` tool configurable. That tool exists and
@@ -147,20 +147,20 @@ track_latest = ["anthropic/claude-opus"]
 # The four built-in names keep their meaning and stay reserved.
 
 [agents]
-default_model         = "anthropic/claude-fable-5"
-pipeline_worker_model = "zai/glm-5.2"
-pipeline_judge_model  = "anthropic/claude-opus-5"
-pipeline_triage_model = "deepseek/deepseek-chat"
-auto_mode             = "off"
-effort_auto           = "on"
-reasoning_auto        = "on"
-headless_scope_bypass = "off"
-hunk_review           = "off"
+default_model           = "anthropic/claude-fable-5"
+pipeline_worker_model   = "zai/glm-5.2"
+pipeline_verifier_model = "anthropic/claude-opus-5"
+pipeline_triage_model   = "deepseek/deepseek-chat"
+auto_mode               = "off"
+effort_auto             = "on"
+reasoning_auto          = "on"
+headless_scope_bypass   = "off"
+hunk_review             = "off"
 # `allowed_models` MOVED to [models].allowed. §6.1 migrates it and warns on
 # the old location for one release.
 
 # ── EXTENDED: a built-in agent gains provider fallback and a tool scope ──
-[agents.judge]
+[agents.verifier]
 model  = "anthropic/claude-opus-5"
 effort = "high"
 
@@ -179,7 +179,8 @@ provider_preference = ["anthropic", "openrouter"]
 on_exhausted        = "fail"   # fail | degrade  (degrade = fall back to the
                                # default agent's model rather than ending the
                                # turn; opt-in, because a silent capability
-                               # drop in a judge is worse than a clean failure)
+                               # drop in a verifier is worse than a clean
+                               # failure)
 
 # NEW — per-agent tool scope. Uses the EXACT SAME grammar as the root
 # [tools] block (name > group > "*"), because a second tool-permission
@@ -188,7 +189,7 @@ on_exhausted        = "fail"   # fail | degrade  (degrade = fall back to the
 # Composition: root [tools] is the workspace floor, this narrows it further,
 # and the managed authority ceiling clamps both. An agent can never GRANT a
 # tool the root block or the ceiling denied — narrowing only.
-[agents.judge.tools]
+[agents.verifier.tools]
 "*"       = "off"
 read_file = "on"
 grep      = "on"
@@ -219,9 +220,9 @@ prompt_file = ".stella/prompts/security-reviewer.md"
 # PIPELINE  ── NEW
 # =============================================================================
 # Today the staged pipeline (triage -> plan -> witness -> execute -> verify ->
-# judge) is hard-coded in `stella-pipeline`, and the only control is
+# verdict) is hard-coded in `stella-pipeline`, and the only control is
 # `--no-pipeline`, which turns the entire thing off and drops to the raw
-# step-loop. There is no way to say "skip the judge" or "allow three revision
+# step-loop. There is no way to say "skip the verdict" or "allow three revision
 # rounds".
 #
 # ONE `enabled` FLAG, NOT TWO. The original example had `[agents.*].enabled`
@@ -231,8 +232,12 @@ prompt_file = ".stella/prompts/security-reviewer.md"
 
 # NOTE — the six stages below are the READABLE subset, not the vocabulary.
 # `StageKind` (stella-protocol/src/event.rs) has eleven variants: Triage,
-# ContextRecall, Plan, ScopeReview, Witness, Execute, Verify, Judge, Reflect,
+# ContextRecall, Plan, ScopeReview, Witness, Execute, Verify, Verdict, Reflect,
 # ContextWrite, Complete. The real block is built against the enum.
+#
+# `Verdict` is the stage; `verifier` is the model that runs it. The stage is
+# named for its output precisely because `verify` (deterministic proof) and
+# `verifier` (a model's opinion) as adjacent stage names hid which was which.
 #
 # Three are deliberately NOT configurable here, because each already has an
 # owner and a second switch is how these blocks rot — see DESIGN.md §4.5:
@@ -249,8 +254,9 @@ enabled   = true
 #   skip  — go straight to the next enabled stage
 #   fail  — refuse to run a pipeline that is missing this stage
 on_disable = "skip"
-# `triage_route` mode only: where this stage may dispatch.
-routes_to  = ["worker", "judge"]
+# `triage_route` mode only: which AGENTS this stage may dispatch to (names from
+# [agents], not stage names).
+routes_to  = ["worker", "verifier"]
 
 [pipeline.stages.plan]
 enabled    = true
@@ -269,10 +275,10 @@ on_disable = "fail"
 enabled    = true
 on_disable = "skip"
 
-[pipeline.stages.judge]
+[pipeline.stages.verdict]
 enabled    = true
 on_disable = "skip"     # worker output is returned unreviewed
-# How many times the judge may bounce work back to the worker.
+# How many times the verifier may bounce work back to the worker.
 max_revisions = 2
 
 

--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -301,7 +301,8 @@ to fire under a single-model posture, the condition held on nearly every turn
 and the extra turn bought nothing on all of them. Capped at one ask per
 candidate and drawn from the same `max_revisions` budget a real failure spends.
 The measurement that switched it back on is in
-`bench/evidence/verifier-evidence-demand-1295/`.
+`bench/evidence/judge-evidence-demand-1295/` — the directory keeps the old word
+because `bench/evidence/` is frozen at the vocabulary each run was recorded in.
 
 ## 11. Revise: bounded retries with escalating candor
 


### PR DESCRIPTION
## What & why

Follow-up to #1417. That PR unbroke the build; this one fixes the *record* — three
places where the `judge` → `verifier` rename (#1394) swept text whose whole job was
to preserve the old word.

### 1. §8.4.4 could no longer say what the old name was

`bench/READINESS.md` §8.4.4 exists to map each posture digest from its published
value to its post-rename one. The rename rewrote its historical column too, so it
read:

```
pipeline_verifier_model  ->  pipeline_verifier_model
agents.verifier          ->  agents.verifier
```

under a header of `| published as (verifier) | now (verifier) |`. Both sides the
same word. #1394's own PR description has it right (`judge`), so this was the
document losing the one fact it was written to carry.

### 2. Three of its seven rows paired two unrelated hashes

The digest hashes the model string, so `z-ai/glm-5.1` and `openrouter/z-ai/glm-5.1`
are **different postures with different digests**. The rows abbreviated the label —
and under that abbreviation the "published as" column had been computed from the
prefixed string while "now" was computed from the bare one:

| row | now (registered) | now (actual) |
|---|---|---|
| `openrouter/z-ai/glm-5.2` | `ce79d6b9…` | **`41f9be3b…`** |
| `openrouter/x-ai/grok-4.5` | `0a59db13…` | **`4505a9f8…`** |
| `openrouter/z-ai/glm-5.1` | `9242ff5a…` | **`8ce2e820…`** |

Following those rows to find a published run's current digest gave the wrong
answer. `deepseek-v4-pro` and the three `anthropic/*` rows were already correct.

Every row now carries the **exact** model string, and every cell was recomputed:
the left column against the merge-base `_benchmark_engine_posture`, the right
against the current one. `bench/terminal-bench-2.1-protocol.md` independently
records the same model strings for the first three, which is what settled which
string each row meant.

The `openrouter/z-ai/glm-5.1` row is the one #1417 already ran into — its `8ce2e820`
is the value that PR restored in `test_tb21_analysis.py`.

### 3. Two references pointed at a directory that does not exist

`bench/READINESS.md` and `docs/design/pipeline-journey.md` both cited
`bench/evidence/verifier-evidence-demand-1295/`. The directory is
`judge-evidence-demand-1295` and **stays that way** — `bench/evidence/` is frozen
at the vocabulary each run was recorded in. Both now say so rather than silently
pointing at nothing.

### 4. `stella.next.toml` described its own design in the old vocabulary

It still had `pipeline_judge_model`, `[agents.judge]`, `[agents.judge.tools]`,
`routes_to = ["worker", "judge"]` and `[pipeline.stages.judge]`. Renaming only the
key I originally flagged would have left one document contradicting itself, so the
whole file moved together:

- **agents** are `verifier` (`[agents.verifier]`, `routes_to = [..., "verifier"]`)
- **the stage** is `verdict` — the name on the wire, per `StageKind` and
  `docs/wire/agentevent.schema.json`
- a note records why those two differ, since `verify` / `verifier` adjacency is the
  exact confusion #1394 set out to remove

## The witness

- [x] No witness needed (docs) — because every factual claim is machine-checked
      instead:

Rather than eyeball the table, I parsed §8.4.4 out of the file and recomputed all
14 cells from the two versions of the posture builder:

```
openrouter/deepseek/deepseek-v4-pro   published=9d7ad135 ok   now=0d732c3e ok
openrouter/z-ai/glm-5.2               published=7e9da633 ok   now=41f9be3b ok
openrouter/x-ai/grok-4.5              published=19c4d345 ok   now=4505a9f8 ok
openrouter/z-ai/glm-5.1               published=8530a36f ok   now=8ce2e820 ok
anthropic/claude-sonnet-5             published=3c428a22 ok   now=c8536200 ok
anthropic/claude-fable-5              published=5d42e236 ok   now=642746e4 ok
openrouter/anthropic/claude-fable-5   published=18a1ba22 ok   now=e5059092 ok

7 rows, 0 wrong
```

`stella.next.toml` was checked by parsing it: `agents.verifier` exists,
`pipeline.stages.verdict` exists, and `routes_to` names an agent that is actually
defined. The cited evidence directory was checked to exist on disk.

## The gate

- [x] All eleven `GATE_GUARDS_FAST` scripts — exit 0 (`doc-links` and `invariants`
      are the ones with teeth here; both resolve every citation)
- [x] No Rust or Python source changed — docs, one design TOML, one markdown record

## Anything reviewers should know?

**Nothing under `bench/evidence/` is touched, and no published number changes
meaning.** A run recorded under `8530a36f` ran the posture that digest describes;
what this PR fixes is the table that tells you which digest describes it *now*.

The `deepseek-v4-pro` row was fine all along — my first pass reported it as
unmatched because I had not tried `openrouter/deepseek/deepseek-v4-pro`, which
`bench/terminal-bench-2.1-protocol.md` names. Correcting that here so the count is
three rows, not four.

## Summary by Sourcery

Clarify and align documentation and design config around the judge→verifier rename and the verdict stage naming, and correct the posture digest mapping table and evidence references.

Documentation:
- Update stella.next.toml design config doc to use verifier agents and a verdict stage name consistent with the wire protocol, documenting the distinction between stage and agent names.
- Fix bench/READINESS.md posture digest table to use exact model strings and correct digests, and restore the historical judge→verifier mapping it exists to record.
- Correct evidence path references in bench/READINESS.md and docs/design/pipeline-journey.md to point to the frozen judge-evidence directory and explain why its name is unchanged.