### PR TITLE
fix(stella-cli): --output-format is declared only where it is honoured (#1493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,11 +454,14 @@ stella inspect   # the exact context a past model call was sent, rebuilt from
 ### Global flags
 
 `--model provider/id` · `--api-key` · `--base-url` · `--budget <usd>` ·
-`--output-format text|json|stream-json` · `--accessible` · `--plain` ·
-`--no-anim` (also as `STELLA_MODEL`, `STELLA_BASE_URL`, `STELLA_BUDGET`,
-`STELLA_OUTPUT_FORMAT`, `STELLA_ACCESSIBLE`, `STELLA_PLAIN`, `STELLA_NO_ANIM`). All of them are registered with every
-subcommand, so they parse before _or_ after the subcommand token. The `json` /
-`stream-json` formats are for headless one-shot `stella run`; interactive
+`--accessible` · `--plain` · `--no-anim` (also as `STELLA_MODEL`,
+`STELLA_BASE_URL`, `STELLA_BUDGET`, `STELLA_ACCESSIBLE`, `STELLA_PLAIN`,
+`STELLA_NO_ANIM`). All of them are registered with every subcommand, so they
+parse before _or_ after the subcommand token.
+`--output-format text|json|stream-json` (env `STELLA_OUTPUT_FORMAT`) is
+deliberately **not** global: it is declared by the commands that honor it —
+`stella run` and `stella fleet` — and goes after the subcommand token
+(`stella run "…" --output-format json`); interactive
 `chat` / `goal` / `monitor` modes render human-readable output. `stella run`
 uses the staged pipeline by default; `--no-pipeline` falls back to the raw
 step-loop. In pipeline mode, `--test-command <cmd>` arms deterministic

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -1706,10 +1706,12 @@ class StellaAgent(BaseInstalledAgent):
     ) -> list[str]:
         """Build the headless one-shot Stella argument vector.
 
-        Global flags (``--model``, ``--budget``, ``--base-url``,
-        ``--output-format``) precede the ``run`` subcommand — they are top-level
-        CLI flags in Stella, not flags of ``run``. Returning an argv preserves
-        the instruction as one literal argument without shell quoting/parsing.
+        Global flags (``--model``, ``--budget``, ``--base-url``) precede the
+        ``run`` subcommand — they are top-level CLI flags in Stella.
+        ``--output-format`` is a flag *of* ``run`` since stella#1493 demoted
+        it from global (it was a promise most subcommands ignored), so it
+        rides after the subcommand token. Returning an argv preserves the
+        instruction as one literal argument without shell quoting/parsing.
         """
         model = model or self._effective_model()
         budget = self._configured_budget()
@@ -1726,8 +1728,6 @@ class StellaAgent(BaseInstalledAgent):
             # Omit-when-absent, same discipline and same reason as `--budget`:
             # an absent flag is "no deadline", an empty value exits 2.
             *(["--turn-budget", turn_budget] if turn_budget is not None else []),
-            "--output-format",
-            "stream-json",
         ]
         if base_url:
             base_url = _validated_public_base_url(base_url)
@@ -1737,7 +1737,7 @@ class StellaAgent(BaseInstalledAgent):
         # instead of parsing as a flag. Without it, `stella run '- foo'`
         # exits 2 before the agent starts — one 2026-07-31 trial
         # (pytorch-model-recovery) died exactly this way and scored 0.
-        parts += ["run", "--", instruction]
+        parts += ["run", "--output-format", "stream-json", "--", instruction]
         return parts
 
     def _selected_provider_credentials(self) -> SelectedProviderCredentials:

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -282,10 +282,11 @@ class TestBuildCommand:
 
         cmd = agent._build_command("Fix the bug")
 
-        # Global flags must precede the `run` subcommand.
+        # Global flags must precede the `run` subcommand; `--output-format`
+        # is a flag OF `run` since stella#1493 and must follow it.
         assert cmd.index("--model") < cmd.index("run")
         assert cmd.index("--budget") < cmd.index("run")
-        assert cmd.index("--output-format") < cmd.index("run")
+        assert cmd.index("--output-format") > cmd.index("run")
         assert cmd[:3] == [
             _INSTALL_PATH,
             "--model",
@@ -293,7 +294,7 @@ class TestBuildCommand:
         ]
         assert cmd[cmd.index("--output-format") + 1] == "stream-json"
         assert cmd[cmd.index("--budget") + 1] == "5.0"  # default budget
-        assert cmd[-3:] == ["run", "--", "Fix the bug"]
+        assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", "Fix the bug"]
         assert "--base-url" not in cmd  # not set
 
     def test_env_overrides_and_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -354,7 +355,7 @@ class TestBuildCommand:
         agent.model_name = "anthropic/claude-fable-5"
         instruction = "rm -rf / ; echo $HOME && $(touch /tmp/owned)"
         cmd = agent._build_command(instruction)
-        assert cmd[-3:] == ["run", "--", instruction]
+        assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", instruction]
 
     def test_secret_bearing_base_url_never_enters_command(
         self, monkeypatch: pytest.MonkeyPatch
@@ -462,7 +463,7 @@ class TestNoBudgetCap:
         assert "--budget" not in cmd
         # The failure mode was an empty argv element, not just a stray flag.
         assert "" not in cmd
-        assert cmd[-3:] == ["run", "--", "Fix the bug"]
+        assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", "Fix the bug"]
 
     def test_whitespace_budget_is_treated_as_no_cap_not_as_a_number(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1414,7 +1415,13 @@ class TestRun:
                 self, *, command: list[str], env: dict[str, str], stdin: bytes
             ):
                 assert command[0] == _INSTALL_PATH
-                assert command[-3:] == ["run", "--", "Fix the task."]
+                assert command[-5:] == [
+                    "run",
+                    "--output-format",
+                    "stream-json",
+                    "--",
+                    "Fix the task.",
+                ]
                 assert command[command.index("--base-url") + 1] == (
                     "https://openrouter.ai/api/v1"
                 )

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -1415,13 +1415,8 @@ class TestRun:
                 self, *, command: list[str], env: dict[str, str], stdin: bytes
             ):
                 assert command[0] == _INSTALL_PATH
-                assert command[-5:] == [
-                    "run",
-                    "--output-format",
-                    "stream-json",
-                    "--",
-                    "Fix the task.",
-                ]
+                tail = ["run", "--output-format", "stream-json", "--", "Fix the task."]
+                assert command[-5:] == tail
                 assert command[command.index("--base-url") + 1] == (
                     "https://openrouter.ai/api/v1"
                 )

--- a/bench/harbor_adapter/tests/test_log_writes.py
+++ b/bench/harbor_adapter/tests/test_log_writes.py
@@ -138,4 +138,5 @@ def test_run_instruction_binds_after_double_dash(monkeypatch: pytest.MonkeyPatch
     cmd = agent._build_command("- start with a dash")
 
     run_at = cmd.index("run")
-    assert cmd[run_at:] == ["run", "--", "- start with a dash"]
+    tail = ["run", "--output-format", "stream-json", "--", "- start with a dash"]
+    assert cmd[run_at:] == tail

--- a/bench/run_swebench.py
+++ b/bench/run_swebench.py
@@ -27,7 +27,7 @@ Usage examples
 
 Stella is invoked one-shot as::
 
-    <stella-bin> --model <model> --budget <usd> --output-format json run "<problem>"
+    <stella-bin> --model <model> --budget <usd> run --output-format json "<problem>"
 
 inside a pristine checkout of the target repo at ``base_commit``. The model's
 patch is collected as the ``git diff`` of the working tree after the run.
@@ -301,9 +301,10 @@ def build_stella_cmd(
 ) -> list[str]:
     """Build the headless one-shot Stella argv.
 
-    Global flags precede the ``run`` subcommand — they are top-level Stella CLI
-    flags, not flags of ``run``. ``--output-format json`` keeps output stable
-    and machine-parseable for cost capture.
+    Global flags precede the ``run`` subcommand — they are top-level Stella
+    CLI flags. ``--output-format`` is a flag *of* ``run`` (demoted from
+    global by stella#1493), and ``json`` keeps output stable and
+    machine-parseable for cost capture.
     """
     cmd = [
         stella_bin,
@@ -311,8 +312,6 @@ def build_stella_cmd(
         model,
         "--budget",
         str(budget),
-        "--output-format",
-        "json",
     ]
     if base_url:
         cmd.extend(["--base-url", base_url])
@@ -321,7 +320,7 @@ def build_stella_cmd(
     # flag and Stella exits 2 before the turn starts — the Harbor adapter
     # fixed exactly this after a trial scored 0 that way (2026-07-31,
     # pytorch-model-recovery).
-    cmd.extend(["run", "--", prompt])
+    cmd.extend(["run", "--output-format", "json", "--", prompt])
     return cmd
 
 

--- a/bench/smoke/smoke_test.py
+++ b/bench/smoke/smoke_test.py
@@ -171,7 +171,8 @@ def check_models(stella: Path) -> Check:
 def check_graceful_no_key(stella: Path) -> Check:
     """The adapter's exact one-shot shape must degrade gracefully with no key.
 
-    Runs ``stella --model <m> --budget 5.0 --output-format json run "<p>"`` in a
+    Runs ``stella --model <m> --budget 5.0 run --output-format json "<p>"``
+    (``--output-format`` is a flag of ``run`` since stella#1493) in a
     scrubbed environment. Classifies the result:
 
     - crash (signal death / panic text)           -> FAIL (real bug)
@@ -185,9 +186,9 @@ def check_graceful_no_key(stella: Path) -> Check:
         "anthropic/claude-fable-5",
         "--budget",
         "5.0",
+        "run",
         "--output-format",
         "json",
-        "run",
         "print the word hello and stop",
     ]
     try:

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -50,6 +50,34 @@ pub(crate) struct Cli {
     pub(crate) command: Option<Command>,
 }
 
+impl Cli {
+    /// The output format this invocation promised its caller.
+    ///
+    /// `--output-format` stopped being global in #1493: 34 of 36 subcommands
+    /// never consulted it, which made the flag a promise the CLI mostly broke.
+    /// It now exists only on the commands that keep it — but three
+    /// process-wide decisions in `main` still need one answer for ANY
+    /// command: whether interactive credential prompts are forbidden, whether
+    /// the env-file announcement may print, and whether a failure gets a
+    /// machine-readable error envelope on stdout.
+    ///
+    /// `Run` and `Fleet` answer with their declared flag. `Arena` has no flag
+    /// to consult because its contract IS stream-json (the runner is the only
+    /// reader), so it answers that — which also closes the hole where an
+    /// arena run could block on a masked credential prompt no runner would
+    /// ever see. Every other command renders human text; their machine
+    /// surfaces are their own `--format` flags.
+    pub(crate) fn output_format(&self) -> OutputFormat {
+        match &self.command {
+            Some(Command::Run { output_format, .. } | Command::Fleet { output_format, .. }) => {
+                *output_format
+            }
+            Some(Command::Arena { .. }) => OutputFormat::StreamJson,
+            _ => OutputFormat::Text,
+        }
+    }
+}
+
 // The two paragraphs below are `//` and not `///` deliberately. clap derive
 // lifts a flattened `Args` struct's doc comment into the *parent's*
 // `long_about` when the parent sets none, which is exactly how these notes —
@@ -73,7 +101,7 @@ pub(crate) struct Cli {
 // in src/tests.rs enforces uniqueness (it is why `connect linear` pastes
 // a key via `--paste-key`, not `--api-key`).
 /// Session-wide flags shared by every subcommand — model routing,
-/// credentials, output shape, spend limit, UI toggles.
+/// credentials, spend limit, UI toggles.
 #[derive(clap::Args)]
 // Heading rather than clap's default "Options": these are the flags that hold
 // for the whole session and are accepted on either side of the subcommand
@@ -106,16 +134,6 @@ pub(crate) struct GlobalArgs {
     /// other provider, where it routes through a proxy.
     #[arg(long, global = true, env = "STELLA_BASE_URL", hide_short_help = true)]
     pub(crate) base_url: Option<String>,
-
-    /// Output shape: text, json, or stream-json
-    #[arg(
-        long,
-        global = true,
-        env = "STELLA_OUTPUT_FORMAT",
-        value_enum,
-        default_value = "text"
-    )]
-    pub(crate) output_format: OutputFormat,
 
     /// Hard USD spend limit for the whole session
     ///
@@ -295,6 +313,17 @@ pub(crate) enum Command {
         /// Pass this to promote it to a real test you can commit.
         #[arg(long)]
         keep_witness: bool,
+
+        /// Output shape: text, json, or stream-json
+        ///
+        /// Declared here rather than globally because this is a promise about
+        /// what reaches stdout, and only the commands that keep it may make it
+        /// (#1493). `json` prints one summary object; `stream-json` prints one
+        /// JSON line per AgentEvent. Both also turn every failure into a
+        /// machine-readable error envelope and refuse interactive credential
+        /// prompts.
+        #[arg(long, env = "STELLA_OUTPUT_FORMAT", value_enum, default_value = "text")]
+        output_format: OutputFormat,
     },
 
     /// arena-bench adapter, invoked by the benchmark runner
@@ -304,6 +333,9 @@ pub(crate) enum Command {
     /// with the protocol's replay oracles. Speaks the adapter contract
     /// (--task-dir/--journal/--state-dir/--resume); see
     /// <https://github.com/macanderson/arena-bench>.
+    ///
+    /// Output is fixed stream-json — the runner is the only intended reader,
+    /// so there is no --output-format here to promise otherwise (#1493).
     Arena {
         /// The episode workspace; the prompt is read from TASK.md inside it.
         #[arg(long)]
@@ -483,6 +515,15 @@ pub(crate) enum Command {
         /// a hung worker on a piped or CI run. Unset = unbounded.
         #[arg(long, value_name = "SECS")]
         task_timeout: Option<u64>,
+
+        /// Output shape: text, json, or stream-json
+        ///
+        /// Anything but `text` keeps the live grid off and the run headless,
+        /// with machine-readable error envelopes and no interactive credential
+        /// prompts. Declared per-command, not globally, so it exists exactly
+        /// where it is honoured (#1493).
+        #[arg(long, env = "STELLA_OUTPUT_FORMAT", value_enum, default_value = "text")]
+        output_format: OutputFormat,
     },
 
     /// Query the code graph — definitions, references, callers, imports

--- a/crates/stella-cli/src/config.rs
+++ b/crates/stella-cli/src/config.rs
@@ -101,7 +101,7 @@ fn trusted_engine_config_override() -> Result<Option<crate::settings::AgentEngin
 /// should pass `false` and get a clean `NotFound` instead of hanging on a read
 /// from a stdin that isn't there." Nothing honoured it. Every `--model
 /// provider/slug` path passed `true` unconditionally, so
-/// `stella --model anthropic/… --output-format json run '…'` launched from an
+/// `stella --model anthropic/… run --output-format json '…'` launched from an
 /// attached terminal with no key stopped dead on a password prompt while the
 /// caller waited on a JSON object that could never arrive — the machine
 /// interface deadlocked on a human one.

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -438,9 +438,11 @@ fn main() -> ExitCode {
 
     // A machine-readable run has nobody to answer a masked password prompt,
     // and its caller is blocked reading stdout for an object that would never
-    // come. Decided here, once, while the requested format is in hand.
+    // come. Decided here, once, from the command's own declaration (#1493) —
+    // which is also what finally covers `arena`, whose fixed stream-json
+    // contract never passed through the old global flag.
     if matches!(
-        cli.globals.output_format,
+        cli.output_format(),
         OutputFormat::Json | OutputFormat::StreamJson
     ) {
         config::forbid_interactive_credentials();
@@ -473,11 +475,11 @@ fn main() -> ExitCode {
 
     // Value-free confirmation (names only), gated on STELLA_ENV_DEBUG + a TTY +
     // a human output format so it never pollutes json/stream-json.
-    env_files::announce(&loaded_env, cli.globals.output_format);
+    env_files::announce(&loaded_env, cli.output_format());
 
     // Captured before `cli` moves into `run`: the catch-all below needs the
     // requested format to honour the machine-readable error contract.
-    let output_format = cli.globals.output_format;
+    let output_format = cli.output_format();
 
     match run(cli, &loaded_env) {
         Ok(()) => ExitCode::SUCCESS,
@@ -869,6 +871,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             no_pipeline,
             test_command,
             keep_witness,
+            output_format,
         } => {
             let prompt = prompt_source::resolve(
                 prompt,
@@ -881,7 +884,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                     &cfg,
                     &prompt,
                     cli.globals.budget,
-                    cli.globals.output_format,
+                    output_format,
                     !no_pipeline,
                     test_command.as_deref(),
                     keep_witness,
@@ -930,6 +933,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             watch,
             no_pipeline,
             task_timeout,
+            output_format,
         } => {
             signals::block_on_interruptible(
                 rt()?,
@@ -943,7 +947,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                     watch,
                     !no_pipeline,
                     task_timeout.map(std::time::Duration::from_secs),
-                    cli.globals.output_format,
+                    output_format,
                 ),
             )?;
         }

--- a/crates/stella-cli/src/memory_cmd.rs
+++ b/crates/stella-cli/src/memory_cmd.rs
@@ -217,7 +217,8 @@ pub fn run_memory_list(format: MemoryFormat) -> Result<(), String> {
             if quarantined > 0 {
                 println!(
                     "\n{} {quarantined} quarantined memor{them} excluded from recall — \
-                     cited untruthful {threshold}+ times. Review with `stella memory list --json`.",
+                     cited untruthful {threshold}+ times. Review with \
+                     `stella memory list --format json`.",
                     "⚠".yellow(),
                     them = if quarantined == 1 { "y" } else { "ies" },
                     threshold = stella_store::QUARANTINE_NEGATIVES_THRESHOLD,

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -421,18 +421,80 @@ fn session_flags_parse_after_subcommand() {
 /// both positions, not moved.
 #[test]
 fn session_flags_parse_before_subcommand() {
-    let cli = Cli::try_parse_from([
-        "stella",
-        "--budget",
-        "2.5",
-        "--output-format",
-        "json",
-        "run",
-        "hi",
-    ])
-    .expect("session flags before the subcommand must keep parsing");
+    let cli = Cli::try_parse_from(["stella", "--budget", "2.5", "run", "hi"])
+        .expect("session flags before the subcommand must keep parsing");
     assert_eq!(cli.globals.budget, Some(2.5));
-    assert_eq!(cli.globals.output_format, OutputFormat::Json);
+}
+
+/// #1493's witness. `--output-format` is a promise about what reaches
+/// stdout, so it exists only on the commands that keep it. Under the old
+/// `global = true` declaration every invocation below parsed cleanly and
+/// was then ignored — the scripted caller got coloured human text where it
+/// was promised JSON, with a JSON error envelope appended on failure.
+#[test]
+fn output_format_is_rejected_where_it_was_never_honoured() {
+    for argv in [
+        vec!["stella", "memory", "list", "--output-format", "json"],
+        vec!["stella", "stats", "--output-format", "json"],
+        vec!["stella", "goal", "ship it", "--output-format", "json"],
+        // The root position dies with the global: a value parsed at the
+        // root has no command bound to honour it. `stella run
+        // --output-format …` is the surviving spelling; the bench adapters
+        // and docs moved in the same PR.
+        vec!["stella", "--output-format", "json", "run", "hi"],
+    ] {
+        assert!(
+            Cli::try_parse_from(argv.clone()).is_err(),
+            "{argv:?} must be a parse error, not a silently ignored flag"
+        );
+    }
+}
+
+/// The two commands that honour the flag still declare it (same name, same
+/// `STELLA_OUTPUT_FORMAT` env), and the effective format `main`'s
+/// process-wide decisions read comes from the command, not a root slot.
+#[test]
+fn run_and_fleet_declare_output_format() {
+    let run = Cli::try_parse_from(["stella", "run", "hi", "--output-format", "json"])
+        .expect("run declares --output-format");
+    assert_eq!(run.output_format(), OutputFormat::Json);
+
+    let fleet = Cli::try_parse_from(["stella", "fleet", "task", "--output-format", "stream-json"])
+        .expect("fleet declares --output-format");
+    assert_eq!(fleet.output_format(), OutputFormat::StreamJson);
+
+    // No subcommand at all (the chat default): human text.
+    let chat = Cli::try_parse_from(["stella"]).expect("bare invocation parses");
+    assert_eq!(chat.output_format(), OutputFormat::Text);
+}
+
+/// `arena` output is the adapter contract, not a choice: there is no flag
+/// to promise otherwise (`--output-format text` used to parse and silently
+/// yield stream-json), and the effective format — what gates interactive
+/// credential prompts and the machine error envelope — is stream-json
+/// without one.
+#[test]
+fn arena_is_stream_json_by_contract_not_by_flag() {
+    let args = |extra: &[&str]| {
+        let mut argv = vec![
+            "stella",
+            "arena",
+            "--task-dir",
+            "t",
+            "--journal",
+            "j",
+            "--state-dir",
+            "s",
+        ];
+        argv.extend_from_slice(extra);
+        argv
+    };
+    assert!(
+        Cli::try_parse_from(args(&["--output-format", "text"])).is_err(),
+        "arena must reject --output-format rather than silently emit stream-json"
+    );
+    let arena = Cli::try_parse_from(args(&[])).expect("the adapter contract parses");
+    assert_eq!(arena.output_format(), OutputFormat::StreamJson);
 }
 
 /// `--budget`'s value parser still guards after a subcommand: a

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -6,7 +6,7 @@ description: The arena-bench harness adapter — run one benchmark episode from 
 `stella arena` is Stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.
 
 <Callout type="info">
-This command exists for **benchmarking Stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how Stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it.
+This command exists for **benchmarking Stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how Stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it. Stdout is **stream-json unconditionally**: the runner is the only intended reader, so there is no `--output-format` flag to promise otherwise.
 </Callout>
 
 ## Synopsis

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -60,7 +60,7 @@ A pass also names the model and where it came from, which is half of what people
 
 Diagnosis never writes. The check opens the database immutably — no locks, no `-shm`, zero bytes written — and escalates to a read-write open only when a first verdict already looks bad and a `-wal` sibling exists. Being asked a question is not a reason to create a `.stella/` that wasn't there.
 
-`stella doctor` runs *before* stella loads your configuration, on purpose: a workspace whose store is corrupt has to stay diagnosable without a working model config. One consequence is that `--output-format` does not apply to it — there is no JSON form of this output.
+`stella doctor` runs *before* stella loads your configuration, on purpose: a workspace whose store is corrupt has to stay diagnosable without a working model config. One consequence is that there is no JSON form of this output — `--output-format` is a flag of `run` and `fleet`, and `doctor` does not take it.
 
 ## Flags
 

--- a/website/content/docs/commands/fleet.mdx
+++ b/website/content/docs/commands/fleet.mdx
@@ -47,6 +47,11 @@ For anything beyond a handful of independent prompts, use a plan file (`--plan`)
   <OptionCard name="--no-pipeline">
     Workers run the raw step loop instead of the staged pipeline.
   </OptionCard>
+  <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
+    `json` / `stream-json` keep the run headless — the live grid stays off and stdout
+    stays machine-readable, including the error envelope on failure. A flag of `fleet`
+    itself, after the subcommand token. Env `STELLA_OUTPUT_FORMAT`.
+  </OptionCard>
 </CardGrid>
 
 ## Budget

--- a/website/content/docs/commands/goal.mdx
+++ b/website/content/docs/commands/goal.mdx
@@ -40,7 +40,7 @@ For the full explanation of judged rounds, the cross-family verifier, and the de
 </CardGrid>
 
 <Callout type="info">
-`stella goal` is an interactive mode: it always renders human-readable text and does **not** honor `--output-format`. Use [`stella run`](/docs/commands/run) for headless `json` / `stream-json` output.
+`stella goal` is an interactive mode: it always renders human-readable text and does **not** take `--output-format` (passing it is a parse error, not a silently ignored flag). Use [`stella run`](/docs/commands/run) for headless `json` / `stream-json` output.
 </Callout>
 
 <Callout type="warn">

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -167,7 +167,7 @@ Two of them are specialized rather than day-to-day. `stella arena` is a benchmar
 
 The following flags apply to **every** command. Most have a corresponding environment variable so you can set it once for a shell session or in your CI configuration — the exception is `--api-key`, which is intentionally env-less (use `credentials.toml` or a provider key env var such as `ANTHROPIC_API_KEY` instead).
 
-Every one of them is registered with every subcommand, so **either position parses** — `stella --output-format json run "…"` and `stella run "…" --output-format json` are equivalent. (That is not clap's default: a plain root-level flag is only accepted before the subcommand token, which is why `main.rs` marks each of these `global = true` and a test asserts no new one is added without it.) Because the flag names are reserved CLI-wide, no subcommand reuses them — `stella connect linear` pastes a key with `--paste-key`, not `--api-key`.
+Every one of them is registered with every subcommand, so **either position parses** — `stella --budget 5 run "…"` and `stella run "…" --budget 5` are equivalent. (That is not clap's default: a plain root-level flag is only accepted before the subcommand token, which is why `main.rs` marks each of these `global = true` and a test asserts no new one is added without it.) Because the flag names are reserved CLI-wide, no subcommand reuses them — `stella connect linear` pastes a key with `--paste-key`, not `--api-key`.
 
 <CardGrid size="md">
   <OptionCard name="--model <provider/model_id>" defaultValue="auto-detected">
@@ -181,10 +181,6 @@ Every one of them is registered with every subcommand, so **either position pars
   <OptionCard name="--base-url <url>" defaultValue="provider default">
     Required with `--model local/<model>` to point at a local OpenAI-compatible server; an
     optional proxy override for any other provider. Env `STELLA_BASE_URL`.
-  </OptionCard>
-  <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
-    Response rendering mode, honored by `stella run` — the interactive `chat`, `goal`, and
-    `monitor` modes always render text. Env `STELLA_OUTPUT_FORMAT`.
   </OptionCard>
   <OptionCard name="--budget <usd>" defaultValue="none (observed)">
     Hard USD spend cap for the whole run or session. Must be positive and finite. Env
@@ -209,7 +205,9 @@ Every one of them is registered with every subcommand, so **either position pars
 Prefer an environment variable or `credentials.toml` for anything long-lived. A key passed with `--api-key` is visible in your shell history and in `ps` output.
 </Callout>
 
-### `--output-format` values
+### `--output-format` (a flag of `run` and `fleet`, not a global)
+
+`--output-format <text|json|stream-json>` (env `STELLA_OUTPUT_FORMAT`) is deliberately **not** in the table above: it is a promise about what reaches stdout, and only the commands that keep that promise declare it — [`stella run`](/docs/commands/run) and [`stella fleet`](/docs/commands/fleet). As a subcommand flag it goes after the subcommand token — `stella run "…" --output-format json` — and passing it anywhere else is a parse error, not a silently ignored flag. [`stella arena`](/docs/commands/arena) emits stream-json unconditionally (the benchmark runner is its only reader), the interactive `chat`, `goal`, and `monitor` modes render text, and query commands with a machine shape declare their own flag (`stella stats --format json`, `stella inspect --format json`, `stella memory list --format json`).
 
 <CardGrid size="sm">
   <OptionCard name="text">

--- a/website/content/docs/commands/monitor.mdx
+++ b/website/content/docs/commands/monitor.mdx
@@ -41,7 +41,7 @@ Under the hood, `monitor` is [goal mode](/docs/agent-modes#outcome-driven-goal-m
 </CardGrid>
 
 <Callout type="info">
-`monitor` is an interactive mode and always renders human-readable text; it does **not** honor `--output-format`.
+`monitor` is an interactive mode and always renders human-readable text; it does **not** take `--output-format` (passing it is a parse error).
 </Callout>
 
 ## Examples

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -53,10 +53,9 @@ The most relevant global flags here:
     Pin the worker model instead of relying on auto-detection.
   </OptionCard>
   <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
-    Use `json` or `stream-json` for machine-readable, headless output. Like every global
-    flag it is registered with the subcommand too, so either position parses —
-    `stella --output-format json run "…"` and `stella run "…" --output-format json` are
-    the same command.
+    Use `json` or `stream-json` for machine-readable, headless output. A flag of `run`
+    itself (not a global), so it goes after the subcommand token:
+    `stella run "…" --output-format json`. Env `STELLA_OUTPUT_FORMAT`.
   </OptionCard>
   <OptionCard name="--budget <usd>">
     Cap total spend for the run; work aborts cleanly once the cap is exceeded.
@@ -74,15 +73,15 @@ stella run "Add a docstring to every public function in src/utils.py"
 Pin a specific model and emit a single JSON object for a script to parse. Global flags read most clearly before the subcommand, though [either position parses](/docs/commands#global-flags):
 
 ```bash
-stella --model anthropic/claude-fable-5 --output-format json \
-  run "Summarize the changes on this branch"
+stella --model anthropic/claude-fable-5 \
+  run --output-format json "Summarize the changes on this branch"
 ```
 
 Cap spend at two US dollars and stream events as they happen (useful in CI logs):
 
 ```bash
-stella --output-format stream-json --budget 2.00 \
-  run "Fix the failing unit tests in the payments module"
+stella --budget 2.00 \
+  run --output-format stream-json "Fix the failing unit tests in the payments module"
 ```
 
 Point at a local OpenAI-compatible server:

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -137,7 +137,7 @@ follows is the complete map; each card links to its detail page.
     href="/docs/scripting"
     meta={[
       { label: "Surface", value: "--output-format · STELLA_OUTPUT_FORMAT" },
-      { label: "Example", value: "stella --output-format json run …" },
+      { label: "Example", value: "stella run --output-format json … (run/fleet only)" },
     ]}
   >
     `text`, `json`, or `stream-json`.
@@ -322,7 +322,7 @@ Full walkthrough: the [coding-plan recipe](/docs/api-providers#zai).
 
 ```bash
 STELLA_MODEL=anthropic/claude-fable-5 STELLA_BUDGET=5 \
-  stella --output-format json run "port the utils module to the new API"
+  stella run --output-format json "port the utils module to the new API"
 ```
 
 **Ship org-wide defaults every project inherits** (a gateway URL + team key), leaving

--- a/website/content/docs/guides/budget.mdx
+++ b/website/content/docs/guides/budget.mdx
@@ -52,7 +52,7 @@ The exit code is `1`, the same as any other failure. If you need to distinguish
 *budget stopped this* from *this failed*, read the JSON:
 
 ```bash
-stella --budget 2.00 --output-format json run "…" | jq '{status, cost_usd, verdict}'
+stella --budget 2.00 run --output-format json "…" | jq '{status, cost_usd, verdict}'
 ```
 
 <Callout type="info">

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -112,8 +112,8 @@ for e in stella claude; do rm -rf "work/$e"; git worktree add -f "work/$e" HEAD;
 
 ```bash
 # Stella — one JSON object on stdout.
-( cd work/stella && stella --budget 1.00 --output-format json \
-  run "$(cat "../../$task/TASK.md")" ) > work/stella/stella.json
+( cd work/stella && stella --budget 1.00 \
+  run --output-format json "$(cat "../../$task/TASK.md")" ) > work/stella/stella.json
 
 # Claude Code — a JSON *array*; the result is the last element.
 ( cd work/claude && claude -p --output-format json --permission-mode acceptEdits \

--- a/website/content/docs/guides/fix-failing-ci.mdx
+++ b/website/content/docs/guides/fix-failing-ci.mdx
@@ -186,8 +186,8 @@ different requirements (a non-TTY surface, JSON output, an explicit scope-review
 bypass):
 
 ```bash
-stella --output-format json --budget 2.00 \
-  run --test-command "cargo test --workspace" "fix the failing tests" \
+stella --budget 2.00 \
+  run --output-format json --test-command "cargo test --workspace" "fix the failing tests" \
   | jq -e '.status == "completed" and .verdict.deterministic == true'
 ```
 

--- a/website/content/docs/guides/troubleshooting.mdx
+++ b/website/content/docs/guides/troubleshooting.mdx
@@ -271,8 +271,9 @@ salvaged database, and your next session starts fresh. Every quarantine is
 undoable with `mv`.
 
 `doctor` runs before configuration loads, on purpose: a workspace whose store is
-corrupt has to stay diagnosable without a working model config. One consequence
-is that `--output-format` does not apply to it.
+corrupt has to stay diagnosable without a working model config. There is no JSON
+form of its output — `--output-format` is a flag of `run` and `fleet`, and
+`doctor` does not take it.
 
 ## "The run ended without doing anything"
 

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -276,7 +276,7 @@ You can read that distinction back out of any headless run. `verdict.determinist
 is `true` exactly when the ladder answered without a verifier call:
 
 ```bash
-stella --output-format json run --test-command "cargo test -p pager" \
+stella run --output-format json --test-command "cargo test -p pager" \
   "fix the off-by-one in the pager" \
   | jq '{status, deterministic: .verdict.deterministic, evidence: .verdict.summary, cost_usd}'
 ```

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -110,7 +110,7 @@ And because the distinction is structural rather than rhetorical, it is
 machine-readable. Every verified run says which kind of evidence it stood on:
 
 ```bash
-stella --output-format json run --test-command "cargo test -p stella-core" \
+stella run --output-format json --test-command "cargo test -p stella-core" \
   "make the loop detector count identical no-op calls as progress-free" \
   | jq '{deterministic: .verdict.deterministic, evidence: .verdict.summary}'
 ```
@@ -118,7 +118,7 @@ stella --output-format json run --test-command "cargo test -p stella-core" \
 A CI gate can therefore insist on the mechanism and refuse the opinion:
 
 ```bash
-stella --output-format json run --test-command "make test" "$TASK" \
+stella run --output-format json --test-command "make test" "$TASK" \
   | jq -e '.verdict.deterministic == true' >/dev/null \
   || { echo "verified only by a model verifier — holding this one for review" >&2; exit 1; }
 ```

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -9,7 +9,12 @@ an environment-variable equivalent for CI.
 
 ## Output formats
 
-`--output-format` (env `STELLA_OUTPUT_FORMAT`) takes one of three values:
+`--output-format` (env `STELLA_OUTPUT_FORMAT`) is a flag of the two commands that honor
+it — [`stella run`](/docs/commands/run) and [`stella fleet`](/docs/commands/fleet) — so it
+goes **after** the subcommand token. It is deliberately not a global flag: on any other
+command it is a parse error rather than a promise the output silently breaks
+([#1493](https://github.com/macanderson/stella/issues/1493)). It takes one of three
+values:
 
 <CardGrid size="md">
   <OptionCard name="text">
@@ -43,10 +48,10 @@ preview — the `text` event that follows carries the full step text and is auth
 
 ```bash
 # One final JSON object
-stella --output-format json run "list the public API of the auth module"
+stella run --output-format json "list the public API of the auth module"
 
 # Newline-delimited event stream, parsed as it arrives
-stella --output-format stream-json run "fix the failing test" | while IFS= read -r line; do
+stella run --output-format stream-json "fix the failing test" | while IFS= read -r line; do
   echo "$line" | jq -r '.type // "event"'
 done
 ```
@@ -142,7 +147,7 @@ Two practical consequences for a consumer:
 
 ```bash
 # Refuse to parse a shape this script was not written for
-stella --output-format json run "…" | jq -e '
+stella run --output-format json "…" | jq -e '
   if .schema_version == 1 then .status else error("unsupported schema_version") end'
 ```
 
@@ -164,7 +169,9 @@ editing the command line:
     through a proxy.
   </OptionCard>
   <OptionCard name="STELLA_OUTPUT_FORMAT" defaultValue="text">
-    Equivalent to `--output-format`: `text`, `json`, or `stream-json`.
+    Equivalent to `--output-format`: `text`, `json`, or `stream-json`. Read
+    exactly where the flag exists — `run` and `fleet` — so exporting it for a
+    whole session never garbles the other commands' output.
   </OptionCard>
   <OptionCard name="STELLA_BUDGET">
     Equivalent to `--budget`. Hard USD cap for the whole run. Unset means
@@ -209,7 +216,7 @@ skipped when there is no TTY:
 
 ```bash
 export ANTHROPIC_API_KEY="$SECRET_ANTHROPIC_KEY"
-stella --output-format json run "generate release notes from the diff since the last tag"
+stella run --output-format json "generate release notes from the diff since the last tag"
 ```
 
 <Callout type="warn">
@@ -224,7 +231,7 @@ Pair headless runs with an [enforced budget](/docs/telemetry#budget-observed-vs-
 so an automated job can never overspend:
 
 ```bash
-stella --budget 3 --output-format json run "port the utils module to the new client"
+stella --budget 3 run --output-format json "port the utils module to the new client"
 ```
 
 Work aborts cleanly once the cap is reached — never mid-tool — so the workspace is left in
@@ -255,7 +262,7 @@ stella --budget 10 fleet --plan cleanup.toml --max-concurrency 4
 </CardGrid>
 
 ```bash
-stella --budget 3 --output-format json run \
+stella --budget 3 run --output-format json \
   --test-command "cargo test -p stella-store" \
   "make the store migration idempotent on an already-v2 file" > result.json
 case $? in
@@ -337,7 +344,7 @@ pipelines worth keeping:
 
 ```bash
 # Gate a script on deterministic evidence only — refuse a verifier-only pass.
-stella --output-format json run --test-command "make test" "$TASK" \
+stella run --output-format json --test-command "make test" "$TASK" \
   | jq -e '.status == "completed" and .verdict.deterministic == true' >/dev/null \
   || { echo "no deterministic proof — not merging" >&2; exit 1; }
 ```
@@ -346,7 +353,7 @@ stella --output-format json run --test-command "make test" "$TASK" \
 # Every file the raw step loop touched, with its line delta. Note the nesting:
 # the summary's `files_touched` key holds the telemetry payload object, whose
 # own `files_touched` key holds the array.
-stella --output-format json run --no-pipeline "tidy up the error types in stella-store" \
+stella run --output-format json --no-pipeline "tidy up the error types in stella-store" \
   | jq -r '.files_touched.files_touched[] | "\(.path)\t+\(.lines_added)/-\(.lines_removed)"'
 ```
 
@@ -354,14 +361,14 @@ stella --output-format json run --no-pipeline "tidy up the error types in stella
 # Watch the stages go by, live, without parsing anything else. Stage names are
 # snake_case: triage, context_recall, plan, scope_review, witness, execute,
 # verify, verifier.
-stella --output-format stream-json run "$TASK" \
+stella run --output-format stream-json "$TASK" \
   | jq -r --unbuffered 'select(.type == "stage") | "→ \(.name)"'
 ```
 
 ```bash
 # Which tools the run actually reached for, most-used first. A tool_start event
 # carries its call under `call`, so the name is `.call.name`.
-stella --output-format json run "$TASK" \
+stella run --output-format json "$TASK" \
   | jq -r '.events[] | select(.type == "tool_start") | .call.name' \
   | sort | uniq -c | sort -rn
 ```

--- a/website/content/docs/telemetry/files-touched.mdx
+++ b/website/content/docs/telemetry/files-touched.mdx
@@ -137,7 +137,7 @@ Which keys the final JSON object carries depends on which execution path ran:
 So a script that asserts on exactly what a run changed must pass `--no-pipeline`:
 
 ```bash
-stella --output-format json run --no-pipeline "add a --health flag and wire the readiness probe" \
+stella run --output-format json --no-pipeline "add a --health flag and wire the readiness probe" \
   | jq '.files_touched.files_touched[] | {path, crud_events, lines_added, lines_removed}'
 ```
 
@@ -165,14 +165,14 @@ it stays entirely on your machine.
 **Fail CI when a run edits files outside a directory.**
 
 ```bash
-touched=$(stella --output-format json run --no-pipeline "$TASK" | jq -r '.files_touched.files_touched[].path')
+touched=$(stella run --output-format json --no-pipeline "$TASK" | jq -r '.files_touched.files_touched[].path')
 echo "$touched" | grep -qv '^src/' && { echo "run touched files outside src/"; exit 1; }
 ```
 
 **Get a one-line change summary of a run.**
 
 ```bash
-stella --output-format json run --no-pipeline "$TASK" \
+stella run --output-format json --no-pipeline "$TASK" \
   | jq -r '.files_touched.files_touched[] | "\(.crud_events|join("")) \(.path) (+\(.lines_added) -\(.lines_removed))"'
 # RU src/router.rs (+18 -4)
 # C  src/health.rs (+22 -0)


### PR DESCRIPTION
## What & why

`--output-format` was a global flag with unqualified help text, while 34 of 36 subcommands silently swallowed it: `stella fleet --output-format json` (or an exported `STELLA_OUTPUT_FORMAT=json`) produced human-coloured stdout with a JSON error envelope appended on failure, and `stella arena --output-format text` silently emitted stream-json. #1493 allowed two honest outcomes; this PR takes the tractable one — **the flag exists exactly where the promise is kept**:

- Declared on `run` and `fleet` (same name, same `STELLA_OUTPUT_FORMAT` env). Because clap reads the env var only where the arg is declared, a whole-session `export STELLA_OUTPUT_FORMAT=json` now scopes itself correctly instead of garbling every other command.
- Everywhere else the flag is a **parse error**, not a silently ignored promise — including the old root position `stella --output-format json run …` (breaking; all in-repo callers moved in this PR, and the docs now show the subcommand position).
- `arena` takes no flag at all: its contract IS stream-json, and its help says so. `Cli::output_format()` answers `StreamJson` for it, which also closes a latent hole — an arena run could previously block on the masked interactive credential prompt, because the forbid-interactive gate read only the global flag (arena's runner would never answer it).
- `main`'s three process-wide decisions (forbid interactive credentials, env-file announce, the machine error envelope on failure) now read the per-command effective format via `Cli::output_format()`.

Callers moved: harbor adapter (`_build_command` + its tests), `bench/smoke/smoke_test.py`, `bench/run_swebench.py`. Docs moved: scripting.mdx (the consumer contract), commands index (flag pulled out of the global grid into its own scoped section), run/fleet/arena/goal/monitor/doctor pages, configuration, telemetry, guides, README.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`output_format_is_rejected_where_it_was_never_honoured` (crates/stella-cli/src/tests.rs): on `main` every listed invocation parses cleanly (the flag is `global = true`), so the `is_err()` assertions fail; here they pass. `arena_is_stream_json_by_contract_not_by_flag` flips the same way for the arena half.

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — deferred to CI: a live arena match owns this machine (standing no-heavy-local-builds rule), so compile tiers run on the PR
- [ ] `cargo test --workspace` — deferred to CI, same reason. Ran locally instead: the full harbor adapter suite (436 passed), file-size / invariants / doc-links / command-docs guards, `py_compile` on every touched Python file
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Ground-rule check

- Breaking CLI change, deliberately: the root-position spelling `stella --output-format json run …` no longer parses. The issue explicitly sanctioned "it stops being global and each command declares it"; the misleading state was the one option not worth keeping. Release notes should carry one line: move the flag after the subcommand token.

Closes #1493

## Summary by Sourcery

Scope the `--output-format` flag to commands that honor it and align callers, tests, and docs with the new per-command behavior.

New Features:
- Add per-command output format selection for `run` and `fleet`, including a helper to derive the effective output format for any invocation.

Bug Fixes:
- Reject `--output-format` on commands that do not support it instead of silently ignoring the flag and emitting mismatched output.
- Ensure arena runs always use stream-json output and no longer hang on interactive credential prompts when called in machine-readable mode.
- Base global behaviors like interactive-credentials gating, env-file announcements, and machine error envelopes on the effective per-command output format.

Enhancements:
- Refine CLI parsing by demoting `--output-format` from a global flag and tightening its contract around stdout promises.
- Update harbor adapter, SWE-bench runner, and smoke tests to pass `--output-format` after the `run`/`fleet` subcommands for headless runs.
- Clarify documentation across commands, scripting, configuration, and guides to describe `--output-format` as a `run`/`fleet` flag and document arena/doctor/goal/monitor output contracts.

Tests:
- Add CLI tests asserting that unsupported uses of `--output-format` are parse errors and that `run`/`fleet`/`arena` report the correct effective output format.
- Adjust harbor adapter tests, smoke tests, and logging tests to verify the new `run`-scoped `--output-format` positioning and behavior.