### PR TITLE
fix(gate): finish the count-check removal — the guard's header still advertised it

### DIFF
--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -26,13 +26,14 @@
 #   2. Every step is named in CONTRIBUTING.md's gate fence, via the alias table
 #      below (that fence lists raw commands, on purpose — its reader wants to
 #      run them without make).
-#   3. Both documents' spelled-out count matches the real number of steps.
-#   4. CONTRIBUTING.md's fence does not run a `check-*.sh` that is no longer a
+#   3. CONTRIBUTING.md's fence does not run a `check-*.sh` that is no longer a
 #      gate step — which is how a removed guard leaves a ghost behind. Only
 #      that fence is checked this way: it is a delimited list of commands,
 #      whereas AGENTS.md's block is prose with parenthetical glosses.
 #
-# What it deliberately does NOT check: the prose *around* the lists. Whether
+# What it deliberately does NOT check: the spelled-out step total — that check
+# existed and was removed; see "The count is deliberately NOT checked any
+# more" below (#1883) — and the prose *around* the lists. Whether
 # "ci.yml's required job runs everything except invariants and doc-links" is
 # still true is a claim about a workflow, not about this list, and pretending a
 # grep could settle it would be worse than leaving it to review.


### PR DESCRIPTION
## What this PR is now

This branch originally implemented issue #1883's option (1) — dropping the spelled-out gate-step total from AGENTS.md/CONTRIBUTING.md and deleting `number_word()` plus both count-check branches from `scripts/check-gate-parity.sh`. While it was open, **#1894 (carrying #1891) landed the same class-removing fix on `main`**: the count is gone from both documents, the count checks and `number_word()` are deleted, and a rationale block citing #1883 sits in the guard's body. #1883 is closed.

Rebased onto `origin/main` (`493e6568`, which also brought #1844's sigpipe hardening of this script), this PR keeps only the honest residue #1894 missed: **the guard's header comment still advertised the deleted check** —

```
# What it checks:
#   ...
#   3. Both documents' spelled-out count matches the real number of steps.
```

Stale comments are bugs by this repo's convention. The change: drop ghost item 3, renumber item 4 → 3, and record the total under "What it deliberately does NOT check", pointing at the "The count is deliberately NOT checked any more" block #1894 added in the body.

## Verification

On the rebased branch (comment-only change to one shell script; no cargo surface):

- `./scripts/check-gate-parity.sh` → `OK — 25 gate steps, named in AGENTS.md and CONTRIBUTING.md.` (exit 0)
- `./scripts/check-gate-parity.sh | head -1` → same OK line, pipeline exit 0 (exercises #1844's buffered-verdict path)
- `shellcheck scripts/check-gate-parity.sh` clean

Refs #1883, #1894, #1891, #1437