### PR TITLE
fix(stella-pipeline): bound what the conversational reply is billed for (#1840)

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -157,6 +157,49 @@ const DEFAULT_SYSTEM_PROMPT: &str =
 /// The system prompt for the conversational fast path. Swapped in for
 /// [`DEFAULT_SYSTEM_PROMPT`] when triage classified the input as chat so the
 /// reply reads as a normal, brief conversational turn rather than a work plan.
+/// How many trailing messages the conversational reply is given, beyond the
+/// leading system message.
+///
+/// Chat needs the thread of the conversation, not the engineering transcript
+/// under it. Twelve messages is roughly the last half-dozen exchanges — enough
+/// that "and the other one?" still resolves, and enough that a follow-up reads
+/// as continuous.
+const CONVERSATIONAL_HISTORY_MESSAGES: usize = 12;
+
+/// The messages a conversational reply is dispatched with: the leading system
+/// message, then the last [`CONVERSATIONAL_HISTORY_MESSAGES`].
+///
+/// Unbounded, this call re-billed the whole running transcript at the full
+/// input rate for a two-sentence answer. It dispatches with `tools:
+/// Vec::new()` and a replaced system message, so not one byte of the prefix
+/// matches the worker's cached one — a 90k-token session where the user types
+/// "thanks" paid for all 90k plus the 1.25x cache-write premium, and every
+/// chat interjection in a long session paid it again (#1840).
+///
+/// Bounding the input is the fix that holds regardless of caching. The
+/// issue's other option — keep the worker's system message so the prefix
+/// matches — cannot deliver a hit on its own while the tool array is empty:
+/// the tools block is part of the same cached prefix, so a matching system
+/// message with no tools still misses. That half is worth doing, and needs
+/// adapter-level work to verify rather than assume.
+///
+/// The system message is kept because the caller's first message may not be
+/// one (`run` seeds it when history is empty, but nothing enforces it for a
+/// caller that seeded its own); dropping a non-system first message here
+/// would silently destroy context the window is meant to preserve.
+fn conversational_window(messages: &[CompletionMessage]) -> Vec<CompletionMessage> {
+    let leads_with_system = messages
+        .first()
+        .is_some_and(|message| matches!(message.role, MessageRole::System));
+    let (head, rest) = if leads_with_system {
+        messages.split_at(1)
+    } else {
+        messages.split_at(0)
+    };
+    let tail = rest.len().saturating_sub(CONVERSATIONAL_HISTORY_MESSAGES);
+    head.iter().chain(&rest[tail..]).cloned().collect()
+}
+
 const CONVERSATIONAL_SYSTEM_PROMPT: &str = "You are Stella, a careful software engineering agent. The user's latest \
      message is a greeting, small talk, or a question about you — not a coding \
      task. Reply briefly and warmly in plain prose: no tools, no code, no plan, \
@@ -1444,7 +1487,7 @@ impl<'a> Pipeline<'a> {
         // silently destroyed — prepend in front of it instead. The swap is
         // local to `convo`, so the caller's own prefix — and its prompt-cache
         // hits, L-E8 — survive the turn untouched.
-        let mut convo = messages.clone();
+        let mut convo = conversational_window(messages);
         let leads_with_system = convo
             .first()
             .is_some_and(|message| matches!(message.role, MessageRole::System));

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -3,6 +3,7 @@
 //! private surface (`CandidateSurface`, `Pipeline::gather_diff`, ...)
 //! stays reachable via `super::*`.
 
+mod conversational_window;
 mod management_accounting;
 mod telemetry;
 

--- a/crates/stella-pipeline/src/pipeline/tests/conversational_window.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/conversational_window.rs
@@ -1,0 +1,76 @@
+//! The conversational fast path's input bound (#1840).
+//!
+//! Split out rather than appended to `tests.rs`, which is a grandfathered
+//! god file closed to growth — the sibling-module shape AGENTS.md asks for.
+
+use super::super::{CONVERSATIONAL_HISTORY_MESSAGES, conversational_window};
+use stella_protocol::CompletionMessage;
+
+/// **Witness (#1840).** The conversational reply must not be handed the whole
+/// transcript.
+///
+/// `run_conversational` cloned the running history and dispatched all of it
+/// with `tools: Vec::new()` and a replaced system message — so not one byte of
+/// the prefix matched the worker's cached one, and a 90k-token session where
+/// the user types "thanks" re-billed all 90k at the full input rate plus the
+/// 1.25x cache-write premium. Every chat interjection in a long session paid
+/// it again.
+///
+/// A pure-function test over the windowing rather than a scripted dispatch:
+/// the cost is decided entirely by which messages are selected, and asserting
+/// that directly cannot be satisfied by a provider double that happens to be
+/// cheap.
+#[test]
+fn the_conversational_window_bounds_a_long_transcript() {
+    let mut history = vec![CompletionMessage::system("worker system prompt")];
+    for i in 0..200 {
+        history.push(CompletionMessage::user(format!("u{i}")));
+        history.push(CompletionMessage::assistant(format!("a{i}")));
+    }
+
+    let window = conversational_window(&history);
+
+    assert_eq!(
+        window.len(),
+        1 + CONVERSATIONAL_HISTORY_MESSAGES,
+        "the system message plus a bounded tail, not 401 messages"
+    );
+    assert_eq!(
+        window[0].content, "worker system prompt",
+        "the leading system message is kept — the caller's may not be one, and \
+         dropping it would destroy the context the window exists to preserve"
+    );
+    assert_eq!(
+        window.last().unwrap().content,
+        "a199",
+        "and the tail is the MOST RECENT exchange, not the oldest — a window \
+         taken from the front would answer about the wrong thing"
+    );
+}
+
+/// A conversation shorter than the window is untouched: the bound must be
+/// invisible for the ordinary case, or it would truncate real context.
+#[test]
+fn a_short_conversation_passes_through_the_window_whole() {
+    let history = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hello"),
+        CompletionMessage::assistant("hi"),
+    ];
+    assert_eq!(conversational_window(&history), history);
+}
+
+/// A caller whose history does NOT lead with a system message keeps every
+/// message it had. `run` seeds one when the history is empty, but nothing
+/// enforces it — and treating a non-system first message as droppable is how
+/// the window would silently eat the very context it is meant to keep.
+#[test]
+fn a_history_with_no_system_message_keeps_its_first_message() {
+    let history = vec![
+        CompletionMessage::user("the only instruction this caller gave"),
+        CompletionMessage::assistant("ok"),
+    ];
+    let window = conversational_window(&history);
+    assert_eq!(window, history);
+    assert_eq!(window[0].content, "the only instruction this caller gave");
+}

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,9 +15,9 @@
 1911 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4334 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-2269 crates/stella-cli/src/agent.rs
+2266 crates/stella-cli/src/agent.rs
 1751 crates/stella-cli/src/agent/tests.rs
-4647 crates/stella-cli/src/command_deck.rs
+4621 crates/stella-cli/src/command_deck.rs
 1504 crates/stella-cli/src/fleet_cmd.rs
 2129 crates/stella-core/src/bus.rs
 2568 crates/stella-core/src/driver.rs
@@ -26,8 +26,8 @@
 2093 crates/stella-model/src/openai.rs
 1565 crates/stella-model/src/zai.rs
 1895 crates/stella-model/src/zai/tests.rs
-3616 crates/stella-pipeline/src/pipeline.rs
-2572 crates/stella-pipeline/src/pipeline/tests.rs
+3573 crates/stella-pipeline/src/pipeline.rs
+2573 crates/stella-pipeline/src/pipeline/tests.rs
 2965 crates/stella-protocol/src/event.rs
 1995 crates/stella-store/src/lib.rs
 2268 crates/stella-store/src/tests.rs


### PR DESCRIPTION
## Problem

`run_conversational` cloned the **entire running transcript** and dispatched all of it with `tools: Vec::new()` and a replaced system message. Not one byte of the prefix matches the worker's cached one, so a 90k-token session where the user types "thanks" re-billed **all 90k** at the full input rate **plus the 1.25× cache-write premium** — for a two-sentence answer. Every chat interjection in a long session paid it again.

## Change

The reply now sees the leading system message plus the last **twelve** messages — roughly the last half-dozen exchanges: enough that "and the other one?" still resolves, and enough that a follow-up reads as continuous.

**401 messages become 13.**

## Why the bound, not the prefix

The issue offers two directions. Bounding the input is the one that **holds regardless of caching**, and it is the larger win.

Its alternative — keep the worker's system message at index 0 so the prefix matches — **cannot deliver a cache hit on its own while the tool array is empty**. The tools block is part of the same cached prefix, so a matching system message with no tools still misses. That half is worth doing and needs adapter-level work to verify rather than assume; claiming a hit here without it would be exactly the unmeasured cache assertion invariant 8 exists to stop.

The system message is **kept rather than assumed**: `run` seeds one when the history is empty, but nothing enforces it, and a caller that seeded a non-system first message would otherwise have the only instruction it gave dropped by the window meant to preserve context.

## Witnesses

- `the_conversational_window_bounds_a_long_transcript` — 401 messages yield 13, the system message survives, and the tail is the **most recent** exchange (a window taken from the front would answer about the wrong thing).
- `a_short_conversation_passes_through_the_window_whole` — the bound is invisible for the ordinary case, so a fix that truncated real context cannot pass.
- `a_history_with_no_system_message_keeps_its_first_message` — the case above.

The first fails on the old code:

```
assertion `left == right` failed: the system message plus a bounded tail, not 401 messages
  left: 401
 right: 13
```

Pure-function tests over the windowing rather than a scripted dispatch: the cost is decided entirely by *which messages are selected*, and asserting that directly cannot be satisfied by a provider double that happens to be cheap.

## On the god file

They live in `pipeline/tests/conversational_window.rs`. Appending them to `pipeline/tests.rs` put it **69 lines over its ceiling**, and that file is grandfathered and closed to growth. The sibling module leaves it **+1** — the `mod` declaration itself, which is the irreducible line the ratchet documents a baseline bump for.

The same regeneration **tightens three ceilings** that had fallen and nobody had banked: `pipeline.rs` 3616→**3573** (lower than its recorded ceiling even after this change), `command_deck.rs` 4647→4621, `agent.rs` 2269→2266.

```
$ cargo test -p stella-pipeline
test result: ok. 565 passed; 0 failed
```

Clippy, `fmt --check`, `check-file-size`, `check-god-files` and `check-module-reachability` all clean. Rebased on current `main`.

Closes #1840

## Summary by Sourcery

Bound the conversational fast path to a small, recent window of messages instead of the full transcript to avoid rebilling long histories, while preserving leading system instructions when present.

Bug Fixes:
- Limit conversational replies to the system message plus a fixed number of trailing messages so long sessions no longer resend and rebill the entire transcript for each short reply.

Enhancements:
- Introduce a reusable conversational window helper that selects the leading system message and a bounded tail of recent messages for chat replies.
- Add focused tests validating the conversational windowing behavior, including long transcripts, short conversations, and histories without a system message.

Tests:
- Add a dedicated conversational window test module that verifies bounding behavior, preservation of the initial system or user message, and that short conversations pass through unchanged.

Chores:
- Update test module structure and file-size baselines to keep within enforced god-file and size ceilings.