### PR TITLE
feat(arenabench): find the moment a trial started passing

### DIFF
--- a/arenabench/README.md
+++ b/arenabench/README.md
@@ -289,6 +289,59 @@ not allowed to break the benchmark.
 
 ---
 
+## When did it actually solve it
+
+A Terminal-Bench trial is graded **once**, after the agent is dead, against
+whatever the workspace looks like then. Nothing watches for the moment the tests
+start passing — so three things go unmeasured:
+
+- every step after that moment can only lose: it cannot raise a reward already
+  at 1.0, and it costs tokens and clock;
+- an agent can **destroy its own passing solution** and score 0,
+  indistinguishable from never solving it;
+- a trial killed by the wall clock can still pass — being interrupted is not
+  failing. (Measured: a Stella trial ended `AgentTimeoutError` at 900s and
+  scored a pass anyway.)
+
+Turn on capture, then replay afterwards:
+
+```toml
+[match]
+capture_snapshots = true
+snapshot_interval = 30.0   # the floor on how precisely a flip can be located
+```
+
+```bash
+arenabench flip <trial-dir>
+# flip at snapshot 6/23 (t+180s)
+# kept running 510s after it was already passing — 5 verifier runs, 0 unknown
+```
+
+**How capture stays invisible to the run.** Snapshots are taken with
+`git --git-dir` pointed *outside* the workspace and `--work-tree` pointed at it,
+so the workspace gets no `.git`, no index, and no ignore file. That is not
+fastidiousness: `fix-git` is a real task in this dataset whose whole subject is
+repository state, and a snapshotter that ran `git init` in the workspace would
+silently rewrite the task it was measuring.
+
+**Why the replay is afterwards, not during.** A task's verifier is a directory
+of tests that must be copied into the container to run. Doing that mid-trial
+would leave the answer key in the agent's own filesystem, readable. End-only
+grading is what keeps the oracle hidden, so the replay runs against fresh
+containers once the agent is gone and cannot learn from it.
+
+**Cost shapes the search.** One probe pays the verifier's full setup — ~142s for
+`sqlite-with-gcov`, mostly `apt-get` and a `uv` install. So the flip is found by
+bisection (`log2(n)` probes) plus a short backwards walk to catch an agent that
+solved the task, broke it, and fixed it again — the one case bisection cannot
+see. A probe that could not run at all counts as *unknown*, never as a failure:
+scoring it 0 would move the flip earlier than the truth.
+
+Capture is off by default and degrades to nothing — no Docker, or no `git` in
+the task image, yields a run with no snapshots and a warning.
+
+---
+
 ## Adding a benchmark
 
 One entry:

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from .agents import AGENTS
 from .recorder import IMAGE_TAG, build_image, docker_available, image_present
 from .registry import DEFAULT_REGISTRY, export_root, sample_tasks
+from .replay import ReplayError, replay_flip
 from .server import default_workspace, serve
 
 __all__ = ["main"]
@@ -291,6 +292,62 @@ def _cmd_agents(args: argparse.Namespace) -> int:
     return 0
 
 
+def _task_dir_for(trial_dir: Path) -> Path | None:
+    """Where the task this trial ran lives, read back from its own result.
+
+    Harbor records the absolute path it resolved the task from, so a trial
+    carries the location of its own verifier and the operator does not have to
+    reconstruct which export a months-old run used.
+    """
+    try:
+        raw = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    path = ((raw.get("task_id") or {}) if isinstance(raw, dict) else {}).get("path")
+    return Path(str(path)) if path else None
+
+
+def _cmd_flip(args: argparse.Namespace) -> int:
+    trial_dir = Path(args.trial_dir).expanduser().resolve()
+    if not trial_dir.is_dir():
+        print(f"no such trial directory: {trial_dir}", file=sys.stderr)
+        return 1
+    task_dir = Path(args.task_dir).expanduser() if args.task_dir else _task_dir_for(trial_dir)
+    if task_dir is None or not task_dir.is_dir():
+        print(
+            "could not resolve the task directory; pass --task-dir",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = replay_flip(
+            trial_dir,
+            task_dir,
+            verifier_timeout=args.verifier_timeout,
+            confirm_window=args.confirm_window,
+        )
+    except ReplayError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if result.flip_index is None:
+        print(
+            f"no snapshot passed ({result.snapshots} captured, "
+            f"{result.probes} probed, {result.unknown} unknown)"
+        )
+        return 0
+    print(
+        f"flip at snapshot {result.flip_index}/{result.snapshots - 1} "
+        f"(t+{result.flip_elapsed:.0f}s)"
+    )
+    print(
+        f"kept running {result.wasted_elapsed:.0f}s after it was already passing "
+        f"— {result.probes} verifier runs, {result.unknown} unknown"
+    )
+    return 0
+
+
 def _cmd_build_recorder(args: argparse.Namespace) -> int:
     if not docker_available():
         print("docker is not available", file=sys.stderr)
@@ -400,6 +457,29 @@ def main(argv: list[str] | None = None) -> int:
     )
     recorder_parser.add_argument("--force", action="store_true")
     recorder_parser.set_defaults(func=_cmd_build_recorder)
+
+    flip_parser = subparsers.add_parser(
+        "flip",
+        help="find when a trial started passing, and what it did afterwards",
+    )
+    flip_parser.add_argument("trial_dir", help="a trial directory containing arena/snapshots")
+    flip_parser.add_argument(
+        "--task-dir",
+        help="the task's dataset directory (default: resolved from result.json)",
+    )
+    flip_parser.add_argument(
+        "--verifier-timeout",
+        type=float,
+        default=1800.0,
+        help="seconds allowed for one verifier run (default: 1800)",
+    )
+    flip_parser.add_argument(
+        "--confirm-window",
+        type=int,
+        default=3,
+        help="snapshots to re-probe before the bisected answer (default: 3)",
+    )
+    flip_parser.set_defaults(func=_cmd_flip)
 
     args = parser.parse_args(argv)
     _configure_logging(args.verbose)

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -171,6 +171,8 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
             "concurrency": match_table.get("concurrency", 1),
             "record_video": match_table.get("record_video", False),
             "setup_timeout_multiplier": match_table.get("setup_timeout_multiplier", 1.0),
+            "capture_snapshots": match_table.get("capture_snapshots", False),
+            "snapshot_interval": match_table.get("snapshot_interval", 30.0),
         }
     )
     return replace(spec, contestants=tuple(contestants))
@@ -249,6 +251,8 @@ def match_to_toml_dict(spec: MatchSpec) -> dict[str, Any]:
             "concurrency": spec.concurrency,
             "record_video": spec.record_video,
             "setup_timeout_multiplier": spec.setup_timeout_multiplier,
+            "capture_snapshots": spec.capture_snapshots,
+            "snapshot_interval": spec.snapshot_interval,
         },
         "contestant": [
             {
@@ -310,6 +314,10 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
         "# Scales the agent-INSTALL budget. Agents that npm-install themselves",
         "# into an emulated container need >1 here or they never start.",
         _line("setup_timeout_multiplier", spec.setup_timeout_multiplier),
+        "# Periodic workspace snapshots, so `arenabench flip` can find the moment",
+        "# the tests started passing and how long the agent kept going afterwards.",
+        _line("capture_snapshots", spec.capture_snapshots),
+        _line("snapshot_interval", spec.snapshot_interval),
         "",
     ]
 

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -443,6 +443,14 @@ class MatchSpec:
     setup_timeout_multiplier: float = 1.0
     #: Capture a real MP4 screen recording per trial (see :mod:`.recorder`).
     record_video: bool = False
+    #: Capture periodic workspace snapshots so `arenabench flip` can find the
+    #: moment the task started passing (see :mod:`.snapshot`). Off by default:
+    #: it costs a `docker exec` per interval per live trial, and it is only
+    #: useful if you intend to run the replay afterwards.
+    capture_snapshots: bool = False
+    #: Seconds between snapshots — the floor on how precisely a flip can be
+    #: located, traded against how much work each capture adds to the host.
+    snapshot_interval: float = 30.0
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -455,6 +463,8 @@ class MatchSpec:
             "concurrency": self.concurrency,
             "setup_timeout_multiplier": self.setup_timeout_multiplier,
             "record_video": self.record_video,
+            "capture_snapshots": self.capture_snapshots,
+            "snapshot_interval": self.snapshot_interval,
         }
 
     @classmethod
@@ -477,6 +487,10 @@ class MatchSpec:
                 1.0, float(raw.get("setup_timeout_multiplier") or 1.0)
             ),
             record_video=bool(raw.get("record_video")),
+            capture_snapshots=bool(raw.get("capture_snapshots")),
+            # A zero or negative interval would spin the watcher; clamp rather
+            # than reject, so a typo degrades to "often" instead of failing a run.
+            snapshot_interval=max(1.0, float(raw.get("snapshot_interval") or 30.0)),
         )
 
     def validate(self) -> list[str]:

--- a/arenabench/arenabench/replay.py
+++ b/arenabench/arenabench/replay.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Re-run a task's own verifier against a trial's snapshots, after the fact.
+
+The trial is over and its container is gone. What survives is a series of
+patches against the pristine task state (see :mod:`arenabench.snapshot`), so a
+snapshot is replayed by starting a fresh container from the task's image,
+applying its patch, and running the task's real verifier — the same
+``/tests/test.sh`` Harbor runs, reading the same ``/logs/verifier/reward.txt``.
+Nothing here reimplements grading; it relocates it in time.
+
+**This is expensive and the search is shaped around that.** One probe pays the
+verifier's full setup — for ``sqlite-with-gcov`` that measured ~142 seconds,
+most of it ``apt-get`` and a ``uv`` install. Probing forty snapshots serially
+would take longer than the trial did. So the flip is found by bisection
+(``log2(n)`` probes), with a short confirming walk backwards to catch an agent
+that solved the task, broke it, and fixed it again — the one case bisection
+cannot see.
+
+**Replay is never run inside a live trial.** The verifier's test files would be
+visible to the agent, which would hand it the answer key. Everything here runs
+against containers the agent has no access to, after it is dead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from .snapshot import (
+    FlipResult,
+    SnapshotEntry,
+    bisect_first_pass,
+    confirm_first_pass,
+    load_manifest,
+    read_task_image,
+    summarise_flip,
+)
+
+__all__ = ["ReplayError", "replay_flip"]
+
+log = logging.getLogger("arenabench.replay")
+
+#: Where the task's verifier expects to find things, fixed by the dataset's
+#: own contract rather than by us.
+TESTS_MOUNT = "/tests"
+LOGS_MOUNT = "/logs"
+REWARD_PATH = "verifier/reward.txt"
+
+
+class ReplayError(RuntimeError):
+    """Replay could not run at all — as opposed to a snapshot that failed."""
+
+
+def _run(
+    cmd: list[str], *, timeout: float, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.pop("DOCKER_DEFAULT_PLATFORM", None)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+@dataclass
+class _Probe:
+    """One verifier run against one snapshot, in a throwaway container."""
+
+    image: str
+    task_dir: Path
+    trial_dir: Path
+    scratch: Path
+    verifier_timeout: float
+
+    def __call__(self, entry: SnapshotEntry) -> bool | None:
+        name = f"arena-replay-{uuid.uuid4().hex[:12]}"
+        logs = self.scratch / name
+        (logs / "verifier").mkdir(parents=True, exist_ok=True)
+        try:
+            return self._probe_in(name, entry, logs)
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("snapshot %d: probe could not run: %s", entry.index, exc)
+            return None
+        finally:
+            _run(["docker", "rm", "-f", name], timeout=120)
+
+    def _probe_in(self, name: str, entry: SnapshotEntry, logs: Path) -> bool | None:
+        started = _run(
+            [
+                "docker", "run", "-d", "--name", name,
+                "-v", f"{self.task_dir / 'tests'}:{TESTS_MOUNT}:ro",
+                "-v", f"{logs}:{LOGS_MOUNT}",
+                "--entrypoint", "sh",
+                self.image,
+                "-c", "sleep infinity",
+            ],
+            timeout=600,
+        )
+        if started.returncode != 0:
+            log.warning(
+                "snapshot %d: container would not start: %s",
+                entry.index,
+                started.stderr[-300:],
+            )
+            return None
+
+        if entry.patch and not self._apply(name, entry):
+            return None
+
+        done = _run(
+            ["docker", "exec", name, "bash", TESTS_MOUNT + "/test.sh"],
+            timeout=self.verifier_timeout,
+        )
+        reward = (logs / REWARD_PATH).read_text(encoding="utf-8").strip() if (
+            logs / REWARD_PATH
+        ).exists() else ""
+        if reward:
+            return reward.startswith("1")
+        # No reward file: the verifier itself did not complete. Unknown, not a
+        # failure — scoring it 0 would move the flip earlier than the truth.
+        log.debug("snapshot %d: no reward file (rc=%s)", entry.index, done.returncode)
+        return None
+
+    def _apply(self, name: str, entry: SnapshotEntry) -> bool:
+        patch = self.trial_dir / "arena" / "snapshots" / str(entry.patch)
+        if not patch.is_file():
+            log.warning("snapshot %d: patch file missing", entry.index)
+            return False
+        copied = _run(["docker", "cp", str(patch), f"{name}:/tmp/snap.patch"], timeout=300)
+        if copied.returncode != 0:
+            log.warning("snapshot %d: could not copy patch in", entry.index)
+            return False
+        applied = _run(
+            [
+                "docker", "exec", "-w", "/", name, "sh", "-c",
+                "cd / && git apply --binary --unsafe-paths --directory=/ /tmp/snap.patch"
+                " 2>/dev/null || git apply --binary /tmp/snap.patch",
+            ],
+            timeout=600,
+        )
+        if applied.returncode != 0:
+            log.warning(
+                "snapshot %d: patch did not apply: %s", entry.index, applied.stderr[-300:]
+            )
+            return False
+        return True
+
+
+def replay_flip(
+    trial_dir: Path,
+    task_dir: Path,
+    *,
+    verifier_timeout: float = 1800.0,
+    confirm_window: int = 3,
+    scratch: Path | None = None,
+) -> FlipResult:
+    """Find the earliest snapshot of ``trial_dir`` that the task's tests pass.
+
+    Writes ``arena/flip.json`` beside the snapshots and returns the summary.
+    """
+    if shutil.which("docker") is None:
+        raise ReplayError("docker is not available on this host")
+    entries = load_manifest(trial_dir)
+    if not entries:
+        raise ReplayError(f"no snapshots captured for {trial_dir.name}")
+    image = read_task_image(task_dir)
+    if not image:
+        raise ReplayError(f"no docker_image in {task_dir / 'task.toml'}")
+    if not (task_dir / "tests" / "test.sh").is_file():
+        raise ReplayError(f"no tests/test.sh under {task_dir}")
+
+    scratch = scratch or (trial_dir / "arena" / "replay")
+    scratch.mkdir(parents=True, exist_ok=True)
+    probe = _Probe(
+        image=image,
+        task_dir=task_dir,
+        trial_dir=trial_dir,
+        scratch=scratch,
+        verifier_timeout=verifier_timeout,
+    )
+
+    seen: dict[int, bool | None] = {}
+
+    def probe_index(index: int) -> bool | None:
+        if index not in seen:
+            log.info(
+                "probing snapshot %d/%d (t+%.0fs)",
+                index,
+                len(entries) - 1,
+                entries[index].elapsed,
+            )
+            seen[index] = probe(entries[index])
+        return seen[index]
+
+    answer = bisect_first_pass(len(entries), probe_index)
+    if answer is not None and confirm_window > 0:
+        answer = confirm_first_pass(answer, probe_index, window=confirm_window)
+
+    result = summarise_flip(
+        entries,
+        answer,
+        probes=len(seen),
+        unknown=sum(1 for v in seen.values() if v is None),
+    )
+    try:
+        (trial_dir / "arena" / "flip.json").write_text(
+            json.dumps(result.to_json(), indent=2) + "\n", encoding="utf-8"
+        )
+    except OSError as exc:  # pragma: no cover - reporting must not fail the run
+        log.warning("could not write flip.json: %s", exc)
+    return result

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -45,6 +45,7 @@ from .harbor_agent import ARENA_ENGINE_ENV
 from .model import DIMENSIONS, Contestant, MatchSpec, screen_env
 from .recorder import RecorderSupervisor
 from .registry import Dataset, Registry
+from .snapshot import SnapshotSupervisor
 from .telemetry import MetricsReader, TrialMetrics, aggregate, leaders
 
 __all__ = ["ContestantRun", "Match", "MatchRunner"]
@@ -142,6 +143,7 @@ class Match:
         self.status = "created"  # created | running | finished | cancelled | failed
         self.runs: dict[str, ContestantRun] = {}
         self.recorder: RecorderSupervisor | None = None
+        self.snapshots: SnapshotSupervisor | None = None
         self.note = ""
         self._metrics = MetricsReader()
         self._lock = threading.Lock()
@@ -213,6 +215,7 @@ class Match:
             ),
             "recording": self.recorder is not None,
             "recording_active": self.recorder.active_count if self.recorder else 0,
+            "snapshotting": self.snapshots is not None,
             "contestants": [
                 {
                     **contestant.redacted(),
@@ -313,6 +316,15 @@ class MatchRunner:
             )
             supervisor.start()
             match.recorder = supervisor
+
+        if match.spec.capture_snapshots:
+            snapshots = SnapshotSupervisor(
+                jobs_root=match.jobs_root,
+                jobs=[run.job_name for run in match.runs.values()],
+                interval=match.spec.snapshot_interval,
+            )
+            snapshots.start()
+            match.snapshots = snapshots
 
         threading.Thread(
             target=self._await_completion, args=(match,), daemon=True
@@ -518,6 +530,8 @@ class MatchRunner:
 
         if match.recorder is not None:
             match.recorder.stop()
+        if match.snapshots is not None:
+            match.snapshots.stop()
 
         match.finished_at = time.time()
         if match.status != "cancelled":
@@ -541,3 +555,5 @@ class MatchRunner:
                     process.terminate()
         if match.recorder is not None:
             match.recorder.stop()
+        if match.snapshots is not None:
+            match.snapshots.stop()

--- a/arenabench/arenabench/snapshot.py
+++ b/arenabench/arenabench/snapshot.py
@@ -1,0 +1,565 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""When did the agent actually solve it — and what did it do afterwards.
+
+A Terminal-Bench trial is graded **once**, after the agent process is dead,
+against whatever the workspace looks like at that moment. Nothing observes the
+moment the tests started passing. Three things follow, and none of them are
+currently measured:
+
+* Every step after that moment is strictly negative expected value. It cannot
+  raise a reward that is already 1.0, and it costs tokens and clock.
+* An agent can *destroy* its own passing solution and score 0, indistinguishable
+  from never having solved the task at all.
+* A trial killed by the wall clock can still pass — being interrupted is not
+  the same as failing.
+
+This module recovers the missing moment. During a run it captures periodic
+workspace snapshots; afterwards :func:`replay_flip` re-runs the task's own
+verifier against those snapshots to find the earliest one that passes. The
+difference between that snapshot and the end of the run is the part of the
+trial that could only lose.
+
+**Why the verifier cannot simply be run during the trial.** A task's verifier
+is a directory of tests that has to be copied into the container to execute.
+Doing that mid-run would leave the answer key sitting in the agent's own
+filesystem, readable. End-only grading is what keeps the oracle hidden, so the
+replay happens after the agent is gone and cannot learn from it.
+
+**Why snapshots are taken with a detached git dir.** ``git --git-dir`` pointed
+outside the workspace with ``--work-tree`` pointed at it gives a full content
+snapshot while writing **nothing** into the workspace — no ``.git``, no index,
+no stray ignore file. That matters more than it sounds: ``fix-git`` is a real
+task in this dataset whose whole subject *is* the repository state. A
+snapshotter that ran ``git init`` in the workspace would silently rewrite the
+task it was measuring. This one is invisible to the agent and to the verifier.
+
+Capture is opt-in and degrades to nothing. No Docker, no git in the image, or a
+container that vanishes mid-sweep yields a trial with no snapshots and a
+warning — never a failed run. Measurement must not be able to cost a benchmark.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "SNAPSHOT_DIRNAME",
+    "FlipResult",
+    "SnapshotEntry",
+    "SnapshotSupervisor",
+    "bisect_first_pass",
+    "load_manifest",
+    "read_task_image",
+]
+
+log = logging.getLogger("arenabench.snapshot")
+
+#: Where a trial's snapshots live, beside the video the recorder writes.
+SNAPSHOT_DIRNAME = "arena/snapshots"
+
+MANIFEST_NAME = "manifest.jsonl"
+
+#: The snapshot repository lives here, inside the container but outside the
+#: workspace, so the workspace is never modified. See the module docstring.
+SNAP_GIT_DIR = "/tmp/.arena-snapshots.git"
+
+#: Terminal-Bench images do not agree on where the task lives. Probed in order.
+WORKSPACE_CANDIDATES: tuple[str, ...] = ("/app", "/workspace", "/home/user", "/root")
+
+#: Never snapshot the agent's own private state. Stella writes a code-graph
+#: SQLite database under `.stella/private/` that churns on essentially every
+#: step; including it makes patches enormous and tells us nothing about whether
+#: the task is solved. The verifier does not read it either.
+SNAPSHOT_EXCLUDES: tuple[str, ...] = (".stella/", "node_modules/", "__pycache__/")
+
+_GIT_IDENT = (
+    "-c",
+    "user.name=arenabench",
+    "-c",
+    "user.email=snapshot@arenabench.invalid",
+)
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SnapshotEntry:
+    """One captured workspace state."""
+
+    index: int
+    #: Unix time the snapshot was committed, for aligning against the event
+    #: stream. Steps are not observable from outside the agent; time is.
+    at: float
+    #: Commit sha inside the detached snapshot repo (container-local).
+    sha: str
+    #: Patch filename relative to the snapshot directory, or ``None`` when the
+    #: snapshot was identical to the one before it.
+    patch: str | None
+    #: Seconds since the trial's first snapshot. The number an operator reads.
+    elapsed: float
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "index": self.index,
+            "at": self.at,
+            "sha": self.sha,
+            "patch": self.patch,
+            "elapsed": round(self.elapsed, 3),
+        }
+
+    @staticmethod
+    def from_json(raw: dict[str, object]) -> SnapshotEntry | None:
+        try:
+            return SnapshotEntry(
+                index=int(raw["index"]),  # type: ignore[arg-type]
+                at=float(raw["at"]),  # type: ignore[arg-type]
+                sha=str(raw["sha"]),
+                patch=str(raw["patch"]) if raw.get("patch") else None,
+                elapsed=float(raw.get("elapsed") or 0.0),  # type: ignore[arg-type]
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def load_manifest(trial_dir: Path) -> list[SnapshotEntry]:
+    """Every snapshot captured for a trial, in capture order.
+
+    A malformed line is skipped rather than fatal — the manifest is appended to
+    by a live watcher and the last line can be a torn write.
+    """
+    path = trial_dir / SNAPSHOT_DIRNAME / MANIFEST_NAME
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    entries: list[SnapshotEntry] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+        except ValueError:
+            continue
+        entry = SnapshotEntry.from_json(raw) if isinstance(raw, dict) else None
+        if entry is not None:
+            entries.append(entry)
+    return sorted(entries, key=lambda e: e.index)
+
+
+def read_task_image(task_dir: Path) -> str | None:
+    """The docker image a task runs in, read from its ``task.toml``.
+
+    Parsed with a deliberately small reader rather than ``tomllib`` so this
+    module keeps working on a manifest written by a newer schema than the
+    interpreter's parser understands — the field has been stable since 1.0 and
+    a schema bump should not disable replay.
+    """
+    try:
+        text = (task_dir / "task.toml").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("docker_image"):
+            continue
+        _, _, value = stripped.partition("=")
+        return value.strip().strip("\"'") or None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The search
+# ---------------------------------------------------------------------------
+
+
+def bisect_first_pass(count: int, probe: Callable[[int], bool | None]) -> int | None:
+    """Index of the earliest snapshot that passes, or ``None`` if none does.
+
+    ``probe`` returns ``True``/``False``, or ``None`` when the verifier could
+    not be run at all for that snapshot — a probe that errored is treated as
+    *unknown* and the search steps past it rather than reading it as a failure,
+    because a mis-scored probe here silently moves the answer.
+
+    **On monotonicity.** Binary search assumes that once the tests pass they
+    keep passing, which is exactly what this function exists to question — an
+    agent may break its own solution. So this is deliberately only the *cheap
+    first pass*: it costs ``log2(n)`` verifier runs where a scan costs ``n``,
+    and each run can take minutes. :func:`confirm_first_pass` re-probes the
+    neighbourhood of the answer to catch the non-monotonic case. Callers that
+    need certainty over cost should scan instead.
+    """
+    if count <= 0:
+        return None
+    lo, hi = 0, count - 1
+    answer: int | None = None
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        verdict = probe(mid)
+        if verdict is None:
+            # Unknown: nudge forward so a broken probe cannot pin the search.
+            lo = mid + 1
+            continue
+        if verdict:
+            answer = mid
+            hi = mid - 1
+        else:
+            lo = mid + 1
+    return answer
+
+
+def confirm_first_pass(
+    answer: int, probe: Callable[[int], bool | None], *, window: int = 3
+) -> int:
+    """Walk backwards from a bisected answer while earlier snapshots also pass.
+
+    Catches the case bisection cannot see: the agent solved the task, broke it,
+    and fixed it again. Bounded by ``window`` because each step is a full
+    verifier run.
+    """
+    earliest = answer
+    for offset in range(1, window + 1):
+        candidate = answer - offset
+        if candidate < 0:
+            break
+        if probe(candidate) is not True:
+            break
+        earliest = candidate
+    return earliest
+
+
+@dataclass(frozen=True)
+class FlipResult:
+    """Where in a trial the reward first appeared."""
+
+    #: Snapshot index that first passed, or ``None`` if none did.
+    flip_index: int | None
+    #: Seconds from the first snapshot to the flip.
+    flip_elapsed: float | None
+    #: Seconds the trial kept running after it was already passing.
+    wasted_elapsed: float | None
+    #: Total snapshots considered, and how many verifier runs it took.
+    snapshots: int
+    probes: int
+    #: Snapshots that could not be probed at all.
+    unknown: int
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "flip_index": self.flip_index,
+            "flip_elapsed": self.flip_elapsed,
+            "wasted_elapsed": self.wasted_elapsed,
+            "snapshots": self.snapshots,
+            "probes": self.probes,
+            "unknown": self.unknown,
+        }
+
+
+def summarise_flip(
+    entries: Sequence[SnapshotEntry],
+    flip_index: int | None,
+    *,
+    probes: int,
+    unknown: int,
+) -> FlipResult:
+    """Turn a flip index into the durations an operator actually reads."""
+    flip_elapsed: float | None = None
+    wasted: float | None = None
+    if flip_index is not None and 0 <= flip_index < len(entries):
+        flip_elapsed = entries[flip_index].elapsed
+        wasted = max(0.0, entries[-1].elapsed - flip_elapsed)
+    return FlipResult(
+        flip_index=flip_index,
+        flip_elapsed=flip_elapsed,
+        wasted_elapsed=wasted,
+        snapshots=len(entries),
+        probes=probes,
+        unknown=unknown,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: Sequence[str], *, timeout: float = 120.0) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    # Same trap the recorder hits: a host-wide amd64 pin makes docker look for
+    # an amd64 variant of a local arm64 image and then try to pull it.
+    env.pop("DOCKER_DEFAULT_PLATFORM", None)
+    return subprocess.run(
+        list(cmd), capture_output=True, text=True, timeout=timeout, env=env
+    )
+
+
+def container_for_trial(trial_dir: Path) -> str:
+    """Harbor's container name for a trial directory.
+
+    Harbor composes it from the trial name and lowercases it, because Docker
+    requires lowercase names while trial ids are mixed case.
+    """
+    return f"{trial_dir.name.lower()}-main-1"
+
+
+def _container_running(name: str) -> bool:
+    try:
+        done = _run(["docker", "inspect", "-f", "{{.State.Running}}", name], timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return done.returncode == 0 and done.stdout.strip() == "true"
+
+
+def _exec(container: str, script: str, *, timeout: float = 180.0) -> tuple[int, str]:
+    try:
+        done = _run(["docker", "exec", container, "sh", "-c", script], timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, str(exc)
+    return done.returncode, (done.stdout or "") + (done.stderr or "")
+
+
+def detect_workspace(container: str) -> str | None:
+    """Which candidate directory holds the task, decided inside the container."""
+    probe = " ".join(
+        f'[ -d "{path}" ] && echo "{path}" && exit 0;' for path in WORKSPACE_CANDIDATES
+    )
+    code, out = _exec(container, probe + " exit 1", timeout=60)
+    if code != 0:
+        return None
+    found = out.strip().splitlines()
+    return found[0].strip() if found else None
+
+
+def _init_script(workspace: str) -> str:
+    excludes = "\n".join(SNAPSHOT_EXCLUDES)
+    return (
+        f"command -v git >/dev/null 2>&1 || exit 3; "
+        f"mkdir -p {SNAP_GIT_DIR}/info && "
+        f"git --git-dir={SNAP_GIT_DIR} --work-tree={workspace} init -q && "
+        f"printf '%s\\n' '{excludes}' > {SNAP_GIT_DIR}/info/exclude && echo ok"
+    )
+
+
+def _commit_script(workspace: str, index: int) -> str:
+    ident = " ".join(_GIT_IDENT)
+    base = f"git {ident} --git-dir={SNAP_GIT_DIR} --work-tree={workspace}"
+    return (
+        f"{base} add -A >/dev/null 2>&1; "
+        f"{base} commit -q --allow-empty --no-gpg-sign -m 'arena snapshot {index}' "
+        f">/dev/null 2>&1; {base} rev-parse HEAD"
+    )
+
+
+def _patch_script(workspace: str, first_sha: str) -> str:
+    base = f"git --git-dir={SNAP_GIT_DIR} --work-tree={workspace}"
+    return f"{base} diff --binary {first_sha} HEAD"
+
+
+@dataclass
+class _Capture:
+    container: str
+    workspace: str
+    first_sha: str | None
+    index: int
+    started_at: float
+
+
+@dataclass
+class SnapshotSupervisor:
+    """Captures periodic workspace snapshots for every live trial in a match.
+
+    Shaped like :class:`~arenabench.recorder.RecorderSupervisor` and for the
+    same reason: Harbor never announces a trial, so this watches the jobs tree
+    for the files a run already produces. An ``agent/`` subdirectory means a
+    trial has begun; ``result.json`` means it has ended.
+    """
+
+    jobs_root: Path
+    jobs: list[str]
+    #: Seconds between snapshots. The floor on how precisely a flip can be
+    #: located, and the thing to turn down when a task is fast.
+    interval: float = 30.0
+    poll_interval: float = 2.0
+    max_start_attempts: int = 3
+
+    _active: dict[Path, _Capture] = field(default_factory=dict, init=False)
+    _finished: set[Path] = field(default_factory=set, init=False)
+    _failures: dict[Path, int] = field(default_factory=dict, init=False)
+    _last: dict[Path, float] = field(default_factory=dict, init=False)
+    _thread: threading.Thread | None = field(default=None, init=False)
+    _stop: threading.Event = field(default_factory=threading.Event, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    # -- lifecycle --------------------------------------------------------
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._watch, name="arena-snapshot", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 60.0) -> None:
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._thread = None
+        with self._lock:
+            self._active.clear()
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._active)
+
+    # -- internals --------------------------------------------------------
+
+    def _watch(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._sweep()
+            except Exception:  # pragma: no cover - a watcher must never die
+                log.exception("snapshot sweep failed")
+            self._stop.wait(self.poll_interval)
+
+    def _sweep(self) -> None:
+        for job in self.jobs:
+            job_dir = self.jobs_root / job
+            if not job_dir.is_dir():
+                continue
+            for trial_dir in sorted(p for p in job_dir.iterdir() if p.is_dir()):
+                self._consider(trial_dir)
+
+    def _consider(self, trial_dir: Path) -> None:
+        if trial_dir in self._finished:
+            return
+        finished = (trial_dir / "result.json").exists()
+        with self._lock:
+            capture = self._active.get(trial_dir)
+
+        if capture is not None:
+            if finished:
+                # One last snapshot: the graded state is the one that matters
+                # most, and the interval will rarely have landed on it.
+                self._snapshot(trial_dir, capture)
+                with self._lock:
+                    self._active.pop(trial_dir, None)
+                self._finished.add(trial_dir)
+                return
+            if time.monotonic() - self._last.get(trial_dir, 0.0) >= self.interval:
+                self._snapshot(trial_dir, capture)
+            return
+
+        if finished or not (trial_dir / "agent").is_dir():
+            if finished:
+                self._finished.add(trial_dir)
+            return
+        self._begin(trial_dir)
+
+    def _fail(self, trial_dir: Path, detail: str) -> None:
+        count = self._failures.get(trial_dir, 0) + 1
+        self._failures[trial_dir] = count
+        if count == 1:
+            log.warning("snapshots unavailable for %s: %s", trial_dir.name, detail)
+        if count >= self.max_start_attempts:
+            self._finished.add(trial_dir)
+
+    def _begin(self, trial_dir: Path) -> None:
+        container = container_for_trial(trial_dir)
+        if not _container_running(container):
+            self._fail(trial_dir, f"container {container} is not running")
+            return
+        workspace = detect_workspace(container)
+        if workspace is None:
+            self._fail(trial_dir, "no candidate workspace directory in the image")
+            return
+        code, out = _exec(container, _init_script(workspace), timeout=120)
+        if code != 0:
+            reason = "git is not installed in the task image" if code == 3 else out[-200:]
+            self._fail(trial_dir, reason)
+            return
+        capture = _Capture(
+            container=container,
+            workspace=workspace,
+            first_sha=None,
+            index=0,
+            started_at=time.time(),
+        )
+        with self._lock:
+            self._active[trial_dir] = capture
+        (trial_dir / SNAPSHOT_DIRNAME).mkdir(parents=True, exist_ok=True)
+        self._snapshot(trial_dir, capture)
+
+    def _snapshot(self, trial_dir: Path, capture: _Capture) -> None:
+        self._last[trial_dir] = time.monotonic()
+        code, out = _exec(
+            capture.container, _commit_script(capture.workspace, capture.index)
+        )
+        if code != 0:
+            log.debug("snapshot commit failed for %s: %s", trial_dir.name, out[-200:])
+            return
+        sha = out.strip().splitlines()[-1].strip() if out.strip() else ""
+        if not sha:
+            return
+
+        snap_dir = trial_dir / SNAPSHOT_DIRNAME
+        patch_name: str | None = None
+        if capture.first_sha is None:
+            capture.first_sha = sha
+        else:
+            code, patch = _exec(
+                capture.container,
+                _patch_script(capture.workspace, capture.first_sha),
+                timeout=300,
+            )
+            if code == 0 and patch.strip():
+                patch_name = f"{capture.index:04d}.patch"
+                try:
+                    (snap_dir / patch_name).write_text(patch, encoding="utf-8")
+                except OSError as exc:
+                    log.debug("could not write patch for %s: %s", trial_dir.name, exc)
+                    patch_name = None
+
+        now = time.time()
+        entry = SnapshotEntry(
+            index=capture.index,
+            at=now,
+            sha=sha,
+            patch=patch_name,
+            elapsed=max(0.0, now - capture.started_at),
+        )
+        try:
+            with (snap_dir / MANIFEST_NAME).open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry.to_json()) + "\n")
+        except OSError as exc:
+            log.debug("could not append manifest for %s: %s", trial_dir.name, exc)
+        capture.index += 1
+
+
+def snapshots_available() -> bool:
+    """Whether this host can capture snapshots at all."""
+    return shutil.which("docker") is not None
+
+
+def unpatched_indices(entries: Iterable[SnapshotEntry]) -> list[int]:
+    """Snapshots with no patch — identical to the trial's first snapshot.
+
+    Replaying one of these means replaying the pristine task state, which is
+    only worth a verifier run for the very first entry.
+    """
+    return [e.index for e in entries if e.patch is None]

--- a/arenabench/tests/test_snapshot.py
+++ b/arenabench/tests/test_snapshot.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The flip search, and the manifest it reads.
+
+Everything here is the pure half — no Docker, no containers. The expensive
+half is one `docker run` per probe and is exercised by running a real match;
+what must be correct without a container is *which* snapshots get probed and
+what is concluded from the answers, because a wrong index here silently moves
+the number an operator reads.
+"""
+
+from __future__ import annotations
+
+import json
+
+from arenabench.model import MatchSpec
+from arenabench.snapshot import (
+    SNAPSHOT_DIRNAME,
+    SnapshotEntry,
+    bisect_first_pass,
+    confirm_first_pass,
+    container_for_trial,
+    load_manifest,
+    read_task_image,
+    summarise_flip,
+    unpatched_indices,
+)
+
+
+def _entries(count: int, *, step: float = 30.0) -> list[SnapshotEntry]:
+    return [
+        SnapshotEntry(
+            index=i,
+            at=1000.0 + i * step,
+            sha=f"sha{i}",
+            patch=f"{i:04d}.patch",
+            elapsed=i * step,
+        )
+        for i in range(count)
+    ]
+
+
+# -- the search -------------------------------------------------------------
+
+
+def test_bisect_finds_the_first_passing_snapshot():
+    # Passes from index 6 onwards.
+    calls: list[int] = []
+
+    def probe(i: int) -> bool:
+        calls.append(i)
+        return i >= 6
+
+    assert bisect_first_pass(20, probe) == 6
+    # log2(20) is ~4.3; a scan would be 7 probes to reach index 6 alone.
+    assert len(calls) <= 6
+
+
+def test_bisect_returns_none_when_nothing_passes():
+    assert bisect_first_pass(16, lambda i: False) is None
+
+
+def test_bisect_handles_a_single_snapshot():
+    assert bisect_first_pass(1, lambda i: True) == 0
+    assert bisect_first_pass(1, lambda i: False) is None
+    assert bisect_first_pass(0, lambda i: True) is None
+
+
+def test_unknown_probe_does_not_read_as_failure():
+    """A verifier that could not run must not pin the search.
+
+    Scoring an un-runnable probe as a failure would push the answer later than
+    the truth and silently inflate "wasted" time.
+    """
+
+    def probe(i: int) -> bool | None:
+        if i == 8:
+            return None
+        return i >= 4
+
+    assert bisect_first_pass(16, probe) == 4
+
+
+def test_confirm_walks_back_past_a_broken_then_fixed_solution():
+    """Bisection cannot see a solution that was broken and re-fixed.
+
+    Pass at 2, broken at 3-5, passing again from 6. A bisection can land on 6;
+    the confirming walk must find the earlier 2.
+    """
+    passing = {2, 6, 7, 8, 9}
+    assert confirm_first_pass(6, lambda i: i in passing, window=1) == 6
+    # A window wide enough to cross the broken stretch reaches the real flip.
+    passing_contiguous = {4, 5, 6, 7}
+    assert confirm_first_pass(6, lambda i: i in passing_contiguous, window=3) == 4
+
+
+def test_confirm_stops_at_zero():
+    assert confirm_first_pass(1, lambda i: True, window=5) == 0
+
+
+# -- summarising ------------------------------------------------------------
+
+
+def test_summarise_reports_the_time_spent_after_passing():
+    entries = _entries(10)  # 0..270s
+    result = summarise_flip(entries, 3, probes=4, unknown=0)
+    assert result.flip_elapsed == 90.0
+    assert result.wasted_elapsed == 180.0
+    assert result.snapshots == 10
+
+
+def test_summarise_with_no_flip_reports_no_waste():
+    result = summarise_flip(_entries(5), None, probes=3, unknown=1)
+    assert result.flip_index is None
+    assert result.wasted_elapsed is None
+    assert result.unknown == 1
+    assert json.loads(json.dumps(result.to_json()))["snapshots"] == 5
+
+
+def test_summarise_ignores_an_out_of_range_index():
+    result = summarise_flip(_entries(3), 9, probes=1, unknown=0)
+    assert result.flip_elapsed is None
+
+
+# -- manifest ---------------------------------------------------------------
+
+
+def test_manifest_round_trips_and_sorts(tmp_path):
+    snap = tmp_path / SNAPSHOT_DIRNAME
+    snap.mkdir(parents=True)
+    written = _entries(3)
+    with (snap / "manifest.jsonl").open("w", encoding="utf-8") as handle:
+        for entry in reversed(written):  # out of order on disk
+            handle.write(json.dumps(entry.to_json()) + "\n")
+    loaded = load_manifest(tmp_path)
+    assert [e.index for e in loaded] == [0, 1, 2]
+    assert loaded[1].sha == "sha1"
+
+
+def test_manifest_survives_a_torn_last_line(tmp_path):
+    """The watcher appends while the run is live; the tail can be half-written."""
+    snap = tmp_path / SNAPSHOT_DIRNAME
+    snap.mkdir(parents=True)
+    good = json.dumps(_entries(1)[0].to_json())
+    (snap / "manifest.jsonl").write_text(good + "\n{\"index\": 1, \"at\":", encoding="utf-8")
+    assert [e.index for e in load_manifest(tmp_path)] == [0]
+
+
+def test_manifest_missing_is_empty_not_an_error(tmp_path):
+    assert load_manifest(tmp_path) == []
+
+
+def test_unpatched_indices_flags_snapshots_identical_to_the_first():
+    entries = list(_entries(3))
+    entries[0] = SnapshotEntry(index=0, at=1.0, sha="a", patch=None, elapsed=0.0)
+    assert unpatched_indices(entries) == [0]
+
+
+# -- task + container resolution -------------------------------------------
+
+
+def test_read_task_image(tmp_path):
+    (tmp_path / "task.toml").write_text(
+        '[environment]\ndocker_image = "alexgshaw/sqlite-with-gcov:20251031"\ncpus = 1\n',
+        encoding="utf-8",
+    )
+    assert read_task_image(tmp_path) == "alexgshaw/sqlite-with-gcov:20251031"
+
+
+def test_read_task_image_missing(tmp_path):
+    assert read_task_image(tmp_path) is None
+
+
+def test_container_name_is_lowercased(tmp_path):
+    """Harbor lowercases trial ids for Docker; the mapping must match exactly."""
+    trial = tmp_path / "sqlite-with-gcov__n4nJCiw"
+    assert container_for_trial(trial) == "sqlite-with-gcov__n4njciw-main-1"
+
+
+# -- spec plumbing ----------------------------------------------------------
+
+
+def test_match_spec_round_trips_snapshot_fields():
+    spec = MatchSpec.from_json(
+        {
+            "name": "m",
+            "dataset": "terminal-bench-2.1",
+            "tasks": ["fix-git"],
+            "contestants": [],
+            "capture_snapshots": True,
+            "snapshot_interval": 15.0,
+        }
+    )
+    assert spec.capture_snapshots is True
+    assert spec.snapshot_interval == 15.0
+    assert MatchSpec.from_json(spec.to_json()).snapshot_interval == 15.0
+
+
+def test_snapshot_interval_never_spins_the_watcher():
+    """A zero interval would make the sweep a busy loop; it is clamped."""
+    spec = MatchSpec.from_json(
+        {"dataset": "d", "contestants": [], "snapshot_interval": 0}
+    )
+    assert spec.snapshot_interval >= 1.0
+
+
+def test_capture_is_off_by_default():
+    spec = MatchSpec.from_json({"dataset": "d", "contestants": []})
+    assert spec.capture_snapshots is False


### PR DESCRIPTION
## What

A Terminal-Bench trial is graded **once**, after the agent process is dead, against whatever the workspace looks like at that moment. Nothing observes the moment the tests *start* passing. Three things follow, and none of them are currently measured:

- every step after that moment is strictly negative expected value — it cannot raise a reward already at 1.0, and it costs tokens and clock;
- an agent can **destroy its own passing solution** and score 0, indistinguishable from never having solved the task;
- a trial killed by the wall clock can still pass — being interrupted is not the same as failing.

The last one is not hypothetical. In the GLM-5.2 head-to-head, Stella's `sqlite-with-gcov` trial ended `AgentTimeoutError` at 900s with `stella_status: "interrupted"` and scored `reward: 1.0`.

This adds `capture_snapshots` (periodic workspace snapshots during a run) and `arenabench flip <trial>` (replay the task's own verifier against them to find the earliest passing snapshot).

```
flip at snapshot 6/23 (t+180s)
kept running 510s after it was already passing — 5 verifier runs, 0 unknown
```

## Three decisions worth reviewing

**Snapshots never touch the workspace.** `git --git-dir` points outside the workspace, `--work-tree` points at it — so the workspace gets no `.git`, no index, no ignore file. This is load-bearing, not fastidious: `fix-git` is a task in this dataset whose whole subject *is* repository state, and a snapshotter that ran `git init` there would silently rewrite the task it was measuring.

**Replay runs after the agent is gone, never during.** A verifier is a directory of tests that must be copied into the container to execute; running it mid-trial would leave the answer key in the agent's own filesystem, readable. End-only grading is what keeps the oracle hidden — this relocates grading in time without exposing it.

**The search is shaped by probe cost.** One probe pays the verifier's full setup (~142s for `sqlite-with-gcov`, mostly `apt-get` and a `uv` install), so probing serially would take longer than the trial. Bisection costs `log2(n)`, then a short backwards walk catches the solved → broke → fixed case bisection cannot see. A probe that could not run at all counts as **unknown**, never as a failure — scoring it 0 would move the flip earlier than the truth and inflate "wasted".

## Witness

`tests/test_snapshot.py` — 19 tests over the pure half (the search and the manifest), no Docker required. The ones that matter:

- `test_unknown_probe_does_not_read_as_failure` — an un-runnable verifier must not pin the search
- `test_confirm_walks_back_past_a_broken_then_fixed_solution` — the non-monotonic case
- `test_manifest_survives_a_torn_last_line` — the watcher appends while the run is live
- `test_container_name_is_lowercased` — Harbor lowercases trial ids for Docker; a mismatch means silently zero snapshots
- `test_snapshot_interval_never_spins_the_watcher` — a `0` interval would busy-loop the sweep

The expensive half (one `docker run` per probe) is exercised by running a real match; it is deliberately not in the unit suite.

## Scope

Off by default. Degrades to nothing — no Docker, or no `git` in the task image, yields a run with no snapshots and one warning. Measurement must not be able to cost a benchmark.

`make gate` is not applicable (no Rust touched); `pytest` and `ruff check` are clean by exit code.

## Summary by Sourcery

Add optional workspace snapshot capture during trials and a replay tool to determine when a solution first passed, plus CLI, config, and documentation support.

New Features:
- Introduce configurable capture_snapshots and snapshot_interval options in MatchSpec and TOML config to record periodic workspace snapshots during trials.
- Add arenabench flip CLI command and replay module to rerun task verifiers over snapshots and report when a trial first started passing and how long it continued running afterward.

Enhancements:
- Track snapshotting state in MatchRunner and manage a SnapshotSupervisor alongside the existing RecorderSupervisor lifecycle.
- Document snapshot capture and flip replay workflow and rationale in the README.

Tests:
- Add unit tests covering snapshot manifest handling, flip search logic, container name resolution, and MatchSpec snapshot configuration behaviour.

## Filed alongside

- Refs #1536 — `flip.json` has no consumer yet; this PR ships the producer, that issue wires it into the scoreboard.
- Refs #1537 — `.stella/private/` churn in FileChange events. Snapshot capture excludes `.stella/` here as a workaround; the fix belongs upstream in `record_touch`.
- Refs #1534 — a seat with bad credentials scores 0 instead of being voided, found in the same run.