### PR TITLE
fix(gate): re-sync the file-size baseline after the #1560 parallel-merge skew

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -9,7 +9,7 @@
 # review like any other change.
 2231 bench/harbor_adapter/stella_harbor/__init__.py
 4292 bench/harbor_adapter/stella_harbor/secure_launcher.py
-2333 bench/harbor_adapter/tests/test_adapter.py
+2335 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8272 bench/terminal_bench_analysis/tb21_analysis.py
 1911 bench/terminal_bench_analysis/tb21_evidence_contract.py
@@ -33,9 +33,9 @@
 2268 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1569 crates/stella-tools/src/media.rs
-2308 crates/stella-tools/src/registry.rs
+2305 crates/stella-tools/src/registry.rs
 1839 crates/stella-tools/src/scripts.rs
-1528 crates/stella-tui/src/deck.rs
+1510 crates/stella-tui/src/deck.rs
 1580 crates/stella-tui/src/deck_render.rs
 4028 crates/stella-tui/src/deck_ui.rs
 1665 crates/stella-tui/src/views/engine.rs


### PR DESCRIPTION
## What

Main is red on the `file-size` guard: `bench/harbor_adapter/tests/test_adapter.py` is 2335 lines against a baseline entry of 2333.

**How it happened — two green PRs, red merge result.** #1560 re-tightened every baseline entry to the actuals its base commit saw (test_adapter.py = 2333). In parallel, another merge grew that file to 2335 — legitimately, since the ceiling *its* base saw was 2339. Each PR's CI was green; neither could see the other; the merge result trips the guard. Same shape as the earlier rename-PR + new-file-PR silent break.

**The fix is a re-sync, not an expedient**: `make file-size-update` recording main's true actuals. The one raise (2333 → 2335) restores the honest current length of a file whose real ceiling history was 2339 — no growth-over-limit is being masked. The same regenerate ratchets two entries DOWN that other merges left slack in: `registry.rs` 2308 → 2305, `deck.rs` 1528 → 1510.

## Verification

`scripts/check-file-size.sh` — fails on main, OK on this branch: 942 files, 33 grandfathered, none grew.

**This unblocks every open PR** (a red main makes them all red). Merge before anything else.

## Summary by Sourcery

Re-sync the file-size baseline to match current main branch measurements so the file-size guard reflects actual file lengths and unblocks CI on main.

Bug Fixes:
- Update file-size baseline entries so the guard no longer fails due to parallel-merge skew rather than real size regressions.

Build:
- Refresh scripts/file-size-baseline.txt with current file-size measurements used by the size-checking script.