### PR TITLE
fix(stella-protocol): uncross the text/text_delta wire field names (#1886)

### DIFF
--- a/arenabench/recorder/render.py
+++ b/arenabench/recorder/render.py
@@ -279,7 +279,9 @@ class Renderer:
             self.state = "running"
 
         if kind in ("text", "reasoning"):
-            fragment = str(event.get("delta") or "")
+            # `text` spells its body `text` since #1886, `delta` before;
+            # `reasoning` still spells it `delta`. Read both.
+            fragment = str(event.get("delta") or event.get("text") or "")
             if fragment:
                 self.stream("reasoning" if kind == "reasoning" else "text", fragment)
             return

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -603,17 +603,36 @@ class TestTranscript:
         self, tmp_path: Path
     ):
         """Stella emits both `text_delta` fragments and one consolidated
-        `text` event per message (the field names are crossed on the wire:
-        the fragment rides in `text`, the complete body in `delta`).
-        Appending both rendered every response twice in the transcript —
-        once assembled, once whole. The consolidated event must replace the
-        run under the same seq, not extend it.
+        `text` event per message. In streams recorded before stella #1886
+        the field names are crossed on the wire: the fragment rides in
+        `text`, the complete body in `delta`. Appending both rendered every
+        response twice in the transcript — once assembled, once whole. The
+        consolidated event must replace the run under the same seq, not
+        extend it.
         """
         path = tmp_path / "e.jsonl"
         write_events(path, [
             {"type": "text_delta", "text": "The work"},
             {"type": "text_delta", "text": "space root is `/app`."},
             {"type": "text", "delta": "The workspace root is `/app`."},
+        ])
+        entries = TranscriptReader().read(path)
+        text = [e for e in entries if e["kind"] == "text"]
+        assert len({e["seq"] for e in text}) == 1, "one message, one entry"
+        assert text[-1]["body"] == "The workspace root is `/app`."
+
+    def test_the_current_self_describing_field_names_read_identically(
+        self, tmp_path: Path
+    ):
+        """Stella #1886 fixed the crossed spellings: fragments now ride in
+        `delta` and the consolidated body in `text`. The reader stays
+        bilingual — both generations of stream produce the same transcript.
+        """
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            {"type": "text_delta", "delta": "The work"},
+            {"type": "text_delta", "delta": "space root is `/app`."},
+            {"type": "text", "text": "The workspace root is `/app`."},
         ])
         entries = TranscriptReader().read(path)
         text = [e for e in entries if e["kind"] == "text"]

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -225,6 +225,31 @@ class TestUtilityFunctions:
         assert envelope["_stella_stream"]["stream_complete"] is False
         assert envelope["_stella_stream"]["diagnostic_lines"] == 1
 
+    def test_stream_parser_reads_current_self_describing_text_fields(self) -> None:
+        # Stella #1886: the fragment now rides in `delta` and the
+        # consolidated body in `text` (the crossed spellings above are the
+        # pre-#1886 legacy). The parser reads both generations.
+        events = [
+            {
+                "type": "step_usage",
+                "model": "provider/model",
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "cached_input_tokens": 0,
+                "cost_usd": 0.02,
+            },
+            {"type": "text_delta", "delta": "Inspec"},
+            {"type": "text", "text": "Inspecting now."},
+            {"type": "complete", "model": "provider/model", "cost_usd": 0.02},
+        ]
+        envelope = _stream_to_envelope(
+            "\n".join(json.dumps(event) for event in events),
+            process_returned=True,
+        )
+        assert envelope is not None
+        assert envelope["status"] == "completed"
+        assert envelope["text"] == "Inspecting now."
+
     def test_stream_parser_preserves_normal_error_terminal(self) -> None:
         events = [
             {
@@ -2052,6 +2077,29 @@ class TestAtifTrajectory:
         assert trajectory.steps[1].message == "authoritative"
         assert trajectory.steps[1].extra["usage_missing"] is True
         assert trajectory.final_metrics.total_prompt_tokens is None
+        Trajectory.model_validate(trajectory.to_json_dict())
+
+    def test_current_self_describing_text_fields_fold_identically(self) -> None:
+        # The same stream as above in the post-#1886 spelling: fragment in
+        # `delta`, consolidated body in `text`. Both generations fold to the
+        # same trajectory.
+        trajectory = envelope_to_trajectory(
+            {
+                "status": "completed",
+                "model": "provider/model",
+                "events": [
+                    {"type": "text_delta", "delta": "preview"},
+                    {"type": "text", "text": "authoritative"},
+                ],
+            },
+            instruction="Answer.",
+            session_id="session-unmetered",
+            agent_version="unknown",
+            default_model=None,
+            return_code=None,
+        )
+        assert len(trajectory.steps) == 2
+        assert trajectory.steps[1].message == "authoritative"
         Trajectory.model_validate(trajectory.to_json_dict())
 
     def test_populate_context_writes_public_trajectory(self, tmp_path: Path) -> None:

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -225,31 +225,6 @@ class TestUtilityFunctions:
         assert envelope["_stella_stream"]["stream_complete"] is False
         assert envelope["_stella_stream"]["diagnostic_lines"] == 1
 
-    def test_stream_parser_reads_current_self_describing_text_fields(self) -> None:
-        # Stella #1886: the fragment now rides in `delta` and the
-        # consolidated body in `text` (the crossed spellings above are the
-        # pre-#1886 legacy). The parser reads both generations.
-        events = [
-            {
-                "type": "step_usage",
-                "model": "provider/model",
-                "input_tokens": 12,
-                "output_tokens": 3,
-                "cached_input_tokens": 0,
-                "cost_usd": 0.02,
-            },
-            {"type": "text_delta", "delta": "Inspec"},
-            {"type": "text", "text": "Inspecting now."},
-            {"type": "complete", "model": "provider/model", "cost_usd": 0.02},
-        ]
-        envelope = _stream_to_envelope(
-            "\n".join(json.dumps(event) for event in events),
-            process_returned=True,
-        )
-        assert envelope is not None
-        assert envelope["status"] == "completed"
-        assert envelope["text"] == "Inspecting now."
-
     def test_stream_parser_preserves_normal_error_terminal(self) -> None:
         events = [
             {
@@ -2077,29 +2052,6 @@ class TestAtifTrajectory:
         assert trajectory.steps[1].message == "authoritative"
         assert trajectory.steps[1].extra["usage_missing"] is True
         assert trajectory.final_metrics.total_prompt_tokens is None
-        Trajectory.model_validate(trajectory.to_json_dict())
-
-    def test_current_self_describing_text_fields_fold_identically(self) -> None:
-        # The same stream as above in the post-#1886 spelling: fragment in
-        # `delta`, consolidated body in `text`. Both generations fold to the
-        # same trajectory.
-        trajectory = envelope_to_trajectory(
-            {
-                "status": "completed",
-                "model": "provider/model",
-                "events": [
-                    {"type": "text_delta", "delta": "preview"},
-                    {"type": "text", "text": "authoritative"},
-                ],
-            },
-            instruction="Answer.",
-            session_id="session-unmetered",
-            agent_version="unknown",
-            default_model=None,
-            return_code=None,
-        )
-        assert len(trajectory.steps) == 2
-        assert trajectory.steps[1].message == "authoritative"
         Trajectory.model_validate(trajectory.to_json_dict())
 
     def test_populate_context_writes_public_trajectory(self, tmp_path: Path) -> None:

--- a/bench/harbor_adapter/tests/test_text_field_spellings.py
+++ b/bench/harbor_adapter/tests/test_text_field_spellings.py
@@ -1,0 +1,69 @@
+"""Both generations of the ``text`` / ``text_delta`` wire spellings parse.
+
+Streams recorded before stella #1886 spell the two fields crossed — the
+fragment rides in ``text_delta``'s ``text`` and the consolidated body in
+``text``'s ``delta``. Current streams use the self-describing names
+(``text_delta.delta``, ``text.text``). The adapter's readers are bilingual;
+``test_adapter.py`` covers the legacy spelling throughout, and this module
+witnesses the current one. In its own file because ``test_adapter.py`` is
+grandfathered at its file-size ceiling and closed to growth.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from harbor.models.trajectories import Trajectory  # noqa: E402
+
+from stella_harbor import _stream_to_envelope  # noqa: E402
+from stella_harbor.atif import envelope_to_trajectory  # noqa: E402
+
+
+def test_stream_parser_reads_current_self_describing_text_fields() -> None:
+    events = [
+        {
+            "type": "step_usage",
+            "model": "provider/model",
+            "input_tokens": 12,
+            "output_tokens": 3,
+            "cached_input_tokens": 0,
+            "cost_usd": 0.02,
+        },
+        {"type": "text_delta", "delta": "Inspec"},
+        {"type": "text", "text": "Inspecting now."},
+        {"type": "complete", "model": "provider/model", "cost_usd": 0.02},
+    ]
+    envelope = _stream_to_envelope(
+        "\n".join(json.dumps(event) for event in events),
+        process_returned=True,
+    )
+    assert envelope is not None
+    assert envelope["status"] == "completed"
+    assert envelope["text"] == "Inspecting now."
+
+
+def test_current_self_describing_text_fields_fold_identically() -> None:
+    # The same stream as test_adapter.py's missing-usage case, in the
+    # post-#1886 spelling. Both generations fold to the same trajectory.
+    trajectory = envelope_to_trajectory(
+        {
+            "status": "completed",
+            "model": "provider/model",
+            "events": [
+                {"type": "text_delta", "delta": "preview"},
+                {"type": "text", "text": "authoritative"},
+            ],
+        },
+        instruction="Answer.",
+        session_id="session-unmetered",
+        agent_version="unknown",
+        default_model=None,
+        return_code=None,
+    )
+    assert len(trajectory.steps) == 2
+    assert trajectory.steps[1].message == "authoritative"
+    Trajectory.model_validate(trajectory.to_json_dict())

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -258,7 +258,7 @@ mod pipeline_sender_tests {
         let events = EventSender::new(raw);
         let pipeline = pipeline_event_sender(&events, format);
         pipeline
-            .send(AgentEvent::Text { delta: "hi".into() })
+            .send(AgentEvent::Text { text: "hi".into() })
             .unwrap();
         pipeline
             .send(AgentEvent::Complete {

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -1022,7 +1022,7 @@ mod stream_tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let _ = events.send(AgentEvent::Text {
-            delta: "let me read the file".into(),
+            text: "let me read the file".into(),
         });
         let _ = events.send(AgentEvent::ToolStart { call: call.clone() });
         let _ = events.send(AgentEvent::ToolResult {

--- a/crates/stella-cli/src/cache_insight.rs
+++ b/crates/stella-cli/src/cache_insight.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn ignores_every_non_step_usage_event() {
-        let text = AgentEvent::Text { delta: "hi".into() };
+        let text = AgentEvent::Text { text: "hi".into() };
         assert!(cache_insight_for("anthropic", "lead", &text).is_none());
     }
 

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -3947,7 +3947,7 @@ async fn run_deck_command(
     let say = |text: String| {
         let _ = in_tx.send(Inbound::Event {
             agent: LEAD.to_string(),
-            event: AgentEvent::Text { text: text },
+            event: AgentEvent::Text { text },
         });
     };
     match trimmed {

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -159,14 +159,14 @@ pub(crate) fn now_ms() -> u64 {
 /// CLI already uses on the normal screen for its own voice — costs a character
 /// and removes the lie.
 pub(crate) fn chrome_note(text: String) -> Inbound {
-    let delta = if text.starts_with(stella_tui::NOTICE_MARKER) {
+    let noted = if text.starts_with(stella_tui::NOTICE_MARKER) {
         text
     } else {
         format!("{}{text}", stella_tui::NOTICE_MARKER)
     };
     Inbound::Event {
         agent: LEAD.to_string(),
-        event: AgentEvent::Text { delta },
+        event: AgentEvent::Text { text: noted },
     }
 }
 
@@ -1439,7 +1439,7 @@ pub async fn run_deck_session(
                 if let Some(report) = custom.problems_report() {
                     let _ = in_tx.send(Inbound::Event {
                         agent: LEAD.to_string(),
-                        event: AgentEvent::Text { delta: report },
+                        event: AgentEvent::Text { text: report },
                     });
                     let _ = in_tx.send(Inbound::Status {
                         agent: LEAD.to_string(),
@@ -1554,7 +1554,7 @@ pub async fn run_deck_session(
             let _ = in_tx.send(Inbound::Event {
                 agent: LEAD.to_string(),
                 event: AgentEvent::Text {
-                    delta: "MCP servers are still connecting — this turn runs with native \
+                    text: "MCP servers are still connecting — this turn runs with native \
                             tools; connected servers join from the next turn"
                         .to_string(),
                 },
@@ -1755,7 +1755,7 @@ pub async fn run_deck_session(
                                 let _ = in_tx.send(Inbound::Event {
                                     agent: LEAD.to_string(),
                                     event: AgentEvent::Text {
-                                        delta: "\n[stopping at the next step boundary — Esc again to cancel immediately]\n".to_string(),
+                                        text: "\n[stopping at the next step boundary — Esc again to cancel immediately]\n".to_string(),
                                     },
                                 });
                             } else {
@@ -2040,7 +2040,7 @@ pub async fn run_deck_session(
                         let _ = in_tx.send(Inbound::Event {
                             agent: LEAD.to_string(),
                             event: AgentEvent::Text {
-                                delta: "\n[stopped at the step boundary — completed work kept]\n"
+                                text: "\n[stopped at the step boundary — completed work kept]\n"
                                     .to_string(),
                             },
                         });
@@ -2658,7 +2658,7 @@ fn handle_supervisor_msg(
                 let _ = in_tx.send(Inbound::Event {
                     agent: LEAD.to_string(),
                     event: AgentEvent::Text {
-                        delta: format!(
+                        text: format!(
                             "note: task #{} already has a live worker — the duplicate \
                              task_assign was not dispatched",
                             request.task_id
@@ -2833,7 +2833,7 @@ fn spawn_session_replay(
             let _ = in_tx.send(Inbound::Event {
                 agent: LEAD.to_string(),
                 event: AgentEvent::Text {
-                    delta: format!("session {id} is no longer in the registry"),
+                    text: format!("session {id} is no longer in the registry"),
                 },
             });
             return;
@@ -2846,9 +2846,9 @@ fn spawn_session_replay(
         let meta = AgentMeta::new(lane.clone(), format!("replay — {}", record.title), now_ms())
             .with_role("replay");
         let _ = in_tx.send(Inbound::Register(meta));
-        let lane_text = |delta: String| Inbound::Event {
+        let lane_text = |text: String| Inbound::Event {
             agent: lane.clone(),
-            event: AgentEvent::Text { delta },
+            event: AgentEvent::Text { text },
         };
         let Some(store) = agent::open_store(std::path::Path::new(&record.workspace)) else {
             let _ = in_tx.send(lane_text(format!(
@@ -3947,7 +3947,7 @@ async fn run_deck_command(
     let say = |text: String| {
         let _ = in_tx.send(Inbound::Event {
             agent: LEAD.to_string(),
-            event: AgentEvent::Text { delta: text },
+            event: AgentEvent::Text { text: text },
         });
     };
     match trimmed {
@@ -4436,7 +4436,7 @@ async fn run_lead_pipeline_turn(
         let wiring = agent::resolve_engine_wiring(cfg, &model_ref, &configured);
         for notice in &wiring.notices {
             let _ = tx.send(AgentEvent::Text {
-                delta: format!("! {notice}\n"),
+                text: format!("! {notice}\n"),
             });
         }
         let resolver =

--- a/crates/stella-cli/src/command_deck/scope_gate.rs
+++ b/crates/stella-cli/src/command_deck/scope_gate.rs
@@ -110,7 +110,7 @@ impl ApprovalGate for DeckApprovalGate {
             let _ = self.inbound.send(Inbound::Event {
                 agent: self.agent.clone(),
                 event: AgentEvent::Text {
-                    delta: format!(
+                    text: format!(
                         "\n[scope trimmed to the first {keep} step{} — {dropped} dropped]\n",
                         if keep == 1 { "" } else { "s" },
                     ),

--- a/crates/stella-cli/src/command_deck/session_clear.rs
+++ b/crates/stella-cli/src/command_deck/session_clear.rs
@@ -424,7 +424,7 @@ mod tests {
         );
         let Inbound::Event {
             agent,
-            event: AgentEvent::Text { delta },
+            event: AgentEvent::Text { text: delta },
         } = &sent[1]
         else {
             panic!(
@@ -603,7 +603,7 @@ mod tests {
         let [
             Inbound::Event {
                 agent,
-                event: AgentEvent::Text { delta },
+                event: AgentEvent::Text { text: delta },
             },
         ] = &sent[..]
         else {

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -624,7 +624,7 @@ fn requeue_front_mirrors_each_front_insert_to_the_deck() {
 fn a_chrome_note_is_marked_as_the_program_speaking() {
     let Inbound::Event {
         agent,
-        event: AgentEvent::Text { delta },
+        event: AgentEvent::Text { text: delta },
     } = chrome_note("conversation cleared".into())
     else {
         panic!("chrome rides the transcript as Text on the lead lane");
@@ -642,7 +642,7 @@ fn a_chrome_note_is_marked_as_the_program_speaking() {
 #[test]
 fn an_already_marked_note_is_not_marked_twice() {
     let Inbound::Event {
-        event: AgentEvent::Text { delta },
+        event: AgentEvent::Text { text: delta },
         ..
     } = chrome_note(format!("{}already mine", stella_tui::NOTICE_MARKER))
     else {

--- a/crates/stella-cli/src/diag_bridge.rs
+++ b/crates/stella-cli/src/diag_bridge.rs
@@ -193,9 +193,9 @@ impl DomainBridge {
 
         match event {
             // ---- Counted, never recorded (§3.8). ------------------------
-            AgentEvent::TextDelta { text } => {
+            AgentEvent::TextDelta { delta } => {
                 self.tally.text_deltas += 1;
-                self.tally.text_bytes += text.len() as u64;
+                self.tally.text_bytes += delta.len() as u64;
             }
             AgentEvent::Reasoning { delta } => {
                 self.tally.reasoning_deltas += 1;
@@ -212,8 +212,8 @@ impl DomainBridge {
             AgentEvent::BudgetTick { .. } => self.tally.budget_ticks += 1,
             // The whole answer, once per step. Its length is the only part of
             // it that is not content.
-            AgentEvent::Text { delta } => {
-                self.tally.text_bytes += delta.len() as u64;
+            AgentEvent::Text { text } => {
+                self.tally.text_bytes += text.len() as u64;
             }
 
             // ---- The model call: tokens, cost, latency, retries. ---------
@@ -768,7 +768,9 @@ mod tests {
     fn ten_thousand_text_deltas_produce_no_records() {
         let (mut bridge, records) = bridge();
         for _ in 0..10_000 {
-            bridge.observe(&AgentEvent::TextDelta { text: "tok".into() });
+            bridge.observe(&AgentEvent::TextDelta {
+                delta: "tok".into(),
+            });
         }
         assert!(
             records.records().is_empty(),
@@ -996,7 +998,7 @@ mod tests {
     fn the_sequence_counts_every_event_not_every_record() {
         let (mut bridge, records) = bridge();
         for _ in 0..5 {
-            bridge.observe(&AgentEvent::TextDelta { text: "x".into() });
+            bridge.observe(&AgentEvent::TextDelta { delta: "x".into() });
         }
         bridge.observe(&tool_call("bash", serde_json::json!({})));
 

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -695,7 +695,7 @@ mod tests {
         assert!(
             journal_record(&Inbound::Event {
                 agent: "lead".into(),
-                event: AgentEvent::Text { delta: "x".into() },
+                event: AgentEvent::Text { text: "x".into() },
             })
             .is_some()
         );
@@ -768,7 +768,7 @@ mod tests {
             },
             JournalRecord::Event {
                 agent: "req:1".into(),
-                event: AgentEvent::Text { delta: "x".into() },
+                event: AgentEvent::Text { text: "x".into() },
             },
             JournalRecord::Pipeline { on: true },
             JournalRecord::PromptStarted {
@@ -854,7 +854,7 @@ mod tests {
             journal_record(&Inbound::Event {
                 agent: lane.clone(),
                 event: AgentEvent::Text {
-                    delta: "historic".into(),
+                    text: "historic".into(),
                 },
             })
             .is_none()
@@ -871,7 +871,7 @@ mod tests {
             journal_record(&Inbound::Event {
                 agent: "req:1".into(),
                 event: AgentEvent::Text {
-                    delta: "live".into()
+                    text: "live".into()
                 },
             })
             .is_some()
@@ -924,7 +924,7 @@ mod tests {
             },
             Inbound::Event {
                 agent: "lead".into(),
-                event: AgentEvent::Text { delta: "on".into() },
+                event: AgentEvent::Text { text: "on".into() },
             },
             Inbound::Event {
                 agent: "lead".into(),
@@ -1108,14 +1108,12 @@ mod tests {
             },
             Inbound::Event {
                 agent: "lead".into(),
-                event: AgentEvent::Text {
-                    delta: "loo".into(),
-                },
+                event: AgentEvent::Text { text: "loo".into() },
             },
             Inbound::Event {
                 agent: "lead".into(),
                 event: AgentEvent::Text {
-                    delta: "king…".into(),
+                    text: "king…".into(),
                 },
             },
             Inbound::Event {
@@ -1164,7 +1162,7 @@ mod tests {
             Inbound::Event {
                 agent: "lead".into(),
                 event: AgentEvent::Text {
-                    delta: "done.".into(),
+                    text: "done.".into(),
                 },
             },
             Inbound::Event {

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -775,7 +775,7 @@ async fn run_worker(
         let _ = in_tx.send(Inbound::Event {
             agent: spec.lane.clone(),
             event: AgentEvent::Text {
-                delta: format!(
+                text: format!(
                     "note: {} task_assign request(s) were not dispatched — delegation \
                      runs from the lead session only",
                     stranded.len()
@@ -863,7 +863,7 @@ pub(crate) fn drain_queue(
         let _ = in_tx.send(Inbound::ShellEvent {
             agent: LEAD.to_string(),
             event: AgentEvent::Text {
-                delta: spawn_notice(&lane, &text),
+                text: spawn_notice(&lane, &text),
             },
         });
         let (stop_tx, stop_rx) = oneshot::channel();

--- a/crates/stella-cli/src/tui.rs
+++ b/crates/stella-cli/src/tui.rs
@@ -400,7 +400,7 @@ pub fn render_event(event: &AgentEvent) {
             // Complete-stage and ToolStart/ToolResult: handled inline at the
             // call site or by a more specific event (see the module doc).
         }
-        AgentEvent::Text { delta } => assistant_response(delta),
+        AgentEvent::Text { text } => assistant_response(text),
         AgentEvent::Reasoning { .. } => {}
         AgentEvent::BudgetTick {
             mode: BudgetMode::Off,

--- a/crates/stella-cli/tests/stats_prune_cli.rs
+++ b/crates/stella-cli/tests/stats_prune_cli.rs
@@ -48,7 +48,7 @@ fn record_turn(store: &Store, prompt: &str) -> i64 {
             id,
             0,
             &stella_protocol::AgentEvent::Text {
-                delta: format!("worked on {prompt}"),
+                text: format!("worked on {prompt}"),
             },
         )
         .expect("event");

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -2112,7 +2112,7 @@ impl<'a> Engine<'a> {
         // answer and must not stream a blank `Text` event.
         if !result.text.trim().is_empty() {
             let _ = events.send(AgentEvent::Text {
-                delta: result.text.clone(),
+                text: result.text.clone(),
             });
         }
         messages.push(CompletionMessage {
@@ -2205,7 +2205,7 @@ impl<'a> Engine<'a> {
         // then abort as "no text" — events and history stay consistent.
         if !result.text.trim().is_empty() {
             let _ = events.send(AgentEvent::Text {
-                delta: result.text.clone(),
+                text: result.text.clone(),
             });
         }
 
@@ -2235,7 +2235,7 @@ impl<'a> Engine<'a> {
                     ContinuationPlan::Continue(plan) => {
                         *length_continuations += 1;
                         let (note, appended) = plan.into_parts();
-                        let _ = events.send(AgentEvent::Text { delta: note });
+                        let _ = events.send(AgentEvent::Text { text: note });
                         messages.extend(appended);
                         return None;
                     }
@@ -2273,7 +2273,7 @@ impl<'a> Engine<'a> {
             // success past this point.
             if result.finish_reason == Some(FinishReason::Length) {
                 let _ = events.send(AgentEvent::Text {
-                    delta: if out_of_time {
+                    text: if out_of_time {
                         // Names the deadline, not the token limit, because the
                         // token limit is what happened and the deadline is why
                         // nothing followed it. A reader who sees only "output

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -710,7 +710,7 @@ async fn text_deltas_precede_the_authoritative_text_and_concatenate_to_it() {
         .iter()
         .enumerate()
         .filter_map(|(i, e)| match e {
-            AgentEvent::TextDelta { text } => Some((i, text.as_str())),
+            AgentEvent::TextDelta { delta: text } => Some((i, text.as_str())),
             _ => None,
         })
         .collect();
@@ -721,7 +721,7 @@ async fn text_deltas_precede_the_authoritative_text_and_concatenate_to_it() {
     );
     let concatenated: String = deltas.iter().map(|(_, t)| *t).collect();
     match &events[text_idx] {
-        AgentEvent::Text { delta } => assert_eq!(
+        AgentEvent::Text { text: delta } => assert_eq!(
             &concatenated, delta,
             "on a clean run the preview equals the committed text"
         ),
@@ -1621,7 +1621,7 @@ async fn length_continuations_are_bounded_per_turn() {
     assert!(
         events.iter().any(|e| matches!(
             e,
-            AgentEvent::Text { delta } if delta.contains("Response was truncated")
+            AgentEvent::Text { text: delta } if delta.contains("Response was truncated")
         )),
         "the exhausted turn still carries the truncation warning"
     );

--- a/crates/stella-core/src/driver/tests/parked_wait.rs
+++ b/crates/stella-core/src/driver/tests/parked_wait.rs
@@ -191,7 +191,7 @@ async fn a_change_on_the_nth_probe_re_invokes_the_model_exactly_once() {
     let texts: Vec<&str> = events
         .iter()
         .filter_map(|e| match e {
-            AgentEvent::Text { delta } => Some(delta.as_str()),
+            AgentEvent::Text { text: delta } => Some(delta.as_str()),
             _ => None,
         })
         .collect();
@@ -293,7 +293,7 @@ async fn a_non_read_only_probe_is_refused_not_replayed() {
         "a refused park must not fabricate a wake"
     );
     let refused = drain_events(&mut rx).into_iter().any(
-        |e| matches!(&e, AgentEvent::Text { delta } if delta.contains("not a read-only tool")),
+        |e| matches!(&e, AgentEvent::Text { text: delta } if delta.contains("not a read-only tool")),
     );
     assert!(refused, "the refusal must be visible on the stream");
 }

--- a/crates/stella-core/src/driver/waiting.rs
+++ b/crates/stella-core/src/driver/waiting.rs
@@ -56,7 +56,7 @@ impl<'a> Engine<'a> {
         for call in replayed {
             if !read_only.contains(&call.name) {
                 let _ = events.send(AgentEvent::Text {
-                    delta: format!(
+                    text: format!(
                         "\n⚠ Ignoring a parked-wait request: `{}` is not a read-only tool, and \
                          the engine only replays read-only calls while the model is not looking.\n",
                         call.name
@@ -67,7 +67,7 @@ impl<'a> Engine<'a> {
         }
 
         let _ = events.send(AgentEvent::Text {
-            delta: format!(
+            text: format!(
                 "\n⏳ Parked: waiting until {} — probing every {}s for up to {}s, with no model \
                  calls while waiting.\n",
                 request.description,
@@ -126,7 +126,7 @@ impl<'a> Engine<'a> {
         };
         let message = wake_message(&request, reason, polls_used, detail.as_deref());
         let _ = events.send(AgentEvent::Text {
-            delta: format!(
+            text: format!(
                 "\n▶ Wait ended after {polls_used} probe{}: {}\n",
                 if polls_used == 1 { "" } else { "s" },
                 match reason {

--- a/crates/stella-core/src/speculation.rs
+++ b/crates/stella-core/src/speculation.rs
@@ -175,7 +175,7 @@ impl ToolCallObserver for SpeculationGate {
         // A send after the renderer hung up is fine — previews are lossy by
         // contract.
         let _ = self.events.send(AgentEvent::TextDelta {
-            text: delta.to_string(),
+            delta: delta.to_string(),
         });
     }
 
@@ -311,7 +311,7 @@ mod tests {
 
         let forwarded: Vec<String> = std::iter::from_fn(|| events_rx.try_recv().ok())
             .map(|e| match e {
-                AgentEvent::TextDelta { text } => text,
+                AgentEvent::TextDelta { delta } => delta,
                 other => panic!("unexpected event: {other:?}"),
             })
             .collect();

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -1110,7 +1110,8 @@ fn recall_timings(conn: &Connection, execution_id: i64) -> Result<Vec<Value>, Db
 /// Shape one raw `events` row into the transcript entry the drawer renders.
 ///
 /// The payload is the internally-tagged `AgentEvent` JSON the store
-/// persisted (`{"type":"text","delta":…}`). Only the fields the transcript
+/// persisted (`{"type":"text","text":…}`; rows written before #1886 spell
+/// the field `delta`, so `text` reads both). Only the fields the transcript
 /// needs are lifted out, keyed by the row's own `event_type` column. A
 /// payload that no longer parses (a hand-edited store, a variant this binary
 /// predates) keeps its seq/type header with no body rather than erroring —
@@ -1134,7 +1135,12 @@ fn journal_entry(row: Value, full: bool) -> Value {
             out["label"] = payload["name"].clone();
         }
         "text" | "reasoning" => {
-            set_journal_body(&mut out, payload["delta"].as_str().unwrap_or(""), full);
+            // `text` carries `text` since #1886, `delta` before; `reasoning`
+            // still carries `delta`. One bilingual read covers all three.
+            let body = payload["text"]
+                .as_str()
+                .or_else(|| payload["delta"].as_str());
+            set_journal_body(&mut out, body.unwrap_or(""), full);
         }
         "tool_start" => {
             out["call_id"] = payload["call"]["call_id"].clone();

--- a/crates/stella-observatory/src/sent_context.rs
+++ b/crates/stella-observatory/src/sent_context.rs
@@ -312,9 +312,11 @@ impl Preimages {
                     }
                 }
                 "text" => {
-                    if let Some(delta) = event["delta"].as_str() {
+                    // Spelled `delta` in journals written before #1886.
+                    let body = event["text"].as_str().or_else(|| event["delta"].as_str());
+                    if let Some(text) = body {
                         out.text_by_digest
-                            .insert(format!("sha256:{}", sha256_hex(delta)), delta.to_owned());
+                            .insert(format!("sha256:{}", sha256_hex(text)), text.to_owned());
                     }
                 }
                 _ => {}
@@ -596,6 +598,26 @@ mod tests {
             content_digest: Some(format!("sha256:{}", sha256_hex(content))),
             content: Some(content.to_owned()),
             ..entry(block_id, kind, message_index)
+        }
+    }
+
+    #[test]
+    fn text_preimages_index_under_both_wire_spellings() {
+        // `text` spelled its body `delta` before #1886; a journal can hold
+        // either generation and both must resolve as digest preimages.
+        let payloads = vec![
+            r#"{"type":"text","delta":"old body"}"#.to_owned(),
+            r#"{"type":"text","text":"new body"}"#.to_owned(),
+        ];
+        let preimages = Preimages::index(&payloads);
+        for body in ["old body", "new body"] {
+            assert_eq!(
+                preimages
+                    .text_by_digest
+                    .get(&format!("sha256:{}", sha256_hex(body)))
+                    .map(String::as_str),
+                Some(body),
+            );
         }
     }
 

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -417,8 +417,8 @@ fn execution_journal_replays_transcript_without_deltas() {
 #[test]
 fn execution_journal_after_seq_returns_only_newer_rows() {
     let ws = seeded_workspace();
-    // Seq 3 is the tool_start row; only tool_result (4) and text (5) — both
-    // > 3 — should come back.
+    // Seq 3 is the tool_start row; only tool_result (4) and the two text
+    // rows (5, 6) — all > 3 — should come back.
     let response = respond(ws.path(), "/api/execution-journal?id=1&after_seq=3");
     let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
     let seqs: Vec<i64> = v
@@ -427,7 +427,7 @@ fn execution_journal_after_seq_returns_only_newer_rows() {
         .iter()
         .map(|e| e["seq"].as_i64().unwrap())
         .collect();
-    assert_eq!(seqs, [4, 5], "only rows with seq > 3 come back");
+    assert_eq!(seqs, [4, 5, 6], "only rows with seq > 3 come back");
     // A cursor past every seeded row degrades to empty, not an error.
     let none = respond(ws.path(), "/api/execution-journal?id=1&after_seq=99");
     let v: serde_json::Value = serde_json::from_slice(&none.body).unwrap();
@@ -438,7 +438,7 @@ fn execution_journal_after_seq_returns_only_newer_rows() {
     let v: serde_json::Value = serde_json::from_slice(&all.body).unwrap();
     assert_eq!(
         v.as_array().unwrap().len(),
-        5,
+        6,
         "seq 0 survives after_seq=-1"
     );
 }

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -161,7 +161,8 @@ fn seeded_workspace() -> TempDir {
              (1, 2, 'reasoning', '{"type":"reasoning","delta":"plan the edit"}'),
              (1, 3, 'tool_start', '{"type":"tool_start","call":{"call_id":"c1","name":"read_file","input":{"path":"src/lib.rs"}}}'),
              (1, 4, 'tool_result', '{"type":"tool_result","call_id":"c1","output":{"ok":{"content":"fn a() {}"}},"duration_ms":12,"speculated":false}'),
-             (1, 5, 'text', '{"type":"text","delta":"added the function"}');"#,
+             (1, 5, 'text', '{"type":"text","delta":"added the function"}'),
+             (1, 6, 'text', '{"type":"text","text":"and named it well"}');"#,
     )
     .unwrap();
     // The context receipts (#1475), also in their own batch: one recorded
@@ -381,7 +382,14 @@ fn execution_journal_replays_transcript_without_deltas() {
         .collect();
     assert_eq!(
         types,
-        ["stage", "reasoning", "tool_start", "tool_result", "text"],
+        [
+            "stage",
+            "reasoning",
+            "tool_start",
+            "tool_result",
+            "text",
+            "text"
+        ],
         "seq order, text_delta excluded"
     );
     assert_eq!(v[0]["label"], "build");
@@ -391,8 +399,11 @@ fn execution_journal_replays_transcript_without_deltas() {
     assert_eq!(v[3]["ok"], true);
     assert_eq!(v[3]["body"], "fn a() {}");
     assert_eq!(v[3]["duration_ms"], 12);
+    // Seq 5 is the pre-#1886 spelling (`delta`), seq 6 the current one
+    // (`text`) — the transcript reads both generations of journal row.
     assert_eq!(v[4]["body"], "added the function");
     assert_eq!(v[4]["truncated"], false);
+    assert_eq!(v[5]["body"], "and named it well");
     // No execution 2 events were seeded — an empty transcript, not an error.
     let none = respond(ws.path(), "/api/execution-journal?id=2");
     let v: serde_json::Value = serde_json::from_slice(&none.body).unwrap();

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1496,7 +1496,7 @@ impl<'a> Pipeline<'a> {
         // keeps context.
         messages.push(CompletionMessage::assistant(reply.clone()));
         self.emit(AgentEvent::Text {
-            delta: reply.clone(),
+            text: reply.clone(),
         });
         self.emit(AgentEvent::Stage {
             name: StageKind::Complete,
@@ -3271,8 +3271,8 @@ impl<'a> Pipeline<'a> {
     /// Emit a narration line when there is one — see `candidate_narration`,
     /// which returns `None` for a single-candidate run.
     fn emit_text(&self, notice: Option<String>) {
-        if let Some(delta) = notice {
-            self.emit(AgentEvent::Text { delta });
+        if let Some(text) = notice {
+            self.emit(AgentEvent::Text { text });
         }
     }
 

--- a/crates/stella-pipeline/src/pipeline/scope_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/scope_stage.rs
@@ -83,7 +83,7 @@ impl Pipeline<'_> {
                     // appears with no stated cause, which reads as the
                     // pipeline having restarted itself.
                     self.emit(AgentEvent::Text {
-                        delta: format!(
+                        text: format!(
                             "\n[re-planning ({spent_revisions}/{MAX_SCOPE_REVISIONS}) with your \
                              note: {note}]\n"
                         ),

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -1196,7 +1196,7 @@ async fn a_greeting_takes_the_conversational_path_and_skips_all_work() {
     assert!(
         events.iter().any(|e| matches!(
             e,
-            AgentEvent::Text { delta } if delta == "Hi! How can I help with your codebase?"
+            AgentEvent::Text { text: delta } if delta == "Hi! How can I help with your codebase?"
         )),
         "the conversational reply is emitted as text"
     );

--- a/crates/stella-pipeline/src/pipeline/tests/best_of_n.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/best_of_n.rs
@@ -535,7 +535,7 @@ async fn a_fan_out_narrates_each_candidate_and_names_the_winner() {
     let text: String = events
         .iter()
         .filter_map(|e| match e {
-            AgentEvent::Text { delta } => Some(delta.as_str()),
+            AgentEvent::Text { text: delta } => Some(delta.as_str()),
             _ => None,
         })
         .collect();
@@ -609,7 +609,7 @@ async fn a_single_candidate_run_emits_no_fan_out_narration() {
     let text: String = events
         .iter()
         .filter_map(|e| match e {
-            AgentEvent::Text { delta } => Some(delta.as_str()),
+            AgentEvent::Text { text: delta } => Some(delta.as_str()),
             _ => None,
         })
         .collect();
@@ -707,7 +707,7 @@ async fn every_isolated_candidate_also_sees_the_steer() {
     let text: String = events
         .iter()
         .filter_map(|e| match e {
-            AgentEvent::Text { delta } => Some(delta.as_str()),
+            AgentEvent::Text { text: delta } => Some(delta.as_str()),
             _ => None,
         })
         .collect();

--- a/crates/stella-pipeline/src/pipeline/tests/best_of_n/fanout_concurrency.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/best_of_n/fanout_concurrency.rs
@@ -415,14 +415,14 @@ async fn a_concurrent_fan_out_mutes_previews_but_never_the_authoritative_text() 
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, AgentEvent::Text { delta } if *delta == expected)),
+                .any(|e| matches!(e, AgentEvent::Text { text: delta } if *delta == expected)),
             "every candidate's authoritative text still reaches the consumer: {events:?}"
         );
     }
     assert!(
         events.iter().any(|e| matches!(
             e,
-            AgentEvent::Text { delta } if delta.contains("candidates at once")
+            AgentEvent::Text { text: delta } if delta.contains("candidates at once")
         )),
         "the fan-out says why the stream went quiet: {events:?}"
     );
@@ -445,7 +445,7 @@ async fn a_sequential_fan_out_still_streams_its_previews() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AgentEvent::TextDelta { text } if text == "frag-a")),
+            .any(|e| matches!(e, AgentEvent::TextDelta { delta: text } if text == "frag-a")),
         "width 1 keeps the live preview: {events:?}"
     );
 }

--- a/crates/stella-pipeline/src/replay/reference_adapter.rs
+++ b/crates/stella-pipeline/src/replay/reference_adapter.rs
@@ -155,7 +155,7 @@ pub fn adapt_reference_stream(jsonl: &str) -> Result<Vec<AgentEvent>, ReferenceA
                     .ok_or(ReferenceAdapterError::UnmappedStage { line, label })?;
                 events.push(AgentEvent::Stage { name });
             }
-            ReferenceEvent::Text { delta } => events.push(AgentEvent::Text { delta }),
+            ReferenceEvent::Text { delta } => events.push(AgentEvent::Text { text: delta }),
             ReferenceEvent::Reasoning { delta } => events.push(AgentEvent::Reasoning { delta }),
             ReferenceEvent::Tool {
                 phase,

--- a/crates/stella-pipeline/tests/stream_conformance.rs
+++ b/crates/stella-pipeline/tests/stream_conformance.rs
@@ -105,7 +105,7 @@ fn corruptions() -> Vec<Corruption> {
             expect: "not the last event",
             apply: |events| {
                 events.push(AgentEvent::Text {
-                    delta: "one more thing".into(),
+                    text: "one more thing".into(),
                 });
             },
         },

--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -200,12 +200,13 @@ equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
 
 ## Gotchas
 
-- **`AgentEvent::Text { delta }` is not a delta.** The field name is
-  wire-frozen legacy; the value is the step's *full* answer text and is
-  authoritative. `AgentEvent::TextDelta { text }` is the live fragment stream.
-  Consumers must **replace** any accumulated preview with `Text`, never append
-  — a retried model call re-streams its deltas from the start and there is no
-  reset marker.
+- **`AgentEvent::Text { text }` is the full answer; `TextDelta { delta }` is
+  the live fragment.** Consumers must **replace** any accumulated preview with
+  `Text`, never append — a retried model call re-streams its deltas from the
+  start and there is no reset marker. Streams recorded before #1886 spell the
+  fields crossed (`text` carried `delta`, `text_delta` carried `text`); the
+  serde aliases keep those parsing, and raw-JSONL readers must stay bilingual
+  the same way.
 - **`LifecycleEventEnvelope::decode` never fails, which cuts both ways.** A
   *recognized* `event_type` whose payload doesn't deserialize degrades to
   `LifecycleEvent::Unknown` rather than erroring, so a renamed payload field

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -296,11 +296,19 @@ pub enum AgentEvent {
     /// in the order the pipeline walks them.
     Stage { name: StageKind },
     /// The step's answer text, in full — the authoritative, durable record.
-    /// The field name `delta` is wire-frozen legacy and does NOT mean a
-    /// fragment: the live fragments are [`AgentEvent::TextDelta`], which the
-    /// journal deliberately drops. Consumers must REPLACE any accumulated
+    /// Not a fragment, despite the live preview sibling
+    /// [`AgentEvent::TextDelta`]: consumers must REPLACE any accumulated
     /// preview with this value, never append it to one.
-    Text { delta: String },
+    ///
+    /// Wire history (#1886): this field was spelled `delta` (and
+    /// `text_delta`'s payload was spelled `text` — each variant carried the
+    /// other's natural name). Serialization writes the self-describing name;
+    /// the alias keeps every recorded stream replaying. Raw-JSONL readers
+    /// must stay bilingual the same way: `text` first, legacy `delta` back.
+    Text {
+        #[serde(alias = "delta")]
+        text: String,
+    },
     /// One in-order fragment of the answer text, emitted live while the
     /// model call streams. Strictly a best-effort preview: the step's
     /// following `Text` event carries the full text and is authoritative —
@@ -309,8 +317,12 @@ pub enum AgentEvent {
     /// accumulation can be garbled; there is no reset marker). Additive to
     /// the stream-json wire contract: consumers must tolerate `text_delta`
     /// lines appearing between events, and persistence layers may drop them
-    /// (the `Text` event is the durable record).
-    TextDelta { text: String },
+    /// (the `Text` event is the durable record). Wire history: `delta` was
+    /// spelled `text` before #1886 — the alias accepts both; see [`AgentEvent::Text`].
+    TextDelta {
+        #[serde(alias = "text")]
+        delta: String,
+    },
     /// One in-order fragment of the model's thinking/extended-reasoning
     /// stream, for the providers that expose it. Unlike [`AgentEvent::Text`]
     /// this really is a fragment — consumers accumulate, and the journal
@@ -1548,20 +1560,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn text_delta_roundtrips_with_its_own_type_tag() {
-        // `text_delta` is additive on the wire: a distinct tag from `text`,
-        // so a pre-delta consumer that skips unknown lines keeps parsing the
-        // authoritative `text` events unchanged.
-        let event = AgentEvent::TextDelta { text: "Hel".into() };
-        let json = serde_json::to_string(&event).unwrap();
-        assert!(json.contains("\"type\":\"text_delta\""), "{json}");
-        let back: AgentEvent = serde_json::from_str(&json).unwrap();
-        match back {
-            AgentEvent::TextDelta { text } => assert_eq!(text, "Hel"),
-            other => panic!("unexpected variant: {other:?}"),
-        }
-    }
+    // The text / text_delta wire spellings — including the pre-#1886 crossed
+    // legacy — are witnessed in `tests/text_event_wire.rs`.
 
     #[test]
     fn tool_result_roundtrips_and_streams_without_speculated_still_parse() {
@@ -2313,7 +2313,7 @@ mod tests {
             AgentEvent::Stage {
                 name: StageKind::Triage,
             },
-            AgentEvent::Text { delta: "hi".into() },
+            AgentEvent::Text { text: "hi".into() },
             AgentEvent::Complete {
                 model: "glm-5.2".into(),
                 cost_usd: 0.001,
@@ -2703,8 +2703,8 @@ mod tests {
             AgentEvent::Stage {
                 name: StageKind::Triage,
             },
-            AgentEvent::Text { delta: "hi".into() },
-            AgentEvent::TextDelta { text: "h".into() },
+            AgentEvent::Text { text: "hi".into() },
+            AgentEvent::TextDelta { delta: "h".into() },
             AgentEvent::Reasoning { delta: "r".into() },
             AgentEvent::SpeculationDiscarded {
                 call_id: "c".into(),
@@ -2802,7 +2802,7 @@ mod tests {
         // Pin two exact tags so a wholesale serde-rename change is caught too.
         assert_eq!(
             AgentEvent::TextDelta {
-                text: String::new()
+                delta: String::new()
             }
             .type_tag(),
             "text_delta"
@@ -2953,13 +2953,13 @@ mod tests {
         // The hand-written codec must be a pass-through for known variants —
         // no tag rename, no extra wrapper, no reordering.
         let event = AgentEvent::Text {
-            delta: "hello".into(),
+            text: "hello".into(),
         };
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
-            r#"{"type":"text","delta":"hello"}"#
+            r#"{"type":"text","text":"hello"}"#
         );
-        let back: AgentEvent = serde_json::from_str(r#"{"type":"text","delta":"hello"}"#).unwrap();
-        assert!(matches!(back, AgentEvent::Text { delta } if delta == "hello"));
+        let back: AgentEvent = serde_json::from_str(r#"{"type":"text","text":"hello"}"#).unwrap();
+        assert!(matches!(back, AgentEvent::Text { text } if text == "hello"));
     }
 }

--- a/crates/stella-protocol/tests/text_event_wire.rs
+++ b/crates/stella-protocol/tests/text_event_wire.rs
@@ -1,0 +1,74 @@
+//! The `text` / `text_delta` wire spellings, both current and legacy.
+//!
+//! Before #1886 the two variants carried each other's natural field name on
+//! the wire: the consolidated body went out as `{"type":"text","delta":…}`
+//! and the live fragment as `{"type":"text_delta","text":…}`. Every consumer
+//! of `stella-events.jsonl` had to learn the swap by observation (arenabench
+//! rendered every response twice until its reader was taught both shapes).
+//!
+//! The contract now: serialization writes the self-describing name — `text`
+//! carries `text`, `text_delta` carries `delta` — and deserialization accepts
+//! the legacy spelling as an alias so every recorded stream keeps replaying.
+//! These tests witness both halves; the legacy half must never be removed
+//! while archived benchmark evidence exists.
+
+use stella_protocol::AgentEvent;
+
+#[test]
+fn text_serializes_with_the_self_describing_field_name() {
+    let event = AgentEvent::Text {
+        text: "the full answer".into(),
+    };
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        r#"{"type":"text","text":"the full answer"}"#
+    );
+}
+
+#[test]
+fn text_delta_serializes_with_the_self_describing_field_name() {
+    let event = AgentEvent::TextDelta {
+        delta: "the fr".into(),
+    };
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        r#"{"type":"text_delta","delta":"the fr"}"#
+    );
+}
+
+#[test]
+fn current_spellings_round_trip() {
+    let text: AgentEvent = serde_json::from_str(r#"{"type":"text","text":"full"}"#).unwrap();
+    assert!(matches!(text, AgentEvent::Text { text } if text == "full"));
+
+    let delta: AgentEvent = serde_json::from_str(r#"{"type":"text_delta","delta":"fr"}"#).unwrap();
+    assert!(matches!(delta, AgentEvent::TextDelta { delta } if delta == "fr"));
+}
+
+#[test]
+fn legacy_crossed_spellings_still_deserialize() {
+    // The exact shapes every stream recorded before #1886 contains. Replay of
+    // archived benchmark evidence depends on these parsing forever.
+    let text: AgentEvent = serde_json::from_str(r#"{"type":"text","delta":"full"}"#).unwrap();
+    assert!(matches!(text, AgentEvent::Text { text } if text == "full"));
+
+    let delta: AgentEvent = serde_json::from_str(r#"{"type":"text_delta","text":"fr"}"#).unwrap();
+    assert!(matches!(delta, AgentEvent::TextDelta { delta } if delta == "fr"));
+}
+
+#[test]
+fn text_delta_keeps_its_own_type_tag() {
+    // `text_delta` stays additive on the wire: a distinct tag from `text`,
+    // so a consumer that skips unknown lines keeps parsing the authoritative
+    // `text` events unchanged.
+    let event = AgentEvent::TextDelta {
+        delta: "Hel".into(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"type\":\"text_delta\""), "{json}");
+    let back: AgentEvent = serde_json::from_str(&json).unwrap();
+    match back {
+        AgentEvent::TextDelta { delta } => assert_eq!(delta, "Hel"),
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}

--- a/crates/stella-protocol/tests/wire_contract.rs
+++ b/crates/stella-protocol/tests/wire_contract.rs
@@ -497,10 +497,10 @@ fn tool_call() -> ToolCall {
 fn sample_events() -> Vec<AgentEvent> {
     let mut events = vec![
         AgentEvent::Text {
-            delta: "the answer".into(),
+            text: "the answer".into(),
         },
         AgentEvent::TextDelta {
-            text: "the ".into(),
+            delta: "the ".into(),
         },
         AgentEvent::Reasoning {
             delta: "considering".into(),

--- a/crates/stella-serve/src/backlog.rs
+++ b/crates/stella-serve/src/backlog.rs
@@ -209,7 +209,9 @@ mod tests {
 
     fn delta() -> ServerFrame {
         ServerFrame::Event {
-            event: AgentEvent::TextDelta { text: "tok".into() },
+            event: AgentEvent::TextDelta {
+                delta: "tok".into(),
+            },
         }
     }
 

--- a/crates/stella-serve/src/frame.rs
+++ b/crates/stella-serve/src/frame.rs
@@ -408,7 +408,7 @@ mod tests {
 
         let event = serde_json::to_value(ServerFrame::Event {
             event: AgentEvent::Text {
-                delta: "hello".to_string(),
+                text: "hello".to_string(),
             },
         })
         .unwrap();

--- a/crates/stella-serve/src/history.rs
+++ b/crates/stella-serve/src/history.rs
@@ -490,7 +490,7 @@ mod envelope_pin {
             7,
             ServerFrame::Event {
                 event: stella_protocol::AgentEvent::TextDelta {
-                    text: "hi".to_string(),
+                    delta: "hi".to_string(),
                 },
             },
         );

--- a/crates/stella-serve/src/observe/tally.rs
+++ b/crates/stella-serve/src/observe/tally.rs
@@ -174,10 +174,10 @@ mod tests {
     fn payload_events_are_inert() {
         let mut fold = TallyFold::default();
         fold.observe(&AgentEvent::Text {
-            delta: "secret".to_string(),
+            text: "secret".to_string(),
         });
         fold.observe(&AgentEvent::TextDelta {
-            text: "secret".to_string(),
+            delta: "secret".to_string(),
         });
         fold.observe(&AgentEvent::Reasoning {
             delta: "secret".to_string(),

--- a/crates/stella-serve/tests/bridge.rs
+++ b/crates/stella-serve/tests/bridge.rs
@@ -435,7 +435,7 @@ async fn streamed_provider_deltas_surface_as_events_before_the_completion() {
                     .unwrap();
             }
             ServerFrame::Event { event } => match event {
-                stella_protocol::AgentEvent::TextDelta { text } => {
+                stella_protocol::AgentEvent::TextDelta { delta: text } => {
                     text_deltas.push(text);
                 }
                 stella_protocol::AgentEvent::Reasoning { .. } => reasoning += 1,

--- a/crates/stella-serve/tests/http.rs
+++ b/crates/stella-serve/tests/http.rs
@@ -465,7 +465,7 @@ async fn provider_deltas_stream_onto_the_event_stream_over_http() {
             // Agent events ride nested under the `event` frame type.
             "event" if event["event"]["type"].as_str() == Some("text_delta") => {
                 text_deltas.push(
-                    event["event"]["text"]
+                    event["event"]["delta"]
                         .as_str()
                         .unwrap_or_default()
                         .to_string(),

--- a/crates/stella-store/src/integrity.rs
+++ b/crates/stella-store/src/integrity.rs
@@ -632,7 +632,7 @@ mod tests {
                 id,
                 0,
                 &AgentEvent::Text {
-                    delta: "recoverable transcript".into(),
+                    text: "recoverable transcript".into(),
                 },
             )
             .expect("event");
@@ -760,7 +760,7 @@ mod tests {
                         id,
                         seq,
                         &AgentEvent::Text {
-                            delta: format!("{seq} {}", "padding ".repeat(24)),
+                            text: format!("{seq} {}", "padding ".repeat(24)),
                         },
                     )
                     .expect("event");

--- a/crates/stella-store/src/journal.rs
+++ b/crates/stella-store/src/journal.rs
@@ -214,7 +214,7 @@ impl SessionJournal {
                 return Ok(());
             }
             let (kind, delta) = match event {
-                AgentEvent::Text { delta } => (DeltaKind::Text, delta),
+                AgentEvent::Text { text } => (DeltaKind::Text, text),
                 AgentEvent::Reasoning { delta } => (DeltaKind::Reasoning, delta),
                 _ => {
                     self.flush_pending()?;
@@ -251,7 +251,7 @@ impl SessionJournal {
             return Ok(());
         };
         let event = match p.kind {
-            DeltaKind::Text => AgentEvent::Text { delta: p.buf },
+            DeltaKind::Text => AgentEvent::Text { text: p.buf },
             DeltaKind::Reasoning => AgentEvent::Reasoning { delta: p.buf },
         };
         self.write_line_unsynced(&JournalRecord::Event {
@@ -490,9 +490,7 @@ mod tests {
     fn text(agent: &str, delta: &str) -> JournalRecord {
         JournalRecord::Event {
             agent: agent.into(),
-            event: AgentEvent::Text {
-                delta: delta.into(),
-            },
+            event: AgentEvent::Text { text: delta.into() },
         }
     }
 
@@ -532,7 +530,9 @@ mod tests {
             // the pending run — the run below must still coalesce whole.
             j.write(&JournalRecord::Event {
                 agent: "lead".into(),
-                event: AgentEvent::TextDelta { text: "hel".into() },
+                event: AgentEvent::TextDelta {
+                    delta: "hel".into(),
+                },
             })
             .unwrap();
             j.write(&text("lead", "lo")).unwrap();

--- a/crates/stella-store/src/receipts.rs
+++ b/crates/stella-store/src/receipts.rs
@@ -513,12 +513,12 @@ mod tests {
             )
             .unwrap();
         store
-            .record_event(solo, 1, &AgentEvent::Text { delta: "a".into() })
+            .record_event(solo, 1, &AgentEvent::Text { text: "a".into() })
             .unwrap();
         // A neighbouring execution's rows stay out of this journal.
         let other = store.begin_execution("run", "x", "zai", "glm-5.2").unwrap();
         store
-            .record_event(other, 0, &AgentEvent::Text { delta: "z".into() })
+            .record_event(other, 0, &AgentEvent::Text { text: "z".into() })
             .unwrap();
         // Genuine damage on the target execution is counted, not fatal.
         {

--- a/crates/stella-store/src/reconstruct.rs
+++ b/crates/stella-store/src/reconstruct.rs
@@ -205,9 +205,9 @@ pub(crate) fn journal_preimages(
             } => {
                 out.tool_outputs.insert(call_id, output);
             }
-            AgentEvent::Text { delta } => {
+            AgentEvent::Text { text } => {
                 out.text_by_digest
-                    .insert(format!("sha256:{}", sha256_hex(&delta)), delta);
+                    .insert(format!("sha256:{}", sha256_hex(&text)), text);
             }
             _ => {}
         }

--- a/crates/stella-store/src/reflection.rs
+++ b/crates/stella-store/src/reflection.rs
@@ -276,7 +276,7 @@ mod tests {
                 id,
                 0,
                 &stella_protocol::AgentEvent::Text {
-                    delta: "done".into(),
+                    text: "done".into(),
                 },
             )
             .unwrap();

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -26,7 +26,7 @@ fn execution_lifecycle_events_and_telemetry_roundtrip() {
             id,
             1,
             &AgentEvent::Text {
-                delta: "done".into(),
+                text: "done".into(),
             },
         )
         .unwrap();
@@ -458,7 +458,7 @@ fn producer_materializes_tool_calls_reflection_and_rolls_up_to_usage() {
             id,
             4,
             &AgentEvent::Text {
-                delta: "done".into(),
+                text: "done".into(),
             },
         )
         .unwrap();
@@ -868,20 +868,20 @@ fn session_events_keeps_unknown_variants_and_skips_only_corrupt_payloads() {
         )
         .unwrap();
     store
-        .record_event(turn_one, 1, &AgentEvent::Text { delta: "a".into() })
+        .record_event(turn_one, 1, &AgentEvent::Text { text: "a".into() })
         .unwrap();
     let turn_two = store
         .begin_execution("run", "two", "zai", "glm-5.2")
         .unwrap();
     store.set_execution_session(turn_two, "ses-j").unwrap();
     store
-        .record_event(turn_two, 0, &AgentEvent::Text { delta: "b".into() })
+        .record_event(turn_two, 0, &AgentEvent::Text { text: "b".into() })
         .unwrap();
     // Another session's execution stays out of this journal.
     let elsewhere = store.begin_execution("run", "x", "zai", "glm-5.2").unwrap();
     store.set_execution_session(elsewhere, "ses-other").unwrap();
     store
-        .record_event(elsewhere, 0, &AgentEvent::Text { delta: "z".into() })
+        .record_event(elsewhere, 0, &AgentEvent::Text { text: "z".into() })
         .unwrap();
     // A payload whose variant this build does not know — inserted raw,
     // exactly as a NEWER stella would have left it on disk. This is a version
@@ -1458,11 +1458,11 @@ fn fresh_database_is_created_at_the_latest_schema_version() {
     // of silently corrupting replay and double-counting cost.
     let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
     store
-        .record_event(id, 0, &AgentEvent::Text { delta: "a".into() })
+        .record_event(id, 0, &AgentEvent::Text { text: "a".into() })
         .unwrap();
     assert!(
         store
-            .record_event(id, 0, &AgentEvent::Text { delta: "b".into() })
+            .record_event(id, 0, &AgentEvent::Text { text: "b".into() })
             .is_err(),
         "duplicate (execution_id, seq) must violate UNIQUE"
     );
@@ -1477,7 +1477,7 @@ fn fresh_database_is_created_at_the_latest_schema_version() {
     );
     // Distinct positions still insert freely.
     store
-        .record_event(id, 1, &AgentEvent::Text { delta: "c".into() })
+        .record_event(id, 1, &AgentEvent::Text { text: "c".into() })
         .unwrap();
     store
         .record_telemetry(id, &drift_row(1, "zai", "glm-5.2", 2_000, 2_900))
@@ -1570,7 +1570,7 @@ fn v1_migration_dedupes_a_v0_database_and_retrofits_the_unique_keys() {
                 1,
                 0,
                 &AgentEvent::Text {
-                    delta: "again".into()
+                    text: "again".into()
                 }
             )
             .is_err()
@@ -1582,13 +1582,7 @@ fn v1_migration_dedupes_a_v0_database_and_retrofits_the_unique_keys() {
     );
     // …while fresh positions and the normal readers keep working.
     store
-        .record_event(
-            1,
-            2,
-            &AgentEvent::Text {
-                delta: "new".into(),
-            },
-        )
+        .record_event(1, 2, &AgentEvent::Text { text: "new".into() })
         .unwrap();
     store
         .record_telemetry(1, &drift_row(2, "zai", "glm-5.2", 400, 500))
@@ -2245,17 +2239,17 @@ fn event_session_ids_lists_sessions_with_events_newest_first() {
     let older = store.begin_execution("run", "a", "zai", "glm-5.2").unwrap();
     store.set_execution_session(older, "ses-old").unwrap();
     store
-        .record_event(older, 0, &AgentEvent::Text { delta: "a".into() })
+        .record_event(older, 0, &AgentEvent::Text { text: "a".into() })
         .unwrap();
     let newer = store.begin_execution("run", "b", "zai", "glm-5.2").unwrap();
     store.set_execution_session(newer, "ses-new").unwrap();
     store
-        .record_event(newer, 0, &AgentEvent::Text { delta: "b".into() })
+        .record_event(newer, 0, &AgentEvent::Text { text: "b".into() })
         .unwrap();
     // An execution with events but NO session id must not appear.
     let orphan = store.begin_execution("run", "c", "zai", "glm-5.2").unwrap();
     store
-        .record_event(orphan, 0, &AgentEvent::Text { delta: "c".into() })
+        .record_event(orphan, 0, &AgentEvent::Text { text: "c".into() })
         .unwrap();
     // A session with an execution but no events must not appear either.
     let silent = store.begin_execution("run", "d", "zai", "glm-5.2").unwrap();

--- a/crates/stella-store/src/tests/private_state.rs
+++ b/crates/stella-store/src/tests/private_state.rs
@@ -31,7 +31,7 @@ fn store_db_is_private_inside_permissive_dot_stella_without_chmodding_project_fi
             execution,
             0,
             &AgentEvent::Text {
-                delta: "private transcript".into(),
+                text: "private transcript".into(),
             },
         )
         .unwrap();

--- a/crates/stella-store/tests/enterprise_telemetry.rs
+++ b/crates/stella-store/tests/enterprise_telemetry.rs
@@ -96,7 +96,7 @@ fn sqlite_integer_writes_reject_u64_overflow() {
         .unwrap();
     assert!(
         store
-            .record_event(id, u64::MAX, &AgentEvent::Text { delta: "x".into() })
+            .record_event(id, u64::MAX, &AgentEvent::Text { text: "x".into() })
             .is_err()
     );
     let telemetry = TelemetryRow {

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -121,7 +121,7 @@ async fn main() -> std::io::Result<()> {
                         let _ = react_tx.send(Inbound::Event {
                             agent: agent.clone(),
                             event: AgentEvent::Text {
-                                delta: format!("scope decision: {decision:?}\n"),
+                                text: format!("scope decision: {decision:?}\n"),
                             },
                         });
                         // Any non-ScopeReview stage clears the pending gate;

--- a/crates/stella-tui/src/accessible/tests.rs
+++ b/crates/stella-tui/src/accessible/tests.rs
@@ -14,7 +14,7 @@ fn say(agent: &str, text: &str) -> Inbound {
     Inbound::Event {
         agent: agent.into(),
         event: AgentEvent::Text {
-            delta: text.to_string(),
+            text: text.to_string(),
         },
     }
 }

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -1272,10 +1272,10 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             (TraceKind::Other, format!("unrecognized `{event_type}`"))
         }
         AgentEvent::Stage { name } => (TraceKind::Stage, format!("{name:?}").to_lowercase()),
-        AgentEvent::Text { delta } => (TraceKind::Text, snip(delta)),
+        AgentEvent::Text { text } => (TraceKind::Text, snip(text)),
         // Mapped for completeness; `apply_event` never traces deltas (one
         // row per token would churn the capped ring — see the guard there).
-        AgentEvent::TextDelta { text } => (TraceKind::Text, snip(text)),
+        AgentEvent::TextDelta { delta } => (TraceKind::Text, snip(delta)),
         AgentEvent::Reasoning { delta } => (TraceKind::Reasoning, snip(delta)),
         AgentEvent::ToolStart { call } => (TraceKind::Tool, format!("{}()", call.name)),
         AgentEvent::SpeculationDiscarded { name, reason, .. } => {

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -26,7 +26,7 @@ fn text_deltas_feed_the_preview_without_flooding_the_trace() {
         w.apply_inbound(&ev(
             "lead",
             AgentEvent::TextDelta {
-                text: "tok ".into(),
+                delta: "tok ".into(),
             },
         ));
     }
@@ -56,7 +56,7 @@ fn session_reset_blanks_transcript_zeroes_cost_and_stops_the_clock() {
     w.apply_inbound(&ev(
         "lead",
         AgentEvent::Text {
-            delta: "hi there".into(),
+            text: "hi there".into(),
         },
     ));
     if let Some(a) = w.agents.first_mut() {
@@ -291,7 +291,7 @@ fn register_then_events_route_to_the_right_agent() {
     w.apply_inbound(&reg("lead"));
     w.apply_inbound(&reg("sub"));
     assert_eq!(w.agents.len(), 2);
-    w.apply_inbound(&ev("sub", AgentEvent::Text { delta: "hi".into() }));
+    w.apply_inbound(&ev("sub", AgentEvent::Text { text: "hi".into() }));
     // The event landed on "sub"'s pure fold, not "lead"'s.
     let sub = &w.agents[w.index_of("sub").unwrap()];
     assert_eq!(sub.model.transcript.len(), 1);
@@ -527,7 +527,7 @@ fn supervisor_status_and_terminal_kill_are_respected() {
         status: AgentStatus::Killed,
     });
     // Even a fresh event cannot resurrect a killed agent's lifecycle.
-    w.apply_inbound(&ev("lead", AgentEvent::Text { delta: "x".into() }));
+    w.apply_inbound(&ev("lead", AgentEvent::Text { text: "x".into() }));
     assert_eq!(w.agents[0].status, AgentStatus::Killed);
 }
 

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -23,7 +23,7 @@ fn full_deck_frame_composes_every_band_at_80_cols() {
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "Found the root cause.".into(),
+            text: "Found the root cause.".into(),
         },
     });
 
@@ -158,7 +158,7 @@ fn trace_strip_shows_a_rule_and_the_newest_trace_entry() {
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "Found the root cause.".into(),
+            text: "Found the root cause.".into(),
         },
     });
     let area = Rect::new(0, 0, 60, 2);

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -845,7 +845,7 @@ mod tests {
             tx.send(Inbound::Event {
                 agent: "lead".into(),
                 event: AgentEvent::TextDelta {
-                    text: format!("{n} "),
+                    delta: format!("{n} "),
                 },
             })
             .unwrap();

--- a/crates/stella-tui/src/deck_ui/tests.rs
+++ b/crates/stella-tui/src/deck_ui/tests.rs
@@ -215,7 +215,7 @@ fn ctrl_o_on_a_non_expandable_selection_is_a_no_op() {
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "hello".into(),
+            text: "hello".into(),
         },
     });
     let mut ui = ready_ui();
@@ -854,7 +854,7 @@ fn running_model() -> WorkspaceModel {
     m.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "working".into(),
+            text: "working".into(),
         },
     });
     m
@@ -1020,7 +1020,7 @@ fn an_esc_claimed_by_the_queue_editor_breaks_the_pair_too() {
     let mut model = model_with_queue(&["one"]);
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
-        event: AgentEvent::Text { delta: "hi".into() },
+        event: AgentEvent::Text { text: "hi".into() },
     });
     let mut ui = ready_ui();
     ui.queue_open = true;

--- a/crates/stella-tui/src/fleet_dashboard.rs
+++ b/crates/stella-tui/src/fleet_dashboard.rs
@@ -451,8 +451,8 @@ impl FleetBoard {
                     row.action = LastAction::Thinking;
                 }
             }
-            AgentEvent::Text { delta } => {
-                let line = first_line(delta);
+            AgentEvent::Text { text } => {
+                let line = first_line(text);
                 if !line.is_empty() {
                     row.action = LastAction::Message(line);
                 }

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -521,14 +521,14 @@ impl SessionModel {
                 }
                 self.transcript.push(TranscriptEntry::Stage(*name));
             }
-            AgentEvent::Text { delta } => {
+            AgentEvent::Text { text } => {
                 // The authoritative step text replaces any streamed preview
                 // outright — merging would duplicate (or, after a retry,
                 // garble) what the deltas already showed.
                 self.streaming_text.clear();
-                self.push_text(delta)
+                self.push_text(text)
             }
-            AgentEvent::TextDelta { text } => self.push_streaming_delta(text),
+            AgentEvent::TextDelta { delta } => self.push_streaming_delta(delta),
             AgentEvent::Reasoning { delta } => self.push_reasoning(delta),
             AgentEvent::ToolStart { call } => {
                 self.transcript.push(TranscriptEntry::ToolStart {

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -11,9 +11,7 @@ use stella_protocol::{
 };
 
 fn text(delta: &str) -> AgentEvent {
-    AgentEvent::Text {
-        delta: delta.into(),
-    }
+    AgentEvent::Text { text: delta.into() }
 }
 
 #[test]
@@ -45,7 +43,7 @@ fn a_stage_between_text_deltas_breaks_coalescing() {
 }
 
 fn delta(text: &str) -> AgentEvent {
-    AgentEvent::TextDelta { text: text.into() }
+    AgentEvent::TextDelta { delta: text.into() }
 }
 
 #[test]

--- a/crates/stella-tui/src/render/tests/thinking.rs
+++ b/crates/stella-tui/src/render/tests/thinking.rs
@@ -138,7 +138,7 @@ fn a_settled_thought_reverts_to_its_head() {
         delta: numbered_thought(9),
     });
     model.apply(&AgentEvent::Text {
-        delta: "here is the answer".into(),
+        text: "here is the answer".into(),
     });
     assert!(
         !reasoning_is_live(&model.transcript, &model.streaming_text),
@@ -202,7 +202,7 @@ fn the_collapsed_row_budget_survives_a_single_paragraph_thought() {
     );
     // Settling must not change the height.
     model.apply(&AgentEvent::Text {
-        delta: "done".into(),
+        text: "done".into(),
     });
     let settled = row_texts(&transcript_lines(&model, false, 60));
     let settled_block = first_block(&settled);
@@ -227,7 +227,7 @@ fn a_thought_inside_the_budget_renders_whole_either_way() {
     });
     let live = row_texts(&transcript_lines(&model, false, 0));
     assert_eq!(live, vec!["⏵ thinking  2 lines", "alpha", "beta", ""]);
-    model.apply(&AgentEvent::Text { delta: "x".into() });
+    model.apply(&AgentEvent::Text { text: "x".into() });
     let settled = row_texts(&transcript_lines(&model, false, 0));
     assert_eq!(&settled[..4], &live[..4], "no marker, no reflow");
 }

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -216,8 +216,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             lead,
             AgentEvent::Text {
-                delta: "Planning the automations cluster: list, editor, triggers, workflows."
-                    .into(),
+                text: "Planning the automations cluster: list, editor, triggers, workflows.".into(),
             },
         ),
         // The task board (`task_*` tools): a full snapshot per change, so the

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1126,7 +1126,7 @@ mod tests {
             AgentEvent::Stage {
                 name: StageKind::Execute,
             },
-            AgentEvent::Text { delta: "t".into() },
+            AgentEvent::Text { text: "t".into() },
             AgentEvent::Reasoning { delta: "r".into() },
             AgentEvent::ToolStart {
                 call: ToolCall {

--- a/crates/stella-tui/src/views/files.rs
+++ b/crates/stella-tui/src/views/files.rs
@@ -559,7 +559,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Text {
-                delta: "an answer the clear must remove".into(),
+                text: "an answer the clear must remove".into(),
             },
         });
         model.apply_inbound(&Inbound::Event {

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -832,7 +832,7 @@ mod tests {
         let key_after = rebuilt.0.clone();
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
-            event: AgentEvent::Text { delta: "hi".into() },
+            event: AgentEvent::Text { text: "hi".into() },
         });
         let mut buf = Buffer::empty(area);
         render(&model, &mut ui, area, &mut buf);
@@ -851,7 +851,7 @@ mod tests {
             model.apply_inbound(&Inbound::Event {
                 agent: "lead".into(),
                 event: AgentEvent::TextDelta {
-                    text: fragment.into(),
+                    delta: fragment.into(),
                 },
             });
         }
@@ -870,7 +870,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Text {
-                delta: "streamed tokens arriving".into(),
+                text: "streamed tokens arriving".into(),
             },
         });
         let mut buf = Buffer::empty(area);
@@ -1129,7 +1129,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Text {
-                delta: "first-message".into(),
+                text: "first-message".into(),
             },
         });
 
@@ -1152,7 +1152,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Text {
-                delta: "\nnoise".repeat(40),
+                text: "\nnoise".repeat(40),
             },
         });
         let mut buf2 = Buffer::empty(area);
@@ -1525,7 +1525,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Text {
-                delta: "working".into(),
+                text: "working".into(),
             },
         });
         let area = Rect::new(0, 0, 80, 1);

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -243,7 +243,7 @@ mod tests {
         model.apply_inbound(&ev(
             "a",
             AgentEvent::Text {
-                delta: "building the auth refactor".into(),
+                text: "building the auth refactor".into(),
             },
         ));
         model.apply_inbound(&ev(

--- a/crates/stella-tui/tests/accessible_layout.rs
+++ b/crates/stella-tui/tests/accessible_layout.rs
@@ -193,7 +193,7 @@ fn scoped_session(accessible: bool) -> (WorkspaceModel, DeckUi) {
         name: StageKind::Execute,
     }));
     model.apply_inbound(&event(AgentEvent::Text {
-        delta: "the transcript body".into(),
+        text: "the transcript body".into(),
     }));
     (model, deck_ui(DeckTab::Session, accessible))
 }
@@ -261,7 +261,7 @@ fn the_live_pane_skips_whatever_is_already_in_scrollback() {
             AgentEvent::Stage {
                 name: StageKind::Execute,
             },
-            AgentEvent::Text { delta: line.into() },
+            AgentEvent::Text { text: line.into() },
         ] {
             model.apply_inbound(&Inbound::Event {
                 agent: "lead".into(),

--- a/crates/stella-tui/tests/accessible_tables.rs
+++ b/crates/stella-tui/tests/accessible_tables.rs
@@ -157,7 +157,7 @@ fn the_traces_timeline_reads_as_labelled_records() {
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "building the auth refactor".into(),
+            text: "building the auth refactor".into(),
         },
     });
 

--- a/crates/stella-tui/tests/render_robustness.rs
+++ b/crates/stella-tui/tests/render_robustness.rs
@@ -217,9 +217,7 @@ fn nasty_unicode_transcript_never_panics_at_any_width() {
         let mut model = WorkspaceModel::new();
         model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "t", 0)));
         for ev in [
-            AgentEvent::Text {
-                delta: text.clone(),
-            },
+            AgentEvent::Text { text: text.clone() },
             AgentEvent::Reasoning {
                 delta: text.clone(),
             },

--- a/crates/stella-tui/tests/subagent_rows.rs
+++ b/crates/stella-tui/tests/subagent_rows.rs
@@ -27,7 +27,7 @@ fn model_with_subagent() -> WorkspaceModel {
     m.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Text {
-            delta: "the transcript body".into(),
+            text: "the transcript body".into(),
         },
     });
     m

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1055,10 +1055,10 @@ export type AgentEvent = {
   name: StageKind;
   type: "stage";
 } | {
-  delta: string;
+  text: string;
   type: "text";
 } | {
-  text: string;
+  delta: string;
   type: "text_delta";
 } | {
   delta: string;

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1662,9 +1662,9 @@
       "type": "object"
     },
     {
-      "description": "The step's answer text, in full — the authoritative, durable record.\nThe field name `delta` is wire-frozen legacy and does NOT mean a\nfragment: the live fragments are [`AgentEvent::TextDelta`], which the\njournal deliberately drops. Consumers must REPLACE any accumulated\npreview with this value, never append it to one.",
+      "description": "The step's answer text, in full — the authoritative, durable record.\nNot a fragment, despite the live preview sibling\n[`AgentEvent::TextDelta`]: consumers must REPLACE any accumulated\npreview with this value, never append it to one.\n\nWire history (#1886): this field was spelled `delta` (and\n`text_delta`'s payload was spelled `text` — each variant carried the\nother's natural name). Serialization writes the self-describing name;\nthe alias keeps every recorded stream replaying. Raw-JSONL readers\nmust stay bilingual the same way: `text` first, legacy `delta` back.",
       "properties": {
-        "delta": {
+        "text": {
           "type": "string"
         },
         "type": {
@@ -1674,14 +1674,14 @@
       },
       "required": [
         "type",
-        "delta"
+        "text"
       ],
       "type": "object"
     },
     {
-      "description": "One in-order fragment of the answer text, emitted live while the\nmodel call streams. Strictly a best-effort preview: the step's\nfollowing `Text` event carries the full text and is authoritative —\nconsumers must REPLACE any accumulated deltas with it, never merge\n(a retried model call re-streams its deltas from the start, so the\naccumulation can be garbled; there is no reset marker). Additive to\nthe stream-json wire contract: consumers must tolerate `text_delta`\nlines appearing between events, and persistence layers may drop them\n(the `Text` event is the durable record).",
+      "description": "One in-order fragment of the answer text, emitted live while the\nmodel call streams. Strictly a best-effort preview: the step's\nfollowing `Text` event carries the full text and is authoritative —\nconsumers must REPLACE any accumulated deltas with it, never merge\n(a retried model call re-streams its deltas from the start, so the\naccumulation can be garbled; there is no reset marker). Additive to\nthe stream-json wire contract: consumers must tolerate `text_delta`\nlines appearing between events, and persistence layers may drop them\n(the `Text` event is the durable record). Wire history: `delta` was\nspelled `text` before #1886 — the alias accepts both; see [`AgentEvent::Text`].",
       "properties": {
-        "text": {
+        "delta": {
           "type": "string"
         },
         "type": {
@@ -1691,7 +1691,7 @@
       },
       "required": [
         "type",
-        "text"
+        "delta"
       ],
       "type": "object"
     },

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -25,10 +25,10 @@ export type AgentEvent = {
   name: StageKind;
   type: "stage";
 } | {
-  delta: string;
+  text: string;
   type: "text";
 } | {
-  text: string;
+  delta: string;
   type: "text_delta";
 } | {
   delta: string;

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -21,9 +21,9 @@
           "type": "object"
         },
         {
-          "description": "The step's answer text, in full — the authoritative, durable record.\nThe field name `delta` is wire-frozen legacy and does NOT mean a\nfragment: the live fragments are [`AgentEvent::TextDelta`], which the\njournal deliberately drops. Consumers must REPLACE any accumulated\npreview with this value, never append it to one.",
+          "description": "The step's answer text, in full — the authoritative, durable record.\nNot a fragment, despite the live preview sibling\n[`AgentEvent::TextDelta`]: consumers must REPLACE any accumulated\npreview with this value, never append it to one.\n\nWire history (#1886): this field was spelled `delta` (and\n`text_delta`'s payload was spelled `text` — each variant carried the\nother's natural name). Serialization writes the self-describing name;\nthe alias keeps every recorded stream replaying. Raw-JSONL readers\nmust stay bilingual the same way: `text` first, legacy `delta` back.",
           "properties": {
-            "delta": {
+            "text": {
               "type": "string"
             },
             "type": {
@@ -33,14 +33,14 @@
           },
           "required": [
             "type",
-            "delta"
+            "text"
           ],
           "type": "object"
         },
         {
-          "description": "One in-order fragment of the answer text, emitted live while the\nmodel call streams. Strictly a best-effort preview: the step's\nfollowing `Text` event carries the full text and is authoritative —\nconsumers must REPLACE any accumulated deltas with it, never merge\n(a retried model call re-streams its deltas from the start, so the\naccumulation can be garbled; there is no reset marker). Additive to\nthe stream-json wire contract: consumers must tolerate `text_delta`\nlines appearing between events, and persistence layers may drop them\n(the `Text` event is the durable record).",
+          "description": "One in-order fragment of the answer text, emitted live while the\nmodel call streams. Strictly a best-effort preview: the step's\nfollowing `Text` event carries the full text and is authoritative —\nconsumers must REPLACE any accumulated deltas with it, never merge\n(a retried model call re-streams its deltas from the start, so the\naccumulation can be garbled; there is no reset marker). Additive to\nthe stream-json wire contract: consumers must tolerate `text_delta`\nlines appearing between events, and persistence layers may drop them\n(the `Text` event is the durable record). Wire history: `delta` was\nspelled `text` before #1886 — the alias accepts both; see [`AgentEvent::Text`].",
           "properties": {
-            "text": {
+            "delta": {
               "type": "string"
             },
             "type": {
@@ -50,7 +50,7 @@
           },
           "required": [
             "type",
-            "text"
+            "delta"
           ],
           "type": "object"
         },

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -136,7 +136,7 @@ it existed sees:
 ```json
 {"type":"stage","name":"execute"}
 {"type":"spline_reticulated","call_id":"q_1","splines":["alpha","beta"]}
-{"type":"text","delta":"Done."}
+{"type":"text","text":"Done."}
 {"type":"complete","model":"m","cost_usd":0.002}
 ```
 

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -45,6 +45,9 @@ a conformance fixture to test your client against.
 In particular, `text_delta` lines stream the answer token by token as a best-effort live
 preview — the `text` event that follows carries the full step text and is authoritative
 (replace any accumulated deltas with it; a retried model call re-streams its deltas).
+The fragment rides in `text_delta`'s `delta` field and the full body in `text`'s `text`
+field; streams recorded by older stellas spell the two fields crossed, so a reader that
+also processes archives should accept either spelling on either event.
 
 ```bash
 # One final JSON object


### PR DESCRIPTION
## What & why

In `stella-events.jsonl` (and every other serialization of `AgentEvent`), the two answer-text events carried each other's natural field name: the consolidated body went out as `{"type":"text","delta":…}` and the live fragment as `{"type":"text_delta","text":…}`. Every consumer had to learn the swap by observation — arenabench rendered every response twice until PR #1884 taught its reader both shapes.

This PR makes the wire self-describing and keeps every recorded stream readable:

- **Emitter** (`stella-protocol::AgentEvent`): `Text` now carries `text`, `TextDelta` carries `delta` — the Rust fields are renamed to match, chased through all 22 crates (compile-checked; exhaustive struct-variant patterns mean no site can be missed).
- **Versioning**: `#[serde(alias)]` on both fields accepts the legacy crossed spelling forever, so archived benchmark evidence, old `store.db` journals, and the committed pipeline replay fixtures (which deliberately stay in the old spelling) all keep parsing. The variant doc comments — which are the wire contract, exported into `docs/wire/agentevent.schema.json` — state the history and the bilingual-reader rule.
- **Raw-JSONL readers made/kept bilingual**: stella-observatory's journal transcript (`db.rs`) and sent-context preimage index (`sent_context.rs`) gained the fallback; arenabench's recorder (`render.py`) gained it; arenabench's TranscriptReader and the harbor adapter (`__init__.py`, `atif.py`) already had it from #1884.
- **docs/wire regenerated** (`make wire-schema-update`), plus the protocol README gotcha, the scripting and event-stream-compatibility website pages.

Exemplar for the mechanism: serde's own `alias` idiom for wire renames, as used across the ecosystem (e.g. cargo's manifest field renames) — canonical name on write, alias on read.

Closes #1886

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-protocol/tests/text_event_wire.rs` — pins the exact serialized bytes of both variants (fails on `main`: the fields don't exist there, E0559/E0026 — verified by restoring `main`'s `event.rs` against the new test file) and witnesses that the legacy crossed spellings still deserialize. Reader-side tests each way: arenabench `test_telemetry.py` (legacy + current transcript), harbor `tests/test_text_field_spellings.py` (current; `test_adapter.py` keeps legacy), stella-observatory journal fixture now holds one row per generation.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (plus `make guards`, arenabench pytest 145 passed, harbor pytest 442 passed)
- [x] Docs updated where behavior/flags changed (protocol README, website scripting + event-stream-compatibility, docs/wire regenerated)
- [x] CLA signed
- [x] `Closes #1886` appears both above and as a commit trailer

## Nothing left behind

- #1910 — `arenabench/recorder/render.py` has no unit tests at all, so its now-bilingual read is the one reader without a test each way (it needs a screen stub first; filed as a handoff).
- `bench/harbor_adapter/tests/test_adapter.py` sits at its file-size ceiling; the new current-spelling tests went into their own module (`test_text_field_spellings.py`) per the god-file rule rather than growing it.

## Summary by Sourcery

Align AgentEvent text event field names with their semantics while preserving backwards compatibility and updating consumers accordingly.

New Features:
- Introduce serde aliases so AgentEvent::Text and AgentEvent::TextDelta accept both legacy and current wire field spellings for text payloads.

Bug Fixes:
- Correct the crossed wire field names for text and text_delta events so consolidated text uses the text field and streaming fragments use the delta field.
- Ensure all raw-JSONL readers and adapters handle both legacy and current text field spellings without duplicating or dropping content.

Enhancements:
- Update all protocol, CLI, core, pipeline, TUI, store, serve, and adapter code paths to use the new AgentEvent text and text_delta field names consistently.
- Refine protocol documentation, wire type definitions, and website docs to describe the corrected contract and field spelling history for text events.

Tests:
- Add dedicated protocol tests pinning the exact serialized/parsed forms of current and legacy text/text_delta events, including type tags.
- Extend arenabench, harbor adapter, and observatory tests and fixtures to verify bilingual handling of both generations of text event field spellings.