### PR TITLE
fix(stella-cli): name the session on stdout when a detached launch is machine-readable (#1688)

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -256,6 +256,7 @@ pub(crate) fn supervise_this_invocation(
     title: &str,
     stdin: &[u8],
     posture: detach::Posture,
+    format: crate::OutputFormat,
 ) -> Result<(), String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot locate the stella binary to supervise: {e}"))?;
@@ -286,7 +287,7 @@ pub(crate) fn supervise_this_invocation(
         stdin,
     )?;
     if posture == detach::Posture::Detached {
-        return detach::release(run);
+        return detach::release(run, format);
     }
     run.announce();
     watch(rt, &registry, run)

--- a/crates/stella-cli/src/daemon/detach.rs
+++ b/crates/stella-cli/src/daemon/detach.rs
@@ -48,6 +48,7 @@
 //! contradictory command line: the flag that asks for *less* machinery wins.
 
 use super::Supervised;
+use crate::OutputFormat;
 
 /// What this invocation does with the supervisor.
 ///
@@ -127,10 +128,16 @@ pub(crate) fn posture(
 /// The announcement is printed on **stderr** for the same reason the attached
 /// banner is: `--output-format json` writes the machine-readable answer to
 /// stdout, and a launcher that garnished it would break every script that
-/// pipes one.
-pub(crate) fn release(run: Supervised) -> Result<(), String> {
+/// pipes one. Under a machine-readable format stdout additionally carries one
+/// [`DetachedRunSummary`] — the id a script needs in order to do anything at
+/// all with the run it just started (#1688).
+pub(crate) fn release(run: Supervised, format: OutputFormat) -> Result<(), String> {
     use colored::Colorize;
 
+    if let Some(summary) = summary_json(format, &run.id) {
+        println!("{summary}");
+        crate::note_json_summary_emitted();
+    }
     eprintln!(
         "{} {} — running in the background",
         "▸ detached".green().bold(),
@@ -146,6 +153,71 @@ pub(crate) fn release(run: Supervised) -> Result<(), String> {
     );
     drop(run);
     Ok(())
+}
+
+/// The stdout envelope for a detached launch under `--output-format
+/// json|stream-json`.
+///
+/// A fourth member of the family in [`crate::SUMMARY_SCHEMA_VERSION`]'s doc,
+/// declared first for the same reason and built from a struct rather than
+/// `serde_json::json!` for the same one. Purely additive — a new envelope with
+/// a new `status`, no existing shape changed — so the version does **not**
+/// bump; that constant's rule reserves a bump for a change that could break a
+/// consumer written against the previous version.
+///
+/// # What it deliberately does not carry
+///
+/// The child's pid, which is right there on [`Supervised`] and would be the
+/// obvious thing to add. A pid answers "not yet reaped", which is a different
+/// question from "still running" — this module's own doc says the liveness
+/// lock is the only correct way to ask the latter. Publishing the pid in a
+/// machine-readable envelope is an invitation to answer the wrong question,
+/// and a contract is much harder to withdraw than to omit.
+#[derive(serde::Serialize)]
+struct DetachedRunSummary<'a> {
+    schema_version: u32,
+    status: &'static str,
+    /// The registry id — what `stella daemon attach|stop` takes, and the one
+    /// value a script cannot proceed without.
+    session_id: &'a str,
+    /// The commands the stderr banner shows, so a consumer reading only
+    /// stdout is not required to reconstruct them by string-building.
+    attach: String,
+    stop: String,
+}
+
+/// The machine-readable launch summary, or `None` for human output.
+///
+/// Pure over the two inputs that decide it so the contract is testable without
+/// spawning anything — the split this crate uses everywhere the orchestration
+/// half is the expensive part.
+fn summary_json(format: OutputFormat, id: &str) -> Option<String> {
+    let value = DetachedRunSummary {
+        schema_version: crate::SUMMARY_SCHEMA_VERSION,
+        status: "detached",
+        session_id: id,
+        attach: format!("stella daemon attach {id}"),
+        stop: format!("stella daemon stop {id}"),
+    };
+    // An integer and four strings cannot fail to serialize; the fallback keeps
+    // the contract rather than proving the point — the same posture as
+    // `crate::error_summary_json`.
+    let fallback = || {
+        format!(
+            r#"{{"schema_version":{},"status":"detached","session_id":"{id}"}}"#,
+            crate::SUMMARY_SCHEMA_VERSION
+        )
+    };
+    match format {
+        OutputFormat::Text => None,
+        OutputFormat::Json => {
+            Some(serde_json::to_string_pretty(&value).unwrap_or_else(|_| fallback()))
+        }
+        // Compact, so the line-delimited contract holds.
+        OutputFormat::StreamJson => {
+            Some(serde_json::to_string(&value).unwrap_or_else(|_| fallback()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/daemon/detach/tests.rs
+++ b/crates/stella-cli/src/daemon/detach/tests.rs
@@ -88,7 +88,7 @@ fn a_detached_run_outlives_its_launcher_and_stays_discoverable_and_stoppable() {
         .expect("supervised spawn");
         let id = run.id.clone();
         // The launcher returns here. Everything below runs with no handle.
-        release(run).expect("release");
+        release(run, crate::OutputFormat::Text).expect("release");
         id
     };
 
@@ -177,4 +177,56 @@ fn only_the_foreground_posture_keeps_the_work_in_this_process() {
     assert!(!Posture::Foreground.supervises());
     assert!(Posture::Attached.supervises());
     assert!(Posture::Detached.supervises());
+}
+
+/// **Witness (#1688).** A detached launch under a machine-readable format
+/// names its session on stdout.
+///
+/// `stella run "…" --detach --output-format json` wrote **nothing at all** to
+/// stdout, so a script piping it into `jq` got an empty stream and could not
+/// learn the id it needs to poll — for the flag whose main use is exactly that
+/// script. The id was recoverable only by scraping the stderr banner or racing
+/// `stella daemon list`.
+#[test]
+fn a_detached_launch_names_its_session_on_stdout_under_json() {
+    let summary = super::summary_json(crate::OutputFormat::Json, "sess-1688")
+        .expect("json asks for a machine-readable answer");
+    let value: serde_json::Value = serde_json::from_str(&summary).expect("parseable by a consumer");
+
+    assert_eq!(
+        value["session_id"], "sess-1688",
+        "the one value a script cannot proceed without: {summary}"
+    );
+    assert_eq!(value["schema_version"], crate::SUMMARY_SCHEMA_VERSION);
+    assert_eq!(value["status"], "detached");
+    assert_eq!(value["attach"], "stella daemon attach sess-1688");
+    assert_eq!(value["stop"], "stella daemon stop sess-1688");
+}
+
+/// `stream-json` gets the object compact, so the line-delimited contract holds.
+///
+/// A pretty-printed object here would be a multi-line document on a stream
+/// whose consumers split on newlines — the failure would land in the consumer,
+/// not in Stella, which is why it is pinned rather than left to the formatter.
+#[test]
+fn the_stream_json_launch_summary_occupies_exactly_one_line() {
+    let summary = super::summary_json(crate::OutputFormat::StreamJson, "sess-1688")
+        .expect("stream-json asks for a machine-readable answer");
+
+    assert!(
+        !summary.contains('\n'),
+        "one JSON document per line: {summary:?}"
+    );
+    let value: serde_json::Value = serde_json::from_str(&summary).expect("parseable");
+    assert_eq!(value["session_id"], "sess-1688");
+}
+
+/// A human run keeps stdout clean — the banner is the answer, on stderr.
+///
+/// The inverse of the witness above, and the reason the fix is gated on the
+/// format rather than always printing: a text-mode `stella run --detach` that
+/// started emitting JSON would be a regression for every interactive user.
+#[test]
+fn a_text_launch_writes_nothing_to_stdout() {
+    assert!(super::summary_json(crate::OutputFormat::Text, "sess-1688").is_none());
 }

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -221,10 +221,11 @@ pub(crate) fn note_json_summary_emitted() {
 
 /// The version of the `--output-format json|stream-json` summary envelope this
 /// build emits. Every summary object carries it — the pipeline summary, the raw
-/// step-loop summary, and the pre-flight error envelope — so a consumer can
-/// branch on the shape instead of sniffing for keys.
+/// step-loop summary, the pre-flight error envelope, and the detached-launch
+/// summary ([`crate::daemon::detach`]) — so a consumer can branch on the shape
+/// instead of sniffing for keys.
 ///
-/// All three envelopes are structs with the version declared first, so a derived
+/// All four envelopes are structs with the version declared first, so a derived
 /// `Serialize` heads the object — a courtesy, not a promise: key order stays
 /// outside the contract and consumers must read by key. Building any with
 /// `serde_json::json!` would undo that (a `json!` object is a sorted map that
@@ -1033,6 +1034,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &supervised_title(&cfg, &prompt),
                     prompt.as_bytes(),
                     posture,
+                    output_format,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1085,6 +1087,9 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &supervised_title(&cfg, &goal),
                     goal.as_bytes(),
                     posture,
+                    // `goal` declares no `--output-format`, so there is no
+                    // machine-readable stream to name the session on.
+                    OutputFormat::Text,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1125,6 +1130,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     ),
                     &[],
                     posture,
+                    output_format,
                 ).map_err(failure::CliFailure::from);
             }
             signals::block_on_interruptible(
@@ -1153,6 +1159,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &supervised_title(&cfg, &format!("monitor {target}")),
                     &[],
                     posture,
+                    // `monitor` declares no `--output-format` either.
+                    OutputFormat::Text,
                 ).map_err(failure::CliFailure::from);
             }
             // Monitoring IS a goal: the verifier (who can call ci_status

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -81,6 +81,28 @@ Two differences from an attached launch, both deliberate:
 - **A terminal is not required.** Plain supervision declines without one, since a run with no terminal to lose is already immune to the hangup. "Return now" is wanted from a pipe, a container, a `cron` job and a shell script exactly as much as from a terminal, so the flag forces supervision rather than merely permitting it.
 - **The exit code is the launch's, not the run's.** `stella run --detach; echo $?` answers "did the launch succeed". The run's own answer arrives in `stella daemon list`.
 
+### Detaching from a script
+
+The banner above is on **stderr**, so it never garnishes a pipe. Under `--output-format json` or `stream-json`, stdout carries one launch summary naming the session — the id a script needs before it can do anything at all with the run it just started:
+
+```bash
+$ stella run "migrate the config loader to serde" --detach --output-format json
+{
+  "schema_version": 1,
+  "status": "detached",
+  "session_id": "ses-1785956826121-25167",
+  "attach": "stella daemon attach ses-1785956826121-25167",
+  "stop": "stella daemon stop ses-1785956826121-25167"
+}
+```
+
+```bash
+id=$(stella run "…" --detach --output-format json | jq -r .session_id)
+stella daemon stop "$id"
+```
+
+`stream-json` gets the same object compact on one line, so the line-delimited contract holds. `status` is `detached` rather than `ok`: the launch succeeded, and the run's own verdict is a later, separate question — see [scripting](/docs/scripting) for the envelope family this joins.
+
 It applies to every supervised verb — `run`, `goal`, `monitor`, `fleet` — and `STELLA_DETACH=1` sets it for a whole shell. `--foreground` wins if both are given: the flag that asks for less machinery is the safer reading of a contradictory command line, and a declared conflict would break the supervised child, which re-parses its parent's argv (`--detach` included) with `STELLA_FOREGROUND=1` in its environment.
 
 A detached run cannot ask *this* terminal anything, because there is no longer one attached — but it does not lose the answer either. A plan that crosses the scope thresholds parks exactly as described below, and the next `stella daemon attach` asks the question.


### PR DESCRIPTION
fix(stella-cli): name the session on stdout when a detached launch is machine-readable

`stella run "…" --detach --output-format json` wrote nothing at all to stdout.
A script piping it into `jq` got an empty stream and could not learn the
session id it needs to poll — for the flag whose main use is precisely that
script. The id was recoverable only by scraping the stderr banner or by racing
`stella daemon list`.

`detach::release` now takes the resolved format and, when it is machine
readable, prints one `DetachedRunSummary` before the human banner. The banner
stays on stderr exactly as before, so nothing that reads stdout today changes.

## The envelope

A fourth member of the family documented on `SUMMARY_SCHEMA_VERSION`, built
the same way for the same reasons: a struct rather than `serde_json::json!` so
the version heads the object, pretty for `json` and compact for `stream-json`
so the line-delimited contract holds, and a serialize fallback that keeps the
contract rather than proving it cannot fail.

Purely additive — a new envelope with a new `status`, no existing shape
touched — so the version does NOT bump. That constant's own rule reserves a
bump for changes that could break a consumer written against the previous
version, and burning the signal on an addition is what #644 warns against.

That doc said "all three envelopes" and now says four; a comment that no
longer describes the code is a bug in review here.

## What it deliberately omits

The child's pid, which sits right there on `Supervised` and is the obvious
thing to add. This module's own doc says the liveness lock is the only correct
way to ask whether a detached run is alive, because a pid answers "not yet
reaped" — a different question. Publishing it in a machine-readable envelope
would invite consumers to answer the wrong one, and a contract is far harder
to withdraw than to omit.

`attach` and `stop` command strings are included instead: a consumer reading
only stdout should not have to reconstruct them by string-building.

## Scope

`supervise_this_invocation` gains the format; `run` and `fleet` pass their
`--output-format`, and `goal` and `monitor` pass `Text` because they declare
no such flag — the run/fleet scoping #1567 established.

## Witnesses

The emission is a pure function of (format, id), so the contract is testable
without spawning anything:

- `a_detached_launch_names_its_session_on_stdout_under_json` — asserts the id,
  the schema version, `status: "detached"`, and both command hints, parsed as
  JSON rather than string-matched.
- `the_stream_json_launch_summary_occupies_exactly_one_line` — pins compactness
  under `stream-json`. A pretty document on a newline-split stream fails in the
  consumer rather than in Stella, which is why it is pinned rather than left to
  the formatter.
- `a_text_launch_writes_nothing_to_stdout` — the inverse, and the reason this
  is gated on format at all: an interactive `--detach` that started printing
  JSON would be a regression for every human user.

All three fail on the old code, which had no such function. That the old
behaviour really was an empty stdout is directly checkable rather than
asserted:

    $ git show origin/main:crates/stella-cli/src/daemon/detach.rs \
        | rg -n '\bprintln!|summary_json|stdout'
    129:/// stdout, and a launcher that garnished it would break every script

— the sole occurrence of the word is inside a comment.

Docs: `website/content/docs/commands/daemon.mdx` gains a "Detaching from a
script" section with the envelope and a two-line `jq` recipe, per the issue.

`cargo test -p stella-cli` — 1442 passed (was 1439), 0 failed. Clippy
`-D warnings`, `fmt --check`, rustdoc `-D warnings`, `command-docs`,
`doc-links`, `check-file-size`, `check-god-files`, `check-module-reachability`
and `check-left-behind` all clean.

Closes #1688
Refs #1607, #1594

## Summary by Sourcery

Ensure detached runs under machine-readable output formats emit a structured session summary on stdout while preserving existing human-facing behavior.

New Features:
- Add a detached-run JSON/stream-json summary envelope that includes schema version, status, session id, and attach/stop command hints on stdout when using machine-readable output formats.

Bug Fixes:
- Fix detached launches with JSON output producing no stdout, allowing scripts to reliably obtain the session id without scraping stderr or polling the daemon.

Enhancements:
- Thread the output format into supervision/detach handling so only machine-readable modes emit the new summary, keeping text-mode stdout clean.
- Document script-friendly detached usage and the new summary envelope in the daemon command documentation, including a jq-based recipe.

Tests:
- Add unit tests covering JSON and stream-json detached launch summaries and asserting that text-mode detached launches produce no stdout output.