### PR TITLE
feat(stella-cli): supervise long-running runs so none dies with its terminal

### DIFF
--- a/crates/stella-cli/src/agent/presence.rs
+++ b/crates/stella-cli/src/agent/presence.rs
@@ -35,13 +35,23 @@ impl SessionPresence {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| cfg.workspace_root.display().to_string());
-        let mut record = stella_store::SessionRecord::new(
-            cfg.workspace_root.display().to_string(),
-            name.clone(),
-        );
+        let registry = stella_store::SessionRegistry::open_default();
+        // A supervised run continues the record its supervisor registered
+        // rather than minting a second one for the same work (#1552). The
+        // supervisor knew the pid and the process group; this side knows the
+        // prompt and, in `finish`, the outcome — and `stella daemon list` has
+        // to show one session, not two halves of one. Its `pid` is already
+        // this process: the supervisor recorded the child's, deliberately.
+        let mut record = crate::daemon::supervised_id()
+            .and_then(|id| registry.get(&id))
+            .unwrap_or_else(|| {
+                stella_store::SessionRecord::new(
+                    cfg.workspace_root.display().to_string(),
+                    name.clone(),
+                )
+            });
         record.title = format!("{name}: {}", crate::command_deck::prompt_line(prompt, 48));
         record.summary = crate::command_deck::prompt_line(prompt, 240);
-        let registry = stella_store::SessionRegistry::open_default();
         let _ = registry.upsert(&record);
         // stderr, not stdout: `--output-format json` owns stdout, and a
         // durability advisory must never land inside a machine-readable

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -270,6 +270,62 @@ pub(crate) struct GlobalArgs {
     /// failed run, and `stella doctor --last-failure` prints the newest.
     #[arg(long, global = true, value_name = "PATH", hide_short_help = true)]
     pub(crate) log_file: Option<std::path::PathBuf>,
+
+    /// Own this terminal instead of surviving it
+    ///
+    /// A long-running verb started from a terminal (`run`, `goal`, `monitor`,
+    /// `fleet`) is normally handed to a supervisor: the work becomes a
+    /// detached process that keeps going when the window closes, and this
+    /// terminal only streams it. `stella daemon list` finds it afterwards;
+    /// `stella daemon attach <id>` picks the stream back up.
+    ///
+    /// This flag runs the work in this process instead, exactly as older
+    /// releases did — closing the terminal kills it, and in exchange the run
+    /// can ask you to approve an expanded scope, which a supervised run has
+    /// nobody to ask. Invocations with no terminal to lose (a pipe, CI, a
+    /// container) are never supervised and are unaffected either way.
+    /// Env: STELLA_FOREGROUND.
+    #[arg(long, global = true, env = "STELLA_FOREGROUND", hide_short_help = true)]
+    pub(crate) foreground: bool,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DaemonCmd {
+    /// List supervised runs on this machine
+    List,
+
+    /// Stream a supervised run's output into this terminal
+    ///
+    /// Picks the stream up live and stays until the run ends; a run that has
+    /// already finished prints in full and exits. Detaching again (Ctrl-C)
+    /// leaves the run alone — `stella daemon stop` is what stops it.
+    Attach {
+        /// Run to attach to. A unique prefix of the id is enough. Omitted:
+        /// the most recently started supervised run.
+        id: Option<String>,
+    },
+
+    /// Print the tail of a supervised run's output and exit
+    Logs {
+        /// Run to read. A unique prefix of the id is enough. Omitted: the
+        /// most recently started supervised run.
+        id: Option<String>,
+
+        /// How many lines back to start from.
+        #[arg(short = 'n', long, default_value_t = 40)]
+        lines: usize,
+    },
+
+    /// Stop a supervised run
+    ///
+    /// Asks it to stop the way Ctrl-C would — the engine finishes the tool it
+    /// is running and aborts at the next safe boundary, never mid-tool. A run
+    /// that has not stopped after the grace period is killed, and either way
+    /// the stop is recorded as deliberate rather than left to read as a crash.
+    Stop {
+        /// Run to stop. A unique prefix of the id is enough.
+        id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -404,6 +460,22 @@ pub(crate) enum Command {
         /// List this machine's sessions (resumable ones marked) and exit.
         #[arg(long)]
         list: bool,
+    },
+
+    /// Find, watch, and stop runs that outlived their terminal
+    ///
+    /// A long-running verb started from a terminal is handed to a supervisor:
+    /// the work runs as a detached process that survives the window closing,
+    /// an `ssh` disconnect, and a logout. These are the commands for finding
+    /// one again afterwards. `--foreground` on the original invocation opts
+    /// out; an invocation with no terminal (a pipe, CI, a container) is never
+    /// supervised and never appears here.
+    ///
+    /// Supervision survives the terminal, not the process: a supervised run
+    /// that is killed loses its turn, and only the fact of it is recorded.
+    Daemon {
+        #[command(subcommand)]
+        cmd: DaemonCmd,
     },
 
     /// Analyze this workspace: domain taxonomy and code graph

--- a/crates/stella-cli/src/cli/help.rs
+++ b/crates/stella-cli/src/cli/help.rs
@@ -33,7 +33,10 @@ use super::Cli;
 /// is an editorial judgement about what the command is *for*, which cannot be
 /// inferred from its type.
 const GROUPS: &[(&str, &[&str])] = &[
-    ("Run the agent", &["run", "chat", "goal", "resume", "init"]),
+    (
+        "Run the agent",
+        &["run", "chat", "goal", "resume", "daemon", "init"],
+    ),
     ("Run many at once", &["fleet", "monitor", "arena"]),
     (
         "Ask about this workspace",

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -366,7 +366,9 @@ fn detach_before_exec(command: &mut std::process::Command, lock_path: PathBuf) {
                 return Err(std::io::Error::last_os_error());
             }
             if lock.as_bytes().is_empty() {
-                return Err(std::io::Error::other("supervisor lock path is not a C string"));
+                return Err(std::io::Error::other(
+                    "supervisor lock path is not a C string",
+                ));
             }
             // Deliberately NOT `O_CLOEXEC`, and deliberately never closed: the
             // lock has to outlive both this function and the `exec` that

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -1,0 +1,858 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The supervisor: how a run outlives the terminal that started it (#1552).
+//!
+//! Closing a terminal window sends `SIGHUP` to its foreground process group,
+//! and a `stella run` in that group dies mid-turn — no answer, no record of
+//! why, and no way back to it. That is a property of *how the process was
+//! started*, not of anything stella decided, so the fix belongs here rather
+//! than anywhere in the engine.
+//!
+//! # What this module does, and what it deliberately does not
+//!
+//! This is **process-level supervision**: the work is re-launched as a
+//! detached child in its own session, its console is two files in the
+//! session's sidecar, and the parent stays only to stream those files back to
+//! the terminal. Close the terminal and the parent dies; the child does not
+//! notice, because it left that session before it began.
+//!
+//! It is **not** engine-level checkpoint/resume. A supervised run survives a
+//! closed terminal, a logout, and an `ssh` disconnect. It does not survive its
+//! own process being killed: that loses the turn, and only the fact of it is
+//! recorded. `stella-engine` exists for the stronger property (drive the step
+//! loop from a durable host, checkpoint between steps) and is tracked
+//! separately — the weaker property is worth shipping first because it is what
+//! a closed laptop lid actually costs today.
+//!
+//! # Why supervision keys on a controlling terminal
+//!
+//! [`should_supervise`] answers yes only when this process has a controlling
+//! terminal. The reasoning is symmetrical: a terminal is exactly what can
+//! close, so a process without one is already immune and supervising it buys
+//! nothing while adding a process, two files, and a copy to every byte of
+//! output. Concretely that leaves every non-interactive caller — CI, a pipe,
+//! `nohup`, and the Terminal-Bench harness, which runs `stella run` on pipes
+//! inside a container — on byte-for-byte the process shape they run today.
+//!
+//! # The three bugs this inherits rather than rediscovers
+//!
+//! `scripts/fullauto.sh` has supervised its own cycles for long enough to pay
+//! for three, and each one is load-bearing here:
+//!
+//! 1. **The child must lead its own process group**, or stopping the
+//!    supervisor orphans the work. [`spawn`] calls `setsid` before `exec` and
+//!    treats a failure as a failed spawn, so a supervised child is *always* a
+//!    session leader and `pgid == pid` is an invariant rather than a hope.
+//! 2. **Stopping must not race the child's own shutdown.** The engine aborts
+//!    at safe boundaries (invariant 6), which takes seconds; a stop that
+//!    escalates to `SIGKILL` after one second lands mid-teardown, the terminal
+//!    status is never written, and a run the operator stopped by hand ages
+//!    into the registry as a crash. [`stop`] waits [`STOP_GRACE`] and records
+//!    the transition on every path, including the one where it had to kill.
+//! 3. **Record the child's pid, not the supervisor's.** The supervisor's pid
+//!    says a supervisor exists; only the child's says the work is running, and
+//!    it is the sole handle anything outside this process has on it.
+//!
+//! # Liveness is a lock, not a pid
+//!
+//! Every other reader of the session registry answers "is it alive?" with
+//! `kill(pid, 0)`, which is right for *display*: the worst a recycled pid does
+//! there is show a dead session as live. This module signals process groups,
+//! where the worst a recycled pgid does is take down a stranger's processes.
+//!
+//! So a supervised child holds an advisory lock
+//! ([`stella_store::supervised::LOCK`]) for its entire life, taken in the same
+//! `pre_exec` as `setsid` and never closed. The kernel releases it when the
+//! process dies — `SIGKILL`, panic and power loss included — so a free lock
+//! means the run is over, and [`stop`] refuses to signal anything once it can
+//! take that lock itself.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use colored::Colorize;
+use stella_store::{SessionRecord, SessionRegistry, SessionStatus, SupervisorInfo, supervised};
+
+use crate::DaemonCmd;
+
+/// Carries the supervised session's registry id into the child.
+///
+/// Two jobs. It tells the child which record to stamp on its way out — the
+/// child is the only process guaranteed to still be there at the end, so a
+/// terminal status written by anyone else is a status that goes missing
+/// exactly when the terminal was closed. And it is the recursion backstop: a
+/// child that somehow reached [`should_supervise`] with an argv that lost
+/// `--foreground` still refuses to supervise itself.
+pub(crate) const SUPERVISED_ENV: &str = "STELLA_SUPERVISED";
+
+/// How long [`stop`] lets a child shut down before escalating to `SIGKILL`.
+///
+/// Sized for what the child is being asked to do, not for how long a human
+/// will wait: `SIGTERM` reaches the engine's own handler, which unwinds the
+/// turn's RAII guards — reaping tool process groups, releasing fleet claims,
+/// removing shadow worktrees — and only then writes the terminal status. The
+/// value comes from `scripts/fullauto.sh`, where a shorter one was measured
+/// killing the handler mid-flight and recording hand-stopped runs as crashes.
+const STOP_GRACE: Duration = Duration::from_secs(8);
+
+/// How often the follow loop and [`stop`] re-check. Cheap: both poll a file
+/// offset or a lock, never a process.
+const POLL: Duration = Duration::from_millis(80);
+
+/// A live supervised child, owned by the parent that spawned it.
+pub(crate) struct Supervised {
+    /// The registry id — what `stella daemon attach` takes.
+    pub(crate) id: String,
+    /// The child's session sidecar, holding both console files.
+    sidecar: PathBuf,
+    /// The child's process group, which is also its pid ([`spawn`]).
+    pgid: i32,
+    child: std::process::Child,
+}
+
+/// Whether this invocation should be handed to the supervisor.
+///
+/// Pure over already-observed booleans so the decision is directly testable;
+/// the caller does the observing. `foreground` is the user's `--foreground`
+/// (or `STELLA_FOREGROUND`), `already_supervised` is [`SUPERVISED_ENV`] being
+/// set, and `has_controlling_terminal` is the module doc's rule.
+pub(crate) fn should_supervise(
+    foreground: bool,
+    already_supervised: bool,
+    has_controlling_terminal: bool,
+) -> bool {
+    !foreground && !already_supervised && has_controlling_terminal
+}
+
+/// This process's supervised session id, when it is itself a supervised child.
+pub(crate) fn supervised_id() -> Option<String> {
+    std::env::var(SUPERVISED_ENV)
+        .ok()
+        .filter(|id| !id.trim().is_empty())
+}
+
+/// The exit code a supervised child answered with, for `main` to forward.
+///
+/// A static for the same reason [`crate::signals`] uses one: `run` threads a
+/// plain `Result<(), String>`, and widening that error type to carry a number
+/// would touch every `?` in the binary to serve one caller.
+static FORWARDED: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(u16::MAX);
+
+/// The exit code this process owes the shell on behalf of its supervised
+/// child, if it had one that exited nonzero.
+///
+/// Fidelity here is the difference between a supervisor and a wrapper: a
+/// script that reads `stella run …; echo $?` must get the run's answer, not
+/// the answer to "did the supervisor manage to stream a log".
+pub(crate) fn forwarded_exit_code() -> Option<u8> {
+    match FORWARDED.load(std::sync::atomic::Ordering::SeqCst) {
+        u16::MAX => None,
+        code => u8::try_from(code).ok(),
+    }
+}
+
+/// Hand this entire invocation to a supervised child, and stream it back here
+/// until it finishes or this terminal goes away.
+///
+/// The child re-parses the same argv with `--foreground` appended, so the
+/// division of labour is exactly one process doing the work and one process
+/// watching — no argument is re-derived, re-quoted, or dropped on the way.
+pub(crate) fn supervise_this_invocation(
+    rt: tokio::runtime::Runtime,
+    workspace: &Path,
+    title: &str,
+    stdin: &[u8],
+    scope_review_lost: bool,
+) -> Result<(), String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("cannot locate the stella binary to supervise: {e}"))?;
+    // This process's argv verbatim, plus the one flag that makes the child do
+    // the work rather than supervise it again. Verbatim because every
+    // alternative re-derives arguments that clap already parsed, and a
+    // reconstruction is one forgotten flag away from running something the
+    // user did not type. `SUPERVISED_ENV` is the backstop if it is ever lost.
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+    args.push("--foreground".to_string());
+
+    let registry = SessionRegistry::open_default();
+    let mut run = spawn(
+        &registry,
+        &workspace.display().to_string(),
+        title,
+        &exe,
+        &args,
+        stdin,
+    )?;
+    run.announce(scope_review_lost);
+
+    match rt.block_on(crate::signals::until_interrupted(run.follow())) {
+        Ok(followed) => {
+            rt.shutdown_timeout(Duration::from_secs(2));
+            if let Some(code) = followed? {
+                FORWARDED.store(u16::from(code), std::sync::atomic::Ordering::SeqCst);
+            }
+            Ok(())
+        }
+        Err(signal) => {
+            // Ctrl-C means stop, here as everywhere else — so the child is
+            // asked to stop and this process stays to watch it happen, rather
+            // than dropping the work future the way `block_on_interruptible`
+            // would. The work is not on this stack to drop.
+            crate::signals::note_interrupt(signal);
+            let drained = rt.block_on(run.interrupt_and_drain());
+            if let Some(record) = registry.get(&run.id) {
+                mark_stopped(&registry, &record);
+            }
+            rt.shutdown_timeout(Duration::from_secs(2));
+            drained?;
+            Err(signal.reason().to_string())
+        }
+    }
+}
+
+/// Whether this process has a controlling terminal — something that can close
+/// and take it down with a `SIGHUP`.
+///
+/// Opening `/dev/tty` is the question itself rather than a proxy for it:
+/// `isatty(0)` answers "is stdin a terminal", which is a different and weaker
+/// thing (`stella run … | tee log` redirects stdout, keeps the terminal, and
+/// still dies when the window closes).
+pub(crate) fn has_controlling_terminal() -> bool {
+    #[cfg(unix)]
+    {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .open("/dev/tty")
+            .is_ok()
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+/// Whether supervising this invocation takes away an interactive scope-review
+/// answer it would otherwise have had.
+///
+/// A supervised child's stdin is a file and its stdout is a log, so
+/// `approval_capability_for` resolves to `Unavailable` and the pipeline runs
+/// headless — where a plan that expands scope stops at a named error instead
+/// of asking. When the terminal invocation *would* have been able to answer,
+/// that is a capability the supervisor removed, and the run must say so before
+/// the first model call rather than after paying for several.
+///
+/// It warns rather than refuses: a headless run that never expands scope is
+/// the common case, and disabling the default surface to protect the uncommon
+/// one would cost every user something to save a few.
+pub(crate) fn loses_interactive_scope_review(had_stdio_approval: bool, bypass_on: bool) -> bool {
+    had_stdio_approval && !bypass_on
+}
+
+/// Launch `program args…` as a detached child and register it as a supervised
+/// session.
+///
+/// `program` is a parameter rather than `current_exe()` so the detachment
+/// itself — `setsid`, the liveness lock, the split console, the stop
+/// escalation — can be tested against a real child process instead of against
+/// a second copy of stella that would need a provider, a key and a workspace
+/// to say anything. Production has one caller and it passes the running
+/// binary.
+///
+/// `stdin` is whatever the parent already consumed (an empty slice when it
+/// consumed nothing) — see [`stella_store::supervised::STDIN`] for why it
+/// travels as a file rather than as an argument.
+pub(crate) fn spawn(
+    registry: &SessionRegistry,
+    workspace: &str,
+    title: &str,
+    program: &Path,
+    args: &[String],
+    stdin: &[u8],
+) -> Result<Supervised, String> {
+    // Minted before the spawn so the child can be told its own id, and so a
+    // failed spawn leaves a directory rather than a half-registered session.
+    let record = SessionRecord::new(workspace, title);
+    let sidecar = registry
+        .prepare_sidecar(&record.id)
+        .map_err(|e| format!("cannot create the session directory: {e}"))?;
+
+    let stdin_path = sidecar.join(supervised::STDIN);
+    stella_store::write_sensitive_file_atomic(&stdin_path, stdin)
+        .map_err(|e| format!("cannot stage the prompt for the supervised run: {e}"))?;
+    let stdin_file = std::fs::File::open(&stdin_path)
+        .map_err(|e| format!("cannot reopen the staged prompt: {e}"))?;
+
+    let out_path = sidecar.join(supervised::STDOUT_LOG);
+    let err_path = sidecar.join(supervised::STDERR_LOG);
+    let out_file = create_console(&out_path)?;
+    let err_file = create_console(&err_path)?;
+
+    let mut command = std::process::Command::new(program);
+    command
+        .args(args)
+        .env(SUPERVISED_ENV, &record.id)
+        .stdin(std::process::Stdio::from(stdin_file))
+        .stdout(std::process::Stdio::from(out_file))
+        .stderr(std::process::Stdio::from(err_file));
+    #[cfg(unix)]
+    detach_before_exec(&mut command, sidecar.join(supervised::LOCK));
+
+    let child = command
+        .spawn()
+        .map_err(|e| format!("cannot start the supervised run: {e}"))?;
+
+    // The CHILD's pid, deliberately: the supervisor's says a supervisor
+    // exists, this says the work is running. Every liveness check in the
+    // registry, and every signal `stop` sends, reads it.
+    let pid = child.id();
+    let pgid = i32::try_from(pid)
+        .map_err(|_| format!("supervised child pid {pid} does not fit a process group"))?;
+    let mut record = SessionRecord {
+        pid,
+        supervisor: Some(SupervisorInfo { pgid }),
+        ..record
+    };
+    record.summary = title.to_string();
+    registry
+        .upsert(&record)
+        .map_err(|e| format!("cannot register the supervised run: {e}"))?;
+
+    Ok(Supervised {
+        id: record.id,
+        sidecar,
+        pgid,
+        child,
+    })
+}
+
+/// Create a console file that is readable only by its owner.
+///
+/// A run's stdout carries whatever the model said and whatever the tools
+/// printed. `ensure_private_dir` already restricts the directory; this keeps
+/// the file itself from being the exception if the directory's mode is ever
+/// widened by hand.
+fn create_console(path: &Path) -> Result<std::fs::File, String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map_err(|e| format!("cannot open {}: {e}", path.display()))
+}
+
+/// Everything that must happen between `fork` and `exec` for the child to be
+/// genuinely detached: leave the terminal's session, and take the liveness
+/// lock.
+///
+/// Both calls are async-signal-safe, which is the bar for anything running in
+/// this window. Either failing fails the spawn — a child that half-detached is
+/// worse than one that never started, because it looks supervised in the
+/// registry while still dying with the terminal.
+#[cfg(unix)]
+fn detach_before_exec(command: &mut std::process::Command, lock_path: PathBuf) {
+    use std::os::unix::process::CommandExt;
+
+    let lock = std::ffi::CString::new(lock_path.into_os_string().into_encoded_bytes())
+        .unwrap_or_else(|_| c"".to_owned());
+    // SAFETY: `setsid`, `open` and `flock` are async-signal-safe, and this
+    // closure allocates nothing (the CString is built above, in the parent).
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if lock.as_bytes().is_empty() {
+                return Err(std::io::Error::other("supervisor lock path is not a C string"));
+            }
+            // Deliberately NOT `O_CLOEXEC`, and deliberately never closed: the
+            // lock has to outlive both this function and the `exec` that
+            // follows it. The kernel is what closes this descriptor, when the
+            // process dies, which is precisely the event readers are asking
+            // about.
+            let fd = libc::open(lock.as_ptr(), libc::O_RDWR | libc::O_CREAT, 0o600);
+            if fd < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+impl Supervised {
+    /// The banner the terminal sees, once, before the child's first byte.
+    ///
+    /// It is printed rather than assumed because supervision changes two
+    /// things a user can otherwise only discover the hard way: the run is no
+    /// longer this terminal's to lose, and there is an id to come back to.
+    pub(crate) fn announce(&self, scope_review_lost: bool) {
+        eprintln!(
+            "{} {} — survives this terminal closing",
+            "▸ supervised".green().bold(),
+            self.id.dimmed()
+        );
+        eprintln!(
+            "  reattach with {}",
+            format!("stella daemon attach {}", self.id).cyan()
+        );
+        if scope_review_lost {
+            eprintln!(
+                "  {} a supervised run is headless: a plan that expands scope stops \
+                 instead of asking. Use --foreground to answer it here, or set \
+                 `headless_scope_bypass = \"on\"`.",
+                "note:".yellow()
+            );
+        }
+    }
+
+    /// Stream the child's console to this terminal until it exits, and answer
+    /// its exit code.
+    ///
+    /// stdout and stderr are replayed onto stdout and stderr, never merged:
+    /// see [`stella_store::supervised::STDOUT_LOG`].
+    pub(crate) async fn follow(&mut self) -> Result<Option<u8>, String> {
+        let mut out = Tail::open(&self.sidecar.join(supervised::STDOUT_LOG))?;
+        let mut err = Tail::open(&self.sidecar.join(supervised::STDERR_LOG))?;
+        loop {
+            let moved = out.pump(&mut std::io::stdout())? + err.pump(&mut std::io::stderr())?;
+            match self
+                .child
+                .try_wait()
+                .map_err(|e| format!("cannot wait on the supervised run: {e}"))?
+            {
+                Some(status) => {
+                    // Ordered after the wait on purpose: this drain catches
+                    // whatever the child wrote between the pump above and its
+                    // exit, and once it has exited nothing more can appear.
+                    out.pump(&mut std::io::stdout())?;
+                    err.pump(&mut std::io::stderr())?;
+                    return Ok(exit_code(&status));
+                }
+                None if moved == 0 => tokio::time::sleep(POLL).await,
+                None => {}
+            }
+        }
+    }
+
+    /// Ask the child to stop the way `SIGTERM` from anywhere else would, then
+    /// keep streaming until it is gone.
+    ///
+    /// Used when the *parent* is interrupted: Ctrl-C in a terminal reaches
+    /// only the foreground group, which the child left, so without this a
+    /// Ctrl-C would detach the run rather than stop it — the opposite of what
+    /// the key means everywhere else.
+    pub(crate) async fn interrupt_and_drain(&mut self) -> Result<(), String> {
+        signal_group(self.pgid, libc::SIGTERM);
+        let deadline = Instant::now() + STOP_GRACE;
+        let mut out = Tail::open(&self.sidecar.join(supervised::STDOUT_LOG))?;
+        let mut err = Tail::open(&self.sidecar.join(supervised::STDERR_LOG))?;
+        out.seek_to_end()?;
+        err.seek_to_end()?;
+        while Instant::now() < deadline {
+            out.pump(&mut std::io::stdout())?;
+            err.pump(&mut std::io::stderr())?;
+            if matches!(self.child.try_wait(), Ok(Some(_))) {
+                return Ok(());
+            }
+            tokio::time::sleep(POLL).await;
+        }
+        eprintln!(
+            "{} supervised run {} did not stop within {}s; killing it",
+            "⚠".yellow(),
+            self.id.dimmed(),
+            STOP_GRACE.as_secs()
+        );
+        signal_group(self.pgid, libc::SIGKILL);
+        let _ = self.child.wait();
+        Ok(())
+    }
+}
+
+/// A file being read forward as something else appends to it.
+struct Tail {
+    file: std::fs::File,
+    offset: u64,
+}
+
+impl Tail {
+    fn open(path: &Path) -> Result<Self, String> {
+        let file = std::fs::File::open(path)
+            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+        Ok(Self { file, offset: 0 })
+    }
+
+    /// Skip whatever is already there — for a reader that only wants what
+    /// happens from now on.
+    fn seek_to_end(&mut self) -> Result<(), String> {
+        self.offset = self
+            .file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("cannot seek the console: {e}"))?;
+        Ok(())
+    }
+
+    /// Start `lines` lines back from the end, or at the beginning if the file
+    /// is shorter than that.
+    ///
+    /// Reads the whole file rather than scanning backwards in blocks: a
+    /// console is bounded by one run's output, and a block-wise reverse scan
+    /// is three times the code for a saving nobody can perceive.
+    fn seek_back_lines(&mut self, lines: usize) -> Result<(), String> {
+        let mut all = Vec::new();
+        self.file
+            .read_to_end(&mut all)
+            .map_err(|e| format!("cannot read the console: {e}"))?;
+        let start = all
+            .iter()
+            .enumerate()
+            .rev()
+            .filter(|(_, byte)| **byte == b'\n')
+            // The trailing newline ends the last line rather than starting
+            // one, so it is not a boundary this may stop at.
+            .skip(usize::from(all.last() == Some(&b'\n')))
+            .nth(lines.saturating_sub(1))
+            .map(|(at, _)| at + 1)
+            .unwrap_or(0);
+        self.offset = start as u64;
+        Ok(())
+    }
+
+    /// Copy everything appended since the last call to `out`, and answer how
+    /// many bytes that was.
+    fn pump(&mut self, out: &mut impl Write) -> Result<usize, String> {
+        self.file
+            .seek(SeekFrom::Start(self.offset))
+            .map_err(|e| format!("cannot seek the console: {e}"))?;
+        let mut buf = Vec::new();
+        let read = self
+            .file
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("cannot read the console: {e}"))?;
+        if read > 0 {
+            // A closed pipe on the reading side is a routine way to stop
+            // watching (`stella daemon attach … | head`), not an error worth
+            // failing a run over.
+            let _ = out.write_all(&buf);
+            let _ = out.flush();
+            self.offset += read as u64;
+        }
+        Ok(read)
+    }
+}
+
+/// Send `signal` to the whole process group `pgid`.
+///
+/// The group, not the pid: the child leads a session whose members include
+/// every tool process it spawned, and a `SIGTERM` to the leader alone leaves a
+/// running build attached to nothing.
+fn signal_group(pgid: i32, signal: i32) {
+    #[cfg(unix)]
+    // SAFETY: `kill` with a negative pid targets a process group; `pgid` is
+    // the child's own, recorded at spawn and confirmed live by the caller.
+    unsafe {
+        libc::kill(-pgid, signal);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (pgid, signal);
+    }
+}
+
+/// The exit code to forward, as the shell would report it.
+fn exit_code(status: &std::process::ExitStatus) -> Option<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return u8::try_from(128 + signal).ok();
+        }
+    }
+    match status.code() {
+        Some(0) | None => None,
+        Some(code) => u8::try_from(code).ok().or(Some(1)),
+    }
+}
+
+/// Whether a supervised run is still going, asked of its lock rather than its
+/// pid (see the module docs).
+///
+/// `None` means the question could not be answered — no lock file, or a
+/// directory we cannot open — and callers treat that as "not live" rather than
+/// guessing, because every consequence of guessing wrong points one way:
+/// signalling something that is not ours.
+fn lock_is_held(sidecar: &Path) -> Option<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let path = sidecar.join(supervised::LOCK);
+        let file = std::fs::OpenOptions::new().read(true).open(path).ok()?;
+        // SAFETY: `file` owns the descriptor for the whole call.
+        let taken = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if taken == 0 {
+            // Nobody held it, so the run is over. Release immediately: this
+            // process is a reader, not the new owner.
+            // SAFETY: same descriptor, still owned by `file`.
+            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+            Some(false)
+        } else {
+            Some(true)
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = sidecar;
+        None
+    }
+}
+
+/// The child's side: hold the liveness lock for the rest of this process.
+///
+/// A no-op in the normal case — the lock was taken in `pre_exec` and the
+/// descriptor is still open — and exists for the case where it was not: a
+/// child started by hand with [`SUPERVISED_ENV`] set, or a future launcher
+/// (launchd, systemd) that spawns the child without going through [`spawn`].
+/// Without it those runs would read as already-finished to every other
+/// process the moment they started.
+pub(crate) fn hold_liveness_lock(registry: &SessionRegistry, id: &str) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let sidecar = registry.sidecar_dir(id);
+        if lock_is_held(&sidecar) != Some(false) {
+            return;
+        }
+        let Ok(file) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(sidecar.join(supervised::LOCK))
+        else {
+            return;
+        };
+        // SAFETY: `file` owns the descriptor, and it is leaked below so it
+        // stays open — and the lock held — until the process exits.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            std::mem::forget(file);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (registry, id);
+    }
+}
+
+/// The child's side: stamp the terminal status on its way out.
+///
+/// The child does this, and not the supervisor, because the supervisor is the
+/// process that is *expected* to be gone — the whole feature is about the
+/// terminal closing. A record whose live status is never replaced reads as a
+/// crash to every viewer, so a supervised run that completed perfectly would
+/// be indistinguishable from one that died the moment its window closed.
+///
+/// A no-op in an unsupervised process, and harmless where a surface already
+/// wrote its own answer: `SessionPresence::finish` runs first on the two paths
+/// that have one, and writes the same value. This is what covers the paths
+/// that do not — `stella fleet`, and any future long-running verb that is
+/// handed to the supervisor before it grows a session presence.
+pub(crate) fn record_outcome_if_supervised(ok: bool) {
+    let Some(id) = supervised_id() else {
+        return;
+    };
+    let status = match (ok, crate::signals::interrupted_exit_code()) {
+        // A signal is not a failure: the run was stopped, and recording it as
+        // an error would put a deliberate `stella daemon stop` in the registry
+        // beside the runs that genuinely broke.
+        (_, Some(_)) => SessionStatus::Cancelled,
+        (true, None) => SessionStatus::Complete,
+        (false, None) => SessionStatus::Error,
+    };
+    let _ = SessionRegistry::open_default().set_status(&id, status);
+}
+
+/// Stop a supervised run from another process — `stella daemon stop`.
+pub(crate) fn stop(registry: &SessionRegistry, id: &str) -> Result<(), String> {
+    let record = resolve(registry, Some(id))?;
+    let Some(supervisor) = record.supervisor.as_ref() else {
+        return Err(format!(
+            "{} is not a supervised run — there is no separate process to stop",
+            record.id
+        ));
+    };
+    let sidecar = registry.sidecar_dir(&record.id);
+
+    if lock_is_held(&sidecar) != Some(true) {
+        // Already over. Still record the transition: a run whose terminal
+        // status was never written reads as a crash, and "the operator
+        // stopped it" is the one thing we know for certain here.
+        mark_stopped(registry, &record);
+        println!("{} {} was already finished", "▸".dimmed(), record.id);
+        return Ok(());
+    }
+
+    signal_group(supervisor.pgid, libc::SIGTERM);
+    let deadline = Instant::now() + STOP_GRACE;
+    while Instant::now() < deadline {
+        if lock_is_held(&sidecar) != Some(true) {
+            mark_stopped(registry, &record);
+            println!("{} stopped {}", "✓".green(), record.id);
+            return Ok(());
+        }
+        std::thread::sleep(POLL);
+    }
+
+    eprintln!(
+        "{} {} did not stop within {}s; killing it",
+        "⚠".yellow(),
+        record.id,
+        STOP_GRACE.as_secs()
+    );
+    signal_group(supervisor.pgid, libc::SIGKILL);
+    // Written here as well as on the graceful path, because on this one the
+    // child's own shutdown never ran and nothing else will write it.
+    mark_stopped(registry, &record);
+    println!("{} killed {}", "✓".green(), record.id);
+    Ok(())
+}
+
+/// Record a stop as deliberate.
+///
+/// Only from a live status: a run that already recorded how it ended — it
+/// completed a second before the stop landed — must keep its own answer rather
+/// than be relabelled by the process that arrived too late to change it.
+fn mark_stopped(registry: &SessionRegistry, record: &SessionRecord) {
+    if record.status.is_live() {
+        let _ = registry.set_status(&record.id, SessionStatus::Cancelled);
+    }
+}
+
+/// Resolve a user-typed id to a record.
+///
+/// Accepts a unique prefix, because the full form (`ses-1754431200000-84213`)
+/// is a timestamp and a pid and nobody is going to type it. `None` picks the
+/// most recent supervised run, which is what "the one I just started" means
+/// nine times in ten.
+fn resolve(registry: &SessionRegistry, id: Option<&str>) -> Result<SessionRecord, String> {
+    let supervised_runs: Vec<SessionRecord> = registry
+        .list()
+        .into_iter()
+        .filter(|r| r.supervisor.is_some())
+        .collect();
+    let Some(id) = id else {
+        return supervised_runs
+            .into_iter()
+            .next()
+            .ok_or_else(|| "no supervised runs on this machine".to_string());
+    };
+
+    let mut matches = supervised_runs
+        .into_iter()
+        .filter(|r| r.id == id || r.id.starts_with(id));
+    let Some(first) = matches.next() else {
+        return Err(format!(
+            "no supervised run matches `{id}` — `stella daemon list` shows what there is"
+        ));
+    };
+    match matches.next() {
+        // An exact hit is never ambiguous, however many ids extend it.
+        None => Ok(first),
+        Some(_) if first.id == id => Ok(first),
+        Some(second) => Err(format!(
+            "`{id}` matches more than one run ({} and {}) — use more of the id",
+            first.id, second.id
+        )),
+    }
+}
+
+/// `stella daemon <cmd>`.
+pub(crate) fn run(cmd: &DaemonCmd) -> Result<(), String> {
+    let registry = SessionRegistry::open_default();
+    match cmd {
+        DaemonCmd::List => list(&registry),
+        DaemonCmd::Attach { id } => attach(&registry, id.as_deref()),
+        DaemonCmd::Logs { id, lines } => logs(&registry, id.as_deref(), *lines),
+        DaemonCmd::Stop { id } => stop(&registry, id),
+    }
+}
+
+fn list(registry: &SessionRegistry) -> Result<(), String> {
+    let runs: Vec<SessionRecord> = registry
+        .list()
+        .into_iter()
+        .filter(|r| r.supervisor.is_some())
+        .collect();
+    if runs.is_empty() {
+        println!("No supervised runs. Every `stella run` in a terminal starts one.");
+        return Ok(());
+    }
+    println!(
+        "{:<28} {:<12} {}",
+        "ID".bold(),
+        "STATUS".bold(),
+        "WHAT".bold()
+    );
+    for run in runs {
+        let live = lock_is_held(&registry.sidecar_dir(&run.id)) == Some(true);
+        // The lock outranks the stored status for a live-looking record: the
+        // status is what the child last wrote, and a child killed between two
+        // writes never got to correct it.
+        let status = match (live, run.status) {
+            (true, status) if status.is_live() => status.label().green(),
+            (true, _) => "Running".green(),
+            (false, status) if status.is_live() => "Crashed".red(),
+            (false, status) => status.label().normal(),
+        };
+        println!("{:<28} {:<12} {}", run.id, status, run.title);
+    }
+    Ok(())
+}
+
+fn attach(registry: &SessionRegistry, id: Option<&str>) -> Result<(), String> {
+    let record = resolve(registry, id)?;
+    let sidecar = registry.sidecar_dir(&record.id);
+    let mut out = Tail::open(&sidecar.join(supervised::STDOUT_LOG))?;
+    let mut err = Tail::open(&sidecar.join(supervised::STDERR_LOG))?;
+    eprintln!(
+        "{} {} — {}",
+        "▸ attached".green().bold(),
+        record.id.dimmed(),
+        record.title
+    );
+    loop {
+        let moved = out.pump(&mut std::io::stdout())? + err.pump(&mut std::io::stderr())?;
+        if lock_is_held(&sidecar) != Some(true) {
+            // Same ordering as `follow`: drain after observing the end, so the
+            // last thing the run wrote is never the thing attach misses.
+            out.pump(&mut std::io::stdout())?;
+            err.pump(&mut std::io::stderr())?;
+            eprintln!("{} {} has finished", "▸".dimmed(), record.id.dimmed());
+            return Ok(());
+        }
+        if moved == 0 {
+            std::thread::sleep(POLL);
+        }
+    }
+}
+
+fn logs(registry: &SessionRegistry, id: Option<&str>, lines: usize) -> Result<(), String> {
+    let record = resolve(registry, id)?;
+    let sidecar = registry.sidecar_dir(&record.id);
+    let mut out = Tail::open(&sidecar.join(supervised::STDOUT_LOG))?;
+    let mut err = Tail::open(&sidecar.join(supervised::STDERR_LOG))?;
+    out.seek_back_lines(lines)?;
+    err.seek_back_lines(lines)?;
+    out.pump(&mut std::io::stdout())?;
+    err.pump(&mut std::io::stderr())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -625,10 +625,16 @@ pub(crate) fn hold_liveness_lock(registry: &SessionRegistry, id: &str) {
     #[cfg(unix)]
     {
         use std::os::unix::io::AsRawFd;
-        let sidecar = registry.sidecar_dir(id);
-        if lock_is_held(&sidecar) != Some(false) {
+        // Only a lock somebody already holds is a reason to stop. `None` — no
+        // lock file, no sidecar — is not that: it is precisely the state a
+        // child spawned outside `spawn` starts in, and returning on it would
+        // make this whole function a no-op in the one case it exists for.
+        if lock_is_held(&registry.sidecar_dir(id)) == Some(true) {
             return;
         }
+        let Ok(sidecar) = registry.prepare_sidecar(id) else {
+            return;
+        };
         let Ok(file) = std::fs::OpenOptions::new()
             .read(true)
             .write(true)

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -202,9 +202,7 @@ pub(crate) fn supervise_this_invocation(
             // would. The work is not on this stack to drop.
             crate::signals::note_interrupt(signal);
             let drained = rt.block_on(run.interrupt_and_drain());
-            if let Some(record) = registry.get(&run.id) {
-                mark_stopped(&registry, &record);
-            }
+            mark_stopped(&registry, &run.id);
             rt.shutdown_timeout(Duration::from_secs(2));
             drained?;
             Err(signal.reason().to_string())
@@ -693,7 +691,7 @@ pub(crate) fn stop(registry: &SessionRegistry, id: &str) -> Result<(), String> {
         // Already over. Still record the transition: a run whose terminal
         // status was never written reads as a crash, and "the operator
         // stopped it" is the one thing we know for certain here.
-        mark_stopped(registry, &record);
+        mark_stopped(registry, &record.id);
         println!("{} {} was already finished", "▸".dimmed(), record.id);
         return Ok(());
     }
@@ -702,7 +700,7 @@ pub(crate) fn stop(registry: &SessionRegistry, id: &str) -> Result<(), String> {
     let deadline = Instant::now() + STOP_GRACE;
     while Instant::now() < deadline {
         if lock_is_held(&sidecar) != Some(true) {
-            mark_stopped(registry, &record);
+            mark_stopped(registry, &record.id);
             println!("{} stopped {}", "✓".green(), record.id);
             return Ok(());
         }
@@ -718,19 +716,27 @@ pub(crate) fn stop(registry: &SessionRegistry, id: &str) -> Result<(), String> {
     signal_group(supervisor.pgid, libc::SIGKILL);
     // Written here as well as on the graceful path, because on this one the
     // child's own shutdown never ran and nothing else will write it.
-    mark_stopped(registry, &record);
+    mark_stopped(registry, &record.id);
     println!("{} killed {}", "✓".green(), record.id);
     Ok(())
 }
 
 /// Record a stop as deliberate.
 ///
-/// Only from a live status: a run that already recorded how it ended — it
-/// completed a second before the stop landed — must keep its own answer rather
-/// than be relabelled by the process that arrived too late to change it.
-fn mark_stopped(registry: &SessionRegistry, record: &SessionRecord) {
-    if record.status.is_live() {
-        let _ = registry.set_status(&record.id, SessionStatus::Cancelled);
+/// Only where the run never recorded an answer of its own: one that completed
+/// a second before the stop landed must keep its own, rather than be
+/// relabelled by the process that arrived too late to change it.
+///
+/// Read through [`SessionRegistry::get`], never from a record that came out of
+/// `list`. `list` presents a live status whose pid is gone as `Error`, so a
+/// guard reading that value sees "it already has an answer" for the one case
+/// that most needs writing — a supervised run whose child is over but whose
+/// status was never replaced. The stored status is the only one that says
+/// whether anybody wrote anything.
+fn mark_stopped(registry: &SessionRegistry, id: &str) {
+    let stored_status = registry.get(id).map(|record| record.status);
+    if stored_status.is_some_and(|status| status.is_live()) {
+        let _ = registry.set_status(id, SessionStatus::Cancelled);
     }
 }
 
@@ -753,18 +759,22 @@ fn resolve(registry: &SessionRegistry, id: Option<&str>) -> Result<SessionRecord
             .ok_or_else(|| "no supervised runs on this machine".to_string());
     };
 
-    let mut matches = supervised_runs
-        .into_iter()
-        .filter(|r| r.id == id || r.id.starts_with(id));
+    // An exact hit is never ambiguous, however many ids extend it — and it is
+    // tested for across the whole set rather than on whichever candidate came
+    // out first, because the list is ordered by start time and has no reason
+    // to put the exact match anywhere in particular.
+    if let Some(exact) = supervised_runs.iter().find(|r| r.id == id) {
+        return Ok(exact.clone());
+    }
+
+    let mut matches = supervised_runs.into_iter().filter(|r| r.id.starts_with(id));
     let Some(first) = matches.next() else {
         return Err(format!(
             "no supervised run matches `{id}` — `stella daemon list` shows what there is"
         ));
     };
     match matches.next() {
-        // An exact hit is never ambiguous, however many ids extend it.
         None => Ok(first),
-        Some(_) if first.id == id => Ok(first),
         Some(second) => Err(format!(
             "`{id}` matches more than one run ({} and {}) — use more of the id",
             first.id, second.id

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -165,7 +165,8 @@ fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
     );
     let _ = run.child.wait();
     assert!(
-        eventually(Duration::from_secs(10), || lock_is_held(&sidecar) == Some(false)),
+        eventually(Duration::from_secs(10), || lock_is_held(&sidecar)
+            == Some(false)),
         "the kernel must release the lock when the process exits"
     );
 

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -292,6 +292,34 @@ fn a_late_stop_does_not_relabel_a_run_that_already_finished_cleanly() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// The fallback exists for a child that did NOT come through [`spawn`] — one
+/// started by hand with the env var set, or by a future launchd/systemd unit.
+/// Such a child starts with no sidecar and no lock file at all, so an
+/// implementation that treats "no lock file" as a reason to do nothing is a
+/// no-op in exactly the case it was written for.
+#[test]
+fn the_liveness_fallback_takes_a_lock_that_does_not_exist_yet() {
+    let (dir, registry) = temp_registry("fallback-lock");
+    let record = SessionRecord::new("/w", "hand-started");
+    registry.upsert(&record).unwrap();
+    let sidecar = registry.sidecar_dir(&record.id);
+    assert_eq!(
+        lock_is_held(&sidecar),
+        None,
+        "precondition: nothing has created a lock file yet"
+    );
+
+    hold_liveness_lock(&registry, &record.id);
+
+    assert_eq!(
+        lock_is_held(&sidecar),
+        Some(true),
+        "the fallback must leave this process holding the lock"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn ids_resolve_by_unique_prefix_and_refuse_an_ambiguous_one() {
     let (dir, registry) = temp_registry("resolve");

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -1,0 +1,377 @@
+//! Supervisor tests (#1552).
+//!
+//! The decision half is pure and tested as arithmetic. The mechanical half —
+//! `setsid`, the liveness lock, the split console, the stop escalation — is
+//! tested against **real child processes**, because every one of those is a
+//! syscall whose behaviour is the thing under test: a fake would assert only
+//! that the fake was written to match the assertion.
+
+use super::*;
+
+/// An isolated registry per test. Not a shared temp dir: these tests spawn
+/// processes and signal process groups, and a registry two tests could both
+/// see is a registry where one test's `stop` can reach the other's child.
+fn temp_registry(tag: &str) -> (PathBuf, SessionRegistry) {
+    let dir = std::env::temp_dir().join(format!(
+        "stella-daemon-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    (dir.clone(), SessionRegistry::open(dir))
+}
+
+/// Spawn `script` under the supervisor as `/bin/sh -c <script>`.
+fn spawn_sh(registry: &SessionRegistry, title: &str, script: &str) -> Supervised {
+    spawn(
+        registry,
+        "/tmp/workspace",
+        title,
+        Path::new("/bin/sh"),
+        &["-c".to_string(), script.to_string()],
+        b"",
+    )
+    .expect("supervised spawn")
+}
+
+/// Wait for `predicate`, up to `budget`. Answers whether it came true.
+///
+/// Generous budgets throughout: these tests assert the difference between
+/// "happens" and "never happens", and a bound tight enough to be a latency
+/// assertion would be a flake on loaded CI.
+fn eventually(budget: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    predicate()
+}
+
+fn session_of(pid: i32) -> i32 {
+    // SAFETY: `getsid` reads kernel state for a pid and cannot fail
+    // destructively; -1 on a dead pid is a value, not an error to handle.
+    unsafe { libc::getsid(pid) }
+}
+
+fn group_of(pid: i32) -> i32 {
+    // SAFETY: as above, for the process group.
+    unsafe { libc::getpgid(pid) }
+}
+
+#[test]
+fn a_terminal_run_is_supervised_and_everything_else_is_not() {
+    // The case the issue is about: a human typed `stella run` in a terminal.
+    assert!(should_supervise(false, false, true));
+
+    // --foreground / STELLA_FOREGROUND is the escape hatch, and wins.
+    assert!(!should_supervise(true, false, true));
+
+    // No terminal to lose: a pipe, CI, a container, the Terminal-Bench
+    // harness. Supervising here would add a process and a copy of every byte
+    // to buy immunity from a hangup that cannot arrive.
+    assert!(!should_supervise(false, false, false));
+
+    // A supervised child re-parses the same argv. If it ever reached this
+    // decision with `--foreground` lost, it must still refuse — one process
+    // does the work, and this is the backstop that keeps it one.
+    assert!(!should_supervise(false, true, true));
+}
+
+#[test]
+fn losing_scope_review_is_only_a_loss_when_there_was_something_to_lose() {
+    // A terminal run could have answered; supervised, it cannot. Say so.
+    assert!(loses_interactive_scope_review(true, false));
+    // The workspace opted out of the gate, so nothing was going to be asked.
+    assert!(!loses_interactive_scope_review(true, true));
+    // Already headless (piped, json): supervision took nothing away.
+    assert!(!loses_interactive_scope_review(false, false));
+    assert!(!loses_interactive_scope_review(false, true));
+}
+
+/// The witness for the whole feature: a supervised run leaves the terminal's
+/// session, so the `SIGHUP` a closing window sends to that session cannot
+/// reach it.
+///
+/// This is the property stated precisely. A test cannot close this process's
+/// terminal — the direct proof would take the test runner down with it — and
+/// "the child ignores SIGHUP" would be the wrong property anyway: the child
+/// does not ignore anything, it is simply no longer in the session being hung
+/// up. That is what `setsid` buys and what this asserts.
+#[test]
+fn a_supervised_child_leaves_this_process_session_and_group() {
+    let (dir, registry) = temp_registry("detached");
+    let run = spawn_sh(&registry, "detachment", "sleep 30");
+    let child = i32::try_from(run.child.id()).expect("pid fits");
+
+    let ours = std::process::id() as i32;
+    assert_ne!(
+        session_of(child),
+        session_of(ours),
+        "a child in our session dies with our terminal"
+    );
+    assert_ne!(group_of(child), group_of(ours));
+    assert_eq!(
+        group_of(child),
+        child,
+        "the child must LEAD its group, or a signal to it misses the tools it spawned"
+    );
+    assert_eq!(
+        run.pgid, child,
+        "the recorded group must be the child's own"
+    );
+
+    stop(&registry, &run.id).expect("stop");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The registry must name the process doing the work, not the one watching it
+/// — the third bug `scripts/fullauto.sh` paid for. Everything downstream reads
+/// this pid: the SESSIONS view's liveness, `daemon list`, and the signal
+/// `daemon stop` sends.
+#[test]
+fn the_record_carries_the_childs_pid_not_the_supervisors() {
+    let (dir, registry) = temp_registry("childpid");
+    let run = spawn_sh(&registry, "pid", "sleep 30");
+
+    let record = registry.get(&run.id).expect("record registered");
+    assert_eq!(record.pid, run.child.id());
+    assert_ne!(record.pid, std::process::id());
+    assert_eq!(
+        record.supervisor.as_ref().map(|s| s.pgid),
+        Some(i32::try_from(run.child.id()).unwrap())
+    );
+    assert_eq!(record.status, SessionStatus::InProgress);
+
+    stop(&registry, &run.id).expect("stop");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Liveness is the lock, not the pid (see the module docs). The kernel
+/// releases it when the process dies, so this is the one liveness answer a
+/// recycled pid cannot forge.
+#[test]
+fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
+    let (dir, registry) = temp_registry("lock");
+    let mut run = spawn_sh(&registry, "lock", "sleep 0.2");
+    let sidecar = registry.sidecar_dir(&run.id);
+
+    assert_eq!(
+        lock_is_held(&sidecar),
+        Some(true),
+        "a running child holds its lock"
+    );
+    let _ = run.child.wait();
+    assert!(
+        eventually(Duration::from_secs(10), || lock_is_held(&sidecar) == Some(false)),
+        "the kernel must release the lock when the process exits"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Reattaching is reading the console from the beginning, which is only
+/// possible because the streams were written to files — and they stay two
+/// files, because a `--output-format json` run is piped into something that
+/// would choke on a warning folded into stdout.
+#[test]
+fn the_console_is_replayable_and_the_two_streams_stay_apart() {
+    let (dir, registry) = temp_registry("console");
+    let mut run = spawn_sh(
+        &registry,
+        "console",
+        "echo to-stdout; echo to-stderr >&2; sleep 0.1",
+    );
+    let sidecar = registry.sidecar_dir(&run.id);
+    let _ = run.child.wait();
+
+    let out_path = sidecar.join(supervised::STDOUT_LOG);
+    let err_path = sidecar.join(supervised::STDERR_LOG);
+    assert!(eventually(Duration::from_secs(10), || {
+        std::fs::read_to_string(&out_path).is_ok_and(|t| t.contains("to-stdout"))
+    }));
+
+    let out = std::fs::read_to_string(&out_path).unwrap();
+    let err = std::fs::read_to_string(&err_path).unwrap();
+    assert!(!out.contains("to-stderr"), "stdout carried stderr: {out}");
+    assert!(!err.contains("to-stdout"), "stderr carried stdout: {err}");
+
+    // What `stella daemon attach` does: a reader arriving after the fact
+    // replays everything, because the console is a file and not a pipe that
+    // was only ever connected to a terminal that has since gone.
+    let mut replay = Tail::open(&out_path).expect("console readable");
+    let mut seen = Vec::new();
+    replay.pump(&mut seen).expect("replay");
+    assert!(String::from_utf8_lossy(&seen).contains("to-stdout"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A stop must reach the whole tree, and must record what it did.
+///
+/// Both halves are the bugs `scripts/fullauto.sh` paid for: a stop that
+/// signals only the leader leaves the tools it spawned running, and a stop
+/// that never writes a terminal status leaves a run the operator ended by hand
+/// to be presented, forever, as a crash.
+#[test]
+fn stopping_ends_the_whole_group_and_records_it_as_deliberate() {
+    let (dir, registry) = temp_registry("stop");
+    // A child with a child: `sh` waits on `sleep`, so a signal that reaches
+    // only `sh` leaves `sleep` behind.
+    let run = spawn_sh(&registry, "stop", "sleep 120 & wait");
+    let sidecar = registry.sidecar_dir(&run.id);
+    let group = run.pgid;
+    // Deliberately dropped before the stop: the run's survival must not depend
+    // on the handle of the process that started it.
+    drop(run.child);
+
+    let id = run.id.clone();
+    stop(&registry, &id).expect("stop");
+
+    assert_eq!(
+        lock_is_held(&sidecar),
+        Some(false),
+        "the run must actually be over"
+    );
+    // SAFETY: probing a group with signal 0 sends nothing.
+    let group_alive = unsafe { libc::kill(-group, 0) } == 0;
+    assert!(!group_alive, "the whole process group must be gone");
+
+    assert_eq!(
+        registry.get(&id).map(|r| r.status),
+        Some(SessionStatus::Cancelled),
+        "a hand-stopped run must not age into the registry as a crash"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Stopping something that already finished is not an error, and must not
+/// signal anything: the pid in the record may by then belong to somebody else
+/// entirely.
+#[test]
+fn stopping_a_finished_run_signals_nothing_and_still_records_the_stop() {
+    let (dir, registry) = temp_registry("stop-finished");
+    let mut run = spawn_sh(&registry, "finished", "true");
+    let _ = run.child.wait();
+    let sidecar = registry.sidecar_dir(&run.id);
+    assert!(eventually(Duration::from_secs(10), || {
+        lock_is_held(&sidecar) == Some(false)
+    }));
+
+    stop(&registry, &run.id).expect("stopping a finished run is not an error");
+    assert_eq!(
+        registry.get(&run.id).map(|r| r.status),
+        Some(SessionStatus::Cancelled)
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A stop that arrives after the run recorded its own answer must not
+/// overwrite it: "it completed" is a fact the run established, and the stopper
+/// only knows it was too late.
+#[test]
+fn a_late_stop_does_not_relabel_a_run_that_already_finished_cleanly() {
+    let (dir, registry) = temp_registry("late-stop");
+    let mut run = spawn_sh(&registry, "late", "true");
+    let _ = run.child.wait();
+    registry
+        .set_status(&run.id, SessionStatus::Complete)
+        .expect("record the run's own answer");
+
+    stop(&registry, &run.id).expect("stop");
+    assert_eq!(
+        registry.get(&run.id).map(|r| r.status),
+        Some(SessionStatus::Complete)
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ids_resolve_by_unique_prefix_and_refuse_an_ambiguous_one() {
+    let (dir, registry) = temp_registry("resolve");
+    let mut a = SessionRecord::new("/w", "a");
+    a.id = "ses-100-1".into();
+    a.supervisor = Some(SupervisorInfo { pgid: 1 });
+    let mut b = SessionRecord::new("/w", "b");
+    b.id = "ses-100-12".into();
+    b.supervisor = Some(SupervisorInfo { pgid: 2 });
+    let mut plain = SessionRecord::new("/w", "unsupervised");
+    plain.id = "ses-200-3".into();
+    for record in [&a, &b, &plain] {
+        registry.upsert(record).unwrap();
+    }
+
+    assert_eq!(resolve(&registry, Some("ses-100-12")).unwrap().id, b.id);
+    // An exact hit is never ambiguous, however many ids extend it.
+    assert_eq!(resolve(&registry, Some("ses-100-1")).unwrap().id, a.id);
+    assert!(resolve(&registry, Some("ses-100")).is_err());
+    assert!(resolve(&registry, Some("ses-999")).is_err());
+    // Unsupervised sessions are not this command's subject.
+    assert!(resolve(&registry, Some("ses-200-3")).is_err());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_exit_code_is_forwarded_the_way_a_shell_reports_it() {
+    let status = |script: &str| {
+        std::process::Command::new("/bin/sh")
+            .args(["-c", script])
+            .status()
+            .expect("sh")
+    };
+    assert_eq!(exit_code(&status("true")), None, "success forwards nothing");
+    assert_eq!(exit_code(&status("exit 3")), Some(3));
+    // 128 + SIGTERM, the convention `stella run` already answers with.
+    assert_eq!(exit_code(&status("kill -TERM $$")), Some(143));
+}
+
+#[test]
+fn logs_start_the_requested_number_of_lines_back() {
+    let dir = std::env::temp_dir().join(format!("stella-daemon-tail-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("console");
+    std::fs::write(&path, "one\ntwo\nthree\nfour\n").unwrap();
+
+    let mut tail = Tail::open(&path).unwrap();
+    tail.seek_back_lines(2).unwrap();
+    let mut seen = Vec::new();
+    tail.pump(&mut seen).unwrap();
+    assert_eq!(String::from_utf8_lossy(&seen), "three\nfour\n");
+
+    // Asking for more than there is starts at the beginning rather than
+    // failing: a run that has printed two lines has printed two lines.
+    let mut all = Tail::open(&path).unwrap();
+    all.seek_back_lines(99).unwrap();
+    let mut everything = Vec::new();
+    all.pump(&mut everything).unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&everything),
+        "one\ntwo\nthree\nfour\n"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A console with no trailing newline is the normal case while a run is still
+/// writing — the tail must not treat the unterminated last line as absent.
+#[test]
+fn a_partial_last_line_is_still_a_line() {
+    let dir = std::env::temp_dir().join(format!("stella-daemon-partial-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("console");
+    std::fs::write(&path, "one\ntwo\nthree").unwrap();
+
+    let mut tail = Tail::open(&path).unwrap();
+    tail.seek_back_lines(2).unwrap();
+    let mut seen = Vec::new();
+    tail.pump(&mut seen).unwrap();
+    assert_eq!(String::from_utf8_lossy(&seen), "two\nthree");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -42,6 +42,7 @@ mod context_records;
 mod contextgraph;
 mod credential_handoff;
 mod credential_status;
+mod daemon;
 // #872, the first slice of #836: the redacted training-trajectory exporter.
 mod dataset_cmd;
 mod deck_mcp;
@@ -297,8 +298,53 @@ fn emit_error_summary(format: OutputFormat, msg: &str) {
 // the per-command modules keep addressing their own subcommand enum as
 // `crate::AuthCmd`, `crate::McpCmd`, … regardless of which file defines it.
 pub(crate) use cli::{
-    AuthCmd, Cli, Command, ConnectCmd, McpCmd, MigrateCmd, ModelsCmd, TelemetryCmd,
+    AuthCmd, Cli, Command, ConnectCmd, DaemonCmd, McpCmd, MigrateCmd, ModelsCmd, TelemetryCmd,
 };
+
+/// Whether this invocation is handed to the supervisor (#1552), and what
+/// supervising it costs.
+///
+/// `None` runs the work in this process, exactly as every release before
+/// supervision existed. `Some(scope_review_lost)` supervises, and the flag
+/// says whether that took away an interactive scope-review answer this
+/// invocation would otherwise have had — see
+/// [`daemon::loses_interactive_scope_review`].
+///
+/// Computed here, once, because it is the only place the parsed flags, the
+/// resolved config, and the real terminal handles are all in hand; each
+/// long-running arm then asks one question instead of re-deriving three.
+fn supervision(globals: &cli::GlobalArgs, cfg: &config::Config) -> Option<bool> {
+    if !daemon::should_supervise(
+        globals.foreground,
+        daemon::supervised_id().is_some(),
+        daemon::has_controlling_terminal(),
+    ) {
+        return None;
+    }
+    let approval = agent::approval_capability_for(
+        matches!(globals.output_format, OutputFormat::Text),
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    );
+    Some(daemon::loses_interactive_scope_review(
+        approval == agent::PipelineApprovalCapability::Stdio,
+        cfg.engine_settings
+            .as_ref()
+            .is_some_and(|engine| engine.headless_scope_bypass_on()),
+    ))
+}
+
+/// The registry title for a supervised run: the same
+/// `<workspace>: <prompt…>` shape a session announces for itself, so a run
+/// reads identically in `stella daemon list` and in the deck's SESSIONS view.
+fn supervised_title(cfg: &config::Config, what: &str) -> String {
+    let name = cfg
+        .workspace_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| cfg.workspace_root.display().to_string());
+    format!("{name}: {}", command_deck::prompt_line(what, 48))
+}
 
 /// `stella resume --list`: every session in the machine-wide registry,
 /// newest activity first, with the rows resumable from THIS directory
@@ -482,8 +528,18 @@ fn main() -> ExitCode {
     let output_format = cli.output_format();
 
     match run(cli, &loaded_env) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(()) => {
+            daemon::record_outcome_if_supervised(true);
+            // A supervisor's own exit code says only whether it managed to
+            // stream a log. What a script wrapping `stella run` is asking
+            // about is the run, so the child's code is forwarded verbatim.
+            match daemon::forwarded_exit_code() {
+                Some(code) => ExitCode::from(code),
+                None => ExitCode::SUCCESS,
+            }
+        }
         Err(e) => {
+            daemon::record_outcome_if_supervised(false);
             eprintln!("{} {}", "stella:".red().bold(), e);
             emit_error_summary(output_format, &e);
             // §7.4's second trigger, and the one that fires more often: most
@@ -524,6 +580,15 @@ fn deck_presentation(globals: &cli::GlobalArgs) -> term_policy::DeckPresentation
 }
 
 fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
+    // A supervised child holds its liveness lock from `pre_exec` onwards; this
+    // is the backstop for a child started some other way (by hand with
+    // STELLA_SUPERVISED set, or by a future launchd/systemd unit). Without it
+    // such a run reads as already-finished to every other process from the
+    // moment it starts.
+    if let Some(id) = daemon::supervised_id() {
+        daemon::hold_liveness_lock(&stella_store::SessionRegistry::open_default(), &id);
+    }
+
     // Models and Version don't need a configured provider/key.
     match &cli.command {
         Some(Command::Models { cmd }) => {
@@ -790,6 +855,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // Listing reads the local registry only — no provider required.
             return run_resume_list();
         }
+        Some(Command::Daemon { .. }) => {
+            // Finding, watching and stopping supervised runs is the local
+            // registry, two console files and a signal. Deliberately before
+            // provider resolution: a run whose model config has since been
+            // broken (a rotated key, a removed provider) is exactly the one an
+            // operator needs to be able to find and stop.
+            let Some(Command::Daemon { cmd }) = &cli.command else {
+                unreachable!("matched Command::Daemon")
+            };
+            return daemon::run(cmd);
+        }
         _ => {}
     }
 
@@ -878,6 +954,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 std::io::stdin().is_terminal(),
                 prompt_source::read_stdin_to_string,
             )?;
+            // Resolved first on purpose: the prompt may have come from this
+            // process's stdin, and a detached child has none to read.
+            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+                return daemon::supervise_this_invocation(
+                    rt()?,
+                    &cfg.workspace_root,
+                    &supervised_title(&cfg, &prompt),
+                    prompt.as_bytes(),
+                    scope_review_lost,
+                );
+            }
             signals::block_on_interruptible(
                 rt()?,
                 agent::run_one_shot(
@@ -920,6 +1007,15 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 std::io::stdin().is_terminal(),
                 prompt_source::read_stdin_to_string,
             )?;
+            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+                return daemon::supervise_this_invocation(
+                    rt()?,
+                    &cfg.workspace_root,
+                    &supervised_title(&cfg, &goal),
+                    goal.as_bytes(),
+                    scope_review_lost,
+                );
+            }
             signals::block_on_interruptible(
                 rt()?,
                 agent::run_goal_cmd(&cfg, &goal, cli.globals.budget, !no_pipeline),
@@ -935,6 +1031,21 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             task_timeout,
             output_format,
         } => {
+            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+                return daemon::supervise_this_invocation(
+                    rt()?,
+                    &cfg.workspace_root,
+                    &supervised_title(
+                        &cfg,
+                        &match plan.as_deref() {
+                            Some(file) => format!("fleet {}", file.display()),
+                            None => format!("fleet ({} tasks)", tasks.len()),
+                        },
+                    ),
+                    &[],
+                    scope_review_lost,
+                );
+            }
             signals::block_on_interruptible(
                 rt()?,
                 fleet_cmd::run_fleet(
@@ -953,6 +1064,15 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         }
         Command::Monitor { target } => {
             let target = target.unwrap_or_else(|| "main".to_string());
+            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+                return daemon::supervise_this_invocation(
+                    rt()?,
+                    &cfg.workspace_root,
+                    &supervised_title(&cfg, &format!("monitor {target}")),
+                    &[],
+                    scope_review_lost,
+                );
+            }
             // Monitoring IS a goal: the verifier (who can call ci_status
             // itself) ends the loop only on a fully green latest run.
             let goal = format!(
@@ -1035,6 +1155,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         // top of `run` before a provider is resolved; Init is handled by the
         // caller. Reaching any of them here is impossible.
         Command::Init
+        | Command::Daemon { .. }
         | Command::Tools { .. }
         | Command::Graph { .. }
         | Command::Scripts { .. }

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -313,7 +313,11 @@ pub(crate) use cli::{
 /// Computed here, once, because it is the only place the parsed flags, the
 /// resolved config, and the real terminal handles are all in hand; each
 /// long-running arm then asks one question instead of re-deriving three.
-fn supervision(globals: &cli::GlobalArgs, cfg: &config::Config) -> Option<bool> {
+fn supervision(
+    globals: &cli::GlobalArgs,
+    output_format: OutputFormat,
+    cfg: &config::Config,
+) -> Option<bool> {
     if !daemon::should_supervise(
         globals.foreground,
         daemon::supervised_id().is_some(),
@@ -322,7 +326,7 @@ fn supervision(globals: &cli::GlobalArgs, cfg: &config::Config) -> Option<bool> 
         return None;
     }
     let approval = agent::approval_capability_for(
-        matches!(globals.output_format, OutputFormat::Text),
+        matches!(output_format, OutputFormat::Text),
         std::io::stdin().is_terminal(),
         std::io::stdout().is_terminal(),
     );
@@ -956,7 +960,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             )?;
             // Resolved first on purpose: the prompt may have come from this
             // process's stdin, and a detached child has none to read.
-            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+            if let Some(scope_review_lost) = supervision(&cli.globals, output_format, &cfg) {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
@@ -1007,7 +1011,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 std::io::stdin().is_terminal(),
                 prompt_source::read_stdin_to_string,
             )?;
-            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+            if let Some(scope_review_lost) = supervision(&cli.globals, OutputFormat::Text, &cfg) {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
@@ -1031,7 +1035,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             task_timeout,
             output_format,
         } => {
-            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+            if let Some(scope_review_lost) = supervision(&cli.globals, output_format, &cfg) {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
@@ -1064,7 +1068,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         }
         Command::Monitor { target } => {
             let target = target.unwrap_or_else(|| "main".to_string());
-            if let Some(scope_review_lost) = supervision(&cli.globals, &cfg) {
+            if let Some(scope_review_lost) = supervision(&cli.globals, OutputFormat::Text, &cfg) {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,

--- a/crates/stella-cli/src/signals.rs
+++ b/crates/stella-cli/src/signals.rs
@@ -159,6 +159,16 @@ async fn race<F: Future>(
 /// error type would touch every `?` in it.
 static INTERRUPTED: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 
+/// Record that a signal cut this process short.
+///
+/// [`block_on_interruptible`] is the usual caller. The supervisor
+/// ([`crate::daemon`]) is the other: it cannot use that wrapper, because a
+/// signal there must stop the *child* and keep streaming rather than drop the
+/// work — but the exit code it owes the shell is the same one.
+pub(crate) fn note_interrupt(signal: Interrupt) {
+    INTERRUPTED.store(signal.exit_code(), std::sync::atomic::Ordering::SeqCst);
+}
+
 /// The exit code to use, if a signal cut this process short.
 pub(crate) fn interrupted_exit_code() -> Option<u8> {
     match INTERRUPTED.load(std::sync::atomic::Ordering::SeqCst) {
@@ -192,7 +202,7 @@ where
             inner
         }
         Err(signal) => {
-            INTERRUPTED.store(signal.exit_code(), std::sync::atomic::Ordering::SeqCst);
+            note_interrupt(signal);
             rt.shutdown_timeout(std::time::Duration::from_secs(2));
             Err(signal.reason().to_string())
         }

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -475,7 +475,12 @@ fn run_and_fleet_declare_output_format() {
 /// without one.
 #[test]
 fn arena_is_stream_json_by_contract_not_by_flag() {
-    let args = |extra: &[&str]| {
+    // A nested `fn`, not a closure. The returned `Vec` borrows from `extra`,
+    // and a closure cannot say so: it gets a higher-ranked signature with a
+    // fresh input lifetime and an unconstrained output, which rustc rejects
+    // however the return type is annotated. Only an item can name the
+    // lifetime that relates them.
+    fn args<'a>(extra: &[&'a str]) -> Vec<&'a str> {
         let mut argv = vec![
             "stella",
             "arena",
@@ -488,7 +493,7 @@ fn arena_is_stream_json_by_contract_not_by_flag() {
         ];
         argv.extend_from_slice(extra);
         argv
-    };
+    }
     assert!(
         Cli::try_parse_from(args(&["--output-format", "text"])).is_err(),
         "arena must reject --output-format rather than silently emit stream-json"

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -206,7 +206,7 @@ pub use receipts::{
     StepManifestRow,
 };
 pub use reconstruct::Reconstruction;
-pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
+pub use sessions::{SessionRecord, SessionRegistry, SessionStatus, SupervisorInfo, supervised};
 pub use telemetry::{SourceTelemetryRow, TelemetryRow};
 pub use tool_calls::{ToolCallAnswer, ToolCallRow, ToolCallState};
 

--- a/crates/stella-store/src/sessions.rs
+++ b/crates/stella-store/src/sessions.rs
@@ -106,6 +106,58 @@ pub struct SessionRecord {
     /// already on. Absent in pre-v2 records.
     #[serde(default)]
     pub exploring: Vec<String>,
+    /// Present when the session runs under the CLI's supervisor rather than in
+    /// the foreground of a terminal (#1552). Absent for every ordinary
+    /// session, and for every record written before supervision existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervisor: Option<SupervisorInfo>,
+}
+
+/// What a **supervised** session's sidecar directory holds, beyond the durable
+/// journal every session gets. The names live here, beside
+/// [`SessionRegistry::sidecar_dir`], because the sidecar's layout has one owner
+/// and a second copy of these strings in the CLI is a rename away from
+/// pointing at a file nothing writes.
+pub mod supervised {
+    /// The child's stdout, verbatim.
+    ///
+    /// Two files rather than one merged console: `stella run --output-format
+    /// json` is piped into `jq`, and a warning folded into stdout breaks the
+    /// parse on the *caller's* side, where it is unattributable. Attaching
+    /// re-splits them onto the same two streams they were written from.
+    pub const STDOUT_LOG: &str = "stdout.log";
+    /// The child's stderr, verbatim. See [`STDOUT_LOG`].
+    pub const STDERR_LOG: &str = "stderr.log";
+    /// The prompt, handed to the child as its stdin.
+    ///
+    /// Not an argv element: an argv-borne prompt is visible to every user on
+    /// the machine in `ps`, and a long one hits `ARG_MAX`. A file in a `0700`
+    /// directory is neither.
+    pub const STDIN: &str = "stdin";
+    /// The advisory lock the child holds open for its whole life.
+    ///
+    /// The kernel releases it when the process dies — crash, `SIGKILL` and
+    /// power loss included — so "is the lock free?" answers "is this run
+    /// over?" without trusting a pid. See [`super::SupervisorInfo::pgid`] for
+    /// why that distinction is load-bearing rather than fastidious.
+    pub const LOCK: &str = "supervisor.lock";
+}
+
+/// How to reach a supervised session's work: it is a detached child in its own
+/// process group, its console is two files in the sidecar, and it outlives the
+/// terminal that started it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupervisorInfo {
+    /// The process **group** to signal, which is also the child's pid: the
+    /// child `setsid`s before `exec`, so it leads its own session.
+    ///
+    /// Stored as a group rather than derived from [`SessionRecord::pid`] at
+    /// use because the two are only equal while that invariant holds, and the
+    /// cost of being wrong is asymmetric — signalling a group that is not ours
+    /// takes down a stranger's processes. A reader that wants to signal must
+    /// still confirm the run is live through [`supervised::LOCK`]: a pid (and
+    /// a pgid) is recycled by the kernel, an open lock is not.
+    pub pgid: i32,
 }
 
 /// A `<id>.json` that is present but unusable — the state
@@ -160,6 +212,7 @@ impl SessionRecord {
             started_at_ms: now,
             updated_at_ms: now,
             exploring: Vec::new(),
+            supervisor: None,
         }
     }
 }
@@ -205,6 +258,19 @@ impl SessionRegistry {
     /// `.json` files, so the directory never shadows a record.
     pub fn sidecar_dir(&self, id: &str) -> PathBuf {
         self.dir.join(Self::safe_id(id))
+    }
+
+    /// Create `id`'s sidecar directory owner-only, and answer its path.
+    ///
+    /// Every other writer of a sidecar creates it on its first write. A
+    /// supervised session needs it to exist *before* the session does: its
+    /// console files and its liveness lock ([`supervised`]) are opened into
+    /// the directory as the child is spawned, and the mode those files inherit
+    /// is not the caller's to reinvent.
+    pub fn prepare_sidecar(&self, id: &str) -> Result<PathBuf> {
+        let dir = self.sidecar_dir(id);
+        crate::ensure_private_dir(&dir)?;
+        Ok(dir)
     }
 
     /// Write (create or replace) `record` atomically, stamping
@@ -844,5 +910,56 @@ mod tests {
         assert!(reg.get(&paused.id).is_some());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Invariant 4 for the field #1552 added: a supervised record survives the
+    /// write/read the registry actually performs, not just `to_string`.
+    #[test]
+    fn a_supervised_record_round_trips_through_the_registry() {
+        let (dir, reg) = temp_registry("supervised-roundtrip");
+
+        let mut rec = SessionRecord::new("/w/space", "space: long run");
+        rec.supervisor = Some(SupervisorInfo { pgid: 4242 });
+        reg.upsert(&rec).unwrap();
+
+        let read = reg.get(&rec.id).expect("record readable");
+        assert_eq!(read.supervisor, Some(SupervisorInfo { pgid: 4242 }));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Every record on every machine that ever ran stella predates the
+    /// `supervisor` field. They must keep parsing: `list` drops what it cannot
+    /// parse, so a required field here would make every existing session
+    /// vanish from the SESSIONS view on upgrade — and take `resume` with it.
+    #[test]
+    fn a_record_written_before_supervision_still_parses() {
+        let pre_1552 = r#"{
+            "id": "ses-1-2",
+            "pid": 2,
+            "workspace": "/w/old",
+            "title": "old: a session from before",
+            "summary": "",
+            "status": "complete",
+            "started_at_ms": 1,
+            "updated_at_ms": 1
+        }"#;
+
+        let record: SessionRecord = serde_json::from_str(pre_1552).expect("legacy record parses");
+        assert_eq!(record.supervisor, None);
+        assert!(record.exploring.is_empty());
+    }
+
+    /// The absent case must stay absent on disk too. `list` is read by the
+    /// deck on every refresh, and a `"supervisor": null` in every record is
+    /// bytes and confusion bought for nothing.
+    #[test]
+    fn an_unsupervised_record_writes_no_supervisor_key() {
+        let rec = SessionRecord::new("/w/space", "space: ordinary");
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(
+            !json.contains("supervisor"),
+            "unsupervised records must not carry the key: {json}"
+        );
     }
 }

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -1,0 +1,86 @@
+---
+title: stella daemon
+description: Find, watch, and stop runs that outlived the terminal they were started from.
+---
+
+A long-running verb started from a terminal — [`run`](/docs/commands/run), [`goal`](/docs/commands/goal), [`monitor`](/docs/commands/monitor), [`fleet`](/docs/commands/fleet) — is handed to a **supervisor**. The work becomes a detached process that survives the window closing, an `ssh` disconnect, and a logout; the terminal you started it in stays only to stream its output. `stella daemon` is how you find that process again afterwards.
+
+## Synopsis
+
+```bash
+stella daemon list
+stella daemon attach [id]
+stella daemon logs [id] [-n LINES]
+stella daemon stop <id>
+```
+
+## Why runs are supervised
+
+Closing a terminal sends `SIGHUP` to its foreground process group. Before this existed, that killed the run mid-turn: no answer, no record of why it stopped, and no way back to it. A supervised run is in its own session before it starts work, so the hangup never reaches it.
+
+You do not start a supervised run — every terminal run already is one. The first two lines it prints say so:
+
+```text
+▸ supervised ses-1785956826121-25167 — survives this terminal closing
+  reattach with stella daemon attach ses-1785956826121-25167
+```
+
+Close that terminal, open another, and the run is still there:
+
+```bash
+$ stella daemon list
+ID                           STATUS       WHAT
+ses-1785956826121-25167      Running      stella: migrate the config loader to serde
+
+$ stella daemon attach ses-1785956826121
+```
+
+## What supervision does and does not survive
+
+It survives **the terminal**: a closed window, a dropped `ssh` session, a logout. It does not survive **the process**: a supervised run that is killed, or a machine that loses power, loses the turn it was in — only the fact of the run is recorded. Durable resume across a killed process is a different mechanism, and for interactive sessions [`stella resume`](/docs/commands/resume) is the one that exists today.
+
+## Which invocations are supervised
+
+Only ones with a controlling terminal to lose. A terminal is exactly what can close, so a run that has none is already immune, and supervising it would add a process and a copy of every byte of output for nothing. Concretely:
+
+| Invocation | Supervised |
+|---|---|
+| `stella run "…"` typed in a terminal | yes |
+| `stella run "…" --foreground` | no — runs in this process, as older releases did |
+| `cat spec.md \| stella run` with output redirected | no — no controlling terminal |
+| a CI step, a container, a `cron` job | no |
+| [`stella chat`](/docs/commands/chat) / [`stella resume`](/docs/commands/resume) | no — the deck *is* the terminal |
+
+`--foreground` (or `STELLA_FOREGROUND=1`) opts any invocation out.
+
+<Callout type="warn">
+A supervised run is **headless**: its stdin is a file and its console is a log, so there is nobody to answer a scope-review prompt. A plan that expands scope stops with a named error instead of asking. The banner says so when it applies. Use `--foreground` to keep the interactive prompt, or set `headless_scope_bypass = "on"` in settings for a workspace where the tree is disposable.
+</Callout>
+
+## `list`
+
+Every supervised run on this machine, newest first. Local reads only — no API key, and no provider needs to resolve, so a run whose model configuration has since broken is still findable and stoppable.
+
+`STATUS` is answered by a lock the run holds for its whole life rather than by its pid, because the kernel releases that lock when the process dies — crash, kill and power loss included. A run whose process is gone without recording an outcome reads as `Crashed`.
+
+## `attach`
+
+Streams the run's output into this terminal, from the beginning, and stays until the run ends. A run that has already finished prints in full and exits. The id can be any unique prefix; omit it for the most recently started run.
+
+Detaching again — `Ctrl-C` — leaves the run alone. `stella daemon stop` is what stops it.
+
+## `logs`
+
+The tail of a finished or running console, without following it. `-n` sets how many lines back to start (default 40).
+
+stdout and stderr are kept in two files and replayed onto the two streams they were written from, so `stella run --output-format json` stays parseable through a supervisor. One consequence is visible here: `logs` prints the stdout tail and then the stderr tail as separate blocks rather than interleaving them chronologically. `attach` on a live run interleaves naturally, because it follows both as they are written.
+
+## `stop`
+
+Asks the run to stop the way `Ctrl-C` would: the signal reaches the whole process group — the run and every tool process it spawned — and the engine finishes the tool it is running and aborts at the next safe boundary, never mid-tool.
+
+A run that has not stopped after 8 seconds is killed. Either way the stop is recorded as **cancelled**, deliberately: a run stopped by hand that recorded nothing would age into the registry indistinguishable from one that crashed.
+
+## Where the state lives
+
+Beside the session registry, under the user-level stella home (`~/.stella/sessions/<id>/`, `STELLA_DATA_DIR` overrides): `stdout.log` and `stderr.log` are the console, `stdin` is the prompt the supervisor staged for the run, and `supervisor.lock` is the liveness lock. All owner-only. The prompt travels as a file rather than as an argument so it is not visible to every user on the machine in `ps`.

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -34,6 +34,9 @@ here and the index your terminal shows can never drift apart.
   <SpecCard title="stella resume" href="/docs/commands/resume">
     Reopen a previous session exactly where it stood
   </SpecCard>
+  <SpecCard title="stella daemon" href="/docs/commands/daemon">
+    Find, watch, and stop runs that outlived their terminal
+  </SpecCard>
   <SpecCard title="stella init" href="/docs/commands/init">
     Analyze this workspace: domain taxonomy and code graph
   </SpecCard>

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -6,6 +6,7 @@
     "chat",
     "goal",
     "resume",
+    "daemon",
     "init",
     "---Run many at once---",
     "fleet",


### PR DESCRIPTION
Process-level supervision from #1552: long-running verbs re-launch as a detached child owned by the session registry, so a closed terminal, ssh disconnect, or logout no longer kills the run. `stella daemon list|attach|logs|stop` manage it; `--foreground` keeps the old behaviour.

Draft while the three follow-ups land on this branch: approval forwarding (#1585), resume at the last step boundary (#1586), bounded console logs (#1588).

Closes #1552

## Summary by Sourcery

Introduce process-level supervision for long-running CLI runs so they survive terminal loss and can be managed via a new `stella daemon` command.

New Features:
- Add supervision of long-running `run`, `goal`, `fleet`, and `monitor` commands by relaunching them as detached child processes managed via the session registry.
- Introduce a `stella daemon` command with `list`, `attach`, `logs`, and `stop` subcommands to discover, follow, and control supervised runs.
- Add a global `--foreground` / `STELLA_FOREGROUND` option to opt out of supervision and keep the legacy in-terminal behaviour.

Enhancements:
- Extend session records with supervisor metadata and per-session sidecar files for split stdout/stderr logs, staged stdin, and a liveness lock, plus support for preparing sidecar directories.
- Ensure supervised children forward their exit codes and correctly record final session status, including signal-based cancellations, in the registry.
- Teach the CLI to reuse existing session records when resuming under supervision and to handle interrupt tracking in a reusable helper.

Documentation:
- Document the new `stella daemon` command, its subcommands, supervision behaviour, and when runs are or are not supervised in the user-facing CLI docs.
- Update the commands index to include `stella daemon` and adjust help grouping to reflect the new command.

Tests:
- Add extensive tests for the supervisor module, covering supervision decisions, process detachment, liveness locking, console handling, stop semantics, id resolution, and log tailing behaviour.
- Add regression tests in the store to ensure supervised session records round-trip correctly and legacy records without supervision metadata remain parseable.