### PR TITLE
Unbreak main: #1717 left half of each #1616 design behind — 9 errors and a twice-deleted witness

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -241,7 +241,7 @@ pub(crate) fn approval_gate_for(
     cfg: &Config,
     capability: PipelineApprovalCapability,
 ) -> crate::daemon::approval::OneShotApprovalGate {
-    let wait = crate::daemon::approval::park_deadline(cfg.engine_settings.as_ref());
+    let wait = cfg.engine_settings.as_ref().and_then(|e| e.approval_wait());
     crate::daemon::approval::OneShotApprovalGate::select(capability, wait)
 }
 

--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -527,7 +527,7 @@ mod tests {
         let record = parked_record(&registry);
         let sidecar = registry.sidecar_dir(&record.id);
         let gate = SidecarApprovalGate::new(sidecar.clone(), registry.clone(), record.id.clone())
-            .with_deadline(Some(std::time::Duration::from_millis(30)));
+            .with_wait(Some(std::time::Duration::from_millis(30)));
 
         // The outer timeout is the assertion's teeth: on a gate without a
         // deadline this future never resolves, and the test would hang rather
@@ -591,7 +591,7 @@ mod tests {
         // up to the poll interval.
         let short =
             SidecarApprovalGate::new(dir.path().into(), registry_in(dir.path()), "id".into())
-                .with_deadline(Some(std::time::Duration::from_millis(5)));
+                .with_wait(Some(std::time::Duration::from_millis(5)));
         let nap = short.next_poll(now).expect("5ms is still ahead");
         assert!(nap <= std::time::Duration::from_millis(5), "{nap:?}");
         // And a deadline already in the past ends the park.

--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -136,10 +136,10 @@ impl SidecarApprovalGate {
     /// Split out of the loop so the arithmetic — the part a wall-clock test
     /// cannot pin down without sleeping through it — is directly testable.
     fn next_poll(&self, parked_at: std::time::Instant) -> Option<std::time::Duration> {
-        let Some(deadline) = self.deadline else {
+        let Some(wait) = self.wait else {
             return Some(ANSWER_POLL);
         };
-        let remaining = deadline.checked_sub(parked_at.elapsed())?;
+        let remaining = wait.checked_sub(parked_at.elapsed())?;
         (!remaining.is_zero()).then(|| ANSWER_POLL.min(remaining))
     }
 
@@ -210,7 +210,7 @@ impl ApprovalGate for SidecarApprovalGate {
                             "{} scope review unanswered for {}s — aborting the run \
                              (agent_engine_config.approval_wait_secs)",
                             "▸ timed out".yellow().bold(),
-                            self.deadline.map_or(0, |d| d.as_secs()),
+                            self.wait.map_or(0, |w| w.as_secs()),
                         );
                         break ScopeDecision::Abort;
                     }
@@ -245,7 +245,8 @@ impl OneShotApprovalGate {
     /// computed from the same predicate, so that arm is a defensive
     /// impossibility, and failing closed is what a missing approver means.
     ///
-    /// `wait` is [`park_deadline`]'s reading of
+    /// `wait` is [`crate::settings::AgentEngineConfig::approval_wait`]'s
+    /// reading of
     /// `agent_engine_config.approval_wait_secs` (#1616), consulted only by
     /// the sidecar gate — the other two have a live reader on the other end,
     /// so a timer there would answer a question someone is already looking

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -432,7 +432,7 @@ fn wall_ms() -> u64 {
 ///
 /// The pumps live behind an `Arc` rather than in this struct because two
 /// different code paths have to be able to end them: `main`'s orderly exit,
-/// and the panic hook [`install_panic_drain`] installs (#1616). Both call the
+/// and the panic hook [`arm_panic_drain`] installs (#1616). Both call the
 /// same idempotent [`Drainable::drain`]; whichever arrives first takes the
 /// streams and the other finds nothing to do.
 pub(crate) struct ConsoleGuard {
@@ -468,24 +468,6 @@ impl ConsoleGuard {
     pub(crate) fn drain(&self) {
         #[cfg(unix)]
         self.pumps.drain();
-    }
-
-    /// Drain whatever guard is still in `cell`, unless the CURRENT thread is
-    /// one of the pumps it owns — see [`PUMP_THREAD_PREFIX`]. Idempotent and
-    /// safe to call from both the normal end-of-`main` path and a panic hook:
-    /// the two race to be first, and whichever wins performs the one real
-    /// drain; the loser finds `None` and does nothing.
-    pub(crate) fn drain_shared(cell: &Mutex<Option<ConsoleGuard>>) {
-        if std::thread::current()
-            .name()
-            .is_some_and(|name| name.starts_with(PUMP_THREAD_PREFIX))
-        {
-            return;
-        }
-        let guard = cell.lock().unwrap_or_else(|p| p.into_inner()).take();
-        if let Some(guard) = guard {
-            guard.drain();
-        }
     }
 }
 
@@ -542,25 +524,37 @@ impl Drainable {
     }
 }
 
-/// Install a panic hook that drains `cell`'s console guard — restoring the
-/// real console fds via `dup2` — BEFORE the previously installed hook (the
-/// diagnostics ring dump, and beneath that the default hook) prints the
-/// panic message (#1616).
+/// Drain the console when this process panics, before the panic message is
+/// lost (#1616).
 ///
-/// Release builds run with `panic = "abort"` (`Cargo.toml`), so this hook is
-/// the only cleanup this process ever gets on a panic — there is no unwind
-/// back to `main`'s own `drain_shared` call to fall back to. Without it, the
-/// default hook's message goes out fd 2 while it is still the pipe a pump
-/// thread reads asynchronously, and a process that aborts before the pump is
-/// next scheduled loses it — usually the one line a postmortem most wants.
-/// Restoring the fd first makes the same `eprintln!` land as an ordinary
-/// synchronous write to the console file instead.
-pub(crate) fn install_panic_drain(cell: Arc<Mutex<Option<ConsoleGuard>>>) {
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        ConsoleGuard::drain_shared(&cell);
-        previous(info);
-    }));
+/// The pump made the console's tail lossy on a violent death: a panic unwinds
+/// past `main`'s orderly [`ConsoleGuard::drain`], the process exits without
+/// joining the pump threads, and up to a pipe buffer of output — the panic
+/// message itself, most of the time — dies in the pipe. That is the one
+/// artifact a postmortem of a supervised child actually wants. Release builds
+/// run with `panic = "abort"`, so this hook is the only cleanup such a process
+/// ever gets.
+///
+/// The hook chains rather than replaces: whatever hook is already installed
+/// (the diagnostics dump, or the default printer) runs FIRST, so its output
+/// goes down the pipe like everything else, and only then is the pipe drained
+/// into the file. Draining first would restore the fds and leave the panic
+/// message to land raw — readable, but ahead of the pump's own `Closed`
+/// marker and outside the bound. The drain is synchronous inside the hook
+/// either way, so nothing is lost to scheduling; what differs is where the
+/// bytes end up.
+pub(crate) fn arm_panic_drain(guard: &ConsoleGuard) {
+    #[cfg(not(unix))]
+    let _ = guard;
+    #[cfg(unix)]
+    {
+        let pumps = guard.pumps.clone();
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            previous(info);
+            pumps.drain();
+        }));
+    }
 }
 
 /// Interpose the bounded pumps on this process's stdout and stderr.

--- a/crates/stella-cli/src/daemon/console/tests.rs
+++ b/crates/stella-cli/src/daemon/console/tests.rs
@@ -262,30 +262,50 @@ fn a_session_without_an_index_falls_back_to_raw_tails() {
     assert_eq!(String::from_utf8_lossy(&out), "legacy\n");
 }
 
-/// The #1616 witness for the new half of the drain path: whichever of the
-/// panic hook and the normal end-of-`main` cleanup reaches a shared guard
-/// first performs the one real drain, and — the specific hazard a panicking
-/// pump thread would create — a pump thread must never try to join itself.
-/// A guard over no streams needs no real fds (this module's own doc comment:
-/// hijacking the test runner's stdout to exercise the fd plumbing would be
-/// the tail wagging the dog), so this is fd-free logic, not glue. On `main`,
-/// `drain_shared` does not exist at all.
+/// The #1616 witness: a panic ends the pump instead of leaving it to die
+/// unjoined with the process.
+///
+/// What the drain does is restore the fd — which closes the pipe's last write
+/// end, so the pump reads EOF, writes everything it holds, and records its
+/// `Closed` marker. That marker is the assertion, because it is the one thing
+/// that cannot happen by luck: a pump that was never drained is still blocked
+/// on its pipe when the process exits, and up to a buffer of output (the panic
+/// message, in a real supervised child) dies with it. Asserting instead that
+/// the bytes reached the file would pass with the hook disarmed — a live pump
+/// in a process that keeps running flushes them on its own schedule.
+///
+/// The pump is interposed on a private descriptor rather than on fd 1, so the
+/// test runner's own stdout is never hijacked; everything downstream of the
+/// `dup2` is the production path.
+#[cfg(unix)]
 #[test]
-fn drain_shared_skips_a_pump_thread_draining_itself_but_runs_from_anywhere_else() {
-    let cell = Arc::new(Mutex::new(Some(ConsoleGuard {
-        pumps: Arc::new(Drainable {
-            streams: Mutex::new(Vec::new()),
-        }),
-    })));
+fn a_panic_drains_the_console_pump() {
+    use std::os::unix::io::IntoRawFd;
 
-    // Called as if FROM a pump thread: a no-op, or a real pump trying to
-    // join itself on its own panic would deadlock the whole process.
-    let from_pump = {
-        let cell = cell.clone();
-        std::thread::Builder::new()
-            .name(format!("{PUMP_THREAD_PREFIX}1"))
-            .spawn(move || ConsoleGuard::drain_shared(&cell))
-            .unwrap()
+    let dir = tempfile::tempdir().unwrap();
+    let sidecar = dir.path();
+    let console = sidecar.join(supervised::STDOUT_LOG);
+    // A descriptor naming the console file — what the OS redirect hands a
+    // supervised child, and what `pump_fd` expects to interpose on.
+    let target_fd = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&console)
+        .unwrap()
+        .into_raw_fd();
+    let stream = pump_fd(
+        console.clone(),
+        target_fd,
+        Stream::Stdout,
+        Arc::new(Mutex::new(Index::open(sidecar))),
+        Arc::new(SharedGeometry::default()),
+    )
+    .unwrap();
+    let guard = ConsoleGuard {
+        pumps: Arc::new(Drainable {
+            streams: Mutex::new(vec![stream]),
+        }),
     };
 
     arm_panic_drain(&guard);

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -335,43 +335,4 @@ mod tests {
         assert_eq!(human_ms(750_000), "12m 30s");
         assert_eq!(human_ms(11_040_000), "3h 04m");
     }
-
-    /// `stella fleet claims` parses as a subcommand rather than as a task
-    /// prompt, and defaults to the live listing in text.
-    #[test]
-    fn fleet_claims_parses_as_a_verb_and_defaults_to_live_text() {
-        let cli = Cli::try_parse_from(["stella", "fleet", "claims"]).unwrap();
-        match cli.command {
-            Some(Command::Fleet {
-                cmd: Some(crate::fleet_verbs::FleetCmd::Claims { all, format }),
-                ..
-            }) => {
-                assert!(!all, "the live listing is the default");
-                assert_eq!(format, QueryFormat::Text);
-            }
-            // `Command` derives no `Debug` — a clap subcommand enum this wide
-            // carries none — so the failure names what was expected.
-            _ => panic!("expected `stella fleet claims` to parse as the claims verb"),
-        }
-
-        let cli = Cli::try_parse_from(["stella", "fleet", "claims", "--all", "--format", "json"])
-            .unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Command::Fleet {
-                cmd: Some(crate::fleet_verbs::FleetCmd::Claims {
-                    all: true,
-                    format: QueryFormat::Json
-                }),
-                ..
-            })
-        ));
-
-        // And the documented escape hatch still works: `--` makes it a prompt.
-        let cli = Cli::try_parse_from(["stella", "fleet", "--", "claims are stale"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Command::Fleet { cmd: None, .. })
-        ));
-    }
 }

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -841,6 +841,23 @@ impl AgentEngineConfig {
         self.hunk_review.is_some_and(Toggle::is_on)
     }
 
+    /// The parked-approval deadline, if the operator set one (#1616).
+    ///
+    /// `0` is spelled and means "no deadline", the same convention
+    /// `model_timeout_secs` uses: in a field whose absence already means
+    /// "the default", zero is the only way for one project to opt out of a
+    /// deadline a user-scope file set. Absent and `0` therefore agree, and
+    /// both park forever.
+    ///
+    /// The single copy of this reading, deliberately: #1616 merged twice,
+    /// and one of the two mappings that resulted was consulted by nothing.
+    /// Witness: `daemon::approval::tests::the_setting_maps_absent_and_zero_to_park_forever`.
+    pub fn approval_wait(&self) -> Option<std::time::Duration> {
+        self.approval_wait_secs
+            .filter(|secs| *secs > 0)
+            .map(std::time::Duration::from_secs)
+    }
+
     /// Persist THIS config as the `agent_engine_config` key of the
     /// settings file at `path`, preserving every other key in the file
     /// byte-for-byte at the value level (providers, hooks, mcp, and any


### PR DESCRIPTION
`main` does not compile at `2fd06550` — **9 errors** in `stella-cli` at `--all-targets`. Two competing reconciliations of #1616 landed back to back: #1711 (mine), then **#1717**, which merged the same code textually rather than semantically and left half of each design behind.

## The nine errors

**1. Two tests spliced into one** — `crates/stella-cli/src/daemon/console/tests.rs`. One function whose head is `drain_shared_skips_a_pump_thread_draining_itself_but_runs_from_anywhere_else` and whose body, from `arm_panic_drain(&guard);` on, is `a_panic_drains_the_console_pump`'s. It names `guard`, `target_fd`, `sidecar` and `console`, binds none of them, and never joins its own `from_pump` handle.

**2. `main.rs:543` calls a deleted hook** — `console::arm_panic_drain`, replaced by `install_panic_drain(cell)`; `main.rs:597` likewise calls `guard.drain()` on a plain `Option<ConsoleGuard>`, not the shared cell that hook needs.

**3. `agent/engine.rs:244` calls `daemon::approval::park_deadline`** — deleted.

**4-5. `daemon/approval.rs:139, 213` read `self.deadline`** — the field is `wait`.

**6-7. `daemon/approval.rs:530, 594` call `.with_deadline(...)`** — the builder is `with_wait`.

**8-9. `fleet_claims.rs` carries a re-added test** — `fleet_claims_parses_as_a_verb_and_defaults_to_live_text`, in a module that no longer imports `clap::Parser` or `cli::{Cli, Command}`: `a47e92b3` had moved it to `src/tests.rs` and dropped the imports with it.

## Resolution — finish the design `main` already carries, don't start a third

**Console.** `main.rs` and `Drainable` on main are already #1711's design; #1717 restored only the *other* design's entry points on top and left both unreachable. So `arm_panic_drain(&guard)` is restored and `install_panic_drain` + `ConsoleGuard::drain_shared` are removed — neither had a caller.

The self-join guard stays the **per-stream `ThreadId`** comparison inside `Drainable::drain`. `drain_shared`'s thread-*name* check returned early from the whole drain, so a panicking **stdout** pump would also skip draining **stderr** and leave its own fd interposed — losing exactly the output the feature exists to save. A `ThreadId` is neither optional nor non-unique, and it skips only the single join that would wait on itself. `PUMP_THREAD_PREFIX` stays (worth having in a backtrace); its doc no longer claims to be load-bearing.

`arm_panic_drain` chains **after** the previously installed hook, so the panic message rides the pipe and lands *inside* the bounded ring ahead of the pump's `Closed` marker. Draining first leaves it raw, past the marker and outside the bound. Under `panic = "abort"` both orders are safe — the drain is synchronous inside the hook either way — so the tiebreak is where the bytes end up.

**Approval.** The setting's mapping settles in **one** place: `AgentEngineConfig::approval_wait` in `settings.rs`. That is what `daemon/approval.rs`'s surviving `the_setting_maps_absent_and_zero_to_park_forever` already asserts, and what its own doc comment asks for — "a second copy of this arithmetic living beside the gate is what let #1616's merge ship a reading of the setting that nothing consulted." `engine.rs` calls it; `park_deadline` stays gone. The field reads and the two test call sites become `wait` / `with_wait`, matching the struct, the constructor and the setting's name.

**fleet_claims.** The re-added test is deleted, not repaired — `src/tests.rs`'s `fleet_claims_parses_as_a_verb_and_defaults_to_the_live_listing` covers the same parse including the `--` escape hatch.

## Witnesses

**`a_panic_drains_the_console_pump` is restored intact — it has now been deleted twice** (once by #1695's rewrite, once by #1717's splice) while `arm_panic_drain` stayed live and unwitnessed. It asserts the pump's **`Closed` index marker**, never "the bytes are in the file": the byte assertion was a first draft that **passed with the hook disarmed**, because a live pump flushes on its own schedule in a process that keeps running. The marker can only exist if the fd was restored and the pump joined. It interposes on a private descriptor, never fd 1, so the test runner's stdout is untouched.

`a_drain_from_the_pump_thread_restores_the_fd_without_joining_itself` covers what `drain_shared_skips_…` covered, against the API that still exists. Its stand-in pump never finishes, so the drain runs on its own thread behind a `recv_timeout` — a regression fails rather than wedging the test binary.

The four #1616 deadline tests still assert what they did; only the builder name changed.

## Verification

- `cargo clippy -p stella-cli --all-targets -- -D warnings` — exit 0 (subsumes `cargo check --all-targets`).
- `cargo fmt --all` — clean.
- `cargo test -p stella-cli --bin stella daemon::` — 63 passed, 0 failed, both witnesses among them.
- `cargo test -p stella-cli --bin stella` — full unit suite green.

Not run locally (16GB machine, a sibling agent compiling concurrently): `--workspace` and the integration test binaries. CI covers them.

Refs #1712, #1711, #1717.
