### PR TITLE
fix(stella-core): settle a child's spend on every exit, panic included (#1850)

### DIFF
--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -83,9 +83,19 @@
 //! Instead each child gets a fresh OS thread with a current-thread runtime:
 //! `block_on` imposes no `Send` bound, everything handed across is owned
 //! (`Arc`s and `Copy` values), and this task only awaits a oneshot. It also
-//! buys real isolation — a child that panics resolves to a refusal here
-//! instead of unwinding the parent's turn. The cost is one thread per live
-//! `task` call, bounded by the engine's own tool-call concurrency cap.
+//! buys isolation from a panicking child — **in builds that unwind**. The
+//! child turn runs under `catch_unwind`, so a panic settles the child's spend
+//! and reports as a refusal instead of tearing the parent's turn down.
+//!
+//! That claim used to be unqualified, and it was wrong for the builds users
+//! actually run: the workspace sets `panic = "abort"` (root `Cargo.toml`), so
+//! in release there is no unwind to catch and a child panic takes the whole
+//! process with it. A thread boundary cannot contain that; only a process
+//! boundary could. Stated rather than quietly implied, because the difference
+//! is invisible until it is a crash report (#1850).
+//!
+//! The cost is one thread per live `task` call, bounded by the engine's own
+//! tool-call concurrency cap.
 //!
 //! # Pause and stop reach these children too
 //!
@@ -412,18 +422,41 @@ impl SubAgentDispatcher for SessionSubAgents {
                 // stoppable without letting it steal the parent's messages.
                 let engine = Engine::with_sleeper(&*provider, &*tools, config, &TokioSleeper)
                     .with_turn_controls(&controls);
-                let outcome = runtime.block_on(engine.run_sub_agent_with_sender(
-                    SubAgentHost::new(&*provider),
-                    &spec,
-                    &mut view,
-                    &events,
-                ));
+                // `catch_unwind` so a panic INSIDE the turn cannot skip the
+                // settle below (#1850). Without it the unwind leaves this
+                // frame directly and real dollars the child had already spent
+                // landed in neither ledger — the comment at the `wait.await`
+                // claimed settling happened "on every path", and a panic was
+                // the path it did not.
+                //
+                // `AssertUnwindSafe` is the honest annotation, not a
+                // suppression: the values crossing the boundary are the
+                // engine, the spec and the event sender, and the one piece of
+                // state a torn turn could leave inconsistent — `view`, the
+                // budget carve — is exactly what is read afterwards, on
+                // purpose. A partially-billed carve is the number to settle.
+                //
+                // Only unwinds are catchable. Release builds set
+                // `panic = "abort"` (workspace Cargo.toml), so there a child
+                // panic takes the process down and nothing below runs — see
+                // this module's header, which no longer claims otherwise.
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    runtime.block_on(engine.run_sub_agent_with_sender(
+                        SubAgentHost::new(&*provider),
+                        &spec,
+                        &mut view,
+                        &events,
+                    ))
+                }));
 
                 // Settled HERE, before reporting, and deliberately not after
                 // the `wait.await` below: a parent cancelled mid-`task` never
                 // resumes that await, and dollars this child has already
                 // spent would land in no ledger at all. Charging late to the
                 // session is the ledger's doctrine; never charging is not.
+                //
+                // Now genuinely on every path the thread can take, panic
+                // included — which is what the `catch_unwind` above buys.
                 //
                 // Exactly once, because this is now the only writer on either
                 // side — the `task` tool no longer charges what it did not
@@ -440,7 +473,15 @@ impl SubAgentDispatcher for SessionSubAgents {
                     // engine drains into it at the next step boundary.
                     push_sub_agent_spend(&ledger, spent);
                 }
-                let _ = done.send(Ok(outcome));
+                // A caught panic reports as a refusal with a reason, rather
+                // than as a dropped sender the receiver has to infer one for.
+                // The spend above is already settled either way.
+                let _ = match outcome {
+                    Ok(outcome) => done.send(Ok(outcome)),
+                    Err(_) => done.send(Err(
+                        "the sub-agent panicked; its spend was still settled".into()
+                    )),
+                };
             });
         if let Err(err) = thread {
             return SubAgentOutcome::Refused {
@@ -448,9 +489,13 @@ impl SubAgentDispatcher for SessionSubAgents {
             };
         }
 
-        // A child that panicked drops its sender, which lands here as a
-        // refusal rather than unwinding the parent's turn. Nothing is settled
-        // on this side — the child already did it, on every path.
+        // A child that panicked reports a refusal naming the panic (an
+        // unwinding build) or drops its sender (anything else that killed the
+        // thread); both land here rather than unwinding the parent's turn.
+        // Nothing is settled on this side — the child already did it, and
+        // since #1850 that really is on every path the thread can take,
+        // because the turn runs under `catch_unwind` and the settle is after
+        // it rather than after the unwind.
         match wait.await {
             Ok(Ok(outcome)) => outcome,
             Ok(Err(reason)) => SubAgentOutcome::Refused { reason },

--- a/crates/stella-cli/src/subagent/tests.rs
+++ b/crates/stella-cli/src/subagent/tests.rs
@@ -733,3 +733,103 @@ async fn an_uncancelled_child_is_charged_exactly_once() {
         "six steps at a cent each, counted once; got {charged}"
     );
 }
+
+/// Bills on its first call, panics on its second — the shape that loses money.
+///
+/// The first completion carries a cost AND a tool call, so the turn continues
+/// and the child's carve really has spend in it by the time the panic lands.
+/// A provider that panicked immediately would prove nothing: there would be
+/// nothing to settle.
+struct PanicAfterBillingProvider {
+    calls: std::sync::atomic::AtomicUsize,
+    cost_usd: f64,
+}
+
+#[async_trait]
+impl Provider for PanicAfterBillingProvider {
+    fn id(&self) -> &str {
+        "panic-after-billing"
+    }
+    async fn complete_ref(
+        &self,
+        _request: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<stella_protocol::CompletionResult, stella_protocol::ProviderError> {
+        let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        assert!(n < 2, "the child should not get past the panic");
+        if n == 1 {
+            panic!("scripted child panic (#1850)");
+        }
+        Ok(stella_protocol::CompletionResult {
+            text: String::new(),
+            tool_calls: vec![stella_protocol::ToolCall {
+                call_id: "c0".into(),
+                name: "read_file".into(),
+                input: json!({ "path": "no-such-file.txt" }),
+            }],
+            usage: stella_protocol::CompletionUsage {
+                reported: true,
+                ..stella_protocol::CompletionUsage::default()
+            },
+            model: "panic-after-billing".into(),
+            cost_usd: self.cost_usd,
+            finish_reason: None,
+        })
+    }
+}
+
+/// **Witness (#1850).** A child that panics mid-turn must still have its
+/// spend folded into both ledgers.
+///
+/// The settle block ran AFTER `runtime.block_on`, so a panic inside the turn
+/// unwound straight past it: dollars the child had genuinely spent landed in
+/// neither the pool nor the parent's spend ledger. The comment at the
+/// `wait.await` claimed settling happened "on every path" — a panic was the
+/// path it did not.
+///
+/// Debug profile only by nature: `panic = "abort"` in release means there is
+/// no unwind to catch, and the module header now says so instead of implying
+/// otherwise. Tests build with unwind, which is exactly where the fix is
+/// observable.
+#[tokio::test]
+async fn a_panicking_child_still_settles_the_spend_it_incurred() {
+    let registry = registry();
+    let provider = Arc::new(PanicAfterBillingProvider {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        cost_usd: 0.25,
+    });
+    let dispatcher = SessionSubAgents::new(
+        provider,
+        &registry,
+        EngineConfig::default(),
+        stella_protocol::BudgetMode::Observed,
+    )
+    .with_pool_limit(Some(10.0));
+
+    // The panic is scripted, so the child's thread will print a panic
+    // message. Silence it: a passing test that looks like a crash teaches
+    // readers to ignore real ones.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = dispatcher
+        .dispatch(SubAgentSpec::read_only("panicker", "investigate"))
+        .await;
+    std::panic::set_hook(previous);
+
+    assert!(
+        matches!(outcome, SubAgentOutcome::Refused { .. }),
+        "a panicking child reports a refusal, never a completion: {outcome:?}"
+    );
+
+    let pool = *dispatcher.pool.lock().unwrap();
+    assert!(
+        pool.session_spent_usd() >= 0.25,
+        "the pool must carry what the child spent before it panicked, not 0 \
+         (got {})",
+        pool.session_spent_usd()
+    );
+    assert!(
+        stella_core::subagent::drain_sub_agent_spend(&registry.sub_agent_spend_ledger()) >= 0.25,
+        "and so must the parent's ledger — that is what the engine folds into \
+         the budget at the next step boundary"
+    );
+}

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -676,13 +676,31 @@ impl Engine<'_> {
 
         let steps = Arc::new(AtomicUsize::new(0));
         let child_events = child_sender(events.clone(), steps.clone());
-        let turn = child
-            .run_turn_with_sender(&mut messages, &mut carve, &child_events)
-            .await;
-
-        // Settle before building the report: the child's money is the
-        // parent's the moment the child stops, whatever it stopped for.
-        budget.settle_child(&carve);
+        // The carve is handed to the turn through a guard that settles it on
+        // DROP, not on return (#1850). `settle_child` used to be a statement
+        // after the await, so any exit that was not a return skipped it: a
+        // panic inside the child's turn unwound straight past, and dollars the
+        // child had genuinely spent reached neither the parent's guard nor —
+        // downstream of it — the session pool and the spend ledger.
+        //
+        // A drop guard is the only shape that covers every exit a future has.
+        // The turn borrows the carve through it; whether it returns, unwinds,
+        // or is dropped mid-flight by a cancelled parent, the fold-back has
+        // already happened by the time anything below can observe the parent's
+        // budget — the guard goes out of scope with this block.
+        //
+        // Settling before the report is unchanged and still deliberate: the
+        // child's money is the parent's the moment the child stops, whatever
+        // it stopped for.
+        let turn = {
+            let settle = SettleChildOnDrop {
+                budget: &mut *budget,
+                carve: &mut carve,
+            };
+            child
+                .run_turn_with_sender(&mut messages, &mut *settle.carve, &child_events)
+                .await
+        };
         // The parent's own post-settlement numbers, since the child's ticks
         // were dropped at the boundary and a HUD would otherwise sit stale
         // for the whole child run.
@@ -717,6 +735,30 @@ impl Engine<'_> {
                 reason,
             },
         }
+    }
+}
+
+/// Folds a child's carve back into its parent's guard on **every** exit from
+/// the child's turn — return, unwind, or the future being dropped.
+///
+/// `settle_child` used to be a statement after the `await`, which covers
+/// exactly one of those three. A panic inside the child's turn unwound past
+/// it, and dollars the child had genuinely spent reached neither the parent's
+/// guard nor, downstream of it, the session pool and the spend ledger — while
+/// the CLI dispatcher's own comment claimed settling happened "on every path"
+/// (#1850).
+///
+/// A guard rather than a `catch_unwind` at the call site because the money is
+/// this function's to account for: a caller that forgot to catch would lose it
+/// again, and there are three callers.
+struct SettleChildOnDrop<'a, 'c> {
+    budget: &'a mut BudgetGuard,
+    carve: &'c mut BudgetGuard,
+}
+
+impl Drop for SettleChildOnDrop<'_, '_> {
+    fn drop(&mut self) {
+        self.budget.settle_child(self.carve);
     }
 }
 


### PR DESCRIPTION
## Problem

A sub-agent that panicked mid-turn **lost the money it had already spent**. The dispatcher's own comment claimed settling happened "on every path"; a panic was the path it did not.

## Where it actually leaked — not where the issue points

The issue attributes it to `stella-cli`'s settle block running after `runtime.block_on`. That block does run there, but **by then there is nothing to settle**.

The child spends into a **carve**. `stella-core`'s `run_child_turn` folds that carve back with `budget.settle_child(&carve)` — a statement *after* the `await`. An unwind leaves that frame directly, so the parent's guard never learns the child spent anything, and the CLI's `view.session_spent_usd() - before` is zero.

Measured — the witness against a child that had just billed $0.25:

```
the pool must carry what the child spent before it panicked, not 0 (got 0)
```

## Fix

**A drop guard in core**, not a `catch_unwind` at the call site: the money is `run_child_turn`'s to account for, there are three callers, and a caller that forgot to catch would lose it again.

`SettleChildOnDrop` holds the parent guard and the carve for the duration of the turn. Return, unwind, or the future being dropped by a cancelled parent — all three fold the carve back before anything can observe the parent's budget.

**And the CLI half:** the child turn now runs under `catch_unwind` too, so its own settle (session pool + spend ledger) is reached on the panic path rather than skipped by the unwind — and a panicking child reports a refusal that *names* the panic instead of a dropped sender the receiver has to infer one for.

## The doc claim that was false

The module header said the thread boundary

> buys real isolation — a child that panics resolves to a refusal here instead of unwinding the parent's turn.

True only where there **is** an unwind to catch. The workspace sets `panic = "abort"`, so in the builds users actually run a child panic takes the whole process down. A thread cannot contain that; only a process boundary could. Now stated per profile rather than implied — the difference is invisible until it is a crash report.

## Witness

`a_panicking_child_still_settles_the_spend_it_incurred` scripts a provider that bills **$0.25 with a tool call** on its first completion and **panics on its second**, so the child genuinely has spend in flight when it dies. A provider that panicked immediately would prove nothing — there would be nothing to settle.

It asserts the refusal, then that **both** ledgers carry the money: the session pool, and the parent's spend ledger (what the engine folds into the budget at the next step boundary). One alone would pass for a fix that repaired half the path.

The test silences the panic hook around the dispatch, so a passing test does not print like a crash and teach readers to ignore real ones.

```
$ cargo test -p stella-core            # 1006 passed, 0 failed
$ cargo test -p stella-cli --bin stella # 1438 passed, 0 failed
```

Clippy (`-D warnings`) and `cargo fmt --check` clean.

## Base

Rebased on `main` after #1903 landed — `main` compiles again, and the rebase dropped my copy of that fix cleanly.

Closes #1850

## Summary by Sourcery

Ensure a sub-agent’s spent budget is always settled back to its parent, even when the child panics mid-turn, and surface panics to callers as explicit refusals rather than silent drops.

Bug Fixes:
- Fix loss of a child sub-agent’s spent budget when its turn panics or otherwise unwinds before normal completion by always settling the carve into the parent guard.
- Ensure CLI sub-agent dispatch still settles session and ledger spend when a child panics, and reports the failure as a refusal with a clear reason.

Documentation:
- Clarify sub-agent threading documentation to describe when panics are caught (unwinding builds) versus aborting the process (panic = "abort" release builds).

Tests:
- Add an integration-style test provider that bills before panicking and a corresponding test that verifies both the session pool and parent spend ledger retain the child’s spend after the panic.