### PR TITLE
docs(stella-cli): the deadline witness named a builder that never survived

### DIFF
--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -517,9 +517,8 @@ mod tests {
     /// The #1616 witness: with `approval_wait_secs` armed, a review nobody
     /// answers unparks itself as an abort instead of waiting forever — and it
     /// hands the record back rather than leaving it stuck on `Needs Input`.
-    /// On `main` a gate has no deadline to arm (`with_deadline` does not
-    /// exist),
-    /// so this is a type-level witness as well as a behavioural one.
+    /// Before #1616 a gate had no deadline to arm (`with_wait` did not
+    /// exist), so this is a type-level witness as well as a behavioural one.
     #[tokio::test]
     async fn an_expired_deadline_unparks_an_unanswered_review_as_an_abort() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
The last stale reference left by the #1682 / #1695 / #1717 collision.

`daemon::approval::tests::an_expired_deadline_unparks_an_unanswered_review_as_an_abort`'s doc comment credits its fail-half to `with_deadline` — #1695's name for the builder, which lost the reconciliation. The method is `with_wait`, so the sentence names a symbol that does not exist and never will.

It also said "On `main` a gate has no deadline to arm", which stopped being true the moment #1616 landed. Reworded to "Before #1616", which stays true for as long as the test does.

Comment only — no behaviour, no witness needed. `cargo fmt --all` clean; the file compiles and its tests pass unchanged (`cargo test -p stella-cli --bin stella daemon::approval`, 9 passed).

Refs #1712, #1720.

## Summary by Sourcery

Documentation:
- Update the test doc comment to reference the correct `with_wait` builder name and accurately describe the pre-#1616 behaviour of gates without deadlines.