### PR TITLE
fix(main): unbreak the build — inherited_lock_fd kept both halves of a rewrite

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -962,15 +962,11 @@ fn inherited_lock_fd(lock_path: &Path) -> Option<i32> {
         });
         let Ok(stat) = probe.metadata() else {
             continue;
-        }
-        // SAFETY: `fstat` returned success, so it initialized the struct.
-        let stat = unsafe { stat.assume_init() };
-        // `st_dev` is `i32` on macOS and already `u64` on Linux, and std's
-        // `MetadataExt::dev()` widens it with exactly this cast — identity
-        // only matches if the conversion does too.
-        #[allow(clippy::unnecessary_cast)] // a no-op on Linux, the point on macOS
-        let dev = stat.st_dev as u64;
-        if dev == lock.dev() && stat.st_ino == lock.ino() {
+        };
+        // `dev()`/`ino()` are `u64` on every Unix, so the comparison needs no
+        // cast and no `#[allow]` — which is the whole reason this reads through
+        // `MetadataExt` rather than a raw `libc::stat`.
+        if stat.dev() == lock.dev() && stat.ino() == lock.ino() {
             return Some(fd);
         }
     }


### PR DESCRIPTION
## main does not compile

```
crates/stella-cli/src/daemon.rs:965  error: expected `;`, found keyword `let`
crates/stella-cli/src/daemon.rs:967  error[E0599]: no method named `assume_init`
                                     found for struct `std::fs::Metadata`
```

## What happened

`inherited_lock_fd` was rewritten to read a descriptor's identity through `MetadataExt` instead of a raw `libc::stat`. The merge **kept lines from both versions**:

- the new half calls `probe.metadata()` and compares against `lock.dev()`/`lock.ino()`
- the old half's `assume_init()`, `stat.st_dev as u64` and `stat.st_ino` survived underneath it
- and the `let … else` in between lost its `;`

`assume_init` belongs to `MaybeUninit<libc::stat>`, which no longer exists in this function, so the leftovers cannot be adapted — they are deleted and the `MetadataExt` half stands alone. That is what the function's own comment already claims it does:

> The identity is read through `MetadataExt`, not a raw `libc::stat`, because `dev_t` is unsigned on Linux and signed on macOS.

## Why the deleted lines mattered

The rewrite was not cosmetic. `st_dev` is `i32` on macOS and `u64` on Linux, so **any single cast of it compiles on one platform and fails on the other** — a local gate can pass while CI goes red. `MetadataExt::dev()`/`ino()` are declared `u64` on every Unix, so the comparison needs no cast at all.

With the cast goes `#[allow(clippy::unnecessary_cast)]`, which existed only to tolerate it. Removing an `#[allow]` rather than adding one.

## Verified

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo test -p stella-cli` | 1414 passed, 0 failed |
| `make guards-fast` | exit 0 |

No witness test: this is a syntax error and a call to a method that does not exist on the receiver. The compiler is the fail→pass evidence.

## Related

This is the **sixth** clean-merge-breaks-main in two days, and the second in the last hour (#1747 and #1749 both fixed a different pair of leftovers in `stella-cli`, in parallel). Always the same shape: two branches rewrite adjacent lines, each is green alone, and the resolution keeps one side and drops the other. `enforce_admins: false` lets a red PR land. Same family as #1464.

## Summary by Sourcery

Bug Fixes:
- Resolve syntax and type errors in inherited_lock_fd by removing obsolete libc::stat-based code and using MetadataExt dev/ino comparisons consistently.