### PR TITLE
feat(gate): bring the self-driving harness into `make gate`, on a pinned binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,10 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + format-check (fmt --check)
                          #   + lint (clippy -D warnings)
                          #   + test (test --workspace)
+                         #   + self-driving-test (the shell harness)
 ```
 
-That is twenty-three steps, and the list is not maintained by hand: it is
+That is twenty-four steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,11 @@ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+cargo build -p stella-cli --bin stella && \
+  STELLA_BIN="$PWD/target/debug/stella" ./scripts/test-self-driving.sh
 ```
 
-Or just `make gate`, which is the twenty-three of them in order.
+Or just `make gate`, which is the twenty-four of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 # CONTRIBUTING.md to the real list instead of a hand-copied one. Both documents
 # had already re-rotted twice, in the same direction each time: a guard was
 # added here and the prose kept the old count (#1437).
-GATE_STEPS := $(GATE_GUARDS) doc-warnings format-check lint test
+GATE_STEPS := $(GATE_GUARDS) doc-warnings format-check lint test self-driving-test
 
 .PHONY: help
 help: ## Show this help
@@ -297,8 +297,15 @@ impacted-test: ## Test the gate-scoping script (hermetic; not part of `gate`)
 	./scripts/test-impacted-crates.sh
 
 .PHONY: self-driving-test
-self-driving-test: ## Test the self-driving control logic — digest, AIMD, aperture, run lifecycle (hermetic; not part of `gate`)
-	./scripts/test-self-driving.sh
+# Pins STELLA_BIN rather than letting the harness locate one. Its own
+# `locate_stella` prefers target/release over target/debug, so a stale release
+# build silently wins over the code under test — three cases went red against a
+# months-old binary that predated the command they exercised, and the harness
+# does not say which binary it measured (#1753). The gate must test what the
+# gate just built.
+self-driving-test: ## Test the self-driving control logic — digest, AIMD, aperture, run lifecycle (hermetic)
+	cargo build -q -p stella-cli --bin stella
+	STELLA_BIN="$(CURDIR)/target/debug/stella" ./scripts/test-self-driving.sh
 
 .PHONY: smoke-artifact-test
 smoke-artifact-test: ## Test the release-artifact smoke gate against synthetic broken artifacts (hermetic; not part of `gate`)

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -99,6 +99,9 @@ contributing_alias() {
   format-check) echo 'cargo fmt' ;;
   lint) echo 'cargo clippy' ;;
   test) echo 'cargo test' ;;
+  # The one guard whose script is not check-*.sh: it is a test harness, not a
+  # tree guard, so it is named for what it tests.
+  self-driving-test) echo 'test-self-driving.sh' ;;
   *) echo "check-$1.sh" ;;
   esac
 }

--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -2,10 +2,16 @@
 # Hermetic tests for the self-driving control logic.
 #
 # Everything here runs against a throwaway $SELF_DRIVING_STATE_DIR: no network, no
-# `gh`, no writes outside the temp tree. Deliberately NOT part of `make gate` —
-# same posture as `impacted-test` and `dev-env-test`.
+# `gh`, no writes outside the temp tree.
 #
-#   make self-driving-test        # or: scripts/test-self-driving.sh
+# A `make gate` step since #1753. It was deliberately excluded before that, on
+# the same reasoning as `impacted-test` and `dev-env-test` — and the cost of
+# the exclusion was three cases sitting red on `main` with nobody watching,
+# testing a `plan` that silently skipped the batch clamp. Hermetic and under a
+# minute, so the usual reason to leave a suite out of the gate never applied.
+#
+#   make self-driving-test        # builds and PINS the binary — prefer this
+#   ./scripts/test-self-driving.sh   # uses whatever locate_stella finds
 #
 # The cases here are the ones whose failure modes are SILENT and PERMANENT: a
 # digest that over-normalizes merges two defects and the second is never filed;
@@ -75,6 +81,12 @@ locate_stella() {
   printf '%s' "$root/target/debug/stella"
 }
 STELLA="$(locate_stella)" || { echo "self-driving-test: cannot obtain a stella binary" >&2; exit 1; }
+# Say which binary is under test, always. `locate_stella` prefers
+# target/release over target/debug, so a stale release build silently wins over
+# the code you just changed — three cases once went red against a months-old
+# binary that predated the subcommand they exercise, and nothing on screen said
+# so (#1753). One line turns an hour of misattribution into a glance.
+printf 'self-driving-test: binary under test: %s\n' "$STELLA" >&2
 mkdir -p "$ROOT/stella-bin"
 ln -sf "$STELLA" "$ROOT/stella-bin/stella"
 # In front of the system PATH so the wrapper's `stella` resolves to the build


### PR DESCRIPTION
## What & why

Closes #1753

`make self-driving-test` was deliberately excluded from the gate, on the same reasoning as `impacted-test` and `dev-env-test`. The cost of that exclusion showed up during the #1757 rename: **three cases had been sitting red on `main` with nobody watching.**

The harness's stub `gh` had no `--version` arm, so `gh_available()` failed, `plan` saw an empty queue, and the batch clamp was skipped entirely — meaning neither the clamp nor the P0 rescue those three cases *name* was ever actually exercised. The suite is hermetic and runs in under a minute, so the usual reason to leave a suite out of the gate never applied here.

## The binary is now pinned

This is the half worth reviewing carefully. `locate_stella` prefers `target/release` over `target/debug`:

```sh
for candidate in "$root/target/release/stella" "$root/target/debug/stella"; do
```

So **a stale release build silently wins over the code under test.** During the rename that produced three phantom failures against a months-old binary that predated the subcommand the cases exercise — and nothing on screen said which binary had been measured. An hour went into attributing failures that were never real.

Two changes:

1. The gate step does `cargo build -q -p stella-cli --bin stella` and passes `STELLA_BIN="$(CURDIR)/target/debug/stella"`. The gate must test what the gate just built.
2. The harness prints the resolved path **unconditionally**, so the next person sees it in one glance rather than an hour:

```
self-driving-test: binary under test: /…/target/debug/stella
```

`locate_stella`'s own preference order is left alone — it is a reasonable default for someone running the script directly, and it is no longer silent.

## The witness

- [x] No witness test in the usual sense — this PR wires an existing suite into the gate. Verified by construction instead:

**A red harness fails the step.** Injecting one failing check:

```
$ make self-driving-test >/dev/null 2>&1; echo $?
2
```

**The step is in the gate.** `gate: $(GATE_STEPS)`, and:

```
$ make -s print-gate-steps | wc -w
24
```

**The pin works.** `make self-driving-test` names the worktree's own debug build, not the machine's stale `target/release/stella`.

**Green on this branch:** 53 / 53.

## Parity

`GATE_STEPS` grew to twenty-four, so AGENTS.md's block, CONTRIBUTING.md's fence, and **both spelled-out counts** move with it — `check-gate-parity.sh` fails until all three agree:

```
check-gate-parity: OK — 24 (twenty-four) gate steps, named in AGENTS.md and CONTRIBUTING.md.
```

One addition to that guard: it maps a step to `check-<step>.sh` by default, and this is the one step whose script is not a tree guard but a test harness, so it gets an explicit alias to `test-self-driving.sh`. An alias is a deliberate, reviewable statement — which is the shape the guard already uses for `shellcheck`, `doc-links` and the four cargo steps.

Also corrected the harness's own header, which said "Deliberately NOT part of `make gate`" — true until this PR, and exactly the kind of stale comment this repo treats as a bug.

## Cost

Only full `make gate` runs it — it is in `GATE_STEPS`, not `GATE_GUARDS`, so `make check` and `make guards-fast` are unchanged. On a warm tree after `cargo test --workspace` the extra `cargo build -p stella-cli` is close to free.

## The gate

- [x] `make gate-parity` — OK, 24 steps, all three copies agree
- [x] `make shellcheck` — clean
- [x] `make god-files`, `make left-behind` — clean
- [x] `make self-driving-test` — 53 / 53 on the pinned binary

## Nothing left behind

#1800 is the one remaining item from this cluster, and it is **not a code change**: making the `file-size` gate unbypassable means either a required status check or `enforce_admins: true` on the branch protection rule. Both need repo admin, and changing merge policy for the whole repository is the maintainer's call, not something to slip into a PR.

## Summary by Sourcery

Integrate the self-driving test harness into the main gate while ensuring it runs against the freshly built CLI binary and keeping gate documentation in sync.

New Features:
- Add the self-driving control logic test harness as a `make gate` step that runs as part of the main gate pipeline.

Enhancements:
- Pin the self-driving test harness to use the newly built debug `stella` binary and always print the binary path under test.
- Clarify usage and behavior of the self-driving test script, including guidance on when to use the Makefile target versus running the script directly.
- Extend the gate-parity check script with an explicit alias for the self-driving test step.

Documentation:
- Update CONTRIBUTING and AGENTS documentation to include the self-driving test in the gate steps and reflect the new total step count.
- Revise comments in the self-driving test harness script to reflect its inclusion in the gate and describe its behavior more accurately.

Tests:
- Wire the existing hermetic self-driving tests into the gate so they run automatically as part of `make gate`.