### PR TITLE
feat(tui): regroup the statline zones — pin, step counter, lane count

### DIFF
--- a/stella-tui/src/cache_panel.rs
+++ b/stella-tui/src/cache_panel.rs
@@ -170,6 +170,54 @@ pub(crate) fn fmt_tokens(n: u64) -> String {
     }
 }
 
+/// The whole SESSION VITALS cache row: `cache 50% hit · 105.3M rd · 40.0K wr
+/// ·  warmth 4:12  ·  saved $1.23`, for the lane at `focused`.
+///
+/// Built here rather than inline in `deck_render` for the reason this module
+/// exists: the formatting is then unit-testable without a frame, and the
+/// overlay renderer stays a layout function. `saved` joined this row when the
+/// statline's zone C narrowed to `turn` + `run` — it is a cumulative session
+/// total, so it answers a question asked at the end of a run, not one glanced
+/// at mid-turn.
+pub fn vitals_spans(model: &WorkspaceModel, focused: usize) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(theme::TEXT_TERTIARY);
+    let ink = Style::default().fg(theme::INK);
+    let savings = model.total_cache_savings_usd();
+    vec![
+        Span::styled("  cache ", dim),
+        Span::styled(
+            cache_volumes(
+                model.cache_hit_tokens(),
+                model.total_cache_write_tokens(),
+                model.total_input_tokens(),
+            ),
+            ink,
+        ),
+        Span::styled("  ·  warmth ", dim),
+        Span::styled(
+            fmt_warmth(
+                model
+                    .agents
+                    .get(focused)
+                    .and_then(|a| a.cache_warmth_secs(model.now_ms)),
+            ),
+            ink,
+        ),
+        Span::styled("  ·  saved ", dim),
+        Span::styled(
+            fmt_savings(savings),
+            // Negative savings — the write premium outran the reads it bought
+            // — is the incident worth surfacing, so it keeps its own color
+            // rather than reading as an ordinary total.
+            if savings < 0.0 {
+                Style::default().fg(theme::DANGER_BRIGHT)
+            } else {
+                Style::default().fg(theme::SUCCESS_BRIGHT)
+            },
+        ),
+    ]
+}
+
 /// The statline's optional second row: a low-hit-rate diagnosis, prefixed
 /// with a warning glyph and rendered in `CacheCause::hint`'s full-sentence
 /// wording — byte-identical to what `stella stats` prints for the same
@@ -303,6 +351,28 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn the_vitals_row_carries_volumes_warmth_and_the_savings_that_left_the_statline() {
+        let mut m = WorkspaceModel::new();
+        m.now_ms = 1_000;
+        m.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        {
+            let a = &mut m.agents[0];
+            a.tokens_in = 200_000;
+            a.cache_read_tokens = 150_000;
+            a.cache_write_tokens = 40_000;
+            a.cache_savings_usd = 1.23;
+        }
+        let text: String = vitals_spans(&m, 0)
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(text.contains("75% hit · 150.0K rd · 40.0K wr"), "{text}");
+        assert!(text.contains("warmth"), "{text}");
+        // The figure zone C stopped carrying has to live somewhere.
+        assert!(text.contains("saved $1.23"), "{text}");
     }
 
     #[test]

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -726,31 +726,18 @@ fn render_context_overlay(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, b
     }
 
     // The session vitals that left the statline (D1): cache volumes, the
-    // warmth countdown, engine and pipeline state. Diagnostics, not
-    // glanceables — this overlay is where a reader who wants them looks.
+    // savings figure, the warmth countdown, engine and pipeline state.
+    // Diagnostics, not glanceables — this overlay is where a reader who wants
+    // them looks. `saved` joined them when zone C narrowed to `turn` + `run`:
+    // it is a cumulative session total, so it answers a question asked at the
+    // end of a run, not one glanced at mid-turn.
     lines.push(Line::default());
     lines.push(Line::from(Span::styled(
         "  SESSION VITALS",
         theme::accent().add_modifier(Modifier::BOLD),
     )));
     let dim = Style::default().fg(theme::TEXT_TERTIARY);
-    let focused = model.agents.get(ui.focused);
-    lines.push(Line::from(vec![
-        Span::styled("  cache ", dim),
-        Span::styled(
-            cache_panel::cache_volumes(
-                model.cache_hit_tokens(),
-                model.total_cache_write_tokens(),
-                model.total_input_tokens(),
-            ),
-            Style::default().fg(theme::INK),
-        ),
-        Span::styled("  ·  warmth ", dim),
-        Span::styled(
-            cache_panel::fmt_warmth(focused.and_then(|a| a.cache_warmth_secs(model.now_ms))),
-            Style::default().fg(theme::INK),
-        ),
-    ]));
+    lines.push(Line::from(cache_panel::vitals_spans(model, ui.focused)));
     lines.push(Line::from(vec![
         Span::styled("  engine ", dim),
         Span::styled(

--- a/stella-tui/src/deck_render/tests.rs
+++ b/stella-tui/src/deck_render/tests.rs
@@ -54,9 +54,11 @@ fn full_deck_frame_composes_every_band_at_80_cols() {
                 "deck @{w}×{h} missing {needle:?}:\n{text}"
             );
         }
-        // The full zone set needs the width; at 190 every zone renders.
+        // The full zone set needs the width; at 190 every zone renders. The
+        // hit rate rides `ctx` and `saved` moved to the context overlay, so
+        // neither is its own cell here any more.
         if w >= 120 {
-            for needle in ["ctx", "cpu", "cache", "turn $", "run $", "saved"] {
+            for needle in ["ctx", "% hit)", "cpu", "session", "turn $", "run $"] {
                 assert!(
                     text.contains(needle),
                     "deck @{w}×{h} missing zone item {needle:?}:\n{text}"

--- a/stella-tui/src/statline.rs
+++ b/stella-tui/src/statline.rs
@@ -2,25 +2,67 @@
 //! separated by a single `│` divider in the theme's divider color (D1):
 //!
 //! ```text
-//! ✦ lead · lead · ● execute │ ctx 35k/200k · cpu 73% · cache 85% │ turn $0.99 · run $1.00 · saved $2.87 │   ✉ 29 · queue empty
-//! └─ zone A: identity ──────┘└─ zone B: resources ─────────────┘└─ zone C: money ─────────────────────┘ └─ zone D: attention ─┘
+//! ✦ triage (glm-5.1-fast) ● execute 1/3 │ ctx 35k/200k (78% hit) · cpu 73% · 3 sessions │ turn $0.99 · run $1.00 │        ✉ 29 · queue empty
+//! └─ zone A: identity ────────┘      step#/steps  └─ zone B: resources ──────────────┘            └─ zone C: money ───────┘ └─ zone D: attention (right-aligned)
 //! ```
 //!
-//! Zone A is identity (brand glyph + focused agent + role + stage dot), B is
-//! resources (`ctx` · `cpu` · `cache` hit-rate), C is money (`turn` · `run
-//! [of cap]` · `saved`), D is attention (`✉` unread + queue status,
-//! right-aligned, plus `✦/◆` lane counts when subagents exist). WARMTH,
-//! ENGINE and PIPELINE left this row for the context overlay / SETTINGS —
+//! Zone A is identity (brand glyph + focused lane + the pin it runs on +
+//! stage dot + step counter), B is resources (`ctx` with its cache hit-rate ·
+//! `cpu` · live lane count), C is money (`turn` · `run [of cap]`), D is
+//! attention (`✉` unread + queue status, right-aligned, plus `✦/◆` lane
+//! counts when subagents exist). WARMTH, ENGINE, PIPELINE and the cache
+//! `saved` figure live in the context overlay's SESSION VITALS —
 //! diagnostics, not glanceables — and the MODELS row is gone outright
-//! (routing lives on the scope card and `/models`).
+//! (routing lives on the scope card and `/models`; zone A names only the pin
+//! the focused lane runs on).
+//!
+//! The lane's free-form `role` left this row with the regroup. For the lead
+//! it never rendered anyway — the driver registers id and role both as
+//! `"lead"`, and the cell was suppressed as a repeat — and for a subagent it
+//! restated what `sub:` in the id and zone D's `◆ N sub` already say. What it
+//! cost was legibility: `✦ triage lead (glm-5.1-fast)` is two bare words
+//! space-joined with no way to tell which is the lane.
+//!
+//! ## Zone A joins with a space, everywhere else with `·`
+//!
+//! Identity is one phrase, not a list: `✦ triage (glm-5.1-fast) ● execute
+//! 1/3` reads as a sentence about who is working, on what, and where they
+//! are. Zones B/C/D are enumerations of independent facts and keep the ` · `
+//! join. `separator` is the single place that rule lives, shared by the
+//! renderer and the width estimator so they can never disagree.
+//!
+//! ## What the numbers actually are
+//!
+//! Every figure is folded state, never a guess (the project thesis: *report*
+//! state, don't fake it).
+//!
+//! - `(glm-5.1-fast)` is [`crate::envelope::AgentMeta::model`]: the route the
+//!   driver registered the lane on, replaced on every metered call by the
+//!   provider that actually *served* it. Rendered whole, `provider/model`
+//!   included — `zai/glm-5.1-fast` and `openrouter/glm-5.1-fast` are
+//!   different runs with different latencies and quantizations, and a row
+//!   that printed them identically would hide the confound a head-to-head
+//!   exists to measure. Absent only when nothing has been registered.
+//! - `1/3` is the focused lane's task board: closed steps over total,
+//!   byte-identical to the `☑ 1/3` the work rail shows, so the two surfaces
+//!   can never disagree. Absent when the board is empty — there is no plan
+//!   progress fraction anywhere in the model to synthesize one from.
+//! - `3 sessions` is the count of **registered lanes** (`agents.len()`) — how
+//!   much work is live right now. Not the SESSIONS overlay's saved-session
+//!   registry, which is a driver snapshot that does not exist until asked
+//!   for and would read `0 sessions` for most of a run.
+//! - `(78% hit)` rides the `ctx` meter because it qualifies the number beside
+//!   it — how much of that context came back from cache. Omitted entirely
+//!   before any input is metered, never shown as `(—% hit)`.
 //!
 //! ## Degradation: zones drop whole, they never squish
 //!
 //! On a narrow row, items are dropped in a fixed order (`cpu`, then the rest
-//! of zone B, then `turn`+`saved`, then `run`, `role`, `queue`, `stage`,
-//! lane counts — zone A's brand and zone D's inbox badge survive to the
-//! narrowest widths). Nothing is elided mid-token, and a dropped zone takes
-//! its divider with it, so two zones never share a divider-less boundary.
+//! of zone B, then zone C's `turn` and `run`, then zone A's `steps` and
+//! `model`, then `queue`, `stage`, lane counts — zone A's brand and zone D's
+//! inbox badge survive to the narrowest widths). Nothing is elided
+//! mid-token, and a dropped zone takes its divider with it, so two zones
+//! never share a divider-less boundary.
 //!
 //! ## Collapse: a card on top gets a quiet floor
 //!
@@ -80,9 +122,28 @@ impl StatItem {
 /// entries go first; anything not listed survives to the narrowest widths
 /// (`agent` — the brand-glyph identity — `inbox`, and a failing-CI PR
 /// badge).
+///
+/// Zone A's extras are ordered by what a reader loses least: `steps` first
+/// (the work rail shows the same counter), then `model` — the slug is the one
+/// thing on this row that answers "what am I paying for".
 const DROP_ORDER: [&str; 9] = [
-    "cpu", "cache", "ctx", "turn", "saved", "run", "role", "queue", "pr",
+    "cpu", "sessions", "ctx", "turn", "run", "steps", "model", "queue", "pr",
 ];
+
+/// The separator between two adjacent left-side items: `│` across a zone
+/// boundary, ` · ` between items of one zone — except zone A, which joins
+/// with a plain space so the identity reads as one phrase rather than a
+/// list. Shared by [`render`] and [`row_width`]: a width estimate that
+/// disagreed with the renderer would drop items the row had space for.
+fn separator(prev: StatZone, next: StatZone) -> &'static str {
+    if prev != next {
+        " │ "
+    } else if next == StatZone::Identity {
+        " "
+    } else {
+        " · "
+    }
+}
 
 /// The statline's items for this frame — THE decision function (collapse
 /// rule included), pure over `(model, ui)` so it is unit-testable without a
@@ -102,14 +163,23 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
         StatZone::Identity,
         vec![
             Span::styled("✦ ", theme::accent()),
-            Span::styled(agent_name.clone(), theme::accent()),
+            Span::styled(agent_name, theme::accent()),
         ],
     );
-    // The role, dimmed — suppressed when it just repeats the id.
-    let role = focused
-        .map(|a| a.meta.role.clone())
-        .filter(|role| !role.is_empty() && *role != agent_name)
-        .map(|role| StatItem::new("role", StatZone::Identity, vec![Span::styled(role, dim)]));
+    // The pin this lane runs on — the registered route until a metered call
+    // replaces it with whatever actually served. Absent only when nothing has
+    // been registered, which is the pre-session state, not a routing claim.
+    let served_model = focused.and_then(|a| a.meta.model.clone()).map(|slug| {
+        StatItem::new(
+            "model",
+            StatZone::Identity,
+            vec![
+                Span::styled("(", dim),
+                Span::styled(slug, Style::new().fg(theme::TEXT_SECONDARY)),
+                Span::styled(")", dim),
+            ],
+        )
+    });
     let stage_kind = focused.and_then(|a| a.model.hud.stage);
     let stage = StatItem::new(
         "stage",
@@ -127,6 +197,22 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
             ),
         ],
     );
+    // `step#/steps` — the focused lane's task board, closed over total. The
+    // same figure `views::work_rail` prints as `☑ 1/3`, derived the same way
+    // from the same field, so the two can never tell different stories about
+    // one board. An empty board yields no item: there is no plan-progress
+    // fraction in the model, and `0/0` would be an invented one.
+    let steps = focused
+        .map(|a| &a.model.tasks)
+        .filter(|tasks| !tasks.is_empty())
+        .map(|tasks| {
+            let done = tasks.iter().filter(|t| !t.status.is_open()).count();
+            StatItem::new(
+                "steps",
+                StatZone::Identity,
+                vec![Span::styled(format!("{done}/{}", tasks.len()), dim)],
+            )
+        });
 
     // ── zone C values shared with the collapsed forms ───────────────────
     let turn_cost = focused.map_or(0.0, |a| a.model.hud.turn_spent_usd());
@@ -190,8 +276,9 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
 
     // ── the full row ────────────────────────────────────────────────────
     let mut items = vec![agent];
-    items.extend(role);
+    items.extend(served_model);
     items.push(stage);
+    items.extend(steps);
 
     items.push(ctx_item(model, ui, dim, primary));
     let cpu = f64::from(model.global_cpu_pct);
@@ -203,38 +290,22 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
             Span::styled(format!("{cpu:.0}%"), primary),
         ],
     ));
-    // The hit rate only — the read/write volumes live in the context
-    // overlay's cache detail now.
-    let hit = cache_panel::hit_pct(model.cache_hit_tokens(), model.total_input_tokens());
+    // How many lanes are live. A resource in the same sense `cpu` is: it is
+    // what the machine is carrying right now, and it is the number that
+    // explains a `combined` token rate or a run cost climbing faster than one
+    // turn can account for.
+    let lanes = model.agents.len();
     items.push(StatItem::new(
-        "cache",
+        "sessions",
         StatZone::Resources,
         vec![
-            Span::styled("cache ", dim),
-            match hit {
-                Some(pct) => Span::styled(format!("{pct}%"), primary),
-                None => Span::styled("—", dim),
-            },
+            Span::styled(lanes.to_string(), primary),
+            Span::styled(if lanes == 1 { " session" } else { " sessions" }, dim),
         ],
     ));
 
     items.push(turn);
     items.push(run);
-    items.push(StatItem::new(
-        "saved",
-        StatZone::Money,
-        vec![
-            Span::styled("saved ", dim),
-            Span::styled(
-                cache_panel::fmt_savings(model.total_cache_savings_usd()),
-                if model.total_cache_savings_usd() < 0.0 {
-                    Style::new().fg(theme::DANGER_BRIGHT)
-                } else {
-                    ok
-                },
-            ),
-        ],
-    ));
 
     // ── zone D: attention (right-aligned) ───────────────────────────────
     let subs = model.subagent_count();
@@ -286,18 +357,29 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
     items
 }
 
-/// The `ctx used/cap` item — used in primary, `/cap` dimmed.
+/// The `ctx used/cap (N% hit)` item — used and hit-rate in primary, the cap
+/// and the qualifier dimmed.
+///
+/// The hit rate rides this item rather than standing beside it as its own
+/// `cache N%` cell: it is a statement *about* the number to its left — how
+/// much of the context in flight came back from cache rather than being
+/// re-sent — and reads as one fact. The read/write volumes and the savings
+/// figure stay in the context overlay's cache detail.
 fn ctx_item(model: &WorkspaceModel, ui: &DeckUi, dim: Style, primary: Style) -> StatItem {
     let used = model.agents.get(ui.focused).map_or(0, |a| a.context_tokens);
-    StatItem::new(
-        "ctx",
-        StatZone::Resources,
-        vec![
-            Span::styled("ctx ", dim),
-            Span::styled(fmt_k(used), primary),
-            Span::styled(format!("/{}", fmt_k(CTX_WINDOW)), dim),
-        ],
-    )
+    let mut spans = vec![
+        Span::styled("ctx ", dim),
+        Span::styled(fmt_k(used), primary),
+        Span::styled(format!("/{}", fmt_k(CTX_WINDOW)), dim),
+    ];
+    // Omitted outright before any input is metered — a parenthetical that
+    // said `(—% hit)` would be noise claiming to be a measurement.
+    if let Some(pct) = cache_panel::hit_pct(model.cache_hit_tokens(), model.total_input_tokens()) {
+        spans.push(Span::styled(" (", dim));
+        spans.push(Span::styled(format!("{pct}%"), primary));
+        spans.push(Span::styled(" hit)", dim));
+    }
+    StatItem::new("ctx", StatZone::Resources, spans)
 }
 
 /// Which card/overlay is on top, for the collapse rule — the card enum for
@@ -351,10 +433,8 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
     let mut left: Vec<Span<'static>> = vec![Span::raw(" ")];
     let mut last_zone: Option<StatZone> = None;
     for item in items.iter().filter(|i| i.zone != StatZone::Attention) {
-        match last_zone {
-            Some(zone) if zone == item.zone => left.push(Span::styled(" · ", sep)),
-            Some(_) => left.push(Span::styled(" │ ", sep)),
-            None => {}
+        if let Some(prev) = last_zone {
+            left.push(Span::styled(separator(prev, item.zone), sep));
         }
         left.extend(item.spans.iter().cloned());
         last_zone = Some(item.zone);
@@ -412,9 +492,8 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
     }
 }
 
-/// The rendered width of `items`: leading pad + spans + separators (` · `
-/// within a zone, ` │ ` between zones on the left; ` · ` + trailing pad on
-/// the right).
+/// The rendered width of `items`: leading pad + spans + separators (per
+/// [`separator`] on the left; ` · ` + trailing pad on the right).
 fn row_width(items: &[StatItem]) -> usize {
     let mut w = 1; // leading pad
     let mut last_zone: Option<StatZone> = None;
@@ -425,8 +504,8 @@ fn row_width(items: &[StatItem]) -> usize {
             w += item.width();
             continue;
         }
-        if last_zone.is_some() {
-            w += 3; // " · " or " │ "
+        if let Some(prev) = last_zone {
+            w += separator(prev, item.zone).width();
         }
         w += item.width();
         last_zone = Some(item.zone);
@@ -519,13 +598,54 @@ mod tests {
         items.iter().map(|i| i.key).collect()
     }
 
+    /// A model with everything zone A and B can show: a routed pin, a
+    /// three-step board with one closed, and metered input with cache reads.
+    fn furnished_model() -> WorkspaceModel {
+        use stella_protocol::{TaskItem, TaskStatus};
+        let mut m = running_model();
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::TaskUpdate {
+                tasks: vec![
+                    TaskItem {
+                        id: "1".into(),
+                        subject: "one".into(),
+                        description: None,
+                        status: TaskStatus::Completed,
+                        owner: None,
+                    },
+                    TaskItem {
+                        id: "2".into(),
+                        subject: "two".into(),
+                        description: None,
+                        status: TaskStatus::InProgress,
+                        owner: None,
+                    },
+                    TaskItem {
+                        id: "3".into(),
+                        subject: "three".into(),
+                        description: None,
+                        status: TaskStatus::Pending,
+                        owner: None,
+                    },
+                ],
+            },
+        });
+        let a = &mut m.agents[0];
+        a.meta.model = Some("glm-5.1-fast".into());
+        a.tokens_in = 100_000;
+        a.cache_read_tokens = 78_000;
+        m
+    }
+
     #[test]
     fn the_full_row_carries_all_four_zones() {
-        let model = running_model();
+        let model = furnished_model();
         let ui = DeckUi::default();
         let items = statline_items(&model, &ui);
         for key in [
-            "agent", "stage", "ctx", "cpu", "cache", "turn", "run", "saved", "inbox", "queue",
+            "agent", "model", "stage", "steps", "ctx", "cpu", "sessions", "turn", "run", "inbox",
+            "queue",
         ] {
             assert!(
                 keys(&items).contains(&key),
@@ -533,10 +653,117 @@ mod tests {
                 keys(&items)
             );
         }
-        // WARMTH / ENGINE / PIPELINE / MODELS left the statline outright.
-        for gone in ["warmth", "engine", "pipeline", "models"] {
+        // WARMTH / ENGINE / PIPELINE / MODELS left the statline outright, and
+        // `cache` folded into `ctx` while `saved` moved to SESSION VITALS —
+        // none of them may come back as their own cell.
+        for gone in ["warmth", "engine", "pipeline", "models", "cache", "saved"] {
             assert!(!keys(&items).contains(&gone), "{gone} must not return");
         }
+    }
+
+    /// The spec row, rendered: `✦ lead (glm-5.1-fast) ● execute 1/3 │ ctx
+    /// …/200k (78% hit) · cpu 0% · 1 session │ turn $0.00 · run $0.00 │ …`.
+    #[test]
+    fn the_row_reads_as_the_documented_layout() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let model = furnished_model();
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &ui, area, &mut buf);
+        let text: String = (0..area.width)
+            .map(|x| buf.cell((x, 0)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+
+        // Zone A is one phrase: space-joined, no `·` anywhere inside it.
+        assert!(
+            text.contains("✦ lead (glm-5.1-fast) ● execute 1/3 │"),
+            "zone A reads as one phrase:\n{text}"
+        );
+        // Zone B: the hit rate rides ctx, and the lane count is singular at 1.
+        assert!(
+            text.contains("(78% hit) · cpu 0% · 1 session │"),
+            "zone B carries the hit rate and lane count:\n{text}"
+        );
+        // Zone C ends at `run` — `saved` is gone from this row.
+        assert!(text.contains("turn $0.00 · run $0.00"), "zone C:\n{text}");
+        assert!(!text.contains("saved"), "saved left zone C:\n{text}");
+        // Zone D holds the right edge.
+        assert!(text.trim_end().ends_with("queue empty"), "zone D:\n{text}");
+    }
+
+    #[test]
+    fn the_lane_count_is_pluralized_and_the_unmetered_row_hides_the_hit_rate() {
+        // A bare session: nothing metered, so no `(N% hit)` parenthetical —
+        // never `(—% hit)`.
+        let model = running_model();
+        let ui = DeckUi::default();
+        let items = statline_items(&model, &ui);
+        let ctx = items.iter().find(|i| i.key == "ctx").expect("ctx");
+        let ctx_text: String = ctx.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(!ctx_text.contains("hit"), "no hit rate yet: {ctx_text}");
+        // …and no board yet, so no step counter.
+        assert!(!keys(&items).contains(&"steps"), "{:?}", keys(&items));
+
+        let mut two = model.clone();
+        two.apply_inbound(&Inbound::Register(AgentMeta::new("sub", "child", 0)));
+        let items = statline_items(&two, &ui);
+        let lanes = items
+            .iter()
+            .find(|i| i.key == "sessions")
+            .expect("sessions");
+        let text: String = lanes.spans.iter().map(|s| s.content.to_string()).collect();
+        assert_eq!(text, "2 sessions");
+    }
+
+    #[test]
+    fn the_lane_role_never_reaches_the_row() {
+        // A subagent lane is the case where id and role genuinely differ. The
+        // row names the lane and the pin; `subagent` is already told by the
+        // `sub:` id and zone D's `◆ N sub`, and space-joined into zone A it
+        // read as a second, unlabelled name.
+        let mut model = running_model();
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("sub:auth", "child", 0).with_role("subagent"),
+        ));
+        let mut ui = DeckUi::default();
+        ui.focused = 1;
+        let items = statline_items(&model, &ui);
+        assert!(!keys(&items).contains(&"role"), "{:?}", keys(&items));
+        let text: String = items
+            .iter()
+            .flat_map(|i| i.spans.iter())
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(!text.contains("subagent"), "no role label: {text}");
+    }
+
+    #[test]
+    fn a_lane_with_no_routed_call_names_no_model() {
+        // The pin is an observation, not an intention: a lane that has not
+        // called anything shows no slug rather than the session default.
+        let model = running_model();
+        let ui = DeckUi::default();
+        assert!(
+            !keys(&statline_items(&model, &ui)).contains(&"model"),
+            "an unrouted lane names no model"
+        );
+    }
+
+    #[test]
+    fn the_step_counter_matches_the_work_rail() {
+        // One number, one derivation: the statline and the work rail read the
+        // same field the same way, so they cannot disagree about one board.
+        let model = furnished_model();
+        let ui = DeckUi::default();
+        let items = statline_items(&model, &ui);
+        let steps = items.iter().find(|i| i.key == "steps").expect("steps");
+        let text: String = steps.spans.iter().map(|s| s.content.to_string()).collect();
+        let tasks = &model.agents[0].model.tasks;
+        let done = tasks.iter().filter(|t| !t.status.is_open()).count();
+        assert_eq!(text, format!("{done}/{}", tasks.len()));
+        assert_eq!(text, "1/3");
     }
 
     #[test]

--- a/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k │ run $0.05 of $7.50
+ ✦ lead ● execute │ ctx 8.2k/200k (63% hit) │ run $0.05 of $7.50

--- a/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/stella-tui/tests/snapshots/deck/card_models.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k │ run $0.05 of $7.50
+ ✦ lead ● execute │ ctx 8.2k/200k (63% hit) │ run $0.05 of $7.50

--- a/stella-tui/tests/snapshots/deck/card_scope.txt
+++ b/stella-tui/tests/snapshots/deck/card_scope.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k │ run $0.05 of $7.50
+ ✦ lead ● execute │ ctx 8.2k/200k (63% hit) │ run $0.05 of $7.50

--- a/stella-tui/tests/snapshots/deck/card_tasks.txt
+++ b/stella-tui/tests/snapshots/deck/card_tasks.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ turn $0.04
+ ✦ lead ● execute │ turn $0.04

--- a/stella-tui/tests/snapshots/deck/card_witness.txt
+++ b/stella-tui/tests/snapshots/deck/card_witness.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ run $0.05 of $7.50                                                                                                  witness executing 2/3
+ ✦ lead ● execute │ run $0.05 of $7.50                                                                                                    witness executing 2/3

--- a/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k │ run $0.05 of $7.50
+ ✦ lead ● execute │ ctx 8.2k/200k (63% hit) │ run $0.05 of $7.50

--- a/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
+++ b/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
+++ b/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
+++ b/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_agents.txt
+++ b/stella-tui/tests/snapshots/deck/tab_agents.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0110  ·  1 line  ·  queue empty
- ✦ sub:auth · subagent · ● execute │ ctx 5.1k/200k │ turn $0.01 · run $0.05 of $7.50 · saved $0.00       ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ sub:auth (glm-5.2) ● execute │ ctx 5.1k/200k (63% hit) │ turn $0.01 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_agents_compact.txt
+++ b/stella-tui/tests/snapshots/deck/tab_agents_compact.txt
@@ -26,4 +26,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands              turn $0.0110  ·  1 line  ·  queue empty
- ✦ sub:auth · subagent · ● execute │ run $0.05 of $7.50          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ sub:auth (glm-5.2) ● execute │ run $0.05 of $7.50             ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_files.txt
+++ b/stella-tui/tests/snapshots/deck/tab_files.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_graph.txt
+++ b/stella-tui/tests/snapshots/deck/tab_graph.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_mcp.txt
+++ b/stella-tui/tests/snapshots/deck/tab_mcp.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_settings.txt
+++ b/stella-tui/tests/snapshots/deck/tab_settings.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_skills.txt
+++ b/stella-tui/tests/snapshots/deck/tab_skills.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/snapshots/deck/tab_traces.txt
+++ b/stella-tui/tests/snapshots/deck/tab_traces.txt
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
- ✦ lead · ● execute │ ctx 8.2k/200k · cache 63% │ turn $0.04 · run $0.05 of $7.50 · saved $0.00          ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty
+ ✦ lead (glm-5.2) ● execute 5/7 │ ctx 8.2k/200k (63% hit) │ turn $0.04 · run $0.05 of $7.50              ✦ 1 lead · ◆ 2 sub · ⇢ #981 open … · ✉ 0 · queue empty

--- a/stella-tui/tests/statline_zones.rs
+++ b/stella-tui/tests/statline_zones.rs
@@ -10,11 +10,17 @@
 //! `run` → the rest, with zone A's brand glyph and zone D's inbox badge
 //! surviving to the narrowest widths, and every open card collapses the row
 //! to ≤4 items chosen for that context.
+//!
+//! The zone *contents* moved once since: the cache hit rate folded into the
+//! `ctx` meter it qualifies, `saved` left for the context overlay's SESSION
+//! VITALS, the lane's `role` left outright, and zone A gained the pin the
+//! lane runs on plus its step counter. What is pinned here is the layout law
+//! those changes had to obey, not the specific cells.
 
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 
-use stella_protocol::{AgentEvent, StageKind};
+use stella_protocol::{AgentEvent, StageKind, TaskItem, TaskStatus};
 use stella_tui::deck_ui::cards::Card;
 use stella_tui::statline::statline_items;
 use stella_tui::{AgentMeta, DeckUi, Inbound, WorkspaceModel, render_deck};
@@ -31,6 +37,34 @@ fn running_model() -> WorkspaceModel {
             name: StageKind::Execute,
         },
     });
+    m
+}
+
+/// `running_model` with everything zone A and B can show: a registered pin, a
+/// three-step board with one closed, and metered input with cache reads.
+fn furnished_model() -> WorkspaceModel {
+    let mut m = running_model();
+    let task = |id: &str, status| TaskItem {
+        id: id.into(),
+        subject: format!("step {id}"),
+        description: None,
+        status,
+        owner: None,
+    };
+    m.apply_inbound(&Inbound::Event {
+        agent: "lead".into(),
+        event: AgentEvent::TaskUpdate {
+            tasks: vec![
+                task("1", TaskStatus::Completed),
+                task("2", TaskStatus::InProgress),
+                task("3", TaskStatus::Pending),
+            ],
+        },
+    });
+    let a = &mut m.agents[0];
+    a.meta.model = Some("zai/glm-5.1-fast".into());
+    a.tokens_in = 100_000;
+    a.cache_read_tokens = 78_000;
     m
 }
 
@@ -52,30 +86,58 @@ fn statline_row(model: &WorkspaceModel, w: u16) -> String {
 
 #[test]
 fn zones_drop_whole_in_the_documented_order_as_the_row_narrows() {
-    let model = running_model();
+    let model = furnished_model();
 
-    // Wide: all four zones render.
+    // Wide: all four zones render, in the documented layout.
     let full = statline_row(&model, 200);
     for needle in [
-        "✦", "lead", "●", "ctx", "cpu", "cache", "turn", "run", "saved", "✉",
+        "✦",
+        "lead",
+        "(zai/glm-5.1-fast)",
+        "● execute",
+        "1/3",
+        "ctx ",
+        "(78% hit)",
+        "cpu ",
+        "1 session",
+        "turn ",
+        "run ",
+        "✉",
     ] {
         assert!(
             full.contains(needle),
             "at 200 cols {needle:?} renders:\n{full}"
         );
     }
+    // Zone A is one phrase, not a list — no `·` between the lane, the pin and
+    // the stage.
+    assert!(
+        full.contains("✦ lead (zai/glm-5.1-fast) ● execute 1/3 │"),
+        "zone A joins with spaces:\n{full}"
+    );
+    // The cells that left: `cache` folded into `ctx`, `saved` moved to the
+    // context overlay, and the lane's role is gone outright.
+    for gone in ["cache ", "saved"] {
+        assert!(!full.contains(gone), "{gone:?} left the row:\n{full}");
+    }
 
     // As the row narrows, items leave whole and in order: `cpu` before the
-    // rest of zone B, zone B before zone C's `turn`/`saved`, and `run` last
-    // of zone C — while the brand glyph and the inbox badge survive.
+    // rest of zone B, zone B before zone C's `turn`, and `run` last of zone C
+    // — while the brand glyph and the inbox badge survive.
     let mut cpu_gone_at = None;
+    let mut sessions_gone_at = None;
     let mut ctx_gone_at = None;
     let mut turn_gone_at = None;
     let mut run_gone_at = None;
+    let mut steps_gone_at = None;
+    let mut model_gone_at = None;
     for w in (20..=200u16).rev() {
         let row = statline_row(&model, w);
         if cpu_gone_at.is_none() && !row.contains("cpu") {
             cpu_gone_at = Some(w);
+        }
+        if sessions_gone_at.is_none() && !row.contains("session") {
+            sessions_gone_at = Some(w);
         }
         if ctx_gone_at.is_none() && !row.contains("ctx") {
             ctx_gone_at = Some(w);
@@ -86,6 +148,12 @@ fn zones_drop_whole_in_the_documented_order_as_the_row_narrows() {
         if run_gone_at.is_none() && !row.contains("run") {
             run_gone_at = Some(w);
         }
+        if steps_gone_at.is_none() && !row.contains("1/3") {
+            steps_gone_at = Some(w);
+        }
+        if model_gone_at.is_none() && !row.contains("glm-5.1-fast") {
+            model_gone_at = Some(w);
+        }
         assert!(row.contains('✦'), "the brand survives {w} cols:\n{row}");
         if w >= 24 {
             assert!(
@@ -94,15 +162,22 @@ fn zones_drop_whole_in_the_documented_order_as_the_row_narrows() {
             );
         }
     }
-    let (cpu, ctx, turn, run) = (
+    let (cpu, sessions, ctx, turn, run, steps, pin) = (
         cpu_gone_at.expect("cpu drops somewhere"),
+        sessions_gone_at.expect("sessions drops somewhere"),
         ctx_gone_at.expect("ctx drops somewhere"),
         turn_gone_at.expect("turn drops somewhere"),
         run_gone_at.expect("run drops somewhere"),
+        steps_gone_at.expect("steps drops somewhere"),
+        model_gone_at.expect("the pin drops somewhere"),
     );
     assert!(
-        cpu >= ctx,
-        "cpu ({cpu}) drops before the rest of zone B ({ctx})"
+        cpu >= sessions,
+        "cpu ({cpu}) drops before the lane count ({sessions})"
+    );
+    assert!(
+        sessions >= ctx,
+        "the lane count ({sessions}) drops before the rest of zone B ({ctx})"
     );
     assert!(
         ctx >= turn,
@@ -111,6 +186,17 @@ fn zones_drop_whole_in_the_documented_order_as_the_row_narrows() {
     assert!(
         turn >= run,
         "zone C keeps only run for a while ({turn} vs {run})"
+    );
+    // Zone A's extras outlive all of zone C, and the pin outlives the step
+    // counter — the work rail shows the same `1/3`, nothing else shows the
+    // pin.
+    assert!(
+        run >= steps,
+        "zone C goes before zone A's step counter ({run} vs {steps})"
+    );
+    assert!(
+        steps >= pin,
+        "the step counter goes before the pin ({steps} vs {pin})"
     );
 }
 

--- a/website/content/docs/commands/stats.mdx
+++ b/website/content/docs/commands/stats.mdx
@@ -39,7 +39,7 @@ Every row also carries three cache-economics columns, derived at display time fr
 <CardGrid size="md">
   <OptionCard name="HIT%">
     Cache-read tokens over total input tokens for that row — the same figure the deck's
-    `CACHE` statline cell shows for the live session.
+    statline shows for the live session, as the `(78% hit)` qualifier on its `ctx` meter.
   </OptionCard>
   <OptionCard name="SAVED ($)">
     Estimated USD saved by prompt caching, priced at **today's** catalog rates — not the
@@ -60,7 +60,7 @@ Every row also carries three cache-economics columns, derived at display time fr
 A `0%` `HIT%` across several turns on an opt-in provider (Anthropic, Bedrock, or Claude-via-OpenRouter) with `CACHE WR` also at `0` usually means the opt-in cache marker never reached the wire — check your adapter config before assuming the model just isn't cacheable. If `CACHE WR` is nonzero but `HIT%` stays low, the prompt prefix is likely being rewritten between turns instead of reused.
 
 <Callout type="info">
-The deck's statline shows the same `CACHE`/`SAVED`/`WARMTH` cells live per session, plus a per-agent breakdown in the Agents tab (`Cache`/`Warmth` columns) and a countdown to when each agent's cached prefix expires.
+The deck shows the same figures live per session: the hit rate rides the statline's `ctx` meter as `(78% hit)`, and the saved-dollars and warmth countdown sit in the session-context overlay's **SESSION VITALS** section (`→` from an empty prompt, or `/context`). There is also a per-agent breakdown in the Agents tab (`Cache`/`Warmth` columns), including a countdown to when each agent's cached prefix expires.
 </Callout>
 
 ## Examples


### PR DESCRIPTION
Zone A becomes one phrase instead of a list: `✦ triage (zai/glm-5.1-fast) ● execute 1/3`. It gains the pin the focused lane runs on and the lane's step counter, joins with spaces rather than `·`, and drops the free-form `role` — which never rendered for the lead (the driver registers id and role both as "lead", so the cell was suppressed as a repeat) and for a subagent only restated what `sub:` in the id and zone D's `◆ N sub` already say. Space-joined beside a pin it read as a second, unlabelled name: `✦ triage lead (glm-5.1-fast)`.

Zone B folds the cache hit rate into the `ctx` meter it qualifies — `ctx 35k/200k (78% hit)`, one fact rather than two cells — and swaps the freed slot for the live lane count. Zone C narrows to `turn` + `run`; `saved` moves to the context overlay's SESSION VITALS, where the volumes and warmth countdown already live. It is a cumulative session total, so it answers a question asked at the end of a run, not mid-turn.

Every new figure is folded state, not a guess:

- the pin is `AgentMeta::model` — the registered route until a metered call replaces it with whatever actually served. Rendered whole, `provider/model` included: `zai/glm-5.1-fast` and `openrouter/glm-5.1-fast` are different runs, and a row that printed them identically would hide the confound a head-to-head measures.
- `1/3` is the task board's closed-over-total, derived exactly as `views::work_rail` derives its `☑ 1/3`, so the two surfaces cannot disagree about one board. Absent on an empty board — there is no plan progress fraction in the model to synthesize one from.
- `(78% hit)` is omitted entirely before any input is metered, never shown as `(—% hit)`.
- the lane count is `agents.len()`, not the SESSIONS overlay's registry (a driver snapshot that does not exist until asked for, and would read `0 sessions` for most of a run).

`separator` is now the single home for the join rule, shared by the renderer and the width estimator — an estimate that disagreed with the renderer would drop items the row had space for.

The SESSION VITALS row moves to `cache_panel::vitals_spans`, which is what that module is for: the formatting becomes testable without a frame and `deck_render.rs` goes back under its size ceiling.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? -->

<!--
  Replace the N below with the issue number, or delete the line if there is no
  issue. A number in the PR *title* does NOT close anything — GitHub only reads
  closing keywords from this description and from commit messages.
  Use `Refs #N` instead if this PR advances the issue without finishing it.
-->

Closes #N

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

## Nothing left behind

Anything you noticed and did not fix — a bug, a missing test, dead or unwired
code, the logical next step of this work — is a GitHub issue before this merges,
written as a handoff a fresh agent could execute (AGENTS.md § "Nothing left
behind"). The gate catches the residue (a `TODO` with no issue number); it
cannot catch what only you saw.

- [ ] Filed: #___, #___ — **or**
- [ ] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

<!-- Delete lines that don't apply. -->

- [ ] No I/O added to `stella-core`; no new deps without justification below
- [ ] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

## Summary by Sourcery

Regroup the statline zones in the TUI to present lane identity, resources, and session vitals more coherently, and move cache economics into the context overlay.

New Features:
- Show the focused lane’s pinned model slug and step counter in zone A as part of a single identity phrase.
- Fold cache hit rate into the `ctx` meter and display the live lane count as a sessions indicator in zone B.
- Expose cache volumes, warmth countdown, and saved-dollar totals in the SESSION VITALS section of the context overlay.

Enhancements:
- Unify separator handling via a shared `separator` helper so rendering and width estimation stay consistent.
- Refine statline degradation order so less critical items (cpu, sessions, ctx, money, steps, pin) drop first while brand and inbox survive at narrow widths.

Documentation:
- Update `stats` command documentation to describe the hit-rate qualifier on the statline `ctx` meter and the relocation of cache and warmth figures to SESSION VITALS.

Tests:
- Add statline and cache-panel tests covering the new zone layout, hit-rate qualifier, sessions count, step counter, and SESSION VITALS rendering.
- Update statline zone-width tests to assert the documented drop order and the new identity phrase layout.
- Adjust deck rendering tests and snapshots to reflect the updated statline contents and movement of cache data to SESSION VITALS.