### PR TITLE
P1 sweep: publish ScopeReviewResultIn, stop sub-agent tool-id collisions, surface silently-downgraded effort

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -588,8 +588,8 @@ pub async fn run_deck_session(
     // one-line notice instead of a silently-dropped setting. Keyed on the
     // explicit settings pin for the lead (Default kind), never the
     // auto-resolved effort — session chrome, re-checked every boot, never
-    // journaled.
-    if let Some(notice) = crate::engine_config::unsupported_effort_notice(
+    // journaled. Also covers a pin accepted at a coarser tier (#1499).
+    for notice in crate::engine_config::effort_notices(
         cfg.provider.id,
         cfg.provider.display_name,
         cfg.engine_settings

--- a/crates/stella-cli/src/engine_config.rs
+++ b/crates/stella-cli/src/engine_config.rs
@@ -460,6 +460,65 @@ pub fn unsupported_effort_notice(
     }
 }
 
+/// One line when a pinned effort IS accepted but not at the tier asked for, or
+/// `None` when the pinned tier reaches the wire as itself (#1499).
+///
+/// The sibling of [`unsupported_effort_notice`], and the case it could not
+/// see. That one fires when the adapter has no reasoning control at all; this
+/// one fires when it has one and cannot express the requested depth. Four of
+/// the eight `Controllable` providers map the finer tiers onto a coarser set
+/// the routed model is guaranteed to accept — the right wire posture, because
+/// sending a tier the model rejects is a hard 400, and the wrong thing to stay
+/// silent about.
+///
+/// Worth a boot line rather than a doc note because effort was the single
+/// largest measured variable in this repo's own paid arena runs: a run
+/// configured at `max` and served `high` is not the run its label says it is,
+/// and nothing else in the transcript would ever say so.
+///
+/// Keyed on the user's explicit pin for the same reason
+/// [`unsupported_effort_notice`] is — `effort_auto` synthesizes a per-agent
+/// effort nobody asked for, and a notice about a level the user never chose is
+/// noise.
+pub fn downgraded_effort_notice(
+    provider_id: &str,
+    provider_label: &str,
+    pinned_effort: Option<ReasoningEffort>,
+) -> Option<String> {
+    let effort = pinned_effort?;
+    let requested = effort_to_str(effort);
+    let served = stella_model::provider_parity::downgraded_effort(provider_id, requested)?;
+    Some(format!(
+        "reasoning effort '{requested}' is pinned, but {provider_label}'s adapter cannot send \
+         that tier — the request goes out at '{served}'. Pin '{served}' to say what you will \
+         actually get, or choose a provider that carries '{requested}'.",
+    ))
+}
+
+/// Every boot notice owed to a user whose pinned reasoning effort will not be
+/// served as pinned.
+///
+/// Two disjoint postures, one line each and never both: the adapter has no
+/// reasoning control ([`unsupported_effort_notice`] — the pin is dropped), or
+/// it has one and cannot express that tier ([`downgraded_effort_notice`] — the
+/// pin is served coarser). Collected here rather than at the call site because
+/// `command_deck.rs` is a god file closed to growth, and because the next
+/// posture that owes a notice should be added in the module that owns them.
+#[must_use]
+pub fn effort_notices(
+    provider_id: &str,
+    provider_label: &str,
+    pinned_effort: Option<ReasoningEffort>,
+) -> Vec<String> {
+    [
+        unsupported_effort_notice(provider_id, provider_label, pinned_effort),
+        downgraded_effort_notice(provider_id, provider_label, pinned_effort),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
 // Enum ↔ string (the TUI edits strings; settings/serde hold enums)
 
 pub fn effort_to_str(effort: ReasoningEffort) -> &'static str {
@@ -1099,6 +1158,55 @@ mod tests {
         assert!(
             unsupported_effort_notice("no-such", "Nope", Some(ReasoningEffort::High)).is_none()
         );
+    }
+
+    #[test]
+    fn downgraded_effort_notice_fires_only_when_the_tier_is_really_coarsened() {
+        // No pin → nothing to be downgraded.
+        assert!(downgraded_effort_notice("openai", "OpenAI", None).is_none());
+
+        // The #1499 case: OpenAI folds xhigh/max into "high". A user who
+        // pinned max was told nothing and served high.
+        let notice = downgraded_effort_notice("openai", "OpenAI", Some(ReasoningEffort::Max))
+            .expect("openai collapses max");
+        assert!(notice.contains("OpenAI"), "{notice}");
+        assert!(notice.contains("max"), "{notice}");
+        assert!(notice.contains("high"), "{notice}");
+
+        // Gemini is coarser still — it loses medium too.
+        assert!(
+            downgraded_effort_notice("gemini", "Gemini", Some(ReasoningEffort::Medium)).is_some()
+        );
+
+        // Tiers that survive the mapping stay silent, on the same providers.
+        assert!(
+            downgraded_effort_notice("openai", "OpenAI", Some(ReasoningEffort::Medium)).is_none()
+        );
+        assert!(downgraded_effort_notice("gemini", "Gemini", Some(ReasoningEffort::Low)).is_none());
+
+        // Anthropic maps all five tiers onto distinct thinking budgets, and
+        // OpenRouter hands the tier to the gateway untouched → silent.
+        assert!(
+            downgraded_effort_notice("anthropic", "Anthropic", Some(ReasoningEffort::Max))
+                .is_none()
+        );
+        assert!(
+            downgraded_effort_notice("openrouter", "OpenRouter", Some(ReasoningEffort::Max))
+                .is_none()
+        );
+
+        // An Unsupported provider does not *downgrade* the effort, it drops
+        // it — that is `unsupported_effort_notice`'s line to print, and this
+        // one must not double up on it.
+        assert!(
+            downgraded_effort_notice("deepseek", "DeepSeek", Some(ReasoningEffort::Max)).is_none()
+        );
+        assert!(
+            unsupported_effort_notice("deepseek", "DeepSeek", Some(ReasoningEffort::Max)).is_some()
+        );
+
+        // Unknown id → no row, no claim.
+        assert!(downgraded_effort_notice("no-such", "Nope", Some(ReasoningEffort::Max)).is_none());
     }
 
     #[test]

--- a/crates/stella-model/src/openai.rs
+++ b/crates/stella-model/src/openai.rs
@@ -456,7 +456,7 @@ struct OpenAiInputTokensDetails {
 /// rejects" posture as the other adapters. (Offering the finer tiers would
 /// require per-model capability gating the picker vocabulary does not yet
 /// carry.)
-fn map_reasoning_effort(effort: ReasoningEffort) -> &'static str {
+pub(crate) fn map_reasoning_effort(effort: ReasoningEffort) -> &'static str {
     match effort {
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -170,6 +170,28 @@ pub enum ReasoningPosture {
         /// Name of the test function that proves the control reaches the
         /// request body; checked for existence by this module's tests.
         witness: &'static str,
+        /// Effort tiers this adapter cannot express distinctly, as
+        /// `(requested, served)` — empty when every tier reaches the wire as
+        /// itself.
+        ///
+        /// `Controllable` used to mean "the effort is honoured", and four of
+        /// the eight rows quietly did not honour it: they map the finer tiers
+        /// onto a coarser set the routed model is guaranteed to accept, which
+        /// is the right wire posture and the wrong thing to stay silent about
+        /// (#1499). A user who pinned `max` on OpenAI was told nothing and
+        /// served `high`.
+        ///
+        /// That matters more here than it would in most codebases: effort was
+        /// the single largest measured variable in this repo's own paid arena
+        /// runs, so serving a different tier than the one configured makes a
+        /// benchmark comparison quietly untrue rather than merely surprising.
+        ///
+        /// Declared rather than computed because the mappings live in each
+        /// adapter as separate functions over different wire vocabularies.
+        /// This module's `collapsed_effort_tiers_match_the_adapters` test
+        /// calls those functions and pins this list against what they really
+        /// return, so a declaration and its adapter cannot drift apart.
+        collapses: &'static [(&'static str, &'static str)],
     },
     /// The provider always reasons and the depth cannot be pinned from the
     /// request. Declared for taxonomy completeness — no id in the current
@@ -204,6 +226,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
             mechanism: "extended-thinking budget (thinking.budget_tokens) + output_config.effort \
                         — all five effort tiers map to distinct budgets",
             witness: "reasoning_true_enables_thinking_raises_max_tokens_and_omits_temperature",
+            collapses: &[],
         },
     ),
     (
@@ -213,6 +236,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
                         budget_tokens}) — the Anthropic legacy thinking shape, effort tiers \
                         mapped to budgets by the same anthropic.rs mapping",
             witness: "reasoning_true_sends_reasoning_config_and_raises_max_tokens",
+            collapses: &[],
         },
     ),
     (
@@ -221,6 +245,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
             mechanism: "normalized reasoning object ({effort} / {enabled}), translated by the \
                         gateway to whatever the routed upstream vendor calls it",
             witness: "openrouter_identity_maps_reasoning_to_the_gateway_object",
+            collapses: &[],
         },
     ),
     (
@@ -229,6 +254,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
             mechanism: "Responses API reasoning.effort (low/medium/high; finer model-dependent \
                         tiers — minimal/xhigh/max — collapse to the universally-safe high)",
             witness: "reasoning_true_without_effort_defaults_to_medium",
+            collapses: &[("xhigh", "high"), ("max", "high")],
         },
     ),
     (
@@ -237,6 +263,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
             mechanism: "thinkingConfig.thinkingLevel (low/high; medium/minimal exist only on some \
                         Gemini 3.x models, so the adapter maps to the portable low/high pair)",
             witness: "complete_sends_generation_config_params_on_the_wire",
+            collapses: &[("medium", "high"), ("xhigh", "high"), ("max", "high")],
         },
     ),
     (
@@ -245,6 +272,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
             mechanism: "thinkingConfig.thinkingLevel via the shared gemini generation-config \
                         builder",
             witness: "complete_sends_shared_generation_config_params_on_the_wire",
+            collapses: &[("medium", "high"), ("xhigh", "high"), ("max", "high")],
         },
     ),
     (
@@ -257,6 +285,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
                         reasoning tokens. A caller who pins no effort still sends no field, so \
                         the model keeps its own default depth",
             witness: "zai_identity_maps_pinned_effort_to_reasoning_effort",
+            collapses: &[("xhigh", "high"), ("max", "high")],
         },
     ),
     (
@@ -266,6 +295,7 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
                         the xai identity on the shared adapter — and, within xai, skipped for the \
                         original grok-4, which reasons but 400s on the param (retiring 2026-08-15)",
             witness: "xai_identity_maps_effort_to_reasoning_effort",
+            collapses: &[("xhigh", "high"), ("max", "high")],
         },
     ),
     (
@@ -294,6 +324,31 @@ pub fn reasoning_posture(provider_id: &str) -> Option<&'static ReasoningPosture>
         .iter()
         .find(|(id, _)| *id == provider_id)
         .map(|(_, posture)| posture)
+}
+
+/// The tier `effort` is really served as by `provider_id`, when the adapter
+/// cannot put that tier on the wire distinctly — `None` when it reaches the
+/// wire as itself.
+///
+/// The question `Controllable` alone could not answer (#1499). A caller that
+/// reads only the posture learns the provider *has* a reasoning control, not
+/// whether the level it asked for survived the mapping; four of the eight
+/// controllable rows collapse the finer tiers onto a coarser set the routed
+/// model is guaranteed to accept. This is the difference between "honoured"
+/// and "accepted and quietly downgraded", and it is the input a notice needs.
+///
+/// `None` also for an unknown id and for every non-`Controllable` posture: a
+/// provider with no reasoning control at all does not *downgrade* an effort,
+/// it drops it, which is [`ReasoningPosture::Unsupported`]'s story to tell.
+#[must_use]
+pub fn downgraded_effort(provider_id: &str, effort: &str) -> Option<&'static str> {
+    match reasoning_posture(provider_id)? {
+        ReasoningPosture::Controllable { collapses, .. } => collapses
+            .iter()
+            .find(|(requested, _)| *requested == effort)
+            .map(|(_, served)| *served),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -346,6 +401,79 @@ mod tests {
                 sources.iter().any(|source| source.contains(&needle)),
                 "cache-posture witness for `{id}` not found in adapter sources: {witness}"
             );
+        }
+    }
+
+    /// Every declared effort collapse is what the adapter really sends.
+    ///
+    /// The matrix says which tiers a provider cannot express; the adapters
+    /// decide it. Declaring by hand is how the two drift, so this calls the
+    /// real mapping functions and compares. It fails in both directions: an
+    /// undeclared collapse (the #1499 bug — a tier silently downgraded with
+    /// nothing to notify from) and a declared one the adapter does not
+    /// actually make (a notice that would lie the other way).
+    #[test]
+    fn collapsed_effort_tiers_match_the_adapters() {
+        use stella_protocol::ReasoningEffort;
+
+        const TIERS: &[(&str, ReasoningEffort)] = &[
+            ("low", ReasoningEffort::Low),
+            ("medium", ReasoningEffort::Medium),
+            ("high", ReasoningEffort::High),
+            ("xhigh", ReasoningEffort::Xhigh),
+            ("max", ReasoningEffort::Max),
+        ];
+
+        /// The tier→tier renames we can call directly.
+        ///
+        /// `None` for the rows with no string mapping to compare: anthropic
+        /// and bedrock map onto token *budgets* (five distinct values, so no
+        /// tier is lost), and openrouter hands the tier to the gateway
+        /// untouched. Those must therefore declare no collapses at all, which
+        /// is asserted below rather than skipped.
+        fn served(provider: &str, effort: ReasoningEffort) -> Option<&'static str> {
+            match provider {
+                "openai" => Some(crate::openai::map_reasoning_effort(effort)),
+                "gemini" | "vertex" => Some(crate::gemini::map_thinking_level(effort)),
+                "zai" => Some(crate::zai::effort::map_zai_effort(effort)),
+                "xai" => Some(crate::zai::effort::map_xai_effort(effort)),
+                _ => None,
+            }
+        }
+
+        for (provider, posture) in REASONING_POSTURE {
+            let ReasoningPosture::Controllable { collapses, .. } = posture else {
+                continue;
+            };
+
+            if served(provider, ReasoningEffort::Low).is_none() {
+                assert!(
+                    collapses.is_empty(),
+                    "{provider} has no tier→tier rename to lose a level in, so it must \
+                     declare no collapses; it declares {collapses:?}"
+                );
+                continue;
+            }
+
+            for (name, tier) in TIERS {
+                let actual = served(provider, *tier).expect("checked directly above");
+                let declared = downgraded_effort(provider, name);
+                if actual == *name {
+                    assert_eq!(
+                        declared, None,
+                        "{provider}: '{name}' reaches the wire as itself, but the matrix \
+                         declares it collapsed — a notice here would be wrong"
+                    );
+                } else {
+                    assert_eq!(
+                        declared,
+                        Some(actual),
+                        "{provider}: '{name}' is really served as '{actual}'. An \
+                         undeclared collapse is the #1499 bug: the user is told nothing \
+                         and gets a tier they did not pin"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -19,7 +19,7 @@ use crate::http;
 use crate::provider::{Provider, ToolCallObserver};
 use crate::sse::SseDecoder;
 
-mod effort;
+pub(crate) mod effort;
 use effort::{xai_reasoning_effort, xai_supports_reasoning_effort, zai_reasoning_effort};
 // `map_zai_effort` is asserted on directly by the wire tests, which reach it
 // through this module's namespace like every other helper here. Its xAI sibling

--- a/crates/stella-model/src/zai/effort.rs
+++ b/crates/stella-model/src/zai/effort.rs
@@ -49,7 +49,7 @@ pub(super) fn xai_supports_reasoning_effort(model: &str) -> bool {
 /// posture as `openai.rs::map_reasoning_effort`: never drop the hint, never
 /// panic on a variant Grok doesn't model — the finer `xhigh`/`max` tiers are
 /// model-dependent on xAI, so they collapse to the universally-safe `high`.
-pub(super) fn map_xai_effort(effort: ReasoningEffort) -> &'static str {
+pub(crate) fn map_xai_effort(effort: ReasoningEffort) -> &'static str {
     match effort {
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",
@@ -89,7 +89,7 @@ pub(super) fn xai_reasoning_effort(
 /// reasoning off is the `thinking` object's job, and only when the caller says
 /// so. Same collapse posture as [`map_xai_effort`]: `xhigh`/`max` fold into the
 /// ceiling GLM models rather than inventing a rung it does not have.
-pub(super) fn map_zai_effort(effort: ReasoningEffort) -> &'static str {
+pub(crate) fn map_zai_effort(effort: ReasoningEffort) -> &'static str {
     match effort {
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",

--- a/crates/stella-serve/README.md
+++ b/crates/stella-serve/README.md
@@ -195,9 +195,12 @@ climbing count means a host is minting per-request provider ids.
   `execute_tool_calls`), and the host's advertised `read_only` flags drive that
   partitioning. Answer by `request_id`, in any order — a host that assumes one
   outstanding request at a time will stall the group.
-- **`request_id`s are per-turn counters** (`prov-0`, `tool-0`), unique only within
-  a turn. They are safe because the resolve routes are scoped by turn id — do not
-  treat them as global handles.
+- **`request_id`s are instance-tagged per-turn counters** (`prov-0-0`, `tool-0-0`),
+  unique only within a turn. The middle field disambiguates the several ports that
+  can share one turn's registry — a worker and a sub-agent build their own provider
+  and tool ports, and a bare counter had them both minting `tool-0` (#1496). Treat
+  the whole string as opaque rather than parsing its shape. They are safe because
+  the resolve routes are scoped by turn id — do not treat them as global handles.
 - **A turn's event stream is exclusive and one-shot.** The second
   `GET /v1/turns/{id}/events` gets 409, and the registry entry is removed when a
   stream ends — or when the turn is cancelled. A *live* turn created and never

--- a/crates/stella-serve/src/remote.rs
+++ b/crates/stella-serve/src/remote.rs
@@ -102,6 +102,19 @@ pub(crate) const DEFAULT_REVERSE_REQUEST_TIMEOUT: Duration = Duration::from_secs
 /// an allocator through every construction site.
 static PROVIDER_INSTANCES: AtomicU64 = AtomicU64::new(0);
 
+/// Mints [`RemoteToolExecutor`] instance tags, for the reason
+/// [`PROVIDER_INSTANCES`] exists (#1496).
+///
+/// The tool port needed this as badly as the provider port and was left
+/// without it. `run_session` builds two executors over the **same** [`Pending`]
+/// registry — the parent's and the sub-agent view's — and each starts its
+/// counter at zero, so both mint `tool-0`. [`Pending::register_tool`] inserts
+/// with `HashMap::insert`, which *replaces* on collision: the displaced
+/// oneshot sender drops, the first waiter wakes with "serve host dropped the
+/// tool call without answering", and the host's answer for `tool-0` resolves
+/// whichever request happened to register last.
+static TOOL_EXECUTOR_INSTANCES: AtomicU64 = AtomicU64::new(0);
+
 /// Hand one streamed fragment to the engine's observer, on the channel that
 /// keeps answer text and thinking apart. A `None` observer (the plain
 /// `complete_ref` path) drops the fragment: the aggregated result is
@@ -339,6 +352,12 @@ impl Provider for RemoteProvider {
 /// [`ServerFrame::ToolRequest`] and blocks on the host's answer.
 pub(crate) struct RemoteToolExecutor {
     schemas: Vec<ToolSchema>,
+    /// Disambiguates this executor's request ids from every other executor
+    /// sharing the turn's [`Pending`] registry (#1496) — the same guarantee,
+    /// for the same reason, that [`RemoteProvider::instance`] gives the
+    /// provider port. See [`TOOL_EXECUTOR_INSTANCES`] for the collision this
+    /// makes unrepresentable.
+    instance: u64,
     frames: crate::backlog::FrameSink,
     pending: Pending,
     counter: AtomicU64,
@@ -364,6 +383,7 @@ impl RemoteToolExecutor {
     ) -> Self {
         Self {
             schemas,
+            instance: TOOL_EXECUTOR_INSTANCES.fetch_add(1, Ordering::Relaxed),
             frames,
             pending,
             counter: AtomicU64::new(0),
@@ -503,7 +523,11 @@ impl RemoteToolExecutor {
     /// and the caller is what brackets this with the hook plane's
     /// `started`/outcome pair.
     async fn dispatch(&self, name: &str, input: &Value) -> ToolOutput {
-        let request_id = format!("tool-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let request_id = format!(
+            "tool-{}-{}",
+            self.instance,
+            self.counter.fetch_add(1, Ordering::Relaxed)
+        );
         let (tx, rx) = oneshot::channel();
         // Same refused-registration handling as the provider port: a cancel
         // landing between the check above and this call must not park the step
@@ -901,6 +925,61 @@ mod tests {
             Some(bus),
         );
         (port, seen)
+    }
+
+    /// Two executors sharing one registry never mint the same request id.
+    ///
+    /// This is the sub-agent boundary (#1496). `run_session` builds a second
+    /// [`RemoteToolExecutor`] over a **clone** of the parent's [`Pending`] —
+    /// and cloning shares the map — so before the instance tag both counters
+    /// started at zero and both first calls were `tool-0`.
+    /// [`Pending::register_tool`] inserts with `HashMap::insert`, which
+    /// replaces rather than rejects, so the collision was silent in the worst
+    /// way: the parent's parked sender dropped, its waiter woke claiming the
+    /// host had abandoned the call, and the host's single answer for `tool-0`
+    /// resolved whichever request registered second.
+    ///
+    /// Both dispatches here time out — the point is the ids on the frames that
+    /// went out, not the answers that never come back.
+    #[tokio::test]
+    async fn two_executors_over_one_registry_mint_distinct_request_ids() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = crate::backlog::FrameSink::new(
+            tx,
+            crate::backlog::FrameBacklog::new(crate::backlog::DEFAULT_MAX_QUEUED_FRAMES),
+        );
+        let pending = Pending::new(
+            crate::observe::null_observer(),
+            TurnRef::new("turn-subagent-boundary"),
+        );
+        let timeout = std::time::Duration::from_millis(20);
+
+        // The parent's port and the sub-agent view's, over the same registry.
+        let parent =
+            RemoteToolExecutor::new(Vec::new(), sink.clone(), pending.clone(), timeout, None);
+        let child = RemoteToolExecutor::new(Vec::new(), sink, pending, timeout, None);
+
+        let _ = parent.dispatch("parent_tool", &serde_json::json!({})).await;
+        let _ = child.dispatch("child_tool", &serde_json::json!({})).await;
+
+        let mut ids = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            if let ServerFrame::ToolRequest { request_id, .. } = frame {
+                ids.push(request_id);
+            }
+        }
+
+        assert_eq!(
+            ids.len(),
+            2,
+            "both dispatches emit a request frame: {ids:?}"
+        );
+        assert_ne!(
+            ids[0], ids[1],
+            "a sub-agent's tool call collided with its parent's in the shared \
+             Pending registry — one of these two answers would resolve the \
+             wrong request"
+        );
     }
 
     /// A `tool.call.started` with no outcome after it leaves an observer

--- a/crates/stella-serve/src/schema_export.rs
+++ b/crates/stella-serve/src/schema_export.rs
@@ -38,7 +38,9 @@ use serde_json::Value;
 use stella_protocol::schema_export::{UnsupportedSchema, typescript_declarations_with_header};
 
 use crate::engine_overrides::EngineOverrides;
-use crate::frame::{ProviderDeltaIn, ProviderResultIn, ServerFrame, ToolResultIn};
+use crate::frame::{
+    ProviderDeltaIn, ProviderResultIn, ScopeReviewResultIn, ServerFrame, ToolResultIn,
+};
 
 /// The JSON Schema (2020-12) for one outbound frame.
 #[must_use]
@@ -62,6 +64,19 @@ pub fn provider_result_schema() -> Value {
 #[must_use]
 pub fn provider_delta_schema() -> Value {
     schemars::schema_for!(ProviderDeltaIn).to_value()
+}
+
+/// The JSON Schema for the scope-review decision a host POSTs back.
+///
+/// The answer to a [`ServerFrame::ScopeReviewRequest`], sent to
+/// `POST /v1/turns/{id}/approve`. It was missing from the published contract
+/// until #1497: the outbound schema described the *request* frame in six
+/// places while the inbound document offered no type for the reply, so a host
+/// generating a client from these artifacts could parse the question and had
+/// nothing to construct the answer from.
+#[must_use]
+pub fn scope_review_result_schema() -> Value {
+    schemars::schema_for!(ScopeReviewResultIn).to_value()
 }
 
 /// The JSON Schema for the optional `engine` object on `POST /v1/turns` and
@@ -90,7 +105,9 @@ pub fn inbound_schema() -> Value {
              answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers \
              POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally \
              streams fragments of an in-flight provider answer to \
-             POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn. \
+             POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn; \
+             ScopeReviewResultIn answers POST /v1/turns/{id}/approve, carrying \
+             the human's decision on a scope_review_request frame. \
              Each is keyed by the request_id carried on the frame it answers. \
              EngineOverrides is not a reverse-request answer at all: it is the \
              optional `engine` object on POST /v1/turns and \
@@ -101,6 +118,7 @@ pub fn inbound_schema() -> Value {
             "ToolResultIn": tool_result_schema(),
             "ProviderResultIn": provider_result_schema(),
             "ProviderDeltaIn": provider_delta_schema(),
+            "ScopeReviewResultIn": scope_review_result_schema(),
             "EngineOverrides": engine_overrides_schema(),
         },
     })
@@ -132,6 +150,10 @@ pub fn artifacts() -> Result<Vec<(&'static str, String)>, UnsupportedSchema> {
     ts.push_str(&typescript_declarations_with_header(
         &provider_delta_schema(),
         DELTA_HEADER,
+    )?);
+    ts.push_str(&typescript_declarations_with_header(
+        &scope_review_result_schema(),
+        SCOPE_REVIEW_HEADER,
     )?);
     ts.push_str(&typescript_declarations_with_header(
         &engine_overrides_schema(),
@@ -235,6 +257,19 @@ const DELTA_HEADER: &str = "
 /// Rides above `EngineOverrides` in the printed `.d.ts`: this is a request
 /// sub-object, not a reverse-request answer, and its clamp semantics live
 /// outside what the schema can say.
+const SCOPE_REVIEW_HEADER: &str = "
+// ── inbound: answering a scope review ───────────────────────────────────────
+//
+// The engine parks a turn on a `scope_review_request` frame when a plan needs
+// a human decision before it executes. The host answers by POSTing this body
+// to `POST /v1/turns/{id}/approve`, keyed by the frame's request_id.
+//
+// `decision` is an internally-tagged union: approve executes the plan as
+// proposed, trim executes only the listed step indices, and the note-carrying
+// arm re-plans with the reviewer's words folded in — an empty note reads as
+// abort, the same collapse the stdio gate makes for a bare \"no\".
+";
+
 const ENGINE_HEADER: &str = "
 // ── request-side: the optional `engine` object on POST /v1/turns ────────────
 //
@@ -263,3 +298,67 @@ const INBOUND_HEADER: &str = "
 // than `oldest_retained` — to rediscover what it owes; obligations announced
 // in frames the ring has already evicted cannot be re-learned this way.
 ";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every inbound body a host can POST is published, by name.
+    ///
+    /// Asserted as an exact set rather than a contains-check, because the
+    /// failure this guards is an **omission**, and a contains-check cannot see
+    /// one. `ScopeReviewResultIn` was missing here while the outbound schema
+    /// described its `scope_review_request` counterpart in six places (#1497):
+    /// the generated contract told a host to expect the question and gave it no
+    /// type to build the answer from. Nothing failed — the exporter ran, the
+    /// artifacts committed, and the hole was only visible to someone diffing
+    /// the two documents by hand.
+    ///
+    /// Adding an inbound body means adding it here, which is the point: an
+    /// exact set turns "I forgot to export it" into a failing test rather than
+    /// a silently incomplete contract.
+    #[test]
+    fn every_inbound_body_is_published_in_the_contract() {
+        let schema = inbound_schema();
+        let defs = schema["$defs"]
+            .as_object()
+            .expect("the inbound document is a $defs container");
+
+        let mut published: Vec<&str> = defs.keys().map(String::as_str).collect();
+        published.sort_unstable();
+
+        assert_eq!(
+            published,
+            [
+                "EngineOverrides",
+                "ProviderDeltaIn",
+                "ProviderResultIn",
+                "ScopeReviewResultIn",
+                "ToolResultIn",
+            ],
+            "the published inbound bodies drifted from the ones a host can POST"
+        );
+    }
+
+    /// The scope-review body is a real schema, not an empty placeholder.
+    ///
+    /// A `$defs` key alone would satisfy the test above while publishing `{}`,
+    /// which is a contract that accepts anything — worse than the omission it
+    /// replaced, because it looks answered.
+    #[test]
+    fn the_scope_review_body_carries_its_fields() {
+        let schema = scope_review_result_schema();
+        let props = schema["properties"]
+            .as_object()
+            .expect("ScopeReviewResultIn is an object schema");
+
+        assert!(
+            props.contains_key("request_id"),
+            "the answer must be keyed by the request_id of the frame it answers: {props:?}"
+        );
+        assert!(
+            props.contains_key("decision"),
+            "the answer must carry the human's decision: {props:?}"
+        );
+    }
+}

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -2202,6 +2202,43 @@ export interface ProviderDeltaIn {
   request_id: string;
 }}
 
+// ── inbound: answering a scope review ───────────────────────────────────────
+//
+// The engine parks a turn on a `scope_review_request` frame when a plan needs
+// a human decision before it executes. The host answers by POSTing this body
+// to `POST /v1/turns/{id}/approve`, keyed by the frame's request_id.
+//
+// `decision` is an internally-tagged union: approve executes the plan as
+// proposed, trim executes only the listed step indices, and the note-carrying
+// arm re-plans with the reviewer's words folded in — an empty note reads as
+// abort, the same collapse the stdio gate makes for a bare "no".
+
+/**
+ * Wire mirror of [`stella_pipeline::ports::ScopeDecision`]. That type lives in
+ * `stella-pipeline` and is not itself `Serialize`/`Deserialize` — this crate
+ * owns the wire mapping, exactly as [`TurnOutcomeWire`] owns `TurnOutcome`'s.
+ */
+export type ScopeDecisionWire = {
+  decision: "approve";
+} | {
+  decision: "trim";
+  keep_steps: number[];
+} | {
+  decision: "revise";
+  note: string;
+} | {
+  decision: "abort";
+};
+
+/**
+ * Host → engine: the human's decision on a [`ServerFrame::ScopeReviewRequest`].
+ */
+export interface ScopeReviewResultIn {
+{
+  decision: ScopeDecisionWire;
+  request_id: string;
+}}
+
 // ── request-side: the optional `engine` object on POST /v1/turns ────────────
 //
 // Per-turn engine knobs (#1167), also accepted on

--- a/docs/wire/serveinbound.schema.json
+++ b/docs/wire/serveinbound.schema.json
@@ -669,6 +669,95 @@
       "title": "ProviderResultIn",
       "type": "object"
     },
+    "ScopeReviewResultIn": {
+      "$defs": {
+        "ScopeDecisionWire": {
+          "description": "Wire mirror of [`stella_pipeline::ports::ScopeDecision`]. That type lives in\n`stella-pipeline` and is not itself `Serialize`/`Deserialize` — this crate\nowns the wire mapping, exactly as [`TurnOutcomeWire`] owns `TurnOutcome`'s.",
+          "oneOf": [
+            {
+              "description": "Execute the plan as proposed.",
+              "properties": {
+                "decision": {
+                  "const": "approve",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Execute only the steps at these indices into the proposed step list.",
+              "properties": {
+                "decision": {
+                  "const": "trim",
+                  "type": "string"
+                },
+                "keep_steps": {
+                  "items": {
+                    "format": "uint",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "decision",
+                "keep_steps"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Re-plan with the reviewer's own words folded into the next attempt. An\nempty `note` reads as [`ScopeDecision::Abort`] — the same collapse\n[`stella_pipeline::ports::StdioApprovalGate`] makes for a bare \"no\".",
+              "properties": {
+                "decision": {
+                  "const": "revise",
+                  "type": "string"
+                },
+                "note": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision",
+                "note"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "decision": {
+                  "const": "abort",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Host → engine: the human's decision on a [`ServerFrame::ScopeReviewRequest`].",
+      "properties": {
+        "decision": {
+          "$ref": "#/$defs/ScopeDecisionWire"
+        },
+        "request_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "request_id",
+        "decision"
+      ],
+      "title": "ScopeReviewResultIn",
+      "type": "object"
+    },
     "ToolResultIn": {
       "$defs": {
         "ToolOutput": {
@@ -740,6 +829,6 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Bodies a host POSTs back to answer a reverse request. ToolResultIn answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally streams fragments of an in-flight provider answer to POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn. Each is keyed by the request_id carried on the frame it answers. EngineOverrides is not a reverse-request answer at all: it is the optional `engine` object on POST /v1/turns and POST /v1/sessions/{id}/turns, published here because it is wire contract. This document is a definitions container, not a union: the bodies are not interchangeable and carry no discriminant.",
+  "description": "Bodies a host POSTs back to answer a reverse request. ToolResultIn answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally streams fragments of an in-flight provider answer to POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn; ScopeReviewResultIn answers POST /v1/turns/{id}/approve, carrying the human's decision on a scope_review_request frame. Each is keyed by the request_id carried on the frame it answers. EngineOverrides is not a reverse-request answer at all: it is the optional `engine` object on POST /v1/turns and POST /v1/sessions/{id}/turns, published here because it is wire contract. This document is a definitions container, not a union: the bodies are not interchangeable and carry no discriminant.",
   "title": "StellaServeInbound"
 }


### PR DESCRIPTION
Three P1s from the audit backlog. Each is independently revertable by commit, and each carries a witness verified to fail on the pre-fix code — the third also carries an anti-drift test that would have caught the bug on its own.

> **On bundling:** this is a P1 sweep, not one logical change. The three commits are cleanly separable (`0d3777a0`, `e223c8c0`, `19375197`) — happy to split into three PRs if review prefers that over one pass.

---

## 1. `ScopeReviewResultIn` missing from the published wire contract — `0d3777a0`

Closes #1497.

`inbound_schema()` and `artifacts()` published four inbound bodies and omitted `ScopeReviewResultIn`, the body of `POST /v1/turns/{id}/approve`. `serveinbound.schema.json` contained **zero** `ScopeReview` occurrences while `serveframe.schema.json` carried six — the contract told a host to expect the question and gave it no type for the answer.

The type already had the `schema` derive, so this was an export-site omission. Regenerated `docs/wire/`; `agentevent.*` untouched (serve transport only).

**Witness** asserts the `$defs` key set *exactly*, because the failure is an omission and a contains-check cannot see one:

```
  left: ["EngineOverrides", "ProviderDeltaIn", "ProviderResultIn", "ToolResultIn"]
 right: ["EngineOverrides", "ProviderDeltaIn", "ProviderResultIn", "ScopeReviewResultIn", "ToolResultIn"]
```

A second test pins the body's fields so a future entry can't satisfy the set check with an empty schema — which would look answered while accepting anything.

## 2. Tool-call ids collided across the sub-agent boundary — `e223c8c0`

Closes #1496.

`dispatch` minted `tool-{counter}` from a counter starting at zero, and `run_session` builds **two** executors over the same `Pending` registry (cloning shares the map) — so both first calls were `tool-0`. `register_tool` uses `HashMap::insert`, which replaces: the displaced sender dropped, the parent's waiter woke claiming *the host dropped the tool call without answering*, and the host's single answer resolved whichever registered second. **A sub-agent could be handed its parent's tool result.**

Exactly the hazard `RemoteProvider` grew its `instance` field to remove, with that reasoning written out in the same file — the tool port was left without it. Mirrors it: process-wide counter, `instance` field, `tool-{instance}-{counter}`.

**Witness** reproduces the bug rather than describing it — on the pre-fix format: `left: "tool-0", right: "tool-0"`.

Also updates the crate README, which documented the old shape and told hosts these were per-turn counters.

## 3. `Controllable` conflated "honoured" with "silently downgraded" — `19375197`

Closes #1499.

`ReasoningPosture::Controllable` meant "has a reasoning control" and was read as "honours the effort" — `unsupported_effort_notice`'s doc said so outright. Four of eight rows don't:

| provider | collapses |
|---|---|
| openai, zai, xai | `xhigh`, `max` → `high` |
| gemini, vertex | `medium`, `xhigh`, `max` → `high` |
| anthropic, bedrock | none — five distinct thinking budgets |
| openrouter | none — gateway normalizes |

Collapsing is the right *wire* posture (a tier the model rejects is a hard 400) and the wrong thing to be silent about. A user pinning `max` on OpenAI was told nothing and served `high`. **Effort was the single largest measured variable in this repo's own paid arena runs** — serving a different tier than configured makes a benchmark comparison quietly untrue, not merely surprising.

Adds `collapses` to `Controllable` and `downgraded_effort()` to query it. I verified every list against the real mapping functions before declaring it.

**The anti-drift test is the important part.** `collapsed_effort_tiers_match_the_adapters` calls `map_reasoning_effort` / `map_thinking_level` / `map_zai_effort` / `map_xai_effort` and pins the declarations against what they actually return, failing in *both* directions — an undeclared collapse (this bug) and a declared one the adapter doesn't make (a notice that would lie the other way). This required widening those three to `pub(crate)`: the parity matrix should be checked against reality, not asserted by hand.

CLI side: `downgraded_effort_notice` is the sibling of `unsupported_effort_notice` — that one fires when there's no control, this one when there is one that can't express the tier. Disjoint, so at most one fires. `effort_notices` collects them in `engine_config.rs` rather than at the deck call site, because `command_deck.rs` is a grandfathered god file and the ratchet caught the +17 lines the naive wiring added. **The final deck diff is one line shorter than what it replaced** — no baseline change.

---

## Verification

- `cargo test -p stella-serve` — 268 pass · `-p stella-model -p stella-cli` — 1290 + 360 + integration, 0 fail
- all three witnesses verified to fail on pre-fix code, then restored
- `make wire-schema` OK · `make guards` OK on this base · `check-file-size` OK, **baseline untouched**
- `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean on all three crates
- pre-push gate passed with no bypass

## Also filed

**#1525** — `diagnose_cache` cannot return `IdleBeyondTtl`, so it misreports an expired cache as prefix instability. Found while building the cache gate in #1234 and deliberately not fixed there: it needs a signature change rippling to two hand-rolled copies of the same gate.

## Deliberately not touched

**#1498** (arenabench z.ai pricing, P1) states outright that the resolution *"is a design decision, not a patch"* and records two reviewers reaching opposite conclusions. It needs a human call.

**#1501** overlaps in-flight PR #1523, which already threads `model_timeout` into the verdict and guidance calls — 2 of its 5 sites. Left alone to avoid a collision.
