### PR TITLE
fix(stella-pipeline): let acceptance return the identity it pinned (#1789)

### DIFF
--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -513,17 +513,22 @@ impl<'a> Pipeline<'a> {
             }
             _ => WitnessAbort::rejected(error.to_string()),
         })?;
-        let path = fingerprints
-            .keys()
-            .next()
-            .expect("validated witness artifact contains exactly one path");
+        // Taken as a pair, so neither the path nor its fingerprint is
+        // recovered by indexing the map a second time (#1789): the validator
+        // above guarantees exactly one entry, and reading it once is how that
+        // guarantee stays a fact about this code rather than a comment.
+        let Some((path, fingerprint)) = fingerprints.iter().next() else {
+            return Err(WitnessAbort::rejected(
+                "the accepted witness artifact named no path".to_string(),
+            ));
+        };
         validate_witness_invocation(path, &invocation)
             .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
         // Accept the artifact where it was written before copying it anywhere:
         // a symlink or multiply-linked file must be rejected in the snapshot
         // that produced it, never resolved by a copy.
         let authored = baseline.repo_status.artifact_identity(path).await;
-        validate_witness_identity(path, &fingerprints[path], authored.as_ref())
+        validate_witness_identity(path, fingerprint, authored)
             .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
 
         // Cross into the tree that executed. A failure here is degradable: the
@@ -549,9 +554,8 @@ impl<'a> Pipeline<'a> {
         // execute — not the identity of the original in a snapshot that is
         // about to be deleted.
         let identity = candidate.repo_status.artifact_identity(path).await;
-        validate_witness_identity(path, &fingerprints[path], identity.as_ref())
+        let identity = validate_witness_identity(path, fingerprint, identity)
             .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
-        let identity = identity.expect("validated witness identity is present");
         // Announced only here, past every integrity check: the rail's "witness
         // authored" row must mean the artifact was accepted AND pinned, never
         // that a model produced a file.

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -499,18 +499,25 @@ fn dotnet_invocation_is_exact(path: &str, args: &[String]) -> bool {
 /// identity must have been observed at the accepted path itself — an
 /// observation the adapter attests was resolved elsewhere (or could not
 /// locate at all) is not the accepted artifact.
+///
+/// Returns the identity it accepted rather than `()`, so the caller that needs
+/// the pinned value gets it *from the proof* instead of re-unwrapping the same
+/// `Option` afterwards (#1789). The unwrap was locally sound and one line from
+/// what proved it, which is exactly how it survived review; making the
+/// signature carry the proof means no future edit between the two lines can
+/// make it unsound again.
 pub fn validate_witness_identity(
     path: &str,
     expected_fingerprint: &str,
-    identity: Option<&ArtifactIdentity>,
-) -> Result<(), WitnessArtifactError> {
+    identity: Option<ArtifactIdentity>,
+) -> Result<ArtifactIdentity, WitnessArtifactError> {
     match identity {
         Some(identity)
             if identity.is_regular_single_link()
                 && identity.path == path
                 && identity.fingerprint == expected_fingerprint =>
         {
-            Ok(())
+            Ok(identity)
         }
         _ => Err(WitnessArtifactError::InvalidIdentity(path.to_string())),
     }
@@ -1214,7 +1221,7 @@ mod tests {
             validate_witness_identity(
                 "tests/authority_witness.rs",
                 "w1",
-                Some(&observed_at_accepted_path)
+                Some(observed_at_accepted_path)
             )
             .is_ok()
         );
@@ -1223,13 +1230,36 @@ mod tests {
             ..identity("w1")
         };
         assert!(
-            validate_witness_identity(
-                "tests/authority_witness.rs",
-                "w1",
-                Some(&observed_elsewhere)
-            )
-            .is_err(),
+            validate_witness_identity("tests/authority_witness.rs", "w1", Some(observed_elsewhere))
+                .is_err(),
             "an identity the adapter attests was resolved elsewhere is not the accepted artifact"
+        );
+    }
+
+    /// **Witness (#1789).** Acceptance hands back the identity it accepted.
+    ///
+    /// The witness stage pinned the grafted artifact by calling this and then
+    /// unwrapping the same `Option` again. That unwrap was sound — this
+    /// function rejects `None` — but soundness proved one line away is the
+    /// shape that decays: any edit between the check and the unwrap makes it a
+    /// panic in the one stage whose entire contract is to degrade rather than
+    /// discard a finished change. Returning the value removes the second read.
+    ///
+    /// Fails to compile on the old signature, which returned `()`.
+    #[test]
+    fn acceptance_yields_the_identity_it_pinned() {
+        let observed = identity("w1");
+        let pinned = validate_witness_identity("tests/authority_witness.rs", "w1", Some(observed))
+            .expect("the identity was observed at the accepted path");
+        assert_eq!(
+            pinned,
+            identity("w1"),
+            "the caller must pin the identity acceptance proved, never a second observation"
+        );
+        assert!(
+            validate_witness_identity("tests/authority_witness.rs", "w1", None).is_err(),
+            "an absent observation is a rejection, which is what makes the caller's \
+             re-unwrap removable rather than merely unlikely"
         );
     }
 


### PR DESCRIPTION
fix(stella-pipeline): let acceptance return the identity it pinned

The last two `expect`s named by #1789, in the one stage whose entire contract
is to degrade rather than discard a finished change. Both were on values
derived from filesystem I/O — runtime data, which invariant 5 puts off limits
regardless of how locally provable the call is.

`validate_witness_identity` returned `()`, so the caller that needed the
pinned identity called it, discarded the answer, and unwrapped the same
`Option` on the next line. That unwrap was sound: the function rejects `None`.
Soundness proved one line away is exactly the shape that survives review and
then decays — any edit landing between the check and the unwrap turns it into
a panic, and this is the stage where a panic throws away a worker's completed
diff for want of scaffolding. Returning the accepted identity removes the
second read, so the invariant is carried by the signature instead of by two
lines happening to stay adjacent.

The path extraction gets the same treatment: taking `(path, fingerprint)` as a
pair from the validated map reads it once, which deletes the `expect` and both
`fingerprints[path]` index lookups — map indexing panics on a miss, and it was
reached twice.

## Witness

`acceptance_yields_the_identity_it_pinned` asserts the accepted identity comes
back, and that an absent observation is still a rejection — the property that
makes the caller's re-unwrap removable rather than merely unlikely.

It fails on the old code as a compile error:

    error[E0308]: mismatched types
      --> crates/stella-pipeline/src/witness.rs:1256:13
       |
    1256 |             identity("w1"),
       |             ^^^^^^^^^^^^^^ expected `()`, found `ArtifactIdentity`

Stronger than a runtime assertion here: no implementation of the old signature
can be made to pass it.

## What was already done

#1789 named two shapes; PR #1890 shipped most of both. The budget arms of the
author and repair turns already degrade rather than reject (covered by
`witness_author_and_repair_are_individually_metered_before_degrade`), and the
`baseline.workspace` and grafting `expect`s are already `let … else` with typed
degradable aborts. This is the remainder, and it closes the issue.

No behavioural change: every reachable path returns exactly what it did
before. `cargo test -p stella-pipeline` — 551 passed, 0 failed, plus 22 across
the integration binaries. Clippy, fmt, `check-file-size`, `check-god-files`,
`check-left-behind` and `check-module-reachability` clean.

Closes #1789

## Summary by Sourcery

Return the validated artifact identity from witness validation and consume witness fingerprints in a single, non-panicking read to keep the witness stage degradable and eliminate fragile re-unwrap patterns.

Bug Fixes:
- Make witness identity validation return the accepted identity so callers no longer re-unwrap the same optional value and risk panics after future edits.
- Avoid multiple map index lookups for witness fingerprints by reading the single validated entry once, preventing potential panics on missing keys.

Enhancements:
- Add a regression test ensuring acceptance returns the pinned identity and rejects absent observations, closing the remaining surface of #1789.