### PR TITLE
fix(stella-pipeline): fail a candidate that writes outside its isolated workspace (#1538)

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -96,6 +96,7 @@ use crate::agent::{
 };
 
 mod adopt;
+mod escape;
 mod snapshot_gaps;
 mod witness_tools;
 use witness_tools::WitnessToolExecutor;
@@ -716,6 +717,10 @@ impl CandidateWorkspace for GitCandidateWorkspace {
         self.sealed_unchanged_inner().await
     }
 
+    async fn escaped_paths(&self) -> Vec<String> {
+        self.escaped_paths_inner().await
+    }
+
     async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
         self.adopt_inner(withhold).await
     }
@@ -786,7 +791,7 @@ mod tests {
     /// - uncommitted tracked edit: `tracked.txt` = "base\ndirty\n"
     /// - staged-but-uncommitted new file: `staged.txt`
     /// - untracked: `untracked.txt`; ignored: `ignored.txt`
-    fn scaffold(tag: &str) -> PathBuf {
+    pub(super) fn scaffold(tag: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
             "stella_cwstest_{tag}_{}_{}",
             std::process::id(),
@@ -840,7 +845,7 @@ mod tests {
         );
     }
 
-    fn read(path: &Path) -> String {
+    pub(super) fn read(path: &Path) -> String {
         std::fs::read_to_string(path).unwrap()
     }
 

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -266,7 +266,9 @@ impl GitCandidateWorkspace {
 /// The blob id a `hash-object` / `rev-parse <rev>:<path>` probe reported, or
 /// `None` when the probe failed — which is how "that path is absent in that
 /// state" arrives, since both commands error rather than print an empty id.
-fn blob_id(probe: Result<String, String>) -> Option<String> {
+/// `pub(super)` because the post-seal escape check ([`super::escape`]) runs
+/// the same three probes proactively.
+pub(super) fn blob_id(probe: Result<String, String>) -> Option<String> {
     probe.ok().map(|id| id.trim().to_string())
 }
 

--- a/crates/stella-cli/src/candidate_ws/escape.rs
+++ b/crates/stella-cli/src/candidate_ws/escape.rs
@@ -1,0 +1,242 @@
+//! Post-seal escape detection (#1538) — did this candidate write *through*
+//! its isolation into the real tree? A child module of `candidate_ws`, like
+//! [`super::adopt`], so the workspace's private fields stay reachable.
+//!
+//! Every other isolation property of a candidate workspace is structural
+//! (detached worktree, re-rooted tool registry, `O_NOFOLLOW` writes); the
+//! shell is the one capability that can still reach the real tree, because
+//! the bash tool is unconfined (#1300 removed the local sandbox). Until this
+//! module, that escape surfaced only when it happened to collide with the
+//! winner's adoption — an entire turn lost, attributed after the fact by
+//! [`super::adopt`]'s conflict forensics. This runs the same blob-signature
+//! comparison *proactively*, immediately after each seal, so the run fails
+//! the escaping candidate in the round that caused it.
+//!
+//! The discriminator is unchanged from [`super::adopt::PathDivergence`]: the
+//! candidate's sealed blob is a signature nothing else on the machine
+//! produces, so a real-tree path holding those exact bytes where the baseline
+//! differed was written by this candidate. A mid-run *user* edit classifies
+//! as [`PathDivergence::ChangedUnderTheRun`] and is deliberately not this
+//! module's business.
+//!
+//! Detection boundaries, accepted and documented: an escape that never enters
+//! the candidate's own sealed delta (bytes written *only* outside the
+//! snapshot) carries no signature and is invisible here, as is an escape by
+//! *deletion* (no bytes to sign). For those, adoption's conflict attribution
+//! remains the backstop. Best-effort throughout — every failed probe reports
+//! "no escape" rather than failing a candidate on broken forensics.
+
+use super::adopt::{PathDivergence, blob_id};
+use super::{GitCandidateWorkspace, git};
+
+/// Ceiling on blob classifications per check — three `git` probes each, on
+/// top of the two flat enumeration calls. A candidate's delta is normally a
+/// handful of paths; a run that changed more than this many *suspicious*
+/// paths gets its first `MAX_CLASSIFIED` examined, and the adoption-time
+/// attribution still covers anything beyond the cap.
+const MAX_CLASSIFIED: usize = 24;
+
+/// Ceiling on pathspecs handed to the one real-tree `git status` call, so an
+/// enormous candidate delta cannot build an unbounded argv.
+const MAX_STATUS_PATHSPECS: usize = 400;
+
+impl GitCandidateWorkspace {
+    /// Workspace-relative paths where the real tree already holds this
+    /// candidate's own sealed bytes at a path whose baseline differed — the
+    /// port contract of `CandidateWorkspace::escaped_paths` (#1538).
+    ///
+    /// Cost on a well-behaved candidate: exactly two `git` invocations (the
+    /// delta enumeration in the shadow, one pathspec-limited `status` against
+    /// the real tree). The three-probe blob classification is paid only for
+    /// paths the real tree reports moved *and* the candidate also changed —
+    /// normally none.
+    pub(super) async fn escaped_paths_inner(&self) -> Vec<String> {
+        let Some(sealed) = self
+            .sealed
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+        else {
+            // Never sealed: there are no candidate bytes to sign a match with.
+            return Vec::new();
+        };
+        let Ok(delta) = git(
+            &self.dir,
+            &[
+                "diff",
+                "--name-only",
+                "--no-renames",
+                "-z",
+                &self.baseline,
+                &sealed,
+            ],
+        )
+        .await
+        else {
+            return Vec::new();
+        };
+        let changed: Vec<&str> = delta
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .take(MAX_STATUS_PATHSPECS)
+            .collect();
+        if changed.is_empty() {
+            return Vec::new();
+        }
+        // One real-tree `status` over exactly the candidate's own paths. A
+        // path the real tree does not report moved cannot be holding fresh
+        // candidate bytes (modulo a candidate re-creating HEAD's exact
+        // content, which also cannot collide with adoption), so everything
+        // clean is skipped without paying a blob probe.
+        let mut status_args = vec![
+            "status",
+            "--porcelain",
+            "-z",
+            "--untracked-files=all",
+            "--no-renames",
+            "--",
+        ];
+        status_args.extend(changed.iter().copied());
+        let Ok(status) = git(&self.toplevel, &status_args).await else {
+            return Vec::new();
+        };
+        let mut escaped = Vec::new();
+        for path in status_paths(&status).into_iter().take(MAX_CLASSIFIED) {
+            // The same three probes as `adopt`'s failure-path attribution:
+            // what the real tree holds now, what the candidate started from,
+            // and what it sealed. `--path` keeps clean filters in play.
+            let real =
+                blob_id(git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await);
+            let baseline = blob_id(
+                git(
+                    &self.dir,
+                    &["rev-parse", &format!("{}:{path}", self.baseline)],
+                )
+                .await,
+            );
+            let sealed_blob =
+                blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);
+            if PathDivergence::classify(real.as_deref(), baseline.as_deref(), sealed_blob.as_deref())
+                == PathDivergence::CandidateWroteOutside
+            {
+                escaped.push(path.to_string());
+            }
+        }
+        escaped.sort();
+        escaped
+    }
+}
+
+/// The paths in `git status --porcelain -z` output: NUL-separated
+/// `XY <path>` entries (two status characters and a space; renames are
+/// disabled by the caller, so no two-path records).
+fn status_paths(raw: &str) -> Vec<&str> {
+    raw.split('\0')
+        .filter_map(|entry| entry.get(3..))
+        .filter(|path| !path.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_pipeline::ports::CandidateWorkspace;
+    use stella_tools::RegistryOptions;
+
+    use super::super::GitCandidateWorkspaces;
+    use super::super::tests::{read, scaffold};
+    use super::status_paths;
+
+    fn port(root: std::path::PathBuf) -> GitCandidateWorkspaces {
+        GitCandidateWorkspaces::new(
+            root,
+            RegistryOptions::default(),
+            Default::default(),
+            Vec::new(),
+            crate::rules::ResolvedRules::default(),
+        )
+    }
+
+    /// The observed Terminal-Bench failure shape: the candidate writes its
+    /// answer inside the snapshot AND copies it to the real tree. The check
+    /// names the path in the round it happened — before adoption can collide.
+    #[tokio::test]
+    async fn a_candidate_copying_its_answer_out_is_named_after_seal() {
+        let root = scaffold("escape-out");
+        let port = port(root.clone());
+        let ws = port.create_workspace().await.unwrap();
+
+        std::fs::write(ws.dir().join("answer.js"), "const answer = 42;\n").unwrap();
+        // The escape: the same bytes land in the real tree out-of-band.
+        std::fs::write(root.join("answer.js"), "const answer = 42;\n").unwrap();
+        ws.seal().await.unwrap();
+
+        assert_eq!(ws.escaped_paths().await, vec!["answer.js".to_string()]);
+
+        // Detection only — the real tree is left exactly as found for the
+        // caller to report; nothing here mutates either tree.
+        assert_eq!(read(&root.join("answer.js")), "const answer = 42;\n");
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A mid-run user edit at a path the candidate also changed is the OTHER
+    /// divergence — it must never be blamed on the candidate.
+    #[tokio::test]
+    async fn a_mid_run_user_edit_is_not_an_escape() {
+        let root = scaffold("escape-user-edit");
+        let port = port(root.clone());
+        let ws = port.create_workspace().await.unwrap();
+
+        std::fs::write(ws.dir().join("tracked.txt"), "base\ndirty\ncandidate\n").unwrap();
+        std::fs::write(root.join("tracked.txt"), "base\nuser-edit\n").unwrap();
+        ws.seal().await.unwrap();
+
+        assert_eq!(ws.escaped_paths().await, Vec::<String>::new());
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A file that was already dirty when the run began (and so is dirty in
+    /// `git status` throughout) still matches the snapshotted baseline —
+    /// the probe classifies it as untouched, not as an escape.
+    #[tokio::test]
+    async fn pre_existing_dirt_the_candidate_edited_only_in_its_snapshot_is_clean() {
+        let root = scaffold("escape-preexisting");
+        let port = port(root.clone());
+        let ws = port.create_workspace().await.unwrap();
+
+        // `tracked.txt` is dirty vs HEAD in the real tree by construction
+        // (scaffold wrote "base\ndirty\n" over the committed "base\n").
+        std::fs::write(ws.dir().join("tracked.txt"), "base\ndirty\ncandidate\n").unwrap();
+        ws.seal().await.unwrap();
+
+        assert_eq!(ws.escaped_paths().await, Vec::<String>::new());
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Before any seal there are no candidate bytes to match — the check
+    /// stays quiet instead of guessing.
+    #[tokio::test]
+    async fn an_unsealed_workspace_reports_nothing() {
+        let root = scaffold("escape-unsealed");
+        let port = port(root.clone());
+        let ws = port.create_workspace().await.unwrap();
+
+        std::fs::write(ws.dir().join("answer.js"), "const answer = 42;\n").unwrap();
+        std::fs::write(root.join("answer.js"), "const answer = 42;\n").unwrap();
+
+        assert_eq!(ws.escaped_paths().await, Vec::<String>::new());
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn status_paths_reads_porcelain_z_records() {
+        assert_eq!(
+            status_paths("?? new file.js\0 M tracked.txt\0"),
+            vec!["new file.js", "tracked.txt"]
+        );
+        assert_eq!(status_paths(""), Vec::<&str>::new());
+    }
+}

--- a/crates/stella-cli/src/candidate_ws/escape.rs
+++ b/crates/stella-cli/src/candidate_ws/escape.rs
@@ -116,8 +116,11 @@ impl GitCandidateWorkspace {
             );
             let sealed_blob =
                 blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);
-            if PathDivergence::classify(real.as_deref(), baseline.as_deref(), sealed_blob.as_deref())
-                == PathDivergence::CandidateWroteOutside
+            if PathDivergence::classify(
+                real.as_deref(),
+                baseline.as_deref(),
+                sealed_blob.as_deref(),
+            ) == PathDivergence::CandidateWroteOutside
             {
                 escaped.push(path.to_string());
             }

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -119,7 +119,7 @@ mod verifier_stage;
 mod verify_probes;
 use verify_probes::DiffProbe;
 mod witness_stage;
-use candidate_result::{CandidateAbort, CandidateResult, TurnAbort};
+use candidate_result::{CandidateAbort, CandidateResult, TurnAbort, escape_abort_reason};
 use fanout_stage::SerialCreates;
 use raw_usage::{RawCall, RawCallError};
 pub use run_error::{PipelineError, PipelineRunError};
@@ -2212,14 +2212,26 @@ impl<'a> Pipeline<'a> {
         let witness_paths = Self::witness_paths(witness);
         let meter = repair_gate::RepairMeter::start(*total);
         loop {
-            if let Some(workspace) = surface.workspace
-                && let Err(error) = workspace.seal().await
-            {
-                return CandidateResult::aborted(
-                    state.messages,
-                    format!("candidate could not be sealed for verification: {error}"),
-                    AbortKind::Failure,
-                );
+            if let Some(workspace) = surface.workspace {
+                if let Err(error) = workspace.seal().await {
+                    return CandidateResult::aborted(
+                        state.messages,
+                        format!("candidate could not be sealed for verification: {error}"),
+                        AbortKind::Failure,
+                    );
+                }
+                // #1538: the seal just pinned this candidate's final bytes — a
+                // real tree already holding them means the candidate wrote
+                // through its isolation. Fail it in the round that caused it,
+                // not at the winner's adoption.
+                let escaped = workspace.escaped_paths().await;
+                if !escaped.is_empty() {
+                    return CandidateResult::aborted(
+                        state.messages,
+                        escape_abort_reason(&escaped),
+                        AbortKind::Failure,
+                    );
+                }
             }
             let (touched_tests_passed, test_tail, test_infra) = self
                 .observe_touched_tests(surface, effective_cmd, &mut state)
@@ -3598,5 +3610,7 @@ fn count_diff_lines(diff: &str) -> u32 {
         .count() as u32
 }
 
+#[cfg(test)]
+mod test_doubles;
 #[cfg(test)]
 mod tests;

--- a/crates/stella-pipeline/src/pipeline/candidate_result.rs
+++ b/crates/stella-pipeline/src/pipeline/candidate_result.rs
@@ -179,7 +179,10 @@ mod tests {
     #[test]
     fn the_escape_reason_names_the_candidate_and_the_paths() {
         let reason = escape_abort_reason(&["app/vm.js".to_string()]);
-        assert!(reason.contains("wrote outside its isolated workspace"), "{reason}");
+        assert!(
+            reason.contains("wrote outside its isolated workspace"),
+            "{reason}"
+        );
         assert!(reason.contains("`app/vm.js`"), "{reason}");
         assert!(
             !reason.contains("user"),
@@ -191,7 +194,10 @@ mod tests {
     fn many_escaped_paths_are_summarized_not_pasted() {
         let paths: Vec<String> = (0..9).map(|i| format!("f{i}.rs")).collect();
         let reason = escape_abort_reason(&paths);
-        assert!(reason.contains("`f3.rs`") && !reason.contains("`f4.rs`"), "{reason}");
+        assert!(
+            reason.contains("`f3.rs`") && !reason.contains("`f4.rs`"),
+            "{reason}"
+        );
         assert!(reason.contains("+5 more"), "{reason}");
     }
 }

--- a/crates/stella-pipeline/src/pipeline/candidate_result.rs
+++ b/crates/stella-pipeline/src/pipeline/candidate_result.rs
@@ -144,3 +144,54 @@ impl CandidateResult {
         }
     }
 }
+
+/// The abort reason for a candidate that wrote through its isolation
+/// (#1538): the post-seal check found the real tree already holding this
+/// candidate's own sealed bytes. Named as the candidate's defect — never a
+/// user edit, never an adoption conflict — because that misattribution is
+/// exactly what the check exists to remove.
+pub(super) fn escape_abort_reason(paths: &[String]) -> String {
+    // Same inline cap as adoption's conflict rendering: a candidate that
+    // escaped on a hundred paths must not paste a hundred paths into one
+    // error line.
+    const INLINE: usize = 4;
+    let shown = paths
+        .iter()
+        .take(INLINE)
+        .map(|path| format!("`{path}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let listed = match paths.len().checked_sub(INLINE) {
+        Some(rest) if rest > 0 => format!("{shown} (+{rest} more)"),
+        _ => shown,
+    };
+    format!(
+        "candidate wrote outside its isolated workspace: the real tree already holds its \
+         sealed bytes at {listed} — isolation was breached by the candidate, so its work is \
+         discarded rather than adopted"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_abort_reason;
+
+    #[test]
+    fn the_escape_reason_names_the_candidate_and_the_paths() {
+        let reason = escape_abort_reason(&["app/vm.js".to_string()]);
+        assert!(reason.contains("wrote outside its isolated workspace"), "{reason}");
+        assert!(reason.contains("`app/vm.js`"), "{reason}");
+        assert!(
+            !reason.contains("user"),
+            "the escape must never read as a user edit: {reason}"
+        );
+    }
+
+    #[test]
+    fn many_escaped_paths_are_summarized_not_pasted() {
+        let paths: Vec<String> = (0..9).map(|i| format!("f{i}.rs")).collect();
+        let reason = escape_abort_reason(&paths);
+        assert!(reason.contains("`f3.rs`") && !reason.contains("`f4.rs`"), "{reason}");
+        assert!(reason.contains("+5 more"), "{reason}");
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/test_doubles.rs
+++ b/crates/stella-pipeline/src/pipeline/test_doubles.rs
@@ -1,0 +1,240 @@
+//! Workspace-isolation test doubles for [`super::tests`] — moved out of
+//! `tests.rs` when it reached its file-size ceiling (the `settlement.rs`
+//! pattern: relieve the ratchet by extracting a coherent cluster, never by
+//! raising it). The substrate doubles these compose (`ScriptedRunner`,
+//! `SeqRepoStatus`, `EmptyTools`) still live beside their many direct users
+//! in `tests.rs`; the deliberate cross-import below is test-only wiring.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use stella_core::ToolExecutor;
+
+use crate::ports::{
+    AdoptedChange, CandidateWorkspace, CandidateWorkspacePort, CmdOutcome, DiagnosticInvocation,
+    DiagnosticRunner, RepoStatusPort, TestInvocation, TestRunner, WorkspaceError,
+};
+
+use super::tests::{EmptyTools, ScriptedRunner, SeqRepoStatus};
+
+/// Session ports that fail the test if touched — the witness that
+/// isolated candidates only ever reach their own workspace's surface,
+/// never the real tree's.
+pub(super) struct NeverRunner;
+#[async_trait]
+impl DiagnosticRunner for NeverRunner {
+    async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
+        panic!(
+            "the session DiagnosticRunner must not serve isolated candidates (got {invocation:?})"
+        );
+    }
+}
+#[async_trait]
+impl TestRunner for NeverRunner {
+    async fn run_test(&self, invocation: &TestInvocation) -> CmdOutcome {
+        panic!("the session TestRunner must not serve isolated candidates (got {invocation:?})");
+    }
+}
+pub(super) struct NeverRepoStatus;
+#[async_trait]
+impl RepoStatusPort for NeverRepoStatus {
+    async fn untracked_fingerprints(&self) -> HashMap<String, String> {
+        panic!("the session RepoStatusPort must not serve isolated candidates");
+    }
+}
+
+/// A scripted [`CandidateWorkspace`]: per-candidate command results, a
+/// canned adoption outcome, and a shared log of lifecycle calls.
+pub(super) struct FakeWorkspace {
+    id: usize,
+    root: String,
+    tools: EmptyTools,
+    diagnostics: ScriptedRunner,
+    repo_status: SeqRepoStatus,
+    adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
+    sealed_unchanged: bool,
+    /// Canned outcome for the one artifact copy between workspaces. `Err`
+    /// stands in for the real failures: the worker already wrote a file at
+    /// that path, or the parent directory is absent.
+    graft_result: Result<(), WorkspaceError>,
+    /// Scripted escape report (#1538) — the paths the post-seal check should
+    /// claim the real tree already holds this candidate's sealed bytes at.
+    escaped: Vec<String>,
+    log: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl FakeWorkspace {
+    pub(super) fn new(
+        id: usize,
+        test_results: Vec<bool>,
+        adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
+        log: Arc<std::sync::Mutex<Vec<String>>>,
+    ) -> Self {
+        Self {
+            id,
+            root: "/candidate/workspace".into(),
+            tools: EmptyTools,
+            diagnostics: ScriptedRunner::new(test_results, "@@ -1 +1 @@\n-a\n+b"),
+            repo_status: SeqRepoStatus::new(vec![]),
+            adopt_result,
+            sealed_unchanged: true,
+            graft_result: Ok(()),
+            escaped: Vec::new(),
+            log,
+        }
+    }
+
+    pub(super) fn with_repo_status(mut self, repo_status: SeqRepoStatus) -> Self {
+        self.repo_status = repo_status;
+        self
+    }
+
+    /// Untracked files this workspace reports, as `(path, added_lines)` —
+    /// what a diff gather bills to the turn unless the path was already known.
+    pub(super) fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
+        self.diagnostics =
+            std::mem::replace(&mut self.diagnostics, ScriptedRunner::new(vec![], ""))
+                .with_untracked(untracked);
+        self
+    }
+
+    /// The diff this workspace reports after execution — what the warrant
+    /// reads to decide whether a witness is worth buying.
+    pub(super) fn with_diff(mut self, diff: &str) -> Self {
+        self.diagnostics.diff = diff.to_string();
+        self
+    }
+
+    pub(super) fn with_graft_failure(mut self, reason: &str) -> Self {
+        self.graft_result = Err(WorkspaceError::Graft {
+            reason: reason.into(),
+            path: "tests/witness.rs".into(),
+            workspace: "/candidate/workspace".into(),
+        });
+        self
+    }
+
+    pub(super) fn with_post_verification_drift(mut self) -> Self {
+        self.sealed_unchanged = false;
+        self
+    }
+
+    pub(super) fn with_root(mut self, root: impl Into<String>) -> Self {
+        self.root = root.into();
+        self
+    }
+
+    /// A candidate that wrote through its isolation (#1538): the post-seal
+    /// escape check will report these paths as already holding the
+    /// candidate's sealed bytes in the real tree.
+    pub(super) fn with_escaped(mut self, paths: Vec<&str>) -> Self {
+        self.escaped = paths.into_iter().map(str::to_string).collect();
+        self
+    }
+}
+
+#[async_trait]
+impl CandidateWorkspace for FakeWorkspace {
+    fn root(&self) -> &str {
+        &self.root
+    }
+    fn tools(&self) -> &dyn ToolExecutor {
+        &self.tools
+    }
+    fn witness_tools(&self) -> &dyn ToolExecutor {
+        &self.tools
+    }
+    fn diagnostics(&self) -> &dyn DiagnosticRunner {
+        &self.diagnostics
+    }
+    fn tests(&self) -> &dyn TestRunner {
+        &self.diagnostics
+    }
+    fn repo_status(&self) -> &dyn RepoStatusPort {
+        &self.repo_status
+    }
+    async fn seal(&self) -> Result<(), WorkspaceError> {
+        self.log.lock().unwrap().push(format!("seal:{}", self.id));
+        Ok(())
+    }
+    async fn sealed_is_unchanged(&self) -> Result<bool, WorkspaceError> {
+        Ok(self.sealed_unchanged)
+    }
+    async fn escaped_paths(&self) -> Vec<String> {
+        self.escaped.clone()
+    }
+    async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        // The withheld set is logged so tests can assert that an authored
+        // witness never reaches the real tree, without reaching for real git.
+        // Unchanged shape when nothing is withheld, so every pre-existing
+        // `adopt:<id>` assertion still reads the same.
+        self.log.lock().unwrap().push(if withhold.is_empty() {
+            format!("adopt:{}", self.id)
+        } else {
+            format!("adopt:{}:withhold={}", self.id, withhold.join(","))
+        });
+        self.adopt_result.clone()
+    }
+    async fn graft_witness(&self, source_root: &str, path: &str) -> Result<(), WorkspaceError> {
+        // Logged with the source so a test can prove the artifact came from a
+        // *different* workspace than the one it lands in — the whole point of
+        // authoring blind in a pristine snapshot.
+        self.log
+            .lock()
+            .unwrap()
+            .push(format!("graft:{}:{source_root}:{path}", self.id));
+        self.graft_result.clone()
+    }
+    async fn remove(&self) {
+        self.log.lock().unwrap().push(format!("remove:{}", self.id));
+    }
+}
+
+/// A scripted [`CandidateWorkspacePort`]: each `create` pops the next
+/// canned workspace (or failure). `panic_on_create` proves a path never
+/// touches isolation at all.
+pub(super) struct FakeWorkspacePort {
+    script: std::sync::Mutex<VecDeque<Result<FakeWorkspace, WorkspaceError>>>,
+    log: Arc<std::sync::Mutex<Vec<String>>>,
+    panic_on_create: bool,
+}
+
+impl FakeWorkspacePort {
+    pub(super) fn new(
+        script: Vec<Result<FakeWorkspace, WorkspaceError>>,
+        log: Arc<std::sync::Mutex<Vec<String>>>,
+    ) -> Self {
+        Self {
+            script: std::sync::Mutex::new(script.into_iter().collect()),
+            log,
+            panic_on_create: false,
+        }
+    }
+
+    pub(super) fn untouchable() -> Self {
+        Self {
+            script: std::sync::Mutex::new(VecDeque::new()),
+            log: Arc::new(std::sync::Mutex::new(Vec::new())),
+            panic_on_create: true,
+        }
+    }
+}
+
+#[async_trait]
+impl CandidateWorkspacePort for FakeWorkspacePort {
+    async fn create(&self) -> Result<Box<dyn CandidateWorkspace>, WorkspaceError> {
+        assert!(
+            !self.panic_on_create,
+            "the candidate workspace port must not be touched on this path"
+        );
+        self.log.lock().unwrap().push("create".into());
+        match self.script.lock().unwrap().pop_front() {
+            Some(Ok(ws)) => Ok(Box::new(ws)),
+            Some(Err(e)) => Err(e),
+            None => Err(WorkspaceError::Snapshot {
+                reason: "workspace script exhausted".into(),
+            }),
+        }
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -28,6 +28,7 @@ use crate::ports::{
     DiagnosticInvocation, DiagnosticRunner, NoContextRecall, NoFileTouches, NoRepoStatus,
     NoRepoStructure, Recall, TestInvocation, TestRunner,
 };
+use super::test_doubles::{FakeWorkspace, FakeWorkspacePort, NeverRepoStatus, NeverRunner};
 use stella_protocol::{ContextProviderUsage, ContextUsage};
 
 // test doubles
@@ -106,7 +107,7 @@ impl crate::ports::FileTouchPort for SeqTouches {
 /// `untracked_fingerprints` call, holding the last once exhausted. Lets a
 /// test make the working tree "change" between the witness stage, the
 /// execute turn, and the tamper check.
-struct SeqRepoStatus {
+pub(super) struct SeqRepoStatus {
     snapshots: std::sync::Mutex<VecDeque<HashMap<String, String>>>,
     last: std::sync::Mutex<HashMap<String, String>>,
     tracked_snapshots: std::sync::Mutex<VecDeque<HashMap<String, String>>>,
@@ -115,7 +116,7 @@ struct SeqRepoStatus {
     artifact_identities: std::sync::Mutex<VecDeque<Option<ArtifactIdentity>>>,
 }
 impl SeqRepoStatus {
-    fn new(snapshots: Vec<Vec<(&str, &str)>>) -> Self {
+    pub(super) fn new(snapshots: Vec<Vec<(&str, &str)>>) -> Self {
         let mapped: VecDeque<HashMap<String, String>> = snapshots
             .into_iter()
             .map(|files| {
@@ -317,12 +318,12 @@ enum TestScript {
     FailWith(&'static str),
 }
 
-struct ScriptedRunner {
+pub(super) struct ScriptedRunner {
     test_results: std::sync::Mutex<VecDeque<TestScript>>,
     /// Total `run_test` invocations, whatever they returned — the
     /// degradation gate pins this as the suite-run spend of a scenario.
     test_runs: std::sync::atomic::AtomicU32,
-    diff: String,
+    pub(super) diff: String,
     /// Untracked files this workspace reports, as `(path, added_lines)`.
     untracked: Vec<(String, u32)>,
     /// What a failing run prints. Configurable so a test can plant a
@@ -337,7 +338,7 @@ struct ScriptedRunner {
     diff_stderr: String,
 }
 impl ScriptedRunner {
-    fn new(test_results: Vec<bool>, diff: &str) -> Self {
+    pub(super) fn new(test_results: Vec<bool>, diff: &str) -> Self {
         Self::scripted(
             test_results
                 .into_iter()
@@ -386,7 +387,7 @@ impl ScriptedRunner {
         self.failure_tail = tail.to_string();
         self
     }
-    fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
+    pub(super) fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
         self.untracked = untracked
             .into_iter()
             .map(|(p, n)| (p.to_string(), n))
@@ -486,7 +487,7 @@ impl TestRunner for ScriptedRunner {
     }
 }
 
-struct EmptyTools;
+pub(super) struct EmptyTools;
 #[async_trait]
 impl ToolExecutor for EmptyTools {
     fn schemas(&self) -> Vec<ToolSchema> {
@@ -495,212 +496,6 @@ impl ToolExecutor for EmptyTools {
     async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
         ToolOutput::Ok {
             content: String::new(),
-        }
-    }
-}
-
-/// Session ports that fail the test if touched — the witness that
-/// isolated candidates only ever reach their own workspace's surface,
-/// never the real tree's.
-struct NeverRunner;
-#[async_trait]
-impl DiagnosticRunner for NeverRunner {
-    async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
-        panic!(
-            "the session DiagnosticRunner must not serve isolated candidates (got {invocation:?})"
-        );
-    }
-}
-#[async_trait]
-impl TestRunner for NeverRunner {
-    async fn run_test(&self, invocation: &TestInvocation) -> CmdOutcome {
-        panic!("the session TestRunner must not serve isolated candidates (got {invocation:?})");
-    }
-}
-struct NeverRepoStatus;
-#[async_trait]
-impl RepoStatusPort for NeverRepoStatus {
-    async fn untracked_fingerprints(&self) -> HashMap<String, String> {
-        panic!("the session RepoStatusPort must not serve isolated candidates");
-    }
-}
-
-/// A scripted [`CandidateWorkspace`]: per-candidate command results, a
-/// canned adoption outcome, and a shared log of lifecycle calls.
-struct FakeWorkspace {
-    id: usize,
-    root: String,
-    tools: EmptyTools,
-    diagnostics: ScriptedRunner,
-    repo_status: SeqRepoStatus,
-    adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
-    sealed_unchanged: bool,
-    /// Canned outcome for the one artifact copy between workspaces. `Err`
-    /// stands in for the real failures: the worker already wrote a file at
-    /// that path, or the parent directory is absent.
-    graft_result: Result<(), WorkspaceError>,
-    log: Arc<std::sync::Mutex<Vec<String>>>,
-}
-
-impl FakeWorkspace {
-    fn new(
-        id: usize,
-        test_results: Vec<bool>,
-        adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
-        log: Arc<std::sync::Mutex<Vec<String>>>,
-    ) -> Self {
-        Self {
-            id,
-            root: "/candidate/workspace".into(),
-            tools: EmptyTools,
-            diagnostics: ScriptedRunner::new(test_results, "@@ -1 +1 @@\n-a\n+b"),
-            repo_status: SeqRepoStatus::new(vec![]),
-            adopt_result,
-            sealed_unchanged: true,
-            graft_result: Ok(()),
-            log,
-        }
-    }
-
-    fn with_repo_status(mut self, repo_status: SeqRepoStatus) -> Self {
-        self.repo_status = repo_status;
-        self
-    }
-
-    /// Untracked files this workspace reports, as `(path, added_lines)` —
-    /// what a diff gather bills to the turn unless the path was already known.
-    fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
-        self.diagnostics =
-            std::mem::replace(&mut self.diagnostics, ScriptedRunner::new(vec![], ""))
-                .with_untracked(untracked);
-        self
-    }
-
-    /// The diff this workspace reports after execution — what the warrant
-    /// reads to decide whether a witness is worth buying.
-    fn with_diff(mut self, diff: &str) -> Self {
-        self.diagnostics.diff = diff.to_string();
-        self
-    }
-
-    fn with_graft_failure(mut self, reason: &str) -> Self {
-        self.graft_result = Err(WorkspaceError::Graft {
-            reason: reason.into(),
-            path: "tests/witness.rs".into(),
-            workspace: "/candidate/workspace".into(),
-        });
-        self
-    }
-
-    fn with_post_verification_drift(mut self) -> Self {
-        self.sealed_unchanged = false;
-        self
-    }
-
-    fn with_root(mut self, root: impl Into<String>) -> Self {
-        self.root = root.into();
-        self
-    }
-}
-
-#[async_trait]
-impl CandidateWorkspace for FakeWorkspace {
-    fn root(&self) -> &str {
-        &self.root
-    }
-    fn tools(&self) -> &dyn ToolExecutor {
-        &self.tools
-    }
-    fn witness_tools(&self) -> &dyn ToolExecutor {
-        &self.tools
-    }
-    fn diagnostics(&self) -> &dyn DiagnosticRunner {
-        &self.diagnostics
-    }
-    fn tests(&self) -> &dyn TestRunner {
-        &self.diagnostics
-    }
-    fn repo_status(&self) -> &dyn RepoStatusPort {
-        &self.repo_status
-    }
-    async fn seal(&self) -> Result<(), WorkspaceError> {
-        self.log.lock().unwrap().push(format!("seal:{}", self.id));
-        Ok(())
-    }
-    async fn sealed_is_unchanged(&self) -> Result<bool, WorkspaceError> {
-        Ok(self.sealed_unchanged)
-    }
-    async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
-        // The withheld set is logged so tests can assert that an authored
-        // witness never reaches the real tree, without reaching for real git.
-        // Unchanged shape when nothing is withheld, so every pre-existing
-        // `adopt:<id>` assertion still reads the same.
-        self.log.lock().unwrap().push(if withhold.is_empty() {
-            format!("adopt:{}", self.id)
-        } else {
-            format!("adopt:{}:withhold={}", self.id, withhold.join(","))
-        });
-        self.adopt_result.clone()
-    }
-    async fn graft_witness(&self, source_root: &str, path: &str) -> Result<(), WorkspaceError> {
-        // Logged with the source so a test can prove the artifact came from a
-        // *different* workspace than the one it lands in — the whole point of
-        // authoring blind in a pristine snapshot.
-        self.log
-            .lock()
-            .unwrap()
-            .push(format!("graft:{}:{source_root}:{path}", self.id));
-        self.graft_result.clone()
-    }
-    async fn remove(&self) {
-        self.log.lock().unwrap().push(format!("remove:{}", self.id));
-    }
-}
-
-/// A scripted [`CandidateWorkspacePort`]: each `create` pops the next
-/// canned workspace (or failure). `panic_on_create` proves a path never
-/// touches isolation at all.
-struct FakeWorkspacePort {
-    script: std::sync::Mutex<VecDeque<Result<FakeWorkspace, WorkspaceError>>>,
-    log: Arc<std::sync::Mutex<Vec<String>>>,
-    panic_on_create: bool,
-}
-
-impl FakeWorkspacePort {
-    fn new(
-        script: Vec<Result<FakeWorkspace, WorkspaceError>>,
-        log: Arc<std::sync::Mutex<Vec<String>>>,
-    ) -> Self {
-        Self {
-            script: std::sync::Mutex::new(script.into_iter().collect()),
-            log,
-            panic_on_create: false,
-        }
-    }
-
-    fn untouchable() -> Self {
-        Self {
-            script: std::sync::Mutex::new(VecDeque::new()),
-            log: Arc::new(std::sync::Mutex::new(Vec::new())),
-            panic_on_create: true,
-        }
-    }
-}
-
-#[async_trait]
-impl CandidateWorkspacePort for FakeWorkspacePort {
-    async fn create(&self) -> Result<Box<dyn CandidateWorkspace>, WorkspaceError> {
-        assert!(
-            !self.panic_on_create,
-            "the candidate workspace port must not be touched on this path"
-        );
-        self.log.lock().unwrap().push("create".into());
-        match self.script.lock().unwrap().pop_front() {
-            Some(Ok(ws)) => Ok(Box::new(ws)),
-            Some(Err(e)) => Err(e),
-            None => Err(WorkspaceError::Snapshot {
-                reason: "workspace script exhausted".into(),
-            }),
         }
     }
 }
@@ -1748,6 +1543,60 @@ async fn witness_authored_command_arms_the_flip_oracle_and_submits_fast() {
     assert!(
         !s.contains(&StageKind::Verdict),
         "verifier skipped on the flip"
+    );
+}
+
+/// #1538: a candidate that wrote through its isolation into the real tree is
+/// failed at verification, in the round that caused it — named as the
+/// candidate's own defect. Before the post-seal check, this escape survived
+/// verification and surfaced only when the winner's adoption collided with
+/// the stray copy, attributed to nobody.
+#[tokio::test]
+async fn a_candidate_that_wrote_outside_its_workspace_is_failed_not_adopted() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("wrote the test.\nTEST_COMMAND: cargo test --test witness witness -- --exact"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_escaped(vec!["app/vm.js"]);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone());
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
+    let (outcome, events, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig::default(),
+        "Fix the retry bug",
+    )
+    .await;
+    let outcome = outcome.expect("run returns an outcome");
+
+    match &outcome.status {
+        PipelineStatus::Aborted { reason, .. } => {
+            assert!(
+                reason.contains("wrote outside its isolated workspace"),
+                "the escape is named as the candidate's defect: {reason}"
+            );
+            assert!(reason.contains("`app/vm.js`"), "the path is named: {reason}");
+            assert!(
+                !reason.contains("git apply"),
+                "caught at verification, not reported as an adoption conflict: {reason}"
+            );
+        }
+        other => panic!("an escaped candidate must abort the run, got {other:?}"),
+    }
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, .. } if message.contains("wrote outside its isolated workspace")
+        )),
+        "the escape reaches the event stream: {events:?}"
+    );
+    let log = log.lock().unwrap();
+    assert!(
+        !log.iter().any(|entry| entry.starts_with("adopt:")),
+        "escaped work must never be adopted: {log:?}"
     );
 }
 

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -23,12 +23,12 @@ use stella_protocol::{
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
+use super::test_doubles::{FakeWorkspace, FakeWorkspacePort, NeverRepoStatus, NeverRunner};
 use crate::ports::{
     AdoptedChange, ArtifactIdentity, ArtifactKind, CmdOutcome, ContextRecallPort,
     DiagnosticInvocation, DiagnosticRunner, NoContextRecall, NoFileTouches, NoRepoStatus,
     NoRepoStructure, Recall, TestInvocation, TestRunner,
 };
-use super::test_doubles::{FakeWorkspace, FakeWorkspacePort, NeverRepoStatus, NeverRunner};
 use stella_protocol::{ContextProviderUsage, ContextUsage};
 
 // test doubles
@@ -1559,9 +1559,17 @@ async fn a_candidate_that_wrote_outside_its_workspace_is_failed_not_adopted() {
         text_result("wrote the test.\nTEST_COMMAND: cargo test --test witness witness -- --exact"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Same authored-witness scripting as the flip test above — the escape
+    // must be caught at *verification*, so the run has to get that far.
     let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/witness.rs", "w1")],
+        ]))
         .with_escaped(vec!["app/vm.js"]);
-    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone());
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
+    );
     let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
     let (outcome, events, _) = run_isolated(
         &provider,
@@ -1578,7 +1586,10 @@ async fn a_candidate_that_wrote_outside_its_workspace_is_failed_not_adopted() {
                 reason.contains("wrote outside its isolated workspace"),
                 "the escape is named as the candidate's defect: {reason}"
             );
-            assert!(reason.contains("`app/vm.js`"), "the path is named: {reason}");
+            assert!(
+                reason.contains("`app/vm.js`"),
+                "the path is named: {reason}"
+            );
             assert!(
                 !reason.contains("git apply"),
                 "caught at verification, not reported as an adoption conflict: {reason}"

--- a/crates/stella-pipeline/src/ports.rs
+++ b/crates/stella-pipeline/src/ports.rs
@@ -778,6 +778,22 @@ pub trait CandidateWorkspace: Send + Sync {
     async fn seal(&self) -> Result<(), WorkspaceError>;
     /// Whether the live worktree and HEAD still exactly match the last seal.
     async fn sealed_is_unchanged(&self) -> Result<bool, WorkspaceError>;
+    /// Workspace-relative paths where the REAL tree already holds this
+    /// candidate's own sealed bytes at a path whose baseline state differed —
+    /// the blob-level signature of the candidate having written *through* its
+    /// isolation (#1538). Nothing else on the machine produces the exact
+    /// sealed blob, so a non-empty answer is attributable to this candidate,
+    /// never to a user's mid-run edit.
+    ///
+    /// Consulted by the pipeline once per verification round, immediately
+    /// after [`Self::seal`] (the seal is what pins the bytes being matched).
+    /// Best-effort by contract: a substrate that cannot measure — or a probe
+    /// that fails — answers empty rather than failing a candidate on broken
+    /// forensics, so the check can only ever *add* a detection. The default
+    /// is empty for the same reason.
+    async fn escaped_paths(&self) -> Vec<String> {
+        Vec::new()
+    }
     /// Apply this workspace's changes — relative to its starting snapshot —
     /// to the real tree. All-or-nothing: on conflict the real tree is left
     /// byte-identical and the error names the conflicting paths


### PR DESCRIPTION
## What & why

An isolated best-of-N candidate could write **through** its isolation into the real tree: every tool in a candidate's stack is re-rooted at its snapshot except the shell (`crates/stella-tools/src/bash.rs` — unconfined since #1300 removed the local sandbox), so isolation's central claim rested on prompt compliance. Observed on a Terminal-Bench 2.1 run: a candidate `cp`'d its answer to `/app` as well as its snapshot, and the escape surfaced only as the winner's adoption failing (`git apply` cannot create a file that already exists) — the whole turn's work discarded, misattributed to a mid-run user edit.

This lands the issue's **option 2**, made proactive: immediately after each candidate seal, the run enumerates the candidate's own baseline→sealed delta, asks the real tree which of those paths currently report moved (one pathspec-limited `git status`), and classifies each suspicious path with the **existing** `PathDivergence` blob signature from the adoption forensics — a real-tree path holding the candidate's exact sealed blob where the baseline differed was written by that candidate; nothing else produces that blob. A non-empty report hard-fails the candidate at verification, in the round that caused it, naming the paths. A mid-run user edit classifies as `ChangedUnderTheRun` and is never blamed.

Structure (in-repo exemplars, per the god-file rules):

- `stella-pipeline/src/ports.rs` — `CandidateWorkspace::escaped_paths`, **defaulted to empty** so substrates that cannot measure only ever *add* detection, and every existing double keeps compiling.
- `stella-cli/src/candidate_ws/escape.rs` — the git mechanism, a sibling child module exactly like `adopt.rs`; reuses `PathDivergence::classify` and `blob_id`. Happy-path cost: two flat `git` calls per verification round; the three-probe classification is paid only per suspicious path (capped at 24, same bound as `attribute_conflict`).
- `stella-pipeline/src/pipeline.rs` `verify_candidate` — the post-seal check, beside the witness-tamper and seal-drift hard-fails it mirrors; the reason formatter lives in `candidate_result.rs` (pipeline.rs is at its size ceiling: 3616/3617 after this change).
- `stella-pipeline/src/pipeline/test_doubles.rs` — the workspace doubles extracted from `pipeline/tests.rs` (which was 3 lines under its own ceiling), the `settlement.rs` relieve-the-ratchet pattern; `FakeWorkspace` gains scripted escapes. `tests.rs` drops from 2595 to ~2450.

Detection boundaries, documented in the module doc: an escape whose bytes never enter the sealed delta carries no signature, and an escape by deletion has no bytes to sign — for both, the adoption-time attribution (already on main) remains the backstop.

Closes #1538

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`pipeline::tests::a_candidate_that_wrote_outside_its_workspace_is_failed_not_adopted`: a scripted candidate whose workspace reports an escape is failed at **verification** with the reason naming the path and the candidate, reaches the event stream as an `Error`, and is never adopted. On `main` the scenario cannot even be expressed — `escaped_paths`/`with_escaped` do not exist, and the behavior it pins (escape caught pre-adoption, attributed to the candidate) is genuinely absent: the same escape on `main` sails through verification and dies later as an adoption conflict.

Mechanism witnesses in `candidate_ws/escape.rs` drive real git repos: the copy-out is named after seal; a mid-run user edit is *not* blamed; pre-existing dirty state the candidate edited only in its snapshot stays clean; an unsealed workspace reports nothing.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-pipeline -p stella-cli --all-targets -- -D warnings` (exit 0)
- [x] `cargo test -p stella-pipeline --lib` (511 passed) and `cargo test -p stella-cli --bin stella candidate_ws` (46 passed), post-rebase on `2658dda4`; full workspace left to CI
- [x] Docs: module docs + port doc comment carry the behavior; no flag changes
- [x] `Closes #1538` appears both above and as a commit trailer

## Summary by Sourcery

Detect and fail candidates that write outside their isolated workspace by introducing an escaped-paths check after sealing and plumbing it through the pipeline.

New Features:
- Add a post-seal escape detection mechanism that reports candidate paths where the real tree already holds the candidate’s sealed bytes.
- Expose an escaped_paths hook on CandidateWorkspace and implement it for Git-backed workspaces using git-based blob comparison.

Enhancements:
- Improve pipeline abort messaging for isolation breaches with a summarized, path-aware escape reason string.
- Refactor pipeline tests by extracting workspace isolation test doubles into a dedicated test_doubles module to keep test files within size limits.

Tests:
- Add pipeline-level tests to ensure escaped candidates are failed at verification and never adopted.
- Add candidate workspace escape unit tests over real git repos, including mid-run user edits, pre-existing dirt, and unsealed workspaces.
- Extend existing test doubles and helpers to support the new escape detection behavior and sharing across test modules.