### PR TITLE
fix(stella-tui): restore deck.rs under its file-size ceiling — main is red

### DIFF
--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -641,17 +641,10 @@ impl WorkspaceModel {
                     summary: format!("↩ {}", snip(text)),
                 });
             }
-            // `/clear`: reset the agent's session to seq-0 — blank the
-            // transcript, zero the cost/token counters and the header clock, and
-            // return the HUD (progress bar) to idle. The prompt echo the paired
-            // `PromptStarted` pushed is wiped along with the rest.
-            //
-            // The file-touch half of the session model is deliberately NOT
-            // reset (`SessionModel::reset_conversation`): [`Self::ledger`] — the
-            // Files tab's rows — is untouched here, and the diffs those rows
-            // render live in the session model (L-T5). Blanking one store and
-            // not the other is what made every post-`/clear` row show accurate
-            // counts beside `(no diff captured)`.
+            // `/clear`: reset the agent's session to seq-0 — blank the transcript,
+            // zero the cost/token counters and the header clock, return the HUD to
+            // idle, and wipe the prompt echo the paired `PromptStarted` pushed. Via
+            // `reset_conversation`, NOT `SessionModel::new()`; its doc says why (#1742).
             Inbound::SessionReset { agent } => {
                 if let Some(idx) = self.index_of(agent) {
                     let entry = &mut self.agents[idx];


### PR DESCRIPTION
## main is red

`make gate` fails on `origin/main` itself, so **every branch cut from it is red**:

```
$ git checkout origin/main && ./scripts/check-file-size.sh
  crates/stella-tui/src/deck.rs grew to 1517 lines, over its baseline ceiling of 1510 (+7)
```

#1742 landed 8 added lines in `crates/stella-tui/src/deck.rs` — a grandfathered god file AGENTS.md closes to growth — without the gate having run on it.

## Why not `make file-size-update`

Seven of those eight lines are a **comment**, restating at the call site the reasoning that `SessionModel::reset_conversation`'s own doc comment already carries in full: which of the two stores `/clear` resets, why the Files tab showed accurate counts beside `(no diff captured)`, and why `file_touch_seq` is carried across. The actual change was one line — `SessionModel::new()` → `reset_conversation()`.

AGENTS.md reserves the baseline bump for "a genuinely irreducible line (a module declaration in an already-oversized `lib.rs`)". A duplicated explanation is not one. Raising the ceiling here would move a gate to accommodate prose that is **better where it already is**, next to the function it describes.

So the block folds back to its original four lines with a pointer to that doc comment. That is the better shape regardless of the gate: a reader who wants the reasoning is sent to the one copy that cannot drift from the code.

```rust
// `/clear`: reset the agent's session to seq-0 — blank the transcript,
// zero the cost/token counters and the header clock, return the HUD to
// idle, and wipe the prompt echo the paired `PromptStarted` pushed. Via
// `reset_conversation`, NOT `SessionModel::new()`; its doc says why (#1742).
```

`deck.rs` returns to **1510 — exactly its recorded ceiling. No baseline change.**

## Verification

```
$ ./scripts/check-file-size.sh
check-file-size: OK — 997 Rust/Python files, none over 1500 lines except 33 grandfathered (none grew).

$ cargo fmt --check          # clean
$ cargo test -p stella-tui   # 862 passed; 0 failed
```

The deck golden frames are included in that run and needed no re-blessing — this changes only a comment, so no rendered output moves.

No witness test: this is a comment-only change restoring a gate, and the gate itself is the check (it fails on `main`, passes here).

## Note for whoever reviews the queue

This is the shape #1645 is about — `enforce_admins` is off and the pre-push gate is routinely bypassed, so a red merge lands and every subsequent PR inherits the failure. Merging this unblocks the others.

Refs #1742, #1645

## Summary by Sourcery

Enhancements:
- Consolidate and shorten the /clear session reset comment in deck.rs, pointing readers to SessionModel::reset_conversation documentation instead of duplicating its explanation.