### PR TITLE
Unbreak main: reconcile the two #1616 landings, and the two test targets that never compiled

### DIFF
--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -137,10 +137,10 @@ impl SidecarApprovalGate {
     /// Split out of the loop so the arithmetic — the part a wall-clock test
     /// cannot pin down without sleeping through it — is directly testable.
     fn next_poll(&self, parked_at: std::time::Instant) -> Option<std::time::Duration> {
-        let Some(wait) = self.wait else {
+        let Some(deadline) = self.deadline else {
             return Some(ANSWER_POLL);
         };
-        let remaining = wait.checked_sub(parked_at.elapsed())?;
+        let remaining = deadline.checked_sub(parked_at.elapsed())?;
         (!remaining.is_zero()).then(|| ANSWER_POLL.min(remaining))
     }
 
@@ -179,23 +179,12 @@ impl ApprovalGate for SidecarApprovalGate {
             .registry
             .set_status(&self.id, SessionStatus::NeedsInput);
 
-        let started = std::time::Instant::now();
+        let parked_at = std::time::Instant::now();
         let decision = loop {
             if (self.interrupted)() {
                 // The same answer the stdio gate gives on EOF: asked to stop
                 // is a no. Unparking here is what lets `stop`'s SIGTERM grace
                 // land as a clean cancel instead of an escalated kill.
-                break ScopeDecision::Abort;
-            }
-            if let Some(deadline) = self.deadline
-                && started.elapsed() >= deadline
-            {
-                eprintln!(
-                    "  {} scope review timed out after {}s with nobody attached \
-                     (approval_wait_secs) — aborting",
-                    "!".yellow(),
-                    deadline.as_secs(),
-                );
                 break ScopeDecision::Abort;
             }
             match std::fs::read_to_string(self.sidecar.join(supervised::APPROVAL_ANSWER)) {
@@ -217,7 +206,7 @@ impl ApprovalGate for SidecarApprovalGate {
                             "{} scope review unanswered for {}s — aborting the run \
                              (agent_engine_config.approval_wait_secs)",
                             "▸ timed out".yellow().bold(),
-                            self.wait.map_or(0, |w| w.as_secs()),
+                            self.deadline.map_or(0, |d| d.as_secs()),
                         );
                         break ScopeDecision::Abort;
                     }
@@ -288,21 +277,6 @@ impl ApprovalGate for OneShotApprovalGate {
             Self::Headless(gate) => gate.confirm(question).await,
         }
     }
-}
-
-/// The configured park deadline, or `None` for the shipped park-forever
-/// behaviour.
-///
-/// `0` is spelled and means "no deadline", the same convention
-/// `model_timeout_secs` uses for its own backstop: in a field whose absence
-/// already means "the default", zero is the only way to say *deliberately*
-/// unbounded — which matters when a user-scope file sets a deadline and one
-/// project wants out of it.
-pub(crate) fn park_deadline(
-    settings: Option<&crate::settings::AgentEngineConfig>,
-) -> Option<std::time::Duration> {
-    let secs = settings?.approval_wait_secs?;
-    (secs > 0).then(|| std::time::Duration::from_secs(secs))
 }
 
 /// The attached-terminal side: answer a parked scope review, if one is
@@ -559,7 +533,7 @@ mod tests {
     /// The #1616 witness: with `approval_wait_secs` armed, a review nobody
     /// answers unparks itself as an abort instead of waiting forever — and it
     /// hands the record back rather than leaving it stuck on `Needs Input`.
-    /// On `main` a gate has no deadline to arm (`with_wait` does not exist),
+    /// On `main` a gate has no deadline to arm (`with_deadline` does not exist),
     /// so this is a type-level witness as well as a behavioural one.
     #[tokio::test]
     async fn an_expired_deadline_unparks_an_unanswered_review_as_an_abort() {
@@ -568,7 +542,7 @@ mod tests {
         let record = parked_record(&registry);
         let sidecar = registry.sidecar_dir(&record.id);
         let gate = SidecarApprovalGate::new(sidecar.clone(), registry.clone(), record.id.clone())
-            .with_wait(Some(std::time::Duration::from_millis(30)));
+            .with_deadline(Some(std::time::Duration::from_millis(30)));
 
         // The outer timeout is the assertion's teeth: on a gate without a
         // deadline this future never resolves, and the test would hang rather
@@ -632,7 +606,7 @@ mod tests {
         // up to the poll interval.
         let short =
             SidecarApprovalGate::new(dir.path().into(), registry_in(dir.path()), "id".into())
-                .with_wait(Some(std::time::Duration::from_millis(5)));
+                .with_deadline(Some(std::time::Duration::from_millis(5)));
         let nap = short.next_poll(now).expect("5ms is still ahead");
         assert!(nap <= std::time::Duration::from_millis(5), "{nap:?}");
         // And a deadline already in the past ends the park.
@@ -647,14 +621,17 @@ mod tests {
     /// aborts every supervised review the instant it parks.
     #[test]
     fn the_setting_maps_absent_and_zero_to_park_forever() {
-        assert_eq!(park_deadline(None), None);
         let mut settings = crate::settings::AgentEngineConfig::default();
-        assert_eq!(park_deadline(Some(&settings)), None);
+        assert_eq!(settings.approval_wait(), None, "absent parks forever");
         settings.approval_wait_secs = Some(0);
-        assert_eq!(park_deadline(Some(&settings)), None);
+        assert_eq!(
+            settings.approval_wait(),
+            None,
+            "`0` is a deliberate no-deadline, not a zero-length one"
+        );
         settings.approval_wait_secs = Some(90);
         assert_eq!(
-            park_deadline(Some(&settings)),
+            settings.approval_wait(),
             Some(std::time::Duration::from_secs(90))
         );
     }

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -433,7 +433,7 @@ fn wall_ms() -> u64 {
 ///
 /// The pumps live behind an `Arc` rather than in this struct because two
 /// different code paths have to be able to end them: `main`'s orderly exit,
-/// and the panic hook [`arm_panic_drain`] installs (#1616). Both call the
+/// and the panic hook [`install_panic_drain`] installs (#1616). Both call the
 /// same idempotent [`Drainable::drain`]; whichever arrives first takes the
 /// streams and the other finds nothing to do.
 pub(crate) struct ConsoleGuard {
@@ -469,6 +469,24 @@ impl ConsoleGuard {
     pub(crate) fn drain(&self) {
         #[cfg(unix)]
         self.pumps.drain();
+    }
+
+    /// Drain whatever guard is still in `cell`, unless the CURRENT thread is
+    /// one of the pumps it owns — see [`PUMP_THREAD_PREFIX`]. Idempotent and
+    /// safe to call from both the normal end-of-`main` path and a panic hook:
+    /// the two race to be first, and whichever wins performs the one real
+    /// drain; the loser finds `None` and does nothing.
+    pub(crate) fn drain_shared(cell: &Mutex<Option<ConsoleGuard>>) {
+        if std::thread::current()
+            .name()
+            .is_some_and(|name| name.starts_with(PUMP_THREAD_PREFIX))
+        {
+            return;
+        }
+        let guard = cell.lock().unwrap_or_else(|p| p.into_inner()).take();
+        if let Some(guard) = guard {
+            guard.drain();
+        }
     }
 }
 
@@ -521,24 +539,6 @@ impl Drainable {
             unsafe {
                 libc::close(stream.saved_fd);
             }
-        }
-    }
-
-    /// Drain whatever guard is still in `cell`, unless the CURRENT thread is
-    /// one of the pumps it owns — see [`PUMP_THREAD_PREFIX`]. Idempotent and
-    /// safe to call from both the normal end-of-`main` path and a panic hook:
-    /// the two race to be first, and whichever wins performs the one real
-    /// drain; the loser finds `None` and does nothing.
-    pub(crate) fn drain_shared(cell: &Mutex<Option<ConsoleGuard>>) {
-        if std::thread::current()
-            .name()
-            .is_some_and(|name| name.starts_with(PUMP_THREAD_PREFIX))
-        {
-            return;
-        }
-        let guard = cell.lock().unwrap_or_else(|p| p.into_inner()).take();
-        if let Some(guard) = guard {
-            guard.drain();
         }
     }
 }
@@ -598,35 +598,6 @@ pub(crate) fn install_bounded(sidecar: &Path) -> Option<ConsoleGuard> {
                 streams: Mutex::new(streams),
             }),
         })
-    }
-}
-
-/// Drain the console when this process panics, before the panic message is
-/// lost (#1616).
-///
-/// The pump made the console's tail lossy on a violent death: a panic unwinds
-/// past `main`'s orderly [`ConsoleGuard::drain`], the process exits without
-/// joining the pump threads, and up to a pipe buffer of output — the panic
-/// message itself, most of the time — dies in the pipe. That is the one
-/// artifact a postmortem of a supervised child actually wants.
-///
-/// The hook chains rather than replaces: whatever hook is already installed
-/// (the diagnostics dump, or the default printer) runs FIRST, so its output
-/// goes down the pipe like everything else, and only then is the pipe drained
-/// into the file. Draining first would restore the fds and leave the panic
-/// message to land raw — readable, but ahead of the pump's own `Closed`
-/// marker and outside the bound.
-pub(crate) fn arm_panic_drain(guard: &ConsoleGuard) {
-    #[cfg(not(unix))]
-    let _ = guard;
-    #[cfg(unix)]
-    {
-        let pumps = guard.pumps.clone();
-        let previous = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            previous(info);
-            pumps.drain();
-        }));
     }
 }
 

--- a/crates/stella-cli/src/daemon/console/tests.rs
+++ b/crates/stella-cli/src/daemon/console/tests.rs
@@ -266,14 +266,16 @@ fn a_session_without_an_index_falls_back_to_raw_tails() {
 /// panic hook and the normal end-of-`main` cleanup reaches a shared guard
 /// first performs the one real drain, and — the specific hazard a panicking
 /// pump thread would create — a pump thread must never try to join itself.
-/// `ConsoleGuard { streams: Vec::new() }` needs no real fds (this module's own
+/// A guard over an empty pump list needs no real fds (this module's own
 /// doc comment: hijacking the test runner's stdout to exercise the fd
 /// plumbing would be the tail wagging the dog), so this is fd-free logic, not
 /// glue. On `main`, `drain_shared` does not exist at all.
 #[test]
 fn drain_shared_skips_a_pump_thread_draining_itself_but_runs_from_anywhere_else() {
     let cell = Arc::new(Mutex::new(Some(ConsoleGuard {
-        streams: Vec::new(),
+        pumps: Arc::new(Drainable {
+            streams: Mutex::new(Vec::new()),
+        }),
     })));
 
     // Called as if FROM a pump thread: a no-op, or a real pump trying to

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -176,10 +176,7 @@ fn render(rows: &[ClaimRow], all: bool) -> String {
     }
 
     let live = rows.iter().filter(|r| r.live).count();
-    out.push_str(&format!(
-        "\n  {} claim(s), {live} live\n\n",
-        rows.len()
-    ));
+    out.push_str(&format!("\n  {} claim(s), {live} live\n\n", rows.len()));
     out
 }
 
@@ -241,7 +238,10 @@ mod tests {
         let out = render(&rows, false);
         assert!(out.contains("task:fix-1136"), "the unit of work: {out}");
         assert!(out.contains("run-8f21a3-41207"), "the holder: {out}");
-        assert!(out.contains("held 3m 00s"), "how long they have had it: {out}");
+        assert!(
+            out.contains("held 3m 00s"),
+            "how long they have had it: {out}"
+        );
         assert!(out.contains("expires in 12m 00s"), "when it lapses: {out}");
         assert!(out.contains("1 claim(s), 1 live"), "the tally: {out}");
     }
@@ -252,14 +252,23 @@ mod tests {
     fn a_lapsed_claim_says_who_held_it_and_how_long_ago_it_went() {
         let now = 600_000;
         let rows = vec![
-            ClaimRow::read(&claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000), now),
-            ClaimRow::read(&claim("task:live", "run-8f21a3-41207", 590_000, 900_000), now),
+            ClaimRow::read(
+                &claim("issue:1136", "run-2b90cc-41999", 60_000, 480_000),
+                now,
+            ),
+            ClaimRow::read(
+                &claim("task:live", "run-8f21a3-41207", 590_000, 900_000),
+                now,
+            ),
         ];
 
         let out = render(&rows, true);
         assert!(out.contains("run-2b90cc-41999"), "the dead holder: {out}");
         assert!(out.contains("lapsed 2m 00s ago"), "when it went: {out}");
-        assert!(out.contains("expires in 5m 00s"), "the live one stays: {out}");
+        assert!(
+            out.contains("expires in 5m 00s"),
+            "the live one stays: {out}"
+        );
         assert!(out.contains("2 claim(s), 1 live"), "the tally: {out}");
         assert!(!rows[0].live && rows[1].live);
     }
@@ -316,7 +325,11 @@ mod tests {
     fn spans_render_in_one_fixed_shape() {
         assert_eq!(human_ms(0), "0s");
         assert_eq!(human_ms(45_000), "45s");
-        assert_eq!(human_ms(-45_000), "45s", "the caller's wording carries the sign");
+        assert_eq!(
+            human_ms(-45_000),
+            "45s",
+            "the caller's wording carries the sign"
+        );
         assert_eq!(human_ms(750_000), "12m 30s");
         assert_eq!(human_ms(11_040_000), "3h 04m");
     }
@@ -352,9 +365,6 @@ mod tests {
 
         // And the documented escape hatch still works: `--` makes it a prompt.
         let cli = Cli::try_parse_from(["stella", "fleet", "--", "claims are stale"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Fleet { cmd: None, .. }
-        ));
+        assert!(matches!(cli.command, Command::Fleet { cmd: None, .. }));
     }
 }

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -340,31 +340,36 @@ mod tests {
     fn fleet_claims_parses_as_a_verb_and_defaults_to_live_text() {
         let cli = Cli::try_parse_from(["stella", "fleet", "claims"]).unwrap();
         match cli.command {
-            Command::Fleet {
+            Some(Command::Fleet {
                 cmd: Some(crate::fleet_verbs::FleetCmd::Claims { all, format }),
                 ..
-            } => {
+            }) => {
                 assert!(!all, "the live listing is the default");
                 assert_eq!(format, QueryFormat::Text);
             }
-            other => panic!("expected `fleet claims`, got {other:?}"),
+            // `Command` carries no `Debug`, so the failure says which verb was
+            // expected rather than printing the one that parsed.
+            _ => panic!("expected `fleet claims` to parse as the Claims verb"),
         }
 
         let cli = Cli::try_parse_from(["stella", "fleet", "claims", "--all", "--format", "json"])
             .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Fleet {
+            Some(Command::Fleet {
                 cmd: Some(crate::fleet_verbs::FleetCmd::Claims {
                     all: true,
                     format: QueryFormat::Json
                 }),
                 ..
-            }
+            })
         ));
 
         // And the documented escape hatch still works: `--` makes it a prompt.
         let cli = Cli::try_parse_from(["stella", "fleet", "--", "claims are stale"]).unwrap();
-        assert!(matches!(cli.command, Command::Fleet { cmd: None, .. }));
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fleet { cmd: None, .. })
+        ));
     }
 }

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -316,9 +316,15 @@ mod tests {
         assert_eq!(row.expires_in_ms, -120_000);
         assert!(!row.live);
 
-        // A claim minted by a clock ahead of ours must not wrap into the past.
+        // A claim minted by a clock ahead of ours must not wrap: an expiry in
+        // the far future stays far in the future (positive, saturated rather
+        // than overflowed), and an acquisition in the far future reads as
+        // negative time held — which is nonsense to a human, and exactly the
+        // nonsense that says "these two clocks disagree" instead of quietly
+        // presenting a lapsed claim as live.
         let skewed = ClaimRow::read(&claim("issue:1", "run-a", u64::MAX, u64::MAX), 0);
-        assert!(skewed.expires_in_ms < 0 && skewed.held_for_ms < 0);
+        assert_eq!(skewed.expires_in_ms, i64::MAX);
+        assert!(skewed.held_for_ms < 0);
     }
 
     #[test]


### PR DESCRIPTION
`main` has not compiled since `366472e0`. Three independent breakages, all from merges landing against a stale base — none of them a defect in the feature they came with.

## 1. Two PRs shipped #1616, and their squash blended into something that never compiled

#1682 and #1695 both implemented the parked-review deadline and the panic console drain. Both merged. What is on `main` is half of each:

- `SidecarApprovalGate` declares `deadline` (from #1695) while `next_poll` reads `self.wait` and the loop's expiry arm reads `parked_at`, a local that the other side had named `started` — three names for two things, none of which resolve.
- Two expiry paths sat in the same loop: an eager check at the top and a `next_poll`-driven one at the bottom, each with its own "timed out" message.
- Two mappings of the same setting: `AgentEngineConfig::approval_wait()` (wired, called from `agent/engine.rs::approval_gate_for`) and `daemon::approval::park_deadline` (orphaned).
- `drain_shared` landed inside `impl Drainable`, which is `#[cfg(unix)]`, while both call sites — `install_panic_drain` and `main.rs` — look for it on `ConsoleGuard`, which is not.
- `arm_panic_drain` (#1682's hook) was left behind unused beside `install_panic_drain` (#1695's, which is the one `main.rs` calls and the better of the two: release builds are `panic = "abort"`, so draining *before* the previous hook prints is what actually saves the message).

Resolved by keeping one of each, and the better one where they differed:

| Kept | Dropped | Why |
|---|---|---|
| `deadline` field + `with_deadline` | `wait` / `with_wait` | The field the constructor and both test suites already use. |
| `next_poll` clipping the nap to what is left | the eager top-of-loop check | One expiry path, one message — and clipping honours a 1s deadline to the second instead of to the 250ms poll grid. |
| `AgentEngineConfig::approval_wait()` | `park_deadline` | The wired one. Its `0 = park forever` contract keeps its test, retargeted. |
| `install_panic_drain` + `drain_shared` (re-homed onto `ConsoleGuard`) | `arm_panic_drain` | Correct under `panic = "abort"`, and the only one `main.rs` calls. |

Both PRs' tests survive — nine between them, including both witnesses.

## 2. The `stella-cli` test target did not compile either

Invisible to `cargo build`, which is presumably how it got in:

- `daemon/console/tests.rs` constructs `ConsoleGuard { streams: Vec::new() }` — the field name from before the merge took the other side's `pumps: Arc<Drainable>`.
- `fleet_claims.rs`'s parse test (#1680) matches `cli.command` as a bare `Command`; it is an `Option<Command>` on `main`, and `Command` has no `Debug` for the test's `{other:?}` arm.

## 3. #1680's clock-skew assertion contradicts its own comment

`a_lapsed_claim_reports_a_negative_time_to_expiry` asserts a claim minted by a clock far ahead of ours reports `expires_in_ms < 0`. `delta_ms` saturates rather than wrapping, so an expiry in the far future stays far in the future — **positive** — which is exactly what the comment above it ("must not wrap into the past") asks for. The implementation is right and the assertion could never hold; it now asserts the saturation (`i64::MAX`) and keeps the negative assertion for `held_for_ms`, where a future acquisition genuinely does read as negative time held.

## Verification

- `cargo build -p stella-cli` — clean.
- `cargo test -p stella-cli --bin stella` — **1408 passed, 0 failed** (it was 1 failed / would-not-compile before).
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean.
- `cargo doc -p stella-cli --no-deps` — clean.
- `cargo fmt --all --check` — clean.

Refs #1616, #1136. Follow-up for the duplicate-PR process failure itself is #1645 (red PRs keep landing on main).

## Summary by Sourcery

Restore the stella-cli crate to a compiling, passing state by reconciling duplicated #1616 changes, fixing CLI parsing and console guard usage, and aligning tests with the intended timekeeping and configuration semantics.

Bug Fixes:
- Unify the sidecar approval gate’s deadline handling and timeout messaging so parked reviews time out correctly based on the configured approval_wait setting.
- Fix the panic-drain integration by exposing drain_shared on ConsoleGuard and removing the unused alternative panic hook implementation.
- Update console tests to construct ConsoleGuard with the current pumps field layout so the test target compiles again.
- Correct fleet claims parsing tests to match the Command being optional and avoid relying on a nonexistent Debug implementation.
- Align the clock-skew assertion in fleet claims tests with the saturating delta_ms behaviour, ensuring future-dated claims are treated as far-future expiries instead of negative.
- Ensure AgentEngineConfig::approval_wait drives the approval deadline semantics, preserving the documented “0 means park forever” behaviour.

Enhancements:
- Simplify approval gate polling by having a single next_poll-based expiry path and consistent timeout message.
- Clarify tests and comments around fleet claim rendering, clock skew behaviour, and panic-drain expectations.

Tests:
- Adjust and extend stella-cli tests for approval deadlines, fleet claim parsing, and console draining so they accurately exercise the fixed behaviour and all test targets compile and pass.