### PR TITLE
fix(stella-observatory): de-link private items from execution_journal's public docs — unbreak main's rustdoc

### DIFF
--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -361,7 +361,7 @@ impl Observatory {
     /// telemetry projections deliberately do not carry.
     ///
     /// This is the second sanctioned read of `events` (after
-    /// [`recall_timings`]) and it obeys the same bargain: the filter is
+    /// `recall_timings`) and it obeys the same bargain: the filter is
     /// `execution_id`-first, which the store's `UNIQUE (execution_id, seq)`
     /// index serves directly, and the route is fetched once on drawer-open —
     /// never on the 5 s poll. A cross-execution transcript view would need a
@@ -371,7 +371,7 @@ impl Observatory {
     /// authoritative full answer and the deltas are a live-preview artifact.
     /// Most stores hold none (the journal drops them at write time), but the
     /// filter is contract, not assumption. Bodies are clipped to
-    /// [`JOURNAL_BODY_CLIP`] chars unless `full`; a clipped entry says so
+    /// `JOURNAL_BODY_CLIP` chars unless `full`; a clipped entry says so
     /// (`truncated: true`) instead of presenting the elision as the data.
     pub fn execution_journal(&self, id: i64, full: bool) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {


### PR DESCRIPTION
## What & why

Unbreaks the `stella-observatory` half of main's red `ci`. `rustdoc -D warnings` rejects public documentation that links to private items, and `execution_journal`'s doc comment (landed in #1478) linked `[`recall_timings`]` and `[`JOURNAL_BODY_CLIP`]` — both private. They stay named as plain code spans.

The fix existed on the #1478 branch as commit 0a9a1e0c but the PR was merged before that second push landed, so main got the broken version. This PR grafts exactly that two-line change onto main.

Note: main's `ci` is **also** failing on a separate `stella-pipeline` compile error (predates + follows this one) — that is tracked separately and deliberately not touched here, so this PR's `ci` run will stay red on the pipeline half until that fix lands. The rustdoc errors for `stella-observatory` are what this removes.

Refs #1461

## The witness

- [x] No witness needed (doc-only fix) — the two `error: public documentation for `execution_journal` links to private item` lines in main's ci run (30982310736) are the failing check this removes; no behavior changes.

## The gate

- [x] Doc-comment-only change; gate runs in CI (a benchmark run owns the local machine)

## Anything reviewers should know?

Built via git plumbing against `origin/main` (the working tree is occupied by an in-flight agent building #1476/#1475), reusing the already-pushed fixed blob from the #1478 branch — the tree diff is exactly the two doc lines.

## Summary by Sourcery

Documentation:
- Update execution_journal documentation to refer to recall_timings and JOURNAL_BODY_CLIP as code spans instead of links, avoiding references to private items.