### PR TITLE
feat(stella-observatory): sent-context inspection — receipt-reconstructed model-call context in the drawer

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -24,9 +24,16 @@ The price used to be three acknowledged copies. `global::data_dir` was one of
 them — a hand-synced mirror of `../stella-store/src/usage.rs` with a comment
 asking readers to keep it equal — and is now shared through `stella-home`
 instead (#1139); linking a crate that is pure path arithmetic over environment
-variables and opens nothing costs none of the isolation above. Two copies
+variables and opens nothing costs none of the isolation above. Three copies
 remain: `project_id_for` ([`src/global.rs`](src/global.rs)) still mirrors the
-store's, and `/api/explorations` re-hashes exploration manifests itself.
+store's, `/api/explorations` re-hashes exploration manifests itself, and
+[`src/sent_context.rs`](src/sent_context.rs) re-implements the receipt
+reconstruction `stella_store::Store::reconstruct_call` performs (#1475). The
+last is the largest of the three and the only one with a *byte-level* coupling
+— it rebuilds a `tool_call` block's preimage in `stella_protocol::ToolCall`'s
+field order — so `tests/schema_conformance.rs` seeds its digests from that
+crate's own serializer: a reordered field fails the suite instead of printing
+"the journal is torn" on a user's dashboard.
 
 Only [`stella-cli`](../stella-cli) depends on it: `run_observe`
 ([`../stella-cli/src/storage_cmd.rs:47`](../stella-cli/src/storage_cmd.rs))
@@ -42,6 +49,7 @@ free one). This crate builds no binary —
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The HTTP responder: the route table, the `Host` and head-cap gates, the CSP, `serve`. Open it to add a route or to touch anything security-relevant. |
 | [`src/db.rs`](src/db.rs) | Every query against `.stella/private/store.db` and `fleet.db`. Open it when a panel needs a new aggregate; the SQL deliberately mirrors `stella stats` semantics (resolved = outcome `completed`, `off-grid` = provider `local`). |
+| [`src/sent_context.rs`](src/sent_context.rs) | `/api/execution-context`: the receipt queries (`step_receipt`, `step_manifest`, `context_blocks`) and the fold that rebuilds the messages one model call was sent, with the digest-verification verdict. Kept out of `src/db.rs` so that file stays clear of the 1500-line ratchet. |
 | [`src/global.rs`](src/global.rs) | The user-tier view over `~/.stella/usage.db`: the project switcher (`/api/projects`, `?project=`) and the hub-telemetry drill (org → workspace → repo → project). |
 | [`src/fsview.rs`](src/fsview.rs) | Views derived from files rather than SQL — skills, memories, rule files, `reflections.jsonl` lessons, `mcp.toml`, the settings scope chain, exploration maps — plus `redact`, the credential scrubber. |
 | [`src/codegraph.rs`](src/codegraph.rs) | `codegraph.db` flattened to `{nodes, edges, groups}` for the force-directed canvas, including the Rust module-path resolution the indexer doesn't do. |

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -296,6 +296,8 @@ pre.cfg{font:var(--fs-micro)/1.6 var(--mono);color:var(--text-2);background:var(
   font:var(--fs-micro)/1 var(--mono);padding:6px 10px;border-radius:var(--radius-sm);
   cursor:pointer;margin-top:8px}
 #drawer .jrnl-full:hover{color:var(--text);border-color:var(--accent)}
+/* The same button, sitting inside a step row rather than under a section. */
+#drawer .ctx-call{margin-top:0;padding:3px 8px}
 .step-row{display:grid;grid-template-columns:34px minmax(0,1fr) 160px;gap:var(--sp2);
           align-items:center;font:var(--fs-micro)/1.6 var(--mono);color:var(--text-3);padding:3px 0}
 .step-row .name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -1175,6 +1177,11 @@ async function openDrawer(id, full = false) {
      attacker-influenced text — so each one goes through esc(). */
   let j = null;
   try { j = await api(`/api/execution-journal?id=${encodeURIComponent(id)}${full ? "&full=1" : ""}`); } catch { j = null; }
+  /* The receipt index (#1475): which model calls this run recorded a receipt
+     for. Only the index is fetched here — a reconstruction is one call's whole
+     prompt, so it loads on demand when a row is drilled into. */
+  let cx = null;
+  try { cx = await api(`/api/execution-context?id=${encodeURIComponent(id)}`); } catch { cx = null; }
   const entries = Array.isArray(j) ? j : [];
   const jrnl = entries.map(journalEntryHtml).join("");
   // Rendered even with zero entries while the run is still going: the
@@ -1229,12 +1236,17 @@ async function openDrawer(id, full = false) {
     ${steps ? `<div class="sect"><div class="kick">Per-step tokens and latency</div>${steps}</div>`
             : `<div class="sect"><div class="kick">Per-step tokens and latency</div>
                <div class="empty">No steps recorded for this run.</div></div>`}
+    ${sentContextSectionHtml(cx)}
     ${jrnlSect}
     ${tools ? `<div class="sect"><div class="kick">Tool calls</div>${tools}</div>` : ""}
     ${files ? `<div class="sect"><div class="kick">Files touched</div>${files}</div>` : ""}
     ${refl}`);
   const fullBtn = $("jrnl-full");
   if (fullBtn) fullBtn.addEventListener("click", () => openDrawer(id, true));
+  for (const b of $("drawer").querySelectorAll(".ctx-call")) {
+    b.addEventListener("click", () =>
+      loadSentContext(id, +b.dataset.turn, +b.dataset.step, +b.dataset.seq));
+  }
   drawerState = {
     id,
     full,
@@ -1277,6 +1289,85 @@ async function refreshDrawerJournal() {
     }
   }
   drawerState.lastSeq = entries[entries.length - 1].seq;
+}
+/* ── sent context (#1475) ────────────────────────────────────────────────
+   What a model call was *given*, as opposed to what the run did: the
+   message array rebuilt server-side from that call's context receipt, the
+   same view `stella inspect <execution> --step N` prints. One row per
+   recorded call — the receipt plane's own step rows, keyed
+   (turn, step, call_seq) — each drilling into the reconstruction below it.
+   Every string here is workspace-influenced text (a system prompt is the
+   most workspace-influenced text on the page), so all of it goes through
+   esc(). */
+function sentContextSectionHtml(cx) {
+  if (!cx) return "";
+  // A store with no receipts is a state, not a failure: say which state, in
+  // the words `stella inspect` uses for the same case.
+  if (!cx.receipts_recorded) {
+    return `<div class="sect"><div class="kick">Context sent</div>
+      <div class="empty">${esc(cx.note ?? "No receipts recorded for this run.")}</div></div>`;
+  }
+  const rows = (cx.calls ?? []).map(c => `<div class="step-row">
+      <span>${fmtInt(c.step)}</span>
+      <span class="name">${esc(c.call_role)} · ${esc(c.provider)}/${esc(c.model)}
+        · ${fmtTok(c.estimated_input_tokens)} tok${
+        num(c.turn) || num(c.call_seq) ? ` · turn ${fmtInt(c.turn)} seq ${fmtInt(c.call_seq)}` : ""}</span>
+      <span><button type="button" class="jrnl-full ctx-call" data-turn="${esc(String(c.turn))}"
+        data-step="${esc(String(c.step))}" data-seq="${esc(String(c.call_seq))}"
+        >context sent</button></span>
+    </div>`).join("");
+  return `<div class="sect"><div class="kick">Context sent</div>${rows}
+    <div id="ctx-body"></div></div>`;
+}
+/* The two failure modes stay separate, as they do on the CLI: an unresolved
+   block is a documented coverage gap, a digest mismatch is a torn-journal or
+   tampering signal. Collapsing them into one "unverified" word would hide
+   which one happened. */
+function sentContextVerdictHtml(c) {
+  if (c.verified) {
+    return `<div class="kick" style="color:var(--ok)">✓ verified · every
+      journal-resolved block re-hashed to its recorded digest</div>`;
+  }
+  const bad = (c.digest_mismatches ?? []).length;
+  const gaps = (c.unresolved ?? []).length;
+  return `${bad ? `<div class="kick" style="color:var(--bad)">✕ ${fmtInt(bad)} block(s)
+      did NOT re-hash to their recorded digest — the journal is torn or was altered</div>` : ""}
+    ${gaps ? `<div class="kick" style="color:var(--warn)">◌ ${fmtInt(gaps)} block(s) could not
+      be resolved (synthetic results, discarded speculation, or attachments)</div>` : ""}`;
+}
+function sentContextMessageHtml(m) {
+  const blocks = m.blocks ?? [];
+  const torn = blocks.some(b => b.digest_verified === false);
+  return `<div class="jrnl${torn ? " err" : ""}">
+    <div class="kick">[${fmtInt(m.index)}] ${esc(m.role)} · ${fmtInt(blocks.length)} block${
+      blocks.length === 1 ? "" : "s"}${
+      m.truncated ? ` · <span style="color:var(--warn)">clipped</span>` : ""}</div>
+    ${m.body ? `<pre class="jrnl-body">${esc(m.body)}</pre>` : ""}</div>`;
+}
+/* Load one call's reconstruction into the open drawer. On demand rather than
+   with the drawer: this is a whole prompt — the largest payload the dashboard
+   can ask for — and a run has one per model call. */
+async function loadSentContext(id, turn, step, callSeq, full = false) {
+  const body = $("ctx-body");
+  if (!body) return;
+  let cx = null;
+  try {
+    cx = await api(`/api/execution-context?id=${encodeURIComponent(id)}`
+      + `&turn=${encodeURIComponent(turn)}&step=${encodeURIComponent(step)}`
+      + `&call_seq=${encodeURIComponent(callSeq)}${full ? "&full=1" : ""}`);
+  } catch { cx = null; }
+  const c = cx && cx.context;
+  if (!c || !c.found) {
+    body.innerHTML = `<div class="empty">${
+      esc((c && c.note) || "That call has no recorded receipt.")}</div>`;
+    return;
+  }
+  const messages = c.messages ?? [];
+  body.innerHTML = `${sentContextVerdictHtml(c)}${messages.map(sentContextMessageHtml).join("")}${
+    messages.some(m => m.truncated)
+      ? `<button type="button" class="jrnl-full" id="ctx-full">show full bodies</button>` : ""}`;
+  const btn = $("ctx-full");
+  if (btn) btn.addEventListener("click", () => loadSentContext(id, turn, step, callSeq, true));
 }
 /* The main poll already re-fetches `/api/executions` (with `finished_at`)
    on every cursor move — reuse that instead of a dedicated per-tick

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -421,6 +421,39 @@ impl Observatory {
         ))
     }
 
+    /// One model call's **sent context** (#1475): the messages that call was
+    /// given, rebuilt from its persisted receipt and the event journal — what
+    /// `stella inspect <execution> --step N` prints in the terminal.
+    ///
+    /// The transcript route above replays what a run *did*; this one answers
+    /// what a call *was sent*, system prompt included, which no other view in
+    /// the dashboard carries. Always returns the index of the execution's
+    /// recorded calls, because that is what the drawer drills from; `step`
+    /// additionally selects one of them to reconstruct (`turn` and `call_seq`
+    /// default to the worker call, as they do on the CLI).
+    ///
+    /// Bodies obey the transcript route's clip policy — `JOURNAL_BODY_CLIP`
+    /// chars unless `full`, and a clipped message says so. An execution with no
+    /// receipts (a store recorded with `context.lifecycle` off, or one older
+    /// than the receipts plane) answers with an explicit no-receipts payload;
+    /// missing is a state here as everywhere else, never an error.
+    ///
+    /// The fold itself lives in `sent_context`, which documents why the
+    /// observatory re-implements it instead of linking `stella-store`.
+    pub fn execution_context(
+        &self,
+        id: i64,
+        turn: i64,
+        step: Option<i64>,
+        call_seq: i64,
+        full: bool,
+    ) -> Result<Value, DbError> {
+        match self.store() {
+            Some(conn) => crate::sent_context::payload(&conn, id, turn, step, call_seq, full),
+            None => Ok(crate::sent_context::no_receipts(id)),
+        }
+    }
+
     /// Per-(provider, model) usage — the same rows `stella stats` prints,
     /// same semantics (`resolved` = outcome `completed`, `off-grid` = local).
     pub fn models(&self) -> Result<Value, DbError> {
@@ -1075,7 +1108,11 @@ fn journal_entry(row: Value, full: bool) -> Value {
 
 /// Attach `body` to a transcript entry, clipped to [`JOURNAL_BODY_CLIP`]
 /// unless `full`, and record which of the two happened.
-fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
+///
+/// Shared with the sent-context messages (`sent_context`), so the transcript
+/// and the reconstruction can never disagree about what "clipped" means or
+/// where the cut falls.
+pub(crate) fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
     let clipped = !full && body.chars().count() > JOURNAL_BODY_CLIP;
     entry["body"] = if clipped {
         json!(truncate(body.to_owned(), JOURNAL_BODY_CLIP))
@@ -1213,7 +1250,7 @@ fn or_empty(result: rusqlite::Result<Value>) -> Result<Value, DbError> {
 /// correctly, for the case it was written for — silently fails to catch a
 /// missing column, so the degradation never fires and the route 500s anyway.
 /// That is precisely how this bug got here.
-fn is_missing_schema(e: &rusqlite::Error) -> bool {
+pub(crate) fn is_missing_schema(e: &rusqlite::Error) -> bool {
     let message = match e {
         rusqlite::Error::SqliteFailure(_, Some(msg)) => msg.as_str(),
         rusqlite::Error::SqlInputError { msg, .. } => msg.as_str(),
@@ -1223,7 +1260,7 @@ fn is_missing_schema(e: &rusqlite::Error) -> bool {
 }
 
 /// Shallow-merge `extra`'s fields into `base` (both must be objects).
-fn merge(base: &mut Value, extra: Value) {
+pub(crate) fn merge(base: &mut Value, extra: Value) {
     if let (Some(base_map), Value::Object(extra_map)) = (base.as_object_mut(), extra) {
         for (k, v) in extra_map {
             base_map.insert(k, v);

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -47,6 +47,7 @@ mod db;
 mod fsview;
 mod global;
 mod live;
+mod sent_context;
 
 use accept::{AcceptAction, AcceptBackoff};
 use std::net::SocketAddr;
@@ -233,6 +234,27 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
                     id,
                     query_param(query, "full").is_some(),
                     query_param(query, "after_seq").and_then(|v| v.parse::<i64>().ok()),
+                ),
+                None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
+            }
+        }
+        // The sent-context inspection (#1475): the messages one model call was
+        // given, rebuilt from its receipt. Without `step` this is the index of
+        // the execution's recorded calls — what the drawer drills from;
+        // `turn`/`call_seq` default to the worker call, as on the CLI, and
+        // `full=1` lifts the per-message clip.
+        "/api/execution-context" => {
+            match query_param(query, "id").and_then(|v| v.parse::<i64>().ok()) {
+                Some(id) => obs.execution_context(
+                    id,
+                    query_param(query, "turn")
+                        .and_then(|v| v.parse::<i64>().ok())
+                        .unwrap_or(0),
+                    query_param(query, "step").and_then(|v| v.parse::<i64>().ok()),
+                    query_param(query, "call_seq")
+                        .and_then(|v| v.parse::<i64>().ok())
+                        .unwrap_or(0),
+                    query_param(query, "full").is_some(),
                 ),
                 None => return Response::error("400 Bad Request", "missing ?id=<execution id>"),
             }

--- a/crates/stella-observatory/src/sent_context.rs
+++ b/crates/stella-observatory/src/sent_context.rs
@@ -1,0 +1,724 @@
+//! The receipt fold: rebuilding the messages one past model call was **sent**,
+//! from its persisted manifest plus the execution's event journal.
+//!
+//! `stella inspect <execution> --step N` answers this on the CLI through
+//! `stella_store::Store::reconstruct_call`. This crate links no workspace crate
+//! but `stella-home` (see `crate::db`'s module docs and the crate README), so
+//! the fold is re-implemented here rather than imported: an **acknowledged
+//! copy**, the same bargain `project_id_for` and the exploration re-hash already
+//! take. Three things keep the copy honest:
+//!
+//! - `tests/schema_conformance.rs` drives this route against a database built
+//!   by the real `Store::open` migration path and seeded through the real write
+//!   API, so a renamed column fails at `cargo test`.
+//! - That suite seeds the block digests by hashing `stella_protocol`'s own
+//!   serialization of a `ToolCall`/`ToolOutput`, so a change to those wire
+//!   shapes flips the verification verdict and fails there too — the one piece
+//!   of this module that is a *byte-level* coupling rather than a column-level
+//!   one (see `tool_call_preimage`).
+//! - Everything the fold cannot vouch for is reported, never smoothed over:
+//!   `unresolved` and `digest_mismatches` are separate lists here for the same
+//!   reason they are separate fields on `stella_store::Reconstruction`.
+//!
+//! # What "verified" means
+//!
+//! Every block whose preimage came from the journal is re-hashed and compared
+//! against the digest the receipt recorded at emission, so a torn journal or a
+//! fabricated block surfaces as a mismatch instead of a plausible-looking lie.
+//! The two gap kinds — the system prefix and the assembled user/recall message
+//! — are stored as local bytes in `context_blocks.content`, so their check is
+//! tautological and is deliberately **not** counted as evidence: they report
+//! `digest_verified: null`, not `true`.
+//!
+//! # Reconstructable boundary
+//!
+//! Byte-exact reconstruction holds for the ordinary turn: system prompt, user
+//! goal, assistant text, and real tool round-trips. It does not cover blocks
+//! with no journal preimage — budget-abort synthetic tool results, discarded
+//! speculation, attachments — which surface in `unresolved` rather than
+//! silently corrupting the output.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::db::{DbError, is_missing_schema};
+
+/// The whole `/api/execution-context` payload for one execution: the index of
+/// its recorded model calls, plus — when `step` addresses one — that call's
+/// reconstruction.
+///
+/// The index is always present because it is what the drawer drills from: a
+/// step row can only offer "context sent" if a receipt exists at that step.
+/// `turn` and `call_seq` default to 0 at the router, matching `stella inspect`,
+/// where `--turn`/`--call-seq` are the worker call unless asked otherwise.
+pub(crate) fn payload(
+    conn: &Connection,
+    id: i64,
+    turn: i64,
+    step: Option<i64>,
+    call_seq: i64,
+    full: bool,
+) -> Result<Value, DbError> {
+    let calls = recorded_calls(conn, id)?;
+    if calls.is_empty() {
+        return Ok(no_receipts(id));
+    }
+    let mut out = json!({
+        "execution_id": id,
+        "receipts_recorded": true,
+        "calls": Value::Array(calls),
+        "context": Value::Null,
+    });
+    if let Some(step) = step {
+        out["context"] = call_context(conn, id, turn, step, call_seq, full)?;
+    }
+    Ok(out)
+}
+
+/// The explicit "no receipts recorded" answer — a state, never an error.
+///
+/// Reached three ways, all of them ordinary: the workspace has no `store.db`
+/// yet, the file predates the receipts plane so `step_receipt` does not exist,
+/// or the execution ran with `context.lifecycle` off and wrote none. The
+/// wording mirrors what `stella inspect` prints for the same case, because a
+/// reader who has seen one should recognise the other.
+pub(crate) fn no_receipts(id: i64) -> Value {
+    json!({
+        "execution_id": id,
+        "receipts_recorded": false,
+        "calls": [],
+        "context": Value::Null,
+        "note": format!(
+            "Execution {id} has no recorded receipts. Receipts are written by builds \
+             carrying the context-receipts plane; an execution from before it landed, \
+             or one recorded with context.lifecycle off, has none."
+        ),
+    })
+}
+
+/// Every model call this execution recorded a receipt for, in wire order — one
+/// row per call, not per step: a step that ran the worker plus an overflow
+/// summarizer appears twice, keyed apart by `call_seq`.
+fn recorded_calls(conn: &Connection, id: i64) -> Result<Vec<Value>, DbError> {
+    let sql = "SELECT turn_instance, step, call_seq, call_role, provider, model,
+                      estimated_input_tokens, effective_budget_tokens,
+                      compiled_frame_id, frame_hash
+               FROM step_receipt WHERE execution_id = ?1
+               ORDER BY turn_instance, step, call_seq";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mapped = stmt.query_map([id], |r| {
+        Ok(json!({
+            "turn": r.get::<_, i64>(0)?,
+            "step": r.get::<_, i64>(1)?,
+            "call_seq": r.get::<_, i64>(2)?,
+            "call_role": r.get::<_, String>(3)?,
+            "provider": r.get::<_, String>(4)?,
+            "model": r.get::<_, String>(5)?,
+            "estimated_input_tokens": r.get::<_, i64>(6)?,
+            "effective_budget_tokens": r.get::<_, i64>(7)?,
+            // Absent for every receipt written while the context lifecycle was
+            // off. Null reads as "not computed", never as "computed and empty".
+            "compiled_frame_id": r.get::<_, Option<String>>(8)?,
+            "frame_hash": r.get::<_, Option<String>>(9)?,
+        }))
+    })?;
+    let mut out = Vec::new();
+    for row in mapped {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// One addressed call's reconstruction, or an honest `found: false` when
+/// nothing was recorded at those coordinates.
+fn call_context(
+    conn: &Connection,
+    id: i64,
+    turn: i64,
+    step: i64,
+    call_seq: i64,
+    full: bool,
+) -> Result<Value, DbError> {
+    let entries = manifest_entries(conn, id, turn, step, call_seq)?;
+    let mut out = json!({
+        "turn": turn,
+        "step": step,
+        "call_seq": call_seq,
+        "found": !entries.is_empty(),
+    });
+    if entries.is_empty() {
+        out["note"] = json!(format!(
+            "no receipt for execution {id} turn {turn} step {step} call-seq {call_seq}"
+        ));
+        return Ok(out);
+    }
+    let preimages = Preimages::index(&journal_payloads(conn, id)?);
+    crate::db::merge(&mut out, reconstruct(&entries, &preimages, full));
+    Ok(out)
+}
+
+/// One call's manifest in wire order, each entry joined to its block registry
+/// row.
+///
+/// A `LEFT JOIN`, deliberately: a manifest citing a block that was never
+/// registered must come back as an entry with no `kind` — an unresolved block
+/// the reader is told about — rather than vanish from the wire order.
+fn manifest_entries(
+    conn: &Connection,
+    id: i64,
+    turn: i64,
+    step: i64,
+    call_seq: i64,
+) -> Result<Vec<ManifestEntry>, DbError> {
+    let sql = "SELECT sm.block_id, sm.cache_zone, sm.resident_since_step, sm.message_index,
+                      sm.call_id, cb.kind, cb.token_cost, cb.content_digest, cb.content,
+                      cb.call_id
+               FROM step_manifest sm
+               LEFT JOIN context_blocks cb
+                 ON cb.execution_id = sm.execution_id AND cb.block_id = sm.block_id
+               WHERE sm.execution_id = ?1 AND sm.turn_instance = ?2 AND sm.step = ?3
+                 AND sm.call_seq = ?4
+               ORDER BY sm.ordinal";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mapped = stmt.query_map([id, turn, step, call_seq], |r| {
+        Ok(ManifestEntry {
+            block_id: r.get(0)?,
+            cache_zone: r.get(1)?,
+            resident_since_step: r.get(2)?,
+            message_index: r.get(3)?,
+            occurrence_call_id: r.get(4)?,
+            kind: r.get(5)?,
+            token_cost: r.get(6)?,
+            content_digest: r.get(7)?,
+            content: r.get(8)?,
+            birth_call_id: r.get(9)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in mapped {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// The execution's slice of the journal that block preimages resolve from.
+///
+/// The third sanctioned read of `events`, on the same bargain as the other
+/// two: `execution_id`-first, which the store's `UNIQUE (execution_id, seq)`
+/// index serves directly, and only on a per-execution detail route.
+fn journal_payloads(conn: &Connection, id: i64) -> Result<Vec<String>, DbError> {
+    let sql = "SELECT payload FROM events
+               WHERE execution_id = ?1
+                 AND event_type IN ('tool_start', 'tool_result', 'text')
+               ORDER BY seq ASC";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mapped = stmt.query_map([id], |r| r.get::<_, String>(0))?;
+    let mut out = Vec::new();
+    for row in mapped {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// One row of a call's manifest, already joined to its block registry entry.
+///
+/// The `Option` fields are all "the join found nothing / the column is NULL",
+/// never a default: a manifest citing a block that was never registered has no
+/// `kind`, and that is what makes it unresolvable rather than empty.
+pub(crate) struct ManifestEntry {
+    /// Content-addressed block id (`blk_…`) — the identity the manifest cites.
+    pub(crate) block_id: String,
+    /// Which cache zone this occurrence sat in (`stable_prefix`, `volatile`, …).
+    pub(crate) cache_zone: String,
+    /// The step this block has been resident since — how long it has been paid
+    /// for.
+    pub(crate) resident_since_step: i64,
+    /// The sent-message this block belonged to; blocks sharing an index regroup
+    /// into one message.
+    pub(crate) message_index: i64,
+    /// This occurrence's tool-call attribution (`step_manifest.call_id`, v15).
+    /// Wins over `birth_call_id` for a rebuilt tool result: block ids are
+    /// content-addressed, so two calls with byte-identical results share one
+    /// registry row and its `call_id` names only the call that minted it first.
+    pub(crate) occurrence_call_id: Option<String>,
+    /// The block's kind (`system_prefix`, `tool_result`, …); `None` when the
+    /// manifest cited a block with no registry row.
+    pub(crate) kind: Option<String>,
+    /// The block's cost under the engine's token rule. `None` means **not
+    /// derivable**, not free.
+    pub(crate) token_cost: Option<i64>,
+    /// `sha256:<64 hex>` over the block's preimage, recorded at emission.
+    pub(crate) content_digest: Option<String>,
+    /// Local-only preimage, present for the gap kinds the journal cannot
+    /// resolve (the system prefix and the assembled user/recall message).
+    pub(crate) content: Option<String>,
+    /// The block's birth provenance (`context_blocks.call_id`).
+    pub(crate) birth_call_id: Option<String>,
+}
+
+/// Per-execution preimage index built once from the event journal: tool calls
+/// and outputs by `call_id`, assistant text by content digest.
+///
+/// The values are the exact preimage **strings** the digests were taken over,
+/// not parsed structures, because verification is the point: a shape that
+/// round-trips through a different serializer is a different preimage.
+#[derive(Default)]
+pub(crate) struct Preimages {
+    tool_calls: HashMap<String, String>,
+    tool_outputs: HashMap<String, String>,
+    /// `content_digest` (`sha256:<hex>`) → the assistant text bytes.
+    text_by_digest: HashMap<String, String>,
+}
+
+impl Preimages {
+    /// Index one execution's `tool_start` / `tool_result` / `text` payloads.
+    ///
+    /// A payload that no longer parses as JSON is skipped: one unreadable event
+    /// costs the blocks that resolve through it, which then report as
+    /// unresolved, and must not cost the rest of the reconstruction.
+    pub(crate) fn index(payloads: &[String]) -> Self {
+        let mut out = Self::default();
+        for payload in payloads {
+            let Ok(event) = serde_json::from_str::<Value>(payload) else {
+                continue;
+            };
+            match event["type"].as_str().unwrap_or_default() {
+                "tool_start" => {
+                    let call = &event["call"];
+                    if let Some(call_id) = call["call_id"].as_str() {
+                        out.tool_calls
+                            .insert(call_id.to_owned(), tool_call_preimage(call));
+                    }
+                }
+                "tool_result" => {
+                    if let Some(call_id) = event["call_id"].as_str() {
+                        out.tool_outputs
+                            .insert(call_id.to_owned(), compact(&event["output"]));
+                    }
+                }
+                "text" => {
+                    if let Some(delta) = event["delta"].as_str() {
+                        out.text_by_digest
+                            .insert(format!("sha256:{}", sha256_hex(delta)), delta.to_owned());
+                    }
+                }
+                _ => {}
+            }
+        }
+        out
+    }
+}
+
+/// The exact bytes a `tool_call` block's digest was taken over:
+/// `serde_json::to_string` of `stella_protocol::ToolCall`, whose fields
+/// serialize in **declaration** order (`call_id`, `name`, `input`).
+///
+/// Built by hand rather than by re-serializing the payload's own object,
+/// because `serde_json::Value` keeps its map sorted — re-serializing would
+/// emit `call_id`, `input`, `name` and every digest would mismatch. The nested
+/// `input` is a `Value` on both sides, so it is safe (and necessary) to
+/// serialize it as one.
+///
+/// This is the module's only byte-level coupling to another crate's wire shape.
+/// `schema_conformance.rs` seeds its digests from `stella_protocol`'s own
+/// serialization, so a reordered field fails there rather than in a user's
+/// dashboard.
+fn tool_call_preimage(call: &Value) -> String {
+    format!(
+        "{{\"call_id\":{},\"name\":{},\"input\":{}}}",
+        compact(&call["call_id"]),
+        compact(&call["name"]),
+        compact(&call["input"])
+    )
+}
+
+/// One JSON value as compact bytes; an unserializable value reads as `null`
+/// rather than failing the whole reconstruction.
+fn compact(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_owned())
+}
+
+/// `sha256` hex of a string. The sha2 0.11 output does not `LowerHex`, so the
+/// bytes are formatted one at a time — the same shape `fsview` uses.
+fn sha256_hex(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// One message under construction — the regrouping target for every block
+/// sharing a `message_index`.
+struct Message {
+    role: &'static str,
+    body: String,
+    blocks: Vec<Value>,
+}
+
+/// Fold one call's manifest into the messages it was sent, with the honest
+/// accounting of what could not be vouched for.
+///
+/// `full` lifts the per-body clip, exactly as it does on the transcript route:
+/// both go through `set_journal_body`, so the two views can never disagree
+/// about what "clipped" means.
+pub(crate) fn reconstruct(entries: &[ManifestEntry], preimages: &Preimages, full: bool) -> Value {
+    let mut messages: Vec<Message> = Vec::new();
+    let mut unresolved: Vec<String> = Vec::new();
+    let mut mismatches: Vec<String> = Vec::new();
+    let mut current: Option<i64> = None;
+
+    for entry in entries {
+        let Some(kind) = entry.kind.as_deref() else {
+            // A manifest citing a block that was never registered: there is
+            // nothing to resolve, and inventing an empty message for it would
+            // be a claim about what the model saw.
+            unresolved.push(entry.block_id.clone());
+            continue;
+        };
+        let Some(content) = resolve_content(entry, kind, preimages) else {
+            unresolved.push(entry.block_id.clone());
+            continue;
+        };
+        // Local gap content is stored bytes, so re-hashing it proves nothing;
+        // `None` says "not evidence" where `true` would claim it was.
+        let digest_verified = match &entry.content {
+            Some(_) => None,
+            None => Some(digest_matches(entry.content_digest.as_deref(), &content)),
+        };
+        if digest_verified == Some(false) {
+            mismatches.push(entry.block_id.clone());
+        }
+        if current != Some(entry.message_index) {
+            messages.push(Message {
+                role: role_for(kind),
+                body: String::new(),
+                blocks: Vec::new(),
+            });
+            current = Some(entry.message_index);
+        }
+        let Some(message) = messages.last_mut() else {
+            continue;
+        };
+        if !append_block(message, entry, kind, &content) {
+            unresolved.push(entry.block_id.clone());
+        }
+        message.blocks.push(json!({
+            "block_id": entry.block_id,
+            "kind": kind,
+            "cache_zone": entry.cache_zone,
+            "token_cost": entry.token_cost,
+            "resident_since_step": entry.resident_since_step,
+            "digest_verified": digest_verified,
+        }));
+    }
+
+    let rendered: Vec<Value> = messages
+        .into_iter()
+        .enumerate()
+        .map(|(index, message)| {
+            let mut out = json!({
+                "index": index,
+                "role": message.role,
+                "blocks": Value::Array(message.blocks),
+            });
+            crate::db::set_journal_body(&mut out, &message.body, full);
+            out
+        })
+        .collect();
+
+    json!({
+        "verified": unresolved.is_empty() && mismatches.is_empty(),
+        "unresolved": unresolved,
+        "digest_mismatches": mismatches,
+        "messages": rendered,
+    })
+}
+
+/// Resolve one block's exact preimage: gap kinds carry it locally, every other
+/// kind is recovered from the journal index. `None` is a documented
+/// non-reconstructable case, never a silent empty body.
+fn resolve_content(entry: &ManifestEntry, kind: &str, preimages: &Preimages) -> Option<String> {
+    if let Some(content) = &entry.content {
+        return Some(content.clone());
+    }
+    match kind {
+        "tool_result" => preimages
+            .tool_outputs
+            .get(entry.birth_call_id.as_deref()?)
+            .cloned(),
+        "tool_call" => preimages
+            .tool_calls
+            .get(entry.birth_call_id.as_deref()?)
+            .cloned(),
+        "assistant_text" => preimages
+            .text_by_digest
+            .get(entry.content_digest.as_deref()?)
+            .cloned(),
+        _ => None,
+    }
+}
+
+/// Whether resolved bytes really are this block's bytes.
+///
+/// Not a formality: a tool block's preimage is found by `call_id`, and one call
+/// can leave several content-addressed blocks behind (compaction stubs and ages
+/// results in place). They all resolve to the same journal event, and only the
+/// digest says which of them those bytes actually are.
+fn digest_matches(recorded: Option<&str>, content: &str) -> bool {
+    let Some(recorded) = recorded else {
+        return false;
+    };
+    let expected = recorded.strip_prefix("sha256:").unwrap_or(recorded);
+    sha256_hex(content) == expected
+}
+
+/// The role a block kind opens a message with — the mapping
+/// `stella_store::reconstruct` uses. `summary` is a **user** message: the
+/// overflow summarizer splices it as one, so rebuilding it as assistant-
+/// authored would show a transcript the model never saw.
+fn role_for(kind: &str) -> &'static str {
+    match kind {
+        "system_prefix" => "system",
+        "user_goal" | "steered" | "summary" | "recalled_frame" | "attachment" => "user",
+        "tool_result" => "tool",
+        // assistant_text, tool_call and anything else open an assistant message.
+        _ => "assistant",
+    }
+}
+
+/// Append one resolved block to the message it belongs to, rendered the way
+/// `stella inspect` renders it (`crates/stella-cli/src/inspect.rs`'s
+/// `message_body`): text kinds concatenate, tool traffic gets its arrow line.
+///
+/// Returns `false` when the bytes resolved but did not parse into the shape the
+/// kind promises — an unresolved block, not a fabricated one.
+fn append_block(message: &mut Message, entry: &ManifestEntry, kind: &str, content: &str) -> bool {
+    match kind {
+        // Append, not assign: one message can decompose into several text
+        // blocks (the recall block splits per item), cut so that concatenating
+        // them in manifest order reproduces the original bytes exactly.
+        "system_prefix" | "user_goal" | "steered" | "assistant_text" | "summary"
+        | "recalled_frame" => {
+            message.body.push_str(content);
+            true
+        }
+        "tool_call" => {
+            let Ok(call) = serde_json::from_str::<Value>(content) else {
+                return false;
+            };
+            separate(&mut message.body);
+            message.body.push_str(&format!(
+                "→ tool_call {} {} {}",
+                call["call_id"].as_str().unwrap_or_default(),
+                call["name"].as_str().unwrap_or_default(),
+                compact(&call["input"])
+            ));
+            true
+        }
+        "tool_result" => {
+            let Ok(output) = serde_json::from_str::<Value>(content) else {
+                return false;
+            };
+            separate(&mut message.body);
+            // `ToolOutput` is externally tagged: `{"ok":{"content":…}}` or
+            // `{"error":{"message":…}}` — the tag is the verdict.
+            // The occurrence's own id wins; birth provenance is the best a
+            // pre-v15 row can know, and an absent one renders as empty rather
+            // than as some other call's id.
+            let call_id = match entry.occurrence_call_id.as_deref() {
+                Some(id) => id,
+                None => entry.birth_call_id.as_deref().unwrap_or_default(),
+            };
+            message.body.push_str(&format!("← tool_result {call_id}\n"));
+            match output["ok"]["content"].as_str() {
+                Some(ok) => message.body.push_str(ok),
+                None => message.body.push_str(&format!(
+                    "error: {}",
+                    output["error"]["message"].as_str().unwrap_or_default()
+                )),
+            }
+            true
+        }
+        // An attachment is carried by its message rather than printed into it,
+        // and is only ever resolvable when the receipt stored its bytes.
+        "attachment" => serde_json::from_str::<Value>(content).is_ok(),
+        _ => false,
+    }
+}
+
+/// Put a newline between two rendered segments of one message body, matching
+/// how `stella inspect` joins them.
+fn separate(body: &mut String) {
+    if !body.is_empty() {
+        body.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(block_id: &str, kind: &str, message_index: i64) -> ManifestEntry {
+        ManifestEntry {
+            block_id: block_id.to_owned(),
+            cache_zone: "cacheable".to_owned(),
+            resident_since_step: 0,
+            message_index,
+            occurrence_call_id: None,
+            kind: Some(kind.to_owned()),
+            token_cost: Some(10),
+            content_digest: None,
+            content: None,
+            birth_call_id: None,
+        }
+    }
+
+    fn gap(block_id: &str, kind: &str, message_index: i64, content: &str) -> ManifestEntry {
+        ManifestEntry {
+            content_digest: Some(format!("sha256:{}", sha256_hex(content))),
+            content: Some(content.to_owned()),
+            ..entry(block_id, kind, message_index)
+        }
+    }
+
+    #[test]
+    fn a_tool_round_trip_rebuilds_verified_from_the_journal() {
+        let payloads = vec![
+            r#"{"type":"tool_start","call":{"call_id":"c1","name":"read_file","input":{"path":"a.rs"}}}"#.to_owned(),
+            r#"{"type":"tool_result","call_id":"c1","output":{"ok":{"content":"fn a() {}"}},"duration_ms":5,"speculated":false}"#.to_owned(),
+        ];
+        let preimages = Preimages::index(&payloads);
+        let call_preimage = preimages.tool_calls.get("c1").cloned().unwrap();
+        let output_preimage = preimages.tool_outputs.get("c1").cloned().unwrap();
+        let entries = vec![
+            gap("blk_sys", "system_prefix", 0, "you are careful"),
+            ManifestEntry {
+                content_digest: Some(format!("sha256:{}", sha256_hex(&call_preimage))),
+                birth_call_id: Some("c1".to_owned()),
+                ..entry("blk_call", "tool_call", 1)
+            },
+            ManifestEntry {
+                content_digest: Some(format!("sha256:{}", sha256_hex(&output_preimage))),
+                birth_call_id: Some("c1".to_owned()),
+                ..entry("blk_res", "tool_result", 2)
+            },
+        ];
+
+        let out = reconstruct(&entries, &preimages, false);
+        assert_eq!(out["verified"], true, "{out}");
+        assert_eq!(out["messages"][0]["role"], "system");
+        assert_eq!(out["messages"][0]["body"], "you are careful");
+        // A locally-stored gap block re-hashes to itself, so it is not evidence.
+        assert!(out["messages"][0]["blocks"][0]["digest_verified"].is_null());
+        assert_eq!(out["messages"][1]["role"], "assistant");
+        assert!(
+            out["messages"][1]["body"]
+                .as_str()
+                .unwrap()
+                .starts_with("→ tool_call c1 read_file "),
+            "{out}"
+        );
+        assert_eq!(out["messages"][1]["blocks"][0]["digest_verified"], true);
+        assert_eq!(out["messages"][2]["role"], "tool");
+        assert_eq!(out["messages"][2]["body"], "← tool_result c1\nfn a() {}");
+    }
+
+    #[test]
+    fn a_block_with_no_preimage_is_unresolved_rather_than_invented() {
+        let preimages = Preimages::index(&[]);
+        let entries = vec![ManifestEntry {
+            birth_call_id: Some("missing".to_owned()),
+            ..entry("blk_orphan", "tool_result", 0)
+        }];
+        let out = reconstruct(&entries, &preimages, false);
+        assert_eq!(out["verified"], false);
+        assert_eq!(out["unresolved"], json!(["blk_orphan"]));
+        assert_eq!(out["messages"], json!([]));
+    }
+
+    #[test]
+    fn resolved_bytes_that_do_not_re_hash_are_a_mismatch_not_a_silent_swap() {
+        // The failure this check exists for: a journal event resolves, but its
+        // bytes are not the ones the receipt recorded a digest over.
+        let payloads =
+            vec![r#"{"type":"text","delta":"what the journal actually holds"}"#.to_owned()];
+        let preimages = Preimages::index(&payloads);
+        let entries = vec![ManifestEntry {
+            content_digest: Some(format!("sha256:{}", sha256_hex("what was recorded"))),
+            ..entry("blk_text", "assistant_text", 0)
+        }];
+        // Nothing resolves at all when the digest is the lookup key…
+        let out = reconstruct(&entries, &preimages, false);
+        assert_eq!(out["unresolved"], json!(["blk_text"]));
+
+        // …so stage the mismatch through a kind that resolves by call id.
+        let payloads = vec![
+            r#"{"type":"tool_result","call_id":"c1","output":{"ok":{"content":"other bytes"}}}"#
+                .to_owned(),
+        ];
+        let preimages = Preimages::index(&payloads);
+        let entries = vec![ManifestEntry {
+            content_digest: Some(format!("sha256:{}", sha256_hex("not what is there"))),
+            birth_call_id: Some("c1".to_owned()),
+            ..entry("blk_res", "tool_result", 0)
+        }];
+        let out = reconstruct(&entries, &preimages, false);
+        assert_eq!(out["verified"], false);
+        assert_eq!(out["digest_mismatches"], json!(["blk_res"]));
+        assert_eq!(out["messages"][0]["blocks"][0]["digest_verified"], false);
+    }
+
+    #[test]
+    fn a_tool_call_preimage_keeps_declaration_order_not_sorted_keys() {
+        // Re-serializing the payload's own object would sort the keys to
+        // call_id, input, name and every tool_call digest would mismatch.
+        let call = serde_json::json!({
+            "call_id": "c1", "name": "read_file", "input": {"path": "a.rs"}
+        });
+        assert_eq!(
+            tool_call_preimage(&call),
+            r#"{"call_id":"c1","name":"read_file","input":{"path":"a.rs"}}"#
+        );
+    }
+
+    #[test]
+    fn an_error_result_renders_as_an_error_not_an_empty_body() {
+        let payloads = vec![
+            r#"{"type":"tool_result","call_id":"e1","output":{"error":{"message":"file not found"}}}"#
+                .to_owned(),
+        ];
+        let preimages = Preimages::index(&payloads);
+        let entries = vec![ManifestEntry {
+            content_digest: Some(format!(
+                "sha256:{}",
+                sha256_hex(r#"{"error":{"message":"file not found"}}"#)
+            )),
+            birth_call_id: Some("e1".to_owned()),
+            ..entry("blk_err", "tool_result", 0)
+        }];
+        let out = reconstruct(&entries, &preimages, false);
+        assert_eq!(out["verified"], true, "{out}");
+        assert_eq!(
+            out["messages"][0]["body"],
+            "← tool_result e1\nerror: file not found"
+        );
+    }
+}

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -164,6 +164,79 @@ fn seeded_workspace() -> TempDir {
              (1, 5, 'text', '{"type":"text","delta":"added the function"}');"#,
     )
     .unwrap();
+    // The context receipts (#1475), also in their own batch: one recorded
+    // worker call plus the overflow summarizer that shares its step, so a
+    // reconstruction has to be scoped by `call_seq` rather than by step.
+    //
+    // The two gap blocks carry their preimage locally (`content`); the other
+    // three resolve from the events above and their `content_digest` is the
+    // real sha256 of the exact preimage bytes — that is what makes the
+    // verification verdict a fact here rather than a fixture constant. The
+    // tool_call digest covers `{"call_id":…,"name":…,"input":…}` in
+    // `stella_protocol::ToolCall`'s declaration order.
+    conn.execute_batch(
+        "CREATE TABLE step_receipt (
+             execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL,
+             step INTEGER NOT NULL, call_seq INTEGER NOT NULL DEFAULT 0,
+             provider TEXT NOT NULL, model TEXT NOT NULL, call_role TEXT NOT NULL,
+             effective_budget_tokens INTEGER NOT NULL,
+             calibration_factor REAL NOT NULL,
+             estimated_input_tokens INTEGER NOT NULL,
+             compiled_frame_id TEXT, frame_hash TEXT,
+             PRIMARY KEY (execution_id, turn_instance, step, call_seq));
+           CREATE TABLE step_manifest (
+             execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL,
+             step INTEGER NOT NULL, call_seq INTEGER NOT NULL DEFAULT 0,
+             ordinal INTEGER NOT NULL, block_id TEXT NOT NULL,
+             cache_zone TEXT NOT NULL, resident_since_step INTEGER NOT NULL,
+             message_index INTEGER NOT NULL DEFAULT 0, call_id TEXT,
+             PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal));
+           CREATE TABLE context_blocks (
+             execution_id INTEGER NOT NULL, block_id TEXT NOT NULL,
+             kind TEXT NOT NULL, origin_turn INTEGER NOT NULL,
+             origin_step INTEGER NOT NULL, call_id TEXT, memory_id TEXT,
+             token_cost INTEGER, content_digest TEXT NOT NULL,
+             citation_label TEXT, content TEXT,
+             first_seen_ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+             PRIMARY KEY (execution_id, block_id));
+           INSERT INTO step_receipt
+             (execution_id, turn_instance, step, call_seq, provider, model,
+              call_role, effective_budget_tokens, calibration_factor,
+              estimated_input_tokens)
+           VALUES
+             (1, 0, 1, 0, 'zai', 'glm-5.2', 'worker', 136363, 1.1, 203),
+             (1, 0, 1, 1, 'zai', 'glm-5.2', 'overflow_summarizer', 136363, 1.1, 12);
+           INSERT INTO context_blocks
+             (execution_id, block_id, kind, origin_turn, origin_step, call_id,
+              token_cost, content_digest, content)
+           VALUES
+             (1, 'blk_sys', 'system_prefix', 0, 0, NULL, 40,
+              'sha256:0bf72c9a096fc5a3c095d830189524ae60b197a0e78dde2c80b914abb1e07b3d',
+              'you are careful'),
+             (1, 'blk_user', 'user_goal', 0, 0, NULL, 30,
+              'sha256:11360c09a451a0c3a39d7fdc2697800d5b500a6b445b8120fba6ad5c0b5eb4e6',
+              'add a function'),
+             (1, 'blk_text', 'assistant_text', 0, 1, NULL, 20,
+              'sha256:f9cbfada6f746168b93daa674d776cd0407b6e3c3777ef3aaf3ca253ba5ae07c',
+              NULL),
+             (1, 'blk_call', 'tool_call', 0, 1, 'c1', 25,
+              'sha256:70b207f5a306abb1d8d7b4534452d37806896cd51569a8e8554f0e4e5109e4ad',
+              NULL),
+             (1, 'blk_res', 'tool_result', 0, 1, 'c1', 88,
+              'sha256:bfd1986b0e5cdf2925326cf75fa8d40320722e0a3971274a7844b2147ac927e7',
+              NULL);
+           INSERT INTO step_manifest
+             (execution_id, turn_instance, step, call_seq, ordinal, block_id,
+              cache_zone, resident_since_step, message_index, call_id)
+           VALUES
+             (1, 0, 1, 0, 0, 'blk_sys',  'stable_prefix', 0, 0, NULL),
+             (1, 0, 1, 0, 1, 'blk_user', 'cacheable',     0, 1, NULL),
+             (1, 0, 1, 0, 2, 'blk_text', 'volatile',      1, 2, NULL),
+             (1, 0, 1, 0, 3, 'blk_call', 'volatile',      1, 2, 'c1'),
+             (1, 0, 1, 0, 4, 'blk_res',  'volatile',      1, 3, 'c1'),
+             (1, 0, 1, 1, 0, 'blk_sys',  'stable_prefix', 0, 0, NULL);",
+    )
+    .unwrap();
     dir
 }
 
@@ -385,6 +458,135 @@ fn execution_journal_clips_long_bodies_unless_full() {
     assert_eq!(v[0]["body"].as_str().unwrap().chars().count(), long.len());
 }
 
+/// The witness for sent-context inspection (#1475): the reconstructed message
+/// array carries the system prompt the receipt recorded, in wire order, and
+/// says so verifiably.
+///
+/// This is the question the dashboard could not answer — the transcript shows
+/// what a run *did*, never what a call was *sent* — and the system prompt is
+/// the part of it that exists nowhere else in the store.
+#[test]
+fn execution_context_rebuilds_the_message_array_a_call_was_sent() {
+    let ws = seeded_workspace();
+    let response = respond(
+        ws.path(),
+        "/api/execution-context?id=1&turn=0&step=1&call_seq=0",
+    );
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(v["receipts_recorded"], true, "{v}");
+    // The index the drawer drills from: both calls that shared step 1.
+    let calls = v["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 2, "{v}");
+    assert_eq!(calls[0]["call_role"], "worker");
+    assert_eq!(calls[0]["estimated_input_tokens"], 203);
+    assert_eq!(calls[1]["call_role"], "overflow_summarizer");
+    // Frame identity is absent for a receipt written with the lifecycle off,
+    // and null must read as "not computed", never as "computed and empty".
+    assert!(calls[0]["compiled_frame_id"].is_null());
+
+    let context = &v["context"];
+    assert_eq!(context["found"], true, "{v}");
+    let messages = context["messages"].as_array().unwrap();
+    let roles: Vec<&str> = messages
+        .iter()
+        .map(|m| m["role"].as_str().unwrap())
+        .collect();
+    assert_eq!(roles, ["system", "user", "assistant", "tool"], "{v}");
+    assert_eq!(
+        messages[0]["body"], "you are careful",
+        "the system prompt the model actually saw"
+    );
+    assert_eq!(messages[1]["body"], "add a function");
+    // One message, several blocks: the assistant text and the tool call it
+    // carried regroup by `message_index`, in manifest order.
+    assert_eq!(
+        messages[2]["body"],
+        "added the function\n→ tool_call c1 read_file {\"path\":\"src/lib.rs\"}"
+    );
+    assert_eq!(messages[3]["body"], "← tool_result c1\nfn a() {}");
+    // Verified means the journal-resolved blocks re-hashed to the digests the
+    // receipt recorded — a fact re-derived here, not a stored verdict.
+    assert_eq!(context["verified"], true, "{v}");
+    assert_eq!(context["unresolved"], serde_json::json!([]));
+    assert_eq!(context["digest_mismatches"], serde_json::json!([]));
+    // A gap block's preimage is stored locally, so its check is tautological
+    // and is deliberately not reported as evidence.
+    assert!(messages[0]["blocks"][0]["digest_verified"].is_null());
+    assert_eq!(messages[3]["blocks"][0]["digest_verified"], true);
+    assert_eq!(messages[3]["blocks"][0]["cache_zone"], "volatile");
+    assert_eq!(messages[3]["blocks"][0]["token_cost"], 88);
+}
+
+/// A step can hold several model calls, and each was sent its own context.
+/// Addressing one must never fold in the other's blocks.
+#[test]
+fn execution_context_is_scoped_to_one_call_seq_not_the_whole_step() {
+    let ws = seeded_workspace();
+    let response = respond(ws.path(), "/api/execution-context?id=1&step=1&call_seq=1");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    let messages = v["context"]["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 1, "the summarizer's own manifest: {v}");
+    assert_eq!(messages[0]["role"], "system");
+    // Coordinates with no receipt are answered, not errored.
+    let none = respond(ws.path(), "/api/execution-context?id=1&step=9");
+    let v: serde_json::Value = serde_json::from_slice(&none.body).unwrap();
+    assert_eq!(none.status, "200 OK");
+    assert_eq!(v["context"]["found"], false, "{v}");
+    assert!(
+        v["context"]["note"].as_str().unwrap().contains("step 9"),
+        "{v}"
+    );
+}
+
+/// An execution recorded with `context.lifecycle` off has no receipts, and
+/// that is a state with its own answer — the wording `stella inspect` uses —
+/// not a 500 and not an empty array pretending nothing was sent.
+#[test]
+fn execution_context_without_receipts_says_so_instead_of_erroring() {
+    let ws = seeded_workspace();
+    let response = respond(ws.path(), "/api/execution-context?id=2&step=1");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(response.status, "200 OK");
+    assert_eq!(v["receipts_recorded"], false, "{v}");
+    assert_eq!(v["calls"], serde_json::json!([]));
+    assert!(v["context"].is_null());
+    assert!(
+        v["note"]
+            .as_str()
+            .unwrap()
+            .contains("has no recorded receipts"),
+        "{v}"
+    );
+}
+
+/// A reconstructed message obeys the transcript route's clip policy: past
+/// `db::JOURNAL_BODY_CLIP` chars it is cut and flagged, and `?full=1` returns
+/// the bytes. A system prompt is thousands of stable lines, so this is the
+/// common case here rather than the edge one.
+#[test]
+fn execution_context_clips_long_messages_unless_full() {
+    use crate::db::JOURNAL_BODY_CLIP;
+    let ws = seeded_workspace();
+    let long = "x".repeat(JOURNAL_BODY_CLIP + 100);
+    Connection::open(ws.path().join(".stella/private/store.db"))
+        .unwrap()
+        .execute(
+            "UPDATE context_blocks SET content = ?1 WHERE block_id = 'blk_sys'",
+            [long.as_str()],
+        )
+        .unwrap();
+    let clipped = respond(ws.path(), "/api/execution-context?id=1&step=1");
+    let v: serde_json::Value = serde_json::from_slice(&clipped.body).unwrap();
+    assert_eq!(v["context"]["messages"][0]["truncated"], true, "{v}");
+    let full = respond(ws.path(), "/api/execution-context?id=1&step=1&full=1");
+    let v: serde_json::Value = serde_json::from_slice(&full.body).unwrap();
+    assert_eq!(v["context"]["messages"][0]["truncated"], false);
+    assert_eq!(
+        v["context"]["messages"][0]["body"].as_str().unwrap().len(),
+        long.len()
+    );
+}
+
 #[test]
 fn tool_leaderboard_counts_errors() {
     let ws = seeded_workspace();
@@ -409,6 +611,8 @@ fn empty_workspace_degrades_to_empty_payloads_not_errors() {
         "/api/executions",
         "/api/execution-journal?id=1",
         "/api/execution-journal?id=1&after_seq=0",
+        "/api/execution-context?id=1",
+        "/api/execution-context?id=1&turn=0&step=1&call_seq=0",
         "/api/models",
         "/api/tools",
         "/api/files",

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -35,11 +35,19 @@
 
 use std::path::Path;
 
+use sha2::{Digest, Sha256};
 use stella_observatory::respond;
+use stella_protocol::{AgentEvent, ContextFrameRef, ProviderShare, ToolCall, ToolOutput};
 use stella_store::{
-    AgentUseRow, ExecutionReflectionRow, FileTouchRow, McpUsageRow, MemoryCitationRow,
-    ReflectionRow, SkillUsageRow, Store, TelemetryRow,
+    AgentUseRow, ContextBlockRow, ExecutionReflectionRow, FileTouchRow, ManifestBlockRow,
+    McpUsageRow, MemoryCitationRow, ReflectionRow, SkillUsageRow, StepManifestRow, Store,
+    TelemetryRow,
 };
+
+/// The seeded system prefix. Named because it is what the sent-context witness
+/// looks for: the system prompt is the part of a model call that exists nowhere
+/// else in the store, and reconstructing it is the whole point of the route.
+const SYSTEM_PROMPT: &str = "you are stella, and you are careful";
 
 /// Every `/api/*` route the router serves, paired with the JSON pointer that
 /// must resolve to seeded (non-empty) data.
@@ -57,6 +65,11 @@ const ROUTES: &[(&str, Option<&str>)] = &[
     ("/api/executions", Some("/0/id")),
     ("/api/execution?id=1", Some("/steps/0/step")),
     ("/api/execution-journal?id=1", Some("/0/type")),
+    ("/api/execution-context?id=1", Some("/calls/0/step")),
+    (
+        "/api/execution-context?id=1&turn=0&step=1&call_seq=0",
+        Some("/context/messages/0/role"),
+    ),
     ("/api/models", Some("/0/provider")),
     ("/api/tools", Some("/0/name")),
     ("/api/files", Some("/0/path")),
@@ -77,25 +90,34 @@ const ROUTES: &[(&str, Option<&str>)] = &[
 ];
 
 /// One tool call's full event round-trip — the announcement and its result.
-fn tool_round_trip(call_id: &str, name: &str) -> [stella_protocol::AgentEvent; 2] {
-    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+///
+/// Takes the call and output rather than building them, so the receipts seeded
+/// below hash the **same** values these events carry. A second definition of
+/// "the tool call" would let the two drift and quietly turn the digest gate
+/// into a tautology.
+fn tool_round_trip(call: &ToolCall, output: &ToolOutput) -> [AgentEvent; 2] {
     [
-        AgentEvent::ToolStart {
-            call: ToolCall {
-                call_id: call_id.into(),
-                name: name.into(),
-                input: serde_json::json!({ "path": "src/lib.rs" }),
-            },
-        },
+        AgentEvent::ToolStart { call: call.clone() },
         AgentEvent::ToolResult {
-            call_id: call_id.into(),
-            output: ToolOutput::Ok {
-                content: "fn a() {}".into(),
-            },
+            call_id: call.call_id.clone(),
+            output: output.clone(),
             duration_ms: 12,
             speculated: false,
         },
     ]
+}
+
+/// `sha256:<hex>` over exactly these bytes — the digest shape the receipts
+/// plane records.
+fn digest(preimage: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(preimage.as_bytes());
+    let hex: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    format!("sha256:{hex}")
 }
 
 /// Build a workspace whose `store.db` came from the **real** migration path,
@@ -114,11 +136,20 @@ fn real_store_workspace() -> tempfile::TempDir {
     // Tool calls arrive as events and are projected from them — seeding the
     // `tool_calls` table any other way would test a write path production
     // does not use.
-    for (seq, event) in tool_round_trip("c1", "read_file").into_iter().enumerate() {
+    let call = ToolCall {
+        call_id: "c1".into(),
+        name: "read_file".into(),
+        input: serde_json::json!({ "path": "src/lib.rs" }),
+    };
+    let output = ToolOutput::Ok {
+        content: "fn a() {}".into(),
+    };
+    for (seq, event) in tool_round_trip(&call, &output).into_iter().enumerate() {
         store
             .record_event(completed, seq as u64, &event)
             .expect("tool event");
     }
+    seed_receipt(&store, completed, &call, &output);
     store
         .record_telemetry(
             completed,
@@ -235,6 +266,109 @@ fn real_store_workspace() -> tempfile::TempDir {
     dir
 }
 
+/// One recorded model call's context receipt: the block registry plus the
+/// ordered manifest `/api/execution-context` reconstructs from (#1475).
+///
+/// The two journal-resolved blocks take their digest over `stella_protocol`'s
+/// **own** serialization of the very call and output the events above carry, so
+/// this seeds the byte-level half of the drift gate: the observatory builds
+/// that preimage by hand (it links no protocol crate), and reordering
+/// `ToolCall`'s fields would make its digests stop matching — here, at
+/// `cargo test`, rather than as an "unverified" banner on a user's dashboard.
+/// The system prefix is a gap block: its preimage is stored locally, exactly as
+/// the engine stores it, because the journal cannot carry it.
+fn seed_receipt(store: &Store, execution_id: i64, call: &ToolCall, output: &ToolOutput) {
+    let call_json = serde_json::to_string(call).expect("tool call json");
+    let output_json = serde_json::to_string(output).expect("tool output json");
+    let blocks = [
+        ContextBlockRow {
+            block_id: "blk_sys".into(),
+            kind: "system_prefix".into(),
+            origin_turn: 0,
+            origin_step: 0,
+            call_id: None,
+            memory_id: None,
+            token_cost: Some(40),
+            content_digest: digest(SYSTEM_PROMPT),
+            citation_label: None,
+            content: Some(SYSTEM_PROMPT.into()),
+        },
+        ContextBlockRow {
+            block_id: "blk_call".into(),
+            kind: "tool_call".into(),
+            origin_turn: 0,
+            origin_step: 1,
+            call_id: Some(call.call_id.clone()),
+            memory_id: None,
+            token_cost: Some(25),
+            content_digest: digest(&call_json),
+            citation_label: None,
+            content: None,
+        },
+        ContextBlockRow {
+            block_id: "blk_res".into(),
+            kind: "tool_result".into(),
+            origin_turn: 0,
+            origin_step: 1,
+            call_id: Some(call.call_id.clone()),
+            memory_id: None,
+            token_cost: Some(88),
+            content_digest: digest(&output_json),
+            citation_label: None,
+            content: None,
+        },
+    ];
+    for block in &blocks {
+        store
+            .record_context_block(execution_id, block)
+            .expect("context block");
+    }
+    store
+        .record_step_manifest(
+            execution_id,
+            &StepManifestRow {
+                turn_instance: 0,
+                step: 1,
+                call_seq: 0,
+                provider: "zai".into(),
+                model: "glm-5.2".into(),
+                call_role: "worker".into(),
+                effective_budget_tokens: 136_363,
+                calibration_factor: 1.1,
+                estimated_input_tokens: 203,
+                compiled_frame_id: None,
+                frame_hash: None,
+                blocks: vec![
+                    ManifestBlockRow {
+                        block_id: "blk_sys".into(),
+                        cache_zone: "stable_prefix".into(),
+                        token_cost: Some(40),
+                        resident_since_step: 0,
+                        message_index: 0,
+                        call_id: None,
+                    },
+                    ManifestBlockRow {
+                        block_id: "blk_call".into(),
+                        cache_zone: "volatile".into(),
+                        token_cost: Some(25),
+                        resident_since_step: 1,
+                        message_index: 1,
+                        call_id: Some(call.call_id.clone()),
+                    },
+                    ManifestBlockRow {
+                        block_id: "blk_res".into(),
+                        cache_zone: "volatile".into(),
+                        token_cost: Some(88),
+                        resident_since_step: 1,
+                        message_index: 2,
+                        call_id: Some(call.call_id.clone()),
+                    },
+                ],
+            },
+        )
+        .expect("step manifest");
+}
+
 /// The gate itself: every route, against a real-migration database.
 #[test]
 fn every_route_survives_the_real_store_schema() {
@@ -274,8 +408,6 @@ fn every_route_survives_the_real_store_schema() {
 /// the run ended — and stayed zero forever if it never did.
 #[test]
 fn an_unfinished_execution_reports_its_tool_calls() {
-    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
-
     let dir = tempfile::TempDir::new().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
     let id = store
@@ -351,8 +483,6 @@ fn an_unfinished_execution_reports_its_tool_calls() {
 /// survivable. Both have to be true at the route, not just in the store.
 #[test]
 fn a_crashed_execution_recovers_its_calls_through_the_api() {
-    use stella_protocol::{AgentEvent, ToolCall};
-
     let dir = tempfile::TempDir::new().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
     let id = store
@@ -406,8 +536,6 @@ fn a_crashed_execution_recovers_its_calls_through_the_api() {
 /// reads it back through the real route.
 #[test]
 fn recall_latency_reaches_the_execution_detail() {
-    use stella_protocol::{AgentEvent, ContextFrameRef, ProviderShare};
-
     let dir = tempfile::TempDir::new().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
     let id = store
@@ -492,6 +620,43 @@ fn a_recall_without_a_measurement_reads_as_null_not_zero() {
         "unmeasured must not render as 0 ms: {detail}"
     );
     assert!(detail["recall"][0]["used_ann_index"].is_null());
+}
+
+/// Sent-context reconstruction, end to end against a real store (#1475).
+///
+/// The strongest form of the drift gate this suite exists for, because it
+/// checks a *byte-level* coupling rather than a column-level one. The
+/// observatory links no protocol crate, so it rebuilds a `tool_call` block's
+/// preimage by hand in `stella_protocol::ToolCall`'s declaration order; the
+/// receipt here was digested over that crate's own serializer. Reorder those
+/// fields and `verified` flips to false right here — the alternative being a
+/// silent "the journal is torn" banner on every dashboard in the field.
+#[test]
+fn sent_context_reconstructs_a_real_stores_receipt_and_verifies_it() {
+    let workspace = real_store_workspace();
+    let body = respond(
+        workspace.path(),
+        "/api/execution-context?id=1&turn=0&step=1&call_seq=0",
+    )
+    .body;
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    let context = &v["context"];
+    assert_eq!(context["found"], true, "{v}");
+    assert_eq!(
+        context["messages"][0]["body"], SYSTEM_PROMPT,
+        "the system prompt the model was actually sent: {v}"
+    );
+    assert_eq!(context["messages"][0]["role"], "system");
+    assert_eq!(
+        context["messages"][2]["body"], "← tool_result c1\nfn a() {}",
+        "the tool result, recovered from the journal: {v}"
+    );
+    assert_eq!(
+        context["verified"], true,
+        "a journal-resolved block stopped re-hashing to the digest \
+         stella_protocol's own serializer produced — a wire shape moved under \
+         the observatory's hand-built preimage: {v}"
+    );
 }
 
 /// **The other half of the drift problem, and the one that actually bit.**

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -44,10 +44,12 @@ panels labeled *all-time* ignore it.
     successes, commits) with MCP traffic, and a memory/reflections/skills digest — plus the
     **Executions** table: every run's kind, prompt, model, outcome, steps, tool calls,
     files touched, tokens, and cost. Clicking a row opens a drill-down drawer with per-step
-    tokens and latency, the **transcript** replayed from the run's event journal — answer
-    text, reasoning, and each tool call's arguments and output, with long bodies clipped
-    until you ask for them in full — every tool call, the files touched, and the post-turn
-    self-reflection.
+    tokens and latency, **context sent** — the message array each recorded model call was
+    given, system prompt included, rebuilt from that call's context receipt and checked
+    against the digests recorded when it was emitted (what `stella inspect` prints) — the
+    **transcript** replayed from the run's event journal — answer text, reasoning, and each
+    tool call's arguments and output, with long bodies clipped until you ask for them in
+    full — every tool call, the files touched, and the post-turn self-reflection.
   </OptionCard>
   <OptionCard name="activity">
     Per-day time series over the window: cost, tokens (input vs output), runs (resolved vs


### PR DESCRIPTION
## What & why

**Stacked, not based on `main`.** This continues the Observatory replay stack: #1461 (transcript replay) → #1486 (after-seq live refresh, which closed #1476) → this. The brief named `observatory-after-seq` as the base, but #1486 had already merged and that head branch was deleted, so the base here is `worktree-observatory-transcript-replay` — the branch that now carries the same tree (verified: `git diff` between the two tips is empty). Review the diff of this branch against that base; the two commits below it belong to the merged PRs.

Phase 2 of the Observatory replay work. The dashboard can replay what a run *did* (#1461: answer text, reasoning, tool traffic) but has never been able to show what a model call *was sent* — the reconstructed message array, system prompt included, that `stella inspect <execution> --step N` builds from context receipts and checks against the digests recorded at emission. Answering "what system prompt did step 3 actually see" still meant leaving the browser for the terminal.

**The route.** `/api/execution-context?id=N[&turn=T&step=S&call_seq=C]`, plus `full=1`.

- Without `step`: the index of the execution's recorded model calls (turn, step, `call_seq`, role, provider/model, estimated input tokens, frame id/hash). One row per *call*, not per step — the worker and the overflow summarizer that share a step are separate rows. This is what the drawer's per-call rows drill from.
- With `step`: that call's reconstruction — the messages regrouped by `message_index`, each with its blocks (kind, cache zone, token cost, residency, per-block `digest_verified`) and the verdict. `unresolved` and `digest_mismatches` stay separate lists, exactly as they are separate fields on `stella_store::Reconstruction`: an unresolved block is a documented coverage gap, a digest mismatch is a torn-journal/tampering signal, and collapsing them into one "unverified" word would hide which happened.
- Bodies obey the transcript route's clip policy. Both go through the *same* `set_journal_body`, so the two views cannot disagree about what "clipped" means or where the cut falls; `full=1` lifts it.
- `turn` and `call_seq` default to `0`, matching the CLI, where `--turn`/`--call-seq` are the worker call unless asked otherwise.

**Design decision: Option 1 from the issue** — hand-written read-only SQL inside `stella-observatory`. No new crate, and no new workspace-crate link: the crate still depends on `stella-home` and nothing else. `src/sent_context.rs` carries the three receipt queries (`step_receipt`; `step_manifest` LEFT JOIN `context_blocks`; the execution's `tool_start`/`tool_result`/`text` journal slice) plus the fold. It lives beside `db.rs` rather than inside it so that file stays clear of the 1500-line ratchet (`db.rs` would have landed at ~1400 otherwise).

**This is a full reconstruction, not the partial-manifest fallback.** The scope guard in the brief allowed shipping a manifest-only view with `"partial": true` if the message array could not be faithfully rebuilt in read-only SQL. It can: the store's `reconstruct.rs` fold needs only `serde_json` and `sha2`, both already direct dependencies here, and the block preimages the receipt tables do not hold live in `events`, which this crate already reads. So the payload carries real message bodies and a real digest verdict, and there is no `partial` flag anywhere.

**The copy, and what keeps it honest.** The README now says there are three acknowledged copies rather than two, and describes this one, because it is the largest and the only one with a *byte-level* coupling: a `tool_call` block's preimage is rebuilt by hand in `stella_protocol::ToolCall`'s **declaration** order (`call_id`, `name`, `input`) — re-serializing the payload's own object would sort the keys to `call_id`, `input`, `name` and mismatch every tool_call digest. `tests/schema_conformance.rs` seeds its digests from `stella_protocol`'s own serializer over the very `ToolCall`/`ToolOutput` its journal events carry, so a reordered field flips `verified` to false *there*, at `cargo test`, rather than printing "the journal is torn" on every dashboard in the field.

**Degradation** (missing is a state, never an error): no `store.db`, no `step_receipt` table (a file older than the receipts plane — this crate never migrates), or an execution recorded with `context.lifecycle` off all answer `receipts_recorded: false` with a note worded the way `stella inspect` words it. Coordinates addressing a call that was never recorded answer `found: false` with a note naming them. Both are 200s.

**UI.** A "Context sent" section in the execution drawer: one row per recorded call — the receipt plane's own step rows — each with a `context sent` button that loads that call's reconstruction inline (on demand, not with the drawer: a reconstruction is a whole prompt, the largest payload the dashboard can ask for). The verdict renders above the messages, a mismatching message gets the error rule, and `show full bodies` re-requests with `full=1`. Every interpolated string goes through `esc()`; the only new strings are `call_role`/`provider`/`model`/message bodies/the server's note, all of which are workspace- or model-derived text.

Closes #1475

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`execution_context_rebuilds_the_message_array_a_call_was_sent` (`src/tests.rs`) seeds a receipt whose journal-resolved blocks carry the real sha256 of their exact preimages, then asserts the route returns `["system", "user", "assistant", "tool"]` with the seeded system prompt as message 0's body, the assistant text and its tool call regrouped into one message, the tool result recovered from the journal, and `verified: true`. It fails on the base branch because the route does not exist (404 → no `context` key).

Four more, all new behaviour rather than refinements:

- `execution_context_is_scoped_to_one_call_seq_not_the_whole_step` — the summarizer sharing step 1 gets its own manifest, and unrecorded coordinates answer `found: false`.
- `execution_context_without_receipts_says_so_instead_of_erroring` — the explicit no-receipts payload.
- `execution_context_clips_long_messages_unless_full` — the clip policy and `full=1`.
- `sent_context_reconstructs_a_real_stores_receipt_and_verifies_it` (`tests/schema_conformance.rs`) — the same reconstruction against a database built by the real `Store::open` migration path and seeded through the real write API, with digests from `stella_protocol`'s serializer. This is the drift gate for both the column-level and the byte-level coupling.

Plus five unit tests on the fold itself in `src/sent_context.rs` (verified round trip, unresolved-not-invented, mismatch-not-silent-swap, preimage key order, error results), and the route added to `empty_workspace_degrades_to_empty_payloads_not_errors` and to `ROUTES`. `every_served_route_is_fetched_by_the_embedded_page` passes because the page fetches the route in both its index and drill forms.

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior changed (crate README layout + the acknowledged-copies paragraph, `website/content/docs/telemetry/dashboard.mdx`, doc comments throughout)
- [x] `Closes #1475` appears both above and as a commit trailer

**Honest note on the gate: it runs in CI, not locally.** A paid benchmark run owns the machine this was written on, so no compilation of any kind was performed here — `cargo fmt -p stella-observatory` was the only cargo command run (formatting is clean). Every API used was verified by reading the file that defines it rather than by compiling: `stella_store::{ContextBlockRow, ManifestBlockRow, StepManifestRow}` and their fields, the `receipts`/`reconstruct` read shapes, `ddl.rs`'s three receipt tables, and the existing `db.rs` helpers. The embedded page's script block was extracted and passed `node --check`. The digests seeded in the unit fixture were computed with `shasum -a 256` over the exact preimage bytes and cross-checked against an independent reimplementation of the preimage indexer. `check-file-size.sh`, `check-no-scratch.sh`, `check-invariants.sh` and `check-doc-links.py` all pass locally. **CI is the first compile — please read its result rather than the checkboxes.**

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies at all** — the fold uses `serde_json` and `sha2`, both already direct dependencies of this crate
- [x] No new outbound network calls; the listener stays loopback-only and every open stays `SQLITE_OPEN_READ_ONLY`
- [x] No new workspace-crate link (the boundary `tests/schema_conformance.rs` exists to protect)

## Anything reviewers should know?

- **The `events` read.** This is the third sanctioned read of `events`, on the same bargain as `recall_timings` and the transcript: `execution_id`-first, served directly by the store's `UNIQUE (execution_id, seq)` index, and only on a per-execution detail route. It is not polled — the drawer fetches the call index once on open and a reconstruction only when a row is drilled.
- **What is deliberately not here.** `stella inspect --diff` (the "what changed since the previous call of this role" view) is a separate question and would need cross-execution session walking; the reconstruction shows the sum, never the delta. Attachment blocks are reported as unresolved, exactly as they are on the CLI.
- **Reviewers should sanity-check** the byte-level preimage claim in `sent_context::tool_call_preimage` against `stella_protocol::ToolCall`, since that is the one place where a green conformance test and a wrong assumption could co-exist if the seeding ever stopped using the real serializer.

## Summary by Sourcery

Introduce sent-context inspection for observatory executions, reconstructing and verifying the exact messages each model call was sent and surfacing them in both the API and dashboard UI.

New Features:
- Add /api/execution-context endpoint to expose per-call model context reconstructed from receipts and event journal, including verification metadata.
- Expose a new "Context sent" section in the execution drawer UI to display reconstructed message arrays for each recorded model call, with on-demand loading and full-body expansion.

Enhancements:
- Implement a standalone sent_context module to perform read-only SQL over receipt tables and rebuild model-call messages without adding new crate dependencies.
- Reuse existing transcript body-clipping logic for sent-context messages to ensure consistent truncation semantics across views.

Documentation:
- Document the new sent-context inspection capability and receipt reconstruction in the stella-observatory README and telemetry dashboard documentation.

Tests:
- Extend schema_conformance tests to seed real store receipts and assert byte-level digest verification for reconstructed tool calls and results.
- Add integration tests covering execution-context reconstruction, call scoping, no-receipts behaviour, and clipping policy, plus unit tests for the sent-context fold and preimage handling.