### PR TITLE
fix(stella-cli): align agent/resume.rs with #1620's typed abort outcomes — the unowned third of #1634

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -213,7 +213,12 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Str
             );
             Ok(())
         }
-        TurnOutcome::Aborted { reason, cost_usd } => {
+        // `kind` stops here: `run_resume` answers with a `String`, so the
+        // deliberate-stop/failure split cannot reach the exit code on this
+        // path until the resume surface is retyped over `CliFailure` (#1637).
+        TurnOutcome::Aborted {
+            reason, cost_usd, ..
+        } => {
             tui::cost_summary(
                 cost_usd,
                 &format!("{}/{}", cfg.provider.id, cfg.model_id),
@@ -261,6 +266,9 @@ pub(crate) async fn drive_resumed_turn(
             engine.discard_checkpoint();
             return TurnOutcome::Aborted {
                 reason,
+                // The engine's own escalation, same as the in-turn cap: the
+                // run stopped by policy, it did not fall over (#1524).
+                kind: stella_core::AbortKind::DeliberateStop,
                 cost_usd: state.total_cost_usd(),
             };
         }
@@ -270,9 +278,17 @@ pub(crate) async fn drive_resumed_turn(
                 engine.discard_checkpoint();
                 return TurnOutcome::Completed { text, cost_usd };
             }
-            StepOutcome::Aborted { reason, cost_usd } => {
+            StepOutcome::Aborted {
+                reason,
+                kind,
+                cost_usd,
+            } => {
                 engine.discard_checkpoint();
-                return TurnOutcome::Aborted { reason, cost_usd };
+                return TurnOutcome::Aborted {
+                    reason,
+                    kind,
+                    cost_usd,
+                };
             }
         }
     }
@@ -399,6 +415,7 @@ mod tests {
             total_cost_usd: 0.0,
             calibration_model: None,
             loop_steered: false,
+            loop_steered_pattern: Vec::new(),
             transcript_rewrites: 0,
         }
     }

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -778,7 +778,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
         Some(Command::Fullauto { cmd }) => {
             // Reads and writes ~/.stella/fullauto/<slug>/ (plus `gh` reads
             // of the defect queue) — works with zero API keys.
-            return fullauto_cmd::run(cmd);
+            return fullauto_cmd::run(cmd).map_err(failure::CliFailure::from);
         }
         Some(Command::Memory { cmd }) => {
             // Reads local stores only (list) / writes one rule file
@@ -903,7 +903,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 // provider resolution, its cwd already pinned to the
                 // record's workspace by the parent's launch.
                 DaemonCmd::Resume { id } if !cli.globals.foreground => {
-                    return daemon::resume_supervised(rt()?, id.as_deref());
+                    return daemon::resume_supervised(rt()?, id.as_deref())
+                        .map_err(failure::CliFailure::from);
                 }
                 DaemonCmd::Resume { .. } => {}
                 _ => return daemon::run(cmd).map_err(failure::CliFailure::from),


### PR DESCRIPTION
## What

The slices of #1634 no other repair PR covers. Two commits:

1. **`agent/resume.rs` vs #1620** — `kind: AbortKind` added to `TurnOutcome`/`StepOutcome` and `loop_steered_pattern` to `Checkpoint` after #1603's resume surface was authored (E0027 ×2, E0063 ×3). `drive_resumed_turn` forwards a step abort's `kind` verbatim and stamps its own step-cap abort `DeliberateStop` (the engine's policy stop, #1524); the String-typed terminal match documents where `kind` dies — retyping over `CliFailure` so a resumed deliberate stop exits 3 is #1637, deliberately not smuggled into an unbreak.
2. **Two String-typed returns in `main.rs`** that `run()`'s `CliFailure` signature rejects and no open PR owned: `fullauto_cmd::run` (#1619) and `daemon::resume_supervised` (#1603), both taking the `map_err(CliFailure::from)` the neighboring call sites already use.

## State after this PR

Measured against main a8fb5ca7 (post-#1632/#1623): with this branch, the only remaining compile failures are the daemon.rs cluster from #1632's pre-#1603 base merging over #1603's module — itemized with a repair handoff in the round-five comment on #1634.

Refs #1634
Refs #1620, #1623, #1628, #1632, #1637