### PR TITLE
feat(stella-observatory): live transcript refresh via after_seq incremental journal fetch

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -1126,6 +1126,11 @@ $("executions").addEventListener("click", (ev) => {
 
 /* ── drawer ──────────────────────────────────────────────────────────── */
 let drawerReturn = null;          // element focus came from, restored on close
+/* The live transcript refresh (#1476): set on drawer-open, cleared on close.
+   `lastSeq` is the highest journal `seq` already rendered — the drawer's
+   incremental poll asks for `after_seq=lastSeq` instead of the whole
+   transcript. `finished` stops the poll once the execution closes out. */
+let drawerState = null;           // { id, full, lastSeq, finished } | null
 function showDrawer(html) {
   const el = $("drawer");
   el.innerHTML = `<button type="button" class="close" aria-label="Close detail">esc</button>` + html;
@@ -1134,6 +1139,21 @@ function showDrawer(html) {
   el.removeAttribute("aria-hidden");
   $("scrim").classList.add("open");
   el.focus();
+}
+/* One transcript entry's HTML — shared by the initial drawer render and the
+   incremental refresh below, so the two can never draw the same entry type
+   differently. Every model/workspace-derived string routes through esc(). */
+function journalEntryHtml(e) {
+  if (e.type === "stage") return `<div class="jrnl-stage">stage · ${esc(e.label ?? "")}</div>`;
+  if (e.type === "speculation_discarded")
+    return `<div class="jrnl"><div class="kick">◌ speculative ${esc(e.name ?? "")} discarded · ${esc(e.reason ?? "")}</div></div>`;
+  const head =
+    e.type === "tool_start" ? `▸ ${esc(e.name ?? "")}` :
+    e.type === "tool_result" ? `${e.ok ? "✓" : "✕"} result${e.duration_ms != null ? ` · ${fmtMs(e.duration_ms)}` : ""}${e.speculated ? " · speculated" : ""}` :
+    e.type === "reasoning" ? "reasoning" : "answer";
+  return `<div class="jrnl${e.type === "tool_result" && !e.ok ? " err" : ""}">
+    <div class="kick">${head}${e.truncated ? ` · <span style="color:var(--warn)">clipped</span>` : ""}</div>
+    ${e.body ? `<pre class="jrnl-body">${esc(e.body)}</pre>` : ""}</div>`;
 }
 async function openDrawer(id, full = false) {
   if (!Number.isFinite(id)) return;
@@ -1156,22 +1176,18 @@ async function openDrawer(id, full = false) {
   let j = null;
   try { j = await api(`/api/execution-journal?id=${encodeURIComponent(id)}${full ? "&full=1" : ""}`); } catch { j = null; }
   const entries = Array.isArray(j) ? j : [];
-  const jrnl = entries.map(e => {
-    if (e.type === "stage") return `<div class="jrnl-stage">stage · ${esc(e.label ?? "")}</div>`;
-    if (e.type === "speculation_discarded")
-      return `<div class="jrnl"><div class="kick">◌ speculative ${esc(e.name ?? "")} discarded · ${esc(e.reason ?? "")}</div></div>`;
-    const head =
-      e.type === "tool_start" ? `▸ ${esc(e.name ?? "")}` :
-      e.type === "tool_result" ? `${e.ok ? "✓" : "✕"} result${e.duration_ms != null ? ` · ${fmtMs(e.duration_ms)}` : ""}${e.speculated ? " · speculated" : ""}` :
-      e.type === "reasoning" ? "reasoning" : "answer";
-    return `<div class="jrnl${e.type === "tool_result" && !e.ok ? " err" : ""}">
-      <div class="kick">${head}${e.truncated ? ` · <span style="color:var(--warn)">clipped</span>` : ""}</div>
-      ${e.body ? `<pre class="jrnl-body">${esc(e.body)}</pre>` : ""}</div>`;
-  }).join("");
-  const jrnlSect = jrnl
-    ? `<div class="sect"><div class="kick">Transcript${full ? " · full" : ""}</div>${jrnl}${
+  const jrnl = entries.map(journalEntryHtml).join("");
+  // Rendered even with zero entries while the run is still going: the
+  // container has to exist up front so the incremental refresh below has
+  // somewhere to append into, rather than reconstructing the drawer's DOM
+  // mid-poll. A finished execution with nothing to show still gets no
+  // section, matching the original one-shot behaviour.
+  const stillRunning = d.finished_at == null;
+  const jrnlSect = (jrnl || stillRunning)
+    ? `<div class="sect" id="jrnl-sect"><div class="kick">Transcript${full ? " · full" : ""}</div>
+        <div id="jrnl-list">${jrnl}</div>${
         entries.some(e => e.truncated)
-          ? `<button class="jrnl-full" id="jrnl-full">show full bodies</button>` : ""}</div>`
+          ? `<button type="button" class="jrnl-full" id="jrnl-full">show full bodies</button>` : ""}</div>`
     : "";
   const tok = (s) => num(s.input_tokens) + num(s.output_tokens);
   const maxTok = Math.max(...(d.steps ?? []).map(tok), 1);
@@ -1219,6 +1235,56 @@ async function openDrawer(id, full = false) {
     ${refl}`);
   const fullBtn = $("jrnl-full");
   if (fullBtn) fullBtn.addEventListener("click", () => openDrawer(id, true));
+  drawerState = {
+    id,
+    full,
+    lastSeq: entries.length ? entries[entries.length - 1].seq : -1,
+    finished: !stillRunning,
+  };
+}
+/* Append newly-persisted journal entries to an open, still-running drawer
+   (#1476) instead of re-fetching the whole transcript. Piggybacked on the
+   page's existing poll — both `pollOnce` and the live-stream tick handler
+   call this right after they notice the cursor moved — so an idle
+   workspace pays only for the `after_seq` query's index probe, and a busy
+   one appends rather than re-downloads. `full` mode carries over: the
+   incremental fetch asks for the same clip setting the drawer opened with. */
+async function refreshDrawerJournal() {
+  if (!drawerState || drawerState.finished) return;
+  const el = $("drawer");
+  if (!el.classList.contains("open")) { drawerState = null; return; }
+  const { id, full, lastSeq } = drawerState;
+  let j = null;
+  try {
+    j = await api(`/api/execution-journal?id=${encodeURIComponent(id)}&after_seq=${lastSeq}${full ? "&full=1" : ""}`);
+  } catch {
+    return;
+  }
+  const entries = Array.isArray(j) ? j : [];
+  if (!entries.length) return;
+  const list = $("jrnl-list");
+  if (list) list.insertAdjacentHTML("beforeend", entries.map(journalEntryHtml).join(""));
+  if (entries.some(e => e.truncated) && !$("jrnl-full")) {
+    const sect = $("jrnl-sect");
+    if (sect) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "jrnl-full";
+      btn.id = "jrnl-full";
+      btn.textContent = "show full bodies";
+      btn.addEventListener("click", () => openDrawer(id, true));
+      sect.appendChild(btn);
+    }
+  }
+  drawerState.lastSeq = entries[entries.length - 1].seq;
+}
+/* The main poll already re-fetches `/api/executions` (with `finished_at`)
+   on every cursor move — reuse that instead of a dedicated per-tick
+   `/api/execution` call just to learn the drawer's execution closed out. */
+function checkDrawerFinished() {
+  if (!drawerState || drawerState.finished) return;
+  const row = (D.executions ?? []).find(e => e.id === drawerState.id);
+  if (row && row.finished_at != null) drawerState.finished = true;
 }
 function closeDrawer() {
   const el = $("drawer");
@@ -1228,6 +1294,7 @@ function closeDrawer() {
   $("scrim").classList.remove("open");
   if (drawerReturn && document.contains(drawerReturn)) drawerReturn.focus();
   drawerReturn = null;
+  drawerState = null;
 }
 $("scrim").addEventListener("click", closeDrawer);
 /* Keep Tab inside the open drawer: it is aria-modal, so focus escaping it
@@ -2225,7 +2292,12 @@ async function pollOnce() {
       ["/api/v1/cursor", "/api/v1/snapshot"].map(api));
     renderInflight(snapshot);
     const stamp = JSON.stringify(cursor);
-    if (stamp !== lastCursor) { lastCursor = stamp; await refresh(); }
+    if (stamp !== lastCursor) {
+      lastCursor = stamp;
+      await refresh();
+      await refreshDrawerJournal();
+      checkDrawerFinished();
+    }
     $("live").classList.remove("paused");
   } catch {
     $("live").classList.add("paused");
@@ -2302,7 +2374,10 @@ function connectLive() {
     // fallback does not re-fetch everything just because it never saw the
     // frames that already updated the page.
     lastCursor = JSON.stringify(payload.cursor);
-    if (payload.changed) refresh();
+    if (payload.changed) {
+      refresh().then(checkDrawerFinished);
+      refreshDrawerJournal();
+    }
   });
   source.onerror = () => {
     // EventSource reconnects on its own, but a refused stream (the server's

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -363,9 +363,13 @@ impl Observatory {
     /// This is the second sanctioned read of `events` (after
     /// `recall_timings`) and it obeys the same bargain: the filter is
     /// `execution_id`-first, which the store's `UNIQUE (execution_id, seq)`
-    /// index serves directly, and the route is fetched once on drawer-open —
-    /// never on the 5 s poll. A cross-execution transcript view would need a
-    /// projection, not a wider `WHERE`.
+    /// index serves directly. The whole transcript is fetched once on
+    /// drawer-open; while the execution is still running, the drawer polls
+    /// back with `after_seq` set to the highest `seq` it already has
+    /// (#1476), so a long run's transcript is never re-downloaded in full —
+    /// the same `(execution_id, seq)` index serves `seq > ?` directly. A
+    /// cross-execution transcript view would need a projection, not a wider
+    /// `WHERE`.
     ///
     /// `text_delta` rows never appear: the journal's `text` event is the
     /// authoritative full answer and the deltas are a live-preview artifact.
@@ -373,28 +377,43 @@ impl Observatory {
     /// filter is contract, not assumption. Bodies are clipped to
     /// `JOURNAL_BODY_CLIP` chars unless `full`; a clipped entry says so
     /// (`truncated: true`) instead of presenting the elision as the data.
-    pub fn execution_journal(&self, id: i64, full: bool) -> Result<Value, DbError> {
+    pub fn execution_journal(
+        &self,
+        id: i64,
+        full: bool,
+        after_seq: Option<i64>,
+    ) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {
             return Ok(Value::Array(Vec::new()));
         };
-        let rows = collect_rows_for(
-            &conn,
-            id,
-            "SELECT seq, ts, event_type, payload
+        // `-1` rather than `0` when unfiltered: `seq` starts at 0
+        // (`Store::record_event`'s first call), and a sentinel of 0 would
+        // silently drop that opening row from every unfiltered fetch.
+        let after = after_seq.unwrap_or(-1);
+        let sql = "SELECT seq, ts, event_type, payload
              FROM events
              WHERE execution_id = ?1
+               AND seq > ?2
                AND event_type IN ('stage', 'text', 'reasoning', 'tool_start',
                                   'tool_result', 'speculation_discarded')
-             ORDER BY seq ASC",
-            |r| {
-                Ok(json!({
-                    "seq": r.get::<_, i64>(0)?,
-                    "ts": r.get::<_, String>(1)?,
-                    "type": r.get::<_, String>(2)?,
-                    "payload": r.get::<_, String>(3)?,
-                }))
-            },
-        )?;
+             ORDER BY seq ASC";
+        let mut stmt = match conn.prepare(sql) {
+            Ok(stmt) => stmt,
+            Err(e) if is_missing_schema(&e) => return Ok(Value::Array(Vec::new())),
+            Err(e) => return Err(e.into()),
+        };
+        let mapped = stmt.query_map([id, after], |r| {
+            Ok(json!({
+                "seq": r.get::<_, i64>(0)?,
+                "ts": r.get::<_, String>(1)?,
+                "type": r.get::<_, String>(2)?,
+                "payload": r.get::<_, String>(3)?,
+            }))
+        })?;
+        let mut rows = Vec::new();
+        for row in mapped {
+            rows.push(row?);
+        }
         Ok(Value::Array(
             rows.into_iter()
                 .map(|row| journal_entry(row, full))

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -224,10 +224,16 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
             None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
         },
         // The transcript replay (#1461). `full=1` lifts the per-body clip —
-        // fetched on drawer-open only, never on the 5 s poll.
+        // fetched whole on drawer-open. `after_seq=<n>` (#1476) narrows to
+        // rows newer than the drawer's last-seen `seq`, for the incremental
+        // poll a still-running execution's transcript gets instead.
         "/api/execution-journal" => {
             match query_param(query, "id").and_then(|v| v.parse::<i64>().ok()) {
-                Some(id) => obs.execution_journal(id, query_param(query, "full").is_some()),
+                Some(id) => obs.execution_journal(
+                    id,
+                    query_param(query, "full").is_some(),
+                    query_param(query, "after_seq").and_then(|v| v.parse::<i64>().ok()),
+                ),
                 None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
             }
         }

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -326,6 +326,39 @@ fn execution_journal_replays_transcript_without_deltas() {
     assert_eq!(v, serde_json::json!([]));
 }
 
+/// `after_seq` (#1476) narrows the transcript to rows newer than the
+/// drawer's last-seen `seq` — the incremental fetch a still-running
+/// execution's poll uses instead of re-downloading the whole transcript
+/// every tick.
+#[test]
+fn execution_journal_after_seq_returns_only_newer_rows() {
+    let ws = seeded_workspace();
+    // Seq 3 is the tool_start row; only tool_result (4) and text (5) — both
+    // > 3 — should come back.
+    let response = respond(ws.path(), "/api/execution-journal?id=1&after_seq=3");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    let seqs: Vec<i64> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["seq"].as_i64().unwrap())
+        .collect();
+    assert_eq!(seqs, [4, 5], "only rows with seq > 3 come back");
+    // A cursor past every seeded row degrades to empty, not an error.
+    let none = respond(ws.path(), "/api/execution-journal?id=1&after_seq=99");
+    let v: serde_json::Value = serde_json::from_slice(&none.body).unwrap();
+    assert_eq!(v, serde_json::json!([]));
+    // Unset behaves exactly like `after_seq=0` would be wrong to: seq 0 (the
+    // opening `stage` row) is still included.
+    let all = respond(ws.path(), "/api/execution-journal?id=1&after_seq=-1");
+    let v: serde_json::Value = serde_json::from_slice(&all.body).unwrap();
+    assert_eq!(
+        v.as_array().unwrap().len(),
+        5,
+        "seq 0 survives after_seq=-1"
+    );
+}
+
 /// A body past [`db::JOURNAL_BODY_CLIP`] chars is clipped and flagged in the
 /// default payload, and returned whole under `?full=1` — the elision must
 /// announce itself, never pose as the data.
@@ -375,6 +408,7 @@ fn empty_workspace_degrades_to_empty_payloads_not_errors() {
         "/api/overview",
         "/api/executions",
         "/api/execution-journal?id=1",
+        "/api/execution-journal?id=1&after_seq=0",
         "/api/models",
         "/api/tools",
         "/api/files",


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

Stacked on #1478 (the `/api/execution-journal` route this builds on).

The drawer's transcript (#1461) was a one-shot fetch: `openDrawer` requested
`/api/execution-journal` once when the drawer opened and never again, so a
running execution's transcript froze at open time while the rest of the
dashboard kept updating — reading as a hang rather than a stale view.

`/api/execution-journal` now accepts `after_seq=<n>`, served directly by the
same `UNIQUE (execution_id, seq)` index the unfiltered query already uses.
While the drawer is open on an execution whose `finished_at` is null, it
piggybacks on the page's existing poll — both `pollOnce`'s fallback loop and
the SSE tick handler — to fetch only rows newer than the last `seq` it has
already rendered, and appends them client-side instead of re-downloading the
whole transcript every tick. The refresh stops once the execution's
`finished_at` shows up in the next `/api/executions` poll, or the drawer
closes. `full`-mode (the no-clip setting) carries across refreshes. No second
SSE stream was added — the live route's connection budget stays untouched.

Closes #1476

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`execution_journal_after_seq_returns_only_newer_rows` in
`crates/stella-observatory/src/tests.rs` seeds five journal rows and asserts
`?after_seq=3` returns only `seq` 4 and 5, `?after_seq=99` degrades to `[]`,
and `?after_seq=-1` (the "no filter" sentinel) still includes `seq` 0 — fails
on `main` (the parameter doesn't exist), passes here.

The UI half (incremental append, stop-on-finish, stop-on-close, full-mode
carrying over) is not covered by an automated test — matching this repo's
stance on TUI-style rendering witnesses — and needs verification by hand
against a live run (`--example serve` + a running session) before merge.

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

A paid benchmark run owns this session's local machine, so none of the gate
commands above could be run locally (only `cargo fmt -p stella-observatory`
was permitted, and was run). The gate runs in CI on this PR instead — check
its result before merging.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

- `after_seq` uses `-1` as the "unfiltered" sentinel rather than `0`, because
  `seq` starts at 0 (`Store::record_event`'s first call) and a `0` sentinel
  would silently drop that opening row from every unfiltered fetch.
- The route's "stop when finished" signal reuses `D.executions` from the
  page's existing 5 s aggregate poll rather than adding a per-tick
  `/api/execution` call, so the incremental refresh costs only the
  `after_seq` query itself on an otherwise idle drawer.

## Summary by Sourcery

Add incremental live transcript updates for running executions in the Stella observatory drawer using the new after_seq execution journal query.

New Features:
- Support after_seq filtering on /api/execution-journal to return only journal entries newer than a given sequence for an execution.
- Enable the execution detail drawer to append new transcript entries incrementally while a run is in progress, preserving full-mode state and stopping when the run finishes.

Tests:
- Add a regression test ensuring execution_journal with after_seq only returns newer rows, degrades to empty when beyond the end, and preserves the initial seq 0 entry when unfiltered.