### PR TITLE
feat(stella-model): seed Claude Opus 5 on both the first-party and OpenRouter routes

### DIFF
--- a/crates/stella-model/src/catalog.rs
+++ b/crates/stella-model/src/catalog.rs
@@ -393,6 +393,33 @@ impl Catalog {
                 // reports as a capability difference. Approved as the Fable
                 // ceiling set (#1211 §6.2).
                 .with_max_output_tokens(Some(128_000)),
+                // Opus 5 was absent from this catalog on both routes, so any
+                // role pinned to it refused the run rather than falling back —
+                // correct behaviour, and useless to a benchmark that wants to
+                // seat a worker on Opus-tier. Seeded here and on `openrouter`
+                // together, because the parity tests below assert the two rows
+                // agree and a one-sided add is the failure they exist to catch.
+                //
+                // Half Fable's price at the same 1M window: $5/$25 per MTok
+                // against Fable's $10/$50 (checked 2026-08-06). Copying the
+                // Fable row would have doubled the reported spend on every
+                // Opus turn — the same class of error the Fable row's own
+                // comment above records, in the other direction.
+                CatalogEntry::new(
+                    "claude-opus-5",
+                    "anthropic",
+                    "claude",
+                    1_000_000,
+                    ToolDialect::AnthropicTools,
+                    Pricing {
+                        input_usd_per_mtok: 5.00,
+                        output_usd_per_mtok: 25.00,
+                        cached_input_usd_per_mtok: 0.50,
+                        cache_write_usd_per_mtok: 6.25,
+                    },
+                )
+                .with_reasoning(Some(true))
+                .with_max_output_tokens(Some(128_000)),
                 CatalogEntry::new(
                     "gpt-5.5",
                     "openai",
@@ -716,6 +743,40 @@ impl Catalog {
                 // `top_provider.max_completion_tokens = 128000` for
                 // `anthropic/claude-sonnet-5` (checked 2026-08-03). Route is
                 // not a model property — see the parity test below.
+                .with_max_output_tokens(Some(128_000)),
+                // Seeded so the head-to-head panel can seat Stella's *worker*
+                // on Opus-tier through the gateway. Without a row here the
+                // adapter refuses the run outright rather than falling back
+                // (`STELLA_CATALOG_AUTO_REFRESH=0`), so a benchmark that pins
+                // this slug fails at launch instead of quietly measuring a
+                // different model — the right failure, but only if the row a
+                // real match needs actually exists.
+                //
+                // Prices are OpenRouter's own quotes, read from its `/models`
+                // endpoint on 2026-08-06, not aliased from the first-party
+                // table: `input_cache_read` is $0.50/MTok and
+                // `input_cache_write` $6.25/MTok, which is where a
+                // cache-heavy agentic run actually spends. They happen to
+                // match Anthropic list here — unlike the Sonnet row above,
+                // where the gateway is cheaper — and that coincidence is
+                // exactly why the number has to be checked rather than
+                // assumed.
+                CatalogEntry::new(
+                    "anthropic/claude-opus-5",
+                    "openrouter",
+                    "claude",
+                    1_000_000,
+                    ToolDialect::OpenaiJson,
+                    Pricing {
+                        input_usd_per_mtok: 5.00,
+                        output_usd_per_mtok: 25.00,
+                        cached_input_usd_per_mtok: 0.50,
+                        cache_write_usd_per_mtok: 6.25,
+                    },
+                )
+                .with_reasoning(Some(true))
+                // `top_provider.max_completion_tokens = 128000` on the same
+                // reading, matching the rest of the family on this route.
                 .with_max_output_tokens(Some(128_000)),
                 CatalogEntry::new(
                     "anthropic/claude-fable-5",
@@ -1058,6 +1119,7 @@ mod tests {
         for (slug, ceiling) in [
             ("claude-sonnet-5", 128_000),
             ("claude-sonnet-4-6", 128_000),
+            ("claude-opus-5", 128_000),
             ("claude-fable-5", 128_000),
         ] {
             assert_eq!(
@@ -1077,6 +1139,7 @@ mod tests {
         // Choosing a route is not supposed to change the model's ceiling.
         for (slug, ceiling) in [
             ("anthropic/claude-sonnet-5", 128_000),
+            ("anthropic/claude-opus-5", 128_000),
             ("anthropic/claude-fable-5", 128_000),
             // Lower than its siblings, on purpose and from the provider —
             // the row that keeps this loop from passing on a shared constant.
@@ -1094,6 +1157,41 @@ mod tests {
     }
 
     /// Route is not a model property: the direct and gateway rows for one
+    /// Opus 5 resolves on both routes, at its own price.
+    ///
+    /// The model was missing from the seed entirely, which is a launch-time
+    /// refusal rather than a wrong answer — `STELLA_CATALOG_AUTO_REFRESH=0` on
+    /// the benchmark adapter, so a role pinned to an unlisted slug stops the
+    /// run. Safe, and it made the model unusable for the head-to-head panel
+    /// that wants Stella's worker on Opus-tier.
+    ///
+    /// The price is asserted against a literal on purpose. A missing row fails
+    /// loudly; a row copied from the Fable 5 block beside it would resolve
+    /// fine and silently double the reported spend on every Opus turn, because
+    /// `cost_usd` is computed from this table. Opus 5 is half Fable's price at
+    /// the same context window, so the two are exactly the pair a copy-paste
+    /// gets wrong.
+    #[test]
+    fn opus_5_is_seeded_on_both_routes_at_its_own_price() {
+        let seed = Catalog::seed();
+        for (provider, slug) in [
+            ("anthropic", "claude-opus-5"),
+            ("openrouter", "anthropic/claude-opus-5"),
+        ] {
+            let entry = seed
+                .resolve_for(provider, slug)
+                .unwrap_or_else(|_| panic!("{provider}/{slug} is not in the seed catalog"));
+            assert_eq!(entry.pricing.input_usd_per_mtok, 5.00, "{slug} input price");
+            assert_eq!(entry.pricing.output_usd_per_mtok, 25.00, "{slug} output price");
+            assert_eq!(entry.context_tokens, 1_000_000, "{slug} context window");
+            assert_eq!(
+                entry.max_output_tokens,
+                Some(128_000),
+                "{slug} output ceiling",
+            );
+        }
+    }
+
     /// model must agree on its ceiling.
     ///
     /// Asserted as equality between the two rows rather than against a
@@ -1106,6 +1204,7 @@ mod tests {
         let seed = Catalog::seed();
         for (direct, gateway) in [
             ("claude-sonnet-5", "anthropic/claude-sonnet-5"),
+            ("claude-opus-5", "anthropic/claude-opus-5"),
             ("claude-fable-5", "anthropic/claude-fable-5"),
         ] {
             assert_eq!(

--- a/crates/stella-model/src/catalog.rs
+++ b/crates/stella-model/src/catalog.rs
@@ -1183,7 +1183,7 @@ mod tests {
                 .unwrap_or_else(|_| panic!("{provider}/{slug} is not in the seed catalog"));
             assert_eq!(entry.pricing.input_usd_per_mtok, 5.00, "{slug} input price");
             assert_eq!(entry.pricing.output_usd_per_mtok, 25.00, "{slug} output price");
-            assert_eq!(entry.context_tokens, 1_000_000, "{slug} context window");
+            assert_eq!(entry.context_window, 1_000_000, "{slug} context window");
             assert_eq!(
                 entry.max_output_tokens,
                 Some(128_000),


### PR DESCRIPTION
## What was missing

Opus 5 was absent from the seed catalog **entirely** — no `anthropic` row, no
`openrouter` row. The only "opus" strings in the crate were stale Opus 4 names
in an unrelated test file.

With `STELLA_CATALOG_AUTO_REFRESH=0` on the benchmark adapter, a role pinned to
an unlisted slug **refuses the run** rather than falling back. That is the
correct behavior — but it made Opus 5 unusable as a worker model, which is what
a head-to-head panel wants to seat Stella on.

## The fix

Both rows, added together, because the two existing parity loops assert they
agree and a one-sided add is precisely the failure they exist to catch.

| | context | max output | in | out | cache read | cache write |
|---|---|---|---|---|---|---|
| `anthropic/claude-opus-5` | 1M | 128K | $5.00 | $25.00 | $0.50 | $6.25 |
| `claude-opus-5` (first-party) | 1M | 128K | $5.00 | $25.00 | $0.50 | $6.25 |

**Prices were read, not assumed.** OpenRouter's `/models` endpoint on
2026-08-06 reports `prompt: 0.000005`, `completion: 0.000025`,
`input_cache_read: 0.0000005`, `input_cache_write: 0.00000625`, and
`top_provider.max_completion_tokens: 128000`. They happen to match Anthropic
list here — unlike the Sonnet 5 row directly above, where the gateway is
genuinely cheaper ($2/$10 vs $3/$15) — and that coincidence is exactly why the
number had to be checked rather than copied.

## Why the witness asserts a literal price

A *missing* row fails loudly at launch. A row **copied from the Fable 5 block
beside it** would resolve cleanly and silently double reported spend on every
Opus turn, because `cost_usd` is computed from this table. Opus 5 is half
Fable's price at the same 1M context window, so those two rows are the pair a
copy-paste gets wrong — the same class of defect the Fable row's own comment
records, in the other direction.

`opus_5_is_seeded_on_both_routes_at_its_own_price` therefore pins input,
output, context window, and output ceiling on both routes.

## Tests

Both existing parity loops gain the row:

- `the_seed_carries_a_ceiling_where_the_frozen_catalog_is_all_there_is` (first-party + gateway ceiling)
- `a_models_ceiling_does_not_depend_on_the_route_it_is_reached_through` (route parity)

`cargo test -p stella-model --lib catalog` → **20 passed, 0 failed**, including
`every_benchmark_role_model_resolves_on_the_gateway_provider`.

Found while configuring a Terminal-Bench 2.1 head-to-head that seats Stella's
worker on Opus 5 via OpenRouter, its judge on Fable 5, and its triage on
Haiku 4.5.

## Summary by Sourcery

Seed Claude Opus 5 in the model catalog for both first-party and OpenRouter routes with correct pricing and limits, and ensure it participates in existing route-parity guarantees.

New Features:
- Add Claude Opus 5 as a first-party catalog entry with 1M context, 128K max output, and its own pricing.
- Add Claude Opus 5 as an OpenRouter catalog entry with matching context, limits, and provider-quoted pricing.

Tests:
- Extend existing ceiling and route-parity tests to cover Claude Opus 5 on both routes and verify its context window and pricing.
- Add a dedicated test that asserts Claude Opus 5 is present on both routes at the expected prices, context window, and output ceiling.