### PR TITLE
feat(stella-cli): stella run --detach — re-land #1594's intent on today's daemon surface

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -291,6 +291,21 @@ pub(crate) struct GlobalArgs {
     /// Env: STELLA_FOREGROUND.
     #[arg(long, global = true, env = "STELLA_FOREGROUND", hide_short_help = true)]
     pub(crate) foreground: bool,
+
+    /// Start the run in the background and return to the shell immediately.
+    ///
+    /// The work is supervised exactly as it would be otherwise — same session
+    /// id, same console, `stella daemon list | attach | logs | stop` all
+    /// address it — but this process does not stay to stream it. Use it to
+    /// launch a long run from a script, or to keep using the terminal you
+    /// started one in. Unlike plain supervision this does not need a terminal,
+    /// so it works from a pipe, a container, or CI.
+    ///
+    /// The exit code is the launch's, not the run's: the run's own answer is
+    /// in `stella daemon list` afterwards. `--foreground` wins if both are
+    /// given. Env: STELLA_DETACH.
+    #[arg(long, global = true, env = "STELLA_DETACH", hide_short_help = true)]
+    pub(crate) detach: bool,
 }
 
 #[derive(Subcommand)]

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -109,6 +109,10 @@ mod service;
 pub(crate) mod approval;
 pub(crate) mod console;
 
+/// `--detach`: the same supervised launch, without the launcher staying to
+/// stream it (#1607).
+pub(crate) mod detach;
+
 /// Carries the supervised session's registry id into the child.
 ///
 /// Two jobs. It tells the child which record to stamp on its way out — the
@@ -239,11 +243,18 @@ pub(crate) fn forwarded_exit_code() -> Option<u8> {
 /// The child re-parses the same argv with `--foreground` appended, so the
 /// division of labour is exactly one process doing the work and one process
 /// watching — no argument is re-derived, re-quoted, or dropped on the way.
+///
+/// `posture` decides whether this process then stays: [`detach::Posture::Attached`]
+/// streams the child back here until it ends, [`detach::Posture::Detached`]
+/// returns the moment the child is registered (#1607). Both spawn through the
+/// same [`spawn`], because "the launcher does not stay" is the only difference
+/// between them and a second launch path is how the two would drift.
 pub(crate) fn supervise_this_invocation(
     rt: tokio::runtime::Runtime,
     workspace: &Path,
     title: &str,
     stdin: &[u8],
+    posture: detach::Posture,
 ) -> Result<(), String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot locate the stella binary to supervise: {e}"))?;
@@ -273,6 +284,9 @@ pub(crate) fn supervise_this_invocation(
         &args,
         stdin,
     )?;
+    if posture == detach::Posture::Detached {
+        return detach::release(run);
+    }
     run.announce();
     watch(rt, &registry, run)
 }

--- a/crates/stella-cli/src/daemon/detach.rs
+++ b/crates/stella-cli/src/daemon/detach.rs
@@ -115,8 +115,13 @@ pub(crate) fn posture(
 /// handle closes this process's ends of the two console tails and drops the
 /// `Child`, which on Unix neither signals nor reaps — the child is already a
 /// session leader with its own console files and its own liveness lock, so it
-/// notices nothing. The launcher then returns, and the run is reparented to
-/// init.
+/// notices nothing. The launcher then returns, the process exits, and the run
+/// is reparented to init, which is what will reap it.
+///
+/// That last hop is the reason nothing here waits: a launcher that stayed to
+/// reap would be the attached launcher. It also means the *only* correct way
+/// to ask whether a detached run is alive is the liveness lock rather than its
+/// pid — a pid answers "not yet reaped", which is a different question.
 ///
 /// The announcement is printed on **stderr** for the same reason the attached
 /// banner is: `--output-format json` writes the machine-readable answer to

--- a/crates/stella-cli/src/daemon/detach.rs
+++ b/crates/stella-cli/src/daemon/detach.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `--detach`: hand the run to the supervisor and give the shell back (#1607).
+//!
+//! Supervision (`super`) already makes a run outlive its terminal. What it
+//! does not do is give the *prompt* back: the launching process stays for the
+//! whole run, streaming the two console files, and `Ctrl-C` there is a stop
+//! rather than a detach — deliberately, because that is what the key means
+//! everywhere else. So on today's surface there is no way to start a run and
+//! keep using the terminal you started it from, and no way at all to start one
+//! from a script that then exits.
+//!
+//! That gap is what `--detach` closes, and it is the surviving half of #1594's
+//! intent. Everything else #1594 proposed — a `stella daemon` command group, a
+//! console in the session sidecar, `setsid`, the liveness lock, stop
+//! escalation, a single registry rather than a second one — landed instead
+//! through #1591/#1603/#1640 and is reused here verbatim. This module is
+//! therefore very small on purpose: **a detached launch is an attached launch
+//! that does not stay**, and any second implementation of the launch would be
+//! the divergence that supervision's own `watch` doc warns about.
+//!
+//! # Two differences from an attached launch, both deliberate
+//!
+//! 1. **A terminal is not required.** [`super::should_supervise`] answers "no"
+//!    without a controlling terminal, because a run with no terminal to lose
+//!    is already immune to the hangup supervision exists to prevent. `--detach`
+//!    is asked for a different property — *this process returns now* — which a
+//!    pipe, a CI step, and a `cron` job want exactly as much as a terminal
+//!    does. So the flag forces supervision rather than merely permitting it.
+//! 2. **The exit code is the launch's, not the run's.** An attached
+//!    supervisor forwards the child's status
+//!    ([`super::forwarded_exit_code`]); a detached one has returned long
+//!    before there is a status to forward, so `stella run --detach; echo $?`
+//!    answers "did the launch succeed". The run's own answer arrives in
+//!    `stella daemon list`.
+//!
+//! # Why `--foreground` wins over `--detach` instead of conflicting with it
+//!
+//! Clap could reject the pair outright, and that would be wrong here: the
+//! supervised child re-parses its parent's argv **verbatim** (`--detach`
+//! included) and is told to do the work through `STELLA_FOREGROUND=1` in its
+//! environment — which clap reads as the `--foreground` flag. A declared
+//! conflict fires on env-sourced values too, so every detached child would die
+//! in argument parsing before it ran a turn. Precedence in [`posture`] is what
+//! keeps that path open, and it also happens to be the safer reading of a
+//! contradictory command line: the flag that asks for *less* machinery wins.
+
+use super::Supervised;
+
+/// What this invocation does with the supervisor.
+///
+/// Three states rather than the `bool` #1591 used, because "supervise" and
+/// "stay and stream it" stopped being the same question once `--detach`
+/// existed. Computed once, from flags and the terminal, by [`posture`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Posture {
+    /// Do the work in this process. Older releases' only shape.
+    Foreground,
+    /// Hand the work to a supervised child and stream it back here until it
+    /// ends — the default for a run typed at a terminal.
+    Attached,
+    /// Hand the work to a supervised child and return immediately.
+    Detached,
+}
+
+impl Posture {
+    /// Whether the work goes to a supervised child at all.
+    pub(crate) fn supervises(self) -> bool {
+        !matches!(self, Self::Foreground)
+    }
+}
+
+/// Resolve the posture from the two flags, the recursion backstop, and the
+/// terminal.
+///
+/// Pure over already-observed booleans for the same reason
+/// [`super::should_supervise`] is — the caller does the observing, so the
+/// decision is testable as arithmetic. It is layered *on* that function rather
+/// than beside it so the "which invocations are supervised" rule keeps exactly
+/// one owner.
+///
+/// Order matters and encodes three rules:
+///
+/// - `--foreground` (or `STELLA_FOREGROUND`) wins over everything, including
+///   `--detach`. See the module docs for why this is precedence, not a clap
+///   conflict.
+/// - A process that is already the supervised child never supervises again,
+///   `--detach` or not. This is the recursion backstop, and `--detach` riding
+///   in the child's verbatim argv is precisely the case it has to survive.
+/// - `--detach` then forces supervision, terminal or no terminal.
+pub(crate) fn posture(
+    foreground: bool,
+    detach: bool,
+    already_supervised: bool,
+    has_controlling_terminal: bool,
+) -> Posture {
+    if foreground || already_supervised {
+        return Posture::Foreground;
+    }
+    if detach {
+        return Posture::Detached;
+    }
+    if super::should_supervise(foreground, already_supervised, has_controlling_terminal) {
+        Posture::Attached
+    } else {
+        Posture::Foreground
+    }
+}
+
+/// Let go of a just-spawned supervised run and tell the terminal how to find
+/// it again.
+///
+/// Taking [`Supervised`] **by value** is the whole mechanism: dropping the
+/// handle closes this process's ends of the two console tails and drops the
+/// `Child`, which on Unix neither signals nor reaps — the child is already a
+/// session leader with its own console files and its own liveness lock, so it
+/// notices nothing. The launcher then returns, and the run is reparented to
+/// init.
+///
+/// The announcement is printed on **stderr** for the same reason the attached
+/// banner is: `--output-format json` writes the machine-readable answer to
+/// stdout, and a launcher that garnished it would break every script that
+/// pipes one.
+pub(crate) fn release(run: Supervised) -> Result<(), String> {
+    use colored::Colorize;
+
+    eprintln!(
+        "{} {} — running in the background",
+        "▸ detached".green().bold(),
+        run.id.dimmed()
+    );
+    eprintln!(
+        "  follow it with {}",
+        format!("stella daemon attach {}", run.id).cyan()
+    );
+    eprintln!(
+        "  stop it with   {}",
+        format!("stella daemon stop {}", run.id).cyan()
+    );
+    drop(run);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/daemon/detach.rs
+++ b/crates/stella-cli/src/daemon/detach.rs
@@ -22,7 +22,7 @@
 //!
 //! # Two differences from an attached launch, both deliberate
 //!
-//! 1. **A terminal is not required.** [`super::should_supervise`] answers "no"
+//! 1. **A terminal is not required.** [`crate::daemon::should_supervise`] answers "no"
 //!    without a controlling terminal, because a run with no terminal to lose
 //!    is already immune to the hangup supervision exists to prevent. `--detach`
 //!    is asked for a different property — *this process returns now* — which a
@@ -30,7 +30,7 @@
 //!    does. So the flag forces supervision rather than merely permitting it.
 //! 2. **The exit code is the launch's, not the run's.** An attached
 //!    supervisor forwards the child's status
-//!    ([`super::forwarded_exit_code`]); a detached one has returned long
+//!    ([`crate::daemon::forwarded_exit_code`]); a detached one has returned long
 //!    before there is a status to forward, so `stella run --detach; echo $?`
 //!    answers "did the launch succeed". The run's own answer arrives in
 //!    `stella daemon list`.
@@ -42,7 +42,8 @@
 //! included) and is told to do the work through `STELLA_FOREGROUND=1` in its
 //! environment — which clap reads as the `--foreground` flag. A declared
 //! conflict fires on env-sourced values too, so every detached child would die
-//! in argument parsing before it ran a turn. Precedence in [`posture`] is what
+//! in argument parsing before it ran a turn. Precedence in
+//! [`crate::daemon::detach::posture`] is what
 //! keeps that path open, and it also happens to be the safer reading of a
 //! contradictory command line: the flag that asks for *less* machinery wins.
 

--- a/crates/stella-cli/src/daemon/detach/tests.rs
+++ b/crates/stella-cli/src/daemon/detach/tests.rs
@@ -47,10 +47,16 @@ fn eventually(budget: Duration, mut predicate: impl FnMut() -> bool) -> bool {
     predicate()
 }
 
-fn alive(pid: i32) -> bool {
-    // SAFETY: signal 0 delivers nothing; it only asks whether the pid exists
-    // and is signallable. It cannot affect the target.
-    unsafe { libc::kill(pid, 0) == 0 }
+/// Whether the run behind `id` is still alive, asked the way the supervisor
+/// itself asks it.
+///
+/// Deliberately not `kill(pid, 0)`. Nothing reaps the child here — production's
+/// launcher exits and init does it, but this test *is* the launcher and stays —
+/// so a finished child lingers as a zombie whose pid still signals. The
+/// liveness lock has no such ambiguity: the kernel releases it when the process
+/// dies, zombie or not, which is exactly why `stop` reads it rather than a pid.
+fn alive(registry: &SessionRegistry, id: &str) -> bool {
+    lock_is_held(&registry.sidecar_dir(id)) == Some(true)
 }
 
 /// The witness for `--detach`: a run handed to the supervisor keeps running
@@ -70,7 +76,7 @@ fn alive(pid: i32) -> bool {
 fn a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable() {
     let (dir, registry) = temp_registry("outlives");
 
-    let (id, pid) = {
+    let id = {
         let run = spawn(
             &registry,
             "/tmp/workspace",
@@ -81,21 +87,15 @@ fn a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable() {
         )
         .expect("supervised spawn");
         let id = run.id.clone();
-        let pid = i32::try_from(run.child.id()).expect("pid fits");
         // The launcher returns here. Everything below runs with no handle.
         release(run).expect("release");
-        (id, pid)
+        id
     };
 
     // It outlived the handle.
     assert!(
-        alive(pid),
+        alive(&registry, &id),
         "the detached run died when its launcher let go of it"
-    );
-    assert_eq!(
-        lock_is_held(&registry.sidecar_dir(&id)),
-        Some(true),
-        "the detached run should still hold its liveness lock"
     );
 
     // It is discoverable — by full id and by the prefix a human would type.
@@ -125,7 +125,7 @@ fn a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable() {
     // And it is stoppable from here, where nothing holds it.
     stop(&registry, &id).expect("stop the detached run");
     assert!(
-        eventually(Duration::from_secs(10), || !alive(pid)),
+        eventually(Duration::from_secs(10), || !alive(&registry, &id)),
         "the detached run survived stop"
     );
     assert_eq!(

--- a/crates/stella-cli/src/daemon/detach/tests.rs
+++ b/crates/stella-cli/src/daemon/detach/tests.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `--detach` tests (#1607).
+//!
+//! The decision half is pure and tested as arithmetic; the mechanical half is
+//! tested against a **real child process**, for the reason the supervisor's
+//! own tests give: `setsid`, the liveness lock and the split console are
+//! syscalls, and a fake would only assert that the fake matched the assertion.
+//!
+//! The scaffolding here (a per-test registry, a `/bin/sh` child, a bounded
+//! wait) deliberately does not reach into `super::super::tests` for its
+//! equivalents: those are private to that module, and widening them would put
+//! this change inside hunks that two open PRs are editing. It is a dozen lines.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use stella_store::{SessionRegistry, SessionStatus};
+
+use super::*;
+use crate::daemon::{lock_is_held, resolve, spawn, stop};
+
+/// An isolated registry per test — these tests signal process groups, and a
+/// shared registry is one where a test's `stop` can reach another's child.
+fn temp_registry(tag: &str) -> (PathBuf, SessionRegistry) {
+    let dir = std::env::temp_dir().join(format!(
+        "stella-detach-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    (dir.clone(), SessionRegistry::open(dir))
+}
+
+/// Wait for `predicate`, up to `budget`. Answers whether it came true. Budgets
+/// are generous on purpose: the assertion is "happens" versus "never happens",
+/// and a bound tight enough to measure latency would flake on loaded CI.
+fn eventually(budget: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    predicate()
+}
+
+fn alive(pid: i32) -> bool {
+    // SAFETY: signal 0 delivers nothing; it only asks whether the pid exists
+    // and is signallable. It cannot affect the target.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// The witness for `--detach`: a run handed to the supervisor keeps running
+/// once the launcher has let go of it, and everything needed to come back to
+/// it — the registry row, the console, the stop — still works from a process
+/// that holds no handle on it at all.
+///
+/// "The launcher let go" is modelled exactly as production models it:
+/// [`release`] consumes the [`Supervised`] handle, which is the only thing
+/// this process ever held. After that line there is no `Child`, no console
+/// tail and no pgid in scope, which is the same state the shell is in after
+/// `stella run --detach` returns. The remaining hop — this *process* also
+/// exiting — is what `setsid` covers, and the supervisor's own
+/// `a_supervised_child_leaves_this_process_session_and_group` is its witness;
+/// a test cannot exit its own runner to prove it a second time.
+#[test]
+fn a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable() {
+    let (dir, registry) = temp_registry("outlives");
+
+    let (id, pid) = {
+        let run = spawn(
+            &registry,
+            "/tmp/workspace",
+            "detached run",
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo working; sleep 30".into()],
+            b"",
+        )
+        .expect("supervised spawn");
+        let id = run.id.clone();
+        let pid = i32::try_from(run.child.id()).expect("pid fits");
+        // The launcher returns here. Everything below runs with no handle.
+        release(run).expect("release");
+        (id, pid)
+    };
+
+    // It outlived the handle.
+    assert!(
+        alive(pid),
+        "the detached run died when its launcher let go of it"
+    );
+    assert_eq!(
+        lock_is_held(&registry.sidecar_dir(&id)),
+        Some(true),
+        "the detached run should still hold its liveness lock"
+    );
+
+    // It is discoverable — by full id and by the prefix a human would type.
+    let found = resolve(&registry, Some(&id)).expect("resolve by id");
+    assert_eq!(found.id, id);
+    assert!(found.status.is_live(), "status was {:?}", found.status);
+    let prefix = &id[..id.len() - 3];
+    assert_eq!(
+        resolve(&registry, Some(prefix))
+            .expect("resolve by prefix")
+            .id,
+        id
+    );
+
+    // Its output reached the console with no terminal attached to receive it.
+    let out = registry
+        .sidecar_dir(&id)
+        .join(stella_store::supervised::STDOUT_LOG);
+    assert!(
+        eventually(Duration::from_secs(10), || {
+            std::fs::read_to_string(&out).is_ok_and(|s| s.contains("working"))
+        }),
+        "the detached run's stdout never reached {}",
+        out.display()
+    );
+
+    // And it is stoppable from here, where nothing holds it.
+    stop(&registry, &id).expect("stop the detached run");
+    assert!(
+        eventually(Duration::from_secs(10), || !alive(pid)),
+        "the detached run survived stop"
+    );
+    assert_eq!(
+        registry.get(&id).map(|r| r.status),
+        Some(SessionStatus::Cancelled),
+        "a stop somebody asked for must not age into the registry as a crash"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+/// `--detach` is asked for a different property than supervision is, so it
+/// answers a different question about the terminal.
+///
+/// Supervision declines without a controlling terminal because there is no
+/// hangup to survive. "Give me the prompt back" is wanted just as much from a
+/// pipe, a CI step or a `cron` job — a shell script that launches a run and
+/// exits is the whole point — so the flag forces it.
+#[test]
+fn detach_forces_supervision_where_a_bare_run_would_decline_it() {
+    // No terminal: supervision declines, --detach does not.
+    assert!(!crate::daemon::should_supervise(false, false, false));
+    assert_eq!(posture(false, true, false, false), Posture::Detached);
+
+    // With a terminal, --detach only changes whether the launcher stays.
+    assert_eq!(posture(false, false, false, true), Posture::Attached);
+    assert_eq!(posture(false, true, false, true), Posture::Detached);
+
+    // And with neither flag nor terminal, nothing changed.
+    assert_eq!(posture(false, false, false, false), Posture::Foreground);
+}
+
+/// The two ways `--detach` must lose, and the second one is load-bearing.
+///
+/// A supervised child re-parses its parent's argv verbatim, `--detach`
+/// included, and is told to do the work through `STELLA_FOREGROUND=1`. If
+/// either rule here failed, that child would supervise itself again — one
+/// process per turn, forever.
+#[test]
+fn foreground_and_the_recursion_backstop_both_beat_detach() {
+    assert_eq!(posture(true, true, false, true), Posture::Foreground);
+    assert_eq!(posture(false, true, true, true), Posture::Foreground);
+    // The child's real shape: both, since the env sets one and argv the other.
+    assert_eq!(posture(true, true, true, true), Posture::Foreground);
+}
+
+#[test]
+fn only_the_foreground_posture_keeps_the_work_in_this_process() {
+    assert!(!Posture::Foreground.supervises());
+    assert!(Posture::Attached.supervises());
+    assert!(Posture::Detached.supervises());
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -306,20 +306,22 @@ pub(crate) use cli::{
     AuthCmd, Cli, Command, ConnectCmd, DaemonCmd, McpCmd, MigrateCmd, ModelsCmd, TelemetryCmd,
 };
 
-/// Whether this invocation is handed to the supervisor (#1552).
+/// How this invocation meets the supervisor (#1552, #1607).
 ///
-/// `false` runs the work in this process, exactly as every release before
-/// supervision existed. Supervision costs no capability any more: a plan
-/// that expands scope parks and asks through the session sidecar (#1585)
-/// instead of dying at the headless scope-review error, so there is no
-/// longer a downgrade to warn about here.
+/// [`daemon::detach::Posture::Foreground`] runs the work in this process, exactly as every
+/// release before supervision existed. Supervision costs no capability any
+/// more: a plan that expands scope parks and asks through the session sidecar
+/// (#1585) instead of dying at the headless scope-review error, so there is no
+/// longer a downgrade to warn about here. [`daemon::detach::Posture::Detached`] is the same
+/// supervised child with the launcher not staying — `--detach`.
 ///
 /// Computed here, once, because it is the only place the parsed flags and
 /// the real terminal handle are both in hand; each long-running arm then
-/// asks one question instead of re-deriving three.
-fn supervision(globals: &cli::GlobalArgs) -> bool {
-    daemon::should_supervise(
+/// asks one question instead of re-deriving four.
+fn supervision(globals: &cli::GlobalArgs) -> daemon::detach::Posture {
+    daemon::detach::posture(
         globals.foreground,
+        globals.detach,
         daemon::supervised_id().is_some(),
         daemon::has_controlling_terminal(),
     )
@@ -1001,12 +1003,14 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             )?;
             // Resolved first on purpose: the prompt may have come from this
             // process's stdin, and a detached child has none to read.
-            if supervision(&cli.globals) {
+            let posture = supervision(&cli.globals);
+            if posture.supervises() {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &prompt),
                     prompt.as_bytes(),
+                    posture,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1051,12 +1055,14 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 std::io::stdin().is_terminal(),
                 prompt_source::read_stdin_to_string,
             )?;
-            if supervision(&cli.globals) {
+            let posture = supervision(&cli.globals);
+            if posture.supervises() {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &goal),
                     goal.as_bytes(),
+                    posture,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1083,7 +1089,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             task_timeout,
             output_format,
         } => {
-            if supervision(&cli.globals) {
+            let posture = supervision(&cli.globals);
+            if posture.supervises() {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
@@ -1095,6 +1102,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                         },
                     ),
                     &[],
+                    posture,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1115,12 +1123,14 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
         }
         Command::Monitor { target } => {
             let target = target.unwrap_or_else(|| "main".to_string());
-            if supervision(&cli.globals) {
+            let posture = supervision(&cli.globals);
+            if posture.supervises() {
                 return daemon::supervise_this_invocation(
                     rt()?,
                     &cfg.workspace_root,
                     &supervised_title(&cfg, &format!("monitor {target}")),
                     &[],
+                    posture,
                 ).map_err(failure::CliFailure::from);
             }
             // Monitoring IS a goal: the verifier (who can call ci_status

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -8,6 +8,7 @@ A long-running verb started from a terminal — [`run`](/docs/commands/run), [`g
 ## Synopsis
 
 ```bash
+stella run "…" --detach
 stella daemon list
 stella daemon attach [id]
 stella daemon logs [id] [-n LINES]
@@ -51,12 +52,36 @@ Only ones with a controlling terminal to lose. A terminal is exactly what can cl
 | Invocation | Supervised |
 |---|---|
 | `stella run "…"` typed in a terminal | yes |
+| `stella run "…" --detach` | yes — and the launcher returns immediately ([below](#--detach-start-it-and-get-the-prompt-back)) |
 | `stella run "…" --foreground` | no — runs in this process, as older releases did |
 | `cat spec.md \| stella run` with output redirected | no — no controlling terminal |
 | a CI step, a container, a `cron` job | no |
 | [`stella chat`](/docs/commands/chat) / [`stella resume`](/docs/commands/resume) | no — the deck *is* the terminal |
 
 `--foreground` (or `STELLA_FOREGROUND=1`) opts any invocation out.
+
+## `--detach`: start it and get the prompt back
+
+Supervision keeps the run alive when the terminal goes; it does not hand the terminal back while the run continues. The launching process stays for the whole run streaming the console, and `Ctrl-C` there **stops** the run — deliberately, because that is what the key means everywhere else.
+
+`--detach` is the other half. The work is supervised exactly as it would be otherwise — same session id, same console, the whole `stella daemon` surface addresses it — but the launcher returns as soon as the run is registered:
+
+```bash
+$ stella run "migrate the config loader to serde" --detach
+▸ detached ses-1785956826121-25167 — running in the background
+  follow it with stella daemon attach ses-1785956826121-25167
+  stop it with   stella daemon stop ses-1785956826121-25167
+$
+```
+
+Two differences from an attached launch, both deliberate:
+
+- **A terminal is not required.** Plain supervision declines without one, since a run with no terminal to lose is already immune to the hangup. "Return now" is wanted from a pipe, a container, a `cron` job and a shell script exactly as much as from a terminal, so the flag forces supervision rather than merely permitting it.
+- **The exit code is the launch's, not the run's.** `stella run --detach; echo $?` answers "did the launch succeed". The run's own answer arrives in `stella daemon list`.
+
+It applies to every supervised verb — `run`, `goal`, `monitor`, `fleet` — and `STELLA_DETACH=1` sets it for a whole shell. `--foreground` wins if both are given: the flag that asks for less machinery is the safer reading of a contradictory command line, and a declared conflict would break the supervised child, which re-parses its parent's argv (`--detach` included) with `STELLA_FOREGROUND=1` in its environment.
+
+A detached run cannot ask *this* terminal anything, because there is no longer one attached — but it does not lose the answer either. A plan that crosses the scope thresholds parks exactly as described below, and the next `stella daemon attach` asks the question.
 
 ## Scope review while supervised
 

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -23,6 +23,8 @@ Because it is non-interactive, `stella run` is the natural place to combine `--o
 `stella run` uses the same tools, providers, and credential chain as every other command. All [global flags](/docs/commands) apply.
 </Callout>
 
+A run typed at a terminal is [supervised](/docs/commands/daemon): it survives the window closing, and this terminal stays only to stream it. Add [`--detach`](/docs/commands/daemon#--detach-start-it-and-get-the-prompt-back) to get the prompt back immediately instead — the run keeps going, and `stella daemon list | attach | logs | stop` address it afterwards. That works from a script or a CI step too, where nothing is supervised by default.
+
 ## Flags
 
 `stella run` adds three command-specific flags on top of the [global flags](/docs/commands):


### PR DESCRIPTION
## What, and what this is not

Re-lands the **one surviving half** of #1594's intent on today's daemon surface. The rest of #1594 already shipped, through different PRs, so this deliberately does not revert-the-revert or cherry-pick anything.

I checked before writing code, as #1607 asks: **most of #1594 is already on main.** #1591 landed the supervisor, #1603 built on it, #1640 added `install`/`uninstall`, and #1586 added `resume`. Every mechanism #1594 proposed — the `stella daemon` command group, a console in the session sidecar, `setsid`, the liveness lock, graceful stop escalation, one registry rather than a second one, the prompt staged as a file — exists on main and is reused here verbatim. Main went further than #1594 did, and flipped supervision on **by default** for every terminal run, which #1594 had explicitly deferred as a maintainer's call.

What is genuinely missing is the thing the flag was named for: **getting the shell prompt back.** On main the launching process stays for the whole run streaming the console, and `Ctrl-C` there *stops* the run rather than detaching (deliberately — `daemon.rs::interrupt_and_drain` documents why). So there is no way to start a run and keep using the terminal, and no way at all to start one from a script that then exits. Nothing on main does that, with any combination of existing flags.

## The change

A global `--detach` (`STELLA_DETACH`), in a new sibling module `crates/stella-cli/src/daemon/detach.rs`:

- `Posture` (`Foreground` | `Attached` | `Detached`) replaces the `bool` that `main.rs::supervision` returned, because "supervise" and "stay and stream it" stopped being one question. `posture()` is pure over already-observed booleans, layered **on** #1591's `should_supervise` so the "which invocations are supervised" rule keeps exactly one owner.
- `release()` — a detached launch is an attached launch that does not stay: same `spawn`, then drop the handle instead of `watch`ing it. No second launch path, which is what `watch`'s own doc warns against.

Two deliberate differences from an attached launch, both documented on the flag and in `daemon.mdx`:

- **`--detach` forces supervision without a controlling terminal.** Plain supervision declines there (nothing to lose), but "return now" is wanted from a script, a container and a CI step exactly as much as from a terminal.
- **The exit code is the launch's, not the run's.** The run's own answer is in `stella daemon list`.

**`--foreground` wins over `--detach` by precedence, not by a clap conflict** — and this is load-bearing rather than taste. The supervised child re-parses its parent's argv **verbatim** (`--detach` included) and is told to do the work through `STELLA_FOREGROUND=1` in its environment. A declared conflict fires on env-sourced values too, so every detached child would die in argument parsing before running a turn. `posture()`'s ordering is what keeps that path open, and `foreground_and_the_recursion_backstop_both_beat_detach` pins it.

Exemplar for the shape: `clap`'s own treatment of mutually-implied flags as precedence in the resolver rather than a hard conflict, and `stella-core/src/driver/settlement.rs` for the "new logic in a sibling submodule" split this repo already uses.

## Witness

`daemon::detach::tests::a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable`

Releases the `Supervised` handle — the only thing the launcher ever holds — and then, from a scope where there is no `Child`, no console tail and no pgid, asserts the run is still alive, resolvable by full id and by prefix, live in the registry, writing to its console with no terminal attached, and stoppable with the stop recorded as `Cancelled` rather than ageing into a crash.

**The fail-half on `main` is type-level and I want to be explicit about it:** the `detach` module, `Posture` and `release` do not exist there, so the test does not compile. That is weaker than a behavioural fail, so I verified the behavioural absence directly against `origin/main` instead of asserting it:

```
$ git show origin/main:crates/stella-cli/src/daemon.rs | rg -c 'detach::|Posture'
0
$ git show origin/main:crates/stella-cli/src/daemon.rs | rg -A2 'run.announce\(\);'
276:    run.announce();
277-    watch(rt, &registry, run)          # unconditional — the launcher always stays
$ git show origin/main:crates/stella-cli/src/cli.rs | rg -- '--detach'        # nothing
```

`supervise_this_invocation` ends unconditionally in `watch`, and `should_supervise(false, false, false)` is `false`, so on `main` no invocation can return while its run continues. The behaviour is genuinely absent, not merely unnamed.

**What I could not verify locally, honestly:** a *real* `stella run --detach` in a *real* shell, returning while the run continues. Nothing in the tree can — the test process is the launcher and cannot exit itself, exactly as `daemon/tests.rs` already says for the hangup property. The last hop rests on `setsid`, which #1591's `a_supervised_child_leaves_this_process_session_and_group` witnesses. **Filed as #1689** rather than left implicit.

One real bug the witness caught, worth reading: the first draft probed liveness with `kill(pid, 0)` and reported a stopped run as still alive. Nothing reaps a detached child *in the launcher* — production's launcher exits and init reaps — so a finished child lingers as a zombie whose pid still signals. The liveness lock is the correct probe, which is exactly why `stop` reads it rather than a pid. Both the test and `release`'s doc now say so.

Also `detach_forces_supervision_where_a_bare_run_would_decline_it`, `foreground_and_the_recursion_backstop_both_beat_detach`, `only_the_foreground_posture_keeps_the_work_in_this_process`.

## Deliberately dropped from #1594

- **Addressing a run by pid.** Main's `resolve` takes an id or a unique prefix; #1594 also took a pid. Not needed for this contract, and a second address space is not free. Filed as #1690.
- **A machine-readable handle on stdout.** `--detach --output-format json` writes nothing parseable today — the banner is on stderr, correctly, but a script piping to `jq` gets an empty stream. The envelope has to join `main.rs`'s versioned summary family rather than be invented here. Filed as #1688, and I would rather a reviewer chose the shape than have me pick one silently.
- Routing verbs through the supervisor by default: already done on main, by #1591.

## God files

None touched. All new logic is in `daemon/detach.rs` + its tests; `daemon.rs` (+14), `cli.rs` (+15) and `main.rs` (+36/-13) take only the flag declaration and dispatch. No baseline ceiling raised — `check-file-size` reports "none grew".

## Verification

- `cargo test -p stella-cli --bin stella` — **1370 passed, 0 failed**
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps --document-private-items` — clean
- `make guards` — every global guard green, including `check-command-docs` (38 subcommands), `check-file-size`, `check-doc-links`, `cargo fmt --check`

Not run locally: `--workspace` builds and tests (16GB machine with three sibling agents; `cargo test -p stella-cli` links integration binaries that OOM). Main is separately red at `crates/stella-tui/src/deck_ui/gates.rs:22` under `cargo doc -D warnings` — PR #1684 owns that unbreak, and it is unrelated to this branch.

## Coordination

Branched from `origin/main`, not stacked on anything. Expected interactions with the open siblings:

- **#1682** (#1616, parked-review deadline) touches `daemon.rs`, `daemon/tests.rs`, `main.rs`. My `daemon.rs` hunks are the `mod detach;` declaration and `supervise_this_invocation`'s signature/tail — different regions from its approval/console work. I deliberately did **not** widen `daemon/tests.rs`'s private helpers (which is why `detach/tests.rs` carries its own dozen lines of scaffolding), specifically to stay out of its hunks.
- **#1674** (#1615, pipeline on resume) and the merged **#1654** (#1637) live in `agent/resume.rs` / `agent/outcome.rs` — untouched here.
- **#1627** (resume-at-boot) is a separate later slice and is not absorbed.

The only plausible textual conflict is `main.rs`'s four supervised arms, which now read `let posture = supervision(&cli.globals); if posture.supervises()` and pass `posture` through — a mechanical resolution if something else edits those arms.

## Issues filed

- #1688 — `--detach --output-format json` has no machine-readable stdout
- #1689 — no end-to-end witness for the supervised launch surface (pty harness)
- #1690 — `stella daemon` addresses runs by id only; #1594 also took a pid

Closes #1607
Refs #1594, #1591, #1552

## Summary by Sourcery

Introduce a global `--detach`/STELLA_DETACH option that allows supervised runs to be launched in the background while returning control to the shell immediately.

New Features:
- Add a `Posture` model to configure how invocations interact with the supervisor, including a new detached mode where the launcher does not stay to stream the run.
- Expose a global `--detach` CLI flag and corresponding environment variable to start supervised runs in the background across `run`, `goal`, `monitor`, and related commands.

Enhancements:
- Refine supervision routing so all long-running commands consult a single posture calculation instead of raw booleans.
- Extend daemon supervision logic with a release path that drops the supervised child handle rather than watching it, while keeping a single launch path.
- Document the new `--detach` behaviour and interaction with supervision and `--foreground` in the daemon and run command docs.

Tests:
- Add integration-style tests for the detach posture logic and for detached runs continuing to run, remaining discoverable, and being stoppable after the launcher returns.