### PR TITLE
fix(stella-pipeline): unbreak main — four sites the Spend refactor missed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.6.126"
+version = "0.6.127"
 
 [[package]]
 name = "stella-engine"

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -337,7 +337,7 @@ impl<'a> Pipeline<'a> {
             TurnOutcome::Aborted {
                 reason, cost_usd, ..
             } => {
-                *total += cost_usd;
+                *spend.total += cost_usd;
                 // A budget stop here is degradable too (#1789): the worker's
                 // change is already complete in the candidate, and discarding
                 // it because the SCAFFOLDING ran out of money threw away real
@@ -346,7 +346,7 @@ impl<'a> Pipeline<'a> {
                 // the next unaffordable call; what degrading buys is the
                 // deterministically-resolvable endings (a warranted waiver,
                 // an abstention) that need no further model spend at all.
-                if let Some(abort) = budget_abort(budget.evaluate()) {
+                if let Some(abort) = budget_abort(spend.budget.evaluate()) {
                     return Err(WitnessAbort::degradable(format!(
                         "witness authoring stopped by the budget ({}); the executed change \
                          stands unproven",
@@ -433,10 +433,10 @@ impl<'a> Pipeline<'a> {
                 TurnOutcome::Aborted {
                     reason, cost_usd, ..
                 } => {
-                    *total += cost_usd;
+                    *spend.total += cost_usd;
                     // Degradable for the same #1789 reason as the author
                     // turn's budget arm above.
-                    if let Some(abort) = budget_abort(budget.evaluate()) {
+                    if let Some(abort) = budget_abort(spend.budget.evaluate()) {
                         return Err(WitnessAbort::degradable(format!(
                             "witness repair stopped by the budget ({}); the executed change \
                              stands unproven",


### PR DESCRIPTION
## `main` does not compile

```
$ git checkout origin/main && cargo check -p stella-pipeline
error[E0425]: cannot find value `total` in this scope
   --> crates/stella-pipeline/src/pipeline/witness_stage.rs:340:18
error[E0425]: cannot find value `budget` in this scope
   --> crates/stella-pipeline/src/pipeline/witness_stage.rs:349:51
error[E0425]: cannot find value `total` in this scope   (:436)
error[E0425]: cannot find value `budget` in this scope  (:439)
error: could not compile `stella-pipeline` (lib) due to 4 previous errors
```

## What happened

A partially-applied refactor. The author and repair turns now take a `spend: &mut Spend<'_>`, and most sites were updated — line 334 already reads `*spend.total += cost_usd` — but the **`Aborted` arm of each of the two turns** kept the old bare names.

Both are on the budget-abort path, which no happy path reaches. So nothing local to the change exercised them, and the crate simply stopped building.

## Fix

Four one-word changes: `total` → `spend.total`, `budget` → `spend.budget`. **No behaviour change** — this is the code the refactor intended, spelled the way the refactor spells it everywhere else in the same function.

```
$ cargo test -p stella-pipeline
test result: ok. 562 passed; 0 failed
```

`cargo clippy -p stella-pipeline --all-targets -- -D warnings` and `cargo fmt --check` clean.

No witness test: the compiler is the check. It fails on `main` and passes here.

## Context

This is the **sixth red-`main` event today**. It is also the second where the required contexts could not have caught it in time — GitHub Actions stopped registering PR runs at ~11:38 UTC (#1899), so PRs have been merging without their gate reporting at all. That combination is #1645's failure mode with the safety net removed.

Refs #1645, #1899, #1789

## Summary by Sourcery

Bug Fixes:
- Resolve compilation failures in stella-pipeline witness_stage by referencing spend.total and spend.budget instead of undefined total and budget locals in abort paths.