### PR TITLE
fix(arenabench): pin the recorder's encoder threads — every video on a many-core host was a 28-byte stub

### DIFF
--- a/arenabench/arenabench/recorder.py
+++ b/arenabench/arenabench/recorder.py
@@ -60,6 +60,17 @@ IMAGE_TAG = "arenabench/recorder:2"
 #: failure mode is a truncated unplayable file rather than a loud error.
 STOP_TIMEOUT_S = 30
 
+#: The recorder's memory ceiling. It films a terminal, so it has no business
+#: growing: Xvfb's framebuffer is a few MB and the encoder's pool is pinned in
+#: ``record.sh`` (``ARENA_THREADS``) precisely so this number can stay small on
+#: any host. Named here because the warning below cites it.
+MEMORY_LIMIT = "512m"
+
+#: Below this, the file cannot contain a playable frame. A fragmented MP4 that
+#: was killed before its first flush is 28 bytes of ``ftyp`` and nothing else,
+#: and it must not be reported as a recording — see ``_stop_container``.
+MIN_PLAYABLE_BYTES = 4096
+
 
 def docker_available() -> bool:
     if shutil.which("docker") is None:
@@ -283,7 +294,7 @@ class RecorderSupervisor:
             "--name", name,
             # No network at all: the recorder reads a file and writes a file.
             "--network", "none",
-            "--memory", "512m",
+            "--memory", MEMORY_LIMIT,
             "--cpus", "0.5",
             "-v", f"{agent_dir}:/logs/agent:ro",
             "-v", f"{out_dir}:/out",
@@ -324,12 +335,29 @@ class RecorderSupervisor:
             log.warning("recorder stop failed for %s: %s", trial_dir.name, exc)
             return
         video = trial_dir / "arena" / "recording.mp4"
-        if video.exists() and video.stat().st_size > 0:
+        size = video.stat().st_size if video.exists() else 0
+        if size >= MIN_PLAYABLE_BYTES:
             log.info(
                 "recorded %s -> %s (%.1f MB)",
                 trial_dir.name,
                 video,
-                video.stat().st_size / 1e6,
+                size / 1e6,
+            )
+        elif size > 0:
+            # A file too small to hold a single frame is the signature of the
+            # encoder dying before it flushed anything -- overwhelmingly an OOM
+            # kill, which is SIGKILL and so leaves no message anywhere. Reported
+            # as a plain `> 0` success this reads as "recorded ... (0.0 MB)" and
+            # an operator has no reason to look, which is how a whole
+            # head-to-head can finish with twenty unplayable stubs.
+            log.warning(
+                "recorder produced only %d bytes for %s -- too small to play. "
+                "The encoder was almost certainly killed before it wrote a "
+                "frame; the usual cause is the container's %s memory limit "
+                "(check `docker inspect --format '{{.State.OOMKilled}}'`).",
+                size,
+                trial_dir.name,
+                MEMORY_LIMIT,
             )
         else:
             log.warning("recorder produced no video for %s", trial_dir.name)

--- a/arenabench/matches/fable5-cc-vs-stella-10task.toml
+++ b/arenabench/matches/fable5-cc-vs-stella-10task.toml
@@ -1,0 +1,139 @@
+# arenabench match — 10-task healthy-mix panel
+#
+#   arenabench run matches/fable5-cc-vs-stella-10task.toml --progress
+#
+# Claude Code vs Stella, both on Fable 5. The variable under test is the agent
+# architecture, not the model — so effort is pinned to `medium` on both seats
+# and neither seat may drift to a different model family.
+#
+# The seats authenticate differently on purpose:
+#
+#   Claude Code  Anthropic first-party, on a Claude subscription
+#                (CLAUDE_CODE_OAUTH_TOKEN — no metered spend)
+#   Stella       OpenRouter, metered (OPENROUTER_API_KEY), because Stella's
+#                pipeline makes ~3 calls per step and a subscription's shared
+#                requests-per-minute cap would measure the quota, not the agent.
+#
+# This file carries no secrets. Export CLAUDE_CODE_OAUTH_TOKEN and
+# OPENROUTER_API_KEY before running.
+
+[match]
+name = "fable 5: claude code vs stella (10-task mix)"
+dataset = "terminal-bench-2.1"
+
+# --- Panel design -----------------------------------------------------------
+#
+# Terminal-Bench 2.1 is 89 tasks: 4 easy / 54 medium / 30 hard. Scaled to ten
+# that is 0.4 / 6.1 / 3.4, so this panel is 1 easy / 6 medium / 3 hard — the
+# sample mirrors the dataset rather than over-weighting the tasks both agents
+# can already do, which would compress the delta under test.
+#
+# Six tasks carry over from matches/fable5-claude-code-vs-stella.toml so this
+# run is comparable against the previous cycle rather than only against itself.
+# Four are new, chosen to add the three hard rungs and a seventh category.
+#
+# No task here is tagged [heavy]: heavy tasks force concurrency to 1 and would
+# serialise the whole panel behind one container.
+#
+#   task                       difficulty  category               origin
+#   fix-git                    easy        software-engineering   carry-over
+#   regex-log                  medium      data-processing        carry-over
+#   sqlite-with-gcov           medium      system-administration  carry-over
+#   large-scale-text-editing   medium      file-operations        carry-over
+#   openssl-selfsigned-cert    medium      security               carry-over
+#   nginx-request-logging      medium      system-administration  carry-over
+#   query-optimize             medium      data-science           new
+#   cancel-async-tasks         hard        software-engineering   new
+#   dna-assembly               hard        scientific-computing   new
+#   write-compressor           hard        software-engineering   new
+#
+# Category spread is 7 of the dataset's 16. software-engineering gets 3 seats
+# because it is 26 of the 89 tasks; system-administration is deliberately one
+# seat over its proportional share, because both of its tasks are carry-overs
+# with prior evidence behind them and comparability won the tie.
+tasks = [
+  "fix-git",
+  "regex-log",
+  "sqlite-with-gcov",
+  "large-scale-text-editing",
+  "openssl-selfsigned-cert",
+  "nginx-request-logging",
+  "query-optimize",
+  "cancel-async-tasks",
+  "dna-assembly",
+  "write-compressor",
+]
+attempts = 1
+
+# The rig is 32 vCPU / 123 GB. One task slot is 2 contestant containers racing,
+# and the largest task asks for 4 CPU, so a slot can want 8 CPU. Three slots is
+# 24 CPU with 8 left for the recorders and the host. Raising this further would
+# start trading CPU against the timeout-bound tasks, and several tasks on this
+# panel are timeout-bound — contention there corrupts the measurement rather
+# than merely slowing it.
+concurrency = 3
+record_video = true
+
+# Claude Code installs itself per trial: apt-get plus the claude.ai installer
+# measured at 229s against a 360s default.
+setup_timeout_multiplier = 4.0
+
+[[contestant]]
+id = "claude-code"
+name = "Claude Code (Fable 5)"
+agent = "claude-code"
+color = "#FF6B9D"
+
+  [contestant.engine]
+  api = "anthropic"
+  model = "claude-fable-5"
+  reasoning = true
+  # `medium` on both arms so effort is not a confound. Measured 2026-08-03:
+  # xhigh timed out on every step budget it was given; medium finished.
+  effort = "medium"
+  # No base_url: this seat runs at Anthropic, authenticated by the subscription
+  # token. No budget_usd either — Claude Code does not honour a spend cap, and
+  # on the plan the marginal spend is zero; the plan's quota is the ceiling.
+
+  [contestant.env]
+  # Names only — never values.
+  required = ["CLAUDE_CODE_OAUTH_TOKEN"]
+
+[[contestant]]
+id = "stella"
+name = "Stella (Fable 5 pipeline)"
+agent = "stella"
+color = "#FFB000"
+
+  [contestant.engine]
+  api = "openrouter"
+  model = "anthropic/claude-fable-5"
+  reasoning = true
+  effort = "medium"
+  # Fable's real output ceiling, same number on both routes (#1211 §6.2).
+  max_tokens = 128000
+  # Per-trial cap (becomes STELLA_BUDGET). Ten trials x $12 = $120 worst case,
+  # with per-trial isolation: one runaway trial cannot eat the other nine
+  # tasks' budget. In practice only the three hard trials approach the cap.
+  budget_usd = 12.0
+
+  # Per-role overrides — the "full pipeline" arm. Every model named here is in
+  # Stella's OFFLINE seed catalog under `openrouter`: the adapter pins
+  # STELLA_CATALOG_AUTO_REFRESH=0, and a role pinned to an unlisted slug
+  # refuses the run rather than silently falling back.
+    [contestant.engine.roles.verifier]
+    # Cross-lab on purpose: verification independent of the model family being
+    # verified, and of the worker in particular.
+    model = "moonshotai/kimi-k3"
+    effort = "high"
+    reasoning = "on"
+
+    [contestant.engine.roles.triage]
+    # Cheapest fast family member, classification only, never touches the
+    # workspace.
+    model = "anthropic/claude-haiku-4.5"
+    effort = "low"
+    reasoning = "off"
+
+  [contestant.env]
+  required = ["OPENROUTER_API_KEY"]

--- a/arenabench/recorder/record.sh
+++ b/arenabench/recorder/record.sh
@@ -24,6 +24,20 @@ EVENTS="${ARENA_EVENTS:-/logs/agent/stella-events.jsonl}"
 OUTPUT="${ARENA_OUTPUT:-/out/recording.mp4}"
 DISPLAY_NUM="${ARENA_DISPLAY:-:99}"
 
+# x264 sizes its thread pool from the number of CPUs it can SEE, which is the
+# host's core count -- `--cpus` is a scheduling quota and does not change it.
+# Each thread carries its own frame buffers, so on a big machine the encoder
+# alone outgrows the recorder's 512 MB cgroup: measured on a 32-vCPU bench rig,
+# x264 chose 28 threads and the container was OOM-killed within a second of
+# ffmpeg starting. The kill is SIGKILL, so nothing is logged and no fragment is
+# flushed -- every recording came out as a 28-byte `ftyp` stub and the run
+# looked like the renderer had silently done nothing.
+#
+# Pinning the pool makes the encoder's footprint a property of this file rather
+# than of whatever host it lands on. Two threads is ample for a 10 fps terminal
+# capture at `--cpus 0.5`, which cannot keep more than that busy anyway.
+THREADS="${ARENA_THREADS:-2}"
+
 mkdir -p "$(dirname "$OUTPUT")"
 
 log() { printf '[arena-recorder] %s\n' "$*" >&2; }
@@ -125,6 +139,7 @@ sleep 0.6
 ffmpeg -nostdin -loglevel error \
   -f x11grab -video_size "${WIDTH}x${HEIGHT}" -framerate "$FPS" -i "$DISPLAY_NUM" \
   -c:v libx264 -preset veryfast -crf 26 -pix_fmt yuv420p \
+  -threads "$THREADS" \
   -movflags +frag_keyframe+empty_moov+default_base_moof \
   -y "$OUTPUT" &
 FFMPEG_PID=$!

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -399,6 +399,92 @@ class TestRecorder:
         assert supervisor._failures[trial_dir] == 1
         assert trial_dir not in supervisor._finished
 
+    def _stub_trial(self, tmp_path: Path, payload: bytes) -> Path:
+        trial_dir = tmp_path / "job" / "t__1"
+        (trial_dir / "arena").mkdir(parents=True)
+        (trial_dir / "arena" / "recording.mp4").write_bytes(payload)
+        return trial_dir
+
+    def _stop(self, supervisor, trial_dir: Path, monkeypatch: pytest.MonkeyPatch):
+        from arenabench.recorder import _Recording
+
+        # `docker stop` is the only shell-out on this path and it is not what
+        # is under test; the file on disk is.
+        monkeypatch.setattr(
+            "arenabench.recorder.subprocess.run", lambda *a, **k: None
+        )
+        supervisor._stop_container(_Recording("c", trial_dir, 0.0), trial_dir)
+
+    def test_a_stub_too_small_to_play_is_not_reported_as_a_recording(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ):
+        """An encoder killed before it flushed a fragment leaves 28 bytes of
+        `ftyp` and nothing else. A bare `size > 0` check calls that a success
+        and prints "recorded ... (0.0 MB)", so an operator has no reason to
+        look — which is how a head-to-head finishes with a full gallery of
+        unplayable stubs. Measured on a 32-vCPU rig, where x264 sized its
+        thread pool from the host's cores and the container was OOM-killed.
+        """
+        import logging
+
+        supervisor = self._supervisor(tmp_path)
+        trial_dir = self._stub_trial(tmp_path, b"\x00" * 28)
+
+        with caplog.at_level(logging.INFO, logger="arenabench.recorder"):
+            self._stop(supervisor, trial_dir, monkeypatch)
+
+        assert not [r for r in caplog.records if r.levelno == logging.INFO], (
+            "a 28-byte stub was reported as a successful recording"
+        )
+        warned = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warned, "a stub too small to play produced no warning at all"
+        # The operator needs the cause, not just the symptom.
+        assert "28 bytes" in warned[0]
+        assert "memory limit" in warned[0]
+
+    def test_a_real_recording_is_still_reported_as_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ):
+        """The guard above must not swallow the ordinary case."""
+        import logging
+
+        from arenabench.recorder import MIN_PLAYABLE_BYTES
+
+        supervisor = self._supervisor(tmp_path)
+        trial_dir = self._stub_trial(tmp_path, b"\x00" * (MIN_PLAYABLE_BYTES + 1))
+
+        with caplog.at_level(logging.INFO, logger="arenabench.recorder"):
+            self._stop(supervisor, trial_dir, monkeypatch)
+
+        assert [r for r in caplog.records if r.levelno == logging.INFO]
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestRecorderEncoder:
+    """The encoder's footprint must be a property of the recorder, not of the
+    host it lands on."""
+
+    def _script(self) -> str:
+        from pathlib import Path as _Path
+
+        import arenabench
+
+        return (
+            _Path(arenabench.__file__).resolve().parent.parent / "recorder" / "record.sh"
+        ).read_text()
+
+    def test_the_encoder_thread_pool_is_pinned(self):
+        """x264 sizes its pool from the CPUs it can *see* — the host's, since
+        `--cpus` is a scheduling quota and not a visible core count. On a
+        32-vCPU host it chose 28 threads, and the per-thread frame buffers blew
+        through the recorder's 512 MB cgroup within a second of ffmpeg
+        starting. Unpinned, this file only works on small machines, and a
+        benchmark rig is not one.
+        """
+        script = self._script()
+        assert "-threads" in script, "ffmpeg's thread pool is unpinned"
+        assert "ARENA_THREADS" in script, "the pool size is not overridable"
+
 
 # --------------------------------------------------------------------------
 # routing an agent off its home provider


### PR DESCRIPTION
## What was wrong

x264 sizes its thread pool from the CPUs it can **see**. `--cpus 0.5` is a
scheduling quota, not a visible core count, so on the 32-vCPU bench rig the
encoder chose **28 threads**, and the per-thread frame buffers blew straight
through the recorder container's 512 MB cgroup within a second of ffmpeg
starting.

The kill is SIGKILL, so nothing was logged and no fragment was ever flushed.
Every recording came out as **28 bytes of `ftyp` and nothing else**.

The second half is what made it expensive: `_stop_container`'s `size > 0`
check called that a success and printed `recorded ... (0.0 MB)`. A whole
head-to-head can finish with a full gallery of unplayable stubs and a
completely clean log. It only reproduces on many-core hosts, which is why dev
machines and colima never saw it.

## The fix

- **`recorder/record.sh`** pins ffmpeg's pool via `ARENA_THREADS` (default 2 —
  ample for a 10 fps terminal capture that is already limited to `--cpus 0.5`).
  The encoder's footprint becomes a property of this file rather than of
  whatever host it lands on. Raising `--memory` instead would only move the
  same failure to a bigger machine.
- **`arenabench/recorder.py`** refuses to report a file too small to hold a
  frame as a recording, and names the memory limit as the likely cause.
  `MEMORY_LIMIT` and `MIN_PLAYABLE_BYTES` are hoisted so the warning cites the
  same number the container is started with.

## Evidence

Measured on the rig, same container settings, before and after:

| | before | after |
|---|---|---|
| `State.OOMKilled` | `true` | `false` |
| container | exited immediately | running, 181 MB / 512 MB |
| `recording.mp4` | 28 bytes, forever | 262 KB @ 15s → 1.0 MB @ 90s |

`ffprobe` on a recording copied *while it was still being written*:
`h264, 1440x900, nb_read_frames=952, duration=120.2` — i.e. genuinely
playable mid-write, which is the property the fragmented-MP4 output exists
to provide.

## Witness

Three tests in `tests/test_arena.py`, verified to fail on `main` and pass here:

- `test_a_stub_too_small_to_play_is_not_reported_as_a_recording` →
  on main: `AssertionError: a 28-byte stub was reported as a successful recording`
- `test_the_encoder_thread_pool_is_pinned` →
  on main: `AssertionError: ffmpeg's thread pool is unpinned`
- `test_a_real_recording_is_still_reported_as_one` (guards against the new
  check swallowing the ordinary case) → on main: `ImportError`

Full suite: 251 passed. `shellcheck` clean on `record.sh`.

## Also included

`arenabench/matches/fable5-cc-vs-stella-10task.toml` — the 10-task
Terminal-Bench 2.1 head-to-head panel this was found with. 1 easy / 6 medium /
3 hard, mirroring the dataset's own 4/54/30 split scaled to ten; six tasks
carry over from the existing 6-task panel so runs stay comparable across
cycles.

## Summary by Sourcery

Constrain the recorder’s resource usage to avoid OOM‑killed recordings on many‑core hosts and ensure unusable video stubs are surfaced as warnings instead of successful runs.

Bug Fixes:
- Prevent recorder containers from being OOM‑killed on many‑core hosts by pinning the ffmpeg/x264 encoder thread pool size via an overridable ARENA_THREADS setting in the recording script.
- Avoid treating tiny, unplayable MP4 stubs as successful recordings by enforcing a minimum playable file size and emitting a clear warning that points to the recorder’s memory limit as the likely cause.

Enhancements:
- Centralize the recorder container’s memory limit and minimum playable file size as named constants so logging and container configuration stay in sync.
- Improve recorder logging to distinguish between no video, clearly unplayable stubs, and valid recordings, with more actionable operator guidance.

Tests:
- Add tests that verify too‑small recording files are not reported as successful recordings and that real recordings still are.
- Add a test to ensure the encoder thread pool is pinned and configurable via ARENA_THREADS in the recording script.

Chores:
- Add a new 10‑task arenabench match configuration for a Claude Code vs Stella comparison on the Terminal‑Bench 2.1 dataset.