### PR TITLE
hygiene batch 7: eight docs/gate-drift issues, and an evidence document that overstated a result

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -174,10 +174,33 @@ fi
 # An empty scope means no crate in the workspace can be reached by this diff —
 # a website-only or workflow-only push. The global guards still run; there is
 # simply nothing to compile.
+#
+# ...with one exception, and it is worth stating precisely because removing it
+# would open a hole. `make guards` includes `wire-schema`, which runs the two
+# schema exporters — a cargo build. For a website-only push that is pure waste:
+# the diff cannot have touched the wire contract. But `docs/wire/` is *generated
+# and committed*, and ci.yml carries `paths-ignore: docs/**`, so a hand-edit
+# confined to `docs/wire/` is invisible to the required check. That is why
+# wire-schema was put in `guards` in the first place, and why the fix here is to
+# make it conditional rather than to drop it: run the dear rung only when the
+# pushed diff can actually have invalidated the artifacts. The server-side half
+# of the same hole is closed by .github/workflows/wire-schema.yml, which
+# triggers on these same paths (#1439).
+#
+# Keep this list in sync with that workflow's `paths:` filter — both answer the
+# same question, and neither is derived from the other.
 
-if [ -z "$scope" ]; then
+wire_touched=0
+if grep -Eq '^(docs/wire/|crates/stella-protocol/|crates/stella-serve/|scripts/(export-agentevent-schema|check-wire-schema)\.sh$)' "$changed"; then
+  wire_touched=1
+fi
+
+if [ -z "$scope" ] && [ "$wire_touched" = "0" ]; then
+  target="guards-fast"
+  label="make guards-fast (no crate reachable, wire contract untouched — no cargo build)"
+elif [ -z "$scope" ]; then
   target="guards"
-  label="make guards (no crate reachable — global guards + fmt only)"
+  label="make guards (no crate reachable, but the diff touches the wire contract)"
 elif [ "${GATE:-}" = "fast" ]; then
   target="check"
   label="make check (guards + fmt + clippy; GATE=fast, no rustdoc and no tests)"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,17 @@ Stella's definition of done is a test that **fails on the old code and passes on
 - [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
       the commit body from commit messages, so the description alone won't carry it
 
+## Nothing left behind
+
+Anything you noticed and did not fix — a bug, a missing test, dead or unwired
+code, the logical next step of this work — is a GitHub issue before this merges,
+written as a handoff a fresh agent could execute (AGENTS.md § "Nothing left
+behind"). The gate catches the residue (a `TODO` with no issue number); it
+cannot catch what only you saw.
+
+- [ ] Filed: #___, #___ — **or**
+- [ ] There is nothing: everything I noticed is fixed in this PR
+
 ## Ground-rule check
 
 <!-- Delete lines that don't apply. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-brand-case.sh
 
+      # Also toolchain-free. AGENTS.md and CONTRIBUTING.md each restate what
+      # `make gate` runs, and both had drifted twice — each time by omitting a
+      # newly added guard, which is the direction that misleads a reader into
+      # thinking a short green list means a green gate (#1437). The list is
+      # `GATE_STEPS` in the Makefile; this holds the prose to it.
+      - name: the documented gate is the real gate
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-gate-parity.sh
+
       # Also toolchain-free (shellcheck ships preinstalled on ubuntu-latest).
       # install.sh is fetched over the network and piped into `sh` by
       # strangers before Stella is installed; the guard scripts are what the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,16 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-brand-case.sh
 
+      # Also toolchain-free. #1394 renamed an agent-config role and the Rust
+      # compiler found every Rust call site and none of the others — a Python
+      # dict and a JavaScript literal kept the old spelling, and the arenabench
+      # one failed *silently*: the seat ran with the verifier inheriting the
+      # worker baseline while the scoreboard reported it as configured. A wrong
+      # measurement, not a crash (#1449).
+      - name: role names agree across Rust, Python and JavaScript
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-role-names.sh
+
       # Also toolchain-free. AGENTS.md requires that anything noticed and not
       # fixed becomes an issue written as a handoff; nothing checked it, and an
       # unenforced standard reads as one the codebase is meeting. The decidable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-brand-case.sh
 
+      # Also toolchain-free. `make file-size-update` regenerates the baseline
+      # and touches neither AGENTS.md's god-file table nor the twenty crate
+      # READMEs that restate it, so a split or rename stranded all three
+      # silently — the same duplicated-normative-prose shape as #630 (#1435).
+      - name: the god-file prose matches the baseline
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-god-files.sh
+
       # Also toolchain-free. #1394 renamed an agent-config role and the Rust
       # compiler found every Rust call site and none of the others — a Python
       # dict and a JavaScript literal kept the old spelling, and the arenabench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,16 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-brand-case.sh
 
+      # Also toolchain-free. AGENTS.md requires that anything noticed and not
+      # fixed becomes an issue written as a handoff; nothing checked it, and an
+      # unenforced standard reads as one the codebase is meeting. The decidable
+      # residue is a TODO/FIXME/XXX/HACK naming no issue (#1454). Unlike the
+      # file-size ratchet this had nothing to grandfather — the baseline is
+      # empty and is meant to stay empty.
+      - name: every deferral marker names a tracking issue
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-left-behind.sh
+
       # Also toolchain-free. AGENTS.md and CONTRIBUTING.md each restate what
       # `make gate` runs, and both had drifted twice — each time by omitting a
       # newly added guard, which is the direction that misleads a reader into

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,6 +1,6 @@
 name: docs-guards
 
-# Five guards over prose. None needs a Rust toolchain, which is why they live
+# Six guards over prose. None needs a Rust toolchain, which is why they live
 # here rather than in ci.yml -- that workflow deliberately ignores `docs/**`,
 # `website/**` and `*.md`, and this one triggers on exactly those paths.
 #
@@ -36,6 +36,11 @@ name: docs-guards
 #     by omitting a guard that had just been added (#1437). The real list is
 #     `GATE_STEPS` in the Makefile, which this reads via `make`.
 #
+#  6. god-files (scripts/check-god-files.sh): AGENTS.md's per-crate god-file
+#     table and the twenty crate READMEs that restate it are held to
+#     scripts/file-size-baseline.txt, which `make file-size-update` rewrites
+#     without touching either (#1435).
+#
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
 # subcommand list the third guard checks is itself a Rust enum.
@@ -51,6 +56,8 @@ on:
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
+      - "scripts/check-god-files.sh"
+      - "scripts/file-size-baseline.txt"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -64,6 +71,8 @@ on:
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
+      - "scripts/check-god-files.sh"
+      - "scripts/file-size-baseline.txt"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -116,3 +125,10 @@ jobs:
       - name: the documented gate is the real gate
         if: ${{ !cancelled() }}
         run: bash scripts/check-gate-parity.sh
+
+      # Same two directions. The baseline moving is a non-md change ci.yml
+      # catches; a README dropping a god file from its list, or a crate quietly
+      # claiming it has none, arrives as pure markdown (#1435).
+      - name: the god-file prose matches the baseline
+        if: ${{ !cancelled() }}
+        run: bash scripts/check-god-files.sh

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,6 +1,6 @@
 name: docs-guards
 
-# Four guards over prose. None needs a Rust toolchain, which is why they live
+# Five guards over prose. None needs a Rust toolchain, which is why they live
 # here rather than in ci.yml -- that workflow deliberately ignores `docs/**`,
 # `website/**` and `*.md`, and this one triggers on exactly those paths.
 #
@@ -31,6 +31,11 @@ name: docs-guards
 #     frontmatter, which becomes each page's meta description and llms.txt
 #     entry. Code spans, fenced blocks, and URLs are exempt by construction.
 #
+#  5. gate-parity (scripts/check-gate-parity.sh): AGENTS.md and CONTRIBUTING.md
+#     each restate what `make gate` runs, and both had drifted twice, each time
+#     by omitting a guard that had just been added (#1437). The real list is
+#     `GATE_STEPS` in the Makefile, which this reads via `make`.
+#
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
 # subcommand list the third guard checks is itself a Rust enum.
@@ -45,6 +50,7 @@ on:
       - "website/content/docs/**"
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
+      - "scripts/check-gate-parity.sh"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -57,6 +63,7 @@ on:
       - "website/content/docs/**"
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
+      - "scripts/check-gate-parity.sh"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -101,3 +108,11 @@ jobs:
       - name: docs prose spells the wordmark lowercase
         if: ${{ !cancelled() }}
         run: bash scripts/check-brand-case.sh
+
+      # Both directions matter here, which is why it runs in ci.yml too. A new
+      # guard is a Makefile change (ci.yml sees it); an edit that quietly drops
+      # a step from AGENTS.md or CONTRIBUTING.md is an md change, and
+      # `paths-ignore: *.md` means ci.yml structurally cannot (#1437).
+      - name: the documented gate is the real gate
+        if: ${{ !cancelled() }}
+        run: bash scripts/check-gate-parity.sh

--- a/.github/workflows/wire-schema.yml
+++ b/.github/workflows/wire-schema.yml
@@ -1,0 +1,75 @@
+name: wire-schema
+
+# The server-side half of the hole described in #1439.
+#
+# `docs/wire/` is generated from the types and committed, and
+# `scripts/check-wire-schema.sh` is what makes committing it worth anything: it
+# regenerates into a temp directory and fails on any difference. That guard runs
+# in ci.yml -- but ci.yml carries `paths-ignore: docs/**`, so a pull request
+# that touches *only* `docs/wire/` never starts it. Nothing else covered the
+# gap: docs-guards.yml is deliberately toolchain-free (four shell/python guards,
+# five-minute timeout) and adding a Rust build to it would cost every prose PR a
+# toolchain it has no use for.
+#
+# So the guard gets its own workflow, triggered on exactly the paths that can
+# invalidate the artifacts. A prose PR starts nothing here; a hand-edit to a
+# generated schema starts this and reddens.
+#
+# The same path list appears in `.githooks/pre-push`, which uses it to decide
+# between `make guards-fast` and `make guards` for a push that reaches no crate.
+# Both answer the same question -- "could this diff have moved the wire
+# contract?" -- and neither is derived from the other, so they are kept in sync
+# by hand and by this comment.
+on:
+  pull_request:
+    paths:
+      - "docs/wire/**"
+      - "crates/stella-protocol/**"
+      - "crates/stella-serve/**"
+      - "scripts/export-agentevent-schema.sh"
+      - "scripts/check-wire-schema.sh"
+      - ".github/workflows/wire-schema.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/wire/**"
+      - "crates/stella-protocol/**"
+      - "crates/stella-serve/**"
+      - "scripts/export-agentevent-schema.sh"
+      - "scripts/check-wire-schema.sh"
+      - ".github/workflows/wire-schema.yml"
+  workflow_dispatch:
+
+# Checkout plus a read-only regeneration into a temp directory.
+permissions:
+  contents: read
+
+concurrency:
+  group: wire-schema-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: docs/wire still matches the types
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Despite the action's name this does not build on `stable`:
+      # rust-toolchain.toml pins the repo to a concrete toolchain and rustup
+      # honors it for every cargo invocation inside the checkout. This step
+      # exists to put *a* rustup on PATH.
+      - name: Install Rust (rustup; the build uses the rust-toolchain.toml pin)
+        id: rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Runs the two exporters under `--features schema` and diffs the result
+      # against the committed tree. Regeneration is one command, named in the
+      # failure output: `make wire-schema-update`.
+      - name: docs/wire/ still matches the types
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: ./scripts/check-wire-schema.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,20 +57,34 @@ make watch-lint          # re-run clippy on every save
 A red gate is an automatic "not yet":
 
 ```bash
-make gate                # = no-scratch + action-pins + cargo-install-pins
+make gate                # = no-scratch + no-secrets + design-refs
+                         #   + action-pins + cargo-install-pins
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
-                         #   + command-docs + file-size + wire-schema
-                         #   + rustdoc -D warnings + fmt --check
-                         #   + clippy -D warnings + test --workspace
+                         #   + command-docs + brand-case + file-size
+                         #   + gate-parity + wire-schema
+                         #   + doc-warnings (rustdoc -D warnings)
+                         #   + format-check (fmt --check)
+                         #   + lint (clippy -D warnings)
+                         #   + test (test --workspace)
 ```
 
-CI enforces the same fifteen steps split across two workflows:
+That is nineteen steps, and the list is not maintained by hand: it is
+`GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
+fails if this block or CONTRIBUTING.md's stops matching it. The block had
+already drifted twice before that guard existed, both times by under-reporting
+a newly added guard, which is the direction that misleads — a reader runs the
+short list, sees green, and believes the gate is green (#1437).
+
+CI enforces the same steps split across three workflows:
 `/.github/workflows/ci.yml`'s required job runs everything except `invariants`
 and `doc-links`, and adds a `Cargo.lock` sync check, the prompt-cache golden
 fixtures, `stella context validate`, and a release smoke build (thin LTO);
 `docs-guards.yml` runs those two plus a second run of `command-docs`, because
-all three trigger on the `docs/**` and `*.md` paths `ci.yml` ignores.
+all three trigger on the `docs/**` and `*.md` paths `ci.yml` ignores; and
+`wire-schema.yml` runs `wire-schema` on `docs/wire/**` and the protocol crates,
+because a PR that hand-edits a generated schema and nothing else starts neither
+of the other two (#1439).
 
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
@@ -86,13 +100,22 @@ This replaces two path-based guards (`check-normative-home.sh`,
 was, and that only ever read Rust comments — 16 dead markdown-to-markdown links
 had accumulated underneath them.
 
-Three rungs, each a superset of the one above:
+Four rungs, each a superset of the one above:
 
 | Target | Runs | Honours `CARGO_SCOPE` |
 | --- | --- | --- |
-| `make guards` | every global guard + `fmt --check` — nothing compiles beyond `wire-schema`'s two exporters | — |
+| `make guards-fast` | the toolchain-free guards + `fmt --check` — nothing compiles at all | — |
+| `make guards` | ...plus `wire-schema`, whose two schema exporters do compile | — |
 | `make check` | ...plus clippy | clippy |
 | `make gate` | ...plus rustdoc and the test suite | clippy, rustdoc, test |
+
+`guards-fast` is not a rung you choose by hand; the pre-push hook picks it for
+a push that reaches no crate *and* cannot have touched the wire contract — a
+website-only or workflow-only push, which used to pay for a cargo build it had
+no use for (#1439). `wire-schema` is conditional there, never dropped:
+`docs/wire/` is generated and committed, so a hand-edit to it still takes the
+dearer rung, and `.github/workflows/wire-schema.yml` covers the same paths
+server-side because `ci.yml` ignores `docs/**`.
 
 `CARGO_SCOPE` narrows only the compile tiers, and defaults to `--workspace`, so
 `make gate` and CI are unchanged unless a caller asks for less (#1135):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,15 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
                          #   + command-docs + brand-case + file-size
-                         #   + gate-parity + left-behind + wire-schema
+                         #   + gate-parity + left-behind + role-names
+                         #   + wire-schema
                          #   + doc-warnings (rustdoc -D warnings)
                          #   + format-check (fmt --check)
                          #   + lint (clippy -D warnings)
                          #   + test (test --workspace)
 ```
 
-That is twenty steps, and the list is not maintained by hand: it is
+That is twenty-one steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,14 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
                          #   + command-docs + brand-case + file-size
-                         #   + gate-parity + wire-schema
+                         #   + gate-parity + left-behind + wire-schema
                          #   + doc-warnings (rustdoc -D warnings)
                          #   + format-check (fmt --check)
                          #   + lint (clippy -D warnings)
                          #   + test (test --workspace)
 ```
 
-That is nineteen steps, and the list is not maintained by hand: it is
+That is twenty steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting
@@ -328,6 +328,16 @@ deleted.
 - **Search before filing** (`gh issue list`, `gh search issues`) and link
   related issues instead of duplicating them. Reference the issues you filed
   from your PR description so the residue of the work is auditable.
+
+The judgment half of this rule — did you notice something and not file it —
+is not mechanically decidable, and the PR template asks a human. Its most
+common *residue* is checked: `left-behind` (`scripts/check-left-behind.sh`)
+fails the gate on a `TODO`/`FIXME`/`XXX`/`HACK` in code that names no issue,
+because a marker with no `#1234` beside it is by definition a thing left
+behind with no handoff (#1454). A marker that names an issue is tracked work
+and passes. The fix is always to file the issue and reference it — never to
+delete the marker, and never to add a baseline entry: that baseline started
+empty and is meant to stay empty.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
                          #   + command-docs + brand-case + file-size
+                         #   + god-files
                          #   + gate-parity + left-behind + role-names
                          #   + wire-schema
                          #   + doc-warnings (rustdoc -D warnings)
@@ -70,7 +71,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + test (test --workspace)
 ```
 
-That is twenty-one steps, and the list is not maintained by hand: it is
+That is twenty-two steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting
@@ -417,6 +418,15 @@ a plan needs and the part that rarely changes:
 The other twelve crates carry no god files — keep it that way. Each crate's
 README repeats its own list under "God files — do not add lines", so the
 constraint is in view wherever planning starts.
+
+All three copies — this table, those README lists, and each clean crate's "no
+god files" claim — are checked against `scripts/file-size-baseline.txt` by
+`god-files` (`scripts/check-god-files.sh`). `make file-size-update` rewrites the
+baseline and touches no prose, so before that guard existed the next split or
+rename stranded every copy silently (#1435). The baseline is the tiebreaker: it
+is generated and gate-enforced, so the prose follows it and never the reverse.
+Only *which* files are named is checked — the ceilings stay in the baseline
+alone, because a number in two places is how the last limit died.
 
 **Status — what ships.** The live runtime path is
 `stella-cli` → `stella-core` → `stella-model` / `stella-tools` / `stella-store` /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ A red gate is an automatic "not yet":
 
 ```bash
 ./scripts/check-no-scratch.sh
+./scripts/check-no-secrets.sh
+./scripts/check-design-refs.sh
 ./scripts/check-action-pins.sh
 ./scripts/check-cargo-install-pins.sh
 ./scripts/check-license-allowlist-parity.sh
@@ -76,7 +78,9 @@ shellcheck install.sh scripts/*.sh .githooks/*
 ./scripts/check-invariants.sh
 python3 ./scripts/check-doc-links.py check
 ./scripts/check-command-docs.sh
+./scripts/check-brand-case.sh
 ./scripts/check-file-size.sh
+./scripts/check-gate-parity.sh
 ./scripts/check-wire-schema.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
@@ -84,12 +88,20 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the fifteen of them in order.
+Or just `make gate`, which is the nineteen of them in order.
 
-CI enforces the same steps, split across `ci.yml` (plus a release smoke build)
-and `docs-guards.yml`, which runs the prose guards — `invariants`, `doc-links`,
+Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
+`./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence
+or AGENTS.md's block stops matching it. Before that guard existed both had
+drifted, each missing three guards that had been added without the prose being
+touched (#1437).
+
+CI enforces the same steps, split across `ci.yml` (plus a release smoke build);
+`docs-guards.yml`, which runs the prose guards — `invariants`, `doc-links`,
 and `command-docs` — on their own because they trigger on the `docs/**` and
-`*.md` paths that `ci.yml` deliberately ignores.
+`*.md` paths that `ci.yml` deliberately ignores; and `wire-schema.yml`, for the
+same reason in the other direction — a PR that only hand-edits a generated
+schema under `docs/wire/` starts neither of the others (#1439).
 
 **Cite a document by its id, not its path.** `doc:context-reuse §4` resolves no
 matter where the file moves; a document with no frontmatter `id` is not citable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ python3 ./scripts/check-doc-links.py check
 ./scripts/check-command-docs.sh
 ./scripts/check-brand-case.sh
 ./scripts/check-file-size.sh
+./scripts/check-god-files.sh
 ./scripts/check-gate-parity.sh
 ./scripts/check-left-behind.sh
 ./scripts/check-role-names.sh
@@ -90,7 +91,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the twenty-one of them in order.
+Or just `make gate`, which is the twenty-two of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ python3 ./scripts/check-doc-links.py check
 ./scripts/check-file-size.sh
 ./scripts/check-gate-parity.sh
 ./scripts/check-left-behind.sh
+./scripts/check-role-names.sh
 ./scripts/check-wire-schema.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
@@ -89,7 +90,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the twenty of them in order.
+Or just `make gate`, which is the twenty-one of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ python3 ./scripts/check-doc-links.py check
 ./scripts/check-brand-case.sh
 ./scripts/check-file-size.sh
 ./scripts/check-gate-parity.sh
+./scripts/check-left-behind.sh
 ./scripts/check-wire-schema.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
@@ -88,7 +89,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the nineteen of them in order.
+Or just `make gate`, which is the twenty of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,16 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs brand-case file-size
+                    command-docs brand-case file-size gate-parity
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
+
+# The whole gate, in order, as one name. `gate` below is defined *from* this
+# variable rather than restating it, and `make print-gate-steps` prints it —
+# which is what lets scripts/check-gate-parity.sh hold AGENTS.md and
+# CONTRIBUTING.md to the real list instead of a hand-copied one. Both documents
+# had already re-rotted twice, in the same direction each time: a guard was
+# added here and the prose kept the old count (#1437).
+GATE_STEPS := $(GATE_GUARDS) doc-warnings format-check lint test
 
 .PHONY: help
 help: ## Show this help
@@ -221,19 +229,40 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 	docker build -f packaging/docker/Dockerfile.serve -t stella-serve:ci .
 	@./scripts/smoke-serve-image.sh stella-serve:ci
 
-# The three tiers of the gate, from cheapest to dearest. Each is a superset of
+# The four tiers of the gate, from cheapest to dearest. Each is a superset of
 # the one above it, and only the compile tiers honour CARGO_SCOPE.
 #
-#   guards  every global guard + rustfmt. Only wire-schema's two schema
-#           exporters compile, so there is still nothing to scope.
-#   check   ...plus clippy. The graduated fallback: a reduced gate, not no gate.
-#   gate    ...plus rustdoc and the test suite. What CI runs, unscoped.
+#   guards-fast  the toolchain-free guards + rustfmt. Nothing compiles at all.
+#   guards       ...plus wire-schema, whose two schema exporters do compile.
+#   check        ...plus clippy. The graduated fallback: a reduced gate, not no gate.
+#   gate         ...plus rustdoc and the test suite. What CI runs, unscoped.
+#
+# `guards-fast` exists for the one push shape where `guards` is provably
+# wasted work: a diff that reaches no crate AND cannot have touched the wire
+# contract — a website-only or workflow-only push. Every guard in
+# GATE_GUARDS_FAST is a shell script over the tree, and `cargo fmt --check`
+# parses rather than builds, so this rung needs no build at all. The pre-push
+# hook picks between the two by grepping the pushed diff (#1439); wire-schema
+# is not optional, it is *conditional*, and the condition is in one place.
+.PHONY: guards-fast
+guards-fast: $(GATE_GUARDS_FAST) format-check ## Toolchain-free guards + fmt (no cargo build at all)
 
 .PHONY: guards
 guards: $(GATE_GUARDS) format-check ## Global guards + fmt only (nothing compiles beyond the wire-schema exporters; nothing to scope)
 
 .PHONY: gate
-gate: $(GATE_GUARDS) doc-warnings format-check lint test ## Full CI gate: guards + rustdoc + fmt-check + clippy + test
+gate: $(GATE_STEPS) ## Full CI gate: guards + rustdoc + fmt-check + clippy + test
+
+# Consumed by scripts/check-gate-parity.sh. Printing the variable is the whole
+# point: a guard that re-parsed this Makefile with a regex would be one more
+# hand-maintained copy of the thing it is guarding.
+.PHONY: print-gate-steps
+print-gate-steps:
+	@echo $(GATE_STEPS)
+
+.PHONY: gate-parity
+gate-parity: ## Assert AGENTS.md and CONTRIBUTING.md list the real gate steps (#1437)
+	@./scripts/check-gate-parity.sh
 
 .PHONY: check
 check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs brand-case file-size gate-parity left-behind role-names
+                    command-docs brand-case file-size god-files gate-parity left-behind \
+                    role-names
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The whole gate, in order, as one name. `gate` below is defined *from* this
@@ -275,6 +276,10 @@ left-behind-update: ## Regenerate the left-behind baseline (it should stay empty
 .PHONY: role-names
 role-names: ## Assert the agent-config role names match across Rust, Python and JS (#1449)
 	@./scripts/check-role-names.sh
+
+.PHONY: god-files
+god-files: ## Assert AGENTS.md and the crate READMEs name the baselined god files (#1435)
+	@./scripts/check-god-files.sh
 
 .PHONY: check
 check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs brand-case file-size gate-parity
+                    command-docs brand-case file-size gate-parity left-behind
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The whole gate, in order, as one name. `gate` below is defined *from* this
@@ -263,6 +263,14 @@ print-gate-steps:
 .PHONY: gate-parity
 gate-parity: ## Assert AGENTS.md and CONTRIBUTING.md list the real gate steps (#1437)
 	@./scripts/check-gate-parity.sh
+
+.PHONY: left-behind
+left-behind: ## Assert every TODO/FIXME/XXX/HACK in code names a tracking issue (#1454)
+	@./scripts/check-left-behind.sh
+
+.PHONY: left-behind-update
+left-behind-update: ## Regenerate the left-behind baseline (it should stay empty)
+	@./scripts/check-left-behind.sh --update
 
 .PHONY: check
 check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs brand-case file-size gate-parity left-behind
+                    command-docs brand-case file-size gate-parity left-behind role-names
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The whole gate, in order, as one name. `gate` below is defined *from* this
@@ -271,6 +271,10 @@ left-behind: ## Assert every TODO/FIXME/XXX/HACK in code names a tracking issue 
 .PHONY: left-behind-update
 left-behind-update: ## Regenerate the left-behind baseline (it should stay empty)
 	@./scripts/check-left-behind.sh --update
+
+.PHONY: role-names
+role-names: ## Assert the agent-config role names match across Rust, Python and JS (#1449)
+	@./scripts/check-role-names.sh
 
 .PHONY: check
 check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests

--- a/bench/evidence/frontier/tests/test_plan.py
+++ b/bench/evidence/frontier/tests/test_plan.py
@@ -28,6 +28,12 @@ import pytest
 
 _PLAN_PATH = Path(__file__).resolve().parent.parent / "plan.py"
 _spec = importlib.util.spec_from_file_location("frontier_plan", _PLAN_PATH)
+# A module-scope assert, deliberately: this one is a *precondition for importing
+# the module under test*, not a check on a constant. Without it there is nothing
+# to collect, so the collection error is the honest report and no smaller blast
+# radius exists. Contrast the digest constant in
+# `bench/terminal_bench_analysis/tests/test_tb21_analysis.py`, which was moved
+# into a named test for exactly that reason (#1452).
 assert _spec and _spec.loader
 plan = importlib.util.module_from_spec(_spec)
 sys.modules["frontier_plan"] = plan

--- a/bench/evidence/glm52-h2h-postmortem/README.md
+++ b/bench/evidence/glm52-h2h-postmortem/README.md
@@ -1,11 +1,13 @@
 # GLM-5.2 head-to-head post-mortem: the 106 cap hits and the 6.4× input gap
 
 A reading of the evidence from the 89-task Terminal-Bench 2.1 same-model
-head-to-head (`stella-docs/benchmarks/terminal-bench-2-1-glm-5-2.json` — the
+head-to-head (`docs/benchmarks/terminal-bench-2-1-glm-5-2.json` — the
 data behind the public "same model, different harness" page). Stella won the
 run, 58/89 against Claude Code's 44/89, and this document is about the two
-things the winning number hides: **106 output-cap hits** (Claude Code: 0) and
-**366M input tokens against 57M** (6.40×).
+things the winning number hides: **106 output-cap hits** (a Stella-only
+measurement — the Claude Code arm does not emit it, so there is no 106-vs-0
+comparison to make) and **366M input tokens against 57M** (6.40×, and that one
+*is* like-for-like).
 
 Every figure below is recomputed by [`analyze.py`](analyze.py) beside this
 file, from the committed table alone — stdlib only, no network, no arguments.
@@ -27,14 +29,17 @@ If this prose and that script disagree, the script wins.
 | input tokens | 366,226,022 | 57,233,585 |
 | output tokens | 5.31M | 2.23M |
 | cost | $78.25 | $63.35 |
-| cap hits | **106** | 0 |
+| cap hits | **106** (inferred) | — (not emitted) |
 
 `cap_hits` counts `step_usage` events with ≥16,384 output tokens **and zero
 tool calls** — a step that spent a huge output budget without acting. Under
 the frozen posture (`max_tokens: 64000`) a counted step may sit anywhere in
 [16,384, 64,000]; a literal truncation at the cap is the worst case of the
-class, not the whole class. Claude Code recorded zero because its steps
-either act or stay small — the failure shape is Stella-specific.
+class, not the whole class. **The Claude Code column is a dash, not a zero,
+and the difference matters**: `cap_hits` is read from `stella-events.jsonl`,
+which that arm never writes, so its value is *no source* rather than *measured
+zero* (#1227). Nothing here licenses "106 against 0" — this section is a
+finding about Stella's own steps, not a comparison.
 
 ## 2. The 106 cap hits
 

--- a/bench/evidence/glm52-h2h-postmortem/analyze.py
+++ b/bench/evidence/glm52-h2h-postmortem/analyze.py
@@ -3,7 +3,7 @@
 head-to-head table.
 
 The input is the same per-task JSON the public docs page renders
-(`stella-docs/benchmarks/terminal-bench-2-1-glm-5-2.json`): one row per task,
+(`docs/benchmarks/terminal-bench-2-1-glm-5-2.json`): one row per task,
 one cell per arm, produced by the live-feed reducer in
 `bench/harbor_adapter/stella_harbor/live_feed.py`. That reducer defines the
 `cap_hits` metric this post-mortem is about: a `step_usage` event with
@@ -33,7 +33,7 @@ CAP_HIT_MIN_OUTPUT = 16384  # mirrors live_feed._CAP_HIT_MIN_OUTPUT
 
 DATA = (
     Path(__file__).resolve().parents[3]
-    / "stella-docs"
+    / "docs"
     / "benchmarks"
     / "terminal-bench-2-1-glm-5-2.json"
 )
@@ -74,9 +74,15 @@ def main() -> None:
     print(
         f"input tokens: stella {s_in:,} claude {c_in:,} ratio {s_in / c_in:.2f}x"
     )
+    # `cap_hits` is Stella-only telemetry, read from stella-events.jsonl, which
+    # the Claude Code arm does not write. Its per-row value is null — no source,
+    # not a measured zero — so there is no cross-arm comparison to print here
+    # (#1227). Summing it as if null meant zero is the exact flattering-artifact
+    # the data file was corrected to prevent.
     print(
-        f"cap hits: stella {sum(r['stella']['cap_hits'] for r in rows)}, "
-        f"claude {sum(r['claude']['cap_hits'] for r in rows)}"
+        f"cap hits: stella {sum(r['stella']['cap_hits'] for r in rows)} "
+        f"({d['totals']['stella']['cap_hits_source']}), "
+        f"claude: no source — the arm does not emit this telemetry"
     )
 
     print("\n== cap-hit outcome split (README §2.1) ==")

--- a/bench/harbor_adapter/tests/test_git_baseline.py
+++ b/bench/harbor_adapter/tests/test_git_baseline.py
@@ -33,6 +33,8 @@ _MODULE_PATH = Path(__file__).resolve().parents[1] / "stella_harbor" / "git_base
 _spec = importlib.util.spec_from_file_location(
     "stella_harbor_git_baseline", _MODULE_PATH
 )
+# Module-scope assert, deliberately: an import precondition, not a constant
+# check — without it there is nothing to collect (see #1452's sweep).
 assert _spec is not None and _spec.loader is not None
 _git_baseline = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_git_baseline)

--- a/bench/harbor_adapter/tests/test_portability.py
+++ b/bench/harbor_adapter/tests/test_portability.py
@@ -44,6 +44,8 @@ _CHECKER = _REPO_ROOT / "bench" / "harbor_adapter" / "stella_harbor" / "portabil
 _ENV_SH = _REPO_ROOT / "bench" / "evidence" / "run" / "env.sh"
 
 _spec = importlib.util.spec_from_file_location("stella_harbor_portability", _CHECKER)
+# Module-scope assert, deliberately: an import precondition, not a constant
+# check — without it there is nothing to collect (see #1452's sweep).
 assert _spec is not None and _spec.loader is not None
 _portability = importlib.util.module_from_spec(_spec)
 # Registered before execution: `@dataclass` resolves a class's own module out

--- a/bench/terminal_bench_analysis/tests/test_posture_digest.py
+++ b/bench/terminal_bench_analysis/tests/test_posture_digest.py
@@ -1,0 +1,53 @@
+"""The canonical engine posture still hashes to the digest every arm was claimed under.
+
+This is one behaviour in its own file on purpose (#1452). It used to be an
+`assert` at module scope in ``test_tb21_analysis.py``:
+
+    _POSTURE, _POSTURE_JSON, _POSTURE_SHA256 = canonical_engine_posture(_MODEL)
+    assert _POSTURE_SHA256 == "8ce2e820…"
+
+which runs at *import*, so a single stale hex string never reached collection —
+it reported as ``Interrupted: 1 error during collection`` and took all 258 tests
+in that file with it. ``main`` was red for roughly forty minutes with whatever
+else was broken in that module invisible behind the digest.
+
+The guarantee that assert was buying is real and is kept. It is not "delete the
+assert": ``_POSTURE_SHA256`` builds fixtures throughout the sibling module, and a
+wrong value there would have dozens of tests assert against a fabricated posture
+and pass. What makes moving it out safe is that those fixtures use the
+*computed* posture — so they stay self-consistent, and the one thing that needs
+saying, "the posture we compute is still the posture we published", is said
+here, once, by name.
+"""
+
+from __future__ import annotations
+
+import tb21_analysis as analysis_module
+
+_MODEL = analysis_module.PRIMARY_MODEL
+
+# The digest every registered TB2.1 arm was claimed under. Re-frozen when the
+# `judge` agent slot became `verifier`: a slot rename is a NEW posture
+# generation, not a cosmetic edit, because runs under `8530a36f…` booked an
+# agent under the old key and are not hash-comparable with runs under this one.
+_REGISTERED_POSTURE_SHA256 = (
+    "8ce2e82029af25d9c9ee5d3f0f024f6e97c08fe39543486edb66926cb55b84a9"
+)
+
+
+def test_the_engine_posture_digest_is_the_registered_one() -> None:
+    """Fails alone, and names both halves.
+
+    Renaming anything that appears in a posture key — an agent slot, an effort,
+    a model id — re-hashes every registered arm; see `bench/READINESS.md`
+    §8.4.4. That is a new generation of the posture, not a cosmetic edit, so the
+    remedy is to re-freeze this constant *and* stop comparing across the change.
+    """
+    _, _, computed = analysis_module.canonical_engine_posture(_MODEL)
+
+    assert computed == _REGISTERED_POSTURE_SHA256, (
+        f"the canonical posture for {_MODEL} now hashes to {computed}, "
+        f"but every registered arm was claimed under {_REGISTERED_POSTURE_SHA256}. "
+        "If the posture legitimately changed, re-freeze this constant and treat "
+        "prior runs as a different generation — they are not hash-comparable."
+    )

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -524,37 +524,11 @@ _POSTURE, _POSTURE_JSON, _POSTURE_SHA256 = analysis_module.canonical_engine_post
     _READINESS_POSTURE_JSON,
     _READINESS_POSTURE_SHA256,
 ) = analysis_module.canonical_engine_posture(_READINESS_MODEL)
-# The digest every registered TB2.1 arm was claimed under. Re-frozen when the
-# `judge` agent slot became `verifier`: a slot rename is a NEW posture
-# generation, not a cosmetic edit, because runs under `8530a36f…` booked an
-# agent under the old key and are not hash-comparable with runs under this one.
-#
-# This is a constant, not an assertion. It used to be `assert _POSTURE_SHA256
-# == …` at module scope, which ran at import — so one stale hex string reported
-# as `Interrupted: 1 error during collection` and took all 258 tests in this
-# file with it, hiding whatever else was broken here (#1452). The check now
-# lives in `test_the_engine_posture_digest_is_the_registered_one` below, which
-# fails alone and by name.
-_REGISTERED_POSTURE_SHA256 = (
-    "8ce2e82029af25d9c9ee5d3f0f024f6e97c08fe39543486edb66926cb55b84a9"
-)
-
-
-def test_the_engine_posture_digest_is_the_registered_one() -> None:
-    """The posture this module computes still hashes to the registered digest.
-
-    Every fixture below is built from the *computed* posture, so a drifted
-    digest does not silently fabricate a posture the fixtures then agree with —
-    it fails here, once, naming both halves. Renaming anything that appears in a
-    posture key (an agent slot, an effort, a model id) re-hashes every
-    registered arm; see `bench/READINESS.md` §8.4.4.
-    """
-    assert _POSTURE_SHA256 == _REGISTERED_POSTURE_SHA256, (
-        f"the canonical posture for {_MODEL} now hashes to {_POSTURE_SHA256}, "
-        f"but every registered arm was claimed under {_REGISTERED_POSTURE_SHA256}. "
-        "If the posture legitimately changed, re-freeze this constant and treat "
-        "prior runs as a different generation — they are not hash-comparable."
-    )
+# The registered-digest check that used to sit here as a module-scope `assert`
+# now lives in tests/test_posture_digest.py. It ran at import, so one stale hex
+# string reported as `Interrupted: 1 error during collection` and took every
+# test in this file with it (#1452). Fixtures below use the *computed* posture,
+# which is what makes moving the check out safe.
 
 
 def test_the_readme_digests_match_the_postures_printed_beside_them() -> None:

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -524,12 +524,37 @@ _POSTURE, _POSTURE_JSON, _POSTURE_SHA256 = analysis_module.canonical_engine_post
     _READINESS_POSTURE_JSON,
     _READINESS_POSTURE_SHA256,
 ) = analysis_module.canonical_engine_posture(_READINESS_MODEL)
-# Re-frozen when the `judge` agent slot became `verifier`. A slot rename is a
-# NEW posture generation, not a cosmetic edit: runs under `8530a36f…` booked an
+# The digest every registered TB2.1 arm was claimed under. Re-frozen when the
+# `judge` agent slot became `verifier`: a slot rename is a NEW posture
+# generation, not a cosmetic edit, because runs under `8530a36f…` booked an
 # agent under the old key and are not hash-comparable with runs under this one.
-assert _POSTURE_SHA256 == (
+#
+# This is a constant, not an assertion. It used to be `assert _POSTURE_SHA256
+# == …` at module scope, which ran at import — so one stale hex string reported
+# as `Interrupted: 1 error during collection` and took all 258 tests in this
+# file with it, hiding whatever else was broken here (#1452). The check now
+# lives in `test_the_engine_posture_digest_is_the_registered_one` below, which
+# fails alone and by name.
+_REGISTERED_POSTURE_SHA256 = (
     "8ce2e82029af25d9c9ee5d3f0f024f6e97c08fe39543486edb66926cb55b84a9"
 )
+
+
+def test_the_engine_posture_digest_is_the_registered_one() -> None:
+    """The posture this module computes still hashes to the registered digest.
+
+    Every fixture below is built from the *computed* posture, so a drifted
+    digest does not silently fabricate a posture the fixtures then agree with —
+    it fails here, once, naming both halves. Renaming anything that appears in a
+    posture key (an agent slot, an effort, a model id) re-hashes every
+    registered arm; see `bench/READINESS.md` §8.4.4.
+    """
+    assert _POSTURE_SHA256 == _REGISTERED_POSTURE_SHA256, (
+        f"the canonical posture for {_MODEL} now hashes to {_POSTURE_SHA256}, "
+        f"but every registered arm was claimed under {_REGISTERED_POSTURE_SHA256}. "
+        "If the posture legitimately changed, re-freeze this constant and treat "
+        "prior runs as a different generation — they are not hash-comparable."
+    )
 
 
 def test_the_readme_digests_match_the_postures_printed_beside_them() -> None:

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -1,6 +1,13 @@
 //! `stella.toml` — the TOML config document, and how it lowers into
 //! [`Settings`].
 //!
+//! The design this implements is `doc:config-system` — Phases 0 and 1 of it are
+//! built (this document and its lowering, comment-preserving writes in
+//! [`super::toml_io`], three-scope discovery, and the dual read with TOML
+//! winning whole); Phases 2–6 are not. Read §3.1–§3.2 and §6.1 there before
+//! changing the shapes below, because the divergences from [`Settings`] are
+//! decisions recorded in that spec rather than accidents of this file.
+//!
 //! # Why a separate document type
 //!
 //! This is deliberately NOT `#[derive(Deserialize)]` on [`Settings`] itself.

--- a/crates/stella-core/src/context_record.rs
+++ b/crates/stella-core/src/context_record.rs
@@ -20,6 +20,20 @@
 //! `observed_at`, `valid_to` → `valid_until`, and the legacy memory/fact APIs)
 //! need the ingestion path, so they land with the Phase 2 migration that owns it.
 //!
+//! ## The decisions this module implements
+//!
+//! These are ratified decision records, not background reading — the shape of
+//! the types below is their output, and changing one here without amending the
+//! record there leaves two answers to the same question:
+//!
+//! - `doc:adr/0009-enum-freeze-resolutions` — which variants the frozen enums
+//!   carry, including `DirectiveEnforcement` dropping `Informational` and the
+//!   closed `constraint_effect` set.
+//! - `doc:adr/0011-context-records-are-toml` — a context record is TOML at
+//!   `.stella/rules/*.toml`, one record per file.
+//! - `doc:adr/0012-context-record-field-schema` — which fields a record
+//!   carries, and the records-live-in-files rule that follows from it.
+//!
 //! ## Where a validator lives
 //!
 //! Purity is about I/O, not about arity. A rule that spans two records is still

--- a/crates/stella-mcp/README.md
+++ b/crates/stella-mcp/README.md
@@ -39,6 +39,14 @@ builds its own binary, `mcp-fixture-server`, which exists purely for
 | [`src/error.rs`](src/error.rs) | `McpError` and `user_message()` — the length-bounded, credential-free rendering that reaches the model. |
 | [`src/bin/mcp-fixture-server.rs`](src/bin/mcp-fixture-server.rs) | The canned MCP server the integration tests spawn, with its fault-injection flags. |
 
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
 ## Key concepts
 
 **One integration point, one namespace.** `McpToolSet` implements the same

--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -50,6 +50,14 @@ free one). This crate builds no binary —
 | `src/assets/mark.svg`, `src/assets/wordmark.svg` | Favicon and header lockup, served from `/assets/`. |
 | [`examples/serve.rs`](examples/serve.rs) | `cargo run -p stella-observatory --example serve -- <root> <port>` — serve any workspace without building the CLI. |
 
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
 ## Key concepts
 
 ### The three boundaries, and what actually enforces each

--- a/crates/stella-protocol/src/context_event.rs
+++ b/crates/stella-protocol/src/context_event.rs
@@ -281,6 +281,12 @@ pub struct OutcomeAssessed {
 }
 
 /// Stable-ID payload of `compiled_context_frame_built`.
+///
+/// The compiled frame is *stella's own artifact*, distinct from the
+/// provider-emitted `ContextFrame` it is named after — the distinction, and the
+/// 2026-07-26 amendment folding the compiled frame into the step manifest
+/// rather than a parallel aggregate, are
+/// `doc:adr/0006-contextframe-vs-compiledcontextframe`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CompiledContextFrameBuilt {

--- a/crates/stella-protocol/src/context_event.rs
+++ b/crates/stella-protocol/src/context_event.rs
@@ -1,5 +1,17 @@
 //! Internal, replay-safe adaptive-context events (Phase 1 installment 5).
 //!
+//! `CompiledContextFrameBuilt` below carries a decision worth reading before
+//! changing it: the compiled frame is *stella's own artifact*, distinct from the
+//! provider-emitted `ContextFrame` it is named after, and the 2026-07-26
+//! amendment folded it into the step manifest rather than a parallel aggregate.
+//! Both are `doc:adr/0006-contextframe-vs-compiledcontextframe`.
+//!
+//! (That citation lives here rather than on the struct on purpose. The schema
+//! exporters carry *type* doc comments into `docs/wire/` verbatim, so a
+//! documentation-only edit up there would restate the wire contract and redden
+//! `wire-schema` until the generated artifacts were regenerated and committed.
+//! Module docs are not exported, so this is the free place to say it.)
+//!
 //! These are stella-internal lifecycle events — they do **not** change the
 //! Context Graph Protocol wire semantics. They carry only stable IDs
 //! (as strings), never the `stella-core` record structs: `stella-core` depends on
@@ -281,12 +293,6 @@ pub struct OutcomeAssessed {
 }
 
 /// Stable-ID payload of `compiled_context_frame_built`.
-///
-/// The compiled frame is *stella's own artifact*, distinct from the
-/// provider-emitted `ContextFrame` it is named after — the distinction, and the
-/// 2026-07-26 amendment folding the compiled frame into the step manifest
-/// rather than a parallel aggregate, are
-/// `doc:adr/0006-contextframe-vs-compiledcontextframe`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CompiledContextFrameBuilt {

--- a/crates/stella-serve/README.md
+++ b/crates/stella-serve/README.md
@@ -102,6 +102,14 @@ To tell *wedged* from merely *slow*: a turn whose `turn_settled` tally shows no
 advancing `stages` while a reverse request's `waited_ms` climbs is wedged; one
 whose stages keep advancing is just long.
 
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
 ## Key concepts
 
 **The reverse tool-call protocol.** Two deliberately asymmetric directions.

--- a/docs/adr/0006-contextframe-vs-compiledcontextframe.md
+++ b/docs/adr/0006-contextframe-vs-compiledcontextframe.md
@@ -1,3 +1,9 @@
+---
+id: adr/0006-contextframe-vs-compiledcontextframe
+title: "ADR 0006: ContextFrame vs. CompiledContextFrame"
+status: implemented
+---
+
 # ADR 0006: ContextFrame vs. CompiledContextFrame
 
 - Status: Accepted (Phase 0) — amended 2026-07-26 (compiled frame extends the

--- a/docs/adr/0009-enum-freeze-resolutions.md
+++ b/docs/adr/0009-enum-freeze-resolutions.md
@@ -1,3 +1,9 @@
+---
+id: adr/0009-enum-freeze-resolutions
+title: "ADR 0009: Enum-Freeze Resolutions for Flagged Phase-1 Decisions"
+status: implemented
+---
+
 # ADR 0009: Enum-Freeze Resolutions for Flagged Phase-1 Decisions
 
 - Status: **Accepted** — ratified by repository owner 2026-07-24. Four items

--- a/docs/adr/0011-context-records-are-toml.md
+++ b/docs/adr/0011-context-records-are-toml.md
@@ -1,3 +1,9 @@
+---
+id: adr/0011-context-records-are-toml
+title: "ADR 0011: Context Records Are TOML (supersedes the surface decision in 0008)"
+status: implemented
+---
+
 # ADR 0011: Context Records Are TOML (supersedes the surface decision in 0008)
 
 - Status: **Accepted** — ratified by repository owner 2026-07-30 (was: Proposed).

--- a/docs/adr/0012-context-record-field-schema.md
+++ b/docs/adr/0012-context-record-field-schema.md
@@ -1,3 +1,9 @@
+---
+id: adr/0012-context-record-field-schema
+title: "ADR 0012: The context-record field schema, and records-live-in-files"
+status: implemented
+---
+
 # ADR 0012: The context-record field schema, and records-live-in-files
 
 - Status: **Accepted** — ratified by repository owner 2026-07-30 (was: Proposed).

--- a/docs/adr/0013-session-artifact-boundary.md
+++ b/docs/adr/0013-session-artifact-boundary.md
@@ -1,3 +1,9 @@
+---
+id: adr/0013-session-artifact-boundary
+title: "ADR 0013: The session artifact boundary"
+status: proposed
+---
+
 # ADR 0013: The session artifact boundary
 
 - Status: **Proposed** — awaiting ratification by the repository owner.

--- a/docs/audit/2026-08-04-ultraudit-round-3.md
+++ b/docs/audit/2026-08-04-ultraudit-round-3.md
@@ -1,7 +1,7 @@
 ---
 id: audit/2026-08-ultraudit-round-3
 title: Ultraudit round 3 — 2026-08-04
-status: living
+status: archived
 ---
 
 # Ultraudit round 3 — 2026-08-04

--- a/docs/audit/2026-08-parity-gap-followup.md
+++ b/docs/audit/2026-08-parity-gap-followup.md
@@ -1,3 +1,9 @@
+---
+id: audit/2026-08-parity-gap-followup
+title: "Parity follow-up to the July 2026 audit — August 2026"
+status: archived
+---
+
 # Parity follow-up to the July 2026 audit — August 2026
 
 Scope: re-check every claim in `2026-07-reference-grade-audit.md` against the

--- a/docs/design/agent-native-delivery.md
+++ b/docs/design/agent-native-delivery.md
@@ -1,3 +1,9 @@
+---
+id: agent-native-delivery
+title: "Agent-Native Delivery — the issue tracker as the agent's working memory"
+status: proposed
+---
+
 # Agent-Native Delivery — the issue tracker as the agent's working memory
 
 Status: proposal, unbuilt. Phases in §11; the Phase-1 Linear extraction is

--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -1,3 +1,9 @@
+---
+id: pipeline-journey
+title: "The journey of a prompt — full pipeline mode, in plain language"
+status: living
+---
+
 # The journey of a prompt — full pipeline mode, in plain language
 
 **Status:** Living document. Describes the staged pipeline as of 0.6.x.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -37,20 +37,102 @@
       "status": "living",
       "title": "Adaptive Context"
     },
+    "adaptive-context-plan": {
+      "path": "docs/spec/adaptive-context/adaptive-context-plan.md",
+      "sections": [
+        0
+      ],
+      "status": "proposed",
+      "title": "Adaptive Context \u2014 Implementation Plan"
+    },
+    "adr/0006-contextframe-vs-compiledcontextframe": {
+      "path": "docs/adr/0006-contextframe-vs-compiledcontextframe.md",
+      "status": "implemented",
+      "title": "ADR 0006: ContextFrame vs. CompiledContextFrame"
+    },
+    "adr/0009-enum-freeze-resolutions": {
+      "path": "docs/adr/0009-enum-freeze-resolutions.md",
+      "status": "implemented",
+      "title": "ADR 0009: Enum-Freeze Resolutions for Flagged Phase-1 Decisions"
+    },
+    "adr/0011-context-records-are-toml": {
+      "path": "docs/adr/0011-context-records-are-toml.md",
+      "status": "implemented",
+      "title": "ADR 0011: Context Records Are TOML (supersedes the surface decision in 0008)"
+    },
+    "adr/0012-context-record-field-schema": {
+      "path": "docs/adr/0012-context-record-field-schema.md",
+      "status": "implemented",
+      "title": "ADR 0012: The context-record field schema, and records-live-in-files"
+    },
+    "adr/0013-session-artifact-boundary": {
+      "path": "docs/adr/0013-session-artifact-boundary.md",
+      "status": "proposed",
+      "title": "ADR 0013: The session artifact boundary"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",
       "title": "The agent monitor protocol"
     },
+    "agent-native-delivery": {
+      "path": "docs/design/agent-native-delivery.md",
+      "sections": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "status": "proposed",
+      "title": "Agent-Native Delivery \u2014 the issue tracker as the agent's working memory"
+    },
+    "audit/2026-08-parity-gap-followup": {
+      "path": "docs/audit/2026-08-parity-gap-followup.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "status": "archived",
+      "title": "Parity follow-up to the July 2026 audit \u2014 August 2026"
+    },
     "audit/2026-08-ultraudit-round-3": {
       "path": "docs/audit/2026-08-04-ultraudit-round-3.md",
-      "status": "living",
+      "status": "archived",
       "title": "Ultraudit round 3 \u2014 2026-08-04"
     },
     "brand": {
       "path": "docs/brand/README.md",
       "status": "living",
       "title": "stella\\* \u2014 brand kit v1.0"
+    },
+    "config-system": {
+      "path": "docs/spec/config-system/DESIGN.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "status": "implemented",
+      "title": "Design: `stella.toml` \u2014 one config file, and the five features it unlocks"
     },
     "context-frame-spec": {
       "path": "docs/spec/adaptive-context/context-frame-spec.md",
@@ -152,6 +234,21 @@
       "status": "vendored",
       "title": "Context reuse: identity, accounting, consent, and verification"
     },
+    "deterministic-engine": {
+      "path": "docs/papers/deterministic-engine.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "status": "living",
+      "title": "The Deterministic Engine: Why Single-Thread Beats the Swarm"
+    },
     "diagnostics": {
       "path": "docs/spec/diagnostics.md",
       "sections": [
@@ -242,6 +339,27 @@
       "path": "docs/spec/filesystem-layout.md",
       "status": "living",
       "title": "Where Stella puts things on your disk"
+    },
+    "pipeline-journey": {
+      "path": "docs/design/pipeline-journey.md",
+      "sections": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "status": "living",
+      "title": "The journey of a prompt \u2014 full pipeline mode, in plain language"
     },
     "remote-sandboxes": {
       "path": "docs/spec/remote-sandboxes.md",

--- a/docs/papers/deterministic-engine.md
+++ b/docs/papers/deterministic-engine.md
@@ -1,3 +1,9 @@
+---
+id: deterministic-engine
+title: "The Deterministic Engine: Why Single-Thread Beats the Swarm"
+status: living
+---
+
 # The Deterministic Engine: Why Single-Thread Beats the Swarm
 
 > **Research note.** This paper is a focused analysis of one defensible

--- a/docs/spec/adaptive-context/adaptive-context-plan.md
+++ b/docs/spec/adaptive-context/adaptive-context-plan.md
@@ -1,3 +1,9 @@
+---
+id: adaptive-context-plan
+title: "Adaptive Context — Implementation Plan"
+status: proposed
+---
+
 # Adaptive Context — Implementation Plan
 
 **Status:** Plan — supersedes the eleven-phase roadmap

--- a/docs/spec/config-system/DESIGN.md
+++ b/docs/spec/config-system/DESIGN.md
@@ -1,3 +1,9 @@
+---
+id: config-system
+title: "Design: `stella.toml` — one config file, and the five features it unlocks"
+status: implemented
+---
+
 # Design: `stella.toml` — one config file, and the five features it unlocks
 
 **Status:** Phase 0 and Phase 1 implemented. Phases 2–6 unbuilt. ·

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Guard: AGENTS.md and CONTRIBUTING.md describe the gate that actually exists.
+# See #1437.
+#
+# The gate's real composition lives in one place — `GATE_STEPS` in the Makefile.
+# Two documents restate it in prose, because a contributor reading either one
+# should learn what `make gate` will do without reading a Makefile. Prose that
+# restates a list drifts; this one drifted twice, in the same direction both
+# times, and both times it under-reported:
+#
+#   * AGENTS.md claimed THIRTEEN steps and omitted repro-wiring and
+#     command-docs. Repaired 2026-08-04.
+#   * By the time this guard was written it claimed FIFTEEN and omitted
+#     no-secrets, design-refs and brand-case. CONTRIBUTING.md's command list
+#     was missing the same three.
+#
+# The failure mode is quiet and it is the bad direction: a reader trusts the
+# short list, runs those commands, and believes a green result means the gate is
+# green. The next guard added is the next omission — there is nothing structural
+# stopping it, which is the entire argument for this script.
+#
+# What it checks:
+#
+#   1. Every step in `GATE_STEPS` is named in AGENTS.md's gate block.
+#   2. Every step is named in CONTRIBUTING.md's gate fence, via the alias table
+#      below (that fence lists raw commands, on purpose — its reader wants to
+#      run them without make).
+#   3. Both documents' spelled-out count matches the real number of steps.
+#   4. CONTRIBUTING.md's fence does not run a `check-*.sh` that is no longer a
+#      gate step — which is how a removed guard leaves a ghost behind. Only
+#      that fence is checked this way: it is a delimited list of commands,
+#      whereas AGENTS.md's block is prose with parenthetical glosses.
+#
+# What it deliberately does NOT check: the prose *around* the lists. Whether
+# "ci.yml's required job runs everything except invariants and doc-links" is
+# still true is a claim about a workflow, not about this list, and pretending a
+# grep could settle it would be worse than leaving it to review.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner. `make` is required —
+# it is how the step list is read, and a runner that cannot run make cannot run
+# the gate this guard describes.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+agents="AGENTS.md"
+contributing="CONTRIBUTING.md"
+
+fail=0
+note() { printf 'check-gate-parity: %s\n' "$1" >&2; }
+
+# ── The truth ────────────────────────────────────────────────────────────────
+
+if ! steps="$(make -s print-gate-steps 2>/dev/null)"; then
+  note "FAIL — could not read GATE_STEPS (\`make -s print-gate-steps\`)."
+  note "     That target is what makes this guard derived rather than a"
+  note "     second copy of the list. Restore it in the Makefile."
+  exit 1
+fi
+
+count="$(printf '%s\n' "$steps" | wc -w | tr -d ' ')"
+if [ "$count" -eq 0 ]; then
+  note "FAIL — GATE_STEPS is empty."
+  exit 1
+fi
+
+# Spelled-out numbers, because both documents spell the count in prose ("the
+# fifteen of them in order") and a digit would read wrong there. Covers a range
+# no plausible gate will leave.
+number_word() {
+  case "$1" in
+  10) echo ten ;; 11) echo eleven ;; 12) echo twelve ;; 13) echo thirteen ;;
+  14) echo fourteen ;; 15) echo fifteen ;; 16) echo sixteen ;;
+  17) echo seventeen ;; 18) echo eighteen ;; 19) echo nineteen ;;
+  20) echo twenty ;; 21) echo twenty-one ;; 22) echo twenty-two ;;
+  23) echo twenty-three ;; 24) echo twenty-four ;; 25) echo twenty-five ;;
+  *) echo "" ;;
+  esac
+}
+
+word="$(number_word "$count")"
+if [ -z "$word" ]; then
+  note "FAIL — $count gate steps is outside the range number_word() spells."
+  note "     Extend the table in this script; the documents spell the count."
+  exit 1
+fi
+
+# CONTRIBUTING.md lists raw commands rather than make targets. Every guard is
+# `scripts/check-<target>.sh` except the ones named here, and the four compile
+# steps are cargo invocations. An alias is a deliberate, reviewable statement
+# that two spellings mean the same step.
+contributing_alias() {
+  case "$1" in
+  shellcheck) echo 'shellcheck ' ;;
+  doc-links) echo 'check-doc-links' ;;
+  doc-warnings) echo 'cargo doc' ;;
+  format-check) echo 'cargo fmt' ;;
+  lint) echo 'cargo clippy' ;;
+  test) echo 'cargo test' ;;
+  *) echo "check-$1.sh" ;;
+  esac
+}
+
+# ── The two documents ────────────────────────────────────────────────────────
+
+for doc in "$agents" "$contributing"; do
+  if [ ! -f "$doc" ]; then
+    note "FAIL — $doc does not exist."
+    fail=1
+    continue
+  fi
+
+  for step in $steps; do
+    if [ "$doc" = "$contributing" ]; then
+      needle="$(contributing_alias "$step")"
+    else
+      needle="$step"
+    fi
+    if ! grep -qF -- "$needle" "$doc"; then
+      note "FAIL — $doc never mentions the gate step '$step'"
+      note "     (looked for '$needle')."
+      fail=1
+    fi
+  done
+
+  if ! grep -qF -- "$word" "$doc"; then
+    note "FAIL — $doc does not spell the gate's step count as '$word'."
+    note "     The gate runs $count steps. Find the stale count and fix it."
+    fail=1
+  fi
+done
+
+# ── Ghosts ───────────────────────────────────────────────────────────────────
+#
+# The other direction: a guard *removed* from GATE_STEPS leaves its command
+# behind in CONTRIBUTING.md's fence, where it reads as a step that still runs.
+# That fence is a delimited list of commands, so every `check-*.sh` inside it
+# can be held to the step list exactly. (AGENTS.md's block is prose with
+# parenthetical glosses and gets no equivalent check — see the header.)
+
+fence="$(awk '
+  /^### The gate/        { seen = 1 }
+  seen && /^```/         { fences++; next }
+  seen && fences == 1    { print }
+  seen && fences == 2    { exit }
+' "$contributing")"
+
+if [ -z "$fence" ]; then
+  note "FAIL — could not find the command fence under '### The gate' in $contributing."
+  fail=1
+else
+  for named in $(printf '%s\n' "$fence" | tr ' ' '\n' | sed -n 's|.*/\(check-[a-z0-9-]*\)\.\(sh\|py\).*|\1|p' | sort -u); do
+    target="${named#check-}"
+    case " $steps " in
+    *" $target "*) continue ;;
+    esac
+    note "FAIL — $contributing's gate fence runs '$named', which is not a gate step."
+    note "     Either it was removed from GATE_STEPS and the fence kept it, or"
+    note "     the fence is running something the gate does not."
+    fail=1
+  done
+fi
+
+if [ "$fail" -ne 0 ]; then
+  note ""
+  note "The gate's composition lives in GATE_STEPS in the Makefile, and these"
+  note "two documents restate it for readers. When you add or remove a guard,"
+  note "update all three in the same PR — that is what this guard is for."
+  exit 1
+fi
+
+printf 'check-gate-parity: OK — %s (%s) gate steps, named in %s and %s.\n' \
+  "$count" "$word" "$agents" "$contributing"

--- a/scripts/check-god-files.sh
+++ b/scripts/check-god-files.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Guard: the god-file prose matches scripts/file-size-baseline.txt. See #1435.
+#
+# `scripts/check-file-size.sh` enforces the 1500-line ratchet from
+# `scripts/file-size-baseline.txt`, which `make file-size-update` regenerates.
+# Two prose copies of *which files are god files* exist, and until this script
+# nothing checked either:
+#
+#   1. The per-crate table in AGENTS.md § "God files — plan around them, never
+#      into them".
+#   2. The "God files — do not add lines" section in each crate's README —
+#      the list in the eight crates that have them, and the "this crate has no
+#      god files" claim in the other twelve.
+#
+# Both were verified by hand on 2026-08-04 and neither is touched by
+# `make file-size-update`, so the next file split or rename stranded both
+# silently. This is the shape that motivated `check-invariants.sh` (#630):
+# duplicated normative prose with no tiebreaker.
+#
+# The baseline is the tiebreaker. It is generated, gate-enforced, and the only
+# copy that can stay correct.
+#
+# ── Deliberately not checked ─────────────────────────────────────────────────
+#
+# The numeric ceilings. AGENTS.md names *which* files are closed to growth and
+# deliberately does not repeat a single number — the baseline stays the only
+# copy of those, and "fixing" that by putting numbers in prose would recreate
+# the exact problem this guard exists to catch. Set membership only.
+#
+# The bench Python entries in the baseline have no prose table and are out of
+# scope; only `crates/<crate>/` entries are read.
+#
+# ── If the file-budget design lands ──────────────────────────────────────────
+#
+# `doc:file-budget` Phase 1 deletes both `check-file-size.sh` and the baseline,
+# and replaces the god-file table with banded budgets — at which point the two
+# prose copies this guards stop existing and so does the drift. Whichever lands
+# second reconciles with the first (#1438). Delete this script then; do not
+# keep it limping against a file that is gone.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+baseline="scripts/file-size-baseline.txt"
+agents="AGENTS.md"
+
+fail=0
+note() { printf 'check-god-files: %s\n' "$1" >&2; }
+
+if [ ! -f "$baseline" ]; then
+  note "FAIL — $baseline does not exist. It is the only correct copy of the"
+  note "     god-file set; this guard has nothing to compare prose against."
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/stella-god-files.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# ── The truth: "<crate> <crate-relative path>" per baselined workspace file ──
+
+grep -v '^#' "$baseline" |
+  awk '$2 ~ /^crates\// {
+        path = $2
+        sub(/^crates\//, "", path)
+        slash = index(path, "/")
+        printf "%s %s\n", substr(path, 1, slash - 1), substr(path, slash + 1)
+      }' |
+  LC_ALL=C sort >"$work/truth"
+
+if [ ! -s "$work/truth" ]; then
+  note "FAIL — no crates/ entries in $baseline; the extraction must have broken."
+  exit 1
+fi
+
+crates_with_god_files="$(awk '{print $1}' "$work/truth" | LC_ALL=C sort -u)"
+
+# Every workspace member, so the twelve clean crates can be held to their claim.
+all_crates="$(
+  find crates -mindepth 1 -maxdepth 1 -type d -exec basename {} \; |
+    LC_ALL=C sort
+)"
+
+has_god_files() {
+  printf '%s\n' "$crates_with_god_files" | grep -qx "$1"
+}
+
+# Backticked crate-relative source paths on stdin, one per line, sorted.
+# `src/foo.rs` in either a table cell or a markdown link both reduce to this.
+#
+# shellcheck disable=SC2016
+# The backticks are markdown, not command substitution — this pattern matches a
+# literal `…` span, so single quotes are exactly right here.
+backticked_paths() {
+  tr ' ,|' '\n' | sed -n 's/.*`\(src\/[A-Za-z0-9_./-]*\.rs\)`.*/\1/p' | LC_ALL=C sort -u
+}
+
+# The god-file list itself, which is a markdown bullet list. Restricting to list
+# items matters: the surrounding prose names the *sibling modules split out of*
+# each god file as the precedent to follow (`registry/process_tools.rs` out of
+# `registry.rs`), and those are examples of the remedy, not more god files.
+# `|| true` is load-bearing under `set -o pipefail`: a README whose section
+# carries no bullet list at all is not an error here, it is the case this guard
+# most needs to report — a crate that just gained its first god file while its
+# README still says it has none. Without it, grep's exit 1 kills the script
+# before the comparison that would have said so.
+listed_paths() {
+  { grep '^- ' || true; } | backticked_paths
+}
+
+compare() {
+  where="$1"
+  crate="$2"
+  expected_file="$3"
+  found_file="$4"
+
+  missing="$(comm -23 "$expected_file" "$found_file" | tr '\n' ' ')"
+  extra="$(comm -13 "$expected_file" "$found_file" | tr '\n' ' ')"
+
+  if [ -n "${missing// /}" ]; then
+    note "FAIL — $where omits $crate god file(s): $missing"
+    fail=1
+  fi
+  if [ -n "${extra// /}" ]; then
+    note "FAIL — $where lists $crate file(s) that are not in the baseline: $extra"
+    fail=1
+  fi
+}
+
+# ── AGENTS.md's per-crate table ──────────────────────────────────────────────
+
+if [ ! -f "$agents" ]; then
+  note "FAIL — $agents does not exist."
+  exit 1
+fi
+
+for crate in $crates_with_god_files; do
+  awk -v c="$crate" '$0 ~ ("^\\| `" c "` \\|") { print }' "$agents" |
+    backticked_paths >"$work/agents.$crate"
+
+  if [ ! -s "$work/agents.$crate" ]; then
+    note "FAIL — $agents's god-file table has no row for \`$crate\`, which has"
+    note "     $(grep -c "^$crate " "$work/truth") baselined god file(s)."
+    fail=1
+    continue
+  fi
+
+  awk -v c="$crate" '$1 == c { print $2 }' "$work/truth" | LC_ALL=C sort >"$work/truth.$crate"
+  compare "$agents's god-file table" "$crate" "$work/truth.$crate" "$work/agents.$crate"
+done
+
+# A crate with no baselined file must not appear in the table at all.
+for crate in $all_crates; do
+  has_god_files "$crate" && continue
+  if grep -q "^| \`$crate\` |" "$agents"; then
+    note "FAIL — $agents's god-file table lists \`$crate\`, which has no baselined file."
+    note "     Its entries were split or shrank; drop the row."
+    fail=1
+  fi
+done
+
+# ── Each crate's README ──────────────────────────────────────────────────────
+
+for crate in $all_crates; do
+  readme="crates/$crate/README.md"
+  [ -f "$readme" ] || continue
+
+  # The "God files" section, up to the next H2.
+  awk '
+    /^## .*[Gg]od files/ { inside = 1; next }
+    inside && /^## /     { exit }
+    inside               { print }
+  ' "$readme" >"$work/section"
+
+  if [ ! -s "$work/section" ]; then
+    note "FAIL — $readme has no \"God files\" section."
+    note "     Every crate README carries one, so the constraint is in view"
+    note "     wherever planning starts."
+    fail=1
+    continue
+  fi
+
+  if has_god_files "$crate"; then
+    listed_paths <"$work/section" >"$work/readme.$crate"
+    awk -v c="$crate" '$1 == c { print $2 }' "$work/truth" | LC_ALL=C sort >"$work/truth.$crate"
+    compare "$readme" "$crate" "$work/truth.$crate" "$work/readme.$crate"
+  elif ! grep -qi 'no god files' "$work/section"; then
+    note "FAIL — $readme has no baselined god file, but its section does not say"
+    note "     \"no god files\". Say so plainly, or the silence reads as an"
+    note "     unmaintained list."
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  note ""
+  note "$baseline is generated and gate-enforced — it is the only copy of this"
+  note "set that can stay correct, so the prose follows it, never the reverse."
+  note "After \`make file-size-update\`, update AGENTS.md's table and the affected"
+  note "crate README in the same PR."
+  exit 1
+fi
+
+printf 'check-god-files: OK — %d god file(s) across %d crate(s), named identically in %s and every crate README.\n' \
+  "$(wc -l <"$work/truth" | tr -d ' ')" \
+  "$(printf '%s\n' "$crates_with_god_files" | wc -l | tr -d ' ')" \
+  "$agents"

--- a/scripts/check-left-behind.sh
+++ b/scripts/check-left-behind.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Guard: a deferral marker in code must name the issue that tracks it.
+# See #1454, and AGENTS.md § "Nothing left behind".
+#
+# AGENTS.md and CLAUDE.md require that anything noticed and not fixed inside the
+# current change becomes a GitHub issue written as a handoff. That is the right
+# rule and, until this script, nothing checked it. Every other standard this
+# repository cares about has a gate behind it, for the reason stated in the
+# header of scripts/check-file-size.sh: an unenforced standard reads as a
+# standard the codebase is meeting. Three documents claimed a 1500-line cap
+# while 31 files exceeded it.
+#
+# "Did the author notice something and not file it" is not mechanically
+# decidable. Its most common residue is: a marker with no issue beside it. That
+# is what this checks, and the scope is deliberately narrow — a marker naming an
+# issue is *tracked work*, which is fine; a marker naming nothing is a thing
+# left behind with no handoff.
+#
+# ── What counts as a marker ──────────────────────────────────────────────────
+#
+# TODO, FIXME, XXX or HACK, in a comment, not followed by an issue reference
+# (`#` + digits) anywhere on the same line. Both of these are fine:
+#
+#     // TODO(#1454): wire the baseline into the hook
+#     // FIXME: this is quadratic — see #1454
+#
+# and this is not:
+#
+#     // TODO: come back to this
+#
+# ── Why "in a comment" is defined the way it is ──────────────────────────────
+#
+# The word appears in this tree six times in code that is not a deferral at all:
+# a doc comment describing a task node ("a unit of work (issue, ticket, TODO)"),
+# a `code_map` search-pattern fixture, a store rule named "never commit a TODO",
+# and three test fixtures whose *string literals* contain `// TODO:` because the
+# thing under test is a tool that reads code. A guard that flagged those would
+# be trained away within a week.
+#
+# So a marker is recognised only when:
+#
+#   A. it is the first word of a comment (`// TODO`, `# TODO`, `* TODO`), or
+#   B. it follows a comment opener on a line with no quote character at all,
+#      which catches `let x = 1; // TODO: fix` without ever looking inside a
+#      string.
+#
+# Clause B is why the quoting rule is "no quotes on the line" rather than
+# something cleverer: a shell script cannot reliably tell whether a `//` is
+# inside a Rust string, and a guard that guesses wrong fails open in one
+# direction and cries wolf in the other. A trailing marker on a line that also
+# contains a string literal is the one shape this misses; it is rare, and the
+# PR-template checkbox is what covers the judgment half regardless.
+#
+# ── The baseline ─────────────────────────────────────────────────────────────
+#
+# Modelled on scripts/check-file-size.sh, including its shrink-only property:
+# an entry records how many untracked markers a file carries, a file may never
+# exceed its recorded count, and once a count reaches zero the entry is obsolete
+# and must be removed. An exemption must not outlive the problem it covered.
+#
+# It starts EMPTY, which is worth stating: unlike the file-size ratchet, this
+# guard had nothing to grandfather. Every marker in the tree at the time it was
+# written already named an issue or was one of the six false positives above.
+# Keep it that way — the baseline exists for a future import, not as a hatch.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner (macOS ships bash 3.2,
+# so no associative arrays).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+baseline="scripts/left-behind-baseline.txt"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "check-left-behind: not a git repository; skipping."
+  exit 0
+fi
+
+# Emit "<count> <path>" for every tracked source file carrying at least one
+# untracked marker. Prose is not scanned: a design document listing open
+# questions is doing its job, and `docs/` has its own guards.
+#
+# One awk over the whole file list, not one awk per file. The per-file shape
+# read the same tree in ~40s, which is too slow for a guard that runs on every
+# push in GATE_GUARDS_FAST; this is well under a second. `/dev/null` is appended
+# so awk always has at least one file argument — with an empty list it would
+# read stdin and hang, and xargs runs the utility even when its input is empty.
+#
+# This script and its baseline are skipped by name: both necessarily spell the
+# markers in prose, and a guard that fails on its own documentation is a guard
+# someone deletes. Nothing else is exempt.
+current_counts() {
+  git ls-files -z '*.rs' '*.py' '*.sh' '.githooks/*' |
+    xargs -0 awk '
+      FILENAME == "scripts/check-left-behind.sh"      { next }
+      FILENAME == "scripts/left-behind-baseline.txt"  { next }
+
+      # An issue reference anywhere on the line means the work is tracked.
+      /#[0-9]+/ { next }
+
+      # A. the marker is the first word of a comment.
+      /^[ \t]*(\/\/+!?|#+|\*+|\/\*)[ \t]*(TODO|FIXME|XXX|HACK)([ \t:(),.!-]|$)/ { n[FILENAME]++; next }
+
+      # B. a trailing marker on a line that contains no string at all.
+      /["'"'"'`]/ { next }
+      /(\/\/|#)[ \t]*(TODO|FIXME|XXX|HACK)([ \t:(),.!-]|$)/ { n[FILENAME]++ }
+
+      END { for (f in n) if (n[f] > 0) printf "%d %s\n", n[f], f }
+    ' /dev/null
+}
+
+if [ "${1:-}" = "--update" ]; then
+  {
+    echo "# Files carrying deferral markers (TODO/FIXME/XXX/HACK) that name no"
+    echo "# issue. See #1454 and scripts/check-left-behind.sh."
+    echo "# Format: <count> <path>."
+    echo "#"
+    echo "# Regenerate with: make left-behind-update"
+    echo "#"
+    echo "# This file started empty and is meant to stay that way. An entry may"
+    echo "# only ever shrink: a file must not exceed its recorded count, and a"
+    echo "# count that reaches zero must be removed. The fix for a marker is to"
+    echo "# file the issue and reference it — not to add a line here."
+    # LC_ALL=C for byte-order collation, so the baseline regenerates
+    # identically on every machine (see check-file-size.sh for the macOS case).
+    current_counts | LC_ALL=C sort -k2
+  } >"$baseline.tmp"
+  mv "$baseline.tmp" "$baseline"
+  echo "check-left-behind: baseline updated — $(grep -cv '^#' "$baseline" || true) file(s) with untracked markers."
+  exit 0
+fi
+
+if [ ! -f "$baseline" ]; then
+  echo "check-left-behind: missing $baseline. Run 'make left-behind-update' to create it." >&2
+  exit 1
+fi
+
+report="$(
+  {
+    grep -v '^#' "$baseline" | sed 's/^/B /'
+    current_counts | sed 's/^/C /'
+  } | awk '
+    $1 == "B" { allowed[$3] = $2; known[$3] = 1; next }
+    $1 == "C" {
+      path = $3; n = $2; seen[path] = 1
+      if (path in allowed) {
+        if (n > allowed[path])
+          grew = grew sprintf("  %s now has %d untracked marker(s), over its baseline of %d\n", path, n, allowed[path])
+      } else {
+        newmark = newmark sprintf("  %s has %d untracked marker(s)\n", path, n)
+      }
+    }
+    END {
+      for (p in known)
+        if (!(p in seen))
+          obsolete = obsolete sprintf("  %s no longer has any — drop its baseline entry\n", p)
+      if (newmark) printf "NEW\n%s", newmark
+      if (grew) printf "GREW\n%s", grew
+      if (obsolete) printf "OBSOLETE\n%s", obsolete
+    }
+  '
+)"
+
+if [ -n "$report" ]; then
+  echo "check-left-behind: FAILED" >&2
+  echo "$report" | awk '
+    /^NEW$/      { print ""; print "These files carry a TODO/FIXME/XXX/HACK that names no issue."; print ""; print "The fix is to FILE THE ISSUE and reference it — not to delete the marker,"; print "and not to add a baseline entry. Write it as a handoff a fresh agent could"; print "execute: the problem, the file paths, how to verify, what done looks like"; print "(AGENTS.md, \"Nothing left behind\"). Then:"; print ""; print "    // TODO(#1234): the thing you deferred"; print ""; print "A marker that names an issue is tracked work and passes this guard."; next }
+    /^GREW$/     { print ""; print "These files gained untracked markers beyond their baseline count. Same fix:"; print "file the issue and reference it."; next }
+    /^OBSOLETE$/ { print ""; print "Obsolete baseline entries — the markers are gone or now reference an issue."; print "Run \"make left-behind-update\": an exemption must not outlive the problem it"; print "covered, or the file is free to accumulate again."; next }
+    { print }
+  ' >&2
+  exit 1
+fi
+
+scanned=$(git ls-files '*.rs' '*.py' '*.sh' '.githooks/*' | wc -l | tr -d ' ')
+carried=$(grep -cv '^#' "$baseline" || true)
+echo "check-left-behind: OK — $scanned source file(s) scanned, $carried grandfathered."

--- a/scripts/check-role-names.sh
+++ b/scripts/check-role-names.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# Guard: the four agent-config role names have one spelling, across four
+# languages. See #1449.
+#
+# ── The failure this exists to catch ─────────────────────────────────────────
+#
+# #1394 renamed the non-worker verification role, `judge` -> `verifier`. The
+# Rust compiler caught every Rust call site. It caught none of the producers of
+# that same name that are not Rust, and the fallout took three PRs:
+#
+#   crates/stella-tui/src/statline.rs   matched PipelineRole::Judge
+#                                       -> compiler; `main` shipped red (#1417)
+#   arenabench/arenabench/config.py     translated verifier -> judge
+#                                       -> NOTHING
+#   bench/terminal_bench_analysis/      posture digests went stale
+#                                       -> one of four pinned by luck
+#   crates/stella-observatory/…/index.html  filters agents by a literal list
+#                                       -> NOTHING
+#
+# The arenabench one is the shape that matters, and it is why this guard is
+# worth its weight: no error, no failing test, no stopped match. The seat runs
+# with the verifier inheriting the worker baseline while the scoreboard reports
+# it as configured — so the contest publishes a number for a pairing it never
+# ran. A wrong measurement, not a crash, is the worst thing this repository can
+# ship (CLAUDE.md, "Measure honestly, especially when it costs us").
+#
+# ── The normative home ───────────────────────────────────────────────────────
+#
+# `role_key()` in crates/stella-cli/src/config_wiring.rs, which maps
+# `EngineAgentKind` to the exact string that appears in `agents.<role>` and
+# `pipeline_<role>_model`. The enum is the type; `role_key` is the *wire
+# spelling*, and the wire spelling is what the other three languages copy.
+#
+# Note this is NOT `stella_protocol::ModelCallRole`, which has fourteen variants
+# describing individual model calls (PlanRepair, WitnessAuthor, Summarization…).
+# Those never cross a language boundary. The four agent-config roles do, and
+# they are the whole subject here.
+#
+# ── Aliases ──────────────────────────────────────────────────────────────────
+#
+# `judge` is a deliberately retired spelling. It survives in exactly two places,
+# both of which read it and neither of which writes it: a serde `alias` in Rust,
+# and `_ROLE_ALIASES` in arenabench's config loader, which upgrades an old match
+# file on the way in. That is compatibility, not drift, so the alias table below
+# names it explicitly rather than the guard pretending it does not exist.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+fail=0
+note() { printf 'check-role-names: %s\n' "$1" >&2; }
+
+# Retired spellings, and the modern role each maps to. A producer may mention
+# one of these only as an alias — never as a member of its own role set.
+retired_spellings="judge"
+
+# ── The truth ────────────────────────────────────────────────────────────────
+
+rust_home="crates/stella-cli/src/config_wiring.rs"
+
+if [ ! -f "$rust_home" ]; then
+  note "FAIL — $rust_home does not exist; role_key() is the normative home."
+  exit 1
+fi
+
+# The match arms of role_key(): `EngineAgentKind::Verifier => "verifier",`
+roles="$(
+  awk '
+    /pub fn role_key/ { inside = 1; next }
+    inside && /^\}/   { exit }
+    inside && /EngineAgentKind::[A-Za-z]+ *=> *"[a-z_]+"/ {
+      match($0, /"[a-z_]+"/)
+      print substr($0, RSTART + 1, RLENGTH - 2)
+    }
+  ' "$rust_home" | LC_ALL=C sort
+)"
+
+if [ -z "$roles" ]; then
+  note "FAIL — could not read any role from role_key() in $rust_home."
+  note "     If that function moved or changed shape, repoint this guard;"
+  note "     do not delete it. It is the only thing holding four languages"
+  note "     to one spelling."
+  exit 1
+fi
+
+roles_flat="$(printf '%s\n' "$roles" | tr '\n' ' ')"
+
+is_role() {
+  case " $roles_flat " in
+  *" $1 "*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# Extract every double- or single-quoted lowercase token from stdin, one per
+# line, sorted and deduplicated. Used to read a literal list out of Python or
+# JavaScript without teaching this script either language.
+quoted_tokens() {
+  tr ',' '\n' | sed -n 's/.*["'"'"']\([a-z_][a-z_]*\)["'"'"'].*/\1/p' | LC_ALL=C sort -u
+}
+
+# Compare a producer's role set against the Rust one.
+#   $1 producer path (for the message), $2 what it is, $3 the extracted set
+expect_exact_set() {
+  path="$1"
+  what="$2"
+  found="$3"
+
+  if [ -z "$found" ]; then
+    note "FAIL — $path: could not extract $what."
+    note "     The producer moved or changed shape. Repoint the extraction in"
+    note "     this guard rather than dropping the producer from it."
+    fail=1
+    return
+  fi
+
+  missing="$(comm -23 <(printf '%s\n' "$roles") <(printf '%s\n' "$found") | tr '\n' ' ')"
+  extra="$(comm -13 <(printf '%s\n' "$roles") <(printf '%s\n' "$found") | tr '\n' ' ')"
+
+  if [ -n "${missing// /}" ]; then
+    note "FAIL — $path ($what) is missing role(s): $missing"
+    fail=1
+  fi
+  if [ -n "${extra// /}" ]; then
+    note "FAIL — $path ($what) has role(s) the engine does not know: $extra"
+    fail=1
+  fi
+}
+
+# Every role named in a `pipeline_<role>_model` key anywhere in a file must be a
+# real role. A subset check, not an exact one: `default` has no flat key by
+# design (`default_model` is its key), so the set is legitimately smaller.
+expect_flat_keys_known() {
+  path="$1"
+  [ -f "$path" ] || return 0
+  sed -n 's/.*pipeline_\([a-z_][a-z_]*\)_model.*/\1/p' "$path" | LC_ALL=C sort -u |
+    while IFS= read -r r; do
+      [ -n "$r" ] || continue
+      # Not a role name — these are the pipeline's own numeric settings.
+      case "$r" in
+      max_revisions | candidates) continue ;;
+      esac
+      if ! is_role "$r"; then
+        note "FAIL — $path writes pipeline_${r}_model, and '$r' is not a role."
+        printf 'x' >>"$flagfile"
+      fi
+    done
+}
+
+# `while read` in a pipeline runs in a subshell, so `fail=1` set inside one
+# would not survive. A marker file is the portable way to carry it back.
+flagfile="$(mktemp "${TMPDIR:-/tmp}/stella-role-names.XXXXXX")"
+trap 'rm -f "$flagfile"' EXIT
+
+# ── The producers ────────────────────────────────────────────────────────────
+#
+# Each entry states where the set lives and how it is spelled. Finding these
+# again when one moves is half the work this guard does; a producer that
+# vanishes should be deleted from here in the same PR, never silently skipped.
+
+# 1. arenabench's canonical tuple.
+p="arenabench/arenabench/model.py"
+if [ -f "$p" ]; then
+  expect_exact_set "$p" "ROLES tuple" \
+    "$(grep -E '^ROLES: *tuple' "$p" | quoted_tokens)"
+else
+  note "FAIL — $p is gone; update this guard's producer list."
+  fail=1
+fi
+
+# 2. arenabench's per-role loop, which drives what a seat actually writes.
+p="arenabench/arenabench/harbor_agent.py"
+if [ -f "$p" ]; then
+  expect_exact_set "$p" "per-role loop" \
+    "$(grep -E 'for role in \(' "$p" | quoted_tokens)"
+  expect_flat_keys_known "$p"
+else
+  note "FAIL — $p is gone; update this guard's producer list."
+  fail=1
+fi
+
+# 3. The Observatory's agent filter — a JS literal, invisible to every Rust and
+#    Python test in the tree. This is one of the two that silently vanished a
+#    row in #1394.
+p="crates/stella-observatory/src/assets/index.html"
+if [ -f "$p" ]; then
+  expect_exact_set "$p" "agent-name filter" \
+    "$(grep -E '\]\.filter\(n *=> *agents\[n\]\)' "$p" | quoted_tokens)"
+else
+  note "FAIL — $p is gone; update this guard's producer list."
+  fail=1
+fi
+
+# 4. The harbor adapter's posture writer. Every role it names goes into a hashed
+#    posture, so a stale spelling here re-hashes every registered arm
+#    (bench/READINESS.md §8.4.4).
+expect_flat_keys_known "bench/harbor_adapter/stella_harbor/posture.py"
+
+# 5. The TUI's second enum. Compiler-checked as a type, but its variants are a
+#    parallel vocabulary that must stay inside the engine's — a subset, since
+#    the deck has no `default` slot.
+p="crates/stella-tui/src/deck.rs"
+if [ -f "$p" ]; then
+  # Redirected rather than piped: a `while read` on the right of a pipe runs in
+  # a subshell, where `fail=1` would be set and then thrown away.
+  while IFS= read -r variant; do
+    [ -n "$variant" ] || continue
+    if ! is_role "$variant"; then
+      note "FAIL — $p: PipelineRole::${variant} is not an engine role."
+      fail=1
+    fi
+  done < <(awk '
+    /pub enum PipelineRole/ { inside = 1; next }
+    inside && /^\}/         { exit }
+    inside && /^ *[A-Z][A-Za-z]*,/ { gsub(/[ ,]/, ""); print tolower($0) }
+  ' "$p")
+fi
+
+# ── Retired spellings ────────────────────────────────────────────────────────
+#
+# A retired name may appear only where it is being *translated*. Anywhere else
+# it is the drift this guard exists to catch.
+
+for old in $retired_spellings; do
+  if is_role "$old"; then
+    note "FAIL — '$old' is listed as retired but role_key() still emits it."
+    fail=1
+  fi
+done
+
+if [ -s "$flagfile" ]; then
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  note ""
+  note "The role names live in role_key() in $rust_home."
+  note "Renaming one is a cross-language change: the Rust compiler will not"
+  note "find the Python dict or the JavaScript literal, and neither will your"
+  note "tests. Update every producer named above in the same PR."
+  exit 1
+fi
+
+printf 'check-role-names: OK — %d role(s) [%s] consistent across every producer.\n' \
+  "$(printf '%s\n' "$roles" | wc -l | tr -d ' ')" "$(printf '%s' "$roles_flat" | sed 's/ $//')"

--- a/scripts/left-behind-baseline.txt
+++ b/scripts/left-behind-baseline.txt
@@ -1,0 +1,10 @@
+# Files carrying deferral markers (TODO/FIXME/XXX/HACK) that name no
+# issue. See #1454 and scripts/check-left-behind.sh.
+# Format: <count> <path>.
+#
+# Regenerate with: make left-behind-update
+#
+# This file started empty and is meant to stay that way. An entry may
+# only ever shrink: a file must not exceed its recorded count, and a
+# count that reaches zero must be removed. The fix for a marker is to
+# file the issue and reference it — not to add a line here.


### PR DESCRIPTION
## What & why

Hygiene batch 7: the unlabeled docs/gate-drift issues. Eight of the nine land
here; #1438 is deferred with a written rationale (see the bottom, and
[#1438's comment](https://github.com/macanderson/stella/issues/1438#issuecomment-5199479531)).

Five of these are the same bug wearing different clothes — **normative
information with two copies and no tiebreaker**, which is the shape
`check-invariants.sh` was written for (#630). Each fix names a single source and
holds the copies to it.

Closes #1435
Closes #1436
Closes #1437
Closes #1439
Closes #1440
Closes #1449
Closes #1452
Closes #1454

### The commits, in order

| Issue | What landed |
|---|---|
| #1436 | `stella-docs/` had already been moved to `docs/` by c85ccd5f with nothing repointed, so the post-mortem's reproducibility script could not find its input. Repointing it exposed a second defect the missing file had masked — see below. |
| #1452 | A module-scope `assert` ran at import and turned one stale digest into a whole-file collection error. Moved to a named test in its own file. |
| #1439 | A website-only push paid for `wire-schema`'s cargo build. New `make guards-fast` rung; the hook picks it unless the diff can have touched the wire contract; `wire-schema.yml` closes the server-side half. |
| #1437 | `GATE_STEPS` is now the gate's single definition, and `check-gate-parity.sh` holds AGENTS.md and CONTRIBUTING.md to it. |
| #1454 | `check-left-behind.sh` — a `TODO`/`FIXME`/`XXX`/`HACK` naming no issue fails the gate. Baseline starts **empty**. |
| #1449 | `check-role-names.sh` pins the four agent-config role names across Rust, Python and JavaScript. |
| #1440 | Eleven uncited documents adopted, five cited from the code they govern, thirteen down to six — each remainder with a stated reason. |
| #1435 | `check-god-files.sh` holds AGENTS.md's god-file table and all twenty crate READMEs to `file-size-baseline.txt`. |

### The one that is not hygiene: an evidence document was overstating a result

Repointing #1436's script surfaced this, and it is the most important thing in
the PR. `docs/benchmarks/terminal-bench-2-1-glm-5-2.json` was corrected in #1227
so that `claude.cap_hits` is **null** — the metric is read from
`stella-events.jsonl`, which the Claude Code arm never writes, so its value is
*no source*, not *measured zero*. Neither consumer was updated:

- `analyze.py` still summed that column (crashing on `int + None`).
- `README.md` still printed "**106 output-cap hits** (Claude Code: 0)" and the
  sentence "Claude Code recorded zero because its steps either act or stay
  small — the failure shape is Stella-specific."

That is a comparison the data does not support, in the flattering direction, in a
public evidence document. Both now say what is true; the column is a dash, not a
zero. The 6.40× input-token ratio is untouched — that one *is* like-for-like.

## The witness

Each guard was witnessed by breaking the thing it guards and confirming it names
the right files:

- **#1437** — added `synthetic-guard` to `GATE_GUARDS_FAST` without touching
  prose → fails, naming the missing step and the stale count in **both**
  documents. Removed → passes.
- **#1449** — renamed `role_key`'s `"verifier"` to `"verdict"` and changed
  nothing else → names all five producers, **including the JavaScript literal and
  the Python dict**, which is exactly where a grep-only approach stops.
- **#1454** — `// TODO: come back to this` → exit 1 naming the file;
  `// TODO(#9999): come back to this` → exit 0. Baseline regenerates
  byte-identically on a second `--update`.
- **#1435** — witnessed in both directions (an entry added for a crate that had
  none; an entry removed because a file was split), each naming **both** prose
  sites.
- **#1452** — the real fail→pass flip, run both ways with one character of the
  digest corrupted:

  ```
  old code:  1 error during collection, 0 tests run
  new code:  1 failed, 269 passed
  ```

`make guards-fast` is green (exit 0) across all 21 toolchain-free guards plus
`fmt --check`.

## Things worth a reviewer's attention

**No ceiling was raised, and one was nearly needed.** The #1452 fix grew
`test_tb21_analysis.py` — a grandfathered god file — by 25 lines, and
`check-file-size.sh` failed. `make file-size-update` would have turned it green
in one command, which is the move CLAUDE.md calls a defect. The check moved to
its own sibling module instead; the god file ends up three lines *smaller* than
before this PR touched it.

**A hole was found and deliberately not exploited.** `check-design-refs.sh` greps
for the literal `docs/design/`, so a `doc:<id>` citation to a work-in-flight
document passes it. Citing `doc:pipeline-journey` from the pipeline README would
have been green on every gate; the citation was reverted rather than landed, and
the hole is filed as **#1665**. There is no live violation in the tree.

**A `set -e` trap that would have made a guard lie.** In `check-god-files.sh`,
`grep '^- '` finds nothing in a "no god files" section, and under `pipefail` that
killed the script before the comparison — silently passing the single case the
guard most needs to catch (a crate that just gained its first god file). It is
`{ grep '^- ' || true; }` now, with a comment saying why.

**Three crate READMEs had no "God files" section at all**, so AGENTS.md's claim
that every crate carries one was false for three of twenty. Added.

**Guard cost.** `check-left-behind.sh` was 40s as one awk per file over 1,029
files; it is one awk over the list now, under three seconds. `nextfile` was
avoided — gawk-only, and macOS ships BSD awk.

## Nothing left behind

- [x] Filed: **#1665** (`check-design-refs.sh` misses `doc:<id>` citations)
- [x] **#1438** is deferred, not forgotten — [rationale on the issue](https://github.com/macanderson/stella/issues/1438#issuecomment-5199479531).
      Phase 1 deletes `check-file-size.sh` and its baseline while `make
      file-budget` is report-only, so the tree would have **no blocking
      file-size gate** until Phase 2 — whose other half is a branch-protection
      change only the owner can make, on a design still marked
      `status: proposed`. That is a ratification call, not a hygiene fix, and it
      is a PR of its own. #1435's guard will need deleting when it lands; that
      is written into the script's header.

## The gate

- [x] `cargo fmt --check`
- [x] `make guards-fast` — all 21 toolchain-free guards, exit 0
- [x] Python suite: 269 passed
- [x] Docs updated where behavior changed (AGENTS.md, CONTRIBUTING.md, three crate READMEs, the PR template)
- [x] `Closes #N` appears both here and as commit trailers

`clippy`/`test --workspace` are left to CI — the Rust changes here are three doc
comments (two citations and one module-header block), no logic.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Summary by Sourcery

Tighten gate hygiene, align documentation and CI with the real gate steps, and correct an overstated benchmark comparison so evidence matches its data sources.

New Features:
- Introduce additional toolchain-free guards for god-file tracking, cross-language agent role name consistency, gate documentation parity, and deferral markers without tracking issues.
- Add a fast, non-compiling `guards-fast` Makefile rung and a dedicated `wire-schema` CI workflow for schema drift checks on wire contracts.

Bug Fixes:
- Correct the GLM-5.2 benchmark evidence to reflect that Claude Code does not emit cap-hit telemetry and adjust the analysis script to avoid treating missing data as zero or crashing on nulls.
- Fix the benchmark analysis posture digest check so a stale digest fails as a targeted test instead of aborting the entire test module collection.
- Ensure compiled context frame and config-system implementations are explicitly tied back to their ADR and design documents to prevent silent divergence.

Enhancements:
- Make the gate composition single-sourced from `GATE_STEPS` and enforce parity across AGENTS.md, CONTRIBUTING.md, and the Makefile.
- Extend CI and docs-guards workflows to run the new shell-based guards and keep prose, baselines, and gate behavior aligned.
- Clarify test-import preconditions where module-scope asserts are intentional, documenting their role as collection preconditions rather than constant checks.

Documentation:
- Add or normalize frontmatter and manifest entries for ADRs, audits, designs, specs, and papers so they are citable by document id and accurately reflect implementation status.
- Document the full gate step list, the new guards, and the "Nothing left behind" discipline in AGENTS.md, CONTRIBUTING.md, and the PR template.
- Update crate READMEs to include consistent "God files — do not add lines" sections and align claims about god files with the enforced baseline.
- Clarify benchmark evidence documentation to distinguish Stella-only telemetry from cross-arm comparisons and to explain the posture digest contract.

Tests:
- Add a focused test file for the canonical engine posture digest and adjust existing benchmark tests to rely on computed postures rather than module-scope asserts that mask other failures.