### PR TITLE
docs(stella-pipeline): distress guidance fires on the second deterministic failure, not 'consecutive'

### DIFF
--- a/crates/stella-pipeline/README.md
+++ b/crates/stella-pipeline/README.md
@@ -157,10 +157,10 @@ red → `Revise` (a red test is already deterministic; never pay a verifier to c
 `ModelVerifier`. `touched_tests_passed: None` means "couldn't run" — inconclusive, never a
 pass. Linters and typecheckers are never fed to `FlipOracle::observe`. A verifier call that
 fails or returns unparseable text falls back to `heuristic_fallback`, which passes only on
-observed-green tests, so an outage never degrades to a blanket pass. On the second
-consecutive deterministic failure, `distress_guidance` buys one verifier call for
-course-correction that rides with the next revision prompt — event-triggered, never a fixed
-mid-run checkpoint. When the verifier PASSES on nothing but its own opinion,
+observed-green tests, so an outage never degrades to a blanket pass. On a candidate's
+second deterministic failure — cumulative, not necessarily consecutive (#868) —
+`distress_guidance` buys one verifier call for course-correction that rides with the next
+revision prompt — event-triggered, never a fixed mid-run checkpoint. When the verifier PASSES on nothing but its own opinion,
 `verifier_evidence_demand` buys one revision asking the worker for corroboration instead —
 once per candidate, and only where a tracked command exists to answer it, because with none
 resolved neither a flip nor a green touched test is reachable and the ask would be pure

--- a/crates/stella-pipeline/src/lib.rs
+++ b/crates/stella-pipeline/src/lib.rs
@@ -55,9 +55,10 @@
 //!   `docs/spec/witness-protocol.md` §7.
 //! - **L-M4** — triage runs with `max_retries = 0` under a latency ceiling.
 //!   [`pipeline::Pipeline::run`].
-//! - **Distress guidance** — on the second consecutive deterministic
-//!   verification failure, one verifier call steers the next revision
-//!   (event-triggered course-correction, never a fixed mid-run checkpoint).
+//! - **Distress guidance** — on a candidate's second deterministic
+//!   verification failure (cumulative, not necessarily consecutive — #868),
+//!   one verifier call steers the next revision (event-triggered
+//!   course-correction, never a fixed mid-run checkpoint).
 //!   [`verify::guidance_prompt`], wired in [`pipeline`].
 //!
 //! # The port surface the CLI glue implements

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -283,12 +283,12 @@ pub struct PipelineConfig {
     /// unchanged either way, since the witness has already done its job by
     /// the time adoption happens.
     pub keep_witness: bool,
-    /// Distress-triggered course-correction: on the *second consecutive*
-    /// deterministic verification failure, spend one verifier call for guidance
-    /// that rides with the next revision prompt ([`crate::verify::guidance_prompt`]).
-    /// Event-triggered by design — never a fixed mid-run checkpoint. Bounded
-    /// by `max_revisions` (at most `max_revisions - 1` guidance calls per
-    /// candidate).
+    /// Distress-triggered course-correction: on a candidate's *second*
+    /// deterministic verification failure — cumulative, not necessarily
+    /// consecutive (#868) — spend one verifier call for guidance that rides
+    /// with the next revision prompt ([`crate::verify::guidance_prompt`]).
+    /// Event-triggered by design — never a fixed mid-run checkpoint. Bounded by
+    /// `max_revisions` (at most `max_revisions - 1` guidance calls per candidate).
     pub distress_guidance: bool,
     /// The closed diagnostic that reports what the turn changed. `None`
     /// disables diff-size and zero-diff inspection.
@@ -2613,16 +2613,16 @@ impl<'a> Pipeline<'a> {
                             score_from_verification(false, Some(false)),
                         );
                     }
-                    // Distress trigger: a SECOND consecutive deterministic
-                    // failure means the evidence alone didn't steer the
-                    // worker — spend one verifier call on course-correction
+                    // Distress trigger: a SECOND deterministic failure of this
+                    // candidate — the ledger is cumulative, so the two need not
+                    // be consecutive (#868) — means the evidence alone didn't
+                    // steer the worker: spend one verifier call on course-correction
                     // (event-triggered, never a fixed midpoint checkpoint).
-                    // Counted from the deterministic-failure ledger
-                    // (`deterministic_disclosure` just recorded this round's
-                    // fingerprint), not from `revisions`: a prior model-verifier
-                    // FAIL also increments `revisions`, and gating on it paid
-                    // a guidance call on the FIRST deterministic red while
-                    // telling the verifier the agent had "failed twice in a row".
+                    // Counted from that ledger (`deterministic_disclosure` just
+                    // recorded this round's fingerprint), not from `revisions`:
+                    // a prior model-verifier FAIL also increments `revisions`,
+                    // and gating on it paid a guidance call on the FIRST deterministic
+                    // red while telling the verifier the agent had "failed twice in a row".
                     let mut reason = brief.message();
                     if self.config.distress_guidance && state.failures.len() >= 2 {
                         // Same witness exclusion as the verdict call (#1433):

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -1988,7 +1988,7 @@ async fn a_witness_that_never_fails_finishes_the_run_without_re_executing_it() {
 /// evidence alone; the SECOND spends one verifier call whose course-correction
 /// rides with the next revision prompt.
 #[tokio::test]
-async fn second_consecutive_red_verification_gets_verifier_guidance() {
+async fn second_deterministic_red_verification_gets_verifier_guidance() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("done"),      // worker

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -1,8 +1,8 @@
 //! End-to-end scenarios for the verification hardening series: typed
-//! infra outcomes (#860), the confirmation run on flip (#859), and the
-//! diagnostics regression veto (#861). Each drives the real pipeline
-//! over scripted ports — no API key, no subprocess — and pins the
-//! decision the ladder must reach.
+//! infra outcomes (#860), the confirmation run on flip (#859), the
+//! diagnostics regression veto (#861), and the cumulative distress-guidance
+//! trigger (#1780). Each drives the real pipeline over scripted ports — no
+//! API key, no subprocess — and pins the decision the ladder must reach.
 
 use super::*;
 use crate::LineMutation;
@@ -1149,5 +1149,113 @@ async fn a_measured_overlap_still_earns_the_deterministic_badge() {
             .diff_coverage
             .as_deref(),
         Some("covered")
+    );
+}
+
+/// #1780: the distress trigger counts a candidate's deterministic failures
+/// cumulatively — the two need not be consecutive. Here the candidate fails
+/// deterministically, then takes a *different* path (the suite times out →
+/// inconclusive → model verifier, which FAILs without touching the
+/// deterministic-failure ledger), then fails deterministically again — and
+/// that second red still buys the guidance call. This pins current behavior,
+/// which is deliberate (#868 chose the cumulative ledger so a stuck worker is
+/// steered early): the docs used to promise "second *consecutive*", and this
+/// test is what keeps the code and the docs telling the same story.
+#[tokio::test]
+async fn a_second_deterministic_failure_fires_guidance_even_when_not_consecutive() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),                                     // worker
+        text_result("first fix"), // revision 1 (deterministic red #1, no guidance)
+        text_result("FAIL — the fix does not address the goal"), // model verifier (timeout round)
+        text_result("second fix"), // revision 2 (verifier FAIL: not on the ledger)
+        text_result("You are patching the symptom; fix the parser instead."), // guidance
+        text_result("third fix"), // revision 3 (carries guidance)
+    ]);
+    let resolver = OneProvider(&provider);
+    // Baseline red (the oracle arms), post-execute red → deterministic
+    // failure #1 → revise on raw evidence; post-revision-1 TIMES OUT →
+    // inconclusive, so the verifier is bought and FAILs → revise (nothing
+    // recorded on the deterministic-failure ledger); post-revision-2 red →
+    // deterministic failure #2 → distress guidance rides with revision 3;
+    // post-revision-3 red → revisions exhausted → deterministic failed verdict.
+    let runner = ScriptedRunner::scripted(
+        vec![
+            TestScript::Fail,
+            TestScript::Fail,
+            TestScript::TimeOut,
+            TestScript::Fail,
+            TestScript::Fail,
+        ],
+        "@@ -1 +1 @@\n-a\n+b",
+    );
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        // Room for the revision that carries the guidance: two revisions are
+        // already spent before the second deterministic red lands.
+        max_revisions: 3,
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    let verdict = outcome.verdict.expect("verified");
+    assert!(!verdict.passed);
+    assert!(verdict.deterministic, "red tests are a deterministic fail");
+    assert_eq!(outcome.revisions, 3);
+
+    // The guidance text reached the worker's revision prompt after the SECOND
+    // deterministic red, even though a verifier-FAIL round separated it from
+    // the first — the ledger is cumulative, not a consecutiveness filter.
+    let carried = messages.iter().any(|m| {
+        m.content.contains("Independent reviewer course-correction")
+            && m.content.contains("fix the parser instead")
+    });
+    assert!(
+        carried,
+        "guidance rides with the revision after the second deterministic red"
+    );
+    assert!(
+        stages(&drain(&mut rx)).contains(&StageKind::Verdict),
+        "the guidance call is an honest Verifier stage in the stream"
     );
 }

--- a/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verifier_evidence_demand.rs
@@ -314,7 +314,7 @@ async fn an_evidence_demand_does_not_spend_a_repair_round() {
         test_command: Some("cargo test -p x".into()),
         diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
         // Off so the model script stays a pure count of worker turns — the
-        // second consecutive red would otherwise buy a guidance call, which
+        // second deterministic red would otherwise buy a guidance call, which
         // has its own witnesses.
         distress_guidance: false,
         // `max_revisions` stays at the default 2: the subject is that BOTH

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -1126,8 +1126,9 @@ pub fn verifier_prompt(
 }
 
 /// The distress-guidance prompt: spent only when the worker is demonstrably
-/// stuck — the *second consecutive* deterministic test failure in the revise
-/// loop (`PipelineConfig::distress_guidance`). Not a verdict (the failure is
+/// stuck — the *second* deterministic test failure a candidate accumulates in
+/// the revise loop, consecutive or not (#868 chose the cumulative ledger;
+/// `PipelineConfig::distress_guidance`). Not a verdict (the failure is
 /// already deterministic — re-judging it would be spend without information,
 /// L-E11); the verifier model instead reads goal + diff + failing evidence and
 /// returns concrete course-correction the next revision turn carries. This is

--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -314,8 +314,9 @@ because `bench/evidence/` is frozen at the vocabulary each run was recorded in.
 
 A `Revise` decision (or a verifier `FAIL`) sends the evidence back into a fresh
 worker turn (`Pipeline::revise_candidate`), up to `max_revisions` times
-(default 2). On the **second consecutive** deterministic failure, the pipeline
-spends one verifier call on **distress guidance** (`verify::guidance_prompt`) —
+(default 2). On the **second** deterministic failure a candidate accumulates —
+consecutive or not (#868) — the pipeline spends one verifier call on
+**distress guidance** (`verify::guidance_prompt`) —
 a course-correction note that rides with the next revision prompt instead of
 letting the worker dig the same hole. Repeated identical failures also widen
 what the revision prompt discloses about the failure

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -206,8 +206,9 @@ heuristic verdict rather than hanging or guessing.
 ### 8. Revise
 
 A failed verification sends the worker back with the failure evidence — up to
-a bounded number of revision turns (2 by default). Once a revision has
-deterministically failed, stella spends one verifier call on **distress guidance**:
+a bounded number of revision turns (2 by default). Once a candidate has
+deterministically failed twice — consecutive or not — stella spends one
+verifier call on **distress guidance**:
 a course-correction note that rides with the next revision prompt instead of
 letting the worker keep digging the same hole.
 


### PR DESCRIPTION
## Problem

Issue #1780: the distress-guidance trigger was documented as firing on the *second consecutive* deterministic verification failure (`PipelineConfig::distress_guidance` docs in `crates/stella-pipeline/src/pipeline.rs`, the `guidance_prompt` docs in `crates/stella-pipeline/src/verify.rs`, plus copies in the crate overview, the crate README, `docs/design/pipeline-journey.md`, and the website pipeline page). The code fires on `state.failures.len() >= 2` in the `LadderDecision::Revise` arm, over a cumulative, never-cleared ledger (`CandidateState::record_failure` in `crates/stella-pipeline/src/pipeline/disclosure.rs`) — so fail / other-path / fail across rounds triggers guidance even though the failures were not consecutive.

## Decision: the code is right, the docs were wrong (option a)

Any second deterministic failure of a candidate is distress. Closed #868 deliberately chose the cumulative fingerprint ledger for *early* triggering, and the trigger comment in `pipeline.rs` documents why the gate reads the deterministic-failure ledger rather than `revisions`. Filtering for consecutiveness (option b) would delay steering for exactly the worker #868 wanted steered sooner, for no benefit. So every doc site now states the true trigger — a candidate's second deterministic failure, cumulative, not necessarily consecutive — and the stale test name (`second_consecutive_red_verification_gets_verifier_guidance`) and a stale comment in `tests/verifier_evidence_demand.rs` were renamed to match.

## Verification

New unit test `a_second_deterministic_failure_fires_guidance_even_when_not_consecutive` in `crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs` drives the real pipeline over scripted ports through fail → suite-timeout/verifier-FAIL → fail and asserts the guidance call fires and its text rides with the next revision prompt.

**Honesty note:** this is a docs-match-behavior fix, so the new test **pins current behavior** — it passes on `main` too and is deliberately *not* a fail-on-old witness. It exists so the semantics the docs now describe cannot silently drift.

Ran locally: `cargo test -p stella-pipeline` (guidance + evidence-demand suites green), `cargo fmt --check`, and the file-size / god-files / left-behind guards. `pipeline.rs` and `pipeline/tests.rs` are grandfathered god files closed to growth: the new test lands in the `verification_hardening.rs` sibling module, and both god files' line counts are byte-for-byte unchanged (3575 / 2568).

Closes #1780

## Summary by Sourcery

Align distress-guidance documentation and tests with the pipeline’s actual behavior, where guidance is triggered on a candidate’s second deterministic failure cumulatively rather than on second consecutive failure.

Documentation:
- Update pipeline, verifier, crate, design, and website docs to describe distress guidance as firing on a candidate’s second deterministic failure cumulatively, not necessarily consecutively.

Tests:
- Add an end-to-end verification hardening scenario that proves guidance fires on a non-consecutive second deterministic failure and ensure existing test names and comments reflect the cumulative trigger semantics.