### PR TITLE
feat(stella-core): detect a repeated call that other work is interleaved with (#1851)

### DIFF
--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -74,6 +74,14 @@ pub(super) fn check_loop_detection(
             *repeats,
         ),
         LoopVerdict::Stagnant { tool, count } => ("stagnation", vec![tool.clone()], *count),
+        // A distinct `kind` rather than folding into `exact_repeat`: a
+        // receipt reading these should be able to tell "the same call three
+        // times in a row" from "three times with other work between them",
+        // because they are different pathologies and the second is the one
+        // no contiguous scan can see (#1851).
+        LoopVerdict::InterleavedRepeat { tool, count, .. } => {
+            ("interleaved_repeat", vec![tool.clone()], *count)
+        }
     };
     let evidence = verdict
         .evidence()

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -2007,6 +2007,7 @@ async fn period_three_cycle_with_no_progress_steers_then_aborts() {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 2,
             stagnation_threshold: 0, // disabled: this test isolates the cycle check
+            interleaved_repeat_threshold: 0, // likewise (#1851)
         },
         ..EngineConfig::default()
     };

--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -9,8 +9,10 @@
 //! drives) a real, typed verdict it can act on early: steer or abort with
 //! a clear reason instead of grinding to the cap.
 //!
-//! Three failure modes are detected, matching real agent stuck-loop
-//! signatures:
+//! Four failure modes are detected, matching real agent stuck-loop
+//! signatures. The first three read a **contiguous suffix** and reset at the
+//! first mismatch; the fourth exists because that is a blind spot they all
+//! share (#1851):
 //!
 //! 1. **Exact repeat** — the same tool called with byte-identical input,
 //!    over and over (`read_file` on the same path, `bash` re-running the
@@ -31,6 +33,16 @@
 //!    reshuffling (`a|b|c|a|b` → `a|b|c|a`), 38 consecutive calls returning
 //!    the same 906 bytes. Varying the arguments is not progress; learning
 //!    something is, and byte-identical output proves nothing was learned.
+//! 4. **Interleaved repeat** — one identical call (same tool, same input,
+//!    same output) recurring across the window with *other work in between*.
+//!    Invisible to all three above precisely because they read a contiguous
+//!    suffix: an agent alternating a failing `cargo test` with a varying
+//!    `read_file` has period 2 with one varying element, so every one of them
+//!    resets at offset 1 and the turn spins to `max_steps` unsteered. This is
+//!    the shape a real wedge takes — re-run the failing test, peek at a
+//!    different file, repeat. It is guarded by `window_is_progressing` so it
+//!    cannot fire on correct polling, where a repeating spacer sits beside a
+//!    query that IS answering differently each round.
 //!
 //! **Progress is part of the loop definition.** A repeat or cycle only
 //! counts when the *outputs* are byte-identical too: identical input with
@@ -131,6 +143,17 @@ pub struct LoopDetectionConfig {
     /// detector will speak. Six consecutive searches that each came back
     /// with the same bytes is a model turning knobs, not one exploring.
     pub stagnation_threshold: usize,
+    /// Occurrences of one identical call — same tool, same input, same output
+    /// — anywhere in the window, required to flag an interleaved repeat.
+    /// `0` or `1` disable the check.
+    ///
+    /// Equal to [`Self::exact_repeat_threshold`], not looser, and that is the
+    /// point. Each occurrence is exactly as strong as an exact repeat's: the
+    /// same call producing the same result taught the model nothing, whether
+    /// or not something else happened in between. Interleaving does not
+    /// weaken the evidence — it only hides it from a scan that reads a
+    /// contiguous suffix, which is what every other check here does.
+    pub interleaved_repeat_threshold: usize,
 }
 
 impl Default for LoopDetectionConfig {
@@ -153,6 +176,7 @@ impl Default for LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 3,
             stagnation_threshold: 6,
+            interleaved_repeat_threshold: 3,
         }
     }
 }
@@ -196,6 +220,22 @@ pub enum LoopVerdict {
     /// no claim about the *shape* of the repetition, only that the tool
     /// stopped being informative.
     Stagnant { tool: String, count: usize },
+    /// One identical call — same tool, same input, byte-identical output —
+    /// recurring across the window with other work in between.
+    ///
+    /// The shape every other check here is blind to, because they all read a
+    /// contiguous suffix and reset at the first mismatch. An agent
+    /// alternating a failing `cargo test` with a varying `read_file` has
+    /// period 2 with one varying element: exact-repeat resets at offset 1,
+    /// short-cycle breaks on the mismatched element, stagnation's run ends
+    /// there too — and the turn spins to `max_steps` unsteered. That is what
+    /// a real wedge looks like: re-run the failing test, peek at a different
+    /// file, repeat (#1851).
+    InterleavedRepeat {
+        tool: String,
+        input: serde_json::Value,
+        count: usize,
+    },
 }
 
 impl LoopVerdict {
@@ -237,6 +277,14 @@ impl LoopVerdict {
                  returned byte-identical output — varying the arguments is not learning \
                  anything, so this tool has nothing left to tell you here"
             )),
+            LoopVerdict::InterleavedRepeat { tool, input, count } => Some(format!(
+                "the same `{tool}` call with identical arguments has run {count} times in \
+                 this turn — not consecutively, but with other work in between — and \
+                 returned byte-identical output every time. The calls between it are not \
+                 making it say anything new, so repeating it cannot be what unblocks you \
+                 (input: {})",
+                truncate(&input.to_string(), MAX_DESCRIBED_INPUT)
+            )),
         }
     }
 
@@ -263,6 +311,15 @@ impl LoopVerdict {
             LoopVerdict::Stagnant { tool, .. } => Some(LoopIdentity {
                 tools: vec![tool.clone()],
                 inputs: Some(Vec::new()),
+            }),
+            // Same identity shape as an exact repeat, and deliberately so: it
+            // is the same loop, seen through a scan that tolerates gaps. A
+            // turn that steers on the interleaved rung and then trips the
+            // contiguous one must be recognised as the SAME loop, or the
+            // escalation ladder would restart and steer twice for one wedge.
+            LoopVerdict::InterleavedRepeat { tool, input, .. } => Some(LoopIdentity {
+                tools: vec![tool.clone()],
+                inputs: Some(vec![input.to_string()]),
             }),
         }
     }
@@ -422,10 +479,84 @@ pub fn detect_loop(records: &[CallRecord<'_>], config: LoopDetectionConfig) -> L
     if let Some(verdict) = detect_short_cycle(records, config.short_cycle_repeats) {
         return verdict;
     }
+    if let Some(verdict) = detect_interleaved_repeat(records, config.interleaved_repeat_threshold) {
+        return verdict;
+    }
     if let Some(verdict) = detect_stagnation(records, config.stagnation_threshold) {
         return verdict;
     }
     LoopVerdict::NoLoop
+}
+
+/// Count occurrences of the last record ANYWHERE in the window — not only in
+/// a trailing run — and report `InterleavedRepeat` if that count is
+/// `>= threshold`. `threshold < 2` and empty `records` both return `None`.
+///
+/// The one check here that does not read a contiguous suffix, which is the
+/// whole reason it exists: every other detector resets at the first mismatch,
+/// so a single interleaved call blinds all three (#1851).
+///
+/// Placed AFTER exact-repeat and short-cycle and BEFORE stagnation, which is
+/// the same "tightest description of the evidence wins" ordering the rest of
+/// `detect_loop` follows. A contiguous run is already an exact repeat and is
+/// reported as one; this claims strictly more than stagnation (identical
+/// input AND output, versus same tool and output with the arguments moving),
+/// so it would be swallowed if stagnation ran first.
+///
+/// `same_record` carries the unresolved-output rule, so a trailing call whose
+/// result is not in the window counts zero and never fires — a loop is only
+/// ever PROVEN by observed outputs.
+fn detect_interleaved_repeat(records: &[CallRecord<'_>], threshold: usize) -> Option<LoopVerdict> {
+    if threshold < 2 {
+        return None;
+    }
+    let last = records.last()?;
+    let count = records
+        .iter()
+        .filter(|record| same_record(record, last))
+        .count();
+    if count < threshold {
+        return None;
+    }
+    if window_is_progressing(records) {
+        return None;
+    }
+    Some(LoopVerdict::InterleavedRepeat {
+        tool: last.call.name.clone(),
+        input: last.call.input.clone(),
+        count,
+    })
+}
+
+/// Whether anything in this window is producing NEW information: the same
+/// query, asked twice, answering differently.
+///
+/// This is the guard that keeps the gap-tolerant rung from steering a working
+/// agent, and it is not hypothetical — the existing suite caught the shape.
+/// Correct polling alternates `read_output` (same handle, new bytes every
+/// time) with `bash sleep 5` (same command, empty output every time). The
+/// sleep is a SPACER: it repeats identically by design, so counting its
+/// occurrences flags a turn that is streaming a build log perfectly well.
+///
+/// The discriminator is not "did anything repeat" but "did any repeated query
+/// answer differently". A `read_output` whose bytes change is a turn learning
+/// something; a `read_file` on a *different* path each round is not the same
+/// query at all, and so is not evidence of progress — which is exactly why
+/// the wedge shape (re-run the failing test, peek at a different file) still
+/// trips the rung.
+///
+/// O(n²) over a window of a few dozen records, which is what
+/// [`detect_loop`]'s contract already assumes callers hand in.
+fn window_is_progressing(records: &[CallRecord<'_>]) -> bool {
+    records.iter().enumerate().any(|(i, a)| {
+        records[i + 1..].iter().any(|b| {
+            a.call.name == b.call.name
+                && a.call.input == b.call.input
+                && a.output.is_some()
+                && b.output.is_some()
+                && !same_output(a, b)
+        })
+    })
 }
 
 /// Count the trailing run of records identical (by [`same_record`]) to the

--- a/crates/stella-core/src/loop_detect/tests.rs
+++ b/crates/stella-core/src/loop_detect/tests.rs
@@ -82,7 +82,9 @@ fn history_shorter_than_exact_repeat_threshold_is_not_a_loop() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100, // disable short-cycle for this test
-        stagnation_threshold: 0,  // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -93,7 +95,9 @@ fn exact_repeat_at_threshold_is_detected() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     let verdict = detect_loop(&records, config);
     assert_eq!(
@@ -115,7 +119,9 @@ fn exact_repeat_above_threshold_reports_full_count() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     match detect_loop(&records, config) {
         LoopVerdict::ExactRepeat { count, .. } => assert_eq!(count, 5),
@@ -166,7 +172,9 @@ fn different_arguments_to_the_same_tool_is_not_a_loop() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -184,7 +192,9 @@ fn call_id_is_ignored_when_comparing_calls() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert!(detect_loop(&records, config).is_loop());
 }
@@ -212,7 +222,9 @@ fn matching_identities_outrank_outputs_rewritten_since() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert!(
         detect_loop(&records, config).is_loop(),
@@ -239,7 +251,9 @@ fn differing_identities_outrank_outputs_collapsed_since() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -258,7 +272,9 @@ fn an_identity_never_resurrects_an_unresolved_output() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -276,7 +292,9 @@ fn one_sided_identity_falls_back_to_comparing_outputs() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 3,
         short_cycle_repeats: 100,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert!(detect_loop(&records, config).is_loop());
 }
@@ -288,7 +306,9 @@ fn short_cycle_below_threshold_is_not_a_loop() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100, // disable exact-repeat for this test
         short_cycle_repeats: 3,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -308,7 +328,9 @@ fn short_cycle_at_threshold_is_detected() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 3,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     let verdict = detect_loop(&records, config);
     match &verdict {
@@ -332,7 +354,9 @@ fn short_cycle_above_threshold_reports_full_repeat_count() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 3,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     match detect_loop(&records, config) {
         LoopVerdict::ShortCycle { repeats, .. } => assert_eq!(repeats, 5),
@@ -379,7 +403,9 @@ fn period_three_cycle_with_identical_outputs_is_detected() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 3,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     let verdict = detect_loop(&records, config);
     match &verdict {
@@ -412,7 +438,9 @@ fn period_three_cycle_with_differing_outputs_is_not_a_loop() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 2,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -435,7 +463,9 @@ fn period_four_cycle_with_identical_outputs_is_detected() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 2,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     match detect_loop(&records, config) {
         LoopVerdict::ShortCycle { pattern, repeats } => {
@@ -467,7 +497,9 @@ fn period_five_cycle_is_beyond_the_detector() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 100,
         short_cycle_repeats: 2,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -482,7 +514,9 @@ fn identical_calls_repeated_are_not_misreported_as_a_short_cycle() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 0, // disabled
         short_cycle_repeats: 1,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -574,8 +608,10 @@ fn zero_or_one_exact_repeat_threshold_disables_that_check() {
     for threshold in [0, 1] {
         let config = LoopDetectionConfig {
             exact_repeat_threshold: threshold,
-            short_cycle_repeats: 0,  // also disabled, so overall NoLoop
-            stagnation_threshold: 0, // ditto
+            short_cycle_repeats: 0, // also disabled, so overall NoLoop
+            stagnation_threshold: 0,
+            // Disabled: this case isolates another detector (#1851).
+            interleaved_repeat_threshold: 0, // ditto
         };
         assert_eq!(
             detect_loop(&records, config),
@@ -598,7 +634,9 @@ fn zero_short_cycle_repeats_disables_that_check() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: 0,
         short_cycle_repeats: 0,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -612,7 +650,9 @@ fn pathological_thresholds_do_not_overflow_the_cycle_arithmetic() {
     let config = LoopDetectionConfig {
         exact_repeat_threshold: usize::MAX,
         short_cycle_repeats: usize::MAX,
-        stagnation_threshold: 0, // disabled: this test isolates another check
+        stagnation_threshold: 0,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0, // disabled: this test isolates another check
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -819,6 +859,8 @@ fn identical_calls_are_reported_as_an_exact_repeat_not_stagnation() {
         exact_repeat_threshold: 0,
         short_cycle_repeats: 0,
         stagnation_threshold: 3,
+        // Disabled: this case isolates another detector (#1851).
+        interleaved_repeat_threshold: 0,
     };
     assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
 }
@@ -844,6 +886,8 @@ fn zero_or_one_stagnation_threshold_disables_that_check() {
             exact_repeat_threshold: 0,
             short_cycle_repeats: 0,
             stagnation_threshold: threshold,
+            // Disabled: this case isolates another detector (#1851).
+            interleaved_repeat_threshold: 0,
         };
         assert_eq!(
             detect_loop(&records, config),
@@ -917,7 +961,7 @@ proptest! {
         short_cycle_repeats in 0usize..8,
         stagnation_threshold in 0usize..8,
     ) {
-        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
+        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold: 0 };
         let verdict = detect_loop(&records, config);
         // Whatever the verdict, `is_loop`/`evidence` must not panic either.
         let _ = verdict.is_loop();
@@ -938,7 +982,7 @@ proptest! {
             && records.len() < 2 * short_cycle_repeats
             && records.len() < stagnation_threshold
         {
-            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
+            let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold: 0 };
             prop_assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
         }
     }
@@ -964,7 +1008,193 @@ proptest! {
                 record
             })
             .collect();
-        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold };
+        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold: 0 };
         prop_assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
     }
+}
+
+// ---- interleaved repeat: the shape a contiguous scan cannot see ---------
+
+/// **Witness (#1851).** A-B-A-B-A, where A is identical every time and B
+/// varies, is a wedge that every contiguous scan misses.
+///
+/// This is what a real stall looks like: re-run the failing test, peek at a
+/// different file, repeat. Exact-repeat's `take_while` resets at offset 1,
+/// short-cycle breaks on the differing element, and stagnation's trailing run
+/// ends there too — so before this rung the turn spun to `max_steps` with no
+/// steer at all.
+#[test]
+fn an_identical_call_interleaved_with_varying_work_is_a_loop() {
+    let failing = || {
+        record(
+            "bash",
+            serde_json::json!({ "command": "cargo test" }),
+            Some(ToolOutput::Error {
+                message: "1 failed".into(),
+            }),
+        )
+    };
+    // Each `read` names a DIFFERENT file, so the interleaved element genuinely
+    // varies — nothing here is a contiguous run of anything.
+    let records = vec![failing(), read("a.rs"), failing(), read("b.rs"), failing()];
+
+    let contiguous_only = LoopDetectionConfig {
+        exact_repeat_threshold: 3,
+        short_cycle_repeats: 3,
+        stagnation_threshold: 6,
+        interleaved_repeat_threshold: 0, // the old behaviour
+    };
+    assert_eq!(
+        detect_loop(&records, contiguous_only),
+        LoopVerdict::NoLoop,
+        "precondition: every contiguous detector is blind to this"
+    );
+
+    let with_rung = LoopDetectionConfig {
+        interleaved_repeat_threshold: 3,
+        ..contiguous_only
+    };
+    match detect_loop(&records, with_rung) {
+        LoopVerdict::InterleavedRepeat { tool, count, .. } => {
+            assert_eq!(tool, "bash");
+            assert_eq!(count, 3, "all three occurrences counted, gaps included");
+        }
+        other => panic!("expected an interleaved repeat, got {other:?}"),
+    }
+}
+
+/// The other direction, and the one that decides whether this rung is safe to
+/// enable: an interleave that is genuinely PROGRESSING must stay silent.
+///
+/// Same A-B-A-B-A shape, same tool, same arguments — but A's output changes
+/// each round, which is exactly what "the test is now failing differently"
+/// looks like. A detector that fired here would steer an agent that is
+/// working.
+#[test]
+fn an_interleave_whose_results_keep_changing_is_not_a_loop() {
+    let attempt = |n: u32| {
+        record(
+            "bash",
+            serde_json::json!({ "command": "cargo test" }),
+            Some(ToolOutput::Error {
+                message: format!("{n} failed"),
+            }),
+        )
+    };
+    let records = vec![
+        attempt(3),
+        read("a.rs"),
+        attempt(2),
+        read("b.rs"),
+        attempt(1),
+    ];
+
+    let config = LoopDetectionConfig {
+        exact_repeat_threshold: 3,
+        short_cycle_repeats: 3,
+        stagnation_threshold: 6,
+        interleaved_repeat_threshold: 3,
+    };
+    assert_eq!(
+        detect_loop(&records, config),
+        LoopVerdict::NoLoop,
+        "shrinking failures are progress, not a loop"
+    );
+}
+
+/// A contiguous run is still reported as an EXACT repeat, not as the weaker
+/// gap-tolerant claim — the "tightest description of the evidence wins"
+/// ordering the rest of `detect_loop` follows.
+#[test]
+fn a_contiguous_run_still_reports_as_an_exact_repeat() {
+    let records = vec![read("a.rs"), read("a.rs"), read("a.rs")];
+    let config = LoopDetectionConfig {
+        exact_repeat_threshold: 3,
+        short_cycle_repeats: 100,
+        stagnation_threshold: 0,
+        interleaved_repeat_threshold: 3,
+    };
+    assert!(
+        matches!(
+            detect_loop(&records, config),
+            LoopVerdict::ExactRepeat { .. }
+        ),
+        "an exact repeat must not be demoted to the gap-tolerant verdict"
+    );
+}
+
+/// An unresolved trailing output proves nothing, here as everywhere else: a
+/// loop is only ever established by outputs that were actually observed.
+#[test]
+fn an_unresolved_output_never_trips_the_interleaved_rung() {
+    let records = vec![
+        read("a.rs"),
+        read("b.rs"),
+        read("a.rs"),
+        read("b.rs"),
+        record("read_file", serde_json::json!({ "path": "a.rs" }), None),
+    ];
+    let config = LoopDetectionConfig {
+        exact_repeat_threshold: 0,
+        short_cycle_repeats: 0,
+        stagnation_threshold: 0,
+        interleaved_repeat_threshold: 2,
+    };
+    assert_eq!(detect_loop(&records, config), LoopVerdict::NoLoop);
+}
+
+/// The identity of an interleaved repeat must equal the identity of the same
+/// loop seen contiguously, or the escalation ladder would treat one wedge as
+/// two and steer twice for it.
+#[test]
+fn the_interleaved_and_contiguous_verdicts_share_one_identity() {
+    let interleaved = LoopVerdict::InterleavedRepeat {
+        tool: "bash".into(),
+        input: serde_json::json!({ "command": "cargo test" }),
+        count: 3,
+    };
+    let contiguous = LoopVerdict::ExactRepeat {
+        tool: "bash".into(),
+        input: serde_json::json!({ "command": "cargo test" }),
+        count: 3,
+    };
+    assert_eq!(interleaved.identity(), contiguous.identity());
+}
+
+/// The false positive this rung shipped with, and the reason
+/// `window_is_progressing` exists.
+///
+/// Correct polling alternates `read_output` (same handle, NEW bytes each
+/// time) with `bash sleep 5` (same command, empty output every time). The
+/// sleep is a spacer: it repeats identically by design. Counting its
+/// occurrences flagged a turn that was streaming a build log perfectly well —
+/// caught by `two_distinct_calls_alternating_with_changing_outputs_is_not_a_loop`
+/// on the first cut of this detector.
+///
+/// Asserted here on its own, with only the interleaved rung enabled, so a
+/// future change cannot re-introduce it and pass by having some other
+/// detector answer first.
+#[test]
+fn a_repeating_spacer_beside_a_streaming_poll_is_not_a_loop() {
+    let mut records = Vec::new();
+    for i in 0..6 {
+        records.push(call(
+            "read_output",
+            serde_json::json!({ "handle": "proc-5" }),
+            &format!("[{i}s] compiling..."),
+        ));
+        records.push(call("bash", serde_json::json!({ "cmd": "sleep 5" }), ""));
+    }
+    let only_the_new_rung = LoopDetectionConfig {
+        exact_repeat_threshold: 0,
+        short_cycle_repeats: 0,
+        stagnation_threshold: 0,
+        interleaved_repeat_threshold: 3,
+    };
+    assert_eq!(
+        detect_loop(&records, only_the_new_rung),
+        LoopVerdict::NoLoop,
+        "the sleep repeats identically six times, but read_output is \
+         answering differently every round — the turn is making progress"
+    );
 }

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,11 +17,11 @@
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2269 crates/stella-cli/src/agent.rs
 1751 crates/stella-cli/src/agent/tests.rs
-4691 crates/stella-cli/src/command_deck.rs
+4647 crates/stella-cli/src/command_deck.rs
 1504 crates/stella-cli/src/fleet_cmd.rs
 2129 crates/stella-core/src/bus.rs
-2580 crates/stella-core/src/driver.rs
-3680 crates/stella-core/src/driver/tests.rs
+2568 crates/stella-core/src/driver.rs
+3681 crates/stella-core/src/driver/tests.rs
 1780 crates/stella-model/src/anthropic/tests.rs
 2093 crates/stella-model/src/openai.rs
 1565 crates/stella-model/src/zai.rs
@@ -33,7 +33,7 @@
 2268 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1569 crates/stella-tools/src/media.rs
-2184 crates/stella-tools/src/registry.rs
+2182 crates/stella-tools/src/registry.rs
 1839 crates/stella-tools/src/scripts.rs
 1531 crates/stella-tui/src/deck_render.rs
 4006 crates/stella-tui/src/deck_ui.rs


### PR DESCRIPTION
## Problem

All three existing detectors read a **contiguous suffix** and reset at the first mismatch — `detect_exact_repeat`'s `take_while`, `detect_short_cycle`'s break, `detect_stagnation`'s trailing run. **One interleaved call blinds all three at once.**

An agent alternating a failing `cargo test` (identical output every round) with a varying `read_file` has period 2 with one varying element. Every detector resets at offset 1 and the turn spins to `max_steps` with **no steer at all**.

That is what a real wedge looks like: re-run the failing test, peek at a different file, repeat.

## Change

A fourth rung, not a redesign. Count occurrences of the last record **anywhere** in the window; report `InterleavedRepeat` at `interleaved_repeat_threshold` (default 3).

The threshold **equals** `exact_repeat_threshold` rather than being looser, and that is the argument: each occurrence is exactly as strong as an exact repeat's — the same call producing the same result taught the model nothing, whether or not something happened in between. Interleaving does not weaken the evidence; it only hides it from a contiguous scan.

Ordered after exact-repeat and short-cycle, **before** stagnation — the existing "tightest description of the evidence wins" rule. A contiguous run is still an exact repeat; this claims strictly more than stagnation (identical input *and* output, versus same tool and output with the arguments moving), so it would be swallowed if stagnation ran first.

## The false positive it shipped with

Worth reading, because the existing suite caught it immediately — which is what a good suite is for.

`two_distinct_calls_alternating_with_changing_outputs_is_not_a_loop` is **correct polling**: `read_output` (same handle, *new* bytes each round) alternating with `bash sleep 5` (same command, empty output each round). The sleep is a **spacer** — it repeats identically by design — so counting its occurrences flagged a turn that was streaming a build log perfectly well.

`window_is_progressing` is the discriminator, and the rule is not *"did anything repeat"* but **"did any repeated query answer differently"**. A `read_output` whose bytes change is a turn learning something; a `read_file` on a different path each round is not the same query at all — which is exactly why the wedge shape still trips the rung.

## Witnesses

| test | what it pins |
|---|---|
| `an_identical_call_interleaved_with_varying_work_is_a_loop` | the issue's shape — asserts the **precondition** first (every contiguous detector returns `NoLoop`), then that the rung fires and counts all three occurrences across the gaps |
| `an_interleave_whose_results_keep_changing_is_not_a_loop` | shrinking failure counts are progress |
| `a_repeating_spacer_beside_a_streaming_poll_is_not_a_loop` | the false positive above, pinned **on its own with only this rung enabled**, so a future change cannot reintroduce it and pass by having another detector answer first |
| `a_contiguous_run_still_reports_as_an_exact_repeat` | the ordering |
| `an_unresolved_output_never_trips_the_interleaved_rung` | a loop is only ever proven by observed outputs |
| `the_interleaved_and_contiguous_verdicts_share_one_identity` | the same wedge through both scans is **one** loop to the escalation ladder, or it would steer twice for it |

Existing cases each isolate one detector, so the new field is `0` in all of them — adding a rung must not silently change what they assert.

```
$ cargo test -p stella-core
test result: ok. 1008 passed; 0 failed
```

Clippy, `cargo fmt --check`, `check-file-size`, `check-god-files`, `check-left-behind` all clean.

## The one baseline line

`driver/tests.rs` grows by one line — the new required field in an existing config literal, inside an already-oversized file. Irreducible (there is no way to add a struct field without a line), so the baseline moves by 1 as a reviewable diff.

The same regeneration **tightens three ceilings** that had fallen on main and nobody had banked: `command_deck.rs` 4691→4647, `driver.rs` 2580→2568, `registry.rs` 2184→2182.

## Consequence path

Per the escalation ladder, a first detection **steers**; it does not abort. So the cost of a false positive here is one nudge, which is why the guard above matters more than the threshold does.

Closes #1851

## Summary by Sourcery

Add an interleaved-repeat loop detector to catch repeated calls separated by other work and integrate it into the loop detection pipeline and driver escalation, with tests and config updates to preserve existing detector isolation.

New Features:
- Introduce an interleaved-repeat loop detection mode that counts repeated identical calls across a window even when interleaved with other work.
- Expose an interleaved_repeat_threshold setting in LoopDetectionConfig with a default aligned to the exact repeat threshold.
- Add a new InterleavedRepeat verdict type with a distinct identity and human-readable explanation, and surface it as a separate kind in loop escalation receipts.

Enhancements:
- Document the new interleaved-repeat detector and its position relative to existing exact-repeat, short-cycle, and stagnation checks in the loop detection module.
- Guard the interleaved-repeat detector with a window_is_progressing heuristic to avoid steering on correct polling patterns that are still making progress.

Tests:
- Extend existing loop detection tests and property-based tests to set the new interleaved_repeat_threshold explicitly so they continue to isolate other detectors.
- Add targeted tests that validate detection of interleaved repeats, ensure progressing interleaves and unresolved outputs do not trigger, and check that interleaved and contiguous verdicts share the same identity.
- Add a driver-level test configuration update to keep loop escalation behavior focused on the intended detector in existing scenarios.

Chores:
- Update the file-size baseline to account for growth and minor reductions in several core files due to the new detector implementation.