### PR TITLE
fix(stella-cli): let the witness author name the candidate root in `glob`

### DIFF
--- a/crates/stella-cli/src/candidate_ws/witness_tools.rs
+++ b/crates/stella-cli/src/candidate_ws/witness_tools.rs
@@ -196,7 +196,15 @@ impl ToolExecutor for WitnessToolExecutor {
             // names-only, root-confined by the tool itself, and its results
             // pass the same credential exclusion the read path enforces.
             "glob" => {
+                // The root itself is spelled `.` or `""` — the `glob` tool
+                // defaults its `path` to `.` and resolves both to the root —
+                // and it is the blind author's whole opening move, so it must
+                // pass. `normalized_candidate_path` answers `None` for them
+                // because it was written for `read_file`, where a path that
+                // names no file is a different question; reusing that answer
+                // here denied the one call #1792 exists to enable.
                 if let Some(raw_path) = input.get("path").and_then(serde_json::Value::as_str)
+                    && !names_candidate_root(raw_path)
                     && normalized_candidate_path(raw_path).is_none()
                 {
                     return Self::denied(name, "the path must stay within the candidate root");
@@ -219,6 +227,24 @@ impl ToolExecutor for WitnessToolExecutor {
             ),
         }
     }
+}
+
+/// Does this `path` name the candidate root itself?
+///
+/// Separate from [`normalized_candidate_path`] rather than folded into it: that
+/// function normalizes to a non-empty *relative* path, and the root does not
+/// have one, so `None` there means both "escapes the root" and "is the root".
+/// Only the listing tools can act on the second, and conflating them is what
+/// made `glob` refuse its own default argument.
+///
+/// Absolute and drive-qualified spellings are excluded first, so `/` — which
+/// would otherwise trim to the empty string — stays an escape.
+fn names_candidate_root(raw: &str) -> bool {
+    let slash = raw.replace('\\', "/");
+    if Path::new(&slash).is_absolute() || slash.as_bytes().get(1) == Some(&b':') {
+        return false;
+    }
+    matches!(slash.trim_end_matches('/'), "" | ".")
 }
 
 pub(super) fn normalized_candidate_path(raw: &str) -> Option<String> {
@@ -604,6 +630,51 @@ mod tests {
             escaped.is_error(),
             "an escaping search path must be refused"
         );
+    }
+
+    /// Naming the root explicitly is the same call as omitting `path`.
+    ///
+    /// The `glob` tool documents `path` as "Subdirectory to search (default:
+    /// workspace root)" and resolves `.` and `""` to the root, so a model that
+    /// spells the default out loud — which they routinely do — must not be
+    /// refused. The guard reused `normalized_candidate_path`, whose `None`
+    /// means "no relative path" and therefore covers both "escapes the root"
+    /// and "*is* the root"; only the second is legal, and collapsing them shut
+    /// the door on the blind author's opening move (#1792).
+    #[tokio::test]
+    async fn glob_accepts_the_root_spelled_out_as_well_as_omitted() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("tests")).unwrap();
+        std::fs::write(root.path().join("tests/existing.rs"), "#[test] fn t() {}").unwrap();
+        let tools = witness_executor(root.path()).await;
+
+        for path in [".", "", "./"] {
+            let output = tools
+                .execute(
+                    "glob",
+                    &serde_json::json!({"pattern": "**/*", "path": path}),
+                )
+                .await;
+            let ToolOutput::Ok { content } = output else {
+                panic!("`path: {path:?}` names the root and must be allowed: {output:?}");
+            };
+            assert!(
+                content.contains("tests/existing.rs"),
+                "`path: {path:?}` must search the root: {content}"
+            );
+        }
+
+        // The root spellings are the only ones that gain entry: `/` trims to
+        // the empty string but is absolute, and must stay an escape.
+        for path in ["/", "..", "../..", "/etc"] {
+            assert!(
+                tools
+                    .execute("glob", &serde_json::json!({"pattern": "*", "path": path}))
+                    .await
+                    .is_error(),
+                "`path: {path:?}` leaves the candidate root and must be refused"
+            );
+        }
     }
 
     /// #1784's witness: the operator's tool policy governs the witness


### PR DESCRIPTION
## What & why

Refs #1792, #1813.

The review bot flagged this on #1813 (`witness_tools.rs:200`) and it merged before the thread was answered, so the defect is on `main` now.

The witness author's `glob` guard **refuses the tool's own default argument**. `crates/stella-tools/src/glob.rs` documents and implements the root two ways:

```rust
"path": { "type": "string", "description": "Subdirectory to search (default: workspace root)" }
...
let search_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
// `.`/empty resolve to the root itself, so existing default-scoped calls keep working.
```

But `WitnessToolExecutor` gated `path` on `normalized_candidate_path`, which answers `None` for both:

- `""` → the `is_empty()` guard
- `"."` → the `CurDir` component is dropped, `parts` ends up empty, and `(!parts.is_empty()).then(...)` yields `None`

So a model that spells the default out loud — which they routinely do — is told *"the path must stay within the candidate root"* about the root itself. That is the blind author's opening move, and the whole reason `glob` was offered to it in #1792.

## The root cause

`normalized_candidate_path`'s `None` conflates two different answers: **"escapes the root"** and **"*is* the root"**. That is correct for `read_file`, which was what it was written for — a path naming no file is simply not readable. It is wrong for a listing tool, where the root is the most ordinary argument there is.

`names_candidate_root` answers the second question separately. It rules out absolute and drive-qualified spellings **first**, so `/` — which would otherwise trim to the empty string and look like the root — stays an escape.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here).

`candidate_ws::witness_tools::tests::glob_accepts_the_root_spelled_out_as_well_as_omitted`, checked the artisanal way:

```
panicked at crates/stella-cli/src/candidate_ws/witness_tools.rs:655:17:
`path: "."` names the root and must be allowed: Error { message:
"`glob` is not available to the witness author: the path must stay within the candidate root" }
test result: FAILED. 0 passed; 1 failed
```

It asserts both directions: `.`, `""`, `./` are allowed and actually search the root; `/`, `..`, `../..`, `/etc` are still refused.

**Why the existing test did not catch it:** `glob_lets_the_author_discover_tests_without_leaking_credentials` only ever passes *no* `path` (exercising the tool's own default, which never reaches the guard) or an escaping one. The explicit-root case sat exactly in the gap between them.

## The gate

- [x] `cargo fmt --check -p stella-cli`
- [x] `cargo test -p stella-cli` — 1421 pass, 0 fail

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

## Summary by Sourcery

Allow the witness `glob` tool to treat explicit root paths as valid while still denying paths that escape the candidate workspace.

Bug Fixes:
- Fix `glob` witness tool incorrectly rejecting explicit root paths such as "." or "" that should resolve to the workspace root.

Enhancements:
- Introduce a helper to detect when a path names the candidate root, distinguishing it from paths that escape the root.

Tests:
- Add a witness test verifying that `glob` accepts explicit root spellings and continues to refuse paths that leave the candidate root.