### PR TITLE
docs(serve): finish the request-id correction #1535 started

### DIFF
--- a/docs/spec/serve-surface.md
+++ b/docs/spec/serve-surface.md
@@ -105,7 +105,8 @@ destination, and which a client written from it gets wrong:
 - **Reverse RPC is keyed by `request_id` on its own frame types**, not by a
   `call_id` on a `tool_start` / `scope_review` / `ask_user` `AgentEvent`. The
   engine emits dedicated `tool_request` / `provider_request` `ServerFrame`
-  variants whose ids are per-turn counters (`prov-0`, `tool-0`, …). This is the
+  variants whose ids are `<port>-<instance>-<counter>` (`prov-1-3`, `tool-0-0`,
+  …) and are opaque to the host — echo them back, never parse them. This is the
   single most dangerous drift in this document for anyone mirroring it in
   another language: it names the wrong field on the wrong frame.
 


### PR DESCRIPTION
#1535 changed the reverse-RPC id format to `<port>-<instance>-<counter>` and updated the routing table, but left the identical claim in the "Reverse RPC is keyed by `request_id`" bullet, which still described the ids as "per-turn counters (`prov-0`, `tool-0`, …)".

That bullet is the one place the document warns it is *"the single most dangerous drift in this document for anyone mirroring it in another language"* — which makes it the worst place in the file to leave a stale format.

It now matches, and states the property that makes the format safe to change at all: the id is **opaque to the host**, which echoes it back and never parses it.

Docs-only; no witness needed. `make guards` green (`check-doc-links`, `check-invariants`).

Refs #1496

## Summary by Sourcery

Documentation:
- Update the serve surface spec to describe reverse RPC request_id values as `<port>-<instance>-<counter>` and explicitly note that they are opaque to the host.