### PR TITLE
feat(arenabench): restore finished matches from disk at boot

### DIFF
--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -158,7 +158,10 @@ class ContestantRun:
         if self.error:
             return "error"
         if self.process is None:
-            return "pending"
+            # No process and a finish stamp is a run restored from disk after
+            # a server restart (#1885) — history, not a seat that never
+            # launched.
+            return "done" if self.finished_at is not None else "pending"
         if self.process.poll() is None:
             return "running"
         return "done" if self.exit_code in (0, None) else "failed"
@@ -394,6 +397,57 @@ def _failure_note(match: Match) -> str:
     return f"no trial ever ran — {per_seat}"
 
 
+def _synthesize_spec(match_id: str, match_dir: Path) -> MatchSpec | None:
+    """A spec rebuilt from what a finished match left behind.
+
+    Matches created before ``spec.json`` existed (#1885) still restore: the
+    seat manifests carry each seat's engine and agent, the job directories
+    carry the slugs and the tasks, and provenance carries the dataset. Good
+    enough to read history by — never to launch, which a restored match
+    never does.
+    """
+    jobs_root = match_dir / "jobs"
+    contestants: list[dict[str, Any]] = []
+    tasks: set[str] = set()
+    for job_dir in sorted(p for p in jobs_root.iterdir() if p.is_dir()):
+        slug = job_dir.name.removeprefix(f"{match_id}-")
+        raw: dict[str, Any] = {}
+        manifest = seat_manifest_path(job_dir)
+        if manifest.is_file():
+            try:
+                parsed = json.loads(manifest.read_text(encoding="utf-8"))
+                raw = parsed if isinstance(parsed, dict) else {}
+            except ValueError:
+                raw = {}
+        contestants.append(
+            {
+                "id": raw.get("contestant") or slug,
+                "name": slug.replace("-", " "),
+                "agent": raw.get("agent") or "stella",
+                "engine": {
+                    "api": raw.get("api") or "openrouter",
+                    "model": raw.get("model") or "",
+                    "base_url": raw.get("base_url"),
+                },
+            }
+        )
+        for trial in job_dir.iterdir():
+            if trial.is_dir():
+                tasks.add(trial.name.rsplit("__", 1)[0])
+    if not contestants:
+        return None
+    record = provenance.read_match(match_dir)
+    return MatchSpec.from_json(
+        {
+            "id": match_id,
+            "name": match_id,
+            "dataset": record.dataset_key if record else "",
+            "tasks": sorted(tasks),
+            "contestants": contestants,
+        }
+    )
+
+
 class MatchRunner:
     """Launches and supervises matches."""
 
@@ -402,6 +456,91 @@ class MatchRunner:
         self.workspace = workspace
         self.matches: dict[str, Match] = {}
         self._lock = threading.Lock()
+
+    # -- restoring --------------------------------------------------------
+
+    def restore_from_disk(self) -> int:
+        """Re-list finished matches from the workspace, after a restart.
+
+        The runner's live state is memory-only, so before this every restart
+        silently erased the UI's history while the artifacts sat intact on
+        disk (#1885). A restored match is history: no process, no supervisor,
+        no recorder — every reader (snapshot, metrics, transcripts, files)
+        already works straight off the job directories.
+        """
+        root = self.workspace / "matches"
+        if not root.is_dir():
+            return 0
+        restored = 0
+        for match_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+            match_id = match_dir.name
+            if match_id in self.matches or not (match_dir / "jobs").is_dir():
+                continue
+            try:
+                match = self._restore_one(match_id, match_dir)
+            except Exception:  # one unreadable match must not hide the rest
+                log.exception("could not restore match %s", match_id)
+                continue
+            if match is None:
+                continue
+            with self._lock:
+                self.matches.setdefault(match_id, match)
+            restored += 1
+        if restored:
+            log.info("restored %d finished match(es) from disk", restored)
+        return restored
+
+    def _restore_one(self, match_id: str, match_dir: Path) -> Match | None:
+        spec: MatchSpec | None = None
+        spec_path = match_dir / "spec.json"
+        if spec_path.is_file():
+            try:
+                spec = MatchSpec.from_json(
+                    json.loads(spec_path.read_text(encoding="utf-8"))
+                )
+            except (ValueError, TypeError, KeyError):
+                spec = None  # fall through to the synthesized shape
+        if spec is None:
+            spec = _synthesize_spec(match_id, match_dir)
+        if spec is None or not spec.contestants:
+            return None
+
+        # An unknown dataset key must not hide the match: any registry entry
+        # lets the snapshot render, and the provenance record beside the
+        # trials keeps saying what actually graded them.
+        dataset = self.registry.get(spec.dataset) or next(
+            iter(self.registry.datasets.values()), None
+        )
+        if dataset is None:
+            return None
+
+        match = Match(spec, dataset, match_dir)
+        record_path = match_dir / "provenance.json"
+        started = (
+            record_path.stat().st_mtime
+            if record_path.is_file()
+            else match_dir.stat().st_mtime
+        )
+        finished = started
+        for result in match_dir.glob("jobs/*/*/result.json"):
+            finished = max(finished, result.stat().st_mtime)
+        match.created_at = match.started_at = min(started, finished)
+        match.finished_at = finished
+        match.status = "finished"
+        match.provenance = provenance.read_match(match_dir)
+        match.note = "restored from artifacts on disk after a server restart"
+        for contestant in spec.contestants:
+            job_name = f"{match_id}-{contestant.slug}"
+            run = ContestantRun(
+                contestant=contestant,
+                job_name=job_name,
+                job_dir=match.jobs_root / job_name,
+                log_path=match_dir / f"{contestant.slug}.log",
+            )
+            run.started_at = match.started_at
+            run.finished_at = finished
+            match.runs[contestant.id] = run
+        return match
 
     # -- launching --------------------------------------------------------
 
@@ -413,6 +552,17 @@ class MatchRunner:
         if dataset is None:
             raise ValueError(f"unknown dataset: {spec.dataset}")
         match = Match(spec, dataset, self.workspace / "matches" / spec.id)
+        # The spec is what a restart cannot rebuild from job directories alone
+        # (names, colors, task order). `to_json` serializes seats through
+        # `redacted()`, so credential values never touch disk. Best-effort: a
+        # match that cannot write its spec still runs, and restores later
+        # through the synthesized path.
+        try:
+            (match.workspace / "spec.json").write_text(
+                json.dumps(spec.to_json(), indent=2) + "\n", encoding="utf-8"
+            )
+        except OSError:
+            log.warning("could not persist spec.json for match %s", spec.id)
         with self._lock:
             self.matches[spec.id] = match
         return match

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -152,6 +152,9 @@ class ArenaServer:
         self.workspace.mkdir(parents=True, exist_ok=True)
         self.registry = registry or DEFAULT_REGISTRY
         self.runner = MatchRunner(self.registry, workspace)
+        # History first: finished matches on disk are listed before any new
+        # one starts, so a restart never erases what the workspace remembers.
+        self.runner.restore_from_disk()
         self.recorder_status: tuple[bool, str] = (False, "not checked")
 
     # -- API handlers -----------------------------------------------------

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -1060,6 +1060,90 @@ class TestFailedMatchStatus:
         assert match.note == ""
 
 
+class TestRestoredMatches:
+    """A server restart must not erase the history sitting on disk (#1885).
+
+    Witness: on the old code every one of these fails — the runner had no
+    restore path at all, so a rebooted `ArenaServer` listed nothing and
+    `arena.match(...)` raised for a match whose artifacts were fully intact.
+    """
+
+    FIXTURE = Path(__file__).parent / "fixtures" / "matches" / "dd52a57a6f49"
+
+    def _workspace_with_fixture(self, tmp_path: Path) -> Path:
+        import shutil
+
+        workspace = tmp_path / "ws"
+        (workspace / "matches").mkdir(parents=True)
+        shutil.copytree(self.FIXTURE, workspace / "matches" / "dd52a57a6f49")
+        return workspace
+
+    def test_a_finished_match_on_disk_is_listed_after_boot(self, tmp_path: Path):
+        from arenabench.server import ArenaServer
+
+        arena = ArenaServer(self._workspace_with_fixture(tmp_path))
+        listed = {m["id"]: m for m in arena.list_matches()["matches"]}
+        assert "dd52a57a6f49" in listed
+        assert listed["dd52a57a6f49"]["status"] == "finished"
+
+    def test_a_restored_match_serves_its_snapshot_and_seats_read_done(
+        self, tmp_path: Path
+    ):
+        from arenabench.server import ArenaServer
+
+        arena = ArenaServer(self._workspace_with_fixture(tmp_path))
+        snap = arena.match("dd52a57a6f49")
+        assert snap["status"] == "finished"
+        assert len(snap["contestants"]) == 2
+        assert all(c["state"] == "done" for c in snap["contestants"])
+        assert snap["rows"], "the task grid must come back from the job dirs"
+        # History replays; it never re-runs. No process, no supervisor.
+        match = arena.runner.matches["dd52a57a6f49"]
+        assert all(run.process is None for run in match.runs.values())
+
+    def test_create_persists_a_secret_free_spec_for_the_next_boot(
+        self, tmp_path: Path
+    ):
+        spec = MatchSpec.from_json(
+            {
+                "name": "kvk",
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["fix-git"],
+                "contestants": [
+                    {
+                        "name": "Stella",
+                        "agent": "stella",
+                        "engine": {"api": "openrouter", "model": "z-ai/glm-5.2"},
+                        "env": "OPENROUTER_API_KEY=sk-secret-value",
+                    },
+                    {
+                        "name": "Claude Code",
+                        "agent": "claude-code",
+                        "engine": {"api": "anthropic", "model": "claude-sonnet-5"},
+                    },
+                ],
+            }
+        )
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path)
+        match = runner.create(spec)
+        raw = (match.workspace / "spec.json").read_text(encoding="utf-8")
+        assert "sk-secret-value" not in raw, "credential values must never touch disk"
+        restored = MatchSpec.from_json(json.loads(raw))
+        assert restored.id == spec.id
+        assert [c.name for c in restored.contestants] == ["Stella", "Claude Code"]
+        assert restored.tasks == ("fix-git",)
+
+    def test_junk_directories_do_not_break_the_boot(self, tmp_path: Path):
+        from arenabench.server import ArenaServer
+
+        workspace = self._workspace_with_fixture(tmp_path)
+        (workspace / "matches" / "no-jobs-here").mkdir()
+        (workspace / "matches" / "empty-jobs" / "jobs").mkdir(parents=True)
+        arena = ArenaServer(workspace)
+        listed = [m["id"] for m in arena.list_matches()["matches"]]
+        assert listed == ["dd52a57a6f49"]
+
+
 class TestSnapshotDetections:
     """The monitor's verdicts ride the snapshot the web UI renders (#1569).
 


### PR DESCRIPTION
## What

`MatchRunner.matches` was memory-only, so every `arenabench serve` restart silently erased the UI's entire match history while the artifacts sat intact under `workspace/matches/<id>/` — snapshots, transcripts, videos and trial files all became unreachable. Hit live on 2026-08-06: deploying a transcript fix mid-match had to wait for the match to end because a restart would have destroyed both the live view and the finished history behind it.

## How

- `MatchRunner.create()` persists `spec.json` beside `provenance.json`. Serialization goes through `Contestant.redacted()`, so **credential values never touch disk** (witnessed: the spec file for a seat with a pasted key does not contain the value).
- `ArenaServer` boot calls `MatchRunner.restore_from_disk()`: one read-only `Match` per finished directory. Spec from `spec.json` when present; for pre-existing matches, synthesized from seat manifests, job-directory slugs, and the provenance record's dataset key. Timestamps from file mtimes, so elapsed stays truthful.
- Restored seats are processless `ContestantRun`s; `state` now reads `done` for a run with a finish stamp and no process (previously that shape meant "pending"). **History replays, never re-runs**: no supervisor thread, no recorder, no launch.
- One unreadable match directory is logged and skipped, never allowed to hide the rest.

## Witness

`TestRestoredMatches` (4 tests) — all fail on main (`assert 'dd52a57a6f49' in {}`, `KeyError`, missing `spec.json`), pass here, against the committed `dd52a57a6f49` fixture. Full `tests/test_arena.py` green.

Closes #1885

## Summary by Sourcery

Restore finished matches from workspace artifacts on server startup so match history survives restarts and is fully visible in the UI.

New Features:
- Rebuild and register finished matches from on-disk artifacts at ArenaServer boot, including synthesized specs for legacy matches without spec.json.
- Persist a redacted match spec to spec.json when creating matches so future restarts can restore richer metadata without storing credentials.

Bug Fixes:
- Ensure restored contestants from disk are treated as completed runs rather than pending when no process exists but a finish timestamp is present.
- Prevent malformed or non-match directories under the matches workspace from breaking startup by logging and skipping unreadable entries.

Enhancements:
- Infer dataset, tasks, and contestants for older matches from seat manifests, job directories, and provenance so historical snapshots and grids can still render.
- Initialize restored match timestamps and status from file modification times to accurately reflect match duration and completion in the UI.

Tests:
- Add TestRestoredMatches suite and fixtures to verify listing, snapshot rendering, spec persistence without secrets, and resilience to junk directories after restart.