### PR TITLE
fix(stella-cli): forward parallel_safe_names through every tool-stack decorator

### DIFF
--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -349,6 +349,14 @@ impl ToolExecutor for ClaimTap<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize the
+    /// inner executor's sibling spawns (see the port's contract). The spawn
+    /// tool names no mutating path and no transient lane, so concurrent
+    /// siblings pass through `execute` above without touching a claim.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 #[cfg(test)]
@@ -372,10 +380,26 @@ mod tests {
                 content: "ok".into(),
             }
         }
+        fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+            std::collections::HashSet::from(["task".to_string()])
+        }
     }
 
     fn store() -> Arc<Store> {
         Arc::new(Store::in_memory().unwrap())
+    }
+
+    /// The tap sits directly under the engine in every deck lane, so a tap
+    /// that swallowed the claim (the default is empty) would serialize
+    /// sibling spawns no matter what the registry advertised.
+    #[test]
+    fn the_claim_tap_forwards_parallel_safe_names() {
+        let inner = Passthrough(Default::default());
+        let tap = ClaimTap::new(&inner, None, "ses-1/lead");
+        assert!(
+            tap.parallel_safe_names().contains("task"),
+            "the inner executor's concurrency claim must survive the tap"
+        );
     }
 
     #[tokio::test]

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -88,7 +88,7 @@ use stella_pipeline::{
 };
 use stella_protocol::{
     AgentEvent, CiStatus, CompletionMessage, CompletionRequest, ModelRef, PrStatus, TaskItem,
-    ToolOutput, ToolSchema,
+    ToolOutput,
 };
 use stella_store::Store;
 use stella_tools::ToolRegistry;
@@ -117,6 +117,7 @@ mod profile_cmd;
 mod scope_gate;
 mod session_clear;
 mod settle;
+mod task_tap;
 mod theme_cmd;
 use crate::memory::{SessionMemory, inject_recall_block};
 use crate::runtime::{SystemClock, TokioSleeper};
@@ -124,6 +125,7 @@ use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::{agents_list_creating, agents_list_inbound, handle_agent_create};
 pub(crate) use forwarder::spawn_forwarder;
 use scope_gate::DeckApprovalGate;
+use task_tap::TaskTap;
 
 /// The lead agent's id — the one conversation this driver runs.
 pub(crate) const LEAD: &str = "lead";
@@ -4687,52 +4689,6 @@ impl AskUserIo for DeckAskUserIo {
             Some(i) => Ok((i + 1).to_string()),
             None => Ok(answer),
         }
-    }
-}
-
-/// Mirrors the task board into the event stream: after any `task_*` tool
-/// call the FULL board snapshot rides the turn's channel as
-/// `AgentEvent::TaskUpdate` — persisted by the forwarder, so replay shows
-/// the checklist exactly as it moved — and `task_assign`'s spawn requests
-/// are handed to the driver's supervisor channel. `supervisor: None` is the
-/// worker configuration (v1 delegation runs from the lead only; a worker's
-/// stranded requests are reported on its lane by `crate::subsession`).
-pub(crate) struct TaskTap<'a> {
-    pub(crate) inner: &'a dyn ToolExecutor,
-    pub(crate) events: UnboundedSender<AgentEvent>,
-    pub(crate) registry: &'a ToolRegistry,
-    pub(crate) supervisor: Option<UnboundedSender<SupervisorMsg>>,
-}
-
-#[async_trait]
-impl ToolExecutor for TaskTap<'_> {
-    fn schemas(&self) -> Vec<ToolSchema> {
-        self.inner.schemas()
-    }
-
-    async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
-        let output = self.inner.execute(name, input).await;
-        if name.starts_with("task_") {
-            let tasks: Vec<TaskItem> = {
-                let board = self.registry.task_board();
-                let guard = board.lock().unwrap_or_else(|p| p.into_inner());
-                guard.items().to_vec()
-            };
-            let _ = self.events.send(AgentEvent::TaskUpdate { tasks });
-            if let Some(sup) = &self.supervisor {
-                for request in self.registry.take_spawn_requests() {
-                    let _ = sup.send(SupervisorMsg::SpawnTask(request));
-                }
-            }
-        }
-        output
-    }
-
-    /// Forwarded: this is a decorator, and a decorator that let the default
-    /// `0.0` stand would silently drop sub-agent spend out of the parent's
-    /// budget (see the port's contract).
-    fn drain_sub_agent_spend_usd(&self) -> f64 {
-        self.inner.drain_sub_agent_spend_usd()
     }
 }
 

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -1,0 +1,107 @@
+//! The deck's task-board tap — split out of `command_deck.rs` (a god file
+//! closed to growth) when the tap grew its `parallel_safe_names` forward.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_core::ports::ToolExecutor;
+use stella_protocol::{AgentEvent, TaskItem, ToolOutput, ToolSchema};
+use stella_tools::ToolRegistry;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::subsession::SupervisorMsg;
+
+/// Mirrors the task board into the event stream: after any `task_*` tool
+/// call the FULL board snapshot rides the turn's channel as
+/// `AgentEvent::TaskUpdate` — persisted by the forwarder, so replay shows
+/// the checklist exactly as it moved — and `task_assign`'s spawn requests
+/// are handed to the driver's supervisor channel. `supervisor: None` is the
+/// worker configuration (v1 delegation runs from the lead only; a worker's
+/// stranded requests are reported on its lane by `crate::subsession`).
+pub(crate) struct TaskTap<'a> {
+    pub(crate) inner: &'a dyn ToolExecutor,
+    pub(crate) events: UnboundedSender<AgentEvent>,
+    pub(crate) registry: &'a ToolRegistry,
+    pub(crate) supervisor: Option<UnboundedSender<SupervisorMsg>>,
+}
+
+#[async_trait]
+impl ToolExecutor for TaskTap<'_> {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        self.inner.schemas()
+    }
+
+    async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
+        let output = self.inner.execute(name, input).await;
+        if name.starts_with("task_") {
+            let tasks: Vec<TaskItem> = {
+                let board = self.registry.task_board();
+                let guard = board.lock().unwrap_or_else(|p| p.into_inner());
+                guard.items().to_vec()
+            };
+            let _ = self.events.send(AgentEvent::TaskUpdate { tasks });
+            if let Some(sup) = &self.supervisor {
+                for request in self.registry.take_spawn_requests() {
+                    let _ = sup.send(SupervisorMsg::SpawnTask(request));
+                }
+            }
+        }
+        output
+    }
+
+    /// Forwarded: this is a decorator, and a decorator that let the default
+    /// `0.0` stand would silently drop sub-agent spend out of the parent's
+    /// budget (see the port's contract).
+    fn drain_sub_agent_spend_usd(&self) -> f64 {
+        self.inner.drain_sub_agent_spend_usd()
+    }
+
+    /// Forwarded: letting the empty default stand would silently serialize
+    /// the inner executor's sibling spawns (see the port's contract). The
+    /// spawn tool is `task`, not `task_*` — the tap never fires for it.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A leaf claiming one parallel-safe name, standing in for the registry.
+    struct Claiming;
+
+    #[async_trait]
+    impl ToolExecutor for Claiming {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+            ToolOutput::Ok {
+                content: String::new(),
+            }
+        }
+        fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+            std::collections::HashSet::from(["task".to_string()])
+        }
+    }
+
+    /// The deck's lead lane wraps the whole stack in this tap last, so a tap
+    /// that swallowed the claim would kill concurrent sibling spawns for
+    /// every deck session no matter what the layers below advertised.
+    #[test]
+    fn the_task_tap_forwards_parallel_safe_names() {
+        let inner = Claiming;
+        let registry = ToolRegistry::with_issue_backend(std::path::PathBuf::from("."), None);
+        let (events, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let tap = TaskTap {
+            inner: &inner,
+            events,
+            registry: &registry,
+            supervisor: None,
+        };
+        assert!(
+            tap.parallel_safe_names().contains("task"),
+            "the tap must forward the inner executor's concurrency claims"
+        );
+    }
+}

--- a/crates/stella-cli/src/discovery.rs
+++ b/crates/stella-cli/src/discovery.rs
@@ -785,6 +785,14 @@ impl ToolExecutor for DiscoveryToolSet<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize the
+    /// inner executor's sibling spawns (see the port's contract). No lean-mode
+    /// intersection — hiding is a prompt-budget measure, and a hidden tool
+    /// called by name still executes above.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 /// Split an advertised `mcp__server__tool` name into (server, tool).

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -131,6 +131,13 @@ impl ToolExecutor for CommitObserver<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize
+    /// the inner executor's sibling spawns (see the port's contract) — the
+    /// spawn tool is not commit-lane routed, so nothing is observed for it.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 /// One attempt's commits, oldest first — and the two ways of knowing which
@@ -317,6 +324,10 @@ mod tests {
             Vec::new()
         }
 
+        fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+            std::collections::HashSet::from(["task".to_string()])
+        }
+
         async fn execute(&self, name: &str, _input: &Value) -> ToolOutput {
             if name == "repo_commit" {
                 let mut script = self.script.lock().unwrap();
@@ -347,6 +358,21 @@ mod tests {
 
     fn shas(commits: &[CommitRecord]) -> Vec<&str> {
         commits.iter().map(|c| c.sha.as_str()).collect()
+    }
+
+    /// The observer wraps every shared-tree fleet worker's stack, so one that
+    /// swallowed the claim (the default is empty) would serialize sibling
+    /// spawns for the whole fleet no matter what the registry advertised.
+    #[test]
+    fn the_commit_observer_forwards_parallel_safe_names() {
+        let tree = Arc::new(SharedTree::default());
+        let tools = CommittingTools::new(tree.clone(), Vec::new());
+        assert!(
+            observer(&tools, &tree, "t1")
+                .parallel_safe_names()
+                .contains("task"),
+            "the inner executor's concurrency claim must survive the observer"
+        );
     }
 
     /// The witness for #1216's first half. Two shared-tree workers commit

--- a/crates/stella-cli/src/interactive.rs
+++ b/crates/stella-cli/src/interactive.rs
@@ -527,6 +527,13 @@ impl ToolExecutor for InteractiveToolSet<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize the
+    /// inner executor's sibling spawns (see the port's contract). The tools
+    /// added here (`ask_user`, skills) make no concurrency claim of their own.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -47,10 +47,12 @@
 //! `task` calls from one step execute concurrently — reachable since the
 //! engine's dispatch scheduler groups the spawn tool with read-only calls
 //! (`Tool::parallel_safe`; before that claim existed, every non-read-only
-//! call was its own barrier and this concurrency was dead code). Two siblings
-//! can therefore each carve against the same headroom before either settles —
-//! an overshoot bounded by one child's cap, and caught by the parent's guard
-//! at the next step boundary regardless.
+//! call was its own barrier and this concurrency was dead code). Every
+//! sibling in one dispatch group can therefore carve against the same
+//! headroom before any settles — an overshoot bounded by one child's cap per
+//! concurrently-running sibling (up to the engine's dispatch cap of 8, so
+//! seven extra caps in the worst case, not one), and caught by the parent's
+//! guard at the next step boundary regardless.
 //!
 //! ## Settling is the child's job
 //!

--- a/crates/stella-cli/src/subagent/tests.rs
+++ b/crates/stella-cli/src/subagent/tests.rs
@@ -34,6 +34,11 @@ impl ToolExecutor for LedgerBase {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         stella_core::subagent::drain_sub_agent_spend(&self.0)
     }
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        // The registry claims exactly this for the `task` tool
+        // (`Tool::parallel_safe`); the stand-in reports it the same way.
+        std::collections::HashSet::from(["task".to_string()])
+    }
 }
 
 struct NeverProvider;
@@ -98,6 +103,39 @@ async fn the_production_tool_stack_forwards_sub_agent_spend() {
         discovery.drain_sub_agent_spend_usd(),
         0.0,
         "and the drain stays destructive through the stack"
+    );
+}
+
+/// **The parallel-dispatch counterpart of the spend witness above.**
+///
+/// `parallel_safe_names` has an empty default, so any decorator that forgets
+/// to forward it silently serializes sibling `task` calls in every real
+/// session — the registry's claim never reaches the engine, and the feature
+/// (#1776) is dead exactly where it shipped. Asserted through the shipped
+/// composition for the same reason as the spend test: a future decorator
+/// inserted into the real stack fails here, and nowhere else.
+#[tokio::test]
+async fn the_production_tool_stack_forwards_parallel_safe_names() {
+    let ledger: SubAgentSpendLedger = Arc::default();
+    let base = LedgerBase(ledger);
+
+    let customs =
+        stella_tools::custom::CustomToolSet::new(&base, Vec::new(), std::path::PathBuf::from("."));
+    let (stub_tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let interactive = crate::interactive::InteractiveToolSet::new(
+        &customs,
+        stub_tx,
+        crate::interactive::default_ask_io(false),
+    );
+    let permitted = crate::agent::PolicyToolSet::new(&interactive, Default::default());
+    let discovery =
+        crate::discovery::DiscoveryToolSet::new(&permitted, std::path::PathBuf::from("."));
+
+    assert!(
+        discovery.parallel_safe_names().contains("task"),
+        "the registry's concurrency claim must survive every decorator \
+         between the engine and the registry — one that swallows it silently \
+         serializes sibling spawns"
     );
 }
 

--- a/crates/stella-cli/src/tool_policy.rs
+++ b/crates/stella-cli/src/tool_policy.rs
@@ -102,6 +102,16 @@ impl ToolExecutor for PolicyToolSet<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.get().drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded minus what the policy withholds. Letting the empty default
+    /// stand would silently serialize the inner executor's sibling spawns —
+    /// but blindly delegating would advertise names `execute` above refuses,
+    /// an empty promise. Same two-sided shape as `schemas`/`execute`.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        let mut names = self.inner.get().parallel_safe_names();
+        names.retain(|name| self.policy.allows(name));
+        names
+    }
 }
 
 /// Which `"tools"` key withheld `name` — the exact name, its group, or the
@@ -160,6 +170,9 @@ mod tests {
             ToolOutput::Ok {
                 content: format!("ran {name}"),
             }
+        }
+        fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+            std::collections::HashSet::from(["task".to_string()])
         }
     }
 
@@ -256,6 +269,32 @@ mod tests {
         assert_eq!(
             disabled_by(&policy, "start_process").as_deref(),
             Some("process")
+        );
+    }
+
+    /// The concurrency claim survives the decorator when the policy allows
+    /// the tool — a set that forgot to forward would silently serialize
+    /// sibling spawns in every real session (the default is empty).
+    #[test]
+    fn parallel_safe_names_are_forwarded_when_the_policy_allows() {
+        let fake = Fake;
+        let set = PolicyToolSet::new(&fake, ToolPolicy::allow_all());
+        assert!(
+            set.parallel_safe_names().contains("task"),
+            "the inner executor's claim must survive the policy layer"
+        );
+    }
+
+    /// The other half of the two-sided shape: a tool the policy withholds is
+    /// refused by `execute`, so advertising it as parallel-safe would claim
+    /// concurrency for a call this decorator will never run.
+    #[test]
+    fn a_disabled_tool_is_not_advertised_as_parallel_safe() {
+        let fake = Fake;
+        let set = PolicyToolSet::new(&fake, ToolPolicy::from_switches([("task".into(), false)]));
+        assert!(
+            set.parallel_safe_names().is_empty(),
+            "a withheld tool must not be advertised as parallel-safe"
         );
     }
 

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -560,6 +560,16 @@ impl ToolExecutor for McpToolSet {
             .as_ref()
             .map_or(0.0, |native| native.drain_sub_agent_spend_usd())
     }
+
+    /// Forwarded from the native layer: letting the empty default stand would
+    /// silently serialize its sibling spawns (see the port's contract).
+    /// External MCP tools never carry this claim — the port pins their
+    /// concurrency to `read_only`, which they are advertised without.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.native
+            .as_ref()
+            .map_or_else(Default::default, |native| native.parallel_safe_names())
+    }
 }
 
 /// A Best-of-N candidate's tool surface (issue #248 Phase 1): built by
@@ -612,6 +622,13 @@ impl ToolExecutor for CandidateMcpView {
     /// budget (see the port's contract).
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
+    }
+
+    /// Forwarded from the candidate's own `native` layer — the executor every
+    /// non-`mcp__` name routes to in `execute` above. `inner`'s set would name
+    /// tools this view never runs, and MCP tools never carry the claim.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.native.parallel_safe_names()
     }
 }
 
@@ -667,6 +684,34 @@ mod tests {
                 content: format!("native ran {name}"),
             }
         }
+        fn parallel_safe_names(&self) -> HashSet<String> {
+            HashSet::from(["task".to_string()])
+        }
+    }
+
+    /// Both wrappers forward the native layer's concurrency claim — the empty
+    /// default would silently serialize sibling spawns in any MCP-connected
+    /// session (and in every Best-of-N candidate).
+    #[tokio::test]
+    async fn parallel_safe_names_forward_from_the_native_layer() {
+        let client = connected_client("files", "read").await;
+        let set = Arc::new(McpToolSet::from_clients(vec![client]).wrapping(Arc::new(FakeNative)));
+        assert!(
+            set.parallel_safe_names().contains("task"),
+            "the native layer's claim must survive the MCP set"
+        );
+
+        let view = set.for_candidates(Arc::new(FakeNative));
+        assert!(
+            view.parallel_safe_names().contains("task"),
+            "and the candidate view forwards its own native layer's claim"
+        );
+
+        let bare = McpToolSet::from_clients(Vec::new());
+        assert!(
+            bare.parallel_safe_names().is_empty(),
+            "no native layer, no claims"
+        );
     }
 
     /// A transport that never answers `tools/call` — used to prove the

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -437,6 +437,14 @@ impl ToolExecutor for DelegatingTools<'_> {
         self.inner.drain_sub_agent_spend_usd()
             + stella_core::subagent::drain_sub_agent_spend(&self.spend)
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize
+    /// the host executor's sibling spawns (see the port's contract). The
+    /// `task` this wrapper itself implements is deliberately not added here —
+    /// claiming it needs a witness on the remoted dispatch path first.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 /// Turn a child's outcome into a model-visible result.
@@ -507,6 +515,55 @@ fn slug(description: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A host executor claiming one parallel-safe name.
+    struct ClaimingHost;
+
+    #[async_trait]
+    impl ToolExecutor for ClaimingHost {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+            ToolOutput::Ok {
+                content: String::new(),
+            }
+        }
+        fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+            std::collections::HashSet::from(["host_task".to_string()])
+        }
+    }
+
+    /// A dispatcher that refuses everything — the wrapper under test never
+    /// dispatches in this test, so any answer would do.
+    struct RefusingDispatcher;
+
+    #[async_trait]
+    impl SubAgentDispatcher for RefusingDispatcher {
+        async fn dispatch(&self, _spec: SubAgentSpec) -> SubAgentOutcome {
+            SubAgentOutcome::Refused {
+                reason: "not in this test".into(),
+            }
+        }
+    }
+
+    /// The wrapper sits between the served engine and the host's executor, so
+    /// one that swallowed the claim (the default is empty) would serialize
+    /// the host's sibling spawns on every served turn.
+    #[test]
+    fn delegating_tools_forward_parallel_safe_names() {
+        let host = ClaimingHost;
+        let tools = DelegatingTools::new(
+            &host,
+            Arc::new(RefusingDispatcher),
+            4,
+            stella_core::subagent::SubAgentSpendLedger::default(),
+        );
+        assert!(
+            tools.parallel_safe_names().contains("host_task"),
+            "the host executor's concurrency claim must survive the wrapper"
+        );
+    }
 
     /// The operator's ceilings bound every caller-settable knob, and a
     /// deployment that has not opted in gets no children whatever the request

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -768,6 +768,13 @@ impl ToolExecutor for CustomToolSet<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.get().drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded: letting the empty default stand would silently serialize the
+    /// inner executor's sibling spawns (see the port's contract). Custom
+    /// script tools spawn workspace subprocesses and make no such claim.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.get().parallel_safe_names()
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-tools/src/hunk_review.rs
+++ b/crates/stella-tools/src/hunk_review.rs
@@ -456,6 +456,13 @@ impl ToolExecutor for HunkGate<'_> {
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
     }
+
+    /// Forwarded — letting the empty default stand would silently serialize
+    /// the inner executor's sibling spawns (see the port's contract); the
+    /// spawn tool is not in `GATED_TOOLS`, so the gate never reviews it.
+    fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
+        self.inner.parallel_safe_names()
+    }
 }
 
 #[cfg(test)]
@@ -529,6 +536,20 @@ mod tests {
 
     fn edit(path: &str, old: &str, new: &str) -> Value {
         serde_json::json!({ "path": path, "old_string": old, "new_string": new })
+    }
+
+    /// The gate wraps the registry in every reviewed session, so one that
+    /// swallowed the claim (the default is empty) would serialize sibling
+    /// spawns exactly where review mode ships. Asserted over the real
+    /// registry, whose `task` tool is the one shipped claimant.
+    #[test]
+    fn the_gate_forwards_parallel_safe_names() {
+        let (dir, reg, _) = fixture();
+        let gate = HunkGate::new(&reg, None, dir.path().to_path_buf());
+        assert!(
+            gate.parallel_safe_names().contains("task"),
+            "the registry's concurrency claim must survive the gate"
+        );
     }
 
     /// The issue's acceptance criterion, end to end and through the real

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -2169,13 +2169,13 @@ impl ToolExecutor for ToolRegistry {
             .filter(|(_, tool)| tool.parallel_safe())
             .map(|(name, _)| name.clone())
             .collect();
-        if let Ok(late) = self.late_tools.read() {
-            names.extend(
-                late.iter()
-                    .filter(|(_, tool)| tool.parallel_safe())
-                    .map(|(name, _)| name.clone()),
-            );
-        }
+        // Poison-tolerant like every sibling `late_tools` read path.
+        let late = self.late_tools.read().unwrap_or_else(|p| p.into_inner());
+        names.extend(
+            late.iter()
+                .filter(|(_, tool)| tool.parallel_safe())
+                .map(|(name, _)| name.clone()),
+        );
         names
     }
 }

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -1421,3 +1421,64 @@ fn a_beliefs_coverage_survives_the_snapshot_round_trip() {
         "a partial belief is still partial after a resume"
     );
 }
+
+/// A minimal parallel-safe tool for the late-enabled overlay.
+struct LateSpawn;
+
+#[async_trait]
+impl Tool for LateSpawn {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "late_spawn".into(),
+            description: "late-enabled spawn stand-in".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+            speculation_safe: false,
+        }
+    }
+    fn parallel_safe(&self) -> bool {
+        true
+    }
+    async fn execute(&self, _input: &Value, _root: &std::path::Path) -> ToolOutput {
+        ToolOutput::Ok {
+            content: String::new(),
+        }
+    }
+}
+
+/// The witness for the poisoned-lock repair in
+/// `ToolExecutor::parallel_safe_names`: every sibling `late_tools` read path
+/// tolerates poison (`unwrap_or_else(|p| p.into_inner())`), but this one used
+/// `if let Ok(..)` — after a panic elsewhere it silently dropped every
+/// late-enabled claim while `schemas` kept advertising the tool, serializing
+/// dispatch with nothing to say so.
+#[test]
+fn parallel_safe_names_survive_a_poisoned_late_overlay() {
+    let (_root, reg) = bare_registry(None);
+    reg.late_tools
+        .write()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert("late_spawn".to_string(), Arc::new(LateSpawn));
+
+    // Poison the lock the only way it happens in production: a panic while
+    // the guard is held.
+    let _ = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let _guard = reg.late_tools.write().unwrap();
+                panic!("poison the overlay");
+            })
+            .join()
+    });
+    assert!(reg.late_tools.is_poisoned(), "the setup really poisoned it");
+
+    let names = stella_core::ports::ToolExecutor::parallel_safe_names(&reg);
+    assert!(
+        names.contains("late_spawn"),
+        "a poisoned overlay must not silently shrink the claim set"
+    );
+    assert!(
+        names.contains("task"),
+        "and the primary map's claims are untouched"
+    );
+}


### PR DESCRIPTION
## Problem

#1776 added `ToolExecutor::parallel_safe_names()` with an empty default, implemented only by `ToolRegistry`. But no production session hands the engine a bare registry — the CLI wraps it as `DiscoveryToolSet(PolicyToolSet(InteractiveToolSet(CustomToolSet(registry))))`, the deck adds `TaskTap`, and stella-mcp/stella-serve/fleet each have their own decorators. **None of them forwarded the method**, so the empty default won at the outermost layer and sibling `task` calls still serialized in every real session — the exact defect #1776 claims to fix, alive one layer up. (Its witness couldn't see this: it implements the trait directly on a bare fake executor.)

Every decorator already forwards the sibling method `drain_sub_agent_spend_usd` for the same reason; this brings `parallel_safe_names` to parity in all eleven:

`discovery.rs`, `tool_policy.rs`, `interactive.rs`, `custom.rs`, `command_deck.rs` (`TaskTap`, split into `command_deck/task_tap.rs` to respect the god-file ceiling), `claims.rs`, `fleet_commits.rs`, `hunk_review.rs`, `stella-mcp/toolset.rs` (both toolsets), `stella-serve/subagents.rs`.

**`PolicyToolSet` intersects instead of delegating blindly**: a tool the policy withholds is refused by `execute`, so advertising it as parallel-safe would be an empty promise — forwarded names are filtered through `policy.allows`.

Also in the same seam:
- `ToolRegistry::parallel_safe_names` now recovers a poisoned `late_tools` lock like every sibling read path (`unwrap_or_else(|p| p.into_inner())`) instead of silently returning an incomplete set.
- The sibling-carve overshoot doc in `subagent.rs` is corrected for the concurrent world: the bound is one child's cap per concurrently-running sibling (dispatch cap 8), not "one child's cap".

## Witness

- `subagent::tests::the_production_tool_stack_forwards_parallel_safe_names` (stella-cli) — builds the real decorator stack and asserts the registry's claim survives to the outermost layer. **Checked the artisanal way**: with `origin/main`'s `discovery.rs` restored it fails (empty set at the top of the stack); with this change it passes.
- `tool_policy`: `parallel_safe_names_are_forwarded_when_the_policy_allows` + `a_disabled_tool_is_not_advertised_as_parallel_safe` (the two-sided contract).
- `stella-mcp`: `parallel_safe_names_forward_from_the_native_layer`.
- `registry/tests.rs`: poisoned-lock recovery.

`cargo test`: stella-cli 1422 passed, stella-tools 718+119, stella-mcp all green, stella-serve 165+ green · clippy `--all-targets -- -D warnings` clean on all four crates · `cargo fmt --check` clean · `check-file-size` OK (command_deck.rs shrank to 4,696).

## Notes

Found by a resilience audit of the #1776 seam. Follow-up defects in the same seam (sibling `agent_id` collision, the unreachable sub-agent spend-pool ceiling, child-panic spend loss) are being filed as separate issues.

## Summary by Sourcery

Ensure tool executor decorators correctly propagate parallel execution capability and harden registry handling of poisoned late tool overlays.

Bug Fixes:
- Fix parallel_safe_names not being forwarded through tool executor decorator stacks, which caused sibling tool calls to be serialized despite registry claims.
- Handle poisoned late_tools locks in ToolRegistry::parallel_safe_names so late-enabled tools remain included in concurrency claims instead of being silently dropped.
- Correct sub-agent spend overshoot documentation to reflect concurrent sibling execution bounds.

Enhancements:
- Forward parallel_safe_names through all relevant ToolExecutor wrappers across CLI, tools, MCP, serve, and fleet components to align with existing sub-agent spend forwarding.
- Split the TaskTap implementation into its own module from command_deck.rs to keep the deck driver maintainable.

Tests:
- Add end-to-end tests in stella-cli to verify the production tool stack and various decorators forward parallel_safe_names correctly.
- Add tests for PolicyToolSet and MCP toolsets to assert that concurrency claims are forwarded and filtered according to policy and native layers.
- Add a registry test to validate that parallel_safe_names remains correct when the late tool overlay lock is poisoned.
- Add decorator-specific tests for TaskTap, ClaimTap, CommitObserver, HunkGate, and DelegatingTools to ensure they preserve inner executors' parallel_safe_names.