### PR TITLE
fix(stella-cli): unbreak main — 'static the arena parse-test argv closure

### DIFF
--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -475,7 +475,11 @@ fn run_and_fleet_declare_output_format() {
 /// without one.
 #[test]
 fn arena_is_stream_json_by_contract_not_by_flag() {
-    let args = |extra: &[&str]| {
+    // `&'static` so the closure's return type unifies with the literals it
+    // extends: an unannotated `&[&str]` param makes the returned Vec borrow
+    // from the closure argument, which cannot outlive the call (E0521 — the
+    // error that broke main's clippy tier when #1567 merged unverified).
+    let args = |extra: &[&'static str]| {
         let mut argv = vec![
             "stella",
             "arena",


### PR DESCRIPTION
## What & why

PR #1567 squash-merged with its `fmt + clippy + test` check red, and the failure is in the change itself: the new `arena_is_stream_json_by_contract_not_by_flag` test's argv closure took `extra: &[&str]`, so the returned `Vec` borrowed from the closure argument — rustc rejects the test build (`lifetime may not live long enough`, `crates/stella-cli/src/tests.rs:490`), which kills clippy **and** `cargo test` for the whole workspace on main. One annotation (`&[&'static str]`) unifies the closure's lifetimes with the string literals it returns.

**Merge this first** — every PR based on current main inherits the red tier until it lands.

## The witness

- [x] No *new* witness needed — this makes #1567's own witness tests actually compile and run for the first time (they were merged unexecuted: the compile error killed the test job before they ran). This PR's CI run is their first real execution.

Fix verified in isolation: an exact repro of the closure shape compiles and runs with the annotation, and reproduces main's error byte-for-byte without it. No workspace build ran locally — two other sessions' cargo builds own this machine (load ~33), and a third cold build would thrash it.

## The gate

- [x] `cargo fmt --check`
- [ ] clippy / test — this PR's CI **is** the run that proves the tier is green again
- [x] Docs: n/a (test-only)
- [x] CLA signed

Refs #1493, #1567

## Summary by Sourcery

Bug Fixes:
- Adjust the arena_is_stream_json_by_contract_not_by_flag test argv closure to take &'static str slices, preventing lifetime errors that broke the main branch test and clippy tiers.