### PR TITLE
fix(stella-tools): keep the head and tail of over-cap bash/custom output instead of dropping the tail (#1889)

### DIFF
--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -45,13 +45,25 @@ use tokio::process::Command;
 use crate::registry::Tool;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
-/// Deliberately 3.3x `exec::MAX_OUTPUT_BYTES` (30k), ratified as-is (#616):
-/// the shell is the agent's primary sensory channel — one `bash` call renders
-/// a whole build or test run whose first error and final summary can sit
-/// 100 KB apart — while the `exec` budget bounds each incremental
+/// Byte cap on one `bash` result before head+tail elision
+/// ([`crate::exec::truncate_middle_capped`]). [`crate::custom`] aliases this
+/// constant, so the two shell-shaped surfaces cannot drift apart (#1889).
+///
+/// 64 KB ≈ 18k estimated tokens ≈ 12% of the 150k compaction budget — the
+/// point #1842 ratified for `read_file`, for the same reason: one large
+/// result does not trigger the compaction that would reclaim it
+/// (`compact_measured` returns early when the rest of the transcript is
+/// small), and the 8-step retention horizon then keeps it verbatim, so its
+/// real cost is eight times its size. The previous 100 KB (#616) put ~19% of
+/// the budget in a single result, ~224k input tokens over the horizon.
+///
+/// Still 2.2x `exec::MAX_OUTPUT_BYTES` (30k), preserving #616's ratio
+/// argument: the shell is the agent's primary sensory channel — one `bash`
+/// call renders a whole build or test run whose first error and final summary
+/// sit far apart — while the `exec` budget bounds each incremental
 /// `read_output` page of a *managed* process the agent polls repeatedly.
 /// Aligning them would either starve the shell or inflate every page read.
-const MAX_OUTPUT_BYTES: usize = 100_000;
+pub(crate) const MAX_OUTPUT_BYTES: usize = 64 * 1024;
 
 /// grep-family commands whose first positional arg is a search pattern.
 const GREP_CMDS: &[&str] = &["grep", "egrep", "fgrep", "rg", "ripgrep", "ag"];
@@ -340,21 +352,12 @@ impl Tool for Bash {
         }
         combined.push_str(&format!("\n[exit code: {status}]"));
 
-        // Truncate from the middle if too long — keep head and tail. Slice
-        // only on char boundaries so multibyte UTF-8 output can't panic.
+        // Over the cap: keep head and tail, elide the middle loudly — the
+        // tail carries the part that usually matters (test summary, last
+        // error), and the marker names what fell out. One shared spelling
+        // for every shell-shaped surface (`crate::exec::truncate_middle_capped`).
         if combined.len() > MAX_OUTPUT_BYTES {
-            let mut head = MAX_OUTPUT_BYTES / 2;
-            while !combined.is_char_boundary(head) {
-                head -= 1;
-            }
-            let mut tail_start = combined.len() - MAX_OUTPUT_BYTES / 2;
-            while !combined.is_char_boundary(tail_start) {
-                tail_start += 1;
-            }
-            let truncated = tail_start - head;
-            let head_str = &combined[..head];
-            let tail_str = &combined[tail_start..];
-            combined = format!("{head_str}\n... [truncated {truncated} bytes] ...\n{tail_str}");
+            combined = crate::exec::truncate_middle_capped(&combined, MAX_OUTPUT_BYTES);
         }
 
         // Append after truncation so the steer is never the part that gets
@@ -534,6 +537,50 @@ mod tests {
             }
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
+    }
+
+    /// Witness for #1889: output just over the cap keeps BOTH its first and
+    /// last lines around an elision marker that names the cap. Sized from the
+    /// constant — the filler alone fills the cap, so the sentinels push it
+    /// over by a hair — which makes the test fail under any larger cap (the
+    /// old 100 KB left this size untouched) and under any head-only cut.
+    #[tokio::test]
+    async fn over_cap_output_keeps_first_and_last_lines_with_a_named_elision() {
+        let dir = std::env::temp_dir();
+        let command = format!(
+            "printf 'FIRST_SENTINEL_LINE\\n'; \
+             head -c {MAX_OUTPUT_BYTES} /dev/zero | tr '\\0' 'x'; \
+             printf '\\nLAST_SENTINEL_LINE\\n'"
+        );
+        let result = Bash
+            .execute(&serde_json::json!({ "command": command }), &dir)
+            .await;
+        let content = match result {
+            ToolOutput::Ok { content } => content,
+            ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
+        };
+        assert!(
+            content.contains("FIRST_SENTINEL_LINE"),
+            "the head survives elision"
+        );
+        assert!(
+            content.contains("LAST_SENTINEL_LINE"),
+            "the tail survives elision"
+        );
+        assert!(
+            content.contains(&format!("the {MAX_OUTPUT_BYTES}-byte cap")),
+            "the marker names the cap it enforced: {}",
+            &content[..200]
+        );
+        assert!(
+            content.contains("bytes truncated"),
+            "the marker names the elided byte count"
+        );
+        assert!(
+            content.len() <= MAX_OUTPUT_BYTES + 256,
+            "bounded by the cap plus the marker (got {} bytes)",
+            content.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -107,9 +107,10 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 /// Hard ceiling on `timeout_ms`; a manifest cannot ask for more. Public so
 /// [`crate::validate`] can warn about the clamp it mirrors.
 pub const MAX_TIMEOUT_MS: u64 = 600_000;
-/// Byte cap on captured stdout/stderr before middle-out truncation kicks in.
-/// Matches [`crate::bash`] so custom and native exec behave the same.
-const MAX_OUTPUT_BYTES: usize = 100_000;
+/// Byte cap on captured stdout/stderr before head+tail elision. An alias for
+/// [`crate::bash`]'s constant — not a copy — so custom and native shell
+/// output budgets cannot drift apart (#1889): same mechanism, same number.
+pub(crate) use crate::bash::MAX_OUTPUT_BYTES;
 
 /// A parsed, validated custom tool ready to advertise and execute.
 #[derive(Debug, Clone)]
@@ -462,44 +463,6 @@ fn scalar_env_value(value: &Value) -> Option<String> {
     }
 }
 
-/// Middle-out truncation on a char boundary: keeps a head and a (larger) tail
-/// with an explicit elision marker. Per lesson L-S3 the tail budget is ≥ the
-/// head budget, because a failing command's signal is usually in its tail.
-fn truncate_middle_out(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_string();
-    }
-    let head_budget = max_bytes * 2 / 5; // 40% head …
-    let tail_budget = max_bytes - head_budget; // … 60% tail (≥ head, L-S3)
-    let head_end = floor_boundary(s, head_budget);
-    let tail_start = ceil_boundary(s, s.len().saturating_sub(tail_budget));
-    let elided = tail_start.saturating_sub(head_end);
-    format!(
-        "{}\n... [truncated {elided} bytes] ...\n{}",
-        &s[..head_end],
-        &s[tail_start..]
-    )
-}
-
-/// Largest char boundary `<= i`.
-fn floor_boundary(s: &str, mut i: usize) -> usize {
-    if i >= s.len() {
-        return s.len();
-    }
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-/// Smallest char boundary `>= i`.
-fn ceil_boundary(s: &str, mut i: usize) -> usize {
-    while i < s.len() && !s.is_char_boundary(i) {
-        i += 1;
-    }
-    i
-}
-
 /// Spawn `cmd`, retrying briefly while the kernel refuses with `ETXTBSY`.
 ///
 /// `ETXTBSY` means the executable is still open for writing somewhere — for a
@@ -667,7 +630,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
     let stdout = String::from_utf8_lossy(&output.stdout);
     if output.status.success() {
         ToolOutput::Ok {
-            content: truncate_middle_out(&stdout, MAX_OUTPUT_BYTES),
+            content: crate::exec::truncate_middle_capped(&stdout, MAX_OUTPUT_BYTES),
         }
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -676,7 +639,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
             .code()
             .map(|c| c.to_string())
             .unwrap_or_else(|| "signal".to_string());
-        let tail = truncate_middle_out(&stderr, MAX_OUTPUT_BYTES);
+        let tail = crate::exec::truncate_middle_capped(&stderr, MAX_OUTPUT_BYTES);
         ToolOutput::Error {
             message: format!(
                 "custom tool `{}` exited with code {code}\n[stderr]\n{tail}",
@@ -1356,7 +1319,7 @@ command = []"#;
     }
 
     #[tokio::test]
-    async fn oversized_output_is_truncated_middle_out() {
+    async fn oversized_output_is_elided_middle_out() {
         let dir = tempfile::tempdir().unwrap();
         // Emit ~200k bytes of 'X' (well past MAX_OUTPUT_BYTES).
         let tool = script_tool(
@@ -1377,6 +1340,47 @@ command = []"#;
             }
             ToolOutput::Error { message } => panic!("expected ok: {message}"),
         }
+    }
+
+    /// Witness for #1889, mirroring `crate::bash`'s: over-cap stdout keeps
+    /// BOTH its first and last lines around a marker naming the cap. Sized
+    /// from the shared constant so the old 100 KB cap (which left this size
+    /// untouched) and any head-only cut both fail it — custom follows bash
+    /// exactly, same mechanism, same number.
+    #[tokio::test]
+    async fn over_cap_output_keeps_first_and_last_lines_with_a_named_elision() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = script_tool(
+            dir.path(),
+            "big-ends.sh",
+            &format!(
+                "#!/bin/sh\necho FIRST_SENTINEL_LINE\n\
+                 head -c {MAX_OUTPUT_BYTES} /dev/zero | tr '\\0' 'x'\necho\n\
+                 echo LAST_SENTINEL_LINE\n"
+            ),
+            5000,
+        );
+        let out = run_custom(&tool, &serde_json::json!({}), dir.path()).await;
+        let content = match out {
+            ToolOutput::Ok { content } => content,
+            ToolOutput::Error { message } => panic!("expected ok: {message}"),
+        };
+        assert!(
+            content.contains("FIRST_SENTINEL_LINE"),
+            "the head survives elision"
+        );
+        assert!(
+            content.contains("LAST_SENTINEL_LINE"),
+            "the tail survives elision"
+        );
+        assert!(
+            content.contains(&format!("the {MAX_OUTPUT_BYTES}-byte cap")),
+            "the marker names the cap it enforced"
+        );
+        assert!(
+            content.contains("bytes truncated"),
+            "the marker names the elided byte count"
+        );
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/exec.rs
+++ b/crates/stella-tools/src/exec.rs
@@ -578,27 +578,60 @@ pub(crate) fn truncate_preview(text: &str, max_bytes: usize) -> String {
     text[..cut].to_string()
 }
 
-/// Keep head and tail when output exceeds the cap — build/test failures
-/// matter at both ends (first error, final summary).
+/// Keep head and tail when output exceeds the shared runner's page budget —
+/// build/test failures matter at both ends (first error, final summary).
 pub(crate) fn truncate_middle(s: String) -> String {
     if s.len() <= MAX_OUTPUT_BYTES {
         return s;
     }
-    let half = MAX_OUTPUT_BYTES / 2;
-    let mut head_end = half;
-    while !s.is_char_boundary(head_end) {
-        head_end -= 1;
+    truncate_middle_capped(&s, MAX_OUTPUT_BYTES)
+}
+
+/// Keep the head and tail of `s` when it exceeds `max_bytes`, eliding the
+/// middle with a marker that names both the elided byte count and the cap.
+///
+/// The crate's ONE model-facing elision spelling: [`truncate_middle`],
+/// [`crate::bash`], and [`crate::custom`] all cut through here, so their
+/// markers and budgets cannot drift apart (#1889 — they had, three ways).
+/// The split is tail-biased — 40% head, 60% tail — because a failing
+/// command's signal concentrates at both ends and the tail end is the denser
+/// one: the final test summary, the last error, the exit status (lesson
+/// L-S3, first applied in `crate::custom`). Both cuts land on UTF-8 char
+/// boundaries so multibyte output can never panic the slice.
+pub(crate) fn truncate_middle_capped(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
     }
-    let mut tail_start = s.len() - half;
-    while !s.is_char_boundary(tail_start) {
-        tail_start += 1;
-    }
+    let head_budget = max_bytes * 2 / 5; // 40% head …
+    let tail_budget = max_bytes - head_budget; // … 60% tail (≥ head, L-S3)
+    let head_end = floor_char_boundary(s, head_budget);
+    let tail_start = ceil_char_boundary(s, s.len().saturating_sub(tail_budget));
+    let elided = tail_start - head_end;
     format!(
-        "{}\n[… {} bytes truncated …]\n{}",
+        "{}\n[… {elided} bytes truncated: output exceeded the {max_bytes}-byte cap; the head \
+         and tail are kept …]\n{}",
         &s[..head_end],
-        s.len() - head_end - (s.len() - tail_start),
         &s[tail_start..]
     )
+}
+
+/// Largest char boundary `<= i` (clamped to `s.len()`).
+fn floor_char_boundary(s: &str, mut i: usize) -> usize {
+    if i >= s.len() {
+        return s.len();
+    }
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Smallest char boundary `>= i`.
+fn ceil_char_boundary(s: &str, mut i: usize) -> usize {
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
 }
 
 #[cfg(test)]
@@ -844,5 +877,46 @@ mod tests {
         assert!(t.starts_with('a'));
         assert!(t.ends_with('z'));
         assert!(t.contains("truncated"));
+    }
+
+    /// The marker must account for every byte: it names the true elided count
+    /// and the cap it enforced, both derived here rather than hard-coded so a
+    /// moved cap cannot leave the assertion silently green (#1842's lesson).
+    #[test]
+    fn truncate_middle_capped_names_the_elided_count_and_cap() {
+        let cap = 1_000;
+        let s = "a".repeat(400) + &"m".repeat(5_000) + &"z".repeat(400);
+        let t = truncate_middle_capped(&s, cap);
+        assert!(t.starts_with('a'), "head survives: {t}");
+        assert!(t.ends_with('z'), "tail survives: {t}");
+        let head_kept = cap * 2 / 5;
+        let tail_kept = cap - head_kept;
+        assert!(tail_kept >= head_kept, "tail budget ≥ head budget (L-S3)");
+        let elided = s.len() - head_kept - tail_kept;
+        assert!(
+            t.contains(&format!("[… {elided} bytes truncated")),
+            "the marker names the elided count: {t}"
+        );
+        assert!(
+            t.contains(&format!("the {cap}-byte cap")),
+            "the marker names the cap: {t}"
+        );
+    }
+
+    /// Both cuts land inside a 3-byte char at a 40/60 split of this cap; a
+    /// raw byte slice would panic, the boundary-safe path must not.
+    #[test]
+    fn truncate_middle_capped_respects_utf8_boundaries() {
+        let s = "€".repeat(1_000);
+        let t = truncate_middle_capped(&s, 1_000);
+        assert!(t.starts_with('€'), "{t}");
+        assert!(t.ends_with('€'), "{t}");
+        assert!(t.contains("bytes truncated"), "{t}");
+    }
+
+    #[test]
+    fn truncate_middle_capped_is_a_no_op_at_or_below_the_cap() {
+        assert_eq!(truncate_middle_capped("hello", 5), "hello");
+        assert_eq!(truncate_middle_capped("hi", 5), "hi");
     }
 }


### PR DESCRIPTION
## Problem

`bash.rs` and `custom.rs` capped tool output at `MAX_OUTPUT_BYTES = 100 KB` — ~28k estimated tokens, **~19% of the 150k compaction budget in one result**. A single large result does not trigger the compaction that would reclaim it (`compact_measured` returns early when the rest of the transcript is small), and the 8-step retention horizon then keeps it verbatim: one `cargo test --workspace` or `npm ci` printing 100 KB cost ~224k input tokens, not 28k (#1889, the deliberate residue of #1842).

On top of the budget shape, the crate had grown **three independent elision spellings**: `exec::truncate_middle` (50/50 split, one marker format), `bash.rs`'s inline copy (50/50, a second marker format), and `custom.rs::truncate_middle_out` (40/60, the second marker format again). Three copies is the shape that lets one drift — and they already had, on both the split and the marker.

## Decision

**Head + tail elision through one shared helper, and a 64 KB cap.**

- **One spelling:** `exec::truncate_middle_capped(s, max_bytes)` is now the crate's single model-facing elision primitive. `exec::truncate_middle`, `bash`, and `custom` all cut through it; `custom.rs`'s private copy (and its boundary helpers) are deleted. It sits in `exec.rs` because that module already owns the output-cap policy for every other runner (`truncate_middle`, `CappedStream`, `truncate_preview`), and `exec.rs` is not a god file.
- **Split: 40% head / 60% tail.** Tail-biased because a failing command's densest signal is at the end — the final test summary, the last error, the exit status. This is lesson L-S3, already ratified in `custom.rs`; `bash` moves from 50/50 to match rather than the reverse, and the shared function makes future divergence structurally impossible. Both cuts land on UTF-8 char boundaries (the existing discipline of `truncate_preview` / the old inline code).
- **Marker names the elided byte count *and* the cap:** `[… N bytes truncated: output exceeded the 65536-byte cap; the head and tail are kept …]` — the model can account for every byte and knows the bound it is working under, mirroring `CappedStream`'s "say which cap did this" convention.
- **Cap: 100 KB → 64 KB (~12% of the compaction budget)** — the exact point #1842 ratified for `read_file` (400 KB → 64 KB, PR #1888), for the same multiplier argument. It stays the same order of magnitude and preserves #616's ratio argument: still 2.2x `exec::MAX_OUTPUT_BYTES` (30k), so the shell remains the agent's wide sensory channel while `read_output` pages stay cheap. `custom.rs` now **aliases** `bash`'s constant (`pub(crate) use`) instead of carrying a copy, so the two cannot drift.
- **Retention-aging is deliberately not here.** The issue's option (b) — aging an oversized result out of retention early — belongs to the engine's retention fold, tracked by #1819 (reclaimable-bytes gate) and the #1438 file-budget umbrella. This PR bounds the cost at the source; those bound what survives the horizon.

Exemplar for the consolidation shape: the crate's own `shell_quote`, which collapsed five drifting copies into one `exec.rs` primitive with a "a new one must be too" contract; this PR does the same for elision.

## Witness

`over_cap_output_keeps_first_and_last_lines_with_a_named_elision`, once per surface (`bash::tests`, `custom::tests`): a command/script emitting a first sentinel line, `MAX_OUTPUT_BYTES` of filler, and a last sentinel line yields a result containing **both sentinel lines**, a marker naming the **elided byte count** and the **cap**, bounded by the cap plus the marker. Every size is derived from the constant — nothing hard-codes a human-readable size, the assertion shape #1842 caught going stale.

Verified failing on the old code the artisanal way — both tests spliced onto the parent commit:

```
test bash::tests::over_cap_output_keeps_first_and_last_lines_with_a_named_elision ... FAILED
test custom::tests::over_cap_output_keeps_first_and_last_lines_with_a_named_elision ... FAILED
  panicked: 'the marker names the cap it enforced'
```

…and passing on this branch. `exec::tests` additionally pin the helper itself: the marker's elided count is arithmetically exact (derived, not hard-coded), tail budget ≥ head budget (L-S3), both cuts survive landing mid-multibyte-char, and at-or-below-cap input is byte-identical.

## Verification

- `cargo test -p stella-tools`: **723 passed** (lib) + all integration suites green, 0 failed.
- `cargo clippy -p stella-tools --all-targets -- -D warnings` clean; `cargo fmt -p stella-tools --check` clean.
- Workspace-wide validation left to CI per build economy (no public API changed; every touched item is `pub(crate)`).

Closes #1889

Refs #1842 #1819 #1438

## Summary by Sourcery

Unify and tighten stdout/stderr truncation across exec, bash, and custom tools to keep both the head and tail of oversized outputs under a smaller shared cap.

Bug Fixes:
- Ensure over-cap bash and custom tool output retains both the first and last lines instead of dropping the tail under some sizes.

Enhancements:
- Introduce a shared truncate_middle_capped helper in exec that performs UTF-8-safe, tail-biased head+tail elision with an explicit marker naming the elided byte count and cap.
- Reduce the bash/custom output cap from 100 KB to 64 KB to better bound transcript and compaction costs, while preserving the intended ratio to exec output limits.
- Alias custom tool output caps and elision behavior to bash so their output budgets and truncation semantics cannot drift apart.

Tests:
- Add unit tests for truncate_middle_capped to validate exact elided byte accounting, UTF-8 boundary safety, and no-op behavior at or below the cap.
- Add integration tests for bash and custom tools that verify over-cap outputs keep both sentinel lines, include a cap- and byte-count-bearing elision marker, and remain within the bounded size.