### PR TITLE
Unbreak main: record #1540's growth in the ratchet baseline

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2270 crates/stella-cli/src/agent.rs
 1754 crates/stella-cli/src/agent/tests.rs
-1629 crates/stella-cli/src/candidate_ws.rs
+1708 crates/stella-cli/src/candidate_ws.rs
 4757 crates/stella-cli/src/command_deck.rs
 1506 crates/stella-cli/src/fleet_cmd.rs
 2129 crates/stella-core/src/bus.rs
@@ -27,8 +27,8 @@
 2076 crates/stella-model/src/openai.rs
 1542 crates/stella-model/src/zai.rs
 1815 crates/stella-model/src/zai/tests.rs
-3874 crates/stella-pipeline/src/pipeline.rs
-2666 crates/stella-pipeline/src/pipeline/tests.rs
+3894 crates/stella-pipeline/src/pipeline.rs
+2678 crates/stella-pipeline/src/pipeline/tests.rs
 2950 crates/stella-protocol/src/event.rs
 2074 crates/stella-store/src/lib.rs
 2268 crates/stella-store/src/tests.rs


### PR DESCRIPTION
Main's file-size gate is red — and with it every open PR's merge head, #1529 included: #1540 grew three grandfathered files past their ceilings and merged without moving them.

| File | Ceiling | Actual |
|---|---:|---:|
| `crates/stella-cli/src/candidate_ws.rs` | 1629 | **1708** |
| `crates/stella-pipeline/src/pipeline.rs` | 3874 | **3894** |
| `crates/stella-pipeline/src/pipeline/tests.rs` | 2666 | **2678** |

This PR records the exact actuals so the gate reflects reality again. **Saying it out loud, per CLAUDE.md: a raised ceiling to turn a gate green is an expedient, and this PR is exactly that.** The correct fix — extracting #1540's additions into sibling modules so all three files drop back under their pre-#1540 ceilings — is bigger than an unbreak and is filed as a handoff in #1545 (which names the extraction targets and the settlement.rs/verifier_stage.rs precedents). `pipeline.rs` in particular has now absorbed three ceiling bumps in two days; the reduction issue exists so that trend has an owner.

`./scripts/check-file-size.sh` passes locally on this branch: 935 files, 34 grandfathered, none grew.

Refs #1540
Refs #1545

## Summary by Sourcery

Enhancements:
- Adjust file-size ceilings for specific grandfathered files in the baseline to match their current sizes.