### PR TITLE
fix(stella-pipeline): stop the verdict negation window reaching a third token past the negator

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -3026,6 +3026,11 @@ impl<'a> Pipeline<'a> {
     /// `mutating_actions` answers "was anything even asked to change", which
     /// nothing can defeat, because it is counted off the calls this pipeline
     /// dispatched rather than off any look at the world.
+    // The eighth parameter (#1798's `opaque_actions`) tipped this over the
+    // lint's threshold; the three tallies are independent by design (doc
+    // comment above), so grouping them to satisfy the count would be shape
+    // without meaning. Tracked for a real revisit in #1809.
+    #[allow(clippy::too_many_arguments)]
     async fn run_engine_turn(
         &self,
         engine: &Engine<'_>,

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -831,8 +831,9 @@ pub fn parse_verifier_response(text: &str) -> Option<Verdict> {
     // A negated verdict token is not that verdict: "the tests do not pass" is
     // a FAIL, and crediting its "pass" token as a PASS inverted real verdicts.
     // The negator must sit within two tokens of the verdict word ("do not
-    // pass", "cannot currently pass") — an unbounded window would misread "not
-    // a problem: PASS". A negated PASS reads as the FAIL it states; a negated
+    // pass" is adjacent, "cannot currently pass" has one token between) — a
+    // wider window would misread an approval lead-in like "not a problem.
+    // PASS". A negated PASS reads as the FAIL it states; a negated
     // FAIL ("did not fail") is skipped rather than trusted as a PASS, since
     // absence of failure is not the protocol's affirmative verdict. "no" is
     // deliberately not a negator for the same reason it is not a FAIL token:
@@ -848,7 +849,10 @@ pub fn parse_verifier_response(text: &str) -> Option<Verdict> {
         if raw.is_empty() {
             continue;
         }
-        let negated = matches!(since_negation, Some(distance) if distance <= 2);
+        // `distance` is 0 for the token immediately after the negator, so the
+        // bound of 1 is the documented two-token window: "not pass" and
+        // "not currently pass" negate; "not a problem. PASS" does not.
+        let negated = matches!(since_negation, Some(distance) if distance <= 1);
         match raw {
             "pass" | "passed" | "approve" | "approved" => {
                 return Some(Verdict {

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -745,6 +745,13 @@ fn a_negated_pass_is_the_fail_it_states() {
         parse_verifier_response("Not a single problem here: PASS").map(|v| v.passed),
         Some(true)
     );
+    // ...and the bound is exactly two tokens: the first window that shipped
+    // reached one token further, inverting this approval lead-in into a FAIL.
+    assert_eq!(
+        parse_verifier_response("Not a problem. PASS").map(|v| v.passed),
+        Some(true),
+        "an approval lead-in two tokens past the negator is a genuine PASS"
+    );
     // An affirmative token before the negator is untouched.
     assert_eq!(
         parse_verifier_response("PASS — this does not fail any case").map(|v| v.passed),


### PR DESCRIPTION
## What — two follow-ups to #1798 (merged as 551be513 while its clippy job was still pending)

### 1. Negation window inverted approval lead-ins

The negation window in `parse_verifier_response` counts `distance = 0` for the token immediately after a negator, so its `distance <= 2` bound let negation reach the **third** token after the negator. An approval lead-in like `"Not a problem. PASS"` sat at distance 2 and was inverted into a FAIL — the opposite of the doc comment's stated intent. Flagged by the Vercel Agent review on #1798, which merged before the fix could land there.

The documented cases only need `distance <= 1`: `"do not pass"` is distance 0, `"cannot currently pass"` is distance 1. The fix tightens the bound to `<= 1` and makes the distance semantics explicit at the comparison site.

### 2. main is clippy-red: `run_engine_turn` has 8 arguments

#1798's `opaque_actions: &mut u32` tipped `run_engine_turn` over `too_many_arguments`, and with the `fmt + clippy + test` job pending at merge time the warning reached main, where `-D warnings` makes it a gate failure. This PR adds the `#[allow]` with a justification comment, matching the six siblings in the same file; the real shape question (seven identical allows = a transport-struct smell) is tracked as #1809.

## Witness

`verify::tests::a_negated_pass_is_the_fail_it_states` gains the exact-boundary case: `"Not a problem. PASS"` must parse as a PASS. Verified the flip the artisanal way: with old `verify.rs` + new test, the test **fails** (parsed as FAIL); with the fix it **passes**. The pre-existing bounded-window case (`"Not a single problem here: PASS"`, distance 4) kept passing throughout — it sat outside both bounds, which is why the bug survived it. The existing negation cases all sit within the tightened window (`"does not currently pass"` = distance 1).

The clippy fix needs no witness (lint hygiene): `cargo clippy -p stella-pipeline --all-targets` emits zero warnings with it and one without.

`cargo test -p stella-pipeline`: 538 lib tests + all integration suites green. `cargo fmt --check` clean.

Refs #1798, #1809