### PR TITLE
fix(stella-cli): type run_resume's answer as CliFailure so a resumed stop exits 3 (#1637)

### DIFF
--- a/crates/stella-cli/src/agent/outcome.rs
+++ b/crates/stella-cli/src/agent/outcome.rs
@@ -12,6 +12,7 @@
 //! non-monotonic total can never bill a negative amount into the ledger.
 
 use stella_context::EpisodeOutcome;
+use stella_core::TurnOutcome;
 use stella_pipeline::{PipelineOutcome, PipelineRunError, PipelineStatus};
 
 use crate::failure::CliFailure;
@@ -78,9 +79,33 @@ pub(super) fn pipeline_status_result(status: &PipelineStatus) -> Result<(), CliF
     }
 }
 
+/// The process-boundary answer a finished engine turn owes `main`.
+///
+/// The one projection from [`TurnOutcome`] to an exit code, so every surface
+/// that drives a turn directly reads an abort the same way: the abort's typed
+/// [`AbortKind`] decides, exactly as it does for a pipeline run
+/// ([`pipeline_status_result`]).
+///
+/// It lives here because the resumed-turn driver
+/// (`crate::agent::resume::run_resume`) used to answer with a `String`, which
+/// has no room for the `kind` — so a resumed stuck-loop stop exited `1` while
+/// the identical un-resumed stop exited `3`, and a wrapper reading exit codes
+/// could not tell a resumed policy stop from a resumed crash (#1637).
+///
+/// [`AbortKind`]: stella_core::AbortKind
+pub(super) fn turn_outcome_result(outcome: &TurnOutcome) -> Result<(), CliFailure> {
+    match outcome {
+        TurnOutcome::Completed { .. } => Ok(()),
+        TurnOutcome::Aborted { reason, kind, .. } => {
+            Err(CliFailure::from_abort(reason.clone(), *kind))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stella_core::AbortKind;
     use stella_pipeline::{PipelineError, PipelineRunError};
 
     #[test]
@@ -101,5 +126,43 @@ mod tests {
     #[test]
     fn cancellation_before_spend_persists_zero() {
         assert_eq!(settled_cost_since(1.25, 1.25), 0.0);
+    }
+
+    #[test]
+    fn a_deliberately_stopped_turn_carries_its_own_exit_code() {
+        let failure = turn_outcome_result(&TurnOutcome::Aborted {
+            reason: stella_core::driver::step_cap_reason(40),
+            kind: AbortKind::DeliberateStop,
+            cost_usd: 0.0,
+        })
+        .expect_err("an aborted turn is not a success");
+
+        assert_eq!(
+            failure.exit_code(),
+            std::process::ExitCode::from(crate::failure::DELIBERATE_STOP_EXIT_CODE)
+        );
+    }
+
+    #[test]
+    fn a_turn_that_fell_over_keeps_the_generic_failure_exit() {
+        let failure = turn_outcome_result(&TurnOutcome::Aborted {
+            reason: "the model call would not commit after retries".into(),
+            kind: AbortKind::Failure,
+            cost_usd: 0.0,
+        })
+        .expect_err("an aborted turn is not a success");
+
+        assert_eq!(failure.exit_code(), std::process::ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn a_completed_turn_is_a_success() {
+        assert!(
+            turn_outcome_result(&TurnOutcome::Completed {
+                text: "done".into(),
+                cost_usd: 0.0,
+            })
+            .is_ok()
+        );
     }
 }

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -40,29 +40,39 @@
 //!   workspace.** The candidate died with the process; the restored staleness
 //!   map is what keeps the resumed writes honest.
 
+use super::outcome::turn_outcome_result;
 use super::*;
+use crate::failure::CliFailure;
 
 /// The child driver: adopt the record, rebuild the turn, drive it to an end.
 ///
 /// `id` is the record to resume (a unique prefix is enough); `None` falls
 /// back to this process's own supervised identity, which is how the spawned
 /// child path always arrives.
-pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), String> {
+///
+/// Answers in [`CliFailure`], not a `String`, because a resumed turn must end
+/// the process exactly as an un-resumed one would: a resumed deliberate stop
+/// (a stuck loop escalated, the step cap reached) exits
+/// [`crate::failure::DELIBERATE_STOP_EXIT_CODE`] and a resumed failure exits
+/// `1`. The parent half (`crate::daemon::resume_supervised`) already forwards
+/// its child's code verbatim, so retyping this boundary is the whole of what
+/// the resumed path was missing (#1637).
+pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), CliFailure> {
     let registry = stella_store::SessionRegistry::open_default();
     let record = match (id, crate::daemon::supervised_id()) {
         (Some(id), _) => crate::daemon::resolve(&registry, Some(id))?,
         (None, Some(own)) => crate::daemon::resolve(&registry, Some(&own))?,
-        (None, None) => return Err("daemon resume needs a run id".to_string()),
+        (None, None) => return Err(CliFailure::error("daemon resume needs a run id")),
     };
     // The hand-run `--foreground` guard: a resumed turn must run where its
     // work is. The spawned child always passes (the parent pinned its cwd).
     let recorded = std::fs::canonicalize(&record.workspace).unwrap_or_default();
     let current = std::fs::canonicalize(&cfg.workspace_root).unwrap_or_default();
     if recorded != current {
-        return Err(format!(
+        return Err(CliFailure::error(format!(
             "{} belongs to {} — resume it from there, or without --foreground",
             record.id, record.workspace
-        ));
+        )));
     }
 
     let provider = build_provider(cfg)?;
@@ -111,12 +121,12 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Str
         eprintln!("  {warning}");
     }
     let Some(json) = cfg.durability.checkpoint() else {
-        return Err(format!(
+        return Err(CliFailure::error(format!(
             "{} has no resume point. A turn leaves one only when its process was killed \
              mid-turn; a run that completed, was stopped, or aborted discards it on the \
              way out",
             record.id
-        ));
+        )));
     };
     let checkpoint = stella_core::step::Checkpoint::from_json(&json).map_err(|e| {
         format!(
@@ -200,33 +210,25 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Str
         set.close_all().await;
     }
 
-    let result = match outcome {
-        TurnOutcome::Completed { cost_usd, .. } => {
-            println!(
-                "\n  {} resumed turn completed (from step {step})",
-                "✓".green().bold()
-            );
-            tui::cost_summary(
-                cost_usd,
-                &format!("{}/{}", cfg.provider.id, cfg.model_id),
-                turn_start.elapsed(),
-            );
-            Ok(())
-        }
-        // `kind` stops here: `run_resume` answers with a `String`, so the
-        // deliberate-stop/failure split cannot reach the exit code on this
-        // path until the resume surface is retyped over `CliFailure` (#1637).
-        TurnOutcome::Aborted {
-            reason, cost_usd, ..
-        } => {
-            tui::cost_summary(
-                cost_usd,
-                &format!("{}/{}", cfg.provider.id, cfg.model_id),
-                turn_start.elapsed(),
-            );
-            Err(reason)
+    let cost_usd = match &outcome {
+        TurnOutcome::Completed { cost_usd, .. } | TurnOutcome::Aborted { cost_usd, .. } => {
+            *cost_usd
         }
     };
+    if matches!(outcome, TurnOutcome::Completed { .. }) {
+        println!(
+            "\n  {} resumed turn completed (from step {step})",
+            "✓".green().bold()
+        );
+    }
+    tui::cost_summary(
+        cost_usd,
+        &format!("{}/{}", cfg.provider.id, cfg.model_id),
+        turn_start.elapsed(),
+    );
+    // The abort's typed `kind` decides the exit code here exactly as it does
+    // for a fresh turn — a resumed stuck-loop stop exits `3`, not `1` (#1637).
+    let result = turn_outcome_result(&outcome);
     // Written here as well as by `record_outcome_if_supervised` (which only
     // covers the spawned child), so the hand-run `--foreground` case records
     // a terminal status too. Same value on both paths; double-writing it is
@@ -518,6 +520,60 @@ mod tests {
         assert!(
             provider.requests.lock().unwrap().is_empty(),
             "no model call may happen past the cap"
+        );
+    }
+
+    /// The #1637 witness: a resumed turn's deliberate stop reaches the process
+    /// boundary AS a deliberate stop.
+    ///
+    /// It drives the real resume path — `drive_resumed_turn` over a restored
+    /// checkpoint, stopping at the step cap the crash was carrying — through
+    /// the exact projection `run_resume` now ends with, and asserts the exit
+    /// code is [`DELIBERATE_STOP_EXIT_CODE`] rather than the generic `1`.
+    ///
+    /// The fail half on `main` is type-level and therefore total: `run_resume`
+    /// answered with a `String`, `turn_outcome_result` did not exist, and no
+    /// value on this path could carry an [`AbortKind`] — so this test does not
+    /// compile there, let alone pass. A full end-to-end `run_resume` witness
+    /// would need a spawned supervised child, a session registry and a live
+    /// provider; the composition below pins the same claim without them, and
+    /// the last mile (`Err(CliFailure)` → `main`'s `e.exit_code()`) is the
+    /// unconditional boundary `crate::failure`'s own tests already cover.
+    ///
+    /// [`AbortKind`]: stella_core::AbortKind
+    /// [`DELIBERATE_STOP_EXIT_CODE`]: crate::failure::DELIBERATE_STOP_EXIT_CODE
+    #[tokio::test]
+    async fn a_resumed_deliberate_stop_exits_distinctly_from_a_crash() {
+        let provider = ScriptedProvider {
+            requests: Mutex::new(Vec::new()),
+        };
+        let tools = NoTools;
+        let config = EngineConfig::default();
+        let mut at_cap = killed_mid_turn();
+        at_cap.step = config.max_steps;
+        let state = TurnState::from_checkpoint(at_cap, &config);
+        let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
+        let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
+        let events = stella_core::EventSender::new(tx);
+
+        let outcome = drive_resumed_turn(&engine, state, &events).await;
+
+        assert!(
+            matches!(
+                outcome,
+                TurnOutcome::Aborted {
+                    kind: stella_core::AbortKind::DeliberateStop,
+                    ..
+                }
+            ),
+            "reaching the step cap is the engine stopping by policy: {outcome:?}"
+        );
+        let failure = turn_outcome_result(&outcome).expect_err("an aborted turn is not a success");
+        assert_eq!(
+            failure.exit_code(),
+            std::process::ExitCode::from(crate::failure::DELIBERATE_STOP_EXIT_CODE),
+            "a resumed stop must exit 3, the same code the un-resumed stop gives — \
+             exiting 1 tells a wrapper the run fell over"
         );
     }
 }


### PR DESCRIPTION
## What & why

#1620 gave aborts a typed `AbortKind`, and `failure.rs::CliFailure::from_abort`
turns it into an exit code: a **deliberate stop** (a stuck loop escalated past
its warning, the step cap reached, an enforced budget) exits `3`, a crash exits
`1`. That is the agent monitor protocol's contract — `bench/harbor_adapter`
reads exactly this code to score a policy stop as a *stop* rather than a crash.

The resumed-turn path could not participate. `agent::resume::run_resume`
answered with `Result<(), String>`, which has no room for the kind, so its match
on `TurnOutcome::Aborted` dropped it (there was a comment at the match site
naming this issue). A resumed stuck-loop stop exited `1` while the byte-identical
un-resumed stop exited `3`.

**The projection is now named once and shared.**
`agent::outcome::turn_outcome_result` maps a finished `TurnOutcome` to the
answer `main` owes the process boundary — `Completed` → `Ok`, `Aborted { kind }`
→ `CliFailure::from_abort` — mirroring the `pipeline_status_result` that already
sits beside it in the same module. `run_resume` ends with it instead of
hand-rolling a `String`, and its early-return paths become `CliFailure::error`.
The `?`-flowing string helpers (`build_provider`, `daemon::resolve`, the
checkpoint decoders) convert through the existing `From<String> for CliFailure`
and stay plain failures, unchanged — that impl is what keeps this a small diff.

**Nothing above `run_resume` needed retyping**, which I checked rather than
assumed:

- `main.rs`'s `Command::Daemon { cmd: DaemonCmd::Resume }` arm sits inside a
  `Result<(), CliFailure>` function and already `?`s the call, so the failure
  reaches `main`'s `e.exit_code()` intact.
- The parent half, `daemon::resume_supervised`, keeps `Result<(), String>` on
  purpose: it does not carry the child's answer in its `Result` at all. `watch`
  stores the child's raw exit code in the `FORWARDED` atomic and returns `Ok`,
  and `main` forwards that verbatim (`daemon::forwarded_exit_code`). A `3` from
  the spawned `--foreground` child is therefore a `3` from the supervisor, with
  no further change.

Two files, both sibling modules — `crates/stella-cli/src/agent.rs` and
`src/agent/tests.rs` are grandfathered god files and no line was added to either.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`agent::resume::tests::a_resumed_deliberate_stop_exits_distinctly_from_a_crash`
(`crates/stella-cli/src/agent/resume.rs`).

It drives the **real resume path** — `drive_resumed_turn` over a
checkpoint-restored `TurnState` whose step allowance the crash had already
spent — asserts the outcome is `Aborted { kind: DeliberateStop }`, and then puts
it through the exact projection `run_resume` now ends with, asserting the exit
code is `DELIBERATE_STOP_EXIT_CODE` and not `ExitCode::FAILURE`.

**Being plain about which witness this is.** It is not a full end-to-end
`run_resume`: that call needs a spawned supervised child, a session registry,
a bound work journal and a live provider, none of which is reachable from a unit
test. What it does pin is the composition the issue is actually about — the
resume driver's abort, carrying its kind, through to an exit code — and the last
mile (`Err(CliFailure)` → `main`'s `e.exit_code()`) is the unconditional
boundary `crate::failure`'s own tests already cover.

**The fail half is type-level, and therefore total.** On `main`, `run_resume`
returns `Result<(), String>` and `turn_outcome_result` does not exist, so no
value on this path can carry an `AbortKind` — the test does not *compile* there,
let alone fail an assertion. That is the strongest form of failing-on-main, and
the same form #1646's witness used. Three unit tests of the projection itself
land in `agent/outcome.rs` beside it.

## The gate

- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli --bin stella` — 1359 passed, 0 failed
- [x] `cargo fmt --all --check` — clean
- [ ] The `tests/` integration binaries were **not** built locally: linking them
      all at once SIGKILLs this 16GB machine (`cargo test -p stella-cli` died
      with `signal: 9` on `stats_graph_cli`). They are untouched by this change —
      they drive the `stella` binary, not `run_resume` — and CI builds them.
- [x] No new dependencies, no I/O added to `stella-core`, no new egress

## Anything reviewers should know?

- This branch was rebased onto `c88589b9` mid-session. It briefly also carried
  its own repairs for the four `main` breakages `#1646` left behind
  (`inherited_lock_fd`'s non-parsing `libc::stat` hybrid, the dead
  `Tail::seek_to_end`, the unused `group` binding, and `stella-tui`'s
  `manual_clamp`). A parallel session landed identical fixes in `af97c36a` /
  `4b9b09d7` / `5470d3da` first, so **all of that is dropped** — the diff here
  is the #1637 change and nothing else.
- **Filed, not fixed:** #1653 — the registry still records a deliberate stop as
  `SessionStatus::Error`, identical to a crash. The exit code now distinguishes
  them; `stella daemon list` and the deck SESSIONS view still do not, because
  both writers reduce the outcome to a `bool` before `outcome_status` sees it.
  It needs a design call (reuse `Cancelled` or add a variant), so it is a
  handoff rather than a hunk in this PR.

Closes #1637
Refs #1620, #1586, #1653

## Summary by Sourcery

Ensure resumed agent turns report abort outcomes consistently with fresh turns so deliberate stops exit with the correct code instead of being treated as crashes.

Bug Fixes:
- Make resumed turns propagate AbortKind via CliFailure so deliberate stops exit with the deliberate-stop code rather than the generic failure code.
- Align the resume path’s process exit behavior with the main turn path so external monitors can distinguish policy stops from crashes for resumed runs.

Enhancements:
- Introduce a shared turn_outcome_result helper to convert TurnOutcome into Result<(), CliFailure> for all turn-driving surfaces.
- Refine cost reporting and completion messaging in the resume path to use the shared TurnOutcome projection while preserving existing summaries.

Tests:
- Add unit tests for turn_outcome_result covering deliberate stops, generic failures, and successful turns.
- Add a resume-path test that drives a resumed deliberate stop through turn_outcome_result and asserts it exits with the deliberate-stop exit code.