### PR TITLE
docs(gate): unbreak docs-guards — spell the gate's step count as twenty-five

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + self-driving-test (the shell harness)
 ```
 
-That is twenty-four steps, and the list is not maintained by hand: it is
+That is twenty-five steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cargo build -p stella-cli --bin stella && \
   STELLA_BIN="$PWD/target/debug/stella" ./scripts/test-self-driving.sh
 ```
 
-Or just `make gate`, which is the twenty-four of them in order.
+Or just `make gate`, which is the twenty-five of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence


### PR DESCRIPTION
## What & why

`docs guards` is red on `main`, and therefore red on every open PR.

`self-driving-test` joined `GATE_STEPS` (#1821) and `module-reachability` joined `GATE_GUARDS_FAST`. Both are correctly named in the step list in AGENTS.md and CONTRIBUTING.md — but the **spelled count** beside that list stayed at "twenty-four" while the real list reached twenty-five. `scripts/check-gate-parity.sh` checks exactly that number:

```
check-gate-parity: FAIL — AGENTS.md does not spell the gate's step count as 'twenty-five'.
check-gate-parity: FAIL — CONTRIBUTING.md does not spell the gate's step count as 'twenty-five'.
```

Two words, one in each file.

This is the drift direction AGENTS.md itself calls out, and the reason the guard exists at all:

> The block had already drifted twice before that guard existed, both times by under-reporting a newly added guard, which is the direction that misleads — a reader runs the short list, sees green, and believes the gate is green (#1437).

Third time. The guard did its job — it just needs someone to answer it.

## The witness

- [ ] Witness test
- [x] No witness needed — this *is* the guard's assertion. It fails on `main` and passes here:

```
$ ./scripts/check-gate-parity.sh          # on main
check-gate-parity: FAIL — AGENTS.md does not spell the gate's step count as 'twenty-five'.

$ ./scripts/check-gate-parity.sh          # here
check-gate-parity: OK — 25 (twenty-five) gate steps, named in AGENTS.md and CONTRIBUTING.md.
```

## Anything reviewers should know?

Only the number word changed — the step lists themselves were already complete and correct in both documents, so there is nothing to re-read beyond confirming twenty-five is the right count.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

## Summary by Sourcery

Documentation:
- Correct the spelled-out gate step count in AGENTS.md and CONTRIBUTING.md to match the current list of twenty-five steps.