### PR TITLE
fix(stella-pipeline,make): unbreak main — witness-stage merge clobber and a duplicate Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,10 +344,6 @@ releases-baseline-update: ## Grandfather the tags that shipped nothing and never
 releases-published-test: ## Test the tag/release reconciliation rule (hermetic; not part of `gate`)
 	./scripts/test-releases-published.sh
 
-.PHONY: guard-sigpipe-test
-guard-sigpipe-test: ## Test that the gate guards survive a reader that closes their pipe early (#1815; hermetic; not part of `gate`)
-	./scripts/test-guard-sigpipe.sh
-
 .PHONY: hooks
 hooks: ## Install the pre-push gate hook (runs `make gate`, scoped to the diff, on every push)
 	git config core.hooksPath .githooks

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -337,7 +337,7 @@ impl<'a> Pipeline<'a> {
             TurnOutcome::Aborted {
                 reason, cost_usd, ..
             } => {
-                *total += cost_usd;
+                *spend.total += cost_usd;
                 // A budget stop here is degradable too (#1789): the worker's
                 // change is already complete in the candidate, and discarding
                 // it because the SCAFFOLDING ran out of money threw away real
@@ -346,7 +346,7 @@ impl<'a> Pipeline<'a> {
                 // the next unaffordable call; what degrading buys is the
                 // deterministically-resolvable endings (a warranted waiver,
                 // an abstention) that need no further model spend at all.
-                if let Some(abort) = budget_abort(budget.evaluate()) {
+                if let Some(abort) = budget_abort(spend.budget.evaluate()) {
                     return Err(WitnessAbort::degradable(format!(
                         "witness authoring stopped by the budget ({}); the executed change \
                          stands unproven",
@@ -433,10 +433,10 @@ impl<'a> Pipeline<'a> {
                 TurnOutcome::Aborted {
                     reason, cost_usd, ..
                 } => {
-                    *total += cost_usd;
+                    *spend.total += cost_usd;
                     // Degradable for the same #1789 reason as the author
                     // turn's budget arm above.
-                    if let Some(abort) = budget_abort(budget.evaluate()) {
+                    if let Some(abort) = budget_abort(spend.budget.evaluate()) {
                         return Err(WitnessAbort::degradable(format!(
                             "witness repair stopped by the budget ({}); the executed change \
                              stands unproven",


### PR DESCRIPTION
## Problem

Local `make gate` on main (`11c4ca1e`) after the ~20-PR merge flurry (merged untested during the GitHub Actions outage, #1899) found stella-pipeline **does not compile**: the Spend-struct refactor and #1789's degradable budget-abort arms merged textually clean but semantically never met — both `Aborted` arms in `witness_stage.rs` still referenced the pre-refactor `total`/`budget` bindings (E0425 ×4). This one break cascades: `lint`, `test`, `doc-warnings`, and the `wire-schema` serve-frame exporter all go red behind it.

Separately, PR #1844 and its stacked PR #1881 each added the identical `guard-sigpipe-test` Makefile target, so every `make` invocation warns about the override.

## Fix

- Align the two `Aborted` arms with their sibling `Completed` arms: `*spend.total += cost_usd` and `budget_abort(spend.budget.evaluate())`. Restores exactly the intent both parent PRs tested independently.
- Delete the duplicate Makefile target block (kept the first).

## Verification (local — Actions is in a major outage, stated per policy)

- `cargo check -p stella-pipeline -j 2`: clean (main: E0425 ×4).
- `cargo test -p stella-pipeline -j 2 witness`: **123 passed, 0 failed** — the entire witness-stage suite, which cannot even compile on main, is the witness here; a new test would be dishonest (no new behavior, only the restoration of two intents that were each already tested).
- `cargo clippy -p stella-pipeline --all-targets -- -D warnings`: clean.
- `make` no longer emits the override warning.

## Remaining main breaks (sibling PRs, from the same gate run)

- `toolset.rs` new god file (1756 > 1500) + the `MAX_SERVER_SCHEMA_BYTES` → private `crate::client::ingest` rustdoc link — in the toolset split PR.

Refs #1899.

## Summary by Sourcery

Fix witness-stage budget handling after a spend-struct refactor and clean up a duplicate Makefile target.

Bug Fixes:
- Correct witness-stage aborted-turn accounting to update the spend tracker and evaluate the budget from the spend structure, restoring compilation and intended budget behavior.

Build:
- Remove a duplicated guard-sigpipe-test Makefile target to eliminate override warnings on make runs.