### PR TITLE
fix(stella-cli): stop a parked run stalling the whole boot resume sweep (#1698)

### DIFF
--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -126,6 +126,14 @@ pub(super) struct BootCandidate {
     pub(super) has_resume_point: bool,
     /// Whether the workspace the turn must continue in still exists.
     pub(super) workspace_exists: bool,
+    /// Whether the run left an unanswered approval request in its sidecar
+    /// ([`supervised::APPROVAL_REQUEST`]).
+    ///
+    /// Such a run does not fail on resume — it *parks*, waiting for a human
+    /// who is not there. The sweep resumes one run at a time and streams each
+    /// to completion, so a parked run never returns and every later id stays
+    /// unresumed with nothing said about why (#1698).
+    pub(super) parked: bool,
     /// Boot-time resumes already spent on this run.
     pub(super) attempts: u32,
 }
@@ -145,6 +153,9 @@ pub(super) enum SkipReason {
     NoResumePoint,
     /// The workspace is gone; a resumed turn must run where its work is.
     WorkspaceGone,
+    /// The run is waiting on an approval nobody is present to give. Resuming
+    /// it at boot would park it again and stall the whole sweep behind it.
+    NeedsInput,
     /// `MAX_BOOT_ATTEMPTS` boot-time resumes have already been spent.
     AttemptsExhausted,
 }
@@ -160,6 +171,9 @@ impl SkipReason {
             }
             Self::NoResumePoint => "no resume point".to_string(),
             Self::WorkspaceGone => "workspace no longer exists".to_string(),
+            Self::NeedsInput => "waiting on an approval — answer it with \
+                 `stella daemon attach <id>`, then `stella daemon resume <id>`"
+                .to_string(),
             Self::AttemptsExhausted => format!(
                 "retired after {MAX_BOOT_ATTEMPTS} boot-time resumes — \
                  `stella daemon resume <id>` tries again by hand"
@@ -202,6 +216,13 @@ pub(super) fn decide(candidate: &BootCandidate) -> BootDecision {
     }
     if !candidate.workspace_exists {
         return BootDecision::Skip(SkipReason::WorkspaceGone);
+    }
+    // Before the attempts brake, deliberately: a parked run has not failed at
+    // anything, so spending a boot attempt on it — and retiring it after
+    // `MAX_BOOT_ATTEMPTS` reboots — would punish it for waiting. It resumes
+    // the moment somebody answers.
+    if candidate.parked {
+        return BootDecision::Skip(SkipReason::NeedsInput);
     }
     if candidate.attempts >= MAX_BOOT_ATTEMPTS {
         return BootDecision::Skip(SkipReason::AttemptsExhausted);
@@ -306,6 +327,15 @@ fn candidate(
         lock_held: super::lock_is_held(&registry.sidecar_dir(&record.id)) == Some(true),
         has_resume_point: super::has_resume_point(record),
         workspace_exists: Path::new(&record.workspace).is_dir(),
+        // The request file, not the answer: an answered request is removed by
+        // the child that consumed it, so a leftover request is exactly the
+        // "still waiting" state. Probing the filesystem here rather than in
+        // `decide` keeps that function pure over already-observed facts, like
+        // every other field on this struct.
+        parked: registry
+            .sidecar_dir(&record.id)
+            .join(stella_store::supervised::APPROVAL_REQUEST)
+            .exists(),
         attempts: ledger.attempts(&record.id),
     }
 }

--- a/crates/stella-cli/src/daemon/boot/tests.rs
+++ b/crates/stella-cli/src/daemon/boot/tests.rs
@@ -25,6 +25,7 @@ fn killed_mid_turn() -> BootCandidate {
         lock_held: false,
         has_resume_point: true,
         workspace_exists: true,
+        parked: false,
         attempts: 0,
     }
 }
@@ -277,6 +278,7 @@ fn every_skip_reason_explains_itself_distinctly() {
         SkipReason::EndedDeliberately,
         SkipReason::NoResumePoint,
         SkipReason::WorkspaceGone,
+        SkipReason::NeedsInput,
         SkipReason::AttemptsExhausted,
     ];
     let mut seen: Vec<String> = Vec::new();
@@ -286,4 +288,67 @@ fn every_skip_reason_explains_itself_distinctly() {
         assert!(!seen.contains(&text), "duplicate explanation: {text}");
         seen.push(text);
     }
+}
+
+/// **Witness (#1698).** A run parked on an approval does not stop the sweep
+/// from reaching the runs after it.
+///
+/// `resume_all` continues runs one at a time and streams each to completion.
+/// A resumed turn that hits a scope review does not fail — it *parks*, waiting
+/// for a human who at boot is not there (there is no terminal under launchd or
+/// systemd). So the sweep stopped at that id forever: every later interrupted
+/// run stayed unresumed, and the service console showed the parked run as
+/// continued and then went quiet. Silent, and it stranded work — the exact
+/// shape #1627 exists to prevent.
+#[test]
+fn a_run_parked_on_an_approval_is_skipped_and_the_sweep_continues_past_it() {
+    let parked = BootCandidate {
+        id: "ses-1754431200000-00001".to_string(),
+        parked: true,
+        ..killed_mid_turn()
+    };
+    assert_eq!(
+        decide(&parked),
+        BootDecision::Skip(SkipReason::NeedsInput),
+        "a run waiting on an answer nobody is there to give must not be resumed"
+    );
+
+    // The half that actually matters: everything AFTER it is still decided.
+    let later = BootCandidate {
+        id: "ses-1754431200000-00002".to_string(),
+        ..killed_mid_turn()
+    };
+    let decisions = plan(&[parked, later.clone()]);
+    assert_eq!(
+        decisions.len(),
+        2,
+        "the sweep must not stop at the parked run"
+    );
+    assert_eq!(
+        decisions[1].1,
+        BootDecision::Continue,
+        "the run behind a parked one is exactly the work #1698 was stranding"
+    );
+    assert_eq!(decisions[1].0.id, later.id);
+}
+
+/// Parking is not a failure, so it must not spend a boot attempt.
+///
+/// `parked` is checked *before* the `MAX_BOOT_ATTEMPTS` brake deliberately: a
+/// run that waits politely across three reboots has done nothing wrong, and
+/// retiring it would turn "needs an answer" into "gone, resume it by hand"
+/// without anyone having been asked anything.
+#[test]
+fn a_parked_run_is_reported_as_needing_input_rather_than_retired() {
+    let parked_and_old = BootCandidate {
+        parked: true,
+        attempts: MAX_BOOT_ATTEMPTS,
+        ..killed_mid_turn()
+    };
+    assert_eq!(
+        decide(&parked_and_old),
+        BootDecision::Skip(SkipReason::NeedsInput),
+        "the actionable reason wins: an operator can answer an approval, but \
+         cannot un-retire a run they were never asked about"
+    );
 }

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -169,6 +169,14 @@ It prints one line per supervised run, continued or skipped, with the reason:
 
 **What it continues.** Exactly the rows `list` paints `Crashed ↩`: a supervised run whose recorded status is still live while its liveness lock is gone, whose workspace still exists, and which left a resume point. A run that finished, was stopped, was set aside, or recorded an error is never resumed — every deliberate ending writes a status on the way out, and a process the kernel took writes nothing, so a live status with a dead lock is the signature of interruption and of nothing else. The rule is deliberately conservative on the one ambiguous case: work you ended on purpose is never resumed behind your back, at the cost of not resuming a crash that managed to record itself.
 
+**What it skips because nobody is there.** A run that was waiting on a plan review when the machine went down is *not* resumed at boot. Resuming it would not fail — it would park again, waiting for an answer, and because the sweep streams one run at a time to completion it would sit there forever with every later run behind it unresumed. So the sweep names it and moves on:
+
+```text
+▸ skipping    ses-1785956700221 — waiting on an approval — answer it with `stella daemon attach <id>`, then `stella daemon resume <id>`
+```
+
+Waiting is not failing, so it does not spend one of the three attempts below: a run can wait across any number of reboots and still be resumable the moment you answer it.
+
 **What bounds it.** Each run gets at most **three** boot-time resumes. The count is durable (`~/.stella/services/resume-boot.json`) and is written *before* the resume is spawned, so a run that takes the machine down with it is still charged for the attempt. Past three, the run is retired from the sweep and left for `stella daemon resume <id>` by hand — a human deciding to try again is what the bound exists to require. Runs are resumed one at a time; several turns resuming at once is several models spending at once on a machine nobody is watching.
 
 Everything `resume` says about a resumed turn applies here, including the honest limits above: a turn interrupted mid-pipeline resumes as a plain engine turn and says which stages it is not restoring — into the service console rather than a terminal.


### PR DESCRIPTION
fix(stella-cli): stop a parked run stalling the whole boot resume sweep

`resume_all` continues interrupted runs one at a time, streaming each to
completion before moving to the next id. Sequential is right — several turns
resuming at once is several models spending at once on an unattended machine.

But a resumed turn can *park* rather than finish. A scope review writes
`approval-request.json` into the sidecar and the run waits for an answer, and
at boot there is nobody to give one: `resume-all` runs under launchd or
systemd with no terminal. So the sweep stopped at that id forever, every later
interrupted run stayed unresumed with nothing said about why, and the service
console showed the parked run as continued and then went quiet.

Silent, and it stranded work — the exact shape #1627 exists to prevent.

## Option 1 of the three the issue lists

Skip at selection time. `BootCandidate` gains a `parked` fact and `SkipReason`
a `NeedsInput`, so the sweep names the run on the console and moves on:

    ▸ skipping    ses-… — waiting on an approval — answer it with
                  `stella daemon attach <id>`, then `stella daemon resume <id>`

Cheapest of the three and consistent with the module's conservative posture.
Option 2 (a per-run wall-clock ceiling) answers the general case — a wedged
tool, not only an approval — and composes with this one; it needs a stop that
is not mid-tool (invariant 6), which is a larger design than this. Option 3
(detach each resume) is not taken alone: it would cost the sweep its console
narration, which #1627 treats as load-bearing — "a run silently resumed at boot
is as bad as one silently lost".

## Two placement decisions

**The probe reads the request file, not the answer.** An answered request is
removed by the child that consumed it, so a leftover request *is* the "still
waiting" state.

**`parked` is checked before the `MAX_BOOT_ATTEMPTS` brake.** A run that waits
politely across three reboots has done nothing wrong, and retiring it there
would silently convert "needs an answer" into "gone, resume it by hand" without
anyone ever having been asked. The actionable reason wins: an operator can
answer an approval; they cannot un-retire a run they were never asked about.

The filesystem probe lives in `candidate()`, not in `decide()`, so that
function stays pure over already-observed facts like every other field on the
struct — which is what makes the rule unit-testable without a boot.

## Witnesses

- `a_run_parked_on_an_approval_is_skipped_and_the_sweep_continues_past_it` —
  asserts the skip AND, the half that actually matters, that `plan` still
  decides the candidate *behind* it. That later run is precisely the work this
  bug was stranding.
- `a_parked_run_is_reported_as_needing_input_rather_than_retired` — pins the
  ordering against the attempts brake.

The first fails on the old code:

    assertion `left == right` failed: a run waiting on an answer nobody is
    there to give must not be resumed
      left: Continue
     right: Skip(NeedsInput)

`NeedsInput` also joins `every_skip_reason_explains_itself_distinctly`, which
enforces that each console line is non-empty and unique.

Docs: `daemon.mdx § resume-all` gains "What it skips because nobody is there",
stating the behaviour and that waiting costs no attempt.

`cargo test -p stella-cli` — 1441 passed (was 1439), 0 failed. Clippy
`-D warnings`, `fmt --check`, `check-file-size`, `check-god-files`,
`check-left-behind` and `command-docs` clean.

Closes #1698
Refs #1585, #1627

## Summary by Sourcery

Ensure boot-time resume sweep skips runs that are parked waiting for approval instead of stalling subsequent resumes.

Bug Fixes:
- Prevent a single run parked on an approval from blocking the entire `resume_all` boot sweep, allowing later interrupted runs to be resumed.
- Avoid incorrectly retiring runs that are merely waiting for input by treating parked runs as needing operator input rather than as failed after max attempts.

Enhancements:
- Track a `parked` state on boot candidates and introduce a `NeedsInput` skip reason with clear operator guidance.
- Keep boot decision logic pure by probing filesystem state when constructing boot candidates rather than during decision-making.

Documentation:
- Document the new boot-time behavior where runs waiting on approval are skipped with an explanatory message and do not consume resume attempts.

Tests:
- Add regression tests ensuring parked runs are skipped without blocking subsequent candidates and are reported as needing input rather than being retired.
- Extend skip-reason coverage tests to include the new `NeedsInput` reason and its distinct console message.