### PR TITLE
feat(gate): fail when a src/ file is unreachable from its crate root (#1750)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-stat-portability.sh
 
+      # Toolchain-free, and it has to be: the three gates that would normally
+      # catch a broken file all walk `mod` declarations from the crate root, so
+      # deleting one line hides a file from rustc, rustfmt and clippy at the
+      # same moment while `cargo test` still reports ok. #1739 lost 19 tests
+      # that way and only a reviewer reading the diff noticed (#1750).
+      - name: every src/ file is reachable from its crate root
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-module-reachability.py
+
       # Also toolchain-free. AGENTS.md requires that anything noticed and not
       # fixed becomes an issue written as a handoff; nothing checked it, and an
       # unenforced standard reads as one the codebase is meeting. The decidable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + command-docs + brand-case + file-size
                          #   + god-files
                          #   + gate-parity + left-behind + role-names
-                         #   + stat-portability
+                         #   + stat-portability + module-reachability
                          #   + wire-schema
                          #   + doc-warnings (rustdoc -D warnings)
                          #   + format-check (fmt --check)
@@ -72,7 +72,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + test (test --workspace)
 ```
 
-That is twenty-three steps, and the list is not maintained by hand: it is
+That is twenty-four steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ python3 ./scripts/check-doc-links.py check
 ./scripts/check-left-behind.sh
 ./scripts/check-role-names.sh
 ./scripts/check-stat-portability.sh
+python3 ./scripts/check-module-reachability.py
 ./scripts/check-wire-schema.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo fmt --check
@@ -92,7 +93,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or just `make gate`, which is the twenty-three of them in order.
+Or just `make gate`, which is the twenty-four of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CARGO_SCOPE ?= --workspace
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     command-docs brand-case file-size god-files gate-parity left-behind \
-                    role-names stat-portability
+                    role-names stat-portability module-reachability
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The whole gate, in order, as one name. `gate` below is defined *from* this
@@ -280,6 +280,14 @@ role-names: ## Assert the agent-config role names match across Rust, Python and 
 .PHONY: stat-portability
 stat-portability: ## Assert file identity is read through MetadataExt, not a raw libc::stat (#1758)
 	@./scripts/check-stat-portability.sh
+
+.PHONY: module-reachability
+module-reachability: ## Assert every .rs under a crate's src/ is reachable from its crate root (#1750)
+	@python3 ./scripts/check-module-reachability.py
+
+.PHONY: module-reachability-test
+module-reachability-test: ## Test the module-reachability walker (hermetic; not part of `gate`)
+	./scripts/test-module-reachability.sh
 
 .PHONY: god-files
 god-files: ## Assert AGENTS.md and the crate READMEs name the baselined god files (#1435)

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -94,7 +94,9 @@ fi
 contributing_alias() {
   case "$1" in
   shellcheck) echo 'shellcheck ' ;;
+  # Two Python guards, so the `.sh` default below does not fit them.
   doc-links) echo 'check-doc-links' ;;
+  module-reachability) echo 'check-module-reachability' ;;
   doc-warnings) echo 'cargo doc' ;;
   format-check) echo 'cargo fmt' ;;
   lint) echo 'cargo clippy' ;;

--- a/scripts/check-module-reachability.py
+++ b/scripts/check-module-reachability.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Guard: every .rs file under a crate's src/ is reachable from its crate root.
+
+See #1750.
+
+Deleting a `mod` declaration silently disables the file it pointed at, and
+nothing else in `make gate` notices. rustc, rustfmt and clippy all walk `mod`
+declarations from the crate root, so an orphaned file is invisible to the
+compiler, the formatter and the linter *simultaneously*, and `cargo test`
+still reports green.
+
+Measured, in PR #1739: commit f6284d0d dropped `#[cfg(test)] mod tests;` from
+the bottom of `crates/stella-graph/src/store.rs`.
+
+    $ cargo test -p stella-graph --lib -- --list | rg -c '^store::tests::'
+    0          # without the declaration — and the suite reports "ok"
+    19         # with it restored
+
+`crates/stella-graph/src/store/tests.rs` was also unformatted the whole time
+and `cargo fmt --check` passed, because rustfmt never reached it either. One
+deleted line hid a file from three gates at once, and only a reviewer reading
+the diff caught it.
+
+This is a fact about the repository rather than about a crate, so it is never
+scoped by CARGO_SCOPE (AGENTS.md § "The gate"), and a text-level walk keeps it
+in the toolchain-free `guards-fast` rung.
+
+Usage:
+    ./scripts/check-module-reachability.py [ROOT]
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# `mod foo;` — a declaration, not an inline `mod foo { … }`, which needs no
+# file. Leading attributes on the same line are allowed so `#[cfg(test)] mod
+# tests;` counts: a cfg-gated declaration still makes the file reachable, and
+# treating it otherwise would report every test module in the tree.
+MOD_DECL = re.compile(
+    r"(?:^|[;{}\]\s])(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+
+# `#[path = "…"]` relocates a module's file, which this walker does not model.
+# There are none in this tree today (#1393 removed the last of them), so rather
+# than guess, the guard says it cannot verify and fails loudly. A silent wrong
+# answer from a reachability check is worse than no check.
+PATH_ATTR = re.compile(r"#\s*\[\s*path\s*=")
+
+
+def strip_comments(src: str) -> str:
+    """Blank out comments, keeping newlines so line structure survives.
+
+    Needed because a `mod x;` inside a doc comment — describing the very rule
+    this guard enforces — would otherwise count as a declaration.
+
+    String literals are tracked, and that is not a nicety. A first version
+    skipped them on the theory that a `mod x;` inside a string is vanishingly
+    rare and the failure would be benign. Both halves were wrong: the risk is
+    not a `mod` inside a string, it is a `/*` inside one. This tree has
+
+        "guard-deny-path: protected/**"
+
+    in `crates/stella-cli/src/agent/tests.rs`, whose `/*` opened a block
+    comment that never closed — blanking the remaining 450 lines, hiding three
+    real `mod` declarations, and reporting three perfectly reachable files as
+    orphans. A reachability guard that answers wrongly is worse than none.
+
+    Raw strings get their hash count matched (`r#"…"#`) so a quoted `"` inside
+    one does not end it early.
+    """
+    out: list[str] = []
+    i, n = 0, len(src)
+    depth = 0  # block-comment nesting; Rust's nest.
+    while i < n:
+        two = src[i : i + 2]
+        if depth:
+            if two == "/*":
+                depth += 1
+                out.append("  ")
+                i += 2
+                continue
+            if two == "*/":
+                depth -= 1
+                out.append("  ")
+                i += 2
+                continue
+            out.append("\n" if src[i] == "\n" else " ")
+            i += 1
+            continue
+        if two == "//":
+            while i < n and src[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if two == "/*":
+            depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        if src[i] == '"':
+            out.append('"')
+            i += 1
+            while i < n:
+                if src[i] == "\\":
+                    out.append(src[i : i + 2])
+                    i += 2
+                    continue
+                out.append(src[i])
+                if src[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if src[i] == "r":
+            hashes = 0
+            while i + 1 + hashes < n and src[i + 1 + hashes] == "#":
+                hashes += 1
+            if i + 1 + hashes < n and src[i + 1 + hashes] == '"':
+                closer = '"' + "#" * hashes
+                end = src.find(closer, i + 2 + hashes)
+                end = n if end == -1 else end + len(closer)
+                out.append(src[i:end])
+                i = end
+                continue
+        out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
+def child_dir(file: Path) -> Path:
+    """Where `mod foo;` inside `file` looks for `foo`.
+
+    A crate/module root (`lib.rs`, `main.rs`, `mod.rs`) owns its own directory;
+    any other module file owns a directory named after itself.
+    """
+    if file.stem in {"lib", "main", "mod"}:
+        return file.parent
+    return file.parent / file.stem
+
+
+def declared_mods(text: str) -> list[str]:
+    return MOD_DECL.findall(text)
+
+
+def crate_roots(crate: Path) -> list[Path]:
+    """Every compilation root of `crate`: the lib, the bin, and extra bins.
+
+    `src/bin/*.rs` is Cargo's auto-discovery and each file there is its own
+    root, not a module of anything — a walker that missed that would report
+    every one of them as an orphan.
+    """
+    roots = [p for p in (crate / "src/lib.rs", crate / "src/main.rs") if p.is_file()]
+    manifest = crate / "Cargo.toml"
+    if manifest.is_file():
+        for m in re.finditer(r'^\s*path\s*=\s*"([^"]+)"', manifest.read_text(), re.M):
+            candidate = crate / m.group(1)
+            if candidate.is_file() and candidate.suffix == ".rs":
+                roots.append(candidate)
+    roots.extend(sorted((crate / "src/bin").glob("*.rs")))
+    return roots
+
+
+def reachable_from(roots: list[Path]) -> tuple[set[Path], list[str]]:
+    seen: set[Path] = set()
+    problems: list[str] = []
+    queue = list(roots)
+    while queue:
+        file = queue.pop()
+        if file in seen or not file.is_file():
+            continue
+        seen.add(file)
+        raw = file.read_text(encoding="utf-8", errors="replace")
+        text = strip_comments(raw)
+        if PATH_ATTR.search(text):
+            problems.append(
+                f"{file}: uses #[path], which this guard does not model — "
+                "teach it the attribute rather than leaving the crate unchecked"
+            )
+        base = child_dir(file)
+        for name in declared_mods(text):
+            for candidate in (base / f"{name}.rs", base / name / "mod.rs"):
+                if candidate.is_file():
+                    queue.append(candidate)
+                    break
+            # A `mod` that resolves to nothing is a compile error rustc will
+            # report; it is not this guard's finding to make.
+    return seen, problems
+
+
+def tracked_sources(root: Path, crate: Path) -> list[Path]:
+    rel = crate.relative_to(root)
+    out = subprocess.run(
+        ["git", "ls-files", "-z", f"{rel}/src/**/*.rs", f"{rel}/src/*.rs"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [root / p for p in out.split("\0") if p]
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    crates = sorted(
+        p.parent
+        for p in root.glob("*/*/Cargo.toml")
+        if (p.parent / "src").is_dir()
+    ) or sorted(
+        p.parent for p in root.glob("*/Cargo.toml") if (p.parent / "src").is_dir()
+    )
+
+    orphans: list[Path] = []
+    problems: list[str] = []
+    checked = 0
+    for crate in crates:
+        roots = crate_roots(crate)
+        if not roots:
+            continue
+        reachable, crate_problems = reachable_from(roots)
+        problems.extend(crate_problems)
+        for src in tracked_sources(root, crate):
+            checked += 1
+            if src.resolve() not in {r.resolve() for r in reachable}:
+                orphans.append(src)
+
+    if problems:
+        print("check-module-reachability: FAILED", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+
+    if orphans:
+        print("check-module-reachability: FAILED", file=sys.stderr)
+        print(
+            "\nThese files are tracked under a crate's src/ but no `mod` declaration\n"
+            "reaches them from the crate root. rustc, rustfmt and clippy all walk the\n"
+            "same declarations, so each of these is invisible to the compiler, the\n"
+            "formatter AND the linter at once — and its tests do not run while the\n"
+            "suite still reports ok (#1750).\n"
+            "\nRestore the `mod` declaration that used to point at it, or delete the\n"
+            "file if it is genuinely dead.\n",
+            file=sys.stderr,
+        )
+        for o in orphans:
+            print(f"  {o.relative_to(root)}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check-module-reachability: OK — {checked} source file(s) across "
+        f"{len(crates)} crate(s), all reachable from a crate root."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-module-reachability.sh
+++ b/scripts/test-module-reachability.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Tests for check-module-reachability.py (#1750).
+#
+#   ./scripts/test-module-reachability.sh
+#
+# Run it after touching that script. Not part of `make gate`: it builds a
+# dozen throwaway git repositories, the same posture as `make impacted-test`.
+#
+# ── Why a fixture instead of the real workspace ──────────────────────────────
+#
+# Asserting against this repository alone would only ever prove the tree is
+# currently clean — which is the one thing the guard says out loud anyway. What
+# needs proving is that it FAILS on an orphan, and there is no orphan in the
+# tree to fail on. So each case builds the shape it is about.
+#
+# ── The two ways this guard can be wrong, and which is worse ─────────────────
+#
+#   misses     an orphaned file is reported reachable. The file's tests never
+#              run and the suite says ok — the exact #1750 defect.
+#   fabricates a reachable file is reported orphaned. Worse in practice: it
+#              fails the gate on a healthy tree, and the reader's only recourse
+#              is to distrust the guard.
+#
+# The `S` cases are the second kind, and they are not hypothetical — the first
+# version of this guard fabricated three orphans in stella-cli because a string
+# literal containing `protected/**` opened a block comment that never closed.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-module-reachability.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway one-crate workspace, tracked in git (the guard asks git which
+# files are tracked, so an untracked fixture would look empty and pass).
+new_crate() { # <case>
+  local dir="$TMP/$1/mycrate"
+  mkdir -p "$dir/src"
+  printf '[package]\nname = "mycrate"\nversion = "0.0.0"\nedition = "2021"\n' >"$dir/Cargo.toml"
+  git -C "$TMP/$1" init -q
+  git -C "$TMP/$1" config user.email t@t.invalid
+  git -C "$TMP/$1" config user.name t
+  echo "$dir"
+}
+
+track() { git -C "$1" add -A; }
+
+# want <name> <expect-pass|expect-fail> <workspace-root> [substring]
+want() {
+  local name="$1" expect="$2" root="$3" sub="${4:-}" out rc
+  out="$(python3 "$SCRIPT" "$root" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -eq 0 ]; then
+      pass=$((pass + 1)); echo "ok   $name"
+    else
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+    fi
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed an orphan:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — failed for the wrong reason (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# ── O: the defect ────────────────────────────────────────────────────────────
+c="$(new_crate orphan)"
+printf 'pub fn a() {}\n' >"$c/src/lib.rs"
+printf '#[test]\nfn never_runs() { assert!(false); }\n' >"$c/src/orphan.rs"
+track "$TMP/orphan"
+want "O1 a file no mod reaches is reported" expect-fail "$TMP/orphan" "src/orphan.rs"
+
+# The #1739 shape exactly: a test module whose declaration was deleted.
+c="$(new_crate dropped_tests)"
+printf 'pub fn a() {}\n' >"$c/src/lib.rs"
+mkdir -p "$c/src/store"
+printf 'pub fn s() {}\n' >"$c/src/store.rs"
+printf '#[test]\nfn t() {}\n' >"$c/src/store/tests.rs"
+track "$TMP/dropped_tests"
+want "O2 a store.rs missing its 'mod tests;' is reported" \
+  expect-fail "$TMP/dropped_tests" "src/store/tests.rs"
+
+# ── N: the shapes that must NOT be reported ──────────────────────────────────
+c="$(new_crate flat)"
+printf 'mod foo;\n' >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/flat"
+want "N1 mod foo; -> src/foo.rs is reachable" expect-pass "$TMP/flat"
+
+c="$(new_crate nested)"
+printf 'mod foo;\n' >"$c/src/lib.rs"
+mkdir -p "$c/src/foo"
+printf 'mod bar;\n' >"$c/src/foo.rs"
+printf 'pub fn b() {}\n' >"$c/src/foo/bar.rs"
+track "$TMP/nested"
+want "N2 a nested module under its parent's directory is reachable" expect-pass "$TMP/nested"
+
+c="$(new_crate modrs)"
+printf 'mod foo;\n' >"$c/src/lib.rs"
+mkdir -p "$c/src/foo"
+printf 'pub fn f() {}\n' >"$c/src/foo/mod.rs"
+track "$TMP/modrs"
+want "N3 the mod.rs form is reachable" expect-pass "$TMP/modrs"
+
+# A cfg-gated declaration still makes the file reachable. Treating it otherwise
+# would report every test module in the tree.
+c="$(new_crate cfgtest)"
+printf 'pub fn a() {}\n\n#[cfg(test)]\nmod tests;\n' >"$c/src/lib.rs"
+printf '#[test]\nfn t() {}\n' >"$c/src/tests.rs"
+track "$TMP/cfgtest"
+want "N4 #[cfg(test)] mod tests; is reachable" expect-pass "$TMP/cfgtest"
+
+c="$(new_crate cfgtest_inline)"
+printf 'pub fn a() {}\n#[cfg(test)] mod tests;\n' >"$c/src/lib.rs"
+printf '#[test]\nfn t() {}\n' >"$c/src/tests.rs"
+track "$TMP/cfgtest_inline"
+want "N5 an attribute on the same line as the declaration is reachable" expect-pass "$TMP/cfgtest_inline"
+
+# src/bin/*.rs is Cargo auto-discovery — each is its own root, not a module of
+# anything. A walker that missed that reports every one as an orphan.
+c="$(new_crate autobin)"
+printf 'pub fn a() {}\n' >"$c/src/lib.rs"
+mkdir -p "$c/src/bin"
+printf 'fn main() {}\n' >"$c/src/bin/tool.rs"
+track "$TMP/autobin"
+want "N6 src/bin/*.rs is a root, not an orphan" expect-pass "$TMP/autobin"
+
+c="$(new_crate pubmod)"
+printf 'pub(crate) mod foo;\n' >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/pubmod"
+want "N7 pub(crate) mod is reachable" expect-pass "$TMP/pubmod"
+
+# ── S: fabricated orphans — the regression that shipped in the first draft ───
+# `protected/**` inside a string literal opened a block comment that never
+# closed, blanking the rest of the file and hiding every declaration after it.
+c="$(new_crate string_slashstar)"
+{
+  printf 'pub const GUARD: &str = "guard-deny-path: protected/**";\n'
+  printf 'mod foo;\n'
+} >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/string_slashstar"
+want "S1 a '/*' inside a string literal does not blank the rest of the file" \
+  expect-pass "$TMP/string_slashstar"
+
+c="$(new_crate raw_string)"
+{
+  printf 'pub const G: &str = r#"a /* b "quoted" c"#;\n'
+  printf 'mod foo;\n'
+} >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/raw_string"
+want "S2 the same through a raw string with an embedded quote" expect-pass "$TMP/raw_string"
+
+# The other direction: a real comment must still be stripped, so a `mod` named
+# only in prose does not count as a declaration.
+c="$(new_crate comment_mod)"
+{
+  printf '// Historically this file carried mod ghost; — it does not now.\n'
+  printf '/* mod ghost; */\n'
+  printf 'pub fn a() {}\n'
+} >"$c/src/lib.rs"
+printf 'pub fn g() {}\n' >"$c/src/ghost.rs"
+track "$TMP/comment_mod"
+want "S3 a mod named only in a comment does not count as a declaration" \
+  expect-fail "$TMP/comment_mod" "src/ghost.rs"
+
+# ── P: the shape the guard refuses to guess about ────────────────────────────
+c="$(new_crate pathattr)"
+printf '#[path = "elsewhere/thing.rs"]\nmod thing;\n' >"$c/src/lib.rs"
+mkdir -p "$c/src/elsewhere"
+printf 'pub fn t() {}\n' >"$c/src/elsewhere/thing.rs"
+track "$TMP/pathattr"
+want "P1 #[path] fails loudly rather than answering wrongly" \
+  expect-fail "$TMP/pathattr" "does not model"
+
+# ── R: the real workspace ────────────────────────────────────────────────────
+want "R1 this repository is clean" expect-pass "$repo_root"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem

Deleting a `mod` declaration silently disables the file it pointed at, and **nothing in `make gate` noticed**. rustc, rustfmt and clippy all walk `mod` declarations from the crate root, so an orphaned file is invisible to the compiler, the formatter and the linter *at the same moment* — and `cargo test` still reports green.

Re-measured on the real regression, by deleting #1739's restored line again:

```
$ cargo test -p stella-graph --lib -- --list | rg -c '^store::tests::'
0          # declaration deleted — and the suite reports "ok"
19         # restored
```

**19 tests vanished and three gates stayed green.** Only a reviewer reading the diff caught it the first time.

## Change

`module-reachability` joins `GATE_GUARDS_FAST`: a text-level walk of `mod` declarations from each crate's roots — `src/lib.rs`, `src/main.rs`, every `[[bin]]` path, and Cargo's auto-discovered `src/bin/*.rs` — reporting any tracked `.rs` under `src/` that nothing reaches.

Toolchain-free, so it rides the cheapest rung and the author's own pre-push hook, an hour earlier than CI. Never scoped by `CARGO_SCOPE`: this is a fact about the repository, not about a crate.

`#[path = "…"]` relocates a module's file and this walker does not model it. There are none in the tree (#1393 removed the last), so rather than guess it **fails loudly and says so** — a silent wrong answer from a reachability check is worse than no check.

## The bug this PR shipped and then caught

Worth reading, because the fixture that catches it is in the suite and the failure mode is the one the guard exists to prevent.

The first draft skipped string literals, reasoning that a `mod x;` inside one is vanishingly rare and the failure direction benign. **Both halves were wrong.** The risk is not a `mod` inside a string — it is a `/*` inside one. This tree has

```rust
"guard-deny-path: protected/**"
```

in `crates/stella-cli/src/agent/tests.rs`. That `/*` opened a block comment that never closed, blanking the remaining 450 lines, hiding three real `mod` declarations, and reporting three perfectly reachable files as orphans:

```
  crates/stella-cli/src/agent/tests/code_graph.rs
  crates/stella-cli/src/agent/tests/engine_wiring.rs
  crates/stella-cli/src/agent/tests/usage_completeness.rs
```

The stripper now tracks string literals, escapes, and raw strings with matched hash counts.

## Witness

`scripts/test-module-reachability.sh` (`make module-reachability-test`, hermetic, not in `gate`). Both directions, because they fail differently and a suite checking one is blind to the other:

```
ok   O1 a file no mod reaches is reported
ok   O2 a store.rs missing its 'mod tests;' is reported          <- the #1739 shape
ok   N1 mod foo; -> src/foo.rs is reachable
ok   N2 a nested module under its parent's directory is reachable
ok   N3 the mod.rs form is reachable
ok   N4 #[cfg(test)] mod tests; is reachable
ok   N5 an attribute on the same line as the declaration is reachable
ok   N6 src/bin/*.rs is a root, not an orphan
ok   N7 pub(crate) mod is reachable
ok   S1 a '/*' inside a string literal does not blank the rest of the file
ok   S2 the same through a raw string with an embedded quote
ok   S3 a mod named only in a comment does not count as a declaration
ok   P1 #[path] fails loudly rather than answering wrongly
ok   R1 this repository is clean

passed 14, failed 0
```

- **Misses** (O): the defect itself, plus the `store.rs` shape from #1739.
- **Fabricates** (S1/S2): the regression above. S3 is its inverse — a real comment must still be stripped, so a fix that simply stopped stripping anything cannot pass.
- **Quiet** (N): every shape in this tree, including `src/bin` auto-discovery, which a naive walker reports as an orphan of nothing.

And the hand-check the issue asked for: deleting `#[cfg(test)] mod tests;` from `crates/stella-graph/src/store.rs` turns the guard red, naming `crates/stella-graph/src/store/tests.rs`, while `cargo test` reports ok.

Live: `check-module-reachability: OK — 817 source file(s) across 22 crate(s), all reachable from a crate root.`

## Gate wiring

All three copies, which is what `gate-parity` enforces — twenty-three steps becomes **twenty-four**:

- `GATE_STEPS` in the `Makefile`
- the block in `AGENTS.md`
- the command list in `CONTRIBUTING.md`
- a step in `ci.yml` beside the other toolchain-free guards
- an alias in `check-gate-parity.sh`: this is the second Python guard, and the default expects `check-<step>.sh` (`doc-links` already has one for the same reason)

`make guards-fast` passes with all 24 steps.

Closes #1750

## Summary by Sourcery

Add a gate step that ensures every tracked Rust source file under a crate’s src/ directory is reachable from a crate root via mod declarations, and wire it into the gate, CI, and contributor docs.

Enhancements:
- Introduce a module-reachability guard that walks mod declarations from crate roots to detect unreachable Rust source files.
- Provide an explicit alias for the module-reachability guard in the gate-parity checker to keep CONTRIBUTING.md in sync with the Makefile gate configuration.

CI:
- Add a CI job step to run the module-reachability guard alongside other toolchain-free checks.

Documentation:
- Update AGENTS.md and CONTRIBUTING.md to document the new module-reachability gate step and the expanded gate sequence.

Tests:
- Add a hermetic test script that exercises the module-reachability guard against synthetic workspaces to cover both missed and fabricated orphan cases.

Chores:
- Register the module-reachability guard and its test target in the Makefile and include it in the fast gate guards list.