### PR TITLE
fix(stella-tui): a diff-less mutation no longer erases the diff before it (#1741)

### DIFF
--- a/crates/stella-tui/src/model/file_state.rs
+++ b/crates/stella-tui/src/model/file_state.rs
@@ -132,6 +132,39 @@ impl FileState {
     fn remembered_at(&self, seq: u32) -> Option<&RememberedDiff> {
         self.recent_diffs.iter().find(|d| d.seq == seq)
     }
+
+    /// The best diff this path can show, and whether it describes the path's
+    /// CURRENT state.
+    ///
+    /// `Some((text, true))` is [`Self::latest_diff`] — the most recent
+    /// mutation's own diff. `Some((text, false))` is the newest diff still
+    /// remembered, from an EARLIER mutation, and a caller that renders it owes
+    /// the reader that distinction.
+    ///
+    /// The fallback exists because a mutating `FileChange` may legitimately
+    /// carry `diff: None` while carrying counts: the pipeline's adoption
+    /// re-emit builds each change from `git diff --name-status`, then attaches
+    /// numstat and diff text in two independent calls, either of which can
+    /// fail. A path only the numstat named keeps `diff: None` on purpose
+    /// (`attach_diffs` would rather report nothing than misattribute a patch).
+    ///
+    /// Without this, such an event left the pane claiming `(no diff captured)`
+    /// for a file whose diff was sitting one field away in `recent_diffs`
+    /// (#1741). `latest_diff` keeps its documented meaning — the diff OF the
+    /// most recent mutation, `None` when that mutation brought none — rather
+    /// than being quietly widened to "the last diff we saw", which would have
+    /// put an older change's text under a newer change's counts with nothing
+    /// on screen to say so.
+    #[must_use]
+    pub fn best_diff(&self) -> Option<(&str, bool)> {
+        if let Some(current) = self.latest_diff.as_deref() {
+            return Some((current, true));
+        }
+        self.recent_diffs
+            .back()
+            .map(|d| (d.text.as_str(), false))
+            .filter(|(text, _)| !text.is_empty())
+    }
 }
 
 #[cfg(test)]
@@ -139,6 +172,53 @@ mod tests {
     use super::*;
     use crate::model::SessionModel;
     use stella_protocol::AgentEvent;
+
+    /// The model half of #1741: a mutation carrying no diff must not destroy
+    /// the one before it, and `best_diff` must say which mutation it is
+    /// handing back.
+    ///
+    /// `latest_diff` keeps its documented meaning — the diff OF the most
+    /// recent mutation, `None` when that mutation brought none. Widening it to
+    /// "the last diff we saw" would have fixed the blank pane by making the
+    /// field lie, which is how the pane ends up showing an older change's text
+    /// under a newer change's counts with nothing to mark it.
+    #[test]
+    fn a_diffless_mutation_leaves_the_previous_diff_reachable_and_marked_stale() {
+        let mut model = SessionModel::new();
+        let mutate = |diff: Option<String>, added: u32| AgentEvent::FileChange {
+            path: "src/a.rs".into(),
+            kind: FileChangeKind::Modified,
+            added,
+            removed: 0,
+            diff,
+        };
+
+        model.apply(&mutate(Some("@@\n+first".into()), 1));
+        let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+        assert_eq!(
+            file.best_diff(),
+            Some(("@@\n+first", true)),
+            "the only mutation's own diff is current"
+        );
+
+        // The adoption shape: mutating, real counts, no text.
+        model.apply(&mutate(None, 5));
+        let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+        assert_eq!(
+            file.latest_diff, None,
+            "the field stays honest — this mutation really brought no diff"
+        );
+        assert_eq!(
+            file.best_diff(),
+            Some(("@@\n+first", false)),
+            "but the earlier diff is still reachable, and flagged as earlier"
+        );
+        assert_eq!(
+            (file.added, file.removed),
+            (6, 0),
+            "counts stay cumulative and transported, never recounted from text"
+        );
+    }
 
     /// #803: the ledger holds at [`MAX_TRACKED_FILES`], evicting by recency
     /// (not insertion order) and counting what it dropped so the files panel

--- a/crates/stella-tui/src/views/files.rs
+++ b/crates/stella-tui/src/views/files.rs
@@ -300,8 +300,24 @@ fn render_diff_pane(
     // footer could disagree about one file.
     let (added, removed) = record.map(|r| (r.added, r.removed)).unwrap_or((0, 0));
     match diff_text {
-        Some(text) if !text.is_empty() => {
-            let lines = diff::body_lines(text, record.map(|r| r.path.as_str()));
+        Some((text, current)) if !text.is_empty() => {
+            let mut lines = diff::body_lines(text, record.map(|r| r.path.as_str()));
+            // Say so when this is an EARLIER mutation's diff. The most recent
+            // mutation can legitimately arrive without one (the adoption
+            // re-emit attaches numstat and diff text in separate calls, either
+            // of which can fail), and showing the previous diff under the
+            // footer's cumulative counts without a word would be the same
+            // quiet mismatch this pane already has too much of (#1741, #1740).
+            if !current {
+                lines.insert(
+                    0,
+                    Line::from(Span::styled(
+                        "(an earlier change to this file — the latest one \
+                         reported no diff)",
+                        theme::muted(),
+                    )),
+                );
+            }
             let total = lines.len();
             ui.metrics.files_diff_total = total;
             ui.metrics.files_diff_height = inner_h;
@@ -327,10 +343,10 @@ fn render_diff_pane(
 /// `SessionModel::files[].latest_diff` (`deck.rs` L-T5) — never re-derived.
 /// Borrowed, not cloned: this runs on every ~30 fps frame the diff pane is
 /// open, and a single mutation's diff can be hundreds of KiB.
-fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<&'a str> {
+fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<(&'a str, bool)> {
     let agent = model.agents.iter().find(|a| a.meta.id == rec.agent)?;
     let file = agent.model.files.iter().find(|f| f.path == rec.path)?;
-    file.latest_diff.as_deref()
+    file.best_diff()
 }
 
 #[cfg(test)]
@@ -427,6 +443,66 @@ mod tests {
         assert!(ui.metrics.files_diff_height > 0, "inner height recorded");
         let text = buffer_text(&buf);
         assert!(text.contains("new"), "expected diff body content:\n{text}");
+    }
+
+    /// **Witness.** A later mutation that carries no diff must not destroy the
+    /// diff an earlier one delivered (#1741).
+    ///
+    /// This is the second, independent route to `(no diff captured)` for a
+    /// file that has a diff. `touch_file`'s mutation arm assigned
+    /// `latest_diff = diff.clone()` unconditionally, so a mutating
+    /// `FileChange` carrying `diff: None` erased it — while `remember_diff`
+    /// early-returns on `None`, leaving the good text in `recent_diffs` one
+    /// field away, which `find_diff` never read.
+    ///
+    /// That event shape is reachable, not theoretical: the pipeline's adoption
+    /// re-emit builds each change from `git diff --name-status` and then
+    /// attaches numstat and diff text in two independent calls. A path only
+    /// the numstat named keeps `diff: None` deliberately — `attach_diffs`
+    /// would rather report nothing than misattribute a patch. So counts
+    /// arrive without text, and if a tool had already edited that path in
+    /// session, the good diff was destroyed rather than merely absent.
+    ///
+    /// Both halves are asserted. Showing the older diff silently would trade
+    /// this defect for #1740's — an earlier change's text under the footer's
+    /// cumulative counts, with nothing on screen to say which mutation it is.
+    #[test]
+    fn a_later_mutation_without_a_diff_does_not_erase_the_one_before_it() {
+        let mut model = sample_model();
+        // The adoption shape: mutating, real counts, no text.
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::FileChange {
+                path: "src/existing.rs".into(),
+                kind: FileChangeKind::Modified,
+                added: 5,
+                removed: 2,
+                diff: None,
+            },
+        });
+
+        let mut ui = DeckUi::default();
+        ui.files_sel = 1; // "existing.rs"
+        ui.files_diff_open = true;
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+
+        assert!(
+            !text.contains("no diff captured"),
+            "the earlier mutation's diff is still remembered, so the pane must \
+             not claim nothing was captured:\n{text}"
+        );
+        assert!(
+            text.contains("new"),
+            "and it must be that diff's actual body:\n{text}"
+        );
+        assert!(
+            text.contains("earlier change"),
+            "shown, but labelled — an older diff under the footer's cumulative \
+             counts with no note is the mismatch #1740 is about:\n{text}"
+        );
     }
 
     /// **Witness.** A `/clear` mid-session must not turn every diff pane into


### PR DESCRIPTION
## Problem

The **second, independent** route to `(no diff captured)` for a file that has a diff. (The first — `/clear` cutting the diff store while the ledger survived — was #1742.)

`touch_file`'s mutation arm assigned unconditionally:

```rust
existing.latest_diff = diff.clone();   // including None
```

So a mutating `FileChange` carrying `diff: None` **erased** what an earlier mutation delivered. `remember_diff` early-returns on `None`, so the good text stayed in `recent_diffs` — one field away from a `find_diff` that read `latest_diff` and nothing else.

On screen: a row with correct cumulative `+`/`-` counts beside a pane claiming nothing was captured, with the bytes sitting right there.

### The producer is real

The pipeline's adoption re-emit builds each `AdoptedChange` from `git diff --name-status`, then attaches numstat and diff text in **two independent calls** — either can fail. A path only the numstat named keeps `diff: None` *deliberately* (`attach_diffs` would rather report nothing than misattribute a patch — see `a_path_the_patch_never_described_stays_uncounted_not_misattributed`).

So counts arrive without text, and if a tool had already edited that path in-session, the good diff was **destroyed** rather than merely absent.

## Option 2, not option 1

The issue offers both and calls the trade-off out. Option 1 — make `touch_file` skip the assignment — is one line, but it widens `latest_diff` from *"the diff **of** the most recent mutation"* to *"the last diff we saw"*. The pane would then show an older change's text under a newer change's cumulative counts, still with nothing to say so. **That trades this defect for #1740's.**

So the field keeps its documented meaning and the fallback lives where it can be honest:

- `FileState::best_diff() -> Option<(&str, bool)>` — the bool is *is this the current mutation's*.
- The pane renders a muted note above an earlier mutation's diff.

One diff store, no second data path (L-T5). Counts stay transported, never recounted from text.

## Witness

Both fail on the old code, reproducing the exact reported symptom:

```
test model::file_state::tests::a_diffless_mutation_leaves_the_previous_diff_reachable_and_marked_stale ... FAILED
test views::files::tests::a_later_mutation_without_a_diff_does_not_erase_the_one_before_it ... FAILED
assertion `left == right` failed: but the earlier diff is still reachable, and flagged as earlier
(no diff captured)
```

- **View half** — folds `Some(diff)` then the adoption shape (mutating, real counts, no text) and asserts three things: the pane does not say `(no diff captured)`, it shows that diff's *actual body*, and it is **labelled**. That third assertion is what stops this fix from becoming #1740.
- **Model half** — `latest_diff` stays `None` (the field is honest) while `best_diff` hands back the earlier text flagged as earlier, and the counts stay cumulative at `(6, 0)`.

```
$ cargo test -p stella-tui
test result: ok. 831 passed; 0 failed
```

Deck golden frames included and none needed re-blessing: the note only appears on a pane that previously rendered nothing, which no golden covered.

`cargo clippy -p stella-tui --all-targets -- -D warnings` and `cargo fmt --check` clean.

Closes #1741
Refs #1740, #1742

## Summary by Sourcery

Preserve previously captured diffs when a subsequent mutation arrives without diff text, and surface that earlier diff in the UI while clearly marking it as stale.

Bug Fixes:
- Ensure a later file mutation that lacks a diff no longer erases an earlier, valid diff for the same file.
- Prevent the diff pane from claiming no diff was captured when an earlier diff is still available for the file.

Enhancements:
- Introduce FileState::best_diff to choose between the current mutation’s diff and the most recent remembered diff, indicating when the latter is stale.
- Update the diff pane to display a muted notice when showing an earlier mutation’s diff under the latest cumulative counts.

Tests:
- Add model tests to verify that a diff-less mutation leaves the previous diff reachable and flagged as stale while counts remain cumulative.
- Add view tests asserting that the diff pane shows the earlier diff body with a clear label instead of reporting that no diff was captured.