### PR TITLE
fix(arenabench): price a seat by the route it recorded at launch (#1498)

### DIFF
--- a/arenabench/arenabench/pricing.py
+++ b/arenabench/arenabench/pricing.py
@@ -25,6 +25,14 @@ labelled as such rather than presented as an invoice.
 lesson of the paragraph above: a plausible wrong figure populates a column,
 sorts against the other arm, and crowns a winner on a dimension nobody
 measured. Missing is strictly better than wrong here.
+
+**A recorded model id cannot say which route served it.** The same model is
+launched under different spellings depending on how the seat is routed
+(``agents.launch_model`` hands a directly-routed seat the bare id and every
+other seat the qualified one), so route attribution comes only from the launch
+record the runner writes beside each job — :func:`price_for_route` — and every
+id read back from a trajectory or event stream collapses to one bare id and
+one gateway rate.
 """
 
 from __future__ import annotations
@@ -35,7 +43,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-__all__ = ["PRICES", "Price", "load_overrides", "price_for", "trial_cost"]
+__all__ = [
+    "PRICES",
+    "Price",
+    "load_overrides",
+    "price_for",
+    "price_for_route",
+    "trial_cost",
+]
 
 
 @dataclass(frozen=True)
@@ -59,29 +74,40 @@ class Price:
         }
 
 
-#: Published list prices, USD per million tokens.
+#: Published list prices, USD per million tokens, keyed two ways.
 #:
-#: Keyed by the provider's own model id with any routing prefix removed, so
-#: ``openrouter/z-ai/glm-5.2``, ``z-ai/glm-5.2`` and ``glm-5.2`` all resolve to
-#: one entry. Verified against OpenRouter's ``/models`` on 2026-08-04; that
-#: endpoint is the source of truth for these numbers and re-checking it is the
-#: way to refresh them.
+#: **Bare ids carry the gateway rate.** ``openrouter/z-ai/glm-5.2``,
+#: ``z-ai/glm-5.2`` and ``glm-5.2`` all resolve to the one ``glm-5.2`` entry,
+#: priced as OpenRouter publishes it (verified against its ``/models`` on
+#: 2026-08-04; that endpoint is the source of truth for the bare tier and
+#: re-checking it is the way to refresh it). The collapse is deliberate: a
+#: model id read back from a trial's artifacts cannot say which route served
+#: it, because a routed seat is launched with the bare model id and an
+#: unrouted one keeps its ``provider/`` prefix — inferring the route from the
+#: spelling would cost Claude Code at z.ai's rate and Stella at OpenRouter's
+#: in a match where both call the identical endpoint. Comparability is the
+#: whole product here, so an id of unknown route means one rate, and it is the
+#: higher published rate rather than a number that flatters whichever seat
+#: happened to be routed.
 #:
-#: **These are gateway rates, and the collapse is deliberate.** A model bought
-#: through OpenRouter and the same model bought from its own provider are two
-#: different rates: GLM-5.2 lists here at 0.76 in / 2.42 out / 0.14 cached, and
-#: at 0.60 / 2.20 / 0.11 direct from z.ai. Keying on the route would price the
-#: *seats of one match* differently, because a routed seat is launched with the
-#: bare model id and an unrouted one keeps its ``provider/`` prefix — Claude
-#: Code would be costed at z.ai's rate and Stella at OpenRouter's, in a match
-#: where both call the identical endpoint. Comparability is the whole product
-#: here, so one id means one rate, and the rate is the higher of the two rather
-#: than a number that flatters whichever seat happened to be routed.
+#: **Route-qualified ids carry a provider's own first-party rate** where it
+#: differs from the gateway's — GLM-5.2 is 0.60 in / 2.20 out / 0.11 cached
+#: direct from z.ai against 0.76 / 2.42 / 0.14 through OpenRouter. These rows
+#: are reachable only through :func:`price_for_route`, with the route the
+#: *seat recorded at launch* (the runner's ``<job>.seat.json``) — never by
+#: parsing a recorded model string, for the reason above. A seat that recorded
+#: no route prices at the bare tier, which errs against the seat rather than
+#: for it (#1498).
 #:
 #: Deliberately small. This is not a price oracle — it covers the models people
 #: actually seat here, and anything else reports no cost rather than a guess.
 PRICES: dict[str, Price] = {
     "glm-5.2": Price(input=0.76, output=2.42, cache_read=0.14),
+    # z.ai's own metered rate for the same model, as its pricing page and the
+    # Stella seed catalog (`crates/stella-model/src/catalog.rs`, the `zai`
+    # row) both carry it. The only family member with a distinct first-party
+    # rate: glm-5.1 and glm-4.5-air publish the same numbers on both routes.
+    "zai/glm-5.2": Price(input=0.60, output=2.20, cache_read=0.11),
     "glm-5.1": Price(input=0.966, output=3.036, cache_read=0.1794),
     "glm-5": Price(input=0.95, output=2.55, cache_read=0.20),
     "glm-5-turbo": Price(input=1.20, output=4.00, cache_read=0.24),
@@ -120,6 +146,12 @@ def load_overrides(path: str | Path | None = None) -> int:
     editing its source is one that quietly goes stale. The file is a flat
     ``{"model": {"input": 1.0, "output": 2.0, ...}}`` in USD per million
     tokens. Returns how many entries were applied.
+
+    A key lands on the tier it names, case aside: a bare id (``glm-5.2``)
+    overrides the gateway rate every recorded string falls to, and a
+    route-qualified id (``zai/glm-5.2``) overrides that route alone. No prefix
+    is stripped — with two tiers in one table, rewriting the operator's key
+    would silently move the override onto the wrong row.
     """
     target = Path(path) if path else Path(
         os.environ.get("ARENABENCH_PRICES", "") or Path.home() / ".arenabench" / "prices.json"
@@ -135,7 +167,7 @@ def load_overrides(path: str | Path | None = None) -> int:
         if not isinstance(entry, dict):
             continue
         try:
-            PRICES[_normalise(str(model))] = Price(
+            PRICES[str(model).strip().lower()] = Price(
                 input=float(entry["input"]),
                 output=float(entry["output"]),
                 cache_read=(
@@ -154,10 +186,35 @@ def load_overrides(path: str | Path | None = None) -> int:
 
 
 def price_for(model: str) -> Price | None:
-    """The published price for a model, or ``None`` if it is not known."""
+    """The published price for a recorded model id, or ``None`` if unknown.
+
+    Route-blind on purpose: the id collapses to its bare form and prices at
+    the gateway tier, however it was spelled. This is the right lookup for
+    every model string read back from a trial's artifacts — see the module
+    docstring for why those strings cannot carry route.
+    """
     if not model:
         return None
     return PRICES.get(_normalise(model))
+
+
+def price_for_route(qualified_model: str) -> Price | None:
+    """The price for a model on the route a seat *recorded at launch*.
+
+    ``qualified_model`` is the seat's own ``api/model`` string from the launch
+    record the runner writes beside each job — the one place the route is a
+    fact rather than an inference. An exact row for that route wins; a route
+    with no row of its own prices like any recorded id, at the gateway tier.
+
+    Never call this with a model string read back from a trajectory or event
+    stream: its spelling depends on how the seat was launched, not on which
+    endpoint served it, and pricing on it would cost the two seats of one
+    match from two different rows.
+    """
+    if not qualified_model:
+        return None
+    exact = PRICES.get(qualified_model.strip().lower())
+    return exact if exact is not None else price_for(qualified_model)
 
 
 def trial_cost(

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -46,7 +46,13 @@ from .model import DIMENSIONS, Contestant, MatchSpec, screen_env
 from .recorder import RecorderSupervisor
 from .registry import Dataset, Registry
 from .snapshot import SnapshotSupervisor
-from .telemetry import MetricsReader, TrialMetrics, aggregate, leaders
+from .telemetry import (
+    MetricsReader,
+    TrialMetrics,
+    aggregate,
+    leaders,
+    seat_manifest_path,
+)
 
 __all__ = ["ContestantRun", "Match", "MatchRunner"]
 
@@ -418,6 +424,33 @@ class MatchRunner:
         env = _base_environment()
         env.update(seat_env)
         env.update(self._agent_environment(contestant, run))
+
+        # The seat's launch record — the only artifact that can say which
+        # route this job's trials were actually served by. `launch_model`
+        # hands a directly-routed seat the bare model id and every other seat
+        # the qualified one, so the ids Harbor and the event streams record
+        # cannot be told apart by route; pricing reads this instead (#1498).
+        # Best-effort by design: a seat that cannot record its route still
+        # runs, warns, and prices at the route-blind gateway rate.
+        record = {
+            "schema": 1,
+            "contestant": contestant.id,
+            "agent": contestant.agent,
+            "api": contestant.engine.api,
+            "model": contestant.engine.model,
+            "qualified_model": contestant.engine.qualified_model,
+            "launch_model": launch_model(contestant),
+            "base_url": contestant.engine.base_url,
+        }
+        try:
+            seat_manifest_path(job_dir).write_text(
+                json.dumps(record, indent=2) + "\n", encoding="utf-8"
+            )
+        except OSError as exc:
+            run.warnings.append(
+                f"could not record the seat's route ({exc}); trials will "
+                "price at the route-blind gateway rate"
+            )
 
         log.info(
             "launching %s: %s (%d tasks)",

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -20,6 +20,13 @@ Per trial, Harbor and the agent leave:
     ATIF and *current* rather than final, so it is preferred wherever both
     speak — it is what makes a live transcript possible at all.
 
+Beside the trials, the *runner* leaves one artifact of its own per job:
+``<job>.seat.json``, the seat's launch record — which provider api and
+route-qualified model the job was actually launched against. It exists because
+no model id the agent or Harbor records can carry that fact (the launch
+spelling differs by route), and pricing needs it (#1498). A job without one —
+every archive predating the record — is read exactly as before.
+
 Two readers sit on top. :class:`MetricsReader` reduces a trial to the seven
 scoreboard dimensions and re-parses a file only when its size changes, so an
 idle dashboard costs ``stat()`` calls. :class:`TranscriptReader` keeps a byte
@@ -37,7 +44,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .pricing import price_for, trial_cost
+from .pricing import price_for, price_for_route, trial_cost
 
 __all__ = [
     "EVENTS_NAME",
@@ -48,11 +55,24 @@ __all__ = [
     "TrialMetrics",
     "aggregate",
     "leaders",
+    "seat_manifest_path",
 ]
 
 EVENTS_NAME = "agent/stella-events.jsonl"
 TRAJECTORY_NAME = "agent/trajectory.json"
 RESULT_NAME = "result.json"
+SEAT_MANIFEST_SUFFIX = ".seat.json"
+
+
+def seat_manifest_path(job_dir: Path) -> Path:
+    """Where the runner records a job's seat launch data.
+
+    A sibling of the job directory rather than a file inside it: Harbor owns
+    that tree's creation, and the record exists before Harbor has made
+    anything. Defined here, next to the reader, so the writer in ``runner.py``
+    and :class:`MetricsReader` can never disagree about the location.
+    """
+    return job_dir.with_name(job_dir.name + SEAT_MANIFEST_SUFFIX)
 
 #: A step that spent its entire output allowance and called no tool is the
 #: signature of output-cap truncation — the "zero-tool" failure class. Matched
@@ -284,6 +304,24 @@ class MetricsReader:
 
     def __init__(self) -> None:
         self._events: dict[Path, tuple[int, dict[str, Any]]] = {}
+        self._seats: dict[Path, dict[str, Any] | None] = {}
+
+    def _seat_route(self, trial_dir: Path) -> str:
+        """The route-qualified model this trial's seat was launched with.
+
+        ``""`` when the job has no launch record — every archive predating
+        it. Cached without invalidation: the record is written once, before
+        the job's first trial exists, so by the time this reader has a trial
+        directory to ask about, the record's presence and content are final.
+        """
+        try:
+            path = seat_manifest_path(trial_dir.parent)
+        except ValueError:
+            return ""
+        if path not in self._seats:
+            self._seats[path] = _load_json(path)
+        seat = self._seats[path]
+        return str(seat.get("qualified_model") or "") if seat else ""
 
     def _events_summary(self, path: Path) -> tuple[dict[str, Any] | None, float | None]:
         try:
@@ -390,21 +428,29 @@ class MetricsReader:
                 metrics.models = (*metrics.models, configured)
 
         # One table, both seats. See pricing.py for why self-reported cost is
-        # recorded but never compared. The configured seat model is tried first:
-        # a single process can log several roles' `step_usage` (verifier, triage)
+        # recorded but never compared. The seat's launch record outranks every
+        # model id read back from the artifacts: launch spelling varies with
+        # routing (a directly-routed seat is launched with the bare id), so
+        # only the record can say which route served the trial, and every
+        # recorded string prices route-blind at the gateway tier (#1498).
+        # Among the recorded ids the configured seat model is tried first: a
+        # single process can log several roles' `step_usage` (verifier, triage)
         # into one stream, so the stream's first-seen model may name a role
         # rather than the seat — pricing on that would mis-cost the whole trial.
-        for name in (configured, *metrics.models, ""):
-            price = price_for(name)
-            if price is not None:
-                metrics.priced_cost = trial_cost(
-                    price,
-                    tokens_in=metrics.tokens_in,
-                    tokens_out=metrics.tokens_out,
-                    cache_read=metrics.cache_read,
-                    cache_write=metrics.cache_write,
-                )
-                break
+        price = price_for_route(self._seat_route(trial_dir))
+        if price is None:
+            for name in (configured, *metrics.models):
+                price = price_for(name)
+                if price is not None:
+                    break
+        if price is not None:
+            metrics.priced_cost = trial_cost(
+                price,
+                tokens_in=metrics.tokens_in,
+                tokens_out=metrics.tokens_out,
+                cache_read=metrics.cache_read,
+                cache_write=metrics.cache_write,
+            )
 
         # A running trial has no finish timestamp, so wall clock has to come
         # from the events file's own span rather than from Harbor.

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -42,6 +42,7 @@ from arenabench.model import (
 )
 from arenabench.registry import DEFAULT_REGISTRY, Task, sample_tasks
 from arenabench.runner import ContestantRun, MatchRunner, _base_environment
+from arenabench.telemetry import seat_manifest_path
 
 # --------------------------------------------------------------------------
 # model
@@ -681,6 +682,56 @@ class TestOfflineTaskSource:
         command = self._launched_command(tmp_path, monkeypatch, export=False)
         assert "--dataset" in command and "--path" not in command
         assert command[command.index("--include-task-name") + 1] == "terminal-bench/alpha"
+
+
+class TestSeatLaunchRecord:
+    """`_launch` leaves the one artifact that can say which route a job used.
+
+    A directly-routed seat is launched with the bare model id, so nothing
+    Harbor records for it can be told apart from a gateway seat by spelling —
+    the record beside the job directory is what pricing reads instead (#1498).
+    """
+
+    def test_the_route_is_recorded_beside_the_job_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("arenabench.runner.shutil.which", lambda _: "/usr/bin/harbor")
+
+        class _Fake:
+            def __init__(self, command, **kwargs):
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+        monkeypatch.setattr("arenabench.runner.subprocess.Popen", _Fake)
+        spec = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["alpha"],
+                "contestants": [
+                    {
+                        "name": "cc",
+                        "agent": "claude-code",
+                        "engine": {
+                            "api": "zai",
+                            "model": "glm-5.2",
+                            "base_url": "https://api.z.ai/api/anthropic",
+                        },
+                    }
+                ],
+            }
+        )
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(spec)
+        run = runner._launch(match, spec.contestants[0])
+
+        record = json.loads(seat_manifest_path(run.job_dir).read_text(encoding="utf-8"))
+        # The two spellings genuinely diverge for this seat — that divergence
+        # is why the record has to exist at all.
+        assert record["launch_model"] == "glm-5.2"
+        assert record["qualified_model"] == "zai/glm-5.2"
+        assert record["api"] == "zai"
 
 
 class TestMatchTemplateRoles:

--- a/arenabench/tests/test_pricing.py
+++ b/arenabench/tests/test_pricing.py
@@ -10,9 +10,13 @@ rates, both seats.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
-from arenabench.pricing import price_for, trial_cost
+import arenabench.pricing as pricing
+from arenabench.pricing import price_for, price_for_route, trial_cost
 
 
 class TestPricing:
@@ -34,11 +38,13 @@ class TestPricing:
         fable = price_for("claude-fable-5")
         assert (fable.input, fable.output) == (10.0, 50.0)
 
-    def test_one_id_resolves_to_one_rate_however_it_was_routed(self):
+    def test_one_recorded_id_resolves_to_one_rate_however_it_was_routed(self):
         """A routed seat is launched with the bare model id and an unrouted one
-        keeps its `provider/` prefix, so route-keyed prices would cost the two
-        seats of a single match from two different rows — the exact
-        subtracting-two-tables error this module exists to prevent."""
+        keeps its `provider/` prefix, so pricing a *recorded* string by its
+        route would cost the two seats of a single match from two different
+        rows — the exact subtracting-two-tables error this module exists to
+        prevent. The first-party tier exists (`zai/glm-5.2` is a PRICES key
+        now), and a recorded string must still never reach it."""
         assert (
             price_for("glm-5.2")
             == price_for("z-ai/glm-5.2")
@@ -57,5 +63,54 @@ class TestPricing:
         price = price_for("glm-5.2")
         cost = trial_cost(price, tokens_in=1_000_000, tokens_out=0, cache_read=900_000)
         assert cost == pytest.approx(0.1 * 0.76 + 0.9 * 0.14)
+
+
+class TestRoutePricing:
+    """The first-party tier is reachable only through a seat's launch record.
+
+    `price_for` stays route-blind because a recorded model string cannot say
+    which route served it; `price_for_route` takes the one string that can —
+    the seat's own launch record — and unlocks the direct rate (#1498).
+    """
+
+    def test_a_seats_recorded_route_prices_at_the_first_party_rate(self):
+        """z.ai's own metered rate, as `catalog.rs`'s `zai` row carries it."""
+        direct = price_for_route("zai/glm-5.2")
+        assert (direct.input, direct.output, direct.cache_read) == (0.60, 2.20, 0.11)
+
+    def test_a_gateway_route_prices_at_the_gateway_rate(self):
+        assert price_for_route("openrouter/z-ai/glm-5.2") == price_for("glm-5.2")
+
+    def test_a_route_with_no_row_of_its_own_prices_at_the_gateway_tier(self):
+        """No published first-party rate means the conservative tier, not a
+        guess — glm-5.1 lists the same numbers on both routes."""
+        assert price_for_route("zai/glm-5.1") == price_for("glm-5.1")
+
+    def test_a_wholly_unknown_route_reports_nothing(self):
+        assert price_for_route("acme/mystery-1") is None
+        assert price_for_route("") is None
+
+    def test_an_override_keyed_by_route_pins_that_route_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Override keys land on the tier they name. Stripping the prefix, as
+        lookups do, would silently move a first-party override onto the
+        gateway row every recorded string resolves to."""
+        monkeypatch.setattr(pricing, "PRICES", dict(pricing.PRICES))
+        table = tmp_path / "prices.json"
+        table.write_text(
+            json.dumps(
+                {
+                    "zai/glm-5.2": {"input": 0.5, "output": 2.0},
+                    "glm-5.2": {"input": 0.8, "output": 2.5},
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert pricing.load_overrides(table) == 2
+        assert pricing.price_for_route("zai/glm-5.2").input == 0.5
+        assert pricing.price_for("zai/glm-5.2").input == 0.8, (
+            "a recorded string still collapses to the bare tier"
+        )
 
 

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -23,6 +23,7 @@ from arenabench.telemetry import (
     TranscriptReader,
     TrialMetrics,
     aggregate,
+    seat_manifest_path,
 )
 
 # --------------------------------------------------------------------------
@@ -208,6 +209,81 @@ class TestMetrics:
         write_events(trial / "agent" / "stella-events.jsonl", [usage(cost_usd=1.0)])
         second = reader.read(trial, "fix-git")
         assert second.total_cost > first.total_cost
+
+    @staticmethod
+    def _seat_on_zai(tmp_path: Path, job: str, recorded_model: str) -> Path:
+        """A finished trial whose seat launched against z.ai first-party.
+
+        `recorded_model` is what Harbor wrote down, which differs by routing:
+        a directly-routed seat is launched (and recorded) as the bare id, an
+        unrouted one as the qualified id. The launch record beside the job
+        says what both spellings cannot — which route served the trial.
+        """
+        trial_dir = tmp_path / job / "t__1"
+        (trial_dir / "agent").mkdir(parents=True)
+        (trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "config": {"agent": {"model_name": recorded_model}},
+                    "verifier_result": {"reward": 1.0},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (trial_dir / "agent" / "trajectory.json").write_text(
+            json.dumps(
+                {
+                    "final_metrics": {
+                        "total_prompt_tokens": 1_000_000,
+                        "total_completion_tokens": 0,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        seat_manifest_path(trial_dir.parent).write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "contestant": job,
+                    "api": "zai",
+                    "model": "glm-5.2",
+                    "qualified_model": "zai/glm-5.2",
+                    "launch_model": recorded_model,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return trial_dir
+
+    def test_the_seats_launch_record_prices_the_route_it_actually_used(
+        self, tmp_path: Path
+    ):
+        """Two seats on the identical z.ai endpoint record different model
+        spellings — a directly-routed seat is launched with the bare id, an
+        unrouted one with the qualified id — so the recorded strings cannot
+        carry route, and pricing them route-blind billed a first-party seat
+        at the gateway's ~27%-higher rate (#1498). With the launch record,
+        both seats price at the rate of the endpoint they actually called,
+        and at the *same* rate as each other."""
+        routed = MetricsReader().read(self._seat_on_zai(tmp_path, "cc", "glm-5.2"), "t")
+        unrouted = MetricsReader().read(
+            self._seat_on_zai(tmp_path, "stella", "zai/glm-5.2"), "t"
+        )
+        # 1M uncached input tokens at z.ai's own 0.60/Mtok, not OpenRouter's 0.76.
+        assert routed.priced_cost == pytest.approx(0.60)
+        assert unrouted.priced_cost == pytest.approx(0.60)
+
+    def test_an_unpriced_route_falls_back_to_the_recorded_model(self, trial: Path):
+        """A launch record whose route has no price of its own must not slam
+        the door: the trial prices exactly as an archive without a record
+        does — from the recorded model ids, at the gateway tier."""
+        seat_manifest_path(trial.parent).write_text(
+            json.dumps({"schema": 1, "api": "acme", "qualified_model": "acme/mystery-1"}),
+            encoding="utf-8",
+        )
+        metrics = MetricsReader().read(trial, "fix-git")
+        assert metrics.priced_cost == pytest.approx(0.004538)
 
 
 


### PR DESCRIPTION
## What & why

A first-party z.ai seat was billed at OpenRouter's gateway rate — ~27% high on input and cache-read — because `pricing.py` collapses every model id to one bare entry priced at the gateway tier. Both reviewers in the issue were right about their failure mode: the collapse *is* wrong for a first-party seat, and route-keying recorded model strings *would* price the two seats of one match from two rows, because `agents.launch_model` hands a directly-routed seat the bare id (`glm-5.2`) and every other seat the qualified one (`zai/glm-5.2`) — the spelling records how the seat was launched, not which endpoint served it.

So the fix is the design the issue sketched: **record the route where it is a fact, not an inference.**

- `runner.py::_launch` now writes a launch record beside each job (`<job>.seat.json`, a sibling of the Harbor-owned job directory — Harbor's tree is never pre-populated) carrying the seat's `api`, `qualified_model`, and `launch_model`. Best-effort: a seat that cannot write it warns and prices at the gateway tier ("degradation warns, never disables").
- `pricing.py` gains a first-party tier — `zai/glm-5.2` at z.ai's own 0.60/2.20/0.11, the only family member whose direct rate differs from the gateway's — reachable **only** through the new `price_for_route`, which takes the launch record's qualified id. `price_for` (recorded strings) stays route-blind; the existing collapse test still passes untouched.
- `telemetry.py::MetricsReader` prices from the launch record first, then falls back to the exact previous behavior. A job with no record — every archive predating this change — prices byte-for-byte as before (the existing gateway-rate fixture assertions are the no-regression witnesses).
- `load_overrides` now stores keys verbatim (case aside) instead of prefix-stripping them: with two tiers in one table, rewriting the operator's key would move an override onto the wrong row. Documented in its docstring and pinned by a test.

Verified end-to-end: the two-seat scenario from the issue (both seats on the identical z.ai endpoint, recorded as `glm-5.2` and `zai/glm-5.2`) prices at $0.76/Mtok for both on `main`, and $0.60/Mtok for both with this change — equal rates in both worlds, so the comparability property the module exists for is preserved while the absolute number becomes the true one.

Closes #1498

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_the_seats_launch_record_prices_the_route_it_actually_used` (test_telemetry.py) is the headline: on `main` it fails at 0.76 ≠ 0.60 (module-level, the imports of `price_for_route`/`seat_manifest_path` don't even resolve). Confirmed by running the fixture scenario against `main`'s package directly: old `$0.7600/$0.7600`, new `$0.6000/$0.6000`. The counter-argument's failure mode is pinned in the *other* direction by the pre-existing `test_one_recorded_id_resolves_to_one_rate_however_it_was_routed`, which passes unchanged.

## The gate

- [x] `python3 -m pytest arenabench/tests` — 152 passed
- [x] Docs updated where behavior changed (pricing.py/telemetry.py module docs, PRICES comment block)
- [x] CLA signed
- [x] `Closes #1498` appears both above and as a commit trailer

`cargo fmt/clippy/test` are unaffected — the diff touches only `arenabench/` (Python); CI runs them regardless.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- **Rejected alternative:** passing the contestant's engine into `MetricsReader.read()` from `Match.metrics_for`. It fixes live matches with no new artifact, but breaks the module's contract that a trial is readable from its artifacts alone — an archived job would price differently from the live match it was. The on-disk record keeps that property.
- **Rejected alternative:** a `priced_model` field on `TrialMetrics` exposing which row billed the trial. Nice for auditing, but it needs the pricing functions to return the matched key and ripples into the UI types for a display nicety; not worth the surface.
- **Follow-up filed separately:** a pipeline seat's verifier/triage tokens are still billed at the worker model's rate (pre-existing, orthogonal to routing).

## Summary by Sourcery

Record and consume per-seat launch route metadata so trials are priced by the actual endpoint they used while preserving comparability for historical and gateway-routed runs.

New Features:
- Persist a per-job seat launch manifest capturing API, launch model, and route-qualified model beside each Harbor job directory.
- Introduce route-aware pricing via a first-party tier entry for zai/glm-5.2 that can be selected independently of the gateway tier.

Enhancements:
- Have MetricsReader prefer the recorded seat route for pricing, falling back to prior route-blind pricing for jobs without a launch record.
- Expose a shared seat_manifest_path helper so runner and telemetry agree on the launch record location.
- Change price overrides to respect verbatim model keys (bare or route-qualified) so operators can target specific tiers without collisions.

Tests:
- Add pricing tests for route-aware lookup, fallback behavior, and route-scoped overrides.
- Add telemetry tests ensuring launch records drive pricing and that missing or unpriced routes behave like historical runs.
- Add runner tests verifying that _launch writes the expected seat launch record beside the job directory.