### PR TITLE
feat(arenabench): saved credential file, env still overrides

### DIFF
--- a/arenabench/.gitignore
+++ b/arenabench/.gitignore
@@ -28,3 +28,9 @@ tests/fixtures/matches/*/
 *.local
 .env
 .env.*
+
+# Saved provider credentials (arenabench/credentials.py). The default location
+# is ~/.arenabench/credentials.env, outside any checkout entirely, but an
+# ARENABENCH_CREDENTIALS override that lands one here must never be tracked.
+credentials.env
+credentials.toml

--- a/arenabench/README.md
+++ b/arenabench/README.md
@@ -49,9 +49,11 @@ arenabench run matches/glm-headtohead.toml --progress --results out.json
 ```
 
 `run` reads each seat's credentials from the **process environment** against
-the `required` list the template declares, and refuses to start if one is
-missing — an unauthenticated arm scores zero, and a zero is indistinguishable
-from a real result on a scoreboard. Override with `--allow-missing-env` if you
+the `required` list the template declares, falls back to the [saved credential
+set](#save-credentials-once-instead-of-pasting-them-every-time) for whatever
+the environment left unset, and refuses to start if a seat still has neither —
+an unauthenticated arm scores zero, and a zero is indistinguishable from a
+real result on a scoreboard. Override with `--allow-missing-env` if you
 genuinely mean it.
 
 While the match runs, `run` also applies the [watch rules](#watch-a-running-match-for-the-failures-that-invalidate-it)
@@ -208,6 +210,38 @@ match between two providers needs two credential sets, so credentials are
 per-contestant rather than global. Values live in the arena process and are
 handed only to that contestant's subprocess — the API returns key *names*,
 never values.
+
+### Save credentials once instead of pasting them every time
+
+Pasting the same `.env` into every match, or `export`-ing the same keys before
+every `arenabench run`, gets old fast. Put them in a saved credential file
+instead:
+
+```bash
+mkdir -p ~/.arenabench
+cat > ~/.arenabench/credentials.env <<'EOF'
+OPENROUTER_API_KEY=sk-or-...
+ANTHROPIC_API_KEY=sk-ant-...
+EOF
+```
+
+Same forgiving format as a pasted `.env` (`export FOO=bar`, quoted values,
+`#` comments) — `arenabench.credentials.load_credentials` parses it with the
+identical `parse_dotenv`. It lives at `~/.arenabench/credentials.env` by
+default (next to the price table and the default workspace — `ARENABENCH_HOME`
+moves all three together), or at an exact path you name with
+`ARENABENCH_CREDENTIALS`. Either way it is outside any git checkout, so there
+is no ignore rule to remember; `arenabench/.gitignore` also excludes
+`credentials.env`/`credentials.toml` defensively, in case you point the
+override at a path inside a checkout.
+
+**It only fills gaps.** Every seat's own credentials — whatever `run` found in
+the process environment, or whatever you pasted into the UI form — are checked
+first and always win; the saved file supplies only the names still missing
+after that, and only the ones that seat's provider actually declares (a seat
+on Anthropic never sees a saved OpenRouter key, even if both are in the file).
+Nothing is eliminated by this — pasting still works exactly as before, and
+still overrides the file whenever the two disagree.
 
 **Eight dimensions, live.**
 

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -40,14 +40,20 @@ def _cmd_run(args: argparse.Namespace) -> int:
     """Run a committed ``arenabench.toml`` headlessly — the CI entry point.
 
     Credentials are read from the process environment against each seat's
-    declared ``required`` list, never from the file. A missing one aborts
-    before any container starts, because an unauthenticated arm scores zero
-    and a zero is indistinguishable from a real result on a scoreboard.
+    declared ``required`` list, never from the file — and then from the saved
+    credential set at :func:`~.credentials.credentials_path` for whatever the
+    environment left unset (:func:`~.credentials.apply_saved_credentials`), so
+    a local, repeat ``arenabench run`` does not need the same ``export`` lines
+    pasted before every invocation. A seat's own environment always wins over
+    the saved file. A candidate still missing from both aborts before any
+    container starts, because an unauthenticated arm scores zero and a zero is
+    indistinguishable from a real result on a scoreboard.
     """
     import os
     import time
 
     from .config import MatchTemplateError, load_match, required_env
+    from .credentials import apply_saved_credentials, credentials_path, load_credentials
     from .monitor import MatchWatcher
     from .runner import MatchRunner
     from .server import ArenaServer
@@ -60,19 +66,33 @@ def _cmd_run(args: argparse.Namespace) -> int:
         return 2
 
     needed = required_env(spec)
-    missing: list[str] = []
     seated: list = []
     for contestant in spec.contestants:
         candidates = needed.get(contestant.id, [])
-        env = {
-            name: os.environ[name] for name in candidates if os.environ.get(name)
-        }
+        env = {name: os.environ[name] for name in candidates if os.environ.get(name)}
+        seated.append(replace(contestant, env=env))
+    spec = replace(spec, contestants=tuple(seated))
+
+    saved = load_credentials()
+    spec = apply_saved_credentials(spec)
+    if saved:
+        filled = sum(
+            1
+            for contestant in spec.contestants
+            for name in needed.get(contestant.id, [])
+            if name in saved and not os.environ.get(name)
+        )
+        if filled:
+            print(f"credentials: {filled} value(s) filled in from {credentials_path()}")
+
+    missing: list[str] = []
+    for contestant in spec.contestants:
+        candidates = needed.get(contestant.id, [])
         # The candidate names are alternatives, not a conjunction: a seat
         # carrying any one of them is credentialled (a Claude subscription
         # token authenticates a seat that has no ANTHROPIC_API_KEY at all).
-        if candidates and not env and not args.allow_missing_env:
+        if candidates and not contestant.env and not args.allow_missing_env:
             missing.append(f"{contestant.name}: any of {', '.join(candidates)}")
-        seated.append(replace(contestant, env=env))
     if missing:
         print("error: required environment variables are not set:", file=sys.stderr)
         for line in missing:
@@ -80,7 +100,6 @@ def _cmd_run(args: argparse.Namespace) -> int:
         print("  (use --allow-missing-env to run anyway)", file=sys.stderr)
         return 2
 
-    spec = replace(spec, contestants=tuple(seated))
     workspace = Path(args.workspace).expanduser()
     arena = ArenaServer(workspace)
     runner: MatchRunner = arena.runner

--- a/arenabench/arenabench/credentials.py
+++ b/arenabench/arenabench/credentials.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""A saved credential set, so a seat's ``.env`` does not need re-pasting.
+
+Per-seat credentials are deliberately file-free everywhere else in ArenaBench
+— see :mod:`.config`'s "no secrets, ever" and :class:`.model.Contestant`'s own
+docstring. This module is the one deliberate exception, for the same reason
+:mod:`.pricing` keeps a price table at ``~/.arenabench``: an operator running
+matches from this machine, over and over, against the same handful of
+providers, ends up retyping or re-pasting the same keys every single time.
+
+``credentials.env`` holds them once, at the location ArenaBench already treats
+as "this machine's own state" — the same ``~/.arenabench`` directory
+:func:`~.server.default_workspace` resolves to, following the same
+``ARENABENCH_HOME`` override. That is what makes "gitignored" automatic rather
+than a rule someone has to remember: the file is never inside a git checkout
+in the first place.
+
+**Never a source of truth by itself.** A value here is only a *default* a seat
+falls back to; anything actually supplied for this run — a template's
+``run``, or a contestant's pasted ``.env`` in the UI — always wins. That
+ordering is what lets an operator override one key for one match (testing a
+second account, routing around a rate limit) without touching the saved file,
+and it is why :func:`apply_saved_credentials` only ever fills gaps, never
+overwrites.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+
+from .config import required_env
+from .model import Contestant, MatchSpec, parse_dotenv, screen_env
+
+__all__ = ["apply_saved_credentials", "credentials_path", "load_credentials"]
+
+
+def credentials_path() -> Path:
+    """Where the saved credential set lives.
+
+    ``ARENABENCH_CREDENTIALS`` names an exact file — useful for tests, or an
+    operator who keeps it somewhere else on purpose. Otherwise it sits beside
+    the rest of this machine's ArenaBench state, honouring the same
+    ``ARENABENCH_HOME`` override :func:`~.server.default_workspace` does, so
+    relocating one relocates the other.
+    """
+    override = os.environ.get("ARENABENCH_CREDENTIALS")
+    if override:
+        return Path(override).expanduser()
+    home = os.environ.get("ARENABENCH_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".arenabench"
+    return base / "credentials.env"
+
+
+def load_credentials() -> dict[str, str]:
+    """The saved credential set, or ``{}`` if none has been saved yet.
+
+    Parsed with :func:`.model.parse_dotenv` — the same forgiving format (quotes,
+    ``export`` prefixes, multi-line values) as a seat's pasted ``.env`` in the
+    UI, so a file copied from one place to the other needs no editing — and
+    screened with :func:`.model.screen_env` on the way out, the same trust
+    boundary a pasted ``.env`` crosses, so a stray line in a hand-edited file
+    cannot hand a subprocess something that was never a credential.
+    """
+    try:
+        text = credentials_path().read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    allowed, _ignored = screen_env(parse_dotenv(text))
+    return allowed
+
+
+def apply_saved_credentials(spec: MatchSpec) -> MatchSpec:
+    """Layer the saved credential file under each seat's own ``.env``.
+
+    Only the variable names that seat's provider and agent actually declare
+    (:func:`~.config.required_env`) are pulled from the saved file, so a
+    contestant never receives a credential for a provider it is not
+    configured against — the saved file may hold keys for several providers
+    at once, but a seat still only sees its own, the same per-seat isolation
+    :class:`~.model.Contestant` promises for a pasted ``.env``. Whatever the
+    seat's own environment already set wins.
+    """
+    saved = load_credentials()
+    if not saved:
+        return spec
+    needed = required_env(spec)
+
+    def seeded(contestant: Contestant) -> Contestant:
+        candidates = needed.get(contestant.id, [])
+        fallback = {name: saved[name] for name in candidates if name in saved}
+        if not fallback:
+            return contestant
+        return replace(contestant, env={**fallback, **contestant.env})
+
+    return replace(spec, contestants=tuple(seeded(c) for c in spec.contestants))

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -62,6 +62,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from .agents import AGENTS
 from .config import MatchTemplateError, dump_match, match_from_toml, required_env
+from .credentials import apply_saved_credentials
 from .model import EFFORTS, ROLES, MatchSpec
 from .recorder import preflight as recorder_preflight
 from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
@@ -205,6 +206,9 @@ class ArenaServer:
         payload = dict(payload)
         payload.setdefault("id", uuid.uuid4().hex[:12])
         spec = MatchSpec.from_json(payload)
+        # Fills gaps only: a seat's own pasted `.env` always wins over the
+        # saved credential set — see `apply_saved_credentials`.
+        spec = apply_saved_credentials(spec)
         match = self.runner.create(spec)
         if spec.record_video:
             ok, reason = recorder_preflight()

--- a/arenabench/tests/test_credentials.py
+++ b/arenabench/tests/test_credentials.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The saved credential set: what it fills in, and what it must never override.
+
+``apply_saved_credentials`` exists so an operator does not have to re-export
+the same provider keys before every ``arenabench run``. The property that
+makes that safe is precedence — a seat's own environment always wins — so
+every witness here proves an override, not just a fill.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from arenabench.credentials import (
+    apply_saved_credentials,
+    credentials_path,
+    load_credentials,
+)
+from arenabench.model import Contestant, Engine, MatchSpec
+
+
+def _spec(*contestants: Contestant) -> MatchSpec:
+    return MatchSpec(
+        id="m",
+        name="m",
+        dataset="terminal-bench-2.1",
+        tasks=(),
+        contestants=tuple(contestants),
+    )
+
+
+class TestCredentialsPath:
+    def test_defaults_under_the_arenabench_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("ARENABENCH_CREDENTIALS", raising=False)
+        monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path))
+        assert credentials_path() == tmp_path / "credentials.env"
+
+    def test_explicit_override_wins(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path))
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(tmp_path / "elsewhere.env"))
+        assert credentials_path() == tmp_path / "elsewhere.env"
+
+
+class TestLoadCredentials:
+    def test_missing_file_is_not_an_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(tmp_path / "nope.env"))
+        assert load_credentials() == {}
+
+    def test_parses_the_same_dotenv_format_as_a_pasted_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "credentials.env"
+        path.write_text(
+            'export ANTHROPIC_API_KEY=sk-ant-1\nOPENROUTER_API_KEY="sk-or-2"\n# a comment\n\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        assert load_credentials() == {
+            "ANTHROPIC_API_KEY": "sk-ant-1",
+            "OPENROUTER_API_KEY": "sk-or-2",
+        }
+
+    def test_screens_out_names_that_are_not_credential_shaped(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "credentials.env"
+        path.write_text(
+            "ANTHROPIC_API_KEY=sk-ant-1\nPATH=/usr/bin\nPYTHONPATH=/tmp/evil\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-ant-1"}
+
+
+class TestApplySavedCredentials:
+    def test_fills_a_seat_that_has_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "credentials.env"
+        path.write_text("OPENROUTER_API_KEY=sk-or-1\n", encoding="utf-8")
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        seat = Contestant(
+            id="a", name="a", agent="stella", engine=Engine(api="openrouter", model="m")
+        )
+        (seeded,) = apply_saved_credentials(_spec(seat)).contestants
+        assert seeded.env == {"OPENROUTER_API_KEY": "sk-or-1"}
+
+    def test_the_seats_own_env_overrides_the_saved_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "credentials.env"
+        path.write_text("OPENROUTER_API_KEY=from-file\n", encoding="utf-8")
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        seat = Contestant(
+            id="a",
+            name="a",
+            agent="stella",
+            engine=Engine(api="openrouter", model="m"),
+            env={"OPENROUTER_API_KEY": "from-run"},
+        )
+        (seeded,) = apply_saved_credentials(_spec(seat)).contestants
+        assert seeded.env == {"OPENROUTER_API_KEY": "from-run"}
+
+    def test_never_leaks_a_key_the_seat_did_not_ask_for(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "credentials.env"
+        path.write_text(
+            "OPENROUTER_API_KEY=sk-or-1\nANTHROPIC_API_KEY=sk-ant-1\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        # This seat is on Anthropic; it must never see the OpenRouter key.
+        seat = Contestant(
+            id="a", name="a", agent="stella", engine=Engine(api="anthropic", model="m")
+        )
+        (seeded,) = apply_saved_credentials(_spec(seat)).contestants
+        assert seeded.env == {"ANTHROPIC_API_KEY": "sk-ant-1"}
+
+    def test_no_saved_file_is_a_no_op(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(tmp_path / "nope.env"))
+        seat = Contestant(
+            id="a", name="a", agent="stella", engine=Engine(api="openrouter", model="m")
+        )
+        spec = _spec(seat)
+        assert apply_saved_credentials(spec) is spec


### PR DESCRIPTION
## Summary
- Adds `arenabench/arenabench/credentials.py`: a saved provider-credential set at `~/.arenabench/credentials.env` (or `ARENABENCH_CREDENTIALS`), parsed with the same `parse_dotenv`/`screen_env` a pasted `.env` already goes through in the UI.
- `arenabench run` (`cli.py`) and match creation from the web UI (`server.py`) both apply it via `apply_saved_credentials` — it only fills gaps: a seat's own process-environment or pasted `.env` values always win, and a seat only ever receives the exact credential names its own provider/agent declares (`config.required_env`), never the whole saved file.
- Nothing about the existing paste-a-`.env`-per-match workflow is removed or changed — this is purely a fallback so an operator running matches from one machine repeatedly doesn't have to re-supply the same keys every time.
- `.gitignore` gets a defensive `credentials.env`/`credentials.toml` entry in case `ARENABENCH_CREDENTIALS` is ever pointed inside a checkout; the default location is outside any git repo entirely.
- README documents the new file under a "Save credentials once instead of pasting them every time" section.

## Test plan
- [x] `python3 -m pytest -q` — 204 passed (full arenabench suite, including new `tests/test_credentials.py`)
- [x] `ruff check` / `ruff format --diff` clean on all touched/new files (pre-existing formatting debt in `cli.py`/`server.py` from lines I did not touch was left alone — appears to be a ruff-version skew, not something this PR should carry)
- [x] New tests cover: default path resolution, `ARENABENCH_CREDENTIALS` override, missing-file no-op, dotenv parsing, credential screening, fill-a-gap, seat-env-overrides-file precedence, and per-seat isolation (a seat on one provider never receives another provider's saved key even when both are in the file)

## Summary by Sourcery

Introduce a saved credential file that is automatically applied as a fallback for match seats while preserving per-seat isolation and environment precedence.

New Features:
- Add a configurable saved credential file (credentials.env) under ~/.arenabench or at ARENABENCH_CREDENTIALS for provider credentials.
- Support loading and applying saved credentials to MatchSpec seats in both CLI runs and web-created matches as a gap-filling fallback.

Enhancements:
- Update CLI run behavior to report credentials filled from the saved file and to treat seats as credentialled when either env or saved values are present.
- Extend server-side match creation to apply saved credentials beneath any pasted per-seat environment.
- Document the saved credential workflow in the README, including location, format, and precedence rules.
- Add gitignore entries to defensively exclude credentials.env/credentials.toml from version control.

Tests:
- Add tests covering credential path resolution, missing-file handling, dotenv parsing and screening, precedence of seat env over saved values, and per-provider isolation when applying saved credentials.