### PR TITLE
fix(arenabench): price each role's tokens at that role's own rate (#1566)

### DIFF
--- a/arenabench/arenabench/pricing.py
+++ b/arenabench/arenabench/pricing.py
@@ -49,6 +49,7 @@ __all__ = [
     "load_overrides",
     "price_for",
     "price_for_route",
+    "price_on_route",
     "trial_cost",
 ]
 
@@ -111,6 +112,11 @@ PRICES: dict[str, Price] = {
     "glm-5.1": Price(input=0.966, output=3.036, cache_read=0.1794),
     "glm-5": Price(input=0.95, output=2.55, cache_read=0.20),
     "glm-5-turbo": Price(input=1.20, output=4.00, cache_read=0.24),
+    # The committed GLM match's triage role. Seated in every pipeline run of
+    # that match, and a trial's cost is the sum of its role subtotals (#1566),
+    # so leaving this row out would blank the whole trial's cost rather than
+    # merely one role's share. Same numbers on both routes, per the catalog.
+    "glm-4.5-air": Price(input=0.13, output=0.85, cache_read=0.025),
     "claude-fable-5": Price(
         input=10.0, output=50.0, cache_read=1.0, cache_write=12.50
     ),
@@ -215,6 +221,28 @@ def price_for_route(qualified_model: str) -> Price | None:
         return None
     exact = PRICES.get(qualified_model.strip().lower())
     return exact if exact is not None else price_for(qualified_model)
+
+
+def price_on_route(route_api: str, model: str) -> Price | None:
+    """The price for any model logged by a seat whose recorded api is known.
+
+    A pipeline seat's stream carries several models — worker, verifier,
+    triage — and every one of them rode the seat's provider: a role config
+    has no ``api`` or ``base_url`` of its own (`model.RoleConfig`), so the
+    seat's launch record speaks for the whole stream. The model id is
+    collapsed to its bare form first — its spelling varies with how the seat
+    was launched, which is the #1498 trap — and the *recorded* api then
+    requalifies it. A route row for that pair wins; otherwise the bare
+    gateway tier; otherwise ``None``.
+
+    ``route_api`` must come from the seat's launch record. With no record
+    there is no route fact, and the caller should use :func:`price_for`.
+    """
+    bare = _normalise(model)
+    if not bare:
+        return None
+    exact = PRICES.get(f"{route_api.strip().lower()}/{bare}")
+    return exact if exact is not None else PRICES.get(bare)
 
 
 def trial_cost(

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -47,7 +47,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .pricing import price_for, price_for_route, trial_cost
+from .pricing import Price, price_for, price_for_route, price_on_route, trial_cost
 
 __all__ = [
     "EVENTS_NAME",
@@ -274,6 +274,11 @@ def _reduce_events(path: Path) -> dict[str, Any] | None:
         "complete": False,
         "verifier_passed": None,
         "models": [],
+        # Token subtotals per model id as the stream spelled it, `""` for a
+        # step that named none. A pipeline seat runs several models at
+        # different rates, so pricing needs the split — the grand totals
+        # above cannot be un-summed (#1566).
+        "by_model": {},
         "usage_incomplete": 0,
         "late_error": "",
     }
@@ -305,6 +310,19 @@ def _reduce_events(path: Path) -> dict[str, Any] | None:
                     if model and model not in seen_models:
                         seen_models.add(model)
                         totals["models"].append(model)
+                    bucket = totals["by_model"].setdefault(
+                        model,
+                        {
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "cache_read": 0,
+                            "cache_write": 0,
+                        },
+                    )
+                    bucket["tokens_in"] += int(event.get("input_tokens") or 0)
+                    bucket["tokens_out"] += out
+                    bucket["cache_read"] += int(event.get("cached_input_tokens") or 0)
+                    bucket["cache_write"] += int(event.get("cache_write_tokens") or 0)
                     # A step after an error means the agent kept working, so
                     # that error was not the run's last word.
                     totals["late_error"] = ""
@@ -334,10 +352,10 @@ class MetricsReader:
         self._events: dict[Path, tuple[int, dict[str, Any]]] = {}
         self._seats: dict[Path, dict[str, Any] | None] = {}
 
-    def _seat_route(self, trial_dir: Path) -> str:
-        """The route-qualified model this trial's seat was launched with.
+    def _seat_record(self, trial_dir: Path) -> dict[str, Any] | None:
+        """The launch record of this trial's seat, or ``None``.
 
-        ``""`` when the job has no launch record — every archive predating
+        ``None`` when the job has no launch record — every archive predating
         it. Cached without invalidation: the record is written once, before
         the job's first trial exists, so by the time this reader has a trial
         directory to ask about, the record's presence and content are final.
@@ -345,11 +363,10 @@ class MetricsReader:
         try:
             path = seat_manifest_path(trial_dir.parent)
         except ValueError:
-            return ""
+            return None
         if path not in self._seats:
             self._seats[path] = _load_json(path)
-        seat = self._seats[path]
-        return str(seat.get("qualified_model") or "") if seat else ""
+        return self._seats[path]
 
     def _events_summary(self, path: Path) -> tuple[dict[str, Any] | None, float | None]:
         try:
@@ -485,24 +502,66 @@ class MetricsReader:
         # routing (a directly-routed seat is launched with the bare id), so
         # only the record can say which route served the trial, and every
         # recorded string prices route-blind at the gateway tier (#1498).
-        # Among the recorded ids the configured seat model is tried first: a
-        # single process can log several roles' `step_usage` (verifier, triage)
-        # into one stream, so the stream's first-seen model may name a role
-        # rather than the seat — pricing on that would mis-cost the whole trial.
-        price = price_for_route(self._seat_route(trial_dir))
-        if price is None:
-            for name in (configured, *metrics.models):
-                price = price_for(name)
-                if price is not None:
+        record = self._seat_record(trial_dir)
+        qualified = ""
+        route_api = ""
+        if record:
+            qualified = str(record.get("qualified_model") or "")
+            route_api = str(record.get("api") or "") or qualified.split("/", 1)[0]
+
+        def single_rate() -> Price | None:
+            """The one-rate fallback for tokens no stream model accounts for.
+
+            The configured seat model is tried before the stream's ids: a
+            single process can log several roles' `step_usage` into one
+            stream, so the stream's first-seen model may name a role rather
+            than the seat — pricing every token on that would mis-cost the
+            whole trial.
+            """
+            price = price_for_route(qualified)
+            if price is None:
+                for name in (configured, *metrics.models):
+                    price = price_for(name)
+                    if price is not None:
+                        break
+            return price
+
+        # A pipeline seat runs several models at several rates — worker,
+        # verifier, triage — so where the stream says which model each step
+        # used, each model's subtotal is priced at its own rate and the trial
+        # costs their sum (#1566). Roles ride the seat's provider (a role
+        # config carries no api of its own), so the launch record's api
+        # qualifies every stream model, never the string's own spelling. One
+        # unpriced subtotal blanks the whole trial: summing only the priced
+        # share would publish a cost that is confidently short, and missing
+        # beats wrong here.
+        by_model = (events or {}).get("by_model") or {}
+        if any(model for model in by_model):
+            total = 0.0
+            for model, bucket in by_model.items():
+                if not model:
+                    price = single_rate()  # steps that named no model
+                elif record:
+                    price = price_on_route(route_api, model)
+                else:
+                    price = price_for(model)  # no route fact: gateway tier
+                if price is None:
+                    total = None
                     break
-        if price is not None:
-            metrics.priced_cost = trial_cost(
-                price,
-                tokens_in=metrics.tokens_in,
-                tokens_out=metrics.tokens_out,
-                cache_read=metrics.cache_read,
-                cache_write=metrics.cache_write,
-            )
+                total += trial_cost(price, **bucket)
+            metrics.priced_cost = total
+        else:
+            # ATIF-only trials publish grand totals and a single model; a
+            # stream that never named one is priced the same way.
+            price = single_rate()
+            if price is not None:
+                metrics.priced_cost = trial_cost(
+                    price,
+                    tokens_in=metrics.tokens_in,
+                    tokens_out=metrics.tokens_out,
+                    cache_read=metrics.cache_read,
+                    cache_write=metrics.cache_write,
+                )
 
         # A running trial has no finish timestamp, so wall clock has to come
         # from the events file's own span rather than from Harbor.

--- a/arenabench/tests/test_pricing.py
+++ b/arenabench/tests/test_pricing.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 
 import arenabench.pricing as pricing
-from arenabench.pricing import price_for, price_for_route, trial_cost
+from arenabench.pricing import price_for, price_for_route, price_on_route, trial_cost
 
 
 class TestPricing:
@@ -37,6 +37,10 @@ class TestPricing:
         assert price_for("z-ai/glm-5.1").input == 0.966
         fable = price_for("claude-fable-5")
         assert (fable.input, fable.output) == (10.0, 50.0)
+        # The committed GLM match's triage role. Unpriced, it would blank the
+        # cost of every pipeline trial in that match (#1566).
+        air = price_for("glm-4.5-air")
+        assert (air.input, air.output, air.cache_read) == (0.13, 0.85, 0.025)
 
     def test_one_recorded_id_resolves_to_one_rate_however_it_was_routed(self):
         """A routed seat is launched with the bare model id and an unrouted one
@@ -89,6 +93,18 @@ class TestRoutePricing:
     def test_a_wholly_unknown_route_reports_nothing(self):
         assert price_for_route("acme/mystery-1") is None
         assert price_for_route("") is None
+
+    def test_a_role_model_prices_on_the_seats_recorded_route(self):
+        """A pipeline's roles ride the seat's provider — a role config has no
+        api of its own — so the record's api qualifies every model the seat's
+        stream logged, whatever spelling the stream used (#1566). The spelling
+        identifies the *model*; only the recorded api carries the route."""
+        assert price_on_route("zai", "glm-5.2") == price_for_route("zai/glm-5.2")
+        assert price_on_route("zai", "openrouter/z-ai/glm-5.2").input == 0.60
+        assert price_on_route("openrouter", "z-ai/glm-5.2") == price_for("glm-5.2")
+        assert price_on_route("zai", "glm-5.1") == price_for("glm-5.1")
+        assert price_on_route("", "glm-5.2") == price_for("glm-5.2")
+        assert price_on_route("zai", "mystery-9") is None
 
     def test_an_override_keyed_by_route_pins_that_route_alone(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -285,6 +285,119 @@ class TestMetrics:
         metrics = MetricsReader().read(trial, "fix-git")
         assert metrics.priced_cost == pytest.approx(0.004538)
 
+    @staticmethod
+    def _zai_record(job_dir: Path) -> None:
+        seat_manifest_path(job_dir).write_text(
+            json.dumps({"schema": 1, "api": "zai", "qualified_model": "zai/glm-5.2"}),
+            encoding="utf-8",
+        )
+
+    def test_a_pipeline_trial_costs_the_sum_of_its_role_subtotals(
+        self, tmp_path: Path
+    ):
+        """The committed GLM match's pipeline arm runs three models at three
+        rates: worker glm-5.2, verifier glm-5.1, triage glm-4.5-air, all on
+        the seat's z.ai route. 1M input tokens on each is
+        $0.60 + $0.966 + $0.13 — not 3M tokens at the worker's rate ($1.80),
+        which is what one-rate pricing published, and the error landed only
+        on the pipeline arm because a single-model arm has no role tokens
+        (#1566)."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(model="zai/glm-5.2", input_tokens=1_000_000, output_tokens=0),
+                usage(
+                    role="verifier",
+                    model="zai/glm-5.1",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+                usage(
+                    role="triage",
+                    model="zai/glm-4.5-air",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+            ],
+        )
+        self._zai_record(trial_dir.parent)
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost == pytest.approx(0.60 + 0.966 + 0.13)
+
+    def test_an_unpriced_role_blanks_the_trial_rather_than_underbilling(
+        self, tmp_path: Path
+    ):
+        """Summing only the priced share would publish a cost that is
+        confidently short, and billing the unpriced role at the worker's rate
+        is the guess this issue exists to remove. Missing beats wrong: one
+        unpriced role model and the trial has no comparable cost at all."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(model="zai/glm-5.2", input_tokens=1_000_000, output_tokens=0),
+                usage(
+                    role="verifier",
+                    model="acme/mystery-1",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+            ],
+        )
+        self._zai_record(trial_dir.parent)
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost is None
+
+    def test_without_a_launch_record_role_subtotals_price_route_blind(
+        self, tmp_path: Path
+    ):
+        """An archive predating the launch record still gets per-model
+        pricing, at the gateway tier each — route stays uninferred from the
+        stream's spellings (#1498), but a verifier token no longer bills at
+        the worker's rate."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(
+                    model="openrouter/z-ai/glm-5.2",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+                usage(
+                    role="verifier",
+                    model="z-ai/glm-5.1",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+            ],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost == pytest.approx(0.76 + 0.966)
+
+    def test_a_step_that_names_no_model_prices_at_the_seat_rate(
+        self, tmp_path: Path
+    ):
+        """A step_usage without a model field cannot join a per-model bucket;
+        its tokens bill the way the whole trial used to — at the seat's own
+        rate — rather than vanishing or blanking the trial."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(model="", input_tokens=1_000_000, output_tokens=0),
+                usage(
+                    role="verifier",
+                    model="zai/glm-5.1",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                ),
+            ],
+        )
+        self._zai_record(trial_dir.parent)
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost == pytest.approx(0.60 + 0.966)
 
 
 class TestAggregate:


### PR DESCRIPTION
## What & why

A pipeline seat's event stream carries several models — worker, verifier, triage — but `MetricsReader` folded every `step_usage` into one grand total and priced it all at the seat's single rate. In the committed GLM match, verifier `glm-5.1` (0.966/Mtok in) and triage `glm-4.5-air` (0.13/Mtok in) tokens billed as worker `glm-5.2`. The error lands only on the pipeline arm — a single-model arm has no role tokens — so it skews the head-to-head cost dimension specifically.

- `_reduce_events` now keeps per-model token subtotals (input/output/cache-read/cache-write each, so `trial_cost`'s cache arithmetic stays exact per bucket) alongside the grand totals.
- Where the stream names models, `priced_cost` is the sum of each subtotal at its own rate. Roles ride the seat's provider — `RoleConfig` carries no `api`/`base_url` of its own — so the new `pricing.price_on_route(api, model)` qualifies each stream model with the **launch record's** api (#1498, PR #1565); the stream's own spelling still never carries route (collapse-then-requalify, pinned by test).
- **One unpriced subtotal blanks the whole trial** (`priced_cost = None`): summing only the priced share would publish a cost that is confidently short, and billing the unpriced role at the worker's rate is the guess this issue exists to remove. Missing beats wrong — the module's standing doctrine, now pinned for the mixed case.
- ATIF-only trials (grand totals, one model) and streams that never name a model price exactly as before, via the same fallback chain as today.
- `glm-4.5-air` joins `PRICES` (0.13/0.85/0.025, same numbers both routes per the catalog): it is the committed GLM match's triage role, and leaving it unpriced would have blanked that match's every pipeline trial under the new rule.

Verified end-to-end against `origin/main`: the three-role pipeline scenario (1M input tokens per role, seat record `api: zai`) prices at **$1.80** on main (3M tokens × worker's $0.60) and **$1.696** with this change ($0.60 + $0.966 + $0.13).

Closes #1566

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_a_pipeline_trial_costs_the_sum_of_its_role_subtotals` is the headline: on `main` it computes $1.80 ≠ $1.696. Confirmed the artisanal way by extracting `origin/main`'s package and running the same fixture: old `$1.8000`, new `$1.6960`. Companion witnesses: an unpriced role blanks the trial (main: $1.20), record-less archives get per-model gateway pricing (main: all-at-first-model), and a model-less step bills at the seat rate. Every pre-existing pricing assertion (`0.004538` fixture, unpriced-model-stays-None, #1498's two-seat equality) passes untouched.

## The gate

- [x] `python3 -m pytest arenabench/tests` — 183 passed
- [x] Docs updated where behavior changed (pricing docstrings, `_reduce_events`/pricing-block comments)
- [x] CLA signed
- [x] `Closes #1566` appears both above and as a commit trailer

`cargo fmt/clippy/test` are unaffected — the diff touches only `arenabench/` (Python); CI runs them regardless.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The blank-on-unpriced-role rule is a deliberate policy choice (the issue asked for one to be picked and pinned). The alternative — price the priced share — publishes a systematically short number, which is the exact wrong-but-plausible failure the module's docstring forbids. Adding the missing rate row is the intended remedy, which is why `glm-4.5-air` ships in the same PR.
- If a *stream-model spelling* mismatches the recorded api (e.g. `openrouter/...` strings under an `api: zai` record), collapse-then-requalify degrades to the bare gateway tier rather than guessing — same conservative direction as #1498.

## Summary by Sourcery

Price pipeline trials by summing per-role model token subtotals at each role’s own rate, adding route-aware role pricing support and tests, and ensuring trials with any unpriced role report no cost rather than underbilling.

New Features:
- Support per-model, per-role token aggregation so pipeline trials can be costed at each model’s own rate.
- Introduce route-qualified role pricing that derives route from the seat’s launch record when available.

Bug Fixes:
- Correct trial cost computation for multi-role pipelines so verifier and triage tokens are no longer billed at the worker model’s rate.
- Ensure trials with any unpriced role model yield no priced cost instead of a partial, systematically low cost.

Enhancements:
- Extend telemetry reduction to track token usage buckets by model id alongside existing grand totals.
- Add pricing data for glm-4.5-air so pipeline triage roles are priced consistently across routes.

Tests:
- Add telemetry and pricing tests covering per-role pipeline costs, blanking behavior for unpriced roles, route-blind archives, and steps that omit model ids.