### PR TITLE
docs(design): measure the file-budget claims — two are refuted

### DIFF
--- a/docs/design/file-budget.md
+++ b/docs/design/file-budget.md
@@ -25,14 +25,35 @@ If that were the whole list, this document should not exist. It is not the
 whole list. The remaining arguments get **sharper** under agent authorship, and
 three of them exist *only* because agents write the code.
 
-**1.1 — The file is the read unit, so file size is a toll on every edit.**
-An agent changing three lines in `command_deck.rs` must first read
-`command_deck.rs`: roughly 60,000 tokens to change three lines. It pays that on
-every turn that touches the file, in every session, forever, in real money. We
-have already measured this problem from the other end — the benchmark notes
-record Claude Code winning the same Terminal-Bench tasks at 45k–64k tokens per
-step while Stella truncates at 32k. Large files spend our scarcest resource on
-code irrelevant to the task.
+**1.1 — A large file is never read; it is re-read.**
+*(Rewritten 2026-08-05. The original claim — "an agent must first read the whole
+file, roughly 60,000 tokens to change three lines" — was **measured and
+refuted**. See §2.7 / EXP-1. Keeping a refuted argument because it supports the
+right conclusion is how the last limit died.)*
+
+Agents do not read large files whole. Measured over 557 `read_file` calls in
+`.stella/private/store.db`, the fraction of reads that are *ranged*
+(`limit`/`offset`/symbol rather than the whole file) rises monotonically with
+file size and hits a ceiling:
+
+| File size | Reads | Ranged | Whole-file |
+|---|---:|---:|---:|
+| <400 | 52 | 77% | 23% |
+| 400–1000 | 165 | 94% | 6% |
+| 1000–2000 | 149 | 98% | 2% |
+| 2000+ | 154 | **100%** | **0%** |
+
+Not one whole-file read of a 2,000+ line file, in the entire store. The toll is
+real but its shape is the opposite of what this section originally claimed: a
+file too large to hold is not loaded once at great expense, it is **peeked at
+repeatedly**, and each peek must first be *located*. That locate step is the
+grep traffic — 293 calls returning ~262k tokens against 557 reads returning
+~729k. The tax is search-and-fragment, not bulk load.
+
+This matters for policy: a cost model based on "size of the file you must load"
+is wrong, and a budget justified by it would be justified by nothing. The
+defensible version is §1.5 (a file with no internal names is expensive to
+navigate) plus §2.7's growth-curve finding.
 
 **1.2 — Irrelevant context makes the model worse, not merely slower.**
 This is a correctness argument, not an efficiency one. A human skims past
@@ -49,14 +70,27 @@ than serializing into merge conflicts. The proof is in the enforcement layer
 itself: `scripts/file-size-baseline.txt` is a single shared file, it conflicted,
 and a resolution silently triple-entered `command_deck.rs` (§3.4).
 
-**1.4 — Agents append. That is the mechanism, and it never self-corrects.**
-Asked to add a feature, an agent adds code at the end. It will not restructure,
-because restructuring risks breaking code it cannot fully see and costs tokens
-it does not have. Unbounded growth is therefore not an accident that care can
-prevent — it is the **default trajectory** of agent-authored code. The header
-comment of `check-file-size.sh` records this happening in the open:
-`deck_ui.rs` grew from 6,632 to 6,884 lines *while three separate design
-documents asserted a 1,500-line cap*. Nothing enforced it, so it grew.
+**1.4 — Growth is the default, but *not* because agents append.**
+*(Rewritten 2026-08-05. The original claim — "asked to add a feature, an agent
+adds code at the end… unbounded growth is the default trajectory" — was the most
+confidently stated mechanism in this document and it is **flatly wrong**. See
+§2.7 / EXP-2, n = 246,010 added lines.)*
+
+Agents edit **throughout** the file. Mean normalized position of an added line
+is 0.480 against a uniform-editing null of 0.500, and only 8.0% of added lines
+land in the last 10% of the file — *below* the 10% that random editing would
+produce. There is no append bias, and no size interaction (delta −0.009).
+
+What survives, and is measured (EXP-3, 4,752 edits with renames and the crates/
+restructure excluded): **files grow relentlessly regardless.** 75–80% of edits
+increase a file's length, 8–15% shrink it, net **+24.95 lines per edit**. So the
+"only turns one way" premise behind the non-increase rule (§5.3) holds — it just
+is not caused by appending. Code is added in the middle, everywhere, always.
+
+The corrected mechanism is in §2.7 and it changes where the budget should bite:
+growth is **fastest in the 400–1000 line band (+34.98 lines/edit)** and nearly
+stops above 2,000 (+4.64). A limit at 1,500 fires after the acceleration is
+over.
 
 **1.5 — A large file is a missing name, and names are how a stranger navigates.**
 Every agent session is a stranger. When 4,551 lines are called
@@ -81,11 +115,22 @@ inspection whether the other 4,550 lines still mean what they meant. Small
 files make the *unchanged* portion reviewable for free.
 
 > **The reframe.** For a human, file size is an ergonomics problem — unpleasant
-> but survivable. For an agent it is simultaneously a **correctness** problem
-> (1.2), a **concurrency** problem (1.3), and a **cost** problem (1.1). The
-> binding constraint moved from "what fits in a person's head" to "what fits in
-> a context window alongside everything else the task needs," and that
-> constraint is tighter.
+> but survivable. For an agent the binding constraint moved from "what fits in a
+> person's head" to "what fits in a context window alongside everything else the
+> task needs," and that constraint is tighter.
+>
+> **Evidence status of this section, after §2.7.** Measured and holding: the
+> navigation cost of a file with no internal names (1.1 as rewritten, 1.5, 1.6),
+> and relentless growth concentrated in the 400–1000 band (1.4 as rewritten).
+> Measured and **refuted**, now rewritten: whole-file reads (original 1.1),
+> append bias (original 1.4). Still **unmeasured** and flagged as such:
+> attention degradation (1.2 — plausible from the literature but not measured on
+> this codebase), merge-conflict cost (1.3 — §12.2 gives the experiment, and it
+> may well kill this one too), and dead-code accumulation (1.7).
+>
+> The conclusion did not move when two of its reasons died, which is the useful
+> thing to know about it. Do not quote an unmeasured line as though it were
+> §2.7.
 
 ---
 
@@ -243,6 +288,80 @@ different but the shape identical (seven files over ceiling, including
 `event.rs` +22 and `pipeline/tests.rs` +21). The set churns; the redness does
 not. Any design that does not explain *how this keeps happening* will be
 defeated the same way.
+
+---
+
+### 2.7 The experiments — what was measured, and what it killed
+
+*Added 2026-08-05.* §1 of the first draft argued from mechanism. Three of those
+mechanisms were guesses, so they were built into re-runnable experiments under
+`scripts/experiments/` and run. Two came back refuted. **The conclusion of this
+document survived; two of its stated reasons did not.**
+
+Each script states its claim, its prediction, its method, the confounds it
+handles, and refuses a verdict below a minimum sample.
+
+| Experiment | Claim tested | n | Verdict |
+|---|---|---:|---|
+| **EXP-1** `exp1_read_cost.py` | §1.1 — a big file must be read whole | 557 reads | **REFUTED** — 100% of 2000+ line reads are ranged |
+| **EXP-2** `exp2_append_bias.py` | §1.4 — agents append | 246,010 added lines | **REFUTED** — mean position 0.480 vs 0.500 null |
+| **EXP-3a** `exp3_growth_ratchet.py` | Growth is effectively one-way | 4,752 edits | **SUPPORTED** — 75–80% of edits grow, net +24.95/edit |
+| **EXP-3b** `exp3_growth_ratchet.py` | Large files grow *faster* | 4,752 edits | **REFUTED (reversed)** — they grow ~7× slower |
+
+**The growth curve — the finding that should set the thresholds.** Bucketing
+each edit by the file's length *before* that edit (so a file is never credited
+to the bucket its own growth created):
+
+| Size before the edit | Edits | Grew | Shrank | **Net lines/edit** |
+|---|---:|---:|---:|---:|
+| <400 | 1,515 | 77% | 8% | +26.05 |
+| 400–1000 | 1,533 | 80% | 8% | **+34.98** |
+| 1000–2000 | 1,193 | 79% | 11% | +19.35 |
+| 2000+ | 511 | 75% | **15%** | **+4.64** |
+
+Growth **accelerates through the 400–1000 band and then collapses.** A file past
+2,000 lines gains 4.64 lines per edit and is the most likely of any bucket to be
+actively shrunk. The history contains **64 deliberate reductions of ≥300 lines**
+— `deck_ui.rs` −2,958 (#697), `agent.rs` −2,187, `driver.rs` −1,929,
+`registry.rs` −1,776. Nobody was forced to do those; they were done because the
+files had become unbearable.
+
+Three consequences, all of which change the design rather than decorate it:
+
+1. **A 1,500-line limit is at the wrong end of the curve.** It fires after the
+   growth it was meant to prevent has already stopped. This is a better
+   explanation for the gate's uselessness than §3.1's "no gradient" and it is
+   measured rather than argued.
+2. **The 400–1000 band is where the budget must bite** — which independently
+   lands on the Green/Yellow boundary (§5.2) proposed for entirely different
+   reasons. That is a genuine confirmation, not a restatement.
+3. **The team already pays for splits, manually, late, and at maximum cost.**
+   The non-increase rule (§5.3) does not introduce new work; it moves 64
+   painful reductions earlier, where each one is small.
+
+**What could not be measured, and why.** The cost curve that would settle the
+threshold numbers directly — bytes read per line changed, by file size — needs
+executions that both read and edit the same file. `files_touched` holds 44 rows
+and yields 1–3 samples per bucket. **Not reportable.** EXP-1 prints the table
+with its n and a power warning rather than a number anyone could quote. Closing
+this needs more logged sessions, not more reasoning; see §12.1.
+
+**Confounds caught during the work, recorded so they are not re-discovered:**
+
+- The first EXP-3 run showed large files *shrinking* (−26.86 lines/edit) and
+  reported CLAIM A refuted. Cause: commit `7df3d73f` ("previous version") moved
+  303 files under `crates/`, deleting 121,963 lines, which git recorded as
+  delete+create and which landed entirely in the 2000+ bucket. Fixed with
+  `-M -C` rename detection plus a mass-move exclusion; the script now prints
+  what it dropped (10 commits, 1,380 rows, 869 rename rows) instead of dropping
+  it silently.
+- EXP-1's re-read tax rises 1.49 → 3.00 → 3.39 → 9.06 with size, which looks
+  like a strong size effect until you notice `deck_ui.rs` is **75% of all 2000+
+  reads**. The bucket is one file that happened to be the task. The script now
+  prints that share automatically so the trap cannot be walked into twice.
+- EXP-2 weights positions by lines added (capped at 50) so one large commit
+  cannot dominate, and excludes file-creation commits, which are 100% "append"
+  by construction and would have manufactured the very result being tested.
 
 ---
 
@@ -746,22 +865,40 @@ time until §9 is done. Revisit afterward for maintenance.
 
 ## 12. Open questions
 
-1. **Is 400/600/800 right?** They are argued from token cost in §5.2, not
-   measured. A cheap experiment: instrument `stella-cli` to log tokens spent on
-   file reads per turn, then correlate against file size across a Terminal-Bench
-   run. That turns §1.1 from a reasoned claim into a measured one, and we have
-   the harness to do it.
-2. **Should the item-count rule (§5.6) apply to `enum` variants?**
+1. **Is 400/600/800 right? — PARTIALLY ANSWERED (2026-08-05).** EXP-3 (§2.7)
+   independently locates the fastest growth in the **400–1000** band, which is
+   where the Green/Yellow boundary sits. That is real corroboration from a
+   direction the numbers were not chosen from. What is still **not** measured is
+   the cost curve — bytes read per line changed, by file size — which is what
+   would justify 800 rather than 700 or 1,000. `files_touched` yields 1–3
+   samples per bucket, far too thin.
+
+   **To close it:** the blocker is data, not method. `exp1_read_cost.py` already
+   computes the curve and takes a store path as its argument; it needs a store
+   with meaningfully more executions that both read and edit the same file.
+   Point it at a Terminal-Bench run's store, or at `~/.stella/usage.db`-scale
+   traffic, and the table fills in. Until then, treat 400/600/800 as a defensible
+   starting point corroborated on one axis, not as a measured optimum — and say
+   so wherever they are quoted.
+2. **Does file size actually cause merge conflicts (§1.3)?** Still a guess, and
+   the one remaining unmeasured claim in §1. It is genuinely uncertain because
+   **git merges by hunk, not by file** — two agents editing distant regions of
+   one 4,000-line file may never conflict, in which case §1.3 is wrong and the
+   concurrency argument for small files collapses. The experiment: for commit
+   pairs touching the same file on divergent branches, measure hunk-range
+   overlap, bucketed by file size. If overlap does not rise with size, delete
+   §1.3 rather than defending it.
+3. **Should the item-count rule (§5.6) apply to `enum` variants?**
    `crates/stella-protocol/src/event.rs` is 21 types and legitimately wide. A protocol
    crate may warrant its own band.
-3. **Does the non-increase rule need a per-PR escape for a security fix?** The
+4. **Does the non-increase rule need a per-PR escape for a security fix?** The
    current answer is no — a security fix is nearly always net-neutral or a
    deletion. If a real counterexample appears, the escape must be a human
    action (a signed trailer, a named reviewer), never a make target.
-4. **`bench/` Python:** these files have no `//!` equivalent enforced and are
+5. **`bench/` Python:** these files have no `//!` equivalent enforced and are
    currently the largest in the tree. Do they adopt the same bands, or does
    `bench/` get its own policy on the grounds that it is not shipped?
-5. **Migration order vs. `main`'s stability.** The repo's history shows `main`
+6. **Migration order vs. `main`'s stability.** The repo's history shows `main`
    repeatedly landing uncompilable. Ten large refactor PRs will conflict with
    in-flight work; §9's one-file-per-PR scoping is the mitigation, but the
    sequencing may need to yield to whatever else is in flight.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -214,6 +214,25 @@
       "status": "implemented",
       "title": "Design: Session-Shared Exploration Maps"
     },
+    "file-budget": {
+      "path": "docs/spec/file-budget.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "status": "proposed",
+      "title": "File budget, module boundaries, and test placement \u2014 a limit an agent cannot quietly exceed"
+    },
     "filesystem-layout": {
       "path": "docs/spec/filesystem-layout.md",
       "status": "living",

--- a/docs/spec/file-budget.md
+++ b/docs/spec/file-budget.md
@@ -1,3 +1,9 @@
+---
+id: file-budget
+title: "File budget, module boundaries, and test placement — a limit an agent cannot quietly exceed"
+status: proposed
+---
+
 # File budget, module boundaries, and test placement — a limit an agent cannot quietly exceed
 
 **Status:** **Proposed.** Supersedes the ratchet in `scripts/check-file-size.sh`

--- a/scripts/experiments/README.md
+++ b/scripts/experiments/README.md
@@ -1,0 +1,75 @@
+# scripts/experiments — settle a claim instead of arguing it
+
+These exist because `docs/design/file-budget.md` shipped with several confident
+mechanism claims that nobody had measured. When they were measured, **two of the
+most confidently stated ones turned out to be wrong** while the document's
+conclusion survived. That is the pattern these scripts exist to make cheap:
+find out which of your reasons are real *before* someone builds a gate on top of
+them.
+
+## The rules every experiment here follows
+
+1. **State the claim, and the prediction that would falsify it.** A script whose
+   claim cannot come back false is not an experiment.
+2. **Print `n` next to every number.** A table without its sample size is an
+   opinion with a decimal point.
+3. **Refuse a verdict below a minimum sample.** `UNDERPOWERED` is a real,
+   frequent, correct result. `exp1` returns it today.
+4. **Name the confounds in the docstring and handle them in code.** Both real
+   findings here were nearly lost to one (see below).
+5. **Never drop data silently.** If rows are excluded, print how many and why.
+6. **Re-runnable with no arguments**, against the repo as it stands.
+
+## The experiments
+
+| Script | Question | Data | Status |
+|---|---|---|---|
+| `exp1_read_cost.py` | Does an agent read a big file whole? What does an edit cost? | `.stella/private/store.db` | §1.1 **refuted**; cost curve **underpowered** |
+| `exp2_append_bias.py` | Do agents append to the end of files? | git history | §1.4 **refuted** (n=246,010) |
+| `exp3_growth_ratchet.py` | Is growth one-way? Do big files grow faster? | git history | one-way **supported**; faster **refuted, reversed** |
+
+```sh
+python3 scripts/experiments/exp1_read_cost.py [path/to/store.db]
+python3 scripts/experiments/exp2_append_bias.py [max_commits]
+python3 scripts/experiments/exp3_growth_ratchet.py
+```
+
+All three are read-only, need no build, and finish in seconds. They are
+deliberately **not** wired into `make gate` — they answer design questions, they
+do not enforce anything, and a gate that runs them would just be slow.
+
+## The confounds that nearly produced two wrong answers
+
+Recorded because both were invisible until the result looked odd, and both would
+have been reported as findings.
+
+**The restructure that looked like a refactor.** EXP-3's first run reported that
+files over 2,000 lines *shrink* by 26.86 lines per edit — a striking result, and
+false. Commit `7df3d73f` moved 303 files under `crates/`, deleting 121,963
+lines, which git recorded as delete+create rather than rename; every one of
+those deletions landed in the largest bucket. Fixed with `-M -C` rename
+detection and a mass-move exclusion. **The tell was that the result was too
+good** — it is worth being suspicious of a number that hands you a headline.
+
+**The bucket that was one file.** EXP-1's re-read tax climbs 1.49 → 3.00 → 3.39
+→ 9.06 with file size, which reads as a clean size effect until you notice
+`deck_ui.rs` is 75% of every read in the top bucket. It measures which file the
+task happened to be about. The script now prints that share automatically, so
+the trap is visible rather than remembered.
+
+**The tautology in the test itself.** EXP-2 had to exclude file-creation commits
+and cap per-hunk weighting: a new file is 100% "append" by construction, and one
+large mechanical commit can carry a bucket on its own. Either would have
+manufactured the exact result being tested.
+
+## Adding one
+
+Copy the docstring shape from `exp2_append_bias.py` — claim, both predictions,
+method, confounds handled, usage — then make the verdict a function of the data
+with an explicit underpowered branch. If you cannot write down what result would
+change your mind, the experiment is not ready to write.
+
+The open one is in `docs/design/file-budget.md` §12.2: **does file size actually
+cause merge conflicts?** Git merges by hunk, not by file, so two agents editing
+distant regions of one 4,000-line file may never collide — in which case §1.3 is
+wrong and should be deleted rather than defended.

--- a/scripts/experiments/README.md
+++ b/scripts/experiments/README.md
@@ -1,6 +1,6 @@
 # scripts/experiments — settle a claim instead of arguing it
 
-These exist because `docs/design/file-budget.md` shipped with several confident
+These exist because `docs/spec/file-budget.md` shipped with several confident
 mechanism claims that nobody had measured. When they were measured, **two of the
 most confidently stated ones turned out to be wrong** while the document's
 conclusion survived. That is the pattern these scripts exist to make cheap:
@@ -69,7 +69,7 @@ method, confounds handled, usage — then make the verdict a function of the dat
 with an explicit underpowered branch. If you cannot write down what result would
 change your mind, the experiment is not ready to write.
 
-The open one is in `docs/design/file-budget.md` §12.2: **does file size actually
+The open one is in `docs/spec/file-budget.md` §12.2: **does file size actually
 cause merge conflicts?** Git merges by hunk, not by file, so two agents editing
 distant regions of one 4,000-line file may never collide — in which case §1.3 is
 wrong and should be deleted rather than defended.

--- a/scripts/experiments/exp1_read_cost.py
+++ b/scripts/experiments/exp1_read_cost.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""EXP-1 — What does an edit actually COST, as a function of file size?
+
+This is the experiment that should set the budget numbers. docs/design/
+file-budget.md §5.2 picked 400/600/800 by reasoning about token cost; §12.1
+admitted they were argued rather than measured. This measures them.
+
+CLAIM (§1.1): "An agent changing three lines in command_deck.rs must first read
+command_deck.rs: roughly 60,000 tokens to change three lines."
+
+PREDICTION if true: whole-file reads dominate, and bytes-read scales with file
+size regardless of how small the edit is.
+
+METHOD: read Stella's own telemetry (.stella/private/store.db).
+  - tool_calls(name='read_file'|'grep'), args_json -> path, bytes_out -> cost
+  - files_touched(execution_id, path, lines_added, lines_removed) -> edit size
+Join per (execution, file); bucket by the file's current line count.
+
+REPORTED MEASURES:
+  1. ranged vs whole-file read fraction, by file size  (tests §1.1 directly)
+  2. reads per (execution, file) pair                  (the re-read tax)
+  3. bytes read per line changed                       (the cost curve)
+
+CONFOUND HANDLED: reads-per-file conflates "big file" with "this file was the
+task". Results are reported per (execution, file) pair, and the single dominant
+file is reported separately so it cannot masquerade as a size effect.
+
+POWER: this store is small (tens of executions). Every table prints its n and
+the script refuses to render a verdict below a minimum sample. Treat a
+low-n bucket as a pointer to run more sessions, not as a result.
+
+Usage:  python3 scripts/experiments/exp1_read_cost.py [path/to/store.db]
+"""
+
+import collections
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.path.expanduser(
+    "~/Projects/stella/.stella/private/store.db")
+BUCKETS = ["<400", "400-1000", "1000-2000", "2000+"]
+MIN_N = 10
+
+
+def bucket(n):
+    return "<400" if n < 400 else "400-1000" if n < 1000 else "1000-2000" if n < 2000 else "2000+"
+
+
+def q(sql):
+    r = subprocess.run(["sqlite3", "-json", "file:%s?mode=ro" % DB, sql], capture_output=True)
+    out = r.stdout.decode(errors="replace").strip()
+    return json.loads(out) if out else []
+
+
+def sizes():
+    files = subprocess.run(["git", "ls-files", "*.rs", "*.py"], capture_output=True).stdout.decode().split()
+    res = {}
+    for f in files:
+        try:
+            with open(f, "rb") as fh:
+                res[f] = fh.read().count(b"\n")
+        except OSError:
+            pass
+    return res
+
+
+def main():
+    if not os.path.exists(DB):
+        print("EXP-1: no store at %s" % DB)
+        return
+    S = sizes()
+
+    def norm(p):
+        for c in (p, "crates/" + p, re.sub(r"^crates/", "", p)):
+            if c in S:
+                return c
+        return None
+
+    reads = q("select execution_id, args_json, bytes_out from tool_calls where name='read_file'")
+    greps = q("select execution_id, bytes_out from tool_calls where name='grep'")
+    touched = q("select execution_id, path, lines_added, lines_removed from files_touched")
+
+    pair_reads = collections.Counter()
+    pair_bytes = collections.Counter()
+    ranged = collections.Counter()
+    total = collections.Counter()
+    for r in reads:
+        try:
+            a = json.loads(r["args_json"])
+        except Exception:
+            continue
+        p = norm(a.get("path", ""))
+        if not p:
+            continue
+        k = bucket(S[p])
+        total[k] += 1
+        if ("limit" in a) or ("offset" in a) or ("name" in a):
+            ranged[k] += 1
+        pair_reads[(r["execution_id"], p)] += 1
+        pair_bytes[(r["execution_id"], p)] += r["bytes_out"] or 0
+
+    print("EXP-1 — the real cost of an edit")
+    print("  store: %s" % DB)
+    print("  read_file calls: %d   grep calls: %d   files_touched rows: %d"
+          % (len(reads), len(greps), len(touched)))
+
+    print()
+    print("  (1) Is the whole file read?  [tests §1.1]")
+    print("  %-11s %8s %10s %12s" % ("file size", "reads", "ranged", "whole-file"))
+    for k in BUCKETS:
+        if not total[k]:
+            continue
+        print("  %-11s %8d %9.0f%% %11.0f%%"
+              % (k, total[k], 100 * ranged[k] / total[k], 100 * (total[k] - ranged[k]) / total[k]))
+
+    print()
+    print("  (2) Re-read tax: reads per (execution, file) pair")
+    by = collections.defaultdict(list)
+    for (ex, p), n in pair_reads.items():
+        by[bucket(S[p])].append(n)
+    print("  %-11s %8s %9s %9s %7s" % ("file size", "pairs", "mean", "median", "max"))
+    for k in BUCKETS:
+        v = by[k]
+        if v:
+            print("  %-11s %8d %9.2f %9.1f %7d"
+                  % (k, len(v), statistics.mean(v), statistics.median(v), max(v)))
+
+    dom = collections.Counter()
+    for (ex, p), n in pair_reads.items():
+        if S[p] >= 2000:
+            dom[p] += n
+    if dom:
+        top, topn = dom.most_common(1)[0]
+        share = 100 * topn / sum(dom.values())
+        print("  NOTE: %s is %.0f%% of all 2000+ reads — that bucket is one file, not a size effect."
+              % (top, share))
+
+    print()
+    print("  (3) Cost curve: bytes read per line changed")
+    changed = collections.Counter()
+    for t in touched:
+        p = norm(t["path"] or "")
+        if p:
+            changed[(t["execution_id"], p)] += (t["lines_added"] or 0) + (t["lines_removed"] or 0)
+    curve = collections.defaultdict(list)
+    for key, lines in changed.items():
+        if lines <= 0 or key not in pair_bytes:
+            continue
+        curve[bucket(S[key[1]])].append(pair_bytes[key] / lines)
+    print("  %-11s %8s %16s" % ("file size", "pairs", "bytes/line-changed"))
+    any_n = False
+    for k in BUCKETS:
+        v = curve[k]
+        if v:
+            any_n = True
+            print("  %-11s %8d %16.0f" % (k, len(v), statistics.median(v)))
+    if not any_n:
+        print("  (no execution both read and edited the same file — needs more sessions)")
+
+    print()
+    ok = sum(total.values()) >= 100
+    if not ok:
+        print("  VERDICT: UNDERPOWERED (%d reads)" % sum(total.values()))
+        return
+    big_ranged = 100 * ranged["2000+"] / total["2000+"] if total["2000+"] else 0
+    print("  VERDICT on §1.1: %s" % (
+        "REFUTED — %.0f%% of reads on 2000+ line files are RANGED, not whole-file. "
+        "The cost is not one big read; it is many small ones." % big_ranged
+        if big_ranged > 80 else
+        "SUPPORTED — whole-file reads dominate on large files."))
+    for k in BUCKETS:
+        if by[k] and len(by[k]) < MIN_N:
+            print("  POWER WARNING: bucket %s has only %d pairs; do not quote it." % (k, len(by[k])))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/exp1_read_cost.py
+++ b/scripts/experiments/exp1_read_cost.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """EXP-1 — What does an edit actually COST, as a function of file size?
 
-This is the experiment that should set the budget numbers. docs/design/
-file-budget.md §5.2 picked 400/600/800 by reasoning about token cost; §12.1
-admitted they were argued rather than measured. This measures them.
+This is the experiment that should set the budget numbers.
+docs/spec/file-budget.md §5.2 picked 400/600/800 by reasoning about token
+cost; §12.1 admitted they were argued rather than measured. This measures them.
 
 CLAIM (§1.1): "An agent changing three lines in command_deck.rs must first read
 command_deck.rs: roughly 60,000 tokens to change three lines."

--- a/scripts/experiments/exp2_append_bias.py
+++ b/scripts/experiments/exp2_append_bias.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """EXP-2 — Do agents append?
 
-CLAIM (docs/design/file-budget.md §1.4): "Asked to add a feature, an agent adds
+CLAIM (docs/spec/file-budget.md §1.4): "Asked to add a feature, an agent adds
 code at the end. It will not restructure." If true, unbounded growth is the
 DEFAULT trajectory of agent-authored code rather than an accident — which is the
 whole argument for a mechanical forcing function instead of a guideline.

--- a/scripts/experiments/exp2_append_bias.py
+++ b/scripts/experiments/exp2_append_bias.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""EXP-2 — Do agents append?
+
+CLAIM (docs/design/file-budget.md §1.4): "Asked to add a feature, an agent adds
+code at the end. It will not restructure." If true, unbounded growth is the
+DEFAULT trajectory of agent-authored code rather than an accident — which is the
+whole argument for a mechanical forcing function instead of a guideline.
+
+PREDICTION if true: added lines land disproportionately near the END of the
+file. Normalized position (hunk start / file length) skews toward 1.0, and the
+skew is STRONGER in large files — an agent that cannot hold the file has nowhere
+to put code except the end.
+
+PREDICTION if false: additions are spread through the file, mean position ~0.5,
+and no interaction with file size.
+
+METHOD: for every non-merge commit modifying a tracked *.rs file, parse
+`git diff -U0` hunk headers (@@ -a,b +c,d @@) for hunks that add lines.
+Normalize the hunk start by the file's line count AT THAT COMMIT, obtained by
+streaming blobs through one `git cat-file --batch`. Bucket by that same length.
+
+WHY THE NULL IS 0.5 AND NOT SOMETHING ELSE: under uniform editing, a hunk is
+equally likely to start anywhere in the file, so E[pos] = 0.5 and 10% of added
+lines fall in the last 10% of the file. Both are reported against those nulls.
+
+CONFOUNDS HANDLED:
+  - Lines are weighted by hunk size, so one 200-line append is not counted the
+    same as one 1-line tweak. Weight is capped at 50 so a single giant commit
+    cannot dominate a bucket.
+  - Files shorter than 50 lines are dropped: "the end" is not meaningful there.
+  - Blobs unreadable at that commit (renames, deletions) are skipped, not
+    guessed.
+  - New-file commits are excluded (--diff-filter=M): creating a file is 100%
+    "append" by construction and would fake the result.
+
+Usage:  python3 scripts/experiments/exp2_append_bias.py [max_commits]
+"""
+
+import collections
+import re
+import statistics
+import subprocess
+import sys
+
+HUNK = re.compile(rb"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+LIMIT = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+BUCKETS = ["<400", "400-1000", "1000-2000", "2000+"]
+
+
+def bucket(n):
+    return "<400" if n < 400 else "400-1000" if n < 1000 else "1000-2000" if n < 2000 else "2000+"
+
+
+def collect_hunks():
+    """Yield (sha, path, [(start, added_count), ...]) for *.rs modifications."""
+    cmd = ["git", "log", "--no-merges", "--format=%H", "-U0", "--diff-filter=M", "--", "*.rs"]
+    if LIMIT:
+        cmd.insert(3, "-n%d" % LIMIT)
+    out = subprocess.run(cmd, capture_output=True).stdout
+    sha = path = None
+    hunks = []
+    for line in out.split(b"\n"):
+        if re.fullmatch(rb"[0-9a-f]{40}", line):
+            if sha and path and hunks:
+                yield sha, path, hunks
+            sha, path, hunks = line.decode(), None, []
+        elif line.startswith(b"+++ b/"):
+            if sha and path and hunks:
+                yield sha, path, hunks
+            path, hunks = line[6:].decode(errors="replace"), []
+        elif line.startswith(b"@@") and path and path.endswith(".rs"):
+            m = HUNK.match(line)
+            if m:
+                cnt = int(m.group(2)) if m.group(2) is not None else 1
+                if cnt > 0:
+                    hunks.append((int(m.group(1)), cnt))
+    if sha and path and hunks:
+        yield sha, path, hunks
+
+
+def blob_lines(refs):
+    """{sha:path -> line count} via one streaming `git cat-file --batch`."""
+    if not refs:
+        return {}
+    p = subprocess.Popen(["git", "cat-file", "--batch"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    out, _ = p.communicate(b"\n".join(r.encode() for r in refs) + b"\n")
+    res, pos = {}, 0
+    for ref in refs:
+        nl = out.find(b"\n", pos)
+        if nl < 0:
+            break
+        header = out[pos:nl]
+        if header.endswith(b"missing"):
+            pos = nl + 1
+            continue
+        try:
+            size = int(header.split()[-1])
+        except (ValueError, IndexError):
+            pos = nl + 1
+            continue
+        body = out[nl + 1 : nl + 1 + size]
+        res[ref] = body.count(b"\n")
+        pos = nl + 1 + size + 1
+    return res
+
+
+def main():
+    records = list(collect_hunks())
+    refs = ["%s:%s" % (sha, path) for sha, path, _ in records]
+    lens = blob_lines(refs)
+
+    positions = collections.defaultdict(list)
+    tail_hit = collections.Counter()
+    tail_all = collections.Counter()
+    for sha, path, hunks in records:
+        n = lens.get("%s:%s" % (sha, path))
+        if not n or n < 50:
+            continue
+        k = bucket(n)
+        for start, cnt in hunks:
+            pos = min(start / n, 1.0)
+            positions[k].extend([pos] * min(cnt, 50))
+            tail_all[k] += cnt
+            if pos >= 0.9:
+                tail_hit[k] += cnt
+
+    print("EXP-2 — do agents append?")
+    print("  commit x file pairs: %d   resolved lengths: %d" % (len(records), len(lens)))
+    print()
+    print("  %-11s %11s %10s %9s %14s" % ("file size", "added-lines", "mean pos", "median", "in last 10%"))
+    for k in BUCKETS:
+        v = positions[k]
+        if not v:
+            continue
+        pct = 100 * tail_hit[k] / tail_all[k] if tail_all[k] else 0
+        print("  %-11s %11d %10.3f %9.3f %13.1f%%" % (k, tail_all[k], statistics.mean(v), statistics.median(v), pct))
+
+    allv = [x for v in positions.values() for x in v]
+    if not allv:
+        print("  no data")
+        return
+    print()
+    print("  NULL (uniform editing): mean pos 0.500, 10.0%% of added lines in last 10%%.")
+    print("  OBSERVED overall:       mean pos %.3f, %.1f%% in last 10%%."
+          % (statistics.mean(allv), 100 * sum(tail_hit.values()) / max(1, sum(tail_all.values()))))
+
+    big = positions["1000-2000"] + positions["2000+"]
+    small = positions["<400"]
+    print()
+    if len(big) < 200 or len(small) < 200:
+        print("  VERDICT: UNDERPOWERED (need >=200 weighted samples per arm; have %d big / %d small)"
+              % (len(big), len(small)))
+        return
+    d = statistics.mean(big) - statistics.mean(small)
+    if d > 0.05:
+        v = "SUPPORTED — append bias is stronger in large files (+%.3f)" % d
+    elif d < -0.05:
+        v = "REFUTED (reversed) — large files are edited EARLIER than small ones (%.3f)" % d
+    else:
+        v = "REFUTED — no size interaction (delta %.3f, within +/-0.05)" % d
+    print("  VERDICT: %s" % v)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/exp3_growth_ratchet.py
+++ b/scripts/experiments/exp3_growth_ratchet.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""EXP-3 — Do files grow monotonically, and do large files grow FASTER?
+
+WHY THIS EXPERIMENT EXISTS: EXP-2 refuted the stated mechanism in
+docs/design/file-budget.md §1.4 ("agents append"). Edits are spread roughly
+uniformly through the file. But files clearly DID get large, so some mechanism
+produced that. This measures the growth process directly instead of inferring
+it.
+
+CLAIM A (the ratchet premise): a file's length is effectively monotonic — edits
+add more than they remove, and files are essentially never made smaller. If
+true, the "only turns one way" argument for a non-increase rule survives even
+though the append explanation did not.
+
+CLAIM B (rich-get-richer): large files grow FASTER than small ones, in lines per
+commit. If true, size is self-reinforcing and an early threshold matters more
+than a late one — the budget should bite well before the file is a problem.
+
+PREDICTION if A true: the share of commits that shrink a file is small, and net
+growth per commit is positive in every size bucket.
+PREDICTION if A false: shrinking commits are common and files routinely get
+smaller on their own, so no ratchet is needed.
+
+PREDICTION if B true: mean net lines/commit rises with file size.
+PREDICTION if B false: net lines/commit is flat or falls with size.
+
+METHOD: `git log --numstat` over all non-merge commits gives (added, removed)
+per file per commit. Walk each file's history forward from its creation,
+tracking running length, and attribute each delta to the bucket the file was in
+BEFORE the commit (so a file is not credited to the bucket its own growth
+created — that would be circular).
+
+CONFOUNDS HANDLED:
+  - Renames (numstat "=>" form) are skipped rather than double-counted.
+  - Binary files (numstat "-") are skipped.
+  - The bucket is taken from the PRE-commit length, which is what makes CLAIM B
+    a real test rather than a tautology.
+  - File creation commits are excluded from the growth stats (a new file is
+    100% addition by construction) but do establish the starting length.
+
+Usage:  python3 scripts/experiments/exp3_growth_ratchet.py
+"""
+
+import collections
+import subprocess
+
+BUCKETS = ["<400", "400-1000", "1000-2000", "2000+"]
+
+
+def bucket(n):
+    return "<400" if n < 400 else "400-1000" if n < 1000 else "1000-2000" if n < 2000 else "2000+"
+
+
+MASS_MOVE_FILES = 100  # a commit touching more than this is a restructure, not editing
+
+# Excluded-commit tally, reported rather than silently dropped.
+EXCLUDED = {"mass_move_commits": 0, "mass_move_rows": 0, "rename_rows": 0}
+
+
+def history():
+    """Oldest-first (sha, [(added, removed, path)]) for *.rs, non-merge.
+
+    `-M -C` turns a rename into a "old => new" row that we skip, instead of a
+    delete+create pair that would read as a huge deliberate reduction. Without
+    it the crates/ restructure (7df3d73f, 303 files / 121,963 deletions) lands
+    entirely in the 2000+ bucket and inverts the result.
+    """
+    out = subprocess.run(
+        ["git", "log", "--no-merges", "--reverse", "-M", "-C", "--format=%H", "--numstat", "--", "*.rs"],
+        capture_output=True,
+    ).stdout.decode(errors="replace")
+    sha, rows = None, []
+
+    def emit(sha, rows):
+        if len(rows) > MASS_MOVE_FILES:
+            EXCLUDED["mass_move_commits"] += 1
+            EXCLUDED["mass_move_rows"] += len(rows)
+            return None
+        return (sha, rows)
+
+    for line in out.split("\n"):
+        line = line.strip()
+        if len(line) == 40 and all(c in "0123456789abcdef" for c in line):
+            if sha:
+                e = emit(sha, rows)
+                if e:
+                    yield e
+            sha, rows = line, []
+        elif line and sha:
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            a, r, p = parts
+            if a == "-" or r == "-":
+                continue
+            if "=>" in p:
+                EXCLUDED["rename_rows"] += 1
+                continue
+            if not p.endswith(".rs"):
+                continue
+            rows.append((int(a), int(r), p))
+    if sha:
+        e = emit(sha, rows)
+        if e:
+            yield e
+
+
+def main():
+    length = {}
+    grew = collections.Counter()
+    shrank = collections.Counter()
+    flat = collections.Counter()
+    net = collections.Counter()
+    commits = collections.Counter()
+    big_shrinks = []
+
+    for sha, rows in history():
+        for a, r, p in rows:
+            if p not in length:
+                length[p] = a  # creation establishes the baseline
+                continue
+            pre = length[p]
+            k = bucket(pre)
+            delta = a - r
+            commits[k] += 1
+            net[k] += delta
+            if delta > 0:
+                grew[k] += 1
+            elif delta < 0:
+                shrank[k] += 1
+                if delta <= -300:
+                    big_shrinks.append((delta, pre, p, sha[:8]))
+            else:
+                flat[k] += 1
+            length[p] = max(0, pre + delta)
+
+    print("EXP-3 — growth ratchet and rich-get-richer")
+    print("  files tracked: %d   commit x file edits: %d" % (len(length), sum(commits.values())))
+    print("  EXCLUDED: %d mass-move commits (>%d files, %d rows) + %d rename rows"
+          % (EXCLUDED["mass_move_commits"], MASS_MOVE_FILES,
+             EXCLUDED["mass_move_rows"], EXCLUDED["rename_rows"]))
+    print()
+    print("  CLAIM A — is length effectively monotonic?")
+    print("  %-11s %8s %8s %8s %8s" % ("pre-size", "edits", "grew", "shrank", "flat"))
+    for k in BUCKETS:
+        if not commits[k]:
+            continue
+        print("  %-11s %8d %7.0f%% %7.0f%% %7.0f%%" % (
+            k, commits[k], 100 * grew[k] / commits[k],
+            100 * shrank[k] / commits[k], 100 * flat[k] / commits[k]))
+
+    print()
+    print("  CLAIM B — do large files grow faster? (net lines per edit)")
+    print("  %-11s %8s %14s" % ("pre-size", "edits", "net lines/edit"))
+    for k in BUCKETS:
+        if commits[k]:
+            print("  %-11s %8d %14.2f" % (k, commits[k], net[k] / commits[k]))
+
+    tot = sum(commits.values())
+    tot_shrank = sum(shrank.values())
+    print()
+    print("  Overall: %.1f%% of edits shrink a file; net %+.2f lines per edit."
+          % (100 * tot_shrank / tot, sum(net.values()) / tot))
+    print("  Large deliberate reductions (<= -300 lines): %d" % len(big_shrinks))
+    for d, pre, p, sha in sorted(big_shrinks)[:8]:
+        print("     %+6d from %5d  %s  (%s)" % (d, pre, p, sha))
+
+    print()
+    a_ok = tot_shrank / tot < 0.35 and all(net[k] > 0 for k in BUCKETS if commits[k])
+    print("  VERDICT A: %s" % (
+        "SUPPORTED — growth is the strong default; files rarely shrink"
+        if a_ok else
+        "REFUTED — files shrink often enough that growth is not a one-way process"))
+
+    rates = [(k, net[k] / commits[k]) for k in BUCKETS if commits[k] >= 100]
+    if len(rates) < 2:
+        print("  VERDICT B: UNDERPOWERED")
+    else:
+        lo, hi = rates[0][1], rates[-1][1]
+        if hi > lo * 1.5:
+            print("  VERDICT B: SUPPORTED — growth rate rises %.1fx from smallest to largest bucket" % (hi / lo))
+        elif hi < lo * 0.67:
+            print("  VERDICT B: REFUTED (reversed) — large files grow SLOWER (%.2f vs %.2f)" % (hi, lo))
+        else:
+            print("  VERDICT B: REFUTED — growth rate is flat across size (%.2f vs %.2f)" % (lo, hi))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/exp3_growth_ratchet.py
+++ b/scripts/experiments/exp3_growth_ratchet.py
@@ -2,7 +2,7 @@
 """EXP-3 — Do files grow monotonically, and do large files grow FASTER?
 
 WHY THIS EXPERIMENT EXISTS: EXP-2 refuted the stated mechanism in
-docs/design/file-budget.md §1.4 ("agents append"). Edits are spread roughly
+docs/spec/file-budget.md §1.4 ("agents append"). Edits are spread roughly
 uniformly through the file. But files clearly DID get large, so some mechanism
 produced that. This measures the growth process directly instead of inferring
 it.


### PR DESCRIPTION
Follow-up to #1246. That doc argued from mechanism; several of those mechanisms were guesses. This builds them into re-runnable experiments and runs them. **Two of the most confidently stated claims came back wrong.** The doc's conclusion survived; two of its reasons did not.

Docs and scripts only — no code, no gate wiring.

## Results

| Experiment | Claim | n | Verdict |
|---|---|---:|---|
| EXP-1 | §1.1 — a big file must be read whole | 557 reads | **REFUTED** |
| EXP-2 | §1.4 — agents append | 246,010 added lines | **REFUTED** |
| EXP-3a | growth is one-way | 4,752 edits | **SUPPORTED** |
| EXP-3b | large files grow faster | 4,752 edits | **REFUTED, reversed** |

**Agents don't read big files whole.** Ranged reads climb 77% → 94% → 98% → **100%** with size. Not one whole-file read of a 2000+ line file exists in the store. The cost is search-and-fragment (293 greps / ~262k tokens locating 557 reads), not bulk load. The "60,000 tokens to change three lines" line is gone.

**Agents don't append.** Mean edit position 0.480 against a uniform null of 0.500; 8.0% of added lines land in the last 10% of the file, *below* random. No size interaction. This was the doc's most confident sentence.

**Growth is still one-way** — 75–80% of edits grow a file, net +24.95 lines/edit — so the non-increase rule's premise survives, just not its explanation.

**But large files grow ~7× SLOWER**, not faster: +4.64 lines/edit at 2000+ vs +34.98 at 400–1000, and they're the most likely bucket to be shrunk. Growth accelerates through 400–1000 then collapses.

## Why that last one changes the design

A 1500-line limit fires *after* the growth it targets has already stopped. The acceleration is in the 400–1000 band — which independently lands on the Green/Yellow boundary the doc proposed for unrelated reasons. That's corroboration from a direction the numbers weren't chosen from.

The history also holds **64 deliberate reductions of ≥300 lines** (`deck_ui.rs` −2,958 in #697, `agent.rs` −2,187, `driver.rs` −1,929). The team already pays for splits — manually, late, at maximum cost. The rule moves that work earlier, where each one is small.

## Confounds caught (both nearly shipped as findings)

- EXP-3 first reported large files *shrinking* 26.86 lines/edit. Cause: `7df3d73f` moved 303 files under `crates/`, deleting 121,963 lines, recorded as delete+create and landing entirely in the top bucket. Fixed with `-M -C` + a mass-move exclusion that now prints what it drops. The tell was that the result was too good.
- EXP-1's re-read tax looks like a clean size effect until you notice `deck_ui.rs` is 75% of the top bucket — task subject, not size. The script prints that share automatically now.
- EXP-2 excludes file-creation commits and caps per-hunk weight; either would have manufactured the result being tested.

## What is still not known

The cost curve that would justify 800 over 700 is **UNDERPOWERED** — `files_touched` has 44 rows, 1–3 per bucket. `exp1_read_cost.py` prints the table with a power warning instead of a quotable number; it takes a store path, so pointing it at a Terminal-Bench run closes this. §12.2 adds the one remaining unmeasured §1 claim — whether file size actually causes merge conflicts — which may kill §1.3 the same way, since git merges by hunk rather than by file.

`no-scratch`, `doc-links`, and `invariants` pass. Full gate is red on pre-existing `main` breakage (documented in §2.6); this diff has zero Rust.

Refs #629
Refs #825

## Summary by Sourcery

Measure and document file-size-related agent behaviors, replacing speculative mechanisms with experimentally validated findings, and add reusable experiment scripts to support future design decisions.

New Features:
- Add a scripts/experiments suite that can be run independently to empirically test assumptions about file size limits and growth behavior.

Enhancements:
- Introduce standalone experiment scripts to analyze agent read costs, append bias, and file growth dynamics from telemetry and git history, enabling re-runnable, data-driven evaluation of file-size policies.

Documentation:
- Update the file-budget design doc to reflect measured behaviors about file reads, edit positions, and growth patterns, explicitly marking which claims are supported, refuted, or unmeasured.
- Document the new experiments and their methodology, results, and open questions, including a dedicated section summarizing experimental findings and evidence status.