### PR TITLE
fix(stella-pipeline): thread model_timeout into verdict and guidance calls

### DIFF
--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -193,3 +193,181 @@ async fn triage_budget_crossing_aborts_before_a_second_provider_call() {
             .any(|event| matches!(event, AgentEvent::Complete { .. }))
     );
 }
+
+/// #1483: `Pipeline::verifier` and `verifier_guidance` used to dispatch with
+/// `RawCall.timeout: None`, so a hung verifier had nothing bounding the call
+/// short of the retry policy — it would sit waiting on the clock that scores
+/// the run (bench timeouts) rather than degrading onto the documented cheap
+/// fallback. Both now thread `EngineConfig::model_timeout` — the same
+/// posture-keyed ceiling the worker path got in #1211/#1277 — into the raw
+/// call, the same shape `triage_latency_ceiling` already gave triage.
+///
+/// A tiny `model_timeout` against a provider that answers well after it
+/// proves the call is abandoned at the ceiling: the verdict falls back to
+/// the deterministic heuristic (`Verdict::heuristic == true`) instead of the
+/// model's real "PASS verified" answer, and the abandonment is recorded as
+/// an explicit `UsageIncomplete { role: Verdict, reason: Timeout }` rather
+/// than silently waiting the call out.
+#[tokio::test]
+async fn late_verdict_is_abandoned_and_falls_back_to_the_heuristic() {
+    let provider = DelayedProvider {
+        result: TokioMutex::new(Some(text_result("PASS verified"))),
+        delay: Duration::from_millis(20),
+    };
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            engine: EngineConfig {
+                model_timeout: Some(Duration::from_millis(1)),
+                ..EngineConfig::default()
+            },
+            ..PipelineConfig::default()
+        },
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let mut total = 0.0;
+    let prompt = ManagementPrompt {
+        instructions: "verdict?",
+        payload: "goal, diff, evidence".into(),
+    };
+    let inputs = LadderInputs {
+        touched_tests_passed: Some(true),
+        ..LadderInputs::default()
+    };
+
+    let verdict = pipeline
+        .verifier(prompt, &inputs, &mut budget, &mut total)
+        .await
+        .expect("a wedged verifier is never a run-ending failure");
+
+    assert!(
+        verdict.heuristic,
+        "the abandoned call must fall back to the deterministic heuristic, \
+         not wait out the model's real answer"
+    );
+    assert_eq!(total, 0.0, "nothing settled, so nothing is charged");
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::UsageIncomplete {
+                role: ModelCallRole::Verdict,
+                reason: stella_protocol::UsageIncompleteReason::Timeout,
+                ..
+            }
+        )),
+        "the missed deadline must surface as an explicit incomplete-usage record: {events:?}"
+    );
+}
+
+/// The distress-guidance sibling of the witness above: a hung guidance call
+/// now abandons onto its own documented best-effort fallback (`Ok(None)`,
+/// evidence-only revision) at the same `model_timeout` ceiling, instead of
+/// stalling the revision loop on a wedged verifier.
+#[tokio::test]
+async fn late_guidance_is_abandoned_and_reported_incomplete() {
+    let provider = DelayedProvider {
+        result: TokioMutex::new(Some(text_result("try a different approach"))),
+        delay: Duration::from_millis(20),
+    };
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            engine: EngineConfig {
+                model_timeout: Some(Duration::from_millis(1)),
+                ..EngineConfig::default()
+            },
+            ..PipelineConfig::default()
+        },
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let mut total = 0.0;
+    let prompt = ManagementPrompt {
+        instructions: "guidance?",
+        payload: "goal, diff, evidence".into(),
+    };
+
+    let guidance = pipeline
+        .verifier_guidance(prompt, &mut budget, &mut total)
+        .await
+        .expect("a wedged guidance call is never a run-ending failure");
+
+    assert_eq!(
+        guidance, None,
+        "the abandoned call degrades to evidence-only revision, not the \
+         model's real (late) steering text"
+    );
+    assert_eq!(total, 0.0, "nothing settled, so nothing is charged");
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::UsageIncomplete {
+                role: ModelCallRole::DistressGuidance,
+                reason: stella_protocol::UsageIncompleteReason::Timeout,
+                ..
+            }
+        )),
+        "the missed deadline must surface as an explicit incomplete-usage record: {events:?}"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/verifier_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/verifier_stage.rs
@@ -46,7 +46,11 @@ impl<'a> Pipeline<'a> {
                     messages,
                     policy: RetryPolicy::deterministic(),
                     overrides: &self.config.role_overrides.verifier,
-                    timeout: None,
+                    // The worker's per-call ceiling (`model_timeout`, #1211/#1277) —
+                    // guidance is best-effort (`Ok(None)` on any failure below), so
+                    // a wedged call degrades to evidence-only revision instead of
+                    // stalling the run on the clock that scores it (#1483).
+                    timeout: self.config.engine.model_timeout,
                 },
                 budget,
                 total,
@@ -98,7 +102,11 @@ impl<'a> Pipeline<'a> {
 
         let messages = prompt.into_messages();
         // Deterministic policy: a verifier call that fails must not hang; it falls
-        // back to the heuristic verdict rather than retrying.
+        // back to the heuristic verdict rather than retrying. The timeout is the
+        // other half of that contract (#1483) — the worker's per-call ceiling
+        // (`model_timeout`, #1211/#1277) so a hung verifier is abandoned onto the
+        // heuristic fallback instead of stalling the run on the clock that
+        // scores it, the same posture `triage_latency_ceiling` gives triage.
         match self
             .metered_raw_call(
                 RawCall {
@@ -107,7 +115,7 @@ impl<'a> Pipeline<'a> {
                     messages,
                     policy: RetryPolicy::deterministic(),
                     overrides: &self.config.role_overrides.verifier,
-                    timeout: None,
+                    timeout: self.config.engine.model_timeout,
                 },
                 budget,
                 total,


### PR DESCRIPTION
## What & why

`Pipeline::verifier()` (the model verdict on inconclusive evidence) and
`Pipeline::verifier_guidance()` (the distress-guidance steering call)
dispatched through `metered_raw_call` with `RawCall.timeout: None`.
`run_accounted_call`'s `None` branch just `.await`s the provider future
directly — nothing wraps it in a `tokio::time::timeout`. A hung verifier
(dead upstream, slow auto-routed model, stuck stream) stalled the whole
run mid-verification, burning the same wall-clock budget that scores a
run (Terminal-Bench's failure profile is 100% timeouts / 0 wrong answers).

The worker's own step call already carries a posture-keyed
`EngineConfig::model_timeout` ceiling (#1211/#1277). The two management
calls in `crates/stella-pipeline/src/pipeline/verifier_stage.rs` now pass
`self.config.engine.model_timeout` instead of a hardcoded `None`, so a
wedged call is abandoned onto its already-documented cheap degradation
path: verdict falls back to the deterministic heuristic
(`heuristic_fallback`), guidance degrades to `Ok(None)` (evidence-only
revision) — the same shape `triage_latency_ceiling` already gives triage.

**Note on the issue's "Where" section:** it also named
`crates/stella-pipeline/src/triage.rs` as a call site to fix. By the time
I got to it, triage's actual `RawCall` (in `pipeline.rs`, not
`triage.rs` — that file is pure classification/parsing logic per its own
module doc) already carried `timeout: Some(self.config.triage_latency_ceiling)`.
No change was needed there; this PR is scoped to the two sites the issue
title names (verdict, guidance).

**Composes with #1515** (still open at the time of this PR): that PR
reworks `stella-core`'s per-call ceiling into an idle deadline that
re-arms on streamed fragments, instead of a flat wall-clock timeout. I
did not touch `accounted_call.rs` — once #1515 lands, `model_timeout`
becomes an idle deadline automatically for these two calls too, with no
further change needed here.

Closes #1483

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Two new tests in `crates/stella-pipeline/src/pipeline/tests/management_accounting.rs`
(the existing home for management-call deadline witnesses, alongside
`late_triage_is_abandoned_and_reported_incomplete`):

- `late_verdict_is_abandoned_and_falls_back_to_the_heuristic` — calls
  `Pipeline::verifier` directly against a provider that answers after
  20ms with a tiny (1ms) `model_timeout`. Asserts the returned verdict
  is the deterministic heuristic (`Verdict::heuristic == true`, not the
  model's real "PASS verified"), and that an
  `AgentEvent::UsageIncomplete { role: Verdict, reason: Timeout }` was
  emitted.
- `late_guidance_is_abandoned_and_reported_incomplete` — same shape
  against `Pipeline::verifier_guidance`, asserting it degrades to `None`
  rather than returning the model's late steering text.

Verified fail→pass manually (temporarily reverting the `timeout: None`
→ `self.config.engine.model_timeout` edits, `git stash` is off-limits
in this repo's worktree setup so I hand-reverted and restored):

```
running 4 tests
test pipeline::tests::management_accounting::triage_budget_crossing_aborts_before_a_second_provider_call ... ok
test pipeline::tests::management_accounting::late_triage_is_abandoned_and_reported_incomplete ... ok
test pipeline::tests::management_accounting::late_guidance_is_abandoned_and_reported_incomplete ... FAILED
test pipeline::tests::management_accounting::late_verdict_is_abandoned_and_falls_back_to_the_heuristic ... FAILED
test result: FAILED. 2 passed; 2 failed; ...
```

With the fix restored, all 4 pass. Both hang scenarios resolve in well
under a second (a 20ms provider delay against a 1ms ceiling) — no real
multi-second sleeps in the suite.

## The gate

- [x] `cargo fmt --all` — exit 0, no diff beyond this change
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings` — exit 0
- [x] `cargo test -p stella-pipeline` — exit 0, 497 unit tests + all integration suites pass
- [x] `./scripts/check-file-size.sh` — exit 0 (no god-file growth; new logic landed in
      `verifier_stage.rs` / `pipeline/tests/management_accounting.rs`, not the closed
      `pipeline.rs` / `pipeline/tests.rs`)
- [ ] Docs updated — no behavior/flag surfaced beyond the existing `model_timeout_secs`
      setting, which already documents this posture
- [x] `Closes #1483` appears both above and as a commit trailer

Full-workspace `make gate` intentionally not run locally (shared machine, CI covers it).

## Ground-rule check

- [x] No I/O added to `stella-core` (this PR doesn't touch `stella-core` at all)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

- Scoped deliberately to the two `RawCall.timeout: None` sites the issue title names.
  Did not touch `stella-core::accounted_call.rs` internals per the coordination note on
  #1515 (still open) — this PR only supplies a real value where the pipeline previously
  passed `None`.
- `pipeline.rs` and `pipeline/tests.rs` are closed god files; both new-test and fix code
  landed in their existing sibling submodules (`verifier_stage.rs`,
  `pipeline/tests/management_accounting.rs`).

## Summary by Sourcery

Thread model_timeout into verifier and guidance management calls to bound hung model calls and ensure they degrade to existing fallback behavior instead of stalling runs.

Tests:
- Add verifier timeout witness ensuring late verdict falls back to deterministic heuristic and records incomplete usage.
- Add guidance timeout witness ensuring late guidance degrades to None and records incomplete usage without charging budget.