### PR TITLE
docs(stella-core): name the env var that exists, not the renamed one

### DIFF
--- a/crates/stella-core/src/self_driving.rs
+++ b/crates/stella-core/src/self_driving.rs
@@ -784,7 +784,7 @@ pub fn rank_defects(issues: Vec<QueueIssue>) -> Vec<QueueIssue> {
 ///
 /// Generous on purpose: a single model call inside an audit phase legitimately
 /// runs for minutes, and calling a live run dead is a worse error than
-/// noticing a dead one late. `FULLAUTO_STALE_AFTER_SECS` overrides it.
+/// noticing a dead one late. `SELF_DRIVING_STALE_AFTER_SECS` overrides it.
 ///
 /// Public because every surface that resolves a run's liveness needs the same
 /// number, and this constant is the only copy — `stella-cli`'s env default and


### PR DESCRIPTION
## What & why

`DEFAULT_STALE_AFTER_SECS` in `crates/stella-core/src/self_driving.rs` documented its override as:

> `FULLAUTO_STALE_AFTER_SECS` overrides it.

**Nothing reads that name.** The loop resolves `SELF_DRIVING_STALE_AFTER_SECS` (`self_driving_cmd::state::stale_after_secs`), so the doc pointed at a variable a reader could export all day with no effect — the worst kind of stale comment, because it reads as instructions.

A rename race rather than a mistake in either PR: #1781 was written against the pre-rename tree and merged after #1757 renamed the surface, so this line is the one occurrence #1757's sweep could not have caught. It is now the only `fullauto` left in the tree apart from the four deliberate legacy on-disk paths in `migrate_legacy_state`, which name bytes already on users' disks and must not be renamed.

## The witness

- [x] No witness needed (docs) — one doc comment, no behaviour change.

Verified the claim rather than assuming it:

```
$ rg -n 'SELF_DRIVING_STALE_AFTER_SECS' crates/stella-cli/src/self_driving_cmd/state.rs
57:        "SELF_DRIVING_STALE_AFTER_SECS",
```

## The gate

- [x] `cargo test -p stella-core` — 983 / 983
- [x] `cargo fmt --check` — clean
- [x] `make wire-schema` — OK (a `///` on a public item can restale the generated wire docs; it did not here)

## Nothing left behind

Nothing new. Open follow-ups from the rename: #1753, #1755, #1756, #1763, and #1800 (making the file-size gate unbypassable).

## Summary by Sourcery

Documentation:
- Update self-driving documentation to reference the actual SELF_DRIVING_STALE_AFTER_SECS override environment variable instead of the obsolete FULLAUTO_STALE_AFTER_SECS.