### PR TITLE
style(stella-model): unbreak main — rustfmt on catalog.rs

### DIFF
--- a/crates/stella-model/src/catalog.rs
+++ b/crates/stella-model/src/catalog.rs
@@ -1182,7 +1182,10 @@ mod tests {
                 .resolve_for(provider, slug)
                 .unwrap_or_else(|_| panic!("{provider}/{slug} is not in the seed catalog"));
             assert_eq!(entry.pricing.input_usd_per_mtok, 5.00, "{slug} input price");
-            assert_eq!(entry.pricing.output_usd_per_mtok, 25.00, "{slug} output price");
+            assert_eq!(
+                entry.pricing.output_usd_per_mtok, 25.00,
+                "{slug} output price"
+            );
             assert_eq!(entry.context_window, 1_000_000, "{slug} context window");
             assert_eq!(
                 entry.max_output_tokens,


### PR DESCRIPTION
`main` is red on `cargo fmt --check`, so the required CI job fails on every branch cut from it:

```
Diff in crates/stella-model/src/catalog.rs:1182:
-            assert_eq!(entry.pricing.output_usd_per_mtok, 25.00, "{slug} output price");
+            assert_eq!(
+                entry.pricing.output_usd_per_mtok, 25.00,
+                "{slug} output price"
+            );
```

#1801 added the assertion one column over rustfmt's width. This is `cargo fmt --all` and nothing else — four lines in one test, no behaviour change.

`cargo test -p stella-model --lib catalog`: 20 passed, 0 failed.

No witness test: the gate is the check. It fails on `main`, passes here.

**This is the fourth red-main event today**, all the same shape — a merge lands without the gate having run and every subsequent PR inherits the failure. That is #1645 (`enforce_admins` off, pre-push gate routinely `--no-verify`'d). Today's earlier instance had three agents independently open competing unbreak PRs for one break (#1764/#1765/#1767).

Refs #1801, #1645

## Summary by Sourcery

Enhancements:
- Apply rustfmt formatting to a long assert_eq in catalog.rs tests to bring the file back within formatting width limits.