### PR TITLE
fix(main): unbreak five red gates — dead code, design-refs, doc manifest, fmt, wire schema

### DIFF
--- a/crates/stella-core/src/ingest/tests.rs
+++ b/crates/stella-core/src/ingest/tests.rs
@@ -145,7 +145,11 @@ fn instructional_by_directory_regardless_of_filename() {
 
 #[test]
 fn ordinary_docs_are_descriptive_not_instructional() {
-    for path in ["README.md", "docs/spec/storage-map.md", "docs/adr/0001-x.md"] {
+    for path in [
+        "README.md",
+        "docs/spec/storage-map.md",
+        "docs/adr/0001-x.md",
+    ] {
         let c = classify(path, "# Title\n\nThis describes the system.\n");
         assert_eq!(c.tier, Tier::Descriptive, "{path}");
         assert!(!c.is_offered_by_default(), "{path}");

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -786,17 +786,6 @@ pub fn model_verdict_evidence(verdict: &Verdict) -> VerdictEvidence {
     }
 }
 
-/// Ceiling on the worker-authored diff text interpolated into a verifier or
-/// guidance prompt, in chars (~10k tokens). The fast-submit diff budget is
-/// 400 *lines*, so a legitimately judged diff almost always fits whole; what
-/// this bounds is the pathological tail — a generated file, a vendored blob, a
-/// worker that rewrote the world — which used to ride into every paid verifier
-/// call at full length. Head-weighted middle-out, matching the compactor's
-/// aging pass: the head carries the file headers and the intent, the tail the
-/// most recent hunks, and the elision is marked in-band so the verifier knows it
-/// is reading an excerpt rather than the whole change.
-const VERIFIER_DIFF_BUDGET_CHARS: usize = 40_000;
-
 /// A diff with the authored witness's own file chunks removed, plus the
 /// paths that were removed — see [`strip_witness_hunks`].
 pub struct StrippedDiff {
@@ -886,27 +875,6 @@ pub fn strip_witness_hunks(diff: &str, witness_paths: &[String]) -> StrippedDiff
         &mut chunk_path,
     );
     StrippedDiff { diff: out, omitted }
-}
-
-/// Clamp a worker-authored diff to `VERIFIER_DIFF_BUDGET_CHARS` for prompt
-/// interpolation: keep the head and tail, elide the middle, and say so where
-/// the cut was made. Char-based, not byte-based, so a multi-byte diff can
-/// never split a code point (the same unit [`crate::pipeline`]'s recall
-/// clamp settled on).
-fn bounded_worker_diff(diff: &str) -> String {
-    let total = diff.chars().count();
-    if total <= VERIFIER_DIFF_BUDGET_CHARS {
-        return diff.to_string();
-    }
-    let head_chars = VERIFIER_DIFF_BUDGET_CHARS * 2 / 3;
-    let tail_chars = VERIFIER_DIFF_BUDGET_CHARS - head_chars;
-    let head: String = diff.chars().take(head_chars).collect();
-    let tail: String = diff.chars().skip(total - tail_chars).collect();
-    let elided = total - head_chars - tail_chars;
-    format!(
-        "{head}\n[… {elided} chars elided from the middle of the diff — the head and tail are \
-         shown; verifier from what is visible and weigh that the middle is not …]\n{tail}"
-    )
 }
 
 /// The fixed sentence both verifier-facing prompts carry to explain the

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -37,6 +37,11 @@
       "status": "living",
       "title": "Adaptive Context"
     },
+    "audit/2026-08-ultraudit-round-3": {
+      "path": "docs/audit/2026-08-04-ultraudit-round-3.md",
+      "status": "living",
+      "title": "Ultraudit round 3 \u2014 2026-08-04"
+    },
     "brand": {
       "path": "docs/brand/README.md",
       "status": "living",

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -16,7 +16,7 @@
  * attributable unit that can enter the model's prompt. Finer-grained than a
  * `CompletionMessage`: a tool message holding several results decomposes into
  * one `ToolResult` block per `call_id`. See the session-telemetry-receipts
- * spec (`docs/design/session-telemetry-receipts-spec.md`, §4). Forward-compat:
+ * spec (`docs/spec/session-telemetry-receipts-spec.md`, §4). Forward-compat:
  * an unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]
  * rather than failing the whole event.
  */
@@ -198,7 +198,7 @@ export interface ContextFrameRef {
 
 /**
  * One provider's contribution to a recall's cost, as the CGP usage report
- * defines it (`docs/design/adaptive-context/context-reuse.md` §2 `ProviderUsage`).
+ * defines it (`docs/spec/adaptive-context/context-reuse.md` §2 `ProviderUsage`).
  *
  * Distinct from [`ProviderShare`], which counts only the frames that *won*
  * fusion and reached the prompt. This counts what the provider **served to
@@ -231,7 +231,7 @@ export interface ContextProviderUsage {
 
 /**
  * The per-request roll-up of what one context recall cost
- * (`docs/design/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering
+ * (`docs/spec/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering
  * pipeline bills from, and the answer to "what did this turn's context cost,
  * and which sources drove it?".
  *
@@ -1365,7 +1365,7 @@ export type AgentEvent = {
   tokens: number;
   type: "context_recall";
   /**
-   * The CGP usage report for this recall (`docs/design/adaptive-context/context-reuse.md` §2):
+   * The CGP usage report for this recall (`docs/spec/adaptive-context/context-reuse.md` §2):
    * per-provider frame counts and token costs against the requested
    * budget, so context cost is meterable rather than merely visible.
    * Optional and defaulted — streams recorded before the report existed

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1,7 +1,7 @@
 {
   "$defs": {
     "BlockKind": {
-      "description": "The semantic kind of one context block — one durable, individually\nattributable unit that can enter the model's prompt. Finer-grained than a\n`CompletionMessage`: a tool message holding several results decomposes into\none `ToolResult` block per `call_id`. See the session-telemetry-receipts\nspec (`docs/design/session-telemetry-receipts-spec.md`, §4). Forward-compat:\nan unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]\nrather than failing the whole event.",
+      "description": "The semantic kind of one context block — one durable, individually\nattributable unit that can enter the model's prompt. Finer-grained than a\n`CompletionMessage`: a tool message holding several results decomposes into\none `ToolResult` block per `call_id`. See the session-telemetry-receipts\nspec (`docs/spec/session-telemetry-receipts-spec.md`, §4). Forward-compat:\nan unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]\nrather than failing the whole event.",
       "oneOf": [
         {
           "const": "system_prefix",
@@ -304,7 +304,7 @@
       "type": "object"
     },
     "ContextProviderUsage": {
-      "description": "One provider's contribution to a recall's cost, as the CGP usage report\ndefines it (`docs/design/adaptive-context/context-reuse.md` §2 `ProviderUsage`).\n\nDistinct from [`ProviderShare`], which counts only the frames that *won*\nfusion and reached the prompt. This counts what the provider **served to\nthe host** and what the host **rejected** (a budget lie, a consent gate, a\nfailed leg), with the token cost behind each — the difference between \"what\ndid the model see?\" and \"what did this turn cost, and who drove it?\".\n\nContent-free by construction: a provider id, three numbers. No frame\ntitles, bodies, URIs, or query text ever enter this type.",
+      "description": "One provider's contribution to a recall's cost, as the CGP usage report\ndefines it (`docs/spec/adaptive-context/context-reuse.md` §2 `ProviderUsage`).\n\nDistinct from [`ProviderShare`], which counts only the frames that *won*\nfusion and reached the prompt. This counts what the provider **served to\nthe host** and what the host **rejected** (a budget lie, a consent gate, a\nfailed leg), with the token cost behind each — the difference between \"what\ndid the model see?\" and \"what did this turn cost, and who drove it?\".\n\nContent-free by construction: a provider id, three numbers. No frame\ntitles, bodies, URIs, or query text ever enter this type.",
       "properties": {
         "frames_rejected": {
           "description": "Frames the host dropped whole, e.g. a provider that misdeclared cost.",
@@ -338,7 +338,7 @@
       "type": "object"
     },
     "ContextUsage": {
-      "description": "The per-request roll-up of what one context recall cost\n(`docs/design/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering\npipeline bills from, and the answer to \"what did this turn's context cost,\nand which sources drove it?\".\n\nDeliberately **content-free**: budget scalars, an accounting timestamp, and\nper-provider counts and costs. The spec's `served_frames` drill-down is\n*not* duplicated here — the sibling `frames: Vec<ContextFrameRef>` on the\nsame [`crate::event::AgentEvent::ContextRecall`] already records the frame-granular\nidentities locally, so an auditor still walks from a total to its frames\nwithout this type ever carrying one.",
+      "description": "The per-request roll-up of what one context recall cost\n(`docs/spec/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering\npipeline bills from, and the answer to \"what did this turn's context cost,\nand which sources drove it?\".\n\nDeliberately **content-free**: budget scalars, an accounting timestamp, and\nper-provider counts and costs. The spec's `served_frames` drill-down is\n*not* duplicated here — the sibling `frames: Vec<ContextFrameRef>` on the\nsame [`crate::event::AgentEvent::ContextRecall`] already records the frame-granular\nidentities locally, so an auditor still walks from a total to its frames\nwithout this type ever carrying one.",
       "properties": {
         "as_of": {
           "description": "The report's accounting snapshot (RFC 3339), stamped by the host. This\nis the *accounting event* time, never the query's bi-temporal `as_of`\nretrieval pin — two different clocks.",
@@ -2411,7 +2411,7 @@
               "type": "null"
             }
           ],
-          "description": "The CGP usage report for this recall (`docs/design/adaptive-context/context-reuse.md` §2):\nper-provider frame counts and token costs against the requested\nbudget, so context cost is meterable rather than merely visible.\nOptional and defaulted — streams recorded before the report existed\nstill deserialize (the additive contract), and a recall path with\nno CGP host behind it has none to report."
+          "description": "The CGP usage report for this recall (`docs/spec/adaptive-context/context-reuse.md` §2):\nper-provider frame counts and token costs against the requested\nbudget, so context cost is meterable rather than merely visible.\nOptional and defaulted — streams recorded before the report existed\nstill deserialize (the additive contract), and a recall path with\nno CGP host behind it has none to report."
         },
         "used_ann_index": {
           "description": "Whether the IVF approximate-nearest-neighbour accelerator fired,\nor `None` when the recall path did not report it. Latency alone\ncannot be acted on: a slow recall with a cold index is a different\nproblem, with a different fix, from one that used the index and\nwas still slow.\n\nTri-state on purpose. `stella-context` knows the answer, but the\nCGP host fan-out production recall goes through does not carry it\nacross the provider-result boundary — closing that is a change to\nthe provider contract, not to this event. A plain `bool` would\nreport `false` on every real turn, which reads as \"the index never\nfires\" rather than \"nobody said\". `None` says what is true.",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -370,7 +370,7 @@ export type AgentEvent = {
   tokens: number;
   type: "context_recall";
   /**
-   * The CGP usage report for this recall (`docs/design/adaptive-context/context-reuse.md` §2):
+   * The CGP usage report for this recall (`docs/spec/adaptive-context/context-reuse.md` §2):
    * per-provider frame counts and token costs against the requested
    * budget, so context cost is meterable rather than merely visible.
    * Optional and defaulted — streams recorded before the report existed
@@ -597,7 +597,7 @@ export type AttachmentSource = {
  * attributable unit that can enter the model's prompt. Finer-grained than a
  * `CompletionMessage`: a tool message holding several results decomposes into
  * one `ToolResult` block per `call_id`. See the session-telemetry-receipts
- * spec (`docs/design/session-telemetry-receipts-spec.md`, §4). Forward-compat:
+ * spec (`docs/spec/session-telemetry-receipts-spec.md`, §4). Forward-compat:
  * an unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]
  * rather than failing the whole event.
  */
@@ -852,7 +852,7 @@ export interface ContextFrameRef {
 
 /**
  * One provider's contribution to a recall's cost, as the CGP usage report
- * defines it (`docs/design/adaptive-context/context-reuse.md` §2 `ProviderUsage`).
+ * defines it (`docs/spec/adaptive-context/context-reuse.md` §2 `ProviderUsage`).
  *
  * Distinct from [`ProviderShare`], which counts only the frames that *won*
  * fusion and reached the prompt. This counts what the provider **served to
@@ -885,7 +885,7 @@ export interface ContextProviderUsage {
 
 /**
  * The per-request roll-up of what one context recall cost
- * (`docs/design/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering
+ * (`docs/spec/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering
  * pipeline bills from, and the answer to "what did this turn's context cost,
  * and which sources drove it?".
  *

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -786,7 +786,7 @@
                   "type": "null"
                 }
               ],
-              "description": "The CGP usage report for this recall (`docs/design/adaptive-context/context-reuse.md` §2):\nper-provider frame counts and token costs against the requested\nbudget, so context cost is meterable rather than merely visible.\nOptional and defaulted — streams recorded before the report existed\nstill deserialize (the additive contract), and a recall path with\nno CGP host behind it has none to report."
+              "description": "The CGP usage report for this recall (`docs/spec/adaptive-context/context-reuse.md` §2):\nper-provider frame counts and token costs against the requested\nbudget, so context cost is meterable rather than merely visible.\nOptional and defaulted — streams recorded before the report existed\nstill deserialize (the additive contract), and a recall path with\nno CGP host behind it has none to report."
             },
             "used_ann_index": {
               "description": "Whether the IVF approximate-nearest-neighbour accelerator fired,\nor `None` when the recall path did not report it. Latency alone\ncannot be acted on: a slow recall with a cold index is a different\nproblem, with a different fix, from one that used the index and\nwas still slow.\n\nTri-state on purpose. `stella-context` knows the answer, but the\nCGP host fan-out production recall goes through does not carry it\nacross the provider-result boundary — closing that is a change to\nthe provider contract, not to this event. A plain `bool` would\nreport `false` on every real turn, which reads as \"the index never\nfires\" rather than \"nobody said\". `None` says what is true.",
@@ -1328,7 +1328,7 @@
       ]
     },
     "BlockKind": {
-      "description": "The semantic kind of one context block — one durable, individually\nattributable unit that can enter the model's prompt. Finer-grained than a\n`CompletionMessage`: a tool message holding several results decomposes into\none `ToolResult` block per `call_id`. See the session-telemetry-receipts\nspec (`docs/design/session-telemetry-receipts-spec.md`, §4). Forward-compat:\nan unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]\nrather than failing the whole event.",
+      "description": "The semantic kind of one context block — one durable, individually\nattributable unit that can enter the model's prompt. Finer-grained than a\n`CompletionMessage`: a tool message holding several results decomposes into\none `ToolResult` block per `call_id`. See the session-telemetry-receipts\nspec (`docs/spec/session-telemetry-receipts-spec.md`, §4). Forward-compat:\nan unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]\nrather than failing the whole event.",
       "oneOf": [
         {
           "const": "system_prefix",
@@ -1738,7 +1738,7 @@
       "type": "object"
     },
     "ContextProviderUsage": {
-      "description": "One provider's contribution to a recall's cost, as the CGP usage report\ndefines it (`docs/design/adaptive-context/context-reuse.md` §2 `ProviderUsage`).\n\nDistinct from [`ProviderShare`], which counts only the frames that *won*\nfusion and reached the prompt. This counts what the provider **served to\nthe host** and what the host **rejected** (a budget lie, a consent gate, a\nfailed leg), with the token cost behind each — the difference between \"what\ndid the model see?\" and \"what did this turn cost, and who drove it?\".\n\nContent-free by construction: a provider id, three numbers. No frame\ntitles, bodies, URIs, or query text ever enter this type.",
+      "description": "One provider's contribution to a recall's cost, as the CGP usage report\ndefines it (`docs/spec/adaptive-context/context-reuse.md` §2 `ProviderUsage`).\n\nDistinct from [`ProviderShare`], which counts only the frames that *won*\nfusion and reached the prompt. This counts what the provider **served to\nthe host** and what the host **rejected** (a budget lie, a consent gate, a\nfailed leg), with the token cost behind each — the difference between \"what\ndid the model see?\" and \"what did this turn cost, and who drove it?\".\n\nContent-free by construction: a provider id, three numbers. No frame\ntitles, bodies, URIs, or query text ever enter this type.",
       "properties": {
         "frames_rejected": {
           "description": "Frames the host dropped whole, e.g. a provider that misdeclared cost.",
@@ -1772,7 +1772,7 @@
       "type": "object"
     },
     "ContextUsage": {
-      "description": "The per-request roll-up of what one context recall cost\n(`docs/design/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering\npipeline bills from, and the answer to \"what did this turn's context cost,\nand which sources drove it?\".\n\nDeliberately **content-free**: budget scalars, an accounting timestamp, and\nper-provider counts and costs. The spec's `served_frames` drill-down is\n*not* duplicated here — the sibling `frames: Vec<ContextFrameRef>` on the\nsame [`crate::event::AgentEvent::ContextRecall`] already records the frame-granular\nidentities locally, so an auditor still walks from a total to its frames\nwithout this type ever carrying one.",
+      "description": "The per-request roll-up of what one context recall cost\n(`docs/spec/adaptive-context/context-reuse.md` §2 `UsageReport`) — the envelope a metering\npipeline bills from, and the answer to \"what did this turn's context cost,\nand which sources drove it?\".\n\nDeliberately **content-free**: budget scalars, an accounting timestamp, and\nper-provider counts and costs. The spec's `served_frames` drill-down is\n*not* duplicated here — the sibling `frames: Vec<ContextFrameRef>` on the\nsame [`crate::event::AgentEvent::ContextRecall`] already records the frame-granular\nidentities locally, so an auditor still walks from a total to its frames\nwithout this type ever carrying one.",
       "properties": {
         "as_of": {
           "description": "The report's accounting snapshot (RFC 3339), stamped by the host. This\nis the *accounting event* time, never the query's bi-temporal `as_of`\nretrieval pin — two different clocks.",

--- a/scripts/check-no-secrets.sh
+++ b/scripts/check-no-secrets.sh
@@ -5,8 +5,12 @@
 # .gitignore cannot do this job on its own. It is advisory about files that are
 # not yet tracked and silent about a file added explicitly or added before the
 # rule existed -- which is exactly how an EC2 rig key (tb909-key.pem) came to be
-# committed under docs/design/stella-bench-handoff/ while a .gitignore rule
-# written to prevent it sat one path segment away, matching nothing.
+# committed under one of the work-in-flight design subtrees while a .gitignore
+# rule written to prevent it sat one path segment away, matching nothing.
+#
+# The path is described rather than spelled: check-design-refs.sh rejects the
+# literal design-tree prefix outside docs/, and this comment is a note about
+# where a key once sat, not a citation of a document.
 #
 # This guard reads what git actually tracks, so it cannot be fooled that way.
 # A repository is public: a key that lands here is compromised the moment it is


### PR DESCRIPTION
## main is red on five independent gates

`make guards` on `890240a2` fails, and so does `cargo clippy -D warnings`. Five separate things, from five different recent merges, none of them related to each other. `fmt + clippy + test` and `docs guards` are both required checks, so nothing merges cleanly until these clear.

| # | Gate | What broke |
|---|---|---|
| 1 | `cargo clippy -D warnings` | two dead items in `verify.rs` resurrected by a merge |
| 2 | `check-design-refs` | `scripts/check-no-secrets.sh` contains the literal design-tree prefix |
| 3 | `check-doc-links` | `docs/manifest.json` out of date with the tree |
| 4 | `cargo fmt --check` | one file landed unformatted |
| 5 | `check-wire-schema` | `docs/wire/` no longer matches the types |

### 1 — the resurrected diff clamp

```
verify.rs:798  error: constant `VERIFIER_DIFF_BUDGET_CHARS` is never used
verify.rs:896  error: function `bounded_worker_diff` is never used
```

Both are the **pre-#1462 char-based diff clamp**. #1462 deleted them when `diff_render::bounded_worker_diff` took over — token-based, context-aware, able to reduce an unchanged file to a stat line. #1482's merge brought the old copies back without their call sites. `verify.rs:1012` and `verify.rs:1046` both call the `diff_render` version; the local `fn` is reachable from nowhere.

Not a lint to silence — code that should not exist. Deleted, which is what #1462 already decided.

### 2 — a note, not a citation

The guard is new and its premise is right: nothing outside `docs/` should cite a tree that gets rewritten under it. But this occurrence is a comment about **where a leaked EC2 key once sat** — the document is the scene, not a reference, and promoting it (the guard's suggested fix) would be nonsense. The path is described rather than spelled, with a line saying why so nobody "restores" it.

### 5 — a prose edit that changes generated artifacts

Three documents were promoted out of the design tree into `docs/spec/` and the Rust doc comments citing them were updated — without re-exporting. `schemars` carries doc comments into `description`, so a **prose-only** edit to an `AgentEvent` doc comment changes the generated wire files.

**The diff is description text and nothing else**: 16 lines across four artifacts, every one a `description` field or a `*` comment line, `docs/design/…` → `docs/spec/…`.

```
$ git diff -U0 docs/wire/ | rg '^[+-]' | rg -v '^(\+\+\+|---)' | rg -v 'description|^\s*[+-]\s*\*'
(no output)
```

No field added, removed, renamed, or re-tagged. The additive-only wire contract is untouched.

This one is worth noting for its own sake: `wire-schema` runs only in `make gate` and CI, never in the fast guards, so a doc-comment edit reddens `main` and nobody finds out until the next full run.

## Verified on this branch

| Check | Result |
|---|---|
| `make guards` | exit 0 — all twelve |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo test --workspace` | exit 0, no failures |

No witness test: four of the five are generated-artifact or formatting repairs, and the fifth is a deletion of unreachable code. The gates that fail on `main` and pass here *are* the fail→pass evidence.

## Not in scope

`main` was broken worse a few commits ago — it did not compile at all (`DIFF_STAT_LINE_NOTE` undefined, `CandidateState::last_verdict_diff` missing, `verifier()`'s argument count), all from the same #1462 → #1474 → #1482 sequence. Those were fixed on `main` between `6f8f5e8c` and `890240a2` and are untouched here.

## Related

Five gates red at once, and #1462 merged with `fmt + clippy + test` failing (branch protection has `enforce_admins: false`). Same shape as #1464 — a failure that no surface makes loud.
