### PR TITLE
docs(stella-cli,stella-tui): mark the deleted seek_to_end absent-on-purpose, and note why clamp cannot panic

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -692,6 +692,13 @@ impl Tail {
         Ok(Self { file, offset: 0 })
     }
 
+    // There is deliberately no `seek_to_end` here, for the same reason
+    // `console::Follower` carries no `skip_to_now`: that pair was the only
+    // caller, and #1632 removed it as a defect — seeking past everything
+    // already written threw away the run's shutdown output, which on the
+    // Ctrl-C path is precisely what the person who pressed the key is
+    // waiting to read.
+
     /// Start `lines` lines back from the end, or at the beginning if the file
     /// is shorter than that.
     ///

--- a/crates/stella-tui/src/views/scope_dialog.rs
+++ b/crates/stella-tui/src/views/scope_dialog.rs
@@ -77,6 +77,8 @@ pub(crate) fn pending<'m>(model: &'m WorkspaceModel, ui: &DeckUi) -> Option<&'m 
 /// `None` renders the one-keypress answers, `Some` renders the note being
 /// typed (`r` was pressed) with its own send/back legend.
 pub(crate) fn render(proposal: &ScopeProposal, note: Option<&str>, area: Rect, buf: &mut Buffer) {
+    // `clamp` panics when max < min; both bounds here are compile-time
+    // constants with 20 < DIALOG_MAX_W, so that case cannot arise.
     let w = area.width.saturating_sub(4).clamp(20, DIALOG_MAX_W);
     let inner_w = (w as usize).saturating_sub(4);
 


### PR DESCRIPTION
Reopens the surviving half of #1647 (closed when its branch was force-updated; it could not be reopened).

Rebased onto current main. **The functional half is gone** — every compile/lint fix this branch originally carried landed independently on main while it was open, via `af97c36a` and `4b9b09d7`. Rather than re-land identical code, this keeps only what main does not have: two comments.

**`crates/stella-cli/src/daemon.rs`** — records that `Tail::seek_to_end` is deliberately absent, in the same shape as the `skip_to_now` note already in `daemon/console.rs`.

This is not decoration. The most expensive single defect in tonight's unbreak sequence was #1646 **resurrecting the `libc::stat` body #1641 had already replaced** — deleted-on-purpose code coming back because nothing at the site said it was deleted on purpose. `seek_to_end` and `skip_to_now` were removed as a pair for a real reason: seeking past everything already written discards the run's shutdown output, which on the Ctrl-C path is exactly what the person who pressed the key is waiting to read. `console.rs` records that; `daemon.rs` did not — so the half most likely to be helpfully restored by the next agent was the undocumented half.

**`crates/stella-tui/src/views/scope_dialog.rs`** — records why the `clamp` main introduced cannot hit its `max < min` panic: both bounds are compile-time constants with `20 < DIALOG_MAX_W` (74). The lint's own help text warns about that panic, so the reason it is safe belongs at the call site.

Comments only — no code, no behavior change, so no witness test.

## Summary by Sourcery

Document intentional absence of certain behavior and justify safety of a UI-related clamp usage.

Documentation:
- Add a comment explaining why `Tail` intentionally does not provide a `seek_to_end` operation in the daemon code.
- Add a comment explaining why the `clamp` call in the scope dialog rendering cannot trigger a `max < min` panic due to its compile-time bounds.