### PR TITLE
fix(stella-cli): stop re-appending a recall block the history already holds (#1846)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.6.126"
+version = "0.6.127"
 
 [[package]]
 name = "stella-engine"

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -585,11 +585,27 @@ pub fn inject_recall_block(messages: &mut Vec<CompletionMessage>, block: Option<
     let is_marker =
         |m: &CompletionMessage| m.role == MessageRole::User && m.content.starts_with(RECALL_MARKER);
     let Some(content) = block else { return };
+    // Against EVERY prior marker, not just the most recent one.
+    //
+    // Comparing only the latest made the dedup order-sensitive: an A → B → A
+    // recall sequence re-appended A, because by then B was the newest marker.
+    // Recall content genuinely does oscillate — it is a function of the
+    // prompt, so returning to an earlier subject returns to an earlier block —
+    // and each one is up to ~3k tokens that nothing can ever reclaim. These
+    // are User messages, and compaction passes 1–4 only rewrite tool results,
+    // so only the overflow summarizer can remove them. A 30-turn REPL session
+    // with shifting recall accumulated ~90k tokens of superseded blocks,
+    // permanently in the paid prefix (#1846).
+    //
+    // A set membership test rather than superseding the old marker in place:
+    // rewriting an earlier message byte-changes the replayed prefix from that
+    // point on, which is precisely the full-rate re-bill the index-1 refresh
+    // was removed for (see this function's header, L-E8). Skipping an append
+    // costs nothing and breaks nothing — the model has already been shown that
+    // block, and it is still in history where it can see it.
     if messages
         .iter()
-        .rev()
-        .find(|m| is_marker(m))
-        .is_some_and(|m| m.content == content)
+        .any(|m| is_marker(m) && m.content == content)
     {
         return;
     }

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -1283,3 +1283,69 @@ fn an_id_less_memory_frame_still_renders_and_does_not_promise_citability() {
     );
     assert!(section.contains("cite_memory"), "{section}");
 }
+
+/// **Witness (#1846).** An A → B → A recall sequence must not re-append A.
+///
+/// The dedup compared only the MOST RECENT marker, so by the time A came
+/// round again B was the newest and A read as fresh. Recall content genuinely
+/// oscillates — it is a function of the prompt, so returning to an earlier
+/// subject returns to an earlier block — and each one is up to ~3k tokens
+/// that nothing can reclaim: these are User messages, and compaction passes
+/// 1–4 only rewrite tool results. A 30-turn session accumulated ~90k tokens
+/// of superseded blocks in the paid prefix.
+///
+/// Two markers is the correct answer, not one: A and B were each genuinely
+/// new when first shown, and removing either would rewrite history — the
+/// full-rate re-bill L-E8 exists to prevent.
+#[test]
+fn inject_does_not_re_append_a_block_the_history_already_holds() {
+    let a = format!("{RECALL_MARKER}\nsubject A");
+    let b = format!("{RECALL_MARKER}\nsubject B");
+    let mut messages = vec![msg(MessageRole::System, "sys")];
+
+    inject_recall_block(&mut messages, Some(a.clone()));
+    messages.push(msg(MessageRole::User, "turn 1"));
+    inject_recall_block(&mut messages, Some(b.clone()));
+    messages.push(msg(MessageRole::User, "turn 2"));
+    let before: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
+
+    inject_recall_block(&mut messages, Some(a));
+
+    let markers = messages
+        .iter()
+        .filter(|m| m.content.starts_with(RECALL_MARKER))
+        .count();
+    assert_eq!(
+        markers, 2,
+        "A returning must not add a third marker — it is already in history"
+    );
+    // And nothing was rewritten to achieve that: the prefix is untouched.
+    let after: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
+    assert_eq!(
+        before, after,
+        "the dedup must skip an append, never rewrite history (L-E8)"
+    );
+    assert!(
+        messages.iter().any(|m| m.content.contains("subject B")),
+        "B is still there — it was genuinely new when it was shown"
+    );
+}
+
+/// The dedup must still let genuinely new content through, or it would be a
+/// fix that simply stops recall working.
+#[test]
+fn inject_still_appends_content_the_history_has_never_held() {
+    let mut messages = vec![msg(MessageRole::System, "sys")];
+    for subject in ["A", "B", "C"] {
+        inject_recall_block(
+            &mut messages,
+            Some(format!("{RECALL_MARKER}\nsubject {subject}")),
+        );
+        messages.push(msg(MessageRole::User, "a turn"));
+    }
+    let markers = messages
+        .iter()
+        .filter(|m| m.content.starts_with(RECALL_MARKER))
+        .count();
+    assert_eq!(markers, 3, "three distinct blocks are three appends");
+}


### PR DESCRIPTION
## Problem

`inject_recall_block` deduped against only the **most recent** marker, which made it order-sensitive: an **A → B → A** recall sequence re-appended A, because by then B was the newest marker.

Recall content genuinely oscillates — it is a function of the prompt, so returning to an earlier subject returns to an earlier block. Each one is up to ~3k tokens (1200 recall + 1500 skills + 2000 record chars + drafts) that **nothing can ever reclaim**: these are `User` messages, and compaction passes 1–4 only rewrite tool results, so only the overflow summarizer can remove them.

A 30-turn REPL session with shifting recall accumulated **~90k tokens of superseded blocks**, permanently in the paid prefix.

## Change

A set membership test over every prior marker, instead of a comparison with the last one.

**Deliberately not superseding the old marker in place.** Rewriting an earlier message byte-changes the replayed prefix from that point on — precisely the full-rate re-bill the index-1 refresh was removed for (L-E8, and this function's own header says so). Skipping an append costs nothing and breaks nothing: the model has already been shown that block, and it is still in history where it can see it.

**Two markers, not one, is the correct answer for A → B → A.** Both were genuinely new when first shown; removing either would rewrite history.

## Witness

- `inject_does_not_re_append_a_block_the_history_already_holds` — the A → B → A sequence. Asserts the marker count **and** that the message list is byte-identical before and after the skipped injection, so a "fix" that achieved the count by rewriting history cannot pass.
- `inject_still_appends_content_the_history_has_never_held` — the other direction, so a dedup that simply stopped recall working cannot pass either.

The first fails on the old code:

```
assertion `left == right` failed: A returning must not add a third marker — it is already in history
```

```
$ cargo test -p stella-cli --bin stella
test result: ok. 1430 passed; 0 failed
```

Clippy and `cargo fmt --check` clean.

## Not fixed here — hence `Refs`, not `Closes`

The issue's second half: **volatile content defeats the dedup entirely.** `exploration.rs` renders `IN PROGRESS by pid {pid} (live)` versus `abandoned draft`, which flips as processes come and go, so the block differs on content that is not really recall.

Normalising it in the dedup key would leave the model reading stale liveness. The issue's own suggestion — moving that content out of durable history onto a per-request volatile message, the L-E8 discipline — is the right shape, and it is a change to how messages are assembled rather than to this function. Left open on #1846.

## Base

Rebased on `main` as of this push. Note `main` currently does not compile (`stella-pipeline`, four E0425s) — **#1903** fixes that; this branch is unaffected by it.

Refs #1846

## Summary by Sourcery

Prevent recall blocks from being re-appended when an identical block already exists in history, avoiding unnecessary token growth while preserving historical message integrity.

Bug Fixes:
- Fix recall block deduplication to check against all prior recall markers instead of only the most recent one, preventing duplicate re-insertion in A → B → A sequences.

Tests:
- Add regression tests covering non-reappend behavior when a recall block already exists in history and successful appending for genuinely new recall content.