### PR TITLE
ci: make the required contexts always report — path filters move from the trigger into the jobs (#1892)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -179,8 +179,9 @@ fi
 # would open a hole. `make guards` includes `wire-schema`, which runs the two
 # schema exporters — a cargo build. For a website-only push that is pure waste:
 # the diff cannot have touched the wire contract. But `docs/wire/` is *generated
-# and committed*, and ci.yml carries `paths-ignore: docs/**`, so a hand-edit
-# confined to `docs/wire/` is invisible to the required check. That is why
+# and committed*, and ci.yml skips its Rust jobs for a diff confined to
+# `docs/**` (a job-level prose filter since #1892), so a hand-edit confined to
+# `docs/wire/` is invisible to the required check. That is why
 # wire-schema was put in `guards` in the first place, and why the fix here is to
 # make it conditional rather than to drop it: run the dear rung only when the
 # pushed diff can actually have invalidated the artifacts. The server-side half

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,24 @@
 name: ci
 
 on:
+  # Deliberately NO `paths-ignore` here (#1892). Both jobs below are required
+  # branch-protection contexts, and a workflow suppressed by a trigger-level
+  # path filter reports nothing at all — GitHub then waits forever for the
+  # missing contexts, and a docs-only PR is permanently BLOCKED with every
+  # reported check green (#1863). A job skipped by an `if:` DOES report (as
+  # `skipped`) and satisfies a required context, so the prose filter lives in
+  # the `changes` job below instead: same cost saving — a prose-only PR pays
+  # one diff, not an hour of Rust — but the contexts always report. bench.yml
+  # solved the same trap the same way for its required context (#659).
+  #
+  # Prose changes still can't break the Rust build, and nothing goes ungated:
+  # the site is built by docs.yml, and `docs-guards.yml` triggers on `docs/**`
+  # and `**/*.md` to run the prose guards. It is deliberately isolated from
+  # this workflow.
   pull_request:
-    # Prose-only changes can't break the Rust build — don't spend an hour of
-    # CI on them. Nothing here goes ungated: the site is built by docs.yml, and
-    # `docs-guards.yml` triggers on `docs/**` and `**/*.md` to run the two
-    # prose guards (doc citations resolve; the AGENTS.md invariant list has one
-    # copy). It is deliberately isolated from this workflow.
-    # (`*.md` matches the repo root only — GitHub's `*` stops at `/` — so a
-    # crate's own README still pays the gate, which is what we want.)
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
-      - "*.md"
-      - ".github/ISSUE_TEMPLATE/**"
+  # A push to `main` is not gated by required contexts, so the trigger-level
+  # filter is still safe here — a docs-only merge does not start the Rust
+  # gate at all. Keep this list and the `changes` job's regex in agreement.
   push:
     branches: [main]
     paths-ignore:
@@ -25,10 +30,11 @@ on:
   # before it lands, so two individually-green PRs can't combine into a red
   # `main` (see #306). The queue evaluates the required checks on the
   # `merge_group` event, so `check` and `supply-chain` — the two required
-  # contexts — must both fire here or the queue can never go green. Note
-  # `merge_group` does NOT honor `paths-ignore`, so a docs-only PR that skips
-  # the Rust gate on `pull_request` still runs the full gate once queued; that
-  # is deliberate — the required check must report on the merged result.
+  # contexts — must both fire here or the queue can never go green. The
+  # `changes` job answers `rust=true` for every non-pull_request event, so a
+  # docs-only PR that skipped the Rust gate on `pull_request` still runs the
+  # full gate once queued; that is deliberate — the required check must report
+  # on the merged result.
   merge_group:
   workflow_dispatch:
 
@@ -50,15 +56,73 @@ concurrency:
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Both jobs only check out, build, and test — nothing here writes to the repo.
+# Every job only checks out, builds, and tests — nothing here writes to the repo.
 # Without the key, GITHUB_TOKEN falls back to the repository default, which on
 # repos created before the 2023 default change is read/write on every scope.
 permissions:
   contents: read
 
 jobs:
+  # The prose filter that used to be a trigger-level `paths-ignore` (#1892).
+  # It has to be a job so that the two required jobs below can skip — and a
+  # skipped job still reports its context, which a path-suppressed workflow
+  # does not (see the trigger comment above).
+  changes:
+    name: is this diff prose-only?
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.scope.outputs.rust }}
+    steps:
+      # Full history, pull requests only: the scope check diffs against the PR
+      # base, and a shallow clone may not contain the merge base. Every other
+      # event runs the full gate without looking at the diff, so it needs no
+      # checkout at all.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+
+      - name: Does this diff reach past the prose paths?
+        id: scope
+        env:
+          # Via env rather than inlined into the shell, so a ref name can
+          # never be read as script (same shape as empty-diff.yml).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Anything that is not a PR — a push to main, the merge queue, a
+          # manual dispatch — always runs the full gate: main and the queued
+          # merge result are what the green claim is about.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The prose paths, mirroring the push trigger's paths-ignore above:
+          # website/, docs/, .github/ISSUE_TEMPLATE/, and root-level *.md
+          # only (`[^/]+\.md$` stops at the first `/`, like the glob `*.md` —
+          # a crate's own README still pays the gate, which is what we want).
+          # `grep -v` inverts: any changed file OUTSIDE those paths means the
+          # gate runs. An empty diff runs nothing here — reporting that PR is
+          # empty-diff.yml's job.
+          if git diff --name-only "$BASE_SHA"...HEAD \
+            | grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+            echo "Prose-only diff — the Rust gate is skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "Both required contexts still report (as skipped), so the PR can merge." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   check:
     name: fmt + clippy + test
+    needs: changes
+    # Skip — never suppress — for a prose-only diff: a skipped job still
+    # reports its required context (#1892). `!= 'false'` rather than
+    # `== 'true'` so a failed `changes` job fails closed: no output reads as
+    # "run the gate". `!cancelled()` (not the implicit success()) is what
+    # lets this evaluate at all in that case.
+    if: ${{ !cancelled() && needs.changes.outputs.rust != 'false' }}
     runs-on: ubuntu-latest
     # Bundled SQLite (stella-store, rusqlite) and tree-sitter grammars are
     # heavy C compiles on a cold cache; rust-cache keeps warm runs fast.
@@ -367,6 +431,10 @@ jobs:
     # mode with a different check. Do not rename without updating branch
     # protection (repo admin, out of band) in the same change.
     name: cargo deny + cargo audit
+    needs: changes
+    # Same skip discipline as `check` above: report the required context as
+    # skipped for a prose-only diff, and fail closed if `changes` failed.
+    if: ${{ !cancelled() && needs.changes.outputs.rust != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,8 +1,9 @@
 name: docs-guards
 
 # Six guards over prose. None needs a Rust toolchain, which is why they live
-# here rather than in ci.yml -- that workflow deliberately ignores `docs/**`,
-# `website/**` and `*.md`, and this one triggers on exactly those paths.
+# here rather than in ci.yml -- that workflow deliberately skips its Rust jobs
+# for a diff confined to `docs/**`, `website/**` and `*.md` (a job-level prose
+# filter since #1892), and this one triggers on exactly those paths.
 #
 #  1. doc-links (scripts/check-doc-links.py): every citation resolves to a
 #     document that has declared an identity. Documents are addressed by a
@@ -105,8 +106,8 @@ jobs:
       # Also runs in ci.yml, which is where the important half is caught: a new
       # `Command` variant is a .rs change, so the required check sees it. This
       # copy covers the other direction, which ci.yml structurally cannot —
-      # `paths-ignore: website/**` means a PR that only deletes a reference
-      # page or drops it from meta.json never starts that workflow.
+      # its prose filter means a PR that only deletes a reference page or
+      # drops it from meta.json skips that workflow's Rust jobs.
       - name: every subcommand has a reference page
         if: ${{ !cancelled() }}
         run: bash scripts/check-command-docs.sh
@@ -120,8 +121,8 @@ jobs:
 
       # Both directions matter here, which is why it runs in ci.yml too. A new
       # guard is a Makefile change (ci.yml sees it); an edit that quietly drops
-      # a step from AGENTS.md or CONTRIBUTING.md is an md change, and
-      # `paths-ignore: *.md` means ci.yml structurally cannot (#1437).
+      # a step from AGENTS.md or CONTRIBUTING.md is an md change, and ci.yml's
+      # prose filter means it structurally cannot see one (#1437).
       - name: the documented gate is the real gate
         if: ${{ !cancelled() }}
         run: bash scripts/check-gate-parity.sh

--- a/.github/workflows/wire-schema.yml
+++ b/.github/workflows/wire-schema.yml
@@ -5,8 +5,10 @@ name: wire-schema
 # `docs/wire/` is generated from the types and committed, and
 # `scripts/check-wire-schema.sh` is what makes committing it worth anything: it
 # regenerates into a temp directory and fails on any difference. That guard runs
-# in ci.yml -- but ci.yml carries `paths-ignore: docs/**`, so a pull request
-# that touches *only* `docs/wire/` never starts it. Nothing else covered the
+# in ci.yml -- but ci.yml skips its Rust jobs for a diff confined to `docs/**`
+# (a job-level prose filter since #1892; a trigger-level `paths-ignore` before
+# that), so a pull request that touches *only* `docs/wire/` never runs it.
+# Nothing else covered the
 # gap: docs-guards.yml is deliberately toolchain-free (four shell/python guards,
 # five-minute timeout) and adding a Rust build to it would cost every prose PR a
 # toolchain it has no use for.

--- a/README.md
+++ b/README.md
@@ -771,10 +771,11 @@ pnpm build       # production build (what docs.yml CI runs)
 ```
 
 Docs content is MDX under `website/content/docs/`. On a pull request a
-docs-only change runs the fast `docs` workflow instead of the Rust gate; the
-merge queue does not honor `paths-ignore`, so it still pays the full gate once
-queued — deliberately, since the required check has to report on the merged
-result.
+docs-only change runs the fast `docs` workflow, and `ci.yml`'s Rust jobs skip
+themselves after a cheap diff check — their required contexts still report, as
+`skipped`, so the PR can merge (#1892). Once queued or pushed to `main` the
+same jobs always run the full gate — deliberately, since the required check
+has to report on the merged result.
 
 To try your working copy against real projects before a release, install it as
 `stella-dev` — it lives side by side with the released `stella`:


### PR DESCRIPTION
## Problem

Branch protection requires `fmt + clippy + test` and `cargo deny + cargo audit`, both from `ci.yml` — which carried a trigger-level `paths-ignore` for `website/**`, `docs/**`, root `*.md` and `.github/ISSUE_TEMPLATE/**`. A workflow suppressed by a path filter **reports nothing at all**, so a docs-only PR waits forever on contexts that never arrive and is permanently `BLOCKED` (live example: #1863). The design assumed the merge queue (#1645), which is not enabled.

## Approach — issue #1892's option (2)

Move the filtering from the trigger into the jobs, following the precedent already in this repo: `bench.yml` solved the identical trap for its own required context after #659, and `empty-diff.yml` supplies the env-var-for-SHA shape.

- `pull_request` loses its `paths-ignore`; the workflow now always starts.
- A cheap `changes` job (plain `git diff --name-only "$BASE_SHA"...HEAD` — no new third-party action; `check-action-pins.sh` stays happy) answers `rust=true/false`. Non-`pull_request` events (push to main, `merge_group`, dispatch) always answer `rust=true`, so the merged result still pays the full gate exactly as the `merge_group` comment promises.
- Both required jobs gate on `if: ${{ !cancelled() && needs.changes.outputs.rust != 'false' }}`. A **skipped job still reports its context** and satisfies branch protection. `!= 'false'` + `!cancelled()` makes a failed `changes` job fail *closed*: no output reads as "run the gate".
- The `push` trigger keeps its `paths-ignore` — pushes are not gated by required contexts, so the trigger-level filter is still safe and free there.
- Required job names are byte-identical: `fmt + clippy + test`, `cargo deny + cargo audit`.
- `docs-guards.yml` and `wire-schema.yml` keep their jobs (#1439); only their comments describing ci.yml's filter mechanism are updated, along with `README.md` and `.githooks/pre-push`.

## Scenarios

| Diff | `changes` verdict | `fmt + clippy + test` / `cargo deny + cargo audit` | PR mergeable? |
| --- | --- | --- | --- |
| docs/website/root-`*.md`/ISSUE_TEMPLATE only | `rust=false` | **skipped — contexts report** | yes (was: BLOCKED forever) |
| any Rust / workflow / crate-README / mixed diff | `rust=true` | run in full | on green |
| empty diff | `rust=false` | skipped (empty-diff.yml reports the PR) | yes |
| `merge_group` / push to main / dispatch | `rust=true` (no diff inspected) | run in full | — |
| `changes` job itself fails | no output | run in full (fail closed) | on green |

The filter regex was dry-tested against sample file lists for all five diff shapes (crate READMEs correctly stay in scope: `[^/]+\.md$` matches the repo root only, like the glob `*.md`). `actionlint` passes on all three edited workflows; `shellcheck` passes on the edited hook.

## Verification

CI-only change — no witness test is possible for GitHub's check-reporting behavior. This PR's own diff touches `.github/workflows/`, so it exercises the `rust=true` path (the `changes` job runs, then the full gate runs). The `rust=false` path is dry-checked above; **the real witness is the first docs-only PR that merges after this lands** — #1863 is the live candidate.

Also audited per the issue: `bench.yml`'s `harbor_adapter + analyzer pytest` context does **not** have the trap — it already runs its scope filter as a step, never at the trigger.

Closes #1892

Refs #1645 #1439 #1863

## Summary by Sourcery

Adjust CI workflow to ensure required Rust checks always report while skipping them for prose-only pull requests.

Enhancements:
- Introduce a dedicated `changes` job in ci.yml to detect whether a pull request touches non-prose files and expose this as an output flag.
- Gate the `fmt + clippy + test` and `cargo deny + cargo audit` jobs on the `changes` job output so they are skipped—but still report their contexts—for prose-only diffs, and always run for non-PR events.
- Clarify comments in docs-guards.yml and wire-schema.yml to describe the new job-level prose filter behavior instead of the previous trigger-level path ignores.
- Update README.md to document how docs-only changes interact with the main CI workflow and required checks under the new scheme.
- Align local pre-push hook and workflow documentation with the updated CI gating logic.

CI:
- Remove `paths-ignore` from the pull_request trigger in ci.yml while retaining it for push events to main, avoiding branch protection deadlocks for docs-only changes.