### PR TITLE
fix(gate): stop checking the gate-step count, which caused reds instead of catching them (#1883)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,17 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + self-driving-test (the shell harness)
 ```
 
-That is twenty-four steps, and the list is not maintained by hand: it is
-`GATE_STEPS` in the `Makefile`, and `gate-parity` (`scripts/check-gate-parity.sh`)
-fails if this block or CONTRIBUTING.md's stops matching it. The block had
-already drifted twice before that guard existed, both times by under-reporting
-a newly added guard, which is the direction that misleads — a reader runs the
-short list, sees green, and believes the gate is green (#1437).
+That list is not maintained by hand: it is `GATE_STEPS` in the `Makefile`, and
+`gate-parity` (`scripts/check-gate-parity.sh`) fails if this block or
+CONTRIBUTING.md's stops matching it. The block had already drifted twice before
+that guard existed, both times by under-reporting a newly added guard, which is
+the direction that misleads — a reader runs the short list, sees green, and
+believes the gate is green (#1437).
+
+Deliberately no total: the guard checks each step by name, so two PRs adding
+different guards merge cleanly, while a spelled-out count is one shared cell
+both must write — and two of them collided on it twice in a day, each time
+leaving `main` red for everyone (#1883).
 
 CI enforces the same steps split across three workflows:
 `/.github/workflows/ci.yml`'s required job runs everything except `invariants`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cargo build -p stella-cli --bin stella && \
   STELLA_BIN="$PWD/target/debug/stella" ./scripts/test-self-driving.sh
 ```
 
-Or just `make gate`, which is the twenty-four of them in order.
+Or just `make gate`, which runs all of them in order.
 
 Do not maintain that list by hand. It is `GATE_STEPS` in the `Makefile`, and
 `./scripts/check-gate-parity.sh` — itself one of the steps — fails if this fence

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -66,26 +66,25 @@ if [ "$count" -eq 0 ]; then
   exit 1
 fi
 
-# Spelled-out numbers, because both documents spell the count in prose ("the
-# fifteen of them in order") and a digit would read wrong there. Covers a range
-# no plausible gate will leave.
-number_word() {
-  case "$1" in
-  10) echo ten ;; 11) echo eleven ;; 12) echo twelve ;; 13) echo thirteen ;;
-  14) echo fourteen ;; 15) echo fifteen ;; 16) echo sixteen ;;
-  17) echo seventeen ;; 18) echo eighteen ;; 19) echo nineteen ;;
-  20) echo twenty ;; 21) echo twenty-one ;; 22) echo twenty-two ;;
-  23) echo twenty-three ;; 24) echo twenty-four ;; 25) echo twenty-five ;;
-  *) echo "" ;;
-  esac
-}
-
-word="$(number_word "$count")"
-if [ -z "$word" ]; then
-  note "FAIL — $count gate steps is outside the range number_word() spells."
-  note "     Extend the table in this script; the documents spell the count."
-  exit 1
-fi
+# ── The count is deliberately NOT checked any more ───────────────────────────
+#
+# Both documents used to spell the total in prose ("the fifteen of them in
+# order") and this guard held them to it. That check is gone, and its removal
+# is the fix for a failure it caused rather than caught (#1883).
+#
+# The step NAMES are checked one at a time, so two PRs that each add a
+# different guard produce diffs that merge cleanly. The TOTAL is a single
+# shared cell both branches must write — and each writes its own correct
+# answer. On 2026-08-06 `module-reachability` and `self-driving-test` landed
+# within an hour of each other, each having dutifully updated both documents
+# to "twenty-four". The second merge left GATE_STEPS at 25 with the prose
+# saying 24, `docs guards` went red on `main`, and every open PR inherited it.
+# Twice in one day.
+#
+# Nothing was lost by dropping it. The count told a reader no fact the checked
+# list does not already carry: if every step is named, the number of them is
+# not independently knowable-wrong. It was a derived value maintained by hand,
+# which is the same defect this guard exists to prevent one level up.
 
 # CONTRIBUTING.md lists raw commands rather than make targets. Every guard is
 # `scripts/check-<target>.sh` except the ones named here, and the four compile
@@ -130,11 +129,6 @@ for doc in "$agents" "$contributing"; do
     fi
   done
 
-  if ! grep -qF -- "$word" "$doc"; then
-    note "FAIL — $doc does not spell the gate's step count as '$word'."
-    note "     The gate runs $count steps. Find the stale count and fix it."
-    fail=1
-  fi
 done
 
 # ── Ghosts ───────────────────────────────────────────────────────────────────
@@ -176,5 +170,5 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-printf 'check-gate-parity: OK — %s (%s) gate steps, named in %s and %s.\n' \
-  "$count" "$word" "$agents" "$contributing"
+printf 'check-gate-parity: OK — all %s gate steps are named in %s and %s.\n' \
+  "$count" "$agents" "$contributing"


### PR DESCRIPTION
## This unbreaks `main`

`main` is red on `gate-parity`, so **`docs guards` fails on every open PR**. This fixes it *and* removes the reason it will happen again.

## The defect

`check-gate-parity.sh` checked two things about AGENTS.md and CONTRIBUTING.md:

| | |
|---|---|
| every step in `GATE_STEPS` is **named** | earns its keep — #1437 records two real drifts it caught |
| the spelled-out **total** matches | a single shared cell two concurrent PRs must both write |

The names are checked one at a time, so two PRs adding different guards produce diffs that merge cleanly. The total does not have that property, and it broke **twice on 2026-08-06**: `module-reachability` (#1750) and `self-driving-test` landed within an hour, each having dutifully updated both documents to "twenty-four". The second merge left `GATE_STEPS` at 25 with the prose saying 24. Two separate agents then opened competing two-line fixes for it (#1863, #1882 — I closed the latter, which was mine).

**A guard that causes reds instead of catching them is not a guard.**

## Why deleting it loses nothing

The count told a reader no fact the checked list does not already carry: **if every step is named, the number of them is not independently knowable-wrong.** It was a derived value maintained by hand — precisely the defect this guard exists to prevent one level up.

Option 1 of the three in #1883, and the only one that leaves nothing to go stale. Deriving the word (option 2) keeps a number nobody reads; a `--fix` flag (option 3) still leaves `main` red until somebody runs it.

`number_word()` and the count comparison go. The name checks, the ghost check (a CONTRIBUTING command that is no longer a gate step) and the fence parsing are untouched.

## Verification, both directions

Narrowing a guard needs proof it still guards:

```
$ perl -pi -e 's/ \+ module-reachability//' AGENTS.md
$ ./scripts/check-gate-parity.sh
check-gate-parity: FAIL — AGENTS.md never mentions the gate step 'module-reachability'

$ # restored
check-gate-parity: OK — all 25 gate steps are named in AGENTS.md and CONTRIBUTING.md.
```

`make shellcheck` clean.

## Why this PR and not #1863

#1863 is the same two-line count fix, opened first, and I closed my duplicate in its favour. **It cannot merge.**

It is docs-only; `ci.yml` carries `paths-ignore` for `*.md`; so all three required contexts (`fmt + clippy + test`, `cargo deny + cargo audit`, `harbor_adapter + analyzer pytest`) never report, and GitHub leaves it `BLOCKED` forever:

```
$ gh pr view 1863 --json mergeStateStatus     # BLOCKED, every reported check passing
$ gh api .../protection/required_status_checks --jq .contexts
["fmt + clippy + test","cargo deny + cargo audit","harbor_adapter + analyzer pytest"]
```

`ci.yml`'s own comment says that filter is safe *because* `merge_group` ignores `paths-ignore` — which is true **only with a merge queue enabled**, and it is not (#1645). So the path filter is currently a trap for every docs-only PR in this repository. Filed separately; it is a bigger problem than this one.

This PR touches `scripts/`, so it gets its checks and can actually land.

Closes #1883
Refs #1750, #1863, #1645

## Summary by Sourcery

Stop enforcing a spelled-out gate-step count in documentation guards to prevent false failures while preserving per-step parity checks between scripts and docs.

Bug Fixes:
- Fix gate-parity script failures caused by mismatched manually maintained total step counts across concurrent documentation changes.

Enhancements:
- Simplify the gate-parity check script by removing unused number-word logic and tightening its success messaging.
- Clarify AGENTS.md and CONTRIBUTING.md to describe gate execution without a hard-coded step count and to document the rationale for dropping the total.