### PR TITLE
fix(stella-serve): give every reverse-RPC port an instance tag so tool-call ids cannot collide

### DIFF
--- a/crates/stella-serve/src/remote.rs
+++ b/crates/stella-serve/src/remote.rs
@@ -102,6 +102,27 @@ pub(crate) const DEFAULT_REVERSE_REQUEST_TIMEOUT: Duration = Duration::from_secs
 /// an allocator through every construction site.
 static PROVIDER_INSTANCES: AtomicU64 = AtomicU64::new(0);
 
+/// Mints [`RemoteToolExecutor`] instance tags, for the same reason and on the
+/// same terms as [`PROVIDER_INSTANCES`] (#1496).
+///
+/// The tool port needs this exactly as much as the provider port does, and for
+/// longer than anyone noticed: `run_session` builds two executors over one
+/// [`Pending`] registry — the parent's and the sub-agent view's — so two
+/// zero-based counters both mint `tool-0`. `Pending::register_tool` inserts
+/// through `HashMap::insert`, which *replaces* on collision, so the displaced
+/// oneshot sender drops, its waiter wakes with "serve host dropped the tool
+/// call without answering", and the host's single answer for `tool-0` resolves
+/// whichever request happened to register last. A sub-agent could therefore be
+/// handed the parent's tool result.
+static TOOL_INSTANCES: AtomicU64 = AtomicU64::new(0);
+
+/// Mints [`RemoteApprovalGate`] instance tags (#1496).
+///
+/// Carried for the same structural reason even though `pipeline_run` builds
+/// exactly one gate per run: "unique because only one exists" is a property of
+/// the call sites, and call sites are what changed underneath the tool port.
+static SCOPE_INSTANCES: AtomicU64 = AtomicU64::new(0);
+
 /// Hand one streamed fragment to the engine's observer, on the channel that
 /// keeps answer text and thinking apart. A `None` observer (the plain
 /// `complete_ref` path) drops the fragment: the aggregated result is
@@ -339,6 +360,10 @@ impl Provider for RemoteProvider {
 /// [`ServerFrame::ToolRequest`] and blocks on the host's answer.
 pub(crate) struct RemoteToolExecutor {
     schemas: Vec<ToolSchema>,
+    /// Disambiguates this executor's request ids from every other executor
+    /// sharing the turn's [`Pending`] registry (#1496) — the same guarantee,
+    /// and the same mechanism, as [`RemoteProvider::instance`].
+    instance: u64,
     frames: crate::backlog::FrameSink,
     pending: Pending,
     counter: AtomicU64,
@@ -364,6 +389,7 @@ impl RemoteToolExecutor {
     ) -> Self {
         Self {
             schemas,
+            instance: TOOL_INSTANCES.fetch_add(1, Ordering::Relaxed),
             frames,
             pending,
             counter: AtomicU64::new(0),
@@ -503,7 +529,11 @@ impl RemoteToolExecutor {
     /// and the caller is what brackets this with the hook plane's
     /// `started`/outcome pair.
     async fn dispatch(&self, name: &str, input: &Value) -> ToolOutput {
-        let request_id = format!("tool-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let request_id = format!(
+            "tool-{}-{}",
+            self.instance,
+            self.counter.fetch_add(1, Ordering::Relaxed)
+        );
         let (tx, rx) = oneshot::channel();
         // Same refused-registration handling as the provider port: a cancel
         // landing between the check above and this call must not park the step
@@ -568,6 +598,12 @@ impl RemoteToolExecutor {
 pub(crate) struct RemoteApprovalGate {
     frames: crate::backlog::FrameSink,
     pending: Pending,
+    /// As on the provider and tool ports (#1496). Only one approval gate is
+    /// built per pipeline run today, so this cannot collide yet — which is
+    /// exactly the state the tool port was in before a sub-agent grew it a
+    /// second executor. Carrying the tag makes the id unique because of how it
+    /// is constructed rather than because of how many callers happen to exist.
+    instance: u64,
     counter: AtomicU64,
     timeout: Duration,
 }
@@ -581,6 +617,7 @@ impl RemoteApprovalGate {
         Self {
             frames,
             pending,
+            instance: SCOPE_INSTANCES.fetch_add(1, Ordering::Relaxed),
             counter: AtomicU64::new(0),
             timeout,
         }
@@ -598,7 +635,11 @@ impl ApprovalGate for RemoteApprovalGate {
         if self.pending.is_cancelled() {
             return ScopeDecision::Abort;
         }
-        let request_id = format!("scope-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let request_id = format!(
+            "scope-{}-{}",
+            self.instance,
+            self.counter.fetch_add(1, Ordering::Relaxed)
+        );
         let (tx, rx) = oneshot::channel();
         if !self.pending.register_scope_review(request_id.clone(), tx) {
             return ScopeDecision::Abort;
@@ -992,6 +1033,87 @@ mod tests {
             TurnRef::new("turn-remotetest"),
         );
         (sink, rx, pending)
+    }
+
+    /// The parent's tool port and a sub-agent's, over one turn's registry,
+    /// must not mint the same request id (#1496).
+    ///
+    /// `run_session` builds exactly this pair — `session.rs` constructs one
+    /// executor for the turn and a second for the sub-agent view, both over
+    /// the same [`Pending`]. With a bare per-instance counter both start at
+    /// zero, `register_tool`'s `HashMap::insert` replaces the first entry, and
+    /// the host's answer for `tool-0` resolves whichever registered last while
+    /// the displaced waiter wakes to a dropped sender. The assertion that
+    /// fails first on the old code is the id inequality; the two that follow
+    /// are the consequence worth naming — each caller gets *its own* answer,
+    /// not the other's.
+    #[tokio::test]
+    async fn two_tool_ports_sharing_a_turn_do_not_collide_on_request_ids() {
+        let (sink, mut rx, pending) = live_channel();
+        let parent = RemoteToolExecutor::new(
+            Vec::new(),
+            sink.clone(),
+            pending.clone(),
+            Duration::from_secs(5),
+            None,
+        );
+        let child = RemoteToolExecutor::new(
+            Vec::new(),
+            sink,
+            pending.clone(),
+            Duration::from_secs(5),
+            None,
+        );
+
+        let parent_call =
+            tokio::spawn(async move { parent.execute("echo", &serde_json::json!({})).await });
+        let ServerFrame::ToolRequest {
+            request_id: first, ..
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("expected the parent's tool request frame");
+        };
+        let child_call =
+            tokio::spawn(async move { child.execute("echo", &serde_json::json!({})).await });
+        let ServerFrame::ToolRequest {
+            request_id: second, ..
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("expected the sub-agent's tool request frame");
+        };
+
+        assert_ne!(
+            first, second,
+            "two executors over one Pending minted the same request id, so one \
+             registration silently replaced the other"
+        );
+
+        // Answer each by its own id, distinguishably.
+        pending
+            .resolve_tool(
+                &first,
+                ToolOutput::Ok {
+                    content: "for-the-parent".to_string(),
+                },
+            )
+            .expect("the parent's request is still registered");
+        pending
+            .resolve_tool(
+                &second,
+                ToolOutput::Ok {
+                    content: "for-the-sub-agent".to_string(),
+                },
+            )
+            .expect("the sub-agent's request is still registered");
+
+        assert!(
+            matches!(parent_call.await.unwrap(), ToolOutput::Ok { content } if content == "for-the-parent"),
+            "the parent must receive the answer addressed to the parent"
+        );
+        assert!(
+            matches!(child_call.await.unwrap(), ToolOutput::Ok { content } if content == "for-the-sub-agent"),
+            "the sub-agent must receive the answer addressed to the sub-agent"
+        );
     }
 
     /// A scope review the host approves round-trips into

--- a/docs/spec/serve-surface.md
+++ b/docs/spec/serve-surface.md
@@ -575,7 +575,11 @@ per-step checkpoint and crash-resume. This is ADR-033 §6 item 1 and §4.3.
   connection loses whatever was streamed while it was down.
 - **Reverse RPC (host → engine):** the engine emits a dedicated
   `ServerFrame::ToolRequest` / `ServerFrame::ProviderRequest` carrying a
-  `request_id` (a per-turn counter — `tool-0`, `prov-0`, …); the host runs the
+  `request_id` (`<port>-<instance>-<counter>` — `tool-0-0`, `prov-1-3`, …:
+  one turn can hold several ports of a kind, so the instance tag is what keeps
+  a sub-agent's requests from colliding with the parent's in the turn's
+  registry. The id is **opaque to the host** — echo it back, never parse it);
+  the host runs the
   governed work and POSTs the result back to
   `/v1/turns/{id}/{tool-result,provider-result}` with that `request_id`. The
   engine's `RemoteToolExecutor::execute` awaits a per-`request_id` oneshot.


### PR DESCRIPTION
## What & why

`RemoteToolExecutor::dispatch` minted request ids as `tool-{counter}` from a per-instance
`AtomicU64` starting at zero, and `run_session` builds **two** executors over the **same**
`Pending` registry — the parent's (`session.rs:661`) and the sub-agent view's (`session.rs:722`).
Both therefore minted `tool-0`.

`Pending::register_tool` inserts through `HashMap::insert`, which *replaces* on collision. So:

1. the displaced oneshot sender drops,
2. its waiter wakes with `serve host dropped the tool call without answering`, and
3. the host's single answer for `tool-0` resolves whichever request registered last.

A sub-agent could be handed the parent's tool result. That is silent cross-boundary
corruption, not a stall.

This is precisely the hazard `RemoteProvider` grew its `instance` field to remove in #1297 —
with the reasoning written out in the same file (`remote.rs:139-147`). The tool port was left
without it.

Closes #1496

## The fix

Mint `tool-{instance}-{counter}` from a process-wide `TOOL_INSTANCES`, mirroring the provider
port exactly rather than inventing a second scheme.

Two things beyond the literal report, both deliberate:

- **`RemoteApprovalGate` gets the tag too.** It has the identical shape and is safe today only
  because `pipeline_run` happens to build exactly one — which is the state the tool port was in
  before a sub-agent grew it a second executor. "Unique because only one exists" is a property of
  the call sites, and call sites are what changed underneath the tool port. After this, uniqueness
  holds because of how the id is constructed. `RemoteVerificationRunner` already drew from a
  process-wide static (`VERIFY_CALL_INSTANCES`) and needed no change, so all four reverse-RPC
  ports now carry the same guarantee for the same reason.
- **The spec text was already wrong.** `docs/spec/serve-surface.md:578` documented the id as
  "a per-turn counter — `tool-0`, `prov-0`, …", which had been stale for `prov` since #1297.

## Not a wire-contract change

The `request_id` is opaque to the host: the engine emits it on the request frame and the host
POSTs it back verbatim to `/v1/turns/{id}/tool-result`. Nothing parses it. The spec now says so
explicitly, because that property is what makes the format free to change — it was true but
unstated, which is how it nearly became a compatibility question. `check-wire-schema` passes
unchanged; no exported type moved.

## The witness

- [x] Fails on `main`, passes here

`two_tool_ports_sharing_a_turn_do_not_collide_on_request_ids` builds the exact pair `run_session`
builds — two executors over one `Pending` — dispatches on each, then answers each by its own id
with a distinguishable payload. On the old code it fails at the first assertion:

```text
assertion `left != right` failed: two executors over one Pending minted the same request id,
so one registration silently replaced the other
  left: "tool-0"
 right: "tool-0"
```

Verified by reverting only the id format and re-running. The two assertions after it are the
consequence worth naming: each caller must receive *its own* answer, not the other's.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-serve --all-targets -D warnings`
- [x] `cargo test -p stella-serve` — 163 lib + every integration suite, 0 failures
- [x] `make guards` — all green, including `check-wire-schema` and `check-file-size`
- [x] `Closes #1496` in this description and as a commit trailer

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Ensure reverse-RPC request IDs for tool and approval ports are globally unique per instance to prevent collisions between parent and sub-agent sessions.

Bug Fixes:
- Prevent tool reverse-RPC request ID collisions when multiple executors share the same Pending registry by tagging IDs with an instance component.
- Avoid potential cross-session approval scope ID collisions by introducing instance-tagged scope request IDs.

Enhancements:
- Align tool and approval reverse-RPC ID schemes with the existing provider scheme using process-wide instance counters for consistency.
- Clarify the serve surface specification that reverse-RPC request IDs are opaque `<port>-<instance>-<counter>` values and must be echoed, not parsed.

Tests:
- Add a regression test ensuring two tool executors sharing a turn do not mint colliding request IDs and each receives its own response.