### PR TITLE
fix(main): unbreak the build — missing import, duplicated match arm, and a guard that read its own comment

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -15,9 +15,9 @@ use clap::{Parser, Subcommand};
 pub(crate) mod help;
 
 use crate::{
-    OutputFormat, build_info, commands_cmd, context_cmd, contextgraph, dataset_cmd, fullauto_cmd,
-    ingest_cmd, inspect, memory_cmd, proposals_cmd, query_format, scripts_cmd, stats, storage_cmd,
-    tune_cmd, usage_cmd,
+    OutputFormat, build_info, commands_cmd, context_cmd, contextgraph, dataset_cmd, fleet_verbs,
+    fullauto_cmd, ingest_cmd, inspect, memory_cmd, proposals_cmd, query_format, scripts_cmd, stats,
+    storage_cmd, tune_cmd, usage_cmd,
 };
 
 #[derive(Parser)]

--- a/crates/stella-cli/src/cli/help.rs
+++ b/crates/stella-cli/src/cli/help.rs
@@ -37,7 +37,10 @@ const GROUPS: &[(&str, &[&str])] = &[
         "Run the agent",
         &["run", "chat", "goal", "resume", "daemon", "init"],
     ),
-    ("Run many at once", &["fleet", "monitor", "fullauto", "arena"]),
+    (
+        "Run many at once",
+        &["fleet", "monitor", "fullauto", "arena"],
+    ),
     (
         "Ask about this workspace",
         &["graph", "storage", "scripts", "tools", "commands"],

--- a/crates/stella-cli/src/fullauto_cmd/state.rs
+++ b/crates/stella-cli/src/fullauto_cmd/state.rs
@@ -337,10 +337,10 @@ impl LoopState {
             if let Some(c) = cycle {
                 doc.insert("cycle".into(), c.into());
             }
-            if let Some(t) = tier {
-                if !t.is_empty() {
-                    doc.insert("tier".into(), t.into());
-                }
+            if let Some(t) = tier
+                && !t.is_empty()
+            {
+                doc.insert("tier".into(), t.into());
             }
             doc.entry("started_at".to_string())
                 .or_insert_with(|| Value::String(now.clone()));

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -803,11 +803,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             // of the defect queue) — works with zero API keys.
             return fullauto_cmd::run(cmd).map_err(failure::CliFailure::from);
         }
-        Some(Command::Fullauto { cmd }) => {
-            // Reads and writes ~/.stella/fullauto/<slug>/ (plus `gh` reads
-            // of the defect queue) — works with zero API keys.
-            return fullauto_cmd::run(cmd);
-        }
         Some(Command::Memory { cmd }) => {
             // Reads local stores only (list) / writes one rule file
             // (promote) — works with zero API keys.

--- a/crates/stella-cli/src/paths.rs
+++ b/crates/stella-cli/src/paths.rs
@@ -408,9 +408,21 @@ mod tests {
         // `var("HOME")`, and it is a WRITE — a different question, guarded
         // elsewhere. Requiring a non-`_` before the match separates the two
         // without pinning the exact `std::env::` spelling a caller used.
+        // Comment lines are prose, not reads. A file that routes through
+        // `crate::paths` and says so — "never `var_os("HOME")`, because …" —
+        // was being reported as an offender for carrying the explanation of
+        // the very rule it obeys, which teaches the next author to delete the
+        // comment rather than keep the discipline. Only whole-line comments
+        // are skipped, so a read with a trailing comment
+        // (`let h = var_os("HOME"); // …`) is still matched: the line does not
+        // start with `//`.
         let reads = |body: &str, pattern: &str| {
-            body.match_indices(pattern)
-                .any(|(at, _)| at == 0 || !body[..at].ends_with('_'))
+            body.lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .any(|line| {
+                    line.match_indices(pattern)
+                        .any(|(at, _)| at == 0 || !line[..at].ends_with('_'))
+                })
         };
 
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");


### PR DESCRIPTION
## main does not compile

`cargo check -p stella-cli --all-targets` fails with two errors, and four more gates fall over behind them. All five are merge residue in `stella-cli`. None is a design question.

| # | Gate | What broke |
|---|---|---|
| 1 | `cargo check` / `clippy` / `doc` / `test` | **E0433** — `cannot find module or crate fleet_verbs` |
| 2 | same | **E0308** — `expected Result<(), CliFailure>, found Result<(), String>` |
| 3 | `cargo fmt --check` | `cli/help.rs` landed unformatted |
| 4 | `clippy -D warnings` | `collapsible_if` in `fullauto_cmd/state.rs` |
| 5 | `cargo test` | a guard test matching **its own comment** |

### 1 — the import that never landed

`fleet_verbs.rs` exists and `main.rs` declares `mod fleet_verbs;`. But `cli.rs` reaches its siblings through a single `use crate::{…}` list, and `fleet_verbs` was never added to it — the field naming the type (`cmd: Option<fleet_verbs::FleetCmd>`) landed without its import.

### 2 — the match arm that landed twice

```rust
Some(Command::Fullauto { cmd }) => { ... fullauto_cmd::run(cmd).map_err(CliFailure::from) }
Some(Command::Fullauto { cmd }) => { ... fullauto_cmd::run(cmd) }   // <- ill-typed AND unreachable
```

Two branches each added the arm; the merge kept both. Removed the second, keeping the one that matches the function's return type.

### 5 — a guard that punished the comment explaining it

`paths::tests::nothing_else_in_this_crate_reads_a_home_out_of_the_environment` reported:

```
fullauto_cmd/state.rs: var_os("HOME")
```

**The code is correct.** It calls `crate::paths::home()`. The match was against the comment directly above it, which explains why it does *not* call `var_os("HOME")`.

The guard scanned raw file text, so a file that obeys the rule **and documents obeying it** was an offender for carrying the explanation. That teaches the next author to delete the comment rather than keep the discipline — so the fix belongs in the guard, not the prose. It now skips whole-line comments.

**Deliberately narrow, and proven still sharp.** Only lines whose trimmed start is `//` are skipped, so a read with a trailing comment still matches — that line does not start with `//`:

```rust
let h = var_os("HOME"); // still an offender
```

I verified this rather than asserting it: injected a real `std::env::var_os("HOME")` on a code line in `fullauto_cmd/state.rs`, watched the test fail naming that exact offender, then reverted.

```
  fullauto_cmd/state.rs: var_os("HOME")
test result: FAILED. 0 passed; 1 failed; ...
```

This is **not** an allow-list entry and **not** a baseline bump — the guard's reach over code is unchanged. Per CLAUDE.md, turning a gate green by weakening it would be a defect; this removes a false positive and leaves the true positives intact.

## Verified on 97ee5887

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | exit 0 |
| `cargo test --workspace` | exit 0, no failures |
| `make guards` | exit 0 |

No witness test: four of the five are a missing import, a duplicated arm, a formatting run, and a lint fold — the compiler and the gates that fail on `main` and pass here *are* the fail→pass evidence. The fifth carries the injected-probe check described above.

## Related

Fifth time in two days that a clean merge produced a `main` that does not compile, always the same way: two branches touch adjacent regions, each is green alone, and the resolution keeps one side's lines and drops the other's. Branch protection has `enforce_admins: false`, so a red PR can still land. Same family as #1464.

## Summary by Sourcery

Restore stella-cli build and tests by fixing merge residue in CLI wiring and guard logic.

Bug Fixes:
- Add the missing fleet_verbs import to the CLI module so Fleet commands compile.
- Remove the duplicate, ill-typed Fullauto command match arm to align with the expected error type.
- Update the HOME-read guard to ignore whole-line comments while still flagging real environment reads.

Enhancements:
- Simplify tier insertion logic in fullauto loop state with a single guarded conditional.
- Reformat CLI help group definitions to match project formatting standards.

Tests:
- Adjust the paths guard test to work with the new comment-skipping behavior without weakening its coverage.