### PR TITLE
docs(stella-tui): restore the clamp-panic note #1661's merge dropped

### DIFF
--- a/crates/stella-tui/src/views/scope_dialog.rs
+++ b/crates/stella-tui/src/views/scope_dialog.rs
@@ -161,6 +161,8 @@ pub(crate) fn render(
     area: Rect,
     buf: &mut Buffer,
 ) {
+    // `clamp` panics when max < min; both bounds here are compile-time
+    // constants with 20 < DIALOG_MAX_W, so that case cannot arise.
     let w = area.width.saturating_sub(4).clamp(20, DIALOG_MAX_W);
     let inner_w = (w as usize).saturating_sub(4);
 


### PR DESCRIPTION
## What & why

A two-line comment casualty of my own merge, reported rather than quietly left.

#1652 added a note above `scope_dialog::render`'s width computation recording why `clamp(20, DIALOG_MAX_W)` cannot panic:

> `clamp` panics when max < min; both bounds here are compile-time constants with 20 < DIALOG_MAX_W, so that case cannot arise.

#1661 changed `render`'s signature on the lines directly above it (`note: Option<&str>` → `input: Option<&ScopeInput>`, and one line → four). The conflict resolution took that whole hunk, and the comment went with it.

Nothing is broken — it is a comment, and the tests it sat beside all pass. But it is precisely the note the next reader wants when they notice a panicking call in a render path, which is the question #1652 existed to answer once so nobody has to re-derive it.

## The witness

- [x] No witness — comment-only restoration, no behavior change. `git show 4711bd56 -- crates/stella-tui/src/views/scope_dialog.rs` is the provenance.

## The gate

- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p stella-tui` — green on this branch's base (`b7223235`) and unaffected by a comment

## Ground-rule check

- [x] Comment-only; no behavior, no deps, no I/O, no network

Refs #1652

## Summary by Sourcery

Documentation:
- Clarify behavior around the `clamp` call in `scope_dialog::render` by reintroducing an explanation comment about its non-panicking bounds.