### PR TITLE
fix(stella-cli): arm the per-task wall-clock deadline a one-shot run already knows (#1503)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -354,7 +354,7 @@ async fn run_pipeline_one_shot(
         // for: skills, draft claims, and the volatile record channel.
         inject_recall_block(&mut messages, m.pipeline_recall_block(prompt).await);
     }
-    let mut budget = build_budget_guard(budget_limit);
+    let mut budget = crate::runtime::one_shot_budget_guard(budget_limit, cfg.turn_budget);
     budget.begin_turn();
 
     let result = {

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -144,15 +144,18 @@ pub(crate) struct GlobalArgs {
     #[arg(long, global = true, env = "STELLA_BUDGET", value_parser = parse_budget)]
     pub(crate) budget: Option<f64>,
 
-    /// Wall-clock seconds one turn may spend, for continuation decisions
+    /// Wall-clock seconds one turn may spend before it wraps up
     ///
-    /// The time twin of `--budget`, and deliberately weaker: this enforces
-    /// nothing and cancels nothing. It exists for callers running under an
-    /// EXTERNAL deadline — a benchmark harness that kills the process on
-    /// elapsed time — so the engine can decline to start an output-limit
-    /// continuation it cannot finish, and end with a truthful partial instead
-    /// of being destroyed mid-flight. Set it slightly below the real deadline.
-    /// Omit for no time-based continuation limit. Env: STELLA_TURN_BUDGET.
+    /// The time twin of `--budget`, for callers running under an EXTERNAL
+    /// deadline — a benchmark harness that kills the process on elapsed
+    /// time. Two mechanisms arm from it: the engine declines to start an
+    /// output-limit continuation it cannot finish (ending with a truthful
+    /// partial instead of being destroyed mid-flight), and a one-shot
+    /// `run` also stops at the next safe boundary once the allowance is
+    /// spent, so the work on disk is scored rather than discarded with the
+    /// kill (#1503). Interactive sessions (chat, the deck) treat it as
+    /// advisory only. Set it slightly below the real deadline. Omit for no
+    /// time-based limit. Env: STELLA_TURN_BUDGET.
     #[arg(long, global = true, env = "STELLA_TURN_BUDGET", value_parser = parse_turn_budget)]
     pub(crate) turn_budget: Option<std::time::Duration>,
 

--- a/crates/stella-cli/src/runtime.rs
+++ b/crates/stella-cli/src/runtime.rs
@@ -66,6 +66,34 @@ impl Sleeper for TokioSleeper {
     }
 }
 
+/// The budget guard for a one-shot invocation, with its wall-clock task
+/// deadline armed (#1503).
+///
+/// A one-shot run is one task, so the `--turn-budget` allowance the caller
+/// resolved — for the bench adapters, Harbor's own per-task timeout minus a
+/// teardown reserve (`bench/harbor_adapter`'s `turn_budget.py`) — IS the
+/// task's ceiling, and this is the one place the shipping binary computes
+/// `Instant::now() + allowance`, the absolute point
+/// `BudgetGuard::set_task_deadline` documents. #1481 built and proved the
+/// stop-at-a-safe-boundary mechanism; until this call nothing armed it, so a
+/// bench task ran into the harness's kill (`AgentTimeoutError`, work on disk
+/// discarded) instead of stopping itself with a scorable partial.
+///
+/// Goal rounds re-enter the one-shot path per round, so each round gets the
+/// same allowance — the flag's documented per-turn contract. The interactive
+/// surfaces (chat, the deck) deliberately keep an unarmed deadline: their
+/// sessions span many turns and no single wall-clock ceiling describes them.
+pub(crate) fn one_shot_budget_guard(
+    budget_limit: Option<f64>,
+    task_allowance: Option<std::time::Duration>,
+) -> stella_core::budget::BudgetGuard {
+    let mut guard = crate::agent::build_budget_guard(budget_limit);
+    if let Some(allowance) = task_allowance {
+        guard.set_task_deadline(Some(std::time::Instant::now() + allowance));
+    }
+    guard
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,6 +118,31 @@ mod tests {
             clock.now_ms() < 1000,
             "a freshly constructed clock starts near zero"
         );
+    }
+
+    /// The #1503 witness: #1481's deadline mechanism was proven by a driver
+    /// test but nothing in the shipping binary armed it — this is the arming,
+    /// so a one-shot task stops itself at a safe boundary instead of running
+    /// into the harness's kill.
+    #[test]
+    fn a_one_shot_guard_arms_the_task_deadline_from_its_allowance() {
+        let allowance = std::time::Duration::from_secs(840);
+        let before = std::time::Instant::now();
+        let guard = one_shot_budget_guard(None, Some(allowance));
+        let deadline = guard
+            .task_deadline()
+            .expect("an allowance arms the deadline");
+        assert!(
+            deadline >= before + allowance,
+            "the deadline is the allowance measured from arming time"
+        );
+        // No allowance leaves the deadline unarmed — the advisory-only shape
+        // every caller had before #1503, and the one chat/deck keep.
+        assert!(one_shot_budget_guard(None, None).task_deadline().is_none());
+        // The dollar axis is orthogonal: arming time must not change mode.
+        let enforced = one_shot_budget_guard(Some(2.5), Some(allowance));
+        assert_eq!(enforced.mode(), stella_protocol::BudgetMode::Enforced);
+        assert!(enforced.task_deadline().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

#1481 built the mechanism — `BudgetGuard::set_task_deadline`, consulted at the settlement boundary, proven by the driver witness `a_past_task_deadline_stops_the_turn_before_the_next_call_with_partial_work` — but **nothing in the shipping binary ever called it**. The deadline stayed scaffolding: a bench task ran into the harness's kill (`AgentTimeoutError`, work on disk discarded) instead of stopping itself with a scorable partial.

## Fix

The caller with a real deadline already existed: the harbor adapter resolves Harbor's per-task `agent_timeout_sec` minus a teardown reserve into `--turn-budget` (`bench/harbor_adapter`'s `turn_budget.py`), and `stella arena` rides the same flag. The value was on the wire, unconsumed by this mechanism.

- `one_shot_budget_guard` (in `runtime.rs`, the binary's wall-clock wiring module) computes `Instant::now() + allowance` exactly once per one-shot invocation and arms the guard — the absolute-point contract `set_task_deadline` documents.
- `run_one_shot` builds its guard through it. **Zero adapter changes needed.**
- `agent.rs` sits at its exact god-file ceiling (2270), so the arming lives in the sibling and the call site swaps one line for one line — net zero.

## The documented choice (the issue's second DoD item)

The CLI knob **is** `--turn-budget`, now truthfully described in its help: one-shot `run` (and `arena`) stop at the next safe boundary once the allowance is spent; goal rounds re-enter the one-shot path per round (the flag's per-turn contract); chat and the deck keep an unarmed deadline, since a multi-turn session has no single wall-clock ceiling. No new flag — one knob, both mechanisms (continuation-decline #1161/#1173 and the settlement stop #1481), which cannot drift apart.

## Witness

`a_one_shot_guard_arms_the_task_deadline_from_its_allowance` (runtime.rs): an allowance arms the deadline at ≥ now+allowance; no allowance leaves it unarmed (the pre-#1503 shape chat/deck keep); the dollar axis is untouched. Fails on main, where the arming does not exist. Full `stella-cli` suite: 1305 passed locally — run with a local copy of #1577/#1579's unbreak (main's `arena_is_stream_json_by_contract_not_by_flag` currently fails to compile), discarded before commit; this branch touches no test that conflicts with either unbreak PR.

The measured half of the issue's verify (re-running the 5-task tuning panel per #1481's acceptance) is a bench-rig run, deliberately not claimed here.

Closes #1503

## Summary by Sourcery

Arm the per-task wall-clock deadline for one-shot runs so they stop safely before external timeouts while clarifying the turn budget CLI behavior.

New Features:
- Add a one-shot budget guard that arms the task deadline from a per-turn wall-clock allowance for single-task runs.

Enhancements:
- Wire one-shot pipeline execution to use the new budget guard so it enforces a wall-clock ceiling derived from the turn budget.
- Update the `--turn-budget` CLI help text to document its dual role in continuation decisions and one-shot wall-clock stopping behavior.

Tests:
- Add a runtime test ensuring the one-shot budget guard correctly arms and omits task deadlines and preserves budget enforcement mode.