### PR TITLE
feat(stella-cli): stella daemon install/uninstall — survive logout and reboot via launchd/systemd (#1587)

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -37,6 +37,11 @@ use std::time::{Duration, Instant};
 
 use stella_store::{SessionRecord, SessionRegistry, SessionStatus};
 
+/// `install` / `uninstall`: the service-manager half (#1587) — what makes a
+/// registered invocation come back after the logout and reboot that a
+/// detached process cannot cross on its own.
+mod service;
+
 /// `stella daemon` — the supervision surface over detached runs.
 #[derive(Debug, clap::Subcommand)]
 pub(crate) enum DaemonCmd {
@@ -56,6 +61,46 @@ pub(crate) enum DaemonCmd {
     Logs {
         /// Session id (`ses-…`) or the run's pid
         target: String,
+    },
+
+    /// Register a stella invocation with the OS's per-user service manager
+    ///
+    /// A detached run survives its terminal; only the service manager
+    /// survives logout and reboot. This writes a per-user definition — a
+    /// launchd agent on macOS, a `systemd --user` unit on Linux — that starts
+    /// the given invocation in the current directory at every login (macOS)
+    /// or boot (Linux, once lingering is on), and loads it now.
+    ///
+    /// Registration, not resume: the command starts from scratch each time,
+    /// so register standing verbs (`monitor`, a fleet watch) — a one-shot
+    /// `run` would repeat its work, and its spend, on every boot. By default
+    /// a command that exits stays down; `--keep-alive` opts into restarts.
+    Install {
+        /// Name for the service (default: the command's first word).
+        /// Lowercase letters, digits and dashes.
+        #[arg(long)]
+        label: Option<String>,
+
+        /// Restart the command whenever it exits, at most once a minute.
+        /// Off by default: an agent that fails the moment it starts would
+        /// otherwise be restarted forever, spending budget each time.
+        #[arg(long)]
+        keep_alive: bool,
+
+        /// The stella invocation to register, after `--`:
+        /// `stella daemon install -- monitor --interval 300`
+        #[arg(last = true, required = true, value_name = "STELLA ARGS")]
+        command: Vec<String>,
+    },
+
+    /// Remove a service registered by `install`
+    ///
+    /// Unloads it from the service manager and deletes the definition.
+    /// Already-gone is reported and succeeds — uninstalling twice is the
+    /// requested state, not an error.
+    Uninstall {
+        /// The label `install` reported.
+        label: String,
     },
 }
 
@@ -255,6 +300,12 @@ pub(crate) fn run(cmd: DaemonCmd) -> Result<(), String> {
             println!("{}", log.display());
             Ok(())
         }
+        DaemonCmd::Install {
+            label,
+            keep_alive,
+            command,
+        } => service::install(label.as_deref(), keep_alive, &command),
+        DaemonCmd::Uninstall { label } => service::uninstall(&label),
     }
 }
 

--- a/crates/stella-cli/src/daemon/service.rs
+++ b/crates/stella-cli/src/daemon/service.rs
@@ -1,0 +1,701 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `stella daemon install` / `uninstall`: registration with the OS's
+//! per-user service manager (#1587).
+//!
+//! A detached run (`stella run --detach`, the parent module) survives its
+//! terminal, which is as far as a process can go on its own behalf: nothing
+//! a process does to itself survives a reboot, and on a machine configured
+//! to reap user processes at logout, nothing keeps it registered either.
+//! Surviving those is the service manager's job — launchd on macOS,
+//! `systemd --user` on Linux — and these two verbs are the explicit,
+//! reversible handshake with it. Explicit and reversible are requirements,
+//! not adjectives: writing under `~/Library/LaunchAgents` and calling
+//! `launchctl` is a side effect on the operator's machine outside any
+//! workspace, so it happens only when `install` is typed and is undone
+//! completely by `uninstall`.
+//!
+//! # What the installed service does — a decision, recorded
+//!
+//! It starts **one stella invocation the operator explicitly registered**, in
+//! the directory `install` was run from, at every login (launchd) or boot
+//! (systemd, once lingering is on). This is *service registration, not
+//! resume*: the command starts from scratch each time, because re-launching a
+//! half-finished agent turn is only correct once resume-at-a-step-boundary
+//! (#1586) exists — today it would be a fresh spend of the same budget. That
+//! makes standing verbs — `monitor`, a fleet watch, a deliberately perpetual
+//! run — the fit, and nothing is ever registered implicitly: an ordinary run
+//! is at most detached, never installed.
+//!
+//! Two consequences of the same budget concern, both deliberate:
+//!
+//! - **No restart unless asked.** The default definition starts the command
+//!   at load and lets it stay down when it exits; only `--keep-alive` adds
+//!   `KeepAlive` / `Restart=always`, and then throttled and (on systemd)
+//!   start-limited. An agent that fails the moment it starts, under an
+//!   unconditional restart policy, is a spend loop with no human in it.
+//! - **The binary is resolved at load, loudly.** A definition naming this
+//!   binary by absolute path breaks the day `brew upgrade` moves it, so the
+//!   service execs through a `/bin/sh` shim that tries the recorded path,
+//!   falls back to a `PATH` lookup widened with the usual install prefixes,
+//!   and otherwise writes one line naming exactly what is missing to the
+//!   service log and exits 127 — a failure the operator can read, not a
+//!   silent no-show at boot.
+//!
+//! The service manager *is* the detacher here, so a registered command must
+//! not carry `--detach`: the direct child would hand the work to a second
+//! process and exit at once, which the manager reads as "the service died"
+//! — and under `--keep-alive` respawns, forever. [`install`] refuses the
+//! flag instead of letting that loop exist. A service-run headless
+//! invocation still announces itself in the session registry like any
+//! other, so `stella daemon list` shows it; its console is the service log,
+//! and the manager's own query (`launchctl print`, `systemctl --user
+//! status`) is the service's status surface.
+//!
+//! # Where things land
+//!
+//! The definition goes where the platform's manager reads —
+//! `~/Library/LaunchAgents/sh.oxagen.stella.<label>.plist`,
+//! `~/.config/systemd/user/stella-<label>.service` — resolved through
+//! `stella-home` like every other home-anchored path. The console goes to
+//! `~/.stella/services/<label>.log` on both platforms, under a directory only
+//! the owner can list — a service's stdout is model output, not something
+//! other local users get to read.
+
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+
+/// The seconds launchd waits between `--keep-alive` restarts
+/// (`ThrottleInterval`), and systemd's `RestartSec`.
+///
+/// launchd's default is 10, which turns an instantly-failing command into six
+/// starts a minute. One a minute is still visibly alive in the log while
+/// being slow enough for an operator to notice and uninstall before the
+/// spend matters.
+const RESTART_SECS: u32 = 60;
+
+/// systemd's brake that launchd lacks: after this many starts inside
+/// [`START_LIMIT_WINDOW_SECS`], the unit enters the failed state and stays
+/// down until a human looks. Five starts in ten minutes is a command that is
+/// not going to succeed on the sixth.
+const START_LIMIT_BURST: u32 = 5;
+/// See [`START_LIMIT_BURST`].
+const START_LIMIT_WINDOW_SECS: u32 = 600;
+
+/// Labels stay boring on purpose: they become file names, launchd labels and
+/// unit names, three grammars with three escaping stories that all accept
+/// this intersection unescaped.
+const LABEL_MAX: usize = 32;
+
+/// Which per-user service manager this build can talk to.
+///
+/// A value, not a `cfg` fence, so every planning and rendering function below
+/// compiles and is tested on every platform — the one `cfg` decision is
+/// [`ServiceManager::current`], and everything downstream of it is data.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ServiceManager {
+    /// macOS: a launchd agent in the user's `gui` domain.
+    Launchd,
+    /// Linux: a `systemd --user` unit.
+    SystemdUser,
+}
+
+impl ServiceManager {
+    /// The manager for the platform this binary is running on.
+    fn current() -> Result<Self, String> {
+        #[cfg(target_os = "macos")]
+        {
+            Ok(Self::Launchd)
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Ok(Self::SystemdUser)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            Err(
+                "stella daemon install/uninstall needs a per-user service manager, and this \
+                 platform has neither launchd (macOS) nor systemd --user (Linux)"
+                    .to_string(),
+            )
+        }
+    }
+
+    /// The definition's file name for `label`.
+    fn file_name(self, label: &str) -> String {
+        match self {
+            // The `sh.oxagen.*` reverse-domain prefix matches the launchd
+            // agents this project already ships (scripts/fullauto.sh).
+            Self::Launchd => format!("sh.oxagen.stella.{label}.plist"),
+            Self::SystemdUser => format!("stella-{label}.service"),
+        }
+    }
+
+    /// Where the manager reads per-user definitions from, or `None` when no
+    /// home directory is discoverable — which means "cannot install", never
+    /// a fallback location, because the manager only reads the real one.
+    fn definition_dir(self) -> Option<PathBuf> {
+        match self {
+            Self::Launchd => stella_home::launch_agents_dir(),
+            Self::SystemdUser => stella_home::systemd_user_unit_dir(),
+        }
+    }
+}
+
+/// What the operator asked to register, fully resolved — the one bundle of
+/// facts every rendering function below is a pure function of.
+struct ServiceSpec<'a> {
+    label: &'a str,
+    /// The running binary, recorded as the shim's first candidate.
+    exe: &'a Path,
+    /// The registered stella argv (everything after `--`).
+    args: &'a [String],
+    /// The directory the service runs in — where `install` was typed.
+    workdir: &'a Path,
+    /// Where the service's stdout and stderr land.
+    log_path: &'a Path,
+    /// Whether the manager restarts the command when it exits.
+    keep_alive: bool,
+}
+
+/// Everything `install` will do, computed before anything is touched, so the
+/// side effects reduce to one file write and the loader calls — and so tests
+/// can hold the whole outcome in their hands without a service manager.
+struct ServicePlan {
+    manager: ServiceManager,
+    label: String,
+    /// The definition file to write.
+    path: PathBuf,
+    /// Its full content.
+    content: String,
+    /// Where the service's stdout and stderr will land.
+    log_path: PathBuf,
+}
+
+/// `stella daemon install [--label L] [--keep-alive] -- <stella args…>`.
+pub(crate) fn install(
+    label: Option<&str>,
+    keep_alive: bool,
+    command: &[String],
+) -> Result<(), String> {
+    let manager = ServiceManager::current()?;
+    reject_detach(command)?;
+    let label = match label {
+        Some(label) => label.to_string(),
+        None => derive_label(command)?,
+    };
+    validate_label(&label)?;
+
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("cannot locate the stella binary to register: {e}"))?;
+    let workdir = std::env::current_dir()
+        .map_err(|e| format!("cannot resolve the directory the service should run in: {e}"))?;
+    let definition_dir = manager
+        .definition_dir()
+        .ok_or("no home directory, so nowhere the service manager would read a definition from")?;
+    let log_path = ensure_service_log_dir()?.join(format!("{label}.log"));
+
+    let plan = plan(
+        manager,
+        &ServiceSpec {
+            label: &label,
+            exe: &exe,
+            args: command,
+            workdir: &workdir,
+            log_path: &log_path,
+            keep_alive,
+        },
+        &definition_dir,
+    )?;
+    write_definition(&plan)?;
+    println!("{} wrote {}", "✓".green(), plan.path.display());
+    load(&plan);
+    println!(
+        "  console: {}",
+        plan.log_path.display().to_string().dimmed()
+    );
+    println!(
+        "  remove with: {}",
+        format!("stella daemon uninstall {label}").cyan()
+    );
+    Ok(())
+}
+
+/// `stella daemon uninstall <label>`.
+///
+/// Unloads first, removes the file second: the reverse order leaves the
+/// manager running a definition that no longer exists on disk. Idempotent on
+/// purpose — uninstalling something already gone reports it and succeeds,
+/// because the state the operator asked for is the state they have.
+pub(crate) fn uninstall(label: &str) -> Result<(), String> {
+    let manager = ServiceManager::current()?;
+    validate_label(label)?;
+    let definition_dir = manager
+        .definition_dir()
+        .ok_or("no home directory, so nowhere a service definition could have been written")?;
+    let path = definition_dir.join(manager.file_name(label));
+
+    unload(manager, label);
+    match remove_definition(&path)? {
+        RemoveOutcome::Removed => println!("{} removed {}", "✓".green(), path.display()),
+        RemoveOutcome::NothingInstalled => {
+            eprintln!("{} nothing installed at {}", "▸".dimmed(), path.display());
+        }
+    }
+    if manager == ServiceManager::SystemdUser {
+        // Re-read now that the file is gone; stale in-memory units otherwise
+        // survive until the next reload for an unrelated reason. Lingering is
+        // deliberately left as the operator set it — other services may
+        // depend on it, and `install` says so when it turns it on.
+        run_tool(&["systemctl", "--user", "daemon-reload"], Quiet::Yes);
+    }
+    Ok(())
+}
+
+/// Compute the whole installation for `manager` from resolved inputs.
+///
+/// Pure over its arguments — no environment reads, no filesystem — which is
+/// what lets the tests pin every byte of both definition formats on any
+/// development platform.
+fn plan(
+    manager: ServiceManager,
+    spec: &ServiceSpec<'_>,
+    definition_dir: &Path,
+) -> Result<ServicePlan, String> {
+    let content = match manager {
+        ServiceManager::Launchd => launchd_plist(spec)?,
+        ServiceManager::SystemdUser => systemd_unit(spec)?,
+    };
+    Ok(ServicePlan {
+        manager,
+        label: spec.label.to_string(),
+        path: definition_dir.join(manager.file_name(spec.label)),
+        content,
+        log_path: spec.log_path.to_path_buf(),
+    })
+}
+
+/// Write the planned definition, refusing to replace one that exists.
+///
+/// Replacing would silently re-point a service the operator installed on
+/// purpose, possibly while the manager still runs the old definition —
+/// `uninstall` then `install` keeps both the human and the manager in the
+/// loop. The atomic owner-only writer is deliberate: the definition embeds
+/// the registered argv, which for an agent command can be a prompt.
+fn write_definition(plan: &ServicePlan) -> Result<(), String> {
+    if plan.path.exists() {
+        return Err(format!(
+            "{} already exists — `stella daemon uninstall {}` first, or pick another --label",
+            plan.path.display(),
+            plan.label
+        ));
+    }
+    if let Some(parent) = plan.path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+    }
+    stella_store::write_sensitive_file_atomic(&plan.path, plan.content.as_bytes())
+        .map_err(|e| format!("cannot write {}: {e}", plan.path.display()))
+}
+
+/// What `uninstall` found on disk. Both are successes: the operator asked
+/// for the service to be gone, and it is.
+#[derive(PartialEq, Eq, Debug)]
+enum RemoveOutcome {
+    Removed,
+    NothingInstalled,
+}
+
+/// Remove the definition file, distinguishing "removed it" from "was
+/// already gone" by the removal's own result rather than a look-then-remove
+/// race.
+fn remove_definition(path: &Path) -> Result<RemoveOutcome, String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(RemoveOutcome::Removed),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(RemoveOutcome::NothingInstalled),
+        Err(e) => Err(format!("cannot remove {}: {e}", path.display())),
+    }
+}
+
+/// The directory service consoles land in, created owner-only.
+///
+/// Owner-only because the log is the run's stdout, which is model output.
+/// The manager creates the log files itself with default modes, so the
+/// directory is what carries the restriction.
+fn ensure_service_log_dir() -> Result<PathBuf, String> {
+    let dir = stella_home::data_dir().join("services");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("cannot restrict {}: {e}", dir.display()))?;
+    }
+    Ok(dir)
+}
+
+/// Hand the written definition to the service manager, falling back to
+/// printing the exact command when the call fails — the fullauto pattern: a
+/// failed `launchctl` must not strand the operator with a file and no next
+/// step.
+fn load(plan: &ServicePlan) {
+    match plan.manager {
+        ServiceManager::Launchd => {
+            let domain = format!("gui/{}", current_uid());
+            let path = plan.path.display().to_string();
+            if run_tool(&["launchctl", "bootstrap", &domain, &path], Quiet::No) {
+                println!(
+                    "{} loaded — starts at every login, including after a reboot",
+                    "✓".green()
+                );
+            } else {
+                eprintln!(
+                    "{} wrote the definition but launchctl bootstrap failed; load it with:",
+                    "⚠".yellow()
+                );
+                eprintln!("    launchctl bootstrap {domain} {path}");
+            }
+        }
+        ServiceManager::SystemdUser => {
+            let unit = plan.manager.file_name(&plan.label);
+            run_tool(&["systemctl", "--user", "daemon-reload"], Quiet::Yes);
+            if run_tool(
+                &["systemctl", "--user", "enable", "--now", &unit],
+                Quiet::No,
+            ) {
+                println!("{} enabled and started", "✓".green());
+            } else {
+                eprintln!(
+                    "{} wrote the definition but systemctl failed; enable it with:",
+                    "⚠".yellow()
+                );
+                eprintln!(
+                    "    systemctl --user daemon-reload && systemctl --user enable --now {unit}"
+                );
+            }
+            // Without lingering, a user manager starts at login and is torn
+            // down at logout — the exact boundary this issue exists to cross.
+            if run_tool(&["loginctl", "enable-linger"], Quiet::No) {
+                println!(
+                    "{} lingering on — survives logout, starts at boot",
+                    "✓".green()
+                );
+            } else {
+                eprintln!(
+                    "{} could not enable lingering; without it the service starts at login and \
+                     stops at logout. Turn it on with: loginctl enable-linger",
+                    "⚠".yellow()
+                );
+            }
+        }
+    }
+}
+
+/// Ask the manager to stop and forget the service, best-effort.
+///
+/// Quiet because the common uninstall is of a service that already exited or
+/// was never loaded, and "no such service" from the manager is that path
+/// working, not a problem to surface.
+fn unload(manager: ServiceManager, label: &str) {
+    match manager {
+        ServiceManager::Launchd => {
+            let target = format!("gui/{}/sh.oxagen.stella.{label}", current_uid());
+            run_tool(&["launchctl", "bootout", &target], Quiet::Yes);
+        }
+        ServiceManager::SystemdUser => {
+            let unit = manager.file_name(label);
+            run_tool(
+                &["systemctl", "--user", "disable", "--now", &unit],
+                Quiet::Yes,
+            );
+        }
+    }
+}
+
+/// Whether to surface a tool's failure output.
+#[derive(PartialEq, Eq)]
+enum Quiet {
+    Yes,
+    No,
+}
+
+/// Run a service-manager command and answer whether it succeeded.
+///
+/// Success output is dropped — `launchctl` and `systemctl` are silent when
+/// they work — and failure output is surfaced (unless `Quiet::Yes`) because
+/// the manager's own message is the actionable half of any failure here.
+fn run_tool(argv: &[&str], quiet: Quiet) -> bool {
+    let Some((program, args)) = argv.split_first() else {
+        return false;
+    };
+    match std::process::Command::new(program).args(args).output() {
+        Ok(out) if out.status.success() => true,
+        Ok(out) => {
+            if quiet == Quiet::No {
+                let err = String::from_utf8_lossy(&out.stderr);
+                let err = err.trim();
+                if !err.is_empty() {
+                    eprintln!("  {}", err.dimmed());
+                }
+            }
+            false
+        }
+        Err(e) => {
+            if quiet == Quiet::No {
+                eprintln!("  {} {}", program, e.to_string().dimmed());
+            }
+            false
+        }
+    }
+}
+
+/// The real uid, for launchd's `gui/<uid>` domain target.
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: `getuid` cannot fail and touches no memory.
+    unsafe { libc::getuid() }
+}
+
+/// Non-unix never reaches a loader — [`ServiceManager::current`] errors
+/// first — but the un-`cfg`ed callers above must still compile.
+#[cfg(not(unix))]
+fn current_uid() -> u32 {
+    0
+}
+
+/// Refuse a registered command that would detach itself.
+///
+/// The service manager is the detacher here: a `--detach` child hands the
+/// work to a second process and exits at once, which the manager reads as
+/// "the service died" — and under `--keep-alive` respawns, forever, each
+/// respawn starting a fresh run. The module docs call this the one loop
+/// `install` must make unrepresentable.
+fn reject_detach(command: &[String]) -> Result<(), String> {
+    if command.iter().any(|arg| arg == "--detach") {
+        return Err(
+            "drop `--detach` from the registered command — the service manager already runs it \
+             detached, and a run that detaches again reads to the manager as an instant exit"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// A label the operator did not pass: the registered command's first word.
+fn derive_label(command: &[String]) -> Result<String, String> {
+    let first = command
+        .first()
+        .ok_or("nothing to register — give the stella invocation after `--`")?;
+    let label: String = first
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let label = label.trim_matches('-');
+    if label.is_empty() {
+        return Err(format!(
+            "cannot derive a service label from `{first}` — pass one with --label"
+        ));
+    }
+    Ok(label.chars().take(LABEL_MAX).collect())
+}
+
+/// A label becomes a file name, a launchd label, and a systemd unit name —
+/// this is the intersection all three accept without escaping.
+fn validate_label(label: &str) -> Result<(), String> {
+    let shaped = !label.is_empty()
+        && label.len() <= LABEL_MAX
+        && label
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !label.starts_with('-');
+    if shaped {
+        Ok(())
+    } else {
+        Err(format!(
+            "service label `{label}` must be 1–{LABEL_MAX} lowercase letters, digits or dashes"
+        ))
+    }
+}
+
+/// The `/bin/sh` shim both definitions exec through — the resolve-at-load
+/// answer to a binary that moves.
+///
+/// One line, because a systemd `ExecStart=` value is one line. The registered
+/// argv is *not* in here: it travels as positional parameters (`"$@"`), so
+/// this string needs no per-argument quoting and the arguments need no
+/// shell escaping at all.
+fn resolver_script(exe: &str, label: &str) -> String {
+    format!(
+        "bin=\"{exe}\"; \
+         if ! [ -x \"$bin\" ]; then \
+         bin=\"$(PATH=\"$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.cargo/bin:$HOME/.local/bin\" \
+         command -v stella || true)\"; fi; \
+         if [ -z \"$bin\" ]; then \
+         echo \"stella service {label}: no stella binary at {exe} or on PATH\" >&2; exit 127; fi; \
+         exec \"$bin\" \"$@\""
+    )
+}
+
+/// A path this module embeds inside the shim's double quotes and, on
+/// systemd, inside a single-quoted `ExecStart=` word.
+///
+/// Rejecting rather than escaping, because a path spelled with shell
+/// metacharacters has no single spelling that all three consumers (plist
+/// XML, POSIX sh, systemd's quoting layer) agree on — and refusing loudly at
+/// install time beats a definition that misfires at boot.
+fn embeddable_path(path: &Path) -> Result<String, String> {
+    let text = path.display().to_string();
+    if text
+        .chars()
+        .any(|c| matches!(c, '"' | '\'' | '$' | '`' | '\\' | '\n' | '\r'))
+    {
+        return Err(format!(
+            "cannot register a service from `{text}` — the path contains shell metacharacters \
+             (quotes, $, backslash or a newline); rename the offending component or run install \
+             from another path"
+        ));
+    }
+    Ok(text)
+}
+
+/// Escape for a plist `<string>` element.
+fn xml_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// The launchd agent definition.
+fn launchd_plist(spec: &ServiceSpec<'_>) -> Result<String, String> {
+    let ServiceSpec {
+        label,
+        exe,
+        args,
+        workdir,
+        log_path,
+        keep_alive,
+    } = *spec;
+    let script = resolver_script(&embeddable_path(exe)?, label);
+    let mut argv = String::new();
+    for arg in args {
+        argv.push_str(&format!("    <string>{}</string>\n", xml_escape(arg)));
+    }
+    let keep = if keep_alive {
+        format!(
+            "  <key>KeepAlive</key><true/>\n  <key>ThrottleInterval</key><integer>{RESTART_SECS}</integer>\n"
+        )
+    } else {
+        String::new()
+    };
+    let log = xml_escape(&log_path.display().to_string());
+    Ok(format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \x20 <key>Label</key><string>sh.oxagen.stella.{label}</string>\n\
+         \x20 <key>ProgramArguments</key>\n\
+         \x20 <array>\n\
+         \x20   <string>/bin/sh</string>\n\
+         \x20   <string>-c</string>\n\
+         \x20   <string>{script}</string>\n\
+         \x20   <string>stella-{label}</string>\n\
+         {argv}\
+         \x20 </array>\n\
+         \x20 <key>WorkingDirectory</key><string>{workdir}</string>\n\
+         \x20 <key>RunAtLoad</key><true/>\n\
+         {keep}\
+         \x20 <key>StandardOutPath</key><string>{log}</string>\n\
+         \x20 <key>StandardErrorPath</key><string>{log}</string>\n\
+         </dict>\n\
+         </plist>\n",
+        script = xml_escape(&script),
+        workdir = xml_escape(&embeddable_path(workdir)?),
+    ))
+}
+
+/// Escape a value for a non-`Exec` systemd directive: `%` specifiers expand
+/// everywhere in a unit file, and a newline would end the directive and
+/// start injecting new ones — which is why it is rejected upstream by
+/// [`embeddable_path`] and re-checked here for arguments.
+fn systemd_value(text: &str) -> Result<String, String> {
+    if text.contains('\n') || text.contains('\r') {
+        return Err("a service definition value cannot contain a newline".to_string());
+    }
+    Ok(text.replace('%', "%%"))
+}
+
+/// Quote one `ExecStart=` word: systemd's double-quote grammar (backslash
+/// escapes), plus the line-level `$` and `%` expansions that apply inside
+/// quotes too.
+fn systemd_word(arg: &str) -> Result<String, String> {
+    if arg.chars().any(|c| c.is_control()) {
+        return Err(format!(
+            "cannot register an argument containing control characters: {arg:?}"
+        ));
+    }
+    let escaped = arg
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "$$")
+        .replace('%', "%%");
+    Ok(format!("\"{escaped}\""))
+}
+
+/// The `systemd --user` unit definition.
+fn systemd_unit(spec: &ServiceSpec<'_>) -> Result<String, String> {
+    let ServiceSpec {
+        label,
+        exe,
+        args,
+        workdir,
+        log_path,
+        keep_alive,
+    } = *spec;
+    let script = resolver_script(&embeddable_path(exe)?, label);
+    // The shim reaches sh verbatim: `$` and `%` are line-level expansions in
+    // `ExecStart=`, applying inside the single quotes as well.
+    let script = script.replace('$', "$$").replace('%', "%%");
+    let mut exec = format!("/bin/sh -c '{script}' stella-{label}");
+    for arg in args {
+        exec.push(' ');
+        exec.push_str(&systemd_word(arg)?);
+    }
+    let start_limit = if keep_alive {
+        format!(
+            "StartLimitIntervalSec={START_LIMIT_WINDOW_SECS}\nStartLimitBurst={START_LIMIT_BURST}\n"
+        )
+    } else {
+        String::new()
+    };
+    let restart = if keep_alive {
+        format!("Restart=always\nRestartSec={RESTART_SECS}\n")
+    } else {
+        String::new()
+    };
+    let log = systemd_value(&log_path.display().to_string())?;
+    Ok(format!(
+        "# Written by `stella daemon install`; `stella daemon uninstall {label}` removes it.\n\
+         [Unit]\n\
+         Description=stella service {label}\n\
+         {start_limit}\
+         \n\
+         [Service]\n\
+         Type=exec\n\
+         WorkingDirectory={workdir}\n\
+         ExecStart={exec}\n\
+         StandardOutput=append:{log}\n\
+         StandardError=append:{log}\n\
+         {restart}\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        workdir = systemd_value(&embeddable_path(workdir)?)?,
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/daemon/service/tests.rs
+++ b/crates/stella-cli/src/daemon/service/tests.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Witness tests for #1587: what the installer writes, what the uninstaller
+//! removes, and the two definition grammars byte-for-byte.
+//!
+//! Everything here drives the pure planning half over injected paths — no
+//! service manager, no home directory, no environment. The `launchctl` /
+//! `systemctl` calls themselves are environment-dependent and are exercised
+//! manually (see the PR for the transcript); these tests pin everything those
+//! calls are handed.
+
+use std::path::Path;
+
+use super::*;
+
+fn args(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+fn spec<'a>(argv: &'a [String], keep_alive: bool) -> ServiceSpec<'a> {
+    ServiceSpec {
+        label: "monitor",
+        exe: Path::new("/opt/homebrew/bin/stella"),
+        args: argv,
+        workdir: Path::new("/Users/dev/proj"),
+        log_path: Path::new("/Users/dev/.stella/services/monitor.log"),
+        keep_alive,
+    }
+}
+
+#[test]
+fn the_default_definition_starts_at_load_and_never_restarts() {
+    let argv = args(&["monitor", "--interval", "300"]);
+    let plist = launchd_plist(&spec(&argv, false)).unwrap();
+    assert!(plist.contains("<key>RunAtLoad</key><true/>"), "{plist}");
+    assert!(
+        !plist.contains("KeepAlive"),
+        "restart-on-exit must be opt-in — an agent that fails instantly under \
+         KeepAlive is a spend loop: {plist}"
+    );
+    let unit = systemd_unit(&spec(&argv, false)).unwrap();
+    assert!(unit.contains("WantedBy=default.target"), "{unit}");
+    assert!(
+        !unit.contains("Restart="),
+        "same spend-loop rule on systemd: {unit}"
+    );
+    assert!(
+        !unit.contains("StartLimit"),
+        "a start limit without a restart policy is dead configuration: {unit}"
+    );
+}
+
+#[test]
+fn keep_alive_is_opt_in_throttled_and_start_limited() {
+    let argv = args(&["monitor"]);
+    let plist = launchd_plist(&spec(&argv, true)).unwrap();
+    assert!(plist.contains("<key>KeepAlive</key><true/>"), "{plist}");
+    assert!(
+        plist.contains("<key>ThrottleInterval</key><integer>60</integer>"),
+        "launchd's default 10s throttle restarts a failing agent six times a minute: {plist}"
+    );
+    let unit = systemd_unit(&spec(&argv, true)).unwrap();
+    assert!(unit.contains("Restart=always\nRestartSec=60"), "{unit}");
+    assert!(
+        unit.contains("StartLimitIntervalSec=600") && unit.contains("StartLimitBurst=5"),
+        "systemd has the brake launchd lacks — use it: {unit}"
+    );
+}
+
+#[test]
+fn the_shim_resolves_the_binary_at_load_and_fails_loudly() {
+    let script = resolver_script("/opt/homebrew/bin/stella", "monitor");
+    assert!(
+        script.contains("bin=\"/opt/homebrew/bin/stella\""),
+        "the recorded path is the first candidate: {script}"
+    );
+    assert!(
+        script.contains("command -v stella"),
+        "a moved binary (brew upgrade) falls back to PATH: {script}"
+    );
+    assert!(
+        script.contains("exit 127") && script.contains(">&2"),
+        "a missing binary must say so in the service log, not vanish: {script}"
+    );
+    assert!(
+        script.contains("exec \"$bin\" \"$@\""),
+        "the registered argv travels as positional parameters, never spliced \
+         into the script: {script}"
+    );
+    assert!(!script.contains('\n'), "a systemd ExecStart= is one line");
+}
+
+#[test]
+fn the_plist_escapes_xml_and_carries_each_argument_verbatim() {
+    let argv = args(&["run", "fix <the> & queue"]);
+    let plist = launchd_plist(&spec(&argv, false)).unwrap();
+    assert!(
+        plist.contains("<string>fix &lt;the&gt; &amp; queue</string>"),
+        "{plist}"
+    );
+    assert!(plist.contains("<string>run</string>"), "{plist}");
+    assert!(
+        plist.contains("<key>Label</key><string>sh.oxagen.stella.monitor</string>"),
+        "{plist}"
+    );
+    assert!(
+        plist.contains("<key>WorkingDirectory</key><string>/Users/dev/proj</string>"),
+        "the service runs where install was typed: {plist}"
+    );
+    assert!(
+        plist.contains(
+            "<key>StandardOutPath</key><string>/Users/dev/.stella/services/monitor.log</string>"
+        ) && plist.contains(
+            "<key>StandardErrorPath</key><string>/Users/dev/.stella/services/monitor.log</string>"
+        ),
+        "both streams land in the one documented console: {plist}"
+    );
+}
+
+#[test]
+fn the_exec_line_escapes_systemds_expansion_grammar() {
+    let argv = args(&["run", "reach 100% of $HOME \"fast\""]);
+    let unit = systemd_unit(&spec(&argv, false)).unwrap();
+    assert!(
+        unit.contains(r#""reach 100%% of $$HOME \"fast\"""#),
+        "`%` and `$` expand at line level even inside quotes: {unit}"
+    );
+    assert!(
+        unit.contains("$$PATH") && unit.contains("$$bin"),
+        "the shim's own variables must reach sh, not systemd: {unit}"
+    );
+    assert!(
+        unit.contains("' stella-monitor "),
+        "argv rides after the single-quoted shim as separate words: {unit}"
+    );
+}
+
+#[test]
+fn paths_with_shell_metacharacters_are_refused_at_install_time() {
+    let argv = args(&["monitor"]);
+    let mut bad = spec(&argv, false);
+    bad.workdir = Path::new("/Users/o'brien/proj");
+    let err = launchd_plist(&bad).unwrap_err();
+    assert!(
+        err.contains("metacharacters"),
+        "refusing loudly at install beats a definition that misfires at boot: {err}"
+    );
+    assert!(systemd_unit(&bad).is_err());
+    let mut bad_exe = spec(&argv, false);
+    bad_exe.exe = Path::new("/tmp/$evil/stella");
+    assert!(launchd_plist(&bad_exe).is_err());
+}
+
+#[test]
+fn a_control_character_cannot_reach_the_unit_file() {
+    let argv = args(&["run", "two\nlines"]);
+    let err = systemd_unit(&spec(&argv, false)).unwrap_err();
+    assert!(
+        err.contains("control characters"),
+        "a newline in an ExecStart word would end the directive and inject \
+         new ones: {err}"
+    );
+}
+
+#[test]
+fn a_registered_command_may_not_detach_itself() {
+    let err = reject_detach(&args(&["run", "--detach", "fix the queue"])).unwrap_err();
+    assert!(
+        err.contains("--detach"),
+        "the service manager is the detacher; a --detach child exits at once \
+         and --keep-alive would respawn it forever: {err}"
+    );
+    reject_detach(&args(&["run", "fix the queue"])).unwrap();
+}
+
+#[test]
+fn labels_are_the_intersection_of_three_grammars() {
+    validate_label("monitor-2").unwrap();
+    for bad in ["", "Nope", "a b", "-x", "a/b", "über"] {
+        assert!(validate_label(bad).is_err(), "{bad:?} must be rejected");
+    }
+    assert!(validate_label(&"x".repeat(LABEL_MAX + 1)).is_err());
+    assert_eq!(
+        ServiceManager::Launchd.file_name("monitor"),
+        "sh.oxagen.stella.monitor.plist"
+    );
+    assert_eq!(
+        ServiceManager::SystemdUser.file_name("monitor"),
+        "stella-monitor.service"
+    );
+}
+
+#[test]
+fn a_label_derives_from_the_commands_first_word() {
+    assert_eq!(derive_label(&args(&["monitor", "--x"])).unwrap(), "monitor");
+    assert_eq!(derive_label(&args(&["Run!"])).unwrap(), "run");
+    assert!(
+        derive_label(&[]).is_err(),
+        "nothing to register is an error, not an empty service"
+    );
+    assert!(derive_label(&args(&["---"])).is_err());
+}
+
+/// The #1587 witness: `install` writes exactly the planned definition where
+/// the manager reads, refuses to replace it, and `uninstall`'s removal takes
+/// it away again — with "already gone" reported as the distinct outcome it
+/// is.
+#[test]
+fn install_writes_once_and_uninstall_removes() {
+    let dir = tempfile::tempdir().unwrap();
+    let argv = args(&["monitor"]);
+    let plan = plan(ServiceManager::Launchd, &spec(&argv, false), dir.path()).unwrap();
+    assert_eq!(
+        plan.path,
+        dir.path().join("sh.oxagen.stella.monitor.plist"),
+        "the definition lands under the directory the manager reads"
+    );
+
+    write_definition(&plan).unwrap();
+    let written = std::fs::read_to_string(&plan.path).unwrap();
+    assert_eq!(written, plan.content, "written byte-for-byte as planned");
+
+    let err = write_definition(&plan).unwrap_err();
+    assert!(
+        err.contains("uninstall"),
+        "replacing a live definition silently would re-point a service the \
+         operator installed on purpose: {err}"
+    );
+
+    assert_eq!(
+        remove_definition(&plan.path).unwrap(),
+        RemoveOutcome::Removed
+    );
+    assert!(!plan.path.exists());
+    assert_eq!(
+        remove_definition(&plan.path).unwrap(),
+        RemoveOutcome::NothingInstalled,
+        "uninstalling twice is the requested state, not a failure"
+    );
+}

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -107,6 +107,51 @@ pub fn resolve_data_dir(data_dir: Option<OsString>, stella_home: Option<PathBuf>
     }
 }
 
+/// Where the user's `systemd --user` units live: `$XDG_CONFIG_HOME`, else
+/// `~/.config`, per the XDG base directory spec.
+pub const XDG_CONFIG_HOME_ENV: &str = "XDG_CONFIG_HOME";
+
+/// The per-user launchd agent directory on macOS: `~/Library/LaunchAgents`.
+///
+/// Not a stella path — launchd only reads this one location, so no stella
+/// override can move it — but it is anchored on the user home, and this crate
+/// is the one place that resolves the home (see the module docs on reading
+/// the environment). `None` when no home directory is discoverable, which the
+/// caller must treat as "cannot install", never as a fallback location.
+#[must_use]
+pub fn launch_agents_dir() -> Option<PathBuf> {
+    resolve_launch_agents_dir(home_dir())
+}
+
+/// [`launch_agents_dir`] over anchors the caller supplies.
+#[must_use]
+pub fn resolve_launch_agents_dir(home: Option<PathBuf>) -> Option<PathBuf> {
+    home.map(|home| home.join("Library").join("LaunchAgents"))
+}
+
+/// The per-user systemd unit directory on Linux:
+/// `$XDG_CONFIG_HOME/systemd/user`, else `~/.config/systemd/user`.
+///
+/// Same contract as [`launch_agents_dir`]: this is where `systemd --user`
+/// looks, stella overrides cannot move it, and `None` means "cannot install".
+#[must_use]
+pub fn systemd_user_unit_dir() -> Option<PathBuf> {
+    resolve_systemd_user_unit_dir(read(XDG_CONFIG_HOME_ENV), home_dir())
+}
+
+/// [`systemd_user_unit_dir`] over anchors the caller supplies.
+#[must_use]
+pub fn resolve_systemd_user_unit_dir(
+    xdg_config_home: Option<OsString>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let config = match xdg_config_home {
+        Some(dir) => PathBuf::from(dir),
+        None => home?.join(".config"),
+    };
+    Some(config.join("systemd").join("user"))
+}
+
 /// Whether any of [`OVERRIDE_ENV_VARS`] is set — i.e. whether resolution is
 /// pointing somewhere other than the `~/.stella` defaults.
 ///
@@ -214,6 +259,34 @@ mod tests {
             PathBuf::from("/home/dev/.stella"),
             "then ~/.stella"
         );
+    }
+
+    /// Witness for #1587: the service installer's paths come from these
+    /// resolvers, not from `HOME` reads scattered through the CLI.
+    #[test]
+    fn service_directories_anchor_on_the_home_the_caller_supplies() {
+        let home = Some(PathBuf::from("/home/dev"));
+        assert_eq!(
+            resolve_launch_agents_dir(home.clone()),
+            Some(PathBuf::from("/home/dev/Library/LaunchAgents")),
+            "launchd reads exactly one per-user location"
+        );
+        assert_eq!(
+            resolve_launch_agents_dir(None),
+            None,
+            "no home means cannot install, never a fallback location"
+        );
+        assert_eq!(
+            resolve_systemd_user_unit_dir(None, home.clone()),
+            Some(PathBuf::from("/home/dev/.config/systemd/user")),
+            "the XDG default is ~/.config"
+        );
+        assert_eq!(
+            resolve_systemd_user_unit_dir(os("/etc/xdg-alt"), home),
+            Some(PathBuf::from("/etc/xdg-alt/systemd/user")),
+            "XDG_CONFIG_HOME moves the config root"
+        );
+        assert_eq!(resolve_systemd_user_unit_dir(None, None), None);
     }
 
     #[test]

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -20,6 +20,8 @@ stella daemon list                          # every session, detached runs marke
 stella daemon attach <id|pid>               # stream its output (Ctrl-C detaches)
 stella daemon stop <id|pid>                 # SIGTERM, then SIGKILL after a grace period
 stella daemon logs <id|pid>                 # print the log file's path
+stella daemon install [--label NAME] [--keep-alive] -- <stella args…>
+stella daemon uninstall <label>             # unload it and delete the definition
 ```
 
 ## What it does
@@ -51,6 +53,69 @@ credential prompt — must be answerable headlessly or the run will fail rather
 than wait forever. A prompt piped on stdin is handed to the detached run as a
 process argument, which makes it visible in `ps` exactly as an inline
 `stella run "…"` prompt already is.
+
+A detached run also cannot outlive **a reboot** — nothing a process arranges
+for itself can — and on a machine configured to reap user processes at
+logout, nothing keeps it registered either. Crossing those boundaries is the
+OS service manager's job, and `install` is the explicit handshake with it.
+
+## `install` / `uninstall`
+
+`install` registers **one stella invocation you explicitly choose** with the
+platform's per-user service manager:
+
+```bash
+stella daemon install -- monitor --interval 300
+stella daemon install --label night-fleet --keep-alive -- fleet watch
+stella daemon uninstall night-fleet
+```
+
+On **macOS** it writes a launchd agent
+(`~/Library/LaunchAgents/sh.oxagen.stella.<label>.plist`) and loads it with
+`launchctl bootstrap`; the command starts at every login, including the login
+after a reboot. On **Linux** it writes a `systemd --user` unit
+(`~/.config/systemd/user/stella-<label>.service`), enables it, and turns on
+lingering (`loginctl enable-linger`) so the command starts at boot and keeps
+running through logout. When a `launchctl`/`systemctl` call fails, the
+definition is still written and the exact command to load it by hand is
+printed.
+
+**This is service registration, not resume.** The registered command starts
+from scratch each time, because re-launching a half-finished agent turn is a
+fresh spend of the same budget, not a continuation. Register standing verbs —
+a monitor, a fleet watch, a deliberately perpetual run — and let ordinary
+one-shot runs stay merely detached. Nothing is ever registered implicitly,
+and a registered command may not itself say `--detach`: the service manager
+is already the detacher, and a child that detaches again reads to the manager
+as an instant exit.
+
+Two defaults keep a broken service from spending money unattended:
+
+- **A command that exits stays down** until the next boot. `--keep-alive`
+  opts into restart-on-exit, throttled to once a minute, and on systemd
+  additionally start-limited (five starts in ten minutes parks the unit in
+  the failed state).
+- **The binary is resolved at load, loudly.** The service execs through a
+  `/bin/sh` shim that tries the path recorded at install time, falls back to
+  `PATH` (plus the usual Homebrew and cargo prefixes) — so a `brew upgrade`
+  that moves the binary does not strand the service — and otherwise writes
+  one line naming what is missing to the service console and exits 127.
+
+The service runs in the directory `install` was typed in, and its console is
+`~/.stella/services/<label>.log` (both streams, owner-only directory). The
+run announces itself in the session registry like any headless run, so it
+shows up in `stella daemon list`; the service itself is queried with the
+platform's own tools:
+
+```bash
+launchctl print gui/$(id -u)/sh.oxagen.stella.<label>   # macOS
+systemctl --user status stella-<label>                  # Linux
+```
+
+`uninstall` unloads the service and deletes the definition — the queries
+above then report it gone. Uninstalling something already removed reports
+that and succeeds. On Linux, lingering is left as you set it, since other
+user services may depend on it.
 
 ## Examples
 


### PR DESCRIPTION
## What

The second half of #1552's boundary story, as #1587 scopes it: a detached run (#1594) survives its terminal, but nothing a process arranges for itself survives a reboot — and a machine configured to reap user processes at logout unregisters it too. `stella daemon install` / `uninstall` are the explicit, reversible handshake with the layer that does survive those: a launchd agent on macOS, a `systemd --user` unit on Linux.

**Stacked on #1617** (the unbreak of main); the base branch is that PR's, so this diff shows only #1587's changes and retargets to main when it lands.

## The decision #1587 asked for, recorded

The issue explicitly asks to decide and document what the service *does*. Decision (recorded in the module doc and the docs page): **service registration, not resume**. The service starts one stella invocation the operator explicitly registered, in the directory `install` was typed in, at every login (launchd) / boot (systemd + linger). Re-launching a half-finished turn is a fresh spend of the same budget until #1586 (resume at a step boundary) exists, so nothing is ever registered implicitly.

Consequences, each pinned by a test:

- **No restart unless asked** — the default definition has no `KeepAlive`/`Restart=`; `--keep-alive` opts in, throttled to once a minute, and start-limited on systemd (5 starts / 10 min parks the unit failed). A failing agent under an unconditional restart policy is a spend loop with no human in it — the issue's hard constraint.
- **`--detach` in the registered command is refused** — the manager is the detacher; a re-detaching child reads as an instant exit that `--keep-alive` would respawn forever.
- **Binary resolved at load, loudly** — the service execs through a one-line `/bin/sh` shim: recorded path, then a PATH lookup widened with the Homebrew/cargo prefixes, else one line to the service log and exit 127. `brew upgrade` moving the binary cannot silently strand the service.
- **Paths with shell metacharacters are refused at install time** rather than mis-quoted across three grammars (plist XML, POSIX sh, systemd's `%`/`$`/quote expansion — the `ExecStart=` escaping is tested character-for-character).

Service-file paths ride new `stella-home` resolvers (`launch_agents_dir`, `resolve_launch_agents_dir`, `systemd_user_unit_dir`, `resolve_systemd_user_unit_dir`) with the crate's pure `resolve_*` split — no `HOME` reads in the CLI. The exemplar for the install/uninstall UX is `scripts/fullauto.sh::daemon_install`, including the fallback that prints the exact `launchctl bootstrap` line when the call fails.

## Witness

`crates/stella-cli/src/daemon/service/tests.rs` fails to compile on the base (the module does not exist) and pins: the file the installer writes lands byte-for-byte as planned where the manager reads, a second install refuses to overwrite, and the uninstaller's removal distinguishes `Removed` from `NothingInstalled` (both successes). The `launchctl`/`systemctl` calls themselves are environment-dependent: verified manually on this machine — transcript in a PR comment.

## Files

- `crates/stella-cli/src/daemon/service.rs` (+ `service/tests.rs`) — the verbs, planning pure over injected paths
- `crates/stella-cli/src/daemon.rs` — `Install`/`Uninstall` variants + dispatch
- `crates/stella-home/src/lib.rs` — the two service-directory resolvers + tests
- `website/content/docs/commands/daemon.mdx` — the reboot boundary + `install`/`uninstall` section

Closes #1587
Refs #1552, #1586, #1617

## Summary by Sourcery

Add stella daemon install/uninstall commands to register per-user services that survive logout and reboot via launchd/systemd, with explicit service definitions and uninstall behavior.

New Features:
- Introduce stella daemon install command to register a user-level stella invocation with launchd on macOS or systemd --user on Linux, optionally with restart-on-exit behavior.
- Introduce stella daemon uninstall command to unload and remove a previously registered service definition while handling already-removed services idempotently.

Enhancements:
- Add stella-home helpers to resolve per-user service directories for launchd agents and systemd user units without ad-hoc HOME reads.
- Document daemon install/uninstall behavior, reboot/logout semantics, and safety constraints in the daemon command documentation page.

Tests:
- Add unit tests covering service definition planning, label validation, shim behavior, escaping rules, and install/uninstall file lifecycle, independent of the actual service manager environment.