### PR TITLE
fix(main): unbreak three gates — clone-on-Copy clippy, event.rs and deck_render.rs file-size overruns

### DIFF
--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -51,8 +51,8 @@ fn apply_role_shaping(mut config: EngineConfig, overrides: &RoleCallOverrides) -
     if let Some(max_output_tokens) = overrides.max_output_tokens {
         config.max_output_tokens = Some(max_output_tokens);
     }
-    if let Some(params) = &overrides.params {
-        config.params = Some(params.clone());
+    if let Some(params) = overrides.params {
+        config.params = Some(params);
     }
     config
 }

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -113,15 +113,13 @@ pub enum StageKind {
     Plan,
     /// The interactive approval gate a large plan passes through (L-E5).
     ScopeReview,
-    /// Witness authoring: after the worker executes — once the warrant has
-    /// read the diff and found something worth proving — an independent
-    /// model (the verifier's resolution, never the worker's transcript)
-    /// writes the witness test in a pristine snapshot of the pre-execution
-    /// tree: a test that FAILS there and will pass once the goal is met,
-    /// arming the deterministic flip oracle (L-E11). The witness is visible
-    /// to the worker's revise turns (iterating against a failing test is
-    /// where convergence comes from); integrity comes from tamper exclusion
-    /// at verify time, not from hiding the test.
+    /// Witness authoring: after the worker executes, once the warrant has
+    /// read the diff, an independent model (the verifier's resolution, never
+    /// the worker's transcript) writes the witness test in a pristine
+    /// snapshot of the pre-execution tree — a test that FAILS there and will
+    /// pass once the goal is met, arming the flip oracle (L-E11). Visible to
+    /// the worker's revise turns; integrity comes from tamper exclusion at
+    /// verify time, not from hiding the test.
     Witness,
     /// The worker's own tool-calling loop — the steps that actually change
     /// the workspace.

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -453,10 +453,7 @@ fn phase_color(phase: crate::envelope::SessionPhase) -> ratatui::style::Color {
         SessionPhase::InProgress => theme::SUCCESS_BRIGHT,
         SessionPhase::NeedsInput => theme::WARNING_BRIGHT,
         SessionPhase::Paused => theme::ACCENT,
-        SessionPhase::Cancelled => theme::TEXT_TERTIARY,
-        // The same calm tone as `Cancelled`: both are deliberate endings,
-        // and the whole point of the variant is not to paint them red.
-        SessionPhase::Stopped => theme::TEXT_TERTIARY,
+        SessionPhase::Cancelled | SessionPhase::Stopped => theme::TEXT_TERTIARY,
         SessionPhase::Complete => theme::SUCCESS,
         SessionPhase::Archived => theme::TEXT_TERTIARY,
         SessionPhase::Error => theme::DANGER_BRIGHT,

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1281,7 +1281,7 @@
         },
         {
           "const": "witness",
-          "description": "Witness authoring: after the worker executes — once the warrant has\nread the diff and found something worth proving — an independent\nmodel (the verifier's resolution, never the worker's transcript)\nwrites the witness test in a pristine snapshot of the pre-execution\ntree: a test that FAILS there and will pass once the goal is met,\narming the deterministic flip oracle (L-E11). The witness is visible\nto the worker's revise turns (iterating against a failing test is\nwhere convergence comes from); integrity comes from tamper exclusion\nat verify time, not from hiding the test.",
+          "description": "Witness authoring: after the worker executes, once the warrant has\nread the diff, an independent model (the verifier's resolution, never\nthe worker's transcript) writes the witness test in a pristine\nsnapshot of the pre-execution tree — a test that FAILS there and will\npass once the goal is met, arming the flip oracle (L-E11). Visible to\nthe worker's revise turns; integrity comes from tamper exclusion at\nverify time, not from hiding the test.",
           "type": "string"
         },
         {

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -2882,7 +2882,7 @@
         },
         {
           "const": "witness",
-          "description": "Witness authoring: after the worker executes — once the warrant has\nread the diff and found something worth proving — an independent\nmodel (the verifier's resolution, never the worker's transcript)\nwrites the witness test in a pristine snapshot of the pre-execution\ntree: a test that FAILS there and will pass once the goal is met,\narming the deterministic flip oracle (L-E11). The witness is visible\nto the worker's revise turns (iterating against a failing test is\nwhere convergence comes from); integrity comes from tamper exclusion\nat verify time, not from hiding the test.",
+          "description": "Witness authoring: after the worker executes, once the warrant has\nread the diff, an independent model (the verifier's resolution, never\nthe worker's transcript) writes the witness test in a pristine\nsnapshot of the pre-execution tree — a test that FAILS there and will\npass once the goal is met, arming the flip oracle (L-E11). Visible to\nthe worker's revise turns; integrity comes from tamper exclusion at\nverify time, not from hiding the test.",
           "type": "string"
         },
         {


### PR DESCRIPTION
## main is red

Three gate failures on `origin/main`, from two merges:

1. **clippy `-D warnings`**: `clippy::clone_on_copy` on `GenerationParams` in `apply_role_shaping` (`crates/stella-pipeline/src/pipeline/witness_stage.rs`) — #1813's auto-merge landed its **pre-rebase head** while the fmt+clippy+test job was still running; the fix existed on the branch but arrived after the merge.
2. **file-size**: `crates/stella-protocol/src/event.rs` at 2964 over its 2962 ceiling — same pre-rebase head; the `StageKind::Witness` doc-comment rewrite is condensed to fit, and `docs/wire/` is regenerated for the reworded description (wire-schema green).
3. **file-size**: `crates/stella-tui/src/deck_render.rs` at 1531 over its 1528 ceiling (+3, from #1828). `Stopped` joins `Cancelled`'s match arm — same theme value, no behavior change, and the grouping states what the deleted comment said. `cargo test -p stella-tui` green (golden frames unchanged — same rendered color).

Verified locally: `check-file-size` green, `check-wire-schema` green, `cargo clippy -p stella-pipeline --all-targets -- -D warnings` green, `cargo test -p stella-tui` green.

Process note: this is the second time a PR auto-merged with its gate job still pending (#1798 did the same). The window between push and required-check completion is mergeable because the required check reports late; worth a look at whether auto-merge should wait on the *run in progress* rather than only registered checks.

## Summary by Sourcery

Address gate failures on main by fixing a clippy warning, reducing file sizes in protocol and TUI code, and regenerating wire schemas.

Bug Fixes:
- Fix clone-on-Copy clippy lint in witness stage role shaping configuration.
- Reduce `StageKind::Witness` documentation length to satisfy event.rs file size limits.
- Consolidate `Cancelled` and `Stopped` phase color handling to keep deck_render.rs within file size constraints.

Documentation:
- Condense `StageKind::Witness` doc comment while preserving its conceptual meaning.
- Regenerate wire schema JSON files to reflect the updated event documentation.