### PR TITLE
fix(stella-tools): give sibling task calls distinct agent ids (#1852)

### DIFF
--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -160,12 +160,48 @@ const CHILD_SYSTEM_PROMPT: &str = "You are a research sub-agent. You have been g
 /// `task` — delegate a bounded research question to a read-only sub-agent.
 pub struct SpawnSubAgent {
     dispatcher: DispatcherSlot,
+    /// How many children this session has already minted per slug, so a
+    /// second child described the same way gets a distinct id (#1852).
+    ///
+    /// A counter rather than a random or time-based suffix: replay
+    /// determinism (invariant 7) means the same call order must produce the
+    /// same ids, and an id that changed between replays would make the
+    /// journal's `SubAgent` brackets unmatchable.
+    minted: std::sync::Mutex<std::collections::HashMap<String, u32>>,
 }
 
 impl SpawnSubAgent {
     #[must_use]
     pub fn new(dispatcher: DispatcherSlot) -> Self {
-        Self { dispatcher }
+        Self {
+            dispatcher,
+            minted: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// A session-unique agent id for `description`.
+    ///
+    /// `slug(description)` alone is a pure function of model-supplied text, so
+    /// two siblings described "research X" got the SAME id. Since sibling
+    /// `task` calls from one step run concurrently, their
+    /// `SubAgent::Started`/`Finished` brackets then interleave under one id on
+    /// the parent's stream: the deck renders indistinguishable rows and any
+    /// consumer that pairs by `agent_id` mis-correlates which child finished.
+    /// The child thread's name is derived from this too, so two threads shared
+    /// a name in every profiler and core dump as well.
+    ///
+    /// First use keeps the bare slug — the overwhelmingly common case reads
+    /// exactly as it did — and each repeat takes the next ordinal.
+    fn mint_agent_id(&self, description: &str) -> String {
+        let base = slug(description);
+        let mut minted = self.minted.lock().unwrap_or_else(|p| p.into_inner());
+        let seen = minted.entry(base.clone()).or_insert(0);
+        *seen += 1;
+        if *seen == 1 {
+            base
+        } else {
+            format!("{base}-{seen}")
+        }
     }
 }
 
@@ -254,7 +290,7 @@ impl Tool for SpawnSubAgent {
         };
 
         let spec = SubAgentSpec {
-            agent_id: slug(description),
+            agent_id: self.mint_agent_id(description),
             system_prompt: Some(CHILD_SYSTEM_PROMPT.to_string()),
             instruction: prompt.to_string(),
             max_steps: MAX_STEPS,

--- a/crates/stella-tools/src/subagent/tests.rs
+++ b/crates/stella-tools/src/subagent/tests.rs
@@ -332,3 +332,60 @@ fn attaching_replaces_rather_than_stacking() {
     drop(second);
     assert!(slot.read().unwrap().is_empty());
 }
+
+/// **Witness (#1852).** Two children described identically must not share an
+/// agent id.
+///
+/// `agent_id` was `slug(description)` — a pure function of model-supplied
+/// text — so two siblings both described "research X" got the SAME id. Since
+/// sibling `task` calls from one step run concurrently (#1836), their
+/// `SubAgent::Started`/`Finished` brackets then interleave under one id on the
+/// parent's stream: the deck renders indistinguishable rows, and any consumer
+/// that pairs by `agent_id` cannot tell which child finished. The child
+/// thread's name is derived from this too, so two threads shared a name in
+/// every profiler and core dump as well.
+///
+/// Deterministic by call order, never random or time-based: replay
+/// determinism (invariant 7) means the same sequence must mint the same ids,
+/// and an id that changed between replays would make those brackets
+/// unmatchable in a journal.
+#[test]
+fn identical_descriptions_mint_distinct_agent_ids() {
+    let tool = SpawnSubAgent::new(Arc::default());
+
+    // The first keeps the bare slug: the overwhelmingly common case — one
+    // child per description — reads exactly as it did before.
+    assert_eq!(tool.mint_agent_id("research X"), "research-x");
+    assert_eq!(tool.mint_agent_id("research X"), "research-x-2");
+    assert_eq!(tool.mint_agent_id("research X"), "research-x-3");
+
+    // A different description is a different counter, not a shared one.
+    assert_eq!(tool.mint_agent_id("trace the caller"), "trace-the-caller");
+    assert_eq!(tool.mint_agent_id("research X"), "research-x-4");
+
+    // Two descriptions that SLUG the same collide in exactly the way the ids
+    // must not: the counter is keyed on the slug, which is what the id is
+    // built from, so this is covered rather than accidentally distinct.
+    assert_eq!(tool.mint_agent_id("Research  x!"), "research-x-5");
+}
+
+/// The same call order mints the same ids on a fresh tool — the replay
+/// property stated as a test rather than left to the doc comment.
+#[test]
+fn minting_is_a_function_of_call_order_alone() {
+    let ids = |()| {
+        let tool = SpawnSubAgent::new(Arc::default());
+        vec![
+            tool.mint_agent_id("a b"),
+            tool.mint_agent_id("a b"),
+            tool.mint_agent_id("c"),
+            tool.mint_agent_id("a b"),
+        ]
+    };
+    assert_eq!(
+        ids(()),
+        ids(()),
+        "replaying the same order must replay the ids"
+    );
+    assert_eq!(ids(()), vec!["a-b", "a-b-2", "c", "a-b-3"]);
+}


### PR DESCRIPTION
## Problem

`agent_id` was `slug(description)` — a pure function of model-supplied text — so two siblings both described "research X" got the **same id**.

That stopped being cosmetic when sibling `task` calls from one step began running concurrently (#1836, now merged). Their `SubAgent::Started`/`Finished` brackets interleave under one id on the parent's stream, so:

- the deck renders **indistinguishable rows**;
- any consumer pairing by `agent_id` **cannot tell which child finished**;
- the child thread's name derives from the same value, so two threads shared a name in every profiler and core dump.

## Change

`mint_agent_id` keeps a per-slug count for the session:

```
research-x, research-x-2, research-x-3
```

The **first use keeps the bare slug**, so the overwhelmingly common case — one child per description — reads exactly as it did.

**A counter, never random or time-based.** Replay determinism (invariant 7) means the same call order must mint the same ids; an id that changed between replays would make those brackets unmatchable in a journal.

**Keyed on the slug, not the raw description.** The slug is what the id is built from, so `"Research  x!"` and `"research X"` collide there and must be counted together rather than accidentally distinct — the witness covers that case explicitly.

## Witness

- `identical_descriptions_mint_distinct_agent_ids` — three identical descriptions, **a different one interleaved** to prove the counters are per-slug and not one shared counter, plus the two-descriptions-one-slug case.
- `minting_is_a_function_of_call_order_alone` — the replay property asserted rather than left to a doc comment: two fresh tools driven through the same order mint the same ids.

The first fails on the old code:

```
assertion `left == right` failed
  left: "research-x"
 right: "research-x-2"
```

```
$ cargo test -p stella-tools
test result: ok. 738 passed; 0 failed
```

`cargo clippy -p stella-tools --all-targets -- -D warnings` and `cargo fmt --check` clean.

Rebased on current `main`.

Closes #1852

## Summary by Sourcery

Ensure sub-agent task invocations receive session-unique, deterministic agent IDs even when sibling tasks share the same description.

Bug Fixes:
- Prevent sibling sub-agent tasks with identical descriptions from sharing the same agent ID, which previously caused interleaved events and indistinguishable UI rows.

Enhancements:
- Introduce a slug-keyed, call-order-based counter in SpawnSubAgent to mint deterministic, session-unique agent IDs while preserving existing IDs for first use.
- Document and enforce the agent ID minting invariants directly in code comments and tests.

Tests:
- Add tests verifying that identical descriptions mint distinct agent IDs and that ID minting depends only on call order, supporting replay determinism.