### PR TITLE
fix(stella-cli): unbreak main — resolve the boot.rs doc link #1920 left dangling

### DIFF
--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -127,7 +127,7 @@ pub(super) struct BootCandidate {
     /// Whether the workspace the turn must continue in still exists.
     pub(super) workspace_exists: bool,
     /// Whether the run left an unanswered approval request in its sidecar
-    /// ([`supervised::APPROVAL_REQUEST`]).
+    /// ([`stella_store::supervised::APPROVAL_REQUEST`]).
     ///
     /// Such a run does not fail on resume — it *parks*, waiting for a human
     /// who is not there. The sweep resumes one run at a time and streams each


### PR DESCRIPTION
## What & why

`RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli` fails on main: the `parked` field's intra-doc link in `crates/stella-cli/src/daemon/boot.rs` names `supervised::APPROVAL_REQUEST` with no `supervised` in scope. The doc-warnings gate is therefore red for **every** open PR. #1920 merged with it because `ci.yml` does not run on a push to main.

One line: qualify the link as `stella_store::supervised::APPROVAL_REQUEST`, the path the code itself uses. Refs #1920.

## The witness

- [x] No witness needed (doc-link fix) — verified with `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps`, which fails on main and exits 0 with this change.

## The gate

- [x] Verified as above; no behavior change, no flags, no docs pages affected.

## Nothing left behind

The same fix rides on the #1921 feature branch (identical line, no conflict either way).

## Summary by Sourcery

Bug Fixes:
- Correct the BootCandidate documentation link to reference stella_store::supervised::APPROVAL_REQUEST so rustdoc no longer fails on main when treating warnings as errors.