### PR TITLE
fix(stella-cli): record a deliberate stop distinctly from a crash in the session registry

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -260,9 +260,14 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
     let result = turn_outcome_result(&outcome);
     // Written here as well as by `record_outcome_if_supervised` (which only
     // covers the spawned child), so the hand-run `--foreground` case records
-    // a terminal status too. Same value on both paths; double-writing it is
-    // harmless, leaving it unwritten reads as a crash forever.
-    let _ = registry.set_status(&record.id, crate::daemon::outcome_status(result.is_ok()));
+    // a terminal status too. Same value on both paths — both now read the
+    // failure itself, so a resumed deliberate stop records `Stopped`, not
+    // `Error` (#1653); double-writing it is harmless, leaving it unwritten
+    // reads as a crash forever.
+    let _ = registry.set_status(
+        &record.id,
+        crate::daemon::outcome_status(result.as_ref().map(|_| ())),
+    );
     result
 }
 

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -116,6 +116,7 @@ mod model_cmd;
 mod profile_cmd;
 mod scope_gate;
 mod session_clear;
+mod sessions_view;
 mod settle;
 mod theme_cmd;
 use crate::memory::{SessionMemory, inject_recall_block};
@@ -124,6 +125,7 @@ use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::{agents_list_creating, agents_list_inbound, handle_agent_create};
 pub(crate) use forwarder::spawn_forwarder;
 use scope_gate::DeckApprovalGate;
+use sessions_view::sessions_inbound;
 
 /// The lead agent's id — the one conversation this driver runs.
 pub(crate) const LEAD: &str = "lead";
@@ -2621,57 +2623,6 @@ fn recorded_call_info(call: &stella_store::RecordedCall) -> stella_tui::Recorded
         provider: call.provider.clone(),
         model: call.model.clone(),
         estimated_input_tokens: call.estimated_input_tokens,
-    }
-}
-
-/// The SESSIONS overlay snapshot: every registry record mapped to the deck's
-/// [`stella_tui::SessionInfo`], flagging this process's own record and the
-/// rows that can be reopened HERE (no live owner, this workspace, durable
-/// state on disk — ⏎ navigates into those).
-fn sessions_inbound(
-    registry: &stella_store::SessionRegistry,
-    mine: &str,
-    workspace: &str,
-) -> Inbound {
-    let sessions = registry
-        .list()
-        .into_iter()
-        .map(|r| {
-            // A session mid-mapping advertises its slices right in the
-            // summary line, so a human sees "already being mapped" before
-            // typing a prompt that would duplicate the exploration.
-            let summary = if r.exploring.is_empty() {
-                r.summary
-            } else {
-                format!("{} [mapping: {}]", r.summary, r.exploring.join(", "))
-            };
-            stella_tui::SessionInfo {
-                mine: r.id == mine,
-                resumable: r.id != mine && r.workspace == workspace && registry.resumable(&r.id),
-                phase: session_phase(r.status),
-                id: r.id,
-                title: r.title,
-                summary,
-                workspace: r.workspace,
-                started_ms: r.started_at_ms,
-                updated_ms: r.updated_at_ms,
-            }
-        })
-        .collect();
-    Inbound::Sessions(sessions)
-}
-
-/// Store status → TUI phase (the TUI mirrors the enum so it never links the
-/// store crate).
-fn session_phase(status: stella_store::SessionStatus) -> stella_tui::SessionPhase {
-    match status {
-        stella_store::SessionStatus::InProgress => stella_tui::SessionPhase::InProgress,
-        stella_store::SessionStatus::NeedsInput => stella_tui::SessionPhase::NeedsInput,
-        stella_store::SessionStatus::Paused => stella_tui::SessionPhase::Paused,
-        stella_store::SessionStatus::Cancelled => stella_tui::SessionPhase::Cancelled,
-        stella_store::SessionStatus::Complete => stella_tui::SessionPhase::Complete,
-        stella_store::SessionStatus::Archived => stella_tui::SessionPhase::Archived,
-        stella_store::SessionStatus::Error => stella_tui::SessionPhase::Error,
     }
 }
 

--- a/crates/stella-cli/src/command_deck/sessions_view.rs
+++ b/crates/stella-cli/src/command_deck/sessions_view.rs
@@ -1,0 +1,57 @@
+//! The SESSIONS overlay's snapshot: session-registry records projected into
+//! the TUI's own types (split out of `command_deck.rs` under the god-file
+//! rule when [`session_phase`] grew its `Stopped` arm, #1653).
+
+use super::Inbound;
+
+/// The SESSIONS overlay snapshot: every registry record mapped to the deck's
+/// [`stella_tui::SessionInfo`], flagging this process's own record and the
+/// rows that can be reopened HERE (no live owner, this workspace, durable
+/// state on disk — ⏎ navigates into those).
+pub(super) fn sessions_inbound(
+    registry: &stella_store::SessionRegistry,
+    mine: &str,
+    workspace: &str,
+) -> Inbound {
+    let sessions = registry
+        .list()
+        .into_iter()
+        .map(|r| {
+            // A session mid-mapping advertises its slices right in the
+            // summary line, so a human sees "already being mapped" before
+            // typing a prompt that would duplicate the exploration.
+            let summary = if r.exploring.is_empty() {
+                r.summary
+            } else {
+                format!("{} [mapping: {}]", r.summary, r.exploring.join(", "))
+            };
+            stella_tui::SessionInfo {
+                mine: r.id == mine,
+                resumable: r.id != mine && r.workspace == workspace && registry.resumable(&r.id),
+                phase: session_phase(r.status),
+                id: r.id,
+                title: r.title,
+                summary,
+                workspace: r.workspace,
+                started_ms: r.started_at_ms,
+                updated_ms: r.updated_at_ms,
+            }
+        })
+        .collect();
+    Inbound::Sessions(sessions)
+}
+
+/// Store status → TUI phase (the TUI mirrors the enum so it never links the
+/// store crate).
+fn session_phase(status: stella_store::SessionStatus) -> stella_tui::SessionPhase {
+    match status {
+        stella_store::SessionStatus::InProgress => stella_tui::SessionPhase::InProgress,
+        stella_store::SessionStatus::NeedsInput => stella_tui::SessionPhase::NeedsInput,
+        stella_store::SessionStatus::Paused => stella_tui::SessionPhase::Paused,
+        stella_store::SessionStatus::Cancelled => stella_tui::SessionPhase::Cancelled,
+        stella_store::SessionStatus::Stopped => stella_tui::SessionPhase::Stopped,
+        stella_store::SessionStatus::Complete => stella_tui::SessionPhase::Complete,
+        stella_store::SessionStatus::Archived => stella_tui::SessionPhase::Archived,
+        stella_store::SessionStatus::Error => stella_tui::SessionPhase::Error,
+    }
+}

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -990,28 +990,35 @@ const LOCK_FD_SCAN_LIMIT: i32 = 64;
 ///
 /// A no-op in an unsupervised process, and harmless where a surface already
 /// wrote its own answer: `SessionPresence::finish` runs first on the two paths
-/// that have one, and writes the same value. This is what covers the paths
-/// that do not — `stella fleet`, and any future long-running verb that is
-/// handed to the supervisor before it grows a session presence.
-pub(crate) fn record_outcome_if_supervised(ok: bool) {
+/// that have one, and this write lands after it (agreeing on every outcome
+/// except a deliberate stop, where this one knows better — the presence sees
+/// only a bool, #1653). This is what covers the paths that do not —
+/// `stella fleet`, and any future long-running verb that is handed to the
+/// supervisor before it grows a session presence.
+pub(crate) fn record_outcome_if_supervised(outcome: Result<(), &crate::failure::CliFailure>) {
     let Some(id) = supervised_id() else {
         return;
     };
-    let _ = SessionRegistry::open_default().set_status(&id, outcome_status(ok));
+    let _ = SessionRegistry::open_default().set_status(&id, outcome_status(outcome));
 }
 
-/// The terminal status a finished run records.
+/// The terminal status a finished run records, from the run's own terminal
+/// answer — not a bool, which is exactly the collapse that used to record a
+/// deliberate stop as a crash (#1653).
 ///
 /// A signal is not a failure: the run was stopped, and recording it as an
 /// error would put a deliberate `stella daemon stop` in the registry beside
-/// the runs that genuinely broke. Shared with the resume driver
-/// (`crate::agent::resume`), which writes its own terminal status for the
-/// hand-run `--foreground` case no supervised env var covers.
-pub(crate) fn outcome_status(ok: bool) -> SessionStatus {
-    match (ok, crate::signals::interrupted_exit_code()) {
+/// the runs that genuinely broke. The same reasoning gives a deliberate stop
+/// (stuck-loop escalation, step cap, enforced budget — the failures that exit
+/// `3`) its own status beside `Cancelled`, never `Error`. Shared with the
+/// resume driver (`crate::agent::resume`), which writes its own terminal
+/// status for the hand-run `--foreground` case no supervised env var covers.
+pub(crate) fn outcome_status(outcome: Result<(), &crate::failure::CliFailure>) -> SessionStatus {
+    match (outcome, crate::signals::interrupted_exit_code()) {
         (_, Some(_)) => SessionStatus::Cancelled,
-        (true, None) => SessionStatus::Complete,
-        (false, None) => SessionStatus::Error,
+        (Ok(()), None) => SessionStatus::Complete,
+        (Err(failure), None) if failure.is_deliberate_stop() => SessionStatus::Stopped,
+        (Err(_), None) => SessionStatus::Error,
     }
 }
 

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -263,6 +263,60 @@ fn stopping_ends_the_whole_group_and_records_it_as_deliberate() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// #1653 witness: the terminal-status write distinguishes a deliberate stop
+/// from a crash. Before, both writers collapsed the outcome to a bool on the
+/// way into `outcome_status`, so a policy stop (stuck-loop escalation, step
+/// cap, enforced budget — the failures that exit `3`) and a genuine crash
+/// (exit `1`) both stored [`SessionStatus::Error`] — on the old signature
+/// this test does not even compile.
+///
+/// No signal is involved on this path, and no test in this binary ever calls
+/// `signals::note_interrupt`, so `interrupted_exit_code()` is reliably `None`
+/// here.
+#[test]
+fn a_deliberate_stop_records_a_status_distinct_from_a_crash() {
+    let stop = crate::failure::CliFailure::deliberate_stop(
+        "stuck-loop detected (persisted after a steering warning)",
+    );
+    let crash = crate::failure::CliFailure::error("model call failed: 500");
+
+    // Driven through the same registry write both real writers perform. The
+    // ids are re-minted by hand: two records minted in the same millisecond
+    // of the same process would otherwise share one `ses-<ms>-<pid>` id.
+    let (dir, registry) = temp_registry("deliberate-status");
+    let mut stopped = SessionRecord::new("/tmp/workspace", "stopped by policy");
+    let mut crashed = SessionRecord::new("/tmp/workspace", "fell over");
+    stopped.id.push_str("-stop");
+    crashed.id.push_str("-crash");
+    registry.upsert(&stopped).unwrap();
+    registry.upsert(&crashed).unwrap();
+    assert!(
+        registry
+            .set_status(&stopped.id, outcome_status(Err(&stop)))
+            .unwrap()
+    );
+    assert!(
+        registry
+            .set_status(&crashed.id, outcome_status(Err(&crash)))
+            .unwrap()
+    );
+
+    let stored_stop = registry.get(&stopped.id).map(|r| r.status);
+    let stored_crash = registry.get(&crashed.id).map(|r| r.status);
+    assert_eq!(
+        stored_stop,
+        Some(SessionStatus::Stopped),
+        "a run that ended itself by policy must not read as a crash"
+    );
+    assert_eq!(stored_crash, Some(SessionStatus::Error));
+    assert_ne!(stored_stop, stored_crash);
+
+    // The happy path is untouched by the widening.
+    assert_eq!(outcome_status(Ok(())), SessionStatus::Complete);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// Stopping something that already finished is not an error, and must not
 /// signal anything: the pid in the record may by then belong to somebody else
 /// entirely.

--- a/crates/stella-cli/src/failure.rs
+++ b/crates/stella-cli/src/failure.rs
@@ -65,6 +65,13 @@ impl CliFailure {
         }
     }
 
+    /// Whether this failure is a deliberate stop — the same bit
+    /// [`Self::exit_code`] reads, exposed so the session registry can record
+    /// a policy stop distinctly from a crash (#1653).
+    pub(crate) fn is_deliberate_stop(&self) -> bool {
+        self.deliberate_stop
+    }
+
     pub(crate) fn exit_code(&self) -> ExitCode {
         if self.deliberate_stop {
             ExitCode::from(DELIBERATE_STOP_EXIT_CODE)

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -553,7 +553,7 @@ fn main() -> ExitCode {
 
     let code = match run(cli, &loaded_env) {
         Ok(()) => {
-            daemon::record_outcome_if_supervised(true);
+            daemon::record_outcome_if_supervised(Ok(()));
             // A supervisor's own exit code says only whether it managed to
             // stream a log. What a script wrapping `stella run` is asking
             // about is the run, so the child's code is forwarded verbatim.
@@ -563,7 +563,9 @@ fn main() -> ExitCode {
             }
         }
         Err(e) => {
-            daemon::record_outcome_if_supervised(false);
+            // The failure itself, not a bool: a deliberate stop must reach
+            // the registry as a stop, not age into it as a crash (#1653).
+            daemon::record_outcome_if_supervised(Err(&e));
             eprintln!("{} {}", "stella:".red().bold(), e);
             emit_error_summary(output_format, e.message());
             // §7.4's second trigger, and the one that fires more often: most

--- a/crates/stella-store/src/sessions.rs
+++ b/crates/stella-store/src/sessions.rs
@@ -42,6 +42,12 @@ pub enum SessionStatus {
     Paused,
     /// The user interrupted the work (Ctrl-C mid-turn, queue abandoned).
     Cancelled,
+    /// The run ended itself by policy — a stuck-loop escalation, the step
+    /// cap, an enforced budget, a scope review the user ended. A deliberate
+    /// ending like [`SessionStatus::Cancelled`], only chosen by the engine
+    /// rather than the human; the CLI exits `3` for exactly this case, and
+    /// the registry keeps the same distinction (#1653).
+    Stopped,
     /// The session ended after finishing its work.
     Complete,
     /// Tucked away by the user from the SESSIONS view; kept until removed.
@@ -53,11 +59,12 @@ pub enum SessionStatus {
 
 impl SessionStatus {
     /// Grouping/order for the SESSIONS view: active work first.
-    pub const ALL: [SessionStatus; 7] = [
+    pub const ALL: [SessionStatus; 8] = [
         SessionStatus::InProgress,
         SessionStatus::NeedsInput,
         SessionStatus::Paused,
         SessionStatus::Cancelled,
+        SessionStatus::Stopped,
         SessionStatus::Complete,
         SessionStatus::Archived,
         SessionStatus::Error,
@@ -70,6 +77,7 @@ impl SessionStatus {
             SessionStatus::NeedsInput => "Needs Input",
             SessionStatus::Paused => "Paused",
             SessionStatus::Cancelled => "Cancelled",
+            SessionStatus::Stopped => "Stopped by policy",
             SessionStatus::Complete => "Complete",
             SessionStatus::Archived => "Archived",
             SessionStatus::Error => "Error",

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -454,6 +454,9 @@ fn phase_color(phase: crate::envelope::SessionPhase) -> ratatui::style::Color {
         SessionPhase::NeedsInput => theme::WARNING_BRIGHT,
         SessionPhase::Paused => theme::ACCENT,
         SessionPhase::Cancelled => theme::TEXT_TERTIARY,
+        // The same calm tone as `Cancelled`: both are deliberate endings,
+        // and the whole point of the variant is not to paint them red.
+        SessionPhase::Stopped => theme::TEXT_TERTIARY,
         SessionPhase::Complete => theme::SUCCESS,
         SessionPhase::Archived => theme::TEXT_TERTIARY,
         SessionPhase::Error => theme::DANGER_BRIGHT,

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -528,6 +528,10 @@ pub enum SessionPhase {
     /// from) with work still pending; the first thing resume looks for.
     Paused,
     Cancelled,
+    /// Ended itself by policy (stuck-loop escalation, step cap, enforced
+    /// budget, ended scope review) — a deliberate ending beside `Cancelled`,
+    /// never an error (#1653).
+    Stopped,
     Complete,
     Archived,
     Error,
@@ -535,11 +539,12 @@ pub enum SessionPhase {
 
 impl SessionPhase {
     /// Display/grouping order: attention-worthy first.
-    pub const ALL: [SessionPhase; 7] = [
+    pub const ALL: [SessionPhase; 8] = [
         SessionPhase::InProgress,
         SessionPhase::NeedsInput,
         SessionPhase::Paused,
         SessionPhase::Cancelled,
+        SessionPhase::Stopped,
         SessionPhase::Complete,
         SessionPhase::Archived,
         SessionPhase::Error,
@@ -551,6 +556,7 @@ impl SessionPhase {
             SessionPhase::NeedsInput => "Needs Input",
             SessionPhase::Paused => "Paused",
             SessionPhase::Cancelled => "Cancelled",
+            SessionPhase::Stopped => "Stopped by policy",
             SessionPhase::Complete => "Complete",
             SessionPhase::Archived => "Archived",
             SessionPhase::Error => "Error",


### PR DESCRIPTION
## What & why

A deliberate stop (`AbortKind::DeliberateStop` — stuck-loop escalation, step cap, enforced budget, an ended scope review) already exits `3` while a crash exits `1` (#1620, #1637), but the session registry collapsed the two: both terminal-status writers reduced the outcome to a bool before calling `outcome_status`, so a run that stopped **by policy** was stored as `SessionStatus::Error` and `stella daemon list` / the deck SESSIONS overlay painted it as a crash. The `CliFailure` at each call site knew it was a deliberate stop and threw that away one line before the write.

**Design decision (the call #1653 asked for): a new `SessionStatus::Stopped` variant** ("Stopped by policy"), placed beside `Cancelled` — both are deliberate endings, one chosen by the human, one by the engine — rather than reusing `Cancelled`. `Cancelled` is documented as "the user interrupted the work" and is what `stella daemon stop` and the signal path already write; folding engine policy stops into it would trade one ambiguity (stop vs. crash) for another (who stopped it). The cascade was exactly the one the issue enumerated, so the fallback to reusing `Cancelled` was not needed.

What changed:

- `crates/stella-store/src/sessions.rs` — `SessionStatus::Stopped`, added to `ALL` (after `Cancelled`, appended semantically as a deliberate ending) and `label()` ("Stopped by policy"). Serialized as `stopped`; old readers tolerate unknown records by skipping, per the registry's design.
- `crates/stella-cli/src/failure.rs` — `CliFailure::is_deliberate_stop()`: the same bit `exit_code()` reads. (Named `is_…` rather than the issue's `deliberate_stop()` because that name is already taken by the constructor.)
- `crates/stella-cli/src/daemon.rs` — `outcome_status` / `record_outcome_if_supervised` now take the terminal answer itself, `Result<(), &CliFailure>`, and map a deliberate-stop failure to `Stopped`; signal → `Cancelled` and crash → `Error` unchanged.
- `crates/stella-cli/src/main.rs` — the `Ok`/`Err` arms of the exit match pass the result through (`Err(&e)` carries the failure).
- `crates/stella-cli/src/agent/resume.rs` — the `--foreground` resume writer passes its `Result<(), CliFailure>` through, so a resumed deliberate stop also records `Stopped`.
- `crates/stella-tui/src/envelope.rs` + `deck_render.rs` — the deck's `SessionPhase` mirror gains the matching variant, grouped beside `Cancelled` and painted in the same calm tertiary tone (never red). `stella daemon list` labels it through its existing catch-all arm.
- `crates/stella-cli/src/command_deck/sessions_view.rs` (new) — `command_deck.rs` sat at its exact 4740-line ceiling and is closed to growth, so the `sessions_inbound`/`session_phase` projection moved to this sibling (the `driver/settlement.rs` pattern), where the new match arm lands. `command_deck.rs` shrinks by ~46 lines.

Closes #1653

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`daemon::tests::a_deliberate_stop_records_a_status_distinct_from_a_crash` drives a deliberate stop and a crash through the same registry write both real writers perform and asserts the stored statuses differ (`Stopped` vs `Error`). On `main` this test does not even compile — `outcome_status` takes a bool and `SessionStatus::Stopped` does not exist — which is the structural form of "fails on the old code" (same shape as resume.rs's #1637 witness).

## The gate

- [x] `cargo fmt` on the touched crates
- [x] `cargo check -p stella-store -j 2` and `cargo check -p stella-cli -j 2` — clean
- [x] `cargo test -p stella-cli --bin stella -j 2` — 1417 passed, 0 failed (includes the witness)
- [x] `cargo test -p stella-store -j 2` — 308 + 31 passed, 0 failed
- [ ] Full workspace clippy/test left to CI per the issue's build-economy constraint (16GB machine; the issue mandates the scoped run above and forbids the full target set)
- [x] Docs updated where behavior changed (doc comments on every touched item)
- [x] `Closes #1653` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #1826 — `SessionPresence::finish(ok: bool)` (and the deck's `session_exit` writer) still collapse the outcome to a bool, so an **unsupervised** headless deliberate stop still records `Error` on that path (masked for supervised runs, where `record_outcome_if_supervised` now writes `Stopped` afterwards). Out of scope here: at those call sites the outcome is a `PipelineStatus`, not a `CliFailure`, so the honest fix is a fifth `PipelineStatus` projection in `agent/outcome.rs`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The variant is inserted between `Cancelled` and `Complete` (grouping is the registry's documented declaration-order contract), which shifts the derived `Ord` of `Complete`/`Archived`/`Error`. Nothing persists or compares those ordinals — serialization is snake_case strings — and the SESSIONS grouping is exactly what the position is for.
- "Stopped by policy" (17 chars) overflows `stella daemon list`'s 12-char STATUS padding by 5 on those rows only; every other label fits. Cosmetic, and only on the rare status the row exists to make visible.
- Golden deck frames are unaffected: the SESSIONS overlay skips empty groups, and no fixture carries the new phase.

## Summary by Sourcery

Introduce a distinct "Stopped by policy" session status and propagate it through CLI and TUI so deliberate engine stops are no longer recorded or displayed as crashes.

New Features:
- Add a new SessionStatus::Stopped value and corresponding SessionPhase::Stopped to represent runs that end themselves by policy, separate from user cancellation and errors.

Bug Fixes:
- Ensure deliberate policy stops are stored in the session registry and rendered in the deck as "Stopped" rather than being misclassified as errors.
- Update supervised and resume flows to record terminal status from the full CliFailure outcome instead of a boolean, preserving the distinction between stops and crashes.

Enhancements:
- Refactor the deck sessions overlay projection into a dedicated sessions_view module to keep command_deck.rs within its size limits and accommodate the new phase mapping.

Tests:
- Add a daemon-level witness test that drives a deliberate stop and a crash through the registry write and asserts they persist as distinct statuses (Stopped vs Error).