### PR TITLE
test(stella-tui): stop the deck goldens pinning the plan-review dialog (#1651)

### DIFF
--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -301,7 +301,29 @@ fn base_ui(tab: DeckTab) -> DeckUi {
     // The driver seeds this at session start, so every frame the real deck
     // draws has it — including the one `/models` renders from.
     ui.engine.pristine = Some(stella_tui::scenario::demo_engine_config());
+    answer_the_scope_gate(&mut ui);
     ui
+}
+
+/// Answer the scripted scenario's pending scope review, the way
+/// `deck_snapshot.rs::answered_ui` does (#1651).
+///
+/// `demo_inbound` reaches a pending scope review, and `deck_render.rs` draws
+/// that dialog **centered over the whole frame**. A golden blessed with it up
+/// pins the dialog across the eleven rows it covers instead of the tab it
+/// exists to pin — so a column that shifted or a row that vanished inside that
+/// band became invisible to the suite, which is the one thing AGENTS.md says
+/// these frames are for.
+///
+/// Applied to every frame rather than only the tabs the dialog currently
+/// reaches: which tabs that is has already changed once, and a harness that
+/// defends only today's answer rots into the same failure the next time it
+/// widens. [`deck_render_snapshots_pin_the_plan_review_dialog`] is what keeps
+/// the dialog itself covered.
+fn answer_the_scope_gate(ui: &mut DeckUi) {
+    for entry in &fixture_model().agents {
+        ui.scope_answered.insert(entry.meta.id.clone());
+    }
 }
 
 fn fixture_skills() -> SkillsView {
@@ -663,6 +685,35 @@ fn deck_render_snapshots_pin_the_floating_cards() {
         let frame = render_frame(&model, &mut ui, W, H);
         assert_golden(name, description, W, H, &frame);
     }
+}
+
+/// The plan-review dialog, on the one frame that is *about* it.
+///
+/// Every other golden now answers the scope gate, so this is the only place
+/// the modal is still pinned — deliberately, because removing it from the
+/// frames it was obscuring must not remove it from the suite (#1651). Rendered
+/// over SESSION, which is the tab the real deck parks on when a plan review
+/// arrives.
+#[test]
+fn deck_render_snapshots_pin_the_plan_review_dialog() {
+    let model = fixture_model();
+    let mut ui = ui_for(DeckTab::Session);
+    // Deliberately unanswered: this frame is the dialog.
+    ui.scope_answered.clear();
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert!(
+        frame.contains("plan review"),
+        "the scenario stopped producing a pending scope review, so this golden \
+         no longer pins the dialog it is named for — and the frames that answer \
+         the gate are now answering nothing:\n{frame}"
+    );
+    assert_golden(
+        "overlay_plan_review",
+        "the pending plan-review dialog, modal over SESSION",
+        W,
+        H,
+        &frame,
+    );
 }
 
 // ─────────────────────────── the harness itself ───────────────────────────

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
-│                                          │                                                                        │  ││                                      │
-│── WITNESS ───────────────────────────────│3 steps  ·  ~11 files  ·  est. ~$0.42                                   │──││                                      │
-│                                          │                                                                        │  ││                                      │
-│── EXECUTE ───────────────────────────────│a approve   t trim   r refine   x abort   ! shell                       │──││                                      │
-│                                          └───────────────────────────────────── one keypress decides · esc aborts ┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                                                                                                      ││                                      │
+│── WITNESS ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
 │● read_file    apps/app/automations/page.tsx                                                                          │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                                                                                     42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                                                                                      ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
-│                                          │┌ models  resolved routing ───────────────────────────────── esc close ┐│  ││                                      │
-│── WITNESS ───────────────────────────────││session   glm-5.2                                                     ││──││                                      │
-│                                          ││auto      model off · effort on · thinking off                        ││  ││                                      │
-│── EXECUTE ───────────────────────────────││                                                                      ││──││                                      │
-│                                          └│lead      zai/glm-5.2-air                                             │┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││                                      │
+│── WITNESS ────────────────────────────────│session   glm-5.2                                                     │───││                                      │
+│                                           │auto      model off · effort on · thinking off                        │   ││                                      │
+│── EXECUTE ────────────────────────────────│                                                                      │───││                                      │
+│                                           │lead      zai/glm-5.2-air                                             │   ││                                      │
 │● read_file    apps/app/automations/page.ts│          medium · thinking on · from default_model                   │   │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                              │think     z-ai/glm-5.2                                    unassigned  │2ms│┌ DONE VERIFICATION ───────────────────┐
 │                                           │          low · thinking off · from agents.triage.model               │   ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                          │                                                                        │  ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
-│                                          │ ○  2. m┌ plan  pending approval · 3 steps  x skip · esc close ┐        │  ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. u│Refactor the automations store into a shared worksp…  │        │  ││○ 3. update 9 imports                 │
-│                                          │        │                                                      │        │  ││                                      │
-│── WITNESS ───────────────────────────────│3 steps │▸ ○ 1. extract types                                  │        │──││                                      │
-│                                          │        │  ○ 2. move hooks                                     │        │  ││                                      │
-│── EXECUTE ───────────────────────────────│a approv│  ○ 3. update 9 imports                               │        │──││                                      │
-│                                          └────────│                                                      │ aborts ┘  ││                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                   ┌ plan  pending approval · 3 steps  x skip · esc close ┐           ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API             │Refactor the automations store into a shared worksp…  │           ││○ 3. update 9 imports                 │
+│                                                   │                                                      │           ││                                      │
+│── WITNESS ────────────────────────────────────────│▸ ○ 1. extract types                                  │───────────││                                      │
+│                                                   │  ○ 2. move hooks                                     │           ││                                      │
+│── EXECUTE ────────────────────────────────────────│  ○ 3. update 9 imports                               │───────────││                                      │
+│                                                   │                                                      │           ││                                      │
 │● read_file    apps/app/automations/page.tsx       │repo      macanderson/web-app ⎇ feat/automations-store│           │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                      │write     packages/automations/** · apps/app/automatio│       42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                   │read      apps/** · packages/**  (2 globs)            │           ││○ warrant  pending                    │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_plan_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_plan_review.txt
@@ -1,5 +1,5 @@
-# deck golden · tab_session
-# the SESSION tab over the scripted demo session
+# deck golden · overlay_plan_review
+# the pending plan-review dialog, modal over SESSION
 # viewport 160×40 · rendered through render_deck, styling stripped
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
@@ -17,17 +17,17 @@
      returns: watch CI + open PR → lead inbox
 ┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                                                                                                      ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
-│                                                                                                                      ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
-│                                                                                                                      ││                                      │
-│── WITNESS ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
-│                                                                                                                      ││                                      │
-│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
-│                                                                                                                      ││                                      │
+└──────────────────────────────────────────┌ plan review ───────────────────────────────────────────────────────────┐──────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────│Refactor the automations store into a shared workspace package          │──┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                          │                                                                        │  ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, │ ○  1. extract types                                                    │  ││○ 1. extract types                    │
+│                                          │ ○  2. move hooks                                                       │  ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API    │ ○  3. update 9 imports                                                 │  ││○ 3. update 9 imports                 │
+│                                          │                                                                        │  ││                                      │
+│── WITNESS ───────────────────────────────│3 steps  ·  ~11 files  ·  est. ~$0.42                                   │──││                                      │
+│                                          │                                                                        │  ││                                      │
+│── EXECUTE ───────────────────────────────│a approve   t trim   r refine   x abort   ! shell                       │──││                                      │
+│                                          └───────────────────────────────────── one keypress decides · esc aborts ┘  ││                                      │
 │● read_file    apps/app/automations/page.tsx                                                                          │└────────────────────── /plan reads it ┘
 │  ⎿ 312 lines                                                                                                     42ms│┌ DONE VERIFICATION ───────────────────┐
 │                                                                                                                      ││○ warrant  pending                    │


### PR DESCRIPTION
test(stella-tui): stop the deck goldens pinning the plan-review dialog

The scripted `demo_inbound` scenario reaches a pending scope review, and
`deck_render.rs` draws that dialog centered over the whole frame. `base_ui`
never answered the gate, so every golden it produced pinned the dialog across
the eleven rows it covers instead of the tab the frame exists to pin.

These tests passed. That is the defect: a regression inside that band — a
column that shifted, a panel that moved, a row that vanished, the three things
AGENTS.md says these frames exist to catch — was invisible to the suite. "A
golden blessed without looking is a changelog, not a test."

`base_ui` now answers the gate the way `deck_snapshot.rs::answered_ui` does,
inserting every `model.agents[..].meta.id` into `ui.scope_answered`. Applied to
every frame rather than only the tabs the dialog currently reaches: which tabs
that is has already changed once, and a harness defending only today's answer
rots into the same failure the next time it widens.

## Coverage moved rather than vanished

`deck_render_snapshots_pin_the_plan_review_dialog` renders the same fixture
with the gate deliberately unanswered, into a new `overlay_plan_review` golden.
It also asserts the frame still contains the dialog before blessing it, so if
the scenario ever stops producing a pending scope review the suite says so —
rather than silently blessing an empty frame while the other fifteen goldens go
on "answering" a gate that no longer exists.

## Scope: four goldens, not the ten the issue predicted

`card_budget`, `card_models`, `card_plan`, `tab_session`. The other frames the
issue lists had already been fixed by the time I got here. The band is real on
these four: on `tab_session` the dialog was overwriting the RIGHT HALF of the
transcript, truncating live content mid-line — `"Planning the automations
cluster: list,"` now reads through to `"...triggers, workflows."`.

## The diff was read, as this issue is entirely about

    $ git diff --numstat crates/stella-tui/tests/snapshots/deck/
    11  11  card_budget.txt
    11  11  card_models.txt
    11  11  card_plan.txt
    11  11  tab_session.txt

    $ git diff -U0 … | rg '^@@'
    @@ -20,11 +20,11 @@   (all four)

One contiguous eleven-row band per frame at exactly rows 20-30, and nothing
outside it — which is what the issue predicted and the condition for blessing
rather than chasing a second, unrelated change riding along.

`cargo test -p stella-tui` — 805 + 12 + the rest, 0 failed. Clippy
`-D warnings`, `fmt --check`, `check-file-size`, `check-god-files`,
`check-module-reachability`, `check-left-behind` and `check-no-scratch` clean.

Closes #1651
Refs #1633, #1649, #1650

## Summary by Sourcery

Ensure deck snapshot tests no longer universally pin the plan-review dialog and instead keep coverage on both the underlying tabs and the dialog itself.

New Features:
- Add a dedicated snapshot test and golden file for the plan-review overlay dialog on the session tab.

Enhancements:
- Update the shared deck UI test fixture to automatically answer the scripted scenario's scope review gate so regular deck snapshots capture the underlying content instead of the modal dialog.
- Adjust existing deck snapshot golden files to reflect frames with the scope gate answered rather than obscured by the plan-review dialog.