### PR TITLE
Unbreak main: #1567's arena arg builder does not compile

### DIFF
--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -475,7 +475,12 @@ fn run_and_fleet_declare_output_format() {
 /// without one.
 #[test]
 fn arena_is_stream_json_by_contract_not_by_flag() {
-    let args = |extra: &[&str]| {
+    // A nested `fn`, not a closure. The returned `Vec` borrows from `extra`,
+    // and a closure cannot say so: it gets a higher-ranked signature with a
+    // fresh input lifetime and an unconstrained output, which rustc rejects
+    // however the return type is annotated. Only an item can name the
+    // lifetime that relates them.
+    fn args<'a>(extra: &[&'a str]) -> Vec<&'a str> {
         let mut argv = vec![
             "stella",
             "arena",
@@ -488,7 +493,7 @@ fn arena_is_stream_json_by_contract_not_by_flag() {
         ];
         argv.extend_from_slice(extra);
         argv
-    };
+    }
     assert!(
         Cli::try_parse_from(args(&["--output-format", "text"])).is_err(),
         "arena must reject --output-format rather than silently emit stream-json"


### PR DESCRIPTION
`cargo test -p stella-cli` has not compiled since #1567 merged.

`arena_is_stream_json_by_contract_not_by_flag` builds its argv in a closure whose returned `Vec` borrows from the closure's own argument:

```text
crates/stella-cli/src/tests.rs:490:9: error: lifetime may not live long enough
  returning this value requires that `'1` must outlive `'2`
```

A closure cannot relate those two lifetimes — it is given a higher-ranked signature with a fresh input lifetime and an unconstrained output — and annotating the return type does not help, because closure elision gives the output its own fresh lifetime too. Only an item can name the lifetime that relates them, so this makes it a nested `fn`.

## Verification

`cargo check -p stella-cli --all-targets` fails on `origin/main` and passes with this commit. The test's assertions are untouched.

## Witness

Not applicable — this is a compile fix for an existing test, and that test compiling *is* the witness. It fails on main by not building.

## Summary by Sourcery

Bug Fixes:
- Rewrite the arena argument builder in the test as a nested function so its returned vector can correctly borrow from its input slice, resolving a lifetime-related compile error.