### PR TITLE
fix(stella-cli): a resumed run says which pipeline stages it is not restoring (#1615)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -455,6 +455,7 @@ async fn run_pipeline_one_shot(
             steering: None,
         };
 
+        crate::resume_frame::declare(&cfg.durability, &pipeline_config);
         let pipeline = Pipeline::new(ports, pipeline_event_sender(&tx, format), pipeline_config);
         pipeline.run(prompt, &mut messages, &mut budget).await
     };

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -31,14 +31,17 @@
 //!   turn-boundary resume regenerates it (rules may have changed); mid-turn,
 //!   fidelity wins — the transcript the provider priced and cached is the
 //!   transcript it gets back.
-//! - **A turn interrupted mid-pipeline resumes as a plain engine turn.** The
-//!   checkpoint captures the worker's turn, not the pipeline's staging, so
-//!   the verify/verdict stages that would have followed do not re-run. The
-//!   resumed turn still answers, and says what it did; re-verifying it is
-//!   `stella run` with the verifier of your choice.
+//! - **A turn interrupted mid-pipeline resumes as a plain engine turn** — but
+//!   never *silently*. The checkpoint captures the worker's turn, not the
+//!   pipeline's staging, so the verify/verdict stages that would have followed
+//!   do not re-run. The pipeline leaves a frame beside its checkpoint saying
+//!   so ([`crate::resume_frame`]), and this driver reads it before the first
+//!   step: the run names every stage it is not restoring, drops the green
+//!   tick, and files its audit row as `resumed_complete_unverified` (#1615).
+//!   Re-verifying it is `stella run` with the verifier of your choice.
 //! - **A turn that executed in a candidate worktree resumes in the
 //!   workspace.** The candidate died with the process; the restored staleness
-//!   map is what keeps the resumed writes honest.
+//!   map is what keeps the resumed writes honest. The frame reports this too.
 
 use super::outcome::turn_outcome_result;
 use super::*;
@@ -136,12 +139,29 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         )
     })?;
 
+    // Read BEFORE the first step, and print before it too: an operator who is
+    // going to be handed less than the run they lost has to learn that while
+    // they can still stop it, not from an audit row afterwards (#1615).
+    let frame = crate::resume_frame::ResumeFrame::read(&cfg.durability);
+
     let turn_start = Instant::now();
     let step = checkpoint.step;
     eprintln!(
         "  resuming {} at step {step} — completed steps stay done, nothing re-runs",
         record.id
     );
+    if let Some(advisory) = frame.advisory() {
+        for (i, line) in advisory.iter().enumerate() {
+            // The marker leads the summary line only; the rest are already
+            // indented continuations of it.
+            let marker = if i == 0 {
+                "!".yellow().bold().to_string()
+            } else {
+                " ".to_string()
+            };
+            eprintln!("  {marker} {line}");
+        }
+    }
     let execution = begin_execution(&store, "resume", &record.title, cfg, Some(&record.id));
     let files_before = tools_registry.files_touched().len();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
@@ -187,8 +207,12 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         .persistence_complete;
     let files = tools_registry.files_touched();
     if let Some((store, id)) = &execution {
+        // A degraded resume gets its own label: the scrollback warning is gone
+        // by the next command, and a stats query that cannot separate a
+        // verified resume from an unverified one reports the wrong number
+        // forever.
         let (label, cost) = match &outcome {
-            TurnOutcome::Completed { cost_usd, .. } => ("resumed_complete", *cost_usd),
+            TurnOutcome::Completed { cost_usd, .. } => (frame.completed_label(), *cost_usd),
             TurnOutcome::Aborted { cost_usd, .. } => ("resumed_aborted", *cost_usd),
         };
         if !record_execution_end(
@@ -216,10 +240,15 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         }
     };
     if matches!(outcome, TurnOutcome::Completed { .. }) {
-        println!(
-            "\n  {} resumed turn completed (from step {step})",
-            "✓".green().bold()
-        );
+        // A degraded resume does not get a green tick. The tick is this
+        // surface's claim that the run finished as it was meant to, and a turn
+        // whose verify and verdict stages never ran did not.
+        let (mark, banner) = if frame.degrades() {
+            ("!".yellow().bold(), frame.completed_banner(step))
+        } else {
+            ("✓".green().bold(), frame.completed_banner(step))
+        };
+        println!("\n  {mark} {banner}");
     }
     tui::cost_summary(
         cost_usd,

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -78,6 +78,16 @@ pub struct SessionDurability {
 struct Bound {
     journal: Arc<WorkJournal>,
     registry: Arc<stella_tools::ToolRegistry>,
+    /// The staged-pipeline frame every checkpoint of this session rides with,
+    /// or `None` while the session is running plain engine turns.
+    ///
+    /// Held here, beside the journal, rather than written once when the
+    /// pipeline starts: a pipeline runs *several* turns (worker, verifier,
+    /// revision), and every turn that ends discards its checkpoint — which
+    /// retracts the frame with it. A frame written once would therefore be
+    /// gone by the second turn, and the turn most likely to be killed is not
+    /// the first one.
+    pipeline: Arc<RwLock<Option<String>>>,
 }
 
 /// `ToolRegistry` is not `Debug` (it holds trait objects), and
@@ -100,7 +110,33 @@ impl SessionDurability {
         *slot = Some(Bound {
             journal: Arc::new(journal),
             registry,
+            pipeline: Arc::new(RwLock::new(None)),
         });
+    }
+
+    /// Declare that this session's turns are running inside a staged pipeline,
+    /// so every checkpoint from here on carries the frame describing it
+    /// ([`stella_store::work_journal::PIPELINE_BLOB`]).
+    ///
+    /// Called once per pipeline run, before the first stage. Silently ignored
+    /// on an unbound handle, like everything else here: a session with no
+    /// durable record has no checkpoint for a frame to ride on either.
+    pub fn set_pipeline_frame(&self, json: String) {
+        let bound = self.bound.read().unwrap_or_else(|p| p.into_inner()).clone();
+        if let Some(bound) = bound {
+            *bound.pipeline.write().unwrap_or_else(|p| p.into_inner()) = Some(json);
+        }
+    }
+
+    /// The staged-pipeline frame the interrupted turn was running inside, or
+    /// `None` when it was a plain engine turn.
+    ///
+    /// The read side of [`Self::set_pipeline_frame`], and the reason
+    /// `stella daemon resume` can tell an operator which stages a resumed run
+    /// is *not* getting back (#1615) instead of quietly finishing as a bare
+    /// turn.
+    pub fn pipeline_frame(&self) -> Option<String> {
+        self.journal()?.pipeline_frame()
     }
 
     /// The sink to hand [`stella_core::EngineConfig::checkpoint_sink`], or
@@ -213,10 +249,16 @@ impl CheckpointSink for JournalCheckpointSink {
     /// exactly as recoverable as it was before the sink existed.
     fn persist(&self, json: &str) {
         let observed = self.bound.registry.observed_snapshot();
-        let _ = self
+        let pipeline = self
             .bound
-            .journal
-            .record_checkpoint(json, observed.as_deref());
+            .pipeline
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+        let _ =
+            self.bound
+                .journal
+                .record_checkpoint(json, observed.as_deref(), pipeline.as_deref());
     }
 
     /// Idempotent by [`WorkJournal::clear_checkpoint`]'s own contract, and free
@@ -350,6 +392,72 @@ mod tests {
             record.checkpoint().is_none(),
             "a turn that ended leaves no resume point behind"
         );
+    }
+
+    /// **The #1615 witness (capture half).** A session running staged-pipeline
+    /// turns carries the frame describing them on *every* checkpoint commit,
+    /// and the frame is retracted with the checkpoint — so the next turn of
+    /// the same pipeline re-declares it and a turn that ended leaves nothing
+    /// claiming a pipeline is still running.
+    ///
+    /// The second half is the one with teeth: a pipeline drives several turns
+    /// (worker, verifier, revision) and each terminal path discards, so a
+    /// frame written once at the start would be gone by the second turn — and
+    /// the turn most likely to be killed is not the first one.
+    #[test]
+    fn a_pipeline_frame_rides_every_checkpoint_and_retires_with_it() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-frame");
+        let durability = SessionDurability::default();
+        durability.bind(record.clone(), registry(ws.path()));
+        durability.set_pipeline_frame(r#"{"version":1}"#.to_string());
+        let sink = durability.sink().expect("bound");
+
+        sink.persist(r#"{"step":1}"#);
+        assert_eq!(
+            durability.pipeline_frame().as_deref(),
+            Some(r#"{"version":1}"#)
+        );
+        sink.persist(r#"{"step":2}"#);
+        assert_eq!(
+            durability.pipeline_frame().as_deref(),
+            Some(r#"{"version":1}"#),
+            "the frame is re-stated at every step boundary, not only the first"
+        );
+
+        sink.discard();
+        assert!(record.checkpoint().is_none());
+        assert!(
+            durability.pipeline_frame().is_none(),
+            "a frame that outlived its turn would tell the next resume it is \
+             re-entering a pipeline nobody is running"
+        );
+
+        // The pipeline's next turn checkpoints, and the frame is back — this
+        // is what a frame written once could not do.
+        sink.persist(r#"{"step":1,"turn":2}"#);
+        assert_eq!(
+            durability.pipeline_frame().as_deref(),
+            Some(r#"{"version":1}"#)
+        );
+    }
+
+    /// A plain engine turn declares no frame, so nothing beside its checkpoint
+    /// claims it lost a pipeline. The delta the witness above is measured
+    /// against.
+    #[test]
+    fn a_bare_turn_leaves_no_pipeline_frame() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let record = journal(store.path(), ws.path(), "ses-bare");
+        let durability = SessionDurability::default();
+        durability.bind(record.clone(), registry(ws.path()));
+
+        durability.sink().expect("bound").persist(r#"{"step":1}"#);
+
+        assert!(record.checkpoint().is_some());
+        assert_eq!(durability.pipeline_frame(), None);
     }
 
     #[test]

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -83,6 +83,7 @@ mod profile;
 mod prompt_source;
 mod proposals_cmd;
 mod query_format;
+mod resume_frame;
 mod rules;
 mod runtime;
 mod scripts_cmd;

--- a/crates/stella-cli/src/resume_frame.rs
+++ b/crates/stella-cli/src/resume_frame.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a killed turn was running *inside*, so a resume cannot silently give
+//! it back as something smaller (#1615).
+//!
+//! `stella run` drives the staged pipeline — triage, plan, witness, execute,
+//! verify, verdict — and the engine checkpoint that `stella daemon resume`
+//! restores describes only the innermost of those: one worker turn. Resuming
+//! from it alone therefore hands the operator a run that answers but was never
+//! verified, which is the one thing this repository refuses to call done. The
+//! checkpoint cannot carry the difference itself: the engine must not learn
+//! pipeline shapes (architecture invariant 1).
+//!
+//! So the pipeline declares a **frame** beside the checkpoint —
+//! [`stella_store::work_journal::PIPELINE_BLOB`], the same commit, one store,
+//! not two — naming the staging the turn belonged to. The resume path reads it
+//! and reports, in [`ResumeFrame::advisory`], exactly which stages it is not
+//! restoring.
+//!
+//! # Why this is a report and not yet a restoration
+//!
+//! Re-entering the pipeline at the execute stage needs more than the frame:
+//! the candidate workspace the turn was writing into died with the process,
+//! and `stella_pipeline::Pipeline` exposes no seam to run the post-execute
+//! stages over an already-produced result (`run` is its only entry point).
+//! Both are tracked separately. What ships here is the half that must never
+//! wait for them: a resumed run **says** it came back smaller instead of
+//! presenting an unverified answer as a finished one.
+//!
+//! # Fail loud, not open
+//!
+//! A frame this build cannot parse is [`ResumeFrame::Unreadable`], not
+//! [`ResumeFrame::BareTurn`]. The two are indistinguishable to a naive reader
+//! and opposite in consequence: guessing "bare turn" on an unreadable frame is
+//! precisely the silent degradation this module exists to end.
+
+use serde::{Deserialize, Serialize};
+
+/// The frame format's version, bumped when a field's *meaning* changes.
+///
+/// Additive fields do not bump it — they carry `#[serde(default)]` and an
+/// older frame simply reads them as absent. A frame numbered above this is
+/// refused rather than half-understood, the same posture
+/// `stella_core::step::Checkpoint` takes.
+pub const FRAME_VERSION: u32 = 1;
+
+/// The staged pipeline a checkpointed turn was running inside.
+///
+/// Deliberately made of *decisions*, not content: which stages the run had
+/// configured, never the goal text, the plan, or a diff. The transcript in the
+/// checkpoint beside it already carries all of that, and duplicating it would
+/// make the frame a second, divergent copy of the same facts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineFrame {
+    /// See [`FRAME_VERSION`].
+    pub version: u32,
+    /// The deterministic verify ladder's command, when `--test-command` armed
+    /// it. `None` means every verification would have escalated to the model
+    /// verifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_command: Option<String>,
+    /// Whether the witness stage would have had an independent model author a
+    /// failing test up front — the flip oracle's whole input.
+    #[serde(default)]
+    pub witness_writer: bool,
+    /// Candidates the run was fanning out over (1 for the ordinary path).
+    #[serde(default)]
+    pub candidates: u32,
+    /// Whether the run's worktree policy allowed isolating execution in a
+    /// candidate workspace.
+    ///
+    /// *Possible*, not *actual*: the decision is taken at triage, after the
+    /// task class is known, and the frame is written before the first stage.
+    /// Reporting the maybe is the honest reading and still the actionable one
+    /// — if a candidate was created it died with the process, and the resumed
+    /// turn writes into the workspace instead.
+    #[serde(default)]
+    pub isolation_possible: bool,
+    /// Revision rounds the verifier could still have demanded.
+    #[serde(default)]
+    pub max_revisions: u32,
+}
+
+impl PipelineFrame {
+    /// The frame for a run configured by `config`.
+    pub fn of(config: &stella_pipeline::PipelineConfig) -> Self {
+        Self {
+            version: FRAME_VERSION,
+            test_command: config.test_command.clone(),
+            witness_writer: config.witness_writer,
+            candidates: config.candidates.unwrap_or(1),
+            isolation_possible: !matches!(
+                config.create_worktrees,
+                stella_pipeline::ports::WorktreePolicy::Never
+            ),
+            max_revisions: config.max_revisions,
+        }
+    }
+}
+
+/// What the run being resumed was, as far as the durable record can say.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResumeFrame {
+    /// No frame beside the checkpoint: the killed turn was a plain engine
+    /// turn, and resuming it as one loses nothing.
+    BareTurn,
+    /// The killed turn belonged to a staged pipeline run.
+    Pipeline(Box<PipelineFrame>),
+    /// A frame is present and this build cannot read it. Carries the reason,
+    /// which is reported rather than swallowed — see the module docs.
+    Unreadable(String),
+}
+
+impl ResumeFrame {
+    /// Read the frame the interrupted turn left beside its checkpoint.
+    pub fn read(durability: &crate::durability::SessionDurability) -> Self {
+        match durability.pipeline_frame() {
+            None => Self::BareTurn,
+            Some(json) => Self::parse(&json),
+        }
+    }
+
+    /// [`Self::read`] over the raw blob, split out so the classification is
+    /// testable without a git-backed record behind it.
+    pub fn parse(json: &str) -> Self {
+        match serde_json::from_str::<PipelineFrame>(json) {
+            Ok(frame) if frame.version <= FRAME_VERSION => Self::Pipeline(Box::new(frame)),
+            Ok(frame) => Self::Unreadable(format!(
+                "it is version {} and this build reads up to {FRAME_VERSION}",
+                frame.version
+            )),
+            Err(e) => Self::Unreadable(e.to_string()),
+        }
+    }
+
+    /// Whether a resume from this frame gives the operator back less than the
+    /// run they lost — the one bit every caller downstream keys off.
+    pub fn degrades(&self) -> bool {
+        !matches!(self, Self::BareTurn)
+    }
+
+    /// The lines to print before the resumed turn's first step, or `None` when
+    /// nothing is being lost.
+    ///
+    /// Written as a list of what will *not* run rather than a single sentence,
+    /// because "the pipeline does not resume" is the summary an operator
+    /// already assumed was false; naming the verdict, the flip credit and the
+    /// candidate workspace individually is what makes it actionable.
+    pub fn advisory(&self) -> Option<Vec<String>> {
+        let frame = match self {
+            Self::BareTurn => return None,
+            Self::Unreadable(why) => {
+                return Some(vec![
+                    "this run left a staged-pipeline frame this build cannot read".to_string(),
+                    format!("  ({why})"),
+                    "  treating it as a pipeline run: the resumed turn is NOT verified".to_string(),
+                ]);
+            }
+            Self::Pipeline(frame) => frame,
+        };
+        let mut lines = vec![
+            "this was a staged pipeline run — the resume continues its interrupted TURN, \
+             not the pipeline around it"
+                .to_string(),
+        ];
+        lines.push(match &frame.test_command {
+            Some(command) => format!(
+                "  the verify stage will NOT re-run `{command}`, and no verdict is recorded"
+            ),
+            None => {
+                "  the verifier will NOT re-read this work, and no verdict is recorded".to_string()
+            }
+        });
+        if frame.witness_writer {
+            lines.push(
+                "  the witness test's fail→pass flip is NOT credited — nothing proves this done"
+                    .to_string(),
+            );
+        }
+        if frame.max_revisions > 0 {
+            lines.push(format!(
+                "  up to {} revision round(s) the verifier could have demanded will NOT happen",
+                frame.max_revisions
+            ));
+        }
+        if frame.candidates > 1 {
+            lines.push(format!(
+                "  {} candidates were in flight; only this one's turn comes back",
+                frame.candidates
+            ));
+        }
+        if frame.isolation_possible {
+            lines.push(
+                "  execution MAY have been isolated in a candidate worktree, which died with \
+                 the process — the resumed turn writes into the workspace, guarded only by \
+                 the restored staleness map"
+                    .to_string(),
+            );
+        }
+        lines.push("  re-verify it with `stella run` before treating this as done".to_string());
+        Some(lines)
+    }
+
+    /// The `executions` row's outcome label for a resumed turn that completed.
+    ///
+    /// A degraded resume gets its own label rather than borrowing the ordinary
+    /// one: the audit trail is the only place the difference survives the
+    /// terminal scrollback, and a stats query that cannot separate a verified
+    /// run from an unverified one reports the wrong number forever.
+    pub fn completed_label(&self) -> &'static str {
+        if self.degrades() {
+            "resumed_complete_unverified"
+        } else {
+            "resumed_complete"
+        }
+    }
+
+    /// The one-line terminal banner a completed resume prints.
+    pub fn completed_banner(&self, step: usize) -> String {
+        if self.degrades() {
+            format!("resumed turn completed UNVERIFIED (from step {step}) — its pipeline did not")
+        } else {
+            format!("resumed turn completed (from step {step})")
+        }
+    }
+}
+
+/// Declare that the turns from here on belong to a staged pipeline run, so
+/// every checkpoint they write carries the frame describing it.
+///
+/// Best-effort and silent by the same contract as the rest of durability: a
+/// run whose frame cannot be serialized is exactly as resumable as it was
+/// before this existed, and refusing to start it would trade a working run for
+/// none. Serialization of a struct of scalars cannot fail in practice — the
+/// arm exists so this function has no `unwrap` on it.
+pub fn declare(
+    durability: &crate::durability::SessionDurability,
+    config: &stella_pipeline::PipelineConfig,
+) {
+    if let Ok(json) = serde_json::to_string(&PipelineFrame::of(config)) {
+        durability.set_pipeline_frame(json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pipeline_frame() -> PipelineFrame {
+        PipelineFrame {
+            version: FRAME_VERSION,
+            test_command: Some("cargo test -p stella-core".into()),
+            witness_writer: true,
+            candidates: 1,
+            isolation_possible: true,
+            max_revisions: 2,
+        }
+    }
+
+    /// Invariant 4: the frame crosses a crate boundary as JSON and must come
+    /// back the same value.
+    #[test]
+    fn a_frame_round_trips_through_json() {
+        let frame = pipeline_frame();
+        let json = serde_json::to_string(&frame).unwrap();
+        assert_eq!(
+            ResumeFrame::parse(&json),
+            ResumeFrame::Pipeline(Box::new(frame))
+        );
+    }
+
+    /// **The #1615 witness (report half).** A turn killed inside a staged
+    /// pipeline resumes knowing it is coming back smaller: the advisory names
+    /// the verify command that will not re-run, the witness flip that will not
+    /// be credited, and the candidate worktree that died — and the audit row
+    /// is labelled `resumed_complete_unverified` rather than borrowing the
+    /// ordinary success label.
+    ///
+    /// On `main` there is no frame at all: `SessionDurability` has no
+    /// `pipeline_frame`, the work journal has no `PIPELINE_BLOB`, and
+    /// `run_resume` labels every completed resume `resumed_complete`. The
+    /// fail-half is therefore type-level — the API this asserts on does not
+    /// exist — which is why the sibling assertion below pins the *unchanged*
+    /// bare-turn behaviour in the same test: the delta, not just the addition,
+    /// is what is being witnessed.
+    #[test]
+    fn a_resumed_pipeline_run_reports_every_stage_it_cannot_restore() {
+        let frame = ResumeFrame::Pipeline(Box::new(pipeline_frame()));
+        assert!(frame.degrades());
+        assert_eq!(frame.completed_label(), "resumed_complete_unverified");
+        assert!(frame.completed_banner(7).contains("UNVERIFIED"));
+
+        let advisory = frame.advisory().expect("a degraded resume must say so");
+        let text = advisory.join("\n");
+        assert!(
+            text.contains("cargo test -p stella-core"),
+            "the verify command that will not re-run is named: {text}"
+        );
+        assert!(text.contains("no verdict is recorded"), "{text}");
+        assert!(text.contains("flip is NOT credited"), "{text}");
+        assert!(text.contains("revision round"), "{text}");
+        assert!(text.contains("candidate worktree"), "{text}");
+
+        // The delta: a plain engine turn is untouched by any of this.
+        let bare = ResumeFrame::BareTurn;
+        assert!(!bare.degrades());
+        assert_eq!(bare.advisory(), None);
+        assert_eq!(bare.completed_label(), "resumed_complete");
+        assert!(!bare.completed_banner(7).contains("UNVERIFIED"));
+    }
+
+    /// A frame present but unreadable must never read as "no frame": the two
+    /// are opposite in consequence, and guessing the safe-looking one is the
+    /// silent degradation this module exists to end.
+    #[test]
+    fn an_unreadable_frame_still_warns() {
+        for json in ["{ not json", r#"{"version":9999}"#] {
+            let frame = ResumeFrame::parse(json);
+            assert!(
+                matches!(frame, ResumeFrame::Unreadable(_)),
+                "{json} must not be mistaken for a bare turn"
+            );
+            assert!(frame.degrades());
+            assert_eq!(frame.completed_label(), "resumed_complete_unverified");
+            let text = frame.advisory().expect("unreadable still warns").join("\n");
+            assert!(text.contains("NOT verified"), "{text}");
+        }
+    }
+
+    /// An older frame stays readable: additive fields default rather than
+    /// failing the parse, so a resume never refuses a run it could report on.
+    #[test]
+    fn a_minimal_frame_from_an_older_writer_still_parses() {
+        let ResumeFrame::Pipeline(frame) = ResumeFrame::parse(r#"{"version":1}"#) else {
+            panic!("a version-1 frame must parse");
+        };
+        assert_eq!(frame.test_command, None);
+        assert!(!frame.witness_writer);
+        assert_eq!(frame.candidates, 0);
+    }
+}

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -181,6 +181,18 @@ pub const CHECKPOINT_BLOB: &str = "checkpoint.json";
 /// the guarantee as its first.
 pub const OBSERVED_BLOB: &str = "observed.json";
 
+/// The reserved blob naming the staged pipeline the in-flight turn is running
+/// *inside*.
+///
+/// A deliberately separate blob rather than a widened [`CHECKPOINT_BLOB`]:
+/// the checkpoint is the engine's own shape and the engine must not learn
+/// pipeline shapes (architecture invariant 1). It shares the checkpoint's
+/// lifetime instead of the staleness map's — a frame describes one turn's
+/// staging and is retracted by [`WorkJournal::clear_checkpoint`] along with
+/// the resume point, because a frame that outlived its turn would tell the
+/// next resume it is re-entering a pipeline that already finished.
+pub const PIPELINE_BLOB: &str = "pipeline.json";
+
 impl WorkJournal {
     /// Open (creating on first use) the durable history for `workspace_root`.
     ///
@@ -414,10 +426,25 @@ impl WorkJournal {
     /// acting on content it believes it knows with the guard no longer watching
     /// (see `ToolRegistry::restore_observed`). `None` leaves whatever was last
     /// written in place.
-    pub fn record_checkpoint(&self, json: &str, observed: Option<&str>) -> Result<String> {
+    ///
+    /// `pipeline` rides along for the same reason and with the *checkpoint's*
+    /// lifetime rather than the map's: it names the staged pipeline this turn
+    /// is running inside ([`PIPELINE_BLOB`]), and a resume that read a frame
+    /// from one commit and a transcript from another could restore a pipeline
+    /// the transcript was never part of. `None` writes no frame, which is
+    /// exactly what a plain engine turn is.
+    pub fn record_checkpoint(
+        &self,
+        json: &str,
+        observed: Option<&str>,
+        pipeline: Option<&str>,
+    ) -> Result<String> {
         let mut blobs: Vec<(&str, Option<&str>)> = vec![(CHECKPOINT_BLOB, Some(json))];
         if let Some(observed) = observed {
             blobs.push((OBSERVED_BLOB, Some(observed)));
+        }
+        if let Some(pipeline) = pipeline {
+            blobs.push((PIPELINE_BLOB, Some(pipeline)));
         }
         self.record(&[], &blobs, "stella: turn checkpoint")
     }
@@ -428,23 +455,38 @@ impl WorkJournal {
         self.blob_at_tip(OBSERVED_BLOB)
     }
 
+    /// The staged-pipeline frame the interrupted turn was running inside, or
+    /// `None` when the turn was a plain engine turn (or the record is
+    /// unreadable — both mean "resume it as a bare turn").
+    pub fn pipeline_frame(&self) -> Option<String> {
+        self.blob_at_tip(PIPELINE_BLOB)
+    }
+
     /// Retract the resume point — the turn it described reached a terminal
     /// outcome, and a checkpoint that outlives its turn invites a resume that
     /// replays work the caller already saw finish.
     ///
+    /// The [`PIPELINE_BLOB`] frame goes with it, in the same commit: the two
+    /// describe the same turn, and a frame left behind by a turn that ended
+    /// would tell the next resume it is re-entering a pipeline nobody is
+    /// running.
+    ///
     /// Idempotent, and cheap when there is nothing to retract: every terminal
     /// path discards unconditionally, including turns that ended before their
-    /// first step boundary, so the common case must not cost a commit. One
-    /// `cat-file -e` answers that.
+    /// first step boundary, so the common case must not cost a commit. Two
+    /// `cat-file -e`s answer that.
     pub fn clear_checkpoint(&self) -> Result<()> {
-        if self.checkpoint().is_none() {
+        let mut retract: Vec<(&str, Option<&str>)> = Vec::new();
+        if self.checkpoint().is_some() {
+            retract.push((CHECKPOINT_BLOB, None));
+        }
+        if self.pipeline_frame().is_some() {
+            retract.push((PIPELINE_BLOB, None));
+        }
+        if retract.is_empty() {
             return Ok(());
         }
-        self.record(
-            &[],
-            &[(CHECKPOINT_BLOB, None)],
-            "stella: turn checkpoint retired",
-        )?;
+        self.record(&[], &retract, "stella: turn checkpoint retired")?;
         Ok(())
     }
 
@@ -908,7 +950,7 @@ mod tests {
             .expect("clearing an absent checkpoint is not an error");
 
         let json = r#"{"version":1,"step":3,"messages":[],"nested":{"quote":"\"x\""}}"#;
-        journal.record_checkpoint(json, None).unwrap();
+        journal.record_checkpoint(json, None, None).unwrap();
         assert_eq!(
             journal.checkpoint().as_deref(),
             Some(json),
@@ -917,7 +959,7 @@ mod tests {
 
         // Rewriting replaces rather than appends: one live turn, one point.
         let second = r#"{"version":1,"step":4}"#;
-        journal.record_checkpoint(second, None).unwrap();
+        journal.record_checkpoint(second, None, None).unwrap();
         assert_eq!(journal.checkpoint().as_deref(), Some(second));
 
         journal.clear_checkpoint().unwrap();
@@ -943,7 +985,9 @@ mod tests {
         journal
             .record(&["kept.txt".into()], &[], "the agent's write")
             .unwrap();
-        journal.record_checkpoint(r#"{"step":2}"#, None).unwrap();
+        journal
+            .record_checkpoint(r#"{"step":2}"#, None, None)
+            .unwrap();
 
         journal.clear_checkpoint().unwrap();
 

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -107,7 +107,20 @@ $ stella daemon resume ses-1785956826121
 
 The relaunch continues the **same session** — same id, same sidecar, the crashed attempt's console preserved — as a fresh supervised child. Completed steps are already in the checkpointed transcript, tool results included, so nothing re-runs and no tool effect is applied twice; the no-clobber staleness map rides the same checkpoint, so a file something else edited while the run was dead is refused rather than overwritten. A run that ended cleanly has nothing to resume, and `resume` says so instead of restarting it.
 
-Two honest limits: a turn that was mid-*pipeline* resumes as a plain engine turn (the verify stages that would have followed do not re-run), and a turn that was executing in a candidate worktree resumes in the workspace — the candidate died with the process.
+Two honest limits remain — and neither is silent any more. A turn that was mid-*pipeline* resumes as a plain engine turn: the checkpoint captures the worker's turn, not the pipeline's staging, so the verify and verdict stages that would have followed do not re-run. A turn that was executing in a candidate worktree resumes in the workspace, because the candidate died with the process.
+
+Both are now *announced*. `stella run` leaves a pipeline frame beside its checkpoint, and `resume` reads it before the first step: the run names every stage it is not restoring — the verify command that will not re-run, the witness flip that will not be credited, the revision rounds that will not happen, the candidate worktree that is gone — drops the green tick, and files its audit row as `resumed_complete_unverified` rather than `resumed_complete`.
+
+```text
+$ stella daemon resume ses-1785956826121
+  resuming ses-1785956826121-25167 at step 14 — completed steps stay done, nothing re-runs
+  ! this was a staged pipeline run — the resume continues its interrupted TURN, not the pipeline around it
+    the verify stage will NOT re-run `cargo test`, and no verdict is recorded
+    the witness test's fail→pass flip is NOT credited — nothing proves this done
+    re-verify it with `stella run` before treating this as done
+```
+
+An unverified resume is a resume you can still act on; an unverified resume you were never told about is not. Re-verifying is `stella run` with the verifier of your choice.
 
 ## `install` / `uninstall`
 


### PR DESCRIPTION
Refs #1615 — the **report** half of a P0. The restoration half is #1671; deliberately not closing #1615.

## The defect

`stella run` drives the staged pipeline (triage → plan → witness → execute → verify → verdict), but the engine checkpoint `stella daemon resume` restores describes only the innermost of those: one worker turn. A resumed supervised run therefore finished with no witness flip credit, no verify stage and no verdict — and printed a green `✓ resumed turn completed` with a `resumed_complete` audit row while doing it. "Verified done, not claimed done" was being dropped silently on the exact path built for the runs big enough to get killed.

## Design

The engine must not learn pipeline shapes (invariant 1), so the checkpoint cannot widen. Instead the pipeline declares a **frame** beside it:

- **`stella-store`** — a third reserved blob, `PIPELINE_BLOB = "pipeline.json"`, written by `record_checkpoint` in the **same commit** as `CHECKPOINT_BLOB` (the issue’s "one store, not two"), and retracted by `clear_checkpoint` alongside it. It takes the *checkpoint’s* lifetime, not the staleness map’s: a frame outliving its turn would tell the next resume it is re-entering a pipeline nobody is running.
- **`stella-cli/src/durability.rs`** — `set_pipeline_frame` / `pipeline_frame`. The frame is held on `Bound` and re-stated on every `persist`, not written once. This is the non-obvious part: a pipeline drives several turns (worker, verifier, revision) and **every terminal path discards the checkpoint**, which retracts the frame with it — so a frame written once at pipeline start is gone by the second turn, and the turn most likely to be killed is not the first one. The `a_pipeline_frame_rides_every_checkpoint_and_retires_with_it` test pins exactly this.
- **`stella-cli/src/resume_frame.rs`** (new sibling module) — `PipelineFrame` (decisions only: test command, witness_writer, candidates, isolation policy, max_revisions — never the goal, plan or diff, which the checkpointed transcript beside it already carries) and `ResumeFrame` with three states. A frame this build cannot parse is `Unreadable`, **never** `BareTurn`: the two are indistinguishable to a naive reader and opposite in consequence, and guessing the safe-looking one is precisely the silent degradation being fixed.
- **`stella-cli/src/agent/resume.rs`** — reads the frame before the first step, prints the advisory, drops the green tick, and files `resumed_complete_unverified`. The label matters as much as the banner: scrollback is gone by the next command, and a stats query that cannot separate a verified resume from an unverified one reports the wrong number forever.

Exemplar for the versioned-blob shape: `stella_core::step::Checkpoint`’s own `CHECKPOINT_VERSION` posture — refuse a version above what this build reads, default additive fields rather than bumping.

```text
  resuming ses-…-25167 at step 14 — completed steps stay done, nothing re-runs
  ! this was a staged pipeline run — the resume continues its interrupted TURN, not the pipeline around it
    the verify stage will NOT re-run `cargo test`, and no verdict is recorded
    the witness test’s fail→pass flip is NOT credited — nothing proves this done
    re-verify it with `stella run` before treating this as done
```

## Why bounded, and said out loud

Fully re-entering the pipeline is genuinely larger than one PR, for two reasons found while building this:

1. `stella_pipeline::Pipeline::run` is its **only** public entry; every stage driver (`verify_candidate`, `verifier_stage`, `witness_stage`) is private/`pub(super)` and the state they thread (`CandidateResult`) is `pub(super)`. A verify-only seam belongs in `stella-pipeline` — and `src/pipeline.rs` is a god file closed to growth, so it needs a sibling submodule.
2. The candidate workspace died with the process; rebuilding it means replaying `WorkJournal::read_at_turn` file states into a re-created worktree, and re-verifying the witness tamper digests before crediting any flip.

Both are filed as **#1671** with the file paths, constraints and definition of done. **#1672** covers the surfaces that still declare no frame (the deck, the goal loop, arena, fleet) — `stella run` is wired, they are not.

No god-file growth: `agent.rs` gained exactly one dispatch line (2269 → 2270, its recorded ceiling — no baseline edit), all new logic is in `resume_frame.rs`. No new dependencies. No `#[allow]`, no `unwrap`/`expect` on runtime data — `declare` swallows a serialization failure by the same best-effort contract as the rest of durability, with the reasoning written down.

## Witness

`crates/stella-cli/src/durability.rs::a_pipeline_frame_rides_every_checkpoint_and_retires_with_it` (capture) and `crates/stella-cli/src/resume_frame.rs::a_resumed_pipeline_run_reports_every_stage_it_cannot_restore` (report).

**The fail-half on `main` is type-level, stated plainly rather than dressed up**: the capability is new, so the tests do not compile against `main` — `SessionDurability::pipeline_frame` does not exist, `work_journal` has no `PIPELINE_BLOB`, and `crates/stella-cli/src/resume_frame.rs` is not a file. Proved with `git show origin/main:<path> | rg`. Because "it does not compile" is weak evidence on its own, both witnesses assert the **delta** in the same test: `a_bare_turn_leaves_no_pipeline_frame` and the `BareTurn` half of the report witness pin that a plain engine turn is byte-for-byte unaffected — same `resumed_complete` label, no advisory, no banner change. `main`’s behaviour for the pipeline case is directly visible at `crates/stella-cli/src/agent/resume.rs:191` on `main`: `("resumed_complete", *cost_usd)`, unconditionally.

Two further tests guard the fail-loud property: `an_unreadable_frame_still_warns` (garbage and a future version both degrade, never read as "bare turn") and `a_minimal_frame_from_an_older_writer_still_parses`.

## Verified locally

`cargo test -p stella-cli --bin stella` (1365 passed), `cargo test -p stella-store --lib` (307 passed), `cargo clippy -p stella-cli -p stella-store --all-targets -D warnings`, `cargo fmt --all`, `cargo doc --no-deps`, `make guards` (file-size included — nothing grew past a ceiling).

**Not run locally, by instruction:** `cargo test --workspace` and the `stella-cli` integration-test binaries — a sibling agent was OOM-killed linking them on this 16GB machine. CI carries the full gate. Nothing outside `stella-cli`/`stella-store` was touched except the docs page, and `record_checkpoint`’s signature change has no callers beyond `durability.rs` and the journal’s own tests (`rg -n "record_checkpoint" crates/`).

## Interaction with #1654

PR #1654 (`run_resume` → `Result<(), CliFailure>` + `turn_outcome_result`) **had already merged** by the time this branch was cut — it is commit `5ae22dae`, this branch’s base. There is no conflict to manage: this change touches the frame-reading, banner and audit-label region of `run_resume`, which is disjoint from #1654’s error-typing and terminal projection.

## Docs

`website/content/docs/commands/daemon.mdx` — the "Two honest limits" paragraph now says both limits are announced, with the actual console output.

Refs #1615
Refs #1671
Refs #1672

## Summary by Sourcery

Report and track staged pipeline context alongside engine checkpoints so resumed runs can warn about unverified pipeline stages, while simplifying related CLI/TUI surfaces, removing fleet GC support, and aligning docs and branding with the updated pipeline and role semantics.

New Features:
- Record staged pipeline configuration alongside engine checkpoints so resumes can describe the interrupted pipeline run.
- Add CLI and TUI support for scoped refine notes in the plan-review dialog without shell escapes.
- Introduce JSON-based pipeline frame parsing and advisory reporting for resumed runs.

Bug Fixes:
- Ensure resumed runs that were mid-pipeline clearly report which stages are not restored and are audited as unverified.
- Keep bare engine turns’ resume behavior unchanged while avoiding silent degradation when pipeline frames are unreadable.
- Simplify scope dialog behavior by removing shell command handling and fixing legend and layout inconsistencies.

Enhancements:
- Refine pipeline documentation, UI labels, and stage naming to consistently distinguish verifier/judge roles and updated stage ordering.
- Tighten visibility and usage of various internal helpers, ports, and test doubles to reduce public test-only surface.
- Clarify terminal and deck behavior around modal dialogs, panel guards, and color handling while updating brand/demo copy.

Build:
- Bump workspace and Homebrew formula versions back to 0.6.117 to align with release tracking.

Documentation:
- Update daemon and fleet command docs to describe resumed pipeline limits and remove fleet clean subcommand documentation.
- Refresh brand site and TUI prompt copy to match the current pipeline wording and provider role names.

Tests:
- Add durability and resume-frame tests to assert pipeline frame lifecycle and resumed-run advisories, and update deck/card snapshot tests for new UI behavior.
- Remove obsolete fleet GC and candidate escape tests and adjust scope dialog tests for simplified refine-only input.

Chores:
- Remove fleet garbage-collection APIs and CLI wiring, and simplify various comments and module references to match current architecture.