### PR TITLE
docs(claude-md): make the reference-grade quality bar a hard rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,45 @@
 
 ## Hard rules for every session
 
+- **The bar is reference-grade Rust, and there is no second bar.** This
+  repository is trying to be the best-engineered open-source agent in the
+  world and the implementation other people cite when they argue about
+  correctness. So when two designs both work, ship the one that is still
+  correct in five years under a different maintainer, a different provider,
+  and a model that does not exist yet — never the one that is faster to write
+  today. Concretely:
+  - **Match the best Rust in the world, not just the nearest file.**
+    AGENTS.md's "match the neighborhood" is the floor, not the ceiling. For
+    anything non-obvious, find the canonical crate that already solved your
+    shape (`tokio`, `serde`, `rust-analyzer`, `cargo`, `ripgrep`) and follow
+    its structure; name the exemplar in the PR description so the choice is
+    reviewable instead of personal taste.
+  - **An expedient is a defect, not a tradeoff.** An `#[allow]` with no
+    comment saying why the lint is wrong *here*, an `unwrap` on runtime data,
+    a widened `deny.toml` allow-list or a raised `scripts/file-size-baseline.txt`
+    ceiling to turn a gate green, a `TODO` standing in for the actual design —
+    each one is a bug against the PR that introduced it. If the correct fix is
+    bigger than the session, file the issue (rule below) and **say so out loud
+    in your final message**. Shipping the shortcut quietly is the one
+    unrecoverable move.
+  - **Correctness is demonstrated or it is not claimed.** A witness test, a
+    property, a golden diff someone actually read — a sentence in a PR
+    description is not evidence. Stella refuses to call a task done without
+    proof; this repo does not get to hold itself to less than the contract it
+    enforces on its users.
+  - **Measure honestly, especially when it costs us.** A benchmark number that
+    flatters Stella because of a measurement artifact is worse than a loss:
+    it spends the exact reputation the project exists to build. Compare like
+    for like, name and exclude operational aborts explicitly, and report the
+    unflattering number when it is the true one.
+  - **The agent-systems architecture is the crown.** The agent loop, the
+    staged pipeline, the context plane, and the port boundaries get more
+    scrutiny than anything else in the tree. Determinism, replayability, and
+    "ports, not concretions" are not negotiable there for any deadline.
+  - **"Now" vs. "right" is the maintainer's call, not yours.** When you truly
+    cannot have both, state which one you are giving up and why, and let a
+    human choose. Deciding it silently is how a reference implementation
+    stops being one.
 - **AGENTS.md is the orientation document.** Commands, architectural
   invariants, workspace routing, testing approach, and gotchas all live there
   (imported above). When this file and AGENTS.md disagree, AGENTS.md wins —


### PR DESCRIPTION
## What

CLAUDE.md's `Hard rules for every session` said **where** things live (AGENTS.md is orientation) and **what must not be dropped** (nothing left behind) — but never **how good the work has to be**. Every session had to re-derive the standard, and the expedient answer was always sitting right there.

This adds the missing frame, first in the list because it governs how the other two are read:

> **The bar is reference-grade Rust, and there is no second bar.** When two designs both work, ship the one still correct in five years under a different maintainer, a different provider, and a model that does not exist yet — never the one that is faster to write today.

## Why six sub-clauses instead of one sentence

A slogan is unenforceable. Each clause names something an agent can actually check itself against:

| Clause | The behaviour it forecloses |
|---|---|
| Match the best Rust, not just the nearest file | Cargo-culting a weak local pattern because "match the neighborhood" said so — that is the floor, not the ceiling |
| An expedient is a defect, not a tradeoff | Uncommented `#[allow]`, `unwrap` on runtime data, widening `deny.toml`, raising a `scripts/file-size-baseline.txt` ceiling to turn a gate green, a `TODO` standing in for the design |
| Correctness is demonstrated or it is not claimed | A PR description asserting a thing works, where a witness test belongs |
| Measure honestly, especially when it costs us | A benchmark number that flatters Stella via a measurement artifact — the failure that spends the exact reputation the project exists to build |
| The agent-systems architecture is the crown | Trading determinism, replayability, or ports-not-concretions in the agent loop / pipeline / context plane against a deadline |
| "Now" vs. "right" is the maintainer's call | An agent silently choosing "now" instead of surfacing the tradeoff |

The escape hatch is the rule already below it: if the correct fix is bigger than the session, file the issue **and say so out loud** — the shortcut may be taken, never taken quietly.

## Verification

Docs-only, so no witness test. Ran the two guards that apply to a `*.md` change:

- `make no-scratch` — OK, no tracked file is gitignored
- `make doc-links` — OK, 240 citations resolve across 34 documents

`doc-links` also prints its standing advisory listing 14 uncited documents; that list is pre-existing, unchanged by this commit, and re-emitted by the guard on every run, so it is not filed as a separate issue.

No issues to close — this originates from a direct instruction, not a tracked defect.

## Summary by Sourcery

Documentation:
- Document a reference-grade Rust quality bar as a mandatory hard rule, with six concrete sub-clauses governing code quality, evidence of correctness, performance measurement, architectural rigor, and how to surface tradeoffs.