### PR TITLE
fix(stella-pipeline): stop waiving the witness for a candidate that dispatched mutating calls (#1701)

### DIFF
--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -176,10 +176,7 @@ fn render(rows: &[ClaimRow], all: bool) -> String {
     }
 
     let live = rows.iter().filter(|r| r.live).count();
-    out.push_str(&format!(
-        "\n  {} claim(s), {live} live\n\n",
-        rows.len()
-    ));
+    out.push_str(&format!("\n  {} claim(s), {live} live\n\n", rows.len()));
     out
 }
 
@@ -241,7 +238,10 @@ mod tests {
         let out = render(&rows, false);
         assert!(out.contains("task:fix-1136"), "the unit of work: {out}");
         assert!(out.contains("run-8f21a3-41207"), "the holder: {out}");
-        assert!(out.contains("held 3m 00s"), "how long they have had it: {out}");
+        assert!(
+            out.contains("held 3m 00s"),
+            "how long they have had it: {out}"
+        );
         assert!(out.contains("expires in 12m 00s"), "when it lapses: {out}");
         assert!(out.contains("1 claim(s), 1 live"), "the tally: {out}");
     }
@@ -252,14 +252,23 @@ mod tests {
     fn a_lapsed_claim_says_who_held_it_and_how_long_ago_it_went() {
         let now = 600_000;
         let rows = vec![
-            ClaimRow::read(&claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000), now),
-            ClaimRow::read(&claim("task:live", "run-8f21a3-41207", 590_000, 900_000), now),
+            ClaimRow::read(
+                &claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000),
+                now,
+            ),
+            ClaimRow::read(
+                &claim("task:live", "run-8f21a3-41207", 590_000, 900_000),
+                now,
+            ),
         ];
 
         let out = render(&rows, true);
         assert!(out.contains("run-2b90cc-41999"), "the dead holder: {out}");
         assert!(out.contains("lapsed 2m 00s ago"), "when it went: {out}");
-        assert!(out.contains("expires in 5m 00s"), "the live one stays: {out}");
+        assert!(
+            out.contains("expires in 5m 00s"),
+            "the live one stays: {out}"
+        );
         assert!(out.contains("2 claim(s), 1 live"), "the tally: {out}");
         assert!(!rows[0].live && rows[1].live);
     }
@@ -316,7 +325,11 @@ mod tests {
     fn spans_render_in_one_fixed_shape() {
         assert_eq!(human_ms(0), "0s");
         assert_eq!(human_ms(45_000), "45s");
-        assert_eq!(human_ms(-45_000), "45s", "the caller's wording carries the sign");
+        assert_eq!(
+            human_ms(-45_000),
+            "45s",
+            "the caller's wording carries the sign"
+        );
         assert_eq!(human_ms(750_000), "12m 30s");
         assert_eq!(human_ms(11_040_000), "3h 04m");
     }
@@ -352,9 +365,6 @@ mod tests {
 
         // And the documented escape hatch still works: `--` makes it a prompt.
         let cli = Cli::try_parse_from(["stella", "fleet", "--", "claims are stale"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Fleet { cmd: None, .. }
-        ));
+        assert!(matches!(cli.command, Command::Fleet { cmd: None, .. }));
     }
 }

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2072,7 +2072,7 @@ impl<'a> Pipeline<'a> {
         // early when a test IS required. Emitting from either would make the
         // rail's first row appear only on some runs, which is the failure this
         // whole surface exists to end.
-        let warrant = warrant(&state.diff_text, state.file_changes);
+        let warrant = warrant(&state.diff_text, state.change_signals());
         self.emit_proof(ProofStep::Warrant {
             required: warrant.is_required(),
             reason: warrant.reason().map(|r| r.sentence().to_string()),
@@ -2524,9 +2524,11 @@ impl<'a> Pipeline<'a> {
                     }
                 }
                 LadderDecision::Unverifiable => {
-                    // Every channel was blind. The verifier is not asked, because
-                    // the only thing it could do is guess from an empty record
-                    // — which in the wild it did, returning `FAIL … the file
+                    // The turn went unobserved — every channel blind, or every
+                    // channel clear-eyed and empty over dispatched mutating
+                    // calls (#1701). The verifier is not asked, because the
+                    // only thing it could do is guess from an empty record —
+                    // which in the wild it did, returning `FAIL … the file
                     // likely does not exist` about a file that was in the
                     // container (#973).
                     //
@@ -2539,15 +2541,13 @@ impl<'a> Pipeline<'a> {
                     // best-of-N and then win the smaller-diff tiebreak.
                     //
                     // The arm above is what makes this defensible. Reaching
-                    // here now means the turn *did* dispatch mutating calls and
-                    // no channel could see their effect — the state the abstain
-                    // rung was built for, and a real one: a Terminal-Bench
+                    // here means the turn *did* dispatch mutating calls and no
+                    // channel saw their effect — a real state: a Terminal-Bench
                     // trial that wrote its answer through shell redirects
                     // recorded no touch, could not be diffed, landed here, and
                     // scored 1.0 against its verifier. Failing that closed
-                    // would report a correct run as broken, and no revision
-                    // could ever clear it, because nothing about that workspace
-                    // will ever become observable.
+                    // would report a correct run as broken, and no revision can
+                    // clear it — that workspace never becomes observable.
                     let mut evidence = unverifiable_evidence(&inputs);
                     evidence.ladder = Some(Box::new(snapshot.clone()));
                     self.unverifiable(&evidence.summary);

--- a/crates/stella-pipeline/src/pipeline/disclosure.rs
+++ b/crates/stella-pipeline/src/pipeline/disclosure.rs
@@ -15,9 +15,24 @@ use stella_protocol::PolicyKind;
 
 use super::*;
 use crate::witness::airlock::FailureBrief;
-use crate::witness::warrant::warrant;
+use crate::witness::warrant::{ChangeSignals, warrant};
 
 impl CandidateState {
+    /// What this candidate *did*, in the form [`warrant`] reads it.
+    ///
+    /// One accessor rather than four literals at the four call sites, because
+    /// the two counts are both `u32` and mean opposite things: `file_changes`
+    /// is what a channel observed, `mutating_actions` is what this pipeline
+    /// dispatched. Transposing them at one call site would silently restore
+    /// #1701 — the warrant would guard on an observation channel that is
+    /// structurally dark inside a candidate.
+    pub(super) fn change_signals(&self) -> ChangeSignals {
+        ChangeSignals {
+            file_changes: self.file_changes,
+            mutating_actions: self.mutating_actions,
+        }
+    }
+
     /// Record one deterministic failure and return how many times *this same*
     /// failure has now occurred, counting this one. `1` is a first sighting.
     ///
@@ -115,7 +130,7 @@ impl Pipeline<'_> {
         state: &CandidateState,
         snapshot: &stella_protocol::LadderSnapshot,
     ) -> Option<VerdictEvidence> {
-        let reason = warrant(&state.diff_text, state.file_changes).reason()?;
+        let reason = warrant(&state.diff_text, state.change_signals()).reason()?;
         if reason.warrants_independent_review() {
             return None;
         }
@@ -171,7 +186,7 @@ impl Pipeline<'_> {
     /// without a verifier). A behavioral diff, a deletion, or anything the diff
     /// machinery could not read keeps its reviewer, whatever triage guessed.
     pub(super) fn verifier_waiver_stands(state: &CandidateState) -> bool {
-        warrant(&state.diff_text, state.file_changes)
+        warrant(&state.diff_text, state.change_signals())
             .reason()
             .is_some_and(|reason| !reason.warrants_independent_review())
     }

--- a/crates/stella-pipeline/src/pipeline/tests/warrant.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/warrant.rs
@@ -363,6 +363,164 @@ async fn a_blind_diff_probe_never_completes_as_nothing_changed() {
     );
 }
 
+/// #1701 — the sibling of the test above, with the *blindness removed*, which
+/// is the whole point: this diff probe worked perfectly.
+///
+/// The trace was a Terminal-Bench system-configuration task ("install and
+/// configure nginx on port 8080"). The worker did the work correctly and had no
+/// choice about where: `apt-get install nginx`, `/etc/nginx/nginx.conf`,
+/// `service nginx restart`, `curl localhost:8080` → 200. You cannot install
+/// nginx into `/tmp/stella_candidate_341_0/etc/nginx` and have the service read
+/// it, so the candidate root stayed empty and the empty diff was the *expected*
+/// outcome, not a fault. The run ended `passed: true, deterministic: true, rung:
+/// waived` over `mutating_actions: 10`.
+///
+/// Both guards `warrant` had were structurally incapable of catching it.
+/// `file_changes` is always zero inside a candidate (the engine emits no
+/// `FileChange` events there — `verify_probes::DIFF_PROBE_FAILED` documents
+/// why), and `diff.trim().is_empty()` was *true and correct*. The signal that
+/// was live — the pipeline's own count of the mutating calls it dispatched —
+/// was computed, threaded into `LadderInputs`, and never passed to `warrant`.
+///
+/// So the fixture is the assertion twice over. `ScriptedRunner::new(vec![], "")`
+/// is a probe that ran, succeeded, and read a genuinely unchanged tree —
+/// `diff_available: true`, which is exactly what distinguishes this from the
+/// blind sibling above and what made `NothingChanged` look defensible.
+/// `OneWritingTool` makes the worker dispatch a call able to write. And three
+/// provider calls means no verifier was bought: the ladder abstains here rather
+/// than escalating, because a revision cannot make an un-snapshot-able
+/// workspace observable, and the work may be entirely correct — merely
+/// uncollected.
+#[tokio::test]
+async fn a_readable_empty_diff_over_mutating_calls_is_never_a_deterministic_pass() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        writing_tool_result("configuring nginx on port 8080"),
+        text_result("nginx is installed and serving on 8080"),
+    ]);
+    let resolver = OneProvider(&provider);
+    // Exit 0, empty stdout: the probe LOOKED and the tree is unchanged.
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = OneWritingTool;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            // No independent witness author, as in the trace — the question
+            // under test is what the warrant and the ladder conclude, not what
+            // an author would have written.
+            witness_writer: false,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run(
+            "Install and configure nginx to serve on port 8080",
+            &mut messages,
+            &mut budget,
+        )
+        .await
+        .expect("run succeeds");
+
+    let verdict = outcome.verdict.expect("a reasoned verdict, not silence");
+    assert!(
+        !verdict.summary.contains("no files changed"),
+        "ten calls able to write landed somewhere; 'no files changed' asserts the \
+         opposite of the one thing this run actually knows: {}",
+        verdict.summary
+    );
+    assert!(
+        !verdict.deterministic,
+        "nothing deterministic was observed — an empty diff over dispatched \
+         mutating calls is the absence of evidence, not evidence of a clean pass"
+    );
+    assert!(
+        verdict.summary.starts_with("UNVERIFIABLE"),
+        "and the summary has to lead with it: {}",
+        verdict.summary
+    );
+    assert!(
+        !verdict.summary.contains("could not read the working tree"),
+        "the abstention must not invent a second lie to explain the first — this \
+         probe read the tree fine: {}",
+        verdict.summary
+    );
+    assert_eq!(
+        outcome.score,
+        Some(crate::candidate::CandidateScore::Unverified),
+        "and the score must agree, or a candidate nothing observed could tie a \
+         genuinely verified sibling in best-of-N and win the diff tiebreak"
+    );
+
+    let rung = verdict
+        .ladder
+        .as_deref()
+        .expect("the verdict carries its snapshot")
+        .rung
+        .expect("a rung is stamped");
+    assert_eq!(
+        rung,
+        stella_protocol::LadderRung::Unverifiable,
+        "`Waived` is the rung this shipped as, and it is the one that made the \
+         claim: waiving a witness asserts there was nothing to prove"
+    );
+    assert!(
+        matches!(
+            crate::reward::outcome_term(rung, verdict.passed, &Default::default()),
+            Err(crate::reward::DiscardReason::Abstained)
+        ),
+        "the consequence that makes the rung load-bearing: an uncollected \
+         trajectory is discarded, never trained on as a win"
+    );
+
+    let events = drain(&mut rx);
+    assert_eq!(
+        provider.prompts().len(),
+        3,
+        "triage and two worker turns — a fourth call would mean a verifier was \
+         asked to guess about a workspace nothing collected"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Proof {
+                step: stella_protocol::ProofStep::VerificationUnavailable { .. }
+            }
+        )),
+        "an abstention must reach the proof rail, not only the log"
+    );
+}
+
 /// The end of the wire the bug broke: what the recorder counted has to be what
 /// the verifier is told.
 ///

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -476,7 +476,7 @@ impl<'a> Pipeline<'a> {
         let Some(authoring) = authoring else {
             return Ok(None);
         };
-        if !warrant(&state.diff_text, state.file_changes).is_required() {
+        if !warrant(&state.diff_text, state.change_signals()).is_required() {
             // No Witness stage is emitted, because none runs. The reason is
             // not lost: `warranted_completion` reads the same warrant during
             // verification and records the sentence on the verdict, which is

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -346,9 +346,12 @@ pub enum LadderDecision {
     /// A determinate finding, not an abstention: revise, and report `passed:
     /// false` if the revisions run out.
     NothingAttempted,
-    /// **Every** evidence channel was unavailable — see
-    /// [`LadderInputs::evidence_is_blind`]. The ladder abstains: no verifier call,
-    /// and the run is scored as unverified rather than passed or failed.
+    /// The turn went unobserved, by either route: **every** evidence channel
+    /// was unavailable ([`LadderInputs::evidence_is_blind`]), or the channels
+    /// were available and saw nothing of work that was demonstrably dispatched
+    /// ([`LadderInputs::effects_escaped_collection`]). The ladder abstains: no
+    /// verifier call, and the run is scored as unverified rather than passed
+    /// or failed.
     Unverifiable,
     /// Inconclusive: no flip evidence, or diff over budget, or tests couldn't
     /// be run — but at least one channel could still see something. Escalate to
@@ -506,6 +509,36 @@ impl LadderInputs {
             && !self.flip_achieved
             && self.touched_tests_passed.is_none()
     }
+
+    /// Whether this turn's effects landed somewhere this run does not collect:
+    /// it dispatched calls able to change the workspace, the diff probe *could*
+    /// read the tree and found it unchanged, and no other channel saw anything
+    /// either.
+    ///
+    /// The exact inverse of [`Self::nothing_was_attempted`] on its one
+    /// load-bearing conjunct, and the reason both exist. A readable, empty diff
+    /// is a confident observation — but only of the tree the probe was pointed
+    /// at. When the dispatch record says calls were made, "the tree did not
+    /// move" and "the work happened elsewhere" produce identical readings, and
+    /// nothing available here separates them. Neither may be asserted, so the
+    /// ladder abstains.
+    ///
+    /// Named after the failure it ends (#1701): a Terminal-Bench
+    /// system-configuration task installed and configured nginx against the
+    /// real `/etc/nginx` — which is the only place `service nginx restart`
+    /// will ever read — while the run collected a candidate root that stayed
+    /// empty. Ten mutating calls, a readable zero-line diff, and a verdict of
+    /// `passed: true, deterministic: true`. Note what does *not* reach here: a
+    /// flip, a green test, or a recorded touch each corroborate the work, and
+    /// any one of them sends the turn on to the rungs that can credit it.
+    pub fn effects_escaped_collection(&self) -> bool {
+        self.mutating_actions > 0
+            && self.diff_available
+            && self.diff_lines == 0
+            && self.file_change_events == 0
+            && !self.flip_achieved
+            && self.touched_tests_passed.is_none()
+    }
 }
 
 /// The evidence ladder (L-E11). Decides submit/revise/abstain/escalate from
@@ -519,6 +552,9 @@ impl LadderInputs {
 ///    it, because "no action was taken" is knowledge, not an absence of it.
 /// 3. **Every channel blind → `Unverifiable`.** Nothing could observe this
 ///    turn, so nothing may be claimed about it — in particular not a failure.
+/// 3b. **Effects escaped collection → `Unverifiable`.** The mirror image: every
+///    channel *could* look and none of them saw the work this run demonstrably
+///    dispatched. Equally unobserved, equally unclaimable.
 /// 4. **Flip + green + within budget → `SubmitFast`.** The full deterministic
 ///    pass: verifier skipped.
 /// 5. **Otherwise → `ModelVerdict`.** Genuinely inconclusive: no flip, or the
@@ -540,6 +576,18 @@ pub fn ladder_decision(inputs: &LadderInputs) -> LadderDecision {
     //    to ask a model to guess from an empty record, and the answer it
     //    produced in the wild was a confident FAIL naming a file that existed.
     if inputs.evidence_is_blind() {
+        return LadderDecision::Unverifiable;
+    }
+    // 3b. The probe could look, looked, and found an unchanged tree — while
+    //     this pipeline's own record says calls able to write it were
+    //     dispatched. That is not a clean turn; it is a turn whose effects
+    //     landed outside what the run collects, and the two are
+    //     indistinguishable from here (#1701). Same abstention as above, for
+    //     the same reason: what cannot be observed cannot be claimed, in
+    //     either direction. Deliberately NOT `Revise` — the work may be
+    //     entirely correct and merely uncollected, and no revision can make
+    //     an un-snapshot-able workspace observable.
+    if inputs.effects_escaped_collection() {
         return LadderDecision::Unverifiable;
     }
     // 4. Full deterministic pass — submit fast, verifier skipped. The
@@ -626,7 +674,7 @@ pub fn deterministic_pass_evidence(
 }
 
 /// Build the `VerdictEvidence` for a [`LadderDecision::Unverifiable`] turn: the
-/// ladder abstained because every channel was blind.
+/// ladder abstained because the turn went unobserved.
 ///
 /// `deterministic: false` — this is the *absence* of a deterministic result,
 /// and marking it `true` would let an unobserved turn wear the ladder's
@@ -634,15 +682,35 @@ pub fn deterministic_pass_evidence(
 /// summarizing, because the only actionable content here is *why* nothing
 /// could be seen: on Terminal-Bench the answer is "the task directory is not a
 /// git repository", which no amount of re-running will change.
+///
+/// Which is also why the two routes to this rung get two summaries. Telling a
+/// reader "the diff probe could not read the working tree" when it read the
+/// tree fine and found it unchanged is a second verification lie in the
+/// sentence written to end the first one — and it points at the wrong repair
+/// (fix the probe, rather than collect the workspace the work actually landed
+/// in).
 pub fn unverifiable_evidence(inputs: &LadderInputs) -> VerdictEvidence {
-    VerdictEvidence {
-        summary: format!(
+    let summary = if inputs.effects_escaped_collection() {
+        format!(
+            "UNVERIFIABLE — this turn dispatched {} call(s) able to change the workspace, and the \
+             diff probe then read the tree and found it unchanged, so nothing here observed the \
+             work and nothing is claimed about it (this is NOT a finding that the work is absent \
+             or wrong): the effects landed outside what this run collects. Flip oracle not armed \
+             (no test command); touched tests not run; file-change events recorded = 0. Verify \
+             the result on its own merits.",
+            inputs.mutating_actions
+        )
+    } else {
+        format!(
             "UNVERIFIABLE — no evidence channel could observe this turn, so nothing is claimed \
              about it (this is NOT a finding that the work is absent or wrong): flip oracle not \
              armed (no test command); touched tests not run; the diff probe could not read the \
              working tree; file-change events recorded = {}. Verify the result on its own merits.",
             inputs.file_change_events
-        ),
+        )
+    };
+    VerdictEvidence {
+        summary,
         deterministic: false,
         evidence_refs: Vec::new(),
         ladder: None,

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -694,9 +694,9 @@ pub fn unverifiable_evidence(inputs: &LadderInputs) -> VerdictEvidence {
             "UNVERIFIABLE — this turn dispatched {} call(s) able to change the workspace, and the \
              diff probe then read the tree and found it unchanged, so nothing here observed the \
              work and nothing is claimed about it (this is NOT a finding that the work is absent \
-             or wrong): the effects landed outside what this run collects. Flip oracle not armed \
-             (no test command); touched tests not run; file-change events recorded = 0. Verify \
-             the result on its own merits.",
+             or wrong): the effects landed outside what this run collects. No fail→pass flip was \
+             observed; no touched-test result; file-change events recorded = 0. Verify the result \
+             on its own merits.",
             inputs.mutating_actions
         )
     } else {

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -550,11 +550,10 @@ impl LadderInputs {
 ///    mutating call and nothing observed a change. Checked *above* the blind
 ///    rung, which it would otherwise satisfy — and does not fall through to
 ///    it, because "no action was taken" is knowledge, not an absence of it.
-/// 3. **Every channel blind → `Unverifiable`.** Nothing could observe this
-///    turn, so nothing may be claimed about it — in particular not a failure.
-/// 3b. **Effects escaped collection → `Unverifiable`.** The mirror image: every
-///    channel *could* look and none of them saw the work this run demonstrably
-///    dispatched. Equally unobserved, equally unclaimable.
+/// 3. **The turn went unobserved → `Unverifiable`.** Two routes, one state.
+///    Either every channel was blind, or every channel could look and none of
+///    them saw the work this run demonstrably dispatched. Nothing may be
+///    claimed about it — in particular not a failure.
 /// 4. **Flip + green + within budget → `SubmitFast`.** The full deterministic
 ///    pass: verifier skipped.
 /// 5. **Otherwise → `ModelVerdict`.** Genuinely inconclusive: no flip, or the

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -5,6 +5,8 @@
 use super::*;
 use proptest::prelude::*;
 
+mod uncollected;
+
 // FlipOracle transitions
 
 #[test]
@@ -338,91 +340,6 @@ fn a_readable_empty_diff_is_not_blindness() {
         }),
         LadderDecision::ModelVerdict,
     );
-}
-
-/// #1701: the nginx trial's ladder inputs. Ten calls able to write, a diff
-/// probe that ran and read an unchanged tree, and nothing else that could
-/// speak. The run reported `passed: true, deterministic: true, rung: waived`.
-///
-/// The mirror image of `every_channel_blind_abstains_…` above: there, no
-/// channel could look; here, they looked and none of them saw work that was
-/// demonstrably done. Both are the same epistemic state — the turn went
-/// unobserved — so both abstain, and neither may claim.
-#[test]
-fn effects_that_escaped_collection_abstain_rather_than_claim_a_clean_tree() {
-    let inputs = LadderInputs {
-        flip_achieved: false,
-        touched_tests_passed: None,
-        diff_lines: 0,
-        diff_budget: 100,
-        diff_available: true,
-        file_change_events: 0,
-        mutating_actions: 10,
-        ..Default::default()
-    };
-    assert!(inputs.effects_escaped_collection());
-    assert!(
-        !inputs.nothing_was_attempted(),
-        "ten dispatched calls is the opposite of the no-op rung's premise"
-    );
-    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverifiable);
-
-    // And the summary must not borrow the blind rung's excuse. This probe
-    // worked; saying it could not read the tree would send a reader to repair
-    // the one part of this that was functioning.
-    let evidence = unverifiable_evidence(&inputs);
-    assert!(evidence.summary.starts_with("UNVERIFIABLE"));
-    assert!(!evidence.deterministic);
-    assert!(
-        !evidence.summary.contains("could not read the working tree"),
-        "the probe read it fine: {}",
-        evidence.summary
-    );
-    assert!(
-        evidence.summary.contains("10"),
-        "and the count that contradicts a clean tree has to appear: {}",
-        evidence.summary
-    );
-}
-
-/// The guard rails on the new rung: any single corroborating observation takes
-/// the turn back to a rung that can credit it. Abstention is for the state
-/// where *nothing* saw the work, not for every empty diff.
-#[test]
-fn one_corroborating_observation_lifts_the_turn_off_the_abstain_rung() {
-    let escaped = LadderInputs {
-        flip_achieved: false,
-        touched_tests_passed: None,
-        diff_lines: 0,
-        diff_budget: 100,
-        diff_available: true,
-        file_change_events: 0,
-        mutating_actions: 10,
-        ..Default::default()
-    };
-    for (label, inputs) in [
-        (
-            "a recorded file touch proves the tree moved",
-            LadderInputs {
-                file_change_events: 3,
-                ..escaped
-            },
-        ),
-        (
-            "a green test is an observation of the work",
-            LadderInputs {
-                touched_tests_passed: Some(true),
-                ..escaped
-            },
-        ),
-    ] {
-        assert!(!inputs.effects_escaped_collection(), "{label}");
-        assert_ne!(
-            ladder_decision(&inputs),
-            LadderDecision::Unverifiable,
-            "{label}"
-        );
-    }
 }
 
 /// The `regex-log` Terminal-Bench 2.1 trial, reconstructed as ladder

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -299,9 +299,19 @@ fn a_red_test_outranks_blindness() {
     assert_eq!(ladder_decision(&inputs), LadderDecision::Revise);
 }
 
-/// The distinction the whole rung exists for: "I looked and saw nothing"
-/// (an available probe reporting a zero-line diff) is inconclusive and
-/// worth a verifier; "I could not look" is not.
+/// The distinction the whole blind rung exists for: "I looked and saw nothing"
+/// is not "I could not look", and a readable probe is never blindness however
+/// empty its answer.
+///
+/// The *decision* moved in #1701 while that property did not. A readable
+/// zero-line diff over dispatched mutating calls used to escalate, on the
+/// reading that an empty diff is merely inconclusive. It is not merely
+/// inconclusive: the verifier reached from here has no flip and no green test
+/// behind it, so a PASS it returns is restamped `Unverifiable` anyway
+/// (`verifier_pass_stands_alone`, #1295/#1540), and a FAIL is a model guessing
+/// from an empty record about a workspace this run never collected — the #973
+/// shape, which produced a confident false negative in the wild. So the ladder
+/// abstains here directly and spends nothing to do it.
 #[test]
 fn a_readable_empty_diff_is_not_blindness() {
     let inputs = LadderInputs {
@@ -314,8 +324,105 @@ fn a_readable_empty_diff_is_not_blindness() {
         mutating_actions: 1,
         ..Default::default()
     };
-    assert!(!inputs.evidence_is_blind());
-    assert_eq!(ladder_decision(&inputs), LadderDecision::ModelVerdict);
+    assert!(
+        !inputs.evidence_is_blind(),
+        "a probe that read the tree is not a probe that could not"
+    );
+    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverifiable);
+    // The property the rung above still owns: a readable diff with content in
+    // it is genuinely inconclusive, and that is what a verifier is for.
+    assert_eq!(
+        ladder_decision(&LadderInputs {
+            diff_lines: 12,
+            ..inputs
+        }),
+        LadderDecision::ModelVerdict,
+    );
+}
+
+/// #1701: the nginx trial's ladder inputs. Ten calls able to write, a diff
+/// probe that ran and read an unchanged tree, and nothing else that could
+/// speak. The run reported `passed: true, deterministic: true, rung: waived`.
+///
+/// The mirror image of `every_channel_blind_abstains_…` above: there, no
+/// channel could look; here, they looked and none of them saw work that was
+/// demonstrably done. Both are the same epistemic state — the turn went
+/// unobserved — so both abstain, and neither may claim.
+#[test]
+fn effects_that_escaped_collection_abstain_rather_than_claim_a_clean_tree() {
+    let inputs = LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        diff_lines: 0,
+        diff_budget: 100,
+        diff_available: true,
+        file_change_events: 0,
+        mutating_actions: 10,
+        ..Default::default()
+    };
+    assert!(inputs.effects_escaped_collection());
+    assert!(
+        !inputs.nothing_was_attempted(),
+        "ten dispatched calls is the opposite of the no-op rung's premise"
+    );
+    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverifiable);
+
+    // And the summary must not borrow the blind rung's excuse. This probe
+    // worked; saying it could not read the tree would send a reader to repair
+    // the one part of this that was functioning.
+    let evidence = unverifiable_evidence(&inputs);
+    assert!(evidence.summary.starts_with("UNVERIFIABLE"));
+    assert!(!evidence.deterministic);
+    assert!(
+        !evidence.summary.contains("could not read the working tree"),
+        "the probe read it fine: {}",
+        evidence.summary
+    );
+    assert!(
+        evidence.summary.contains("10"),
+        "and the count that contradicts a clean tree has to appear: {}",
+        evidence.summary
+    );
+}
+
+/// The guard rails on the new rung: any single corroborating observation takes
+/// the turn back to a rung that can credit it. Abstention is for the state
+/// where *nothing* saw the work, not for every empty diff.
+#[test]
+fn one_corroborating_observation_lifts_the_turn_off_the_abstain_rung() {
+    let escaped = LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        diff_lines: 0,
+        diff_budget: 100,
+        diff_available: true,
+        file_change_events: 0,
+        mutating_actions: 10,
+        ..Default::default()
+    };
+    for (label, inputs) in [
+        (
+            "a recorded file touch proves the tree moved",
+            LadderInputs {
+                file_change_events: 3,
+                ..escaped
+            },
+        ),
+        (
+            "a green test is an observation of the work",
+            LadderInputs {
+                touched_tests_passed: Some(true),
+                ..escaped
+            },
+        ),
+    ] {
+        assert!(!inputs.effects_escaped_collection(), "{label}");
+        assert_ne!(
+            ladder_decision(&inputs),
+            LadderDecision::Unverifiable,
+            "{label}"
+        );
+    }
 }
 
 /// The `regex-log` Terminal-Bench 2.1 trial, reconstructed as ladder

--- a/crates/stella-pipeline/src/verify/tests/uncollected.rs
+++ b/crates/stella-pipeline/src/verify/tests/uncollected.rs
@@ -1,0 +1,99 @@
+//! #1701: the ladder rung for work whose effects this run never collected.
+//!
+//! Its own module because the parent was one edit away from the 1500-line
+//! ratchet, and because these cases share a premise the rest of the ladder
+//! tests do not: every probe here *worked*. The blind rung's tests next door
+//! ask what happens when nothing could look. These ask the harder question —
+//! what a clear-eyed zero means when the pipeline's own record says calls able
+//! to write the workspace were dispatched.
+
+use crate::verify::{LadderDecision, LadderInputs, ladder_decision, unverifiable_evidence};
+
+/// The inputs shared by both cases: the nginx trial, read off its own stream.
+fn escaped() -> LadderInputs {
+    LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        diff_lines: 0,
+        diff_budget: 100,
+        // The half that matters. The probe ran, succeeded, and reported an
+        // unchanged tree — this is not the blind case wearing a disguise.
+        diff_available: true,
+        file_change_events: 0,
+        mutating_actions: 10,
+        ..Default::default()
+    }
+}
+
+/// The nginx trial's ladder inputs. Ten calls able to write, a diff probe that
+/// ran and read an unchanged tree, and nothing else that could speak. The run
+/// reported `passed: true, deterministic: true, rung: waived`.
+///
+/// The mirror image of `every_channel_blind_abstains_…` in the parent module:
+/// there, no channel could look; here, they looked and none of them saw work
+/// that was demonstrably done. Both are the same epistemic state — the turn
+/// went unobserved — so both abstain, and neither may claim.
+#[test]
+fn effects_that_escaped_collection_abstain_rather_than_claim_a_clean_tree() {
+    let inputs = escaped();
+    assert!(inputs.effects_escaped_collection());
+    assert!(
+        !inputs.nothing_was_attempted(),
+        "ten dispatched calls is the opposite of the no-op rung's premise"
+    );
+    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverifiable);
+
+    // And the summary must not borrow the blind rung's excuse. This probe
+    // worked; saying it could not read the tree would send a reader to repair
+    // the one part of this that was functioning.
+    let evidence = unverifiable_evidence(&inputs);
+    assert!(evidence.summary.starts_with("UNVERIFIABLE"));
+    assert!(!evidence.deterministic);
+    assert!(
+        !evidence.summary.contains("could not read the working tree"),
+        "the probe read it fine: {}",
+        evidence.summary
+    );
+    assert!(
+        evidence.summary.contains("10"),
+        "and the count that contradicts a clean tree has to appear: {}",
+        evidence.summary
+    );
+}
+
+/// The guard rails on the rung: any single corroborating observation takes the
+/// turn back to a rung that can credit it. Abstention is for the state where
+/// *nothing* saw the work, not for every empty diff.
+#[test]
+fn one_corroborating_observation_lifts_the_turn_off_the_abstain_rung() {
+    for (label, inputs) in [
+        (
+            "a recorded file touch proves the tree moved",
+            LadderInputs {
+                file_change_events: 3,
+                ..escaped()
+            },
+        ),
+        (
+            "a green test is an observation of the work",
+            LadderInputs {
+                touched_tests_passed: Some(true),
+                ..escaped()
+            },
+        ),
+        (
+            "a flip is the strongest corroboration there is",
+            LadderInputs {
+                flip_achieved: true,
+                ..escaped()
+            },
+        ),
+    ] {
+        assert!(!inputs.effects_escaped_collection(), "{label}");
+        assert_ne!(
+            ladder_decision(&inputs),
+            LadderDecision::Unverifiable,
+            "{label}"
+        );
+    }
+}

--- a/crates/stella-pipeline/src/witness/warrant.rs
+++ b/crates/stella-pipeline/src/witness/warrant.rs
@@ -31,8 +31,9 @@
 /// contributors are held to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NoWitnessReason {
-    /// The turn changed no files at all — a question, a lookup, an
-    /// explanation. There is no behavior to prove.
+    /// The turn changed no files at all *and never asked to* — a question, a
+    /// lookup, an explanation. There is no behavior to prove. Both halves are
+    /// load-bearing; [`ChangeSignals`] says why.
     NothingChanged,
     /// Only documentation changed. Prose has no runtime behavior to flip.
     DocsOnly,
@@ -157,24 +158,69 @@ fn untracked_marker_paths(diff: &str) -> Vec<String> {
     paths
 }
 
+/// What the turn *did*, as distinct from what the diff *shows*.
+///
+/// Every field is a count the pipeline kept while the turn ran, and that is
+/// what earns them a say here. A probe that comes back empty may simply have
+/// been unable to look; a record of what was dispatched cannot be. So these
+/// are the only inputs [`warrant`] is willing to read as evidence of
+/// *absence* — the same asymmetry
+/// [`crate::verify::LadderInputs::nothing_was_attempted`] is built on.
+///
+/// `Default` is the all-quiet input: nothing observed, nothing dispatched.
+/// Callers name the fields they exercise and take the rest from it, so adding
+/// a signal does not rewrite every literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ChangeSignals {
+    /// `FileChange` events the turn emitted, from the registry's
+    /// `FileTouchPort`. Non-zero is positive proof the tree moved even when
+    /// nothing can render *how*.
+    ///
+    /// Read it as a one-way signal only. Inside a best-of-N or witness
+    /// candidate the engine emits no `FileChange` events at all
+    /// (`crate::pipeline::verify_probes` documents why), so a zero here is
+    /// routinely a candidate's silence rather than a quiet workspace — which
+    /// is precisely why it cannot be the sole guard below.
+    pub file_changes: u32,
+    /// Tool calls this turn that were *capable* of changing the workspace:
+    /// every dispatched call except those whose tool the registry advertises
+    /// as `read_only`. A call whose tool is unknown counts as mutating, so an
+    /// unrecognized name can never be the reason a turn is written off.
+    pub mutating_actions: u32,
+}
+
 /// Decide from the change what the prompt could never tell us.
 ///
-/// `file_changes` is the count of `FileChange` events the turn emitted. It is
-/// consulted only to distinguish "genuinely changed nothing" from "changed
-/// something the diff machinery could not see" — the same honesty guard
-/// `verification_honest_diff` exists for. A turn that touched files but
-/// produced no readable diff is [`WitnessWarrant::Required`], never
-/// [`NoWitnessReason::NothingChanged`].
-pub fn warrant(diff: &str, file_changes: u32) -> WitnessWarrant {
+/// `signals` exists to distinguish "genuinely changed nothing" from "changed
+/// something this run cannot see" — the same honesty guard
+/// `verification_honest_diff` exists for. A turn that touched files, or merely
+/// *asked* to, but produced no readable diff is [`WitnessWarrant::Required`],
+/// never [`NoWitnessReason::NothingChanged`].
+pub fn warrant(diff: &str, signals: ChangeSignals) -> WitnessWarrant {
     let mut paths = changed_paths(diff);
 
     if paths.is_empty() {
-        // A blind diff over a turn that demonstrably touched files is the one
-        // case that must not read as "nothing happened". An untracked-only
-        // change lands here too (its markers are not diff headers) and stays
-        // `Required`: the marker names a path but shows no content, and a
-        // change this module cannot read is one it does not waive.
-        return if file_changes == 0 && diff.trim().is_empty() {
+        // A turn that demonstrably touched files — or dispatched a call able
+        // to — is the one case that must not read as "nothing happened". An
+        // untracked-only change lands here too (its markers are not diff
+        // headers) and stays `Required`: the marker names a path but shows no
+        // content, and a change this module cannot read is one it does not
+        // waive.
+        //
+        // `mutating_actions` is the half added by #1701, and it is the half
+        // that works inside a candidate. A system-configuration task —
+        // `apt-get install nginx`, then `/etc/nginx`, then `service nginx
+        // restart` — cannot land its effects under the candidate root, so the
+        // empty diff is the *expected* outcome and `file_changes` is
+        // structurally zero there. With only those two signals the module
+        // waived the witness and the run completed `passed: true,
+        // deterministic: true` over ten mutating calls it had itself
+        // dispatched. The dispatch record is the one channel that cannot go
+        // dark, so it is what keeps this branch honest.
+        return if signals.file_changes == 0
+            && signals.mutating_actions == 0
+            && diff.trim().is_empty()
+        {
             WitnessWarrant::NotRequired(NoWitnessReason::NothingChanged)
         } else {
             WitnessWarrant::Required

--- a/crates/stella-pipeline/src/witness/warrant/tests.rs
+++ b/crates/stella-pipeline/src/witness/warrant/tests.rs
@@ -13,10 +13,20 @@ fn diff(paths: &[&str], body: &str) -> String {
     out
 }
 
+/// A turn that recorded `file_changes` touches and dispatched nothing else
+/// worth naming — the signals every path-rule case below wants, where the diff
+/// is the subject and the counts are scenery.
+fn observed(file_changes: u32) -> ChangeSignals {
+    ChangeSignals {
+        file_changes,
+        ..ChangeSignals::default()
+    }
+}
+
 #[test]
 fn a_question_that_touched_nothing_needs_no_test() {
     assert_eq!(
-        warrant("", 0),
+        warrant("", observed(0)),
         WitnessWarrant::NotRequired(NoWitnessReason::NothingChanged)
     );
 }
@@ -25,14 +35,66 @@ fn a_question_that_touched_nothing_needs_no_test() {
 fn a_turn_that_touched_files_invisibly_still_needs_one() {
     // The honesty guard: FileChange events fired but the diff is blind. This
     // must never read as "nothing happened".
-    assert_eq!(warrant("", 3), WitnessWarrant::Required);
+    assert_eq!(warrant("", observed(3)), WitnessWarrant::Required);
+}
+
+#[test]
+fn a_turn_that_dispatched_a_mutating_call_still_needs_one() {
+    // #1701. Both of the guards this module had say "clean": no FileChange
+    // events (structurally true of every candidate) and an empty diff that was
+    // read successfully (true, and correct — a system-configuration task lands
+    // its effects on `/etc`, not under the candidate root). Only the dispatch
+    // record disagrees, and it is the only one that cannot go dark.
+    assert_eq!(
+        warrant(
+            "",
+            ChangeSignals {
+                file_changes: 0,
+                mutating_actions: 10,
+            }
+        ),
+        WitnessWarrant::Required,
+        "ten calls able to write the workspace is not 'there is no behavior to prove'"
+    );
+}
+
+#[test]
+fn only_a_turn_that_neither_touched_nor_tried_is_nothing_changed() {
+    // The other direction, which is the one that keeps the rule from being a
+    // blanket `Required`: a question or a lookup dispatched nothing able to
+    // write, and that is knowledge rather than an absence of it. This is the
+    // sole surviving route to `NothingChanged`.
+    for signals in [
+        ChangeSignals {
+            file_changes: 1,
+            mutating_actions: 0,
+        },
+        ChangeSignals {
+            file_changes: 0,
+            mutating_actions: 1,
+        },
+        ChangeSignals {
+            file_changes: 1,
+            mutating_actions: 1,
+        },
+    ] {
+        assert_eq!(
+            warrant("", signals),
+            WitnessWarrant::Required,
+            "{signals:?} has a live signal and must not waive the witness"
+        );
+    }
+    assert_eq!(
+        warrant("", ChangeSignals::default()),
+        WitnessWarrant::NotRequired(NoWitnessReason::NothingChanged)
+    );
 }
 
 #[test]
 fn docs_only_needs_no_test() {
     let d = diff(&["README.md", "docs/spec/x.md"], "+Some new prose.\n");
     assert_eq!(
-        warrant(&d, 2),
+        warrant(&d, observed(2)),
         WitnessWarrant::NotRequired(NoWitnessReason::DocsOnly)
     );
 }
@@ -41,7 +103,7 @@ fn docs_only_needs_no_test() {
 fn tests_only_needs_no_test() {
     let d = diff(&["stella-core/src/foo/tests.rs"], "+assert_eq!(1, 1);\n");
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::NotRequired(NoWitnessReason::TestsOnly)
     );
 }
@@ -57,7 +119,7 @@ fn config_only_needs_no_test() {
     ] {
         let d = diff(&[path], "+  timeout-minutes: 30\n");
         assert_eq!(
-            warrant(&d, 1),
+            warrant(&d, observed(1)),
             WitnessWarrant::NotRequired(NoWitnessReason::ConfigOnly),
             "{path} is a build/CI/dependency manifest"
         );
@@ -79,7 +141,7 @@ fn behavior_bearing_yaml_is_not_config() {
     ] {
         let d = diff(&[path], "+  replicas: 3\n");
         assert_eq!(
-            warrant(&d, 1),
+            warrant(&d, observed(1)),
             WitnessWarrant::Required,
             "{path} carries behavior and must keep its verification"
         );
@@ -93,7 +155,7 @@ fn comments_only_needs_no_test() {
         "-// old note\n+// a clearer note\n+\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::NotRequired(NoWitnessReason::CommentsOnly)
     );
 }
@@ -105,7 +167,7 @@ fn a_pure_removal_needs_no_test() {
         "-pub fn unused() -> u32 {\n-    7\n-}\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::NotRequired(NoWitnessReason::PureRemoval)
     );
 }
@@ -117,7 +179,7 @@ fn a_removal_that_leaves_a_note_is_still_a_removal() {
         "-pub fn unused() -> u32 {\n-    7\n-}\n+// removed: superseded by `live()`\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::NotRequired(NoWitnessReason::PureRemoval)
     );
 }
@@ -131,7 +193,7 @@ fn docs_plus_source_is_a_source_change() {
         "+let x = compute();\n",
     );
     assert_eq!(
-        warrant(&d, 2),
+        warrant(&d, observed(2)),
         WitnessWarrant::Required,
         "a source change that also updated its docs is still a source change"
     );
@@ -143,7 +205,7 @@ fn tests_plus_source_is_a_source_change() {
         &["tests/a.rs", "stella-core/src/driver.rs"],
         "+let x = compute();\n",
     );
-    assert_eq!(warrant(&d, 2), WitnessWarrant::Required);
+    assert_eq!(warrant(&d, observed(2)), WitnessWarrant::Required);
 }
 
 #[test]
@@ -153,7 +215,7 @@ fn a_removal_that_adds_real_code_is_a_rewrite() {
         "-pub fn old() -> u32 { 7 }\n+pub fn new() -> u32 { 8 }\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::Required,
         "replacing code is a behavior change, not a removal"
     );
@@ -168,7 +230,7 @@ fn a_rust_deref_assignment_is_code_not_a_comment() {
         "-    *counter = 0;\n+    *counter = 1;\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::Required,
         "a deref assignment is a behavior change, not a comment"
     );
@@ -180,12 +242,12 @@ fn a_js_private_field_and_c_preprocessor_are_code_not_comments() {
         &["ui/src/wallet.ts"],
         "-    #balance = 0;\n+    #balance = 100;\n",
     );
-    assert_eq!(warrant(&js, 1), WitnessWarrant::Required);
+    assert_eq!(warrant(&js, observed(1)), WitnessWarrant::Required);
     let c = diff(
         &["native/buffer.c"],
         "-#define BUFFER 256\n+#define BUFFER 512\n",
     );
-    assert_eq!(warrant(&c, 1), WitnessWarrant::Required);
+    assert_eq!(warrant(&c, observed(1)), WitnessWarrant::Required);
 }
 
 #[test]
@@ -194,7 +256,7 @@ fn a_decrement_is_code_not_a_sql_comment() {
         &["stella-core/src/driver.rs"],
         "-    --count;\n+    --count;\n+    step();\n",
     );
-    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+    assert_eq!(warrant(&d, observed(1)), WitnessWarrant::Required);
 }
 
 #[test]
@@ -206,7 +268,7 @@ fn block_and_sql_comments_still_read_as_comments() {
         "+ * a doc line\n+ */\n+-- a note\n+# a python note\n",
     );
     assert_eq!(
-        warrant(&d, 1),
+        warrant(&d, observed(1)),
         WitnessWarrant::NotRequired(NoWitnessReason::CommentsOnly)
     );
 }
@@ -214,7 +276,7 @@ fn block_and_sql_comments_still_read_as_comments() {
 #[test]
 fn an_unrecognized_path_buys_the_test() {
     let d = diff(&["some/unknown/thing.zz"], "+data\n");
-    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+    assert_eq!(warrant(&d, observed(1)), WitnessWarrant::Required);
 }
 
 #[test]
@@ -230,7 +292,7 @@ fn an_untracked_source_file_beside_a_docs_edit_is_a_source_change() {
         untracked_change_line("src/backdoor.rs", 42)
     );
     assert_eq!(
-        warrant(&d, 2),
+        warrant(&d, observed(2)),
         WitnessWarrant::Required,
         "an untracked source file must count as a source change"
     );
@@ -244,7 +306,7 @@ fn an_untracked_docs_file_beside_a_docs_edit_stays_docs_only() {
         untracked_change_line("docs/notes.md", 8)
     );
     assert_eq!(
-        warrant(&d, 2),
+        warrant(&d, observed(2)),
         WitnessWarrant::NotRequired(NoWitnessReason::DocsOnly)
     );
 }
@@ -257,7 +319,7 @@ fn an_untracked_only_change_still_buys_the_test() {
     for path in ["src/new_module.rs", "docs/new_page.md"] {
         let d = format!("{}\n", untracked_change_line(path, 12));
         assert_eq!(
-            warrant(&d, 1),
+            warrant(&d, observed(1)),
             WitnessWarrant::Required,
             "{path}: an untracked-only change is unreadable and must fail closed"
         );
@@ -268,7 +330,7 @@ fn an_untracked_only_change_still_buys_the_test() {
 fn a_source_file_under_a_docs_named_crate_is_not_docs() {
     // `stella-docs/src/lib.rs` is Rust, not prose.
     let d = diff(&["stella-docs/src/lib.rs"], "+pub fn render() {}\n");
-    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+    assert_eq!(warrant(&d, observed(1)), WitnessWarrant::Required);
 }
 
 #[test]

--- a/docs/spec/witness-protocol.md
+++ b/docs/spec/witness-protocol.md
@@ -254,6 +254,22 @@ machinery falls through to "witness required". An unnecessary witness costs one
 model call; a missing one ships unverified behavior. Where the warrant is
 unsure, it buys the test.
 
+**An empty diff is not a clean turn.** `NothingChanged` is the one reason that
+rests on an *absence*, so it is the one that needs a signal which cannot go
+dark. A probe reporting nothing may have been unable to look — or may have
+looked at the wrong place: a system-configuration task installs into `/etc`,
+because that is where the service will read, and the candidate root it was
+handed stays empty by construction. Both of the warrant's original guards said
+"clean" for that shape, and the run completed `deterministic: true` over ten
+mutating calls. So the warrant also reads `mutating_actions` — the pipeline's
+tally of the calls it dispatched itself, not a probe into the world — and
+waives the witness only when nothing changed *and nothing tried*. The ladder
+carries the same rule one rung further: dispatched mutating calls plus a
+readable, empty diff and no other observation resolves to `Unverifiable`, an
+abstention, never a pass. It is deliberately not a failure — the work may be
+entirely correct and merely uncollected, and no revision can make an
+un-snapshot-able workspace observable.
+
 **No test needed is not the same as no review needed.** A removal's proof is
 its diff, but deleting the *wrong* thing is a real mistake a reader catches and
 no test would have covered — so `TestsOnly` and `PureRemoval` keep the


### PR DESCRIPTION
## What & why

`witness::warrant` could return `NoWitnessReason::NothingChanged` for a turn
that dispatched ten mutating tool calls, and `warranted_completion` then emitted
`Verdict { passed: true, deterministic: true, rung: Waived }`. A run reported a
clean deterministic pass while the candidate workspace had collected nothing.

Both guards the module had were structurally incapable of catching it:

- `file_changes` is always `0` inside a candidate — the engine emits no
  `FileChange` events there, which `verify_probes.rs` already documents. The
  warrant's one anti-lie signal could never fire on the path that needed it.
- `diff.trim().is_empty()` was **true and correct**. A Terminal-Bench
  system-configuration task ("install and configure nginx on port 8080")
  installs into `/etc/nginx` because that is the only place
  `service nginx restart` will read. You cannot `apt-get install` into
  `/tmp/stella_candidate_341_0/`, so the empty candidate diff is the *expected*
  outcome, not a fault.

The one signal that was live — `mutating_actions`, the pipeline's tally of the
calls it dispatched itself — was computed, threaded into `LadderInputs`, and
never passed to `warrant`. All four call sites passed only
`(diff_text, file_changes)`.

**The fix, in two halves.**

1. `warrant` now takes `ChangeSignals { file_changes, mutating_actions }`, and
   `NothingChanged` requires **both** counts to be zero alongside the empty
   diff. A dispatch record cannot go dark the way a probe can, which is what
   lets a zero there mean "never tried" rather than "could not tell" — the same
   asymmetry `LadderInputs::nothing_was_attempted` is built on. A named struct
   rather than a third positional `u32`, mirroring `LadderInputs`: two adjacent
   `u32` counts that mean opposite things is a silent-swap hazard, and the next
   signal should be an added field rather than a fifth argument and four more
   call-site edits.
2. New ladder rung `LadderInputs::effects_escaped_collection` — mutating calls
   dispatched, a diff probe that **ran successfully** and read an unchanged
   tree, and no other channel that saw anything — resolves to `Unverifiable`.
   Deliberately **not** `Revise`: the work may be entirely correct and merely
   uncollected, and no revision can make an un-snapshot-able workspace
   observable. This is the mirror image of the blind rung (#973): there nothing
   could look, here everything looked and saw nothing of work that was
   demonstrably done. Same epistemic state, same abstention.

`unverifiable_evidence` also gained a second summary. Telling a reader "the diff
probe could not read the working tree" when it read the tree fine is a second
verification lie in the sentence written to end the first one, and it points at
the wrong repair.

Closes #1701

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`pipeline::tests::warrant::a_readable_empty_diff_over_mutating_calls_is_never_a_deterministic_pass`,
beside its blind-probe sibling. `ScriptedRunner::new(vec![], "")` gives a
readable, genuinely empty diff (`diff_available: true` — the distinction from
the blind sibling, and what made `NothingChanged` look defensible);
`OneWritingTool` makes the worker dispatch a call able to write; no test
command.

Verified the artisanal way — source files reverted to the parent commit with the
new test kept, which reproduces the reported verdict verbatim:

```
panicked at crates/stella-pipeline/src/pipeline/tests/warrant.rs:456:5:
ten calls able to write landed somewhere; 'no files changed' asserts the opposite
of the one thing this run actually knows: no witness test warranted: no files
changed; there is no behavior to prove
```

Plus unit witnesses at both seams: `warrant`'s
`a_turn_that_dispatched_a_mutating_call_still_needs_one` and
`only_a_turn_that_neither_touched_nor_tried_is_nothing_changed`, and the ladder's
`effects_that_escaped_collection_abstain_rather_than_claim_a_clean_tree` and
`one_corroborating_observation_lifts_the_turn_off_the_abstain_rung`.

## The gate

- [x] `cargo fmt --check` — **see "reviewers should know" below**
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo test -p stella-pipeline` (520 lib + 22 integration, 0 failed)
- [x] `make guards` — all 22 steps green, including `file-size`, `god-files`,
      `wire-schema`, `invariants`, `doc-links`
- [x] `make doc-warnings CARGO_SCOPE="-p stella-pipeline"` (rustdoc `-D warnings`;
      this change adds several intra-doc links)
- [x] Docs updated: `docs/spec/witness-protocol.md` §7 gains "An empty diff is
      not a clean turn", since that section is the normative home for the
      warrant's rules and its "Fail closed" clause covered only diff-invisibility
- [x] `Closes #1701` appears both above and as a commit trailer

Not run locally: workspace-wide `clippy`/`test`. The only file touched outside
`stella-pipeline` is a pure `cargo fmt` reformat (below). CI covers the rest.

## Nothing left behind

- [x] Filed: #1715

#1701's definition of done §3 asked for a decision on what a non-snapshot-able
task class should do *at all* — abstention is now that class's ceiling, which is
honest but is not success. #1715 is the handoff: it lays out the two designs the
issue named (detect-and-run-un-isolated vs. a `TaskClass` variant), a third the
issue did not (keep isolation, earn the verdict from a post-condition command —
`curl localhost:8080` is exactly the flip oracle's shape), the files, the witness
shape, and the god-file/ratchet constraints a fresh agent would otherwise walk
into.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `ChangeSignals` is crate-internal, and no
      `stella-protocol` type changed, so `wire-schema` is unaffected (verified)

## Anything reviewers should know?

**One commit is an unrelated `main` unbreak.** `crates/stella-cli/src/fleet_claims.rs`
landed unformatted in #1680, so `format-check` — and therefore `make gate` and
the required CI job — was red on `main` and on every branch cut from it. My
toolchain matches the `rust-toolchain.toml` pin exactly (1.97.0 / rustfmt
1.9.0-stable), so this is not version skew. `c798568e` is pure `cargo fmt`
output on a file this PR does not otherwise touch. Happy to split it out if you
would rather it landed separately.

**A behavior change beyond the reported bug, called out deliberately.** The
existing test `verify::tests::a_readable_empty_diff_is_not_blindness` asserted
that a readable zero-line diff over dispatched mutating calls escalates to
`ModelVerdict`. It now abstains. The reasoning, recorded on the test: the
verifier reached from that state has no flip and no green test behind it, so a
PASS it returns is restamped `Unverifiable` anyway by
`verifier_pass_stands_alone` (#1295/#1540) — and a FAIL is a model guessing from
an empty record about a workspace this run never collected, which is the #973
shape that produced a confident false negative in the wild. So the call was
near-pure cost with a known-bad failure mode. The test keeps its original
property (a readable probe is never *blindness*) and gains a case pinning that a
readable diff **with content** still escalates. If you would rather keep buying
the verifier there, that is a one-line revert of the rung and the witness still
passes on the warrant half alone.

**`verify/tests.rs` was split, not baselined.** It sat at 1415 lines and my
tests pushed it to 1522, over the 1500 ratchet. The baseline takes no new
entries by design, so the new cases live in `verify/tests/uncollected.rs`
(`c798568e`'s parent). Parent is back to 1439 — still close, worth knowing
before the next edit lands there.

**Exemplar.** The `ChangeSignals` shape follows `LadderInputs` in this same
crate: a named struct of evidence signals with `Default`, passed to a pure
decision function, so tests name the fields they exercise and a new channel does
not rewrite every literal.

## Summary by Sourcery

Tighten the witness warrant and verification ladder so turns that dispatch mutating actions but produce an empty diff no longer waive witnesses or report deterministic passes, instead abstaining as Unverifiable, and document this rule in the witness protocol.

Bug Fixes:
- Prevent runs with mutating tool calls and an empty, readable diff from being treated as clean deterministic passes or waived witnesses.
- Ensure unverifiable verdicts distinguish between blind evidence channels and cases where effects escaped collection, avoiding misleading summaries about unreadable working trees.

Enhancements:
- Introduce a ChangeSignals struct and propagate mutating action counts into the warrant decision so NothingChanged applies only when nothing changed and nothing tried.
- Extend the ladder with an effects-escaped-collection condition that routes such turns to the Unverifiable rung without invoking a verifier.

Documentation:
- Update the witness protocol spec to state that an empty diff is not sufficient to declare a clean turn and to explain how mutating_actions and Unverifiable are used in these cases.

Tests:
- Add pipeline tests covering readable empty diffs over mutating calls and their Unverifiable outcomes, including proof-rail behavior and score handling.
- Add warrant unit tests for mutating actions and ChangeSignals, and ladder tests for effects escaping collection and corroborating observations lifting turns off the abstain rung.
- Refactor verify tests by splitting uncollected-effect cases into a dedicated module to stay within the file size ratchet.

Chores:
- Reformat stella-cli fleet_claims code to satisfy rustfmt and fix a failing format-check on main.