### PR TITLE
docs(stella-core): unbreak main — rustdoc links to private items in loop_detect.rs

### DIFF
--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -207,8 +207,9 @@ impl LoopVerdict {
     /// A human-readable evidence string for the driver to surface when it
     /// steers or aborts. `None` for `NoLoop`.
     ///
-    /// The quoted input is truncated through the same [`truncate`] and
-    /// [`MAX_DESCRIBED_INPUT`] [`LoopIdentity::describe`] uses, not a second
+    /// The quoted input is truncated through the same `truncate` and
+    /// `MAX_DESCRIBED_INPUT` (private to this module) that
+    /// [`LoopIdentity::describe`] uses, not a second
     /// budget of its own. This string becomes an `AgentEvent::Error` message,
     /// the abort reason on `TurnOutcome::Aborted`, the red line in the Command
     /// Deck, and the `loop_detected` journal event — so an untruncated


### PR DESCRIPTION
## What

Main's `doc-warnings` gate (rustdoc with `-D warnings`) is red since cb82e7f1 (#1775): the doc comment on `LoopVerdict::evidence` in `crates/stella-core/src/loop_detect.rs` links `[\`truncate\`]` and `[\`MAX_DESCRIBED_INPUT\`]`, both module-private, tripping `rustdoc::private_intra_doc_links`.

```
error: public documentation for `evidence` links to private item `truncate`
  --> crates/stella-core/src/loop_detect.rs:210:58
```

This makes every PR that merges main red on the required CI job (first seen on #1810).

## Fix

Demote the two private-item links to plain code spans and note they are private to the module; the `[\`LoopIdentity::describe\`]` link stays because that item is public. Prose meaning unchanged.

## Witness

Docs-only change — no behavior, no witness test. Verified by the `doc-warnings` CI step itself: red on main, green with this diff.

The same commit is also pushed onto #1810's branch (a87f0fe5) so that PR unblocks without waiting; identical content merges cleanly whichever lands first.

Refs #1775

## Summary by Sourcery

Documentation:
- Clarify `LoopVerdict::evidence` documentation by replacing links to private items with code spans and noting their module-private status.