### PR TITLE
docs(stella-home): record why a feature-specific root clears the boundary bar

### DIFF
--- a/crates/stella-home/README.md
+++ b/crates/stella-home/README.md
@@ -32,6 +32,17 @@ in `crates/stella-cli/src/paths.rs`. Even a new resolver has a bar to clear:
 both sides of the store/observatory divide must need the same answer — a
 helper only one consumer wants belongs in that consumer.
 
+`self_driving_root` / `legacy_self_driving_roots` are the worked example of a
+**feature-specific** path clearing that bar (#1755). They look like they belong
+in `stella-cli`, and would, but for the same reason the crate exists at all:
+`stella-cli` is the single writer of that directory and `stella-observatory`
+reads it back read-only, the two must not know each other, and a root spelled
+differently in one of them shows an operator an empty dashboard for a machine
+holding a full ledger. That is one answer needed on both sides of the divide,
+which is the test — not "is it about the home directory". They still answer
+"where" and never "make it so": the lazy migration those legacy roots exist for
+is I/O with failure modes, and it stays in the CLI.
+
 This crate is also the workspace's worked example of when a new crate is
 justified. The rule: a new crate is warranted only when functionality (a) sits
 behind a port/trait and would otherwise drag heavy dependencies into a crate


### PR DESCRIPTION
## What & why

Refs #1755

#1810 added `self_driving_root` and `legacy_self_driving_roots` to `stella-home`. The crate's README opens by scoping it to *"what path a process should treat as the stella home, the user-tier data dir, and the config dir"*, and its Boundary section is explicit that a helper only one consumer wants belongs in that consumer.

Read literally, those two resolvers look like they violate that — a *feature-specific* path in a crate about home resolution. **Left unsaid, the next reader would reasonably delete them.**

They actually clear the bar the README itself states, for exactly the reason the crate exists:

> both sides of the store/observatory divide must need the same answer

`stella-cli` is the single writer of that directory and `stella-observatory` reads it back read-only; the two must not know each other; and a root spelled differently in one of them shows an operator an empty dashboard for a machine holding a full ledger. That is one answer needed on both sides — which is the test, not "is it about the home directory".

The paragraph also pins what did *not* move: they answer "where" and never "make it so". The lazy migration those legacy roots exist for is I/O with failure modes and stays in the CLI.

## The witness

- [x] No witness needed (docs) — one paragraph, no code change.

This paragraph was written as part of #1810 but was orphaned: that PR merged while the commit was still local, so it never reached `main`. This re-lands it alone.

## The gate

- [x] `make god-files` — OK
- [x] `make doc-links` — 254 citations resolve
- [x] `make brand-case` — clean

## Summary by Sourcery

Documentation:
- Clarify in the stella-home README why self_driving_root and legacy_self_driving_roots belong in this crate and how they satisfy the shared-answer requirement across store and observatory.