### PR TITLE
fix(stella-pipeline): drop the goal parameter McpPrefetchPort never honored

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -442,7 +442,9 @@ impl CandidateWorkspacePort for GitCandidateWorkspaces {
 /// [`McpPrefetchPort`] (issue #248 Phase 1): the orchestrator calls this
 /// ONCE before a best-of-N fan-out, never per candidate — see
 /// [`stella_mcp::McpToolSet::prefetch_candidate_context`] for what actually
-/// gets called and why it is safe to call blind.
+/// gets called and why it is safe to call blind. Goal-blind by the port's
+/// contract (#1779): the sweep only ever calls zero-argument tools with
+/// `{}`, so there is no goal to deliver anywhere.
 pub(crate) struct McpPrefetchAdapter(Arc<stella_mcp::McpToolSet>);
 
 impl McpPrefetchAdapter {
@@ -453,7 +455,7 @@ impl McpPrefetchAdapter {
 
 #[async_trait]
 impl McpPrefetchPort for McpPrefetchAdapter {
-    async fn prefetch(&self, _goal: &str) -> Option<String> {
+    async fn prefetch(&self) -> Option<String> {
         self.0.prefetch_candidate_context().await
     }
 }

--- a/crates/stella-pipeline/src/mcp_prefetch.rs
+++ b/crates/stella-pipeline/src/mcp_prefetch.rs
@@ -16,17 +16,17 @@ use crate::ports::McpPrefetchPort;
 /// whole one.
 const PREFETCH_BUDGET_CHARS: usize = 20_000;
 
-/// `goal`/`n` describe the fan-out about to start; `port` is `None` when the
-/// caller wired no pre-fetch hook. `Some` only when there is genuinely new
+/// `n` is the width of the fan-out about to start; `port` is `None` when the
+/// caller wired no pre-fetch hook. The sweep is goal-blind by contract
+/// ([`McpPrefetchPort`], #1779). `Some` only when there is genuinely new
 /// context to share — `None` means the caller's original `base_messages`
 /// must be used unchanged (never allocate a redundant clone).
 pub(crate) async fn fold(
     port: Option<&dyn McpPrefetchPort>,
-    goal: &str,
     n: u32,
     base_messages: &[CompletionMessage],
 ) -> Option<Vec<CompletionMessage>> {
-    let context = port?.prefetch(goal).await?;
+    let context = port?.prefetch().await?;
     let context = {
         let mut kept: String = context.chars().take(PREFETCH_BUDGET_CHARS).collect();
         if kept.chars().count() < context.chars().count() {

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1701,7 +1701,7 @@ impl<'a> Pipeline<'a> {
         total: &mut f64,
     ) -> Result<(CandidateResult, Option<String>, u32), PipelineError> {
         // Orchestrator pre-fetch (issue #248) — see `crate::mcp_prefetch::fold`.
-        let prefetched = crate::mcp_prefetch::fold(self.mcp_prefetch, goal, n, base_messages).await;
+        let prefetched = crate::mcp_prefetch::fold(self.mcp_prefetch, n, base_messages).await;
         let base_messages: &[CompletionMessage] = prefetched.as_deref().unwrap_or(base_messages);
         let Some(port) = self.candidate_workspaces else {
             if author_witness {

--- a/crates/stella-pipeline/src/pipeline/tests/mcp_prefetch.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/mcp_prefetch.rs
@@ -1,7 +1,9 @@
 //! The orchestrator MCP pre-fetch hook (issue #248): [`McpPrefetchPort::prefetch`]
 //! is consulted once at the top of `run_best_of_n`, and its result — when
 //! `Some` — rides in every candidate's shared message history rather than
-//! each candidate independently paying to look it up.
+//! each candidate independently paying to look it up. The sweep is
+//! goal-blind by contract (#1779): `prefetch` takes no arguments, so no
+//! double here can even observe what goal the run carries.
 
 use super::*;
 
@@ -12,7 +14,7 @@ struct FixedPrefetch(&'static str);
 
 #[async_trait]
 impl McpPrefetchPort for FixedPrefetch {
-    async fn prefetch(&self, _goal: &str) -> Option<String> {
+    async fn prefetch(&self) -> Option<String> {
         Some(self.0.to_string())
     }
 }
@@ -83,12 +85,12 @@ async fn an_oversized_prefetch_is_clamped_with_a_visible_marker() {
     struct OwnedPrefetch(String);
     #[async_trait]
     impl McpPrefetchPort for OwnedPrefetch {
-        async fn prefetch(&self, _goal: &str) -> Option<String> {
+        async fn prefetch(&self) -> Option<String> {
             Some(self.0.clone())
         }
     }
     let port = OwnedPrefetch("x".repeat(60_000));
-    let folded = crate::mcp_prefetch::fold(Some(&port), "goal", 2, &[])
+    let folded = crate::mcp_prefetch::fold(Some(&port), 2, &[])
         .await
         .expect("a hit folds a message");
     let msg = &folded.last().expect("one folded message").content;
@@ -106,7 +108,7 @@ async fn a_prefetch_miss_never_aborts_the_run() {
     struct EmptyPrefetch;
     #[async_trait]
     impl McpPrefetchPort for EmptyPrefetch {
-        async fn prefetch(&self, _goal: &str) -> Option<String> {
+        async fn prefetch(&self) -> Option<String> {
             None
         }
     }

--- a/crates/stella-pipeline/src/ports.rs
+++ b/crates/stella-pipeline/src/ports.rs
@@ -868,12 +868,19 @@ pub trait CandidateWorkspacePort: Send + Sync {
 /// even at N=1), and a single-shot run isolated into a throwaway worktree
 /// (`isolate_in_worktree` answering yes). Only a single-shot run executing
 /// in the session tree never reaches it.
+///
+/// Deliberately goal-blind (#1779): the sweep calls every candidate-safe
+/// zero-argument tool with `{}` and concatenates the output, so there is
+/// nothing a goal could steer — a `goal` parameter here would advertise
+/// relevance no implementor delivers. A goal-aware prefetch that runs ahead
+/// of planning is the research-stage design deferred to #1778, which may
+/// subsume this port entirely.
 #[async_trait]
 pub trait McpPrefetchPort: Send + Sync {
     /// Best-effort: `None` when there is nothing worth injecting (no
     /// candidate-safe servers connected, every call failed, or every call
     /// returned nothing) — a prefetch miss never aborts the run.
-    async fn prefetch(&self, goal: &str) -> Option<String>;
+    async fn prefetch(&self) -> Option<String>;
 }
 
 /// A human's decision at the scope-review gate (L-E5). `Trim` carries the


### PR DESCRIPTION
## What & why

`McpPrefetchPort::prefetch(&self, goal: &str)` advertised goal-aware prefetch, but nothing behind the port ever delivered it: the CLI adapter (`crates/stella-cli/src/candidate_ws.rs`) bound `_goal` and `McpToolSet::prefetch_candidate_context` (`crates/stella-mcp/src/toolset.rs`) blindly calls every candidate-safe zero-argument MCP tool with `{}` and concatenates the output. A signature that promises relevance no implementor provides is the kind of quiet lie the port boundary exists to prevent.

**Decision: option (a) — make the port honestly goal-blind.** The `goal` parameter is dropped from `McpPrefetchPort::prefetch` and the signature is chased through `mcp_prefetch::fold`, the `run_best_of_n` call site, the CLI adapter, and every test double. The port and adapter doc comments now describe what the sweep actually is — a blind pass over candidate-safe zero-arg tools — and name the deferral.

**Why not option (b) (goal-aware + moved ahead of planning):** that is the research-stage design deliberately deferred to the research-stage epic #1778, where a research sub-agent with MCP read tools may subsume this port entirely. Building goal-awareness into this port now would prejudge that design.

Closes #1779

Refs #1778

## The witness

- [x] No witness needed — because: the change is the removal of a parameter, which is compiler-enforced: any implementor, caller, or double still passing a goal fails `cargo check`, so a classic fail-on-old runtime witness is impractical for a type-level change. The existing prefetch behavior tests (`crates/stella-pipeline/src/pipeline/tests/mcp_prefetch.rs`: fold-into-every-candidate, budget clamp with visible marker, miss-never-aborts) still pin the sweep's behavior and pass, and after this change no double can even observe a goal — the goal-independence the issue asked to pin is now structural.

## The gate

- [x] `cargo fmt --check` (on the two touched crates)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — left to CI (constrained machine; scoped `cargo check -p stella-pipeline` and `-p stella-cli` both pass locally)
- [ ] `cargo test --workspace` — left to CI; scoped run of the three `mcp_prefetch` pipeline tests passes locally
- [x] Docs updated where behavior changed (port, fold, and adapter doc comments)
- [x] CLA signed
- [x] `Closes #1779` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing new: the remaining half of issue #1779's audit — prefetch running after every steering decision, invisible to triage/planner/witness author — is exactly what the already-filed research-stage epic #1778 tracks, and this PR's doc comments point there.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`crates/stella-pipeline/src/pipeline.rs` is a grandfathered god file; its call-site change is net-zero lines. The trait-doc growth lands in `ports.rs`, which is not in the baseline.

## Summary by Sourcery

Make MCP prefetching explicitly goal-blind by removing the unused goal parameter from the MCP prefetch port and its pipeline integration.

Enhancements:
- Simplify the McpPrefetchPort trait and mcp_prefetch::fold helper by dropping the unused goal argument and updating the pipeline call site accordingly.
- Clarify documentation for the MCP prefetch port, fold helper, and CLI adapter to describe the goal-blind, zero-argument prefetch sweep and reference the related research epic (#1778).
- Update MCP prefetch test doubles and adapter implementations to match the new goal-agnostic prefetch interface while preserving existing behavior.