### PR TITLE
fix(docs): enforce the brand's lowercase wordmark, and make the tree comply (#1500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,14 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-command-docs.sh
 
+      # Also toolchain-free. The brand's lowercase rule was documented in two
+      # places and enforced in none — 389 capitalised uses accumulated in the
+      # docs tree, including inside `description:` frontmatter, which is what
+      # search engines and model crawlers read first (#1500).
+      - name: docs prose spells the wordmark lowercase
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-brand-case.sh
+
       # Also toolchain-free (shellcheck ships preinstalled on ubuntu-latest).
       # install.sh is fetched over the network and piped into `sh` by
       # strangers before Stella is installed; the guard scripts are what the

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,6 +1,6 @@
 name: docs-guards
 
-# Three guards over prose. None needs a Rust toolchain, which is why they live
+# Four guards over prose. None needs a Rust toolchain, which is why they live
 # here rather than in ci.yml -- that workflow deliberately ignores `docs/**`,
 # `website/**` and `*.md`, and this one triggers on exactly those paths.
 #
@@ -24,9 +24,16 @@ name: docs-guards
 #     that still exists (#993). #928 found seven undocumented surfaces at once
 #     precisely because nothing related the two.
 #
-# Rust sources are in the path filter because all three read them: a citation
-# added to a .rs comment is exactly how one goes stale, and the subcommand list
-# the third guard checks is itself a Rust enum.
+#  4. brand-case (scripts/check-brand-case.sh): docs prose spells the
+#     wordmark lowercase — "stella", never "Stella" (#1500). The rule was
+#     documented in the brand kit and website/README.md and enforced nowhere;
+#     389 capitalised uses accumulated, including inside `description:`
+#     frontmatter, which becomes each page's meta description and llms.txt
+#     entry. Code spans, fenced blocks, and URLs are exempt by construction.
+#
+# Rust sources are in the path filter because the first three read them: a
+# citation added to a .rs comment is exactly how one goes stale, and the
+# subcommand list the third guard checks is itself a Rust enum.
 on:
   pull_request:
     paths:
@@ -35,8 +42,9 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
-      - "website/content/docs/commands/**"
+      - "website/content/docs/**"
       - "scripts/check-command-docs.sh"
+      - "scripts/check-brand-case.sh"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -46,8 +54,9 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
-      - "website/content/docs/commands/**"
+      - "website/content/docs/**"
       - "scripts/check-command-docs.sh"
+      - "scripts/check-brand-case.sh"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -85,3 +94,10 @@ jobs:
       - name: every subcommand has a reference page
         if: ${{ !cancelled() }}
         run: bash scripts/check-command-docs.sh
+
+      # Docs-only by nature — ci.yml also runs it for code PRs, but a
+      # capitalised wordmark arrives in .mdx prose, which only this workflow
+      # sees.
+      - name: docs prose spells the wordmark lowercase
+        if: ${{ !cancelled() }}
+        run: bash scripts/check-brand-case.sh

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs file-size
+                    command-docs brand-case file-size
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 .PHONY: help
@@ -185,6 +185,10 @@ doc-adopt: ## Scaffold frontmatter onto a document so it can be cited: make doc-
 .PHONY: command-docs
 command-docs: ## Assert every stella subcommand has a listed reference page (#993)
 	@./scripts/check-command-docs.sh
+
+.PHONY: brand-case
+brand-case: ## Assert docs prose spells the wordmark lowercase (#1500)
+	@./scripts/check-brand-case.sh
 
 .PHONY: wire-schema
 wire-schema: ## Assert docs/wire/ still describes the AgentEvent wire format (#971)

--- a/scripts/check-brand-case.sh
+++ b/scripts/check-brand-case.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Guard: the brand's lowercase rule is enforced, not just documented (#1500).
+#
+# docs/brand/brand-guidelines.html is normative: the wordmark is "stella" —
+# lowercase, always; never "Stella" or "STELLA". website/README.md restates
+# it, and website/content/docs is the surface where a violation matters most:
+# `description:` frontmatter becomes each page's meta description and its
+# llms.txt entry, so a capitalised name there is the first thing search
+# engines and model crawlers read. Before this guard the tree carried 389
+# capitalised uses against 1806 lowercase — a documented rule with no gate
+# behind it is an unenforced rule.
+#
+# Prose-aware, because the rule is about the *name in prose*, never code:
+#
+#   - fenced code blocks (``` / ~~~) are skipped whole — sample output, Rust
+#     paths, and config excerpts are quotations, not brand copy;
+#   - inline code spans (`...`) are stripped before matching, so a genuine
+#     identifier is exempted by writing it as code, which the docs style
+#     wants anyway;
+#   - URLs are stripped — a path segment is an address, not prose;
+#   - compound identifiers (StellaError, StellaHome) never match: the word
+#     boundary is part of the rule, which covers the standalone name only.
+#
+# Portable POSIX awk/find, no toolchain — runs beside the other early guards.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+docs_dir="website/content/docs"
+if [ ! -d "$docs_dir" ]; then
+    echo "check-brand-case: $docs_dir is missing — the docs tree moved; update this guard" >&2
+    exit 1
+fi
+
+violations="$(
+    find "$docs_dir" -name '*.mdx' -print | sort | while IFS= read -r file; do
+        awk -v file="$file" '
+            /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
+            fence { next }
+            {
+                line = $0
+                gsub(/`[^`]*`/, "", line)
+                gsub(/https?:\/\/[^[:space:])]+/, "", line)
+                rest = line
+                while (match(rest, /[A-Za-z0-9_]+/)) {
+                    word = substr(rest, RSTART, RLENGTH)
+                    if (tolower(word) == "stella" && word != "stella") {
+                        printf "%s:%d: %s\n", file, FNR, $0
+                        break
+                    }
+                    rest = substr(rest, RSTART + RLENGTH)
+                }
+            }
+        ' "$file"
+    done
+)"
+
+if [ -n "$violations" ]; then
+    count="$(printf '%s\n' "$violations" | wc -l | tr -d ' ')"
+    {
+        echo "check-brand-case: $count line(s) spell the wordmark capitalised in docs prose:"
+        printf '%s\n' "$violations"
+        echo
+        echo "The wordmark is lowercase, always: \"stella\", never \"Stella\" or \"STELLA\""
+        echo "(docs/brand/brand-guidelines.html). Fix the prose — or, for a genuine code"
+        echo "identifier, write it as an inline code span: fenced blocks and \`...\` are exempt."
+    } >&2
+    exit 1
+fi
+
+echo "check-brand-case: docs prose spells the wordmark lowercase"

--- a/website/content/docs/accessibility.mdx
+++ b/website/content/docs/accessibility.mdx
@@ -3,7 +3,7 @@ title: Accessibility
 description: Run the Command Deck so a screen reader can read it — what --accessible changes, what it deliberately leaves alone, and how it differs from --plain.
 ---
 
-Stella's interactive surface is the **Command Deck**, a tabbed terminal UI. By default it
+stella's interactive surface is the **Command Deck**, a tabbed terminal UI. By default it
 draws the way full-window terminal apps do: on the alternate screen, repainting a whole
 grid many times a second. That is a good surface for an eye and a poor one for a screen
 reader, which is handed cell churn with no notion of *a new line appeared* — and which
@@ -122,7 +122,7 @@ quiet, because announcing it would bury the moves that matter.
 
 ### The program's own voice is marked
 
-Messages Stella itself speaks — "conversation cleared", driver and chrome notices — open
+Messages stella itself speaks — "conversation cleared", driver and chrome notices — open
 with `▸`. In the default deck those are distinguished by which rail they render on, which
 is a *visual* distinction, and therefore exactly the one that does not survive being read
 aloud. Without the marker the transcript asserts that the model said "conversation
@@ -145,7 +145,7 @@ behavior. If a feature works in the deck, it works here.
 
 ## When your terminal will not cooperate
 
-Drawing inline means anchoring to the cursor's current position, which Stella has to
+Drawing inline means anchoring to the cursor's current position, which stella has to
 *ask* for: it writes a cursor-position request and waits for the terminal to answer.
 Every real emulator answers. Some minimal terminals and most test harnesses do not, and
 the request times out.
@@ -222,4 +222,4 @@ emulator and reader named.
 ## See also
 
 - [`stella chat`](/docs/commands/chat) — the command reference, including every flag
-- [Agent Modes](/docs/agent-modes) — the other ways to drive Stella
+- [Agent Modes](/docs/agent-modes) — the other ways to drive stella

--- a/website/content/docs/agent-engine-in-your-app.mdx
+++ b/website/content/docs/agent-engine-in-your-app.mdx
@@ -1,6 +1,6 @@
 ---
-title: How to use Stella as the Agent Engine in your GenAI app
-description: Run Stella's agent loop inside your own product — the engine orchestrates, your app owns every model call, tool call, and credential. Includes an 80-line working host.
+title: How to use stella as the Agent Engine in your GenAI app
+description: Run stella's agent loop inside your own product — the engine orchestrates, your app owns every model call, tool call, and credential. Includes an 80-line working host.
 ---
 
 Writing an agent loop that survives contact with production is a grind. You
@@ -9,12 +9,12 @@ fills, per-turn spend limits, retry classification that knows a rate limit from
 a bad request, and loop detection for the model that calls the same tool nine
 times. None of that is your product. All of it is on your critical path.
 
-Stella already does it, and you can run it inside your own app without giving
+stella already does it, and you can run it inside your own app without giving
 up control of your models, your tools, or your data.
 
 ## What you get, and what you keep
 
-| Stella handles | You keep |
+| stella handles | You keep |
 |---|---|
 | The step loop: model call, tool dispatch, repeat until done | Every model call. Your gateway, your keys, your routing |
 | History compaction and token budgeting | Every tool call. Your sandbox, your RBAC, your database |
@@ -27,7 +27,7 @@ up control of your models, your tools, or your data.
 This is the part worth understanding before you write any code, because it
 inverts the usual shape.
 
-Stella's engine does not call your tools. It **asks you to call them**, then
+stella's engine does not call your tools. It **asks you to call them**, then
 waits. Same for the model: it does not hold an API key and it does not make an
 HTTP request. It emits a request and parks until your app answers.
 
@@ -427,7 +427,7 @@ Re-verified absent as of 0.6.10, so design around them rather than discovering t
 
 ## Licensing: AGPL or commercial
 
-Stella is **dual-licensed**. You choose the track.
+stella is **dual-licensed**. You choose the track.
 
 | | Open source track | Commercial track |
 |---|---|---|
@@ -439,10 +439,10 @@ Stella is **dual-licensed**. You choose the track.
 
 ### You do not need a commercial license to
 
-- Use Stella as a developer tool, at work, on proprietary code. **Using Stella
+- Use stella as a developer tool, at work, on proprietary code. **Using stella
   to write closed-source software does not make that software AGPL.** The
-  license covers Stella and works derived from it, not the output of running it.
-- Run **unmodified** Stella internally, including on your own servers.
+  license covers stella and works derived from it, not the output of running it.
+- Run **unmodified** stella internally, including on your own servers.
 - Evaluate, benchmark, audit, or study it.
 - Build on the [Context Graph
   Protocol](https://github.com/macanderson/context-graph-protocol), which is a
@@ -451,11 +451,11 @@ Stella is **dual-licensed**. You choose the track.
 
 ### You do need one to
 
-- Ship Stella, or anything derived from it, inside a product whose source you do
+- Ship stella, or anything derived from it, inside a product whose source you do
   not publish.
-- Offer a **modified** Stella to third parties over a network without publishing
+- Offer a **modified** stella to third parties over a network without publishing
   your modifications. This is AGPL section 13, and hosting is not a loophole.
-- Keep a proprietary fork private, or sublicense Stella to your own customers
+- Keep a proprietary fork private, or sublicense stella to your own customers
   under other terms.
 
 ### Where the sidecar lands
@@ -489,7 +489,7 @@ answer about whether you need a license at all, including "you do not."
 1. **Email [licensing@oxagen.sh](mailto:licensing@oxagen.sh).** One message starts it. There is no portal
    and no sales sequence.
 2. **Tell us what you are building and roughly how you will deploy it.** What
-   the product does, whether Stella is linked in or run as a sidecar, whether
+   the product does, whether stella is linked in or run as a sidecar, whether
    you modify it, and rough scale (self-hosted or SaaS, number of environments,
    order of magnitude of users). Pricing depends on scope and deployment size,
    so this is what determines the number.
@@ -507,7 +507,7 @@ releases (everything up to v0.5.14 remains perpetually available under
 
 ## Where to go next
 
-- [Drop Stella in as your agent engine](/docs/guides/embed-the-engine): the
+- [Drop stella in as your agent engine](/docs/guides/embed-the-engine): the
   guide-shaped version of this page — which shape to pick, how to port an
   existing feature onto the engine in an afternoon, and the integration test
   that exercises the whole loop with no API key.

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -1,9 +1,9 @@
 ---
 title: Agent Engine Paths
-description: Every entry point into Stella's agent engine — one-shot runs, REPL, Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — when to use each.
+description: Every entry point into stella's agent engine — one-shot runs, REPL, Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — when to use each.
 ---
 
-Stella has **one agent engine and many doors into it**. Whether you type into
+stella has **one agent engine and many doors into it**. Whether you type into
 the Command Deck, script `stella run` in CI, or fan a fleet out across
 worktrees, the same core loop does the work: the step-driver in
 `stella-core`, driving the same tool stack, metered by the same budget,

--- a/website/content/docs/agent-fleets.mdx
+++ b/website/content/docs/agent-fleets.mdx
@@ -4,7 +4,7 @@ description: Fan a dependency-ordered task DAG out to parallel workers in one sh
 ---
 
 `stella fleet` runs **many tasks at once** — each task handled by a full
-Stella worker. By default the workers share **one tree**: every worker runs
+stella worker. By default the workers share **one tree**: every worker runs
 in the repository root, coordinated by cooperative file claims, so conflicts
 surface at write time with the rival named, commits interleave on one
 branch, and the build cache stays warm. A task marked
@@ -51,7 +51,7 @@ stella fleet \
    instead of the staged pipeline.
 5. **Record.** Every attempt, commit, and dollar lands in the fleet ledger
    at `.stella/private/fleet.db` — local SQLite, like all
-   [Stella telemetry](/docs/telemetry), with `runs`, `tasks`, `attempts`,
+   [stella telemetry](/docs/telemetry), with `runs`, `tasks`, `attempts`,
    and `commits` tables you can query directly. Past runs also surface on
    the **Fleet runs** card of the
    [Observatory dashboard](/docs/telemetry/dashboard).
@@ -113,7 +113,7 @@ Every task field, in the shape the plan parser accepts:
     `tasks` row. Never interpreted.
   </OptionCard>
   <OptionCard name="prompt" required>
-    What the worker is asked to do — a full Stella prompt.
+    What the worker is asked to do — a full stella prompt.
   </OptionCard>
   <OptionCard name="depends_on" defaultValue="[]">
     Ids that must succeed before this task dispatches; this is what orders the

--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -1,9 +1,9 @@
 ---
 title: Agent Modes
-description: The ways to drive Stella — Command Deck chat, one-shot pipeline runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
+description: The ways to drive stella — Command Deck chat, one-shot pipeline runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
 ---
 
-Stella has one engine and several ways to drive it. Pick the mode by how much
+stella has one engine and several ways to drive it. Pick the mode by how much
 autonomy you're delegating and how the work should be checked. (For the
 under-the-hood view — what each mode actually does differently inside the
 engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
@@ -172,7 +172,7 @@ output. Routing the verifier to a different family provides a genuinely independ
 second opinion.
 
 <Callout type="info">
-If only one provider family is configured, Stella cannot route the verifier to a
+If only one provider family is configured, stella cannot route the verifier to a
 different family — so the worker doubles as the verifier. Configuring a second
 provider family enables true cross-family judging and a more independent
 verdict.
@@ -180,13 +180,13 @@ verdict.
 
 ### Example
 
-Give Stella a concrete objective and let it iterate until the verifier signs off:
+Give stella a concrete objective and let it iterate until the verifier signs off:
 
 ```bash
 stella goal "Add input validation to the /signup endpoint and make sure the existing test suite passes"
 ```
 
-Stella will work in rounds — editing code, running the tests, reading the
+stella will work in rounds — editing code, running the tests, reading the
 output — and a cross-family verifier will assess each round from the evidence. The
 run finishes only once the verifier confirms the endpoint is validated and the test
 suite is green.

--- a/website/content/docs/agent-tools/commands.mdx
+++ b/website/content/docs/agent-tools/commands.mdx
@@ -173,7 +173,7 @@ tools' directories as symlinks — `.claude/commands/` and
 `.agents/commands/` (workspace scope), `~/.claude/commands/` and
 `~/.agents/commands/` (user scope) — so your existing setup carries over
 instead of being rewritten. `.claude` wins over `.agents` on a name
-collision, existing Stella-side definitions are never clobbered, and the
+collision, existing stella-side definitions are never clobbered, and the
 sync is idempotent. The same adoption covers skills and agents — the full
 mechanics are documented on the
 [Custom Agents](/docs/agent-tools/custom-agents#adopted-from-claude-and-agents-on-init)

--- a/website/content/docs/agent-tools/custom-agents.mdx
+++ b/website/content/docs/agent-tools/custom-agents.mdx
@@ -104,13 +104,13 @@ No `.versions/` entry is created until the first edit, so hand-authored
 agents stay exactly as you wrote them. Editing an agent that was adopted as
 a symlink (see below) replaces the symlink with a real file in the agents
 directory — the original stays untouched, and your edit lives on the
-Stella side from then on.
+stella side from then on.
 
 ## Adopted from .claude/ and .agents/ on init
 
 Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
 `.agents/{commands,skills,agents}`. On `stella init` (and `/init`),
-definitions found there are **symlinked** into the matching Stella
+definitions found there are **symlinked** into the matching stella
 directory — adopted, not copied, so edits stay in one place and your
 existing setup carries over instead of being rewritten:
 
@@ -145,7 +145,7 @@ directories.) Three rules keep the adoption sane:
    so the sync is idempotent and your own definitions always win.
 3. **Never follow a symlink.** Other tools symlink between these
    directories too (e.g. `.claude/agents/x → ../../.agents/agents/x`);
-   Stella links each definition from its *real* home exactly once. A
+   stella links each definition from its *real* home exactly once. A
    directory entry with no `AGENT.md` inside is also skipped — and
    reported, so nothing disappears silently.
 

--- a/website/content/docs/agent-tools/custom-tools.mdx
+++ b/website/content/docs/agent-tools/custom-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: Custom Tools
-description: Extend the Stella agent with your own script tools by dropping a TOML manifest into your workspace or user config directory.
+description: Extend the stella agent with your own script tools by dropping a TOML manifest into your workspace or user config directory.
 ---
 
 Beyond the [built-in tools](/docs/agent-tools), you can give the agent your own developer-defined script tools. A custom tool is described by a small TOML manifest; once discovered, it appears alongside the built-ins and can be called by the agent like any other tool.
@@ -107,7 +107,7 @@ The `timeout_ms` default is **30 seconds** — half of the 60-second default tha
 
 ## How input reaches your script
 
-When the agent calls a custom tool, Stella spawns `command` **directly** from the argv array — never through a shell, so the tool's input has no injection surface — with the working directory set to the workspace root. The model's input JSON is then delivered **two ways**, so trivial scripts need no JSON parser:
+When the agent calls a custom tool, stella spawns `command` **directly** from the argv array — never through a shell, so the tool's input has no injection surface — with the working directory set to the workspace root. The model's input JSON is then delivered **two ways**, so trivial scripts need no JSON parser:
 
 1. The whole input object is written to the script's **stdin** as one JSON document, then stdin is closed — your script sees EOF.
 2. Each top-level **scalar** property (string, number, bool) is exported as `STELLA_INPUT_<UPPER_SNAKE_KEY>` — `path` becomes `STELLA_INPUT_PATH`, `dry_run` becomes `STELLA_INPUT_DRY_RUN`. Nested objects and arrays are delivered on stdin only.
@@ -115,7 +115,7 @@ When the agent calls a custom tool, Stella spawns `command` **directly** from th
 The manifest's `[env]` table is applied on top of the inherited environment, before the `STELLA_INPUT_*` exports. Input keys come from the model but are namespaced under `STELLA_INPUT_`, so they can never clobber `PATH` or your `[env]` values.
 
 <Callout type="warn">
-The child's environment is **credential-scrubbed last**, after both the inherited environment and the manifest's `[env]`. A custom tool never sees Stella's provider keys (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …) or repository/AWS tokens, and a manifest cannot reintroduce one by naming it in `[env]` — that entry is removed too. Ordinary task configuration in `[env]` survives untouched. If your script genuinely needs a credential, pass it as a tool *input* or have the script fetch it from your own secret store.
+The child's environment is **credential-scrubbed last**, after both the inherited environment and the manifest's `[env]`. A custom tool never sees stella's provider keys (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …) or repository/AWS tokens, and a manifest cannot reintroduce one by naming it in `[env]` — that entry is removed too. Ordinary task configuration in `[env]` survives untouched. If your script genuinely needs a credential, pass it as a tool *input* or have the script fetch it from your own secret store.
 </Callout>
 
 A script consuming both channels:

--- a/website/content/docs/agent-tools/hooks.mdx
+++ b/website/content/docs/agent-tools/hooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hooks
-description: Run shell commands on Stella's agent lifecycle events — SessionStart, PreToolUse, and PostToolUse — configured under the hooks key in settings.json.
+description: Run shell commands on stella's agent lifecycle events — SessionStart, PreToolUse, and PostToolUse — configured under the hooks key in settings.json.
 ---
 
 Hooks are shell commands that fire on agent lifecycle events. They are configured under the `hooks` key in your `settings.json` and follow Claude Code parity, so existing hook knowledge carries over.
@@ -10,13 +10,13 @@ Each hook receives the event payload as **JSON on stdin**, so your command can r
 <Callout type="info">
   This page covers the **config-driven shell hooks** — the `hooks` key in `settings.json`,
   no code required. For the *programmatic* in-process event bus (observe every event, gate
-  actions with allow / modify / deny / require-approval, in code when you embed Stella's
+  actions with allow / modify / deny / require-approval, in code when you embed stella's
   engine), see [Extension hooks](/docs/extensions).
 </Callout>
 
 ## Events
 
-Stella fires hooks on three lifecycle events. Each behaves differently, and each has its own rules for matching and blocking.
+stella fires hooks on three lifecycle events. Each behaves differently, and each has its own rules for matching and blocking.
 
 <HookLifecycleDiagram />
 

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Built-in Tools
-description: The complete catalog of tools the Stella agent can call in every session, including which are read-only and which mutate your workspace.
+description: The complete catalog of tools the stella agent can call in every session, including which are read-only and which mutate your workspace.
 ---
 
-Stella ships with a set of built-in tools that are always available to the agent. On top of these, you can add your own [custom script tools](/docs/agent-tools/custom-tools) and merge in tools from [MCP servers](/docs/agent-tools/mcp). Every tool is subject to a [per-tool permission model](/docs/agent-tools/permissions).
+stella ships with a set of built-in tools that are always available to the agent. On top of these, you can add your own [custom script tools](/docs/agent-tools/custom-tools) and merge in tools from [MCP servers](/docs/agent-tools/mcp). Every tool is subject to a [per-tool permission model](/docs/agent-tools/permissions).
 
 ## Listing tools
 
@@ -334,7 +334,7 @@ Three of the four register with **no key required** — `web_fetch`, `web_extrac
 
 #### Logging in to sites (`web_auth.toml`)
 
-To fetch pages behind a login — your subscriptions, a paywalled news site, an internal tool — give Stella your own session in `~/.stella/web_auth.toml` (override the path with `STELLA_WEB_AUTH_FILE`). Cookies and headers are injected per domain at request time and **never appear in tool output**, so the secrets stay out of the model's context.
+To fetch pages behind a login — your subscriptions, a paywalled news site, an internal tool — give stella your own session in `~/.stella/web_auth.toml` (override the path with `STELLA_WEB_AUTH_FILE`). Cookies and headers are injected per domain at request time and **never appear in tool output**, so the secrets stay out of the model's context.
 
 ```toml title="~/.stella/web_auth.toml"
 # Optional: override the default `stella/<version>` User-Agent for all requests.
@@ -363,7 +363,7 @@ chmod 600 ~/.stella/web_auth.toml
 ```
 
 <Callout type="warn">
-`web_auth.toml` holds live session secrets — treat it like `credentials.toml`. Stella redacts the values from its own logs and never echoes them into a tool result, but the file itself is plaintext: restrict it to owner-only (`chmod 600`). Unknown keys are a hard parse error, and a broken file makes every web tool fail loudly rather than silently fetching unauthenticated. `cookie` and `authorization` are dropped on a cross-host redirect; a secret in a custom `headers` entry is **not** — it would follow the redirect, so only put secrets in custom headers for hosts you trust to redirect.
+`web_auth.toml` holds live session secrets — treat it like `credentials.toml`. stella redacts the values from its own logs and never echoes them into a tool result, but the file itself is plaintext: restrict it to owner-only (`chmod 600`). Unknown keys are a hard parse error, and a broken file makes every web tool fail loudly rather than silently fetching unauthenticated. `cookie` and `authorization` are dropped on a cross-host redirect; a secret in a custom `headers` entry is **not** — it would follow the redirect, so only put secrets in custom headers for hosts you trust to redirect.
 </Callout>
 
 <Callout type="warn">

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -1,13 +1,13 @@
 ---
 title: MCP Servers
-description: Connect Model Context Protocol servers to Stella so their tools merge into the agent at session start.
+description: Connect Model Context Protocol servers to stella so their tools merge into the agent at session start.
 ---
 
-Stella can connect to [Model Context Protocol](https://modelcontextprotocol.io) (MCP) servers and merge their tools into the agent. This lets you extend the agent with capabilities that live outside your workspace — without writing a [custom script tool](/docs/agent-tools/custom-tools) for each one.
+stella can connect to [Model Context Protocol](https://modelcontextprotocol.io) (MCP) servers and merge their tools into the agent. This lets you extend the agent with capabilities that live outside your workspace — without writing a [custom script tool](/docs/agent-tools/custom-tools) for each one.
 
 ## Configuration
 
-MCP servers are configured in `.stella/mcp.toml` in your workspace. Stella connects to each configured server at **session start** and merges the tools it exposes into the agent, alongside the [built-in tools](/docs/agent-tools) and any custom tools.
+MCP servers are configured in `.stella/mcp.toml` in your workspace. stella connects to each configured server at **session start** and merges the tools it exposes into the agent, alongside the [built-in tools](/docs/agent-tools) and any custom tools.
 
 The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) command family — no hand-editing:
 
@@ -36,7 +36,7 @@ Because the tools are added at session start, connecting a new server takes effe
   name an arbitrary `cmd` that runs at session start — the `git clone && stella`
   remote-execution hole — or an attacker-controlled `url` that workspace content gets
   sent to, which is the same risk class as [project hooks](/docs/agent-tools/hooks).
-  Untrusted, Stella connects nothing and prints the reason once. Opt in per repo:
+  Untrusted, stella connects nothing and prints the reason once. Opt in per repo:
 
   ```bash
   export STELLA_TRUST_PROJECT=1
@@ -70,7 +70,7 @@ A server entry needs a `transport` discriminant — `stdio` or `http` — and th
     on it.
   </OptionCard>
   <OptionCard name="cmd">
-    stdio only, required there. The executable Stella launches, speaking
+    stdio only, required there. The executable stella launches, speaking
     JSON-RPC over the child's stdio.
   </OptionCard>
   <OptionCard name="args" defaultValue="[]">
@@ -80,7 +80,7 @@ A server entry needs a `transport` discriminant — `stdio` or `http` — and th
     stdio only. The variables the child receives — see the scrub note below.
   </OptionCard>
   <OptionCard name="url">
-    http only, required there. A streamable-HTTP endpoint Stella POSTs JSON-RPC
+    http only, required there. A streamable-HTTP endpoint stella POSTs JSON-RPC
     to.
   </OptionCard>
   <OptionCard name="headers" defaultValue="{}">
@@ -94,7 +94,7 @@ A server entry needs a `transport` discriminant — `stdio` or `http` — and th
   </OptionCard>
 </CardGrid>
 
-Either way, Stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide, and the entry's name in `mcp.toml` is what shows up in the middle segment.
+Either way, stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide, and the entry's name in `mcp.toml` is what shows up in the middle segment.
 
 <Callout type="warn">
 A stdio MCP subprocess runs with a **scrubbed environment** — ambient shell variables (including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`) are **not** inherited. Any variable the server needs must be listed explicitly in the entry's `env` table, e.g. `env = { GITHUB_TOKEN = "…" }`. The single exception is `PATH`, which is inherited so a bare runner (`npx`, `uvx`, `docker`) can resolve at all; an `env` entry named `PATH` overrides it.
@@ -137,14 +137,14 @@ checked are genuinely read-only and cwd-independent.
 Speculative execution is off the table entirely for MCP tools: they register
 as mutating (`read_only: false`) and never claim `speculation_safe`, so the
 engine runs each call exactly once, at dispatch — an external server's
-request count and rate limit are not Stella's to spend twice.
+request count and rate limit are not stella's to spend twice.
 
 Two things follow from a server being `candidate_safe`:
 
 - Every candidate's engine can call that server's tools live, mid-turn,
   through the same already-connected session client (no extra subprocess
   per candidate).
-- Before the fan-out starts, Stella calls that server's zero-argument tools
+- Before the fan-out starts, stella calls that server's zero-argument tools
   **once** and folds the results into every candidate's starting context —
   covering the common case where every candidate would otherwise ask the
   same read-only question (a schema listing, say) N times over. A tool that

--- a/website/content/docs/agent-tools/permissions.mdx
+++ b/website/content/docs/agent-tools/permissions.mdx
@@ -1,9 +1,9 @@
 ---
 title: Permissions
-description: How Stella's per-tool permission model separates read-only tools from mutating and shell tools, and how PreToolUse hooks can gate or block tool calls.
+description: How stella's per-tool permission model separates read-only tools from mutating and shell tools, and how PreToolUse hooks can gate or block tool calls.
 ---
 
-Every tool the agent can call — built-in, [custom](/docs/agent-tools/custom-tools), or provided by an [MCP server](/docs/agent-tools/mcp) — has a per-tool permission model. This is what lets Stella treat a harmless file read differently from a shell command that can change your system.
+Every tool the agent can call — built-in, [custom](/docs/agent-tools/custom-tools), or provided by an [MCP server](/docs/agent-tools/mcp) — has a per-tool permission model. This is what lets stella treat a harmless file read differently from a shell command that can change your system.
 
 <PermissionGateDiagram />
 
@@ -31,7 +31,7 @@ The permission model is enforced ahead of each tool call, and it can be extended
 This gives you a programmable gate in front of any tool. A `PreToolUse` hook's matcher is a glob over the tool name, so you can target a single tool (for example, `bash`) or a family of tools.
 
 <Callout type="info">
-For blocking by pattern without a hook script, Stella also has native workspace-rule guards enforced at the tool boundary: `guard-tool` (deny a tool), `guard-deny-command` (a glob over the `bash` command), and `guard-deny-path` (a glob over a file tool's path). A rule such as `guard-deny-command: "git push --force*"` is hard-enforced per invocation.
+For blocking by pattern without a hook script, stella also has native workspace-rule guards enforced at the tool boundary: `guard-tool` (deny a tool), `guard-deny-command` (a glob over the `bash` command), and `guard-deny-path` (a glob over a file tool's path). A rule such as `guard-deny-command: "git push --force*"` is hard-enforced per invocation.
 </Callout>
 
 ```json title="~/.stella/settings.json"
@@ -55,11 +55,11 @@ For blocking by pattern without a hook script, Stella also has native workspace-
 
 For the full hook model — events, matchers, timeouts, and the JSON payload delivered on stdin — see [Hooks](/docs/agent-tools/hooks).
 
-## Containment: run Stella in a container
+## Containment: run stella in a container
 
 Hooks and guard rules decide *whether* a command runs. Containment bounds what it can reach once it does — the difference that matters when instructions hidden in a file the agent read steer the model into running something you never asked for.
 
-**Stella has no per-command sandbox.** Earlier versions had one: `STELLA_BASH_SANDBOX=workspace-write|restricted` wrapped the [`bash`](/docs/agent-tools#shell) tool in `sandbox-exec` (Seatbelt) on macOS or `bwrap` (bubblewrap) on Linux. It was removed, and the variable now does nothing.
+**stella has no per-command sandbox.** Earlier versions had one: `STELLA_BASH_SANDBOX=workspace-write|restricted` wrapped the [`bash`](/docs/agent-tools#shell) tool in `sandbox-exec` (Seatbelt) on macOS or `bwrap` (bubblewrap) on Linux. It was removed, and the variable now does nothing.
 
 <Callout type="warn">
 If you set `STELLA_BASH_SANDBOX` in a shell profile, a CI job, or a service unit, it is inert — nothing reads it and nothing warns you. Remove it, and if you were relying on it for containment, replace it with a container.
@@ -67,7 +67,7 @@ If you set `STELLA_BASH_SANDBOX` in a shell profile, a CI job, or a service unit
 
 The reason it went is that it covered `bash` and nothing else. `build_project` and `run_tests` take a `command` override, `verify_done` a `test_cmd`, `run_script` composes a line from the scripts index, `start_process` takes an argv whose `argv[0]` may be an interpreter, and the `repo_*`, `ci_status`, custom-manifest, and hook paths all spawn on their own — every one of them ran unconfined while the setting said "sandbox: on". A boundary you can step around by starting a process a different way is not a boundary, and one that people believe in is worse than a clearly absent one.
 
-Run the whole Stella process inside a container instead — Docker, Podman, or a remote sandbox. The boundary then sits *outside* every spawn path rather than on one of them, so no tool can route around it, and it holds for file writes, network, and process execution alike.
+Run the whole stella process inside a container instead — Docker, Podman, or a remote sandbox. The boundary then sits *outside* every spawn path rather than on one of them, so no tool can route around it, and it holds for file writes, network, and process execution alike.
 
 No official CLI image ships today, so build one that puts `stella` on `PATH` (the [install script](/docs/getting-started/installation) works inside a `debian:bookworm-slim` stage), then mount only the repository you want the agent to touch:
 

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -4,7 +4,7 @@ description: Reusable capabilities in SKILL.md files — project and user scopes
 ---
 
 A **skill** is a reusable capability described in Markdown — a checklist, a
-workflow, a house style — that Stella injects when it's relevant and that you
+workflow, a house style — that stella injects when it's relevant and that you
 can invoke explicitly as a slash command.
 
 ## The format
@@ -110,7 +110,7 @@ on demand instead of frontloading them all.
 
 ## The public registry
 
-Stella integrates with the community skills registry via `npx skills`:
+stella integrates with the community skills registry via `npx skills`:
 
 - **`search_skills`** (agent tool, read-only) / the SKILLS tab search — runs
   `npx skills find <query>`.

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: API Providers
-description: Every provider Stella speaks to — the matrix, the auto-detection order, the credential chain, and the per-provider differences that actually matter.
+description: Every provider stella speaks to — the matrix, the auto-detection order, the credential chain, and the per-provider differences that actually matter.
 ---
 
-Stella is BYOK and vendor-agnostic: no proxy in the middle, no markup, and each
+stella is BYOK and vendor-agnostic: no proxy in the middle, no markup, and each
 provider's native wire dialect spoken directly. Switching vendors is a `--model` flag.
 
 <ProviderGrid />
@@ -77,12 +77,12 @@ failed:
   `temperature`, `top_p`, and `top_k` are omitted unconditionally on `anthropic`.
   Turning `reasoning` off does not buy temperature control back. Claude 4.5 and below
   use the legacy `thinking: {type: enabled, budget_tokens: N}` shape and do accept
-  sampling; Stella classifies by model id and sends whichever the generation requires.
+  sampling; stella classifies by model id and sends whichever the generation requires.
 </Callout>
 
 ## Auto-detection
 
-With no `--model` and no configured default, Stella picks the first provider in the
+With no `--model` and no configured default, stella picks the first provider in the
 matrix above that has a resolvable credential.
 
 <Callout type="info">
@@ -90,7 +90,7 @@ matrix above that has a resolvable credential.
 
   OpenRouter sits first because `OPENROUTER_API_KEY` is gateway-specific — nobody has one
   exported by accident — and it reaches every other vendor in the matrix. An instance
-  holding one has already decided how it wants to route, so Stella gives it a whole
+  holding one has already decided how it wants to route, so stella gives it a whole
   [default engine posture](#the-default-posture), not just a default model.
 
   Vertex and Bedrock sit last for the mirror-image reason: they key off generic cloud
@@ -172,7 +172,7 @@ Everything above is shared. These are the differences worth knowing.
 
 ### Anthropic
 
-Prompt caching is first-class: Stella meters both cache reads and cache writes, so
+Prompt caching is first-class: stella meters both cache reads and cache writes, so
 Observatory figures reflect the true bill. Cached input bills at $0.30/Mtok against a
 $3.00 list price — the 10× discount on the byte-stable prefix the
 [context engine](/docs/context-engine) maintains.
@@ -236,7 +236,7 @@ export AWS_REGION=us-east-1         # or AWS_DEFAULT_REGION; default us-east-1
 ```
 
 <Callout type="warn">
-  Stella reads **only these environment variables** — it does not walk the AWS credential
+  stella reads **only these environment variables** — it does not walk the AWS credential
   chain. `AWS_PROFILE`, `~/.aws/credentials`, SSO caches, and IMDS/instance roles are
   never consulted. On a profile or SSO setup, materialize env vars first:
   `eval "$(aws configure export-credentials --profile dev --format env)"`.
@@ -293,7 +293,7 @@ Or, durably, in **user scope**:
   personal, so put it in user scope.
 </Callout>
 
-On a coding plan the `$` figures in `stella stats` are notional — Stella prices tokens at
+On a coding plan the `$` figures in `stella stats` are notional — stella prices tokens at
 catalog list rates, and you pay the flat subscription. Token counts, step counts, and
 cross-model $/resolved comparisons stay meaningful; absolute dollars for `zai/*` do not.
 `--budget` caps meter against those notional prices too.
@@ -302,7 +302,7 @@ cross-model $/resolved comparisons stay meaningful; absolute dollars for `zai/*`
 
 One key, every vendor. Gateway slugs are `vendor/model` and pass through **unseeded** —
 any slug the gateway serves works verbatim, and a typo fails with OpenRouter's own
-400/404 rather than a Stella error. The default model is `moonshotai/kimi-k3`.
+400/404 rather than a stella error. The default model is `moonshotai/kimi-k3`.
 
 #### The default posture
 
@@ -316,7 +316,7 @@ no configuration at all, an OpenRouter instance runs:
 | verifier | `anthropic/claude-opus-5` | a different vendor's strongest reasoner — not the worker grading itself |
 | triage | `z-ai/glm-5.2` | fast and cheap, and it runs on every turn |
 
-Note the verifier is deliberately a different **family** from the driver. Stella already
+Note the verifier is deliberately a different **family** from the driver. stella already
 treats cross-family judging as the goal (see `auto_mode`); this default just reaches it
 without asking you to configure anything.
 
@@ -350,7 +350,7 @@ stella --model openrouter/openrouter/auto          run "let the gateway pick per
   Every OpenRouter model id is `vendor/model`, and the meta-router's own id is
   `openrouter/auto` — so the full spec is `openrouter` + `/` + `openrouter/auto`. Write
   `--model openrouter/auto` and the wire slug becomes a bare `auto`, which OpenRouter
-  does not serve; Stella warns on stderr that it is missing the vendor namespace, but the
+  does not serve; stella warns on stderr that it is missing the vendor namespace, but the
   warning is advisory and the run still fails at the gateway.
 </Callout>
 
@@ -370,7 +370,7 @@ OpenAI and cross-family preference works through the gateway.
 
 <Callout type="info">
   **Cost telemetry comes from the gateway, not the catalog.** Gateway slugs are unseeded,
-  so there is no local list price. Stella requests OpenRouter's usage accounting on every
+  so there is no local list price. stella requests OpenRouter's usage accounting on every
   call — and sends app-attribution headers — and takes the gateway's reported per-call
   cost as authoritative. If a call's final usage frame carries no cost, that call falls
   back to `$0`; treat the OpenRouter dashboard as the reconciliation source of record.

--- a/website/content/docs/api-providers/models.mdx
+++ b/website/content/docs/api-providers/models.mdx
@@ -3,9 +3,9 @@ title: Model guide
 description: The master model catalog — context windows, list prices per million tokens, release timing, and which model to use for which role in the pipeline.
 ---
 
-This is the master list. Every model Stella seeds into its catalog, with the numbers you
+This is the master list. Every model stella seeds into its catalog, with the numbers you
 need to make a decision — context window, list price, and what the model is actually good
-at. The pricing figures come from **Stella's seed catalog**; prices are list
+at. The pricing figures come from **stella's seed catalog**; prices are list
 **$/Mtok** (input / output / cached-input). The **Released** and **Best for** columns are
 editorial — context these docs add, not fields the catalog stores or syncs. Verify with
 your provider before budgeting — prices and lineups drift.
@@ -27,14 +27,14 @@ your provider before budgeting — prices and lineups drift.
 | <ProviderMark id="gemini" /> `gemini-3-pro` | `gemini` (also `vertex`) | 1M | 1.25 | 10.00 | 0.31 | Q4 2025 | The 1M-token window: whole-repo comprehension, long-log analysis. Solid worker, good verifier. |
 | <ProviderMark id="xai" /> `grok-4` | `xai` | 256k | 3.00 | 15.00 | 0.75 | Q3 2025 | Strong reasoning; a distinct model family, useful as an alternate verifier. |
 | <ProviderMark id="deepseek" /> `deepseek-chat` | `deepseek` | 128k | 0.27 | 1.10 | 0.07 | Q4 2024 (V3 line, revised through 2025) | The price/performance outlier. Ideal triage model; a very capable budget worker. |
-| <ProviderMark id="zai" /> `glm-5.2` | `zai` | 200k | 0.60 | 2.20 | 0.11 | 2026 | Excellent coding at a fraction of flagship price — Stella's default worker tier. The coding-plan endpoint makes it a subscription workhorse. |
+| <ProviderMark id="zai" /> `glm-5.2` | `zai` | 200k | 0.60 | 2.20 | 0.11 | 2026 | Excellent coding at a fraction of flagship price — stella's default worker tier. The coding-plan endpoint makes it a subscription workhorse. |
 | <ProviderMark id="bedrock" /> `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 200k | 3.00 | 15.00 | 0.30 | Sep 2025 | Claude under AWS governance — for orgs that must keep inference inside their cloud account. |
 | <ProviderMark id="openrouter" /> `moonshotai/kimi-k3` | `openrouter` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Long-context agentic driver, and the OpenRouter default — a 1M window that holds a whole repo while it works. Runs at `xhigh` effort with thinking on. |
 | <ProviderMark id="openrouter" /> `openrouter/auto` | `openrouter` | 128k | gateway-priced | gateway-priced | — | rolling | OpenRouter's meta-router; and any `vendor/model` slug on the gateway routes verbatim (one key, every vendor). |
 
 ## Which model for which role
 
-Stella's [pipeline](/docs/inference-pipeline) runs three distinct roles, and they want
+stella's [pipeline](/docs/inference-pipeline) runs three distinct roles, and they want
 different things from a model:
 
 - **Worker** — writes the code. It wants the strongest coding model you can afford; this
@@ -73,7 +73,7 @@ stella models list --provider anthropic    # browse valid slugs + live pricing
 ```
 
 - **Master list, locally.** One public, unauthenticated document covering every provider
-  Stella can select (plus ~160 more) lands in a user-tier SQLite catalog
+  stella can select (plus ~160 more) lands in a user-tier SQLite catalog
   (`catalog.db`, next to `usage.db`): **model cards** keyed per API provider, and
   **model card versions** holding each pricing configuration. A refresh appends a new
   version only when pricing actually changed — the version history is real change
@@ -107,7 +107,7 @@ stella models list --provider anthropic    # browse valid slugs + live pricing
 
   - **Each configured provider's own `/models` listing** auto-syncs whenever it is stale,
     **including the very first time** — this is what surfaces new releases as they ship.
-    That traffic is BYOK-clean: it goes to a provider you already gave Stella a key for,
+    That traffic is BYOK-clean: it goes to a provider you already gave stella a key for,
     the same host your next turn calls anyway. No credential for a provider means nothing
     is fetched for it.
   - **The models.dev master list** is a third party, so the no-phone-home rule forbids
@@ -128,7 +128,7 @@ Only the models.dev master list is keyless.
 
 ## Prompt caching changes the math
 
-The **cached-input** column is what most worker input actually costs mid-run. Stella keeps
+The **cached-input** column is what most worker input actually costs mid-run. stella keeps
 the prompt prefix byte-stable on purpose — the [context engine](/docs/context-engine)
 appends rather than rewrites — so after the first turn, the bulk of every request is a
 cache hit billed at the cached-input rate: a 10x–20x discount depending on provider. This

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -3,10 +3,10 @@ title: stella arena
 description: The arena-bench harness adapter — run one benchmark episode from a task directory, recording the trace journal judged against replay oracles.
 ---
 
-`stella arena` is Stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.
+`stella arena` is stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.
 
 <Callout type="info">
-This command exists for **benchmarking Stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how Stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it. Stdout is **stream-json unconditionally**: the runner is the only intended reader, so there is no `--output-format` flag to promise otherwise.
+This command exists for **benchmarking stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it. Stdout is **stream-json unconditionally**: the runner is the only intended reader, so there is no `--output-format` flag to promise otherwise.
 </Callout>
 
 ## Synopsis

--- a/website/content/docs/commands/auth.mdx
+++ b/website/content/docs/commands/auth.mdx
@@ -21,7 +21,7 @@ A key stored here persists across sessions and shells, so you don't re-export an
 
 ### `stella auth set <provider>`
 
-Store (or replace) a provider's key. With no flag, Stella shows an interactive masked prompt — the recommended path, since nothing lands in your shell history.
+Store (or replace) a provider's key. With no flag, stella shows an interactive masked prompt — the recommended path, since nothing lands in your shell history.
 
 <CardGrid size="md">
   <OptionCard name="--key <key>">

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella chat
-description: Start an interactive session with Stella — the Command Deck TUI by default, an accessible mode of the same deck, or a plain line REPL.
+description: Start an interactive session with stella — the Command Deck TUI by default, an accessible mode of the same deck, or a plain line REPL.
 ---
 
 Start an interactive session. This is the **default** command: running `stella` with no subcommand is exactly the same as running `stella chat`.
@@ -109,7 +109,7 @@ path.
 
 ### Multimodal input
 
-Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and Stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment.
+Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment.
 
 <Callout type="info">
 All [global flags](/docs/commands) apply, in either position — `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session, and `stella chat --model openai/gpt-5.5` does the same thing.
@@ -208,7 +208,7 @@ Open a tab or run an action:
     Search the MCP registry and install servers without leaving the deck.
   </OptionCard>
   <OptionCard name="/sessions">
-    Every Stella session on this machine, grouped by status. Also reachable with `←` on an
+    Every stella session on this machine, grouped by status. Also reachable with `←` on an
     empty prompt.
   </OptionCard>
   <OptionCard name="/context">
@@ -226,7 +226,7 @@ Open a tab or run an action:
     Export session telemetry to a ZIP plus an HTML dashboard.
   </OptionCard>
   <OptionCard name="/donate">
-    Support Stella — become a GitHub Sponsor.
+    Support stella — become a GitHub Sponsor.
   </OptionCard>
 </CardGrid>
 
@@ -258,17 +258,17 @@ Parsing is deliberately conservative: one recognized token (plus `refresh --forc
 
 Run `/profile` with no argument to see which profile your current settings match, what this session is running, and what each profile would pick right now.
 
-**How the models are chosen.** Stella's catalog carries no capability tier, so a profile ranks the reachable models by list output price — the same proxy `auto_mode` already uses to pick a verifier. This means the choice tracks catalog refreshes instead of going stale, but it is a proxy: a cheap frontier model ranks low until its price says otherwise. The confirmation names every model it picked, so you can always see what you got. Models the catalog has no price for (gateway rows like `openrouter/auto`, which bill at whatever they route to) are left out of the ranking rather than treated as free.
+**How the models are chosen.** stella's catalog carries no capability tier, so a profile ranks the reachable models by list output price — the same proxy `auto_mode` already uses to pick a verifier. This means the choice tracks catalog refreshes instead of going stale, but it is a proxy: a cheap frontier model ranks low until its price says otherwise. The confirmation names every model it picked, so you can always see what you got. Models the catalog has no price for (gateway rows like `openrouter/auto`, which bill at whatever they route to) are left out of the ranking rather than treated as free.
 
 The four roles are not tuned identically. Triage stays below the worker in every profile — it is a short classification under a latency ceiling, and spending your best model on it buys nothing.
 
-The verifier is the interesting one, because two goals pull against each other: a verifier from the worker's own family lets a shared blind spot pass review twice, but a verifier well below the worker's tier cannot follow the work it grades and rubber-stamps. Stella resolves it in the order that gives up least. A model that is both independent and at least as capable wins outright. If nothing clears that bar but the strongest independent model is only one rung down the price list, independence is worth the single rung. Only when the best independent option is further down than that does capability take over — and then the confirmation tells you the review is correlated with the work.
+The verifier is the interesting one, because two goals pull against each other: a verifier from the worker's own family lets a shared blind spot pass review twice, but a verifier well below the worker's tier cannot follow the work it grades and rubber-stamps. stella resolves it in the order that gives up least. A model that is both independent and at least as capable wins outright. If nothing clears that bar but the strongest independent model is only one rung down the price list, independence is worth the single rung. Only when the best independent option is further down than that does capability take over — and then the confirmation tells you the review is correlated with the work.
 
 **What it writes, and what it leaves alone.** A profile owns the per-role model, effort, thinking switch, verbosity, and service tier, saved to your user settings. It deliberately turns `effort_auto`, `reasoning_auto`, and `auto_mode` **off**: those switches override per-agent effort, so leaving them on would let `/profile ultra` print `max` and run `medium`. Everything else survives untouched — custom per-agent prompts, pinned providers, temperatures, seeds, and your `allowed_models` list.
 
 `/profile auto` is the way back out. It restores all three switches and drops the per-role effort, thinking, verbosity, and service-tier pins a profile wrote, handing those choices to the engine again. Model pins are left alone: one may well predate the profile, and `auto_mode` re-picks the verifier on its own.
 
-**Effort, and the providers that cannot express it.** The five-rung ladder is Stella's vocabulary, not every provider's: Gemini and Vertex offer only `low` and `high`, the OpenAI shapes stop at `high`, and Z.ai has no request-level effort control at all (its thinking switch is on/off). A pick whose provider cannot express the level the profile asked for is written at the highest rung it does support.
+**Effort, and the providers that cannot express it.** The five-rung ladder is stella's vocabulary, not every provider's: Gemini and Vertex offer only `low` and `high`, the OpenAI shapes stop at `high`, and Z.ai has no request-level effort control at all (its thinking switch is on/off). A pick whose provider cannot express the level the profile asked for is written at the highest rung it does support.
 
 Clamping alone would flatten the ladder — on a two-rung provider both `fast` and `balanced` land on `low` — so the missing rung is bought back on the axis that can still carry it: among models at the same price, the one whose provider *can* express the requested level wins. That is a tiebreak and nothing more. The search never leaves the price band, so a profile cannot overspend its tier to buy a knob, and it takes the cheapest qualifying model rather than the best. Where nothing at that price can express the level, the clamp stands and the confirmation says which levels moved.
 
@@ -310,7 +310,7 @@ The line REPL has a smaller, different set:
     Change the accent color, for multi-window setups.
   </OptionCard>
   <OptionCard name="exit  /exit  /quit">
-    Leave Stella. **Ctrl-D** does the same.
+    Leave stella. **Ctrl-D** does the same.
   </OptionCard>
 </CardGrid>
 

--- a/website/content/docs/commands/commands.mdx
+++ b/website/content/docs/commands/commands.mdx
@@ -78,7 +78,7 @@ stella commands convert .claude/commands --force
 
 ## Why conversion is deliberate, and never part of `init`
 
-[`stella init`](/docs/commands/init) **symlinks** `.claude/commands/` rather than copying it. That link is the point: commands you maintain for another agent tool stay live, and editing them there updates what Stella offers with no second step.
+[`stella init`](/docs/commands/init) **symlinks** `.claude/commands/` rather than copying it. That link is the point: commands you maintain for another agent tool stay live, and editing them there updates what stella offers with no second step.
 
 A converted copy trades that live link for two things TOML does better — a typed `allowed-tools` list, and a delimiter-free `prompt` (no frontmatter fence to escape inside a prompt that itself contains markdown). Both are real wins, and neither is worth taking your live link away without being asked. So conversion is a command you run, not something `init` does to you.
 

--- a/website/content/docs/commands/completions.mdx
+++ b/website/content/docs/commands/completions.mdx
@@ -68,7 +68,7 @@ it.
 <Callout type="info">
 The script is generated from the same command definitions the binary parses with,
 so completions cannot drift away from the flags that actually exist. Re-run the
-command after upgrading Stella to pick up new subcommands.
+command after upgrading stella to pick up new subcommands.
 </Callout>
 
 ## Not sure it took?

--- a/website/content/docs/commands/connect.mdx
+++ b/website/content/docs/commands/connect.mdx
@@ -3,9 +3,9 @@ title: stella connect
 description: Connect GitHub or Linear via OAuth (or a pasted key) so the issue tools and the deck's Issues tab light up.
 ---
 
-Establish a tracker connection so Stella can search, read, create, comment on, label, assign, and change the status of issues — from the agent's tools (`search_issues`, `get_issue`, `create_issue`, `update_issue`, `close_issue`, `list_labels`, `list_members`, `start_work_on_issue`) and from the Command Deck's **Issues** tab.
+Establish a tracker connection so stella can search, read, create, comment on, label, assign, and change the status of issues — from the agent's tools (`search_issues`, `get_issue`, `create_issue`, `update_issue`, `close_issue`, `list_labels`, `list_members`, `start_work_on_issue`) and from the Command Deck's **Issues** tab.
 
-Connecting is explicit and opt-in: Stella never talks to a tracker unless you ran `stella connect` (or configured `LINEAR_API_KEY` / the `gh` CLI yourself). Credentials are stored **owner-only (0600)** in `~/.stella/integrations.json` — user-global, like `credentials.toml`, because an account connection belongs to you, not to one workspace.
+Connecting is explicit and opt-in: stella never talks to a tracker unless you ran `stella connect` (or configured `LINEAR_API_KEY` / the `gh` CLI yourself). Credentials are stored **owner-only (0600)** in `~/.stella/integrations.json` — user-global, like `credentials.toml`, because an account connection belongs to you, not to one workspace.
 
 ## Synopsis
 
@@ -19,14 +19,14 @@ Needs no model API key.
 
 ### `stella connect github`
 
-Runs the OAuth **device flow**: Stella shows a short code and a `github.com` URL; you enter the code in the browser and approve. Device-flow apps are public clients, so no client secret exists anywhere in the binary.
+Runs the OAuth **device flow**: stella shows a short code and a `github.com` URL; you enter the code in the browser and approve. Device-flow apps are public clients, so no client secret exists anywhere in the binary.
 
 ```bash
 stella connect github            # device flow
 stella connect github --token    # paste a personal access token instead
 ```
 
-The device flow needs a GitHub OAuth app client id with *device flow* enabled — set `STELLA_GITHUB_CLIENT_ID` (or use the built-in Stella app id when shipped). `--token` always works: paste a PAT with `repo` scope at a masked prompt.
+The device flow needs a GitHub OAuth app client id with *device flow* enabled — set `STELLA_GITHUB_CLIENT_ID` (or use the built-in stella app id when shipped). `--token` always works: paste a PAT with `repo` scope at a masked prompt.
 
 Once connected, GitHub issue operations run over the REST API directly — the `gh` CLI is **not** required.
 
@@ -62,4 +62,4 @@ Linear beats GitHub deliberately: an explicitly-set Linear credential is a stron
 
 - Tokens live in one owner-only JSON file, written atomically, never logged; `Debug` output redacts them.
 - OAuth refresh tokens (when the provider issues them) are refreshed automatically at session start.
-- The only network calls this feature makes are to the tracker you connected, and only when you (or the agent you invoked) use an issue tool. Stella's no-phone-home invariant is unchanged.
+- The only network calls this feature makes are to the tracker you connected, and only when you (or the agent you invoked) use an issue tool. stella's no-phone-home invariant is unchanged.

--- a/website/content/docs/commands/goal.mdx
+++ b/website/content/docs/commands/goal.mdx
@@ -3,7 +3,7 @@ title: stella goal
 description: Work in judged rounds until a verifier model confirms the goal is met.
 ---
 
-Give Stella a goal and let it work in **judged rounds** until a verifier model confirms, from evidence, that the goal has actually been met.
+Give stella a goal and let it work in **judged rounds** until a verifier model confirms, from evidence, that the goal has actually been met.
 
 ## Synopsis
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Commands
-description: Overview of every Stella subcommand, the default chat behavior, global flags, and exit codes.
+description: Overview of every stella subcommand, the default chat behavior, global flags, and exit codes.
 ---
 
 The `stella` binary is a fast, BYOK (bring-your-own-key), model-agnostic terminal coding agent. Every piece of functionality is exposed through a subcommand.
@@ -161,7 +161,7 @@ Each command page in this section documents its usage synopsis, behavior, releva
 
 Three tests in `stella-cli` keep this page honest. `every_subcommand_has_a_reference_page` diffs the live clap command tree against this section's `meta.json`, so a new subcommand cannot land undocumented. `the_docs_nav_mirrors_these_groups` fails if the sidebar grouping drifts from the one `--help` renders, and `the_docs_index_summaries_are_the_clis_own` fails if any summary above differs from the CLI's own string.
 
-Two of them are specialized rather than day-to-day. `stella arena` is a benchmark-harness adapter for measuring Stella, not for doing work with it; `stella telemetry` operates the managed enterprise spool and is disabled without a signed org-managed enrollment.
+Two of them are specialized rather than day-to-day. `stella arena` is a benchmark-harness adapter for measuring stella, not for doing work with it; `stella telemetry` operates the managed enterprise spool and is disabled without a signed org-managed enrollment.
 
 ## Global flags
 
@@ -237,7 +237,7 @@ Token usage, cost, and per-step metering are recorded in a local SQLite store on
 
 ## Model selection
 
-If you do not pass `--model`, Stella auto-detects a provider by picking the first one with a resolvable credential, in this preference order:
+If you do not pass `--model`, stella auto-detects a provider by picking the first one with a resolvable credential, in this preference order:
 
 ```text
 zai, anthropic, openai, xai, deepseek, gemini, openrouter, then vertex, and bedrock LAST
@@ -275,4 +275,4 @@ case $? in
 esac
 ```
 
-This makes Stella safe to compose in scripts and CI pipelines — check `$?` (or rely on `set -e`) to react to failures.
+This makes stella safe to compose in scripts and CI pipelines — check `$?` (or rely on `set -e`) to react to failures.

--- a/website/content/docs/commands/ingest.mdx
+++ b/website/content/docs/commands/ingest.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella ingest
-description: Turn markdown you already wrote — AGENTS.md, CLAUDE.md, or any file you name — into reviewable context-record proposals Stella can check, cite, and retire.
+description: Turn markdown you already wrote — AGENTS.md, CLAUDE.md, or any file you name — into reviewable context-record proposals stella can check, cite, and retire.
 ---
 
-`stella ingest` reads markdown you already wrote and turns it into steering Stella can check, cite, and retire. It has two halves, and which one runs depends entirely on whether you name a file.
+`stella ingest` reads markdown you already wrote and turns it into steering stella can check, cite, and retire. It has two halves, and which one runs depends entirely on whether you name a file.
 
 With **no arguments** it scans the workspace and shows you what it found, grouped by tier. That half is offline and needs no API key. Name **one or more paths** and it extracts them: one model call per document splits it into atomic claims, each claim is mapped to a context record, run through a deterministic safety gate, probed against the tree for staleness, and written to `.stella/proposals/` as a reviewable TOML file. Nothing you ingest steers anything until you review it.
 

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -22,7 +22,7 @@ stella init [global flags]
 It works **offline** using a heuristic fallback, so it never hard-fails on configuration — you can initialize a workspace even without a resolvable provider credential.
 
 <Callout type="info">
-Run `stella init` once per workspace to prime Stella's understanding of your codebase. The generated files live under `<workspace>/.stella/`.
+Run `stella init` once per workspace to prime stella's understanding of your codebase. The generated files live under `<workspace>/.stella/`.
 </Callout>
 
 ## Flags

--- a/website/content/docs/commands/mcp.mdx
+++ b/website/content/docs/commands/mcp.mdx
@@ -3,7 +3,7 @@ title: stella mcp
 description: Manage MCP servers — search a registry, install into .stella/mcp.toml, list configured servers, and show usage telemetry.
 ---
 
-Manage the Model Context Protocol servers Stella connects at session start. `stella mcp` is the scriptable half of the surface; the [Command Deck](/docs/commands/chat)'s **MCP tab** (`/mcp`) is the interactive half, where per-session enable/disable and the masked credential prompt live.
+Manage the Model Context Protocol servers stella connects at session start. `stella mcp` is the scriptable half of the surface; the [Command Deck](/docs/commands/chat)'s **MCP tab** (`/mcp`) is the interactive half, where per-session enable/disable and the masked credential prompt live.
 
 For how MCP tools reach the agent, see [MCP servers](/docs/agent-tools/mcp). This page is the command reference.
 

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -3,7 +3,7 @@ title: stella models
 description: List configured providers and available models, and manage the live model catalog.
 ---
 
-List the configured providers and their available models, and manage the **live model catalog**. For each provider, Stella shows its key status, default model, and base URL.
+List the configured providers and their available models, and manage the **live model catalog**. For each provider, stella shows its key status, default model, and base URL.
 
 ## Synopsis
 
@@ -42,7 +42,7 @@ There are two catalog sources, and they follow deliberately different rules. Bot
   <OptionCard name="Native provider listings">
     Each configured provider's own `/models` endpoint. Auto-syncs whenever it is stale,
     **including the very first time** — this is what surfaces new releases as they ship.
-    BYOK-clean: the request goes to a provider you already gave Stella a key for, the same
+    BYOK-clean: the request goes to a provider you already gave stella a key for, the same
     host your next turn calls anyway. No credential, nothing fetched.
   </OptionCard>
   <OptionCard name="The models.dev master list">

--- a/website/content/docs/commands/observe.mdx
+++ b/website/content/docs/commands/observe.mdx
@@ -19,8 +19,8 @@ stella observe [--port <N>] [--open]
 `stella observe` starts a local HTTP server (default port `7787`) and serves the embedded
 dashboard — no separate install, no build step, and no Observatory egress: the server
 binds loopback and `stella observe` itself never sends anything off the machine. It reads
-the same SQLite stores every Stella command writes, so it works on any workspace that has
-run Stella at least once, and it needs no API key. (Telemetry can leave the machine only
+the same SQLite stores every stella command writes, so it works on any workspace that has
+run stella at least once, and it needs no API key. (Telemetry can leave the machine only
 through the two paths [the telemetry page enumerates](/docs/telemetry), neither of which
 this command uses.)
 

--- a/website/content/docs/commands/scoreboard.mdx
+++ b/website/content/docs/commands/scoreboard.mdx
@@ -15,7 +15,7 @@ stella scoreboard
 
 ## What it does
 
-Agent quality metrics have an obvious failure mode: ask the model how it did. Stella's store does carry a self-rating field (`execution_reflection.self_rating`) and the scoreboard **deliberately does not use it** — that is the model grading its own homework. Every number here is either counted from events that happened or read from a judgement a human made.
+Agent quality metrics have an obvious failure mode: ask the model how it did. stella's store does carry a self-rating field (`execution_reflection.self_rating`) and the scoreboard **deliberately does not use it** — that is the model grading its own homework. Every number here is either counted from events that happened or read from a judgement a human made.
 
 <CardGrid size="md">
   <SpecCard title="Model calls">

--- a/website/content/docs/commands/scripts.mdx
+++ b/website/content/docs/commands/scripts.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella scripts
-description: List and run the project's package-manager scripts through Stella's canonical-verb index — the same frames the agent sees.
+description: List and run the project's package-manager scripts through stella's canonical-verb index — the same frames the agent sees.
 ---
 
 `stella scripts` lists and runs the project's package-manager scripts. Detection is deterministic static parsing of your manifests (cargo, npm/pnpm/yarn, uv, go, make, just, …), mapped onto canonical verbs — `install`, `build`, `check`, `start`, `test`, `lint`, `format`. It mirrors the [`list_scripts` and `run_script` tools](/docs/agent-tools) one-for-one, so a human at the CLI and the model inside a turn see the same script index. Offline: manifest parsing plus a local subprocess, no API key.
@@ -14,7 +14,7 @@ stella scripts run <script> [--dir <path>] [--timeout-secs <n>] [-- <args...>]
 
 ## What it does
 
-Instead of guessing that a repo uses `pnpm test` versus `cargo test` versus `make check`, Stella reads the manifests and presents one normalized index. The agent draws its verbs from exactly this index, which is why a run and a review agree on what "run the tests" means in your repo.
+Instead of guessing that a repo uses `pnpm test` versus `cargo test` versus `make check`, stella reads the manifests and presents one normalized index. The agent draws its verbs from exactly this index, which is why a run and a review agree on what "run the tests" means in your repo.
 
 ### `stella scripts list`
 

--- a/website/content/docs/commands/storage.mdx
+++ b/website/content/docs/commands/storage.mdx
@@ -17,7 +17,7 @@ stella storage prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] 
 
 ## What it does
 
-The storage map is Stella's vendor-agnostic index of where your data lives — SQL tables, key-value namespaces, document collections, and their fields — so the agent (and you) can reason about persistence without re-deriving the schema every time. It is the zero-drift companion to the [code graph](/docs/commands/graph): the code graph answers "who calls what," the storage map answers "what is stored where, and what does it mean."
+The storage map is stella's vendor-agnostic index of where your data lives — SQL tables, key-value namespaces, document collections, and their fields — so the agent (and you) can reason about persistence without re-deriving the schema every time. It is the zero-drift companion to the [code graph](/docs/commands/graph): the code graph answers "who calls what," the storage map answers "what is stored where, and what does it mean."
 
 <CardGrid size="md">
   <OptionCard name="tree">

--- a/website/content/docs/commands/telemetry.mdx
+++ b/website/content/docs/commands/telemetry.mdx
@@ -90,7 +90,7 @@ Prints the number sent, plus the resulting pending and dropped counts. The batch
 Delivery is **at least once and sink-scoped**: rows are acknowledged only after a successful HTTPS response, and redirects are refused. A credential, transport, or server failure releases the *exact* lease with capped exponential backoff plus jitter — from one second up to five minutes, with jitter capped at 25%.
 
 <Callout type="info">
-Stella already starts a detached best-effort flush after enrollment is verified at process startup. That attempt never delays agent execution and is not waited on at shutdown. Use explicit `flush` when an operator needs a **synchronous** delivery attempt — before host maintenance, or to confirm an intake change took effect.
+stella already starts a detached best-effort flush after enrollment is verified at process startup. That attempt never delays agent execution and is not waited on at shutdown. Use explicit `flush` when an operator needs a **synchronous** delivery attempt — before host maintenance, or to confirm an intake change took effect.
 </Callout>
 
 ### `stella telemetry rollover-discard`

--- a/website/content/docs/commands/tune.mdx
+++ b/website/content/docs/commands/tune.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella tune
-description: Eval-driven self-tuning of Stella's own policy — A/B one knob over two loop-bench runs, promote the winner only when it confidently wins, or roll it back.
+description: Eval-driven self-tuning of stella's own policy — A/B one knob over two loop-bench runs, promote the winner only when it confidently wins, or roll it back.
 ---
 
-`stella tune` is how Stella's own policy gets tuned by evidence instead of taste. It A/B tests one knob over two [loop-bench](https://github.com/macanderson/stella/tree/main/bench/loop-bench) runs, scores each arm from the per-trial rewards, and promotes the candidate **only** when it confidently beats the baseline — with a reversible rollback record either way.
+`stella tune` is how stella's own policy gets tuned by evidence instead of taste. It A/B tests one knob over two [loop-bench](https://github.com/macanderson/stella/tree/main/bench/loop-bench) runs, scores each arm from the per-trial rewards, and promotes the candidate **only** when it confidently beats the baseline — with a reversible rollback record either way.
 
 The first knob is the worker's reasoning effort. Offline: reads two result files and the local ledger, writes settings only on `--promote`. No provider, no API key.
 

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella version
-description: Print the installed Stella version and exit.
+description: Print the installed stella version and exit.
 ---
 
 Print the version of the installed `stella` binary and exit.

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -300,7 +300,7 @@ cross-family as your lineup changes:
 
 ## Output token ceilings
 
-**By default every model is asked for its own maximum.** Stella reads that
+**By default every model is asked for its own maximum.** stella reads that
 ceiling from the model catalog, which learns it from the provider's own
 `/models` endpoint, so you never have to configure anything to get a
 full-length answer. A cap set below the model's ceiling decides where work
@@ -375,7 +375,7 @@ read: it means the output cap on some gateways and the whole context window on
 others, and reading it the wrong way round would seed a ceiling several times
 the model's real one.
 
-Bedrock and Vertex publish no listing Stella can read, so those rows carry a
+Bedrock and Vertex publish no listing stella can read, so those rows carry a
 seeded value instead. `stella models refresh` (and the startup sync) replaces
 seeded numbers with the provider's own wherever one is published.
 
@@ -413,7 +413,7 @@ maps reasoning to the provider's native mechanism:
   >
     The normalized reasoning object. Some upstreams OpenRouter fronts make
     reasoning mandatory and answer `reasoning: {enabled: false}` with a hard
-    400 — Stella resends once without the object rather than losing the call,
+    400 — stella resends once without the object rather than losing the call,
     since "off" is an economy preference, not a correctness requirement.
   </SpecCard>
   <SpecCard
@@ -439,7 +439,7 @@ maps reasoning to the provider's native mechanism:
     meta={[{ label: "Reasoning", value: "reasoning.effort" }]}
   >
     Plus `text.verbosity` and `service_tier` from `params`. `temperature` and
-    `top_p` are omitted for reasoning models — an API rule, not a Stella
+    `top_p` are omitted for reasoning models — an API rule, not a stella
     choice.
   </SpecCard>
   <SpecCard

--- a/website/content/docs/configuration/credentials.mdx
+++ b/website/content/docs/configuration/credentials.mdx
@@ -1,9 +1,9 @@
 ---
 title: Credentials
-description: How Stella stores and resolves API keys — the credential chain and the credentials.toml file.
+description: How stella stores and resolves API keys — the credential chain and the credentials.toml file.
 ---
 
-Stella resolves an API key for the selected provider through a well-defined chain, and can
+stella resolves an API key for the selected provider through a well-defined chain, and can
 persist keys in a permission-restricted file so you're only prompted once.
 
 ## The credential chain
@@ -28,7 +28,7 @@ and nothing below the first hit is ever read:
    [settings.json](/docs/configuration/settings)).
 4. **`~/.stella/credentials.toml`** — the stored-keys file below.
 5. **Interactive prompt** — on a TTY, when you've named a provider with
-   `--model provider/model_id` (e.g. `--model anthropic/claude-fable-5`), Stella prompts for
+   `--model provider/model_id` (e.g. `--model anthropic/claude-fable-5`), stella prompts for
    the key and saves it to `credentials.toml`, so you are only asked once. A bare invocation
    with no `--model` uses auto-detection, which does **not** prompt — it errors with guidance
    to name a provider instead.
@@ -70,10 +70,10 @@ together = "..."
   plaintext, the same threat model as `~/.ssh/config`.
 - Writes are atomic (a temp file is renamed into place), so a reader never sees a
   half-written file.
-- When you enter a key at the interactive prompt, Stella writes it here automatically.
+- When you enter a key at the interactive prompt, stella writes it here automatically.
 - If the file arrived some other way — hand-written, restored from a backup, checked
   out from a dotfiles repo — and its mode lets your group or anyone else read it,
-  Stella **warns at startup and reads it anyway**:
+  stella **warns at startup and reads it anyway**:
 
   ```text
   ⚠ credentials: ~/.stella/credentials.toml is mode 0644 — its plaintext provider keys

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Configuration
-description: How Stella is configured — settings.json, credentials, workspace files, and the scope hierarchy.
+description: How stella is configured — settings.json, credentials, workspace files, and the scope hierarchy.
 ---
 
-Stella reads configuration from a few well-defined places. Most users need only an API
+stella reads configuration from a few well-defined places. Most users need only an API
 key; teams and power users reach for `settings.json`.
 
 ## What lives where
@@ -60,7 +60,7 @@ specific scope winning:
 
 A project entry overrides an org-managed one, which overrides a user one — per field, so a
 project can change just a base URL while inheriting an API key from a higher scope. This is
-the same layering the rest of Stella's settings use.
+the same layering the rest of stella's settings use.
 
 <SettingsCascadeDiagram />
 
@@ -83,7 +83,7 @@ Both feed the [credential chain](/docs/getting-started/providers#the-credential-
 
 ## Everything you can configure
 
-Stella is configured through three kinds of surface — **files**, **environment variables**,
+stella is configured through three kinds of surface — **files**, **environment variables**,
 and **command-line flags** — with flags winning over env vars winning over files. What
 follows is the complete map; each card links to its detail page.
 
@@ -302,7 +302,7 @@ follows is the complete map; each card links to its detail page.
 </Callout>
 
 <Callout type="info">
-  Stella **auto-detects** the provider from whichever API keys are present in your
+  stella **auto-detects** the provider from whichever API keys are present in your
   environment — the minimum viable configuration is a single `*_API_KEY` env var and nothing
   else. Everything above is for when you want to override that default behavior.
 </Callout>

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -3,7 +3,7 @@ title: settings.json
 description: Configure providers, agents, tools, context, and managed authority across project, org-managed, and user scopes.
 ---
 
-`settings.json` is Stella's configuration file. It has ten top-level sections, each with
+`settings.json` is stella's configuration file. It has ten top-level sections, each with
 its own merge rule across the [scope hierarchy](#the-scope-hierarchy):
 
 <Callout type="info">
@@ -97,7 +97,7 @@ its own merge rule across the [scope hierarchy](#the-scope-hierarchy):
 </CardGrid>
 
 <Callout type="info">
-  `authority_policy` is **not** a file key. It is the effective authority Stella computes
+  `authority_policy` is **not** a file key. It is the effective authority stella computes
   while loading the scope chain, and it is skipped during parsing precisely so repository
   text cannot supply it.
 </Callout>
@@ -162,7 +162,7 @@ model selection) rather than being ignored; only `api_key` treats empty as unset
 <Callout type="info">
   `providers` both overrides built-ins and **defines brand-new providers**: use an id that
   isn't built-in, set the required `base_url`, and optionally a `dialect` (defaults to
-  `openai-compatible`). That is how you point Stella at any OpenAI-compatible gateway from
+  `openai-compatible`). That is how you point stella at any OpenAI-compatible gateway from
   config alone.
 </Callout>
 
@@ -289,7 +289,7 @@ The merged result for `zai` — **with the project trusted** (`STELLA_TRUST_PROJ
 `api_key` &gt; `~/.stella/credentials.toml` &gt; interactive prompt. See the
 [credential chain](/docs/getting-started/providers#the-credential-chain).
 
-An API key configured **only** in `settings.json` is enough for Stella to auto-detect and
+An API key configured **only** in `settings.json` is enough for stella to auto-detect and
 run that provider — no provider-specific environment variable required.
 
 ## The Z.ai coding-plan example
@@ -343,7 +343,7 @@ so a project can point at a different registry than the user default.
 
 ## The `tools` section
 
-Stella ships with **every tool on**, `bash` and the web family included. The top-level
+stella ships with **every tool on**, `bash` and the web family included. The top-level
 `tools` section is the one way to turn something off, and it works identically for
 built-ins, MCP-server tools, and tools you registered yourself:
 
@@ -738,7 +738,7 @@ schema, the sink-authorization rules, and the closed event envelope are document
 
 A repository you just cloned can carry a `<workspace>/.stella/settings.json` — and an
 untrusted repo must not be able to run commands on your machine or route your API keys to
-a server it controls. Stella therefore holds back the dangerous parts of a project-scope
+a server it controls. stella therefore holds back the dangerous parts of a project-scope
 file until you opt in with **`STELLA_TRUST_PROJECT=1`**:
 
 - **Hooks.** Project-scope `hooks` load only when the project is trusted. (The legacy

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -3,7 +3,7 @@ title: stella.toml
 description: The comment-preserving, schema-versioned TOML config format — where each scope's file lives, what moved from settings.json, what stays identical, and what is not built yet.
 ---
 
-`stella.toml` is Stella's config file in TOML instead of JSON. It reads across the same
+`stella.toml` is stella's config file in TOML instead of JSON. It reads across the same
 three scopes as [`settings.json`](/docs/configuration/settings), merges by the same rules,
 and is gated by the same [project trust boundary](/docs/configuration/settings#the-project-trust-boundary)
 — the file format changed, nothing about who is trusted did. What TOML adds is what JSON
@@ -74,7 +74,7 @@ says what you meant. Full walkthrough: [`stella migrate`](/docs/commands/migrate
 
 ## TOML and settings.json are never merged
 
-If both files exist at a scope, Stella reads the TOML **whole** and ignores the JSON —
+If both files exist at a scope, stella reads the TOML **whole** and ignores the JSON —
 never a field-by-field composite of the two. A composite would make "which file configures
 this?" unanswerable from either file alone; the actual failure mode that guards against is
 someone editing the JSON, seeing no effect, and having nothing to look at.

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -1,9 +1,9 @@
 ---
 title: Context Engine
-description: How Stella remembers — bi-temporal memory, prompt-cache-native recall, the citation loop, reflections, the tree-sitter code graph, and the domain taxonomy.
+description: How stella remembers — bi-temporal memory, prompt-cache-native recall, the citation loop, reflections, the tree-sitter code graph, and the domain taxonomy.
 ---
 
-Stella accumulates knowledge about your workspace so each session starts
+stella accumulates knowledge about your workspace so each session starts
 smarter than a blank slate — and it does so **prompt-cache-natively**: durable
 knowledge rides the provider's prompt cache instead of being re-billed at
 full price every call.
@@ -44,7 +44,7 @@ Everything is on your disk, under `.stella/`:
 </CardGrid>
 
 *Bi-temporal* means the context store keeps both when a fact was true and
-when Stella believed it: re-running `stella init` **supersedes** stale facts
+when stella believed it: re-running `stella init` **supersedes** stale facts
 rather than deleting them, so "what did we believe then?" stays answerable.
 
 ### Where rules come from
@@ -75,7 +75,7 @@ under a provenance-qualified id so both constraints stay in force.
 
 ## Local-first today; share rules through Git
 
-The stores above are **workspace-local**. Stella does not currently aggregate
+The stores above are **workspace-local**. stella does not currently aggregate
 memories, reflection logs, or telemetry into a hosted team graph, and it does
 not silently publish a learned pattern as organization policy.
 
@@ -99,7 +99,7 @@ boundary rather than make private local telemetry a shared source of truth.
 
 ## Two injection points, one cache discipline
 
-Stella feeds context to the model at exactly two places, chosen so the
+stella feeds context to the model at exactly two places, chosen so the
 expensive part never changes:
 
 1. **The baked prefix (stable).** At session start, workspace memories and
@@ -129,7 +129,7 @@ into the prompt. It maximizes relevance and **destroys prompt-cache
 locality** — every turn's prompt is different, the cache misses every call,
 and the whole system prompt re-bills at full input price, forever.
 
-Stella is built so invalidation *structurally cannot happen*, at two layers:
+stella is built so invalidation *structurally cannot happen*, at two layers:
 
 - **The cache layer.** The prefix is byte-stable by discipline — same
   memories, same order, same bytes, every call of the session — and the
@@ -142,12 +142,12 @@ Stella is built so invalidation *structurally cannot happen*, at two layers:
   would convert every subsequent cache hit into a miss.
 - **The knowledge layer.** The context store is bi-temporal: new facts
   **supersede** old ones with validity windows — they never overwrite or
-  delete them. Re-initializing a workspace doesn't invalidate what Stella
+  delete them. Re-initializing a workspace doesn't invalidate what stella
   believed before; it records what changed and when. History stays
   queryable, provenance stays intact, and a recalled fact can always say
   *when* it was true.
 
-The practical significance: Stella's memory gets **cheaper and richer** as a
+The practical significance: stella's memory gets **cheaper and richer** as a
 session runs and as a workspace ages — where per-turn-injection designs get
 more expensive with every memory they add. Cost architecture, not a cache
 trick.
@@ -156,11 +156,11 @@ trick.
 
 The recall seam isn't private plumbing — it is a versioned, open wire
 protocol: the **[Context Graph Protocol](https://github.com/macanderson/context-graph-protocol)**
-(`contextgraph/1.0-draft`), now its own project, with Stella as its reference host.
+(`contextgraph/1.0-draft`), now its own project, with stella as its reference host.
 
 - **Zero-dependency wire types.** The protocol's types depend on nothing but
   a JSON codec — a context provider can be written in any language without
-  importing a line of Stella.
+  importing a line of stella.
 - **Machine-checked conformance.** "CGP conformant" isn't marketing — it's
   green on the public conformance suite. A conforming provider works with
   any CGP host, checked at CI time rather than discovered at integration
@@ -173,14 +173,14 @@ protocol: the **[Context Graph Protocol](https://github.com/macanderson/context-
 
 The consequence for you: the context engine is **extensible without forks**.
 Your company wiki, your issue tracker, your vector store — anything that
-speaks CGP can feed Stella's recall block under the same budget, scoring,
+speaks CGP can feed stella's recall block under the same budget, scoring,
 and citation rules as the built-in providers. The full analysis lives in
 [the CGP advantages paper](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md).
 
 
 ## The citation loop: memories that earn their place
 
-Memory in Stella is not write-only. It is a feedback loop:
+Memory in stella is not write-only. It is a feedback loop:
 
 - **`save_memory`** writes a lesson (a slug plus ≤ 2,000 chars of Markdown)
   to `.stella/memories/`.
@@ -233,7 +233,7 @@ Concretely, over a few sessions:
 ## Reflections: learning from every working turn
 
 After any turn that did real work (tool calls happened — a pure chat turn is
-skipped to save the call), Stella spends one cheap, deterministic model call
+skipped to save the call), stella spends one cheap, deterministic model call
 to extract **0–3 lessons**, tagged with allowed domains, written to both the
 context store and `.stella/private/reflections.jsonl`. Failed turns get a dedicated
 root-cause prompt — failure is treated as the highest-value learning signal,
@@ -249,7 +249,7 @@ capped per session and never clobbering an existing skill.
 
 ### Honest measurement: A/B control turns
 
-Does recall actually help? Stella measures instead of assuming: at a fixed
+Does recall actually help? stella measures instead of assuming: at a fixed
 rate (every 10th turn by default), recall is deterministically suppressed and
 the turn recorded as a **control turn** — its episode summary carries an
 `[ab-control]` marker. Comparing outcomes with and against controls keeps the
@@ -294,7 +294,7 @@ files change, for exactly as long as the session runs.
 ## Exploration maps: understanding that outlives the turn
 
 Understanding a slice of a codebase is expensive — and most agents throw it
-away the moment the turn ends. Stella keeps it. When the agent works out how a
+away the moment the turn ends. stella keeps it. When the agent works out how a
 subsystem fits together, it can call `save_exploration` to write a high-fidelity
 **exploration map** to `.stella/explorations/`; a later session (or a teammate)
 reads it back with the read-only `explorations` tool instead of re-deriving the
@@ -302,7 +302,7 @@ same picture from scratch.
 
 Two properties make the maps trustworthy rather than stale notes:
 
-- **Per-file staleness.** Each map carries a `path → sha256` manifest, so Stella
+- **Per-file staleness.** Each map carries a `path → sha256` manifest, so stella
   can tell you *exactly which files* have changed since the map was written —
   a per-file verdict, not a blunt "this might be old."
 - **Draft maps double as claims.** A map saved in *draft* status is also a

--- a/website/content/docs/donate.mdx
+++ b/website/content/docs/donate.mdx
@@ -1,15 +1,15 @@
 ---
 title: Donate
-description: Stella is free, BYOK, zero-telemetry-egress, and vendor-agnostic — built and funded by one person. If it saves you time or money, consider sponsoring.
+description: stella is free, BYOK, zero-telemetry-egress, and vendor-agnostic — built and funded by one person. If it saves you time or money, consider sponsoring.
 ---
 
-Stella is free software. Community/default use has no account or subscription and zero
+stella is free software. Community/default use has no account or subscription and zero
 telemetry egress — and keeping that independent default is the point. Organizations
 may separately provision the explicit, signed
 [Oxagen Enterprise managed mode](/docs/telemetry#oxagen-enterprise-managed-export);
 that narrow operational boundary does not change the Community default.
 
-If Stella saves you time or money, please consider sponsoring its development:
+If stella saves you time or money, please consider sponsoring its development:
 
 <Callout type="info">
   **[Sponsor @macanderson on GitHub →](https://github.com/sponsors/macanderson)**
@@ -17,7 +17,7 @@ If Stella saves you time or money, please consider sponsoring its development:
 
 ## Why sponsorship matters here
 
-Stella is not a thin wrapper around one vendor's API. It is a large, serious
+stella is not a thin wrapper around one vendor's API. It is a large, serious
 piece of systems engineering, built and maintained by one person:
 
 - **A workspace of focused Rust crates** — a deterministic agent engine, a
@@ -37,7 +37,7 @@ piece of systems engineering, built and maintained by one person:
 
 ## What open source is supposed to look like
 
-Stella is built on a few non-negotiable principles:
+stella is built on a few non-negotiable principles:
 
 - **Zero telemetry egress by default.** Community/default telemetry — executions,
   tokens, cost, the files-touched ledger, and content — stays in local SQLite. Your
@@ -50,14 +50,14 @@ Stella is built on a few non-negotiable principles:
   bill. No middleman markup, no metered proxy, no lock-in.
 - **Model and vendor agnostic.** Anthropic, OpenAI, Google (Gemini and
   Vertex), Amazon Bedrock, xAI, DeepSeek, Z.ai, OpenRouter, or any local
-  OpenAI-compatible server — pick per agent, per role, per run. Stella has no
+  OpenAI-compatible server — pick per agent, per role, per run. stella has no
   favorite and takes no rebate.
-- **Open source, and staying that way.** Stella is licensed under
+- **Open source, and staying that way.** stella is licensed under
   **AGPL-3.0-only** — free to use, read, fork, and ship, with one condition: if
-  you distribute a modified Stella, or offer one to users over a network, you
+  you distribute a modified stella, or offer one to users over a network, you
   publish your changes too. The copyleft is the point. It keeps improvements
   flowing back instead of disappearing into someone's closed fork. Building
-  proprietary software *with* Stella is unaffected — the license covers Stella
+  proprietary software *with* stella is unaffected — the license covers stella
   itself, not the code you write using it. If you need to embed it in a
   closed-source product, a [commercial license](https://github.com/macanderson/stella/blob/main/LICENSING.md)
   is available and is part of what funds the work.
@@ -75,7 +75,7 @@ Sponsorship is the most direct support, but not the only kind:
 - **Write about your setup** — provider configs, fleet plans, and skills that
   worked for you help the next person.
 
-Thank you for using Stella — and thank you for keeping independent,
+Thank you for using stella — and thank you for keeping independent,
 local-first developer tooling alive.
 
 **[github.com/sponsors/macanderson](https://github.com/sponsors/macanderson)**

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -1,13 +1,13 @@
 ---
 title: Event stream compatibility
-description: The versioning contract behind Stella's event stream — what stays stable, what may change, and what a client must do to keep working across upgrades.
+description: The versioning contract behind stella's event stream — what stays stable, what may change, and what a client must do to keep working across upgrades.
 ---
 
-Every machine-readable surface Stella exposes carries the same event objects:
+Every machine-readable surface stella exposes carries the same event objects:
 
 - [`--output-format stream-json`](/docs/scripting) — one event per line on stdout
 - `--output-format json` — the same objects, batched under an `events` key
-- the session journal Stella writes to `.stella/private/` and replays on `stella resume`
+- the session journal stella writes to `.stella/private/` and replays on `stella resume`
 
 So there is one compatibility contract to learn, and it applies everywhere. This
 page is that contract, stated for someone writing a client in a language other
@@ -15,8 +15,8 @@ than Rust.
 
 ## The guarantee
 
-**A client written against one version of Stella keeps working against later
-versions, without changes.** Concretely, upgrading Stella will not make your
+**A client written against one version of stella keeps working against later
+versions, without changes.** Concretely, upgrading stella will not make your
 parser fail on a stream it used to handle.
 
 That holds in both directions:
@@ -58,14 +58,14 @@ Growth is by addition.
 ## The two rules that matter
 
 Everything above reduces to a single distinction that your client should mirror,
-because Stella's own reader enforces it exactly:
+because stella's own reader enforces it exactly:
 
 <EventContractDiagram />
 
 **1. An event `type` you do not recognize is normal. Skip it and keep going.**
 
-It means the stream came from a newer Stella than your client knows about. It is
-not an error, and it is not a reason to stop reading. Stella's own decoder
+It means the stream came from a newer stella than your client knows about. It is
+not an error, and it is not a reason to stop reading. stella's own decoder
 preserves such events whole rather than failing the line.
 
 **2. A `type` you *do* recognize, carrying a body that does not fit, is a real
@@ -130,7 +130,7 @@ for (const line of stream) {
 
 ## Unrecognized events in practice
 
-Suppose a future Stella adds a `spline_reticulated` event. A client built before
+Suppose a future stella adds a `spline_reticulated` event. A client built before
 it existed sees:
 
 ```json
@@ -162,7 +162,7 @@ it next, which may be a newer client that would have understood them.
   step text, and you must *replace* accumulated deltas with it rather than append
   (a retried model call re-streams its deltas from the start). See
   [Scripting & automation](/docs/scripting).
-- **Internal lifecycle events.** Stella's adaptive-context machinery emits its own
+- **Internal lifecycle events.** stella's adaptive-context machinery emits its own
   versioned envelope, deliberately kept off this stream. Do not build on it.
 - **Byte-level stability.** Whitespace and key order may vary.
 
@@ -180,14 +180,14 @@ that parses it end to end, reports two unrecognized events, and reconstructs the
 run from the rest is forward compatible. A client that throws is not — however
 well it handles today's vocabulary.
 
-If you maintain a Stella client, run it against that file in CI. It is the
+If you maintain a stella client, run it against that file in CI. It is the
 cheapest possible guard against the failure mode this contract exists to
 prevent, and it costs one test.
 
 ## Detecting a version gap
 
-You do not need to know Stella's version to consume the stream correctly — that
+You do not need to know stella's version to consume the stream correctly — that
 is the point of rule 1. But if you want to *report* a gap ("this run used
 features your dashboard cannot display"), count unrecognized types and surface
-the count. Stella's Rust decoder exposes the same information through the
+the count. stella's Rust decoder exposes the same information through the
 `KNOWN_TYPE_TAGS` list in `stella-protocol`.

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -8,7 +8,7 @@ Pick the profile that matches the keys you hold, paste its file whole, and verif
 fragment.
 
 <Callout type="info">
-This page answers *how do I set Stella up*. For *how do I get this done* — a red CI
+This page answers *how do I set stella up*. For *how do I get this done* — a red CI
 run, an unfamiliar repository, a budget you have to hold — see the
 **[Guides](/docs/guides)**.
 </Callout>
@@ -51,7 +51,7 @@ Three consequences:
 2. **A flagship verifier is cheap insurance.** One verifier call is a few thousand input tokens
    and under a thousand out — 1–2¢ on `gpt-5.5`, 2–3¢ on `claude-fable-5`. Make it a
    *different family* than the worker. Arm `--test-command` and many runs skip it.
-3. **Prompt caching does the heavy lifting.** Stella keeps the system prefix byte-stable
+3. **Prompt caching does the heavy lifting.** stella keeps the system prefix byte-stable
    so most execute-step input bills at the cached rate, 4–10× cheaper. See the
    [context engine](/docs/context-engine).
 
@@ -333,7 +333,7 @@ the first-slash split and the `openrouter/openrouter/auto` doubling.
 
 ## Local and air-gapped
 
-Point Stella at any OpenAI-compatible local server. No key, no metering, no cloud.
+Point stella at any OpenAI-compatible local server. No key, no metering, no cloud.
 
 ```bash
 # Ollama
@@ -382,7 +382,7 @@ stella doctor    # checks the local session store's integrity; reads local state
 Community/default telemetry stays in `.stella/private/store.db`, the
 [Observatory](/docs/telemetry/dashboard) binds `127.0.0.1`, memories and the code graph
 are files in your workspace, and `stella init` works offline with a heuristic fallback.
-To keep it that way, leave both telemetry-egress paths unconfigured — Stella has
+To keep it that way, leave both telemetry-egress paths unconfigured — stella has
 [exactly two](/docs/telemetry): leave
 [Oxagen Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export)
 unenrolled, and write no `drain` block into `~/.stella/cloud.json` (without one,
@@ -402,7 +402,7 @@ in auto-detection, so pin them explicitly. Setup and credential rules are in
 [API providers](/docs/api-providers#google-vertex-ai); this is the org-wide half.
 
 The **org-managed scope** is the enterprise deployment surface: a `settings.json` outside
-any repo, shipped by MDM, that every Stella on the machine inherits.
+any repo, shipped by MDM, that every stella on the machine inherits.
 
 ```json title="/Library/Application Support/stella/settings.json (macOS) · /etc/stella/settings.json (Linux)"
 {

--- a/website/content/docs/extensions.mdx
+++ b/website/content/docs/extensions.mdx
@@ -1,18 +1,18 @@
 ---
 title: Extension hooks
-description: A typed, in-process event bus that lets extensions observe Stella's activity and gate sensitive actions with allow, modify, deny, or require-approval.
+description: A typed, in-process event bus that lets extensions observe stella's activity and gate sensitive actions with allow, modify, deny, or require-approval.
 ---
 
-Stella's engine (`stella-core`) exposes a typed **event bus** that extensions and embedders
+stella's engine (`stella-core`) exposes a typed **event bus** that extensions and embedders
 use to *observe* everything the agent does and, on an explicit allowlist of
 policy-sensitive actions, to *intercept* it. Every event flows through one uniform
 envelope, and every subscription is disposable and cleanup-safe.
 
 <Callout type="info">
-  Two different things are both called "hooks" in Stella. **[Lifecycle hooks](/docs/agent-tools/hooks)**
+  Two different things are both called "hooks" in stella. **[Lifecycle hooks](/docs/agent-tools/hooks)**
   are shell commands you declare in `settings.json` — no code required. **Extension hooks**
   (this page) are the *programmatic* in-process bus you register handlers against when you
-  embed Stella's engine as a library. They share the event vocabulary but not the wiring.
+  embed stella's engine as a library. They share the event vocabulary but not the wiring.
 </Callout>
 
 ## The event envelope
@@ -206,7 +206,7 @@ than discovering it in a quarantine event.
 ## Relationship to file-touch telemetry
 
 The bus is how you react to file changes *as they happen*: the same
-[file-touch telemetry](/docs/telemetry/files-touched) that Stella records also drives `file.created`,
+[file-touch telemetry](/docs/telemetry/files-touched) that stella records also drives `file.created`,
 `file.updated`, `file.deleted`, and `files_touched.updated` events, each carrying the path,
 reason, and line deltas of the touch (never the file contents).
 

--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install Stella, set a provider key, initialize your repo, and run your first verified change — in under five minutes.
+description: Install stella, set a provider key, initialize your repo, and run your first verified change — in under five minutes.
 ---
 
 This walks you from zero to a verified change:
@@ -29,16 +29,16 @@ stella run "explain what this repository does, then list the riskiest files"
 
 ## 1. Set an API key
 
-Stella is bring-your-own-key. Export a key for any one provider — Stella auto-detects it:
+stella is bring-your-own-key. Export a key for any one provider — stella auto-detects it:
 
 ```bash
 export ANTHROPIC_API_KEY=your_key_here   # or OPENAI_API_KEY, GEMINI_API_KEY, ZAI_API_KEY, …
 ```
 
-No key handy? Point Stella at a local OpenAI-compatible server instead — see
+No key handy? Point stella at a local OpenAI-compatible server instead — see
 [Providers &amp; models](/docs/getting-started/providers#local--any-openai-compatible-server).
 
-Confirm what Stella resolved:
+Confirm what stella resolved:
 
 ```bash
 stella config    # provider, model, redacted key, base URL, workspace
@@ -107,7 +107,7 @@ See [Goal mode](/docs/agent-modes#outcome-driven-goal-mode) for how the verifier
 
 ## 6. Pin a specific model (optional)
 
-By default Stella auto-detects the provider. Pin one explicitly with `--model`:
+By default stella auto-detects the provider. Pin one explicitly with `--model`:
 
 ```bash
 stella --model anthropic/claude-fable-5 run "refactor the database layer"
@@ -140,4 +140,4 @@ Then, when you want the underlying account:
 - **[The inference pipeline](/docs/inference-pipeline)** — how work gets verified, not just done.
 - **[Agent modes](/docs/agent-modes)** — deck, run, goal, monitor, fleet: which to use when.
 - **[Configuration](/docs/configuration)** — settings.json, per-agent models, credentials.
-- **[Scripting](/docs/scripting)** — run Stella headlessly in CI with JSON output.
+- **[Scripting](/docs/scripting)** — run stella headlessly in CI with JSON output.

--- a/website/content/docs/getting-started/initialization.mdx
+++ b/website/content/docs/getting-started/initialization.mdx
@@ -3,7 +3,7 @@ title: Repo initialization
 description: Prime a workspace with stella init — the domain taxonomy, the tree-sitter code graph, extension adoption, and everything that lands under .stella/.
 ---
 
-Stella works in any directory with zero setup — but one command primes it
+stella works in any directory with zero setup — but one command primes it
 with structured knowledge of your codebase:
 
 ```bash
@@ -39,7 +39,7 @@ hard-fails: you can initialize before configuring any provider key.
 
 ## What lands where
 
-Everything Stella knows about a workspace lives under `.stella/` — plain
+Everything stella knows about a workspace lives under `.stella/` — plain
 files and SQLite databases you can inspect, version, or delete at will:
 
 ### Shared — commit these
@@ -105,7 +105,7 @@ files and SQLite databases you can inspect, version, or delete at will:
 </CardGrid>
 
 When upgrading from a release that wrote private files directly under
-`.stella/`, Stella migrates safe, closed legacy files into `.stella/private/`
+`.stella/`, stella migrates safe, closed legacy files into `.stella/private/`
 on first use. Unsafe permissions or live SQLite WAL/SHM sidecars fail closed
 with an actionable error and remain untouched.
 
@@ -120,7 +120,7 @@ version control (prefer
 [`api_key_env` or `credentials.toml`](/docs/configuration/credentials)).
 
 Everything under `.stella/private/` is local state, including MCP OAuth tokens.
-Stella generates `.stella/.gitignore` for you, covering the private directory
+stella generates `.stella/.gitignore` for you, covering the private directory
 and any stray database or reflection log left by an older layout:
 
 ```text title=".stella/.gitignore"

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install the Stella CLI via the install script, Homebrew, cargo, or from source.
+description: Install the stella CLI via the install script, Homebrew, cargo, or from source.
 ---
 
-Stella ships as a single self-contained binary named `stella`. There is no runtime to
+stella ships as a single self-contained binary named `stella`. There is no runtime to
 install alongside it. Installing is the first of four steps:
 
 <QuickstartDiagram />

--- a/website/content/docs/getting-started/providers.mdx
+++ b/website/content/docs/getting-started/providers.mdx
@@ -1,9 +1,9 @@
 ---
 title: Providers & models
-description: The full provider matrix, how to select a model, the credential chain, and pointing Stella at a local OpenAI-compatible server.
+description: The full provider matrix, how to select a model, the credential chain, and pointing stella at a local OpenAI-compatible server.
 ---
 
-Stella is model-agnostic. It speaks each provider's native wire dialect and auto-detects
+stella is model-agnostic. It speaks each provider's native wire dialect and auto-detects
 which provider to use from the API keys you have set.
 
 This page is the quick reference. For per-provider deep dives — setup walkthroughs,
@@ -14,7 +14,7 @@ and for choosing between models (pricing, release dates, what each is best at) s
 ## Supported providers
 
 Each card carries what you need to start: the provider id you put before the `/` in
-`--model`, the env var Stella reads, the model you get if you name none, and the wire
+`--model`, the env var stella reads, the model you get if you name none, and the wire
 dialect it speaks. Click through for setup and provider-specific configuration.
 
 <ProviderGrid />
@@ -41,7 +41,7 @@ stella --model zai/glm-5.2 run "fix the failing test"
 export STELLA_MODEL=anthropic/claude-fable-5
 ```
 
-With no `--model`, Stella **auto-detects**: it selects the first provider that has a
+With no `--model`, stella **auto-detects**: it selects the first provider that has a
 resolvable credential, in preference order — `zai`, `anthropic`, `openai`, `xai`,
 `deepseek`, `gemini`, `openrouter`, then `vertex` and `bedrock` **last**.
 
@@ -54,7 +54,7 @@ resolvable credential, in preference order — `zai`, `anthropic`, `openai`, `xa
 
 ## The credential chain
 
-For the selected provider, Stella resolves the API key in this order — **first hit wins**:
+For the selected provider, stella resolves the API key in this order — **first hit wins**:
 
 1. `--api-key` flag (needs an explicit `--model provider/...`)
 2. The provider's env var (and aliases, e.g. `GOOGLE_API_KEY` for Gemini)
@@ -64,7 +64,7 @@ For the selected provider, Stella resolves the API key in this order — **first
    are only prompted once
 
 <Callout type="info">
-  Before the env-var step (2) runs, Stella first loads project **dotenv files** into the
+  Before the env-var step (2) runs, stella first loads project **dotenv files** into the
   environment: `.env.<mode>.local` → `.env.local` → `.env`, most-specific first, and
   **nearest-scope-wins** — confined to the enclosing git repository (never the home
   directory or above). It never loads `.env.example` or a committed `.env.<mode>`, an

--- a/website/content/docs/guides/budget.mdx
+++ b/website/content/docs/guides/budget.mdx
@@ -1,6 +1,6 @@
 ---
 title: Work within a budget
-description: A hard dollar ceiling, and what Stella does as it approaches one — where the abort lands and what the scope gate stops before you spend anything.
+description: A hard dollar ceiling, and what stella does as it approaches one — where the abort lands and what the scope gate stops before you spend anything.
 ---
 
 You have a number in mind and you do not want to find out you passed it
@@ -68,7 +68,7 @@ A budget stops a run partway. The [scope review](/docs/inference-pipeline#3-scop
 stops it *before the first edit*, which is usually the outcome you actually
 wanted.
 
-When a plan's blast radius crosses any of three thresholds, Stella pauses and
+When a plan's blast radius crosses any of three thresholds, stella pauses and
 shows you the plan:
 
 <CardGrid size="sm">
@@ -155,7 +155,7 @@ A ceiling only helps if you know what is pushing against it.
 
 A long run's cost is not only what it does — it is how much conversation it
 carries while doing it. When the transcript approaches the compaction budget
-(**150,000 tokens** by default), Stella compacts it and keeps going, rather than
+(**150,000 tokens** by default), stella compacts it and keeps going, rather than
 failing or silently truncating.
 
 Compaction applies four mechanisms, **least-lossy first**:

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gate on engine quality in CI
-description: Run Stella and Claude Code side by side on one task set every pull request. Block the merge on loop correctness; report the quality delta, never gate on it.
+description: Run stella and Claude Code side by side on one task set every pull request. Block the merge on loop correctness; report the quality delta, never gate on it.
 ---
 
 Once an agent engine is a dependency of your product, it regresses like any
@@ -9,7 +9,7 @@ trace. A prompt change, a model swap, a settings edit, an upstream release: the
 turn still exits zero, still prints something plausible, and does less work than
 it did last week.
 
-This guide sets up a CI job that catches that. It runs Stella and Claude Code
+This guide sets up a CI job that catches that. It runs stella and Claude Code
 over the same committed task set on every pull request, and — this is the part
 that matters — it treats their two outputs as answers to two different
 questions.
@@ -165,7 +165,7 @@ Here is what each one gives you, trimmed to the keys a gate reads:
 
 Two notes before you write the comparison.
 
-**Read `model`, not your own flag.** Stella reports the model that actually
+**Read `model`, not your own flag.** stella reports the model that actually
 served the worker turns, which a
 [worker-model route](/docs/configuration/agent-engine-config) can change out from
 under your `--model` argument. Attribute spend to what the receipt says.
@@ -178,7 +178,7 @@ works on both paths, which is why the assertions below use events.
 
 ## Step 3: The blocking half — loop correctness
 
-This is Stella's own gate on itself, and the vocabulary is worth borrowing
+This is stella's own gate on itself, and the vocabulary is worth borrowing
 because it was built by watching real failures. `loop-bench` collapses a run into
 one of four verdicts, checked in this order:
 
@@ -198,17 +198,17 @@ Read against the receipts from step 2, that becomes four assertions:
     run with fewer rows — gate still green.
   </OptionCard>
   <OptionCard name="2. Work happened">
-    At least one `tool_start` event for Stella; `num_turns > 1` and a non-empty
+    At least one `tool_start` event for stella; `num_turns > 1` and a non-empty
     diff for Claude Code. Zero tool calls on a task that requires an edit is the
     failure this whole job exists to catch.
   </OptionCard>
   <OptionCard name="3. It terminated, and said why">
-    Stella: `status` is `completed`, or `reason` is non-null. Claude Code:
+    stella: `status` is `completed`, or `reason` is non-null. Claude Code:
     `terminal_reason` is present. A run that ends with neither vanished, and that
     is `SILENT-DEATH`.
   </OptionCard>
   <OptionCard name="4. Nothing was silently blocked">
-    A non-empty `permission_denials`, or a Stella run aborted on a scope gate with
+    A non-empty `permission_denials`, or a stella run aborted on a scope gate with
     nobody to ask, means the agent was stopped rather than finished. Fail loudly —
     this reads as low quality otherwise, and you will spend a week tuning prompts.
   </OptionCard>
@@ -323,7 +323,7 @@ jobs:
 ```
 
 **Make it a required status check.** A check that is not required does not block a
-merge, and a check that does not block a merge does not do anything. Stella
+merge, and a check that does not block a merge does not do anything. stella
 learned this the expensive way: a dependency bump broke the bench workflow, the
 workflow reported failure, and the pull request merged twelve minutes later. It
 stayed broken for five days.
@@ -334,9 +334,9 @@ never reports — and a required context that never reports blocks the pull requ
 forever. The job above always runs and always reports; only the expensive part is
 conditional. An unrelated PR pays one runner start-up, not two agent runs.
 
-## If you are working on Stella itself
+## If you are working on stella itself
 
-The harness described above is the portable version. Stella ships its own, and it
+The harness described above is the portable version. stella ships its own, and it
 is cheaper and sharper if the thing you are changing *is* the engine:
 
 ```bash
@@ -352,7 +352,7 @@ report path), `3` that no trial artifacts were found at all — an infrastructur
 failure, deliberately distinguished from a loop regression — and `4` that the
 loop was healthy but fewer trials passed than `--min-pass` demanded.
 
-Stella runs it against itself nightly, not per-PR: it needs Docker, a task
+stella runs it against itself nightly, not per-PR: it needs Docker, a task
 runner, a provider key, and real money. Two details of that job are worth
 copying. The task list is pinned **by name** rather than taken as "the first
 four of the pool", because the pool is an ordinary source constant and
@@ -400,11 +400,11 @@ itself is worse than none.
 ## See also
 
 <CardGrid size="sm">
-  <SpecCard title="Drop Stella in as your agent engine" href="/docs/guides/embed-the-engine">
+  <SpecCard title="Drop stella in as your agent engine" href="/docs/guides/embed-the-engine">
     The companion guide. Get the engine inside your app and under test first — this
     page assumes a loop CI can already run.
   </SpecCard>
-  <SpecCard title="Scripting Stella" href="/docs/scripting">
+  <SpecCard title="Scripting stella" href="/docs/scripting">
     The full JSON envelope contract, the `schema_version` rule, and the jq patterns
     the scripts above are built from.
   </SpecCard>

--- a/website/content/docs/guides/embed-the-engine.mdx
+++ b/website/content/docs/guides/embed-the-engine.mdx
@@ -1,6 +1,6 @@
 ---
-title: Drop Stella in as your agent engine
-description: Replace your hand-rolled agent loop with Stella's, keeping your own models, tools, keys, and data — and end on an integration test that needs no API key.
+title: Drop stella in as your agent engine
+description: Replace your hand-rolled agent loop with stella's, keeping your own models, tools, keys, and data — and end on an integration test that needs no API key.
 ---
 
 You shipped an LLM feature. The first version was a `while` loop around a
@@ -12,7 +12,7 @@ being a feature and started being a distributed system nobody owns.
 
 None of that is your product. All of it is on your critical path.
 
-This guide replaces that loop with Stella's, without giving up a single thing
+This guide replaces that loop with stella's, without giving up a single thing
 you care about — your models, your keys, your tools, your data, your bill.
 
 ## The move, in one paragraph
@@ -209,7 +209,7 @@ dependencies regress.
 
 <CardGrid size="md">
   <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
-    Run Stella and Claude Code side by side on the same committed task set on every
+    Run stella and Claude Code side by side on the same committed task set on every
     pull request. Block the merge on loop correctness, which is deterministic and
     cheap; report the quality delta, which is neither. The companion to this guide.
   </SpecCard>

--- a/website/content/docs/guides/fix-failing-ci.mdx
+++ b/website/content/docs/guides/fix-failing-ci.mdx
@@ -116,7 +116,7 @@ the new root cause. That is what the round loop is for.
 ### The same failure comes back
 
 A revision that has already deterministically failed triggers **distress
-guidance**: Stella spends one verifier call producing a course-correction note that
+guidance**: stella spends one verifier call producing a course-correction note that
 rides along with the next revision prompt, rather than letting the worker keep
 digging in the same direction. You will see the same-failure case resolve or
 change shape rather than repeat identically.
@@ -136,7 +136,7 @@ the diff — read on.
 ### It cannot be fixed from the code
 
 Some red CI is not a code problem: an expired token, a billing cap, a runner
-that no longer exists, a required check whose workflow file never starts. Stella
+that no longer exists, a required check whose workflow file never starts. stella
 will keep proposing code changes because code changes are what it can make. The
 tell is a `ci_status` conclusion that never reaches the test step at all — a job
 that fails in setup, or a run whose conclusion is `startup_failure`.
@@ -181,7 +181,7 @@ command, and gate on `verdict.deterministic` — the
 ## Running it *from* CI instead of *at* CI
 
 `monitor` watches a remote pipeline from your machine. The other arrangement —
-Stella running headlessly *inside* a CI job — is a different setup with
+stella running headlessly *inside* a CI job — is a different setup with
 different requirements (a non-TTY surface, JSON output, an explicit scope-review
 bypass):
 

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -3,7 +3,7 @@ title: Guides
 description: Task-shaped walkthroughs — fix a red CI run, land a change in an unfamiliar codebase, find out what a run cost. Each one carried to a verified result.
 ---
 
-The rest of the documentation is organized around Stella's parts: a page per
+The rest of the documentation is organized around stella's parts: a page per
 command, a page per subsystem. This section is organized around **your
 afternoon**. Each guide is one real task carried from the symptom to a verified
 result, in the order you would actually type the commands.
@@ -34,22 +34,22 @@ stop and read the whole flag surface at the moment you need it and not before.
     exact bytes of the model call that produced it — `stats`, `observe`, `inspect`.
   </SpecCard>
   <SpecCard title="Work within a budget" href="/docs/guides/budget">
-    A hard ceiling in dollars, and what Stella does as it approaches one: where the
+    A hard ceiling in dollars, and what stella does as it approaches one: where the
     abort lands, what compaction costs, and how to spend the money on the task
     instead of on the transcript.
   </SpecCard>
-  <SpecCard title="Drop Stella in as your agent engine" href="/docs/guides/embed-the-engine">
+  <SpecCard title="Drop stella in as your agent engine" href="/docs/guides/embed-the-engine">
     You have a product with an LLM feature and a hand-rolled loop. Replace the loop
     and keep your models, tools, keys, and data — ending on an integration test that
     exercises the whole agent loop without an API key.
   </SpecCard>
   <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
-    Run Stella and Claude Code side by side on the same committed task set on every
+    Run stella and Claude Code side by side on the same committed task set on every
     pull request. Block the merge on loop correctness, which is deterministic; report
     the quality delta, which is not.
   </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
-    Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other. The
+    Terminal-Bench 2.1 with stella in one arm and Claude Code in the other. The
     setup, the parity checks that make the comparison mean something, and the traps
     that quietly void a result.
   </SpecCard>
@@ -62,7 +62,7 @@ stop and read the whole flag surface at the moment you need it and not before.
 
 ## What these assume
 
-Every guide assumes you have [installed Stella](/docs/getting-started/installation)
+Every guide assumes you have [installed stella](/docs/getting-started/installation)
 and that one provider key resolves — `stella config` prints a provider, a model,
 and a redacted key preview rather than an error. If that is not yet true,
 [Getting started](/docs/getting-started) is thirty seconds long and this section
@@ -74,7 +74,7 @@ happens if you don't have it.
 
 ## The idea the guides share
 
-Stella's distinguishing behavior is not any single command — it is that **work
+stella's distinguishing behavior is not any single command — it is that **work
 ends on evidence rather than on the worker's own claim**. A test that failed
 before the change and passes after it. A diff that exists. A CI run whose latest
 attempt is green. A verifier from a different model family than the worker, reading
@@ -82,7 +82,7 @@ the diff and not the narration.
 
 That is worth knowing before the first guide, because it explains a shape you
 will see in all of them: the fastest, cheapest path is usually the one that hands
-Stella something deterministic to check.
+stella something deterministic to check.
 
 ```bash
 # The strongest flag on the CLI. It arms the fail→pass flip oracle, which
@@ -98,7 +98,7 @@ that works. You do not need it to follow any guide here.
 <CardGrid size="sm">
   <SpecCard title="Examples & recipes" href="/docs/examples">
     The configuration half — complete `settings.json` files for a given set of keys
-    and a given budget. Answers *how do I set Stella up*, where the guides answer
+    and a given budget. Answers *how do I set stella up*, where the guides answer
     *how do I get this done*.
   </SpecCard>
   <SpecCard title="Agent modes" href="/docs/agent-modes">

--- a/website/content/docs/guides/parallel-fixes.mdx
+++ b/website/content/docs/guides/parallel-fixes.mdx
@@ -9,7 +9,7 @@ is small, none of them depend on each other, and doing them one at a time is an
 afternoon of watching a progress bar.
 
 This is what [`stella fleet`](/docs/commands/fleet) is for: many tasks at once,
-each handled by a full Stella worker, coordinated so they don't overwrite each
+each handled by a full stella worker, coordinated so they don't overwrite each
 other.
 
 ## The whole thing, first
@@ -173,7 +173,7 @@ dependents — they end the run as `skipped`, which is a distinct outcome from
 "failed" and means the work was never attempted.
 
 Start with the ledger, `.stella/private/fleet.db` — local SQLite, like all
-[Stella telemetry](/docs/telemetry):
+[stella telemetry](/docs/telemetry):
 
 ```bash
 # What failed in the most recent run, and what the worker said about it.

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -1,9 +1,9 @@
 ---
-title: Benchmark Stella against Claude Code
-description: Run Terminal-Bench 2.1 with Stella in one arm and Claude Code in the other — the setup, and the parity checks that make the comparison mean anything.
+title: Benchmark stella against Claude Code
+description: Run Terminal-Bench 2.1 with stella in one arm and Claude Code in the other — the setup, and the parity checks that make the comparison mean anything.
 ---
 
-You want a number: on the same tasks, with the same model, does Stella solve
+You want a number: on the same tasks, with the same model, does stella solve
 more than Claude Code — and at what cost? Terminal-Bench 2.1 is 89 containerized
 terminal tasks with a deterministic grader, which makes it the right instrument.
 Running it *twice*, once per agent, is the head-to-head.
@@ -14,7 +14,7 @@ differs in a second variable measures nothing and costs the same money.
 
 ## The shape of it
 
-Two Harbor jobs over one frozen dataset. Arm A is Stella, arm B is Claude Code:
+Two Harbor jobs over one frozen dataset. Arm A is stella, arm B is Claude Code:
 
 ```
 <tag>-armA-stella        harbor run --agent-import-path stella_harbor:StellaAgent
@@ -52,7 +52,7 @@ for the line between them before publishing anything from here.
     schedule.
   </OptionCard>
   <OptionCard name="uv, zig, cargo-zigbuild, rustup">
-    `uv` provisions the adapter venv; the zig toolchain cross-compiles the Stella
+    `uv` provisions the adapter venv; the zig toolchain cross-compiles the stella
     binary that runs *inside* the task containers.
   </OptionCard>
   <OptionCard name="Two API keys, one per arm">
@@ -76,7 +76,7 @@ constant*, not an upgrade candidate: the adapter refuses to launch unless
 `.github/dependabot.yml` ignores the package because an automated bump to 0.20.0
 once broke the run path for five days.
 
-The version also decides the CLI spelling. In 0.6.1 the Stella arm is selected
+The version also decides the CLI spelling. In 0.6.1 the stella arm is selected
 with `--agent-import-path`; 0.20.0 folded that into `--agent`. If you ever move
 off the pin, check the help text before spending anything —
 `harbor run --help` is the authority, and Harbor renders it through Rich, so
@@ -101,7 +101,7 @@ step.
 bench/evidence/run/build_sut.sh
 ```
 
-This cross-compiles Stella against `x86_64-unknown-linux-gnu.2.17` via
+This cross-compiles stella against `x86_64-unknown-linux-gnu.2.17` via
 `cargo-zigbuild`. That glibc floor is what lets **one** binary execute in every
 task image — including the two on `debian:bullseye-slim`, whose glibc 2.31 is the
 oldest in the dataset.
@@ -113,7 +113,7 @@ five trials before the agent ever started. Every integrity check still passed,
 because they all answer *did the file arrive intact* — and it had. Nothing
 answered *can this file run here*. Harbor recorded `NonZeroAgentExitCodeError`
 and scored each trial 0.0, which under a fixed denominator is arithmetically
-indistinguishable from Stella failing those tasks.
+indistinguishable from stella failing those tasks.
 </Callout>
 
 A host-side preflight now refuses to start a run whose binary requires a glibc
@@ -147,7 +147,7 @@ string to `harbor run --dataset`.
 
 ## 4. Make the two arms comparable
 
-Everything so far applies to a solo Stella run. This step is what makes it a
+Everything so far applies to a solo stella run. This step is what makes it a
 head-to-head, and it is the step people skip.
 
 ### Pick one API surface for both arms
@@ -183,7 +183,7 @@ solved.
 Both arms should be pinned to the same effort tier, by whatever mechanism each
 one actually honors:
 
-- **Stella** — the frozen benchmark posture (`agents.<role>.effort`), which is
+- **stella** — the frozen benchmark posture (`agents.<role>.effort`), which is
   asserted by digest rather than by reading the constant, so the value the
   launcher delivers and the value you assert cannot drift apart.
 - **Claude Code** — `harbor --ak reasoning_effort=<tier>`, which Harbor's
@@ -214,9 +214,9 @@ before it returns.
 
 ### Decide the per-trial spend cap deliberately
 
-Stella can be given a per-trial budget. Claude Code, as Harbor runs it, has no
-spend ceiling. Leaving Stella's default cap in place therefore hands the
-comparator an advantage that will not appear anywhere in the output — Stella's
+stella can be given a per-trial budget. Claude Code, as Harbor runs it, has no
+spend ceiling. Leaving stella's default cap in place therefore hands the
+comparator an advantage that will not appear anywhere in the output — stella's
 capped trials simply abort and score 0.
 
 Setting `STELLA_BUDGET` to the empty string means *no per-trial cap*, and that
@@ -304,11 +304,11 @@ re-derive it instead of trusting it.
 
 <Callout type="warn">
 **Self-reported cost can invert the ranking.** On one smoke dataset the agents'
-own numbers said Claude Code $2.65 / Stella $3.27, while a single price table
-applied to both said Claude Code $3.00 / Stella $1.93 — the opposite ordering.
+own numbers said Claude Code $2.65 / stella $3.27, while a single price table
+applied to both said Claude Code $3.00 / stella $1.93 — the opposite ordering.
 Always publish a recomputed, normalized cost. The price table in
 `bench/terminal_bench_analysis/normalized_cost.py` strips the routing prefix
-Stella carries and the comparator does not, so `anthropic/claude-sonnet-5` and
+stella carries and the comparator does not, so `anthropic/claude-sonnet-5` and
 `claude-sonnet-5` hit one row — but it still needs an entry for the model
 itself, and for the date the run happened on when that model's rate has
 changed.
@@ -365,7 +365,7 @@ denominator.
     The local stores a run writes, and how to query them.
   </SpecCard>
   <SpecCard title="Scripting" href="/docs/scripting">
-    Driving Stella headlessly with JSON output — the same surface the adapter
+    Driving stella headlessly with JSON output — the same surface the adapter
     uses.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/troubleshooting.mdx
+++ b/website/content/docs/guides/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: When something isn't working
 description: Config that isn't applying, a key that won't resolve, hooks that never fire, a run that does nothing — the checks in the order that finds it fastest.
 ---
 
-Most Stella problems are one of a small number of things, and nearly all of them
+Most stella problems are one of a small number of things, and nearly all of them
 are answerable locally in a few seconds. This page is organized by **symptom**,
 and each section is ordered so the cheapest check that could explain it comes
 first.
@@ -25,7 +25,7 @@ config mystery ends.
 
 Four checks, in this order.
 
-### 1. Is Stella reading the file you are editing?
+### 1. Is stella reading the file you are editing?
 
 There are three scopes, and they are merged rather than chosen:
 
@@ -119,7 +119,7 @@ Three specific traps:
 <CardGrid size="md">
   <SpecCard title="The key is only in a .env file your shell never loads">
     Project dotenv files are loaded into the environment before step 2, so a repo's
-    `.env.local` does reach Stella — but an **exported shell value always wins**, and a
+    `.env.local` does reach stella — but an **exported shell value always wins**, and a
     dotenv loaded by an interactive-shell hook is not loaded for a non-interactive
     invocation. `stella auth set <provider>` is the durable fix.
   </SpecCard>
@@ -153,12 +153,12 @@ error blames the wrong party.
 ```
 
 The fix is to make the two agree: pin the provider to the host
-(`--model zai/glm-5.2`), or drop the override. A host Stella does not recognize
+(`--model zai/glm-5.2`), or drop the override. A host stella does not recognize
 is left alone — a proxy or a private gateway is a legitimate use of the flag.
 
 ### Auto-detection picked a provider you did not expect
 
-With no `--model`, Stella takes the first provider with a resolvable credential,
+With no `--model`, stella takes the first provider with a resolvable credential,
 in this order:
 
 ```text

--- a/website/content/docs/guides/unfamiliar-codebase.mdx
+++ b/website/content/docs/guides/unfamiliar-codebase.mdx
@@ -142,7 +142,7 @@ make, just, …). It is offline and needs no API key.
 
 ### If you can't express "done" as a test
 
-Then don't pass `--test-command`, and Stella supplies the oracle itself. An
+Then don't pass `--test-command`, and stella supplies the oracle itself. An
 independent model — the **witness author**, never the worker — writes a minimal
 *failing* test pinning the intended behavior, and that test arms the flip oracle
 instead. Witness files are watched for tampering: a worker that edits the

--- a/website/content/docs/guides/what-a-run-cost.mdx
+++ b/website/content/docs/guides/what-a-run-cost.mdx
@@ -3,7 +3,7 @@ title: Understand what a run cost, and why
 description: Follow one expensive run from the dollar figure down to the exact bytes the model was sent — stats, the Observatory, stella inspect. Entirely local.
 ---
 
-A run cost more than you expected. Most tools can tell you *that*. Stella can
+A run cost more than you expected. Most tools can tell you *that*. stella can
 tell you **which model call**, **what it was sent**, and **what changed between
 that call and the one before it** — from local records, with no network access
 and no API key.

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: Stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when done.
+description: stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when done.
 ---
 
-Stella is a model-agnostic coding agent that runs in your terminal. It is
+stella is a model-agnostic coding agent that runs in your terminal. It is
 bring-your-own-key: Community/default use has no account and no sign-up, runs on provider
 credentials you already have, records locally, and sends telemetry nowhere unless you
 [configure it to](/docs/telemetry).
@@ -25,7 +25,7 @@ stella run "add a --json flag to the export command and update the tests"
 
 ## Bring your own provider
 
-Stella speaks each provider's native wire dialect rather than funnelling everything
+stella speaks each provider's native wire dialect rather than funnelling everything
 through one OpenAI-shaped adapter, so provider features — Anthropic's thinking blocks,
 Gemini's thinking levels, Bedrock's Converse shape — are native rather than emulated.
 
@@ -35,7 +35,7 @@ Gemini's thinking levels, Bedrock's Converse shape — are native rather than em
 
 <HeroFlowDiagram />
 
-Stella sends your prompt to the model you selected, lets the model call tools to read and
+stella sends your prompt to the model you selected, lets the model call tools to read and
 change your workspace, feeds the results back, and repeats until the task is done. Inside
 the box: the tool registry, MCP servers from `.stella/mcp.toml`, and the memory and
 code-graph context engine. In [goal mode](/docs/agent-modes#outcome-driven-goal-mode) a
@@ -80,10 +80,10 @@ install, one key, `stella init`, first verified change. Something not working?
 | **Understand** | How the [pipeline](/docs/inference-pipeline) proves work, the [engine's one loop](/docs/agent-engine-paths), how the [context engine](/docs/context-engine) makes recall cheap, the [modes](/docs/agent-modes) you drive it with, and [where telemetry goes](/docs/telemetry). |
 | **Configure** | [`settings.json`](/docs/configuration), [providers](/docs/api-providers), [tools and permissions](/docs/agent-tools), and ready-made [recipes](/docs/examples). |
 | **Reference** | Every [command and flag](/docs/commands), the [event bus](/docs/extensions), and [release notes](/docs/release-notes). |
-| **Project** | The [showcase](/docs/showcase), and [supporting Stella](/docs/donate). |
+| **Project** | The [showcase](/docs/showcase), and [supporting stella](/docs/donate). |
 
 <Callout type="info">
-  Stella never proxies model traffic through a hosted service — your keys call your
+  stella never proxies model traffic through a hosted service — your keys call your
   provider directly. Community/default telemetry stays local; only an explicitly enrolled
   Oxagen Enterprise seat can send the documented minimal operational envelope to its exact
   allowlisted HTTPS sink. See [Telemetry](/docs/telemetry).

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -1,9 +1,9 @@
 ---
 title: Inference Pipeline
-description: How Stella turns a prompt into verified work — the step loop, the staged pipeline from triage to verifier, deterministic verification, and per-role routing.
+description: How stella turns a prompt into verified work — the step loop, the staged pipeline from triage to verifier, deterministic verification, and per-role routing.
 ---
 
-Stella's answer to "did the agent actually do the work?" is structural, not
+stella's answer to "did the agent actually do the work?" is structural, not
 rhetorical. Every prompt runs through an **inference pipeline** that separates
 *doing* the work from *verifying* it — with deterministic checks preferred
 over model opinion, and an independent verifier preferred over self-assessment.
@@ -15,7 +15,7 @@ At the bottom of everything is a simple, single-threaded **step loop**:
 1. **The model proposes tool calls.** Given the conversation so far — the
    prompt, prior tool results, recalled memories and rules — the model decides
    what to do next.
-2. **Tools execute.** Stella runs each proposed tool: reading files, editing
+2. **Tools execute.** stella runs each proposed tool: reading files, editing
    code, running commands. Independent read-only calls fan out in parallel.
 3. **Results feed back.** Tool output is appended to the conversation.
 4. **Repeat until done.** The loop continues until the model stops proposing
@@ -24,7 +24,7 @@ At the bottom of everything is a simple, single-threaded **step loop**:
 There is no coordinator process and no hidden multi-agent swarm — one
 deterministic loop: plan, fan tools out, observe, compact if the conversation
 gets noisy, repeat. When the conversation approaches the compaction budget,
-Stella compacts it and keeps going.
+stella compacts it and keeps going.
 
 `stella run --no-pipeline` and interactive chat drive this raw loop directly.
 Everything else in this page is structure built **on top of** it.
@@ -51,7 +51,7 @@ a **lookup** ("what does this function do?") skips planning entirely, a
 **single concrete change** gets a light path (one execute turn, still verified), a
 **genuinely multi-step** task gets the full plan → scope-review → execute → verify → verdict
 pipeline. Triage runs under a hard latency ceiling (10 seconds); if the model
-doesn't answer in time, Stella falls through to the full path rather than
+doesn't answer in time, stella falls through to the full path rather than
 waiting. Triage can run on its own [configured model](/docs/configuration/agent-engine-config) —
 typically the cheapest, fastest one you have.
 
@@ -64,7 +64,7 @@ blocks the work.
 
 ### 3. Scope review
 
-If the plan's blast radius crosses any of three configured thresholds, Stella
+If the plan's blast radius crosses any of three configured thresholds, stella
 pauses for an interactive **scope review** — you approve, trim, revise, or
 abort the plan before any file changes:
 
@@ -200,14 +200,14 @@ When a model verdict is needed, the **verifier** — a separate model call, by
 preference from a *different model family* than the worker — reviews the goal,
 the diff, and the evidence summary, and answers with a leading `PASS` or
 `FAIL`. The verifier never sees the worker's narration, only what actually
-changed. If the verifier call fails, Stella falls back to a conservative
+changed. If the verifier call fails, stella falls back to a conservative
 heuristic verdict rather than hanging or guessing.
 
 ### 8. Revise
 
 A failed verification sends the worker back with the failure evidence — up to
 a bounded number of revision turns (2 by default). Once a revision has
-deterministically failed, Stella spends one verifier call on **distress guidance**:
+deterministically failed, stella spends one verifier call on **distress guidance**:
 a course-correction note that rides with the next revision prompt instead of
 letting the worker keep digging the same hole.
 

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -1,11 +1,11 @@
 ---
 title: Determinism over intelligence
-description: Why Stella is a deterministic single-thread engine, not a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and what follows from both.
+description: Why stella is a deterministic single-thread engine, not a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and what follows from both.
 ---
 
 The dominant trend in agent architecture is the swarm: a navigator agent, a
 coder agent, a reviewer agent, a tester agent, and a coordinator conducting
-them. Stella deliberately went the other way — **one deterministic,
+them. stella deliberately went the other way — **one deterministic,
 single-threaded step loop** — and treats that as a feature, not a
 limitation. This page distills
 [the full research note](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
@@ -37,7 +37,7 @@ complexity.
 
 <SingleThreadDiagram />
 
-## Stella's answer, by construction
+## stella's answer, by construction
 
 - **One loop.** Plan, fan tool calls out in parallel, observe, compact if
   noisy, repeat. No coordinator to go stale, no peer to disagree with, no
@@ -50,7 +50,7 @@ complexity.
   synchronous functions over owned data, which is what makes it
   property-testable — and what makes its behavior *reproducible* at all.
 
-Where parallelism genuinely pays, Stella provides it **without a shared
+Where parallelism genuinely pays, stella provides it **without a shared
 coordinator or shared engine state**: [fleets](/docs/agent-fleets) run N
 independent single-thread engines over one shared tree, coordinated only by
 cooperative file claims (dedicated git worktrees per task on opt-in) — parallel
@@ -84,7 +84,7 @@ failure class has nowhere to occur.
 
 ## The principle generalized
 
-"Prefer determinism over intelligence" is not anti-model — Stella exists to
+"Prefer determinism over intelligence" is not anti-model — stella exists to
 put frontier models to work. It is a statement about **where to spend
 them**:
 

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Engineering Principles
-description: The design invariants behind Stella — determinism over intelligence, evidence over opinion, a zero-I/O engine, and budgets enforced at safe boundaries.
+description: The design invariants behind stella — determinism over intelligence, evidence over opinion, a zero-I/O engine, and budgets enforced at safe boundaries.
 ---
 
-Stella's repository ships two research papers alongside the code — a
+stella's repository ships two research papers alongside the code — a
 [capstone analysis of seven architectural invariants](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md)
 and a focused study of
 [the deterministic engine](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
@@ -12,7 +12,7 @@ Every claim is grounded in the shipping implementation.
 
 ## The master rule: given a choice, prefer determinism over intelligence
 
-Wherever Stella can decide something with a deterministic mechanism *or* a
+Wherever stella can decide something with a deterministic mechanism *or* a
 model's judgment, it chooses the mechanism — and reserves the model for the
 places only intelligence can fill. [The full argument](/docs/principles/determinism)
 has the research grounding; the shape of it:

--- a/website/content/docs/principles/no-clobber.mdx
+++ b/website/content/docs/principles/no-clobber.mdx
@@ -1,6 +1,6 @@
 ---
 title: No agent silently overwrites another's work
-description: Stella refuses a write that would land on top of a change it never saw — without a lock, a daemon, or any knowledge that the other party exists. How the guarantee works, what it deliberately does not claim, and why it survives a crash.
+description: stella refuses a write that would land on top of a change it never saw — without a lock, a daemon, or any knowledge that the other party exists. How the guarantee works, what it deliberately does not claim, and why it survives a crash.
 ---
 
 Point two agents at one repository and the failure is not a corrupted file.
@@ -10,7 +10,7 @@ person in an editor — changed the same file. A's write succeeds. Nothing
 errors. B's work is gone, and the only record that it existed is a diff
 nobody is going to read.
 
-Stella refuses that write.
+stella refuses that write.
 
 ## The guarantee
 
@@ -57,7 +57,7 @@ There is no registry, no daemon, no lease, and no channel between agents.
 That is not a simplification — it is the point. *Agent B's write is what makes
 agent A's memory stale*, so A detects it locally, with no knowledge that B
 exists. Two processes, two containers, a CI job, and a human typing in Vim are
-all the same case, and none of them has to be running Stella.
+all the same case, and none of them has to be running stella.
 
 Reads count. A read is how an agent acquires the belief a later write acts on,
 so it is recorded exactly as a write is. A delete drops the entry — after a
@@ -93,8 +93,8 @@ on content it believed it knew, while the guard, having forgotten the read
 ever happened, waved the overwrite through. Precisely the combination the
 guard exists to prevent.
 
-So the map is now written down. It lives in Stella's durable work record — a
-git store kept in Stella's own directory, never in your repository — and is
+So the map is now written down. It lives in stella's durable work record — a
+git store kept in stella's own directory, never in your repository — and is
 restored when the session [resumes](/docs/commands/resume), before anything can
 touch a file. A resumed session is exactly as guarded as the one that died.
 

--- a/website/content/docs/principles/session-artifacts.mdx
+++ b/website/content/docs/principles/session-artifacts.mdx
@@ -1,12 +1,12 @@
 ---
 title: A session is an artifact, not a service
-description: Stella will hand you a session you can carry to another machine — and will not carry it for you. Why the line sits there, what Stella still owes you when the artifact lands somewhere new, and what it deliberately refuses to own.
+description: stella will hand you a session you can carry to another machine — and will not carry it for you. Why the line sits there, what stella still owes you when the artifact lands somewhere new, and what it deliberately refuses to own.
 ---
 
-Stella already survives a crash. Kill the process mid-turn and the next run
+stella already survives a crash. Kill the process mid-turn and the next run
 picks up the resume point, with the [no-clobber
 guarantee](/docs/principles/no-clobber) intact, because both live in a durable
-git store Stella keeps in its own directory.
+git store stella keeps in its own directory.
 
 What it does not survive is a *machine*. Your laptop dies, or you want to hand a
 half-finished session to a colleague, or start something on a desktop and finish
@@ -24,10 +24,10 @@ about, because it points straight at where the line belongs.
 
 ## Why local state is local on purpose
 
-Stella's durable store is keyed on a machine-local workspace id. That id lives
+stella's durable store is keyed on a machine-local workspace id. That id lives
 in `.stella/private/`, which is gitignored by construction, so a clone never
 carries it. Identity is decided by comparing absolute paths — a comparison with
-no meaning across machines. And when Stella sees the same id at a path where
+no meaning across machines. And when stella sees the same id at a path where
 another copy is still live, it deliberately mints a *fresh* id, so two copies of
 a project can never silently write into each other's history.
 
@@ -35,26 +35,26 @@ Every one of those choices is right for the question that module answers: *is
 this the same working copy I saw last time?* Every one of them is fatal to
 resuming somewhere else.
 
-The obvious fix is to give Stella a portable identity — an account, a project
+The obvious fix is to give stella a portable identity — an account, a project
 id, a login. That is the fix this project declines, and declining it is the
 whole decision.
 
 ## The line
 
-**Stella provides a checkpoint API and a replay API. The checkpoint API returns
+**stella provides a checkpoint API and a replay API. The checkpoint API returns
 a self-contained artifact; the replay API accepts one.** Identifying a
 workspace, storing the artifact, moving it, authenticating it, and deciding who
 may read it are the caller's concerns.
 
-That is not a division invented for this feature. It is the line Stella already
+That is not a division invented for this feature. It is the line stella already
 draws everywhere else.
 
-When Stella runs as a headless engine behind a host — the `stella-serve` crate —
+When stella runs as a headless engine behind a host — the `stella-serve` crate —
 every governed side effect is remoted back to the host. Model calls and tool
 calls are *requests the host answers*. The engine never holds ambient authority,
 which means a served turn is structurally incapable of reading one of your
 files: it can only ask, and something else decides. The workspace was never
-Stella's in that model.
+stella's in that model.
 
 Durability is the same shape of problem, so it gets the same answer. Extending
 an existing line costs nothing to explain. Carving an exception into it costs
@@ -65,7 +65,7 @@ you the ability to say what the system does.
 It is one integration instead of two, and for a single user with two machines
 that is a real advantage. It loses anyway, on three counts.
 
-**It requires an identity nobody can derive.** Stella sees a directory. It has
+**It requires an identity nobody can derive.** stella sees a directory. It has
 no way to know that `~/src/api` on your laptop and `/work/api` on the build box
 are the same project — only something with a concept of *project* knows that.
 Every scheme that guesses eventually binds two unrelated codebases together,
@@ -75,15 +75,15 @@ which is worse than an honest miss.
 credentials, and [zero telemetry egress by
 default](/docs/principles#the-seven-invariants-briefly) are load-bearing claims,
 with exactly two explicit opt-in exceptions. A first-party upload path makes
-them conditional — and the condition is precisely the thing people choose Stella
+them conditional — and the condition is precisely the thing people choose stella
 to avoid. An artifact API adds no third path: producing an artifact writes bytes
-locally, and Stella still uploads nothing.
+locally, and stella still uploads nothing.
 
 **It builds the easy half twice.** Storage, auth, tenancy, retention, audit —
 these are solved, and they do not get better for being reimplemented inside a
 CLI.
 
-## What Stella still owes you
+## What stella still owes you
 
 "Identity is the caller's problem" is right. "Any artifact may be replayed into
 any tree" is not.
@@ -96,7 +96,7 @@ prevent, for the same reason it is worse to be quietly misinformed than loudly
 blocked.
 
 So the artifact carries a fingerprint of the tree it came from, and **replay
-verifies it and refuses by default**. Stella is not naming your workspace. It is
+verifies it and refuses by default**. stella is not naming your workspace. It is
 checking that this artifact belongs to this tree.
 
 The fingerprint is not a new mechanism — it is the staleness map the no-clobber
@@ -104,7 +104,7 @@ guard already keeps: every path this session touched, and the digest of what it
 saw there. Verifying it is re-hashing those paths in the target tree. A mismatch
 names the exact files, exactly as a refused write does, and nothing is consumed.
 Overriding it is possible, but it is a distinct argument you pass, never a
-fallback Stella takes on your behalf when the check fails.
+fallback stella takes on your behalf when the check fails.
 
 That map covers the files the session actually touched and no others — so it
 cannot cry wolf over unrelated churn elsewhere in the repo, and it cannot detect
@@ -123,10 +123,10 @@ never inferred from what happens to be on disk.
 - **Materialize** writes the session's files out first. The cross-machine case.
 
 Materialize has a limit worth stating plainly: the artifact holds *the files the
-agent touched*, not your whole repository. Stella records the base commit it was
+agent touched*, not your whole repository. stella records the base commit it was
 captured against so a caller can name it, but it does not carry the base and
 will not — bundling your entire tree into a session artifact would move files
-the agent never read, and that is an egress decision Stella has no standing to
+the agent never read, and that is an egress decision stella has no standing to
 make on your behalf.
 
 Fetching the base is exactly the kind of thing a control plane is for. It has
@@ -142,16 +142,16 @@ That sentence belongs in the documentation of the type that holds it, where
 someone reads it before writing the code that moves the bytes — not in a release
 note and not in a banner.
 
-Stella does not encrypt it, redact it, classify it, or expire it. Those need to
+stella does not encrypt it, redact it, classify it, or expire it. Those need to
 know whose data it is, what jurisdiction it sits in, and who may read it, and
-Stella knows none of those. Its entire obligation here is to be accurate about
+stella knows none of those. Its entire obligation here is to be accurate about
 the contents so your decision is an informed one. That is not a gap in the
 design; it is the boundary doing its job.
 
 ## Forks stay visible
 
 Two machines replay the same artifact. Which one wins is a policy question, and
-Stella does not answer it.
+stella does not answer it.
 
 What it guarantees is that the divergence is *honest*: every replay starts its
 own session, with its own ref in the durable store, and the artifact's origin is
@@ -161,7 +161,7 @@ outcome that cannot be untangled afterwards.
 
 ## Where the line falls
 
-| Stella owns | Your control plane owns |
+| stella owns | Your control plane owns |
 |---|---|
 | what is in the artifact | naming a workspace or project |
 | byte-exact round-trip | storing artifacts, and keeping them |
@@ -171,11 +171,11 @@ outcome that cannot be untangled afterwards.
 | telling you what the artifact contains | who wins a conflict, and when |
 
 [Oxagen](https://oxagen.sh) is that control plane at enterprise scale —
-accounts and projects as the portable identity Stella refuses to invent, a
+accounts and projects as the portable identity stella refuses to invent, a
 store, access control, audit, and resuming a session from a browser.
 
 That is a **layering, not a dependency**, and the distinction is the test of
-whether the line is in the right place. Stella has to stay fully usable and
+whether the line is in the right place. stella has to stay fully usable and
 fully durable on its own: the work journal, crash resume, and the no-clobber
 guarantee are local mechanisms and stay local mechanisms. If a change ever made
 one of them conditional on a control plane existing, the change would be the
@@ -183,14 +183,14 @@ thing that is wrong.
 
 ## What this deliberately does not claim
 
-- **It is not sync.** There is no `stella login`, no Stella-hosted store, and no
+- **It is not sync.** There is no `stella login`, no stella-hosted store, and no
   first-party upload path. Not deferred — declined.
 - **Old artifacts do not read forever.** A stored artifact stays replayable
   across a stated support window, not indefinitely. When a build genuinely
   cannot read one, it says so and names what can — it does not guess at a format
   it half-understands, which would resume your session subtly wrong.
-- **Stella does not merge forks.** It makes them visible. Resolving them needs
-  to know which one matters, which is exactly what Stella does not know.
+- **stella does not merge forks.** It makes them visible. Resolving them needs
+  to know which one matters, which is exactly what stella does not know.
 - **The artifact is not a backup of your repository.** It is what the agent did,
   plus the identity of what it did it to.
 

--- a/website/content/docs/release-notes.mdx
+++ b/website/content/docs/release-notes.mdx
@@ -1,9 +1,9 @@
 ---
 title: Release notes
-description: What's new in Stella, per minor release — the user-facing changes behind each version, with the commit-level changelog linked on its GitHub Release.
+description: What's new in stella, per minor release — the user-facing changes behind each version, with the commit-level changelog linked on its GitHub Release.
 ---
 
-Stella follows [semantic versioning](https://semver.org). Every merge to `main`
+stella follows [semantic versioning](https://semver.org). Every merge to `main`
 cuts a release and publishes prebuilt binaries plus a Homebrew formula, so
 `brew upgrade stella` always tracks the latest build.
 
@@ -103,7 +103,7 @@ all, because work still in flight has not been judged.
 
 ### Brand: one identity, written down
 
-`docs/brand/BRAND.md` is now the normative source for Stella's visual identity —
+`docs/brand/BRAND.md` is now the normative source for stella's visual identity —
 electric blue and gold on deep space — and the terminal palette, the brand assets, the
 docs site tokens, and the Observatory dashboard all mirror it. Four surfaces had drifted
 to three different identities, and the drift was possible because nothing was normative.
@@ -112,11 +112,11 @@ theme, and the `--stella-sky*` token names they shipped under.
 
 ## 0.6.0
 
-The `0.6.x` line opens with the feature the `0.5.x` series was building toward: **Stella now learns from working in your codebase, and shows its work.** The adaptive context lifecycle is complete and on by default. Alongside it, this release gathers a large security and reliability pass, streaming on every provider that supports it, a rebuilt transcript, and a relicense.
+The `0.6.x` line opens with the feature the `0.5.x` series was building toward: **stella now learns from working in your codebase, and shows its work.** The adaptive context lifecycle is complete and on by default. Alongside it, this release gathers a large security and reliability pass, streaming on every provider that supports it, a rebuilt transcript, and a relicense.
 
 ### Adaptive context — the loop closes
 
-Stella has always recalled memories. What it could not do was tell you *why* a memory was chosen, whether it helped, or stop selecting one that never did. All four phases of that work landed in this line.
+stella has always recalled memories. What it could not do was tell you *why* a memory was chosen, whether it helped, or stop selecting one that never did. All four phases of that work landed in this line.
 
 - **Every turn is accountable.** The step manifest is now a compiled context frame with a deterministic identity and a content hash, and recall is decomposed into one block per item instead of a single undifferentiated blob. For any past turn you can see exactly which memories entered it, in what order, at what token cost, and where each came from.
 - **`stella inspect`** reconstructs the exact message array any past model call was sent, verified against the digests taken at emission, and reports coverage gaps and digest mismatches separately rather than papering over them. `Ctrl-G` opens the same view inside the deck.
@@ -158,7 +158,7 @@ Stella has always recalled memories. What it could not do was tell you *why* a m
 
 - **`git clone && stella` is no longer arbitrary code execution.** A repo's `.env` could set `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, `BASH_ENV`, `GIT_SSH_COMMAND` or a redirected `PATH`. Loader, interpreter and config-redirect names are refused from project `.env` files and printed on stderr; a live shell env still wins, so `LD_PRELOAD=… stella …` works when a human means it.
 - **Ambient authority scrubbed from model-controlled subprocesses**, including git's config/SSH/proxy hooks and `SSH_AUTH_SOCK`. Escape hatch: `STELLA_SUBPROCESS_ENV_ALLOW`.
-- Secrets are zeroized on drop and no longer dumpable via `{:?}`; files Stella creates are owner-only; `run_tests`' `filter` is quoted per token, closing a command-injection path; a stored-XSS hole in the exported dashboard is closed; MCP servers are bounded on every axis (an MCP server streaming without a newline used to OOM-kill Stella).
+- Secrets are zeroized on drop and no longer dumpable via `{:?}`; files stella creates are owner-only; `run_tests`' `filter` is quoted per token, closing a command-injection path; a stored-XSS hole in the exported dashboard is closed; MCP servers are bounded on every axis (an MCP server streaming without a newline used to OOM-kill stella).
 - **Releases carry build-provenance attestation** covering both the tarballs and `SHA256SUMS`, and `install.sh` verifies it. A *contradicted* attestation always aborts; set `STELLA_REQUIRE_PROVENANCE=1` to make *unverifiable* abort too.
 - A new [threat model](https://github.com/macanderson/stella/blob/main/docs/spec/threat-model.md) records nine residual risks — including that "bash is off" was never the same claim as "the agent cannot run code."
 
@@ -182,7 +182,7 @@ A mobile-first overhaul turned reference tables into card grids and added diagra
 
 ### Licensing
 
-Stella is relicensed from `MIT OR Apache-2.0` to **`AGPL-3.0-only`**, dual-licensed with commercial licenses from Oxagen, Inc. Two carve-outs worth stating plainly: **using Stella to write proprietary code does not make that code AGPL**, and **releases up to v0.5.14 remain perpetually available under MIT/Apache**, including the right to fork from that point. Contributions now require a CLA. The Context Graph Protocol stays Apache-2.0.
+stella is relicensed from `MIT OR Apache-2.0` to **`AGPL-3.0-only`**, dual-licensed with commercial licenses from Oxagen, Inc. Two carve-outs worth stating plainly: **using stella to write proprietary code does not make that code AGPL**, and **releases up to v0.5.14 remain perpetually available under MIT/Apache**, including the right to fork from that point. Contributions now require a CLA. The Context Graph Protocol stays Apache-2.0.
 
 ### Upgrading — what changes under you
 
@@ -217,7 +217,7 @@ fleet-scale telemetry.
 
 - **read→edit drift oracle.** `edit_file` now keeps a per-file record of the
   content the model last *saw* (via a read, or its own successful write). When
-  an edit's `old_string` no longer matches, Stella distinguishes an
+  an edit's `old_string` no longer matches, stella distinguishes an
   out-of-band change to the file from a genuine not-found, echoes the current
   content, and lets the model recover — instead of blindly retrying a stale
   edit.
@@ -225,7 +225,7 @@ fleet-scale telemetry.
   of edits across many files atomically, with a dry-run preflight that reports
   exactly what would change before anything is written. Either the whole batch
   applies or none of it does.
-- **`run_tests scope:"impacted"`.** Test selection is now graph-driven: Stella
+- **`run_tests scope:"impacted"`.** Test selection is now graph-driven: stella
   walks the tree-sitter code graph from your changes to the tests that actually
   exercise them, so a focused change runs a focused suite.
 - **graph-derived planner context.** The planner localizes a goal to the
@@ -234,7 +234,7 @@ fleet-scale telemetry.
 
 ### Context engine
 
-- **Adaptive-context baseline (Phase 0 & 1).** The foundation of Stella's
+- **Adaptive-context baseline (Phase 0 & 1).** The foundation of stella's
   durable memory: a typed record taxonomy with scope and temporal axes, and
   canonical JCS hashing for stable content identity. Context receipts now emit
   **typed decision events** (loop-detection, budget, retry, and policy

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -1,9 +1,9 @@
 ---
 title: Scripting & automation
-description: Run Stella headlessly in CI with JSON and streaming-JSON output, environment-variable configuration, and enforced budgets.
+description: Run stella headlessly in CI with JSON and streaming-JSON output, environment-variable configuration, and enforced budgets.
 ---
 
-Stella is built to run unattended. The `--output-format` flag switches from the
+stella is built to run unattended. The `--output-format` flag switches from the
 human-oriented terminal rendering to machine-readable output, and every important flag has
 an environment-variable equivalent for CI.
 
@@ -32,11 +32,11 @@ values:
   </OptionCard>
 </CardGrid>
 
-`stream-json` is a line-per-event serialization of Stella's internal event enum — a stable
+`stream-json` is a line-per-event serialization of stella's internal event enum — a stable
 machine interface you can parse incrementally. Each line is one event object tagged
 `"type"` in snake_case (`stage`, `text`, `reasoning`, `tool_start`, `tool_result`, …).
 The vocabulary is additive-only: skip lines whose `type` you don't recognize, and a
-client that does so keeps working across Stella upgrades without changes. Note the
+client that does so keeps working across stella upgrades without changes. Note the
 converse — a `type` you *do* recognize carrying a body that doesn't fit is a real error,
 not something to skip. See
 [Event stream compatibility](/docs/event-stream-compatibility) for the full contract and
@@ -201,7 +201,7 @@ export STELLA_BUDGET=5
 stella run "update the changelog for the pending release"
 ```
 
-Stella also loads project dotenv files into the environment before any of this
+stella also loads project dotenv files into the environment before any of this
 resolves — `.env.<mode>.local`, then `.env.local`, then `.env`, most-specific
 first, confined to the enclosing git repository. An exported shell value always
 beats a file value, `.env.example` and committed `.env.<mode>` files are never
@@ -220,7 +220,7 @@ stella run --output-format json "generate release notes from the diff since the 
 ```
 
 <Callout type="warn">
-  With no resolvable key and no TTY, Stella fails fast with a clear error rather than
+  With no resolvable key and no TTY, stella fails fast with a clear error rather than
   hanging on a prompt that can never be answered. Make sure a key is in the environment
   before the run.
 </Callout>

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -1,16 +1,16 @@
 ---
 title: Self-improvement
-description: The track where Stella makes Stella measurably more capable — seven components, their dependency order, what's built today, and the guardrails on each.
+description: The track where stella makes stella measurably more capable — seven components, their dependency order, what's built today, and the guardrails on each.
 ---
 
-Most of what gets called agent "self-improvement" is recall: a note file the agent writes to and reads back. That is useful, and Stella does it — see [Memory](/docs/context-engine). It is also not the same thing as getting *better*.
+Most of what gets called agent "self-improvement" is recall: a note file the agent writes to and reads back. That is useful, and stella does it — see [Memory](/docs/context-engine). It is also not the same thing as getting *better*.
 
-This track is the other thing. Each component below changes what Stella can do, not just what it remembers, and each one carries a **success metric and a guardrail** so that "improvement" is something proven rather than asserted.
+This track is the other thing. Each component below changes what stella can do, not just what it remembers, and each one carries a **success metric and a guardrail** so that "improvement" is something proven rather than asserted.
 
 <Callout type="warn">
 **This page describes a direction, most of which is not built.** One first slice has shipped
 ([`stella tune`](/docs/commands/tune)). Everything else is a design under active discussion in the
-issue tracker, and the details will change. Read it as a map of where Stella is heading, and check
+issue tracker, and the details will change. Read it as a map of where stella is heading, and check
 the linked issue for the current state of any one component.
 </Callout>
 
@@ -24,17 +24,17 @@ So the pattern repeats. A candidate change is generated cheaply, evaluated again
 
 <CardGrid size="md">
   <SpecCard title="Tool Foundry (#830)">
-    Stella authors, tests, and installs its own tools at runtime. When it hits a capability gap
+    stella authors, tests, and installs its own tools at runtime. When it hits a capability gap
     — the same shell incantation reconstructed three times — it synthesizes a typed tool, proves
     it with a witness test, and registers it. Expands the *action space*, not just memory.
   </SpecCard>
   <SpecCard title="Eval-driven self-tuning (#831)">
-    A bandit over Stella's own prompts, policies, and model routing. Variants run A/B on real
+    A bandit over stella's own prompts, policies, and model routing. Variants run A/B on real
     tasks, scored from receipts; the winner is promoted. Optimizes the *policy that acts on
     facts* rather than the facts.
   </SpecCard>
   <SpecCard title="stella-maintains-stella (#832)">
-    The most literal version: Stella audits its own source, opens gated draft PRs against
+    The most literal version: stella audits its own source, opens gated draft PRs against
     itself, drives them through the witness gate, and lands verified improvements behind a
     human merge gate.
   </SpecCard>
@@ -44,7 +44,7 @@ So the pattern repeats. A candidate change is generated cheaply, evaluated again
     promoted only on measured lift.
   </SpecCard>
   <SpecCard title="Causal self-model (#834)">
-    A model of Stella's own failure modes — wrong-model pick, tool-choice error, loop, budget
+    A model of stella's own failure modes — wrong-model pick, tool-choice error, loop, budget
     blow-out — that predicts the likely failure of the *current* plan and intervenes before it
     costs a turn.
   </SpecCard>
@@ -109,7 +109,7 @@ The load-bearing edge is **dataset → eval**. #836's own stated first slice is 
   <SpecCard title="Exists, not wired — loop-bench">
     `bench/loop-bench` works from the command line and is what `stella tune` scores. It does
     **not** run in CI — the bench workflow runs the Python analysis tooling's pytest suite and
-    never runs Stella against a task. That gap is #873.
+    never runs stella against a task. That gap is #873.
   </SpecCard>
   <SpecCard title="Not built — the dataset">
     There is no `stella dataset export`. `stella export` dumps raw, unredacted session

--- a/website/content/docs/showcase.mdx
+++ b/website/content/docs/showcase.mdx
@@ -1,16 +1,16 @@
 ---
 title: Showcase
-description: Teams and projects shipping real software with Stella, and stella-examples, the open cookbook with a working example for every configurable surface.
+description: Teams and projects shipping real software with stella, and stella-examples, the open cookbook with a working example for every configurable surface.
 ---
 
-Real teams, shipping real software, with Stella in the loop. Each entry names
-who they are, what they ship, and how Stella fits the way they work.
+Real teams, shipping real software, with stella in the loop. Each entry names
+who they are, what they ship, and how stella fits the way they work.
 
 ## Oxagen
 
-**[oxagen.sh](https://oxagen.sh)** ships **Oxagen** with the Stella CLI as
+**[oxagen.sh](https://oxagen.sh)** ships **Oxagen** with the stella CLI as
 their **code agent of choice**. Day-to-day feature work, refactors, and
-fix-ups run through Stella sessions: the [Command Deck](/docs/commands/chat)
+fix-ups run through stella sessions: the [Command Deck](/docs/commands/chat)
 for interactive work, [goal mode](/docs/agent-modes#outcome-driven-goal-mode) when there's a
 definition of done to drive to green, and
 [fleets](/docs/agent-fleets) when a batch of tasks can fan out across
@@ -21,7 +21,7 @@ Oxagen also hosts this documentation site — `stella.oxagen.sh` runs on their
 infrastructure.
 
 <Callout type="info">
-Stella is BYOK and local-first for showcased teams too. Community/default sessions use
+stella is BYOK and local-first for showcased teams too. Community/default sessions use
 their own provider keys and send telemetry nowhere until someone configures a path for it.
 There are [exactly two such paths](/docs/telemetry): the governed Enterprise mode an
 organization may explicitly enroll, which can send only the documented content-free
@@ -33,9 +33,9 @@ intake you name. The full local store stays on the machine either way.
 ## stella-examples
 
 **[github.com/macanderson/stella-examples](https://github.com/macanderson/stella-examples)**
-is the open configuration cookbook for Stella itself: a working example for
+is the open configuration cookbook for stella itself: a working example for
 **every configurable surface** in the CLI, each file matching the schema
-Stella actually parses, each directory README saying where the file goes on
+stella actually parses, each directory README saying where the file goes on
 disk. Clone it, copy a file into place, and it works.
 
 <CardGrid size="md">
@@ -163,10 +163,10 @@ repo until you opt in with `STELLA_TRUST_PROJECT=1`.
 
 ## Add your project
 
-Shipping with Stella? Open a pull request against
+Shipping with stella? Open a pull request against
 [macanderson/stella](https://github.com/macanderson/stella) that adds an entry
 to `website/content/docs/showcase.mdx` — who you are, a link, and a few
-sentences on how Stella fits your workflow. Entries should be things that
+sentences on how stella fits your workflow. Entries should be things that
 actually ship; hello-worlds are better served by the
 [examples](/docs/examples). Have a hook, agent, profile, or plan worth
 sharing instead? Send it to

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -15,7 +15,7 @@ stella observe --port 0   # pick any free port
 ## Local by construction
 
 The Observatory is built to the same no-phone-home standard as the rest of
-Stella — not as a policy, as a construction:
+stella — not as a policy, as a construction:
 
 - **Loopback only.** It binds `127.0.0.1` and nothing else. There is no
   remote mode, no auth because there is no exposure.
@@ -161,5 +161,5 @@ clock, not the moment you typed `/export`. Every entry nests under a matching
 <Callout type="info">
   The Observatory is for *living* workspaces — point it at your repo and
   watch spend and resolve rates as you work. `/export` is for *sharing* — a
-  frozen, portable snapshot anyone can open without Stella installed.
+  frozen, portable snapshot anyone can open without stella installed.
 </Callout>

--- a/website/content/docs/telemetry/files-touched.mdx
+++ b/website/content/docs/telemetry/files-touched.mdx
@@ -1,9 +1,9 @@
 ---
 title: Files touched
-description: Every file Stella reads, creates, updates, or deletes — a per-session CRUD ledger with reasons and line deltas, live in the TUI, in JSON, and in the store.
+description: Every file stella reads, creates, updates, or deletes — a per-session CRUD ledger with reasons and line deltas, live in the TUI, in JSON, and in the store.
 ---
 
-Every time Stella touches a file through one of its file tools, it records the touch in a
+Every time stella touches a file through one of its file tools, it records the touch in a
 per-session **file-touch ledger**: which file, what happened (**C**reate / **R**ead /
 **U**pdate / **D**elete), *why*, and how many lines it added and removed. The ledger is
 surfaced live in the TUI, included in `--output-format json` output on raw
@@ -12,7 +12,7 @@ have an auditable record of exactly what a run changed.
 
 ## What gets recorded
 
-Only Stella's dedicated file tools are attributable. Shell commands are opaque — Stella
+Only stella's dedicated file tools are attributable. Shell commands are opaque — stella
 cannot see what a `bash` command did to the filesystem, which is one reason the file tools
 exist and the agent is steered toward them.
 
@@ -51,7 +51,7 @@ out-of-workspace path never produces a ledger entry.
 
 Each of `read_file`, `write_file`, `edit_file`, and `delete_file` accepts an optional
 `reason` string. It is stored (trimmed of surrounding whitespace) in the audit log so the
-ledger reads like a changelog rather than a list of paths. When omitted, Stella fills in a per-operation
+ledger reads like a changelog rather than a list of paths. When omitted, stella fills in a per-operation
 default (`"file updated (no reason given)"`, etc.).
 
 ```jsonc
@@ -155,9 +155,9 @@ stella run --output-format json --no-pipeline "add a --health flag and wire the 
 
 ### Persisted to the local store
 
-Every execution's file-touch ledger is written to Stella's local session store at
+Every execution's file-touch ledger is written to stella's local session store at
 `<workspace>/.stella/private/store.db` (one row per touched path, with the CRUD letters, line-delta
-totals, and the JSON audit log). Like the rest of [Stella's telemetry](/docs/telemetry),
+totals, and the JSON audit log). Like the rest of [stella's telemetry](/docs/telemetry),
 it stays entirely on your machine.
 
 ## Common tasks

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -3,14 +3,14 @@ title: Telemetry & budget
 description: Local-first metering, the opt-in Oxagen Enterprise operational export boundary, spool diagnostics, and how --budget becomes a hard spend cap.
 ---
 
-Stella meters every run **locally**. Token usage, cost, per-step accounting, and the
+stella meters every run **locally**. Token usage, cost, per-step accounting, and the
 full execution record land in SQLite on your disk.
 
 <TelemetryFlowDiagram />
 
 **Telemetry leaves your machine only if you configure it to.** A default install
 constructs no telemetry spool and no telemetry HTTP client. The model provider you
-selected remains Stella's normal BYOK network path; the local Observatory remains
+selected remains stella's normal BYOK network path; the local Observatory remains
 loopback-only.
 
 Exactly two things count as configuring telemetry egress. Both are explicit local
@@ -27,7 +27,7 @@ file a repository ships:
    from the Enterprise export — its own wire contract, its own encoder, its own endpoint
    — and it fires only when the file carries **both** an `org_id` (written by `stella
    cloud register`) and a `drain` block. With either absent, `stella cloud sync` performs
-   no network I/O, and nothing else in Stella invokes it.
+   no network I/O, and nothing else in stella invokes it.
 
 That list is complete: those two transports are the only code paths in the tree that send
 telemetry anywhere.
@@ -197,15 +197,15 @@ unsupported.
 
 ### Option A product boundary
 
-Stella remains the local execution product: provider calls, tools, workspace access,
+stella remains the local execution product: provider calls, tools, workspace access,
 the full event stream, context, and the Observatory stay on the developer host. Oxagen
 is the optional Enterprise control plane: it may provision signed enrollment and
 receive the minimal operational envelope described here.
 
-This repository implements Stella's enrollment verification, projection, durable
+This repository implements stella's enrollment verification, projection, durable
 spool, and HTTPS delivery client. A production Oxagen intake with matching
 authentication, schema validation, idempotency, tenancy, retention, and observability
-is a **companion server requirement**; these Stella docs do not claim that intake is
+is a **companion server requirement**; these stella docs do not claim that intake is
 already deployed.
 
 ### Enrollment and sink authorization
@@ -332,9 +332,9 @@ or expired managed configuration fails with a diagnostic rather than reporting a
 enrolled state.
 
 `flush` attempts one bounded delivery batch immediately and reports sent, pending, and
-dropped counts. Stella also starts a detached best-effort flush after enrollment is
+dropped counts. stella also starts a detached best-effort flush after enrollment is
 verified at process startup. That background attempt is non-blocking: it never delays
-agent execution and Stella does not wait for it during shutdown. Use explicit `flush`
+agent execution and stella does not wait for it during shutdown. Use explicit `flush`
 when an operator needs a synchronous delivery attempt before maintenance.
 
 ## Budget: observed vs. enforced
@@ -342,7 +342,7 @@ when an operator needs a synchronous delivery attempt before maintenance.
 The `--budget` flag (or the `STELLA_BUDGET` environment variable) attaches a USD spend
 limit to the whole run or session.
 
-- **Observed mode (default, no `--budget`)** — Stella meters spend for the end-of-run cost
+- **Observed mode (default, no `--budget`)** — stella meters spend for the end-of-run cost
   summary but never blocks. Use it to *see* what a task costs.
 - **Enforced mode (`--budget <usd>`)** — a hard cap. Once total spend exceeds the limit,
   work aborts **cleanly** — never in the middle of a tool call — so you are never left with


### PR DESCRIPTION
## Problem

The brand kit is normative — *lowercase, always: "stella", never "Stella" or "STELLA"* — and `website/README.md` restates it, but nothing checked it. `website/content/docs` carried **389 capitalised uses against 1806 lowercase**, including inside `description:` frontmatter, which becomes each page's meta description and its llms.txt entry — the first thing search engines and model crawlers read. A documented rule with no gate behind it is an unenforced rule.

## Fix — the issue's option A: add the guard

**`scripts/check-brand-case.sh`** — prose-aware by construction, per the issue's exemption requirements:
- fenced code blocks (``` / `~~~`) skipped whole (sample output, Rust paths are quotations, not brand copy);
- inline code spans stripped before matching — a genuine identifier is exempted by writing it as code, which docs style wants anyway;
- URLs stripped;
- compound identifiers (`StellaError`, `StellaHome`) never match — the word boundary is part of the rule.

Portable POSIX awk/find in the house guard-script idiom (`check-command-docs.sh` is the exemplar it follows), shellcheck-clean.

**Wiring**: joins `GATE_GUARDS_FAST` (so `make guards`/`check`/`gate` and the pre-push hook all run it), a `ci.yml` guard step, and `docs-guards.yml` — the load-bearing copy, since `ci.yml` deliberately ignores `website/**`; its path filter now watches all of `website/content/docs` rather than only `commands/`.

**The other 370 lines are the tree earning the green**: every standalone capitalised wordmark in docs prose lowercased ("stella has one engine…" — the npm/git register the brand kit asks for), code spans and fences untouched, mechanical single-word diff throughout.

## Verified

- `make brand-case` fails on main's tree (370 violating lines listed) and passes on this branch — the guard is its own witness.
- `make shellcheck`, `make command-docs`, `make doc-links` green locally.
- Note: `make guards` currently fails on **main-side** breakage unrelated to this diff — `design-refs` (fullauto scripts citing `docs/design/stella-bench-handoff/`) and `file-size` (`bench/harbor_adapter/tests/test_adapter.py` at 2335 vs 2333). Neither file is touched here.

Closes #1500

## Summary by Sourcery

Enforce the lowercase 'stella' wordmark across documentation and add an automated guard to prevent capitalized usages in the docs tree.

Enhancements:
- Add a docs guard script that scans documentation prose for capitalized instances of the 'stella' wordmark while exempting code, URLs, and identifiers.
- Integrate the brand-case guard into Makefile guard targets and both CI and docs-guards workflows so it runs on relevant pushes and pull requests.
- Normalize documentation content to use the lowercase 'stella' wordmark in titles, descriptions, headings, tables, and narrative prose across the website docs.