### PR TITLE
fix(stella-cli): make --output-format honest about where it applies (#1493)

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -107,7 +107,14 @@ pub(crate) struct GlobalArgs {
     #[arg(long, global = true, env = "STELLA_BASE_URL", hide_short_help = true)]
     pub(crate) base_url: Option<String>,
 
-    /// Output shape: text, json, or stream-json
+    /// Output shape for `run` and `fleet`: text, json, or stream-json
+    ///
+    /// Those are the subcommands that render turn output, so they are the
+    /// ones this steers (#1493). Typing the flag on any other subcommand is
+    /// an error rather than a silently swallowed promise; a session-wide
+    /// STELLA_OUTPUT_FORMAT export applies where honoured and resolves to
+    /// text everywhere else. Machine formats also make credential prompts
+    /// impossible and shape the on-failure error envelope.
     #[arg(
         long,
         global = true,
@@ -303,7 +310,9 @@ pub(crate) enum Command {
     /// while recording a contextgraph-trace journal the arena runner verifiers
     /// with the protocol's replay oracles. Speaks the adapter contract
     /// (--task-dir/--journal/--state-dir/--resume); see
-    /// <https://github.com/macanderson/arena-bench>.
+    /// <https://github.com/macanderson/arena-bench>. Output is one stream-json
+    /// line per event by that contract — the runner owns the rendering, which
+    /// is why `--output-format` does not apply here.
     Arena {
         /// The episode workspace; the prompt is read from TASK.md inside it.
         #[arg(long)]

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -293,6 +293,50 @@ fn emit_error_summary(format: OutputFormat, msg: &str) {
     }
 }
 
+/// What `--output-format` means for this invocation (#1493).
+///
+/// The flag renders *turn output*, and exactly the subcommands listed in
+/// [`honors_output_format`] produce any — for every other command the flag
+/// used to parse and then be silently swallowed, handing a scripted caller
+/// human-coloured stdout it asked to receive as json. Now:
+///
+/// - a command that honors the flag gets the requested format, whichever of
+///   the flag or `STELLA_OUTPUT_FORMAT` supplied it;
+/// - an **explicitly typed** flag on a command that cannot answer in that
+///   shape is an error naming the commands that can — loud beats swallowed;
+/// - an **environment-supplied** value on such a command resolves to `Text`:
+///   the env var is a session-wide "machine output where possible"
+///   preference, and erroring on it would break every other command for the
+///   rest of the session.
+fn resolve_output_format(
+    command: Option<&Command>,
+    requested: OutputFormat,
+    explicit_flag: bool,
+) -> Result<OutputFormat, String> {
+    if honors_output_format(command) {
+        return Ok(requested);
+    }
+    if explicit_flag && requested != OutputFormat::Text {
+        return Err(
+            "--output-format applies to `stella run` and `stella fleet`; this subcommand \
+             renders its own output shape (see its --help for any machine format it offers)"
+                .to_string(),
+        );
+    }
+    Ok(OutputFormat::Text)
+}
+
+/// The subcommands whose turn output `--output-format` actually renders.
+/// Destructured by variant so the honoring set is a fact checked against the
+/// real dispatch (`run` hands it to `agent::run_one_shot`, `fleet` to
+/// `fleet_cmd::run_fleet`) rather than a string list that can drift.
+fn honors_output_format(command: Option<&Command>) -> bool {
+    matches!(
+        command,
+        Some(Command::Run { .. }) | Some(Command::Fleet { .. })
+    )
+}
+
 // The argument tree itself lives in `cli.rs`; re-exported at the crate root so
 // the per-command modules keep addressing their own subcommand enum as
 // `crate::AuthCmd`, `crate::McpCmd`, … regardless of which file defines it.
@@ -431,18 +475,35 @@ fn main() -> ExitCode {
     // Not `Cli::parse()`: the root help is grouped by `cli::help::command()`,
     // and clap renders `--help` from whichever `Command` does the parsing. The
     // derived `Cli` on the other side is byte-for-byte the same value.
-    let cli = match Cli::from_arg_matches(&cli::help::command().get_matches()) {
+    let matches = cli::help::command().get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
         Ok(cli) => cli,
         Err(err) => err.exit(),
+    };
+
+    // `--output-format` steers exactly the subcommands that render turn
+    // output (#1493); resolve what it means for THIS invocation before
+    // anything keys off it, and refuse an explicit flag the resolved command
+    // would silently swallow. `value_source` is what tells a typed flag (the
+    // user asked this command for json — an error if it cannot answer) from
+    // a session-wide `STELLA_OUTPUT_FORMAT` export (a preference, honored
+    // where it applies).
+    let output_format = match resolve_output_format(
+        cli.command.as_ref(),
+        cli.globals.output_format,
+        matches.value_source("output_format") == Some(clap::parser::ValueSource::CommandLine),
+    ) {
+        Ok(format) => format,
+        Err(msg) => {
+            eprintln!("{} {}", "stella:".red().bold(), msg);
+            return ExitCode::from(2);
+        }
     };
 
     // A machine-readable run has nobody to answer a masked password prompt,
     // and its caller is blocked reading stdout for an object that would never
     // come. Decided here, once, while the requested format is in hand.
-    if matches!(
-        cli.globals.output_format,
-        OutputFormat::Json | OutputFormat::StreamJson
-    ) {
+    if matches!(output_format, OutputFormat::Json | OutputFormat::StreamJson) {
         config::forbid_interactive_credentials();
     }
 
@@ -473,11 +534,7 @@ fn main() -> ExitCode {
 
     // Value-free confirmation (names only), gated on STELLA_ENV_DEBUG + a TTY +
     // a human output format so it never pollutes json/stream-json.
-    env_files::announce(&loaded_env, cli.globals.output_format);
-
-    // Captured before `cli` moves into `run`: the catch-all below needs the
-    // requested format to honour the machine-readable error contract.
-    let output_format = cli.globals.output_format;
+    env_files::announce(&loaded_env, output_format);
 
     match run(cli, &loaded_env) {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -13,7 +13,10 @@ use super::build_info::{
 use super::term_policy::{
     PlainReason, accessible_env, animation_disabled, deck_decision, dumb_terminal,
 };
-use super::{AuthCmd, Cli, Command, ConnectCmd, OutputFormat, TelemetryCmd, error_summary_json};
+use super::{
+    AuthCmd, Cli, Command, ConnectCmd, OutputFormat, TelemetryCmd, error_summary_json,
+    resolve_output_format,
+};
 
 /// `-V` stays one greppable line; `--version` answers the two questions a bug
 /// report otherwise costs a round trip. Both must agree about the version
@@ -433,6 +436,53 @@ fn session_flags_parse_before_subcommand() {
     .expect("session flags before the subcommand must keep parsing");
     assert_eq!(cli.globals.budget, Some(2.5));
     assert_eq!(cli.globals.output_format, OutputFormat::Json);
+}
+
+/// #1493: `--output-format` steers exactly the subcommands that render turn
+/// output. Before this resolver, 34 of 36 subcommands parsed the flag and
+/// silently swallowed it — a scripted `stella stats --output-format json`
+/// got human-coloured stdout with a JSON error envelope appended on failure,
+/// unparseable by any consumer.
+#[test]
+fn output_format_is_honoured_refused_or_defused_by_command() {
+    let parse = |argv: &[&str]| Cli::try_parse_from(argv).expect("parses");
+
+    // The honouring commands get exactly what was asked, flag or env alike.
+    let run = parse(&["stella", "run", "hi", "--output-format", "json"]);
+    assert_eq!(
+        resolve_output_format(run.command.as_ref(), run.globals.output_format, true),
+        Ok(OutputFormat::Json)
+    );
+    let fleet = parse(&["stella", "fleet", "t", "--output-format", "stream-json"]);
+    assert_eq!(
+        resolve_output_format(fleet.command.as_ref(), fleet.globals.output_format, false),
+        Ok(OutputFormat::StreamJson)
+    );
+
+    // An explicitly typed machine format on a command that renders its own
+    // shape is an error naming where the flag applies — loud beats swallowed.
+    let stats = parse(&["stella", "stats", "--output-format", "json"]);
+    let err = resolve_output_format(stats.command.as_ref(), stats.globals.output_format, true)
+        .expect_err("an explicit flag the command would swallow must refuse");
+    assert!(err.contains("`stella run` and `stella fleet`"), "{err}");
+    // The bare default command is chat, which renders a terminal UI.
+    let chat = parse(&["stella", "--output-format", "json"]);
+    assert!(
+        resolve_output_format(chat.command.as_ref(), chat.globals.output_format, true).is_err()
+    );
+
+    // The same value arriving from a session-wide STELLA_OUTPUT_FORMAT
+    // export is a preference, not a demand on this command: it resolves to
+    // text instead of failing every non-rendering command in the session.
+    assert_eq!(
+        resolve_output_format(stats.command.as_ref(), OutputFormat::Json, false),
+        Ok(OutputFormat::Text)
+    );
+    // And an explicit `--output-format text` is a harmless no-op anywhere.
+    assert_eq!(
+        resolve_output_format(stats.command.as_ref(), OutputFormat::Text, true),
+        Ok(OutputFormat::Text)
+    );
 }
 
 /// `--budget`'s value parser still guards after a subcommand: a


### PR DESCRIPTION
## Problem

`--output-format` was declared global with unqualified help text, and 34 of 36 subcommands silently swallowed it. A scripted `stella stats --output-format json` (or a session-wide `STELLA_OUTPUT_FORMAT` export) got human-coloured stdout with a JSON error envelope appended on failure — unparseable by any consumer.

## The chosen resolution, stated plainly

The issue offers two honest end-states: make the flag work everywhere, or stop advertising it where it doesn't. **This PR ships the second** — the truthful surface — and does *not* build per-command JSON output for the other 34 subcommands; that convergence (four per-command format enums, two `--json` booleans, three unversioned machine shapes) is filed as a follow-up rather than half-shipped here.

A third constraint shaped the mechanics: `session_flags_parse_before_subcommand` pins the pre-subcommand flag position as a deliberate contract, so demoting the flag out of the global group would break `stella --output-format json run` scripts. The flag therefore **stays global at the parse level**; what changes is that `main` resolves what it *means* before anything keys off it:

- `run` and `fleet` — the two subcommands that actually render turn output — get exactly what was asked, flag or env alike;
- an **explicitly typed** machine format on any other subcommand errors, naming where the flag applies. Provenance comes from clap's own `ValueSource` API (the canonical way to tell a typed flag from an env default — no shadow state);
- an **env-supplied** value on such a command resolves to `Text`: the export is a session preference, and erroring on it would break every other command for the rest of the session.

The cross-cutting behaviours — credential-prompt refusal, the env-files announcement gate, the on-failure machine error envelope — now key off the **resolved** format, so a swallowed request can no longer half-engage them (the exact mixed-output failure the issue documents). Arena's help now states its stream-json adapter contract, answering the `arena --output-format text` confusion.

## Witness

`output_format_is_honoured_refused_or_defused_by_command` — honoured on `run`/`fleet`, refused when typed on `stats`/bare `chat`, defused to text when env-sourced, no-op for explicit `text`. **Fails on main** (main has no resolver; the flag is silently swallowed). The pre-existing position fence (`session_flags_parse_before_subcommand`) still passes, pinning that no script's flag placement broke. Full `stella-cli` test surface: 1280 passed locally.

Refs the audit trail in `docs/audit/2026-08-04-ultraudit-round-3.md`.

Closes #1493

## Summary by Sourcery

Restrict and clarify how the global --output-format flag is applied across stella-cli commands to prevent silently swallowed machine-output requests and mixed human/JSON output.

Enhancements:
- Resolve the effective output format per invocation based on subcommand and whether the value came from the CLI flag or STELLA_OUTPUT_FORMAT, defaulting non-applicable commands to text.
- Limit --output-format to run and fleet subcommands and emit a clear error when a non-text format is explicitly requested on other commands.
- Ensure downstream behaviours such as credential prompt disabling, env-file announcements, and machine-readable error envelopes key off the resolved output format rather than the raw global flag.
- Document the restricted scope and behaviour of --output-format in the CLI help, including arena's stream-json adapter contract.

Tests:
- Add coverage to verify that --output-format is honoured for run/fleet, refused for explicit machine formats on other commands, defused to text for env-sourced values, and treated as a no-op for explicit text.