### PR TITLE
fix(stella-pipeline): pin role-shaped output bounds on the management chokepoint

### DIFF
--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -7,7 +7,9 @@ use stella_core::retry::RetryPolicy;
 use stella_core::{
     AccountedCall, AccountedCallError, BudgetGuard, ReceiptContext, run_accounted_call,
 };
-use stella_protocol::{CompletionMessage, CompletionRequest, CompletionResult, ModelCallRole};
+use stella_protocol::{
+    CompletionMessage, CompletionRequest, CompletionResult, ModelCallRole, ReasoningEffort,
+};
 
 use super::stage_budget::{PipelineBudgetAbort, budget_abort};
 use super::{Pipeline, ResolvedRole, RoleCallOverrides};
@@ -41,6 +43,49 @@ pub(super) enum RawCallError {
     Provider,
     Timeout,
     Budget(PipelineBudgetAbort),
+}
+
+/// Role-shaped request bounds `(max_output_tokens, effort)` for the
+/// management chokepoint, applied between the caller's explicit overrides
+/// (which always win) and the engine config's worker-tier base.
+///
+/// The base is the wrong default here: `engine.max_output_tokens` is seeded
+/// from the model catalog's full ceiling (64k on current Claude rows) and an
+/// unset `effort` leaves the provider's own default (high) reasoning
+/// allowance in force — dispatching a role whose written output contract is
+/// two to six lines with a 64k allowance and unbounded thinking. The bounded
+/// shape is the one the engine's own overflow summarizer already pins
+/// (`stella-core`'s `run_compaction_pass`: 1,200 tokens, `effort: Low`).
+///
+/// Exhaustive over [`ModelCallRole`] on purpose: a new role dispatched
+/// through this chokepoint must decide its bounds here, not inherit the
+/// worker ceiling by omission.
+fn management_bounds(role: ModelCallRole) -> (Option<u32>, Option<ReasoningEffort>) {
+    match role {
+        // Three-line classification, already under the L-M4 decision-latency
+        // ceiling: pinned-low effort is not only cheaper, it keeps the call
+        // inside the ceiling so the fast route actually gets taken.
+        ModelCallRole::Triage => (Some(512), Some(ReasoningEffort::Low)),
+        // A small ordered-JSON plan. Output is bounded; effort is inherited —
+        // plan quality rides the session's own reasoning posture.
+        ModelCallRole::Plan | ModelCallRole::PlanRepair => (Some(4096), None),
+        // "PASS or FAIL, then one line" / "at most 6 lines" by their own
+        // prompts. Effort inherited: both are judgment calls on evidence.
+        ModelCallRole::Verdict | ModelCallRole::DistressGuidance => (Some(1024), None),
+        // The only raw `Worker` call is the conversational fast path, whose
+        // instructions say "reply briefly and warmly in plain prose".
+        ModelCallRole::Worker => (Some(2048), Some(ReasoningEffort::Low)),
+        // Never dispatched through this chokepoint today; if one ever is,
+        // inheriting the engine base is exactly the pre-existing behavior.
+        ModelCallRole::Unknown
+        | ModelCallRole::WitnessAuthor
+        | ModelCallRole::WitnessRepair
+        | ModelCallRole::AgentAuthor
+        | ModelCallRole::SkillAuthor
+        | ModelCallRole::DomainInference
+        | ModelCallRole::Reflection
+        | ModelCallRole::Summarization => (None, None),
+    }
 }
 
 impl<'a> Pipeline<'a> {
@@ -90,11 +135,15 @@ impl<'a> Pipeline<'a> {
         // verifier prompt from anything reading the estimate.
         let estimated_input_tokens =
             stella_core::estimator::estimate_conversation_tokens(&messages);
+        let (role_cap, role_effort) = management_bounds(role);
         let req = CompletionRequest {
             messages,
-            max_output_tokens: overrides.max_output_tokens.or(engine.max_output_tokens),
+            max_output_tokens: overrides
+                .max_output_tokens
+                .or(role_cap)
+                .or(engine.max_output_tokens),
             temperature: overrides.temperature.or(engine.temperature),
-            effort: overrides.effort.or(engine.effort),
+            effort: overrides.effort.or(role_effort).or(engine.effort),
             reasoning: overrides.reasoning.or(engine.reasoning),
             params: overrides.params.or(engine.params),
             tools: Vec::new(),

--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -470,3 +470,168 @@ async fn a_late_plan_is_abandoned_and_falls_back_to_the_single_step_plan() {
         "the missed deadline must surface as an explicit incomplete-usage record: {events:?}"
     );
 }
+
+/// Serves one scripted result per call while recording the request-shaping
+/// fields that reached it, so a test can assert the *allowance* a management
+/// call was dispatched with — `ScriptedProvider` records prompts, not bounds.
+struct BoundsProvider {
+    script: TokioMutex<VecDeque<CompletionResult>>,
+    bounds: std::sync::Mutex<Vec<(Option<u32>, Option<stella_protocol::ReasoningEffort>)>>,
+}
+
+impl BoundsProvider {
+    fn new(results: Vec<CompletionResult>) -> Self {
+        Self {
+            script: TokioMutex::new(results.into_iter().collect()),
+            bounds: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Each request's `(max_output_tokens, effort)`, in call order.
+    fn bounds(&self) -> Vec<(Option<u32>, Option<stella_protocol::ReasoningEffort>)> {
+        self.bounds.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Provider for BoundsProvider {
+    fn id(&self) -> &str {
+        "bounds"
+    }
+
+    async fn complete_ref(
+        &self,
+        req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.bounds
+            .lock()
+            .unwrap()
+            .push((req.max_output_tokens, req.effort));
+        let mut q = self.script.lock().await;
+        q.pop_front()
+            .ok_or_else(|| ProviderError::Terminal("bounds provider exhausted".into()))
+    }
+}
+
+/// Triage answers in three lines, but with no role bounds it inherited the
+/// worker's whole allowance: `engine.max_output_tokens` (the model catalog's
+/// full ceiling once the CLI seeds it) and an unset effort, which leaves the
+/// provider's default (high) reasoning allowance burning thinking tokens on a
+/// classification. The chokepoint must pin the bounded shape instead.
+#[tokio::test]
+async fn triage_dispatches_with_pinned_management_bounds() {
+    let provider = BoundsProvider::new(vec![text_result("single")]);
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None);
+    let mut total = 0.0;
+
+    pipeline
+        .triage("fix the failing parser test", &mut budget, &mut total)
+        .await
+        .expect("a served triage call must classify");
+
+    assert_eq!(
+        provider.bounds(),
+        vec![(Some(512), Some(stella_protocol::ReasoningEffort::Low))],
+        "the triage dispatch must carry the pinned management bounds, not \
+         fall through to the worker-tier allowance"
+    );
+}
+
+/// A settings-supplied role override must keep winning over the pinned role
+/// bounds — the bounds are a default between the caller's explicit overrides
+/// and the engine base, never a cap on operator intent.
+#[tokio::test]
+async fn explicit_triage_overrides_win_over_the_role_bounds() {
+    let provider = BoundsProvider::new(vec![text_result("single")]);
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            role_overrides: PipelineRoleOverrides {
+                triage: RoleCallOverrides {
+                    max_output_tokens: Some(9000),
+                    effort: Some(stella_protocol::ReasoningEffort::High),
+                    ..RoleCallOverrides::default()
+                },
+                ..PipelineRoleOverrides::default()
+            },
+            ..PipelineConfig::default()
+        },
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None);
+    let mut total = 0.0;
+
+    pipeline
+        .triage("fix the failing parser test", &mut budget, &mut total)
+        .await
+        .expect("a served triage call must classify");
+
+    assert_eq!(
+        provider.bounds(),
+        vec![(Some(9000), Some(stella_protocol::ReasoningEffort::High))],
+        "explicit role overrides must not be shadowed by the role bounds"
+    );
+}


### PR DESCRIPTION
## Problem

Every raw management call — triage, plan, plan-repair, verdict, distress guidance, and the conversational fast path — inherited the **worker's** request shape from the engine config: `max_output_tokens` seeded from the model catalog's full ceiling (64k on current Claude rows) and an unset `effort`, leaving the provider's default (high) reasoning allowance in force. Roles whose written output contracts are two to six lines (`PASS`/`FAIL` + one line; "at most 6 lines"; a three-line triage classification) were dispatched with a 64k allowance and unbounded thinking on every pipeline run — pure output-token burn, the most expensive tokens in the request. On triage it is also a latency defect: default-high thinking eats the L-M4 decision-latency ceiling, so slow triage calls get abandoned and the fast route is lost.

The repo already knows the right pattern: the engine's overflow summarizer pins `max_output_tokens: 1_200, effort: Low` (`stella-core`'s `run_compaction_pass`), and `goal.rs` pins `verifier_max_output_tokens: Some(1024)`. The management chokepoint never got the same treatment.

## Fix

`metered_raw_call` now applies role-keyed bounds *between* the caller's explicit overrides (which always win — witnessed) and the engine base:

| Role | max_output_tokens | effort |
|---|---|---|
| Triage | 512 | Low (classification, under a latency ceiling, heuristic fallback) |
| Plan / PlanRepair | 4096 | inherited (plan quality rides the session posture) |
| Verdict / DistressGuidance | 1024 | inherited (judgment calls on evidence) |
| Worker (conversational fast path only) | 2048 | Low ("reply briefly and warmly in plain prose") |

The match is exhaustive over `ModelCallRole`, so a new role dispatched through the chokepoint must decide its bounds instead of inheriting the worker ceiling by omission.

## Witness

`crates/stella-pipeline/src/pipeline/tests/management_accounting.rs`:

- `triage_dispatches_with_pinned_management_bounds` — a bounds-recording provider asserts the dispatched request carries `(Some(512), Some(Low))`. **Checked the artisanal way**: with `origin/main`'s `raw_usage.rs` restored it fails (`(None, None)` reaches the provider); with this change it passes.
- `explicit_triage_overrides_win_over_the_role_bounds` — a settings-supplied `(9000, High)` override still reaches the wire untouched.

`cargo test -p stella-pipeline --lib` 540 passed · clippy `--all-targets -- -D warnings` clean · `cargo fmt --check` clean.

## Exemplar

The bounded-role shape follows `stella-core`'s overflow summarizer (driver.rs `run_compaction_pass`) — the one management-shaped call that was already pinned.

Found by a cost audit of the pipeline's raw calls; ~15–40k output tokens of ceremony per staged run at default settings.

## Summary by Sourcery

Introduce role-specific output token and reasoning effort bounds for management pipeline calls to reduce cost and latency while preserving explicit overrides.

Bug Fixes:
- Apply bounded max_output_tokens and reasoning effort per management role instead of inheriting the worker-level engine defaults, preventing excessive token and reasoning usage.

Enhancements:
- Add a management_bounds helper to centralize role-based defaults for output limits and effort in the raw call chokepoint.
- Ensure unknown or non-management roles explicitly fall back to engine defaults rather than implicit worker ceilings.

Tests:
- Add a bounds-recording provider and tests verifying triage calls use the pinned management bounds and that explicit triage overrides still take precedence over role defaults.