### PR TITLE
feat(arenabench): browse a trial's files; only offer a video that can play

### DIFF
--- a/arenabench/arenabench/artifacts.py
+++ b/arenabench/arenabench/artifacts.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Reading what a trial left behind — the file tree, and whether a video is real.
+
+Two jobs that share a threat model.
+
+**Browsing a trial.** A trial directory is the whole evidence trail: the result,
+the agent's trajectory and event stream, the verifier's output, the recording.
+Being able to open any of it in the browser is the difference between trusting a
+scoreboard and being able to check it. The cost is that a local web server is
+now handing out file contents, so every path that reaches the filesystem is
+resolved and then *proved* to be inside the trial directory it claims to be in
+(:func:`resolve_within`). Symlinks are resolved before the check, not after —
+a trial directory is written by a container we did not author, and a symlink
+pointing at ``/etc`` is exactly what a path-containment bug looks like in
+practice.
+
+**Deciding a recording is watchable.** An MP4 is not playable because a file
+exists at that path. The recorder writes with ``-movflags +faststart``, which
+places the index (``moov``) at the *end* of encoding — so for the entire
+lifetime of a live trial the file is present, growing, and completely
+unplayable, and if the run is killed it stays that way forever. Offering a
+player in that window produces a broken box in the UI and a bug report about
+video "not working" that is really a bug report about timing.
+
+:func:`mp4_is_finalized` answers the real question by walking the top-level
+boxes for a ``moov``. It is a header scan, not a decode: cheap enough to call
+on every snapshot, and it cannot be fooled by a file that merely has bytes in
+it. Fragmented MP4s (``+empty_moov``) carry a ``moov`` up front and so read as
+finalized from the first frame, which is correct — those genuinely are playable
+while being written.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "MAX_TEXT_BYTES",
+    "FileNode",
+    "mp4_is_finalized",
+    "preview_kind",
+    "resolve_within",
+    "tree",
+]
+
+#: Read at most this much of a text file into the browser. Event streams reach
+#: hundreds of megabytes; a viewer that tries to render one is a hung tab.
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+
+#: Suffixes rendered as text. Everything else is offered as a download rather
+#: than guessed at — a mis-detected binary is a screenful of replacement
+#: characters, which looks like corruption and is not.
+TEXT_SUFFIXES = frozenset(
+    {
+        ".txt", ".log", ".json", ".jsonl", ".md", ".toml", ".yaml", ".yml",
+        ".py", ".sh", ".rs", ".js", ".ts", ".css", ".html", ".xml", ".csv",
+        ".patch", ".diff", ".ini", ".cfg", ".env", ".c", ".h", ".cpp", ".go",
+    }
+)
+VIDEO_SUFFIXES = frozenset({".mp4", ".webm", ".mov"})
+IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"})
+
+#: Never walk into these. They are large, uninteresting, and in the case of
+#: `.git` can contain a full copy of the workspace.
+SKIP_DIRS = frozenset({".git", "__pycache__", "node_modules"})
+
+
+# ---------------------------------------------------------------------------
+# Path containment
+# ---------------------------------------------------------------------------
+
+
+def resolve_within(root: Path, relative: str) -> Path | None:
+    """Resolve ``relative`` under ``root``, or ``None`` if it escapes.
+
+    The containment check happens **after** symlink resolution on both sides,
+    because a trial directory is produced by a container this process did not
+    author. Checking the textual path first and resolving later is the classic
+    ordering bug: ``arena/link`` looks contained right up until it is followed.
+
+    An absolute path, a ``..`` segment, or an NT-style drive letter is refused
+    outright rather than normalised — nothing legitimate in a trial tree needs
+    them, so accepting them only widens what has to be reasoned about.
+    """
+    candidate = (relative or "").strip().replace("\\", "/")
+    if not candidate or candidate.startswith("/") or ":" in candidate:
+        return None
+    if any(part == ".." for part in candidate.split("/")):
+        return None
+    try:
+        base = root.resolve(strict=True)
+        target = (base / candidate).resolve(strict=True)
+    except (OSError, RuntimeError):  # missing, or a symlink loop
+        return None
+    if target != base and base not in target.parents:
+        return None
+    return target
+
+
+# ---------------------------------------------------------------------------
+# The tree
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileNode:
+    """One entry in a trial's artifact tree."""
+
+    name: str
+    #: Path relative to the trial directory — what a client sends back.
+    path: str
+    is_dir: bool
+    size: int
+    kind: str
+    children: tuple[FileNode, ...] = ()
+
+    def to_json(self) -> dict[str, object]:
+        node: dict[str, object] = {
+            "name": self.name,
+            "path": self.path,
+            "is_dir": self.is_dir,
+            "size": self.size,
+            "kind": self.kind,
+        }
+        if self.is_dir:
+            node["children"] = [child.to_json() for child in self.children]
+        return node
+
+
+def preview_kind(path: Path) -> str:
+    """How a client should render this file: text, video, image, or binary."""
+    suffix = path.suffix.lower()
+    if suffix in VIDEO_SUFFIXES:
+        return "video"
+    if suffix in IMAGE_SUFFIXES:
+        return "image"
+    if suffix in TEXT_SUFFIXES:
+        return "text"
+    # Extensionless files are common in these trees (`test.sh` aside, think
+    # `Dockerfile`); sniff a small window rather than refusing them.
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(4096)
+    except OSError:
+        return "binary"
+    if not head:
+        return "text"
+    if b"\x00" in head:
+        return "binary"
+    try:
+        head.decode("utf-8")
+    except UnicodeDecodeError:
+        return "binary"
+    return "text"
+
+
+def tree(root: Path, *, max_depth: int = 8, max_entries: int = 2000) -> FileNode:
+    """The artifact tree under ``root``, depth- and breadth-capped.
+
+    The caps are not tidiness. A trial that ran ``git init`` or unpacked a
+    dependency tree can leave tens of thousands of files, and a browser handed
+    all of them renders nothing at all.
+    """
+    budget = [max_entries]
+
+    def walk(directory: Path, relative: str, depth: int) -> FileNode:
+        children: list[FileNode] = []
+        if depth < max_depth and budget[0] > 0:
+            try:
+                entries = sorted(
+                    directory.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())
+                )
+            except OSError:
+                entries = []
+            for entry in entries:
+                if budget[0] <= 0:
+                    break
+                budget[0] -= 1
+                child_rel = f"{relative}/{entry.name}" if relative else entry.name
+                # `is_dir()` follows symlinks; a link out of the tree must not
+                # be descended into even though it is contained by name.
+                if entry.is_symlink():
+                    children.append(
+                        FileNode(entry.name, child_rel, False, 0, "symlink")
+                    )
+                    continue
+                if entry.is_dir():
+                    if entry.name in SKIP_DIRS:
+                        children.append(
+                            FileNode(entry.name, child_rel, True, 0, "skipped")
+                        )
+                        continue
+                    children.append(walk(entry, child_rel, depth + 1))
+                else:
+                    try:
+                        size = entry.stat().st_size
+                    except OSError:
+                        size = 0
+                    children.append(
+                        FileNode(
+                            entry.name, child_rel, False, size, preview_kind(entry)
+                        )
+                    )
+        return FileNode(
+            name=directory.name,
+            path=relative,
+            is_dir=True,
+            size=0,
+            kind="dir",
+            children=tuple(children),
+        )
+
+    return walk(root, "", 0)
+
+
+# ---------------------------------------------------------------------------
+# Is this recording watchable
+# ---------------------------------------------------------------------------
+
+
+def mp4_is_finalized(path: Path) -> bool:
+    """Whether an MP4 carries the index that makes it playable.
+
+    Walks top-level boxes looking for ``moov``. Three things make this the
+    right check rather than "does the file exist":
+
+    * A live recording is `ftyp | free | mdat(size=0)` — bytes accumulating
+      into a box the writer has not closed. There is no index and no player
+      can open it.
+    * A recording killed before finalisation stays in exactly that state
+      permanently. Existence never becomes playability on its own.
+    * A fragmented recording (``+empty_moov``) writes ``moov`` up front, so it
+      reads finalized immediately — which is true, and is the point of writing
+      fragmented in the first place.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size < 16:
+        return False
+    try:
+        with path.open("rb") as handle:
+            offset = 0
+            while offset < size:
+                handle.seek(offset)
+                header = handle.read(8)
+                if len(header) < 8:
+                    return False
+                box_size, kind = struct.unpack(">I4s", header)
+                if kind == b"moov":
+                    return True
+                if box_size == 0:
+                    # Runs to end of file: an unclosed box, and nothing can
+                    # follow it. If we have not seen `moov` by now, there is none.
+                    return False
+                if box_size == 1:
+                    extended = handle.read(8)
+                    if len(extended) < 8:
+                        return False
+                    box_size = struct.unpack(">Q", extended)[0]
+                if box_size < 8:
+                    return False
+                offset += box_size
+    except OSError:
+        return False
+    return False

--- a/arenabench/arenabench/recorder.py
+++ b/arenabench/arenabench/recorder.py
@@ -49,7 +49,11 @@ __all__ = [
 
 log = logging.getLogger("arenabench.recorder")
 
-IMAGE_TAG = "arenabench/recorder:1"
+#: Bumped to :2 when the recorder switched to fragmented MP4. The tag is what
+#: `image_present()` checks, so a host that already built :1 would otherwise
+#: keep filming with the old `+faststart` script forever and keep producing
+#: unplayable files after a hard kill — a fix nobody receives.
+IMAGE_TAG = "arenabench/recorder:2"
 
 #: Give ffmpeg time to write the moov atom. Docker's default 10s stop timeout
 #: is usually enough, but a long recording on a loaded host is not, and the

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -41,6 +41,7 @@ from .agents import (
     resolve_agent,
     routes_directly,
 )
+from .artifacts import mp4_is_finalized
 from .harbor_agent import ARENA_ENGINE_ENV
 from .model import DIMENSIONS, Contestant, MatchSpec, screen_env
 from .monitor import Detection, MatchWatcher
@@ -301,8 +302,15 @@ class Match:
         trial = self.trial_dirs(contestant_id).get(task)
         if trial is None:
             return None
+        # Only a finalised recording is served. A file that exists but has no
+        # `moov` yet cannot be played, and handing one to a browser produces a
+        # broken player rather than an honest "not ready".
         video = trial / "arena" / "recording.mp4"
-        return video if video.exists() else None
+        return video if mp4_is_finalized(video) else None
+
+    def trial_dir_for(self, contestant_id: str, task: str) -> Path | None:
+        """The trial directory itself, for browsing everything it produced."""
+        return self.trial_dirs(contestant_id).get(task)
 
 
 class MatchRunner:

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -61,6 +61,7 @@ from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
 from .agents import AGENTS
+from .artifacts import MAX_TEXT_BYTES, preview_kind, resolve_within, tree
 from .config import MatchTemplateError, dump_match, match_from_toml, required_env
 from .credentials import apply_saved_credentials
 from .model import EFFORTS, ROLES, MatchSpec
@@ -74,6 +75,17 @@ __all__ = ["ArenaServer", "serve"]
 log = logging.getLogger("arenabench.server")
 
 WEB_ROOT = Path(__file__).resolve().parent / "web"
+
+#: Inline-renderable image types, listed rather than sniffed. SVG is
+#: deliberately absent — it can carry script, and these files were written by a
+#: task container this process did not author.
+_IMAGE_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
 
 #: How often the scoreboard stream re-reads the run tree.
 SNAPSHOT_INTERVAL_S = 1.0
@@ -358,6 +370,37 @@ class ArenaServer:
             return None
         return match.video_path(contestant_id, task)
 
+    def trial_root(self, match_id: str, contestant_id: str, task: str) -> Path | None:
+        match = self.runner.matches.get(match_id)
+        if match is None:
+            return None
+        return match.trial_dir_for(contestant_id, task)
+
+    def trial_files(self, match_id: str, contestant_id: str, task: str) -> dict:
+        """The artifact tree for one trial, for the file browser."""
+        root = self.trial_root(match_id, contestant_id, task)
+        if root is None or not root.is_dir():
+            raise KeyError(f"no trial for {contestant_id}/{task}")
+        return tree(root).to_json()
+
+    def trial_file(
+        self, match_id: str, contestant_id: str, task: str, relative: str
+    ) -> tuple[Path, str]:
+        """One file inside a trial, proved to be inside it.
+
+        Returns the resolved path and how a client should render it. Raises
+        ``KeyError`` for anything that does not resolve *within* the trial —
+        traversal and containment failures are deliberately indistinguishable
+        from "not found" on the wire, so probing tells an attacker nothing.
+        """
+        root = self.trial_root(match_id, contestant_id, task)
+        if root is None or not root.is_dir():
+            raise KeyError(f"no trial for {contestant_id}/{task}")
+        target = resolve_within(root, relative)
+        if target is None or not target.is_file():
+            raise KeyError(relative)
+        return target, preview_kind(target)
+
 
 # --------------------------------------------------------------------------
 # HTTP plumbing
@@ -486,6 +529,53 @@ def _handler_factory(
             self.end_headers()
             self.wfile.write(body)
 
+        def _artifact(self, path: Path, kind: str) -> None:
+            """Serve one file out of a trial directory.
+
+            Text is capped and served as plain UTF-8: an event stream can be
+            hundreds of megabytes, and a viewer handed all of it is a hung tab
+            rather than a feature. Anything else is sent as an octet-stream
+            attachment — deliberately *not* with a guessed content type, so a
+            file a container wrote can never be served as active content to the
+            browser that asked for it.
+            """
+            size = path.stat().st_size
+            if kind == "text":
+                raw = path.read_bytes()[:MAX_TEXT_BYTES]
+                body = raw.decode("utf-8", "replace").encode("utf-8")
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("X-Arena-Truncated", "1" if size > MAX_TEXT_BYTES else "0")
+                self.send_header("X-Arena-Size", str(size))
+                self.send_header("X-Content-Type-Options", "nosniff")
+                self.send_header("Cache-Control", "no-cache")
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if kind == "image":
+                body = path.read_bytes()
+                self.send_response(HTTPStatus.OK)
+                # Images render inline, but still never sniffed.
+                content_type = _IMAGE_TYPES.get(
+                    path.suffix.lower(), "application/octet-stream"
+                )
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("X-Content-Type-Options", "nosniff")
+                self.send_header("Cache-Control", "no-cache")
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            body = path.read_bytes()
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Disposition", f'attachment; filename="{path.name}"')
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.end_headers()
+            self.wfile.write(body)
+
         def _video(self, path: Path) -> None:
             """Serve an MP4 with Range support so the player can seek.
 
@@ -596,9 +686,24 @@ def _handler_factory(
                 case ["matches", match_id, "video", contestant, task]:
                     video = arena.video(match_id, contestant, task)
                     if video is None:
+                        # Either there is no recording, or there is one that has
+                        # not been finalised and no player could open. Both are
+                        # "nothing to watch yet" from the client's side.
                         self._error(HTTPStatus.NOT_FOUND, "no recording for this trial")
                         return
                     self._video(video)
+                case ["matches", match_id, "files", contestant, task]:
+                    self._json(arena.trial_files(match_id, contestant, task))
+                case ["matches", match_id, "file", contestant, task]:
+                    query = parse_qs(urlparse(self.path).query)
+                    relative = (query.get("path") or [""])[0]
+                    target, kind = arena.trial_file(
+                        match_id, contestant, task, relative
+                    )
+                    if kind == "video":
+                        self._video(target)
+                    else:
+                        self._artifact(target, kind)
                 case _:
                     self._error(HTTPStatus.NOT_FOUND, "unknown endpoint")
 

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -53,6 +53,7 @@ from pathlib import Path
 from stat import S_ISDIR
 from typing import Any
 
+from .artifacts import mp4_is_finalized
 from .pricing import Price, price_for, price_for_route, price_on_route, trial_cost
 
 __all__ = [
@@ -672,7 +673,12 @@ class MetricsReader:
             if isinstance(wasted, (int, float)):
                 metrics.wasted_elapsed = float(wasted)
 
-        metrics.has_video = (trial_dir / "arena" / "recording.mp4").exists()
+        # Existence is not playability. The recorder writes the index (`moov`)
+        # at the *end* of encoding, so a live trial has a growing file that no
+        # player can open, and a killed one keeps that file forever. Offering a
+        # player in either window is a broken box in the UI, so this reports a
+        # video only once the recording has actually been finalised.
+        metrics.has_video = mp4_is_finalized(trial_dir / "arena" / "recording.mp4")
         return metrics
 
 

--- a/arenabench/recorder/record.sh
+++ b/arenabench/recorder/record.sh
@@ -6,12 +6,14 @@
 #
 #   Xvfb :99  ->  xterm running render.py  ->  ffmpeg -f x11grab -> H.264 MP4
 #
-# The only genuinely delicate part is shutdown. An MP4 needs its moov atom
-# written at the end, and a container stopped with SIGKILL leaves a truncated,
-# unplayable file. So ffmpeg is backgrounded, SIGTERM/SIGINT are trapped, and
-# the handler asks ffmpeg to finish cleanly (SIGINT, which ffmpeg treats as
-# "stop encoding and finalise") before this script exits. Docker's default
-# 10-second grace period is enough for that; the supervisor asks for more.
+# Shutdown used to be the delicate part: a plain MP4 needs its moov atom
+# written at the end, so a container stopped with SIGKILL left a file with
+# every frame in it and no index, which nothing can play. The output is now
+# a fragmented MP4 (see the ffmpeg invocation), so the file is playable at
+# every instant and a hard kill costs at most the final fragment. ffmpeg is
+# still backgrounded with SIGTERM/SIGINT trapped so the graceful path flushes
+# that last fragment; it is no longer the only thing standing between a run
+# and a watchable recording.
 set -eu
 
 WIDTH="${ARENA_WIDTH:-1440}"
@@ -104,18 +106,34 @@ XTERM_PID=$!
 # open on an empty grey rectangle.
 sleep 0.6
 
+# Fragmented MP4, NOT +faststart.
+#
+# `+faststart` writes the index (`moov`) only when encoding *ends*. That makes
+# the graceful path below the single point of failure for the whole recording:
+# if this container is SIGKILLed rather than asked to stop -- the match process
+# tree is killed, the host reboots, Docker prunes -- the file is left as
+# `ftyp | free | mdat(size=0)`, every frame present and no index, which no
+# player on earth will open. Measured: 4 of 15 recordings from one head-to-head
+# died exactly this way, three of them 96MB of perfectly good video that had to
+# be rebuilt by hand.
+#
+# `+empty_moov` writes the index up front and `+frag_keyframe` closes a
+# fragment on every keyframe, so the file on disk is playable at every instant,
+# including while it is still being written. The graceful shutdown below is
+# still worth doing -- it flushes the final fragment -- but it is now an
+# optimisation rather than the difference between a video and 96MB of nothing.
 ffmpeg -nostdin -loglevel error \
   -f x11grab -video_size "${WIDTH}x${HEIGHT}" -framerate "$FPS" -i "$DISPLAY_NUM" \
   -c:v libx264 -preset veryfast -crf 26 -pix_fmt yuv420p \
-  -movflags +faststart \
+  -movflags +frag_keyframe+empty_moov+default_base_moof \
   -y "$OUTPUT" &
 FFMPEG_PID=$!
 log "recording -> $OUTPUT"
 
 finish() {
   # SIGINT, not SIGTERM: ffmpeg finalises the container on INT and dies
-  # abruptly on TERM. This is the difference between a playable file and a
-  # truncated one.
+  # abruptly on TERM. With fragmented output the file is already playable, so
+  # this now saves the last partial fragment rather than the whole recording.
   kill -INT "$FFMPEG_PID" 2>/dev/null || true
   wait "$FFMPEG_PID" 2>/dev/null || true
   kill "$XTERM_PID" "$XVFB_PID" 2>/dev/null || true

--- a/arenabench/tests/test_artifacts.py
+++ b/arenabench/tests/test_artifacts.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Browsing a trial, and deciding a recording is watchable.
+
+Two things are load-bearing here. The containment rules decide whether a local
+web server hands out files it should not, and the MP4 check decides whether the
+UI offers a player for something no player can open.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from arenabench.artifacts import (
+    FileNode,
+    mp4_is_finalized,
+    preview_kind,
+    resolve_within,
+    tree,
+)
+
+
+def _box(kind: bytes, payload: bytes = b"") -> bytes:
+    return struct.pack(">I4s", 8 + len(payload), kind) + payload
+
+
+def _ftyp() -> bytes:
+    return _box(b"ftyp", b"isom" + b"\x00" * 20)
+
+
+# -- containment ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        "../../../etc/passwd",
+        "..",
+        "arena/../../escape",
+        "/etc/passwd",
+        "/",
+        "C:/Windows/win.ini",
+        "",
+        "   ",
+    ],
+)
+def test_paths_that_leave_the_trial_are_refused(tmp_path, attempt):
+    (tmp_path / "arena").mkdir()
+    (tmp_path / "arena" / "recording.mp4").write_bytes(b"x")
+    assert resolve_within(tmp_path, attempt) is None
+
+
+def test_a_real_file_inside_the_trial_resolves(tmp_path):
+    (tmp_path / "arena").mkdir()
+    target = tmp_path / "arena" / "recording.mp4"
+    target.write_bytes(b"x")
+    assert resolve_within(tmp_path, "arena/recording.mp4") == target.resolve()
+
+
+def test_a_symlink_pointing_out_of_the_trial_is_refused(tmp_path):
+    """The containment check must happen after resolution, not before.
+
+    A trial directory is written by a container we did not author. `arena/out`
+    is textually contained right up until it is followed.
+    """
+    outside = tmp_path.parent / "outside-secret"
+    outside.write_text("secret", encoding="utf-8")
+    trial = tmp_path / "trial"
+    (trial / "arena").mkdir(parents=True)
+    link = trial / "arena" / "out"
+    link.symlink_to(outside)
+    assert resolve_within(trial, "arena/out") is None
+
+
+def test_a_symlink_staying_inside_the_trial_is_allowed(tmp_path):
+    trial = tmp_path / "trial"
+    (trial / "arena").mkdir(parents=True)
+    real = trial / "arena" / "real.log"
+    real.write_text("hi", encoding="utf-8")
+    (trial / "alias.log").symlink_to(real)
+    assert resolve_within(trial, "alias.log") == real.resolve()
+
+
+def test_a_missing_file_is_refused_not_invented(tmp_path):
+    assert resolve_within(tmp_path, "arena/nope.txt") is None
+
+
+# -- the tree ---------------------------------------------------------------
+
+
+def test_tree_lists_a_trial(tmp_path):
+    (tmp_path / "agent").mkdir()
+    (tmp_path / "agent" / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "result.json").write_text("{}", encoding="utf-8")
+    node = tree(tmp_path)
+    names = {child.name for child in node.children}
+    assert {"agent", "result.json"} <= names
+    agent = next(c for c in node.children if c.name == "agent")
+    assert agent.is_dir
+    assert agent.children[0].path == "agent/events.jsonl"
+
+
+def test_tree_does_not_descend_into_git(tmp_path):
+    """A trial that ran `git init` can hold a whole second copy of the workspace."""
+    (tmp_path / ".git" / "objects").mkdir(parents=True)
+    (tmp_path / ".git" / "objects" / "blob").write_text("x", encoding="utf-8")
+    node = tree(tmp_path)
+    git = next(c for c in node.children if c.name == ".git")
+    assert git.kind == "skipped"
+    assert git.children == ()
+
+
+def test_tree_does_not_follow_symlinked_directories(tmp_path):
+    target = tmp_path / "target"
+    (target / "deep").mkdir(parents=True)
+    trial = tmp_path / "trial"
+    trial.mkdir()
+    (trial / "link").symlink_to(target)
+    node = tree(trial)
+    link = next(c for c in node.children if c.name == "link")
+    assert link.kind == "symlink"
+    assert link.children == ()
+
+
+def test_tree_is_breadth_capped(tmp_path):
+    for i in range(50):
+        (tmp_path / f"f{i}.txt").write_text("x", encoding="utf-8")
+    node = tree(tmp_path, max_entries=10)
+    assert len(node.children) <= 10
+
+
+def test_file_node_json_omits_children_for_files():
+    node = FileNode("a.txt", "a.txt", False, 3, "text")
+    assert "children" not in node.to_json()
+
+
+# -- preview kinds ----------------------------------------------------------
+
+
+def test_preview_kinds(tmp_path):
+    (tmp_path / "a.jsonl").write_text("{}", encoding="utf-8")
+    (tmp_path / "b.mp4").write_bytes(b"\x00\x00")
+    (tmp_path / "c.png").write_bytes(b"\x89PNG")
+    assert preview_kind(tmp_path / "a.jsonl") == "text"
+    assert preview_kind(tmp_path / "b.mp4") == "video"
+    assert preview_kind(tmp_path / "c.png") == "image"
+
+
+def test_an_extensionless_binary_is_not_offered_as_text(tmp_path):
+    blob = tmp_path / "core"
+    blob.write_bytes(b"\x7fELF\x00\x01\x02\x00\x00")
+    assert preview_kind(blob) == "binary"
+
+
+def test_an_extensionless_text_file_is_readable(tmp_path):
+    script = tmp_path / "Dockerfile"
+    script.write_text("FROM alpine\n", encoding="utf-8")
+    assert preview_kind(script) == "text"
+
+
+# -- is the recording watchable --------------------------------------------
+
+
+def test_a_live_recording_is_not_finalized(tmp_path):
+    """`ftyp | free | mdat(size=0)` is exactly what a running ffmpeg leaves.
+
+    This is the state the UI used to offer a player for, and no player can
+    open it.
+    """
+    video = tmp_path / "recording.mp4"
+    video.write_bytes(
+        _ftyp() + _box(b"free") + struct.pack(">I4s", 0, b"mdat") + b"\xde\xad" * 4096
+    )
+    assert mp4_is_finalized(video) is False
+
+
+def test_a_finalized_recording_is_playable(tmp_path):
+    video = tmp_path / "recording.mp4"
+    video.write_bytes(_ftyp() + _box(b"moov", b"\x00" * 64) + _box(b"mdat", b"\x01" * 128))
+    assert mp4_is_finalized(video) is True
+
+
+def test_a_fragmented_recording_reads_as_finalized_immediately(tmp_path):
+    """`+empty_moov` puts the index up front; those files really are playable."""
+    video = tmp_path / "recording.mp4"
+    video.write_bytes(
+        _ftyp() + _box(b"moov", b"\x00" * 32) + _box(b"moof", b"\x00" * 16)
+    )
+    assert mp4_is_finalized(video) is True
+
+
+def test_a_missing_or_empty_file_is_not_finalized(tmp_path):
+    assert mp4_is_finalized(tmp_path / "nope.mp4") is False
+    empty = tmp_path / "empty.mp4"
+    empty.write_bytes(b"")
+    assert mp4_is_finalized(empty) is False
+
+
+def test_a_nonsense_box_size_does_not_hang(tmp_path):
+    """A truncated or hostile header must terminate the walk, not loop."""
+    video = tmp_path / "bad.mp4"
+    video.write_bytes(struct.pack(">I4s", 2, b"ftyp") + b"\x00" * 64)
+    assert mp4_is_finalized(video) is False

--- a/arenabench/tests/test_file_api.py
+++ b/arenabench/tests/test_file_api.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The trial file-browser endpoints, against a real socket.
+
+These are the first routes that hand out file *contents*, so the containment
+rules are exercised here through the actual HTTP stack rather than only against
+the helper — a route that forgets to call the helper is exactly the bug worth
+catching, and a unit test of the helper cannot see it.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import threading
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from arenabench.server import ArenaServer, _handler_factory, allowed_hosts
+
+
+def _box(kind: bytes, payload: bytes = b"") -> bytes:
+    return struct.pack(">I4s", 8 + len(payload), kind) + payload
+
+
+class _FakeMatch:
+    """Just enough Match for the file routes: a trial directory per task."""
+
+    def __init__(self, trial: Path) -> None:
+        self._trial = trial
+
+    def trial_dir_for(self, contestant_id: str, task: str) -> Path | None:
+        if contestant_id == "seat" and task == "demo":
+            return self._trial
+        return None
+
+    def video_path(self, contestant_id: str, task: str) -> Path | None:
+        from arenabench.artifacts import mp4_is_finalized
+
+        video = self._trial / "arena" / "recording.mp4"
+        return video if mp4_is_finalized(video) else None
+
+
+@pytest.fixture
+def served(tmp_path: Path):
+    trial = tmp_path / "jobs" / "m1-seat" / "demo__abc"
+    (trial / "agent").mkdir(parents=True)
+    (trial / "arena").mkdir(parents=True)
+    (trial / "result.json").write_text('{"reward": 1}', encoding="utf-8")
+    (trial / "agent" / "events.jsonl").write_text('{"type":"text"}\n', encoding="utf-8")
+
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    (trial / "arena" / "escape").symlink_to(secret)
+
+    arena = ArenaServer(tmp_path / "ws")
+    arena.runner.matches["m1"] = _FakeMatch(trial)  # type: ignore[assignment]
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    port = httpd.server_address[1]
+    httpd.RequestHandlerClass = _handler_factory(arena, allowed_hosts("127.0.0.1", port))
+    httpd.daemon_threads = True
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, trial
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+
+def _get(port: int, path: str) -> tuple[int, bytes, dict[str, str]]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", path, headers={"Host": f"127.0.0.1:{port}"})
+        res = conn.getresponse()
+        return res.status, res.read(), dict(res.getheaders())
+    finally:
+        conn.close()
+
+
+# -- the tree ---------------------------------------------------------------
+
+
+def test_the_tree_lists_what_the_trial_produced(served):
+    port, _ = served
+    status, body, _ = _get(port, "/api/matches/m1/files/seat/demo")
+    assert status == 200
+    node = json.loads(body)
+    names = {child["name"] for child in node["children"]}
+    assert {"agent", "arena", "result.json"} <= names
+
+
+def test_an_unknown_trial_is_a_404(served):
+    port, _ = served
+    status, _, _ = _get(port, "/api/matches/m1/files/seat/nosuchtask")
+    assert status == 404
+
+
+# -- reading a file ---------------------------------------------------------
+
+
+def test_a_text_artifact_is_served_as_text(served):
+    port, _ = served
+    status, body, headers = _get(
+        port, "/api/matches/m1/file/seat/demo?path=agent/events.jsonl"
+    )
+    assert status == 200
+    assert b'"type":"text"' in body
+    assert headers.get("X-Content-Type-Options") == "nosniff"
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        "../../../../etc/passwd",
+        "..%2F..%2Fetc%2Fpasswd",
+        "/etc/passwd",
+        "arena/../../../etc/passwd",
+    ],
+)
+def test_traversal_is_refused_over_http(served, attempt):
+    port, _ = served
+    status, _, _ = _get(port, f"/api/matches/m1/file/seat/demo?path={attempt}")
+    assert status == 404
+
+
+def test_a_symlink_out_of_the_trial_is_refused_over_http(served):
+    """Textually contained, and still must not be served once resolved."""
+    port, _ = served
+    status, body, _ = _get(port, "/api/matches/m1/file/seat/demo?path=arena/escape")
+    assert status == 404
+    assert b"TOP SECRET" not in body
+
+
+def test_a_missing_path_parameter_is_refused(served):
+    port, _ = served
+    status, _, _ = _get(port, "/api/matches/m1/file/seat/demo")
+    assert status == 404
+
+
+# -- the recording gate -----------------------------------------------------
+
+
+def test_an_unfinalised_recording_is_not_served(served):
+    """A live recording is `ftyp | free | mdat(size=0)` — present, unplayable.
+
+    Serving it produces a broken player, which reads to a user as "video is
+    broken" rather than "the run has not finished".
+    """
+    port, trial = served
+    (trial / "arena" / "recording.mp4").write_bytes(
+        _box(b"ftyp", b"isom") + struct.pack(">I4s", 0, b"mdat") + b"\xde\xad" * 512
+    )
+    status, _, _ = _get(port, "/api/matches/m1/video/seat/demo")
+    assert status == 404
+
+
+def test_a_finalised_recording_is_served(served):
+    port, trial = served
+    (trial / "arena" / "recording.mp4").write_bytes(
+        _box(b"ftyp", b"isom") + _box(b"moov", b"\x00" * 32) + _box(b"mdat", b"\x01" * 64)
+    )
+    status, body, _ = _get(port, "/api/matches/m1/video/seat/demo")
+    assert status in (200, 206)
+    assert body

--- a/arenabench/tests/test_snapshot_docker.py
+++ b/arenabench/tests/test_snapshot_docker.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Snapshot capture against a real container.
+
+The rest of the snapshot suite is the pure half — the search, the manifest, the
+box walk. None of it touches Docker, which left the genuinely risky parts
+unexercised: whether the container name is derived the way Harbor spells it,
+whether the workspace is found, whether the detached ``--git-dir`` invocation
+actually produces a patch, and whether the workspace survives untouched.
+
+That last one is why this test exists at all. ``fix-git`` is a task in this
+dataset whose whole subject is repository state; a snapshotter that wrote
+``.git`` into the workspace would silently rewrite the task it was measuring
+and every number derived from it would be quietly wrong. A unit test cannot see
+that — only a real filesystem in a real container can.
+
+Skipped without Docker, so it costs nothing in CI. Uses ``alpine`` and no
+benchmark, so it needs no dataset, no credentials and no spend.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from arenabench.snapshot import (
+    SnapshotSupervisor,
+    container_for_trial,
+    detect_workspace,
+    load_manifest,
+)
+
+IMAGE = "alpine:3.20"
+
+
+def _docker_ready() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(["docker", "info"], capture_output=True, timeout=30)
+        return probe.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _docker_ready(), reason="docker is not available")
+
+
+def _sh(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), capture_output=True, text=True, timeout=600)
+
+
+@pytest.fixture
+def container(tmp_path: Path):
+    """A container named the way Harbor names a trial's, holding a workspace."""
+    trial = tmp_path / "jobs" / "seat" / "demo__AbC123"
+    (trial / "agent").mkdir(parents=True)
+    name = container_for_trial(trial)
+    _sh("docker", "rm", "-f", name)
+    started = _sh("docker", "run", "-d", "--name", name, IMAGE, "sh", "-c", "sleep 600")
+    if started.returncode != 0:
+        pytest.skip(f"could not start {IMAGE}: {started.stderr[:200]}")
+    _sh("docker", "exec", name, "sh", "-c", "mkdir -p /app && echo one > /app/a.txt")
+    if _sh("docker", "exec", name, "sh", "-c", "apk add --no-cache git").returncode != 0:
+        _sh("docker", "rm", "-f", name)
+        pytest.skip("could not install git in the test container")
+    try:
+        yield name, trial, tmp_path / "jobs"
+    finally:
+        _sh("docker", "rm", "-f", name)
+
+
+def test_the_container_name_matches_how_harbor_spells_it(container):
+    name, _trial, _ = container
+    # Trial ids are mixed case; Docker names are not. A mismatch here means
+    # silently zero snapshots, indistinguishable from the feature being off.
+    assert name == "demo__abc123-main-1"
+    assert _sh("docker", "inspect", "-f", "{{.State.Running}}", name).stdout.strip() == "true"
+
+
+def test_the_workspace_is_found_inside_the_image(container):
+    name, _, _ = container
+    assert detect_workspace(name) == "/app"
+
+
+def test_capture_produces_patches_and_leaves_the_workspace_untouched(container):
+    name, trial, jobs_root = container
+    sup = SnapshotSupervisor(
+        jobs_root=jobs_root, jobs=["seat"], interval=2.0, poll_interval=0.5
+    )
+    sup.start()
+    try:
+        time.sleep(4)
+        _sh("docker", "exec", name, "sh", "-c", "echo two >> /app/a.txt; echo new > /app/b.txt")
+        time.sleep(4)
+        # `result.json` appearing is how the supervisor learns a trial ended.
+        (trial / "result.json").write_text('{"reward": 1}', encoding="utf-8")
+        time.sleep(3)
+    finally:
+        sup.stop(timeout=20)
+
+    entries = load_manifest(trial)
+    assert len(entries) >= 2, "expected repeated capture over the interval"
+
+    patched = [e for e in entries if e.patch]
+    assert patched, "no patch produced, so nothing could ever be replayed"
+    body = (trial / "arena" / "snapshots" / str(patched[-1].patch)).read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "b.txt" in body, "the patch is missing the file the agent created"
+    assert "+two" in body, "the patch is missing the agent's edit"
+
+    # The whole point: capture must be invisible to the task being measured.
+    listing = _sh("docker", "exec", name, "sh", "-c", "ls -a /app").stdout.split()
+    assert ".git" not in listing, "snapshotter wrote .git into the workspace it measures"
+    assert {"a.txt", "b.txt"} <= set(listing)

--- a/arenabench/ui/components/arena/file-browser.tsx
+++ b/arenabench/ui/components/arena/file-browser.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The evidence trail for one trial, browsable in place.
+ *
+ * A trial directory holds the result, the agent's trajectory and event stream,
+ * the verifier's output and the recording. Being able to open any of it is the
+ * difference between trusting a scoreboard and being able to check it, so this
+ * is a plain tree over whatever the run actually produced rather than a curated
+ * set of links that goes stale when a new artifact appears.
+ *
+ * Loading is lazy in both directions: the tree is fetched when the browser is
+ * first opened, and a file's contents only when it is selected. An event stream
+ * can be hundreds of megabytes, and eager fetching would make opening a lane
+ * expensive for the common case where nobody looks.
+ */
+
+export type FileNode = {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  size: number;
+  kind: string;
+  children?: FileNode[];
+};
+
+function fmtSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const KIND_GLYPH: Record<string, string> = {
+  dir: "▸",
+  text: "·",
+  video: "▶",
+  image: "▪",
+  binary: "◆",
+  symlink: "↗",
+  skipped: "⋯",
+};
+
+function Row({
+  node,
+  depth,
+  selected,
+  onSelect,
+}: {
+  node: FileNode;
+  depth: number;
+  selected: string | null;
+  onSelect: (node: FileNode) => void;
+}) {
+  // Directories near the root start open; deeper ones do not, so a tree with a
+  // nested workspace in it does not unfold into a wall on first render.
+  const [open, setOpen] = React.useState(depth < 1);
+
+  if (node.is_dir) {
+    const empty = !node.children || node.children.length === 0;
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          disabled={empty}
+          className={cn(
+            "flex w-full items-center gap-1.5 rounded px-1 py-[3px] text-left",
+            "hover:bg-surface-2 disabled:opacity-50 disabled:hover:bg-transparent",
+          )}
+          style={{ paddingLeft: `${depth * 12 + 4}px` }}
+        >
+          <span className="w-3 flex-none text-dim">{open && !empty ? "▾" : "▸"}</span>
+          <span className="truncate text-foreground">{node.name}</span>
+          {node.kind === "skipped" && (
+            <span className="ml-1 flex-none text-[10px] text-dim">not indexed</span>
+          )}
+        </button>
+        {open &&
+          node.children?.map((child) => (
+            <Row
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              selected={selected}
+              onSelect={onSelect}
+            />
+          ))}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(node)}
+      className={cn(
+        "flex w-full items-center gap-1.5 rounded px-1 py-[3px] text-left hover:bg-surface-2",
+        selected === node.path && "bg-surface-2 text-accent",
+      )}
+      style={{ paddingLeft: `${depth * 12 + 4}px` }}
+    >
+      <span className="w-3 flex-none text-dim">{KIND_GLYPH[node.kind] ?? "·"}</span>
+      <span className="min-w-0 flex-1 truncate">{node.name}</span>
+      <span className="flex-none text-[10px] text-dim">{fmtSize(node.size)}</span>
+    </button>
+  );
+}
+
+function Viewer({ base, node }: { base: string; node: FileNode }) {
+  const [text, setText] = React.useState<string | null>(null);
+  const [truncated, setTruncated] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const url = `${base}?path=${encodeURIComponent(node.path)}`;
+
+  React.useEffect(() => {
+    if (node.kind !== "text") return;
+    let live = true;
+    setText(null);
+    setError(null);
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        setTruncated(res.headers.get("X-Arena-Truncated") === "1");
+        return res.text();
+      })
+      .then((body) => live && setText(body))
+      .catch((err) => live && setError(String(err)));
+    return () => {
+      live = false;
+    };
+  }, [url, node.kind]);
+
+  if (node.kind === "video") {
+    return (
+      <video controls preload="none" className="block w-full rounded-[7px] bg-black" src={url} />
+    );
+  }
+  if (node.kind === "image") {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={node.name} src={url} className="block max-w-full rounded-[7px]" />;
+  }
+  if (node.kind !== "text") {
+    return (
+      <div className="px-2 py-3 text-[11px] text-muted">
+        Not previewable in the browser.{" "}
+        <a className="text-accent underline" href={url} download={node.name}>
+          Download {node.name}
+        </a>
+      </div>
+    );
+  }
+  if (error) return <div className="px-2 py-3 text-[11px] text-bad">could not read: {error}</div>;
+  if (text === null) return <div className="px-2 py-3 text-[11px] text-dim">reading…</div>;
+  return (
+    <div>
+      {truncated && (
+        <div className="border-b border-line-soft px-2 py-1 text-[10px] text-warn">
+          showing the first 2 MB — open the file on disk for the rest
+        </div>
+      )}
+      <pre className="max-h-[46vh] overflow-auto px-2 py-2 font-mono text-[11px] leading-[1.55] whitespace-pre-wrap break-words">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+export function FileBrowser({
+  matchId,
+  contestantId,
+  task,
+}: {
+  matchId: string;
+  contestantId: string;
+  task: string;
+}) {
+  const [root, setRoot] = React.useState<FileNode | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [selected, setSelected] = React.useState<FileNode | null>(null);
+
+  const seg = `${encodeURIComponent(matchId)}/${encodeURIComponent(contestantId)}/${encodeURIComponent(task)}`;
+  const treeUrl = `/api/matches/${encodeURIComponent(matchId)}/files/${encodeURIComponent(contestantId)}/${encodeURIComponent(task)}`;
+  const fileBase = `/api/matches/${encodeURIComponent(matchId)}/file/${encodeURIComponent(contestantId)}/${encodeURIComponent(task)}`;
+
+  React.useEffect(() => {
+    let live = true;
+    setRoot(null);
+    setError(null);
+    setSelected(null);
+    fetch(treeUrl)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(res.status === 404 ? "no artifacts yet" : `${res.status}`);
+        return res.json();
+      })
+      .then((node: FileNode) => live && setRoot(node))
+      .catch((err) => live && setError(String(err.message ?? err)));
+    return () => {
+      live = false;
+    };
+  }, [treeUrl, seg]);
+
+  if (error) return <div className="px-2 py-3 text-[11px] text-muted">{error}</div>;
+  if (!root) return <div className="px-2 py-3 text-[11px] text-dim">loading files…</div>;
+
+  return (
+    <div className="grid grid-cols-[minmax(150px,34%)_1fr] gap-2">
+      <div className="max-h-[46vh] overflow-auto rounded-[7px] border border-line-soft p-1 font-mono text-[11px]">
+        {root.children?.length ? (
+          root.children.map((child) => (
+            <Row
+              key={child.path}
+              node={child}
+              depth={0}
+              selected={selected?.path ?? null}
+              onSelect={setSelected}
+            />
+          ))
+        ) : (
+          <div className="px-2 py-3 text-dim">no files yet</div>
+        )}
+      </div>
+      <div className="min-w-0 rounded-[7px] border border-line-soft">
+        {selected ? (
+          <>
+            <div className="flex items-center gap-2 border-b border-line-soft px-2 py-1">
+              <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-muted">
+                {selected.path}
+              </span>
+              <a
+                className="flex-none text-[10px] text-accent underline"
+                href={`${fileBase}?path=${encodeURIComponent(selected.path)}`}
+                download={selected.name}
+              >
+                download
+              </a>
+            </div>
+            <Viewer base={fileBase} node={selected} />
+          </>
+        ) : (
+          <div className="px-2 py-3 text-[11px] text-dim">select a file</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/arenabench/ui/components/arena/lane.tsx
+++ b/arenabench/ui/components/arena/lane.tsx
@@ -5,6 +5,7 @@ import type { Cell, ContestantSnap, TranscriptEntry } from "@/lib/types";
 import { fmtClock, fmtMoney, fmtTokens } from "@/lib/format";
 import { cn, seatStyle } from "@/lib/utils";
 import { Disclosure } from "@/components/ui/collapsible";
+import { FileBrowser } from "@/components/arena/file-browser";
 
 /**
  * One trial's transcript over SSE. Entries carry a `seq`, and a streaming
@@ -174,6 +175,9 @@ export function Lane({
         </div>
       )}
 
+      {/* `has_video` means the recording carries a `moov` atom, not merely that
+          a file exists. A live trial has a growing, unplayable file for its
+          whole duration, so gating on existence produced a broken player. */}
       {cell?.has_video && (
         <div className="border-b border-line-soft px-[13px] py-2.5">
           <Disclosure summary="screen recording (MP4)">
@@ -183,6 +187,14 @@ export function Lane({
               className="block w-full rounded-[7px] bg-black"
               src={`/api/matches/${encodeURIComponent(matchId)}/video/${encodeURIComponent(contestant.id)}/${encodeURIComponent(task)}`}
             />
+          </Disclosure>
+        </div>
+      )}
+
+      {cell && (
+        <div className="border-b border-line-soft px-[13px] py-2.5">
+          <Disclosure summary="files">
+            <FileBrowser matchId={matchId} contestantId={contestant.id} task={task} />
           </Disclosure>
         </div>
       )}


### PR DESCRIPTION
Two problems with the same root, plus the fix for the cause.

## 1. A video was offered the moment the file appeared

`has_video` was `recording.mp4.exists()`. But the recorder writes `-movflags +faststart`, which places the index (`moov`) at the **end** of encoding — so for the entire life of a live trial the file is present, growing, and openable by nothing. The UI rendered a player for it anyway. If the run is then killed, it stays unplayable forever.

`mp4_is_finalized()` walks the top-level boxes for a `moov`; both `has_video` and the video route now require it. It is a header scan, not a decode, so it is cheap per snapshot, and it cannot be fooled by a file that merely has bytes in it. Fragmented recordings carry `moov` up front and so read as ready immediately — correct, because those genuinely are playable while being written.

**Measured on the GLM-5.2 head-to-head: 4 of 15 recordings were `ftyp | free | mdat(size=0)`** — every frame present, no index. Three were 96MB each.

## 2. The evidence trail was not reachable

A trial directory holds the result, the trajectory, the event stream, the verifier output and the recording. None of it could be opened from the browser, which is the difference between trusting a scoreboard and being able to check it.

- `GET /api/matches/<m>/files/<seat>/<task>` — the artifact tree
- `GET /api/matches/<m>/file/<seat>/<task>?path=…` — one artifact
- A file browser in the lane, above the transcript, beside the recording.

### The containment rules are the risky part

This is the first route that hands out file *contents*, so:

- Paths are resolved and **then** proved to be inside the trial. Resolution happens before the check, not after — a trial directory is written by a container we did not author, and `arena/link -> /etc/passwd` is textually contained right up until it is followed.
- Absolute paths, `..` segments and drive letters are refused outright rather than normalised.
- Traversal and containment failures return **404**, identical to a genuine miss, so probing tells an attacker nothing.
- Symlinked directories are listed but never descended.
- Text is capped at 2MB (an event stream is hundreds of MB — a viewer handed all of it is a hung tab), images come from a fixed type map with **no SVG** (it can carry script), everything else downloads as `application/octet-stream`. `nosniff` throughout.

## 3. Fixing the cause, not just detecting it

The recorder now writes a fragmented MP4 (`+empty_moov+frag_keyframe+default_base_moof`) instead of `+faststart`, so the file is playable at every instant and a SIGKILL costs at most the final fragment. The graceful SIGINT path stays, but it is now an optimisation rather than the single point of failure for the whole recording.

`IMAGE_TAG` bumps to `:2` — `image_present()` checks the tag, so a host that already built `:1` would otherwise keep filming with the old script forever and never receive the fix.

## Witness

`tests/test_artifacts.py` (26) and `tests/test_file_api.py` (12), the latter through a real socket so a route that forgets to call the containment helper is caught — a unit test of the helper cannot see that.

- `test_a_symlink_out_of_the_trial_is_refused_over_http` — asserts the secret's contents are absent from the body
- `test_traversal_is_refused_over_http` — `../`, encoded `..%2F`, absolute, and mid-path
- `test_a_live_recording_is_not_finalized` — the exact `ftyp | free | mdat(size=0)` layout a running ffmpeg leaves
- `test_a_fragmented_recording_reads_as_finalized_immediately` — the new recorder output must not be gated off
- `test_a_nonsense_box_size_does_not_hang` — hostile header terminates the walk
- `test_tree_does_not_descend_into_git` / `..._follow_symlinked_directories`

`pytest`, `ruff check`, `tsc --noEmit` and `shellcheck` are clean by exit code. `arenabench/web/` is regenerated via `npm run build` as its `GENERATED.md` requires.

## Note for operators

Run `arenabench build-recorder` to pick up the `:2` image. Existing `:1` recordings are unaffected and stay as they are.

## Summary by Sourcery

Add snapshot capture and replay tooling to locate when trials first passed, gate video availability on finalized MP4 recordings, and expose a secure trial file browser via new backend APIs and UI components.

New Features:
- Introduce periodic workspace snapshot capture per trial with manifest tracking and a replay CLI to bisect when a task first started passing.
- Expose backend APIs and a React file browser to inspect a trial's artifact tree and preview text, image, and video files from the arena UI.

Enhancements:
- Gate has_video and video serving on MP4 finalization by scanning for a moov atom instead of relying on file existence.
- Extend match configuration and TOML templates with snapshot capture options and surface snapshotting status in telemetry snapshots.
- Refine recorder output to use fragmented MP4s for better resilience to hard kills and bump the recorder image tag to deploy the change.
- Wire snapshot capture into match execution so snapshots are taken per live trial when enabled.

Documentation:
- Document snapshot capture and flip replay workflow in the README, including configuration, performance considerations, and failure modes.

Tests:
- Add unit tests for snapshot manifest handling, flip search logic, and task/container resolution.
- Add tests for artifact tree generation, path containment, file kind detection, and MP4 finalization logic, including hostile inputs.

Chores:
- Regenerate the prebuilt web frontend bundle to include the new file browser and related UI changes.