### PR TITLE
fix(stella-pipeline): end a verdict negator's reach at its clause, not N tokens later

### DIFF
--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -818,7 +818,8 @@ impl Verdict {
 /// Parse a Role::Verifier model response into a verdict. The verifier prompt (see
 /// [`verifier_prompt`]) asks for a leading `PASS` or `FAIL` token; this scans
 /// token-by-token (case-insensitive) for the first of either — honoring a
-/// nearby negator, so "the tests do not pass" reads as the FAIL it states —
+/// negator in the same clause, so "the tests do not pass" reads as the FAIL it
+/// states while "No issues. Not blocking. PASS" reads as the PASS it states —
 /// and treats the remainder as reasoning. Returns `None` when no verdict
 /// token appears — the signal the caller uses to invoke the
 /// [`heuristic_fallback`] verdict rather than trusting an unparseable
@@ -830,10 +831,17 @@ pub fn parse_verifier_response(text: &str) -> Option<Verdict> {
     // obvious issues. PASS" as a FAIL because "no" was hit first.
     // A negated verdict token is not that verdict: "the tests do not pass" is
     // a FAIL, and crediting its "pass" token as a PASS inverted real verdicts.
-    // The negator must sit within two tokens of the verdict word ("do not
-    // pass" is adjacent, "cannot currently pass" has one token between) — a
-    // wider window would misread an approval lead-in like "not a problem.
-    // PASS". A negated PASS reads as the FAIL it states; a negated
+    // A negator's reach is bounded two ways, because either bound alone lets a
+    // real reply through wrong:
+    //   * It binds inside its own CLAUSE. Terminal punctuation ends it, so
+    //     "No issues. Not blocking. PASS" approves — the window cannot express
+    //     that, since the negator there is one token from the verdict, closer
+    //     than "cannot currently pass" needs.
+    //   * Within a clause it spans two tokens ("do not pass" is adjacent,
+    //     "cannot currently pass" has one token between). Unpunctuated prose
+    //     has no boundary to stop it, and "not a problem PASS" must still
+    //     approve.
+    // A negated PASS reads as the FAIL it states; a negated
     // FAIL ("did not fail") is skipped rather than trusted as a PASS, since
     // absence of failure is not the protocol's affirmative verdict. "no" is
     // deliberately not a negator for the same reason it is not a FAIL token:
@@ -842,39 +850,46 @@ pub fn parse_verifier_response(text: &str) -> Option<Verdict> {
         "not", "never", "cannot", "don", "doesn", "didn", "isn", "aren", "wasn", "weren", "couldn",
         "wouldn", "shouldn", "won",
     ];
+    // Terminal punctuation only. A comma and an em-dash are deliberately
+    // absent: they join clauses at least as often as they separate them
+    // ("it does not, in this case, pass"), so counting them would drop real
+    // negations to buy back cases the token window already handles.
+    const CLAUSE_BREAKS: &[char] = &['.', '!', '?', ';', ':'];
     let first_line = text.lines().map(str::trim).find(|l| !l.is_empty())?;
     let lower = first_line.to_ascii_lowercase();
-    let mut since_negation: Option<u32> = None;
-    for raw in lower.split(|c: char| !c.is_ascii_alphanumeric()) {
-        if raw.is_empty() {
-            continue;
-        }
-        // `distance` is 0 for the token immediately after the negator, so the
-        // bound of 1 is the documented two-token window: "not pass" and
-        // "not currently pass" negate; "not a problem. PASS" does not.
-        let negated = matches!(since_negation, Some(distance) if distance <= 1);
-        match raw {
-            "pass" | "passed" | "approve" | "approved" => {
-                return Some(Verdict {
-                    passed: !negated,
-                    reasoning: text.trim().to_string(),
-                    heuristic: false,
-                });
+    for clause in lower.split(CLAUSE_BREAKS) {
+        let mut since_negation: Option<u32> = None;
+        for raw in clause.split(|c: char| !c.is_ascii_alphanumeric()) {
+            if raw.is_empty() {
+                continue;
             }
-            "fail" | "failed" | "reject" | "rejected" if !negated => {
-                return Some(Verdict {
-                    passed: false,
-                    reasoning: text.trim().to_string(),
-                    heuristic: false,
-                });
+            // `distance` is 0 for the token immediately after the negator, so the
+            // bound of 1 is the documented two-token window: "not pass" and
+            // "not currently pass" negate; "not a problem PASS" does not.
+            let negated = matches!(since_negation, Some(distance) if distance <= 1);
+            match raw {
+                "pass" | "passed" | "approve" | "approved" => {
+                    return Some(Verdict {
+                        passed: !negated,
+                        reasoning: text.trim().to_string(),
+                        heuristic: false,
+                    });
+                }
+                "fail" | "failed" | "reject" | "rejected" if !negated => {
+                    return Some(Verdict {
+                        passed: false,
+                        reasoning: text.trim().to_string(),
+                        heuristic: false,
+                    });
+                }
+                _ => {}
             }
-            _ => {}
+            since_negation = if NEGATORS.contains(&raw) {
+                Some(0)
+            } else {
+                since_negation.map(|distance| distance + 1)
+            };
         }
-        since_negation = if NEGATORS.contains(&raw) {
-            Some(0)
-        } else {
-            since_negation.map(|distance| distance + 1)
-        };
     }
     None
 }

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -5,6 +5,7 @@
 use super::*;
 use proptest::prelude::*;
 
+mod parse;
 mod uncollected;
 
 // FlipOracle transitions
@@ -685,85 +686,7 @@ fn tests_indeterminate_escalates_to_verifier() {
     assert_eq!(decision, LadderDecision::ModelVerdict);
 }
 
-// verifier parsing + fallback
-
-#[test]
-fn parses_pass_and_fail_verdicts() {
-    assert_eq!(
-        parse_verifier_response("PASS — looks correct").map(|v| v.passed),
-        Some(true)
-    );
-    assert_eq!(
-        parse_verifier_response("FAIL: missing edge case").map(|v| v.passed),
-        Some(false)
-    );
-    assert_eq!(
-        parse_verifier_response("Verdict: approved").map(|v| v.passed),
-        Some(true)
-    );
-    // A PASS line whose reasoning contains "no" must not be flipped to
-    // FAIL by an over-eager "no" match.
-    assert_eq!(
-        parse_verifier_response("PASS — no obvious issues").map(|v| v.passed),
-        Some(true)
-    );
-    // Only the first non-empty line is authoritative.
-    assert_eq!(
-        parse_verifier_response("FAIL\nthe change looks fine otherwise").map(|v| v.passed),
-        Some(false)
-    );
-}
-
-/// A negated verdict token states the OPPOSITE verdict, and the parser used
-/// to credit it as written: "The tests do not pass" parsed as a PASS — the
-/// most damaging possible misread, converting a stated refusal into the
-/// verdict that ends the run. The `yes`/`no` mirror of this bug was found
-/// and fixed years earlier (see `parses_pass_and_fail_verdicts`); the
-/// `pass`/`fail` half had no negation handling and no test.
-#[test]
-fn a_negated_pass_is_the_fail_it_states() {
-    for line in [
-        "The tests do not pass",
-        "This does not pass the edge case",
-        "Cannot pass this without the missing test",
-        "The suite doesn't pass",
-        "The change does not currently pass review",
-    ] {
-        assert_eq!(
-            parse_verifier_response(line).map(|v| v.passed),
-            Some(false),
-            "{line:?} states a refusal and must parse as FAIL"
-        );
-    }
-    // A negated FAIL is skipped, never trusted as an affirmative PASS —
-    // "did not fail" is absence of failure, not the protocol's verdict —
-    // and with no other token the reply is unparseable (heuristic fallback).
-    assert_eq!(parse_verifier_response("The suite did not fail"), None);
-    // The negation window is bounded: a negator more than two tokens back
-    // does not reach the verdict word.
-    assert_eq!(
-        parse_verifier_response("Not a single problem here: PASS").map(|v| v.passed),
-        Some(true)
-    );
-    // ...and the bound is exactly two tokens: the first window that shipped
-    // reached one token further, inverting this approval lead-in into a FAIL.
-    assert_eq!(
-        parse_verifier_response("Not a problem. PASS").map(|v| v.passed),
-        Some(true),
-        "an approval lead-in two tokens past the negator is a genuine PASS"
-    );
-    // An affirmative token before the negator is untouched.
-    assert_eq!(
-        parse_verifier_response("PASS — this does not fail any case").map(|v| v.passed),
-        Some(true)
-    );
-}
-
-#[test]
-fn unparseable_verifier_response_is_none() {
-    assert_eq!(parse_verifier_response("hmm, hard to say"), None);
-    assert_eq!(parse_verifier_response(""), None);
-}
+// verifier fallback (the response-parsing half lives in `parse`)
 
 #[test]
 fn heuristic_fallback_passes_only_on_confirmed_green_tests() {

--- a/crates/stella-pipeline/src/verify/tests/parse.rs
+++ b/crates/stella-pipeline/src/verify/tests/parse.rs
@@ -1,0 +1,136 @@
+//! Verdict parsing: reading a verifier model's prose back as PASS or FAIL.
+//!
+//! Its own module because the parent had reached the 1500-line ratchet exactly,
+//! and because these cases share a subject the rest of the file does not: every
+//! one of them is a *string*, written the way a model actually writes it. The
+//! ladder tests next door reason about structured evidence, where a bug picks
+//! the wrong rung. These reason about English, where a bug inverts a verdict —
+//! so they are worth keeping together and worth reading as a set.
+
+use crate::verify::parse_verifier_response;
+
+#[test]
+fn parses_pass_and_fail_verdicts() {
+    assert_eq!(
+        parse_verifier_response("PASS — looks correct").map(|v| v.passed),
+        Some(true)
+    );
+    assert_eq!(
+        parse_verifier_response("FAIL: missing edge case").map(|v| v.passed),
+        Some(false)
+    );
+    assert_eq!(
+        parse_verifier_response("Verdict: approved").map(|v| v.passed),
+        Some(true)
+    );
+    // A PASS line whose reasoning contains "no" must not be flipped to
+    // FAIL by an over-eager "no" match.
+    assert_eq!(
+        parse_verifier_response("PASS — no obvious issues").map(|v| v.passed),
+        Some(true)
+    );
+    // Only the first non-empty line is authoritative.
+    assert_eq!(
+        parse_verifier_response("FAIL\nthe change looks fine otherwise").map(|v| v.passed),
+        Some(false)
+    );
+}
+
+/// A negated verdict token states the OPPOSITE verdict, and the parser used
+/// to credit it as written: "The tests do not pass" parsed as a PASS — the
+/// most damaging possible misread, converting a stated refusal into the
+/// verdict that ends the run. The `yes`/`no` mirror of this bug was found
+/// and fixed years earlier (see `parses_pass_and_fail_verdicts`); the
+/// `pass`/`fail` half had no negation handling and no test.
+#[test]
+fn a_negated_pass_is_the_fail_it_states() {
+    for line in [
+        "The tests do not pass",
+        "This does not pass the edge case",
+        "Cannot pass this without the missing test",
+        "The suite doesn't pass",
+        "The change does not currently pass review",
+    ] {
+        assert_eq!(
+            parse_verifier_response(line).map(|v| v.passed),
+            Some(false),
+            "{line:?} states a refusal and must parse as FAIL"
+        );
+    }
+    // A negated FAIL is skipped, never trusted as an affirmative PASS —
+    // "did not fail" is absence of failure, not the protocol's verdict —
+    // and with no other token the reply is unparseable (heuristic fallback).
+    assert_eq!(parse_verifier_response("The suite did not fail"), None);
+    // The negation window is bounded: a negator more than two tokens back
+    // does not reach the verdict word.
+    assert_eq!(
+        parse_verifier_response("Not a single problem here: PASS").map(|v| v.passed),
+        Some(true)
+    );
+    // ...and the bound is exactly two tokens: the first window that shipped
+    // reached one token further, inverting this approval lead-in into a FAIL.
+    assert_eq!(
+        parse_verifier_response("Not a problem. PASS").map(|v| v.passed),
+        Some(true),
+        "an approval lead-in two tokens past the negator is a genuine PASS"
+    );
+    // An affirmative token before the negator is untouched.
+    assert_eq!(
+        parse_verifier_response("PASS — this does not fail any case").map(|v| v.passed),
+        Some(true)
+    );
+}
+
+/// The token window cannot be the whole rule, because it measures the wrong
+/// thing. "No issues. Not blocking. PASS" puts the negator ONE token from the
+/// verdict — nearer than "cannot currently pass", which must keep negating —
+/// so no window wide enough for the second can exclude the first. What
+/// separates them is not distance but the sentence between them: a negator
+/// binds inside its own clause, and terminal punctuation ends its reach.
+///
+/// The direction matters. This is an approval inverted into a refusal, which
+/// sends a finished, correct candidate back for revision and spends a whole
+/// turn's budget denying its own result.
+#[test]
+fn a_negator_does_not_reach_past_the_end_of_its_clause() {
+    for line in [
+        // The window alone reads every one of these as a refusal.
+        "No issues. Not blocking. PASS",
+        "Not blocking; PASS",
+        "Nothing is wrong here. Not one thing! PASS",
+    ] {
+        assert_eq!(
+            parse_verifier_response(line).map(|v| v.passed),
+            Some(true),
+            "{line:?} approves in a later clause and must parse as PASS"
+        );
+    }
+    // The boundary narrows the negator's scope, never its meaning: a refusal
+    // stated after one still reads as the FAIL it states.
+    for line in [
+        "The diff is small. It does not pass.",
+        "I read the whole change; it cannot pass without the missing test.",
+    ] {
+        assert_eq!(
+            parse_verifier_response(line).map(|v| v.passed),
+            Some(false),
+            "{line:?} refuses in its final clause and must parse as FAIL"
+        );
+    }
+    // And an unpunctuated negation still has only the window to stop it, so
+    // the window is still doing its job inside the clause.
+    assert_eq!(
+        parse_verifier_response("The tests do not pass").map(|v| v.passed),
+        Some(false)
+    );
+    assert_eq!(
+        parse_verifier_response("Not a problem PASS").map(|v| v.passed),
+        Some(true)
+    );
+}
+
+#[test]
+fn unparseable_verifier_response_is_none() {
+    assert_eq!(parse_verifier_response("hmm, hard to say"), None);
+    assert_eq!(parse_verifier_response(""), None);
+}


### PR DESCRIPTION
## What & why

Refs #1798, follows #1808.

#1808 narrowed the negation window in `parse_verifier_response` from three tokens to two, which fixed the case the review bot reported (`"Not a problem. PASS"`). But the window measures the wrong thing, and one shape survives it — measured on `c8faa37a`:

| verifier reply | main today | correct |
|---|---|---|
| `Not a problem. PASS` | PASS ✅ | fixed by #1808 |
| `This does not concern me; PASS` | PASS ✅ | |
| **`No issues. Not blocking. PASS`** | **FAIL ❌** | PASS |

The negator in that last one sits **one token** from the verdict — *nearer* than `"cannot currently pass"`, which must keep negating. So no window wide enough for the second can exclude the first. Distance cannot separate them; the sentence between them can.

## The change

A negator's scope now ends at terminal punctuation (`.` `!` `?` `;` `:`), and the two-token window still applies **within** a clause. Both bounds are load-bearing, which the test asserts in both directions:

- drop the clause break → `No issues. Not blocking. PASS` inverts
- drop the window → `Not a problem PASS` (unpunctuated) inverts

A comma and an em-dash are deliberately **not** boundaries. They join clauses at least as often as they separate them (`"it does not, in this case, pass"`), so counting them would drop real negations to buy back cases the window already handles.

### Why this direction of bug is the expensive one

The parser's existing comments frame a negated PASS as the damaging misread. This is the mirror: an **approval** read as a **refusal**. That sends a finished, correct candidate back for revision and spends a whole turn's budget denying its own result — and unlike a wrong FAIL from a real refusal, nothing downstream disagrees with it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here).

`verify::tests::parse::a_negator_does_not_reach_past_the_end_of_its_clause`, checked the artisanal way against `c8faa37a`:

```
assertion `left == right` failed: "No issues. Not blocking. PASS" approves in a later clause and must parse as PASS
  left: Some(false)
 right: Some(true)
```

It also pins the two directions that must NOT change: refusals stated after a boundary (`"The diff is small. It does not pass."`) still parse FAIL, and the unpunctuated window cases still behave as #1808 set them.

## The gate

- [x] `cargo fmt --check -p stella-pipeline`
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo test -p stella-pipeline` — 539 pass, 0 fail
- [x] `scripts/check-file-size.sh` — OK, none grew

## Anything reviewers should know?

**`verify/tests.rs` was at exactly 1500 lines** on `main` — the ratchet limit, zero headroom, so *any* test added to that file fails the gate. Rather than raise the ceiling, the verdict-parsing tests move into a `parse` submodule beside the existing `uncollected` one, per AGENTS.md § "God files — plan around them, never into them". That takes the parent to 1421 and gives the next person somewhere to put a parsing test. No baseline entry was added.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

One case is deliberately **not** changed, because it is correct by design rather than a bug: `"The old code did not pass. This one does. PASS"` parses FAIL. The first verdict token wins, and that token genuinely is negated — clause scoping does not and should not rescue it, since a reply that states a refusal before its approval is ambiguous and the conservative read is the safe one.

## Summary by Sourcery

Limit verifier verdict negation to the same clause while preserving a two-token window, and reorganize verdict parsing tests into their own module.

Bug Fixes:
- Ensure verifier replies like "No issues. Not blocking. PASS" are parsed as PASS by ending negators' scope at clause boundaries instead of a fixed token distance.

Tests:
- Add targeted tests covering clause-bounded negation, unpunctuated negation windows, and general verdict parsing behavior, moved into a dedicated parse test module.