### PR TITLE
feat(stella-pipeline): ground triage in the workspace listing, not the goal string alone

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1276,7 +1276,8 @@ impl<'a> Pipeline<'a> {
                 RawCall {
                     role: ModelCallRole::Triage,
                     resolved: &resolved,
-                    messages: triage_prompt(goal).into_messages(),
+                    messages: triage_prompt(goal, &self.repo.structure_summary().await)
+                        .into_messages(),
                     policy: RetryPolicy::deterministic(),
                     overrides: &self.config.role_overrides.triage,
                     timeout: Some(self.config.triage_latency_ceiling),

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -2369,6 +2369,7 @@ mod mcp_prefetch;
 mod scope_gate_interactive;
 mod shared_worktree;
 mod terminal_outcomes;
+mod triage_context;
 mod usage;
 /// Bounded repair after a refuted success claim (#1479).
 mod verdict_repair;

--- a/crates/stella-pipeline/src/pipeline/tests/triage_context.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/triage_context.rs
@@ -1,0 +1,102 @@
+//! Triage classifies with workspace evidence, not the goal string alone:
+//! the [`RepoStructurePort`] summary the planner and witness author already
+//! receive also rides in the triage payload (bounded — see
+//! `crate::triage::triage_prompt`). Triage decides the highest-leverage
+//! questions in the pipeline — how much orchestration, whether a witness is
+//! warranted, whether this is a task at all — and used to be the only stage
+//! deciding anything blind.
+
+use crate::ports::RepoStructurePort;
+
+use super::*;
+
+/// A [`RepoStructurePort`] answering with a fixed sentinel listing — proves
+/// the orchestrator consults the port for triage and lands the summary in the
+/// paid call's payload, independent of how the real CLI adapter renders it.
+struct FixedStructure(&'static str);
+
+#[async_trait]
+impl RepoStructurePort for FixedStructure {
+    async fn structure_summary(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[tokio::test]
+async fn the_triage_call_carries_the_workspace_listing_in_its_payload() {
+    // triage → "single"; worker turn → final text (no tool calls).
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![false, true], "@@ -1 +1 @@\n-old\n+new");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = FixedStructure("src/lib.rs\nSENTINEL-STRUCTURE.rs\ntests/smoke.rs");
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+
+    // The first provider request is the triage call. Its volatile USER half
+    // carries the listing and the goal; the cacheable SYSTEM half (#1434)
+    // must stay workspace-independent or every triage call re-bills its
+    // instruction block at the uncached rate.
+    let shapes = provider.shapes();
+    let triage_call = shapes.first().expect("a triage call was made");
+    let user_payload: String = triage_call
+        .iter()
+        .filter(|(role, _)| *role == stella_protocol::MessageRole::User)
+        .map(|(_, text)| text.as_str())
+        .collect();
+    assert!(
+        user_payload.contains("SENTINEL-STRUCTURE.rs"),
+        "the triage payload must carry the RepoStructurePort summary; got:\n{user_payload}"
+    );
+    assert!(user_payload.contains("Fix the failing test"));
+    for (role, text) in triage_call {
+        if *role == stella_protocol::MessageRole::System {
+            assert!(
+                !text.contains("SENTINEL-STRUCTURE.rs"),
+                "workspace bytes in the system half would break the cacheable prefix"
+            );
+        }
+    }
+}

--- a/crates/stella-pipeline/src/triage.rs
+++ b/crates/stella-pipeline/src/triage.rs
@@ -923,11 +923,54 @@ fn has_action_request(goal: &str) -> bool {
 /// Stella was pointed at, so the split that matters is *does this ask for
 /// anything to be done*, not *is this about source files*. See
 /// [`resolve_conversational`] for the deterministic backstop.
-pub fn triage_prompt(goal: &str) -> ManagementPrompt {
+///
+/// `structure` is the workspace listing the `RepoStructurePort` already
+/// supplies to the planner and the witness author — bounded here to
+/// [`TRIAGE_STRUCTURE_CHARS`] and rendered *before* the task so the
+/// `Task:`/`Answer:` pair stays adjacent at the end. Triage decides the
+/// highest-leverage questions in the pipeline (how much orchestration, whether
+/// a witness is warranted, whether this is a task at all) and until this
+/// section existed it was the only stage deciding anything from the goal
+/// string alone: `WITNESS: no` was guessed with no way to see whether the
+/// workspace even has a test harness, and the chat-vs-task call had no
+/// evidence of what the workspace *is*. Empty structure (no git, port
+/// unavailable) renders the legacy goal-only payload byte-for-byte — the
+/// listing is evidence when it exists, never a requirement. It rides in the
+/// volatile payload half, so the cacheable instruction block (#1434) is
+/// untouched.
+pub fn triage_prompt(goal: &str, structure: &str) -> ManagementPrompt {
+    let structure = bounded_structure(structure);
+    let payload = if structure.is_empty() {
+        format!("Task:\n{goal}\n\nAnswer:")
+    } else {
+        format!("Workspace listing (truncated):\n{structure}\n\nTask:\n{goal}\n\nAnswer:")
+    };
     ManagementPrompt {
         instructions: TRIAGE_INSTRUCTIONS,
-        payload: format!("Task:\n{goal}\n\nAnswer:"),
+        payload,
     }
+}
+
+/// Ceiling on the workspace-listing characters the triage payload may carry —
+/// the same order as one recalled frame (`RECALL_FRAME_CHARS` in
+/// `crate::pipeline`). Triage is the cheap, latency-capped tier: the listing's
+/// job is to show *what kind of workspace this is* (code with a test tree, a
+/// folder of documents, a monorepo) and roughly how big, which the head of a
+/// sorted listing answers; past this point more paths add cost per call
+/// without changing any triage decision. Counted in `chars`, not bytes, so
+/// multi-byte paths are not over-charged.
+const TRIAGE_STRUCTURE_CHARS: usize = 4_000;
+
+/// Clamp a structure summary to [`TRIAGE_STRUCTURE_CHARS`], head-kept, with an
+/// explicit marker when anything was dropped — a truncated listing must never
+/// read as the whole workspace.
+fn bounded_structure(structure: &str) -> String {
+    let trimmed = structure.trim();
+    if trimmed.chars().count() <= TRIAGE_STRUCTURE_CHARS {
+        return trimmed.to_string();
+    }
+    let kept: String = trimmed.chars().take(TRIAGE_STRUCTURE_CHARS).collect();
+    format!("{kept}\n[… listing truncated at the triage budget …]")
 }
 
 /// The triage protocol block (#1434): fully literal, so it is a plain
@@ -954,6 +997,11 @@ const TRIAGE_INSTRUCTIONS: &str = "Classify the following user message, and deci
      like any other task. Use `chat` ONLY when the message asks you to do \
      nothing at all. If it asks you to look at, decide about, or change \
      anything, it is never `chat`.\n\n\
+     A truncated listing of the workspace's files may precede the task. It \
+     is evidence, not the ask: use it to judge what kind of workspace this \
+     is, how far the task could reach, and whether a test could even run \
+     here — a workspace with no test files or build manifest usually \
+     warrants WITNESS: no. Classify the message, never the listing.\n\n\
      WITNESS is whether a failing test should be written first to pin the \
      intended behavior. Say no when the change is mechanical, when \
      correctness is already obvious from the diff, or when the project \

--- a/crates/stella-pipeline/src/triage/tests.rs
+++ b/crates/stella-pipeline/src/triage/tests.rs
@@ -608,7 +608,10 @@ fn the_verifier_nudge_prefers_review_when_unsure() {
 
 #[test]
 fn the_triage_payload_carries_the_workspace_listing_when_one_exists() {
-    let p = triage_prompt("Fix the failing test", "src/main.rs\nsrc/lib.rs\ntests/smoke.rs");
+    let p = triage_prompt(
+        "Fix the failing test",
+        "src/main.rs\nsrc/lib.rs\ntests/smoke.rs",
+    );
     // Evidence rides in the volatile payload half, never the cacheable
     // instruction block (#1434) — an instruction block that varied per
     // workspace would kill the prefix cache on every triage call.

--- a/crates/stella-pipeline/src/triage/tests.rs
+++ b/crates/stella-pipeline/src/triage/tests.rs
@@ -326,7 +326,7 @@ fn action_request_matching_is_whole_word() {
 
 #[test]
 fn the_triage_prompt_does_not_frame_every_real_class_as_code() {
-    let p = triage_prompt("anything").rendered();
+    let p = triage_prompt("anything", "").rendered();
     // The regression: `lookup`/`single`/`multi` each said "code", leaving a
     // non-code task no bucket but `chat`.
     assert!(
@@ -491,7 +491,7 @@ fn the_ceiling_leaves_every_other_witness_decision_untouched() {
 
 #[test]
 fn triage_prompt_names_all_four_class_tokens_and_the_goal() {
-    let p = triage_prompt("Fix the failing test").rendered();
+    let p = triage_prompt("Fix the failing test", "").rendered();
     assert!(p.contains("chat"));
     assert!(p.contains("lookup"));
     assert!(p.contains("single"));
@@ -598,10 +598,77 @@ fn requirement_bullets_do_not_floor_to_multi_step() {
 
 #[test]
 fn the_verifier_nudge_prefers_review_when_unsure() {
-    let p = triage_prompt("anything").rendered();
+    let p = triage_prompt("anything", "").rendered();
     // The witness keeps its skip-nudge; the verifier must not share it —
     // the verifier is only ever consulted when no test settled the outcome,
     // which is exactly when review has value.
     assert!(p.contains("when unsure, say yes"));
     assert!(!p.contains("Prefer `no` for both"));
+}
+
+#[test]
+fn the_triage_payload_carries_the_workspace_listing_when_one_exists() {
+    let p = triage_prompt("Fix the failing test", "src/main.rs\nsrc/lib.rs\ntests/smoke.rs");
+    // Evidence rides in the volatile payload half, never the cacheable
+    // instruction block (#1434) — an instruction block that varied per
+    // workspace would kill the prefix cache on every triage call.
+    assert!(p.payload.contains("Workspace listing (truncated):"));
+    assert!(p.payload.contains("tests/smoke.rs"));
+    assert!(!p.instructions.contains("src/main.rs"));
+    // The Task:/Answer: pair stays adjacent at the end, after the listing.
+    let listing_at = p
+        .payload
+        .find("Workspace listing")
+        .expect("listing section");
+    let task_at = p.payload.find("Task:").expect("task section");
+    assert!(
+        listing_at < task_at,
+        "the listing is context and must precede the task, not interrupt it"
+    );
+    assert!(p.payload.trim_end().ends_with("Answer:"));
+}
+
+#[test]
+fn an_empty_structure_renders_the_legacy_goal_only_payload() {
+    // No git, no port, a bare directory: the listing is evidence when it
+    // exists, never a requirement — and the fallback is byte-identical to
+    // the pre-structure payload, not a payload with an empty section.
+    let with_empty = triage_prompt("Fix the failing test", "");
+    let with_blank = triage_prompt("Fix the failing test", "   \n  ");
+    assert_eq!(with_empty.payload, "Task:\nFix the failing test\n\nAnswer:");
+    assert_eq!(with_blank.payload, with_empty.payload);
+    assert!(!with_empty.payload.contains("Workspace listing"));
+}
+
+#[test]
+fn an_oversized_listing_is_truncated_at_the_triage_budget() {
+    // One long sorted listing — far past the ceiling.
+    let huge: String = (0..2_000)
+        .map(|i| format!("src/module_{i:04}.rs\n"))
+        .collect();
+    let p = triage_prompt("anything", &huge);
+    assert!(
+        p.payload
+            .contains("[… listing truncated at the triage budget …]"),
+        "a truncated listing must never read as the whole workspace"
+    );
+    // The payload stays the same order of magnitude as the budget — the
+    // listing must not grow the cheap tier's per-call cost unboundedly.
+    assert!(
+        p.payload.chars().count() < TRIAGE_STRUCTURE_CHARS + 200,
+        "payload {} chars exceeds the triage structure budget",
+        p.payload.chars().count()
+    );
+    // Head-kept: the earliest paths survive, the tail is what drops.
+    assert!(p.payload.contains("src/module_0000.rs"));
+    assert!(!p.payload.contains("src/module_1999.rs"));
+}
+
+#[test]
+fn the_instructions_ground_the_listing_as_evidence_not_the_ask() {
+    let p = triage_prompt("anything", "src/lib.rs").rendered();
+    assert!(p.contains("Classify the message, never the listing"));
+    // The witness call is the decision the listing exists to inform: a
+    // workspace that cannot run a test should not buy witness authoring.
+    assert!(p.contains("whether a test could even run"));
 }


### PR DESCRIPTION
## Problem

Triage decides the highest-leverage steering questions in the pipeline — task class (plan or not), `WITNESS: yes|no`, `VERIFIER: yes|no`, and the terminal chat-vs-task route — and it was structurally the blindest stage in the whole flow: its prompt was the raw goal string and nothing else (`triage_prompt(goal)`). Even the planner gets a repository listing; triage guessed "can a test even run here" with zero evidence. The chat route is terminal no-work, and the module docs already record a real task silently dropped there (`organize my documents folder`).

## Fix

The `RepoStructurePort` summary the planner and witness author already receive now rides in the triage payload too:

- `triage_prompt(goal, structure)` renders a `Workspace listing (truncated):` section **before** the `Task:`/`Answer:` pair, bounded to 4,000 chars head-kept with an explicit truncation marker (chars not bytes, matching `bound_recalled_frames`).
- The listing lands in the **volatile user half** of the management prompt — the cacheable `&'static str` instruction block (#1434) is byte-stable as before. The instruction block gains one paragraph grounding the listing as evidence ("a workspace with no test files or build manifest usually warrants WITNESS: no; classify the message, never the listing").
- Empty structure (no git, port unavailable) renders the legacy goal-only payload **byte-for-byte**.
- `pipeline.rs` plumbing is one line (`&self.repo.structure_summary().await`), fetched after the deterministic greeting short-circuit so a bare `hi` still pays nothing.

## Witness

`pipeline::tests::triage_context::the_triage_call_carries_the_workspace_listing_in_its_payload` — runs the full pipeline with a sentinel `RepoStructurePort` and asserts the first provider request's user half carries the sentinel while the system half does not. Fails on main (the payload never contained structure), passes here. Plus four unit tests pinning the section shape, the byte-identical empty fallback, the truncation budget, and the instruction grounding.

`cargo test -p stella-pipeline --lib`: 525 passed.

## Exemplar

The bounded-evidence shape follows `bound_recalled_frames` (#616): clamp at the source, marker on truncation, one budget every consumer inherits.

## Notes

- `pipeline.rs` lands at exactly its 3617 baseline ceiling (net +1 from the rustfmt wrap of the one changed line).
- Depends on main being green again: #1767 unbreaks the file-size gate #1742 left red.
- Part of a triage-steering series; a follow-up PR makes sibling `task` research calls actually run concurrently, and the pre-plan research fan-out stage is being filed as a designed issue.

## Summary by Sourcery

Include workspace structure summaries in triage prompts so classification decisions are grounded in repository context while preserving the cacheable instruction prefix.

Enhancements:
- Extend triage prompts to accept a bounded workspace listing that is injected into the volatile payload ahead of the task description.
- Add character-based truncation and explicit truncation markers for oversized workspace listings to cap triage call cost.
- Update triage instructions to explain how the workspace listing should inform classification without becoming part of the task itself.

Tests:
- Add unit tests validating triage payload shape, legacy goal-only behavior when structure is empty, listing truncation semantics, and instruction grounding.
- Add an integration-style pipeline test ensuring the triage call fetches RepoStructurePort summaries and only the user payload carries workspace-specific bytes.
