### PR TITLE
fix(stella-tui): unbreak main — deck.rs grew past its god-file ceiling

### DIFF
--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -642,16 +642,9 @@ impl WorkspaceModel {
                 });
             }
             // `/clear`: reset the agent's session to seq-0 — blank the
-            // transcript, zero the cost/token counters and the header clock, and
-            // return the HUD (progress bar) to idle. The prompt echo the paired
-            // `PromptStarted` pushed is wiped along with the rest.
-            //
-            // The file-touch half of the session model is deliberately NOT
-            // reset (`SessionModel::reset_conversation`): [`Self::ledger`] — the
-            // Files tab's rows — is untouched here, and the diffs those rows
-            // render live in the session model (L-T5). Blanking one store and
-            // not the other is what made every post-`/clear` row show accurate
-            // counts beside `(no diff captured)`.
+            // transcript, zero the counters and header clock, return the HUD to
+            // idle, wipe the prompt echo. The file-touch half and
+            // [`Self::ledger`] survive; why is on `SessionModel::reset_conversation`.
             Inbound::SessionReset { agent } => {
                 if let Some(idx) = self.index_of(agent) {
                     let entry = &mut self.agents[idx];


### PR DESCRIPTION
Unbreaks `main`, which is red at `2fcf63a4`.

## What & why

Every other step of `ci.yml`'s required job passes at that commit — `cargo fmt --check`,
`cargo clippy -D warnings`, `cargo doc -D warnings`, the prompt-cache goldens, `cargo test`,
`stella context validate`. The single failure is the file-size ratchet:

```
crates/stella-tui/src/deck.rs grew to 1517 lines,
over its baseline ceiling of 1510 (+7)
```

#1742 added a seven-line comment above the `Inbound::SessionReset` arm explaining that the
file-touch half of the session model deliberately survives a `/clear`.

The explanation is correct and worth having. It also **already exists**, in more depth, on
`SessionModel::reset_conversation` in `crates/stella-tui/src/model.rs` — down to the same
`+64 -6` beside `(no diff captured)` symptom and the `file_touch_seq` eviction-ordering
argument. `deck.rs` was carrying a second copy of a doc comment one file over.

## Why not just raise the ceiling

Because that would be the expedient CLAUDE.md names explicitly ("a raised
`scripts/file-size-baseline.txt` ceiling to turn a gate green ... is a bug against the PR
that introduced it"). `deck.rs` is a grandfathered god file, closed to growth by AGENTS.md,
and `make file-size-update` exists for a genuinely irreducible line — a module declaration
in an already-oversized `lib.rs` — not for prose that duplicates a doc comment.

Collapsed to a pointer at the normative home, which is where a reader should land anyway:
the invariant belongs to `reset_conversation`, not to its caller. Nothing about #1742's
behaviour changes — this is comments only.

Back to **1510**: at the ceiling rather than under it, which is the ratchet working as
intended for a file that is not supposed to grow. The next line added to `deck.rs` should
fail, and will.

## The witness

- [x] `./scripts/check-file-size.sh` exits **1** before this change and **0** after. A
      comment cannot be witnessed by a unit test — the guard is the oracle, and it was
      checked in both directions.
- [x] No behaviour, flag, or public API changed, so there is nothing else to witness.

## The gate

- [x] `make guards-fast` — green across all 22 steps
- [x] `cargo fmt --check` — clean
- [x] Comments only; `cargo clippy`/`cargo test` are untouched by this diff and pass on
      `main` already at `2fcf63a4`.

Refs #1742

## Summary by Sourcery

Keep stella-tui’s main branch passing the file-size gate by trimming an overlong comment in deck.rs without changing behavior.

Enhancements:
- Condense the `/clear` session reset comment in deck.rs and point readers to SessionModel::reset_conversation as the canonical documentation.

Chores:
- Restore deck.rs to its file-size ceiling so the file-size ratchet CI guard passes without raising the baseline.