### PR TITLE
fix(arenabench): two ways a contestant was scored for something it did not do

### DIFF
--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -114,6 +114,14 @@ INFRASTRUCTURE_FAILURES: frozenset[str] = frozenset(
         "AuthenticationError",
         "OAuthCallbackError",
         "RefreshTokenExpiredError",
+        # The run was killed out from under the agent. Distinct from
+        # `AgentTimeoutError`, where the agent had its full budget and spent
+        # it: here the clock was stopped early by something outside the
+        # contest, so the trial has no result to report in either direction.
+        # Observed for real — an operator restarted the match server and every
+        # in-flight trial landed as a loss against a contestant that was still
+        # working, which is the exact mis-scoring this set exists to prevent.
+        "CancelledError",
         # The verifier broke, so no verdict exists to record either way.
         "VerifierTimeoutError",
         "VerifierOutputParseError",

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -926,6 +926,26 @@ class TestInfrastructureFailuresAreNotLosses:
         m = self._trial(tmp_path, "VerifierTimeoutError")
         assert m.infrastructure is True and m.resolved is None
 
+    def test_a_trial_killed_by_the_host_is_not_a_loss(self, tmp_path: Path):
+        """Restarting the match server cancels every in-flight trial. Those
+        agents were mid-task and on course — one of them had already made the
+        verifier pass — so scoring the cancellation 0 marks a contestant down
+        for something the operator did. Unlike `AgentTimeoutError`, the agent
+        never got the budget it was promised."""
+        m = self._trial(tmp_path, "CancelledError")
+        assert m.infrastructure is True
+        assert m.resolved is None, "unjudged, not lost"
+
+    def test_a_cancelled_trial_does_not_dilute_the_solve_rate(self, tmp_path: Path):
+        """The bug this pins: two arms each solved every task they were
+        allowed to finish, and both boards read 75% because the host killed
+        the fourth."""
+        solved = [
+            TrialMetrics(task=f"t{i}", trial=f"t{i}", resolved=True) for i in range(3)
+        ]
+        killed = self._trial(tmp_path, "CancelledError")
+        assert aggregate([*solved, killed])["solve_rate"] == 100.0
+
     def test_infrastructure_trials_leave_the_solve_rate_alone(self, tmp_path: Path):
         """Eight of ten never started; the arm won both it actually ran. The
         rate must say 100% of 2 judged, and the count of the missing eight must


### PR DESCRIPTION
Two mis-scorings found while running a live GLM-5.2 head-to-head (Claude Code
vs Stella, same worker model, one provider). Both make a contestant look beaten
when it was never given a fair attempt, and neither announced itself.

## 1. A host-killed trial is not a loss

`CancelledError` was missing from `INFRASTRUCTURE_FAILURES`, so a trial killed
out from under the agent scored **0** instead of being left unjudged.

The match server was restarted mid-run and Harbor cancelled the in-flight trial
on **both** arms. Each arm had solved every task it was allowed to finish, and
both boards read **75%**.

The set already draws this line; this is a case it missed:

| exception | attribution | reason |
|---|---|---|
| `AgentTimeoutError` | agent failure | it had its full budget and spent it |
| `NonZeroAgentExitCodeError` | agent failure | it ran and quit |
| `CancelledError` | **infrastructure** | the clock was stopped from outside the contest |

Same symptom (no verdict), opposite attribution.

## 2. A seat that never started is not a seat that lost

A contestant whose Harbor dies during startup writes no trials, which the
scoreboard renders identically to one that attempted everything and won
nothing. Nothing in the run reported the difference.

Hit for real: the Stella seat needs both its own adapter and the `stella_harbor`
base it subclasses on `PYTHONPATH`. Launched without `ARENABENCH_STELLA_ADAPTER`,
Harbor raised `ModuleNotFoundError` and exited in seconds with an empty job log,
while the opposing seat ran the full task list. That would have published a 0%
arm as a result.

A non-zero exit *after* trials exist stays ordinary and keeps its results —
Stella returns 1 on a failed verification, and blanking the seat there would
discard real work.

## Tests

90 → 94, additive. Covers both classifications, the aggregate behaviour that
actually bit (3 solved + 1 cancelled must read 100%, not 75%), and that the
cause travels with the verdict so the fix is diagnosable from the board.