### PR TITLE
feat(stella-cli): let stella daemon address a run by its pid (#1690)

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -319,15 +319,15 @@ pub(crate) enum DaemonCmd {
     /// already finished prints in full and exits. Detaching again (Ctrl-C)
     /// leaves the run alone — `stella daemon stop` is what stops it.
     Attach {
-        /// Run to attach to. A unique prefix of the id is enough. Omitted:
-        /// the most recently started supervised run.
+        /// Run to attach to. A unique prefix of the id, or the run's pid,
+        /// is enough. Omitted: the most recently started supervised run.
         id: Option<String>,
     },
 
     /// Print the tail of a supervised run's output and exit
     Logs {
-        /// Run to read. A unique prefix of the id is enough. Omitted: the
-        /// most recently started supervised run.
+        /// Run to read. A unique prefix of the id, or the run's pid, is
+        /// enough. Omitted: the most recently started supervised run.
         id: Option<String>,
 
         /// How many lines back to start from.
@@ -342,7 +342,8 @@ pub(crate) enum DaemonCmd {
     /// that has not stopped after the grace period is killed, and either way
     /// the stop is recorded as deliberate rather than left to read as a crash.
     Stop {
-        /// Run to stop. A unique prefix of the id is enough.
+        /// Run to stop. A unique prefix of the id, or the run's pid, is
+        /// enough.
         id: String,
     },
 
@@ -355,8 +356,8 @@ pub(crate) enum DaemonCmd {
     /// applied twice. A run that ended cleanly discarded its resume point on
     /// the way out, and resume says so instead of restarting it.
     Resume {
-        /// Run to resume. A unique prefix of the id is enough. Omitted: the
-        /// most recently started supervised run.
+        /// Run to resume. A unique prefix of the id, or the run's pid, is
+        /// enough. Omitted: the most recently started supervised run.
         id: Option<String>,
     },
 

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -1174,9 +1174,12 @@ fn mark_stopped(registry: &SessionRegistry, id: &str) {
 /// Resolve a user-typed id to a record.
 ///
 /// Accepts a unique prefix, because the full form (`ses-1754431200000-84213`)
-/// is a timestamp and a pid and nobody is going to type it. `None` picks the
-/// most recent supervised run, which is what "the one I just started" means
-/// nine times in ten.
+/// is a timestamp and a pid and nobody is going to type it. It also accepts a
+/// bare **pid**, because that is the address `ps`, `top`, Activity Monitor and
+/// an OOM-killer log hand you, and without this rung translating one back to a
+/// run means eyeballing `stella daemon list` (#1690). `None` picks the most
+/// recent supervised run, which is what "the one I just started" means nine
+/// times in ten.
 pub(crate) fn resolve(
     registry: &SessionRegistry,
     id: Option<&str>,
@@ -1201,18 +1204,57 @@ pub(crate) fn resolve(
         return Ok(exact.clone());
     }
 
-    let mut matches = supervised_runs.into_iter().filter(|r| r.id.starts_with(id));
+    // An id begins `ses-`, so an argument that parses as a number cannot be a
+    // prefix of one: the two address spaces are disjoint, and a pid that hits
+    // nothing is reported as a pid rather than falling through to a prefix
+    // scan that could not have matched either. The ambiguity rule is the same
+    // one — pids are recycled, and a finished run keeps the one it ran under —
+    // but the advice is not, since there are no further digits to type.
+    if let Ok(pid) = id.parse::<u32>() {
+        return only(
+            supervised_runs.into_iter().filter(|r| r.pid == pid),
+            || {
+                format!(
+                    "no supervised run has pid {pid} — `stella daemon list` shows what there is"
+                )
+            },
+            |first, second| {
+                format!(
+                    "pid {pid} matches more than one run ({} and {}) — use the id `stella daemon list` prints",
+                    first.id, second.id
+                )
+            },
+        );
+    }
+
+    only(
+        supervised_runs.into_iter().filter(|r| r.id.starts_with(id)),
+        || format!("no supervised run matches `{id}` — `stella daemon list` shows what there is"),
+        |first, second| {
+            format!(
+                "`{id}` matches more than one run ({} and {}) — use more of the id",
+                first.id, second.id
+            )
+        },
+    )
+}
+
+/// The one record in `matches`, or the error for none and for several.
+///
+/// Shared by [`resolve`]'s prefix and pid rungs: the rule ("exactly one, or
+/// say so") is the same on both, while the sentences are not — what to type
+/// instead depends on which address space the caller was using.
+fn only(
+    mut matches: impl Iterator<Item = SessionRecord>,
+    miss: impl FnOnce() -> String,
+    ambiguous: impl FnOnce(&SessionRecord, &SessionRecord) -> String,
+) -> Result<SessionRecord, String> {
     let Some(first) = matches.next() else {
-        return Err(format!(
-            "no supervised run matches `{id}` — `stella daemon list` shows what there is"
-        ));
+        return Err(miss());
     };
     match matches.next() {
         None => Ok(first),
-        Some(second) => Err(format!(
-            "`{id}` matches more than one run ({} and {}) — use more of the id",
-            first.id, second.id
-        )),
+        Some(second) => Err(ambiguous(&first, &second)),
     }
 }
 

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -427,6 +427,57 @@ fn ids_resolve_by_unique_prefix_and_refuse_an_ambiguous_one() {
 }
 
 #[test]
+fn a_bare_pid_resolves_the_run_that_is_running_under_it() {
+    let (dir, registry) = temp_registry("resolve-pid");
+    let mut supervised = SessionRecord::new("/w", "supervised");
+    supervised.id = "ses-100-4242".into();
+    supervised.pid = 4242;
+    supervised.supervisor = Some(SupervisorInfo { pgid: 4242 });
+    let mut plain = SessionRecord::new("/w", "unsupervised");
+    plain.id = "ses-200-777".into();
+    plain.pid = 777;
+    for record in [&supervised, &plain] {
+        registry.upsert(record).unwrap();
+    }
+
+    // The address `ps`, Activity Monitor and an OOM-killer log hand you.
+    assert_eq!(resolve(&registry, Some("4242")).unwrap().id, supervised.id);
+
+    // A miss is reported in the address space the caller used: an id begins
+    // `ses-`, so "9999" was never a prefix anything could have matched.
+    let miss = resolve(&registry, Some("9999")).unwrap_err();
+    assert!(miss.contains("pid 9999"), "{miss}");
+
+    // Unsupervised sessions are not this command's subject by pid either.
+    assert!(resolve(&registry, Some("777")).is_err());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_pid_two_runs_have_held_is_refused_rather_than_guessed() {
+    let (dir, registry) = temp_registry("resolve-pid-recycled");
+    // The kernel recycles pids and a finished run keeps the one it ran under,
+    // so two records sharing one is reachable, not hypothetical — and picking
+    // whichever the registry listed first would stop the wrong run.
+    for id in ["ses-100-4242", "ses-900-4242"] {
+        let mut record = SessionRecord::new("/w", id);
+        record.id = id.into();
+        record.pid = 4242;
+        record.supervisor = Some(SupervisorInfo { pgid: 4242 });
+        registry.upsert(&record).unwrap();
+    }
+
+    let ambiguous = resolve(&registry, Some("4242")).unwrap_err();
+    assert!(ambiguous.contains("ses-100-4242"), "{ambiguous}");
+    assert!(ambiguous.contains("ses-900-4242"), "{ambiguous}");
+    // "use more of the id" is useless advice for a pid: there is no more of it.
+    assert!(ambiguous.contains("use the id"), "{ambiguous}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn an_exit_code_is_forwarded_the_way_a_shell_reports_it() {
     let status = |script: &str| {
         std::process::Command::new("/bin/sh")

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -99,7 +99,7 @@ Every supervised run on this machine, newest first. Local reads only — no API 
 
 ## `attach`
 
-Streams the run's output into this terminal, from the beginning, and stays until the run ends. A run that has already finished prints in full and exits. The id can be any unique prefix; omit it for the most recently started run. If the run is parked on a scope review, attach renders the proposal and delivers your answer.
+Streams the run's output into this terminal, from the beginning, and stays until the run ends. A run that has already finished prints in full and exits. The id can be any unique prefix — or the run's **pid**, which is the address `ps`, `top`, Activity Monitor and an OOM-killer log give you; omit it for the most recently started run. If the run is parked on a scope review, attach renders the proposal and delivers your answer.
 
 Detaching again — `Ctrl-C` — leaves the run alone. `stella daemon stop` is what stops it.
 


### PR DESCRIPTION
Closes #1690.

## What

`daemon::resolve` took a session id or a unique prefix of one. A **pid** is what `ps`, `top`, Activity Monitor and an OOM-killer log hand you, and it was a dead end — translating one back to a run meant eyeballing `stella daemon list`. The reverted #1594 accepted a pid; the re-land (#1607) deliberately did not carry it, and the issue asks for it back.

```bash
$ stella daemon stop 25167          # the number ps just gave you
$ stella daemon attach 25167        # same, for every verb that takes a run
```

## Why the two address spaces cannot collide

A session id is `ses-<millis>-<pid>`, so **an id always begins `ses-`** and an argument that parses as a number can never be a prefix of one. That makes the pid rung a pure addition: no id resolves differently than it did before, and the rung needs no disambiguating sigil. It also means a numeric miss is reported *as a pid* rather than falling through to a prefix scan that could not have matched anything — `no supervised run has pid 9999`, not `no supervised run matches \`9999\``.

## Ambiguity is kept, not assumed away

The issue says ambiguity rules stay as they are, and a pid genuinely can be ambiguous: the kernel recycles pids, and a finished run keeps the one it ran under, so two supervised records can share one. Returning whichever the registry happened to list first would **stop the wrong run**. So the pid rung refuses, exactly as the prefix rung does.

The rule is identical on both rungs and is now written once (`only`), because the *advice* is not identical: "use more of the id" is useless when the caller typed a pid — there are no further digits to type — so each rung supplies its own sentence.

Four verbs — `attach`, `logs`, `stop`, `resume` — share this one resolver, so all four `--help` strings and the docs page say so, not just `attach`.

## Witness

Two tests in `crates/stella-cli/src/daemon/tests.rs`, both **failing on `main`'s resolver** and passing on this one. Checked the artisanal way — main's `daemon.rs` copied over this branch's, tests left in place:

```
test daemon::tests::a_pid_two_runs_have_held_is_refused_rather_than_guessed ... FAILED
test daemon::tests::a_bare_pid_resolves_the_run_that_is_running_under_it ... FAILED
   panicked: no supervised run matches `4242` — `stella daemon list` shows what there is
test result: FAILED. 0 passed; 2 failed
```

and with the resolver restored:

```
test result: ok. 65 passed; 0 failed        # cargo test -p stella-cli --bin stella daemon::
```

- `a_bare_pid_resolves_the_run_that_is_running_under_it` — a pid resolves its run; a numeric miss is reported as a pid; an **unsupervised** session is not this command's subject by pid either (the pid rung filters the same set every other rung does).
- `a_pid_two_runs_have_held_is_refused_rather_than_guessed` — two records sharing a recycled pid refuse rather than guess, and the message names both runs and says to use the id.

## Base

`main` at `2fd06550` did not compile — #1717 and #1711 reconciled the same #1616 code back to back and the second landed textually over the first. **#1720 has since fixed that and this branch is updated onto it.** The verification above was run on this branch merged with #1720's; this branch's own diff touches none of the files involved (`daemon.rs::resolve`, `daemon/tests.rs`, `cli.rs` help strings, `daemon.mdx`).

## Left behind

- #1721 — `daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period` fails under full-suite load and passes alone. Found while verifying this; not fixed here.
