### PR TITLE
revert: remove #1594's duplicate supervision surface — unbreaks main

### DIFF
--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -239,9 +239,18 @@ fn stopping_ends_the_whole_group_and_records_it_as_deliberate() {
         Some(false),
         "the run must actually be over"
     );
-    // SAFETY: probing a group with signal 0 sends nothing.
-    let group_alive = unsafe { libc::kill(-group, 0) } == 0;
-    assert!(!group_alive, "the whole process group must be gone");
+    // "Gone" is eventually-true, not instantly-true: the TERM'd `sleep` was
+    // orphaned when `sh` died, so it lingers as a zombie until PID 1 reaps
+    // it — and a zombie still answers a group probe. launchd reaps before
+    // the next statement on a laptop; a CI container's init can lose that
+    // race, which is a fact about reap latency, not about `stop`.
+    assert!(
+        eventually(Duration::from_secs(10), || {
+            // SAFETY: probing a group with signal 0 sends nothing.
+            unsafe { libc::kill(-group, 0) } != 0
+        }),
+        "the whole process group must be gone"
+    );
 
     assert_eq!(
         registry.get(&id).map(|r| r.status),


### PR DESCRIPTION
## What

**Main does not compile.** Two implementations of #1552 were built in parallel and **both merged**: #1591 (the fuller design — default supervision + `--foreground` across run/goal/fleet/monitor, split logs, staged stdin, liveness lock) landed first; #1594's stale branch merged over it. The textual union broke `stella-cli` three ways:

- `mod daemon;` declared twice (main.rs:45 and :47)
- the `Daemon` Command variant defined twice (cli.rs:489 and :824)
- the add/add on `src/daemon.rs` resolved to #1594's file, so every #1591 call site (`should_supervise`, `supervised_id`, `has_controlling_terminal`, …) points at functions that no longer exist — and #1594's pre-#1593 base dropped `mod query_format;` on the way in.

## The fix

`git revert 3c3e19a7` (#1594) wholesale. This restores #1591's `daemon.rs` and reference docs, removes the duplicate declarations, and brings back `query_format`. **Nothing of value is lost**: #1594 was the strictly smaller design (opt-in `--detach`, `run` only, pid-keyed single log); every capability it added exists in #1591's landed form, and #1591's follow-ups (#1585, #1586, #1588) carry the remainder.

## Verification

- `cargo check -p stella-cli`: three error families on main → clean here
- Full suite: CI (plus a local run in flight)

**Merge before anything else — main is red at compile, so every open PR is red.** And a process note worth keeping: #1582 and #1594 were both merged before their CI finished; the last three unbreak PRs (#1576, #1601, this) all trace to merges that outran their checks.

Refs #1552, #1591, #1594

## Summary by Sourcery

Restore the richer supervision implementation for stella-cli and fix main so it compiles again.

New Features:
- Make long-running terminal verbs run under a default supervisor that detaches work from the originating terminal while streaming its output.
- Expose a refined `stella daemon` surface for listing, attaching to, tailing logs from, and stopping supervised runs keyed by session ids.
- Propagate supervised child exit codes back to the parent process so shells see the run's actual status.

Bug Fixes:
- Resolve duplicate daemon module and command definitions and restore missing query_format wiring so the CLI crate builds again.
- Ensure supervised run liveness and stopping logic operate on the correct child process group instead of stale or incorrect pids.

Enhancements:
- Rework supervision internals to use per-session sidecars, split stdout/stderr logs, and a filesystem liveness lock rather than pid checks.
- Tighten daemon UX by allowing id prefixes, improving status reporting, and making attach/logs behavior more consistent for finished and running sessions.
- Adjust CLI help grouping and command docs to reflect supervision as the default behavior rather than an opt-in detach flag.

Documentation:
- Rewrite the `stella daemon` documentation to describe the new default supervision model, lifecycle semantics, and usage across run/goal/monitor/fleet.
- Update the commands index to align with the new supervision surface and remove outdated references to `stella run --detach`.

Tests:
- Add or update supervision tests to cover detached child lifecycle, logging, and signal handling behavior.