### PR TITLE
feat(stella-observatory): replay an execution's transcript in the dashboard drawer

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -286,6 +286,16 @@ pre.cfg{font:var(--fs-micro)/1.6 var(--mono);color:var(--text-2);background:var(
 #drawer .close:hover{color:var(--text);border-color:var(--accent)}
 #drawer h2{font:600 var(--fs-md)/1.4 var(--mono);margin:6px 0 2px;max-width:85%}
 #drawer .sect{margin-top:var(--sp3)}
+#drawer .jrnl{margin:10px 0;border-left:2px solid var(--hairline);padding-left:10px}
+#drawer .jrnl.err{border-left-color:var(--bad)}
+#drawer .jrnl-body{font:var(--fs-sm)/1.5 var(--mono);color:var(--text-2);margin:4px 0 0;
+  white-space:pre-wrap;word-break:break-word;max-height:320px;overflow-y:auto}
+#drawer .jrnl-stage{font:var(--fs-micro)/1.4 var(--mono);color:var(--text-3);
+  text-transform:uppercase;letter-spacing:.08em;margin:12px 0 2px}
+#drawer .jrnl-full{background:none;border:1px solid var(--hairline);color:var(--text-2);
+  font:var(--fs-micro)/1 var(--mono);padding:6px 10px;border-radius:var(--radius-sm);
+  cursor:pointer;margin-top:8px}
+#drawer .jrnl-full:hover{color:var(--text);border-color:var(--accent)}
 .step-row{display:grid;grid-template-columns:34px minmax(0,1fr) 160px;gap:var(--sp2);
           align-items:center;font:var(--fs-micro)/1.6 var(--mono);color:var(--text-3);padding:3px 0}
 .step-row .name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -1125,7 +1135,7 @@ function showDrawer(html) {
   $("scrim").classList.add("open");
   el.focus();
 }
-async function openDrawer(id) {
+async function openDrawer(id, full = false) {
   if (!Number.isFinite(id)) return;
   drawerReturn = document.activeElement;
   let d = null;
@@ -1138,6 +1148,31 @@ async function openDrawer(id) {
       indicator in the masthead reports the connection.</p>`);
     return;
   }
+  /* The transcript replay: the run's answer text, reasoning and tool
+     traffic, folded server-side from the events journal. Fetched once per
+     drawer-open (never on the 5 s poll); `full` lifts the per-body clip.
+     Every string field here is model/workspace output — the page's most
+     attacker-influenced text — so each one goes through esc(). */
+  let j = null;
+  try { j = await api(`/api/execution-journal?id=${encodeURIComponent(id)}${full ? "&full=1" : ""}`); } catch { j = null; }
+  const entries = Array.isArray(j) ? j : [];
+  const jrnl = entries.map(e => {
+    if (e.type === "stage") return `<div class="jrnl-stage">stage · ${esc(e.label ?? "")}</div>`;
+    if (e.type === "speculation_discarded")
+      return `<div class="jrnl"><div class="kick">◌ speculative ${esc(e.name ?? "")} discarded · ${esc(e.reason ?? "")}</div></div>`;
+    const head =
+      e.type === "tool_start" ? `▸ ${esc(e.name ?? "")}` :
+      e.type === "tool_result" ? `${e.ok ? "✓" : "✕"} result${e.duration_ms != null ? ` · ${fmtMs(e.duration_ms)}` : ""}${e.speculated ? " · speculated" : ""}` :
+      e.type === "reasoning" ? "reasoning" : "answer";
+    return `<div class="jrnl${e.type === "tool_result" && !e.ok ? " err" : ""}">
+      <div class="kick">${head}${e.truncated ? ` · <span style="color:var(--warn)">clipped</span>` : ""}</div>
+      ${e.body ? `<pre class="jrnl-body">${esc(e.body)}</pre>` : ""}</div>`;
+  }).join("");
+  const jrnlSect = jrnl
+    ? `<div class="sect"><div class="kick">Transcript${full ? " · full" : ""}</div>${jrnl}${
+        entries.some(e => e.truncated)
+          ? `<button class="jrnl-full" id="jrnl-full">show full bodies</button>` : ""}</div>`
+    : "";
   const tok = (s) => num(s.input_tokens) + num(s.output_tokens);
   const maxTok = Math.max(...(d.steps ?? []).map(tok), 1);
   const steps = (d.steps ?? []).map(s => {
@@ -1178,9 +1213,12 @@ async function openDrawer(id) {
     ${steps ? `<div class="sect"><div class="kick">Per-step tokens and latency</div>${steps}</div>`
             : `<div class="sect"><div class="kick">Per-step tokens and latency</div>
                <div class="empty">No steps recorded for this run.</div></div>`}
+    ${jrnlSect}
     ${tools ? `<div class="sect"><div class="kick">Tool calls</div>${tools}</div>` : ""}
     ${files ? `<div class="sect"><div class="kick">Files touched</div>${files}</div>` : ""}
     ${refl}`);
+  const fullBtn = $("jrnl-full");
+  if (fullBtn) fullBtn.addEventListener("click", () => openDrawer(id, true));
 }
 function closeDrawer() {
   const el = $("drawer");

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -51,6 +51,12 @@ pub(crate) const TOOL_CALL_SCAN_WINDOW: usize = 10_000;
 /// the stream enormous.
 pub(crate) const MAX_RUNNING_CALLS: usize = 200;
 
+/// Char cap on one transcript body in the default
+/// [`Observatory::execution_journal`] payload. A single `read_file` result
+/// can be megabytes; the drawer needs the shape of the turn, not the bytes,
+/// and `?full=1` is the escape hatch for the reader who wants them.
+pub(crate) const JOURNAL_BODY_CLIP: usize = 4_000;
+
 /// Everything that can go wrong serving observatory data.
 #[derive(Debug, thiserror::Error)]
 pub enum DbError {
@@ -348,6 +354,52 @@ impl Observatory {
             reflection
         };
         Ok(out)
+    }
+
+    /// One execution's transcript, replayed from its slice of the `events`
+    /// journal (#1461): the answer text, reasoning and tool traffic the
+    /// telemetry projections deliberately do not carry.
+    ///
+    /// This is the second sanctioned read of `events` (after
+    /// [`recall_timings`]) and it obeys the same bargain: the filter is
+    /// `execution_id`-first, which the store's `UNIQUE (execution_id, seq)`
+    /// index serves directly, and the route is fetched once on drawer-open —
+    /// never on the 5 s poll. A cross-execution transcript view would need a
+    /// projection, not a wider `WHERE`.
+    ///
+    /// `text_delta` rows never appear: the journal's `text` event is the
+    /// authoritative full answer and the deltas are a live-preview artifact.
+    /// Most stores hold none (the journal drops them at write time), but the
+    /// filter is contract, not assumption. Bodies are clipped to
+    /// [`JOURNAL_BODY_CLIP`] chars unless `full`; a clipped entry says so
+    /// (`truncated: true`) instead of presenting the elision as the data.
+    pub fn execution_journal(&self, id: i64, full: bool) -> Result<Value, DbError> {
+        let Some(conn) = self.store() else {
+            return Ok(Value::Array(Vec::new()));
+        };
+        let rows = collect_rows_for(
+            &conn,
+            id,
+            "SELECT seq, ts, event_type, payload
+             FROM events
+             WHERE execution_id = ?1
+               AND event_type IN ('stage', 'text', 'reasoning', 'tool_start',
+                                  'tool_result', 'speculation_discarded')
+             ORDER BY seq ASC",
+            |r| {
+                Ok(json!({
+                    "seq": r.get::<_, i64>(0)?,
+                    "ts": r.get::<_, String>(1)?,
+                    "type": r.get::<_, String>(2)?,
+                    "payload": r.get::<_, String>(3)?,
+                }))
+            },
+        )?;
+        Ok(Value::Array(
+            rows.into_iter()
+                .map(|row| journal_entry(row, full))
+                .collect(),
+        ))
     }
 
     /// Per-(provider, model) usage — the same rows `stella stats` prints,
@@ -942,6 +994,76 @@ fn recall_timings(conn: &Connection, execution_id: i64) -> Result<Vec<Value>, Db
             }))
         },
     )
+}
+
+/// Shape one raw `events` row into the transcript entry the drawer renders.
+///
+/// The payload is the internally-tagged `AgentEvent` JSON the store
+/// persisted (`{"type":"text","delta":…}`). Only the fields the transcript
+/// needs are lifted out, keyed by the row's own `event_type` column. A
+/// payload that no longer parses (a hand-edited store, a variant this binary
+/// predates) keeps its seq/type header with no body rather than erroring —
+/// one unreadable row must not blank the transcript around it.
+fn journal_entry(row: Value, full: bool) -> Value {
+    let ty = row["type"].as_str().unwrap_or("").to_owned();
+    let payload: Value = row["payload"]
+        .as_str()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .unwrap_or(Value::Null);
+    let mut out = json!({
+        "seq": row["seq"],
+        "ts": row["ts"],
+        "type": ty,
+    });
+    if payload.is_null() {
+        return out;
+    }
+    match ty.as_str() {
+        "stage" => {
+            out["label"] = payload["name"].clone();
+        }
+        "text" | "reasoning" => {
+            set_journal_body(&mut out, payload["delta"].as_str().unwrap_or(""), full);
+        }
+        "tool_start" => {
+            out["call_id"] = payload["call"]["call_id"].clone();
+            out["name"] = payload["call"]["name"].clone();
+            let args = serde_json::to_string_pretty(&payload["call"]["input"]).unwrap_or_default();
+            set_journal_body(&mut out, &args, full);
+        }
+        "tool_result" => {
+            out["call_id"] = payload["call_id"].clone();
+            out["duration_ms"] = payload["duration_ms"].clone();
+            out["speculated"] = json!(payload["speculated"].as_bool().unwrap_or(false));
+            // `ToolOutput` is externally tagged: `{"ok":{"content":…}}` or
+            // `{"error":{"message":…}}` — the tag is the ok/failed verdict.
+            out["ok"] = json!(!payload["output"]["ok"].is_null());
+            let body = payload["output"]["ok"]["content"]
+                .as_str()
+                .or_else(|| payload["output"]["error"]["message"].as_str())
+                .unwrap_or("");
+            set_journal_body(&mut out, body, full);
+        }
+        "speculation_discarded" => {
+            out["call_id"] = payload["call_id"].clone();
+            out["name"] = payload["name"].clone();
+            out["reason"] = payload["reason"].clone();
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Attach `body` to a transcript entry, clipped to [`JOURNAL_BODY_CLIP`]
+/// unless `full`, and record which of the two happened.
+fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
+    let clipped = !full && body.chars().count() > JOURNAL_BODY_CLIP;
+    entry["body"] = if clipped {
+        json!(truncate(body.to_owned(), JOURNAL_BODY_CLIP))
+    } else {
+        json!(body)
+    };
+    entry["truncated"] = json!(clipped);
 }
 
 /// The promoted-rules query, shared by [`Observatory::rules`] and

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -223,6 +223,14 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
             Some(id) => obs.execution(id),
             None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
         },
+        // The transcript replay (#1461). `full=1` lifts the per-body clip —
+        // fetched on drawer-open only, never on the 5 s poll.
+        "/api/execution-journal" => {
+            match query_param(query, "id").and_then(|v| v.parse::<i64>().ok()) {
+                Some(id) => obs.execution_journal(id, query_param(query, "full").is_some()),
+                None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
+            }
+        }
         "/api/models" => obs.models(),
         "/api/tools" => obs.tools(),
         "/api/files" => obs.files(),

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -142,6 +142,28 @@ fn seeded_workspace() -> TempDir {
              VALUES ('no-vacuous-fixes', 'a fix must change production code', 'reflection');",
     )
     .unwrap();
+    // The events journal, seeded in its own batch: the payloads are the
+    // internally-tagged `AgentEvent` JSON `Store::record_event` persists,
+    // and a raw string keeps their quoting readable. The `text_delta` row is
+    // there to be *excluded* — the journal route must drop live-preview
+    // fragments in favor of the authoritative `text` event.
+    conn.execute_batch(
+        r#"CREATE TABLE events (
+             execution_id INTEGER NOT NULL,
+             seq INTEGER NOT NULL,
+             ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+             event_type TEXT NOT NULL,
+             payload TEXT NOT NULL,
+             UNIQUE (execution_id, seq));
+           INSERT INTO events (execution_id, seq, event_type, payload) VALUES
+             (1, 0, 'stage', '{"type":"stage","name":"build"}'),
+             (1, 1, 'text_delta', '{"type":"text_delta","text":"add"}'),
+             (1, 2, 'reasoning', '{"type":"reasoning","delta":"plan the edit"}'),
+             (1, 3, 'tool_start', '{"type":"tool_start","call":{"call_id":"c1","name":"read_file","input":{"path":"src/lib.rs"}}}'),
+             (1, 4, 'tool_result', '{"type":"tool_result","call_id":"c1","output":{"ok":{"content":"fn a() {}"}},"duration_ms":12,"speculated":false}'),
+             (1, 5, 'text', '{"type":"text","delta":"added the function"}');"#,
+    )
+    .unwrap();
     dir
 }
 
@@ -268,6 +290,68 @@ fn execution_detail_includes_steps_tools_files() {
     );
 }
 
+/// The transcript replay (#1461): the journal route folds an execution's
+/// `events` slice into an ordered transcript, drops `text_delta` fragments
+/// (the `text` event is the authoritative answer), and surfaces tool
+/// arguments and outputs — the content the telemetry projections
+/// deliberately do not carry.
+#[test]
+fn execution_journal_replays_transcript_without_deltas() {
+    let ws = seeded_workspace();
+    let response = respond(ws.path(), "/api/execution-journal?id=1");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    let types: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["type"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        types,
+        ["stage", "reasoning", "tool_start", "tool_result", "text"],
+        "seq order, text_delta excluded"
+    );
+    assert_eq!(v[0]["label"], "build");
+    assert_eq!(v[1]["body"], "plan the edit");
+    assert_eq!(v[2]["name"], "read_file");
+    assert!(v[2]["body"].as_str().unwrap().contains("src/lib.rs"));
+    assert_eq!(v[3]["ok"], true);
+    assert_eq!(v[3]["body"], "fn a() {}");
+    assert_eq!(v[3]["duration_ms"], 12);
+    assert_eq!(v[4]["body"], "added the function");
+    assert_eq!(v[4]["truncated"], false);
+    // No execution 2 events were seeded — an empty transcript, not an error.
+    let none = respond(ws.path(), "/api/execution-journal?id=2");
+    let v: serde_json::Value = serde_json::from_slice(&none.body).unwrap();
+    assert_eq!(v, serde_json::json!([]));
+}
+
+/// A body past [`db::JOURNAL_BODY_CLIP`] chars is clipped and flagged in the
+/// default payload, and returned whole under `?full=1` — the elision must
+/// announce itself, never pose as the data.
+#[test]
+fn execution_journal_clips_long_bodies_unless_full() {
+    use crate::db::JOURNAL_BODY_CLIP;
+    let ws = seeded_workspace();
+    let long = "x".repeat(JOURNAL_BODY_CLIP + 100);
+    Connection::open(ws.path().join(".stella/private/store.db"))
+        .unwrap()
+        .execute(
+            "INSERT INTO events (execution_id, seq, event_type, payload)
+             VALUES (2, 0, 'text', ?1)",
+            [serde_json::json!({"type": "text", "delta": long}).to_string()],
+        )
+        .unwrap();
+    let response = respond(ws.path(), "/api/execution-journal?id=2");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(v[0]["truncated"], true);
+    assert!(v[0]["body"].as_str().unwrap().chars().count() <= JOURNAL_BODY_CLIP + 1);
+    let full = respond(ws.path(), "/api/execution-journal?id=2&full=1");
+    let v: serde_json::Value = serde_json::from_slice(&full.body).unwrap();
+    assert_eq!(v[0]["truncated"], false);
+    assert_eq!(v[0]["body"].as_str().unwrap().chars().count(), long.len());
+}
+
 #[test]
 fn tool_leaderboard_counts_errors() {
     let ws = seeded_workspace();
@@ -290,6 +374,7 @@ fn empty_workspace_degrades_to_empty_payloads_not_errors() {
         "/api/meta",
         "/api/overview",
         "/api/executions",
+        "/api/execution-journal?id=1",
         "/api/models",
         "/api/tools",
         "/api/files",

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -56,6 +56,7 @@ const ROUTES: &[(&str, Option<&str>)] = &[
     ("/api/overview", Some("/runs")),
     ("/api/executions", Some("/0/id")),
     ("/api/execution?id=1", Some("/steps/0/step")),
+    ("/api/execution-journal?id=1", Some("/0/type")),
     ("/api/models", Some("/0/provider")),
     ("/api/tools", Some("/0/name")),
     ("/api/files", Some("/0/path")),

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -44,7 +44,9 @@ panels labeled *all-time* ignore it.
     successes, commits) with MCP traffic, and a memory/reflections/skills digest — plus the
     **Executions** table: every run's kind, prompt, model, outcome, steps, tool calls,
     files touched, tokens, and cost. Clicking a row opens a drill-down drawer with per-step
-    tokens and latency, every tool call, the files touched, and the post-turn
+    tokens and latency, the **transcript** replayed from the run's event journal — answer
+    text, reasoning, and each tool call's arguments and output, with long bodies clipped
+    until you ask for them in full — every tool call, the files touched, and the post-turn
     self-reflection.
   </OptionCard>
   <OptionCard name="activity">


### PR DESCRIPTION
## What & why

`stella observe` could drill an execution down only to telemetry: token counts per step, tool-call metadata, files touched. The actual run — the answer text, the reasoning, each tool call's arguments and output — lived in the `events` journal, reachable through `stella inspect` on the CLI and nowhere in the dashboard. This PR adds the transcript replay: a new `/api/execution-journal?id=N` route folds the execution's slice of the journal into an ordered transcript, and the execution drawer renders it between the per-step bars and the tool list.

Design points, in the crate's own terms:

- **Second sanctioned read of `events`**, alongside `recall_timings`, under the same bargain: `execution_id`-first (served directly by the store's `UNIQUE (execution_id, seq)` index), fetched once on drawer-open, never on the 5 s poll. The doc comment carries the rule forward: a cross-execution view means a projection, not a wider `WHERE`.
- **Bodies clip at 4,000 chars** (`JOURNAL_BODY_CLIP`) with a `truncated: true` flag and a "show full bodies" refetch (`?full=1`) — a single `read_file` result can be megabytes, and the elision announces itself instead of posing as the data.
- **`text_delta` fragments are excluded by contract** — the journal's `text` event is the authoritative answer (`stella-protocol` freezes that semantics), and the fixture seeds a delta row specifically to assert its exclusion.
- **Degradation**: missing store, missing `events` table, or a missing column all yield an empty transcript via the existing `collect_rows_for`/`is_missing_schema` path; an unparseable payload row keeps its seq/type header rather than blanking the transcript around it.
- **Escaping**: every rendered string (tool names, args, outputs, answer text — the page's most attacker-influenced content) goes through `esc()`, per the injection invariant at the top of `index.html`.

Closes #1461
Refs #1475, #1476 (the sent-context inspection and live-refresh follow-ons split out of the original issue)

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`execution_journal_replays_transcript_without_deltas` and `execution_journal_clips_long_bodies_unless_full` in `crates/stella-observatory/src/tests.rs` — on `main` the route 404s (and the query function doesn't exist, so the suite doesn't compile with them). `tests/schema_conformance.rs` gains the route with a JSON-pointer emptiness check against a real-migration store, and the degradation list gains `/api/execution-journal?id=1`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (dashboard tour in `website/content/docs/telemetry/dashboard.mdx`)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

(Gate run by CI on this branch — a benchmark match owns the local machine.)

## Ground-rule check

- [ ] No new outbound network calls (Stella never phones home) — the route is loopback-only, read-only, same as every observatory surface; nothing new leaves the machine

## Anything reviewers should know?

- The `every_served_route_is_fetched_by_the_embedded_page` and `dashboard_html_has_no_external_references` gates both cover the new surface, and the conformance suite exercises it against a store built by the real migration path.
- The drawer's transcript is a one-shot fetch: for a still-running execution it's frozen at open time. That's #1476 (incremental `after_seq` refresh), deliberately not in this PR.

## Summary by Sourcery

Add execution transcript replay to the observatory dashboard by exposing a new execution journal API and rendering its entries in the execution drawer.

New Features:
- Introduce an /api/execution-journal endpoint that replays an execution's transcript from the events journal, excluding text_delta fragments and supporting optional full-body retrieval.
- Display the reconstructed transcript in the execution drawer, including stages, reasoning, tool invocations, and results with clipping indicators.

Enhancements:
- Cap transcript body length by default with configurable full-body fetching to keep the dashboard responsive while preserving access to complete data.

Documentation:
- Update telemetry dashboard documentation to describe the execution transcript replay, including clipping behavior and full-body viewing.

Tests:
- Add integration and schema conformance tests for the execution journal API, including transcript ordering, delta exclusion, body clipping behavior, and route degradation handling.