### PR TITLE
fix(self-driving): stop install-commands leaving a broken /fullauto behind

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -67,7 +67,7 @@ free one). This crate builds no binary —
 | [`src/sent_context.rs`](src/sent_context.rs) | `/api/execution-context`: the receipt queries (`step_receipt`, `step_manifest`, `context_blocks`) and the fold that rebuilds the messages one model call was sent, with the digest-verification verdict. Kept out of `src/db.rs` so that file stays clear of the 1500-line ratchet. |
 | [`src/global.rs`](src/global.rs) | The user-tier view over `~/.stella/usage.db`: the project switcher (`/api/projects`, `?project=`) and the hub-telemetry drill (org → workspace → repo → project). |
 | [`src/fsview.rs`](src/fsview.rs) | Views derived from files rather than SQL — skills, memories, rule files, `reflections.jsonl` lessons, `mcp.toml`, the settings scope chain, exploration maps — plus `redact`, the credential scrubber. |
-| [`src/self-driving.rs`](src/self-driving.rs) | The perpetual delivery loop's runs, cycles and controller state, read from `~/.stella/self-driving/<slug>/`. Plain JSONL, no database — see below for why the `crashed` status is computed here rather than read. |
+| [`src/self_driving.rs`](src/self_driving.rs) | The perpetual delivery loop's runs, cycles and controller state, read from `~/.stella/self-driving/<slug>/`. Plain JSONL, no database — see below for why the `crashed` status is computed here rather than read. |
 | [`src/codegraph.rs`](src/codegraph.rs) | `codegraph.db` flattened to `{nodes, edges, groups}` for the force-directed canvas, including the Rust module-path resolution the indexer doesn't do. |
 | [`src/assets/index.html`](src/assets/index.html) | The entire dashboard — markup, styles and script in one file, embedded at compile time. |
 | `src/assets/mark.svg`, `src/assets/wordmark.svg` | Favicon and header lockup, served from `/assets/`. |

--- a/scripts/self-driving.sh
+++ b/scripts/self-driving.sh
@@ -3,8 +3,8 @@
 #
 # The deterministic half of the loop is `stella self-driving` (#1548): the
 # governor, the ledger, the aperture ladder, the dedup oracle, and the run
-# lifecycle are engine code with types and tests (stella-core::self-driving +
-# stella-cli's self-driving_cmd). This script keeps only what is genuinely shell
+# lifecycle are engine code with types and tests (stella-core::self_driving +
+# stella-cli's self_driving_cmd). This script keeps only what is genuinely shell
 # work — the benchmark arms, the Homebrew ship step, the daemon's process
 # supervision, and the Claude command install — and DELEGATES every ported
 # verb one-for-one, so exactly one copy of every decision exists.
@@ -66,7 +66,7 @@ readonly RIG_KEY="${SELF_DRIVING_RIG_KEY:-${STELLA_HOME:-$HOME/.stella}/keys/tb9
 readonly H2H_MATCH="${SELF_DRIVING_MATCH:-arenabench/matches/fable5-claude-code-vs-stella.toml}"
 
 # The controller ceilings, the floors, the aperture ladder, and the dry-streak
-# target all live in the binary now (stella-core::self-driving), still answering
+# target all live in the binary now (stella-core::self_driving), still answering
 # to the same SELF_DRIVING_* environment knobs they always did.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -94,7 +94,7 @@ repo_slug() {
   esac
 }
 
-# State lives under the stella home, not a top-level ~/.self-driving, so it sits
+# State lives under the stella home, not a top-level ~/.fullauto, so it sits
 # beside every other durable per-user artifact and `STELLA_HOME` moves it with
 # the rest. The observatory resolves the same path through `stella-home` and
 # reads it read-only.
@@ -893,6 +893,40 @@ PY
 # repo (#448), so the commands cannot live at .claude/commands and survive.
 # This copies them into the user-scope command directory instead.
 
+# Remove the `/fullauto` command tree this project installed before #1757
+# renamed the loop.
+#
+# Left in place it is not merely redundant, it is BROKEN: those files tell the
+# agent to run `scripts/fullauto.sh` and `stella fullauto`, and neither exists
+# any more. Nothing warns the user — `/fullauto` still autocompletes, because
+# the file is still on disk.
+#
+# Deliberately surgical. $dst is the user's shared ~/.claude/commands and holds
+# commands from other tools and hand-written ones; an `rm -rf "$dst/fullauto"`
+# that met a user's own `fullauto/` would be data loss strictly worse than the
+# staleness it fixes. So: remove only the exact basenames this project ships,
+# and rmdir the directory only if that leaves it empty.
+prune_legacy_commands() {
+  local dst="$1" src="$2"
+  local removed=0 f verb
+  if [ -f "$dst/fullauto.md" ]; then
+    rm -f "$dst/fullauto.md" && removed=$((removed + 1))
+  fi
+  if [ -d "$dst/fullauto" ]; then
+    for f in "$src"/self-driving/*.md; do
+      verb="$(basename "$f")"
+      if [ -f "$dst/fullauto/$verb" ]; then
+        rm -f "$dst/fullauto/$verb" && removed=$((removed + 1))
+      fi
+    done
+    # Only when empty — never -r. A leftover here is a file we did not put
+    # there, and it is not ours to delete.
+    rmdir "$dst/fullauto" 2>/dev/null || true
+  fi
+  [ "$removed" -gt 0 ] && say "removed $removed stale /fullauto command file(s) — renamed to /self-driving"
+  return 0
+}
+
 cmd_install_commands() {
   local src="$REPO_ROOT/scripts/self-driving/commands"
   local dst="${SELF_DRIVING_COMMAND_DIR:-$HOME/.claude/commands}"
@@ -900,6 +934,7 @@ cmd_install_commands() {
   mkdir -p "$dst/self-driving" || die "cannot write $dst"
   cp "$src/self-driving.md" "$dst/self-driving.md" || die "copy failed"
   cp "$src"/self-driving/*.md "$dst/self-driving/" || die "copy failed"
+  prune_legacy_commands "$dst" "$src"
   say "installed into $dst"
   pass "/self-driving"
   local f

--- a/scripts/self-driving/README.md
+++ b/scripts/self-driving/README.md
@@ -99,7 +99,7 @@ that gates the merge anyway.
 
 ## State
 
-`~/.self-driving/<repo>/` — outside the repository, because `make no-scratch` fails
+`~/.stella/self-driving/<repo>/` — outside the repository, because `make no-scratch` fails
 the gate if a tracked file matches a `.gitignore` rule. Keyed off the **remote
 URL**, not the directory name, so a git worktree shares the main checkout's
 memory instead of starting a fresh one.
@@ -142,7 +142,7 @@ a parser, so every parsed `gh` call goes through `gh_plain`.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `SELF_DRIVING_STATE_DIR` | `~/.self-driving/<repo>` | ledger, seen set, aperture, calibration |
+| `SELF_DRIVING_STATE_DIR` | `~/.stella/self-driving/<repo>` | ledger, seen set, aperture, calibration |
 | `SELF_DRIVING_COMMAND_DIR` | `~/.claude/commands` | where `install-commands` writes |
 | `SELF_DRIVING_DRY_STREAK` | `2` | dry cycles that advance the aperture |
 | `SELF_DRIVING_BATCH_MAX` | `20` | AIMD hard ceiling |

--- a/scripts/self-driving/commands/self-driving/audit.md
+++ b/scripts/self-driving/commands/self-driving/audit.md
@@ -76,7 +76,7 @@ of re-running `rubric` will ever say so.
 
 ## What backs each lens (#1549)
 
-Every lens declares, on the record (`stella-core::self-driving::LENSES`, printed by
+Every lens declares, on the record (`stella-core::self_driving::LENSES`, printed by
 `aperture --list`), either the concrete command the cycle runs and how to
 interpret it, or that it is **model-only**. No lens is silently a no-op:
 

--- a/scripts/self-driving/commands/self-driving/status.md
+++ b/scripts/self-driving/commands/self-driving/status.md
@@ -72,7 +72,7 @@ is a loop that destroys findings, and that is worse than a loop that does not ru
 
 ## Resetting
 
-The state lives in `~/.self-driving/stella/` (`ledger.jsonl`, `seen.txt`, `cycle`) —
+The state lives in `~/.stella/self-driving/stella/` (`ledger.jsonl`, `seen.txt`, `cycle`) —
 outside the repo, because `make no-scratch` fails the gate if a tracked file
 matches a `.gitignore` rule.
 
@@ -80,7 +80,7 @@ To start a fresh convergence run over the same codebase, move it aside rather
 than deleting it — the old ledger is the record of what previous cycles decided:
 
 ```bash
-mv ~/.self-driving/stella ~/.self-driving/stella.$(date -u +%Y%m%d)
+mv ~/.stella/self-driving/stella ~/.stella/self-driving/stella.$(date -u +%Y%m%d)
 ```
 
 Clearing `seen.txt` alone re-opens every finding ever triaged, including the ones

--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -34,8 +34,8 @@
 # starting.
 set -uo pipefail
 
-FA="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/self-driving.sh"
-readonly FA
+SD_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/self-driving.sh"
+readonly SD_SH
 ROOT="$(mktemp -d)"
 readonly ROOT
 trap 'rm -rf "$ROOT"' EXIT
@@ -51,7 +51,7 @@ head_() { printf '\n\033[1m%s\033[0m\n' "$*"; }
 # seen-set or ledger decide a later one's result.
 fa() {
   local case_dir="$1"; shift
-  SELF_DRIVING_STATE_DIR="$ROOT/$case_dir" "$FA" "$@"
+  SELF_DRIVING_STATE_DIR="$ROOT/$case_dir" "$SD_SH" "$@"
 }
 
 check_eq() {
@@ -232,7 +232,7 @@ head_ "daemon — a stop that does not stop costs real money"
 # turns a working daemon into a red test and sends the reader hunting a bug
 # that is not there. (Both happened while writing this.)
 SELF_DRIVING_STATE_DIR="$ROOT/dmn" SELF_DRIVING_CYCLE_CMD="sleep 120" \
-  "$FA" daemon start 60 >/dev/null 2>&1
+  "$SD_SH" daemon start 60 >/dev/null 2>&1
 sleep 3
 cycle_pid="$(python3 -c 'import json,sys
 try: print(json.load(open(sys.argv[1])).get("cycle_pid",""))
@@ -243,7 +243,7 @@ else
   bad "the daemon never started (or never recorded) its cycle child"
 fi
 
-stop_out="$(SELF_DRIVING_STATE_DIR="$ROOT/dmn" "$FA" daemon stop 2>&1)"
+stop_out="$(SELF_DRIVING_STATE_DIR="$ROOT/dmn" "$SD_SH" daemon stop 2>&1)"
 sleep 1
 if [ -n "$cycle_pid" ] && kill -0 "$cycle_pid" 2>/dev/null; then
   bad "daemon stop ORPHANED the in-flight cycle (pid $cycle_pid still running, still spending)"
@@ -258,7 +258,7 @@ else
   ok "daemon stop lets the shutdown handler finish instead of racing it"
 fi
 
-dmn_status="$(SELF_DRIVING_STATE_DIR="$ROOT/dmn" "$FA" runs | awk '/^r-/ {print $2}')"
+dmn_status="$(SELF_DRIVING_STATE_DIR="$ROOT/dmn" "$SD_SH" runs | awk '/^r-/ {print $2}')"
 check_eq "cancelled" "$dmn_status" "a hand-stopped run records cancelled, not crashed"
 
 # ---------------------------------------------------------------------------
@@ -279,7 +279,7 @@ want_plan() { # want_plan <name> <case_dir> "<tier build par scope bench batch a
       SELF_DRIVING_PROBE_CPU=8 SELF_DRIVING_PROBE_LOAD1=1 \
       SELF_DRIVING_PROBE_MEM_TOTAL_GB=16 SELF_DRIVING_PROBE_MEM_FREE_GB=8 \
       SELF_DRIVING_PROBE_DISK_FREE_GB=50 SELF_DRIVING_PROBE_ON_BATTERY=0 \
-      SELF_DRIVING_PROBE_CONTENTION=0 "$@" "$FA" plan \
+      SELF_DRIVING_PROBE_CONTENTION=0 "$@" "$SD_SH" plan \
     | awk -F= '
         $1 == "SELF_DRIVING_TIER"        { t = $2 }
         $1 == "SELF_DRIVING_LOCAL_BUILD" { b = $2 }
@@ -351,7 +351,7 @@ JSON
 
 queue_numbers() { # queue_numbers <limit>
   env PATH="$STUB_BIN:$PATH" GH_FIX_QUEUE="$QFIX" SELF_DRIVING_STATE_DIR="$ROOT/qr" \
-    "$FA" queue --format json --limit "$1" \
+    "$SD_SH" queue --format json --limit "$1" \
     | python3 -c 'import json,sys;print(" ".join(str(i["number"]) for i in json.load(sys.stdin)["rows"]))'
 }
 
@@ -418,7 +418,7 @@ rig_h2h() { # rig_h2h <case_dir> [VAR=v ...] -- [extra h2h flags ...]
   env PATH="$STUB_BIN:$PATH" SELF_DRIVING_STATE_DIR="$ROOT/$dir" \
       SELF_DRIVING_RIG_KEY="$RIG_FIX_KEY" SELF_DRIVING_MATCH="$RIG_FIX_MATCH" \
       STUB_LOG="$ROOT/$dir/stub.log" \
-      ${envs[@]+"${envs[@]}"} "$FA" bench h2h --rig "$@"
+      ${envs[@]+"${envs[@]}"} "$SD_SH" bench h2h --rig "$@"
 }
 
 # The dry run: every check runs, the plan prints, the instance never starts.
@@ -512,7 +512,7 @@ mkdir -p "$CMDS/fullauto"
 : > "$CMDS/fullauto/my-own-notes.md"
 : > "$CMDS/unrelated-tool.md"
 
-SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1
+SELF_DRIVING_COMMAND_DIR="$CMDS" "$SD_SH" install-commands >/dev/null 2>&1
 
 if [ -f "$CMDS/self-driving.md" ] && [ -f "$CMDS/self-driving/audit.md" ]; then
   ok "the current /self-driving tree is installed"
@@ -541,7 +541,7 @@ else
 fi
 
 # Second run: the prune must be idempotent, not an error once the tree is gone.
-if SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1; then
+if SELF_DRIVING_COMMAND_DIR="$CMDS" "$SD_SH" install-commands >/dev/null 2>&1; then
   ok "a second install-commands is a clean no-op"
 else
   bad "install-commands is not idempotent"
@@ -552,7 +552,7 @@ fi
 rm -f "$CMDS/fullauto/my-own-notes.md"
 mkdir -p "$CMDS/fullauto"
 : > "$CMDS/fullauto/scale.md"
-SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1
+SELF_DRIVING_COMMAND_DIR="$CMDS" "$SD_SH" install-commands >/dev/null 2>&1
 if [ ! -d "$CMDS/fullauto" ]; then
   ok "the legacy directory is removed once the prune empties it"
 else

--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -20,7 +20,7 @@
 # CI runner), and queue ranking (a stub `gh` first on PATH serves fixtures, so
 # "no network" holds even where the real `gh` is installed). The observatory
 # half of the same contract is tested in
-# crates/stella-observatory/src/self-driving.rs.
+# crates/stella-observatory/src/self_driving.rs.
 #
 # Since #1548 the ported verbs delegate to `stella self-driving`, so the one thing
 # this suite needs beyond a shell is a stella binary (located or built by
@@ -493,6 +493,70 @@ if grep -q 'ec2 stop-instances' "$ROOT/rg-ok/stub.log" 2>/dev/null; then
   ok "the stop trap fires on success as well — ALWAYS stop"
 else
   bad "the stop trap missed the success path"
+fi
+
+# ---------------------------------------------------------------------------
+head_ "install-commands — the rename must not leave a broken /fullauto behind"
+
+# #1763: install wrote the new tree but never removed the old one, so a user
+# who had run install-commands before #1757 kept a `/fullauto` that still
+# autocompletes and still tells the agent to run `scripts/fullauto.sh` — a
+# script that no longer exists. Nothing warned them.
+CMDS="$ROOT/commands"
+mkdir -p "$CMDS/fullauto"
+: > "$CMDS/fullauto.md"
+: > "$CMDS/fullauto/audit.md"
+: > "$CMDS/fullauto/bench.md"
+# Two files this project never installed: one the user wrote by hand, and one
+# belonging to some other tool. Neither is ours to delete.
+: > "$CMDS/fullauto/my-own-notes.md"
+: > "$CMDS/unrelated-tool.md"
+
+SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1
+
+if [ -f "$CMDS/self-driving.md" ] && [ -f "$CMDS/self-driving/audit.md" ]; then
+  ok "the current /self-driving tree is installed"
+else
+  bad "install-commands did not install /self-driving"
+fi
+if [ ! -e "$CMDS/fullauto.md" ]; then
+  ok "the stale /fullauto command is removed"
+else
+  bad "the stale /fullauto command survived — it still names scripts/fullauto.sh"
+fi
+if [ ! -e "$CMDS/fullauto/audit.md" ] && [ ! -e "$CMDS/fullauto/bench.md" ]; then
+  ok "the stale /fullauto:<verb> commands are removed"
+else
+  bad "a stale /fullauto:<verb> command survived"
+fi
+if [ -f "$CMDS/fullauto/my-own-notes.md" ]; then
+  ok "a file this project never installed is left alone"
+else
+  bad "install-commands deleted a user file it did not install (data loss)"
+fi
+if [ -f "$CMDS/unrelated-tool.md" ]; then
+  ok "another tool's command in the shared dir is untouched"
+else
+  bad "install-commands deleted another tool's command"
+fi
+
+# Second run: the prune must be idempotent, not an error once the tree is gone.
+if SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1; then
+  ok "a second install-commands is a clean no-op"
+else
+  bad "install-commands is not idempotent"
+fi
+
+# A directory left empty by the prune is removed; one holding a stranger's
+# file is not.
+rm -f "$CMDS/fullauto/my-own-notes.md"
+mkdir -p "$CMDS/fullauto"
+: > "$CMDS/fullauto/scale.md"
+SELF_DRIVING_COMMAND_DIR="$CMDS" "$FA" install-commands >/dev/null 2>&1
+if [ ! -d "$CMDS/fullauto" ]; then
+  ok "the legacy directory is removed once the prune empties it"
+else
+  bad "an empty legacy directory was left behind"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Closes #1763

`install-commands` wrote the new `/self-driving` tree but **never removed the old one**, so anyone who had run it before #1757 kept both. The stale set is not merely redundant — it is **broken**: those files tell the agent to run `scripts/fullauto.sh` and `stella fullauto`, and neither exists any more. Nothing warns the user, because `/fullauto` still autocompletes: the file is still on disk.

### The prune is deliberately surgical

`$dst` is the user's shared `~/.claude/commands`. It holds commands from other tools and hand-written ones. An `rm -rf "$dst/fullauto"` that met a user's own `fullauto/` would be **data loss strictly worse than the staleness it fixes**. So the prune:

- removes only the exact basenames this project ships (`fullauto.md`, and `fullauto/<verb>.md` for the verbs in `scripts/self-driving/commands/self-driving/`)
- `rmdir`s the legacy directory only if that leaves it **empty** — never `-r`
- reports what it removed, in the shape the command already uses

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here).

Six hermetic cases in `scripts/test-self-driving.sh`, driving the real script against a throwaway `$SELF_DRIVING_COMMAND_DIR` seeded with a stale tree, a hand-written file, and another tool's command.

Checked against the broken variant rather than assumed — removing the `prune_legacy_commands` call gives:

```
  ✓ the current /self-driving tree is installed
  ✗ the stale /fullauto command survived — it still names scripts/fullauto.sh
  ✗ a stale /fullauto:<verb> command survived
  ✓ a file this project never installed is left alone
  ✓ another tool's command in the shared dir is untouched
  ✓ a second install-commands is a clean no-op
  ✗ an empty legacy directory was left behind

self-driving-test: FAILED — 57 passed, 3 failed
```

Exactly the three that assert removal fail; the two "do not delete what we did not install" cases correctly keep passing, which is what makes them worth having — they would catch a fix that over-reached.

With the fix: **60 / 60**.

## Also: eleven references the rename got wrong

Same surface, same root cause, two distinct classes. Both were found by grepping for the old name a few hours after #1757 landed — a repo-wide rename cannot catch a branch that has not merged yet, and cannot catch its own over-application.

**1. Rust module paths that took the kebab spelling and should not have.** `stella-core::self-driving` → `::self_driving`, `self-driving_cmd` → `self_driving_cmd`, `src/self-driving.rs` → `src/self_driving.rs`. The last one was a markdown **link** in `stella-observatory/README.md`, so it pointed at a file that does not exist.

**2. Paths naming a directory that has never existed.** These documented `~/.fullauto/<repo>` and were *already stale before the rename* — the state had moved under the stella home some time ago. Renaming them mechanically produced `~/.self-driving/<repo>`, which is wrong in a new way. They now name the real default:

```
STATE_DIR="${SELF_DRIVING_STATE_DIR:-$(stella_home)/self-driving/$(repo_slug)}"
```

The one genuine historical reference — the comment contrasting today's home with the old top-level one — keeps the `~/.fullauto` spelling, because that is what was actually on disk.

## The gate

- [x] `make shellcheck` — clean
- [x] `make self-driving-test` — 60 / 60
- [x] `make doc-links` — 254 citations resolve
- [x] `make command-docs` — 38 subcommands, each with a listed reference page

## Nothing left behind

Remaining from the rename: #1753 (harness not in `gate` — next), #1800 (make the file-size gate unbypassable — a branch-protection setting needing repo admin, not a code change). #1755/#1756 are in #1810.

## Summary by Sourcery

Prune legacy /fullauto command files during self-driving command installation and correct remaining self-driving naming and path references.

Bug Fixes:
- Remove stale /fullauto command entrypoints that reference deleted scripts while preserving user and third-party commands in the shared command directory.
- Fix incorrect module and file path references from the self-driving rename, including Rust module names and documentation links.
- Correct outdated state directory paths in self-driving documentation to point at the current ~/.stella/self-driving location.

Enhancements:
- Add a targeted prune_legacy_commands step to install-commands to keep the shared command directory clean and idempotent.
- Extend the self-driving shell test suite with hermetic cases covering legacy command pruning, idempotency, and safety against deleting non-project files.

Tests:
- Add new self-driving tests that verify stale /fullauto commands are removed, other tools' commands and user files are preserved, and repeated installs are no-ops.