### PR TITLE
docs: unbreak main — the gate runs twenty-five steps, not twenty-four

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + self-driving-test (the shell harness)
 ```
 
-That is twenty-four steps, and the list is not maintained by hand: it is
+That is twenty-five steps, and the list is not maintained by hand: it is
 `GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
 fails if this block or CONTRIBUTING.md's stops matching it. The block had
 already drifted twice before that guard existed, both times by under-reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cargo build -p stella-cli --bin stella && \
   STELLA_BIN="$PWD/target/debug/stella" ./scripts/test-self-driving.sh
 ```
 
-Or just `make gate`, which is the twenty-four of them in order.
+Or just `make gate`, which is the twenty-five of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence


### PR DESCRIPTION
`main` is red on `gate-parity`, so **`docs guards` fails on every open PR**:

```
check-gate-parity: FAIL — AGENTS.md does not spell the gate's step count as 'twenty-five'.
check-gate-parity: FAIL — CONTRIBUTING.md does not spell the gate's step count as 'twenty-five'.
```

## What happened

A parallel-merge collision, and a clean illustration of the shape `gate-parity` exists to catch. Two PRs each added one gate step and each *correctly* updated both documents to **its own** new total — `module-reachability` (#1750) and `self-driving-test` both wrote "twenty-four". Both were right against their own base. The second to merge left `GATE_STEPS` at 25 with the prose still saying 24.

Neither PR was wrong. The count is a derived number that two branches cannot both own.

Both new steps are already **named** in both documents, which is why the guard reported only the counts. So this is those two numbers and nothing else.

```
$ ./scripts/check-gate-parity.sh
check-gate-parity: OK — 25 (twenty-five) gate steps, named in AGENTS.md and CONTRIBUTING.md.
```

No witness test: the guard is the check. It fails on `main` and passes here.

## Follow-up worth having

The step *names* are checked mechanically against `make print-gate-steps`, but the spelled-out **total** is hand-written prose that any two concurrent guard-adding PRs will collide on — this is the second such collision today. Deriving the word from the count at render time, or dropping the total from the prose entirely (the list itself is already checked, so the number adds nothing a reader can act on), would remove the class.

Deliberately **not** done here: unbreaking main should not carry a design change. Happy to open it separately.

Refs #1750, #1645

## Summary by Sourcery

Update documentation to reflect the current gate step count and restore gate-parity on main.

Documentation:
- Correct the spelled-out gate step total in AGENTS.md to match the current GATE_STEPS value of twenty-five.
- Correct the spelled-out gate step total in CONTRIBUTING.md to match the current GATE_STEPS value of twenty-five.