### PR TITLE
docs(stella-core): unbreak main — drop private intra-doc links in LoopVerdict::evidence

### DIFF
--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -207,8 +207,8 @@ impl LoopVerdict {
     /// A human-readable evidence string for the driver to surface when it
     /// steers or aborts. `None` for `NoLoop`.
     ///
-    /// The quoted input is truncated through the same [`truncate`] and
-    /// [`MAX_DESCRIBED_INPUT`] [`LoopIdentity::describe`] uses, not a second
+    /// The quoted input is truncated through the same private `truncate` and
+    /// `MAX_DESCRIBED_INPUT` [`LoopIdentity::describe`] uses, not a second
     /// budget of its own. This string becomes an `AgentEvent::Error` message,
     /// the abort reason on `TurnOutcome::Aborted`, the red line in the Command
     /// Deck, and the `loop_detected` journal event — so an untruncated

--- a/crates/stella-pipeline/src/triage.rs
+++ b/crates/stella-pipeline/src/triage.rs
@@ -926,7 +926,7 @@ fn has_action_request(goal: &str) -> bool {
 ///
 /// `structure` is the workspace listing the `RepoStructurePort` already
 /// supplies to the planner and the witness author — bounded here to
-/// [`TRIAGE_STRUCTURE_CHARS`] and rendered *before* the task so the
+/// the private `TRIAGE_STRUCTURE_CHARS` cap and rendered *before* the task so the
 /// `Task:`/`Answer:` pair stays adjacent at the end. Triage decides the
 /// highest-leverage questions in the pipeline (how much orchestration, whether
 /// a witness is warranted, whether this is a task at all) and until this

--- a/crates/stella-pipeline/src/witness/warrant.rs
+++ b/crates/stella-pipeline/src/witness/warrant.rs
@@ -188,7 +188,7 @@ pub struct ChangeSignals {
     /// unrecognized name can never be the reason a turn is written off.
     pub mutating_actions: u32,
     /// The subset of `mutating_actions` whose effects the diff CANNOT be
-    /// trusted to account for ([`diff_accountable_mutator`]): shell calls,
+    /// trusted to account for (per the crate-private `diff_accountable_mutator`): shell calls,
     /// process spawns, repo pushes, MCP and custom tools — anything able to
     /// act outside the file-CRUD surface the diff probes observe.
     ///


### PR DESCRIPTION
## Problem

`cargo doc -D warnings` is red on main, failing every open PR's `fmt + clippy + test` check (#1811 and #1814 show the identical failure). Two layers:

1. `crates/stella-core/src/loop_detect.rs` — the doc comment on the public `LoopVerdict::evidence` links the private `truncate` and `MAX_DESCRIBED_INPUT` (landed with the #1744 fix, PR #1775).
2. Hidden behind it (rustdoc documents dependencies first, so it only surfaced once layer 1 was fixed): `crates/stella-pipeline` — public `triage_prompt` linked the private `TRIAGE_STRUCTURE_CHARS` (PR #1768), and the public `opaque_actions` field linked the crate-private `diff_accountable_mutator` (PR #1798).

All three landed through auto-merged/red merges — the #1645 enforcement hole.

## Fix

Name the private items in plain code font; keep public links (`LoopIdentity::describe`). Four lines across three files, docs only.

## Why no further layers are expected

The only remaining crates downstream of stella-pipeline are `stella-cli` and `stella-serve` (binaries — rustdoc documents bins with private items reachable, so private links there don't warn, which is why their many existing ones never have) and `stella-runtime` (lib; swept, no private-target links).

## Verification

Doc-only change; the witness is CI's `cargo doc -D warnings` step going green on this PR where main's is red (pure-docs change, no witness test per CONTRIBUTING).