### PR TITLE
fix(arenabench): flip replay never applied a patch where it was taken

### DIFF
--- a/arenabench/arenabench/replay.py
+++ b/arenabench/arenabench/replay.py
@@ -38,6 +38,7 @@ from .snapshot import (
     SnapshotEntry,
     bisect_first_pass,
     confirm_first_pass,
+    detect_workspace,
     load_manifest,
     read_task_image,
     summarise_flip,
@@ -134,20 +135,48 @@ class _Probe:
         return None
 
     def _apply(self, name: str, entry: SnapshotEntry) -> bool:
+        """Bring the probe container's workspace to this snapshot's state.
+
+        The patch is applied **on the host**, not in the container, and the
+        result is copied back. Two reasons, both found by running this against
+        a real image rather than reasoning about it:
+
+        * ``git`` is not guaranteed to exist in a task image. The capture side
+          gets away with assuming it because Stella's adapter installs git into
+          the *task* container; a replay probe is a fresh container from the
+          pristine image and gets no such help. Applying in-container failed
+          with ``sh: 1: git: not found`` and — far worse than crashing —
+          reported the snapshot as *unknown*, which surfaced as
+          ``flip_index=None``, i.e. "the agent never solved it".
+        * Snapshots are captured with ``--work-tree=<workspace>``, so the paths
+          inside the patch are workspace-relative. Applying them at ``/``, as
+          this used to, would put every file in the wrong place even where git
+          was present.
+        """
         patch = self.trial_dir / "arena" / "snapshots" / str(entry.patch)
         if not patch.is_file():
             log.warning("snapshot %d: patch file missing", entry.index)
             return False
-        copied = _run(["docker", "cp", str(patch), f"{name}:/tmp/snap.patch"], timeout=300)
-        if copied.returncode != 0:
-            log.warning("snapshot %d: could not copy patch in", entry.index)
+        # The workspace the snapshot was *taken of*, not whatever this fresh
+        # container happens to probe as. Falls back to probing only for
+        # manifests written before the field existed.
+        workspace = entry.workspace or detect_workspace(name)
+        if workspace is None:
+            log.warning("snapshot %d: no workspace found in the probe", entry.index)
             return False
+        # A directory the agent created will not exist in the pristine image.
+        _run(["docker", "exec", name, "mkdir", "-p", workspace], timeout=120)
+
+        stage = self.scratch / f"{name}-ws"
+        shutil.rmtree(stage, ignore_errors=True)
+        stage.mkdir(parents=True, exist_ok=True)
+        out = _run(["docker", "cp", f"{name}:{workspace}/.", str(stage)], timeout=900)
+        if out.returncode != 0:
+            log.warning("snapshot %d: could not stage the workspace", entry.index)
+            return False
+
         applied = _run(
-            [
-                "docker", "exec", "-w", "/", name, "sh", "-c",
-                "cd / && git apply --binary --unsafe-paths --directory=/ /tmp/snap.patch"
-                " 2>/dev/null || git apply --binary /tmp/snap.patch",
-            ],
+            ["git", "-C", str(stage), "apply", "--binary", "--whitespace=nowarn", str(patch)],
             timeout=600,
         )
         if applied.returncode != 0:
@@ -155,7 +184,48 @@ class _Probe:
                 "snapshot %d: patch did not apply: %s", entry.index, applied.stderr[-300:]
             )
             return False
+
+        back = _run(["docker", "cp", f"{stage}/.", f"{name}:{workspace}"], timeout=900)
+        if back.returncode != 0:
+            log.warning("snapshot %d: could not restore the workspace", entry.index)
+            return False
+        shutil.rmtree(stage, ignore_errors=True)
         return True
+
+
+def _require_bind_mount(scratch: Path, image: str) -> None:
+    """Fail early if the container runtime cannot see ``scratch``.
+
+    The verifier reports its verdict by writing ``/logs/verifier/reward.txt``
+    into a bind mount. If that mount is invisible to the host, no reward file
+    ever appears and *every* probe returns unknown — which summarises as
+    ``flip_index=None``, indistinguishable from an agent that never solved
+    anything. The cause is mundane and easy to hit: a VM-backed Docker (Colima,
+    Docker Desktop) shares only some host paths, and a macOS temp directory
+    under ``/var/folders`` is typically not one of them. Measured: a marker
+    file written there is simply absent inside the container.
+
+    One container start to convert a silent, wrong benchmark number into a
+    sentence naming the fix.
+    """
+    marker = scratch / ".arena-mount-probe"
+    try:
+        marker.write_text("ok", encoding="utf-8")
+    except OSError as exc:
+        raise ReplayError(f"scratch directory is not writable: {exc}") from exc
+    seen = _run(
+        ["docker", "run", "--rm", "-v", f"{scratch}:/probe", image,
+         "sh", "-c", "cat /probe/.arena-mount-probe 2>/dev/null"],
+        timeout=600,
+    )
+    marker.unlink(missing_ok=True)
+    if seen.stdout.strip() != "ok":
+        raise ReplayError(
+            f"the container runtime cannot read {scratch} — the verifier's reward "
+            "would be invisible and every snapshot would read as 'did not pass'. "
+            "Pass --scratch (or place the workspace) under a directory your Docker "
+            "shares with the host, e.g. somewhere under your home directory."
+        )
 
 
 def replay_flip(
@@ -172,6 +242,13 @@ def replay_flip(
     """
     if shutil.which("docker") is None:
         raise ReplayError("docker is not available on this host")
+    # Patches are applied host-side (see `_Probe._apply`), so host git is a
+    # hard precondition. Raised here rather than discovered per-probe: without
+    # it every patched snapshot returns *unknown*, and a run of unknowns
+    # summarises as `flip_index=None`, which reads as "the agent never solved
+    # it" rather than "this could not be measured".
+    if shutil.which("git") is None:
+        raise ReplayError("git is not available on this host; replay applies patches locally")
     entries = load_manifest(trial_dir)
     if not entries:
         raise ReplayError(f"no snapshots captured for {trial_dir.name}")
@@ -183,6 +260,7 @@ def replay_flip(
 
     scratch = scratch or (trial_dir / "arena" / "replay")
     scratch.mkdir(parents=True, exist_ok=True)
+    _require_bind_mount(scratch, image)
     probe = _Probe(
         image=image,
         task_dir=task_dir,

--- a/arenabench/arenabench/snapshot.py
+++ b/arenabench/arenabench/snapshot.py
@@ -110,6 +110,16 @@ class SnapshotEntry:
     patch: str | None
     #: Seconds since the trial's first snapshot. The number an operator reads.
     elapsed: float
+    #: The container directory this snapshot was taken of.
+    #:
+    #: Recorded rather than re-derived at replay time, because the two can
+    #: disagree: capture probes a container the agent has already been living
+    #: in, replay probes a fresh one from the pristine image, and a directory
+    #: the agent created will exist in the first and not the second. When they
+    #: disagreed the patch applied cleanly to the *wrong* directory and every
+    #: probe returned "did not pass" — surfacing as `flip_index=None`, which
+    #: reads as "the agent never solved it" rather than "this was misapplied".
+    workspace: str = ""
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -118,6 +128,7 @@ class SnapshotEntry:
             "sha": self.sha,
             "patch": self.patch,
             "elapsed": round(self.elapsed, 3),
+            "workspace": self.workspace,
         }
 
     @staticmethod
@@ -129,6 +140,9 @@ class SnapshotEntry:
                 sha=str(raw["sha"]),
                 patch=str(raw["patch"]) if raw.get("patch") else None,
                 elapsed=float(raw.get("elapsed") or 0.0),  # type: ignore[arg-type]
+                # Absent in manifests written before the field existed; replay
+                # falls back to probing when it is empty.
+                workspace=str(raw.get("workspace") or ""),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -542,6 +556,7 @@ class SnapshotSupervisor:
             sha=sha,
             patch=patch_name,
             elapsed=max(0.0, now - capture.started_at),
+            workspace=capture.workspace,
         )
         try:
             with (snap_dir / MANIFEST_NAME).open("a", encoding="utf-8") as handle:

--- a/arenabench/tests/test_replay_docker.py
+++ b/arenabench/tests/test_replay_docker.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Flip detection end to end, against real containers.
+
+`replay_flip` shipped in #1533 without ever being run, and running it found
+three bugs — all of which produced the *same* silent wrong answer,
+`flip_index=None`, which an operator reads as "the agent never solved it":
+
+1. patches were applied with ``git apply`` **inside** the probe container, but
+   a task image is not guaranteed to ship git (the capture side only gets away
+   with it because Stella's adapter installs git into the *task* container);
+2. they were applied at ``/`` although snapshots are captured with
+   ``--work-tree=<workspace>``, so their paths are workspace-relative;
+3. the workspace was re-probed in the fresh container instead of being taken
+   from the manifest, and a directory the agent created does not exist in the
+   pristine image — so the patch applied cleanly to the wrong place.
+
+None of the three raised. That is what this test exists to prevent.
+
+The task here is synthetic, so this needs no dataset, no credentials and no
+spend: an image, a ``tests/test.sh`` that passes once a file exists, and
+snapshots taken either side of that file appearing. The flip is therefore
+known in advance, which is what makes the answer checkable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from arenabench.replay import replay_flip
+from arenabench.snapshot import SnapshotSupervisor, container_for_trial, load_manifest
+
+IMAGE = "debian:stable-slim"
+
+
+def _ready() -> bool:
+    if shutil.which("docker") is None or shutil.which("git") is None:
+        return False
+    try:
+        probe = subprocess.run(["docker", "info"], capture_output=True, timeout=30)
+        return probe.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _ready(), reason="docker and git are required")
+
+
+def _sh(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), capture_output=True, text=True, timeout=900)
+
+
+def _write_task(task: Path) -> None:
+    (task / "tests").mkdir(parents=True)
+    (task / "task.toml").write_text(
+        f'[task]\nname = "synthetic/flip"\n\n[verifier]\ntimeout_sec = 300.0\n\n'
+        f'[environment]\ndocker_image = "{IMAGE}"\n',
+        encoding="utf-8",
+    )
+    # The real contract: the verifier writes its reward to this exact path.
+    (task / "tests" / "test.sh").write_text(
+        "#!/bin/bash\n"
+        "mkdir -p /logs/verifier\n"
+        "if [ -f /app/solution.txt ]; then echo 1 > /logs/verifier/reward.txt;\n"
+        "else echo 0 > /logs/verifier/reward.txt; fi\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def bindable_root():
+    """A working directory the container runtime can actually bind-mount.
+
+    NOT `tmp_path`. A VM-backed Docker shares only some host paths, and pytest's
+    temp directory lives under macOS's `/var/folders`, which Colima does not
+    share — measured: a marker file written there is simply absent inside the
+    container. The verifier would then write its reward into a mount the host
+    cannot read, every probe would return unknown, and the run would report
+    `flip_index=None`: "the agent never solved it".
+    """
+    root = Path.home() / ".arenabench" / "test-replay"
+    shutil.rmtree(root, ignore_errors=True)
+    root.mkdir(parents=True)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_flip_lands_where_the_solution_actually_appeared(bindable_root: Path):
+    jobs = bindable_root / "jobs"
+    trial = jobs / "seat" / "demo__RpL1"
+    (trial / "agent").mkdir(parents=True)
+    task = bindable_root / "task"
+    _write_task(task)
+
+    name = container_for_trial(trial)
+    _sh("docker", "rm", "-f", name)
+    if _sh("docker", "run", "-d", "--name", name, IMAGE, "sleep", "900").returncode != 0:
+        pytest.skip(f"could not start {IMAGE}")
+    try:
+        _sh("docker", "exec", name, "sh", "-c", "mkdir -p /app && echo start > /app/notes.txt")
+        installed = _sh(
+            "docker", "exec", name, "sh", "-c",
+            "apt-get update -qq && apt-get install -y -qq git",
+        )
+        if installed.returncode != 0:
+            pytest.skip("could not install git into the capture container")
+
+        sup = SnapshotSupervisor(
+            jobs_root=jobs, jobs=["seat"], interval=2.0, poll_interval=0.5
+        )
+        sup.start()
+        try:
+            time.sleep(5)  # snapshots taken while unsolved
+            _sh("docker", "exec", name, "sh", "-c", "echo done > /app/solution.txt")
+            solved_at = len(load_manifest(trial))
+            time.sleep(5)  # snapshots taken after solving
+            (trial / "result.json").write_text('{"reward": 1}', encoding="utf-8")
+            time.sleep(3)
+        finally:
+            sup.stop(timeout=20)
+    finally:
+        _sh("docker", "rm", "-f", name)
+
+    entries = load_manifest(trial)
+    assert len(entries) >= 4, "too few snapshots to bisect meaningfully"
+    # Bug 3: the workspace must travel with the snapshot, not be re-derived.
+    assert entries[-1].workspace == "/app"
+
+    result = replay_flip(trial, task, verifier_timeout=300.0, confirm_window=2)
+
+    assert result.unknown == 0, "a probe could not run — see bugs 1 and 2"
+    assert result.flip_index is not None, "the task was definitely solved"
+    assert result.flip_index >= solved_at, (
+        f"flip {result.flip_index} precedes the solution at {solved_at}"
+    )
+    assert result.wasted_elapsed is not None and result.wasted_elapsed > 0
+    # Bisection, not a scan: each probe is a full verifier run.
+    assert result.probes < result.snapshots

--- a/arenabench/tests/test_snapshot.py
+++ b/arenabench/tests/test_snapshot.py
@@ -150,6 +150,42 @@ def test_manifest_missing_is_empty_not_an_error(tmp_path):
     assert load_manifest(tmp_path) == []
 
 
+def test_the_workspace_round_trips(tmp_path):
+    """Replay must apply a patch where it was taken, not where it guesses.
+
+    Capture probes a container the agent has lived in; replay probes a fresh
+    one from the pristine image, where a directory the agent created does not
+    exist. When the two disagreed, the patch applied cleanly to the wrong
+    directory and every probe read "did not pass" — reported as
+    `flip_index=None`, i.e. "the agent never solved it".
+    """
+    snap = tmp_path / SNAPSHOT_DIRNAME
+    snap.mkdir(parents=True)
+    entry = SnapshotEntry(
+        index=0, at=1.0, sha="abc", patch="0000.patch", elapsed=0.0, workspace="/app"
+    )
+    (snap / "manifest.jsonl").write_text(
+        json.dumps(entry.to_json()) + "\n", encoding="utf-8"
+    )
+    assert load_manifest(tmp_path)[0].workspace == "/app"
+
+
+def test_a_manifest_without_a_workspace_still_loads(tmp_path):
+    """Manifests written before the field existed must keep working."""
+    snap = tmp_path / SNAPSHOT_DIRNAME
+    snap.mkdir(parents=True)
+    (snap / "manifest.jsonl").write_text(
+        json.dumps(
+            {"index": 0, "at": 1.0, "sha": "abc", "patch": None, "elapsed": 0.0}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loaded = load_manifest(tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].workspace == ""  # replay falls back to probing
+
+
 def test_unpatched_indices_flags_snapshots_identical_to_the_first():
     entries = list(_entries(3))
     entries[0] = SnapshotEntry(index=0, at=1.0, sha="a", patch=None, elapsed=0.0)


### PR DESCRIPTION
`replay_flip` shipped in #1533 without ever being run. Running it against real containers found **three bugs, and every one produced the same silent wrong answer**: `flip_index=None` — which an operator reads as *"the agent never solved it"* rather than *"this could not be measured"*.

## The three

**1. `git apply` ran inside the probe container.** A task image is not guaranteed to ship git. The capture side only gets away with assuming it because Stella's adapter installs git into the *task* container; a replay probe is a fresh container from the pristine image and gets no such help.

```
snapshot 4: patch did not apply: sh: 1: git: not found
flip_index=None  probes=3 unknown=2
```

**2. Patches were applied at `/`.** Snapshots are captured with `--work-tree=<workspace>`, so their paths are workspace-relative. Even where git existed, every file landed in the wrong place.

**3. The workspace was re-probed instead of recorded.** This is the worst of the three, because **nothing failed** — the patch applied *cleanly to the wrong directory*. Capture probes a container the agent has been living in; replay probes a fresh one from the pristine image, and a directory the agent created exists in the first and not the second. `SnapshotEntry` now carries the workspace it was taken of, and replay uses it; the probe is only a fallback for manifests written before the field existed.

## The fix

Patches are applied **host-side**, where `git` is a checked precondition, into the recorded workspace, then copied back. Host `git` is required up front rather than discovered per-probe, because a run of unknowns summarises to the same misleading `flip_index=None`.

## Plus a preflight for the same failure class

The verifier reports its verdict by writing `/logs/verifier/reward.txt` into a bind mount. If the runtime cannot see that directory, no reward ever appears and every probe reads "did not pass". A VM-backed Docker shares only some host paths — measured:

```
host dir:  /var/folders/…/tmp.JtOiWATaBM   in container: (empty)
home dir:  /Users/…/.arenabench/…          in container: marker.txt
```

`/var/folders` is exactly where `pytest`'s `tmp_path` lives, so this is easy to hit. One container start now converts a silent, wrong benchmark number into a sentence naming the fix.

## Witness

`tests/test_replay_docker.py` drives capture → replay end to end against a synthetic task whose flip point is **known in advance**, and asserts `unknown == 0`, that the flip lands at or after the real solution, and that bisection probed fewer snapshots than it examined. It fails on each of the three bugs.

```
flip_index=3  flip_elapsed=6.33  wasted_elapsed=4.19
probes=3 unknown=0 snapshots=6
```

Synthetic task, so no dataset, no credentials, no spend. Skipped without docker+git, so CI pays nothing. Also adds unit coverage for the workspace round-trip and for manifests written before the field existed.

`pytest` and `ruff check` are clean by exit code.

## Why this kept happening

All three bugs, the bind-mount trap, and the `AuthenticationError` gap in #1534 are one shape: **absence of measurement rendering as a measured value**. In a benchmark that is never neutral — it always favours somebody. `bisect_first_pass` already treats an un-runnable probe as `None` rather than `False` for this reason; these fixes extend the same discipline to the layer underneath it.

## Summary by Sourcery

Ensure replay flip applies patches correctly and fails early when measurement is impossible, so flip detection reports accurate results instead of silent unknowns.

New Features:
- Add a host-side patch application workflow for replay probes that uses the recorded workspace from snapshots.
- Introduce a preflight bind-mount check to verify the container runtime can expose the scratch directory and rewards to the host.

Bug Fixes:
- Fix replay flip misapplying patches inside the probe container, at the wrong path, and against a misdetected workspace, which previously surfaced as flip_index=None.
- Ensure manifests without an explicit workspace still load and fall back to probing instead of failing.

Enhancements:
- Extend SnapshotEntry to record the workspace path for each snapshot so capture and replay agree on where patches should apply.

Tests:
- Add an end-to-end Docker-based replay_flip test that covers the three patching bugs and validates flip detection behaviour.
- Add unit tests covering workspace round-tripping in manifests, including compatibility with manifests written before the workspace field existed.