### PR TITLE
fix(self-driving): shed the bench arm on the saturation rung

### DIFF
--- a/crates/stella-core/src/self_driving.rs
+++ b/crates/stella-core/src/self_driving.rs
@@ -585,8 +585,9 @@ pub fn plan_cycle(
     } else if supply.load1 >= supply.cpu {
         tier = Tier::Light;
         parallel = 1;
+        bench = BenchArm::Off;
         reason = format!(
-            "load {} at or above {} cores — the box is already saturated",
+            "load {} at or above {} cores — the box is already saturated; a bench timed here is a number the loop cannot trust",
             supply.load1, supply.cpu
         );
     } else if supply.mem_total_gb >= 32

--- a/crates/stella-core/src/self_driving/tests.rs
+++ b/crates/stella-core/src/self_driving/tests.rs
@@ -382,13 +382,16 @@ fn the_supply_rungs_decide_the_tier() {
         d,
         ("light", true, 1, "impacted", "off", 5, "deep"),
     );
+    // Saturation sheds the bench arm too — a loop-bench timed on a box whose
+    // load already equals its cores is a number the ledger would mislearn
+    // from (#1564). The build stays: it runs slower, not wrong.
     assert_plan(
         Supply {
             load1: 8,
             ..base_supply()
         },
         d,
-        ("light", true, 1, "impacted", "loop", 5, "deep"),
+        ("light", true, 1, "impacted", "off", 5, "deep"),
     );
 }
 

--- a/scripts/self-driving/commands/self-driving/scale.md
+++ b/scripts/self-driving/commands/self-driving/scale.md
@@ -43,7 +43,7 @@ explained gets overridden and then ignored.
 | a build or match owns the box | `light` | **no local build**, serial — a concurrent cargo run corrupts a measured match |
 | free memory < 4 GB | `light` | **no local build**, serial — this swap-thrashes |
 | on battery | `light` | serial, no bench — shed compute, keep the cycle useful |
-| load ≥ cores | `light` | serial — the box is already saturated |
+| load ≥ cores | `light` | serial, no bench — the box is already saturated, and a bench timed here is a number the loop cannot trust |
 | ≥32 GB, ≥100 GB free, load < half the cores | `heavy` | full workspace scope, measured head-to-head |
 | otherwise | `normal` | the calibrated ceiling |
 

--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -315,8 +315,8 @@ want_plan "a breached memory floor reads like a busy box" \
   g-m1 "light 0 1 ci off 5 deep" SELF_DRIVING_PROBE_MEM_FREE_GB=2
 want_plan "battery sheds compute but keeps the local build" \
   g-p1 "light 1 1 impacted off 5 deep" SELF_DRIVING_PROBE_ON_BATTERY=1
-want_plan "a saturated box narrows concurrency and nothing else" \
-  g-l1 "light 1 1 impacted loop 5 deep" SELF_DRIVING_PROBE_LOAD1=8
+want_plan "a saturated box narrows concurrency and sheds the bench arm" \
+  g-l1 "light 1 1 impacted off 5 deep" SELF_DRIVING_PROBE_LOAD1=8
 
 # Demand rungs: the queue can shrink the batch, and a P0 can rescue a light
 # cycle — but demand never upgrades the tier and never widens the batch.


### PR DESCRIPTION
## Problem

Issue #1564: in the governor (`plan_cycle`, ported since the issue was filed from `scripts/fullauto.sh cmd_plan` to `crates/stella-core/src/self_driving.rs`), every light rung that detects a box unfit for measured work sheds the bench arm — disk floor, contention, memory floor, battery — except the saturation rung (`load1 >= cpu`), which only narrowed parallelism and left `bench = loop` (and the build on). A loop-bench timed on a box whose load already equals its core count is a number the loop then learns from: the ledger feeds `/self-driving:evolve`, and the nightly loop-bench gate is already timing-sensitive (#1524).

## Decision

The issue offered (a) shed the bench, or (b) comment why saturation deliberately keeps it. Taken: **(a)**. Same principle as the busy rung's own reason string ("a concurrent cargo run corrupts a measured match") — a measured number this repo cannot trust is worse than no number. The rung's shape now matches the battery rung: `tier=light`, `parallel=1`, `bench=off`, **local build stays on** — a build on a saturated box runs slower, not wrong, unlike a measurement.

## Changes

- `crates/stella-core/src/self_driving.rs` — the saturation rung sets `bench = BenchArm::Off` and its reason string says why.
- `crates/stella-core/src/self_driving/tests.rs` — the pinned tuple in `the_supply_rungs_decide_the_tier` flips `"loop"` → `"off"` for the `load1: 8` case (this is the witness; the whole-tuple exact assertion is what made the old behavior visible).
- `scripts/test-self-driving.sh` — the shell golden is renamed from "a saturated box narrows concurrency and nothing else" to "…and sheds the bench arm", tuple `light 1 1 impacted off 5 deep`.
- `scripts/self-driving/commands/self-driving/scale.md` — the tier table row for `load ≥ cores` now says "serial, no bench".

## Verification

Fail-on-old, demonstrated against a prebuilt old-code binary (stella 0.6.124) — the issue's repro, spelled with today's `SELF_DRIVING_*` names:

```
SELF_DRIVING_PROBE_CPU=8 SELF_DRIVING_PROBE_LOAD1=8 ... stella self-driving plan
SELF_DRIVING_BENCH=loop          # the bug, reproduced
```

and the updated shell golden run with `STELLA_BIN` pinned to that old binary:

```
✗ a saturated box narrows concurrency and sheds the bench arm
  (want 'light 1 1 impacted off 5 deep', got 'light 1 1 impacted loop 5 deep')
self-driving-test: FAILED — 52 passed, 1 failed   # only the flipped case is red
```

Pass-with-fix: no local cargo build on this machine (standing policy — CI runs the workspace). CI's `cargo test --workspace` runs the updated `stella-core` golden, which exercises the changed rung directly; `shellcheck scripts/test-self-driving.sh` is clean. The shell suite is deliberately not in `make gate`/CI, so the Rust golden is the gate-enforced witness.

Closes #1564

## Summary by Sourcery

Align self-driving saturation behavior with other resource-constrained rungs by disabling benchmarking on already-saturated hosts while keeping builds enabled.

Bug Fixes:
- Disable the bench arm for the saturation rung so saturated hosts no longer run untrustworthy loop benchmarks.

Documentation:
- Update self-driving scaling documentation to note that saturated hosts run serially without benchmarks.

Tests:
- Adjust self-driving Rust and shell golden tests to expect the bench arm to be off on saturated hosts.