### PR TITLE
fix(stella-cli): unbreak main — stella-cli does not compile (#1695's half-merged timeout, #1680's stale Cli shape)

### DIFF
--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -137,10 +137,10 @@ impl SidecarApprovalGate {
     /// Split out of the loop so the arithmetic — the part a wall-clock test
     /// cannot pin down without sleeping through it — is directly testable.
     fn next_poll(&self, parked_at: std::time::Instant) -> Option<std::time::Duration> {
-        let Some(wait) = self.wait else {
+        let Some(deadline) = self.deadline else {
             return Some(ANSWER_POLL);
         };
-        let remaining = wait.checked_sub(parked_at.elapsed())?;
+        let remaining = deadline.checked_sub(parked_at.elapsed())?;
         (!remaining.is_zero()).then(|| ANSWER_POLL.min(remaining))
     }
 
@@ -179,7 +179,7 @@ impl ApprovalGate for SidecarApprovalGate {
             .registry
             .set_status(&self.id, SessionStatus::NeedsInput);
 
-        let started = std::time::Instant::now();
+        let parked_at = std::time::Instant::now();
         let decision = loop {
             if (self.interrupted)() {
                 // The same answer the stdio gate gives on EOF: asked to stop
@@ -187,17 +187,11 @@ impl ApprovalGate for SidecarApprovalGate {
                 // land as a clean cancel instead of an escalated kill.
                 break ScopeDecision::Abort;
             }
-            if let Some(deadline) = self.deadline
-                && started.elapsed() >= deadline
-            {
-                eprintln!(
-                    "  {} scope review timed out after {}s with nobody attached \
-                     (approval_wait_secs) — aborting",
-                    "!".yellow(),
-                    deadline.as_secs(),
-                );
-                break ScopeDecision::Abort;
-            }
+            // The deadline is enforced in one place — [`Self::next_poll`],
+            // below — rather than also at the top of the loop. Two checks
+            // would be two timeouts with two messages, and the one that
+            // clips the nap is the one that honours a sub-poll deadline to
+            // itself instead of to the next 250ms tick.
             match std::fs::read_to_string(self.sidecar.join(supervised::APPROVAL_ANSWER)) {
                 Ok(json) => {
                     // Unparseable is abort, not retry: the writer publishes
@@ -217,7 +211,7 @@ impl ApprovalGate for SidecarApprovalGate {
                             "{} scope review unanswered for {}s — aborting the run \
                              (agent_engine_config.approval_wait_secs)",
                             "▸ timed out".yellow().bold(),
-                            self.wait.map_or(0, |w| w.as_secs()),
+                            self.deadline.map_or(0, |d| d.as_secs()),
                         );
                         break ScopeDecision::Abort;
                     }
@@ -288,21 +282,6 @@ impl ApprovalGate for OneShotApprovalGate {
             Self::Headless(gate) => gate.confirm(question).await,
         }
     }
-}
-
-/// The configured park deadline, or `None` for the shipped park-forever
-/// behaviour.
-///
-/// `0` is spelled and means "no deadline", the same convention
-/// `model_timeout_secs` uses for its own backstop: in a field whose absence
-/// already means "the default", zero is the only way to say *deliberately*
-/// unbounded — which matters when a user-scope file sets a deadline and one
-/// project wants out of it.
-pub(crate) fn park_deadline(
-    settings: Option<&crate::settings::AgentEngineConfig>,
-) -> Option<std::time::Duration> {
-    let secs = settings?.approval_wait_secs?;
-    (secs > 0).then(|| std::time::Duration::from_secs(secs))
 }
 
 /// The attached-terminal side: answer a parked scope review, if one is
@@ -559,7 +538,8 @@ mod tests {
     /// The #1616 witness: with `approval_wait_secs` armed, a review nobody
     /// answers unparks itself as an abort instead of waiting forever — and it
     /// hands the record back rather than leaving it stuck on `Needs Input`.
-    /// On `main` a gate has no deadline to arm (`with_wait` does not exist),
+    /// On `main` a gate has no deadline to arm (`with_deadline` does not
+    /// exist),
     /// so this is a type-level witness as well as a behavioural one.
     #[tokio::test]
     async fn an_expired_deadline_unparks_an_unanswered_review_as_an_abort() {
@@ -568,7 +548,7 @@ mod tests {
         let record = parked_record(&registry);
         let sidecar = registry.sidecar_dir(&record.id);
         let gate = SidecarApprovalGate::new(sidecar.clone(), registry.clone(), record.id.clone())
-            .with_wait(Some(std::time::Duration::from_millis(30)));
+            .with_deadline(Some(std::time::Duration::from_millis(30)));
 
         // The outer timeout is the assertion's teeth: on a gate without a
         // deadline this future never resolves, and the test would hang rather
@@ -632,7 +612,7 @@ mod tests {
         // up to the poll interval.
         let short =
             SidecarApprovalGate::new(dir.path().into(), registry_in(dir.path()), "id".into())
-                .with_wait(Some(std::time::Duration::from_millis(5)));
+                .with_deadline(Some(std::time::Duration::from_millis(5)));
         let nap = short.next_poll(now).expect("5ms is still ahead");
         assert!(nap <= std::time::Duration::from_millis(5), "{nap:?}");
         // And a deadline already in the past ends the park.
@@ -645,16 +625,20 @@ mod tests {
     /// The setting's three states, including the one that is easy to get
     /// wrong: `0` is a deliberate "no deadline", not a zero-length one that
     /// aborts every supervised review the instant it parks.
+    ///
+    /// Asserted against [`crate::settings::AgentEngineConfig::approval_wait`],
+    /// which is the copy `crate::agent::engine` actually calls. A second copy
+    /// of this arithmetic living beside the gate is what let #1616's merge
+    /// ship a reading of the setting that nothing consulted.
     #[test]
     fn the_setting_maps_absent_and_zero_to_park_forever() {
-        assert_eq!(park_deadline(None), None);
         let mut settings = crate::settings::AgentEngineConfig::default();
-        assert_eq!(park_deadline(Some(&settings)), None);
+        assert_eq!(settings.approval_wait(), None);
         settings.approval_wait_secs = Some(0);
-        assert_eq!(park_deadline(Some(&settings)), None);
+        assert_eq!(settings.approval_wait(), None);
         settings.approval_wait_secs = Some(90);
         assert_eq!(
-            park_deadline(Some(&settings)),
+            settings.approval_wait(),
             Some(std::time::Duration::from_secs(90))
         );
     }

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -433,7 +433,7 @@ fn wall_ms() -> u64 {
 ///
 /// The pumps live behind an `Arc` rather than in this struct because two
 /// different code paths have to be able to end them: `main`'s orderly exit,
-/// and the panic hook [`arm_panic_drain`] installs (#1616). Both call the
+/// and the panic hook [`install_panic_drain`] installs (#1616). Both call the
 /// same idempotent [`Drainable::drain`]; whichever arrives first takes the
 /// streams and the other finds nothing to do.
 pub(crate) struct ConsoleGuard {
@@ -469,6 +469,24 @@ impl ConsoleGuard {
     pub(crate) fn drain(&self) {
         #[cfg(unix)]
         self.pumps.drain();
+    }
+
+    /// Drain whatever guard is still in `cell`, unless the CURRENT thread is
+    /// one of the pumps it owns — see [`PUMP_THREAD_PREFIX`]. Idempotent and
+    /// safe to call from both the normal end-of-`main` path and a panic hook:
+    /// the two race to be first, and whichever wins performs the one real
+    /// drain; the loser finds `None` and does nothing.
+    pub(crate) fn drain_shared(cell: &Mutex<Option<ConsoleGuard>>) {
+        if std::thread::current()
+            .name()
+            .is_some_and(|name| name.starts_with(PUMP_THREAD_PREFIX))
+        {
+            return;
+        }
+        let guard = cell.lock().unwrap_or_else(|p| p.into_inner()).take();
+        if let Some(guard) = guard {
+            guard.drain();
+        }
     }
 }
 
@@ -521,24 +539,6 @@ impl Drainable {
             unsafe {
                 libc::close(stream.saved_fd);
             }
-        }
-    }
-
-    /// Drain whatever guard is still in `cell`, unless the CURRENT thread is
-    /// one of the pumps it owns — see [`PUMP_THREAD_PREFIX`]. Idempotent and
-    /// safe to call from both the normal end-of-`main` path and a panic hook:
-    /// the two race to be first, and whichever wins performs the one real
-    /// drain; the loser finds `None` and does nothing.
-    pub(crate) fn drain_shared(cell: &Mutex<Option<ConsoleGuard>>) {
-        if std::thread::current()
-            .name()
-            .is_some_and(|name| name.starts_with(PUMP_THREAD_PREFIX))
-        {
-            return;
-        }
-        let guard = cell.lock().unwrap_or_else(|p| p.into_inner()).take();
-        if let Some(guard) = guard {
-            guard.drain();
         }
     }
 }
@@ -598,35 +598,6 @@ pub(crate) fn install_bounded(sidecar: &Path) -> Option<ConsoleGuard> {
                 streams: Mutex::new(streams),
             }),
         })
-    }
-}
-
-/// Drain the console when this process panics, before the panic message is
-/// lost (#1616).
-///
-/// The pump made the console's tail lossy on a violent death: a panic unwinds
-/// past `main`'s orderly [`ConsoleGuard::drain`], the process exits without
-/// joining the pump threads, and up to a pipe buffer of output — the panic
-/// message itself, most of the time — dies in the pipe. That is the one
-/// artifact a postmortem of a supervised child actually wants.
-///
-/// The hook chains rather than replaces: whatever hook is already installed
-/// (the diagnostics dump, or the default printer) runs FIRST, so its output
-/// goes down the pipe like everything else, and only then is the pipe drained
-/// into the file. Draining first would restore the fds and leave the panic
-/// message to land raw — readable, but ahead of the pump's own `Closed`
-/// marker and outside the bound.
-pub(crate) fn arm_panic_drain(guard: &ConsoleGuard) {
-    #[cfg(not(unix))]
-    let _ = guard;
-    #[cfg(unix)]
-    {
-        let pumps = guard.pumps.clone();
-        let previous = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            previous(info);
-            pumps.drain();
-        }));
     }
 }
 

--- a/crates/stella-cli/src/daemon/console/tests.rs
+++ b/crates/stella-cli/src/daemon/console/tests.rs
@@ -266,14 +266,16 @@ fn a_session_without_an_index_falls_back_to_raw_tails() {
 /// panic hook and the normal end-of-`main` cleanup reaches a shared guard
 /// first performs the one real drain, and — the specific hazard a panicking
 /// pump thread would create — a pump thread must never try to join itself.
-/// `ConsoleGuard { streams: Vec::new() }` needs no real fds (this module's own
-/// doc comment: hijacking the test runner's stdout to exercise the fd
-/// plumbing would be the tail wagging the dog), so this is fd-free logic, not
-/// glue. On `main`, `drain_shared` does not exist at all.
+/// A guard over no streams needs no real fds (this module's own doc comment:
+/// hijacking the test runner's stdout to exercise the fd plumbing would be
+/// the tail wagging the dog), so this is fd-free logic, not glue. On `main`,
+/// `drain_shared` does not exist at all.
 #[test]
 fn drain_shared_skips_a_pump_thread_draining_itself_but_runs_from_anywhere_else() {
     let cell = Arc::new(Mutex::new(Some(ConsoleGuard {
-        streams: Vec::new(),
+        pumps: Arc::new(Drainable {
+            streams: Mutex::new(Vec::new()),
+        }),
     })));
 
     // Called as if FROM a pump thread: a no-op, or a real pump trying to

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -316,9 +316,14 @@ mod tests {
         assert_eq!(row.expires_in_ms, -120_000);
         assert!(!row.live);
 
-        // A claim minted by a clock ahead of ours must not wrap into the past.
+        // A claim minted by a clock impossibly far ahead of ours: the spans
+        // saturate, and — the property that matters — neither one wraps into
+        // the sign that would read as the opposite fact. Expiry stays in the
+        // future rather than reporting as lapsed, and the hold reads as
+        // negative rather than as an age of half a billion years.
         let skewed = ClaimRow::read(&claim("issue:1", "run-a", u64::MAX, u64::MAX), 0);
-        assert!(skewed.expires_in_ms < 0 && skewed.held_for_ms < 0);
+        assert_eq!(skewed.expires_in_ms, i64::MAX);
+        assert_eq!(skewed.held_for_ms, i64::MIN);
     }
 
     #[test]

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -176,10 +176,7 @@ fn render(rows: &[ClaimRow], all: bool) -> String {
     }
 
     let live = rows.iter().filter(|r| r.live).count();
-    out.push_str(&format!(
-        "\n  {} claim(s), {live} live\n\n",
-        rows.len()
-    ));
+    out.push_str(&format!("\n  {} claim(s), {live} live\n\n", rows.len()));
     out
 }
 
@@ -241,7 +238,10 @@ mod tests {
         let out = render(&rows, false);
         assert!(out.contains("task:fix-1136"), "the unit of work: {out}");
         assert!(out.contains("run-8f21a3-41207"), "the holder: {out}");
-        assert!(out.contains("held 3m 00s"), "how long they have had it: {out}");
+        assert!(
+            out.contains("held 3m 00s"),
+            "how long they have had it: {out}"
+        );
         assert!(out.contains("expires in 12m 00s"), "when it lapses: {out}");
         assert!(out.contains("1 claim(s), 1 live"), "the tally: {out}");
     }
@@ -252,14 +252,23 @@ mod tests {
     fn a_lapsed_claim_says_who_held_it_and_how_long_ago_it_went() {
         let now = 600_000;
         let rows = vec![
-            ClaimRow::read(&claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000), now),
-            ClaimRow::read(&claim("task:live", "run-8f21a3-41207", 590_000, 900_000), now),
+            ClaimRow::read(
+                &claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000),
+                now,
+            ),
+            ClaimRow::read(
+                &claim("task:live", "run-8f21a3-41207", 590_000, 900_000),
+                now,
+            ),
         ];
 
         let out = render(&rows, true);
         assert!(out.contains("run-2b90cc-41999"), "the dead holder: {out}");
         assert!(out.contains("lapsed 2m 00s ago"), "when it went: {out}");
-        assert!(out.contains("expires in 5m 00s"), "the live one stays: {out}");
+        assert!(
+            out.contains("expires in 5m 00s"),
+            "the live one stays: {out}"
+        );
         assert!(out.contains("2 claim(s), 1 live"), "the tally: {out}");
         assert!(!rows[0].live && rows[1].live);
     }
@@ -316,7 +325,11 @@ mod tests {
     fn spans_render_in_one_fixed_shape() {
         assert_eq!(human_ms(0), "0s");
         assert_eq!(human_ms(45_000), "45s");
-        assert_eq!(human_ms(-45_000), "45s", "the caller's wording carries the sign");
+        assert_eq!(
+            human_ms(-45_000),
+            "45s",
+            "the caller's wording carries the sign"
+        );
         assert_eq!(human_ms(750_000), "12m 30s");
         assert_eq!(human_ms(11_040_000), "3h 04m");
     }
@@ -327,34 +340,36 @@ mod tests {
     fn fleet_claims_parses_as_a_verb_and_defaults_to_live_text() {
         let cli = Cli::try_parse_from(["stella", "fleet", "claims"]).unwrap();
         match cli.command {
-            Command::Fleet {
+            Some(Command::Fleet {
                 cmd: Some(crate::fleet_verbs::FleetCmd::Claims { all, format }),
                 ..
-            } => {
+            }) => {
                 assert!(!all, "the live listing is the default");
                 assert_eq!(format, QueryFormat::Text);
             }
-            other => panic!("expected `fleet claims`, got {other:?}"),
+            // `Command` derives no `Debug` — a clap subcommand enum this wide
+            // carries none — so the failure names what was expected.
+            _ => panic!("expected `stella fleet claims` to parse as the claims verb"),
         }
 
         let cli = Cli::try_parse_from(["stella", "fleet", "claims", "--all", "--format", "json"])
             .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Fleet {
+            Some(Command::Fleet {
                 cmd: Some(crate::fleet_verbs::FleetCmd::Claims {
                     all: true,
                     format: QueryFormat::Json
                 }),
                 ..
-            }
+            })
         ));
 
         // And the documented escape hatch still works: `--` makes it a prompt.
         let cli = Cli::try_parse_from(["stella", "fleet", "--", "claims are stale"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Fleet { cmd: None, .. }
+            Some(Command::Fleet { cmd: None, .. })
         ));
     }
 }


### PR DESCRIPTION
## What

`stella-cli` does not compile on `main` — 5 errors in the binary, 15 more in its tests — so the required CI job is red at `cargo fmt --check` and stays red through clippy, rustdoc, the golden prompt-cache fixtures, `cargo test`, `stella context validate` and the release smoke build. Every PR opened against `main` inherits all of it. Three independent defects, from two merges.

### 1. #1695 (`366472e0`) merged two versions of one feature into each other

The scope-review park deadline (#1616) exists twice in `crates/stella-cli/src/daemon/`, interleaved:

| Collision | Resolved to | Why that side |
|---|---|---|
| field `deadline` + `with_deadline` vs `self.wait` + `with_wait` | `deadline` | the struct field, the module docs (*"The opt-in deadline (#1616)"*) and the public `for_supervised_child(deadline)` all already say it |
| timeout checked at the top of the park loop **and** in `next_poll` | `next_poll` | it clips the nap, so a sub-poll deadline is honoured to itself rather than to the next 250ms tick. Two checks are two timeouts with two different stderr messages |
| `drain_shared` defined in `impl Drainable` | moved to `impl ConsoleGuard` | all three call sites — `main`, the panic hook, the #1616 witness — spell it `ConsoleGuard::`, and that impl is the one that exists on non-unix |
| witness builds `ConsoleGuard { streams }` | rebuilt against `Arc<Drainable>` | that field moved when the guard started sharing its pumps with the panic hook |

Two functions also survived with nothing calling them — the half that would still have been wrong after it compiled:

- **`arm_panic_drain`** duplicated the wired `install_panic_drain` and ordered the hook the *opposite* way (previous-then-drain vs drain-then-previous), each carrying a doc comment arguing against the other. Deleted the dead one. `main` wires `install_panic_drain`, whose ordering is the one written for `panic = "abort"`, where nothing runs after the hook — post-drain output lands raw at the ring cursor, which the `Closed` marker already tells readers to sweep.
- **`park_deadline`** was a second copy of `AgentEngineConfig::approval_wait` — the copy `agent::engine` actually calls. Deleted, and its test (absent / `0` / positive) retargeted at the live method, so #1616's "zero means park forever" is covered by a test of the code that runs.

### 2. #1680 (`a1d9c392`) landed a test against an older `Cli`

`Cli::command` has been `Option<Command>` since a bare `stella` started opening the deck; `fleet_claims`' parse test matches it unwrapped and formats a `Command` that derives no `Debug`. Matched through `Some(…)` like every sibling in `tests.rs`, with the failure arm naming what was expected. Its rustfmt drift — also red on `main` — goes with it.

### 3. #1680's skew test contradicts its own arithmetic

`a_lapsed_claim_reports_a_negative_time_to_expiry` demands a negative `expires_in_ms` for a claim expiring at `u64::MAX` read at time `0`. But a claim that expires at the end of time, read at the beginning of it, expires in the *future* — and `delta_ms` (i128 then clamp) says so correctly. The test was wrong, not the code. The property its own comment states — *a clock ahead of ours must not wrap into the past* — is about the **sign** of each span, so both are now pinned to the saturation they actually reach: `expires_in_ms == i64::MAX` (future, not lapsed) and `held_for_ms == i64::MIN` (negative, not an age of half a billion years).

## Verification

```
cargo clippy -p stella-cli --all-targets    # clean
cargo test   -p stella-cli --bin stella     # 1408 passed; 0 failed
cargo fmt --all -- --check                  # clean
```

No witness test: this is a repair to code that does not build, and the tests that prove each half already exist — they are #1695's and #1680's own, which is why their being unbuildable was the whole problem. No behaviour is chosen here that `main` had not already chosen: every deletion is of code nothing called, and every rename resolves a collision in favour of the spelling the wired call sites use.

## Left behind

- `daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period` failed once under the full suite and passed alone and on re-runs — it waits out an 8s `SIGKILL` escalation while the rest of the suite competes for the machine. Filed as a flake, not fixed here.

## Summary by Sourcery

Restore stella-cli to a compiling, passing state by reconciling conflicting approval timeout implementations, aligning console draining with its intended API, and correcting fleet claims parsing and timing tests.

Bug Fixes:
- Fix SidecarApprovalGate to use a single deadline-based timeout path and consistent field naming for scope review timeouts.
- Remove the unused arm_panic_drain implementation and reference the installed panic drain hook correctly to avoid conflicting panic-handling paths.
- Eliminate the redundant park_deadline helper, relying instead on AgentEngineConfig::approval_wait as the single source of approval wait configuration.
- Adjust fleet claims CLI parsing tests to match the current optional Command shape used by Cli.
- Correct the skewed time-to-expiry expectations in fleet claims tests so they match the saturating arithmetic used by the implementation.

Enhancements:
- Move drain_shared from the Drainable impl onto ConsoleGuard so shared console draining matches actual call sites and is available on all targets.

Tests:
- Update daemon approval gate tests to exercise the deadline-based API and the AgentEngineConfig::approval_wait behaviour instead of the removed helper.
- Reformat and extend fleet claims tests to clearly assert rendering, lapsed vs live behaviour, and saturated skewed-span values.