### PR TITLE
feat(stella-cli): an opt-in deadline on a parked scope review, and a console drain on panic

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -417,7 +417,7 @@ async fn run_pipeline_one_shot(
         pipeline_config.keep_witness = keep_witness;
 
         let approval_gate =
-            crate::daemon::approval::OneShotApprovalGate::select(approval_capability);
+            crate::daemon::approval::OneShotApprovalGate::select(approval_capability, cfg);
         let no_recall = NoContextRecall;
         // The workspace memory doubles as the pipeline's recall port so the
         // split-context planner sees the same durable lessons the worker's

--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -29,6 +29,24 @@
 //! escalation grace honest: a parked child that ignored `SIGTERM` would be
 //! `SIGKILL`ed at the deadline and recorded as a crash it did not have.
 //!
+//! # The opt-in deadline (#1616)
+//!
+//! Parking forever is right when someone is coming and wrong when nobody is:
+//! an unattended overnight run holds a worktree and a session slot until a
+//! human notices. `agent_engine_config.approval_wait_secs` is that operator's
+//! knob — absent or `0` keeps the shipped park-forever default, and any
+//! positive value unparks the review as [`ScopeDecision::Abort`] once it
+//! elapses.
+//!
+//! Abort rather than approve, and rather than a new "expired" outcome,
+//! because every other missing-yes edge in this file already resolves that
+//! way: an unwritable request, an unparseable answer, a `SIGTERM`, an EOF on
+//! the stdio gate. The gate's contract is that nothing over the thresholds
+//! runs without a human's yes, and a deadline that ran out is precisely a
+//! yes that never arrived — so the timer may only ever *stop* work, never
+//! start it. The abort is announced on stderr naming the setting, so the
+//! postmortem reads "this was configured" rather than "this vanished".
+//!
 //! # Why the prompt never touches the console files
 //!
 //! The two console files are byte-verbatim stdout/stderr —
@@ -61,6 +79,10 @@ pub(crate) struct SidecarApprovalGate {
     /// behaviour is testable without raising a process-global signal flag.
     /// Production passes [`interrupted`].
     interrupted: fn() -> bool,
+    /// How long the park may last before it resolves itself as an abort
+    /// (#1616). `None` — the shipped default — parks until answered or
+    /// interrupted.
+    wait: Option<std::time::Duration>,
 }
 
 /// The production interrupt probe: has this process been asked to stop?
@@ -85,7 +107,15 @@ impl SidecarApprovalGate {
             registry,
             id,
             interrupted,
+            wait: None,
         }
+    }
+
+    /// Arm the opt-in park deadline (#1616). `None` keeps the park-forever
+    /// default, which is what an absent or `0` `approval_wait_secs` means.
+    pub(crate) fn with_wait(mut self, wait: Option<std::time::Duration>) -> Self {
+        self.wait = wait;
+        self
     }
 
     /// Replace the interrupt probe (tests only — production keeps the signal
@@ -94,6 +124,21 @@ impl SidecarApprovalGate {
     pub(crate) fn with_interrupt_probe(mut self, probe: fn() -> bool) -> Self {
         self.interrupted = probe;
         self
+    }
+
+    /// How long the park loop may sleep before its next check: the poll
+    /// interval, clipped by whatever is left of the deadline so a one-second
+    /// wait is honoured to the second rather than to the poll. `None` means
+    /// the deadline has passed and the park is over.
+    ///
+    /// Split out of the loop so the arithmetic — the part a wall-clock test
+    /// cannot pin down without sleeping through it — is directly testable.
+    fn next_poll(&self, parked_at: std::time::Instant) -> Option<std::time::Duration> {
+        let Some(wait) = self.wait else {
+            return Some(ANSWER_POLL);
+        };
+        let remaining = wait.checked_sub(parked_at.elapsed())?;
+        (!remaining.is_zero()).then(|| ANSWER_POLL.min(remaining))
     }
 
     /// Remove both transport files, tolerating either being already gone.
@@ -131,6 +176,7 @@ impl ApprovalGate for SidecarApprovalGate {
             .registry
             .set_status(&self.id, SessionStatus::NeedsInput);
 
+        let parked_at = std::time::Instant::now();
         let decision = loop {
             if (self.interrupted)() {
                 // The same answer the stdio gate gives on EOF: asked to stop
@@ -146,7 +192,22 @@ impl ApprovalGate for SidecarApprovalGate {
                     break serde_json::from_str::<ScopeDecision>(&json)
                         .unwrap_or(ScopeDecision::Abort);
                 }
-                Err(_) => tokio::time::sleep(ANSWER_POLL).await,
+                Err(_) => match self.next_poll(parked_at) {
+                    Some(nap) => tokio::time::sleep(nap).await,
+                    None => {
+                        // Said out loud on stderr, not folded into stdout:
+                        // stdout is the run's byte-verbatim machine format,
+                        // and a postmortem asking "why did this abort?" is
+                        // reading the stderr console anyway.
+                        eprintln!(
+                            "{} scope review unanswered for {}s — aborting the run \
+                             (agent_engine_config.approval_wait_secs)",
+                            "▸ timed out".yellow().bold(),
+                            self.wait.map_or(0, |w| w.as_secs()),
+                        );
+                        break ScopeDecision::Abort;
+                    }
+                },
             }
         };
 
@@ -176,12 +237,21 @@ impl OneShotApprovalGate {
     /// process turns out not to be a supervised child after all — the two are
     /// computed from the same predicate, so that arm is a defensive
     /// impossibility, and failing closed is what a missing approver means.
-    pub(crate) fn select(capability: crate::agent::PipelineApprovalCapability) -> Self {
+    ///
+    /// `cfg` is read for one thing only: the sidecar park's opt-in deadline
+    /// (#1616). The other two gates have a live reader on the other end, so a
+    /// timer would be answering a question someone is already looking at.
+    pub(crate) fn select(
+        capability: crate::agent::PipelineApprovalCapability,
+        cfg: &crate::config::Config,
+    ) -> Self {
         use crate::agent::PipelineApprovalCapability as Capability;
         match capability {
             Capability::Stdio => Self::Stdio(stella_pipeline::StdioApprovalGate),
             Capability::Sidecar => match SidecarApprovalGate::for_supervised_child() {
-                Some(gate) => Self::Sidecar(gate),
+                Some(gate) => {
+                    Self::Sidecar(gate.with_wait(park_deadline(cfg.engine_settings.as_ref())))
+                }
                 None => Self::Headless(stella_pipeline::AlwaysAbortGate),
             },
             Capability::Unavailable => Self::Headless(stella_pipeline::AlwaysAbortGate),
@@ -206,6 +276,21 @@ impl ApprovalGate for OneShotApprovalGate {
             Self::Headless(gate) => gate.confirm(question).await,
         }
     }
+}
+
+/// The configured park deadline, or `None` for the shipped park-forever
+/// behaviour.
+///
+/// `0` is spelled and means "no deadline", the same convention
+/// `model_timeout_secs` uses for its own backstop: in a field whose absence
+/// already means "the default", zero is the only way to say *deliberately*
+/// unbounded — which matters when a user-scope file sets a deadline and one
+/// project wants out of it.
+pub(crate) fn park_deadline(
+    settings: Option<&crate::settings::AgentEngineConfig>,
+) -> Option<std::time::Duration> {
+    let secs = settings?.approval_wait_secs?;
+    (secs > 0).then(|| std::time::Duration::from_secs(secs))
 }
 
 /// The attached-terminal side: answer a parked scope review, if one is
@@ -407,6 +492,109 @@ mod tests {
         // With the stale answer cleared at park time, the interrupted gate
         // falls through to abort rather than adopting the ghost's yes.
         assert_eq!(gate.review(&proposal()).await, ScopeDecision::Abort);
+    }
+
+    /// The #1616 witness: with `approval_wait_secs` armed, a review nobody
+    /// answers unparks itself as an abort instead of waiting forever — and it
+    /// hands the record back rather than leaving it stuck on `Needs Input`.
+    /// On `main` a gate has no deadline to arm (`with_wait` does not exist),
+    /// so this is a type-level witness as well as a behavioural one.
+    #[tokio::test]
+    async fn an_expired_deadline_unparks_an_unanswered_review_as_an_abort() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry_in(dir.path());
+        let record = parked_record(&registry);
+        let sidecar = registry.sidecar_dir(&record.id);
+        let gate = SidecarApprovalGate::new(sidecar.clone(), registry.clone(), record.id.clone())
+            .with_wait(Some(std::time::Duration::from_millis(30)));
+
+        // The outer timeout is the assertion's teeth: on a gate without a
+        // deadline this future never resolves, and the test would hang rather
+        // than fail.
+        let decision =
+            tokio::time::timeout(std::time::Duration::from_secs(10), gate.review(&proposal()))
+                .await
+                .expect("an armed deadline must end the park");
+
+        assert_eq!(decision, ScopeDecision::Abort);
+        assert_eq!(
+            registry.get(&record.id).unwrap().status,
+            SessionStatus::InProgress,
+            "an expired review hands the record back, like an answered one"
+        );
+        assert!(
+            !sidecar.join(supervised::APPROVAL_REQUEST).exists(),
+            "the transport still cleans up after itself"
+        );
+    }
+
+    /// The default is unchanged: with no deadline the park outlives any
+    /// wait a caller is willing to sit through.
+    #[tokio::test]
+    async fn without_a_deadline_the_review_stays_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry_in(dir.path());
+        let record = parked_record(&registry);
+        let gate = SidecarApprovalGate::new(
+            registry.sidecar_dir(&record.id),
+            registry.clone(),
+            record.id.clone(),
+        );
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(750),
+                gate.review(&proposal()),
+            )
+            .await
+            .is_err(),
+            "an unanswered review with no deadline must still park"
+        );
+    }
+
+    /// The deadline arithmetic, without sleeping through it: a poll never
+    /// overshoots the deadline, and an elapsed deadline is over.
+    #[test]
+    fn the_poll_is_clipped_by_what_is_left_of_the_deadline() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry_in(dir.path());
+        let bare = SidecarApprovalGate::new(dir.path().into(), registry, "id".into());
+        let now = std::time::Instant::now();
+
+        assert_eq!(
+            bare.next_poll(now),
+            Some(ANSWER_POLL),
+            "no deadline polls at the usual cadence forever"
+        );
+        // A deadline shorter than one poll is honoured to itself, not rounded
+        // up to the poll interval.
+        let short =
+            SidecarApprovalGate::new(dir.path().into(), registry_in(dir.path()), "id".into())
+                .with_wait(Some(std::time::Duration::from_millis(5)));
+        let nap = short.next_poll(now).expect("5ms is still ahead");
+        assert!(nap <= std::time::Duration::from_millis(5), "{nap:?}");
+        // And a deadline already in the past ends the park.
+        assert_eq!(
+            short.next_poll(now - std::time::Duration::from_secs(1)),
+            None
+        );
+    }
+
+    /// The setting's three states, including the one that is easy to get
+    /// wrong: `0` is a deliberate "no deadline", not a zero-length one that
+    /// aborts every supervised review the instant it parks.
+    #[test]
+    fn the_setting_maps_absent_and_zero_to_park_forever() {
+        assert_eq!(park_deadline(None), None);
+        let mut settings = crate::settings::AgentEngineConfig::default();
+        assert_eq!(park_deadline(Some(&settings)), None);
+        settings.approval_wait_secs = Some(0);
+        assert_eq!(park_deadline(Some(&settings)), None);
+        settings.approval_wait_secs = Some(90);
+        assert_eq!(
+            park_deadline(Some(&settings)),
+            Some(std::time::Duration::from_secs(90))
+        );
     }
 
     /// A piped attach notes the parked run once and answers nothing.

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -423,9 +423,21 @@ fn wall_ms() -> u64 {
 }
 
 /// The live pumps, held by `main` for the life of the supervised child.
+///
+/// The pumps live behind an `Arc` rather than in this struct because two
+/// different code paths have to be able to end them: `main`'s orderly exit,
+/// and the panic hook [`arm_panic_drain`] installs (#1616). Both call the
+/// same idempotent [`Drainable::drain`]; whichever arrives first takes the
+/// streams and the other finds nothing to do.
 pub(crate) struct ConsoleGuard {
     #[cfg(unix)]
-    streams: Vec<PumpedStream>,
+    pumps: Arc<Drainable>,
+}
+
+/// The drainable half of a [`ConsoleGuard`], shareable with the panic hook.
+#[cfg(unix)]
+struct Drainable {
+    streams: Mutex<Vec<PumpedStream>>,
 }
 
 #[cfg(unix)]
@@ -435,6 +447,10 @@ struct PumpedStream {
     /// The fd the pipe replaced (1 or 2).
     target_fd: i32,
     pump: Option<std::thread::JoinHandle<u64>>,
+    /// Which thread the pump runs on. A drain reached *from* that thread —
+    /// the pump itself panicking — must not join it, which would be a thread
+    /// waiting on itself forever.
+    pump_thread: std::thread::ThreadId,
 }
 
 impl ConsoleGuard {
@@ -443,9 +459,21 @@ impl ConsoleGuard {
     /// only write ends, so each pump sees EOF, writes its `Closed` marker,
     /// and exits; anything printed after this lands raw at the ring cursor,
     /// which the marker tells readers to sweep.
-    pub(crate) fn drain(self) {
+    pub(crate) fn drain(&self) {
         #[cfg(unix)]
-        for mut stream in self.streams {
+        self.pumps.drain();
+    }
+}
+
+#[cfg(unix)]
+impl Drainable {
+    /// Idempotent drain: take the streams out under the lock, then do the
+    /// blocking part (the `join`) with the lock released, so a panicking pump
+    /// thread arriving here cannot deadlock against the drain already
+    /// running.
+    fn drain(&self) {
+        let streams = std::mem::take(&mut *self.streams.lock().unwrap_or_else(|p| p.into_inner()));
+        for mut stream in streams {
             let Some(pump) = stream.pump.take() else {
                 continue;
             };
@@ -455,6 +483,17 @@ impl ConsoleGuard {
             // read end so no descriptor is closed twice.
             unsafe {
                 libc::dup2(stream.saved_fd, stream.target_fd);
+            }
+            if stream.pump_thread == std::thread::current().id() {
+                // The pump itself panicked and this drain is running inside
+                // its own panic hook. The fd is restored (above), which is
+                // what keeps the process's remaining output reaching the
+                // file; joining from here would wait on this very thread.
+                // SAFETY: as below — the install-time duplicate is done.
+                unsafe {
+                    libc::close(stream.saved_fd);
+                }
+                continue;
             }
             if let Ok(resume_at) = pump.join() {
                 // Post-drain appends continue at the ring cursor rather than
@@ -508,7 +547,40 @@ pub(crate) fn install_bounded(sidecar: &Path) -> Option<ConsoleGuard> {
             )?;
             streams.push(stream);
         }
-        Some(ConsoleGuard { streams })
+        Some(ConsoleGuard {
+            pumps: Arc::new(Drainable {
+                streams: Mutex::new(streams),
+            }),
+        })
+    }
+}
+
+/// Drain the console when this process panics, before the panic message is
+/// lost (#1616).
+///
+/// The pump made the console's tail lossy on a violent death: a panic unwinds
+/// past `main`'s orderly [`ConsoleGuard::drain`], the process exits without
+/// joining the pump threads, and up to a pipe buffer of output — the panic
+/// message itself, most of the time — dies in the pipe. That is the one
+/// artifact a postmortem of a supervised child actually wants.
+///
+/// The hook chains rather than replaces: whatever hook is already installed
+/// (the diagnostics dump, or the default printer) runs FIRST, so its output
+/// goes down the pipe like everything else, and only then is the pipe drained
+/// into the file. Draining first would restore the fds and leave the panic
+/// message to land raw — readable, but ahead of the pump's own `Closed`
+/// marker and outside the bound.
+pub(crate) fn arm_panic_drain(guard: &ConsoleGuard) {
+    #[cfg(not(unix))]
+    let _ = guard;
+    #[cfg(unix)]
+    {
+        let pumps = guard.pumps.clone();
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            previous(info);
+            pumps.drain();
+        }));
     }
 }
 
@@ -586,6 +658,7 @@ fn pump_fd(
     Some(PumpedStream {
         saved_fd,
         target_fd,
+        pump_thread: pump.thread().id(),
         pump: Some(pump),
     })
 }

--- a/crates/stella-cli/src/daemon/console/tests.rs
+++ b/crates/stella-cli/src/daemon/console/tests.rs
@@ -261,3 +261,85 @@ fn a_session_without_an_index_falls_back_to_raw_tails() {
     follower.pump(&mut out, &mut err).unwrap();
     assert_eq!(String::from_utf8_lossy(&out), "legacy\n");
 }
+
+/// The #1616 witness: a panic ends the pump instead of leaving it to die
+/// unjoined with the process.
+///
+/// What the drain does is restore the fd — which closes the pipe's last write
+/// end, so the pump reads EOF, writes everything it holds, and records its
+/// `Closed` marker. That marker is the assertion, because it is the one thing
+/// that cannot happen by luck: a pump that was never drained is still blocked
+/// on its pipe when the process exits, and up to a buffer of output (the panic
+/// message, in a real supervised child) dies with it. On `main` there is no
+/// panic hook and no shareable drain — `arm_panic_drain` does not exist — so
+/// this test does not compile there, let alone pass.
+///
+/// The pump is interposed on a private descriptor rather than on fd 1, so the
+/// test runner's own stdout is never hijacked; everything downstream of the
+/// `dup2` is the production path.
+#[cfg(unix)]
+#[test]
+fn a_panic_drains_the_console_pump() {
+    use std::os::unix::io::IntoRawFd;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sidecar = dir.path();
+    let console = sidecar.join(supervised::STDOUT_LOG);
+    // A descriptor naming the console file — what the OS redirect hands a
+    // supervised child, and what `pump_fd` expects to interpose on.
+    let target_fd = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&console)
+        .unwrap()
+        .into_raw_fd();
+    let stream = pump_fd(
+        console.clone(),
+        target_fd,
+        Stream::Stdout,
+        Arc::new(Mutex::new(Index::open(sidecar))),
+        Arc::new(SharedGeometry::default()),
+    )
+    .unwrap();
+    let guard = ConsoleGuard {
+        pumps: Arc::new(Drainable {
+            streams: Mutex::new(vec![stream]),
+        }),
+    };
+
+    arm_panic_drain(&guard);
+    let last_words = b"thread 'main' panicked: the supervised child died\n";
+    // SAFETY: `target_fd` is this test's own descriptor, now the pipe's write
+    // end, and the buffer outlives the call.
+    unsafe {
+        libc::write(target_fd, last_words.as_ptr().cast(), last_words.len());
+    }
+
+    let panicked = std::panic::catch_unwind(|| panic!("the supervised child died"));
+    assert!(panicked.is_err());
+    // Restore the hook this test installed process-wide before asserting, so
+    // a failure below cannot leave the harness carrying it.
+    let _ = std::panic::take_hook();
+
+    let index = std::fs::read_to_string(sidecar.join(INDEX)).unwrap_or_default();
+    let closed = index
+        .lines()
+        .filter_map(|line| serde_json::from_str::<IndexRecord>(line).ok())
+        .any(|record| matches!(record, IndexRecord::Closed { s, .. } if s == Stream::Stdout));
+    assert!(
+        closed,
+        "the panic hook must drain the pump: no Closed marker means it was \
+         still blocked on the pipe when the panic unwound\n{index}"
+    );
+    assert!(
+        String::from_utf8_lossy(&std::fs::read(&console).unwrap()).contains("the supervised child"),
+        "and everything the pipe held must have reached the console file"
+    );
+
+    // SAFETY: the descriptor is this test's own and no longer used. The drain
+    // restored it over the pipe, so this closes the console file, not the pump.
+    unsafe {
+        libc::close(target_fd);
+    }
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -527,6 +527,14 @@ fn main() -> ExitCode {
             &stella_store::SessionRegistry::open_default().sidecar_dir(&id),
         )
     });
+    // A panic unwinds past the drain below, and the pump threads die with the
+    // process holding whatever the pipe still had — usually the panic message
+    // itself, which is the one line a postmortem is looking for. The hook
+    // chains onto the diagnostics hook installed above, so the message is
+    // printed first and drained second (#1616).
+    if let Some(console) = &console {
+        daemon::console::arm_panic_drain(console);
+    }
 
     // Value-free confirmation (names only), gated on STELLA_ENV_DEBUG + a TTY +
     // a human output format so it never pollutes json/stream-json.

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -518,6 +518,24 @@ pub struct AgentEngineConfig {
     /// compaction.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_result_horizon_steps: Option<u64>,
+    /// Seconds a *supervised* run may sit parked on a scope review before it
+    /// aborts itself (#1616). Absent or `0` parks until answered or
+    /// interrupted, which is what every run did before this key existed.
+    ///
+    /// Only the sidecar gate reads it (`stella run` under `stella daemon
+    /// start`): the interactive gates have a human looking at the prompt, so a
+    /// timer there would answer a question someone is already reading. The
+    /// expiry resolves as an *abort* — never an approval — because it is a
+    /// human's yes that failed to arrive, and this gate exists so nothing over
+    /// the scope thresholds runs without one.
+    ///
+    /// Set it where nobody is watching: an overnight batch, a CI supervisor, a
+    /// benchmark harness that must not hold a worktree hostage. Leave it unset
+    /// wherever an operator will eventually attach — the parked run is
+    /// discoverable as `Needs Input` in `stella daemon list`, and waiting
+    /// costs nothing but a session slot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_wait_secs: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agents: Option<AgentEngineAgents>,
 }

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -191,6 +191,8 @@ pub struct AgentsSection {
     pub compaction_budget_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_result_horizon_steps: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_wait_secs: Option<u64>,
 
     // The four built-in agents, as tables. Serialized LAST so the flat scalars
     // above are not stranded after a table header — TOML would then read them
@@ -591,6 +593,7 @@ pub fn raise_agents(cfg: &AgentEngineConfig) -> (AgentsSection, ModelsSection) {
         model_timeout_secs: cfg.model_timeout_secs,
         compaction_budget_tokens: cfg.compaction_budget_tokens,
         tool_result_horizon_steps: cfg.tool_result_horizon_steps,
+        approval_wait_secs: cfg.approval_wait_secs,
         default: per_agent.default,
         worker: per_agent.worker,
         verifier: per_agent.verifier,
@@ -663,6 +666,7 @@ fn lower_agents(agents: AgentsSection, models: ModelsSection) -> Option<AgentEng
         model_timeout_secs: agents.model_timeout_secs,
         compaction_budget_tokens: agents.compaction_budget_tokens,
         tool_result_horizon_steps: agents.tool_result_horizon_steps,
+        approval_wait_secs: agents.approval_wait_secs,
         agents: agents_field,
     })
 }

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -102,6 +102,7 @@ pub(crate) const ENGINE_ROOT_FIELDS: &[&str] = &[
     "model_timeout_secs",
     "compaction_budget_tokens",
     "tool_result_horizon_steps",
+    "approval_wait_secs",
     "agents",
 ];
 

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -80,6 +80,10 @@ pin just the verifier model while your user scope keeps everything else.
     // long steps stop on the timeout instead of the cap.
     "model_timeout_secs": 816,
 
+    // Seconds a supervised run may sit parked on a scope review nobody
+    // answers before it aborts. 0 (the default) parks until answered.
+    "approval_wait_secs": 0,
+
     // Per-agent deep config. Set a field and it goes on the wire; leave it
     // out and the provider default applies.
     "agents": {
@@ -266,6 +270,18 @@ Set any of the three autos to `"on"` and stop thinking about it:
     budget: a step allowed 128,000 output tokens against a timeout sized for
     64,000 stops on the timeout, which looks like a model that could not
     finish rather than a ceiling nobody scaled.
+  </OptionCard>
+  <OptionCard name="approval_wait_secs" defaultValue="0">
+    Seconds a **supervised** run (`stella run` under the daemon) may sit parked
+    on a scope review before it gives up. `0` or absent parks until somebody
+    answers, which is the default and usually the right one: the parked run is
+    discoverable as `Needs Input` in `stella daemon list`, and waiting costs
+    nothing but a session slot.
+
+    When it expires the run **aborts** — never approves. It is a human's yes
+    that failed to arrive, and a timer here may only ever stop work. Set it
+    where nobody is watching: an overnight batch, a CI supervisor, a harness
+    that must not hold a worktree hostage.
   </OptionCard>
 </CardGrid>
 


### PR DESCRIPTION
Two residues of PR #1603, tracked together by #1616 because both are deliberate gaps its own docs name.

## (a) An opt-in deadline on a parked scope review

`SidecarApprovalGate::review` parks a supervised run until an operator answers or the process is interrupted. That is right when somebody is coming and wrong when nobody is — an unattended overnight run holds a worktree and a session slot until a human notices.

New setting: **`agent_engine_config.approval_wait_secs`** (also `[agents] approval_wait_secs` in `stella.toml`). Absent or `0` keeps the shipped park-forever default; any positive value ends the park.

**Expiry policy: `ScopeDecision::Abort`, never an approval, and no new "expired" outcome.** The issue named it and the surrounding code already agrees: every other missing-yes edge in `daemon/approval.rs` resolves to `Abort` — an unwritable request, an unparseable answer, a `SIGTERM`, and the stdio gate's EOF. The gate's contract is that nothing over the scope thresholds runs without a human's yes, and a deadline that ran out *is* a yes that never arrived, so the timer may only ever stop work. A `Trim` or `Revise` would have to invent an intent nobody expressed. The abort prints one line on stderr naming the setting, so the postmortem reads "this was configured", not "this vanished".

Two details worth review:
- `0` is spelled and means "no deadline", matching `model_timeout_secs`'s convention — the only way for a project to opt out of a user-scope deadline.
- The poll sleep is clipped to the remaining time (`next_poll`), so a 1s deadline is honoured to the second rather than to the 250ms poll grid.

Only the sidecar gate reads it. The stdio and hunk gates have a human looking at the prompt; a timer there would answer a question someone is already reading.

Plumbing: `OneShotApprovalGate::select` now takes `&Config` (one changed line in the `agent.rs` god file, no growth); the mapping lives in `daemon/approval.rs::park_deadline`.

## (b) Drain the console when the process panics

`ConsoleGuard::drain` ran only at the end of `main`; a panic unwinds past it and the process exits with the pump threads unjoined, losing up to a pipe buffer (~64 KiB) — usually including the panic message, the one artifact a postmortem of a supervised child wants.

`console::arm_panic_drain` installs a hook beside the guard in `main.rs`. It **chains**: the existing hook (diagnostics dump / default printer) runs first so the panic text goes down the pipe like everything else, and only then is the pipe drained into the bounded file. Draining first would leave the message to land raw, past the pump's `Closed` marker and outside the bound.

Deadlock ordering, as the issue asked:
- The pumps moved behind an `Arc<Drainable>` with an idempotent `drain(&self)`: it takes the stream list out **under** the mutex and does the blocking `join` with the lock released, so `main` and the hook cannot wedge each other.
- A drain reached *from* a pump thread (that pump panicking) restores the fd and skips the join on itself, which would be a thread waiting on itself forever.

## Witnesses

| Test | Fail half |
|---|---|
| `daemon::approval::tests::an_expired_deadline_unparks_an_unanswered_review_as_an_abort` | Type-level on `main` (`with_wait` does not exist). Behaviourally proved by deleting the `.with_wait(...)` from the test: `an armed deadline must end the park: Elapsed(())` — the review never resolves and the 10s outer `tokio::time::timeout` is what fails instead of hanging. |
| `daemon::approval::tests::without_a_deadline_the_review_stays_parked` | Pins the unchanged default — an unanswered park still outlives a 750ms wait. |
| `daemon::approval::tests::the_poll_is_clipped_by_what_is_left_of_the_deadline` | The arithmetic, without sleeping through it. |
| `daemon::approval::tests::the_setting_maps_absent_and_zero_to_park_forever` | Guards the easy defect: `0` must not abort every supervised review instantly. |
| `daemon::console::tests::a_panic_drains_the_console_pump` | Type-level on `main` (`arm_panic_drain` does not exist). Behaviourally proved by commenting out the `arm_panic_drain(&guard)` call: `no Closed marker means it was still blocked on the pipe when the panic unwound`. |

The console witness deliberately asserts the pump's **`Closed` index marker**, not "the bytes are in the file": a first draft asserted the bytes and passed even with the hook disarmed, because a live pump thread flushes them on its own schedule in a process that keeps running. The marker only appears when the fd was restored and the pump joined — which is exactly what the hook adds and what a dying process otherwise never does. It interposes on a private descriptor rather than fd 1, so the test runner's stdout is never hijacked.

## Rebased onto current main — the unbreak commits are gone

An earlier revision of this PR carried four unrelated repairs, because `main` was red at
`4bcee7e6` and nothing here compiled without them: the `daemon.rs::inherited_lock_fd`
parse error, the dead `Tail::seek_to_end`, `stella-tui`'s `clippy::manual_clamp` in
`scope_dialog.rs`, and an unused `pgid` binding in `daemon/tests.rs`. Parallel work
landed equivalent fixes upstream (#1658, #1661, #1673 and the daemon repairs), so all
four have been **dropped** — verified against `origin/main` file by file, not assumed.

What is left is #1616 and nothing else: nine files, all of it the deadline, the panic
drain, their tests, the settings key, and the docs page.

## Verification

- `cargo test -p stella-cli` — green (13 test binaries, 0 failures).
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean.
- `make guards` — clean (file-size: nothing grew past its ceiling; no god file gained lines beyond the one changed call line in `agent.rs`).

Docs: the key is documented in `website/content/docs/configuration/agent-engine-config.mdx` beside `model_timeout_secs`.

Closes #1616
