### PR TITLE
Unbreak main: #1603 merged red — four clippy errors plus a non-compiling merge-resolution hunk

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -213,7 +213,9 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Str
             );
             Ok(())
         }
-        TurnOutcome::Aborted { reason, cost_usd } => {
+        TurnOutcome::Aborted {
+            reason, cost_usd, ..
+        } => {
             tui::cost_summary(
                 cost_usd,
                 &format!("{}/{}", cfg.provider.id, cfg.model_id),
@@ -261,6 +263,9 @@ pub(crate) async fn drive_resumed_turn(
             engine.discard_checkpoint();
             return TurnOutcome::Aborted {
                 reason,
+                // The engine's own cap exit calls this a policy stop, and a
+                // resumed turn must exit exactly as a fresh one would.
+                kind: stella_core::step::AbortKind::DeliberateStop,
                 cost_usd: state.total_cost_usd(),
             };
         }
@@ -270,9 +275,17 @@ pub(crate) async fn drive_resumed_turn(
                 engine.discard_checkpoint();
                 return TurnOutcome::Completed { text, cost_usd };
             }
-            StepOutcome::Aborted { reason, cost_usd } => {
+            StepOutcome::Aborted {
+                reason,
+                kind,
+                cost_usd,
+            } => {
                 engine.discard_checkpoint();
-                return TurnOutcome::Aborted { reason, cost_usd };
+                return TurnOutcome::Aborted {
+                    reason,
+                    kind,
+                    cost_usd,
+                };
             }
         }
     }
@@ -399,6 +412,7 @@ mod tests {
             total_cost_usd: 0.0,
             calibration_model: None,
             loop_steered: false,
+            loop_steered_pattern: Vec::new(),
             transcript_rewrites: 0,
         }
     }

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -432,25 +432,29 @@ mod tests {
         };
         assert_eq!(text, "resumed answer");
 
-        let requests = provider.requests.lock().unwrap();
-        assert_eq!(
-            requests.len(),
-            1,
-            "resuming after step 0 makes exactly one further call — re-running \
-             the completed step would make two"
-        );
-        let transcript = &requests[0];
-        assert!(
-            transcript.iter().any(|m| m
-                .tool_results
-                .iter()
-                .any(|r| matches!(&r.output, ToolOutput::Ok { content } if content == "the file's contents"))),
-            "the completed step's tool result must arrive as transcript, not be re-executed"
-        );
-        assert_eq!(
-            transcript[0].content, "the original system prompt",
-            "mid-turn fidelity: the checkpointed system prompt rides verbatim"
-        );
+        // Scoped so the guard drops before the `rx.recv().await` below — a
+        // std MutexGuard must never be held across an await point.
+        {
+            let requests = provider.requests.lock().unwrap();
+            assert_eq!(
+                requests.len(),
+                1,
+                "resuming after step 0 makes exactly one further call — re-running \
+                 the completed step would make two"
+            );
+            let transcript = &requests[0];
+            assert!(
+                transcript.iter().any(|m| m
+                    .tool_results
+                    .iter()
+                    .any(|r| matches!(&r.output, ToolOutput::Ok { content } if content == "the file's contents"))),
+                "the completed step's tool result must arrive as transcript, not be re-executed"
+            );
+            assert_eq!(
+                transcript[0].content, "the original system prompt",
+                "mid-turn fidelity: the checkpointed system prompt rides verbatim"
+            );
+        }
 
         // A finished resume discards its checkpoint — leaving it would offer
         // to resume a turn everyone watched complete.

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -253,11 +253,11 @@ impl Index {
         let total_of = |records: &[IndexRecord], stream: Stream| {
             records
                 .iter()
-                .filter_map(|r| match r {
+                .rev()
+                .find_map(|r| match r {
                     IndexRecord::Write { s, c, n, .. } if *s == stream => Some(c + n),
                     _ => None,
                 })
-                .last()
                 .unwrap_or(0)
         };
         let out_total = total_of(&self.entries, Stream::Stdout);

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -955,23 +955,27 @@ pub(crate) fn replay_logs(
         }
     }
 
-    // `-n`: each stream keeps its newest `lines` lines, order preserved.
+    // `-n`: each stream keeps its newest `lines` lines. The skips are
+    // computed per stream but the emission is ONE pass over `ordered` — a
+    // per-stream emission loop would print all of stdout and then all of
+    // stderr, un-interleaving exactly the order this whole function exists
+    // to reconstruct (the witness test caught that emission shape).
+    let mut skips: std::collections::HashMap<Stream, usize> = std::collections::HashMap::new();
     for stream in [Stream::Stdout, Stream::Stderr] {
         let total_lines: usize = ordered
             .iter()
             .filter(|(s, _)| *s == stream)
             .map(|(_, b)| bytecount_lines(b))
             .sum();
-        let mut skip = total_lines.saturating_sub(lines);
-        for (s, bytes) in &ordered {
-            if *s != stream {
-                continue;
-            }
-            let sink: &mut dyn Write = match stream {
-                Stream::Stdout => out,
-                Stream::Stderr => err,
-            };
-            emit_after_skipping(bytes, &mut skip, sink);
+        skips.insert(stream, total_lines.saturating_sub(lines));
+    }
+    for (s, bytes) in &ordered {
+        let sink: &mut dyn Write = match s {
+            Stream::Stdout => out,
+            Stream::Stderr => err,
+        };
+        if let Some(skip) = skips.get_mut(s) {
+            emit_after_skipping(bytes, skip, sink);
         }
     }
     let _ = out.flush();

--- a/crates/stella-cli/src/daemon/console/tests.rs
+++ b/crates/stella-cli/src/daemon/console/tests.rs
@@ -119,7 +119,8 @@ fn an_overflowing_console_keeps_its_head_and_tail_within_the_cap() {
         "the head must survive an overflow: {:?}",
         &out[..16.min(out.len())]
     );
-    let expected_last: u8 = b'A' + 4 + (39 % 3);
+    // The generator's last byte: i=4, j=39, and 39 % 3 == 0.
+    let expected_last: u8 = b'A' + 4;
     assert_eq!(
         out.last().copied(),
         Some(expected_last),
@@ -131,11 +132,14 @@ fn an_overflowing_console_keeps_its_head_and_tail_within_the_cap() {
     );
 }
 
+/// What the recorder accumulates: each contiguous burst, tagged by stream.
+type RecordedBursts = Arc<Mutex<Vec<(Stream, Vec<u8>)>>>;
+
 /// Two sinks that share one recorder, so a test can observe the ORDER writes
 /// reached the pair — the thing `daemon logs` could never reconstruct before
 /// the index existed.
 #[derive(Clone, Default)]
-struct Recorder(Arc<Mutex<Vec<(Stream, Vec<u8>)>>>);
+struct Recorder(RecordedBursts);
 
 struct RecorderSink(Recorder, Stream);
 

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -235,8 +235,10 @@ fn stopping_ends_the_whole_group_and_records_it_as_deliberate() {
     // race, which is a fact about reap latency, not about `stop`.
     assert!(
         eventually(Duration::from_secs(10), || {
-            // SAFETY: probing a group with signal 0 sends nothing.
-            unsafe { libc::kill(-group, 0) } != 0
+            // SAFETY: probing a group with signal 0 sends nothing. The
+            // parentheses are load-bearing: a bare `unsafe { … }` opening a
+            // statement ends the statement at the block, orphaning the `!=`.
+            (unsafe { libc::kill(-group, 0) }) != 0
         }),
         "the whole process group must be gone"
     );

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -778,7 +778,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
         Some(Command::Fullauto { cmd }) => {
             // Reads and writes ~/.stella/fullauto/<slug>/ (plus `gh` reads
             // of the defect queue) — works with zero API keys.
-            return fullauto_cmd::run(cmd);
+            return fullauto_cmd::run(cmd).map_err(failure::CliFailure::from);
         }
         Some(Command::Memory { cmd }) => {
             // Reads local stores only (list) / writes one rule file
@@ -903,7 +903,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 // provider resolution, its cwd already pinned to the
                 // record's workspace by the parent's launch.
                 DaemonCmd::Resume { id } if !cli.globals.foreground => {
-                    return daemon::resume_supervised(rt()?, id.as_deref());
+                    return daemon::resume_supervised(rt()?, id.as_deref())
+                        .map_err(failure::CliFailure::from);
                 }
                 DaemonCmd::Resume { .. } => {}
                 _ => return daemon::run(cmd).map_err(failure::CliFailure::from),
@@ -999,7 +1000,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &prompt),
                     prompt.as_bytes(),
-                    scope_review_lost,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1050,7 +1050,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &goal),
                     goal.as_bytes(),
-                    scope_review_lost,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1080,7 +1079,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                         },
                     ),
                     &[],
-                    scope_review_lost,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1107,7 +1105,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &format!("monitor {target}")),
                     &[],
-                    scope_review_lost,
                 ).map_err(failure::CliFailure::from);
             }
             // Monitoring IS a goal: the verifier (who can call ci_status


### PR DESCRIPTION
PR #1603 was merged while its `fmt + clippy + test` job was red (the MSRV check had just gone green; the clippy pass had not). Main now fails `cargo clippy -D warnings` with four errors, all inside #1603's new files:

- `daemon/console.rs`: `Iterator::last` on a `DoubleEndedIterator` → `rev().find_map`
- `agent/resume.rs` (test): a std `MutexGuard` held across an `await` → scoped before the recv
- `daemon/console/tests.rs`: `identity_op` (`+ (39 % 3)`) → constant folded with the derivation in a comment
- `daemon/console/tests.rs`: `type_complexity` → a `RecordedBursts` alias

Mechanical fixes only, no behaviour change; each matches the lint's own suggestion.

Refs #1603, #1585, #1586, #1588

## Summary by Sourcery

Fix clippy warning regressions introduced in recent changes so main builds cleanly with `cargo clippy -D warnings`.

Bug Fixes:
- Avoid holding a std MutexGuard across an await point in the resume agent test by scoping the lock more narrowly.
- Adjust console index aggregation to use a clippy-compliant pattern when retrieving the last matching write record.
- Simplify console test expectations by constant-folding the generator’s last-byte expression and introducing a type alias to reduce type complexity.

**Second breakage found while fixing the first:** a `Merge branch main` commit pushed to #1603 after its last CI run hand-resolved `daemon/tests.rs` into a form that never compiled — `unsafe { libc::kill(-group, 0) } != 0` at statement position ends the statement at the block and orphans the `!=`. Parenthesized (`(unsafe { … }) != 0`), keeping the eventually-based flake hardening that hunk was adding.


**Round 3 additions (main kept drifting under the fix):** the same late merge also left `main.rs` calling `supervise_this_invocation` with a `scope_review_lost` argument whose binding it had deleted (4 sites), and left #1619's fullauto arm returning `Result<(), String>` where the `CliFailure` migration expects mapping; #1620 added `AbortKind` to the Aborted outcomes and `loop_steered_pattern` to `Checkpoint`, which the resume driver and its test now carry. Rebased onto current main.


**Division of labour with #1628:** round 3 got the tree compiling; of the three remaining test failures, one was this PR's own (`logs` replay's `-n` trim pass un-interleaved the streams — fixed, the witness test caught it) and the other two (`fullauto state|queue --json` idiom, `fullauto_cmd/state.rs` HOME read) belong to #1619 and are fixed by the open #1628. Merging both PRs is what returns main to green; neither alone can.
