### PR TITLE
fix(stella-pipeline): stop an isolated candidate escaping its workspace, and stamp an uncorroborated pass as an abstention

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -21,8 +21,11 @@
 //! the shadow in a private commit. Adoption requires the shadow to remain
 //! byte-identical to that seal, diffs the immutable baseline against that
 //! exact verified commit, and applies the result in one `git apply`. The
-//! worker cannot race verification with adoption, and a file the user edited
-//! mid-run fails the whole adoption loudly instead of half-applying.
+//! worker cannot race verification with adoption, and a real tree that no
+//! longer matches what the candidate started from fails the whole adoption
+//! loudly instead of half-applying — naming which of the two divergences it
+//! was, a user edit or a candidate that wrote outside its snapshot (see
+//! [`adopt::PathDivergence`]).
 //!
 //! # What a candidate's engine can reach
 //!
@@ -95,7 +98,10 @@ use crate::agent::{
 mod adopt;
 mod snapshot_gaps;
 mod witness_tools;
-use adopt::{attach_diffs, attach_numstat, conflict_paths_from_stderr, parse_name_status};
+use adopt::{
+    PathDivergence, attach_diffs, attach_numstat, conflict_paths_from_stderr, describe_divergence,
+    parse_name_status,
+};
 use witness_tools::WitnessToolExecutor;
 
 /// The commit identity for snapshot plumbing commits (which exist only
@@ -134,6 +140,13 @@ const ADOPT_CACHE_EXCLUDES: &[&str] = &[
 /// Shadow names carry pid + a process-wide counter (the `verify_done`
 /// pattern): concurrent candidates must never collide on a path.
 static SHADOW_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// The blob id a `hash-object` / `rev-parse <rev>:<path>` probe reported, or
+/// `None` when the probe failed — which is how "that path is absent in that
+/// state" arrives, since both commands error rather than print an empty id.
+fn blob_id(probe: Result<String, String>) -> Option<String> {
+    probe.ok().map(|id| id.trim().to_string())
+}
 
 /// One git command against `repo` through the fleet's [`SystemGitCli`]
 /// (explicit `-C` targeting, hook-exported `GIT_*` env scrubbed, no
@@ -832,14 +845,77 @@ impl GitCandidateWorkspace {
         match apply {
             Ok(out) if out.success => Ok(changes),
             // `git apply` verifies every hunk's preimage before writing
-            // anything, so a rejection means the real tree changed under us
-            // (user edits mid-run) — and NOTHING was applied.
-            Ok(out) => Err(fail(
-                format!("`git apply` rejected the patch: {}", out.stderr.trim()),
-                conflict_paths_from_stderr(&out.stderr, &changes),
-            )),
+            // anything, so a rejection means the real tree is not the tree this
+            // patch was built against — and NOTHING was applied.
+            //
+            // WHICH divergence it is, git cannot say, and the module used to
+            // guess: "the real tree changed under us (user edits mid-run)". The
+            // guess is wrong in the case that matters most, where an isolated
+            // candidate wrote through to the real tree and its own bytes are
+            // what the patch now collides with. So the precondition is stated
+            // explicitly here rather than inferred from the failure.
+            //
+            // Run only on the failure path, deliberately. A pre-check would pay
+            // on every successful adoption for an answer `git apply` already
+            // gives atomically — and, worse, could pass and then be contradicted
+            // by the apply, since the tree can move in between. The apply's own
+            // preimage verification IS the precondition test; what was missing
+            // was the attribution of its result, which is exactly what can be
+            // computed after the fact against a tree nothing has written to.
+            Ok(out) => {
+                let paths = conflict_paths_from_stderr(&out.stderr, &changes);
+                let git_said = format!("`git apply` rejected the patch: {}", out.stderr.trim());
+                let reason = match self.attribute_conflict(&paths, &sealed).await {
+                    Some(attribution) => format!("{attribution}. {git_said}"),
+                    None => git_said,
+                };
+                Err(fail(reason, paths))
+            }
             Err(e) => Err(fail(e.to_string(), all_paths())),
         }
+    }
+
+    /// Name what actually broke the adoption precondition, by comparing the
+    /// real tree's current bytes at each conflicting path against the two
+    /// states this candidate knows: the baseline it snapshotted and the commit
+    /// it sealed. See [`PathDivergence`] for why those two answer the question
+    /// git's stderr cannot.
+    ///
+    /// Best-effort throughout: every probe that fails leaves its side `None`,
+    /// which classifies as "not the problem". A path this cannot read is one it
+    /// stays quiet about, so an unreadable tree degrades to git's own message
+    /// rather than inventing an attribution — the misleading claim is what this
+    /// exists to remove, and replacing it with a differently misleading one
+    /// would be no better.
+    async fn attribute_conflict(&self, paths: &[String], sealed: &str) -> Option<String> {
+        // Three cheap `git` calls per path, on a path already known to be
+        // failing. Bounded so a patch conflicting on hundreds of files cannot
+        // fork hundreds of processes while reporting an error.
+        const MAX_EXAMINED: usize = 24;
+        let examined = paths.len().min(MAX_EXAMINED);
+        let mut classified = Vec::with_capacity(examined);
+        for path in paths.iter().take(examined) {
+            // `--path` so the clean filter is applied exactly as it was when
+            // the blob was written; without it a repo with `.gitattributes`
+            // filters would hash raw bytes and every path would look diverged.
+            let real = blob_id(
+                git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await,
+            );
+            let baseline = blob_id(
+                git(&self.dir, &["rev-parse", &format!("{}:{path}", self.baseline)]).await,
+            );
+            let sealed_blob =
+                blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);
+            classified.push((
+                path.clone(),
+                PathDivergence::classify(
+                    real.as_deref(),
+                    baseline.as_deref(),
+                    sealed_blob.as_deref(),
+                ),
+            ));
+        }
+        describe_divergence(&classified, paths.len() > examined)
     }
 }
 

--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -898,11 +898,14 @@ impl GitCandidateWorkspace {
             // `--path` so the clean filter is applied exactly as it was when
             // the blob was written; without it a repo with `.gitattributes`
             // filters would hash raw bytes and every path would look diverged.
-            let real = blob_id(
-                git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await,
-            );
+            let real =
+                blob_id(git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await);
             let baseline = blob_id(
-                git(&self.dir, &["rev-parse", &format!("{}:{path}", self.baseline)]).await,
+                git(
+                    &self.dir,
+                    &["rev-parse", &format!("{}:{path}", self.baseline)],
+                )
+                .await,
             );
             let sealed_blob =
                 blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -64,6 +64,136 @@ pub(crate) fn conflict_paths_from_stderr(stderr: &str, changes: &[AdoptedChange]
     paths
 }
 
+/// Where the real tree stands at one path whose hunk `git apply` refused,
+/// relative to the two states adoption already knows: `baseline`, the tree the
+/// candidate snapshotted when it started, and `sealed`, the tree it finished
+/// with.
+///
+/// # Why the adoption error needs this at all
+///
+/// `git apply` verifies every preimage before writing anything, so a rejection
+/// always means "the real tree is not what this patch was built against". For a
+/// long time the module read that as one thing — the user edited a file
+/// mid-run — and said so. It is not one thing, and the other case is the more
+/// interesting one: a candidate that wrote *through* to the real tree, `cp`ing
+/// its answer to the absolute path the task named instead of leaving it in its
+/// snapshot. Then git reports `already exists in working directory` and the
+/// error blames a user who did nothing, while the actual defect — an isolated
+/// candidate escaping its isolation — goes unnamed and unfixed.
+///
+/// The two are distinguishable, because the candidate's own output is a
+/// signature. Nothing else on the machine produces the exact sealed blob for
+/// that path; if the real tree holds those bytes and the baseline did not, the
+/// candidate put them there. That is what this enum records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathDivergence {
+    /// The real tree already holds the candidate's OWN sealed bytes at a path
+    /// whose baseline differed. The candidate wrote outside its workspace.
+    CandidateWroteOutside,
+    /// The real tree moved off the baseline, and not toward the candidate's
+    /// result — something outside this run changed it, most often the user.
+    ChangedUnderTheRun,
+    /// The real tree still matches what the candidate started from. Not what
+    /// the rejection was about; carried so a caller can report it as ruled out
+    /// rather than silently dropping it.
+    Matches,
+}
+
+impl PathDivergence {
+    /// Classify one path from three blob identities: what the real tree holds
+    /// now, what the candidate started from, and what it sealed. `None` means
+    /// the file is absent in that state.
+    ///
+    /// A path the real tree does not have cannot be the thing blocking a patch
+    /// that writes it, so absence is always [`Self::Matches`] — the interesting
+    /// asymmetry is the other direction, where a path absent from the baseline
+    /// and present in the real tree with the sealed bytes is the escape.
+    pub(crate) fn classify(
+        real: Option<&str>,
+        baseline: Option<&str>,
+        sealed: Option<&str>,
+    ) -> Self {
+        let Some(real) = real else {
+            return Self::Matches;
+        };
+        if Some(real) == baseline {
+            return Self::Matches;
+        }
+        // Ordered before the generic divergence on purpose: a real tree holding
+        // the sealed bytes satisfies BOTH conditions, and only the specific
+        // reading is actionable.
+        if Some(real) == sealed {
+            return Self::CandidateWroteOutside;
+        }
+        Self::ChangedUnderTheRun
+    }
+}
+
+/// The sentence that leads an adoption failure, given what each conflicting
+/// path turned out to be. `None` when nothing diverged — then git's own stderr
+/// is the better account and this must not talk over it.
+///
+/// The escape is reported first and unconditionally when present, even
+/// alongside ordinary user edits: it is a defect in the run rather than a fact
+/// about the user's tree, and it is the one of the two that will recur on every
+/// future turn until it is fixed.
+pub(crate) fn describe_divergence(
+    classified: &[(String, PathDivergence)],
+    truncated: bool,
+) -> Option<String> {
+    let named = |want: PathDivergence| -> Vec<&str> {
+        classified
+            .iter()
+            .filter(|(_, divergence)| *divergence == want)
+            .map(|(path, _)| path.as_str())
+            .collect()
+    };
+    let escaped = named(PathDivergence::CandidateWroteOutside);
+    let edited = named(PathDivergence::ChangedUnderTheRun);
+    if escaped.is_empty() && edited.is_empty() {
+        return None;
+    }
+    let mut reason = String::new();
+    if !escaped.is_empty() {
+        reason.push_str(&format!(
+            "the candidate wrote outside its workspace: the real tree already holds this \
+             candidate's own final bytes at {} — so it did not confine its work to its \
+             snapshot, and the patch cannot re-create what is already there",
+            render_paths(&escaped)
+        ));
+    }
+    if !edited.is_empty() {
+        if !reason.is_empty() {
+            reason.push_str("; additionally, ");
+        }
+        reason.push_str(&format!(
+            "the real tree changed under the run at {} (content that is neither the state \
+             the candidate started from nor the state it produced)",
+            render_paths(&edited)
+        ));
+    }
+    if truncated {
+        reason.push_str(" (only the first conflicting paths were examined)");
+    }
+    Some(reason)
+}
+
+/// Up to four paths inline, then a count — an adoption that conflicts on a
+/// hundred files must not paste a hundred paths into one error line.
+fn render_paths(paths: &[&str]) -> String {
+    const INLINE: usize = 4;
+    let shown = paths
+        .iter()
+        .take(INLINE)
+        .map(|path| format!("`{path}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    match paths.len().checked_sub(INLINE) {
+        Some(rest) if rest > 0 => format!("{shown} (+{rest} more)"),
+        _ => shown,
+    }
+}
+
 /// Attach each file's own slice of a multi-file `git diff` to its change.
 ///
 /// Splitting on `diff --git` is what makes the per-file attribution possible,
@@ -320,6 +450,127 @@ deleted file mode 100644
         attach_numstat(&mut changes, "4\t5\tmy dir/b c.rs\0");
         assert_eq!((changes[0].added, changes[0].removed), (1, 0));
         assert_eq!((changes[1].added, changes[1].removed), (4, 5));
+    }
+
+    /// The escape, and the discriminator that identifies it: the real tree
+    /// holds bytes the candidate sealed at a path the candidate started
+    /// without. Nothing else produces that blob.
+    #[test]
+    fn the_real_tree_holding_the_sealed_bytes_is_the_candidate_writing_outside() {
+        assert_eq!(
+            // Absent from the baseline, present in the real tree, and equal to
+            // what the candidate sealed — the `cp` out of the workspace.
+            PathDivergence::classify(Some("sealed"), None, Some("sealed")),
+            PathDivergence::CandidateWroteOutside
+        );
+        assert_eq!(
+            // Same reading when the path did exist before and the real tree now
+            // carries the candidate's version of it.
+            PathDivergence::classify(Some("sealed"), Some("base"), Some("sealed")),
+            PathDivergence::CandidateWroteOutside
+        );
+    }
+
+    /// The case the module used to assume was the only one. It must survive
+    /// intact: content that is neither what the candidate started from nor what
+    /// it produced came from outside the run.
+    #[test]
+    fn content_from_neither_known_state_is_an_edit_under_the_run() {
+        assert_eq!(
+            PathDivergence::classify(Some("other"), Some("base"), Some("sealed")),
+            PathDivergence::ChangedUnderTheRun
+        );
+    }
+
+    #[test]
+    fn a_path_still_matching_its_baseline_is_not_the_conflict() {
+        assert_eq!(
+            PathDivergence::classify(Some("base"), Some("base"), Some("sealed")),
+            PathDivergence::Matches
+        );
+        assert_eq!(
+            PathDivergence::classify(None, None, Some("sealed")),
+            PathDivergence::Matches,
+            "a file the real tree does not have cannot be blocking a patch that writes it"
+        );
+        assert_eq!(
+            PathDivergence::classify(None, Some("base"), Some("sealed")),
+            PathDivergence::Matches,
+            "an absent real file is still not what a rejected preimage collided with"
+        );
+    }
+
+    /// A tree whose probes all failed reads as `Matches` everywhere, and then
+    /// this must stay silent — git's own stderr is a better account than an
+    /// attribution built from nothing.
+    #[test]
+    fn nothing_diverged_produces_no_attribution() {
+        let classified = vec![
+            ("a.rs".to_string(), PathDivergence::Matches),
+            ("b.rs".to_string(), PathDivergence::Matches),
+        ];
+        assert_eq!(describe_divergence(&classified, false), None);
+        assert_eq!(describe_divergence(&[], false), None);
+    }
+
+    #[test]
+    fn the_escape_is_named_first_and_never_reported_as_a_user_edit() {
+        let classified = vec![
+            (
+                "src/edited.rs".to_string(),
+                PathDivergence::ChangedUnderTheRun,
+            ),
+            ("app/vm.js".to_string(), PathDivergence::CandidateWroteOutside),
+        ];
+        let reason = describe_divergence(&classified, false).expect("a divergence is described");
+
+        let escape = reason
+            .find("wrote outside its workspace")
+            .expect("the escape is named");
+        let edit = reason
+            .find("changed under the run")
+            .expect("the user edit is still reported");
+        assert!(
+            escape < edit,
+            "the run's own defect leads; it recurs every turn until fixed: {reason}"
+        );
+        assert!(reason.contains("`app/vm.js`"), "{reason}");
+        assert!(reason.contains("`src/edited.rs`"), "{reason}");
+    }
+
+    /// The old message blamed the user unconditionally. A pure escape must not
+    /// mention a mid-run edit at all — that sentence is what sent the last
+    /// diagnosis down the wrong path.
+    #[test]
+    fn a_pure_escape_does_not_mention_a_mid_run_edit() {
+        let classified = vec![("app/vm.js".to_string(), PathDivergence::CandidateWroteOutside)];
+        let reason = describe_divergence(&classified, false).expect("described");
+        assert!(reason.contains("wrote outside its workspace"), "{reason}");
+        assert!(
+            !reason.contains("changed under the run"),
+            "nothing changed under this run — the candidate did it: {reason}"
+        );
+    }
+
+    #[test]
+    fn many_conflicting_paths_are_summarized_not_pasted() {
+        let classified: Vec<_> = (0..9)
+            .map(|i| (format!("f{i}.rs"), PathDivergence::CandidateWroteOutside))
+            .collect();
+        let reason = describe_divergence(&classified, true).expect("described");
+        assert!(
+            reason.contains("`f0.rs`") && reason.contains("`f3.rs`"),
+            "{reason}"
+        );
+        assert!(
+            !reason.contains("`f4.rs`"),
+            "only the first four are inlined: {reason}"
+        );
+        assert!(reason.contains("+5 more"), "{reason}");
+        assert!(
+            reason.contains("only the first conflicting paths were examined"),
+            "a bounded examination must say it was bounded: {reason}"
+        );
     }
 
     #[test]

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -520,7 +520,10 @@ deleted file mode 100644
                 "src/edited.rs".to_string(),
                 PathDivergence::ChangedUnderTheRun,
             ),
-            ("app/vm.js".to_string(), PathDivergence::CandidateWroteOutside),
+            (
+                "app/vm.js".to_string(),
+                PathDivergence::CandidateWroteOutside,
+            ),
         ];
         let reason = describe_divergence(&classified, false).expect("a divergence is described");
 
@@ -543,7 +546,10 @@ deleted file mode 100644
     /// diagnosis down the wrong path.
     #[test]
     fn a_pure_escape_does_not_mention_a_mid_run_edit() {
-        let classified = vec![("app/vm.js".to_string(), PathDivergence::CandidateWroteOutside)];
+        let classified = vec![(
+            "app/vm.js".to_string(),
+            PathDivergence::CandidateWroteOutside,
+        )];
         let reason = describe_divergence(&classified, false).expect("described");
         assert!(reason.contains("wrote outside its workspace"), "{reason}");
         assert!(

--- a/crates/stella-pipeline/src/candidate_narration.rs
+++ b/crates/stella-pipeline/src/candidate_narration.rs
@@ -93,6 +93,25 @@ pub(crate) fn candidate_winner_notice(best_idx: usize, n: u32, ran: u32) -> Opti
 /// A candidate that knows can reinstall; a candidate that doesn't reports the
 /// project as broken.
 ///
+/// # Why it must promise adoption, not just forbid the escape
+///
+/// Naming the root and forbidding `cd` was the whole of this notice, and it was
+/// not enough — because it described the isolation without ever describing the
+/// hand-off. A candidate reading only "work outside this root does not count"
+/// learns that its answer is trapped somewhere the user will never see it, and
+/// the *helpful* response to that belief is to deliver the answer by hand: `cp`
+/// the finished file to the absolute path the task named. That is not a model
+/// ignoring the instruction, it is a model obeying the goal under a
+/// true-sounding premise nobody corrected. It is also the one move that
+/// guarantees the loss it was trying to prevent — the out-of-band write lands
+/// in the real tree, so the winner's patch can no longer create a file that is
+/// already there and adoption fails for every path at once.
+///
+/// So the notice states the mechanism: the winner's diff is applied to the real
+/// project automatically. With that said, staying inside the root is no longer
+/// a rule the model must trust against its own reading of the task — it is the
+/// path that visibly delivers the work, and copying out is visibly redundant.
+///
 /// Appended AFTER the shared prefix, never inside it: the candidates of a
 /// fan-out share one cached prefix, so the single message that differs between
 /// them has to be last (the prompt-cache stability invariant).
@@ -105,11 +124,17 @@ pub(crate) fn messages_rooted_at(
         let root = ws.root();
         let mut notice = format!(
             "Workspace: your tools and shell are rooted at `{root}`, an isolated \
-             snapshot of the project. Only work inside this root is collected when \
-             the turn finishes. Absolute paths in the task above name the original \
-             tree; resolve them against this root instead (`/x/y` -> `{root}/x/y`). \
-             Another copy of the project may be readable elsewhere on this machine — \
-             editing it does not count, so do not `cd` out of this root."
+             snapshot of the project. Absolute paths in the task above name the \
+             original tree; resolve them against this root instead \
+             (`/x/y` -> `{root}/x/y`).\n\
+             Your work is collected for you: if this turn is chosen, everything you \
+             changed inside this root is applied to the real project automatically, \
+             at the paths the task names. You never need to copy, move, or install \
+             your result anywhere else to make it count.\n\
+             So write only inside this root. Another copy of the project may be \
+             readable elsewhere on this machine — do not `cd` out of this root and \
+             do not write to it. Work placed there is not collected, and it also \
+             breaks the automatic hand-off above, which discards this turn entirely."
         );
         let omitted = ws.omitted_paths();
         if !omitted.is_empty() {
@@ -242,8 +267,38 @@ mod tests {
             "the escape hatch that splits a turn across two trees: {notice}"
         );
         assert!(
-            notice.contains("Only work inside this root is collected"),
+            notice.contains("not collected"),
             "naming the root is not enough — say the other copy does not count: {notice}"
+        );
+    }
+
+    /// The half that removes the *motive* for the escape rather than
+    /// forbidding it again.
+    ///
+    /// A candidate told only that outside work "does not count" concludes its
+    /// answer is stranded, and the cooperative move is then to deliver it by
+    /// hand to the absolute path the task named — which is exactly the
+    /// out-of-band write that makes the winner's patch unappliable. The notice
+    /// has to state that adoption happens automatically, or the prohibition is
+    /// asking the model to leave the task undelivered.
+    #[test]
+    fn an_isolated_candidate_is_told_its_work_is_adopted_for_it() {
+        let ws = NoticeOnlyWorkspace::at("/tmp/stella_candidate_7_0");
+        let rooted = messages_rooted_at(&[CompletionMessage::user("write vm.js to /app")], Some(&ws));
+        let notice = &rooted[1].content;
+
+        assert!(
+            notice.contains("applied to the real project automatically"),
+            "the candidate must learn its work is adopted, not stranded: {notice}"
+        );
+        assert!(
+            notice.contains("never need to copy"),
+            "name the specific move the old wording invited — the `cp` out: {notice}"
+        );
+        assert!(
+            notice.contains("breaks the automatic hand-off"),
+            "writing outside is not merely uncounted, it fails adoption for the \
+             whole candidate — say the real cost: {notice}"
         );
     }
 

--- a/crates/stella-pipeline/src/candidate_narration.rs
+++ b/crates/stella-pipeline/src/candidate_narration.rs
@@ -284,7 +284,8 @@ mod tests {
     #[test]
     fn an_isolated_candidate_is_told_its_work_is_adopted_for_it() {
         let ws = NoticeOnlyWorkspace::at("/tmp/stella_candidate_7_0");
-        let rooted = messages_rooted_at(&[CompletionMessage::user("write vm.js to /app")], Some(&ws));
+        let rooted =
+            messages_rooted_at(&[CompletionMessage::user("write vm.js to /app")], Some(&ws));
         let notice = &rooted[1].content;
 
         assert!(

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2976,6 +2976,26 @@ impl<'a> Pipeline<'a> {
                                  corroboration (no flip, no green test) — {}",
                                 abstained.summary
                             );
+                            // The rung has to move with the decision. Every
+                            // other channel here already says abstention — the
+                            // score is `Unverified`, the summary leads with
+                            // UNVERIFIED, and `unverifiable()` puts
+                            // `VerificationUnavailable` on the rail — but the
+                            // snapshot was stamped `ModelJudge` above, when the
+                            // verifier answered and before this branch knew the
+                            // answer stood alone. Left there it is the one
+                            // reader-facing field that disagrees, and the
+                            // disagreement is not cosmetic: `reward::outcome_term`
+                            // reads the rung and nothing else, so it credits
+                            // `+weights.judged` to an uncorroborated pass instead
+                            // of discarding it as `Abstained` — training on
+                            // exactly the verdicts #871 exists to distrust. The
+                            // most concrete way to reach here is a warranted
+                            // witness whose baseline run came back
+                            // `infra_failure`: no toolchain, so no flip, so
+                            // nothing deterministic behind the verifier's "done".
+                            abstained.ladder =
+                                Some(Box::new(snapshot.with_rung(LadderRung::Unverifiable)));
                             self.unverifiable(&abstained.summary);
                             return state.into_verified(
                                 true,

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -304,6 +304,12 @@ enum TestScript {
     /// modelled as the runner classifies it, so a test can drive the retry
     /// without faking a signal.
     OutOfMemory,
+    /// The command never produced a real exit status because it could not be
+    /// spawned — the missing-toolchain shape (`pytest` with no Python). Its own
+    /// variant rather than a shade of [`Self::TimeOut`] because the pipeline
+    /// treats the two differently: a timeout may be worth waiting out, an
+    /// unspawnable runner will be unspawnable on every retry.
+    Infra,
     /// A pass whose stdout carries scripted runner output — for the #867
     /// fingerprint scenarios, which read test names from the tail.
     PassWith(&'static str),
@@ -457,6 +463,12 @@ impl TestRunner for ScriptedRunner {
                 stdout_tail: String::new(),
                 stderr_tail: "Killed".to_string(),
                 kind: CmdKind::OutOfMemory,
+            },
+            TestScript::Infra => CmdOutcome {
+                exit_code: -1,
+                stdout_tail: String::new(),
+                stderr_tail: "No such file or directory (os error 2)".to_string(),
+                kind: CmdKind::Infra,
             },
             TestScript::PassWith(output) => CmdOutcome {
                 exit_code: 0,

--- a/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
@@ -274,3 +274,82 @@ async fn the_demand_can_be_switched_off() {
     assert_eq!(outcome.revisions, 0, "off means no ask");
     assert_eq!(calls, 3, "triage, worker, verifier");
 }
+
+/// An uncorroborated verifier pass must be stamped `Unverifiable` on the wire,
+/// not `ModelJudge`.
+///
+/// Every other channel on this path already says abstention: the score is
+/// `Unverified`, the summary leads with UNVERIFIED, and `unverifiable()` puts
+/// `VerificationUnavailable` on the rail. The snapshot's rung was the one field
+/// left disagreeing — stamped when the verifier answered, before the branch
+/// below discovered the answer stood alone.
+///
+/// It is not a labelling nicety. `reward::outcome_term` reads the rung and
+/// nothing else: `ModelJudge` earns `+weights.judged`, while `Unverifiable`
+/// returns `DiscardReason::Abstained`. Left wrong, every pass the ladder
+/// declined to believe was fed back as a positive training signal — the exact
+/// verdicts #871's asymmetric trust exists to refuse.
+///
+/// The scenario is the one that produced it in the wild: a warranted witness
+/// whose runner is not installed. `TestScript::Infra` observes no assertion, so
+/// there is no flip and no green test, and the verifier's "done" is all that is
+/// left standing.
+#[tokio::test]
+async fn an_uncorroborated_verifier_pass_is_stamped_as_an_abstention_not_a_judgement() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("PASS — the change reads correct"),
+    ]);
+    let runner = ScriptedRunner::scripted(
+        vec![TestScript::Fail, TestScript::Infra],
+        "@@ -1 +1 @@\n-old\n+new",
+    );
+    let config = PipelineConfig {
+        test_command: Some("pytest -q".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        // The ask is a separate axis with its own tests above; switching it off
+        // keeps this scenario on the relabelling branch it is about.
+        verifier_evidence_demand: false,
+        ..PipelineConfig::default()
+    };
+
+    let (outcome, _events, _calls) = run_scenario!(provider, runner, config);
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(
+        verdict.passed && !verdict.deterministic,
+        "an unverified pass is still not a failure"
+    );
+    assert_eq!(
+        outcome.score,
+        Some(crate::candidate::CandidateScore::Unverified),
+        "the score already knew this was not a real pass"
+    );
+    assert!(
+        verdict.summary.starts_with("UNVERIFIED"),
+        "and so did the summary: {}",
+        verdict.summary
+    );
+
+    let rung = verdict
+        .ladder
+        .as_deref()
+        .expect("the verdict carries its snapshot")
+        .rung
+        .expect("a rung is stamped");
+    assert_eq!(
+        rung,
+        stella_protocol::LadderRung::Unverifiable,
+        "the rung must agree with the abstention every other channel recorded — \
+         `ModelJudge` here is what fed an uncorroborated pass into reward as a win"
+    );
+    assert!(
+        matches!(
+            crate::reward::outcome_term(rung, verdict.passed, &Default::default()),
+            Err(crate::reward::DiscardReason::Abstained)
+        ),
+        "the consequence that makes the rung load-bearing: this trajectory must \
+         be discarded, never credited"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -196,7 +196,19 @@ impl<'a> Pipeline<'a> {
 
         let mut messages = vec![
             CompletionMessage::system(WITNESS_SYSTEM_PROMPT),
-            CompletionMessage::user(witness_prompt(goal, frames, &structure)),
+            CompletionMessage::user(witness_prompt(
+                goal,
+                frames,
+                &structure,
+                // Only a command that PARSED is offered as an anchor. An
+                // unparseable one names no runner the author could copy, and
+                // the run already refuses before reaching here.
+                self.configured_test
+                    .as_ref()
+                    .ok()
+                    .and_then(Option::as_ref)
+                    .and(self.config.test_command.as_deref()),
+            )),
         ];
         // Both tallies are local and discarded, on the same reasoning: they
         // measure the *witness author*, and the ladder's channels are about

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -618,7 +618,10 @@ pub fn witness_prompt(
          - End your reply with exactly one line:\n\
          TEST_COMMAND: <the direct, artifact-specific test command>\n",
     );
-    if let Some(command) = project_test_command.map(str::trim).filter(|c| !c.is_empty()) {
+    if let Some(command) = project_test_command
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+    {
         // The strongest available evidence that a runner exists, and the only
         // one that is a fact rather than an inference: this project names this
         // command, so its toolchain is installed here. Given first, above the

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -578,7 +578,12 @@ pub fn witness_identity_matches(
 /// hard requirements — new file only, must fail now, no production edits,
 /// marker line — are the parts [`parse_witness_command`] and the pipeline's
 /// fail-check enforce mechanically; the prose is guidance.
-pub fn witness_prompt(goal: &str, recall: &[RecalledFrame], repo_structure: &str) -> String {
+pub fn witness_prompt(
+    goal: &str,
+    recall: &[RecalledFrame],
+    repo_structure: &str,
+    project_test_command: Option<&str>,
+) -> String {
     let mut s = String::from(
         "You are the WITNESS AUTHOR for a coding agent. Write a witness test: a minimal \
          test that FAILS on the current code and will PASS once the goal below is correctly \
@@ -586,7 +591,16 @@ pub fn witness_prompt(goal: &str, recall: &[RecalledFrame], repo_structure: &str
          Hard requirements:\n\
          - Create ONE NEW test file. Never modify existing files, and never touch \
          production code — the implementation is someone else's job.\n\
-         - Put it where the language's runner collects it. Rust integration tests MUST \
+         - CHOOSE A RUNNER THIS REPOSITORY ALREADY USES. You cannot execute anything in \
+         this role, so you cannot discover a missing toolchain — and a command whose \
+         runner is not installed does not fail the test, it produces NO observation at \
+         all, which discards your witness and leaves the work unverified. Pick the \
+         ecosystem the repository listing below evidences (a manifest such as \
+         `Cargo.toml`, `package.json`, `pyproject.toml`/`setup.py`, `go.mod`, or a \
+         `*.csproj`, plus existing tests written for it) and match the conventions of \
+         the tests already there. If the listing evidences no test runner at all, say \
+         so in prose and emit no TEST_COMMAND line rather than guessing one.\n\
+         - Put it where that runner collects it. Rust integration tests MUST \
          live in `tests/` (cargo cannot run a test file under `src/`); Python, Vitest, Go \
          and .NET may use their filename conventions.\n\
          - The test must fail NOW for the RIGHT reason (it exercises the missing/broken \
@@ -604,6 +618,18 @@ pub fn witness_prompt(goal: &str, recall: &[RecalledFrame], repo_structure: &str
          - End your reply with exactly one line:\n\
          TEST_COMMAND: <the direct, artifact-specific test command>\n",
     );
+    if let Some(command) = project_test_command.map(str::trim).filter(|c| !c.is_empty()) {
+        // The strongest available evidence that a runner exists, and the only
+        // one that is a fact rather than an inference: this project names this
+        // command, so its toolchain is installed here. Given first, above the
+        // file listing, because it settles the choice the listing can only hint
+        // at.
+        s.push_str(&format!(
+            "\n## This project's own test command\n`{command}`\nIts runner is installed \
+             and working here. Author for that runner, and shape your TEST_COMMAND like \
+             this one — narrowed to your single new test.\n"
+        ));
+    }
     if !repo_structure.trim().is_empty() {
         s.push_str("\n## Repository structure\n");
         s.push_str(repo_structure.trim());
@@ -1168,7 +1194,7 @@ mod tests {
             id: None,
             content_digest: None,
         }];
-        let p = witness_prompt("fix the retry bug", &recall, "src/\n  lib.rs");
+        let p = witness_prompt("fix the retry bug", &recall, "src/\n  lib.rs", None);
         assert!(p.contains("TEST_COMMAND:"));
         assert!(p.contains("fix the retry bug"));
         assert!(p.contains("src/"));
@@ -1179,6 +1205,53 @@ mod tests {
         // costs the same round trip the screen exists to save.
         assert!(p.contains("assert_eq!(2, 2)"), "{p}");
         assert!(p.contains("REFUSED"), "{p}");
+    }
+
+    /// The author has `read_file` and one create — no execution at all — so it
+    /// cannot discover that the runner it picked is not installed. A command
+    /// naming an absent toolchain yields `infra_failure`, which observes NO
+    /// assertion and discards the witness entirely, so the prompt has to say
+    /// that choosing a runner is a decision made from evidence, not a default.
+    #[test]
+    fn the_author_is_told_it_cannot_probe_and_must_pick_an_evidenced_runner() {
+        let p = witness_prompt("add a parser", &[], "go.mod\nmain.go", None);
+        assert!(
+            p.contains("CHOOSE A RUNNER THIS REPOSITORY ALREADY USES"),
+            "{p}"
+        );
+        assert!(
+            p.contains("cannot execute anything in this role"),
+            "the author must know its own blindness, not just the rule: {p}"
+        );
+        assert!(
+            p.contains("NO observation at all"),
+            "the cost has to be named — a missing runner is not a failing test: {p}"
+        );
+        assert!(
+            p.contains("emit no TEST_COMMAND line rather than guessing"),
+            "with no evidenced runner, abstaining beats a fabricated command: {p}"
+        );
+    }
+
+    /// The one anchor that is a fact rather than an inference: this project
+    /// names this command, so its runner is installed on this machine.
+    #[test]
+    fn a_configured_test_command_anchors_the_authors_runner_choice() {
+        let anchored = witness_prompt("add a parser", &[], "go.mod", Some("go test ./..."));
+        assert!(anchored.contains("`go test ./...`"), "{anchored}");
+        assert!(
+            anchored.contains("Its runner is installed and working here"),
+            "the whole value of the anchor is that it is observed, not guessed: {anchored}"
+        );
+
+        // Nothing to anchor on: the section must be absent rather than empty.
+        let bare = witness_prompt("add a parser", &[], "go.mod", None);
+        assert!(!bare.contains("This project's own test command"), "{bare}");
+        let blank = witness_prompt("add a parser", &[], "go.mod", Some("   "));
+        assert!(
+            !blank.contains("This project's own test command"),
+            "a whitespace command anchors nothing: {blank}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Four defects found while diagnosing a Terminal-Bench 2.1 run in which an isolated candidate `cp`'d its answer into `/app`, escaped its snapshot, and broke adoption for the whole turn.

### 1. The isolation notice gave the candidate a reason to escape

`messages_rooted_at` told the candidate that work outside its root "does not count" — true, and read as *your answer is trapped where nobody will see it*. The cooperative response to that belief is to deliver the answer by hand to the absolute path the task named, which is exactly the out-of-band write that makes the winner's patch unappliable.

The notice now states the mechanism it had been omitting: everything changed inside the root is applied to the real project automatically if this turn is chosen. Staying inside stops being a rule to obey against the task's own wording and becomes the path that visibly delivers the work.

### 2. Adoption blamed the user for the candidate's escape

`git apply` verifies every preimage, so a rejection means "the real tree is not what this patch was built against" — and the module read that as one thing, a mid-run user edit, and said so.

They are distinguishable. The candidate's own output is a signature: nothing else on the machine produces the exact sealed blob for a path. `PathDivergence::classify` compares the real tree's current blob against both the baseline the candidate snapshotted and the commit it sealed, and `describe_divergence` leads with the escape when it is present.

Runs **only on the failure path**, deliberately — a pre-check would tax every successful adoption for an answer `git apply` already gives atomically, and could pass and then be contradicted by the apply since the tree can move in between. The apply's own preimage verification *is* the precondition test; what was missing was the attribution of its result.

### 3. An uncorroborated pass was fed to reward as a win

When the verifier passes with nothing deterministic behind it, the pipeline already scored `Unverified`, already led the summary with `UNVERIFIED`, and already emitted `VerificationUnavailable`. But `evidence.ladder` was stamped `ModelJudge` a few lines earlier, before that branch knew the answer stood alone.

`reward::outcome_term` reads the rung and nothing else: `ModelJudge` earns `+weights.judged`, `Unverifiable` returns `DiscardReason::Abstained`. So every pass the ladder declined to believe was training signal — the exact verdicts #871's asymmetric trust exists to refuse. The rung now moves with the decision.

The most concrete way to reach that state is (4).

### 4. The witness author picked runners it could not verify exist

Its tool surface is `read_file` plus one atomic create — no execution at all, by design — so it cannot discover that `pytest` has no Python behind it. A missing runner does not fail the test; it produces `CmdKind::Infra`, which observes no assertion, discards the witness, and leaves the turn on the unauthored ladder.

`witness_prompt` now says that plainly, requires a runner the repository evidences, tells the author to emit no `TEST_COMMAND` rather than guess when nothing is evidenced, and injects the project's own configured test command as an anchor when one exists — the only available evidence that a runner is genuinely installed.

## Witness tests

Each behaviour change carries a test that fails on `main`:

| Test | Pins |
|---|---|
| `an_isolated_candidate_is_told_its_work_is_adopted_for_it` | the adoption promise, and that the cost of writing outside is named |
| `the_real_tree_holding_the_sealed_bytes_is_the_candidate_writing_outside` | the escape discriminator |
| `a_pure_escape_does_not_mention_a_mid_run_edit` | the old message's wrong attribution cannot come back |
| `the_escape_is_named_first_and_never_reported_as_a_user_edit` | ordering: the run's own defect leads |
| `an_uncorroborated_verifier_pass_is_stamped_as_an_abstention_not_a_judgement` | the rung, **and** that `outcome_term` discards rather than credits |
| `the_author_is_told_it_cannot_probe_and_must_pick_an_evidenced_runner` | the author learns its own blindness |
| `a_configured_test_command_anchors_the_authors_runner_choice` | the anchor appears only when there is one |

Plus `many_conflicting_paths_are_summarized_not_pasted`, `nothing_diverged_produces_no_attribution`, `content_from_neither_known_state_is_an_edit_under_the_run`, `a_path_still_matching_its_baseline_is_not_the_conflict`.

`TestScript::Infra` was added to the pipeline test harness to model an unspawnable runner without faking a signal.

## Verification

- `cargo test -p stella-pipeline --lib` — 504 passed, 0 failed
- `cargo test -p stella-cli --bins candidate_ws` — 41 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p stella-pipeline -p stella-cli --all-targets -- -D warnings` — clean

Global guards (`file-size`, `wire-schema`, `doc-links`, `invariants`) and rustdoc were not run locally. No new files and no `AgentEvent`/wire-type fields are added, so I expect them unaffected — stating that as an expectation, not a verified fact.

## Not fixed here

Both filed as handoffs rather than left in a transcript:

- #1538 — the candidate's `bash` is unconfined (sandbox removed in #1300), so isolation is still enforced only by prompt. This PR removes the motive and names the escape after the fact; it does not remove the capability.
- #1539 — the witness author still cannot probe a toolchain. This PR takes the prompt-level half; the pipeline-side runner probe is the structural fix.

Refs #1538
Refs #1539

## Summary by Sourcery

Clarify isolation and adoption behavior for candidate workspaces, attribute git apply failures to either user edits or candidate escapes, and ensure unverifiable verifier passes and witness prompts are treated as abstentions with explicit runner evidence guidance.

Bug Fixes:
- Prevent isolated candidates from being encouraged to write outside their workspace by explicitly promising automatic adoption of in-root changes.
- Differentiate git apply failures caused by user edits from those caused by candidates writing directly to the real tree, and report escapes first without misattributing them to users.
- Treat uncorroborated verifier passes as abstentions by aligning ladder rungs and reward outcomes with existing Unverified scoring.

Enhancements:
- Augment witness author prompts to require evidence-backed test runners, optionally anchored by a configured project test command, and document the constraints more explicitly.
- Introduce richer adoption diagnostics that summarize conflicting paths without flooding error messages, including new tests covering divergence classification and messaging behavior.

Tests:
- Add tests covering path divergence classification, adoption failure messaging, isolation notice wording, witness prompt guidance, unspawnable test runners, and unverifiable verifier passes.