### PR TITLE
docs(stella-pipeline): unbreak main round 2 — two more doc links to private items

### DIFF
--- a/crates/stella-pipeline/src/triage.rs
+++ b/crates/stella-pipeline/src/triage.rs
@@ -926,7 +926,7 @@ fn has_action_request(goal: &str) -> bool {
 ///
 /// `structure` is the workspace listing the `RepoStructurePort` already
 /// supplies to the planner and the witness author — bounded here to
-/// [`TRIAGE_STRUCTURE_CHARS`] and rendered *before* the task so the
+/// `TRIAGE_STRUCTURE_CHARS` and rendered *before* the task so the
 /// `Task:`/`Answer:` pair stays adjacent at the end. Triage decides the
 /// highest-leverage questions in the pipeline (how much orchestration, whether
 /// a witness is warranted, whether this is a task at all) and until this

--- a/crates/stella-pipeline/src/witness/warrant.rs
+++ b/crates/stella-pipeline/src/witness/warrant.rs
@@ -188,7 +188,7 @@ pub struct ChangeSignals {
     /// unrecognized name can never be the reason a turn is written off.
     pub mutating_actions: u32,
     /// The subset of `mutating_actions` whose effects the diff CANNOT be
-    /// trusted to account for ([`diff_accountable_mutator`]): shell calls,
+    /// trusted to account for (`diff_accountable_mutator`): shell calls,
     /// process spawns, repo pushes, MCP and custom tools — anything able to
     /// act outside the file-CRUD surface the diff probes observe.
     ///


### PR DESCRIPTION
## What

Main is still red after #1822/#1829: the stella-core rustdoc error was masking two more `rustdoc::private_intra_doc_links` errors behind it in `stella-pipeline`, which CI only reached once the core fix landed (see #1822's `fmt + clippy + test` failure):

- `crates/stella-pipeline/src/triage.rs:929` — `TRIAGE_STRUCTURE_CHARS` is private
- `crates/stella-pipeline/src/witness/warrant.rs:191` — `diff_accountable_mutator` is private

## Fix

Plain backticks instead of intra-doc links, same shape as #1822. Public-item links (`resolve_conversational`, `LoopIdentity::describe`) stay.

## Verification

A workspace-wide `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` is running locally to confirm no further masked breaks; result will be posted on this PR. Docs-only; no witness test applicable.

## Summary by Sourcery

Documentation:
- Replace intra-doc links to private symbols in stella-pipeline docs with plain code formatting to satisfy rustdoc::private_intra_doc_links warnings.