### PR TITLE
fix(stella-core): let a refuted success claim earn bounded repair rounds

### DIFF
--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -107,6 +107,7 @@ lib.rs), never as a planning assumption.
 | [`src/estimator.rs`](src/estimator.rs) | Conservative token estimate plus `Calibration`/`CalibrationMap`, the per-model drift correction fed by reported usage. |
 | [`src/loop_detect.rs`](src/loop_detect.rs) | `detect_loop()` — exact repeats and short cycles over `CallRecord`s. |
 | [`src/retry.rs`](src/retry.rs) | `RetryPolicy`, backoff computation, `retry_with_backoff*`, and the `Sleeper` port. |
+| [`src/repair.rs`](src/repair.rs) | `plan_repair()` — whether a verdict that refuted the model's success claim earns another attempt, bounded by an explicit cap and by the budget/wall-clock headroom the caller measured. |
 | [`src/speculation.rs`](src/speculation.rs) | Early execution of read-only tool calls announced mid-stream (`pub(crate)`). |
 | [`src/receipts.rs`](src/receipts.rs) | `ReceiptLedger` — `BlockRegistered` + `StepManifest` context receipts, content-free (digests, never payloads). |
 | [`src/accounted_call.rs`](src/accounted_call.rs), [`src/event_sender.rs`](src/event_sender.rs) | A one-shot accounted provider call for callers that are not the engine, and the channel wrapper that can journal an event durably before admitting it. |

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ports;
 pub mod receipts;
 pub mod records;
 pub mod redact;
+pub mod repair;
 pub mod retry;
 pub mod router;
 pub mod rules;
@@ -69,6 +70,7 @@ pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_h
 pub use loop_detect::{CallRecord, LoopDetectionConfig, LoopVerdict, detect_loop};
 pub use mcp_usage::{McpUsageLedger, McpUsageRecord, drain_usage, push_usage};
 pub use ports::{Clock, ToolExecutor};
+pub use repair::{RepairCost, RepairHeadroom, RepairPlan, RepairRefusal, plan_repair};
 pub use retry::{RetryOutcome, RetryPolicy, retry_with_backoff};
 pub use router::{RoleTable, Router};
 pub use rules::{

--- a/crates/stella-core/src/repair.rs
+++ b/crates/stella-core/src/repair.rs
@@ -1,0 +1,391 @@
+//! Repair admission — whether a refuted success claim earns another attempt.
+//!
+//! Verification catching the model lying about success is the expensive half
+//! of a run: the tests were run, the diff was read, the verdict was paid for.
+//! Ending the run on that finding throws all of it away, and scores a *caught*
+//! wrong answer identically to an uncaught one. What was missing is the cheap
+//! half — a path from "the probe says FAIL" back into the loop while the run
+//! still has room to act on it (#1479).
+//!
+//! Room is the whole of the decision, so this module is where it is decided,
+//! and it is decided the same way [`crate::driver`]'s length-continuation
+//! allowance is: pure synchronous functions over owned data, with the caller
+//! supplying the measurements. Nothing here reads a clock, a budget guard, or
+//! a config file.
+//!
+//! # Bounded three ways
+//!
+//! An unbounded verify/repair cycle trades one failure class for another —
+//! a wrong answer becomes a timeout — so admission is bounded on three
+//! independent axes, and the *tightest* one binds:
+//!
+//! 1. **The cap.** [`REPAIR_ATTEMPT_CAP`] is the hard ceiling on attempts for
+//!    one verification arc, whatever any measurement says.
+//! 2. **The allowance.** Attempts inside the caller's configured revision
+//!    allowance are granted unconditionally — that is the behaviour every
+//!    caller already had, and this module never takes it away.
+//! 3. **The measurement.** Attempts *past* the allowance are granted only
+//!    when a measured axis says another one fits.
+//!
+//! # Why an unmeasured run gets nothing extra
+//!
+//! [`RepairHeadroom`] is `Option` on every axis, and an axis nobody
+//! configured abstains rather than approving. A caller that declared no
+//! ceiling and no deadline therefore keeps its old bound exactly, which is
+//! the conservative default the same reasoning gives
+//! [`crate::driver::EngineConfig::turn_budget`]: only a caller that knows its
+//! own limits can say there is room left, and inventing one here would spend
+//! money and wall clock nobody agreed to.
+//!
+//! Refusal is never suppression. A refused repair still returns a named
+//! reason for the caller to report; the verdict it was refused for is
+//! reported either way (degradation warns, it never disables).
+
+use std::time::Duration;
+
+/// The hard ceiling on repair attempts within one verification arc.
+///
+/// Four, because the shape this exists for is a worker that was *close* —
+/// it did the work and got one criterion wrong — and the measured
+/// distribution of those is one or two more rounds, not ten. Past that the
+/// evidence is not steering the model and more rounds buy a timeout rather
+/// than a fix, which is the failure class this bound exists to avoid trading
+/// into. It is a ceiling and not a target: the measured axes below routinely
+/// stop well short of it.
+pub const REPAIR_ATTEMPT_CAP: u32 = 4;
+
+/// What one repair attempt is expected to cost, taken from the attempts
+/// already run.
+///
+/// The estimate is deliberately backward-looking. A repair attempt re-runs
+/// the same shape of work the refuted attempt just ran — one worker turn plus
+/// one verification round — so what it already cost is the best available
+/// statement of what the next one will cost. This mirrors
+/// `driver::truncation::ContinuationBudget`, which decides the same question
+/// for length continuations by the same rule.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RepairCost {
+    /// Expected spend, in USD.
+    pub usd: f64,
+    /// Expected wall clock.
+    pub wall: Duration,
+}
+
+impl RepairCost {
+    /// The mean cost of `rounds` rounds that together spent `usd` and `wall`.
+    ///
+    /// `rounds` is saturated to at least one, so a caller that has not
+    /// finished a round yet gets the whole measurement rather than a
+    /// division by zero.
+    #[must_use]
+    pub fn mean_of(rounds: u32, usd: f64, wall: Duration) -> Self {
+        let rounds = rounds.max(1);
+        Self {
+            usd: (usd / f64::from(rounds)).max(0.0),
+            wall: wall / rounds,
+        }
+    }
+}
+
+/// What the run has left, on each axis the caller can actually measure.
+///
+/// `None` means "nobody is measuring this", never "there is none left" — an
+/// unmeasured axis abstains from the decision entirely. See the module docs
+/// for why that default is the conservative one.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RepairHeadroom {
+    /// USD left before the tightest configured budget limit trips
+    /// (`BudgetGuard::headroom_usd`), or `None` when the guard is unmetered.
+    pub budget_usd: Option<f64>,
+    /// Wall clock left before the caller's own deadline
+    /// ([`crate::driver::EngineConfig::turn_budget`]), or `None` when the
+    /// caller declared no deadline.
+    pub wall_clock: Option<Duration>,
+}
+
+impl RepairHeadroom {
+    /// Whether no axis is measured at all.
+    #[must_use]
+    pub fn is_unmeasured(&self) -> bool {
+        self.budget_usd.is_none() && self.wall_clock.is_none()
+    }
+
+    /// Whether every *measured* axis has strictly more left than `cost`.
+    ///
+    /// Strictly greater, and no safety margin invented here: the caller owns
+    /// its limits and can set conservative ones. A margin baked in at this
+    /// level would be a second, invisible policy — the same call
+    /// `ContinuationBudget::affords_another` makes.
+    #[must_use]
+    pub fn affords(&self, cost: RepairCost) -> bool {
+        self.budget_usd.is_none_or(|left| left > cost.usd)
+            && self.wall_clock.is_none_or(|left| left > cost.wall)
+    }
+}
+
+/// Why a refuted verdict did not earn another attempt. Every variant is a
+/// reportable reason — a refusal is stated, never silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairRefusal {
+    /// [`REPAIR_ATTEMPT_CAP`] (or the caller's larger allowance) is spent.
+    /// The evidence stopped steering the model; more rounds buy a timeout.
+    CapReached,
+    /// The configured allowance is spent and nothing measures the run, so
+    /// nothing can say another attempt is affordable.
+    Unmeasured,
+    /// A measured axis cannot afford another attempt. Refused even *inside*
+    /// the allowance: starting a repair that cannot finish converts a
+    /// reported failure into a budget abort or an external kill, which is
+    /// strictly worse than reporting the verdict.
+    NoHeadroom,
+}
+
+impl RepairRefusal {
+    /// One clause, for the operator-facing warning a caller emits alongside
+    /// the verdict it is about to report.
+    #[must_use]
+    pub fn sentence(self) -> &'static str {
+        match self {
+            Self::CapReached => "the repair-attempt cap is spent",
+            Self::Unmeasured => {
+                "the revision allowance is spent and no budget or deadline is set to \
+                 justify another attempt"
+            }
+            Self::NoHeadroom => "there is not enough budget or wall clock left to finish another",
+        }
+    }
+}
+
+/// What happens after verification refutes the model's success claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairPlan {
+    /// Re-enter the loop. `attempt` is 1-based and `cap` is the ceiling it
+    /// counts against, so a caller can say "repair 3/4" without re-deriving
+    /// the bound.
+    Attempt { attempt: u32, cap: u32 },
+    /// Stop and report the verdict, for this reason.
+    Stop(RepairRefusal),
+}
+
+impl RepairPlan {
+    /// Whether this plan re-enters the loop.
+    #[must_use]
+    pub fn is_attempt(self) -> bool {
+        matches!(self, Self::Attempt { .. })
+    }
+}
+
+/// Decide whether a refuted success claim earns another repair attempt.
+///
+/// `spent` is how many repair attempts this verification arc has already
+/// made, `allowance` the caller's configured revision allowance, and the
+/// remaining two arguments are the measurements described on
+/// [`RepairHeadroom`] and [`RepairCost`]. The effective cap is
+/// `max(allowance, REPAIR_ATTEMPT_CAP)` — a caller that configured a *larger*
+/// allowance than the ceiling keeps it, because the ceiling exists to bound
+/// what this module grants on its own, never to withdraw what the caller
+/// already asked for.
+///
+/// The order the bounds are tested in is load-bearing. The cap is absolute,
+/// so it comes first. Affordability comes next and applies at every level,
+/// including inside the allowance: a run with a measured axis that cannot pay
+/// for another attempt must not start one, whatever its count says. Only then
+/// does the allowance grant, and only past the allowance does an unmeasured
+/// run stop.
+#[must_use]
+pub fn plan_repair(
+    spent: u32,
+    allowance: u32,
+    headroom: RepairHeadroom,
+    cost: RepairCost,
+) -> RepairPlan {
+    let cap = allowance.max(REPAIR_ATTEMPT_CAP);
+    if spent >= cap {
+        return RepairPlan::Stop(RepairRefusal::CapReached);
+    }
+    if !headroom.affords(cost) {
+        return RepairPlan::Stop(RepairRefusal::NoHeadroom);
+    }
+    if spent >= allowance && headroom.is_unmeasured() {
+        return RepairPlan::Stop(RepairRefusal::Unmeasured);
+    }
+    RepairPlan::Attempt {
+        attempt: spent.saturating_add(1),
+        cap,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Room on the budget axis and nothing else measured.
+    fn funded() -> RepairHeadroom {
+        RepairHeadroom {
+            budget_usd: Some(5.0),
+            wall_clock: None,
+        }
+    }
+
+    /// A cheap round: any realistic headroom affords another one.
+    fn cheap() -> RepairCost {
+        RepairCost {
+            usd: 0.01,
+            wall: Duration::from_secs(1),
+        }
+    }
+
+    /// The witness this module exists for: the allowance is spent, a measured
+    /// axis has room, and the refutation buys another round instead of ending
+    /// the run.
+    #[test]
+    fn a_spent_allowance_with_measured_headroom_still_earns_an_attempt() {
+        assert_eq!(
+            plan_repair(1, 1, funded(), cheap()),
+            RepairPlan::Attempt { attempt: 2, cap: 4 }
+        );
+    }
+
+    /// The conservative default: an unmeasured run keeps its configured bound
+    /// exactly, so no caller starts spending more than it used to by doing
+    /// nothing.
+    #[test]
+    fn an_unmeasured_run_stops_at_its_allowance() {
+        assert_eq!(
+            plan_repair(1, 1, RepairHeadroom::default(), cheap()),
+            RepairPlan::Stop(RepairRefusal::Unmeasured)
+        );
+        // ...and inside the allowance it is unaffected.
+        assert!(plan_repair(0, 1, RepairHeadroom::default(), cheap()).is_attempt());
+    }
+
+    /// The cap binds however much room the measurements report.
+    #[test]
+    fn the_cap_binds_a_run_with_unlimited_measured_room() {
+        let rich = RepairHeadroom {
+            budget_usd: Some(1_000_000.0),
+            wall_clock: Some(Duration::from_secs(86_400)),
+        };
+        assert_eq!(
+            plan_repair(REPAIR_ATTEMPT_CAP, 1, rich, cheap()),
+            RepairPlan::Stop(RepairRefusal::CapReached)
+        );
+    }
+
+    /// A caller that configured a larger allowance than the ceiling keeps it:
+    /// the ceiling bounds what this module grants unasked, not what the
+    /// caller asked for.
+    #[test]
+    fn a_larger_configured_allowance_is_never_withdrawn() {
+        let cap = REPAIR_ATTEMPT_CAP + 4;
+        assert_eq!(
+            plan_repair(REPAIR_ATTEMPT_CAP, cap, RepairHeadroom::default(), cheap()),
+            RepairPlan::Attempt {
+                attempt: REPAIR_ATTEMPT_CAP + 1,
+                cap,
+            }
+        );
+    }
+
+    /// Refusing *inside* the allowance is the point of testing affordability
+    /// before the count: a repair that cannot finish turns a reported failure
+    /// into a budget abort or an external kill.
+    #[test]
+    fn an_unaffordable_attempt_is_refused_even_inside_the_allowance() {
+        let broke = RepairHeadroom {
+            budget_usd: Some(0.001),
+            wall_clock: None,
+        };
+        assert_eq!(
+            plan_repair(0, 3, broke, cheap()),
+            RepairPlan::Stop(RepairRefusal::NoHeadroom)
+        );
+    }
+
+    /// Each axis refuses on its own — a run with money and no time is as
+    /// stopped as one with time and no money.
+    #[test]
+    fn either_measured_axis_can_refuse_alone() {
+        let out_of_time = RepairHeadroom {
+            budget_usd: Some(500.0),
+            wall_clock: Some(Duration::from_millis(10)),
+        };
+        assert_eq!(
+            plan_repair(0, 3, out_of_time, cheap()),
+            RepairPlan::Stop(RepairRefusal::NoHeadroom)
+        );
+    }
+
+    /// An exactly-equal axis refuses: `affords` is strictly greater, so a run
+    /// with precisely one attempt's worth left does not start one it would
+    /// finish on the line.
+    #[test]
+    fn headroom_equal_to_the_cost_does_not_afford() {
+        let exact = RepairHeadroom {
+            budget_usd: Some(cheap().usd),
+            wall_clock: None,
+        };
+        assert!(!plan_repair(0, 3, exact, cheap()).is_attempt());
+    }
+
+    #[test]
+    fn mean_cost_divides_by_the_rounds_that_produced_it() {
+        let mean = RepairCost::mean_of(4, 1.0, Duration::from_secs(8));
+        assert!((mean.usd - 0.25).abs() < 1e-9);
+        assert_eq!(mean.wall, Duration::from_secs(2));
+        // Zero rounds is the caller's first measurement, not a division by
+        // zero.
+        let first = RepairCost::mean_of(0, 1.0, Duration::from_secs(8));
+        assert!((first.usd - 1.0).abs() < 1e-9);
+    }
+
+    proptest! {
+        /// The bound is absolute: whatever the measurements say, an attempt
+        /// is never granted at or past the effective cap, and a granted
+        /// attempt number never exceeds it.
+        #[test]
+        fn no_inputs_grant_an_attempt_past_the_cap(
+            spent in 0u32..64,
+            allowance in 0u32..16,
+            budget in proptest::option::of(0.0f64..1_000.0),
+            secs in proptest::option::of(0u64..10_000),
+            cost_usd in 0.0f64..10.0,
+            cost_secs in 0u64..600,
+        ) {
+            let plan = plan_repair(
+                spent,
+                allowance,
+                RepairHeadroom {
+                    budget_usd: budget,
+                    wall_clock: secs.map(Duration::from_secs),
+                },
+                RepairCost { usd: cost_usd, wall: Duration::from_secs(cost_secs) },
+            );
+            let cap = allowance.max(REPAIR_ATTEMPT_CAP);
+            if let RepairPlan::Attempt { attempt, cap: reported } = plan {
+                prop_assert_eq!(reported, cap);
+                prop_assert!(attempt <= cap);
+                prop_assert!(spent < cap);
+            }
+        }
+
+        /// Termination: repeatedly granting attempts from a run whose costs
+        /// are always affordable still stops, in at most `cap` steps. This is
+        /// the property that makes the re-entry safe to wire into a loop.
+        #[test]
+        fn granting_every_affordable_attempt_still_terminates(allowance in 0u32..16) {
+            let unlimited = RepairHeadroom {
+                budget_usd: Some(f64::MAX),
+                wall_clock: Some(Duration::MAX),
+            };
+            let cap = allowance.max(REPAIR_ATTEMPT_CAP);
+            let mut spent = 0u32;
+            while plan_repair(spent, allowance, unlimited, cheap()).is_attempt() {
+                spent += 1;
+                prop_assert!(spent <= cap, "granted more attempts than the cap allows");
+            }
+            prop_assert_eq!(spent, cap);
+        }
+    }
+}

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -109,6 +109,7 @@ mod authored;
 mod disclosure;
 mod fanout_stage;
 mod raw_usage;
+mod repair_gate;
 mod run_error;
 mod scope_stage;
 mod stage_budget;
@@ -953,6 +954,9 @@ pub struct Pipeline<'a> {
     /// authoritative `Text` — still goes out live. See
     /// `pipeline::fanout_stage`'s module doc.
     shared_event_lane: AtomicBool,
+    /// When this pipeline was constructed — the turn's own elapsed clock, one
+    /// pipeline being one turn. Read only by [`repair_gate`].
+    started: std::time::Instant,
 }
 
 impl<'a> Pipeline<'a> {
@@ -994,6 +998,7 @@ impl<'a> Pipeline<'a> {
             verifier_caveat_warned: AtomicBool::new(false),
             verifier_fallback_warned: AtomicBool::new(false),
             shared_event_lane: AtomicBool::new(false),
+            started: std::time::Instant::now(),
         }
     }
 
@@ -2304,6 +2309,7 @@ impl<'a> Pipeline<'a> {
         });
         let effective_cmd = self.effective_test_command(witness);
         let witness_paths = Self::witness_paths(witness);
+        let meter = repair_gate::RepairMeter::start(*total);
         loop {
             if let Some(workspace) = surface.workspace
                 && let Err(error) = workspace.seal().await
@@ -2578,7 +2584,7 @@ impl<'a> Pipeline<'a> {
                         passed: false,
                         evidence: evidence.clone(),
                     });
-                    if state.revisions >= self.config.max_revisions {
+                    if !self.affords_repair(&state, &meter, *total, budget) {
                         return state.into_verified(
                             false,
                             &evidence,
@@ -2647,7 +2653,7 @@ impl<'a> Pipeline<'a> {
                         passed: false,
                         evidence: evidence.clone(),
                     });
-                    if state.revisions >= self.config.max_revisions {
+                    if !self.affords_repair(&state, &meter, *total, budget) {
                         return state.into_verified(
                             false,
                             &evidence,
@@ -2983,7 +2989,7 @@ impl<'a> Pipeline<'a> {
                             score_from_verification(false, Some(true)),
                         );
                     }
-                    if state.revisions >= self.config.max_revisions {
+                    if !self.affords_repair(&state, &meter, *total, budget) {
                         return state.into_verified(
                             false,
                             &evidence,

--- a/crates/stella-pipeline/src/pipeline/repair_gate.rs
+++ b/crates/stella-pipeline/src/pipeline/repair_gate.rs
@@ -1,0 +1,122 @@
+//! The repair gate (#1479): the single place that answers "verification just
+//! refuted the model's claim — is there room to try again?".
+//!
+//! Every failing rung of the verification ladder used to answer it with the
+//! same bare count, `revisions >= max_revisions`. A count cannot see the
+//! constraint that actually binds. The run that produced this issue caught
+//! the worker claiming a byte-for-byte match that did not exist, spent its
+//! two revisions, and reported `VerificationFailed` with roughly two thirds
+//! of its allowance still unspent — so the expensive half of verification
+//! (knowing the work is wrong) bought nothing, and a caught wrong answer
+//! scored exactly like an uncaught one.
+//!
+//! The decision itself lives in [`stella_core::repair`], which is pure and
+//! bounded and property-tested there. This module is only the measuring tape:
+//! it reads what the pipeline actually knows about the run's remaining money
+//! and wall clock and hands those over as owned data.
+
+use std::time::Instant;
+
+use stella_core::BudgetGuard;
+use stella_core::repair::{RepairCost, RepairHeadroom, RepairPlan, plan_repair};
+use stella_protocol::BudgetMode;
+
+use super::{CandidateState, Pipeline};
+
+/// Meters one candidate's verification arc from the moment it starts
+/// verifying, so the gate can price the next repair attempt from the rounds
+/// that already ran.
+///
+/// Started once per candidate and never restarted: the estimate the gate
+/// wants is the *mean* round, and a mean over the whole arc is both steadier
+/// than the last round alone and cheaper to thread — one value taken before
+/// the loop instead of a reassignment on every path that revises.
+///
+/// It starts where verification starts, so the candidate's first worker turn
+/// sits outside it and the first round's mean reads low. Every round after
+/// that contains a whole repair (the revise turn plus the verification round
+/// it earned), so the estimate only ever climbs toward the truth — and it
+/// errs toward granting, which the cap is there to bound.
+pub(super) struct RepairMeter {
+    started_usd: f64,
+    started_at: Instant,
+}
+
+impl RepairMeter {
+    /// Begin metering at the run's current cumulative spend.
+    pub(super) fn start(spent_usd: f64) -> Self {
+        Self {
+            started_usd: spent_usd,
+            started_at: Instant::now(),
+        }
+    }
+
+    /// The mean cost of the `rounds` verification rounds run so far, given
+    /// the run's current cumulative spend.
+    fn mean_round(&self, spent_usd: f64, rounds: u32) -> RepairCost {
+        RepairCost::mean_of(
+            rounds,
+            (spent_usd - self.started_usd).max(0.0),
+            self.started_at.elapsed(),
+        )
+    }
+}
+
+impl Pipeline<'_> {
+    /// Whether a refuted verdict earns another repair round.
+    ///
+    /// `false` ends the candidate on the verdict it was just handed — and
+    /// says why first, because a run that stops with room it could not use
+    /// looks identical from the outside to one that simply gave up
+    /// (degradation warns, it never disables).
+    pub(super) fn affords_repair(
+        &self,
+        state: &CandidateState,
+        meter: &RepairMeter,
+        spent_usd: f64,
+        budget: &BudgetGuard,
+    ) -> bool {
+        // Rounds run = revisions spent + the one that just produced this
+        // refutation.
+        let rounds = state.revisions.saturating_add(1);
+        match plan_repair(
+            state.revisions,
+            self.config.max_revisions,
+            self.repair_headroom(budget),
+            meter.mean_round(spent_usd, rounds),
+        ) {
+            RepairPlan::Attempt { .. } => true,
+            RepairPlan::Stop(refusal) => {
+                self.warn(format!(
+                    "verification refuted this result and no repair round was started: {}.",
+                    refusal.sentence()
+                ));
+                false
+            }
+        }
+    }
+
+    /// What this run can still measure about its own remaining room.
+    ///
+    /// Both axes are `None` unless the caller declared the limit itself. An
+    /// `Off` budget guard is treated as unmetered even when limits are set on
+    /// it: `Off` means nothing is gated on spend, and letting a decorative
+    /// limit stop a repair round would make it a hard ceiling by the back
+    /// door.
+    fn repair_headroom(&self, budget: &BudgetGuard) -> RepairHeadroom {
+        RepairHeadroom {
+            budget_usd: (budget.mode() != BudgetMode::Off)
+                .then(|| budget.headroom_usd())
+                .flatten(),
+            // The same deadline the engine declines length continuations
+            // against, measured from when this pipeline was constructed —
+            // one pipeline drives one turn, so its own lifetime is the turn's
+            // elapsed time.
+            wall_clock: self
+                .config
+                .engine
+                .turn_budget
+                .map(|budget| budget.saturating_sub(self.started.elapsed())),
+        }
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -2385,6 +2385,8 @@ mod mcp_prefetch;
 mod scope_gate_interactive;
 mod terminal_outcomes;
 mod usage;
+/// Bounded repair after a refuted success claim (#1479).
+mod verdict_repair;
 mod verification_hardening;
 /// Asking for corroboration when only a model verifier approved the work
 /// (#1295), and — the part that decides whether the ask is affordable —

--- a/crates/stella-pipeline/src/pipeline/tests/verdict_repair.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verdict_repair.rs
@@ -1,0 +1,170 @@
+//! #1479: a refuted success claim is a *finding*, not the end of the run.
+//!
+//! Verification catching the model lying about success is the expensive half
+//! of the work, and it was being thrown away: the revision allowance is a
+//! bare count, so once it was spent the run reported `VerificationFailed`
+//! however much budget and wall clock were still sitting unspent. A caught
+//! failure and an uncaught one scored identically.
+//!
+//! These scenarios pin both directions of the gate — a measured axis with
+//! room grants bounded repair attempts past the allowance, and an
+//! unmeasured one grants nothing, so a caller that never declared a ceiling
+//! keeps exactly the behaviour it always had.
+
+use super::*;
+
+/// The three verification rounds every scenario here runs: a red baseline
+/// (arming the flip oracle), two red candidate rounds, then a green one and
+/// its pre-submit confirmation re-run.
+fn three_round_runner() -> ScriptedRunner {
+    ScriptedRunner::new(
+        vec![false, false, false, true, true],
+        "@@ -1 +1 @@\n-old\n+new",
+    )
+}
+
+/// Triage, the worker, and one turn per repair attempt. Two spare entries so
+/// the run that stops early is stopped by the gate under test rather than by
+/// an exhausted script.
+fn repair_provider() -> ScriptedProvider {
+    ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("second attempt"),
+        text_result("third attempt"),
+        text_result("unused"),
+    ])
+}
+
+/// Every port is scripted the same way in both scenarios; only the budget
+/// guard and the assertion differ, which is exactly the variable under test.
+macro_rules! repair_scenario {
+    ($provider:expr, $runner:expr, $budget:expr) => {{
+        let provider = $provider;
+        let resolver = OneProvider(&provider);
+        let runner = $runner;
+        let tools = EmptyTools;
+        let recall = NoContextRecall;
+        let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
+        let approvals = AutoApproveGate;
+        let sleeper = NoopSleeper;
+        let router = router();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let pipeline = Pipeline::new(
+            PipelinePorts {
+                router: &router,
+                providers: &resolver,
+                tools: &tools,
+                recall: &recall,
+                repo: &repo,
+                repo_status: &repo_status,
+                touches: &NoFileTouches,
+                diagnostics: &runner,
+                tests: &runner,
+                lint: None,
+                mutation: None,
+                coverage: None,
+                approvals: &approvals,
+                sleeper: &sleeper,
+                hooks: None,
+                candidate_workspaces: None,
+                mcp_prefetch: None,
+                steering: None,
+            },
+            tx,
+            PipelineConfig {
+                test_command: Some("cargo test -p x".into()),
+                // One revision by configuration: the second red round is the
+                // one the allowance can no longer pay for, which is where the
+                // repair gate has to answer.
+                max_revisions: 1,
+                // Off so the scenario's model script stays a pure count of
+                // worker turns — the guidance call is a separate feature with
+                // its own witnesses.
+                distress_guidance: false,
+                ..PipelineConfig::default()
+            },
+        );
+        let mut messages = vec![CompletionMessage::system("sys")];
+        let mut budget = $budget;
+        let outcome = pipeline
+            .run(
+                "Make input.csv match expected.csv",
+                &mut messages,
+                &mut budget,
+            )
+            .await
+            .expect("a refuted verdict is a typed outcome, never a hard error");
+        (outcome, drain(&mut rx))
+    }};
+}
+
+/// The witness. Two red rounds spend the configured allowance; a declared
+/// budget ceiling with room left in it buys a third round, and that one goes
+/// green. Before #1479 the run stopped on the second refutation and reported
+/// `VerificationFailed` with 99.9% of the declared ceiling unspent.
+#[tokio::test]
+async fn a_refuted_verdict_with_headroom_earns_another_repair_round() {
+    let (outcome, events) = repair_scenario!(
+        repair_provider(),
+        three_round_runner(),
+        BudgetGuard::new(BudgetMode::Observed, None, Some(5.0))
+    );
+
+    assert_eq!(
+        outcome.status,
+        PipelineStatus::Completed,
+        "a repair round the declared budget could afford must be taken, not \
+         thrown away with the ceiling almost untouched: {:?}",
+        outcome.verdict
+    );
+    let verdict = outcome
+        .verdict
+        .expect("the passing round produced a verdict");
+    assert!(
+        verdict.passed,
+        "the third round's fail->pass flip is the verdict: {verdict:?}"
+    );
+    assert_eq!(
+        outcome.revisions, 2,
+        "one revision from the configured allowance plus one earned from the \
+         measured headroom"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::Complete { .. })),
+        "a repaired run ends on the success terminal event: {events:?}"
+    );
+}
+
+/// The other direction, and the reason the gate reads a *measured* axis
+/// rather than granting attempts on optimism: a guard that declares no
+/// ceiling at all cannot say whether another round is affordable, so the
+/// configured allowance stays the whole of the bound. Identical script to the
+/// witness above — only the budget guard changes.
+#[tokio::test]
+async fn an_unmeasured_budget_grants_no_repair_past_the_allowance() {
+    let (outcome, events) = repair_scenario!(
+        repair_provider(),
+        three_round_runner(),
+        BudgetGuard::new(BudgetMode::Off, None, None)
+    );
+
+    assert!(
+        matches!(outcome.status, PipelineStatus::VerificationFailed { .. }),
+        "with nothing measuring the run, the allowance is the only bound: {:?}",
+        outcome.status
+    );
+    assert_eq!(
+        outcome.revisions, 1,
+        "exactly the configured allowance — no round is granted on optimism"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::Complete { .. })),
+        "a refuted run must never emit the success terminal event: {events:?}"
+    );
+}

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,8 +27,8 @@
 2076 crates/stella-model/src/openai.rs
 1542 crates/stella-model/src/zai.rs
 1815 crates/stella-model/src/zai/tests.rs
-3868 crates/stella-pipeline/src/pipeline.rs
-2664 crates/stella-pipeline/src/pipeline/tests.rs
+3874 crates/stella-pipeline/src/pipeline.rs
+2666 crates/stella-pipeline/src/pipeline/tests.rs
 2950 crates/stella-protocol/src/event.rs
 2074 crates/stella-store/src/lib.rs
 2268 crates/stella-store/src/tests.rs


### PR DESCRIPTION
## What & why

Verification catching the model lying about success was being thrown away.

Every failing rung of the verification ladder gated its next revision on the
same bare count — `state.revisions >= self.config.max_revisions` — and a count
cannot see the constraint that actually binds. The run behind the issue
(ArenaBench `dd52a57a6f49`, `terminal-bench/large-scale-text-editing`) caught
the worker claiming a byte-for-byte match that did not exist, spent its two
revisions, and reported `VerificationFailed` with roughly two thirds of the
task allowance still unspent. The expensive half of the work — *knowing* the
answer is wrong — bought nothing, and a caught wrong answer scored identically
to an uncaught one.

**The decision moves into `stella-core`.** `repair::plan_repair` is a pure,
synchronous function over owned data (no clock, no budget guard, no config —
the caller supplies the measurements), bounded on three independent axes with
the tightest one binding:

1. **The cap** — `REPAIR_ATTEMPT_CAP` (4) is the hard ceiling on attempts for
   one verification arc, whatever the measurements say. A caller that
   configured a *larger* allowance keeps it; the ceiling bounds what this
   module grants unasked, never what the caller asked for.
2. **The allowance** — attempts inside `max_revisions` are granted
   unconditionally. Nothing any caller already had is withdrawn.
3. **The measurement** — attempts *past* the allowance are granted only when a
   measured axis says another one fits.

An axis nobody configured **abstains** rather than approving, so a run that
declared no ceiling and no deadline keeps its old bound exactly — the same
conservative default `EngineConfig::turn_budget` already takes, and the reason
no existing test changed behaviour. A measured axis that cannot pay for another
round refuses **even inside the allowance**: starting a repair that cannot
finish converts a reported failure into a budget abort or an external kill,
which is strictly worse than reporting the verdict.

Refusal is never suppression. Every refusal carries a named reason
(`CapReached` / `Unmeasured` / `NoHeadroom`), the gate warns with it, and the
verdict is reported either way — degradation warns, it never disables.

**`pipeline::repair_gate` is only the measuring tape.** It reads
`BudgetGuard::headroom_usd()` (only when the guard actually meters — an `Off`
guard's decorative limit must not become a hard ceiling by the back door) and
`EngineConfig::turn_budget` against the pipeline's own elapsed clock, prices
the next round from the mean of the rounds already run, and replaces the three
count comparisons in `verify_candidate`. The refutation itself already rides
back to the worker as the revision prompt (the deterministic brief, the
verifier's reasoning through the airlock) — this PR is the missing half: the
path that lets it be sent at all.

Closes #1479

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`pipeline::tests::verdict_repair::a_refuted_verdict_with_headroom_earns_another_repair_round`
scripts a red baseline, two red verification rounds against a one-revision
allowance, and a green third, with a declared budget ceiling that has room in
it.

Proven the artisanal way — the test file was written and run **first**, against
unmodified production code:

```
test ...a_refuted_verdict_with_headroom_earns_another_repair_round ... FAILED
  left: VerificationFailed { verdict: Verdict { passed: false, ... rung: Some(Revise) ... } }
 right: Completed
```

and after the fix:

```
test ...an_unmeasured_budget_grants_no_repair_past_the_allowance ... ok
test ...a_refuted_verdict_with_headroom_earns_another_repair_round ... ok
```

Two more layers back the bound itself:

- The sibling scenario pins the **other** direction — an unmeasured guard
  grants nothing past the allowance, so no caller starts spending more by
  doing nothing.
- `repair.rs` carries unit tests for each refusal and two property tests: no
  inputs ever grant an attempt at or past the effective cap, and *granting
  every affordable attempt still terminates* — the property that makes
  re-entry safe to wire into a loop at all.

## The gate

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p stella-core --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-core` — 928 pass, 0 fail
- [x] `cargo test -p stella-pipeline` — 477 + 22 pass, 0 fail
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core -p stella-pipeline --no-deps` — clean
- [x] `check-file-size`, `check-invariants`, `check-doc-links`, `check-no-scratch` — clean
- [x] Docs updated: module doc comments throughout, plus the `stella-core`
      README module map
- [x] `Closes #1479` appears both here and as a commit trailer

The full workspace build was left to CI deliberately (shared 16 GB machine);
the change is additive at every crate boundary — a new public module in
`stella-core` and one private field on `Pipeline` constructed internally — so
nothing downstream can fail to compile.

## Ground-rule check

- [x] No I/O added to `stella-core` — `repair.rs` is plain synchronous
      functions over owned data, in the same shape as `budget`, `loop_detect`
      and `driver/truncation`. Every measurement is supplied by the caller.
- [x] No new dependencies
- [x] No new outbound network calls
- [x] Budget aborts stay at safe boundaries — the gate is consulted between
      verification rounds, never mid-tool
- [x] God files respected — no new logic in `driver.rs`; the pipeline's three
      call sites are edits in place, and all new code lives in two new sibling
      modules

## Anything reviewers should know?

**The `+6` / `+2` file-size baseline bump is deliberate and minimal.**
`pipeline.rs` and `pipeline/tests.rs` were both sitting exactly on their
recorded ceilings, so the module declaration, the `started` field and the meter
could not land silently. Every line of new logic went into
`pipeline/repair_gate.rs` and `pipeline/tests/verdict_repair.rs`; what remains
in the god files is the module declaration, one field, one `let`, and three
in-place condition edits.

**Why the cap is a const rather than a config knob.** `REPAIR_ATTEMPT_CAP`
lives in `stella-core` with its rationale attached. Making it a
`PipelineConfig` field would have grown `pipeline.rs` further for a knob nobody
has asked for yet; filed as #1506 rather than guessed at.

Follow-ups filed, not fixed here:

- **#1506** — expose the repair-attempt cap as a `PipelineConfig` field.
- **#1507** — the wall-clock axis reads `EngineConfig::turn_budget`, which is a
  *per-engine-turn* budget; a multi-step plan runs several engine turns inside
  one pipeline run, so using it as the run's deadline systematically
  under-reports remaining time. Conservative (it refuses early rather than
  over-granting), but a first-class pipeline-run deadline is the right fix.
- **#1509** — `verifier_evidence_demand` spends from the same `revisions`
  counter a real repair does, so a run that spends its allowance on an
  unanswered evidence demand has none left for the repair the refutation
  actually earned.
