### PR TITLE
docs: repair gate/CI drift, add missing crate READMEs, add CLAUDE.md + the nothing-left-behind rule

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,7 +30,7 @@
 #
 # WHAT IT COSTS
 #
-# `make gate` compiles, documents and tests all 21 workspace members. Running
+# `make gate` compiles, documents and tests all 22 workspace members. Running
 # that unconditionally meant a test-only change confined to one crate paid the
 # full workspace, twice, once per push (observed on #911: the push blew a
 # two-minute timeout and had to be re-run detached). So the compile tiers —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,17 +58,19 @@ A red gate is an automatic "not yet":
 
 ```bash
 make gate                # = no-scratch + action-pins + cargo-install-pins
-                         #   + license-allowlist-parity + shellcheck
-                         #   + invariants + doc-links + file-size
-                         #   + wire-schema + rustdoc -D warnings + fmt --check
+                         #   + license-allowlist-parity + repro-wiring
+                         #   + shellcheck + invariants + doc-links
+                         #   + command-docs + file-size + wire-schema
+                         #   + rustdoc -D warnings + fmt --check
                          #   + clippy -D warnings + test --workspace
 ```
 
-CI enforces the same thirteen steps split across two workflows:
+CI enforces the same fifteen steps split across two workflows:
 `/.github/workflows/ci.yml`'s required job runs everything except `invariants`
-and `doc-links`, and adds a release smoke build (thin LTO); `docs-guards.yml`
-runs those two, because they trigger on the `docs/**` and `*.md` paths `ci.yml`
-ignores.
+and `doc-links`, and adds a `Cargo.lock` sync check, the prompt-cache golden
+fixtures, `stella context validate`, and a release smoke build (thin LTO);
+`docs-guards.yml` runs those two plus a second run of `command-docs`, because
+all three trigger on the `docs/**` and `*.md` paths `ci.yml` ignores.
 
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
@@ -88,7 +90,7 @@ Three rungs, each a superset of the one above:
 
 | Target | Runs | Honours `CARGO_SCOPE` |
 | --- | --- | --- |
-| `make guards` | global guards + `fmt --check` — nothing compiles | — |
+| `make guards` | every global guard + `fmt --check` — nothing compiles beyond `wire-schema`'s two exporters | — |
 | `make check` | ...plus clippy | clippy |
 | `make gate` | ...plus rustdoc and the test suite | clippy, rustdoc, test |
 
@@ -278,6 +280,34 @@ loop, and the `/pipeline` deck toggle.
 
 ---
 
+## Nothing left behind — every finding becomes a fix or a GitHub issue
+
+The standing rule for every session, human or agent, and the companion to the
+witness-test contract above: work is not finished while anything you noticed
+lives only in your head, a chat transcript, or a worktree that is about to be
+deleted.
+
+- **Fix what you can inside the change you are already making.** A bug you can
+  fix safely within your current scope gets fixed, not filed.
+- **Everything else becomes a GitHub issue before you finish** — a bug you saw
+  and did not fix, a defect you worked around, a missing test, an idea worth
+  keeping, dead or unwired code you noticed, and the logical next step of the
+  work you just completed. If your change ships scaffolding that something else
+  must later wire up, file the issue for that wiring in the same breath as the
+  PR — unwired code with no tracking issue is exactly the failure mode this
+  rule exists to prevent.
+- **Write every issue as a handoff.** Assume the reader is a fresh agent with
+  none of your session's context: state the problem, the files involved (paths,
+  not descriptions), how to reproduce or verify, the constraints you already
+  discovered (gates, invariants, related PRs and issues), and what "done" looks
+  like. A one-line issue that needs your memory to interpret is a note to
+  yourself, not a handoff.
+- **Search before filing** (`gh issue list`, `gh search issues`) and link
+  related issues instead of duplicating them. Reference the issues you filed
+  from your PR description so the residue of the work is auditable.
+
+---
+
 ## Workspace layout — where a change goes
 
 Twenty crates, every one under the `crates/` directory (`crates/stella-core`,
@@ -420,7 +450,7 @@ the identity that scopes it.
 
 ## Glossary — the identifiers that look alike
 
-Five different ids in this workspace can all be read as "one thing the agent
+Six different ids in this workspace can all be read as "one thing the agent
 did", and they are genuinely distinct entities owned by different crates. The
 join keys are correct today (`crates/stella-observatory/src/db.rs` joins both
 `execution_id` and `run_id`), so this is a naming hazard, not a bug — but read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+## Hard rules for every session
+
+- **AGENTS.md is the orientation document.** Commands, architectural
+  invariants, workspace routing, testing approach, and gotchas all live there
+  (imported above). When this file and AGENTS.md disagree, AGENTS.md wins —
+  and the disagreement is itself a bug: fix it in the same PR you noticed it.
+- **Nothing left behind.** Every bug, defect, idea, missing test, piece of
+  unwired code, or logical next step you notice and do not fix inside your
+  current change MUST be filed as a GitHub issue before you finish — written
+  as a handoff a fresh agent could execute without your session's context
+  (problem, file paths, repro/verify steps, constraints, definition of done).
+  Search for an existing issue first; link, don't duplicate. The full policy
+  is AGENTS.md § "Nothing left behind — every finding becomes a fix or a
+  GitHub issue". Never end a turn with untracked half-finished work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,20 +69,27 @@ A red gate is an automatic "not yet":
 ```bash
 ./scripts/check-no-scratch.sh
 ./scripts/check-action-pins.sh
+./scripts/check-cargo-install-pins.sh
+./scripts/check-license-allowlist-parity.sh
+./scripts/check-repro-wiring.sh
+shellcheck install.sh scripts/*.sh .githooks/*
 ./scripts/check-invariants.sh
 python3 ./scripts/check-doc-links.py check
+./scripts/check-command-docs.sh
 ./scripts/check-file-size.sh
+./scripts/check-wire-schema.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the nine of them in order.
+Or just `make gate`, which is the fifteen of them in order.
 
 CI enforces the same steps, split across `ci.yml` (plus a release smoke build)
-and `docs-guards.yml`, which runs the two prose guards on their own because they
-trigger on the `docs/**` and `*.md` paths that `ci.yml` deliberately ignores.
+and `docs-guards.yml`, which runs the prose guards — `invariants`, `doc-links`,
+and `command-docs` — on their own because they trigger on the `docs/**` and
+`*.md` paths that `ci.yml` deliberately ignores.
 
 **Cite a document by its id, not its path.** `doc:context-reuse §4` resolves no
 matter where the file moves; a document with no frontmatter `id` is not citable

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ CARGO_SCOPE ?= --workspace
 # The guard tiers, named so the gate, the fast check and the hook can compose
 # them instead of restating the list three times and drifting apart.
 # GATE_GUARDS_FAST needs no toolchain at all (shell scripts over the tree);
-# wire-schema is separated out because it runs the two schema exporters, which
-# is a cargo build.
+# wire-schema joins in GATE_GUARDS because it runs the two schema exporters,
+# which is a cargo build. Every rung below runs the full GATE_GUARDS — `check`
+# compiles the workspace for clippy anyway, so excluding wire-schema there
+# saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch action-pins cargo-install-pins license-allowlist-parity \
                     repro-wiring shellcheck invariants doc-links command-docs file-size
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
@@ -209,18 +211,19 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 # The three tiers of the gate, from cheapest to dearest. Each is a superset of
 # the one above it, and only the compile tiers honour CARGO_SCOPE.
 #
-#   guards  every global guard + rustfmt. No crate compiles, so nothing to scope.
+#   guards  every global guard + rustfmt. Only wire-schema's two schema
+#           exporters compile, so there is still nothing to scope.
 #   check   ...plus clippy. The graduated fallback: a reduced gate, not no gate.
 #   gate    ...plus rustdoc and the test suite. What CI runs, unscoped.
 
 .PHONY: guards
-guards: $(GATE_GUARDS) format-check ## Global guards + fmt only (no crate compiles; nothing to scope)
+guards: $(GATE_GUARDS) format-check ## Global guards + fmt only (nothing compiles beyond the wire-schema exporters; nothing to scope)
 
 .PHONY: gate
 gate: $(GATE_GUARDS) doc-warnings format-check lint test ## Full CI gate: guards + rustdoc + fmt-check + clippy + test
 
 .PHONY: check
-check: $(GATE_GUARDS_FAST) format-check lint ## Fast pre-push check: toolchain-free guards + fmt + clippy, no rustdoc and no tests
+check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests
 
 .PHONY: impacted
 impacted: ## Print the cargo scope for a diff (RANGE=origin/main..HEAD)

--- a/crates/stella-engine/README.md
+++ b/crates/stella-engine/README.md
@@ -1,0 +1,70 @@
+# stella-engine
+
+The **step-scoped facade** over [`stella-core`](../stella-core)'s turn loop
+(#971). [`Engine::run_turn`] drives a whole turn and returns when it is over —
+the right shape for a CLI and the wrong one for a durable host, which has to
+persist progress between steps, stop a turn on a deadline or a shutdown, and
+resume it in a different process. This crate exposes the same engine one step
+at a time: `Engine::run_step` advances exactly one committed step,
+`TurnState` owns what the step loop mutates, and `Checkpoint` round-trips that
+state through serde so a host can pause, cancel and resume between steps.
+
+Nothing here re-implements the loop. `run_turn` is itself a loop over
+`run_step`, so a host driving steps and a CLI driving turns run the identical
+per-step code and emit the identical per-step `AgentEvent` sequence. What
+`run_turn` adds is turn *framing* the host owns for itself in step mode: the
+`Stage(Execute)` event before the first step, the step-cap gate, and — on that
+exit — a non-retryable `Error` carrying `step_cap_reason`.
+
+Consumed by [`stella-serve`](../stella-serve) and external hosts.
+`stella-cli` deliberately does **not** link it — the CLI drives turns through
+`stella-core` directly.
+
+## Boundary — does this change belong here?
+
+Almost nothing belongs here. This crate **re-exports and documents**; the step
+loop, the checkpoint type, and every behavior it fronts live in
+`stella-core` (`src/step.rs`, `src/driver.rs`), and a change to how a step
+runs is a `stella-core` change. The only code that lives here is the thin
+`encode_checkpoint` / `decode_checkpoint` pair — conveniences a host can hand
+to a storage boundary — and the facade's own tests, which pin the re-exported
+surface and the checkpoint round-trip so a `stella-core` refactor cannot
+silently change what hosts see.
+
+A new re-export is legitimate when a host genuinely cannot drive a turn
+without it, and it arrives with doc prose explaining its place in the
+host-driving story. Anything with logic, I/O, or state is wrong here by
+construction: the crate inherits `stella-core`'s I/O-free posture (its tokio
+dependency is `sync`-only, deliberately) and `#![forbid(unsafe_code)]`.
+
+Two contracts every consumer must know, documented at length in `src/lib.rs`:
+
+- **Cancel, do not drop.** `CancelToken` is read at the top of every step, so
+  the in-flight step finishes and commits first. Dropping the turn future
+  stops it immediately, and the cost is an unpaired `tool_use` in the borrowed
+  history, a billed-but-lost model call, and everything since the last
+  checkpoint.
+- **The turn future is `!Send`.** Neither `run_step` nor `run_turn` can be
+  `tokio::spawn`ed onto a multi-thread runtime; drive them on a
+  current-thread runtime, one OS thread per session (the pattern
+  `stella-cli`'s fleet worker uses).
+
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
+## Testing
+
+`src/tests.rs` exercises the facade the way a host would: driving a turn to
+done step by step, proving `run_turn` emits the identical event sequence to a
+hand-driven step loop, resuming from a checkpoint and getting the same
+downstream events, cancelling mid-turn at a safe boundary with a valid
+transcript, cancelling before the first step for free, and round-tripping a
+between-steps checkpoint through `encode_checkpoint`/`decode_checkpoint`. The
+deeper step-loop properties (loop detection, budget, retry) and the
+`CHECKPOINT_VERSION` refusal are `stella-core`'s tests
+(`crates/stella-core/src/step.rs`); do not duplicate them here.

--- a/crates/stella-parity/README.md
+++ b/crates/stella-parity/README.md
@@ -1,0 +1,64 @@
+# stella-parity
+
+The **cross-surface capability matrix** — the structural guard against a
+feature shipping on one of Stella's surfaces and silently not the other.
+Stella is one engine behind two customer-facing surfaces: the CLI
+(`stella-cli`, the community tool) and the API (`stella-serve`, the embeddable
+sidecar). Nothing used to enforce that a capability landing on one surface
+landed on — or was *deliberately declared absent from* — the other, and the
+two drifted exactly the way per-provider features drifted before
+`stella-model/src/provider_parity.rs`: when this matrix was written, the API
+could set precisely one of `EngineConfig`'s ~15 tuning knobs, the goal loop
+and sub-agents were CLI-only, and the serve crate's own route tests covered 7
+of its 14 routes.
+
+The matrix makes that class of gap structural instead of tribal, with the same
+three instruments the provider matrix proved out:
+
+- **A declared row per capability**, with a `SurfacePosture` on every surface.
+  An absence is legal only as `Deferred` (naming what it waits on) or
+  `NotApplicable` (naming the design reason) — never as silence.
+- **Witness tests named and checked.** A `Shipped` posture names the test that
+  proves the wiring on that surface, and this crate's tests fail when the
+  named function no longer exists in the surface's sources.
+  `ShippedUnwitnessed` counts the debt instead of hiding it, bounded by
+  `UNWITNESSED_BASELINE` — a ratchet that only goes down.
+- **Completeness enforced from both ends.** Every real API route
+  (`stella_serve::observe::Route::ALL`) must be claimed by a row, and every
+  public `Engine` entry point in `stella-core`'s driver/goal modules must be
+  claimed by a row or by the `COMPOSITION_SEAMS` allowlist — so adding a route
+  or an engine capability without a matrix decision fails
+  `cargo test --workspace`, in the same PR that added it.
+
+**The law for new features:** adding an engine capability, an API route, or an
+agent-facing CLI behavior means updating this matrix in the same PR.
+`Deferred` is an honest and expected answer — the point is that a human wrote
+the answer down where a test can keep it true, not that every feature ships
+everywhere at once. The embedding story the matrix serves is
+[`docs/design/engine-embedding.md`](../../docs/design/engine-embedding.md).
+
+## Boundary — does this change belong here?
+
+One file, one job: `src/lib.rs` holds the posture types, the matrix rows, and
+the tests (inline `mod tests`) that keep the rows honest. A change belongs
+here when it is a matrix decision — a new row, a posture change, a witness
+name, a composition-seam entry, lowering `UNWITNESSED_BASELINE` after writing
+a missing witness. The capability *itself* never lives here: its engine home
+is `stella-core`, its surfaces are `stella-cli` and `stella-serve`, and this
+crate only records how they relate.
+
+The dependency set is the boundary made concrete: `stella-serve` only, for
+`Route::ALL` — the enumerable API surface the matrix sweeps. The CLI is a
+binary crate, so its surface is checked against source text, the same
+discipline `provider_parity.rs` uses for adapter witnesses. Adding any other
+dependency here is a design smell: the matrix reads declarations and source
+text, it does not run the stack.
+
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. `src/lib.rs` grows a few lines per matrix row, which
+is sustainable; if it ever approaches the limit, split the rows from the
+types before it crosses.

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -1,0 +1,63 @@
+# stella-runtime
+
+**The construction sequence, once.** `RuntimeSpec` → `RuntimeBuilder` →
+`SessionRuntime`: the engine-assembly bottom half — provider adapter, tool
+registry, store, calibration, budget — built from explicit inputs into one
+value any surface can drive: the CLI, the serve sidecar, or a test.
+
+The crate exists because `stella-cli` is a bin-only crate — no `[lib]` target —
+so nothing inside it is callable from anywhere else. That one manifest fact is
+why the same engine setup got re-typed at seven call sites (`agent.rs` twice,
+`agent/goal.rs` twice, `command_deck.rs`, `fleet_cmd.rs`, `subsession.rs`):
+there was no shared home for it, and each new driver copied the nearest
+existing one. A fix to the ordering had to be applied seven times, and had
+been missed before — and `stella-serve` cannot link a binary at all. This
+crate is that shared home.
+
+## Boundary — does this change belong here?
+
+The line `SessionRuntime` draws (`src/session.rs` states it in full): **below
+it sit the resources**, which are pure functions of a `RuntimeSpec` and
+identical whether a TUI, an SSE stream, or a test harness is driving. **Above
+it sit the ports** — the approval gate is a terminal prompt in one host and a
+reverse HTTP request in another; the event sink is a renderer thread in one
+and an SSE pump in the other. Only the bottom half lives here; the top half
+stays in each surface crate and can differ per surface without this crate
+knowing.
+
+So: a change to *how a resource is constructed* (provider from parts, registry
+rooting, store opening, calibration seeding, budget mode) belongs here, in
+`src/parts.rs`, surfaced as a `Notice` when it degrades rather than fails. A
+change to *what the engine does* with those resources belongs in
+[`stella-core`](../stella-core). A change to *how a host presents or approves
+things* belongs in that host's crate. Construction only — no decision logic,
+no rendering, no routes.
+
+## The invariant: no ambient reads
+
+**Nothing in this crate reads the process environment or the current
+directory.** Every ambient switch the CLI consults — `STELLA_NO_SETTINGS`, the
+enterprise process-free authority flag, `HOME` — is a field on `RuntimeSpec`
+instead, filled in by the caller. That is what makes N concurrent sessions
+with N different workspace roots and N different trust postures sound in one
+process — the thing a server needs and a CLI never did. The rule is enforced
+executably by `tests/no_ambient_reads.rs`, not just asserted; extending this
+crate means keeping that test green without an allowlist entry.
+
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
+## Layout
+
+| File | Owns |
+|---|---|
+| `src/spec.rs` | The inputs, as **values**: `RuntimeSpec`, `ProviderParts`, `Persistence`, `Notice`. Every field is something the CLI used to read ambiently. |
+| `src/parts.rs` | The individual construction steps: `build_provider`, `tool_registry`, `open_store`, `seed_calibration`, `budget_guard`. |
+| `src/session.rs` | The composite: `RuntimeBuilder` assembling a `SessionRuntime`. Overridable per-step as hosts diverge (today: `with_provider`). |
+| `src/error.rs` | `RuntimeError` — typed construction failures. Degradations are `Notice`s on the built runtime instead, per the warn-never-disable posture. |
+| `tests/no_ambient_reads.rs` | The executable form of the invariant above. |

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
     "@types/node": "25.9.1",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3"
   }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: '>=8.5.18'
+  postcss: '>=8.5.23'
   sharp: '>=0.35.0'
 
 importers:
@@ -59,7 +59,7 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
       postcss:
-        specifier: 8.5.23
+        specifier: '>=8.5.23'
         version: 8.5.23
       tailwindcss:
         specifier: 4.3.0

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
       postcss:
-        specifier: '>=8.5.18'
+        specifier: 8.5.23
         version: 8.5.23
       tailwindcss:
         specifier: 4.3.0
@@ -1705,8 +1705,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3737,7 +3737,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -3797,7 +3797,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -34,10 +34,14 @@ minimumReleaseAgeExclude:
   - baseline-browser-mapping
 
 # Next 16.2.11 pulls in postcss@8.4.31 (path traversal + XSS, patched at
-# 8.5.10/8.5.18) and sharp@0.34.5 (patched at 0.35.0) through its own
-# dependency tree — not through anything this package depends on directly, so
-# there's no version bump here that fixes it. `pnpm audit` clears once these
-# are forced across every resolution.
+# 8.5.10/8.5.18; GHSA-fxqj-rqcc-2cmp then found the sourceMappingURL fix
+# incomplete, re-patched at 8.5.23) and sharp@0.34.5 (patched at 0.35.0)
+# through its own dependency tree — not through anything this package depends
+# on directly, so there's no version bump here that fixes it. `pnpm audit`
+# clears once these are forced across every resolution. NOTE: with an override
+# in force, `pnpm install --frozen-lockfile` (docs.yml) checks the importer
+# specifiers against the override-applied range — keep this floor and the
+# direct `postcss` devDependency in `package.json` moving together.
 overrides:
-  postcss: ">=8.5.18"
+  postcss: ">=8.5.23"
   sharp: ">=0.35.0"


### PR DESCRIPTION
## What & why

A consistency sweep of the agent-facing docs, fixing every drifted claim found by checking them against the tree, plus two small real fixes the sweep surfaced:

- **AGENTS.md**: the gate list omitted `repro-wiring` and `command-docs` and said "thirteen steps" (it is fifteen); the CI-split sentence missed that `docs-guards.yml` also runs `command-docs` and that `ci.yml` adds lock-sync / cache-correctness / `context validate` steps; the rung table claimed `make guards` compiles nothing (wire-schema builds the two exporters); the glossary said five look-alike ids where its table lists six.
- **CONTRIBUTING.md**: the hand-copied gate list had nine of fifteen commands.
- **Makefile + .githooks/pre-push**: `make check` composed `GATE_GUARDS_FAST` and silently dropped `wire-schema`, breaking the documented "each rung is a superset" contract and leaving `GATE=fast` pushes able to land stale generated wire artifacts (the #1185 shape, one rung down). `check` now runs the full guard set — it already compiles the workspace for clippy, so the exclusion saved nothing. Hook's stale "21 workspace members" → 22.
- **Three missing crate READMEs**: `stella-engine`, `stella-runtime`, `stella-parity` shipped without the per-crate README AGENTS.md links to and routes planning through. Added in the sibling pattern (identity, boundary, god-file ratchet, testing), written from their sources.
- **CLAUDE.md** (new, imports AGENTS.md) and a new AGENTS.md section, **"Nothing left behind — every finding becomes a fix or a GitHub issue"**: anything noticed and not fixed in the current change must be filed as a handoff-quality GitHub issue before finishing.
- **website**: postcss 8.5.18 → 8.5.23 (Dependabot alert 29, GHSA-fxqj-rqcc-2cmp, medium). No vulnerable copy remains in the lockfile; `pnpm run build` passes.

Unfixed findings from the same sweep were filed per the new rule: Refs #1435, #1436, #1437, #1438, #1439, #1440.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: docs, Makefile/hook comments and composition, a dependency patch bump, and new READMEs; no Rust behavior changed. Verified instead by running the affected guards (below) and building the website.

## The gate

- [x] Toolchain-free guards all green locally: `no-scratch`, `action-pins`, `cargo-install-pins`, `license-allowlist-parity`, `repro-wiring`, `shellcheck` (covers the edited hook), `invariants`, `doc-links`, `command-docs`, `file-size`
- [x] `make -n check` confirmed to now include `check-wire-schema.sh`
- [x] `pnpm --dir website run build` green after the postcss bump
- [x] fmt/clippy/test not run locally — no `.rs` file touched; CI runs them regardless
- [x] Docs updated where behavior changed (the `check` rung's help text and AGENTS.md/CONTRIBUTING.md describe the new composition)
- [x] CLA signed

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (postcss is an existing dep, patch-bumped)
- [x] No new outbound network calls

## Anything reviewers should know?

The one behavioral change is `make check` (and therefore `GATE=fast git push`) now running `wire-schema` — a deliberate cost increase argued in the Makefile comment. The alternative (moving wire-schema out of `guards` to spare website-only pushes) was rejected because it would leave `docs/wire/`-only edits caught by no gate anywhere; that trade-off is written up in #1439 for a proper fix.

## Summary by Sourcery

Align agent-facing documentation, guard descriptions, and CI behavior with the actual gate composition, and introduce a "nothing left behind" rule for capturing findings as fixes or GitHub issues.

New Features:
- Add CLAUDE.md as an agent-specific orientation entrypoint that imports AGENTS.md and codifies session rules.
- Add per-crate READMEs for stella-engine, stella-runtime, and stella-parity documenting their roles, boundaries, and testing approach.
- Introduce an explicit "Nothing left behind — every finding becomes a fix or a GitHub issue" policy section in AGENTS.md.

Bug Fixes:
- Correct drifted gate and CI descriptions in AGENTS.md and CONTRIBUTING.md, including the full list of guards and CI steps.
- Ensure `make check` (and the pre-push hook) runs the full guard set including `wire-schema`, restoring the rung superset contract and preventing stale generated wire artifacts.

Enhancements:
- Clarify the behavior and compilation scope of the guards/check/gate rungs in the Makefile and AGENTS.md.
- Tighten the AGENTS glossary description of look-alike identifiers to reflect the current set.

Build:
- Update the website PostCSS dependency from 8.5.18 to 8.5.23 to address a security advisory and keep the build green.

Documentation:
- Expand agent and contributor documentation around gates, CI workflows, crate responsibilities, and the new no-residue workflow rule.