### PR TITLE
fix(stella-core): make bus agent attribution a stack, not a save/restore slot (#1853)

### DIFF
--- a/crates/stella-core/src/bus.rs
+++ b/crates/stella-core/src/bus.rs
@@ -497,10 +497,13 @@ impl Drop for HookSubscription {
 
 // The bus
 
+/// Ambient agent attribution (#1853): a stack, not a slot.
+pub mod attribution;
+
 #[derive(Default)]
 struct AmbientContext {
     turn_id: Option<String>,
-    agent_id: Option<String>,
+    agents: attribution::AgentStack,
 }
 
 /// Cap on the in-memory failure log — enough for a session postmortem,
@@ -584,14 +587,8 @@ impl HookBus {
             .turn_id = turn_id;
     }
 
-    /// Set (or clear) the ambient agent id (fleet/subagent attribution),
-    /// returning the id it replaced — which makes attribution nestable: a
-    /// sub-agent (`crate::subagent`) restores what it displaced instead of
-    /// clearing, so a grandchild's exit cannot un-attribute its parent.
-    pub fn set_agent(&self, agent_id: Option<String>) -> Option<String> {
-        let mut context = self.inner.context.lock().unwrap_or_else(|p| p.into_inner());
-        std::mem::replace(&mut context.agent_id, agent_id)
-    }
+    // Agent attribution lives in `bus::attribution` (#1853): the save/restore
+    // slot that used to sit here could not survive two siblings overlapping.
 
     // ---- registration ------------------------------------------------
 
@@ -805,7 +802,7 @@ impl HookBus {
         let sequence = self.inner.sequence.fetch_add(1, Ordering::Relaxed) + 1;
         let (ambient_turn, ambient_agent) = {
             let ctx = self.inner.context.lock().unwrap_or_else(|p| p.into_inner());
-            (ctx.turn_id.clone(), ctx.agent_id.clone())
+            (ctx.turn_id.clone(), ctx.agents.current())
         };
         HookEvent {
             id: format!("evt_{}_{sequence}", self.inner.session_id),

--- a/crates/stella-core/src/bus/attribution.rs
+++ b/crates/stella-core/src/bus/attribution.rs
@@ -1,0 +1,214 @@
+//! Ambient agent attribution: which sub-agent a bus event belongs to (#1853).
+//!
+//! # Why a stack and not a slot
+//!
+//! This was one `Option<String>` on the bus's ambient context, saved and
+//! restored by a guard. That is correct under strict LIFO nesting — a
+//! grandchild entering and leaving inside its parent — and wrong the moment
+//! two siblings overlap:
+//!
+//! ```text
+//! A enters   prev = None          ambient = a
+//! B enters   prev = Some(a)       ambient = b
+//! A drops    restores None        ambient = NONE   ← b is still running
+//! B drops    restores Some(a)     ambient = a      ← a finished long ago
+//! ```
+//!
+//! Both wrong answers outlive the mistake: events emitted while B is still
+//! working are attributed to nobody, and every one of the parent's remaining
+//! events is attributed to a child that has already exited. Nothing ever puts
+//! it back, because the slot has no memory of what it lost.
+//!
+//! A stack keyed by token fixes both, and the key is that a guard removes
+//! **its own** entry rather than popping the top:
+//!
+//! ```text
+//! A enters   [(1,a)]              current = a
+//! B enters   [(1,a),(2,b)]        current = b
+//! A drops    [(2,b)]              current = b      ← still B's work
+//! B drops    []                   current = None   ← back to pre-entry
+//! ```
+//!
+//! # Not live today, which is exactly why it is worth fixing now
+//!
+//! Both dispatchers build their host with no bus, so the guard is a no-op and
+//! no ordering can be observed. It arms the instant anyone calls
+//! `SubAgentHost::with_bus` — and `stella-serve` already attaches a bus to the
+//! engine, so that is the obvious next step for someone. A latent corruption
+//! is cheapest to fix while it is still latent: there is no migration, no
+//! recorded telemetry to reinterpret, and no bug report to reconcile.
+
+use super::HookBus;
+
+/// Identifies one entry in the attribution stack.
+///
+/// Opaque and non-`Clone` on purpose: it is a capability to remove exactly the
+/// entry that created it, and a second copy would let a guard remove an entry
+/// twice — reintroducing, by hand, the pop-the-wrong-entry bug the stack
+/// exists to prevent.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AttributionToken(u64);
+
+/// The ambient agent stack. Entries are `(token, agent id)`; the innermost
+/// still-live entry is the current attribution.
+#[derive(Debug, Default)]
+pub(super) struct AgentStack {
+    entries: Vec<(u64, String)>,
+    next: u64,
+}
+
+impl AgentStack {
+    fn push(&mut self, agent_id: String) -> AttributionToken {
+        // Monotonic and never reused within a process, so a token cannot
+        // address an entry pushed after the one it was minted for.
+        self.next += 1;
+        self.entries.push((self.next, agent_id));
+        AttributionToken(self.next)
+    }
+
+    fn remove(&mut self, token: &AttributionToken) {
+        self.entries.retain(|(id, _)| *id != token.0);
+    }
+
+    /// The current attribution: the most recently entered scope that has not
+    /// yet been left. `None` once every scope has exited, which is the value
+    /// the parent's own events want.
+    pub(super) fn current(&self) -> Option<String> {
+        self.entries.last().map(|(_, agent)| agent.clone())
+    }
+}
+
+impl HookBus {
+    /// Enter attribution for `agent_id`, returning the token that leaves it.
+    ///
+    /// Prefer [`crate::subagent::AgentAttribution`], which pairs this with its
+    /// [`Drop`] so the exit survives a cancelled future or a panicking tool.
+    /// This is the primitive underneath it.
+    pub fn push_agent(&self, agent_id: String) -> AttributionToken {
+        self.inner
+            .context
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .agents
+            .push(agent_id)
+    }
+
+    /// Leave the scope `token` names.
+    ///
+    /// Removes that entry wherever it sits, rather than popping the top: a
+    /// sibling that entered later may still be running, and its attribution
+    /// must survive this one exiting.
+    pub fn drop_agent(&self, token: &AttributionToken) {
+        self.inner
+            .context
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .agents
+            .remove(token);
+    }
+
+    /// The ambient agent id an event with no explicit attribution inherits.
+    pub fn current_agent(&self) -> Option<String> {
+        self.inner
+            .context
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .agents
+            .current()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **Witness (#1853).** Two overlapping scopes leave the ambient id at its
+    /// pre-entry value, and the still-running one keeps its attribution while
+    /// its sibling exits.
+    ///
+    /// On the save/restore slot this failed twice over: `current` read `None`
+    /// between the drops (B was still working), and settled on `Some("a")`
+    /// forever afterwards — attributing every later parent event to a child
+    /// that had finished.
+    #[test]
+    fn overlapping_siblings_do_not_corrupt_the_ambient_agent() {
+        let bus = HookBus::new("session-1653");
+        assert_eq!(bus.current_agent(), None, "nothing entered yet");
+
+        let a = bus.push_agent("a".to_string());
+        let b = bus.push_agent("b".to_string());
+        assert_eq!(bus.current_agent(), Some("b".to_string()));
+
+        // A exits first — the non-LIFO order a slot cannot represent.
+        bus.drop_agent(&a);
+        assert_eq!(
+            bus.current_agent(),
+            Some("b".to_string()),
+            "b is still running, so events between the drops are b's"
+        );
+
+        bus.drop_agent(&b);
+        assert_eq!(
+            bus.current_agent(),
+            None,
+            "both scopes are gone, so the parent's events are the parent's again"
+        );
+    }
+
+    /// Strict nesting — the only case the slot got right — still behaves.
+    #[test]
+    fn nested_scopes_restore_their_parent() {
+        let bus = HookBus::new("session-1653");
+        let parent = bus.push_agent("parent".to_string());
+        let child = bus.push_agent("child".to_string());
+        assert_eq!(bus.current_agent(), Some("child".to_string()));
+
+        bus.drop_agent(&child);
+        assert_eq!(
+            bus.current_agent(),
+            Some("parent".to_string()),
+            "a grandchild's exit must not un-attribute its parent"
+        );
+        bus.drop_agent(&parent);
+        assert_eq!(bus.current_agent(), None);
+    }
+
+    /// Leaving a scope twice is inert.
+    ///
+    /// Reachable through a guard that is dropped after its bus has already
+    /// been cleared, and the failure it must not have is removing somebody
+    /// else's entry — which a pop-the-top implementation would do.
+    #[test]
+    fn dropping_a_scope_twice_does_not_disturb_a_live_sibling() {
+        let bus = HookBus::new("session-1653");
+        let a = bus.push_agent("a".to_string());
+        let b = bus.push_agent("b".to_string());
+
+        bus.drop_agent(&a);
+        bus.drop_agent(&a);
+        assert_eq!(
+            bus.current_agent(),
+            Some("b".to_string()),
+            "a repeated exit must not consume the sibling's entry"
+        );
+        bus.drop_agent(&b);
+        assert_eq!(bus.current_agent(), None);
+    }
+
+    /// Three-deep interleaving, exited in entry order — the worst ordering for
+    /// a slot, and the one a fan-out of siblings actually produces.
+    #[test]
+    fn entry_order_exits_leave_the_innermost_survivor_attributed() {
+        let bus = HookBus::new("session-1653");
+        let a = bus.push_agent("a".to_string());
+        let b = bus.push_agent("b".to_string());
+        let c = bus.push_agent("c".to_string());
+
+        bus.drop_agent(&a);
+        assert_eq!(bus.current_agent(), Some("c".to_string()));
+        bus.drop_agent(&b);
+        assert_eq!(bus.current_agent(), Some("c".to_string()));
+        bus.drop_agent(&c);
+        assert_eq!(bus.current_agent(), None);
+    }
+}

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -450,7 +450,13 @@ impl TurnSteering for ChildSteering<'_> {
 /// child that is no longer running.
 pub struct AgentAttribution<'a> {
     bus: Option<&'a HookBus>,
-    previous: Option<String>,
+    /// The stack entry this guard owns, removed on drop.
+    ///
+    /// A token rather than the displaced value (#1853): restoring what was
+    /// displaced is only correct while scopes nest strictly, and two sibling
+    /// children overlap. Removing *this* entry leaves a later sibling's
+    /// attribution standing and cannot resurrect an earlier one.
+    token: Option<crate::bus::attribution::AttributionToken>,
 }
 
 impl<'a> AgentAttribution<'a> {
@@ -458,15 +464,15 @@ impl<'a> AgentAttribution<'a> {
     /// so callers without an extension bus pay nothing.
     #[must_use]
     pub fn enter(bus: Option<&'a HookBus>, agent_id: &str) -> Self {
-        let previous = bus.and_then(|bus| bus.set_agent(Some(agent_id.to_string())));
-        Self { bus, previous }
+        let token = bus.map(|bus| bus.push_agent(agent_id.to_string()));
+        Self { bus, token }
     }
 }
 
 impl Drop for AgentAttribution<'_> {
     fn drop(&mut self) {
-        if let Some(bus) = self.bus {
-            bus.set_agent(self.previous.take());
+        if let (Some(bus), Some(token)) = (self.bus, self.token.as_ref()) {
+            bus.drop_agent(token);
         }
     }
 }

--- a/crates/stella-core/src/subagent/tests.rs
+++ b/crates/stella-core/src/subagent/tests.rs
@@ -1039,31 +1039,34 @@ fn empty_turn_controls_leave_an_engine_exactly_as_it_was() {
 }
 
 #[test]
-fn attribution_restores_what_it_displaced_including_on_an_unwind() {
+fn attribution_leaves_its_own_scope_including_on_an_unwind() {
     let bus = HookBus::new("session-1");
-    bus.set_agent(Some("parent".into()));
+    let parent = bus.push_agent("parent".into());
 
     {
         let _child = AgentAttribution::enter(Some(&bus), "child");
-        // Nested one deeper, then unwound by panic — the restore must still
-        // run, and must restore "child", not clear to None.
+        // Nested one deeper, then unwound by panic — the guard must still run
+        // on the way out, and must leave "child" attributed rather than
+        // clearing to None.
         let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _grandchild = AgentAttribution::enter(Some(&bus), "grandchild");
             panic!("a tool blew up");
         }));
         assert!(unwound.is_err());
         assert_eq!(
-            bus.set_agent(Some("child".into())),
+            bus.current_agent(),
             Some("child".to_string()),
-            "the grandchild restored the child, not None"
+            "the grandchild's guard ran during the unwind and left the child attributed"
         );
     }
 
     assert_eq!(
-        bus.set_agent(None),
+        bus.current_agent(),
         Some("parent".to_string()),
-        "the child restored the parent on the way out"
+        "the child's exit leaves its parent attributed"
     );
+    bus.drop_agent(&parent);
+    assert_eq!(bus.current_agent(), None);
 }
 
 #[test]


### PR DESCRIPTION
fix(stella-core): make bus agent attribution a stack, not a save/restore slot

Ambient agent attribution was one `Option<String>` on the bus context, saved
and restored by a guard. That is correct while scopes nest strictly — a
grandchild entering and leaving inside its parent — and wrong the moment two
siblings overlap:

    A enters   prev = None          ambient = a
    B enters   prev = Some(a)       ambient = b
    A drops    restores None        ambient = NONE   <- b is still running
    B drops    restores Some(a)     ambient = a      <- a finished long ago

Both wrong answers outlive the mistake. Events emitted while B is still
working are attributed to nobody, and every one of the parent's remaining
events is attributed to a child that has already exited. Nothing puts it back,
because a slot has no memory of what it lost.

Attribution is now a stack of `(token, agent id)`, and the load-bearing detail
is that a guard removes **its own** entry rather than popping the top:

    A enters   [(1,a)]              current = a
    B enters   [(1,a),(2,b)]        current = b
    A drops    [(2,b)]              current = b      <- still B's work
    B drops    []                   current = None   <- back to pre-entry

Removing-by-token and popping-the-top are indistinguishable under nesting and
diverge completely under overlap, which is both why the slot survived review
and why the bug is invisible until siblings actually run concurrently.

`AttributionToken` is deliberately not `Clone`: it is a capability to remove
exactly the entry that minted it, and a second copy would let a guard remove an
entry twice — reintroducing the pop-the-wrong-entry bug by hand.

## Not live today, which is why it is worth fixing now

Both dispatchers build their host with no bus, so the guard is a no-op and no
ordering is observable. It arms the instant anyone calls
`SubAgentHost::with_bus`, and `stella-serve` already attaches a bus to the
engine, so that is the obvious next step for someone. A latent corruption is
cheapest to fix while it is still latent: no migration, no recorded telemetry
to reinterpret, no bug report to reconcile.

## Witnesses

Four, in `bus/attribution.rs`. Three of them fail on the old semantics, each
in a different way — verified by temporarily restoring pop-the-top:

    overlapping_siblings_do_not_corrupt_the_ambient_agent
      left: Some("a")   right: Some("b")   (a finished child attributed)
    dropping_a_scope_twice_does_not_disturb_a_live_sibling
      left: None        right: Some("b")   (a live sibling un-attributed)
    entry_order_exits_leave_the_innermost_survivor_attributed
      left: Some("b")   right: Some("c")

The fourth, `nested_scopes_restore_their_parent`, **passes on both** — and it
should: strict LIFO is the one case the slot got right, so a suite that failed
there too would be testing something other than the defect.

`subagent/tests.rs`'s existing unwind test is rewritten to the new API rather
than dropped: it pins that the guard still runs during a panic unwind, which is
the property the guard exists for and is orthogonal to this change.

## The god file

`bus.rs` is grandfathered and closed to growth, so the stack lands in a sibling
(`bus/attribution.rs`) and the `impl HookBus` block lives there too — an
inherent impl may sit in any module of the defining crate. Moving `set_agent`
out and replacing one field means bus.rs **shrinks**, 2129 -> 2126, while
gaining the fix.

`cargo test -p stella-core` — 1005 passed, 0 failed. Workspace `cargo check
--all-targets`, clippy `-D warnings`, `fmt --check`, rustdoc `-D warnings`,
`check-file-size`, `check-god-files`, `check-module-reachability` and
`check-left-behind` all clean.

Closes #1853
Refs #1836

## Summary by Sourcery

Make HookBus agent attribution track a stack of sub-agent scopes instead of a single save/restore slot to handle overlapping siblings correctly.

Bug Fixes:
- Fix incorrect ambient agent attribution when overlapping sub-agent scopes cause save/restore to un-attribute a live sibling or resurrect a finished one.

Enhancements:
- Introduce a dedicated bus::attribution module with an AgentStack and opaque AttributionToken to manage ambient agent scopes on the HookBus.
- Expose HookBus helpers push_agent, drop_agent, and current_agent to manage and query ambient attribution via the new stack mechanism.
- Update AgentAttribution guard to own a stack token and remove only its own stack entry on drop, preserving other active scopes.

Tests:
- Add focused tests in bus::attribution verifying correct behavior for overlapping siblings, strict nesting, double-dropping scopes, and non-LIFO exit ordering.
- Adjust subagent unwind test to use the new attribution API and assert that ambient attribution remains correct through panic unwinds.