### PR TITLE
fix(fullauto): unbreak main — evict the rig key from docs/design, satisfy CI shellcheck

### DIFF
--- a/scripts/fullauto.sh
+++ b/scripts/fullauto.sh
@@ -61,7 +61,11 @@ readonly SHADOW_PATH_LINE='export PATH="$HOME/Projects/stella/target/release:$PA
 readonly RIG_INSTANCE="${FULLAUTO_RIG_INSTANCE:-i-07d46341dcc9a31b3}"
 readonly RIG_REGION="${FULLAUTO_RIG_REGION:-us-east-1}"
 readonly RIG_USER="ubuntu"
-readonly RIG_KEY="docs/design/stella-bench-handoff/tb909-key.pem"
+# A credential is not a document: the key lives under the stella home, not in
+# the repository. Its old home was the docs/design scratchpad, which
+# check-design-refs forbids citing — and a key that sits in a docs tree is one
+# `git add -A` away from being published.
+readonly RIG_KEY="${FULLAUTO_RIG_KEY:-${STELLA_HOME:-$HOME/.stella}/keys/tb909-key.pem}"
 
 # The head-to-head match: Claude Code vs Stella on Terminal-Bench 2.1, same
 # model on both arms so the agent architecture is the variable under test.
@@ -594,7 +598,7 @@ probe_disk_free_gb() {
   [ -n "${FULLAUTO_PROBE_DISK_FREE_GB:-}" ] && { echo "$FULLAUTO_PROBE_DISK_FREE_GB"; return 0; }
   # -P forces POSIX single-line output; without it a long device name wraps and
   # the field offsets silently shift.
-  df -Pk "${1:-$REPO_ROOT}" 2>/dev/null | awk 'NR==2 {printf "%d", $4/1024/1024}' || echo 0
+  df -Pk "$REPO_ROOT" 2>/dev/null | awk 'NR==2 {printf "%d", $4/1024/1024}' || echo 0
 }
 
 probe_on_battery() {
@@ -1629,8 +1633,8 @@ bench_h2h() {
   fi
 
   have aws || die "bench h2h --rig needs the aws CLI"
-  [ -f "$REPO_ROOT/$RIG_KEY" ] || die "rig key not found at $RIG_KEY"
-  chmod 600 "$REPO_ROOT/$RIG_KEY" 2>/dev/null || true
+  [ -f "$RIG_KEY" ] || die "rig key not found at $RIG_KEY (place it there, or point FULLAUTO_RIG_KEY at it)"
+  chmod 600 "$RIG_KEY" 2>/dev/null || true
 
   # The rig bills by the hour. Stopping it is the only step in this script that
   # MUST happen even on failure, interrupt, or a dropped SSH connection.
@@ -1654,14 +1658,14 @@ bench_h2h() {
   local ip
   ip="$(aws ec2 describe-instances --region "$RIG_REGION" --instance-ids "$RIG_INSTANCE" \
         --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)"
-  [ -n "$ip" ] && [ "$ip" != "None" ] || die "rig has no public IP"
+  if [ -z "$ip" ] || [ "$ip" = "None" ]; then die "rig has no public IP"; fi
   pass "rig at $ip (IP changes across stop/start — never hardcode it)"
 
   # SSH can be refused for a minute after instance-running; poll rather than
   # racing it.
   local tries=0
   until ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8 \
-        -i "$REPO_ROOT/$RIG_KEY" "$RIG_USER@$ip" true 2>/dev/null; do
+        -i "$RIG_KEY" "$RIG_USER@$ip" true 2>/dev/null; do
     tries=$((tries + 1))
     [ "$tries" -gt 20 ] && die "rig unreachable over ssh after 20 tries"
     sleep 10
@@ -1669,12 +1673,12 @@ bench_h2h() {
   pass "ssh up"
 
   say "running the head-to-head on the rig"
-  ssh -o StrictHostKeyChecking=accept-new -i "$REPO_ROOT/$RIG_KEY" "$RIG_USER@$ip" \
+  ssh -o StrictHostKeyChecking=accept-new -i "$RIG_KEY" "$RIG_USER@$ip" \
     "set -e; cd ~/stella && git fetch --quiet && git checkout --quiet origin/main -- . || true; \
      DOCKER_DEFAULT_PLATFORM=linux/amd64 arenabench run $H2H_MATCH --progress --results /tmp/h2h.json" \
     || warn "the match returned nonzero — read the results before calling it a loss"
 
-  if scp -o StrictHostKeyChecking=accept-new -i "$REPO_ROOT/$RIG_KEY" \
+  if scp -o StrictHostKeyChecking=accept-new -i "$RIG_KEY" \
        "$RIG_USER@$ip:/tmp/h2h.json" "$out" 2>/dev/null; then
     pass "results -> $out"
   else

--- a/scripts/fullauto/commands/fullauto/bench.md
+++ b/scripts/fullauto/commands/fullauto/bench.md
@@ -67,8 +67,9 @@ number anyone quotes.
 `--rig` drives the EC2 host instead:
 
 - Instance `stella-vs-cc-rig`, `us-east-1`, 32 vCPU / 123 GB.
-- Key at `docs/design/stella-bench-handoff/tb909-key.pem`, user `ubuntu`. The
-  public IP changes across stop/start — always read it from AWS, never hardcode.
+- Key at `~/.stella/keys/tb909-key.pem` (override with `FULLAUTO_RIG_KEY`),
+  user `ubuntu`. The public IP changes across stop/start — always read it from
+  AWS, never hardcode.
 - **It bills $1.90/hr and $45.56/day.** Left idle from one run it alone pushed a
   ~$68/month account to a $1,006 forecast and tripped the budget alarm. The
   script stops it on exit, interrupt, and failure — but check `aws ec2


### PR DESCRIPTION
## What & why

**Main is red.** The #1551 merge landed with three findings its stale PR checks never saw (the classic merges-land-broken shape: the branch's checks predate later guard/toolchain movement), and the required `fmt + clippy + test` job now fails on every merge head — #1562's run and the in-flight runs after it all hit the same wall. This PR fixes what the job names:

- **`check-design-refs`**: `RIG_KEY` defaulted to a private SSH key path inside `docs/design/`, which nothing outside `docs/` may cite — and the guard's ALLOW list is explicitly not for this. The real defect is deeper: a credential defaulting to a path inside the repository's docs tree is one `git add -A` away from being published. The default moves to `${STELLA_HOME:-~/.stella}/keys/tb909-key.pem` with a `FULLAUTO_RIG_KEY` override (matching `FULLAUTO_RIG_INSTANCE`/`FULLAUTO_RIG_REGION`), every ssh/scp site uses it absolute instead of `$REPO_ROOT`-relative, and the missing-key error says how to repoint. `bench.md` documents the new location.
- **shellcheck SC2120/SC2119**: `probe_disk_free_gb` declared a `${1:-$REPO_ROOT}` parameter that no caller ever passed. The dead parameter is gone. (Local older shellcheck never flagged it; CI's newer one does — the known version-skew trap.)
- **shellcheck SC2015**: the rig-IP check was `A && B || die`, which can die even when A holds; now an explicit `if`.

**Operator action (Mac):** the rig key needs relocating once:
`mkdir -p ~/.stella/keys && mv "docs/design/stella-bench-handoff/tb909-key.pem" ~/.stella/keys/` — or set `FULLAUTO_RIG_KEY` to wherever it lives. Until then the bench arm dies with an error naming both options.

## The witness

- [x] No witness needed (CI fix) — because: the failing guards are themselves the tests. `./scripts/check-design-refs.sh` and CI's shellcheck fail on `main` and pass here; both fixes are structural (no `$1` reference and no `A && B || C` remain to flag, regardless of shellcheck version). `make fullauto-test` still passes (38 checks).

## The gate

- [x] `check-design-refs.sh`, `shellcheck`, `check-no-scratch.sh` green locally
- [x] `make fullauto-test` green (38 checks)
- [x] Docs updated: `bench.md` names the new key location and override
- [x] CLA signed
- [x] No issue to close — red main fixed in the same session that observed it

## Ground-rule check

- [x] No new outbound network calls; no Rust touched

## Anything reviewers should know?

Only what stays red after this merges is genuinely the newer PRs' — the arenabench-watch merge head is running the same gauntlet now.

## Summary by Sourcery

Relocate the fullauto rig SSH key out of the repository, align fullauto scripts with stricter shellcheck rules, and update bench documentation to match the new rig key location.

New Features:
- Allow configuring the fullauto rig SSH key path via the FULLAUTO_RIG_KEY environment variable.

Bug Fixes:
- Move the default rig SSH key path from the repository docs tree to a per-user stella home directory to avoid accidental publication and resolve design-reference checks.
- Fix the rig IP availability check to avoid false failures due to short-circuited boolean logic.
- Remove an unused probe_disk_free_gb parameter to satisfy newer shellcheck diagnostics and simplify its usage of REPO_ROOT.

Documentation:
- Document the new default rig SSH key location and FULLAUTO_RIG_KEY override in the fullauto bench documentation.