### PR TITLE
Verification rounds stop paying twice: verdict reuse on unchanged inputs + witness diff excluded from paid prompts

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2870,7 +2870,18 @@ impl<'a> Pipeline<'a> {
                             .await
                         {
                             Ok(verdict) => {
-                                state.last_verdict = Some((inputs_digest, verdict.clone()));
+                                // Only pin a real model verdict for reuse. A
+                                // heuristic fallback is a transient-outage
+                                // stand-in (unresolvable provider, unparseable
+                                // response, failed/timed-out call), not the
+                                // opinion this candidate bought: caching it
+                                // would suppress recovery on the next round
+                                // (the verifier may have come back) and graft
+                                // the "no new model call was made" reuse note
+                                // onto a fallback that never made one.
+                                if !verdict.heuristic {
+                                    state.last_verdict = Some((inputs_digest, verdict.clone()));
+                                }
                                 verdict
                             }
                             Err(abort) => {

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -820,6 +820,12 @@ struct CandidateState {
     /// progress and hit something new" — the signal that decides how much the
     /// next revision is told (`witness::airlock`).
     failures: Vec<FailureFingerprint>,
+    /// The last model verdict this candidate bought, keyed by a digest of the
+    /// exact inputs that produced it (#1431). A revision that changed nothing
+    /// the verdict depends on reuses the opinion instead of re-buying it —
+    /// the verifier is stateless across rounds, so identical inputs are the
+    /// same question, and paying twice buys only sampling noise.
+    last_verdict: Option<(u64, crate::verify::Verdict)>,
 }
 
 impl CandidateState {
@@ -2128,6 +2134,7 @@ impl<'a> Pipeline<'a> {
             evidence_demands: 0,
             witness_paths: Vec::new(),
             failures: Vec::new(),
+            last_verdict: None,
         };
 
         if let Err(reason) = self
@@ -2647,10 +2654,15 @@ impl<'a> Pipeline<'a> {
                     // telling the verifier the agent had "failed twice in a row".
                     let mut reason = brief.message();
                     if self.config.distress_guidance && state.failures.len() >= 2 {
+                        // Same witness exclusion as the verdict call (#1433):
+                        // guidance reads the change under correction, and the
+                        // verifier's own test is not part of it.
+                        let stripped =
+                            crate::verify::strip_witness_hunks(&state.diff_text, &witness_paths);
                         match self
                             .verifier_guidance(
                                 goal,
-                                &state.diff_text,
+                                &stripped.diff,
                                 &evidence.summary,
                                 budget,
                                 total,
@@ -2799,21 +2811,63 @@ impl<'a> Pipeline<'a> {
                         // witness it is weighing is the authored one.
                         evidence_summary.push_str("; witness_tamper_check=intact");
                     }
-                    let verdict = match self
-                        .verifier(
-                            goal,
-                            &state.diff_text,
-                            &evidence_summary,
-                            &inputs,
-                            budget,
-                            total,
-                        )
-                        .await
-                    {
-                        Ok(verdict) => verdict,
-                        Err(abort) => {
-                            return CandidateResult::aborted(state.messages, abort.reason);
+                    // The witness's own chunks never ride into the paid prompt
+                    // as "worker-authored data" (#1433): they are the
+                    // verifier's own artifact, and everything the verdict needs
+                    // to know about the witness is already in the trusted
+                    // evidence above. The omission is named HERE — the trusted
+                    // zone — never in-band in the diff, where the framing says
+                    // every byte is forgeable worker data.
+                    let stripped =
+                        crate::verify::strip_witness_hunks(&state.diff_text, &witness_paths);
+                    if !stripped.omitted.is_empty() {
+                        evidence_summary.push_str(&format!(
+                            "; witness_files_omitted_from_diff=[{}] (verifier-authored test, \
+                             not part of the change under review)",
+                            stripped.omitted.join(", ")
+                        ));
+                    }
+                    // Reuse before re-buying (#1431): a revision that changed
+                    // nothing the verdict depends on — same goal, same diff,
+                    // same evidence, byte for byte — would re-ask the same
+                    // question and pay full price for sampling noise. The
+                    // cached verdict is the same opinion at zero cost, and the
+                    // appended note steers the worker better than a fresh
+                    // reading of an unchanged tree ever did.
+                    let inputs_digest =
+                        verdict_inputs_digest(goal, &stripped.diff, &evidence_summary);
+                    let cached = state
+                        .last_verdict
+                        .as_ref()
+                        .filter(|(digest, _)| *digest == inputs_digest)
+                        .map(|(_, verdict)| verdict.clone());
+                    let verdict = match cached {
+                        Some(mut verdict) => {
+                            verdict.reasoning.push_str(
+                                "\n(verdict reused: the goal, diff, and evidence are unchanged \
+                                 since the previous review round — no new model call was made)",
+                            );
+                            verdict
                         }
+                        None => match self
+                            .verifier(
+                                goal,
+                                &stripped.diff,
+                                &evidence_summary,
+                                &inputs,
+                                budget,
+                                total,
+                            )
+                            .await
+                        {
+                            Ok(verdict) => {
+                                state.last_verdict = Some((inputs_digest, verdict.clone()));
+                                verdict
+                            }
+                            Err(abort) => {
+                                return CandidateResult::aborted(state.messages, abort.reason);
+                            }
+                        },
                     };
                     let mut evidence = model_verdict_evidence(&verdict);
                     evidence.ladder = Some(Box::new(snapshot.with_rung(verdict.rung())));
@@ -3729,6 +3783,20 @@ fn assemble_user_message(
         VerificationContract::None => {}
     }
     s
+}
+
+/// One digest over everything a model verdict depends on — goal, the (witness
+/// -stripped) diff, and the evidence summary. Byte-identical inputs are the
+/// same question; the ModelVerdict arm reuses its previous answer rather than
+/// paying for sampling noise (#1431). Within-run only, so the std hasher's
+/// stability across versions is irrelevant.
+fn verdict_inputs_digest(goal: &str, diff: &str, evidence_summary: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    goal.hash(&mut hasher);
+    diff.hash(&mut hasher);
+    evidence_summary.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// The instruction appended to a revision turn, carrying the failing

--- a/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
@@ -168,7 +168,6 @@ async fn the_ask_is_spent_once_even_when_the_evidence_never_arrives() {
         text_result("done"),
         text_result("PASS — the change reads correct"),
         text_result("there is no test surface for this"),
-        text_result("PASS — still reads correct"),
     ]);
     // Never observable: every run is inconclusive, so the evidence the ask
     // wants cannot appear however many times it is asked for.
@@ -195,9 +194,55 @@ async fn the_ask_is_spent_once_even_when_the_evidence_never_arrives() {
     );
     assert_eq!(outcome.revisions, 1, "one ask, not one per verifier pass");
     assert_eq!(
-        calls, 5,
-        "triage, worker, verifier, the single ask, and the verifier re-reading the \
-         revised turn — then it stops"
+        calls, 4,
+        "triage, worker, verifier, and the single ask. The revised turn changed \
+         nothing the verdict depends on, so the verifier's re-read is the CACHED \
+         pass (#1431) — no fifth call"
+    );
+    assert!(
+        verdict.summary.contains("verdict reused"),
+        "the reused verdict says so, so the transcript stays honest: {}",
+        verdict.summary
+    );
+}
+
+/// The FAIL shape of the same reuse (#1431): a revision that changes neither
+/// the diff nor the evidence re-asks the verifier the byte-identical question.
+/// The cached opinion is the same opinion at zero cost — a second paid call
+/// could differ only by sampling noise, and no one defends a verification
+/// layer that flips on noise.
+#[tokio::test]
+async fn an_unchanged_revision_reuses_the_verdict_instead_of_rebuying_it() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("FAIL — the change does not handle the empty case"),
+        text_result("I believe the change is correct as written"),
+    ]);
+    let runner = ScriptedRunner::scripted(
+        vec![TestScript::Fail, TestScript::TimeOut, TestScript::TimeOut],
+        "@@ -1 +1 @@\n-old\n+new",
+    );
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        max_revisions: 1,
+        ..PipelineConfig::default()
+    };
+
+    let (outcome, _events, calls) = run_scenario!(provider, runner, config);
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(!verdict.passed, "the reused FAIL still fails the run");
+    assert_eq!(
+        calls, 4,
+        "triage, worker, verifier, one revision — the second verdict round is \
+         the cached FAIL, not a fifth call"
+    );
+    assert!(
+        verdict.summary.contains("verdict reused"),
+        "the reuse is stated in the verdict the run reports: {}",
+        verdict.summary
     );
 }
 

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -793,6 +793,97 @@ pub fn model_verdict_evidence(verdict: &Verdict) -> VerdictEvidence {
 /// is reading an excerpt rather than the whole change.
 const VERIFIER_DIFF_BUDGET_CHARS: usize = 40_000;
 
+/// A diff with the authored witness's own file chunks removed, plus the
+/// paths that were removed — see [`strip_witness_hunks`].
+pub struct StrippedDiff {
+    pub diff: String,
+    pub omitted: Vec<String>,
+}
+
+/// Remove the authored witness's file chunks from a diff bound for a
+/// verifier-facing prompt.
+///
+/// The witness artifact is grafted into the candidate tree before
+/// verification, so the working-tree diff carries the verifier's OWN test
+/// under the prompt's "worker-authored data" heading — misattributed, and
+/// billed against the diff budget on every escalated verdict and guidance
+/// call. What the verifier needs to know about the witness it already gets
+/// from the trusted evidence summary (`witness_tamper_check`,
+/// `witness_tautological`, the oracle trace); the test's text says nothing
+/// about the change under review.
+///
+/// Paths are matched the way [`coverage::changed_lines`] excludes them: each
+/// chunk's first `+++ ` header, `b/`-stripped, compared exactly. The omitted
+/// paths are RETURNED, not written into the diff — the caller names them in
+/// the evidence summary, which is the trusted zone; an in-band note would sit
+/// in the region the verifier is told to treat as forgeable worker data.
+pub fn strip_witness_hunks(diff: &str, witness_paths: &[String]) -> StrippedDiff {
+    if witness_paths.is_empty() || diff.is_empty() {
+        return StrippedDiff {
+            diff: diff.to_string(),
+            omitted: Vec::new(),
+        };
+    }
+    let mut out = String::with_capacity(diff.len());
+    let mut omitted: Vec<String> = Vec::new();
+    let mut chunk = String::new();
+    let mut chunk_path: Option<String> = None;
+
+    fn flush(
+        out: &mut String,
+        omitted: &mut Vec<String>,
+        witness_paths: &[String],
+        chunk: &mut String,
+        chunk_path: &mut Option<String>,
+    ) {
+        if chunk.is_empty() {
+            return;
+        }
+        let dropped = chunk_path
+            .as_deref()
+            .is_some_and(|path| witness_paths.iter().any(|w| w == path));
+        if dropped {
+            omitted.push(chunk_path.take().expect("dropped chunks carry a path"));
+        } else {
+            out.push_str(chunk);
+        }
+        chunk.clear();
+        *chunk_path = None;
+    }
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git ") {
+            flush(
+                &mut out,
+                &mut omitted,
+                witness_paths,
+                &mut chunk,
+                &mut chunk_path,
+            );
+        }
+        // First `+++ ` per chunk only: the real new-file header lands right
+        // after `--- `, before any content line can start with `+++ `.
+        if chunk_path.is_none()
+            && let Some(path) = line.strip_prefix("+++ ")
+        {
+            let path = path.strip_prefix("b/").unwrap_or(path).trim();
+            if path != "/dev/null" {
+                chunk_path = Some(path.to_string());
+            }
+        }
+        chunk.push_str(line);
+        chunk.push('\n');
+    }
+    flush(
+        &mut out,
+        &mut omitted,
+        witness_paths,
+        &mut chunk,
+        &mut chunk_path,
+    );
+    StrippedDiff { diff: out, omitted }
+}
+
 /// Clamp a worker-authored diff to `VERIFIER_DIFF_BUDGET_CHARS` for prompt
 /// interpolation: keep the head and tail, elide the middle, and say so where
 /// the cut was made. Char-based, not byte-based, so a multi-byte diff can

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -1277,3 +1277,70 @@ fn an_evidence_demand_is_bounded_on_every_axis() {
         "one revision left is enough to ask"
     );
 }
+
+// strip_witness_hunks
+
+/// The witness is grafted into the candidate tree, so the working-tree diff
+/// carries the verifier's own test. It must not ride into the verifier prompt
+/// as "worker-authored data" — drop its chunks, return its paths for the
+/// trusted evidence zone, and leave every worker chunk byte-intact.
+#[test]
+fn witness_chunks_are_stripped_and_named_never_billed() {
+    let diff = "diff --git a/src/lib.rs b/src/lib.rs\n\
+                --- a/src/lib.rs\n\
+                +++ b/src/lib.rs\n\
+                @@ -1,2 +1,3 @@\n\
+                 fn f() {}\n\
+                +fn g() {}\n\
+                diff --git a/tests/witness_g.rs b/tests/witness_g.rs\n\
+                --- /dev/null\n\
+                +++ b/tests/witness_g.rs\n\
+                @@ -0,0 +1,2 @@\n\
+                +#[test]\n\
+                +fn g_works() { g(); }\n";
+    let stripped = strip_witness_hunks(diff, &["tests/witness_g.rs".to_string()]);
+    assert!(
+        stripped.diff.contains("+fn g() {}"),
+        "worker chunk survives:\n{}",
+        stripped.diff
+    );
+    assert!(
+        !stripped.diff.contains("witness_g"),
+        "witness chunk is gone:\n{}",
+        stripped.diff
+    );
+    assert_eq!(stripped.omitted, vec!["tests/witness_g.rs".to_string()]);
+}
+
+/// No witness, no change: the common test-command path must pass the diff
+/// through byte-identically.
+#[test]
+fn stripping_with_no_witness_paths_is_the_identity() {
+    let diff = "diff --git a/a.rs b/a.rs\n--- a/a.rs\n+++ b/a.rs\n@@ -1 +1 @@\n+x\n";
+    let stripped = strip_witness_hunks(diff, &[]);
+    assert_eq!(stripped.diff, diff);
+    assert!(stripped.omitted.is_empty());
+}
+
+/// Preamble lines before the first `diff --git` (the honest-diff banner, the
+/// untracked-change notes) belong to no file and always survive; and an added
+/// content line that happens to start with `+++ ` cannot hijack the chunk's
+/// path because only the FIRST `+++ ` per chunk is read.
+#[test]
+fn preamble_survives_and_content_cannot_hijack_the_chunk_path() {
+    let diff = "3 files changed but the probe saw an empty diff\n\
+                diff --git a/src/a.rs b/src/a.rs\n\
+                --- a/src/a.rs\n\
+                +++ b/src/a.rs\n\
+                @@ -1 +1,2 @@\n\
+                +++ b/tests/witness_g.rs\n\
+                +real added line\n";
+    let stripped = strip_witness_hunks(diff, &["tests/witness_g.rs".to_string()]);
+    assert!(stripped.diff.contains("empty diff"), "preamble survives");
+    assert!(
+        stripped.diff.contains("+real added line"),
+        "the chunk keyed on its real header (src/a.rs), not on forged content:\n{}",
+        stripped.diff
+    );
+    assert!(stripped.omitted.is_empty());
+}


### PR DESCRIPTION
Ships the first slice of #1431 and the witness-exclusion slice of #1433, from the verification-layer cost audit.

## Verdict reuse (#1431, step 1)

The ModelVerdict arm digests `(goal, diff, evidence summary)` and reuses the previous round's verdict when a revision changed none of them, instead of re-buying the same question. The verifier is stateless across rounds — byte-identical inputs can only differ by sampling noise, and the verification layer must not flip on noise. The reused verdict appends an explicit note, which also flows through the normal feedback path so the worker hears it changed nothing the verdict depends on. Conservative by construction: any byte of drift in goal, diff, or evidence forces a fresh paid call.

## Witness exclusion (#1433, first slice)

The witness artifact is grafted into the candidate tree, so the working-tree diff carried the verifier's **own test** into the paid verdict and guidance prompts under the "worker-authored data" heading — misattributed, and spending the 40k-char diff budget on text that says nothing about the change under review. `strip_witness_hunks` removes those chunks before both calls, matching paths exactly the way `coverage::changed_lines` already excludes them. The omission is named in the evidence summary (trusted zone), never in-band in the diff, where the D5 framing declares every byte forgeable worker data.

## Tests

- 3 new unit tests for `strip_witness_hunks` (drop + name, identity on no-witness, preamble survival + content-hijack resistance)
- New `an_unchanged_revision_reuses_the_verdict_instead_of_rebuying_it` (FAIL shape)
- `the_ask_is_spent_once_even_when_the_evidence_never_arrives` updated: the unanswered-ask path now costs 4 calls, not 5 — the re-read after a no-op revision is the cached pass
- `cargo test -p stella-pipeline`: all suites green (479 lib + integration)

Remaining scope of #1431 (delta framing) and #1433 (token-based, relevance-ranked clamp; budget rebalance) stays open — tracked on the issues.

## Summary by Sourcery

Reuse model verdicts across unchanged revisions and exclude verifier-authored witness files from paid verifier prompts.

New Features:
- Cache and reuse model verdicts when goal, diff, and evidence summary are unchanged between verification rounds.
- Strip verifier-authored witness file hunks from diffs before sending them to verdict and guidance prompts, while recording omitted paths in trusted evidence.

Tests:
- Add unit tests for witness hunk stripping behavior and preamble handling.
- Extend pipeline tests to cover verdict reuse for both PASS and FAIL outcomes and update expectations for model call counts.