### PR TITLE
fix(arenabench): wire `[contestant.env] required` names from the ambient environment

### DIFF
--- a/arenabench/arenabench/agents.py
+++ b/arenabench/arenabench/agents.py
@@ -327,12 +327,18 @@ def missing_credentials(contestant: Contestant) -> list[str]:
     credentialled either way: ``ZAI_API_KEY`` is what the provider calls it
     and ``ANTHROPIC_AUTH_TOKEN`` is what Claude Code reads it from, and
     warning about the one an operator did not use would be noise.
+
+    A seat that *declared* its own list (``[contestant.env] required = [...]``)
+    is measured against that list alone — the declaration is the seat's whole
+    credential contract (#1777).
     """
-    spec = resolve_agent(contestant.agent)
-    candidates = list(credential_env_for(contestant.engine.api))
-    for name in spec.token_env + spec.alt_credential_env:
-        if name not in candidates:
-            candidates.append(name)
+    candidates = list(contestant.required_env)
+    if not candidates:
+        spec = resolve_agent(contestant.agent)
+        candidates = list(credential_env_for(contestant.engine.api))
+        for name in spec.token_env + spec.alt_credential_env:
+            if name not in candidates:
+                candidates.append(name)
     if not candidates:
         return []
     if any(contestant.env.get(name) for name in candidates):

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -35,7 +35,14 @@ from pathlib import Path
 from typing import Any
 
 from .agents import resolve_agent
-from .model import ARENA_COLORS, Contestant, Engine, MatchSpec, RoleConfig
+from .model import (
+    ARENA_COLORS,
+    Contestant,
+    Engine,
+    MatchSpec,
+    RoleConfig,
+    is_credential_name,
+)
 
 __all__ = [
     "MatchTemplateError",
@@ -73,6 +80,43 @@ class MatchTemplateError(ValueError):
 def _role_key(name: str) -> str:
     """Normalise a role name from a template to its member of :data:`.ROLES`."""
     return _ROLE_ALIASES.get(name.strip().lower(), name.strip().lower())
+
+
+def _declared_env(
+    raw: dict[str, Any], problems: list[str], where: str
+) -> tuple[str, ...]:
+    """The ``required = [...]`` declaration of a ``[contestant.env]`` table.
+
+    Names only, never values: any other key is a value smuggled into a file
+    that promises to carry none (see module docstring), and a name outside
+    :func:`.model.screen_env`'s credential shapes would let a committed
+    template pull an arbitrary host variable into a seat's subprocess. Both
+    are template faults, reported like any other — loudly, before any
+    container starts (#1777).
+    """
+    names: tuple[str, ...] = ()
+    for key, value in raw.items():
+        if key != "required":
+            problems.append(
+                f"{where}: [contestant.env] carries {key!r} — names only, never "
+                'values; declare `required = ["NAME"]` and supply the value in '
+                "the environment (or the saved credential set) at launch"
+            )
+            continue
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in value
+        ):
+            problems.append(f"{where}: env.required must be a list of variable names")
+            continue
+        bad = [item for item in value if not is_credential_name(item)]
+        if bad:
+            problems.append(
+                f"{where}: env.required names {', '.join(map(repr, bad))} are not "
+                "credential-shaped and would never be honoured (see screen_env)"
+            )
+            continue
+        names = tuple(dict.fromkeys(value))
+    return names
 
 
 def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> Engine:
@@ -146,14 +190,23 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
         if not engine.model:
             problems.append(f"{where}: engine.model is required")
 
+        env_raw = entry.get("env")
+        declared: tuple[str, ...] = ()
+        if env_raw is not None:
+            if not isinstance(env_raw, dict):
+                problems.append(f"{where}: [contestant.env] must be a table")
+            else:
+                declared = _declared_env(env_raw, problems, where)
+
         contestants.append(
             Contestant(
                 id=str(entry.get("id") or f"seat{seat + 1}"),
                 name=str(entry.get("name") or agent or f"seat {seat + 1}"),
                 agent=agent or "stella",
                 engine=engine,
-                env={},  # never from a file — see module docstring
+                env={},  # never values from a file — see module docstring
                 color=str(entry.get("color") or ARENA_COLORS[seat % len(ARENA_COLORS)]),
+                required_env=declared,
             )
         )
 
@@ -189,22 +242,22 @@ def load_match(path: Path, *, match_id: str | None = None) -> MatchSpec:
     return match_from_toml(data, match_id=match_id)
 
 
-def required_env(
-    spec: MatchSpec, declared: dict[str, list[str]] | None = None
-) -> dict[str, list[str]]:
+def required_env(spec: MatchSpec) -> dict[str, list[str]]:
     """Environment variables each seat needs, by contestant id.
 
-    Derived from each seat's provider unless the template declared its own
-    list. This is what turns "no secrets in the file" from a restriction into
-    a contract: the template still says exactly what must be supplied.
+    Derived from each seat's provider unless the seat declared its own list
+    (``[contestant.env] required = [...]``), which is then the seat's whole
+    contract — declaring only the subscription token is how a template keeps a
+    metered key out of a seat on purpose (#1777). This is what turns "no
+    secrets in the file" from a restriction into a contract: the template
+    still says exactly what must be supplied.
     """
     from .agents import credential_env_for, resolve_agent
 
     out: dict[str, list[str]] = {}
     for contestant in spec.contestants:
-        explicit = (declared or {}).get(contestant.id)
-        if explicit:
-            out[contestant.id] = list(explicit)
+        if contestant.required_env:
+            out[contestant.id] = list(contestant.required_env)
             continue
         candidates = list(credential_env_for(contestant.engine.api))
         agent_spec = resolve_agent(contestant.agent)
@@ -260,6 +313,8 @@ def match_to_toml_dict(spec: MatchSpec) -> dict[str, Any]:
                 "name": c.name,
                 "agent": c.agent,
                 "color": c.color,
+                # The declaration round-trips; values never exist to round-trip.
+                **({"env": {"required": list(c.required_env)}} if c.required_env else {}),
                 "engine": {
                     **{
                         k: v

--- a/arenabench/arenabench/credentials.py
+++ b/arenabench/arenabench/credentials.py
@@ -23,6 +23,13 @@ ordering is what lets an operator override one key for one match (testing a
 second account, routing around a rate limit) without touching the saved file,
 and it is why :func:`apply_saved_credentials` only ever fills gaps, never
 overwrites.
+
+This module also owns the launch-time half of a template's credential
+*declaration*: :func:`apply_ambient_credentials` resolves the names a seat
+declared (``[contestant.env] required = [...]``) from the launching process's
+environment, and :func:`missing_required_credentials` names the seats that
+still hold none of theirs — so a caller can refuse to launch an
+unauthenticated arm instead of scoring a silent ``0.0`` (#1777).
 """
 
 from __future__ import annotations
@@ -34,7 +41,13 @@ from pathlib import Path
 from .config import required_env
 from .model import Contestant, MatchSpec, parse_dotenv, screen_env
 
-__all__ = ["apply_saved_credentials", "credentials_path", "load_credentials"]
+__all__ = [
+    "apply_ambient_credentials",
+    "apply_saved_credentials",
+    "credentials_path",
+    "load_credentials",
+    "missing_required_credentials",
+]
 
 
 def credentials_path() -> Path:
@@ -96,3 +109,51 @@ def apply_saved_credentials(spec: MatchSpec) -> MatchSpec:
         return replace(contestant, env={**fallback, **contestant.env})
 
     return replace(spec, contestants=tuple(seeded(c) for c in spec.contestants))
+
+
+def apply_ambient_credentials(
+    spec: MatchSpec, environ: dict[str, str] | None = None
+) -> MatchSpec:
+    """Resolve each seat's *declared* credential names from the environment.
+
+    Only names a template declared (``[contestant.env] required = [...]``) are
+    read: a declaration is the committed, reviewed statement that this seat
+    means to be credentialled from the launching process, so honouring it is
+    what makes "names only, never values" a contract rather than a comment
+    (#1777). Seats that declared nothing get nothing here — on the server path
+    the ambient environment is otherwise deliberately kept away from seats
+    (see the scrub in :func:`.runner._base_environment`), and this is the one
+    explicit, per-seat exception. Whatever the seat already carries wins;
+    like :func:`apply_saved_credentials`, this only ever fills gaps.
+    """
+    source = os.environ if environ is None else environ
+
+    def seeded(contestant: Contestant) -> Contestant:
+        fallback = {
+            name: source[name] for name in contestant.required_env if source.get(name)
+        }
+        if not fallback:
+            return contestant
+        return replace(contestant, env={**fallback, **contestant.env})
+
+    contestants = tuple(seeded(c) for c in spec.contestants)
+    if all(new is old for new, old in zip(contestants, spec.contestants)):
+        return spec
+    return replace(spec, contestants=contestants)
+
+
+def missing_required_credentials(spec: MatchSpec) -> dict[str, list[str]]:
+    """Seats that declared required credentials and hold none of them.
+
+    The declared names are alternatives, not a conjunction: a seat carrying
+    any one of them is credentialled. An entry here means the seat would
+    launch unauthenticated and score a ``0.0`` indistinguishable from a real
+    loss on the scoreboard — the caller's job is to refuse to start it, loudly
+    (#1777).
+    """
+    out: dict[str, list[str]] = {}
+    for contestant in spec.contestants:
+        names = contestant.required_env
+        if names and not any(contestant.env.get(name) for name in names):
+            out[contestant.name] = list(names)
+    return out

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -38,6 +38,7 @@ __all__ = [
     "Engine",
     "MatchSpec",
     "RoleConfig",
+    "is_credential_name",
     "parse_dotenv",
     "screen_env",
     "slugify",
@@ -382,6 +383,16 @@ class Contestant:
     #: Names :func:`screen_env` refused to carry into the subprocess, kept so
     #: the seat can say what it dropped instead of dropping it in silence.
     ignored_env: tuple[str, ...] = ()
+    #: Credential names this seat *declared* it needs — a template's
+    #: ``[contestant.env] required = [...]`` list. Names only, never values;
+    #: alternatives, not a conjunction (any one credentials the seat). When
+    #: non-empty this is the seat's whole credential contract: declaring only
+    #: the subscription token is how a template keeps a metered key out of a
+    #: seat on purpose. Values are resolved at launch from the launching
+    #: process's environment or the saved credential set — and a seat still
+    #: holding none of them refuses to start rather than score a silent 0.0
+    #: (#1777).
+    required_env: tuple[str, ...] = ()
 
     @property
     def slug(self) -> str:
@@ -402,6 +413,7 @@ class Contestant:
             "engine_label": self.engine.label,
             "env_keys": sorted(self.env),
             "ignored_env_keys": list(self.ignored_env),
+            "required_env": list(self.required_env),
             "color": self.color,
         }
 
@@ -410,13 +422,32 @@ class Contestant:
         name = str(raw.get("name") or "").strip()
         agent = str(raw.get("agent") or "stella").strip()
         env = raw.get("env")
+        declared: list[str] = []
         if isinstance(env, str):
             env = parse_dotenv(env)
         elif isinstance(env, dict):
+            env = dict(env)
+            required = env.pop("required", None)
+            if isinstance(required, (list, tuple)):
+                # A template's `[contestant.env] required = [...]` arriving as
+                # JSON: a declaration of credential *names*, never a variable
+                # literally called "required" (#1777).
+                declared = [str(item) for item in required]
+            elif required is not None:
+                # A scalar really is somebody's variable; let screen_env rule.
+                env["required"] = required
             env = {str(k): str(v) for k, v in env.items()}
         else:
             env = {}
+        if not declared and isinstance(raw.get("required_env"), (list, tuple)):
+            declared = [str(item) for item in raw["required_env"]]
         env, ignored = screen_env(env)
+        # Declared names cross the same fence as pasted values: a declaration
+        # outside the credential shapes ("PATH") is reported, never resolved.
+        declared = list(dict.fromkeys(declared))
+        dropped = [item for item in declared if not is_credential_name(item)]
+        if dropped:
+            ignored = sorted({*ignored, *dropped})
         engine = Engine.from_json(raw.get("engine") or {})
         return cls(
             id=str(raw.get("id") or uuid.uuid4().hex[:12]),
@@ -426,6 +457,9 @@ class Contestant:
             env=env,
             color=str(raw.get("color") or ARENA_COLORS[seat % len(ARENA_COLORS)]),
             ignored_env=tuple(ignored),
+            required_env=tuple(
+                item for item in declared if is_credential_name(item)
+            ),
         )
 
 
@@ -568,6 +602,21 @@ _ENV_ALLOWED_SUFFIXES: tuple[str, ...] = (
     "_BASE_URL",
     "_API_BASE",
 )
+
+
+def is_credential_name(name: str) -> bool:
+    """Whether ``name`` could ever name a credential a seat may carry.
+
+    The same suffix fence :func:`screen_env` applies to pasted values, plus the
+    identifier shape :func:`parse_dotenv` requires of a key — applied to a
+    template's *declared* names (``required = [...]``) before anything resolves
+    them. A declaration is a promise to read that variable out of the launching
+    process's environment, so ``required = ["PATH"]`` must die in validation
+    rather than pull an arbitrary host variable into a seat's subprocess.
+    """
+    return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)) and name.upper().endswith(
+        _ENV_ALLOWED_SUFFIXES
+    )
 
 
 def screen_env(env: dict[str, str]) -> tuple[dict[str, str], list[str]]:

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -63,7 +63,12 @@ from urllib.parse import parse_qs, unquote, urlparse
 from .agents import AGENTS
 from .artifacts import MAX_TEXT_BYTES, preview_kind, resolve_within, tree
 from .config import MatchTemplateError, dump_match, match_from_toml, required_env
-from .credentials import apply_saved_credentials
+from .credentials import (
+    apply_ambient_credentials,
+    apply_saved_credentials,
+    credentials_path,
+    missing_required_credentials,
+)
 from .model import EFFORTS, ROLES, MatchSpec
 from .recorder import preflight as recorder_preflight
 from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
@@ -218,9 +223,24 @@ class ArenaServer:
         payload = dict(payload)
         payload.setdefault("id", uuid.uuid4().hex[:12])
         spec = MatchSpec.from_json(payload)
-        # Fills gaps only: a seat's own pasted `.env` always wins over the
-        # saved credential set — see `apply_saved_credentials`.
+        # A seat's declared credential names resolve from the arena's own
+        # environment first, then the saved credential set fills whatever is
+        # still unset. Both fill gaps only: a seat's own pasted `.env` always
+        # wins — see `apply_saved_credentials`.
+        spec = apply_ambient_credentials(spec)
         spec = apply_saved_credentials(spec)
+        missing = missing_required_credentials(spec)
+        if missing:
+            # Refuse rather than launch: an unauthenticated arm scores a 0.0
+            # indistinguishable from a real loss on the scoreboard (#1777).
+            lines = "; ".join(
+                f"{name} needs any of {', '.join(names)}"
+                for name, names in missing.items()
+            )
+            raise ValueError(
+                f"required credentials are not set: {lines} — export them in "
+                f"the arena's environment or save them at {credentials_path()}"
+            )
         match = self.runner.create(spec)
         if spec.record_video:
             ok, reason = recorder_preflight()

--- a/arenabench/tests/test_credentials.py
+++ b/arenabench/tests/test_credentials.py
@@ -14,10 +14,13 @@ from pathlib import Path
 
 import pytest
 
+from arenabench.config import MatchTemplateError, match_from_toml, required_env
 from arenabench.credentials import (
+    apply_ambient_credentials,
     apply_saved_credentials,
     credentials_path,
     load_credentials,
+    missing_required_credentials,
 )
 from arenabench.model import Contestant, Engine, MatchSpec
 
@@ -134,3 +137,180 @@ class TestApplySavedCredentials:
         )
         spec = _spec(seat)
         assert apply_saved_credentials(spec) is spec
+
+
+def _template(env: dict | None, agent: str = "stella", api: str = "openrouter") -> dict:
+    contestant: dict = {
+        "id": "seat1",
+        "agent": agent,
+        "engine": {"api": api, "model": "z-ai/glm-5.2"},
+    }
+    if env is not None:
+        contestant["env"] = env
+    return {
+        "match": {"name": "t", "dataset": "terminal-bench-2.1"},
+        "contestant": [contestant],
+    }
+
+
+class TestDeclaredRequiredEnv:
+    """A template's ``[contestant.env] required = [...]`` is a contract (#1777).
+
+    The block used to wire nothing: the declaration parsed as a variable
+    literally named ``required``, ``screen_env`` dropped it, and the seat
+    launched with an empty environment — an operational abort scored as an
+    agent loss. Every witness here proves the declaration is honoured or the
+    launch is refused, never that an unauthenticated arm runs.
+    """
+
+    def test_a_template_declaration_is_the_seats_whole_contract(self) -> None:
+        spec = match_from_toml(_template({"required": ["OPENROUTER_API_KEY"]}))
+        (seat,) = spec.contestants
+        assert seat.required_env == ("OPENROUTER_API_KEY",)
+        # Declared beats derived: the list is exactly what the template said,
+        # not the provider superset — declaring only one name is how a match
+        # keeps an unintended credential out of a seat on purpose.
+        assert required_env(spec) == {"seat1": ["OPENROUTER_API_KEY"]}
+
+    def test_a_declared_name_present_in_the_environment_credentials_the_seat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-ambient")
+        spec = match_from_toml(_template({"required": ["OPENROUTER_API_KEY"]}))
+        (seat,) = apply_ambient_credentials(spec).contestants
+        assert seat.env == {"OPENROUTER_API_KEY": "sk-or-ambient"}
+        assert missing_required_credentials(apply_ambient_credentials(spec)) == {}
+
+    def test_the_seats_own_env_wins_over_the_ambient_value(self) -> None:
+        seat = Contestant(
+            id="a",
+            name="a",
+            agent="stella",
+            engine=Engine(api="openrouter", model="m"),
+            env={"OPENROUTER_API_KEY": "from-seat"},
+            required_env=("OPENROUTER_API_KEY",),
+        )
+        (seeded,) = apply_ambient_credentials(
+            _spec(seat), environ={"OPENROUTER_API_KEY": "from-host"}
+        ).contestants
+        assert seeded.env == {"OPENROUTER_API_KEY": "from-seat"}
+
+    def test_a_seat_that_declared_nothing_gets_nothing_from_ambient(self) -> None:
+        """The server-side scrub stands: ambient credentials reach a seat only
+        through an explicit declaration, never implicitly."""
+        seat = Contestant(
+            id="a", name="a", agent="stella", engine=Engine(api="openrouter", model="m")
+        )
+        spec = _spec(seat)
+        assert apply_ambient_credentials(
+            spec, environ={"OPENROUTER_API_KEY": "sk-or"}
+        ) is spec
+
+    def test_the_json_required_key_is_a_declaration_not_a_variable(self) -> None:
+        seat = Contestant.from_json(
+            {
+                "name": "s",
+                "agent": "stella",
+                "engine": {"api": "openrouter", "model": "m"},
+                "env": {"required": ["OPENROUTER_API_KEY"]},
+            }
+        )
+        assert seat.required_env == ("OPENROUTER_API_KEY",)
+        assert seat.env == {}
+        assert "required" not in seat.ignored_env
+
+    def test_the_dotenv_and_plain_dict_forms_still_carry_values(self) -> None:
+        pasted = Contestant.from_json(
+            {"name": "s", "engine": {"model": "m"}, "env": "OPENROUTER_API_KEY=sk-1"}
+        )
+        assert pasted.env == {"OPENROUTER_API_KEY": "sk-1"}
+        assert pasted.required_env == ()
+        mapped = Contestant.from_json(
+            {"name": "s", "engine": {"model": "m"}, "env": {"ZAI_API_KEY": "zk"}}
+        )
+        assert mapped.env == {"ZAI_API_KEY": "zk"}
+
+    def test_a_non_credential_shaped_json_declaration_is_reported(self) -> None:
+        """`required = ["PATH"]` over HTTP must never resolve the host's PATH
+        into a seat — the name lands in `ignored_env`, visibly."""
+        seat = Contestant.from_json(
+            {
+                "name": "s",
+                "engine": {"model": "m"},
+                "env": {"required": ["PATH", "OPENROUTER_API_KEY"]},
+            }
+        )
+        assert seat.required_env == ("OPENROUTER_API_KEY",)
+        assert "PATH" in seat.ignored_env
+
+    def test_the_saved_file_fills_only_declared_names(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A subscription-only seat stays subscription-only: a metered key in
+        the saved file must not credential a seat that declared it does not
+        want one."""
+        path = tmp_path / "credentials.env"
+        path.write_text("ANTHROPIC_API_KEY=sk-ant-metered\n", encoding="utf-8")
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(path))
+        seat = Contestant(
+            id="cc",
+            name="cc",
+            agent="claude-code",
+            engine=Engine(api="anthropic", model="claude-fable-5"),
+            required_env=("CLAUDE_CODE_OAUTH_TOKEN",),
+        )
+        (seeded,) = apply_saved_credentials(_spec(seat)).contestants
+        assert seeded.env == {}
+
+    def test_a_value_in_the_env_table_fails_validation(self) -> None:
+        with pytest.raises(MatchTemplateError) as excinfo:
+            match_from_toml(_template({"OPENROUTER_API_KEY": "sk-secret"}))
+        assert any("names only, never" in problem for problem in excinfo.value.problems)
+
+    def test_a_non_credential_shaped_declaration_fails_validation(self) -> None:
+        with pytest.raises(MatchTemplateError) as excinfo:
+            match_from_toml(_template({"required": ["PATH"]}))
+        assert any("'PATH'" in problem for problem in excinfo.value.problems)
+
+    def test_match_creation_refuses_a_seat_with_none_of_its_declared_names(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The loud half of the contract: `POST /api/matches` must fail before
+        any container starts, naming the missing variables — never launch an
+        arm whose 401s score as an agent loss."""
+        from arenabench.server import ArenaServer
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("ARENABENCH_CREDENTIALS", str(tmp_path / "none.env"))
+        arena = ArenaServer(tmp_path / "ws")
+        payload = {
+            "name": "m",
+            "dataset": "terminal-bench-2.1",
+            "contestants": [
+                {
+                    "name": "stella",
+                    "agent": "stella",
+                    "engine": {"api": "openrouter", "model": "z-ai/glm-5.2"},
+                    "env": {"required": ["OPENROUTER_API_KEY"]},
+                }
+            ],
+        }
+        with pytest.raises(ValueError) as excinfo:
+            arena.create_match(payload)
+        assert "OPENROUTER_API_KEY" in str(excinfo.value)
+        assert arena.runner.matches == {}, "a refused match must not exist"
+
+    def test_every_committed_template_declares_its_credentials(self) -> None:
+        """The issue's repro, inverted: loading a committed template must keep
+        the declared names, not drop them into an empty seat env."""
+        from arenabench.config import load_match
+
+        matches = Path(__file__).resolve().parents[1] / "matches"
+        templates = sorted(matches.glob("*.toml"))
+        assert templates, "the committed match templates have moved"
+        for template in templates:
+            spec = load_match(template)
+            for seat in spec.contestants:
+                assert seat.required_env, (
+                    f"{template.name}: {seat.id} declares no credentials"
+                )


### PR DESCRIPTION
## Problem

Every committed match template declares its seats' credentials as `[contestant.env] required = ["OPENROUTER_API_KEY"]` — and the block wired nothing. `Contestant.from_json` treats `env` as a dotenv string or a NAME→VALUE dict, so the declaration parsed as one variable literally named `required`, `screen_env` dropped it, and the seat launched with `env == {}`. On the TOML path `match_from_toml` dropped the table outright. The failure was silent and asymmetric: the Stella seat died at credential selection with 0 steps, the Claude Code seat ran into 401s — and both scored a `0.0` indistinguishable from an agent loss (observed on the 10-task TB2.1 head-to-head where all 20 trials were operational aborts and the scoreboard still rendered a leader).

## Fix (issue direction 1 + 3: honour the declaration, refuse to launch empty)

- **`Contestant.required_env`** (new field): the declared names, carried from both `match_from_toml` and the JSON shape (`env: {"required": [...]}` is now a declaration, never a variable). Names only, values never touch the file.
- **Trust boundary held**: declared names must pass the same credential-shape fence `screen_env` applies (`is_credential_name`), so `required = ["PATH"]` fails template validation — over HTTP the bad name lands in `ignored_env`, visibly. `screen_env` itself is untouched.
- **`required_env()`** treats a declared list as the seat's whole contract, falling back to provider/agent derivation only when nothing was declared — declaring only `CLAUDE_CODE_OAUTH_TOKEN` now genuinely keeps a metered `ANTHROPIC_API_KEY` out of a subscription seat (per-seat isolation preserved in `apply_saved_credentials`, which keys off the same list).
- **`apply_ambient_credentials()`**: resolves *declared* names from the launching process's environment, gaps only, the seat's own env always wins. Seats that declared nothing get nothing — the server-side ambient scrub stands; the declaration is the one explicit, per-seat exception. `arenabench run` already read the ambient environment against `required_env()`, so the CLI docstring's claim ("against each seat's declared `required` list") is now actually true.
- **Loud refusal**: `POST /api/matches` now fails with a 400 naming the missing variables and the saved-credential path when a declaring seat still holds none of its names after ambient + saved resolution — before any container exists. `arenabench run` already refused (and keeps `--allow-missing-env`).
- **Direction 2 too**: any `[contestant.env]` key other than `required` — a value smuggled into a file that promises "no secrets, ever" — fails `MatchTemplateError` validation.
- Backward compatible: dotenv-string and plain NAME→VALUE dict `env` forms are unchanged; `match_to_toml_dict`/`dump_match` round-trip the declaration.

The committed templates and README comments ("Names only — never values", "Export … before running", "A missing one fails the match immediately") now describe real behavior, so no comment edits were needed — the fix makes them true.

## Verification

New witness tests in `arenabench/tests/test_credentials.py` (`TestDeclaredRequiredEnv`, 12 tests): declaration reaches the spec and beats the derived superset; ambient env credentials the seat; seat env wins over ambient; undeclared seats get nothing from ambient; JSON `required` key is a declaration; dotenv/dict forms still carry values; `PATH` declarations rejected on both paths; saved file fills only declared names; value-in-env-table and non-credential-shaped names fail validation; match creation refuses with the names in the error and no match registered; every committed template declares and loads.

- Old code (fix stashed): the suite fails at collection (`ImportError: apply_ambient_credentials`), and a standalone probe shows the silent path: template seats load with `env == {}` and names gone, the JSON seat gets `ignored: ('required',)`, and `create_match` **launches** (`status = running`) with no credentials.
- New code: same probe → `create_match refused: required credentials are not set: stella needs any of OPENROUTER_API_KEY — export them in the arena's environment or save them at …`.
- `python3 -m pytest tests/` in `arenabench/`: **268 passed** (0 failures), ~3m07s.

Closes #1777

## Summary by Sourcery

Enforce match templates’ declared credential requirements as a first-class contract, wiring `[contestant.env] required` names through parsing, environment resolution, and server match creation to prevent silently unauthenticated seats from running.

New Features:
- Support per-seat declared credential names via `required_env` on contestants, populated from TOML `[contestant.env] required` and JSON payloads, and surfaced in match serialization.
- Add ambient-environment credential seeding and detection of seats missing all required credentials so callers can fail match creation before launch.

Bug Fixes:
- Fix `[contestant.env] required` blocks being ignored so that declared credential names are honored instead of producing empty seat environments and silent unauthenticated runs.
- Ensure non-credential-shaped or value-bearing env declarations in templates and JSON are rejected or reported rather than silently misused.

Enhancements:
- Tighten credential name validation with a shared `is_credential_name` helper, aligning declared names with `screen_env`’s safety rules.
- Adjust agent-level missing-credential reporting and required-env derivation so declared lists override provider-derived defaults and become the sole contract where present.

Tests:
- Add comprehensive credential contract tests covering declaration propagation, ambient and saved credential resolution precedence, validation failures, server-side refusal on missing credentials, and verification of all committed templates’ declarations.