### PR TITLE
fix(stella-pipeline): reconcile verdict-reuse merge — unbreak main

### DIFF
--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -361,7 +361,7 @@ impl Observatory {
     /// telemetry projections deliberately do not carry.
     ///
     /// This is the second sanctioned read of `events` (after
-    /// [`recall_timings`]) and it obeys the same bargain: the filter is
+    /// `recall_timings`) and it obeys the same bargain: the filter is
     /// `execution_id`-first, which the store's `UNIQUE (execution_id, seq)`
     /// index serves directly, and the route is fetched once on drawer-open —
     /// never on the 5 s poll. A cross-execution transcript view would need a
@@ -371,7 +371,7 @@ impl Observatory {
     /// authoritative full answer and the deltas are a live-preview artifact.
     /// Most stores hold none (the journal drops them at write time), but the
     /// filter is contract, not assumption. Bodies are clipped to
-    /// [`JOURNAL_BODY_CLIP`] chars unless `full`; a clipped entry says so
+    /// `JOURNAL_BODY_CLIP` chars unless `full`; a clipped entry says so
     /// (`truncated: true`) instead of presenting the elision as the data.
     pub fn execution_journal(&self, id: i64, full: bool) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -822,11 +822,20 @@ struct CandidateState {
     /// next revision is told (`witness::airlock`).
     failures: Vec<FailureFingerprint>,
     /// The last model verdict this candidate bought, keyed by a digest of the
-    /// exact inputs that produced it (#1431). A revision that changed nothing
-    /// the verdict depends on reuses the opinion instead of re-buying it —
-    /// the verifier is stateless across rounds, so identical inputs are the
-    /// same question, and paying twice buys only sampling noise.
+    /// exact inputs that produced it (#1431 step 1). A revision that changed
+    /// nothing the verdict depends on reuses the opinion instead of
+    /// re-buying it — the verifier is stateless across rounds, so identical
+    /// inputs are the same question, and paying twice buys only sampling
+    /// noise.
     last_verdict: Option<(u64, crate::verify::Verdict)>,
+    /// The joined diff text as it stood when the model verifier last answered
+    /// a fresh verdict on this candidate — the delta-framing baseline (#1431
+    /// remaining scope). The next escalated round renders file sections
+    /// byte-identical to this as stat lines instead of re-buying their
+    /// bodies. `None` until a model verdict has been bought, and never set by
+    /// a heuristic fallback: a verdict no model read must not let the next
+    /// round claim its diff was already reviewed.
+    last_verdict_diff: Option<String>,
 }
 
 impl CandidateState {
@@ -2136,6 +2145,7 @@ impl<'a> Pipeline<'a> {
             witness_paths: Vec::new(),
             failures: Vec::new(),
             last_verdict: None,
+            last_verdict_diff: None,
         };
 
         if let Err(reason) = self
@@ -2654,44 +2664,22 @@ impl<'a> Pipeline<'a> {
                     // a guidance call on the FIRST deterministic red while
                     // telling the verifier the agent had "failed twice in a row".
                     let mut reason = brief.message();
-                    if self.config.distress_guidance && state.failures.len() >= 2 {
-                        // Same witness exclusion as the verdict call (#1433):
-                        // guidance reads the change under correction, and the
-                        // verifier's own test is not part of it.
-                        let stripped =
-                            crate::verify::strip_witness_hunks(&state.diff_text, &witness_paths);
-                        match self
-                            .verifier_guidance(
+                    if self.config.distress_guidance
+                        && state.failures.len() >= 2
+                        && let Err(abort) = self
+                            .distress_guidance_reason(
                                 goal,
-                                &stripped.diff,
+                                &state.diff_text,
+                                &witness_paths,
                                 &evidence.summary,
-                                // Guidance never carries a delta baseline: its
-                                // render is already evidence-scoped (#1432),
-                                // and "unchanged since a verdict round" is a
-                                // verdict-shaped claim.
-                                &DiffContext {
-                                    witness_paths: &witness_paths,
-                                    previous: None,
-                                },
+                                &sealed,
+                                &mut reason,
                                 budget,
                                 total,
                             )
                             .await
-                        {
-                            Ok(Some(guidance)) => {
-                                if let Some(text) =
-                                    self.airlock_forward(&guidance, "distress_guidance", &sealed)
-                                {
-                                    reason
-                                        .push_str("\n\nIndependent reviewer course-correction:\n");
-                                    reason.push_str(&text);
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(abort) => {
-                                return CandidateResult::aborted(state.messages, abort.reason);
-                            }
-                        }
+                    {
+                        return CandidateResult::aborted(state.messages, abort.reason);
                     }
                     if let Err(reason) = self
                         .revise_candidate(engine, surface, budget, &reason, total, &mut state)
@@ -2735,167 +2723,39 @@ impl<'a> Pipeline<'a> {
                     }
                     // Inconclusive — escalate to the model verifier (verifier ≠
                     // worker; a verifier-call failure falls back to a heuristic).
-                    let mut evidence_summary = format!(
-                        "flip_achieved={}; touched_tests={:?}; diff_lines={} (budget {}); \
-                         file_change_events={}",
-                        inputs.flip_achieved,
-                        inputs.touched_tests_passed,
-                        state.diff_lines,
-                        self.config.diff_budget_lines,
-                        state.file_changes,
+                    // The evidence summary assembles every deterministic
+                    // signal the ladder collected (#859, #860, #861, #864,
+                    // #867, #870, #1291) — split out alongside
+                    // `ladder_snapshot` in `verify_probes.rs`.
+                    let mut evidence_summary = self.model_verdict_evidence_summary(
+                        &inputs,
+                        &state,
+                        test_infra,
+                        &lint_sample,
+                        &snapshot,
                     );
-                    if let Some(label) = test_infra {
-                        // #860: the run ended without observing an assertion.
-                        // Named so the verifier reads "the suite timed out", not
-                        // "the suite failed".
-                        evidence_summary
-                            .push_str(&format!("; test_run={label} (no assertion observed)"));
-                    }
-                    if state.oracle.is_unstable() {
-                        // #859: a fail→pass flip WAS observed but could not
-                        // be reproduced on the same tree — a different fact
-                        // from "the test never passed", and one the verifier
-                        // should weigh explicitly.
-                        evidence_summary.push_str(
-                            "; unstable_flip=true (the flip's confirmation re-run did not pass)",
-                        );
-                    }
-                    if inputs.diff_coverage != DiffCoverage::Unmeasured {
-                        // #1291: stated only when it was actually measured.
-                        // An `unmeasured` line here would be pure noise in a
-                        // verifier prompt — the ladder already escalated for some
-                        // other reason, and "nobody looked" adds nothing to
-                        // reason from. It stays on the snapshot either way.
-                        evidence_summary.push_str("; ");
-                        evidence_summary.push_str(inputs.diff_coverage.explain());
-                    }
-                    if state.witness_mutation == Some(false) {
-                        // #870: the witness reacted to the change without
-                        // constraining it — it stayed green while the
-                        // changed lines were deliberately broken.
-                        evidence_summary.push_str(
-                            "; witness_tautological=true (the witness stayed green under every \
-                             trivial mutation of the changed lines)",
-                        );
-                    }
-                    if state.oracle.refused_different_failure() {
-                        // #867: the suite passed, but its own complete test
-                        // listing did not contain the baseline's failing
-                        // tests — the observed failure was not fixed, it
-                        // disappeared. The verifier should treat the passing
-                        // exit code accordingly.
-                        evidence_summary.push_str(
-                            "; flip_refused=the passing run's test listing does not contain \
-                             the test(s) that failed on the baseline (fixed a different \
-                             failure, or the failing test was removed)",
-                        );
-                    }
-                    if inputs.new_diag_errors > 0 || inputs.new_diag_warnings > 0 {
-                        // #861: the regression the veto saw, capped to a
-                        // 3-line sample so the verifier reads the delta, not
-                        // the linter's whole opinion.
-                        evidence_summary.push_str(&format!(
-                            "; new_diagnostics={} error(s), {} warning(s) vs baseline",
-                            inputs.new_diag_errors, inputs.new_diag_warnings
-                        ));
-                        if !lint_sample.is_empty() {
-                            evidence_summary.push('\n');
-                            evidence_summary.push_str(lint_sample.trim_end());
+                    // Witness exclusion (#1433), verdict reuse (#1431 step 1),
+                    // and the delta-framing baseline (#1431 remaining scope)
+                    // all live in `resolve_verdict` — one nameable concern,
+                    // split out for the same reason the rest of
+                    // `verifier_stage.rs` is.
+                    let verdict = match self
+                        .resolve_verdict(
+                            goal,
+                            &mut evidence_summary,
+                            &mut state,
+                            &witness_paths,
+                            &inputs,
+                            budget,
+                            total,
+                        )
+                        .await
+                    {
+                        Ok(verdict) => verdict,
+                        Err(abort) => {
+                            return CandidateResult::aborted(state.messages, abort.reason);
                         }
-                    }
-                    if !snapshot.oracle_trace.is_empty() {
-                        // #864: the oracle trace, rendered compactly. The
-                        // verifier sees WHY the ladder was inconclusive — which
-                        // runs happened, in order, and what each observed —
-                        // instead of a diff cold.
-                        evidence_summary.push_str(&format!(
-                            "; oracle_trace=[{}]",
-                            crate::replay::render_oracle_trace(&snapshot.oracle_trace)
-                        ));
-                    }
-                    if snapshot.witness_intact == Some(true) {
-                        // #864: the tamper-exclusion result, stated. A
-                        // tampered witness never reaches a verifier, so what the
-                        // verifier learns here is that the check RAN and the
-                        // witness it is weighing is the authored one.
-                        evidence_summary.push_str("; witness_tamper_check=intact");
-                    }
-                    // The witness's own chunks never ride into the paid prompt
-                    // as "worker-authored data" (#1433): they are the
-                    // verifier's own artifact, and everything the verdict needs
-                    // to know about the witness is already in the trusted
-                    // evidence above. The omission is named HERE — the trusted
-                    // zone — never in-band in the diff, where the framing says
-                    // every byte is forgeable worker data.
-                    let stripped =
-                        crate::verify::strip_witness_hunks(&state.diff_text, &witness_paths);
-                    if !stripped.omitted.is_empty() {
-                        evidence_summary.push_str(&format!(
-                            "; witness_files_omitted_from_diff=[{}] (verifier-authored test, \
-                             not part of the change under review)",
-                            stripped.omitted.join(", ")
-                        ));
-                    }
-                    // Reuse before re-buying (#1431): a revision that changed
-                    // nothing the verdict depends on — same goal, same diff,
-                    // same evidence, byte for byte — would re-ask the same
-                    // question and pay full price for sampling noise. The
-                    // cached verdict is the same opinion at zero cost, and the
-                    // appended note steers the worker better than a fresh
-                    // reading of an unchanged tree ever did.
-                    let inputs_digest =
-                        verdict_inputs_digest(goal, &stripped.diff, &evidence_summary);
-                    let cached = state
-                        .last_verdict
-                        .as_ref()
-                        .filter(|(digest, _)| *digest == inputs_digest)
-                        .map(|(_, verdict)| verdict.clone());
-                    let verdict = match cached {
-                        Some(mut verdict) => {
-                            verdict.reasoning.push_str(
-                                "\n(verdict reused: the goal, diff, and evidence are unchanged \
-                                 since the previous review round — no new model call was made)",
-                            );
-                            verdict
-                        }
-                        None => match self
-                            .verifier(
-                                goal,
-                                &stripped.diff,
-                                &evidence_summary,
-                                &inputs,
-                                budget,
-                                total,
-                            )
-                            .await
-                        {
-                            Ok(verdict) => {
-                                // Only pin a real model verdict for reuse. A
-                                // heuristic fallback is a transient-outage
-                                // stand-in (unresolvable provider, unparseable
-                                // response, failed/timed-out call), not the
-                                // opinion this candidate bought: caching it
-                                // would suppress recovery on the next round
-                                // (the verifier may have come back) and graft
-                                // the "no new model call was made" reuse note
-                                // onto a fallback that never made one.
-                                if !verdict.heuristic {
-                                    state.last_verdict = Some((inputs_digest, verdict.clone()));
-                                }
-                                verdict
-                            }
-                            Err(abort) => {
-                                return CandidateResult::aborted(state.messages, abort.reason);
-                            }
-                        },
                     };
-                    if !verdict.heuristic {
-                        // The delta-framing baseline (#1431) advances only on
-                        // a verdict a model actually answered: a heuristic
-                        // fallback read nothing, and must not let the next
-                        // round stat-line text no model ever saw.
-                        state.last_verdict_diff = Some(state.diff_text.clone());
-                    }
                     let mut evidence = model_verdict_evidence(&verdict);
                     evidence.ladder = Some(Box::new(snapshot.with_rung(verdict.rung())));
                     self.emit(AgentEvent::Verdict {
@@ -3810,20 +3670,6 @@ fn assemble_user_message(
         VerificationContract::None => {}
     }
     s
-}
-
-/// One digest over everything a model verdict depends on — goal, the (witness
-/// -stripped) diff, and the evidence summary. Byte-identical inputs are the
-/// same question; the ModelVerdict arm reuses its previous answer rather than
-/// paying for sampling noise (#1431). Within-run only, so the std hasher's
-/// stability across versions is irrelevant.
-fn verdict_inputs_digest(goal: &str, diff: &str, evidence_summary: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    goal.hash(&mut hasher);
-    diff.hash(&mut hasher);
-    evidence_summary.hash(&mut hasher);
-    hasher.finish()
 }
 
 /// The instruction appended to a revision turn, carrying the failing

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -4,7 +4,10 @@
 //! stays reachable via `super::*`.
 
 mod management_accounting;
+mod scripted_provider;
 mod telemetry;
+
+use scripted_provider::ScriptedProvider;
 
 use super::*;
 use crate::CmdKind;
@@ -201,65 +204,6 @@ impl RepoStatusPort for SeqRepoStatus {
                     link_count: 1,
                 })
         })
-    }
-}
-
-/// A scripted provider serving triage, plan, worker, and verifier calls from
-/// one ordered queue (the resolver hands the same provider to every role).
-struct ScriptedProvider {
-    script: TokioMutex<VecDeque<CompletionResult>>,
-    /// Every prompt this provider was asked to complete, in order — so a test
-    /// can assert what actually reached the model, not just what came back.
-    seen: std::sync::Mutex<Vec<String>>,
-    /// The same requests with per-message roles preserved, so a test can
-    /// assert the system/user split of a management call (#1434) — the joined
-    /// text above cannot show which half a sentence landed in.
-    shapes: std::sync::Mutex<Vec<Vec<(stella_protocol::MessageRole, String)>>>,
-}
-impl ScriptedProvider {
-    fn new(results: Vec<CompletionResult>) -> Self {
-        Self {
-            script: TokioMutex::new(results.into_iter().collect()),
-            seen: std::sync::Mutex::new(Vec::new()),
-            shapes: std::sync::Mutex::new(Vec::new()),
-        }
-    }
-
-    /// The message text of each request, one joined string per call.
-    fn prompts(&self) -> Vec<String> {
-        self.seen.lock().unwrap().clone()
-    }
-
-    /// Each request's messages as `(role, content)` pairs, in call order.
-    fn shapes(&self) -> Vec<Vec<(stella_protocol::MessageRole, String)>> {
-        self.shapes.lock().unwrap().clone()
-    }
-}
-#[async_trait]
-impl Provider for ScriptedProvider {
-    fn id(&self) -> &str {
-        "scripted"
-    }
-    async fn complete_ref(
-        &self,
-        req: CompletionRequestRef<'_>,
-    ) -> Result<CompletionResult, ProviderError> {
-        self.seen.lock().unwrap().push(
-            req.messages
-                .iter()
-                .map(|m| m.content.as_str())
-                .collect::<Vec<_>>()
-                .join("\n"),
-        );
-        self.shapes.lock().unwrap().push(
-            req.messages
-                .iter()
-                .map(|m| (m.role, m.content.clone()))
-                .collect(),
-        );
-        let mut q = self.script.lock().await;
-        q.pop_front()
-            .ok_or_else(|| ProviderError::Terminal("scripted provider exhausted".into()))
     }
 }
 

--- a/crates/stella-pipeline/src/pipeline/tests/scripted_provider.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/scripted_provider.rs
@@ -1,0 +1,64 @@
+//! [`ScriptedProvider`] — the one-provider-serves-every-role test double used
+//! across almost every pipeline test. Split out of `tests.rs` to keep that
+//! file under the size gate; nothing here is orchestration, just a fixture.
+
+use super::*;
+
+/// A scripted provider serving triage, plan, worker, and verifier calls from
+/// one ordered queue (the resolver hands the same provider to every role).
+pub(super) struct ScriptedProvider {
+    pub(super) script: TokioMutex<VecDeque<CompletionResult>>,
+    /// Every prompt this provider was asked to complete, in order — so a test
+    /// can assert what actually reached the model, not just what came back.
+    seen: std::sync::Mutex<Vec<String>>,
+    /// The same requests with per-message roles preserved, so a test can
+    /// assert the system/user split of a management call (#1434) — the joined
+    /// text above cannot show which half a sentence landed in.
+    shapes: std::sync::Mutex<Vec<Vec<(stella_protocol::MessageRole, String)>>>,
+}
+impl ScriptedProvider {
+    pub(super) fn new(results: Vec<CompletionResult>) -> Self {
+        Self {
+            script: TokioMutex::new(results.into_iter().collect()),
+            seen: std::sync::Mutex::new(Vec::new()),
+            shapes: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The message text of each request, one joined string per call.
+    pub(super) fn prompts(&self) -> Vec<String> {
+        self.seen.lock().unwrap().clone()
+    }
+
+    /// Each request's messages as `(role, content)` pairs, in call order.
+    pub(super) fn shapes(&self) -> Vec<Vec<(stella_protocol::MessageRole, String)>> {
+        self.shapes.lock().unwrap().clone()
+    }
+}
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+    async fn complete_ref(
+        &self,
+        req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.seen.lock().unwrap().push(
+            req.messages
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        self.shapes.lock().unwrap().push(
+            req.messages
+                .iter()
+                .map(|m| (m.role, m.content.clone()))
+                .collect(),
+        );
+        let mut q = self.script.lock().await;
+        q.pop_front()
+            .ok_or_else(|| ProviderError::Terminal("scripted provider exhausted".into()))
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/verifier_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/verifier_stage.rs
@@ -66,6 +66,57 @@ impl<'a> Pipeline<'a> {
         }
     }
 
+    /// Best-effort distress-guidance course-correction, appended to `reason`
+    /// when the verifier returns one — the second-consecutive-failure trigger
+    /// in `Pipeline::verify_candidate`. Same witness exclusion as the verdict
+    /// call (#1433): guidance reads the change under correction, and the
+    /// verifier's own test is not part of it. Guidance never carries a delta
+    /// baseline (#1431/#1432) — its render is already evidence-scoped, and
+    /// "unchanged since a verdict round" is a verdict-shaped claim.
+    ///
+    /// The arguments are the guidance call's inherent inputs (prompt shaping,
+    /// leak scrubbing, call metering); grouping them into a request struct is
+    /// a larger refactor than this arity warrants.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn distress_guidance_reason(
+        &self,
+        goal: &str,
+        diff_text: &str,
+        witness_paths: &[String],
+        evidence_summary: &str,
+        sealed: &SealedFailure<'_>,
+        reason: &mut String,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Result<(), PipelineBudgetAbort> {
+        let stripped = crate::verify::strip_witness_hunks(diff_text, witness_paths);
+        let guidance = self
+            .verifier_guidance(
+                goal,
+                &stripped.diff,
+                evidence_summary,
+                &DiffContext {
+                    witness_paths,
+                    previous: None,
+                },
+                budget,
+                total,
+            )
+            .await?;
+        if let Some(guidance) = guidance
+            && let Some(text) = self.airlock_forward(&guidance, "distress_guidance", sealed)
+        {
+            reason.push_str("\n\nIndependent reviewer course-correction:\n");
+            reason.push_str(&text);
+        }
+        Ok(())
+    }
+
+    // `diff_ctx` (delta framing #1431 + witness exclusion #1433) and
+    // `inputs`/`budget`/`total` (ladder inputs + call metering) are separate
+    // concerns threaded through the one escalation call; grouping them into a
+    // request struct is a larger refactor than this arity warrants.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn verifier(
         &self,
         goal: &str,
@@ -131,6 +182,105 @@ impl<'a> Pipeline<'a> {
         }
     }
 
+    /// Resolve this round's model verdict for the escalated `ModelVerdict`
+    /// arm — witness exclusion (#1433), verdict reuse (#1431 step 1), and the
+    /// delta-framing baseline (#1431 remaining scope) all live here, split out
+    /// of `pipeline.rs` for the same reason the rest of this module is.
+    ///
+    /// The pipeline-authored witness's own hunks are stripped from the diff
+    /// before it can ride into the paid prompt as "worker-authored data"; the
+    /// omission is named in `evidence_summary` (the trusted zone), never
+    /// in-band in the diff. A revision that changed nothing the verdict
+    /// depends on — goal, stripped diff, evidence, byte for byte — reuses
+    /// `state.last_verdict` instead of paying for sampling noise. A fresh
+    /// call renders under the delta-framing baseline
+    /// (`state.last_verdict_diff`), and only a real model verdict — never a
+    /// heuristic fallback, which read nothing — advances either baseline.
+    ///
+    /// Same arity rationale as [`Self::verifier`]: witness exclusion, verdict
+    /// reuse, and call metering are separate concerns threaded through one
+    /// escalation call.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn resolve_verdict(
+        &self,
+        goal: &str,
+        evidence_summary: &mut String,
+        state: &mut CandidateState,
+        witness_paths: &[String],
+        inputs: &LadderInputs,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Result<ModelVerifierVerdict, PipelineBudgetAbort> {
+        let stripped = crate::verify::strip_witness_hunks(&state.diff_text, witness_paths);
+        if !stripped.omitted.is_empty() {
+            evidence_summary.push_str(&format!(
+                "; witness_files_omitted_from_diff=[{}] (verifier-authored test, not part of \
+                 the change under review)",
+                stripped.omitted.join(", ")
+            ));
+        }
+        // Reuse before re-buying (#1431): a revision that changed nothing the
+        // verdict depends on — same goal, same diff, same evidence, byte for
+        // byte — would re-ask the same question and pay full price for
+        // sampling noise. The cached verdict is the same opinion at zero
+        // cost, and the appended note steers the worker better than a fresh
+        // reading of an unchanged tree ever did.
+        let inputs_digest = verdict_inputs_digest(goal, &stripped.diff, evidence_summary);
+        let cached = state
+            .last_verdict
+            .as_ref()
+            .filter(|(digest, _)| *digest == inputs_digest)
+            .map(|(_, verdict)| verdict.clone());
+        let verdict = match cached {
+            Some(mut verdict) => {
+                verdict.reasoning.push_str(
+                    "\n(verdict reused: the goal, diff, and evidence are unchanged since the \
+                     previous review round — no new model call was made)",
+                );
+                verdict
+            }
+            None => {
+                // Delta framing (#1431 remaining scope): a fresh call still
+                // renders under the witness exclusion above, plus the
+                // previous round's diff as the baseline so unchanged file
+                // sections stat-line instead of re-buying their bodies.
+                let diff_ctx = DiffContext {
+                    witness_paths,
+                    previous: state.last_verdict_diff.as_deref(),
+                };
+                let verdict = self
+                    .verifier(
+                        goal,
+                        &stripped.diff,
+                        evidence_summary,
+                        &diff_ctx,
+                        inputs,
+                        budget,
+                        total,
+                    )
+                    .await?;
+                // Only pin a real model verdict for reuse. A heuristic
+                // fallback is a transient-outage stand-in (unresolvable
+                // provider, unparseable response, failed/timed-out call), not
+                // the opinion this candidate bought: caching it would
+                // suppress recovery on the next round (the verifier may have
+                // come back) and graft the "no new model call was made" reuse
+                // note onto a fallback that never made one.
+                if !verdict.heuristic {
+                    state.last_verdict = Some((inputs_digest, verdict.clone()));
+                }
+                verdict
+            }
+        };
+        if !verdict.heuristic {
+            // The delta-framing baseline (#1431) advances only on a verdict a
+            // model actually answered: a heuristic fallback read nothing, and
+            // must not let the next round stat-line text no model ever saw.
+            state.last_verdict_diff = Some(state.diff_text.clone());
+        }
+        Ok(verdict)
+    }
+
     /// Surface the verifier's resolution-quality caveat — same-family
     /// degradation (L-M8) — as a warning, once per run.
     ///
@@ -163,4 +313,18 @@ impl<'a> Pipeline<'a> {
             ));
         }
     }
+}
+
+/// One digest over everything a model verdict depends on — goal, the (witness
+/// -stripped) diff, and the evidence summary. Byte-identical inputs are the
+/// same question; [`Pipeline::resolve_verdict`] reuses its previous answer
+/// rather than paying for sampling noise (#1431). Within-run only, so the std
+/// hasher's stability across versions is irrelevant.
+fn verdict_inputs_digest(goal: &str, diff: &str, evidence_summary: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    goal.hash(&mut hasher);
+    diff.hash(&mut hasher);
+    evidence_summary.hash(&mut hasher);
+    hasher.finish()
 }

--- a/crates/stella-pipeline/src/pipeline/verify_probes.rs
+++ b/crates/stella-pipeline/src/pipeline/verify_probes.rs
@@ -207,4 +207,100 @@ impl<'a> Pipeline<'a> {
             diff_coverage: Some(inputs.diff_coverage.as_str().to_string()),
         }
     }
+
+    /// The textual evidence summary handed to the escalated model verifier —
+    /// every deterministic signal the ladder collected before deciding
+    /// "inconclusive, ask a model" (#859, #860, #861, #864, #867, #870,
+    /// #1291). Split out alongside [`Self::ladder_snapshot`] for the same
+    /// reason: pure assembly over the same probe results, not orchestration.
+    pub(super) fn model_verdict_evidence_summary(
+        &self,
+        inputs: &LadderInputs,
+        state: &CandidateState,
+        test_infra: Option<&'static str>,
+        lint_sample: &str,
+        snapshot: &LadderSnapshot,
+    ) -> String {
+        let mut evidence_summary = format!(
+            "flip_achieved={}; touched_tests={:?}; diff_lines={} (budget {}); \
+             file_change_events={}",
+            inputs.flip_achieved,
+            inputs.touched_tests_passed,
+            state.diff_lines,
+            self.config.diff_budget_lines,
+            state.file_changes,
+        );
+        if let Some(label) = test_infra {
+            // #860: the run ended without observing an assertion. Named so
+            // the verifier reads "the suite timed out", not "the suite
+            // failed".
+            evidence_summary.push_str(&format!("; test_run={label} (no assertion observed)"));
+        }
+        if state.oracle.is_unstable() {
+            // #859: a fail→pass flip WAS observed but could not be
+            // reproduced on the same tree — a different fact from "the test
+            // never passed", and one the verifier should weigh explicitly.
+            evidence_summary
+                .push_str("; unstable_flip=true (the flip's confirmation re-run did not pass)");
+        }
+        if inputs.diff_coverage != DiffCoverage::Unmeasured {
+            // #1291: stated only when it was actually measured. An
+            // `unmeasured` line here would be pure noise in a verifier
+            // prompt — the ladder already escalated for some other reason,
+            // and "nobody looked" adds nothing to reason from. It stays on
+            // the snapshot either way.
+            evidence_summary.push_str("; ");
+            evidence_summary.push_str(inputs.diff_coverage.explain());
+        }
+        if state.witness_mutation == Some(false) {
+            // #870: the witness reacted to the change without constraining
+            // it — it stayed green while the changed lines were
+            // deliberately broken.
+            evidence_summary.push_str(
+                "; witness_tautological=true (the witness stayed green under every trivial \
+                 mutation of the changed lines)",
+            );
+        }
+        if state.oracle.refused_different_failure() {
+            // #867: the suite passed, but its own complete test listing did
+            // not contain the baseline's failing tests — the observed
+            // failure was not fixed, it disappeared. The verifier should
+            // treat the passing exit code accordingly.
+            evidence_summary.push_str(
+                "; flip_refused=the passing run's test listing does not contain the test(s) \
+                 that failed on the baseline (fixed a different failure, or the failing test \
+                 was removed)",
+            );
+        }
+        if inputs.new_diag_errors > 0 || inputs.new_diag_warnings > 0 {
+            // #861: the regression the veto saw, capped to a 3-line sample
+            // so the verifier reads the delta, not the linter's whole
+            // opinion.
+            evidence_summary.push_str(&format!(
+                "; new_diagnostics={} error(s), {} warning(s) vs baseline",
+                inputs.new_diag_errors, inputs.new_diag_warnings
+            ));
+            if !lint_sample.is_empty() {
+                evidence_summary.push('\n');
+                evidence_summary.push_str(lint_sample.trim_end());
+            }
+        }
+        if !snapshot.oracle_trace.is_empty() {
+            // #864: the oracle trace, rendered compactly. The verifier sees
+            // WHY the ladder was inconclusive — which runs happened, in
+            // order, and what each observed — instead of a diff cold.
+            evidence_summary.push_str(&format!(
+                "; oracle_trace=[{}]",
+                crate::replay::render_oracle_trace(&snapshot.oracle_trace)
+            ));
+        }
+        if snapshot.witness_intact == Some(true) {
+            // #864: the tamper-exclusion result, stated. A tampered witness
+            // never reaches a verifier, so what the verifier learns here is
+            // that the check RAN and the witness it is weighing is the
+            // authored one.
+            evidence_summary.push_str("; witness_tamper_check=intact");
+        }
+        evidence_summary
+    }
 }

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -786,17 +786,6 @@ pub fn model_verdict_evidence(verdict: &Verdict) -> VerdictEvidence {
     }
 }
 
-/// Ceiling on the worker-authored diff text interpolated into a verifier or
-/// guidance prompt, in chars (~10k tokens). The fast-submit diff budget is
-/// 400 *lines*, so a legitimately judged diff almost always fits whole; what
-/// this bounds is the pathological tail — a generated file, a vendored blob, a
-/// worker that rewrote the world — which used to ride into every paid verifier
-/// call at full length. Head-weighted middle-out, matching the compactor's
-/// aging pass: the head carries the file headers and the intent, the tail the
-/// most recent hunks, and the elision is marked in-band so the verifier knows it
-/// is reading an excerpt rather than the whole change.
-const VERIFIER_DIFF_BUDGET_CHARS: usize = 40_000;
-
 /// A diff with the authored witness's own file chunks removed, plus the
 /// paths that were removed — see [`strip_witness_hunks`].
 pub struct StrippedDiff {
@@ -888,26 +877,21 @@ pub fn strip_witness_hunks(diff: &str, witness_paths: &[String]) -> StrippedDiff
     StrippedDiff { diff: out, omitted }
 }
 
-/// Clamp a worker-authored diff to `VERIFIER_DIFF_BUDGET_CHARS` for prompt
-/// interpolation: keep the head and tail, elide the middle, and say so where
-/// the cut was made. Char-based, not byte-based, so a multi-byte diff can
-/// never split a code point (the same unit [`crate::pipeline`]'s recall
-/// clamp settled on).
-fn bounded_worker_diff(diff: &str) -> String {
-    let total = diff.chars().count();
-    if total <= VERIFIER_DIFF_BUDGET_CHARS {
-        return diff.to_string();
-    }
-    let head_chars = VERIFIER_DIFF_BUDGET_CHARS * 2 / 3;
-    let tail_chars = VERIFIER_DIFF_BUDGET_CHARS - head_chars;
-    let head: String = diff.chars().take(head_chars).collect();
-    let tail: String = diff.chars().skip(total - tail_chars).collect();
-    let elided = total - head_chars - tail_chars;
-    format!(
-        "{head}\n[… {elided} chars elided from the middle of the diff — the head and tail are \
-         shown; verifier from what is visible and weigh that the middle is not …]\n{tail}"
-    )
-}
+/// The fixed sentence both verifier-facing prompts carry to explain the
+/// renderer's `#` stat lines ([`diff_render`]). One constant, for the same
+/// reason [`UNTRUSTED_DIFF_HEADING_SUFFIX`] is one: prompts and tests must
+/// read the same spelling or the guard outlives the thing it guards.
+///
+/// Unconditional — present even when the render happened to reduce nothing —
+/// because the instruction text is exactly the part of these prompts that
+/// must stay byte-stable across calls (the management-call caching work,
+/// #1434, depends on that stability).
+const DIFF_STAT_LINE_NOTE: &str = "Inside the diff, a line beginning with `#` is a rendering note from the pipeline, not \
+     part of the change: a file section may be reduced to one such stat line when it is \
+     unchanged since a previous review round of this same candidate (a prior round read its \
+     full text), when it is the pipeline's own witness test rather than the worker's change, \
+     or when the diff exceeds its token budget. A summarized file is still part of the \
+     change — weigh what its stat line states.";
 
 /// The one framing under which worker-authored text may enter a verifier-facing
 /// prompt (witness-protocol D5, `docs/design/witness-protocol.md` §2): the

--- a/crates/stella-pipeline/src/verify/diff_render.rs
+++ b/crates/stella-pipeline/src/verify/diff_render.rs
@@ -159,7 +159,7 @@ fn split_segments(diff: &str) -> Vec<Segment> {
             let old_path = rest.strip_prefix("a/").unwrap_or(rest).trim();
             let starts_new_file = current
                 .as_ref()
-                .map_or(true, |seg| !seg.is_file || seg.has_old_header);
+                .is_none_or(|seg| !seg.is_file || seg.has_old_header);
             if starts_new_file {
                 segments.extend(current.take());
                 current = Some(Segment::file(raw));
@@ -189,7 +189,7 @@ fn split_segments(diff: &str) -> Vec<Segment> {
             }
             continue;
         }
-        if line.starts_with('#') && current.as_ref().map_or(true, |seg| seg.is_file) {
+        if line.starts_with('#') && current.as_ref().is_none_or(|seg| seg.is_file) {
             // A joining marker between segments (the authored-section
             // header). Flush the file it closed; the marker itself is prose.
             segments.extend(current.take());


### PR DESCRIPTION
## What & why

`origin/main` tip `6f8f5e8c` was red. Four commits merged within ~2 minutes of
the last green commit (`7c3ab928`):

- `bed6a87e` (#1462) — token-budgeted, per-file-segment diff rendering
  (`verify/diff_render`, `DiffContext`, delta framing via
  `CandidateState::last_verdict_diff`, the `DIFF_STAT_LINE_NOTE` prompt
  constant, a 7th `diff_ctx` argument on `Pipeline::verifier`/`verifier_guidance`).
- `6dd75500` — byte-stable system prefix for management calls (unrelated to
  the conflict below; only touched shared test fixtures).
- `233dd0ba` — observatory transcript replay (`execution_journal`).
- `6f8f5e8c` (#1482) — verdict-reuse caching (`CandidateState::last_verdict`,
  keyed by an inputs digest) and witness-hunk stripping (`strip_witness_hunks`).

They merged cleanly at the text level but were semantically incompatible:
`6f8f5e8c`'s diff was authored against a **stale, pre-`bed6a87e`** `verify.rs`.
It deleted `DIFF_STAT_LINE_NOTE` and the `diff_render`/`DiffContext` wiring
`bed6a87e` had just added — but left the two prompt-building functions that
still interpolate `{DIFF_STAT_LINE_NOTE}` untouched, orphaning the constant.
It also reintroduced the old char-based `bounded_worker_diff`/
`VERIFIER_DIFF_BUDGET_CHARS` clamp that `bed6a87e` had deleted in favor of
`diff_render`'s per-segment renderer (as dead, unreferenced duplicate code).
It **renamed** `CandidateState::last_verdict_diff` to `last_verdict` instead of
adding a second field (the two serve different purposes — one is a
verdict-reuse cache, the other is the delta-framing baseline), and it dropped
the 7th `diff_ctx` argument from the `self.verifier(...)` call site without
updating the still-7-argument function signature. Result:

```
error[E0425]: cannot find value `DIFF_STAT_LINE_NOTE` in this scope (2 sites)
error[E0061]: this method takes 7 arguments but 6 were supplied
error[E0609]: no field `last_verdict_diff` on type `pipeline::CandidateState`
```

Plus a `cargo doc -D warnings` failure in `stella-observatory` (two intra-doc
links in `execution_journal`'s doc comment pointing at private items) and a
file-size ratchet failure (`pipeline.rs` +95, `pipeline/tests.rs` +16) —
unrelated defects that happened to land in the same window.

## The fix

Reconciled so **both** features' intent survives:

- `CandidateState` keeps **both** `last_verdict` (verdict-reuse cache) and
  `last_verdict_diff` (delta-framing baseline) — they answer different
  questions and both are needed on the next escalated round.
- `verify.rs` keeps the `diff_render`-based rendering (`DIFF_STAT_LINE_NOTE`
  restored) and drops the dead, reintroduced char-clamp duplicate.
- The `ModelVerdict` arm now: strips witness hunks first (#1433), checks the
  verdict-reuse cache against a digest of the stripped diff (#1431 step 1),
  and on a cache miss calls the verifier with a full `DiffContext` carrying
  both `witness_paths` and the delta-framing `previous` baseline (#1431
  remaining scope) — the union of what both PRs intended.

Also fixed, surfaced only once the crate compiled again far enough for clippy
and rustdoc to actually run:

- Two rustdoc intra-doc links in `stella-observatory`'s `execution_journal`
  doc comment pointed at private items (`recall_timings`, `JOURNAL_BODY_CLIP`)
  — changed to plain code spans, matching the file's existing idiom elsewhere.
- Two `clippy::unnecessary_map_or` and three `clippy::too_many_arguments`
  lints that were latent in `bed6a87e`'s own diff (masked by the compile
  errors — clippy never got far enough to check them before this fix): fixed
  with `is_none_or` and `#[allow(clippy::too_many_arguments)]` plus a one-line
  justification each, since the arity is inherent to threading prompt
  shaping, leak scrubbing, and call metering through one escalation call.

Brought `pipeline.rs` (3851 -> ~3620 lines) and `pipeline/tests.rs` (2664 ->
2608 lines) back under the file-size ratchet by **extracting**, not editing
the baseline: `Pipeline::resolve_verdict` and
`Pipeline::distress_guidance_reason` (`pipeline/verifier_stage.rs`), the
evidence-summary assembly into `Pipeline::model_verdict_evidence_summary`
(`pipeline/verify_probes.rs`), and the `ScriptedProvider` test double into its
own file (`pipeline/tests/scripted_provider.rs`) — the same
sibling-submodule pattern as `stella-core`'s `driver/settlement.rs` split.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is a
      build fix reconciling a merge race, not a behavior change. The
      verdict-reuse and witness-exclusion behaviors already have witness-style
      tests from #1482 (`an_unchanged_revision_reuses_the_verdict_instead_of_rebuying_it`,
      the `strip_witness_hunks` unit tests), which pass unmodified against the
      reconciled code.

## The gate

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p stella-pipeline -p stella-observatory --all-targets -- -D warnings`
- [x] `cargo test -p stella-pipeline` (495 lib tests + all integration suites, all green)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-observatory --no-deps`
- [x] `./scripts/check-file-size.sh`
- [ ] `cargo test --workspace` — not run locally (16GB shared machine,
      time-critical unbreak); CI covers the rest of the workspace, which this
      PR does not touch outside `stella-pipeline` and `stella-observatory`.

## Ground-rule check

- [x] No I/O added to `stella-core` (this PR doesn't touch `stella-core`)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

- No baseline edit (`scripts/file-size-baseline.txt` untouched) — the fix is
  extraction only, per `AGENTS.md`'s god-file guidance.
- `git diff --stat` is deliberately larger than the minimal 3-error fix would
  suggest: most of it is code *moving* to sibling submodules to satisfy the
  file-size gate, not new logic.

## Summary by Sourcery

Reconcile model-verdict reuse and diff-rendering changes in the pipeline while restoring build and docs health and keeping pipeline files under the size gate.

Bug Fixes:
- Fix broken main by restoring `CandidateState` fields and verifier call signatures so verdict reuse, witness stripping, and diff rendering all compile and work together.
- Correct invalid rustdoc intra-doc links in `stella-observatory`'s `execution_journal` docs that pointed to private items.
- Address clippy lints in the diff renderer and verifier pipeline code to satisfy `-D warnings` in CI.

Enhancements:
- Extract model-verdict resolution, distress guidance handling, and evidence summary assembly into dedicated helpers (`verifier_stage` and `verify_probes`) to shrink `pipeline.rs` and improve separation of concerns.
- Preserve and clarify verdict-reuse caching and delta-framing baselines by storing both the last verdict and its associated diff on `CandidateState`.
- Document and centralize the diff stat-line explanation constant used in verifier-facing prompts so prompts and tests share a stable spelling.
- Split the `ScriptedProvider` test double into its own module for reuse across pipeline tests while satisfying file-size constraints.

Documentation:
- Clarify observatory execution-journal documentation by replacing broken intra-doc links with code-formatted identifiers.

Tests:
- Refactor the common `ScriptedProvider` test double into a separate module and rewire tests to use it without changing coverage or behavior.