### PR TITLE
docs(stella-core): unbreak main — drop doc links to private items in evidence()

### DIFF
--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -207,8 +207,8 @@ impl LoopVerdict {
     /// A human-readable evidence string for the driver to surface when it
     /// steers or aborts. `None` for `NoLoop`.
     ///
-    /// The quoted input is truncated through the same [`truncate`] and
-    /// [`MAX_DESCRIBED_INPUT`] [`LoopIdentity::describe`] uses, not a second
+    /// The quoted input is truncated through the same `truncate` and
+    /// `MAX_DESCRIBED_INPUT` [`LoopIdentity::describe`] uses, not a second
     /// budget of its own. This string becomes an `AgentEvent::Error` message,
     /// the abort reason on `TurnOutcome::Aborted`, the red line in the Command
     /// Deck, and the `loop_detected` journal event — so an untruncated


### PR DESCRIPTION
## What

Main's `doc-warnings` gate (rustdoc `-D warnings`) is red: the `LoopVerdict::evidence` doc comment added in #1775 links `[`truncate`]` and `[`MAX_DESCRIBED_INPUT`]`, both private items, tripping `rustdoc::private_intra_doc_links`.

## Fix

Plain backticks instead of intra-doc links — the file's existing convention for private references (see `LoopDetectionConfig::short_cycle_repeats` on the `ShortCycle` variant). The `[`LoopIdentity::describe`]` link stays: that item is public.

The similar `[`truncate`]` link in `crates/stella-mcp/src/http.rs` is untouched and fine — both items there are `pub(crate)`, so the public-docs lint never sees them.

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps` fails on main with exactly the two reported errors and exits 0 with this change. Docs-only; no witness test applicable.

## Summary by Sourcery

Documentation:
- Replace intra-doc links to private truncate and MAX_DESCRIBED_INPUT items with plain code formatting in LoopVerdict::evidence documentation to satisfy rustdoc warning policy.