### PR TITLE
docs(stella-core,stella-pipeline): unbreak main — drop rustdoc links to private items

### DIFF
--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -207,8 +207,8 @@ impl LoopVerdict {
     /// A human-readable evidence string for the driver to surface when it
     /// steers or aborts. `None` for `NoLoop`.
     ///
-    /// The quoted input is truncated through the same [`truncate`] and
-    /// [`MAX_DESCRIBED_INPUT`] [`LoopIdentity::describe`] uses, not a second
+    /// The quoted input is truncated through the same `truncate` and
+    /// `MAX_DESCRIBED_INPUT` [`LoopIdentity::describe`] uses, not a second
     /// budget of its own. This string becomes an `AgentEvent::Error` message,
     /// the abort reason on `TurnOutcome::Aborted`, the red line in the Command
     /// Deck, and the `loop_detected` journal event — so an untruncated

--- a/crates/stella-pipeline/src/triage.rs
+++ b/crates/stella-pipeline/src/triage.rs
@@ -926,7 +926,7 @@ fn has_action_request(goal: &str) -> bool {
 ///
 /// `structure` is the workspace listing the `RepoStructurePort` already
 /// supplies to the planner and the witness author — bounded here to
-/// [`TRIAGE_STRUCTURE_CHARS`] and rendered *before* the task so the
+/// `TRIAGE_STRUCTURE_CHARS` and rendered *before* the task so the
 /// `Task:`/`Answer:` pair stays adjacent at the end. Triage decides the
 /// highest-leverage questions in the pipeline (how much orchestration, whether
 /// a witness is warranted, whether this is a task at all) and until this

--- a/crates/stella-pipeline/src/witness/warrant.rs
+++ b/crates/stella-pipeline/src/witness/warrant.rs
@@ -188,7 +188,7 @@ pub struct ChangeSignals {
     /// unrecognized name can never be the reason a turn is written off.
     pub mutating_actions: u32,
     /// The subset of `mutating_actions` whose effects the diff CANNOT be
-    /// trusted to account for ([`diff_accountable_mutator`]): shell calls,
+    /// trusted to account for (`diff_accountable_mutator`): shell calls,
     /// process spawns, repo pushes, MCP and custom tools — anything able to
     /// act outside the file-CRUD surface the diff probes observe.
     ///


### PR DESCRIPTION
## What

Main's required `doc-warnings` gate (`cargo doc --workspace`, `-D rustdoc::private-intra-doc-links`) is red with **two independent clusters** of public docs linking private items:

| File | Public item | Private link target | Introduced by |
|---|---|---|---|
| `crates/stella-pipeline/src/triage.rs:929` | `triage_prompt` | `TRIAGE_STRUCTURE_CHARS` | #1768 |
| `crates/stella-pipeline/src/witness/warrant.rs:191` | `ChangeSignals::opaque_actions` | `diff_accountable_mutator` | #1798 |
| `crates/stella-core/src/loop_detect.rs:210-211` | `LoopVerdict::evidence` | `truncate`, `MAX_DESCRIBED_INPUT` | #1775 |

The fix converts the four `[\`…\`]` intra-doc links to plain backticks, matching the file-local convention for private items (`RECALL_FRAME_CHARS` in the same triage doc block is already plain). Links to the same items from *private* docs (`bounded_structure`) are legal and untouched.

## Why one PR for both clusters

Each CI run only surfaced one cluster because `cargo doc` bails per-crate, so the parallel single-crate unbreaks — #1822, #1823, #1829 (all loop_detect-only, no pipeline fix) — **cannot go green on their merge refs**, and neither could a pipeline-only fix. This PR is the minimal change that can pass the workspace gate. The loop_detect hunk is byte-identical to #1829's, so whichever lands first leaves the other a no-op.

Once this merges: close #1822 / #1823 / #1829 as superseded, and `gh pr update-branch 1810` (its doc-warnings failure is inherited from main, not its own diff — it touches only stella-observatory).

## Witness

Docs-only change — no behavior to witness. Verified by the gate itself: `doc-warnings` fails on main at c8faa37a with exactly these four errors and passes with this diff (see this PR's CI).

## Summary by Sourcery

Fix rustdoc private intra-doc link warnings by converting references to private items into plain code formatting in loop detection and pipeline documentation.

Documentation:
- Update loop detection docs to reference internal helpers as inline code instead of intra-doc links.
- Adjust triage and witness pipeline docs to remove rustdoc links to private items while preserving their descriptions.