### PR TITLE
fix(bench): three more postures printed next to a digest of a different one

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -445,13 +445,17 @@ earlier revision of this table mislabeled the `max`-era digests as the
 `xhigh`/32000 ones for three models; both prior generations are shown below,
 each re-verified by recomputing the exact posture variant.)
 
+Model strings are exact, for the reason 8.4.4 spells out: the digest hashes the
+string, so four of these rows are `openrouter/`-prefixed and the fifth is not,
+and an abbreviated label makes a row impossible to recompute.
+
 | model | was (`max`, uncapped) | was (`xhigh`, 32000) | now (`xhigh`, 64000) |
 |---|---|---|---|
-| deepseek-v4-pro | `0de2116f…` | `4249a1f9…` | `9d7ad135…` |
-| z-ai/glm-5.2 | `a0ab8a75…` | `b906090c…` | `7e9da633…` |
-| x-ai/grok-4.5 | `ff61cb06…` | `a1b0df58…` | `19c4d345…` |
-| z-ai/glm-5.1 | `f15536e5…` | `b80a9d06…` | `8530a36f…` |
-| anthropic/claude-sonnet-5 | `5176b46b…` | `55c6ef4c…` | `3c428a22…` |
+| `openrouter/deepseek/deepseek-v4-pro` | `0de2116f…` | `4249a1f9…` | `9d7ad135…` |
+| `openrouter/z-ai/glm-5.2` | `a0ab8a75…` | `b906090c…` | `7e9da633…` |
+| `openrouter/x-ai/grok-4.5` | `ff61cb06…` | `a1b0df58…` | `19c4d345…` |
+| `openrouter/z-ai/glm-5.1` | `f15536e5…` | `b80a9d06…` | `8530a36f…` |
+| `anthropic/claude-sonnet-5` | `5176b46b…` | `55c6ef4c…` | `3c428a22…` |
 
 Runs published under the 32000 posture remain described by the 8.4.1 table.
 The registered tables in the protocol and the analyzer README carry the new

--- a/bench/terminal_bench_analysis/README.md
+++ b/bench/terminal_bench_analysis/README.md
@@ -209,7 +209,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "9d7ad135db12e32d4519f893b8d8ed9d918b0ef54c7a4e4d22d1398b0015785b"
+        "sha256": "0d732c3e42a394a059be359de78ed153eb840477b946f167b8a0f3048023ff84"
       },
       "openrouter/z-ai/glm-5.2": {
         "version": "stella-tb21-engine-posture-v1",
@@ -225,7 +225,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "7e9da63355a399025c537e6d26528a0500a533b096e4f1eda1b88a3e3c51c0b4"
+        "sha256": "41f9be3b5f290529b10a94fcd87e3ad87b4798bdd4dd605bb7e678ecaa5d227d"
       },
       "openrouter/x-ai/grok-4.5": {
         "version": "stella-tb21-engine-posture-v1",
@@ -241,7 +241,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "19c4d3454de88a1fe5560d17bdf9a063be1d1720190a90a5dc1bdcb2159c9f15"
+        "sha256": "4505a9f8a582b25872c7c93bf1c63f3d6a335bac02e474ee5231e240f485802f"
       }
     },
     "job_name": "stella-tb21-calibration-20260721",

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -532,6 +532,33 @@ assert _POSTURE_SHA256 == (
 )
 
 
+def test_the_readme_digests_match_the_postures_printed_beside_them() -> None:
+    """Every posture block in README.md hashes to its own stated digest.
+
+    The rename (#1394) rewrote the ``agents`` key *inside* these blocks and left
+    the digests under them alone, so the document printed a posture body next to
+    a hash of a different posture — in four places. Nothing caught it: the blocks
+    are prose to every test here, and a reader recomputing one had no way to tell
+    which half was stale. Reading the pairs back out of the file is the only
+    check that scales to however many the README grows.
+    """
+    import re
+
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text()
+    pairs = re.findall(
+        r'"default_model":\s*"([^"]+)".*?"(?:engine_posture_)?sha256":\s*"([0-9a-f]{64})"',
+        readme,
+        re.S,
+    )
+    assert pairs, "no posture/digest pairs found — did the README format change?"
+    for model, printed in pairs:
+        _, _, actual = analysis_module.canonical_engine_posture(model)
+        assert actual == printed, (
+            f"README prints {printed[:8]}… for {model}, but that posture hashes "
+            f"to {actual[:8]}…"
+        )
+
+
 def test_posture_matches_the_adapters() -> None:
     """The analyzer's posture copy is byte-identical to the adapter's.
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -13,7 +13,7 @@
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8211 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
-4210 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+4237 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2270 crates/stella-cli/src/agent.rs
 1754 crates/stella-cli/src/agent/tests.rs
@@ -34,10 +34,10 @@
 2268 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1569 crates/stella-tools/src/media.rs
-2318 crates/stella-tools/src/registry.rs
+2308 crates/stella-tools/src/registry.rs
 1839 crates/stella-tools/src/scripts.rs
 1528 crates/stella-tui/src/deck.rs
-1611 crates/stella-tui/src/deck_render.rs
-4068 crates/stella-tui/src/deck_ui.rs
+1581 crates/stella-tui/src/deck_render.rs
+4028 crates/stella-tui/src/deck_ui.rs
 1665 crates/stella-tui/src/views/engine.rs
 1619 crates/stella-tui/src/views/session.rs


### PR DESCRIPTION
## What & why

Third and last follow-up to #1394's merge (after #1417 and #1429). Two fixes, one
new guard.

### The same defect #1417 fixed, three more times

`bench/terminal_bench_analysis/README.md` prints four registered engine postures,
each as a JSON block with its `sha256` beside it. The rename rewrote the `agents`
key **inside** each block (`judge` → `verifier`) and left the digests alone, so the
document showed a posture body that does not hash to the number printed under it:

| model | printed | actual |
|---|---|---|
| `openrouter/deepseek/deepseek-v4-pro` | `9d7ad135…` | **`0d732c3e…`** |
| `openrouter/z-ai/glm-5.2` | `7e9da633…` | **`41f9be3b…`** |
| `openrouter/x-ai/grok-4.5` | `19c4d345…` | **`4505a9f8…`** |

#1417 fixed the fourth (`openrouter/z-ai/glm-5.1`) because a test happened to pin
it. Nothing pinned these three.

This is not cosmetic: `bench/READINESS.md` §8.4.2 states that this README carries
the values *the launcher will actually emit*, "because a document that disagrees
with the code is the `harbor==0.6.1` failure again, in a different file." It
disagreed.

### A guard, so it cannot drift again

`test_the_readme_digests_match_the_postures_printed_beside_them` reads the
`(default_model, sha256)` pairs back out of the README and rehashes each one. It
scales to however many blocks the README grows rather than to a hardcoded list —
which matters, because the hardcoded-list approach is exactly what left three of
four unguarded.

Against `main` it fails and names both halves:

```
AssertionError: README prints 9d7ad135… for openrouter/deepseek/deepseek-v4-pro,
but that posture hashes to 0d732c3e…
```

### §8.4.2 gets the exact model strings

Same trap #1429 fixed one table down. Four of §8.4.2's five rows are
`openrouter/`-prefixed and the fifth is not, so an abbreviated label leaves a row
that cannot be recomputed — and picking the wrong form yields a different,
entirely valid-looking digest.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here) — the README
      guard above, verified by checking out `main`'s README and watching it fail.

## The gate

- [x] `bench/terminal_bench_analysis` pytest — 259 passed (258 on `main`)
- [x] All eleven `GATE_GUARDS_FAST` scripts — exit 0
- [x] No Rust changed

`scripts/file-size-baseline.txt` moves four lines. Mine grows by the new test
(`4210 → 4237`); `make file-size-update` also tightened `registry.rs`,
`deck_render.rs` and `deck_ui.rs`, which shrank on `main` since the baseline was
last regenerated. Kept as generated rather than hand-edited.

## Anything reviewers should know?

No published number changes meaning. A run recorded under `9d7ad135` ran the
posture that digest describes; what changes is the README's claim about what the
launcher emits *today*. `bench/evidence/` is untouched.

### Filed rather than fixed

Two are decisions about preregistered artifacts rather than defects with one right
answer:

- **#1446** — the #1295 two-arm run script can no longer select its own arm
  (`STELLA_JUDGE_EVIDENCE_DEMAND` is now unregistered, and the adapter fails closed
  on unregistered `STELLA_*`). It fails loudly, and the run is unfunded/unrun.
- **#1450** — `bench/terminal-bench-2.1-protocol.md`'s registered digest table is
  pre-rename. §8.4.2 says that table tracks the code; the table's own preamble says
  it is frozen at SUT 0.5.1. Both cannot be true.

The rest are the class, not the instance:

- **#1449** — nothing pins the four non-Rust producers of role names to the Rust
  enum. This is the root cause of every item above.
- **#1452** — the module-scope `assert` that turned one stale digest into a
  258-test collection error and kept `main` red.
- **#1455** — both brand site mockups still show `judge` as the last pipeline stage.
- **#1454** — enforcement for the "Nothing left behind" rule #1441 adds to
  `AGENTS.md`/`CLAUDE.md`.

One thing I did not verify: §8.4.2's two *historical* columns (`max`-era and
`xhigh`/32000-era digests). I gave every row its exact model string, and I
machine-checked the rightmost column against the current builder — but recomputing
the two older posture variants would mean reconstructing pre-#1394 posture code
from further back than the merge base. The model identity is not in doubt
(`bench/terminal-bench-2.1-protocol.md` names the same strings); the older digests
are taken as recorded.

## Summary by Sourcery

Align terminal bench analysis documentation with actual engine posture digests and add a regression test to keep them in sync.

Bug Fixes:
- Correct mismatched engine posture sha256 digests in the terminal bench analysis README to reflect the current postures.
- Fix posture digest table in bench readiness docs to use exact model identifier strings that can be recomputed.

Enhancements:
- Add a test that re-derives engine posture digests from the README and ensures they match the registered postures, preventing future drift.

Tests:
- Introduce a README guard test that validates each documented posture against its stated sha256 digest.