### PR TITLE
fix(stella-fleet): surface a lost dispatch lease on the task handle and in fleet output

### DIFF
--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1099,15 +1099,11 @@ fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
         if !handle.outcome.summary.is_empty() {
             println!("      {}", handle.outcome.summary.dimmed());
         }
-        if let Some(error) = &handle.ledger_error {
-            // The result above is authoritative; what was lost is the durable
-            // row. Silent here would mean the only witness to an open
-            // attempts row is a future `stella doctor`.
-            println!(
-                "      {} attempt not recorded in the fleet ledger ({error}) — the row stays \
-                 open; `stella doctor` will report it",
-                "!".yellow()
-            );
+        // Durable-failure notices (a ledger close that failed after the
+        // worker settled, a dispatch lease lost mid-run) are composed in
+        // stella-fleet — this file is at its size ceiling (#1677).
+        for notice in stella_fleet::handle_notices(handle) {
+            println!("      {} {notice}", "!".yellow());
         }
     }
     for (task_id, reason) in &report.dispatch_failures {
@@ -1408,6 +1404,7 @@ mod tests {
             worktree: None,
             budget: BudgetOutcome::Continue,
             ledger_error: None,
+            lease_loss: None,
         }
     }
 

--- a/crates/stella-fleet/README.md
+++ b/crates/stella-fleet/README.md
@@ -87,6 +87,7 @@ is nearest today — split it before it crosses.
 | [`src/lib.rs`](src/lib.rs) | The five-pieces-one-seam overview and the crate's re-exports. Read it first. |
 | [`src/plan.rs`](src/plan.rs) | `Plan`/`Task`/`Isolation` and the pure DAG scheduling: `validate`, `topological_order`, `ready_tasks`, cycle detection. No I/O, no async — open it to change how waves are formed or what a plan may declare. |
 | [`src/fleet.rs`](src/fleet.rs) | `Fleet::dispatch` (the seam), `run_wave`, `run_plan`, the claim/control RAII guards, and the per-task pause/resume/stop verbs. The biggest file and the one that orders everything else. |
+| [`src/fleet/notice.rs`](src/fleet/notice.rs) | `handle_notices` — the per-handle warning lines (`ledger_error`, `lease_loss`, #1677) the `stella fleet` report prints; composed here because `fleet_cmd.rs` is at its file-size ceiling. |
 | [`src/ledger.rs`](src/ledger.rs) | `fleet.db`: schema, migrations, and every read/write of runs, tasks, attempts, commits, lineage and spend. |
 | [`src/ledger/lease.rs`](src/ledger/lease.rs) | Dispatch claims (#1136): the check-and-set, expiring lease on one unit of dispatch — `claim_dispatch` / `renew_dispatch` / `release_dispatch` and the reads a human or a dispatcher asks "who is on this?" with. |
 | [`src/git.rs`](src/git.rs) | The `GitCli` port, `SystemGitCli`, and `WorktreeManager` — worktree create/remove/list plus the pathspec-only commit helper. |

--- a/crates/stella-fleet/src/fleet.rs
+++ b/crates/stella-fleet/src/fleet.rs
@@ -317,6 +317,28 @@ pub struct TaskHandle {
     /// left open and its commits/spend rows were not written, so anything
     /// reading the ledger later sees an attempt that never closed.
     pub ledger_error: Option<String>,
+    /// `Some` when this attempt's dispatch lease (#1136) was lost mid-run: a
+    /// heartbeat renewal came back [`RenewOutcome::Lost`] — the attempt
+    /// stalled past `DISPATCH_LEASE_TTL` and a rival session reclaimed the
+    /// task — or the ledger became unreadable. The same "attempt succeeded
+    /// but something durable failed" seam as `ledger_error`: the worker was
+    /// deliberately left to finish (never killed mid-flight), so the outcome
+    /// above is real work, but a rival may have run the same task in
+    /// parallel, and this run is the one that can report the overlap instead
+    /// of leaving it to whoever inspects the ledger's bumped fence (#1677).
+    pub lease_loss: Option<LeaseLoss>,
+}
+
+/// The record of a dispatch lease lost mid-attempt, carried on
+/// [`TaskHandle::lease_loss`] (#1677).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseLoss {
+    /// The rival session now holding the task — its run id, which embeds the
+    /// minting pid (see [`FleetConfig::run_id`]) — when the failed renewal
+    /// could read one. `None` when the ledger was unreadable, the row had
+    /// vanished, or this run's own lease had merely lapsed with no rival
+    /// taking it.
+    pub taken_by: Option<String>,
 }
 
 /// The result of running a whole plan.
@@ -658,7 +680,9 @@ where
     /// finish the work that is already paid for. It finishes. The row is not
     /// re-taken behind the rival's back — renewal fails and the guard's
     /// fenced release leaves the rival's claim alone — so the overlap is
-    /// visible in the ledger rather than silently repaired.
+    /// visible in the ledger, and the loss is stamped onto the settled
+    /// handle as [`TaskHandle::lease_loss`] so the run that can report two
+    /// workers on one task actually does (#1677).
     async fn dispatch_leased(
         &self,
         task: &Task,
@@ -667,12 +691,14 @@ where
         let beat = std::time::Duration::from_millis(lease.lease.heartbeat_interval_ms());
         let attempt = self.dispatch_claimed(task);
         tokio::pin!(attempt);
-        let mut holding = true;
+        let mut lease_loss: Option<LeaseLoss> = None;
         loop {
             tokio::select! {
                 biased;
-                settled = &mut attempt => return settled,
-                () = tokio::time::sleep(beat), if holding => {
+                settled = &mut attempt => {
+                    return settled.map(|handle| TaskHandle { lease_loss, ..handle });
+                }
+                () = tokio::time::sleep(beat), if lease_loss.is_none() => {
                     let now_ms = self.clock.now_ms();
                     let renewed = {
                         let ledger = self.lock_ledger();
@@ -680,10 +706,21 @@ where
                     };
                     match renewed {
                         Ok(RenewOutcome::Renewed(extended)) => lease.lease = extended,
-                        // Superseded, or the ledger is unreadable: either way
-                        // this attempt no longer has a lease to prove, so stop
-                        // beating and let the work it already paid for finish.
-                        Ok(RenewOutcome::Lost(_)) | Err(_) => holding = false,
+                        // Superseded: this attempt no longer has a lease to
+                        // prove, so stop beating and let the work it already
+                        // paid for finish — recording who took the task. A
+                        // row still naming THIS run is not a rival: the lease
+                        // merely lapsed unclaimed.
+                        Ok(RenewOutcome::Lost(claim)) => {
+                            lease_loss = Some(LeaseLoss {
+                                taken_by: claim
+                                    .filter(|c| c.owner != self.config.run_id)
+                                    .map(|c| c.owner),
+                            });
+                        }
+                        // The ledger is unreadable — same policy, no holder
+                        // to name.
+                        Err(_) => lease_loss = Some(LeaseLoss { taken_by: None }),
                     }
                 }
             }
@@ -846,6 +883,9 @@ where
             worktree,
             budget,
             ledger_error,
+            // A lease loss is observed by the heartbeat in `dispatch_leased`,
+            // which stamps it over this on the way out.
+            lease_loss: None,
         })
     }
 
@@ -1173,6 +1213,8 @@ where
             .commits_for_task(&self.config.run_id, task_id)?)
     }
 }
+
+pub mod notice;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-fleet/src/fleet/notice.rs
+++ b/crates/stella-fleet/src/fleet/notice.rs
@@ -1,0 +1,114 @@
+//! The per-handle warning lines `stella fleet`'s end-of-run report prints —
+//! one line per durable failure a settled attempt survived: a ledger close
+//! that failed after the worker settled ([`TaskHandle::ledger_error`]) and a
+//! dispatch lease lost mid-run ([`TaskHandle::lease_loss`], #1677).
+//!
+//! The text is composed here rather than in `stella-cli/src/fleet_cmd.rs`
+//! because that file is grandfathered at its file-size ceiling and closed to
+//! growth (AGENTS.md § God files) — the CLI iterates the returned lines and
+//! owns only color and layout.
+
+use super::TaskHandle;
+
+/// The warning lines the fleet report prints under `handle`'s row, in a
+/// fixed order (ledger close first, lease loss second). Empty for the
+/// common, healthy attempt. Plain text — the caller owns color and layout,
+/// and prints each line exactly once.
+#[must_use]
+pub fn handle_notices(handle: &TaskHandle) -> Vec<String> {
+    let mut notices = Vec::new();
+    if let Some(error) = &handle.ledger_error {
+        // The in-memory result is authoritative; what was lost is the
+        // durable row. Silent here would mean the only witness to an open
+        // attempts row is a future `stella doctor`.
+        notices.push(format!(
+            "attempt not recorded in the fleet ledger ({error}) — the row stays open; \
+             `stella doctor` will report it"
+        ));
+    }
+    if let Some(loss) = &handle.lease_loss {
+        // The worker was deliberately left to finish (never killed
+        // mid-flight), so the result above is real work — but a rival may
+        // have produced the same work in parallel, and this line is the one
+        // place that overlap reaches a human.
+        notices.push(match &loss.taken_by {
+            Some(owner) => format!(
+                "task `{}` lost its dispatch lease mid-run to session `{owner}` — two workers \
+                 may have run this task; review both results before keeping either",
+                handle.task_id
+            ),
+            None => format!(
+                "task `{}` lost its dispatch lease mid-run (no rival holder was readable) — \
+                 the attempt finished without a live claim on the task",
+                handle.task_id
+            ),
+        });
+    }
+    notices
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_core::BudgetOutcome;
+
+    use super::super::{LeaseLoss, TaskHandle, WorkerOutcome};
+    use super::*;
+
+    fn handle() -> TaskHandle {
+        TaskHandle {
+            task_id: "t1".to_string(),
+            attempt_id: 1,
+            outcome: WorkerOutcome {
+                cost_usd: 0.0,
+                commits: Vec::new(),
+                summary: String::new(),
+                success: true,
+            },
+            worktree: None,
+            budget: BudgetOutcome::Continue,
+            ledger_error: None,
+            lease_loss: None,
+        }
+    }
+
+    #[test]
+    fn a_healthy_attempt_has_no_notices() {
+        assert!(handle_notices(&handle()).is_empty());
+    }
+
+    #[test]
+    fn a_lost_lease_names_the_task_and_the_session_that_took_it_over() {
+        let mut h = handle();
+        h.lease_loss = Some(LeaseLoss {
+            taken_by: Some("run-b".to_string()),
+        });
+        let notices = handle_notices(&h);
+        assert_eq!(notices.len(), 1, "one loss, one line");
+        assert!(notices[0].contains("`t1`"), "names the task: {notices:?}");
+        assert!(
+            notices[0].contains("`run-b`"),
+            "names the rival session: {notices:?}"
+        );
+    }
+
+    #[test]
+    fn a_lost_lease_with_no_readable_rival_still_reports() {
+        let mut h = handle();
+        h.lease_loss = Some(LeaseLoss { taken_by: None });
+        let notices = handle_notices(&h);
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("lost its dispatch lease"));
+    }
+
+    #[test]
+    fn ledger_and_lease_notices_stack_in_a_fixed_order() {
+        let mut h = handle();
+        h.ledger_error = Some("disk I/O error".to_string());
+        h.lease_loss = Some(LeaseLoss { taken_by: None });
+        let notices = handle_notices(&h);
+        assert_eq!(notices.len(), 2);
+        assert!(notices[0].contains("not recorded in the fleet ledger"));
+        assert!(notices[0].contains("disk I/O error"));
+        assert!(notices[1].contains("lost its dispatch lease"));
+    }
+}

--- a/crates/stella-fleet/src/fleet/tests.rs
+++ b/crates/stella-fleet/src/fleet/tests.rs
@@ -1204,3 +1204,60 @@ async fn a_live_attempt_holds_its_task_against_a_rival() {
     gate.add_permits(1);
     assert!(f.dispatch(&task).await.unwrap().outcome.success);
 }
+
+/// **Witness (#1677).** An attempt whose dispatch lease is reclaimed by a
+/// rival mid-run still finishes — the no-mid-flight-kill contract — but the
+/// loss no longer vanishes: it is reported on the settled handle, naming the
+/// session that took the task over. Fails on the old code, where
+/// `TaskHandle` had no field to carry it.
+#[tokio::test(start_paused = true)]
+async fn a_lost_dispatch_lease_is_reported_on_the_settled_handle() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("fleet.db");
+    let gate = Arc::new(tokio::sync::Semaphore::new(0));
+    let f = Fleet::new(
+        GatedWorker { gate: gate.clone() },
+        WorktreeManager::new(OkGit::new(), "/repo"),
+        Ledger::open(&db).unwrap(),
+        BudgetGuard::new(BudgetMode::Observed, None, None),
+        SeqClock::new(),
+        FleetConfig::new("run-a", "HEAD"),
+    )
+    .unwrap();
+    let rival = Ledger::open(&db).unwrap();
+
+    let task = Task::new("t1", "title", "prompt").shared_tree();
+    let (handle, ()) = tokio::join!(f.dispatch(&task), async {
+        // While the worker is parked on its gate, the rival reclaims the
+        // task as if this attempt had stalled past its TTL — a far-future
+        // `now_ms` expires the live lease inside the claim statement itself.
+        let outcome = rival
+            .claim_dispatch(
+                &dispatch_claim_key("t1"),
+                "run-b",
+                u64::from(u32::MAX),
+                900_000,
+            )
+            .unwrap();
+        assert!(
+            matches!(outcome, ClaimOutcome::Granted(_)),
+            "the rival reclaims the expired lease, got {outcome:?}"
+        );
+        // Paused time auto-advances to the dispatch's heartbeat while every
+        // task is parked; sleeping two beats guarantees the renewal has
+        // failed against the moved fence before the gate opens.
+        tokio::time::sleep(DISPATCH_LEASE_TTL * 2 / 3).await;
+        gate.add_permits(1);
+    });
+
+    let handle = handle.unwrap();
+    assert!(handle.outcome.success, "the worker still finishes");
+    let loss = handle
+        .lease_loss
+        .expect("a lost lease must be reported on the handle");
+    assert_eq!(
+        loss.taken_by.as_deref(),
+        Some("run-b"),
+        "the report names the session that took the task over"
+    );
+}

--- a/crates/stella-fleet/src/lib.rs
+++ b/crates/stella-fleet/src/lib.rs
@@ -80,8 +80,8 @@ pub mod plan;
 
 pub use cache_schedule::{RunnableSession, warmest_first};
 pub use fleet::{
-    CacheWarmthLookup, Fleet, FleetConfig, FleetError, FleetRunReport, FleetWorker, TaskHandle,
-    WorkerControls, WorkerOutcome,
+    CacheWarmthLookup, Fleet, FleetConfig, FleetError, FleetRunReport, FleetWorker, LeaseLoss,
+    TaskHandle, WorkerControls, WorkerOutcome, notice::handle_notices,
 };
 pub use gc::{
     BranchAction, BranchVerdict, Gc, GcError, GcOptions, GcReport, KeepReason, WorktreeAction,


### PR DESCRIPTION
## What & why

`Fleet::dispatch_leased` (`crates/stella-fleet/src/fleet.rs`) heartbeats the task's dispatch lease (#1136) while the worker runs. When a renewal came back `RenewOutcome::Lost` — the attempt stalled past `DISPATCH_LEASE_TTL` and a rival session reclaimed the task, or the ledger became unreadable — it stopped beating and let the worker finish (deliberate, kept: this codebase never kills a worker mid-flight), but the event left **no trace**: no field on `TaskHandle`, nothing in `FleetRunReport`, nothing printed. The one run that could report two workers on the same task was exactly the run that stayed silent.

**Approach** — mirrors the `ledger_error` seam ("the attempt succeeded but something durable failed"):

- The heartbeat records the loss and stamps it onto the settled handle as `TaskHandle::lease_loss: Option<LeaseLoss>`, carrying the rival session's run id (`taken_by`) when the failed renewal could read one. A row still naming *this* run is a lapse, not a takeover, and is deliberately not counted as a rival; a ledger read error records the loss with no holder to name.
- `stella fleet`'s end-of-run report prints it once per handle, naming the task and the session that took it over. `crates/stella-cli/src/fleet_cmd.rs` is grandfathered at its exact file-size ceiling (1507) and closed to growth, so the line composition lives in a new sibling module of stella-fleet — `crates/stella-fleet/src/fleet/notice.rs::handle_notices` — which also composes the existing `ledger_error` line. `fleet_cmd.rs` **shrinks by 3 lines** (1507 → 1504); no baseline change.
- No new `AgentEvent`: `stella-protocol/src/event.rs` is itself a god file closed to growth and any new variant restales the generated `docs/wire` schema; no existing variant fits, and the emit-shape helpers in `monitor.rs` only build existing protocol events. The handle field is the natural path the issue names first, so the event was deliberately not added.

Closes #1677
Refs #1136

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`fleet::tests::a_lost_dispatch_lease_is_reported_on_the_settled_handle` — built on the `a_live_attempt_holds_its_task_against_a_rival` harness: a gated worker parks holding the lease, a second `Ledger` connection reclaims the task with a far-future `now_ms` (expiring the live lease inside the claim statement, moving the fence), paused tokio time auto-advances to the heartbeat so the renewal fails, then the gate opens. Asserts the worker still finishes AND the settled handle's `lease_loss.taken_by` names `run-b`. On `main` the test fails by construction: `TaskHandle` has no `lease_loss` field to assert on (the "field absent" failure mode the issue names).

Verified here:

```
test fleet::tests::a_lost_dispatch_lease_is_reported_on_the_settled_handle ... ok
test result: ok. 35 passed; 0 failed  (cargo test -p stella-fleet fleet — includes the
original rival-claim harness and the four new fleet::notice::tests)
```

## The gate

- [x] `cargo fmt --check` (touched crates: stella-fleet, stella-cli — clean)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally (16GB machine, heavy-build constraint); CI validates
- [ ] `cargo test --workspace` — `cargo check -p stella-fleet` + `cargo test -p stella-fleet fleet` run locally (35/35 green); CI runs the workspace
- [x] Docs updated where behavior changed (doc comments on `TaskHandle::lease_loss`, `LeaseLoss`, `dispatch_leased`; stella-fleet README Layout row for `src/fleet/notice.rs`)
- [x] CLA signed
- [x] `Closes #1677` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The `settled` arm of `dispatch_leased`'s select now returns `settled.map(|handle| TaskHandle { lease_loss, ..handle })` — struct-update over the handle `dispatch_claimed` built with `lease_loss: None`, so the heartbeat's observation always wins on the way out and `dispatch_claimed` stays ignorant of leases (its concern boundary is unchanged).

## Summary by Sourcery

Surface dispatch lease losses on task handles and in fleet run reports so runs that lose a lease mid-execution can report the overlap explicitly.

New Features:
- Record mid-run dispatch lease loss on TaskHandle via an optional LeaseLoss field, including the rival session when readable.
- Expose structured lease loss information and notice composition through stella-fleet, including the new handle_notices helper for CLI consumers.

Enhancements:
- Factor per-handle durable-failure messaging (ledger errors and lease losses) into a dedicated stella-fleet notice module to keep CLI reporting thin.

Documentation:
- Document the new lease_loss behavior on TaskHandle and dispatch_leased, and describe the new notice module in the stella-fleet README layout table.

Tests:
- Add a witness test ensuring a reclaimed dispatch lease is reported on the settled handle, and unit tests for the new handle_notices formatting logic.