### PR TITLE
Unbreak main: restore the three items #1632's daemon.rs rewrite deleted, plus a Linux-only cast

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -683,16 +683,6 @@ impl Tail {
         Ok(Self { file, offset: 0 })
     }
 
-    /// Skip whatever is already there — for a reader that only wants what
-    /// happens from now on.
-    fn seek_to_end(&mut self) -> Result<(), String> {
-        self.offset = self
-            .file
-            .seek(SeekFrom::End(0))
-            .map_err(|e| format!("cannot seek the console: {e}"))?;
-        Ok(())
-    }
-
     /// Start `lines` lines back from the end, or at the beginning if the file
     /// is shorter than that.
     ///

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -358,8 +358,45 @@ pub(crate) fn spawn(
     args: &[std::ffi::OsString],
     stdin: &[u8],
 ) -> Result<Supervised, String> {
+    // Minted before the spawn so the child can be told its own id, and so a
+    // failed spawn leaves a directory rather than a half-registered session.
     let mut record = SessionRecord::new(workspace, title);
     record.summary = title.to_string();
+    launch(registry, record, program, args, stdin, Console::Fresh, None)
+}
+
+/// How a launched child's console files begin life.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Console {
+    /// A fresh run: truncate whatever a previous life left behind.
+    Fresh,
+    /// A resumed run (#1586): append, keeping the killed attempt's output —
+    /// that tail is the context a human reads to understand why there was
+    /// something to resume, and `attach --from-start` should show one
+    /// continuous story.
+    Preserve,
+}
+
+/// The mechanical half of [`spawn`], over a caller-supplied record: detach,
+/// take the liveness lock, wire the console, register. A fresh spawn mints
+/// its record; a resume ([`resume_supervised`]) re-launches under the record
+/// — and therefore the session id — it already has, because the checkpoint,
+/// the sidecar, and the registry row are all keyed by that id and a new one
+/// would strand every piece of state this exists to pick back up.
+///
+/// `cwd` pins the child's working directory. A fresh spawn inherits this
+/// process's (the child re-parses the same argv, and relative paths in it
+/// must keep meaning what the user meant); a resume sets the record's
+/// workspace, because the resuming parent may be run from anywhere.
+fn launch(
+    registry: &SessionRegistry,
+    mut record: SessionRecord,
+    program: &Path,
+    args: &[std::ffi::OsString],
+    stdin: &[u8],
+    console: Console,
+    cwd: Option<&Path>,
+) -> Result<Supervised, String> {
     let sidecar = registry
         .prepare_sidecar(&record.id)
         .map_err(|e| format!("cannot create the session directory: {e}"))?;
@@ -646,6 +683,16 @@ impl Tail {
         Ok(Self { file, offset: 0 })
     }
 
+    /// Skip whatever is already there — for a reader that only wants what
+    /// happens from now on.
+    fn seek_to_end(&mut self) -> Result<(), String> {
+        self.offset = self
+            .file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("cannot seek the console: {e}"))?;
+        Ok(())
+    }
+
     /// Start `lines` lines back from the end, or at the beginning if the file
     /// is shorter than that.
     ///
@@ -874,15 +921,22 @@ fn inherited_lock_fd(lock_path: &Path) -> Option<i32> {
 
     let lock = std::fs::metadata(lock_path).ok()?;
     for fd in 3..LOCK_FD_SCAN_LIMIT {
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: `fstat` writes only into `stat`, and reports EBADF for a
-        // descriptor that is not open rather than doing anything with it.
-        if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+        // The identity is read through `MetadataExt`, not a raw `libc::stat`,
+        // because `dev_t` is unsigned on Linux and signed on macOS: no single
+        // conversion of `st_dev` compiles on both, while `dev()`/`ino()` are
+        // declared `u64` on every Unix.
+        //
+        // SAFETY: the descriptor is borrowed, never owned — `ManuallyDrop`
+        // keeps `File`'s destructor from closing an fd this only looks at.
+        // `metadata` is an `fstat`, which reports EBADF for a descriptor that
+        // is not open rather than doing anything with it.
+        let probe = std::mem::ManuallyDrop::new(unsafe {
+            <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(fd)
+        });
+        let Ok(stat) = probe.metadata() else {
             continue;
-        }
-        // SAFETY: `fstat` returned success, so it initialized the struct.
-        let stat = unsafe { stat.assume_init() };
-        if u64::from(stat.st_dev.cast_unsigned()) == lock.dev() && stat.st_ino == lock.ino() {
+        };
+        if stat.dev() == lock.dev() && stat.ino() == lock.ino() {
             return Some(fd);
         }
     }
@@ -964,11 +1018,11 @@ pub(crate) fn resume_supervised(
     let checkpoint = resume_point(&record)?;
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot locate the stella binary to resume with: {e}"))?;
-    let args = vec![
-        "daemon".to_string(),
-        "resume".to_string(),
-        record.id.clone(),
-        "--foreground".to_string(),
+    let args: Vec<std::ffi::OsString> = vec![
+        "daemon".into(),
+        "resume".into(),
+        record.id.clone().into(),
+        "--foreground".into(),
     ];
     let id = record.id.clone();
     let run = launch(
@@ -1166,7 +1220,18 @@ fn list(registry: &SessionRegistry) -> Result<(), String> {
         let (label, paint): (&str, fn(&str) -> ColoredString) = match (live, run.status) {
             (true, status) if status.is_live() => (status.label(), |s| s.green()),
             (true, _) => ("Running", |s| s.green()),
-            (false, status) if status.is_live() => ("Crashed", |s| s.red()),
+            // Probed only on this rare arm: a crashed run holding a resume
+            // point is exactly the row `daemon resume` exists for (#1586),
+            // and a killed run's journal already exists, so the probe opens
+            // rather than creates.
+            (false, status) if status.is_live() => {
+                if has_resume_point(&run) {
+                    any_resumable = true;
+                    ("Crashed ↩", |s| s.red())
+                } else {
+                    ("Crashed", |s| s.red())
+                }
+            }
             (false, status) => (status.label(), |s| s.normal()),
         };
         // Padded before it is painted. A width applied to a `ColoredString`
@@ -1217,9 +1282,10 @@ fn attach(registry: &SessionRegistry, id: Option<&str>) -> Result<(), String> {
         approval::forward_pending_approval(&sidecar, interactive, &mut approval_noted);
         if lock_is_held(&sidecar) != Some(true) {
             // Same ordering as `follow`: drain after observing the end, so the
-            // last thing the run wrote is never the thing attach misses.
-            out.drain(&mut std::io::stdout())?;
-            err.drain(&mut std::io::stderr())?;
+            // last thing the run wrote is never the thing attach misses. One
+            // `Follower::pump` is bounded, so "everything that is left" is the
+            // loop rather than the single call.
+            while console.pump(&mut std::io::stdout(), &mut std::io::stderr())? > 0 {}
             eprintln!("{} {} has finished", "▸".dimmed(), record.id.dimmed());
             return Ok(());
         }

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -679,32 +679,11 @@ impl Follower {
         Ok(moved)
     }
 
-    /// Skip everything already written — for a reader that only wants what
-    /// happens from now on (the interrupt drain).
-    pub(crate) fn skip_to_now(&mut self) -> Result<(), String> {
-        for record in self.new_records()? {
-            match record {
-                IndexRecord::Geometry { s, g } => self.stream_mut(s).adopt(g),
-                IndexRecord::Write { s, c, n, .. } => {
-                    let stream = self.stream_mut(s);
-                    stream.consumed = stream.consumed.max(c + n);
-                }
-                IndexRecord::Closed { s, total } => {
-                    let stream = self.stream_mut(s);
-                    stream.closed_at = Some(total);
-                    stream.consumed = stream.consumed.max(total);
-                }
-            }
-        }
-        for stream in [Stream::Stdout, Stream::Stderr] {
-            let followed = self.stream_mut(stream);
-            match followed.geometry {
-                Some(geometry) => followed.tail.offset = geometry.file_offset(followed.consumed),
-                None => followed.tail.seek_to_end()?,
-            }
-        }
-        Ok(())
-    }
+    // There is deliberately no `skip_to_now` here. `interrupt_and_drain` was
+    // its only caller, and #1632 removed that call as a defect: seeking past
+    // everything already written threw away the run's shutdown output, which
+    // on the Ctrl-C path is precisely what the person who pressed the key is
+    // waiting to read.
 
     fn stream_mut(&mut self, stream: Stream) -> &mut FollowedStream {
         match stream {

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -248,20 +248,10 @@ fn stopping_ends_the_whole_group_and_records_it_as_deliberate() {
         Some(false),
         "the run must actually be over"
     );
-    // "Gone" is eventually-true, not instantly-true: the TERM'd `sleep` was
-    // orphaned when `sh` died, so it lingers as a zombie until PID 1 reaps
-    // it — and a zombie still answers a group probe. launchd reaps before
-    // the next statement on a laptop; a CI container's init can lose that
-    // race, which is a fact about reap latency, not about `stop`.
-    assert!(
-        eventually(Duration::from_secs(10), || {
-            // SAFETY: probing a group with signal 0 sends nothing. The
-            // parentheses are load-bearing: a bare `unsafe { … }` opening a
-            // statement ends the statement at the block, orphaning the `!=`.
-            (unsafe { libc::kill(-group, 0) }) != 0
-        }),
-        "the whole process group must be gone"
-    );
+    // No `kill(-pgid, 0)` probe beside it: the doc comment above explains why
+    // the lock is the assertion and the group probe was retired (#1609). A
+    // zombie is still a group member, so the probe reports a group of one dead
+    // process as alive — deterministically, on Actions.
 
     // Reap our own child so the test leaves no zombie of its own behind.
     let _ = run.child.wait();
@@ -520,7 +510,10 @@ fn a_resumed_launch_keeps_the_record_and_the_crashed_console() {
         &registry,
         record,
         Path::new("/bin/sh"),
-        &["-c".to_string(), "echo the resumed attempt".to_string()],
+        &[
+            std::ffi::OsString::from("-c"),
+            std::ffi::OsString::from("echo the resumed attempt"),
+        ],
         b"",
         Console::Preserve,
         None,

--- a/crates/stella-cli/src/fullauto_cmd/state.rs
+++ b/crates/stella-cli/src/fullauto_cmd/state.rs
@@ -337,10 +337,10 @@ impl LoopState {
             if let Some(c) = cycle {
                 doc.insert("cycle".into(), c.into());
             }
-            if let Some(t) = tier {
-                if !t.is_empty() {
-                    doc.insert("tier".into(), t.into());
-                }
+            if let Some(t) = tier
+                && !t.is_empty()
+            {
+                doc.insert("tier".into(), t.into());
             }
             doc.entry("started_at".to_string())
                 .or_insert_with(|| Value::String(now.clone()));

--- a/crates/stella-core/src/fullauto.rs
+++ b/crates/stella-core/src/fullauto.rs
@@ -156,7 +156,7 @@ pub fn calibrate(cal: &mut Calibration, outcome: CycleOutcome, limits: &AimdLimi
         CycleOutcome::Ok => {
             cal.clean_run += 1;
             cal.batch_ceiling = (cal.batch_ceiling + 2).min(limits.batch_max);
-            if cal.clean_run % 3 == 0 {
+            if cal.clean_run.is_multiple_of(3) {
                 cal.parallel_ceiling = (cal.parallel_ceiling + 1).min(limits.parallel_max);
             }
             cal.note = format!("clean run {}", cal.clean_run);

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -360,7 +360,7 @@ impl TurnState {
             calibration_model: checkpoint.calibration_model,
             loop_steered: checkpoint
                 .loop_steered
-                .then(|| checkpoint.loop_steered_pattern),
+                .then_some(checkpoint.loop_steered_pattern),
             transcript_rewrites: checkpoint.transcript_rewrites,
             step: checkpoint.step,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),


### PR DESCRIPTION
## What & why

`main` has not compiled since 2017d547. **#1632 and #1623 were both merged
red** — each had `fmt + clippy + test` and `cargo check on the declared MSRV`
failing at merge time. #1623 fixed the four errors it named in its title; this
PR is the rest.

The bulk of it is one root cause. **#1632 rewrote `daemon.rs` and inlined
`launch` into `spawn`, but left `launch`'s parameters referenced in the body
and deleted three items whose call sites all survived:**

| Deleted by #1632 | Still called by |
|---|---|
| `enum Console` | `create_console`'s signature, `resume_supervised`, `daemon/tests.rs` |
| `fn launch` | `resume_supervised`, and its own witness test |
| `Tail::seek_to_end` | `console::Follower::skip_to_now` |

`launch` is restored as the mechanical half of `spawn`, keeping **every**
#1632 improvement: register-before-spawn, `abandon` on a failed spawn, the
`Tail` pair, `STELLA_FOREGROUND`, and `OsString` argv.

### The Linux-only one

`inherited_lock_fd` (new in #1632) never compiled on Linux at all:

```rust
u64::from(stat.st_dev.cast_unsigned())
```

`dev_t` is **unsigned on Linux and signed on macOS**, and `cast_unsigned()`
exists only on signed integers — so this builds on the author's Mac and fails
on every CI runner. It now reads identity through `MetadataExt`, whose
`dev()`/`ino()` are declared `u64` on every Unix, which removes the platform
difference rather than papering over it (and drops a `MaybeUninit` +
`libc::fstat` dance for one borrowed-fd `metadata()` call).

### Orphans that are hard errors under `-D warnings`

- `list`'s `any_resumable` was never assigned and `has_resume_point` was never
  called — the `↩` resume marker (#1586) is wired back up.
- `attach` drained through a `Tail` pair that #1623 had already replaced with a
  `Follower`; it now loops the bounded pump.
- `Follower::skip_to_now` + `Tail::seek_to_end` are **deleted**, not restored.
  `interrupt_and_drain` was the only caller and #1632 removed that call *as one
  of its four defect fixes* — seeking past everything already written discarded
  the run's shutdown output, which on the Ctrl-C path is exactly what the person
  who pressed the key is waiting to read. A comment sits where the method was so
  the next reader does not restore it.

### The stop test

`stopping_ends_the_whole_group_and_records_it_as_deliberate` asserted an empty
process group against an **undefined `group` binding**. Its own doc comment
(added by #1609) explains that the liveness lock *replaced* that probe: a zombie
is still a group member, so `kill(-pgid, 0)` reports a group of one dead process
as alive — deterministically, on Actions. The doc was updated in the merge and
the code was not. The assertion is removed, as its own documentation prescribes.

### Two `stella-core` clippy errors

`manual_is_multiple_of` in `fullauto.rs` and `unnecessary_lazy_evaluations` in
`step.rs`. These are what CI actually died on first — and because clippy aborted
in `stella-core`, it **never reached `stella-cli`**, hiding a `collapsible_if` in
`fullauto_cmd/state.rs` that is also fixed here.

Refs #1632, #1623, #1609, #1586

## The witness

- [x] No witness needed (pure unbreak — restoring deleted code and fixing lints) — because:
      the witness already exists and could not compile.
      `a_resumed_launch_keeps_the_record_and_the_crashed_console`
      (`crates/stella-cli/src/daemon/tests.rs`) is #1586's witness for `launch` +
      `Console::Preserve`; its doc literally reads *"On `main`, `launch` does not
      exist and every spawn mints a fresh record"*. Restoring `launch` is what
      lets that test build and run again.

## The gate

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p stella-core -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo check -p stella-cli --all-targets` — clean, zero warnings
- [ ] `cargo test --workspace` — see below
- [x] Docs updated where behavior changed — n/a, no flag or command surface moved

## Anything reviewers should know?

**Three older unbreak PRs are open and all predate this state**: #1628, #1638,
and #1639 are cut against `23d306a5`, which is two merges behind. #1639 in
particular also fixes the same two `stella-core` clippy errors, so it will
conflict here — this PR is against `a8fb5ca7` (current `main`) and covers the
`daemon.rs` breakage none of them can see, because that breakage arrived with
#1632 *after* they were branched.

The `cast_unsigned` fix is the one thing I cannot prove locally: it is a
Linux-only compile failure and this was developed on macOS. CI on this PR is the
verification for it.

## Summary by Sourcery

Restore deleted daemon process management pieces and fix cross-platform and clippy-induced build failures so main builds cleanly again.

Bug Fixes:
- Reintroduce the daemon launch machinery and console handling enum used by spawn and resume paths to restore broken session supervision and resume behavior.
- Fix inherited lock file descriptor detection to use portable metadata-based dev/inode comparison instead of platform-specific stat casting that failed on Linux.
- Repair session listing to correctly detect and mark resumable crashed runs and wire the resume marker back up in the CLI output.
- Ensure attach fully drains remaining console output via a bounded pump loop so shutdown output is not skipped when a run finishes.
- Remove a flaky process group liveness assertion from the stopping test that contradicted its own documentation and caused nondeterministic failures.

Enhancements:
- Factor spawn into a reusable launch helper that works with both fresh and resumed sessions while preserving recent daemon behavior improvements.
- Replace string arguments with OsString in resume_supervised and related tests for better argv fidelity across platforms.

Documentation:
- Clarify in-code comments around follower behavior, shutdown output handling, process group probing, and why skip-to-now is intentionally absent.

Tests:
- Update daemon tests to align with the restored launch API, remove the obsolete process group probe assertion, and keep the resume witness test compiling and validating resumed console behavior.

Chores:
- Address clippy warnings in stella-core and stella-cli by using is_multiple_of, then_some, and a collapsible-if pattern so the workspace builds with -D warnings.