### PR TITLE
feat(release): break the silence when a release ships nothing (#1464)

### DIFF
--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -1,0 +1,73 @@
+name: release-reconcile
+
+# Break the silence around a failed release (#1464).
+#
+# `release.yml` failed on 31 consecutive tags (v0.6.75 → v0.6.108, about two
+# days) and nothing anywhere said so. The repository kept cutting version
+# numbers the whole time while shipping no binaries.
+#
+# It was invisible because every surface a maintainer glances at reported
+# success: `ci` on main green, `auto-tag` succeeded (it tags, dispatches, and
+# exits without ever looking at the outcome), the version-sync PR opened and
+# auto-merged, CHANGELOG.md rolled, and the manifests were stamped. Only the
+# last two jobs of `release.yml` skipped, and nothing reads `gh release list`
+# on a cadence.
+#
+# ── Why a reconciler and not a watcher ───────────────────────────────────────
+#
+# The tempting fix is to have `auto-tag` watch the run it dispatches — it
+# already does exactly that for the version-sync PR. But `auto-tag`'s
+# concurrency group is serialized with `cancel-in-progress: false` and its
+# comments are explicit that every failure path warns and exits 0 *specifically*
+# so a bad release cannot jam the queue under a burst of merges. Holding that
+# job open for an hour of full-LTO builds is the thing it was written to avoid.
+#
+# Comparing state instead of watching a run also catches strictly more: a
+# dispatch that never started, a run cancelled by a runner outage, and a release
+# deleted after the fact are all invisible to a watcher and all visible here.
+#
+# ── Cadence ──────────────────────────────────────────────────────────────────
+#
+# Hourly. The script's own 90-minute grace window is what keeps this quiet
+# during a build — a red release run is indistinguishable at a glance from one
+# still going, since full-LTO plus the independent rebuild arm takes the better
+# part of an hour. Running more often than the grace window would just re-ask a
+# question whose answer cannot have changed.
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      grace-secs:
+        description: "Seconds a tag may go unpublished before it is reported"
+        type: string
+        default: "5400"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-reconcile
+  cancel-in-progress: true
+
+jobs:
+  reconcile:
+    name: every tag has a published release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full history and tags: the check reads tag creation dates out of git
+      # (`gh api .../tags` carries no date at all), so a shallow clone would
+      # see no tags and report a clean bill of health it had not earned.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Reconcile tags against published releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/check-releases-published.sh \
+            --grace-secs "${{ inputs.grace-secs || '5400' }}"

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,19 @@ automerge-nudge-test: ## Test which PR the auto-merge nudge picks (hermetic; not
 file-size-test: ## Test which languages the file-size ratchet actually watches (hermetic; not part of `gate`)
 	./scripts/test-file-size.sh
 
+.PHONY: releases-published
+releases-published: ## Assert every v* tag older than the grace window has a published release (#1464)
+	@./scripts/check-releases-published.sh
+
+.PHONY: releases-baseline-update
+releases-baseline-update: ## Grandfather the tags that shipped nothing and never will (review the diff!)
+	@./scripts/check-releases-published.sh --update
+	@git --no-pager diff --stat -- scripts/unpublished-tags-baseline.txt || true
+
+.PHONY: releases-published-test
+releases-published-test: ## Test the tag/release reconciliation rule (hermetic; not part of `gate`)
+	./scripts/test-releases-published.sh
+
 .PHONY: hooks
 hooks: ## Install the pre-push gate hook (runs `make gate`, scoped to the diff, on every push)
 	git config core.hooksPath .githooks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,6 +140,50 @@ That push starts the `Release` workflow, which:
   version + per-target SHA-256 sums) and commits it to the Homebrew tap
   (skipped if `HOMEBREW_TAP_TOKEN` is not configured).
 
+## When a release fails
+
+A failed release used to be **silent**. `release.yml` failed on 31 consecutive
+tags (v0.6.75 → v0.6.108, about two days) and nothing said so: `ci` on main was
+green, `auto-tag` succeeded — it tags, dispatches, and exits without looking at
+the outcome — the version-sync PR opened and auto-merged, `CHANGELOG.md` rolled,
+and every manifest was stamped. Only the last two jobs of `release.yml` skipped.
+Every surface a maintainer glances at said "released" (#1464).
+
+Two things now catch it, and they catch different failures:
+
+- **`smoke`** (in `release.yml`) unpacks the artifact and runs it before
+  anything is published, so a release that *builds* but does not *work* cannot
+  reach the Homebrew tap (#1626).
+- **`release-reconcile.yml`** runs hourly and compares `git tag -l 'v*'` against
+  `gh release list`, failing when a tag older than 90 minutes has no release.
+  That window is deliberate: full-LTO plus the independent rebuild arm takes the
+  better part of an hour, so "not published yet" is the normal state for a long
+  time after every merge.
+
+Run it yourself at any time:
+
+```bash
+make releases-published
+```
+
+It compares state rather than watching the dispatched run, which catches
+strictly more — a dispatch that never started, a run killed by a runner outage,
+and a release deleted after the fact are all invisible to a watcher. It also
+deliberately does **not** read workflow conclusions: the `release`/`homebrew`
+jobs are gated on a tag ref, so "skipped" is the correct state for a
+`workflow_dispatch` on a branch and reading conclusions would report those as
+failures.
+
+`scripts/unpublished-tags-baseline.txt` grandfathers the tags that shipped
+nothing and are not going to be republished (#1463), so the check is an alarm
+about **new** silence rather than a daily recital of a backlog. Adding to it is
+a decision — that tag will never have a release — and lands as a reviewable
+diff:
+
+```bash
+make releases-baseline-update    # then read the diff
+```
+
 ## Verify a published binary yourself
 
 Release builds are reproducible: the same tag, built on the pinned toolchain,

--- a/crates/stella-model/src/catalog.rs
+++ b/crates/stella-model/src/catalog.rs
@@ -1182,7 +1182,10 @@ mod tests {
                 .resolve_for(provider, slug)
                 .unwrap_or_else(|_| panic!("{provider}/{slug} is not in the seed catalog"));
             assert_eq!(entry.pricing.input_usd_per_mtok, 5.00, "{slug} input price");
-            assert_eq!(entry.pricing.output_usd_per_mtok, 25.00, "{slug} output price");
+            assert_eq!(
+                entry.pricing.output_usd_per_mtok, 25.00,
+                "{slug} output price"
+            );
             assert_eq!(entry.context_window, 1_000_000, "{slug} context window");
             assert_eq!(
                 entry.max_output_tokens,

--- a/scripts/check-releases-published.sh
+++ b/scripts/check-releases-published.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# Reconcile tags against published releases. See #1464.
+#
+#   ./scripts/check-releases-published.sh [--grace-secs N]
+#   ./scripts/check-releases-published.sh --select --now <unix> --grace-secs <n>   # pure: JSON on stdin
+#
+# ── The silence ──────────────────────────────────────────────────────────────
+#
+# `release.yml` failed on 31 consecutive tags (v0.6.75 → v0.6.108, about two
+# days) and nothing anywhere said so. The repository kept cutting version
+# numbers the whole time while shipping no binaries.
+#
+# It was invisible because every surface a maintainer glances at reported
+# success: `ci` on main green, `auto-tag` succeeded (it tags, dispatches, and
+# exits without looking at the outcome), the version-sync PR opened and
+# auto-merged, CHANGELOG.md rolled, and the manifests were stamped. Only the
+# last two jobs of `release.yml` skipped. `gh release list` was the single
+# place the gap showed, and nobody reads it on a cadence.
+#
+# ── Why a reconciler rather than watching the dispatched run ─────────────────
+#
+# The obvious fix is to have `auto-tag` watch the `release.yml` run it
+# dispatches. But `auto-tag`'s concurrency group is serialized with
+# `cancel-in-progress: false`, and its comments are explicit that every failure
+# path warns and exits 0 *specifically* so a bad release cannot jam the queue
+# under a burst of merges. Holding that job open for an hour of full-LTO builds
+# is the thing it was written to avoid.
+#
+# Comparing state also catches strictly more: a dispatch that never started, a
+# run cancelled by a runner outage, and a release deleted after the fact are all
+# invisible to a watcher of one run and all visible here.
+#
+# ── The grace window ─────────────────────────────────────────────────────────
+#
+# A red release run is indistinguishable at a glance from one still building —
+# full-LTO plus the independent rebuild arm takes the better part of an hour, so
+# "not published yet" is the NORMAL state for a long window after every merge.
+# A tag younger than the grace window is therefore not evidence of anything and
+# is skipped. Too short and this cries wolf on every release; too long and the
+# silence it exists to break lasts that much longer.
+set -euo pipefail
+
+grace_secs=$((90 * 60))
+select_only=0
+update=0
+now=""
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Tags already known to have shipped nothing, so the alarm is about NEW silence.
+# Enforcing bare would have fired on 26 historical tags the first time it ran,
+# and an alarm that reports a backlog every run is one everybody mutes — which
+# is the same outcome as the silence it replaced. Same reasoning, and the same
+# shape, as scripts/file-size-baseline.txt.
+baseline="$repo_root/scripts/unpublished-tags-baseline.txt"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --grace-secs) grace_secs="${2:?--grace-secs needs a number}"; shift 2 ;;
+    --now) now="${2:?--now needs a unix timestamp}"; shift 2 ;;
+    --select) select_only=1; shift ;;
+    --update) update=1; shift ;;
+    -h|--help) sed -n '2,8p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ── The decision, as a pure function ─────────────────────────────────────────
+#
+# Reads one JSON document on stdin:
+#
+#   { "tags":     [ { "name": "v0.6.75", "created_unix": 1234567890 }, … ],
+#     "releases": [ "v0.6.74", "v0.6.109", … ] }
+#
+# and prints one `<tag>\t<age-in-seconds>` line per tag that should have been
+# published and was not, oldest first. Kept free of I/O so
+# scripts/test-releases-published.sh can drive every rule from a fixture rather
+# than from the live repository — a suite that asked GitHub would pass or fail
+# for reasons that have nothing to do with the rule under test.
+#
+# Note what is NOT consulted: the outcome of any workflow run. A `release`/
+# `homebrew` job is gated on `startsWith(github.ref, 'refs/tags/')`, so
+# "skipped" is the correct state for a `workflow_dispatch` on a branch and
+# reading run conclusions would report those as failures. Tag-versus-release is
+# the question that has one right answer.
+#
+# `.known` is the grandfathered set (see `baseline` above). It is an input to
+# the pure function rather than read from disk here, so the suite can drive the
+# grandfathering rule too — an exemption that nothing tests is an exemption
+# nobody can be sure still applies to what it was written for.
+select_unpublished() {
+  jq -r --argjson now "$now" --argjson grace "$grace_secs" '
+    ( [ .releases[] | { (.): true } ] | add // {} ) as $published
+    | ( [ (.known // [])[] | { (.): true } ] | add // {} ) as $known
+    | [ .tags[]
+        | select($published[.name] | not)
+        | select($known[.name] | not)
+        | select(($now - .created_unix) > $grace)
+      ]
+    | sort_by(.created_unix)
+    | .[]
+    | "\(.name)\t\($now - .created_unix)"
+  '
+}
+
+# The baseline as a JSON array, ignoring comments and blank lines.
+known_json() {
+  if [ -f "$baseline" ]; then
+    grep -v '^[[:space:]]*#' "$baseline" | jq -R -s 'split("\n") | map(select(length > 0))'
+  else
+    echo '[]'
+  fi
+}
+
+if [ "$select_only" -eq 1 ]; then
+  [ -n "$now" ] || { echo "--select needs --now" >&2; exit 2; }
+  select_unpublished
+  exit 0
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "::error::gh is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "::error::jq is not installed" >&2; exit 1; }
+[ -n "$now" ] || now="$(date -u +%s)"
+
+# Tag creation dates come from git rather than the API: `gh api .../tags` pages
+# by name and carries no date at all, and the workflow checks out with
+# fetch-tags anyway. `creatordate` is the tag's own date for an annotated tag
+# and the commit's for a lightweight one, which is the date a reader means.
+tags_json="$(
+  git for-each-ref --format='%(refname:short) %(creatordate:unix)' 'refs/tags/v*' \
+    | jq -R -s 'split("\n") | map(select(length > 0) | split(" ") | { name: .[0], created_unix: (.[1] | tonumber) })'
+)"
+
+# `gh` colorizes even `--json` output when it believes it has a terminal, which
+# makes the result invalid JSON. It costs nothing on a runner (never a TTY) and
+# is the difference between working and not when a maintainer runs this by hand.
+#
+# The limit is deliberately far above the real count and then CHECKED. A
+# truncated release list makes every release beyond the cut look unpublished:
+# at `--limit 200` against 313 releases this script reported 137 missing tags
+# instead of the true 26. An alarm that inflates by 5x is one nobody believes,
+# and the inflation is silent — so it is asserted rather than assumed.
+releases_limit=1000
+releases_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh release list --limit "$releases_limit" --json tagName --jq '[.[].tagName]')"
+if [ "$(printf '%s' "$releases_json" | jq 'length')" -ge "$releases_limit" ]; then
+  echo "::error::the release list hit the ${releases_limit} page limit, so it may be truncated — every release past the cut would be reported as an unpublished tag. Raise releases_limit in $0." >&2
+  exit 1
+fi
+
+doc="$(jq -n --argjson tags "$tags_json" --argjson releases "$releases_json" \
+  --argjson known "$(known_json)" '{ tags: $tags, releases: $releases, known: $known }')"
+
+if [ "$update" -eq 1 ]; then
+  {
+    echo "# Tags that shipped nothing and are NOT going to be republished."
+    echo "# See #1463 (what to do with them) and #1464 (why this file exists)."
+    echo "#"
+    echo "# Regenerate with: make releases-baseline-update"
+    echo "#"
+    echo "# Grandfathering these is what lets check-releases-published.sh be an"
+    echo "# alarm about NEW silence. A tag added here is a release that will never"
+    echo "# exist, so every addition should be a decision someone made, visible in"
+    echo "# review — not a way to quiet the check."
+    printf '%s' "$doc" | jq -r --argjson now "$now" --argjson grace "$grace_secs" '
+      ( [ .releases[] | { (.): true } ] | add // {} ) as $published
+      | [ .tags[] | select($published[.name] | not) | select(($now - .created_unix) > $grace) ]
+      | sort_by(.created_unix) | .[] | .name'
+  } >"$baseline.tmp"
+  mv "$baseline.tmp" "$baseline"
+  echo "check-releases-published: baseline updated — $(grep -cv '^#' "$baseline") grandfathered tag(s)."
+  exit 0
+fi
+
+report="$(printf '%s' "$doc" | select_unpublished)"
+
+total_tags="$(printf '%s' "$tags_json" | jq 'length')"
+known_count="$(known_json | jq 'length')"
+if [ -z "$report" ]; then
+  echo "check-releases-published: OK — every v* tag older than $((grace_secs / 60))m has a published release (${total_tags} tag(s) checked, ${known_count} grandfathered)."
+  exit 0
+fi
+
+count="$(printf '%s\n' "$report" | wc -l | tr -d ' ')"
+echo "::error::${count} tag(s) were cut but never published. The repository is stamping version numbers while shipping no binaries — this is the #1464 silence, live."
+echo ""
+echo "Tag                  Age"
+printf '%s\n' "$report" | while IFS="$(printf '\t')" read -r tag age; do
+  printf '  %-18s %sh\n' "$tag" "$((age / 3600))"
+done
+echo ""
+echo "Check what happened:  gh run list --workflow=release.yml --limit 40 --json conclusion,headBranch"
+echo "Re-run one by hand:   see RELEASING.md § When a release fails"
+exit 1

--- a/scripts/test-releases-published.sh
+++ b/scripts/test-releases-published.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Tests for check-releases-published.sh's reconciliation rule (#1464).
+#
+#   ./scripts/test-releases-published.sh
+#
+# Run it after touching that script. Not part of `make gate`: a dozen jq
+# invocations over fixtures, the same posture as `make impacted-test`.
+#
+# ── What is under test ───────────────────────────────────────────────────────
+#
+# This is an alarm, and both ways an alarm fails are bad in different ways:
+#
+#   silent   the thing it exists to catch goes unreported. That already
+#            happened for two days and 31 tags, which is why the script exists.
+#   crying   it fires while a release is still building. Full-LTO plus the
+#            independent rebuild arm takes the better part of an hour, so a
+#            just-cut tag with no release is the NORMAL state — an alarm that
+#            reports it is one everybody learns to ignore, which is the same
+#            outcome as silence but with more noise on the way.
+#
+# Every case below straddles one of those. The `--select` mode exists so they
+# can: it is the rule with the I/O taken out, so a fixture is a complete input
+# and no live repository or API is involved.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-releases-published.sh"
+
+# A fixed clock. Real time would make these cases drift into and out of the
+# grace window depending on when the suite ran.
+NOW=1000000
+GRACE=5400 # 90 minutes, the script's default
+
+pass=0
+fail=0
+
+# want <name> <expected-tags-space-separated-or-empty> <json>
+want() {
+  local name="$1" expect="$2" json="$3" got
+  got="$(printf '%s' "$json" | "$SCRIPT" --select --now "$NOW" --grace-secs "$GRACE" 2>&1 | cut -f1 | tr '\n' ' ')"
+  got="${got% }"
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — wanted '${expect}', got '${got}'"
+  fi
+}
+
+# tag <name> <seconds-ago>
+tag() { printf '{"name":"%s","created_unix":%s}' "$1" "$((NOW - $2))"; }
+
+day=86400
+
+# ── Silent: the failure this exists to catch ─────────────────────────────────
+# The #1464 shape — a run of consecutive tags, none published.
+want "S1 a run of unpublished old tags is reported, oldest first" \
+  "v0.6.75 v0.6.76 v0.6.77" \
+  "{\"tags\":[$(tag v0.6.77 $((2 * day))),$(tag v0.6.75 $((4 * day))),$(tag v0.6.76 $((3 * day)))],\"releases\":[\"v0.6.74\"]}"
+
+want "S2 one unpublished tag among published ones is still caught" \
+  "v0.6.76" \
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.77 $day)],\"releases\":[\"v0.6.75\",\"v0.6.77\"]}"
+
+# A release that was published and later deleted looks exactly like one that
+# never published, and is equally worth knowing about. A watcher of the
+# dispatched run cannot see this at all.
+want "S3 a tag whose release was deleted after the fact is caught" \
+  "v0.6.80" \
+  "{\"tags\":[$(tag v0.6.80 $((5 * day)))],\"releases\":[]}"
+
+# ── Crying wolf: what must NOT fire ──────────────────────────────────────────
+want "C1 a tag inside the grace window is not reported — the release is still building" \
+  "" \
+  "{\"tags\":[$(tag v0.6.90 $((30 * 60)))],\"releases\":[]}"
+
+# The boundary, from both sides. An off-by-one here is the difference between
+# an alarm that fires every release and one that fires none.
+want "C2 a tag exactly at the grace boundary is not reported" \
+  "" \
+  "{\"tags\":[$(tag v0.6.90 $GRACE)],\"releases\":[]}"
+
+want "C3 a tag one second past the boundary is reported" \
+  "v0.6.90" \
+  "{\"tags\":[$(tag v0.6.90 $((GRACE + 1)))],\"releases\":[]}"
+
+want "C4 a fully published history reports nothing" \
+  "" \
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day)))],\"releases\":[\"v0.6.75\",\"v0.6.76\"]}"
+
+want "C5 no tags at all reports nothing" "" '{"tags":[],"releases":[]}'
+
+# A release for a tag that no longer exists is somebody else's problem, not an
+# unpublished tag. Reporting it would send a reader looking for a build that
+# was never owed.
+want "C6 a release with no matching tag is not a finding" \
+  "" \
+  "{\"tags\":[$(tag v0.6.75 $((2 * day)))],\"releases\":[\"v0.6.75\",\"v0.6.99\"]}"
+
+# ── Grandfathering ───────────────────────────────────────────────────────────
+# The baseline is what lets this be an alarm about NEW silence instead of a
+# daily recital of a backlog nobody is going to republish (#1463). An exemption
+# nothing tests is one nobody can be sure still covers what it was written for.
+want "K1 a grandfathered tag is not reported" \
+  "" \
+  "{\"tags\":[$(tag v0.4.29 $((30 * day)))],\"releases\":[],\"known\":[\"v0.4.29\"]}"
+
+want "K2 grandfathering one tag does not silence its neighbours" \
+  "v0.4.30" \
+  "{\"tags\":[$(tag v0.4.29 $((30 * day))),$(tag v0.4.30 $((29 * day)))],\"releases\":[],\"known\":[\"v0.4.29\"]}"
+
+want "K3 an absent baseline grandfathers nothing" \
+  "v0.4.29" \
+  "{\"tags\":[$(tag v0.4.29 $((30 * day)))],\"releases\":[]}"
+
+# ── Mixed: the realistic case ────────────────────────────────────────────────
+# Old-and-published, old-and-missing, and fresh-and-missing together. A rule
+# applied in the wrong order reports the fresh one or misses the old one.
+want "M1 a mixed history reports only the old unpublished tag" \
+  "v0.6.76" \
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.99 $((10 * 60)))],\"releases\":[\"v0.6.75\"]}"
+
+# The age column is what tells a reader "two days" from "twenty minutes", so it
+# has to be right, not merely present.
+age_of() {
+  printf '%s' "{\"tags\":[$(tag v0.6.75 $((2 * day)))],\"releases\":[]}" \
+    | "$SCRIPT" --select --now "$NOW" --grace-secs "$GRACE" | cut -f2
+}
+if [ "$(age_of)" = "$((2 * day))" ]; then
+  pass=$((pass + 1)); echo "ok   A1 the reported age is the tag's real age"
+else
+  fail=$((fail + 1)); echo "FAIL A1 the reported age is the tag's real age — got '$(age_of)'"
+fi
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/unpublished-tags-baseline.txt
+++ b/scripts/unpublished-tags-baseline.txt
@@ -1,0 +1,33 @@
+# Tags that shipped nothing and are NOT going to be republished.
+# See #1463 (what to do with them) and #1464 (why this file exists).
+#
+# Regenerate with: make releases-baseline-update
+#
+# Grandfathering these is what lets check-releases-published.sh be an
+# alarm about NEW silence. A tag added here is a release that will never
+# exist, so every addition should be a decision someone made, visible in
+# review — not a way to quiet the check.
+v0.1.1
+v0.1.2
+v0.1.3
+v0.1.4
+v0.1.5
+v0.1.6
+v0.1.7
+v0.1.8
+v0.1.9
+v0.1.10
+v0.1.11
+v0.1.12
+v0.1.13
+v0.2.2
+v0.3.1
+v0.3.2
+v0.4.3
+v0.4.4
+v0.4.5
+v0.4.6
+v0.4.7
+v0.4.8
+v0.4.9
+v0.4.29


### PR DESCRIPTION
## Problem (P0)

`release.yml` failed on **31 consecutive tags** (v0.6.75 → v0.6.108, about two days) and nothing anywhere said so. The repository kept cutting version numbers the whole time while shipping no binaries.

It was invisible because every surface a maintainer glances at reported success: `ci` on main green, `auto-tag` **succeeded** (it tags, dispatches, and exits without ever looking at the outcome), the version-sync PR opened and auto-merged, `CHANGELOG.md` rolled, every manifest stamped. Only the last two jobs of `release.yml` skipped. `gh release list` was the single place the gap showed, and nobody reads it on a cadence.

## Change

An hourly reconciler comparing `git tag -l 'v*'` against `gh release list`, failing when a tag older than 90 minutes has no release.

### Option 2, not option 1 — deliberately

Having `auto-tag` watch the run it dispatches is the tempting fix; it already does exactly that for the version-sync PR. But `auto-tag`'s concurrency group is serialized with `cancel-in-progress: false`, and its comments are explicit that every failure path warns and exits 0 **specifically so a bad release cannot jam the queue** under a burst of merges. Holding that job open for an hour of full-LTO builds is the thing it was written to avoid — the issue flags this tension directly.

Comparing *state* also catches strictly more than watching a run: a dispatch that never started, a run killed by a runner outage, and a release deleted after the fact are all invisible to a watcher and all visible here.

### The grace window is load-bearing

A red release run is indistinguishable at a glance from one still building — full-LTO plus the independent rebuild arm takes the better part of an hour — so a just-cut tag with no release is the **normal** state. An alarm that reports it is one everybody mutes, which is the same outcome as the silence it replaced.

## Two things the first draft got wrong

Both caught by running it against the live repository rather than reasoning about it:

**1. Silent truncation inflated the alarm 5x.** `gh release list --limit 200` against 313 releases meant every release past the cut looked unpublished:

```
::error::137 tag(s) were cut but never published        # wrong
```

The true number is 26. The limit is now far above the real count **and asserted**, because the inflation is silent and a 5x-inflated alarm is one nobody believes.

**2. Enforcing bare would have fired on 24 historical tags on day one.** `scripts/unpublished-tags-baseline.txt` grandfathers the tags that shipped nothing and are not going to be republished (#1463), so this is an alarm about **new** silence rather than a daily recital of a backlog. Same reasoning, and the same shape, as `scripts/file-size-baseline.txt` — whose header already explains why enforcing bare fails on day one.

## Witness

The decision is a pure function over `{tags, releases, known}` with the I/O taken out, so the suite drives it from fixtures rather than from the live repository — a suite that asked GitHub would pass or fail for reasons unrelated to the rule.

`scripts/test-releases-published.sh` (`make releases-published-test`, hermetic, not in `gate`) covers **both** ways an alarm fails:

```
ok   S1 a run of unpublished old tags is reported, oldest first
ok   S2 one unpublished tag among published ones is still caught
ok   S3 a tag whose release was deleted after the fact is caught
ok   C1 a tag inside the grace window is not reported — the release is still building
ok   C2 a tag exactly at the grace boundary is not reported
ok   C3 a tag one second past the boundary is reported
ok   C4 a fully published history reports nothing
ok   C5 no tags at all reports nothing
ok   C6 a release with no matching tag is not a finding
ok   K1 a grandfathered tag is not reported
ok   K2 grandfathering one tag does not silence its neighbours
ok   K3 an absent baseline grandfathers nothing
ok   M1 a mixed history reports only the old unpublished tag
ok   A1 the reported age is the tag's real age

passed 14, failed 0
```

C2/C3 straddle the boundary from both sides — an off-by-one there is the difference between an alarm that fires every release and one that fires none.

**The decisive one:** replaying the actual #1464 incident — v0.6.75..v0.6.108 unpublished, two days old — through the rule reports **all 34 tags**. Against the live repository today it reports none:

```
check-releases-published: OK — every v* tag older than 90m has a published release (339 tag(s) checked, 24 grandfathered).
```

## What it deliberately does not do

It does not read workflow conclusions. `release`/`homebrew` are gated on `startsWith(github.ref, 'refs/tags/')`, so "skipped" is the *correct* state for a `workflow_dispatch` on a branch, and reading conclusions would report those as failures — the issue calls this out as a constraint. Tag-versus-release is the question with one right answer.

`RELEASING.md` gains a "When a release fails" section covering the check, the grace window, and the baseline.

`make shellcheck`, `scripts/check-action-pins.sh` (61 pinned refs) and `make guards-fast` pass.

## Base

Stacked on #1806, which unbreaks `cargo fmt --check` on `main`.

Closes #1464

## Summary by Sourcery

Add an hourly GitHub Actions workflow and supporting scripts to reconcile tags against published releases, ensuring failed or missing releases are detected instead of remaining silent.

New Features:
- Provide a CLI check (`make releases-published`) to assert that every v* tag older than a grace window has a corresponding published GitHub release.
- Add a CLI helper (`make releases-baseline-update`) to update a baseline of tags that intentionally shipped no binaries and will never be republished.
- Introduce a dedicated test target (`make releases-published-test`) to validate the tag/release reconciliation rule against fixtures.

Enhancements:
- Document the new release failure detection mechanisms and procedures in RELEASING.md, including how to run the checks and manage the baseline.
- Add a GitHub Actions workflow (`release-reconcile.yml`) that runs hourly to automatically enforce the tag-versus-release reconciliation check.
- Minor formatting adjustment in a catalog pricing test for consistency.

Documentation:
- Extend RELEASING.md with a section explaining how failed releases are detected, how the grace window works, and how to manage grandfathered tags via the baseline file.

Tests:
- Add scripts and tests to exercise the tag/release reconciliation logic in a hermetic way, ensuring correct behavior around grace windows, deleted releases, and grandfathered tags.