### PR TITLE
fix(stella-tui): unbreak main — restore the plan-review dialog's modality, fix the harness instead

### DIFF
--- a/crates/stella-tui/src/views/scope_dialog.rs
+++ b/crates/stella-tui/src/views/scope_dialog.rs
@@ -40,7 +40,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
 use stella_protocol::ScopeProposal;
 
-use crate::deck::{DeckTab, WorkspaceModel};
+use crate::deck::WorkspaceModel;
 use crate::deck_ui::DeckUi;
 use crate::plan::PlanStepState;
 use crate::theme;
@@ -55,17 +55,21 @@ const DIALOG_MAX_W: u16 = 74;
 /// predicate for "the dialog is up". Shared by the renderer, the key handler's
 /// caller and the cursor-suppression check so they can never disagree.
 ///
-/// Scoped to the Session tab, like every other tab-owned modal in
-/// `deck_render`'s cursor-suppression list (`DeckTab::Issues`'s sub-modes,
-/// `DeckTab::Settings`'s config editors). The gate belongs to the focused
-/// agent's REPL surface — it was a band above that transcript before it became
-/// a dialog, and its reach did not widen when its shape changed. Without this
-/// the frame-sized overlay paints over AGENTS, TRACES, GRAPH, FILES and MCP,
-/// blanking tabs that answer questions the dialog cannot.
+/// Deliberately **not** scoped to a tab. Unlike `DeckTab::Issues`'s sub-modes
+/// or `DeckTab::Settings`'s config editors — modals a user opens on the tab
+/// that owns them — this one opens *unbidden*, when the lead proposes a plan.
+/// A reviewer browsing AGENTS is still browsing it at that moment, and the
+/// gate has halted the session, so the surface announcing that has to be the
+/// thing they see. `deck_ui::gates` swallows every other key for the same
+/// reason: the decision is answered where the user stands.
+///
+/// Scoping this to Session made the dialog invisible on every other tab while
+/// the session sat halted with no indication why — the failure #1633 exists to
+/// prevent. Tests that need an unobstructed tab body answer the gate instead
+/// (`answered_ui` in `deck_snapshot.rs`, `base_ui` in
+/// `deck_render_snapshots.rs`); narrowing the renderer to suit the harness is
+/// what put this backwards once already.
 pub(crate) fn pending<'m>(model: &'m WorkspaceModel, ui: &DeckUi) -> Option<&'m ScopeProposal> {
-    if ui.tab != DeckTab::Session {
-        return None;
-    }
     let entry = model.agents.get(ui.focused)?;
     if ui.scope_answered.contains(&entry.meta.id) {
         return None;

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -291,13 +291,25 @@ fn fixture_model() -> WorkspaceModel {
     model
 }
 
-/// A deck past the splash, on `tab`, with the code graph loaded — the state a
-/// user is in a few seconds after launch.
-fn base_ui(tab: DeckTab) -> DeckUi {
+/// A deck past the splash, on `tab`, with the code graph loaded and the
+/// scenario's plan review answered — the state a user is in a few seconds
+/// after launch.
+///
+/// Answering the gate is what makes these frames pin a *tab body*. The demo
+/// scenario reaches an unanswered scope review, and that dialog is modal by
+/// design (`views::scope_dialog::pending`), so a bare `DeckUi::default()`
+/// renders eleven rows of `plan review` over whichever tab is under test —
+/// pinning the overlay instead of the surface. The dialog's own appearance is
+/// covered where it belongs, by `deck_snapshot.rs`'s
+/// `a_pending_plan_review_is_modal_over_the_tab_body`.
+fn base_ui(model: &WorkspaceModel, tab: DeckTab) -> DeckUi {
     let mut ui = DeckUi::default();
     ui.splash.skip();
     ui.tab = tab;
     ui.graph = Some(demo_graph());
+    for entry in &model.agents {
+        ui.scope_answered.insert(entry.meta.id.clone());
+    }
     // The driver seeds this at session start, so every frame the real deck
     // draws has it — including the one `/models` renders from.
     ui.engine.pristine = Some(stella_tui::scenario::demo_engine_config());
@@ -472,8 +484,8 @@ fn fixture_mcp_servers() -> Vec<stella_tui::McpServerInfo> {
 /// The representative state for each tab: populated entries, a moved cursor,
 /// and whatever out-of-band snapshot that tab reads. A tab rendered from
 /// `DeckUi::default()` would pin its empty state and nothing else.
-fn ui_for(tab: DeckTab) -> DeckUi {
-    let mut ui = base_ui(tab);
+fn ui_for(model: &WorkspaceModel, tab: DeckTab) -> DeckUi {
+    let mut ui = base_ui(model, tab);
     match tab {
         // The transcript of the focused agent, scrolled to the live tail.
         DeckTab::Session => ui.focused = 0,
@@ -525,7 +537,7 @@ fn tab_snapshot_name(tab: DeckTab) -> &'static str {
 fn deck_render_snapshots_cover_every_tab() {
     let model = fixture_model();
     for tab in DeckTab::ALL {
-        let mut ui = ui_for(tab);
+        let mut ui = ui_for(&model, tab);
         let frame = render_frame(&model, &mut ui, W, H);
         assert_golden(
             tab_snapshot_name(tab),
@@ -547,7 +559,7 @@ fn deck_render_snapshots_cover_every_tab() {
 #[test]
 fn deck_render_snapshots_pin_the_compact_agents_dashboard() {
     let model = fixture_model();
-    let mut ui = ui_for(DeckTab::Agents);
+    let mut ui = ui_for(&model, DeckTab::Agents);
     let frame = render_frame(&model, &mut ui, 120, 24);
     assert_golden(
         "tab_agents_compact",
@@ -566,7 +578,7 @@ fn deck_render_snapshots_pin_the_compact_agents_dashboard() {
 #[test]
 fn deck_render_snapshots_pin_the_settings_tools_pane() {
     let model = fixture_model();
-    let mut ui = ui_for(DeckTab::Settings);
+    let mut ui = ui_for(&model, DeckTab::Settings);
     ui.settings_pane = SettingsPane::Tools;
     let frame = render_frame(&model, &mut ui, W, H);
     assert_golden(
@@ -585,7 +597,7 @@ fn deck_render_snapshots_pin_the_settings_tools_pane() {
 #[test]
 fn deck_render_snapshots_pin_the_help_overlay() {
     let model = fixture_model();
-    let mut ui = ui_for(DeckTab::Skills);
+    let mut ui = ui_for(&model, DeckTab::Skills);
     ui.help_open = true;
     let frame = render_frame(&model, &mut ui, W, H);
     assert_golden(
@@ -604,7 +616,7 @@ fn deck_render_snapshots_pin_the_help_overlay() {
 #[test]
 fn deck_render_snapshots_pin_the_skills_create_dialog() {
     let model = fixture_model();
-    let mut ui = ui_for(DeckTab::Skills);
+    let mut ui = ui_for(&model, DeckTab::Skills);
     ui.skills.prompt = Some(SkillPrompt::CreateDescription {
         buffer: "review a terraform plan for destructive changes".to_string(),
     });
@@ -622,7 +634,7 @@ fn deck_render_snapshots_pin_the_skills_create_dialog() {
 #[test]
 fn deck_render_snapshots_pin_the_skills_scope_picker() {
     let model = fixture_model();
-    let mut ui = ui_for(DeckTab::Skills);
+    let mut ui = ui_for(&model, DeckTab::Skills);
     ui.skills.prompt = Some(SkillPrompt::Scope {
         action: ScopeAction::Create {
             description: "review a terraform plan for destructive changes".to_string(),
@@ -658,7 +670,7 @@ fn deck_render_snapshots_pin_the_floating_cards() {
         (Card::Models, "card_models", "the /models routing card"),
         (Card::Budget, "card_budget", "the /budget editor"),
     ] {
-        let mut ui = ui_for(DeckTab::Session);
+        let mut ui = ui_for(&model, DeckTab::Session);
         ui.cards.raise(card);
         let frame = render_frame(&model, &mut ui, W, H);
         assert_golden(name, description, W, H, &frame);
@@ -677,8 +689,11 @@ fn deck_render_snapshots_pin_the_floating_cards() {
 #[test]
 fn deck_render_snapshots_are_reproducible() {
     for tab in DeckTab::ALL {
-        let first = render_frame(&fixture_model(), &mut ui_for(tab), W, H);
-        let second = render_frame(&fixture_model(), &mut ui_for(tab), W, H);
+        // A fresh model per render, deliberately: the point is that two
+        // independent builds of the same fixture produce the same frame.
+        let (m1, m2) = (fixture_model(), fixture_model());
+        let first = render_frame(&m1, &mut ui_for(&m1, tab), W, H);
+        let second = render_frame(&m2, &mut ui_for(&m2, tab), W, H);
         assert!(
             first == second,
             "the {} tab rendered differently on a second pass — something in \

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
-│                                          │                                                                        │  ││                                      │
-│── WITNESS ───────────────────────────────│3 steps  ·  ~11 files  ·  est. ~$0.42                                   │──││                                      │
-│                                          │                                                                        │  ││                                      │
-│── EXECUTE ───────────────────────────────│a approve    t trim    r refine    x abort                              │──││                                      │
-│                                          └───────────────────────────────────── one keypress decides · esc aborts ┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                                                                                                      ││                                      │
+│── WITNESS ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
 │● read_file    apps/app/automations/page.tsx                                                                          │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                                                                                     42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                                                                                      ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
-│                                          │┌ models  resolved routing ───────────────────────────────── esc close ┐│  ││                                      │
-│── WITNESS ───────────────────────────────││session   glm-5.2                                                     ││──││                                      │
-│                                          ││auto      model off · effort on · thinking off                        ││  ││                                      │
-│── EXECUTE ───────────────────────────────││                                                                      ││──││                                      │
-│                                          └│lead      zai/glm-5.2-air                                             │┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││                                      │
+│── WITNESS ────────────────────────────────│session   glm-5.2                                                     │───││                                      │
+│                                           │auto      model off · effort on · thinking off                        │   ││                                      │
+│── EXECUTE ────────────────────────────────│                                                                      │───││                                      │
+│                                           │lead      zai/glm-5.2-air                                             │   ││                                      │
 │● read_file    apps/app/automations/page.ts│          medium · thinking on · from default_model                   │   │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                              │think     z-ai/glm-5.2                                    unassigned  │2ms│┌ DONE VERIFICATION ───────────────────┐
 │                                           │          low · thinking off · from agents.triage.model               │   ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. m┌ plan  pending approval · 3 steps  x skip · esc close ┐        │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. u│Refactor the automations store into a shared worksp…  │        │  ││○ 3. update 9 imports                 │
-│                                          │        │                                                      │        │  ││                                      │
-│── WITNESS ───────────────────────────────│3 steps │▸ ○ 1. extract types                                  │        │──││                                      │
-│                                          │        │  ○ 2. move hooks                                     │        │  ││                                      │
-│── EXECUTE ───────────────────────────────│a approv│  ○ 3. update 9 imports                               │        │──││                                      │
-│                                          └────────│                                                      │ aborts ┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                   ┌ plan  pending approval · 3 steps  x skip · esc close ┐           ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API             │Refactor the automations store into a shared worksp…  │           ││○ 3. update 9 imports                 │
+│                                                   │                                                      │           ││                                      │
+│── WITNESS ────────────────────────────────────────│▸ ○ 1. extract types                                  │───────────││                                      │
+│                                                   │  ○ 2. move hooks                                     │           ││                                      │
+│── EXECUTE ────────────────────────────────────────│  ○ 3. update 9 imports                               │───────────││                                      │
+│                                                   │                                                      │           ││                                      │
 │● read_file    apps/app/automations/page.tsx       │repo      macanderson/web-app ⎇ feat/automations-store│           │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                      │write     packages/automations/** · apps/app/automatio│       42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                   │read      apps/** · packages/**  (2 globs)            │           ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
-│                                          │                                                                        │  ││                                      │
-│── WITNESS ───────────────────────────────│3 steps  ·  ~11 files  ·  est. ~$0.42                                   │──││                                      │
-│                                          │                                                                        │  ││                                      │
-│── EXECUTE ───────────────────────────────│a approve    t trim    r refine    x abort                              │──││                                      │
-│                                          └───────────────────────────────────── one keypress decides · esc aborts ┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                                                                                                      ││                                      │
+│── WITNESS ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
 │● read_file    apps/app/automations/page.tsx                                                                          │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                                                                                     42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                                                                                      ││○ warrant  pending                    │


### PR DESCRIPTION
## What & why

Main is red on `cargo test -p stella-tui --test deck_snapshot` —
`a_pending_plan_review_is_modal_over_the_tab_body`. The cause is two commits
**eleven minutes apart** that reached opposite conclusions about the same three
failing tab tests, neither aware of the other:

| | commit | what it changed | conclusion |
|---|---|---|---|
| 18:09 | `5470d3da` | **the renderer** — `scope_dialog::pending` returns `None` off SESSION | the dialog's reach was too wide |
| 18:20 | `2658dda4` (#1650) | **the harness** — `answered_ui` at nine sites, plus a new modality test | "the harness was wrong, not the renderer" |

Main now scopes the dialog to SESSION *and* asserts it draws over AGENTS. Both
cannot hold, so the newer test fails.

## Which one is right

#1650's, and the scoping carried a worse defect than the one it fixed.

`5470d3da` also routed `deck_ui::gates` through `pending` (correctly — a single
predicate beats a duplicated condition). But combined with the tab scope, a plan
proposal raised while the reviewer browsed AGENTS then **neither drew its dialog
nor swallowed keys**: the session sat halted, with nothing on screen saying why.
That is precisely the failure #1633 turned the band into a modal to prevent, and
it is unreachable by any test that only renders SESSION.

The gate is not a tab-owned modal like `Issues`' sub-modes or `Settings`' config
editors — those a user *opens* on the tab that owns them. This one opens
**unbidden**, when the lead proposes a plan. The reviewer is wherever they are.

## The change

- **`views/scope_dialog.rs`** — the `ui.tab != DeckTab::Session` early return
  comes out; the doc comment now records *why* it is deliberately unscoped and
  that narrowing the renderer to suit the harness is what put this backwards.
- **`tests/deck_render_snapshots.rs`** — `base_ui` takes the model and seeds
  `scope_answered`, mirroring `deck_snapshot.rs`'s `answered_ui`. The golden
  suite now pins tab bodies because it *answers the gate*, not because the
  renderer was narrowed.
- **Four goldens re-blessed.** This is the fix #1651 asks for.

## Read the golden diff

All four are SESSION-derived (`tab_session`, `card_plan`, `card_models`,
`card_budget`) and every one **removes** the eleven-row `plan review` box,
revealing the surface it was covering:

```diff
-└─────────────────────────────────────┌ plan review ──────────────────────┐──────────────┘
-┌ transcript · 21 lines · following ──│Refactor the automations store into│──┐┌ PLAN ○ …
-│  Planning the automations cluster: l│ ○  1. extract types               │  ││Refactor …
+└──────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────┐┌ PLAN ○ …
+│  Planning the automations cluster: list, editor, triggers, workflows.    ││Refactor …
```

Row count is unchanged (22 lines in, 22 out) — this is content revealed, not
layout moved. The other fifteen goldens were already dialog-free from `c88589b9`
and are untouched.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_pending_plan_review_is_modal_over_the_tab_body` — added by #1650, currently
**failing on main**, passing here. It renders the gate unanswered on AGENTS and
asserts both the dialog and its `one keypress decides` legend appear.

## The gate

- [x] `cargo test -p stella-tui` — **851 pass, 0 fail** (main: 1 fail)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean
- [x] Goldens regenerated under `BLESS=1` **and the diff read**, per AGENTS.md

Run locally this time rather than deferred to CI: the machine's load average had
dropped from 34 to 6.8 (the arenabench run finished), and a golden re-bless is
not something to do blind.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] One `src/` file touched, and it removes a branch rather than adding one

Closes #1651
Refs #1633, #1649, #1650

## Summary by Sourcery

Restore the plan review dialog as a global modal over all tabs and align the snapshot harness with that behavior.

Bug Fixes:
- Fix the pending plan review dialog so it appears and remains modal regardless of the active deck tab, avoiding halted sessions with no visible gate.

Enhancements:
- Seed answered scope state in deck render snapshot fixtures so golden snapshots capture unobstructed tab bodies rather than the plan review overlay.
- Adjust snapshot reproducibility tests to build separate models for each render while still asserting identical frames.

Tests:
- Update deck render snapshot helpers to accept the workspace model and mark scope reviews as answered, then re-bless affected golden frames to match the restored dialog behavior.