### PR TITLE
feat(stella-cli): bound each boot resume by wall clock so a wedged run cannot stall the sweep (#1921)

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -370,11 +370,23 @@ pub(crate) enum DaemonCmd {
     /// touching a run that finished, was stopped, or was set aside. Each run
     /// gets at most three boot-time resumes before it is retired from the
     /// sweep and left for `stella daemon resume <id>` by hand.
+    ///
+    /// The sweep is sequential, so each resumed run is also bounded by a
+    /// wall-clock ceiling: a turn that never ends — a wedged tool, a provider
+    /// that never returns — is stopped gracefully at the ceiling (asked
+    /// first, killed only past the grace period, never mid-tool) so the runs
+    /// behind it still get their resume.
     ResumeAll {
         /// Print the decision for every run and exit without resuming
         /// anything — no process spawned, no budget spent.
         #[arg(long)]
         dry_run: bool,
+
+        /// Minutes one resumed run may take before the sweep stops it
+        /// gracefully and moves on. `stella daemon resume <id>` by hand has
+        /// no ceiling.
+        #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..))]
+        ceiling: u64,
     },
 
     /// Register a stella invocation with the OS's per-user service manager

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -92,7 +92,6 @@
 //!   is why this is a caveat rather than a design; POSIX offers no way to
 //!   close it.
 
-use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -290,7 +289,19 @@ pub(crate) fn supervise_this_invocation(
         return detach::release(run, format);
     }
     run.announce();
-    watch(rt, &registry, run)
+    watch(rt, &registry, run, None).map(|_| ())
+}
+
+/// How a [`watch`] ended, for the caller that set a ceiling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Watched {
+    /// The child ran to its own end — its console and its terminal status
+    /// carry the verdict, whatever it was.
+    Finished,
+    /// The caller's wall-clock ceiling expired first, and the child was
+    /// stopped the way Ctrl-C stops one — asked with `SIGTERM`, given
+    /// [`STOP_GRACE`] to abort at a safe boundary, killed only then.
+    CeilingReached,
 }
 
 /// Stream a just-spawned child to this terminal until it finishes — or until
@@ -302,18 +313,53 @@ pub(crate) fn supervise_this_invocation(
 /// implementation because the interrupt path is the subtle half — Ctrl-C must
 /// reach the child as a stop, and a divergent copy here is how a resumed run
 /// would come to treat it as a detach.
+///
+/// `ceiling` bounds the watch by wall clock, for a caller with more runs
+/// waiting behind this one (the boot sweep, #1921). Expiry stops the child
+/// through [`Supervised::interrupt_and_drain`] — the same graceful discipline
+/// as Ctrl-C, never a bare kill that would land mid-tool (invariant 6) — and
+/// records the stop as deliberate, exactly as the interrupt arm does.
 fn watch(
     rt: tokio::runtime::Runtime,
     registry: &SessionRegistry,
     mut run: Supervised,
-) -> Result<(), String> {
-    match rt.block_on(crate::signals::until_interrupted(run.follow())) {
-        Ok(followed) => {
+    ceiling: Option<Duration>,
+) -> Result<Watched, String> {
+    // `None` from the race means the ceiling expired before the child exited;
+    // dropping the abandoned `follow` future loses nothing, because every
+    // byte of streaming state lives on `run` itself.
+    let bounded = async {
+        match ceiling {
+            None => Some(run.follow().await),
+            Some(limit) => tokio::select! {
+                followed = run.follow() => Some(followed),
+                () = tokio::time::sleep(limit) => None,
+            },
+        }
+    };
+    match rt.block_on(crate::signals::until_interrupted(bounded)) {
+        Ok(Some(followed)) => {
             rt.shutdown_timeout(Duration::from_secs(2));
             if let Some(code) = followed? {
                 FORWARDED.store(u16::from(code), std::sync::atomic::Ordering::SeqCst);
             }
-            Ok(())
+            Ok(Watched::Finished)
+        }
+        Ok(None) => {
+            // Reachable only through the race's `Some(limit)` arm.
+            if let Some(limit) = ceiling {
+                eprintln!(
+                    "{} {} hit its {} ceiling; stopping it at a safe boundary",
+                    "⚠".yellow(),
+                    run.id.dimmed(),
+                    boot::describe_ceiling(limit)
+                );
+            }
+            let drained = rt.block_on(run.interrupt_and_drain());
+            mark_stopped(registry, &run.id);
+            rt.shutdown_timeout(Duration::from_secs(2));
+            drained?;
+            Ok(Watched::CeilingReached)
         }
         Err(signal) => {
             // Ctrl-C means stop, here as everywhere else — so the child is
@@ -703,100 +749,6 @@ impl Supervised {
     }
 }
 
-/// A file being read forward as something else appends to it.
-struct Tail {
-    file: std::fs::File,
-    offset: u64,
-}
-
-impl Tail {
-    fn open(path: &Path) -> Result<Self, String> {
-        let file = std::fs::File::open(path)
-            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
-        Ok(Self { file, offset: 0 })
-    }
-
-    // There is deliberately no `seek_to_end` here, for the same reason
-    // `console::Follower` carries no `skip_to_now`: that pair was the only
-    // caller, and #1632 removed it as a defect — seeking past everything
-    // already written threw away the run's shutdown output, which on the
-    // Ctrl-C path is precisely what the person who pressed the key is
-    // waiting to read.
-
-    /// Start `lines` lines back from the end, or at the beginning if the file
-    /// is shorter than that.
-    ///
-    /// Reads the whole file rather than scanning backwards in blocks: a
-    /// console is bounded by one run's output, and a block-wise reverse scan
-    /// is three times the code for a saving nobody can perceive.
-    fn seek_back_lines(&mut self, lines: usize) -> Result<(), String> {
-        let mut all = Vec::new();
-        self.file
-            .read_to_end(&mut all)
-            .map_err(|e| format!("cannot read the console: {e}"))?;
-        let start = all
-            .iter()
-            .enumerate()
-            .rev()
-            .filter(|(_, byte)| **byte == b'\n')
-            // The trailing newline ends the last line rather than starting
-            // one, so it is not a boundary this may stop at.
-            .skip(usize::from(all.last() == Some(&b'\n')))
-            .nth(lines.saturating_sub(1))
-            .map(|(at, _)| at + 1)
-            .unwrap_or(0);
-        self.offset = start as u64;
-        Ok(())
-    }
-
-    /// Copy up to [`PUMP_CHUNK`] bytes appended since the last call to `out`,
-    /// and answer how many that was.
-    ///
-    /// Bounded rather than "everything to EOF": attaching to a run that has
-    /// been writing `stream-json` for a day would otherwise read a console of
-    /// arbitrary size into one allocation before printing a byte of it. The
-    /// callers all loop until a terminal condition, so a partial pump is a
-    /// smaller step, never a lost one — and a nonzero return already means
-    /// "come straight back", so a backlog drains at memory speed.
-    fn pump(&mut self, out: &mut impl Write) -> Result<usize, String> {
-        self.file
-            .seek(SeekFrom::Start(self.offset))
-            .map_err(|e| format!("cannot seek the console: {e}"))?;
-        let mut buf = vec![0u8; PUMP_CHUNK];
-        let read = self
-            .file
-            .read(&mut buf)
-            .map_err(|e| format!("cannot read the console: {e}"))?;
-        if read > 0 {
-            // A closed pipe on the reading side is a routine way to stop
-            // watching (`stella daemon attach … | head`), not an error worth
-            // failing a run over.
-            let _ = out.write_all(&buf[..read]);
-            let _ = out.flush();
-            self.offset += read as u64;
-        }
-        Ok(read)
-    }
-}
-
-/// The most one [`Tail::pump`] moves. Large enough that a normal run is one
-/// read, small enough that a huge console cannot be a huge allocation.
-const PUMP_CHUNK: usize = 64 * 1024;
-
-impl Tail {
-    /// Copy everything appended so far, however many [`PUMP_CHUNK`]s that
-    /// takes.
-    ///
-    /// This is what every *terminal* read must use. A single bounded `pump`
-    /// where the run has just ended shows the first 64KiB of what is left and
-    /// silently drops the rest — and the rest, at that moment, is the run's
-    /// answer.
-    fn drain(&mut self, out: &mut impl Write) -> Result<(), String> {
-        while self.pump(out)? > 0 {}
-        Ok(())
-    }
-}
-
 /// Send `signal` to the whole process group `pgid`.
 ///
 /// The group, not the pid: the child leads a session whose members include
@@ -1034,10 +986,14 @@ pub(crate) fn outcome_status(outcome: Result<(), &crate::failure::CliFailure>) -
 /// committed step boundary (`crate::agent::resume`); completed steps are
 /// already in the checkpointed transcript, so nothing re-runs and nothing is
 /// double-applied.
+///
+/// `ceiling` is the boot sweep's wall-clock bound (#1921); a hand-run resume
+/// passes `None` and streams for as long as the turn takes.
 pub(crate) fn resume_supervised(
     rt: tokio::runtime::Runtime,
     id: Option<&str>,
-) -> Result<(), String> {
+    ceiling: Option<Duration>,
+) -> Result<Watched, String> {
     let registry = SessionRegistry::open_default();
     let record = resolve(&registry, id)?;
     let sidecar = registry.sidecar_dir(&record.id);
@@ -1085,19 +1041,20 @@ pub(crate) fn resume_supervised(
         id.dimmed(),
         checkpoint.step
     );
-    watch(rt, &registry, run)
+    watch(rt, &registry, run, ceiling)
 }
 
 /// `stella daemon resume-all` — the boot-time sweep (#1627).
 ///
 /// Thin on purpose: the decision about *which* runs a boot continues, and the
-/// bound that stops it continuing them forever, live in [`boot`] where they
-/// are pure enough to witness.
-pub(crate) fn resume_all<F>(dry_run: bool, runtime: F) -> Result<(), String>
+/// bounds that stop it continuing them forever — the attempt ledger and the
+/// per-run wall-clock `ceiling` (#1921) — live in [`boot`] where they are
+/// pure enough to witness.
+pub(crate) fn resume_all<F>(dry_run: bool, ceiling: Duration, runtime: F) -> Result<(), String>
 where
     F: FnMut() -> Result<tokio::runtime::Runtime, String>,
 {
-    boot::resume_all(dry_run, runtime)
+    boot::resume_all(dry_run, ceiling, runtime)
 }
 
 /// The resume point `record` left behind, decoded — or the precise reason
@@ -1427,8 +1384,8 @@ fn logs(registry: &SessionRegistry, id: Option<&str>, lines: usize) -> Result<()
     )? {
         return Ok(());
     }
-    let mut out = Tail::open(&sidecar.join(supervised::STDOUT_LOG))?;
-    let mut err = Tail::open(&sidecar.join(supervised::STDERR_LOG))?;
+    let mut out = console::Tail::open(&sidecar.join(supervised::STDOUT_LOG))?;
+    let mut err = console::Tail::open(&sidecar.join(supervised::STDERR_LOG))?;
     out.seek_back_lines(lines)?;
     err.seek_back_lines(lines)?;
     out.drain(&mut std::io::stdout())?;

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -325,16 +325,13 @@ fn watch(
     mut run: Supervised,
     ceiling: Option<Duration>,
 ) -> Result<Watched, String> {
-    // `None` from the race means the ceiling expired before the child exited;
-    // dropping the abandoned `follow` future loses nothing, because every
-    // byte of streaming state lives on `run` itself.
+    // `None` means the ceiling expired before the child exited; dropping the
+    // timed-out `follow` future loses nothing, because every byte of
+    // streaming state lives on `run` itself.
     let bounded = async {
         match ceiling {
             None => Some(run.follow().await),
-            Some(limit) => tokio::select! {
-                followed = run.follow() => Some(followed),
-                () = tokio::time::sleep(limit) => None,
-            },
+            Some(limit) => tokio::time::timeout(limit, run.follow()).await.ok(),
         }
     };
     match rt.block_on(crate::signals::until_interrupted(bounded)) {

--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -60,6 +60,40 @@
 //!   hand with `stella daemon resume <id>` — a human deciding to try again is
 //!   exactly what the bound exists to require.
 //!
+//! # What stops a stalled *sweep* — the per-run ceiling (#1921)
+//!
+//! The brakes above bound how many boots one run can spend; nothing in them
+//! bounds how long one run can hold *this* boot. The sweep is sequential and
+//! streams each resumed turn to completion, so any turn that never ends — a
+//! wedged tool, a provider that never returns, a model call retrying forever
+//! — used to stall every id after it, silently. (#1920 fixed the one such
+//! state visible on disk before spawning, a parked approval; the ceiling
+//! covers every way a turn fails to end that only running it reveals.)
+//!
+//! So each resumed run gets a wall-clock ceiling (`--ceiling`, minutes).
+//! Expiry never kills the child outright — a `SIGKILL` at the ceiling would
+//! land mid-edit, which is worse than the stall it fixes. It goes through the
+//! same graceful discipline as Ctrl-C and `stella daemon stop`: `SIGTERM`,
+//! then `STOP_GRACE` for the engine to abort at a safe boundary (invariant 6)
+//! and write its own terminal status, escalation only then. The two ways that
+//! ends compose with the brakes above rather than needing new ones:
+//!
+//! - A child that **responds** to the stop ends deliberately — checkpoint
+//!   discarded, `Cancelled` recorded, exactly as if an operator had stopped
+//!   it — so the next sweep skips it as ended and returns its attempts.
+//! - A child so wedged it had to be **killed** wrote nothing, keeps its
+//!   resume point, and is swept again next boot — where the attempt already
+//!   charged for this resume counts against `MAX_BOOT_ATTEMPTS`.
+//!
+//! That is also the answer to whether a timed-out run is **charged a boot
+//! attempt: yes**. The attempt was recorded before the spawn (as every
+//! attempt is), and it stays spent, because the only run still resumable
+//! after a timeout is the wedged one — the exact recurring failure the
+//! three-attempt bound exists to stop. A run that was merely slower than the
+//! ceiling ended deliberately at a safe boundary, and slower-than-the-ceiling
+//! by hand is what `stella daemon resume <id>` — which has no ceiling — is
+//! for.
+//!
 //! # What the operator sees
 //!
 //! Every candidate, continued or skipped, prints one line with its reason —
@@ -340,12 +374,46 @@ fn candidate(
     }
 }
 
+/// A ceiling for a console line: `--ceiling` speaks minutes, so the console
+/// does too whenever the value is whole minutes, and seconds otherwise (a
+/// sub-minute ceiling exists only in tests, but a line that printed `0m`
+/// there would be a lie).
+pub(super) fn describe_ceiling(ceiling: std::time::Duration) -> String {
+    let secs = ceiling.as_secs();
+    if secs >= 60 && secs.is_multiple_of(60) {
+        format!("{}-minute", secs / 60)
+    } else {
+        format!("{secs}-second")
+    }
+}
+
+/// The one line the console gets when a resumed run outlived `ceiling` —
+/// pure, so the console contract is testable without a wedged run (#1921).
+///
+/// It states the honest ambiguity: from out here the sweep cannot tell a
+/// stop the child honoured (ended deliberately, nothing left to resume) from
+/// a kill it forced (resume point kept, swept again next boot), so the line
+/// names the one command that answers either way.
+pub(super) fn ceiling_report(ceiling: std::time::Duration) -> String {
+    format!(
+        "did not finish within the {} ceiling and was stopped at a safe boundary; \
+         the sweep continues with the runs behind it — `stella daemon list` shows \
+         where this one ended up",
+        describe_ceiling(ceiling)
+    )
+}
+
 /// `stella daemon resume-all` — the verb a registered service runs at boot.
 ///
 /// Sequential on purpose: N turns resumed at once is N models spending at once
 /// on a machine nobody is watching, and the runs were not concurrent when they
-/// were killed either.
-pub(super) fn resume_all<F>(dry_run: bool, mut runtime: F) -> Result<(), String>
+/// were killed either. `ceiling` bounds each of those turns by wall clock so
+/// one that never ends cannot stall the ids behind it — see the module docs.
+pub(super) fn resume_all<F>(
+    dry_run: bool,
+    ceiling: std::time::Duration,
+    mut runtime: F,
+) -> Result<(), String>
 where
     F: FnMut() -> Result<tokio::runtime::Runtime, String>,
 {
@@ -410,13 +478,18 @@ where
     for id in &to_continue {
         let spent = ledger.record_attempt(id);
         // Persisted before the spawn, so a resume that never returns is still
-        // counted against the bound.
+        // counted against the bound — and, for a run the ceiling below has to
+        // stop, deliberately never refunded (see the module docs).
         ledger.store(&path)?;
         println!("  boot-time resume {spent} of {MAX_BOOT_ATTEMPTS} for {id}");
-        if let Err(e) = super::resume_supervised(runtime()?, Some(id)) {
+        match super::resume_supervised(runtime()?, Some(id), Some(ceiling)) {
+            Ok(super::Watched::Finished) => {}
+            Ok(super::Watched::CeilingReached) => {
+                println!("{} {} — {}", "⚠".yellow(), id, ceiling_report(ceiling));
+            }
             // One failed resume must not strand the rest: the sweep's whole
             // job is the runs it can still continue.
-            eprintln!("{} could not resume {id}: {e}", "⚠".yellow());
+            Err(e) => eprintln!("{} could not resume {id}: {e}", "⚠".yellow()),
         }
     }
     Ok(())

--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -161,7 +161,7 @@ pub(super) struct BootCandidate {
     /// Whether the workspace the turn must continue in still exists.
     pub(super) workspace_exists: bool,
     /// Whether the run left an unanswered approval request in its sidecar
-    /// ([`supervised::APPROVAL_REQUEST`]).
+    /// ([`stella_store::supervised::APPROVAL_REQUEST`]).
     ///
     /// Such a run does not fail on resume — it *parks*, waiting for a human
     /// who is not there. The sweep resumes one run at a time and streams each
@@ -382,8 +382,10 @@ pub(super) fn describe_ceiling(ceiling: std::time::Duration) -> String {
     let secs = ceiling.as_secs();
     if secs >= 60 && secs.is_multiple_of(60) {
         format!("{}-minute", secs / 60)
-    } else {
+    } else if secs > 0 {
         format!("{secs}-second")
+    } else {
+        format!("{}-millisecond", ceiling.as_millis())
     }
 }
 

--- a/crates/stella-cli/src/daemon/boot/tests.rs
+++ b/crates/stella-cli/src/daemon/boot/tests.rs
@@ -289,7 +289,8 @@ fn a_ceiling_stop_names_the_ceiling_the_safe_stop_and_the_next_step() {
         "an operator must be handed the command that answers what happened: {line}"
     );
     // The console speaks the flag's unit for whole minutes and falls back to
-    // seconds, so a test ceiling is not rounded into a fiction.
+    // seconds — or milliseconds — so a test ceiling is never rounded into a
+    // fiction like "0-second".
     assert_eq!(
         describe_ceiling(std::time::Duration::from_secs(90)),
         "90-second"
@@ -297,6 +298,10 @@ fn a_ceiling_stop_names_the_ceiling_the_safe_stop_and_the_next_step() {
     assert_eq!(
         describe_ceiling(std::time::Duration::from_secs(120)),
         "2-minute"
+    );
+    assert_eq!(
+        describe_ceiling(std::time::Duration::from_millis(250)),
+        "250-millisecond"
     );
 }
 

--- a/crates/stella-cli/src/daemon/boot/tests.rs
+++ b/crates/stella-cli/src/daemon/boot/tests.rs
@@ -267,6 +267,39 @@ fn every_candidate_appears_in_the_plan_exactly_once_and_in_order() {
     assert!(matches!(planned[2].1, BootDecision::Skip(_)));
 }
 
+/// #1921: the console line for a run the per-run ceiling stopped — the
+/// reporting half of the contract, witnessed pure the way
+/// [`SkipReason::explain`] is. #1627 holds that a run silently resumed at
+/// boot is as bad as one silently lost; a run silently *stopped* at boot
+/// would be worse than either.
+#[test]
+fn a_ceiling_stop_names_the_ceiling_the_safe_stop_and_the_next_step() {
+    let line = ceiling_report(std::time::Duration::from_secs(30 * 60));
+    assert!(line.contains("30-minute ceiling"), "{line}");
+    assert!(
+        line.contains("safe boundary"),
+        "the line must say the stop was the graceful one: {line}"
+    );
+    assert!(
+        line.contains("the sweep continues"),
+        "the whole point of the ceiling is the runs behind this one: {line}"
+    );
+    assert!(
+        line.contains("stella daemon list"),
+        "an operator must be handed the command that answers what happened: {line}"
+    );
+    // The console speaks the flag's unit for whole minutes and falls back to
+    // seconds, so a test ceiling is not rounded into a fiction.
+    assert_eq!(
+        describe_ceiling(std::time::Duration::from_secs(90)),
+        "90-second"
+    );
+    assert_eq!(
+        describe_ceiling(std::time::Duration::from_secs(120)),
+        "2-minute"
+    );
+}
+
 /// Every skip reason is something an operator can act on — an empty or
 /// duplicated explanation would be a row in the boot console that says
 /// nothing.

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -675,10 +675,107 @@ fn pump_fd(
 
 // ── the read side ─────────────────────────────────────────────────────────
 
+/// A file being read forward as something else appends to it.
+///
+/// The raw rung of the read side — what every reader used before the index
+/// existed and still falls back to without one. Lived in the parent module
+/// until #1921; `pub(super)` because `daemon::logs` still tails a console
+/// directly.
+pub(super) struct Tail {
+    file: std::fs::File,
+    offset: u64,
+}
+
+impl Tail {
+    pub(super) fn open(path: &Path) -> Result<Self, String> {
+        let file = std::fs::File::open(path)
+            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+        Ok(Self { file, offset: 0 })
+    }
+
+    // There is deliberately no `seek_to_end` here, for the same reason
+    // [`Follower`] carries no `skip_to_now`: that pair was the only
+    // caller, and #1632 removed it as a defect — seeking past everything
+    // already written threw away the run's shutdown output, which on the
+    // Ctrl-C path is precisely what the person who pressed the key is
+    // waiting to read.
+
+    /// Start `lines` lines back from the end, or at the beginning if the file
+    /// is shorter than that.
+    ///
+    /// Reads the whole file rather than scanning backwards in blocks: a
+    /// console is bounded by one run's output, and a block-wise reverse scan
+    /// is three times the code for a saving nobody can perceive.
+    pub(super) fn seek_back_lines(&mut self, lines: usize) -> Result<(), String> {
+        let mut all = Vec::new();
+        self.file
+            .read_to_end(&mut all)
+            .map_err(|e| format!("cannot read the console: {e}"))?;
+        let start = all
+            .iter()
+            .enumerate()
+            .rev()
+            .filter(|(_, byte)| **byte == b'\n')
+            // The trailing newline ends the last line rather than starting
+            // one, so it is not a boundary this may stop at.
+            .skip(usize::from(all.last() == Some(&b'\n')))
+            .nth(lines.saturating_sub(1))
+            .map(|(at, _)| at + 1)
+            .unwrap_or(0);
+        self.offset = start as u64;
+        Ok(())
+    }
+
+    /// Copy up to [`PUMP_CHUNK`] bytes appended since the last call to `out`,
+    /// and answer how many that was.
+    ///
+    /// Bounded rather than "everything to EOF": attaching to a run that has
+    /// been writing `stream-json` for a day would otherwise read a console of
+    /// arbitrary size into one allocation before printing a byte of it. The
+    /// callers all loop until a terminal condition, so a partial pump is a
+    /// smaller step, never a lost one — and a nonzero return already means
+    /// "come straight back", so a backlog drains at memory speed.
+    pub(super) fn pump(&mut self, out: &mut impl Write) -> Result<usize, String> {
+        self.file
+            .seek(SeekFrom::Start(self.offset))
+            .map_err(|e| format!("cannot seek the console: {e}"))?;
+        let mut buf = vec![0u8; PUMP_CHUNK];
+        let read = self
+            .file
+            .read(&mut buf)
+            .map_err(|e| format!("cannot read the console: {e}"))?;
+        if read > 0 {
+            // A closed pipe on the reading side is a routine way to stop
+            // watching (`stella daemon attach … | head`), not an error worth
+            // failing a run over.
+            let _ = out.write_all(&buf[..read]);
+            let _ = out.flush();
+            self.offset += read as u64;
+        }
+        Ok(read)
+    }
+
+    /// Copy everything appended so far, however many [`PUMP_CHUNK`]s that
+    /// takes.
+    ///
+    /// This is what every *terminal* read must use. A single bounded `pump`
+    /// where the run has just ended shows the first 64KiB of what is left and
+    /// silently drops the rest — and the rest, at that moment, is the run's
+    /// answer.
+    pub(super) fn drain(&mut self, out: &mut impl Write) -> Result<(), String> {
+        while self.pump(out)? > 0 {}
+        Ok(())
+    }
+}
+
+/// The most one [`Tail::pump`] moves. Large enough that a normal run is one
+/// read, small enough that a huge console cannot be a huge allocation.
+pub(super) const PUMP_CHUNK: usize = 64 * 1024;
+
 /// A reader's view of one stream: its geometry, how much of it it has
 /// relayed, and the raw fallback it uses until (and after) the index speaks.
 struct FollowedStream {
-    tail: super::Tail,
+    tail: Tail,
     geometry: Option<Geometry>,
     /// Cumulative bytes relayed. While raw, this equals the tail's offset —
     /// the head region is append-pure, so the two coordinate systems agree
@@ -712,7 +809,7 @@ impl Follower {
 
     /// Relay what is new, in write order, and answer how many bytes moved.
     ///
-    /// One call is bounded — the raw path moves at most one [`super::Tail`]
+    /// One call is bounded — the raw path moves at most one [`Tail`]
     /// chunk per stream — so a caller that must see everything loops until
     /// this answers zero, and a live loop treats nonzero as "come straight
     /// back".
@@ -770,7 +867,7 @@ impl Follower {
     /// Relay everything currently written, however many pumps that takes.
     ///
     /// This is what every *terminal* read must use — the raw-sweep half of
-    /// [`Self::pump`] is bounded by [`super::Tail::pump`]'s chunk, so a single
+    /// [`Self::pump`] is bounded by [`Tail::pump`]'s chunk, so a single
     /// pump where the run has just ended can show the first chunk of what is
     /// left and silently drop the rest. And the rest, at that moment, is the
     /// run's answer.
@@ -831,7 +928,7 @@ impl Follower {
 impl FollowedStream {
     fn open(path: PathBuf) -> Result<Self, String> {
         Ok(Self {
-            tail: super::Tail::open(&path)?,
+            tail: Tail::open(&path)?,
             geometry: None,
             consumed: 0,
             closed_at: None,

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -9,12 +9,13 @@
 //! What is NOT covered here, so the list is not mistaken for the whole
 //! surface: `Supervised::follow` and `interrupt_and_drain` write to this
 //! process's real stdout and stderr, which an in-process test cannot capture,
-//! so their streaming is exercised through [`Tail`] — which is where the
-//! truncation and lost-tail bugs actually live — rather than end to end. The
+//! so their streaming is exercised through [`console::Tail`] — which is where
+//! the truncation and lost-tail bugs actually live — rather than end to end. The
 //! end-to-end property (a `stella run` in a terminal survives that terminal's
 //! hangup) needs a pty and a live run; it is verified by hand, and the
 //! procedure is in the PR that added this module.
 
+use super::console::{PUMP_CHUNK, Tail};
 use super::*;
 
 /// An isolated registry per test. Not a shared temp dir: these tests spawn
@@ -454,6 +455,73 @@ fn a_run_that_ignores_term_is_killed_after_the_grace_period() {
     );
 
     let _ = run.child.wait();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// #1921's witness: a run that outlives a watch's wall-clock ceiling is
+/// stopped and the watch RETURNS — the property the boot sweep rests on,
+/// because its sequential loop reaches the runs behind a wedged one only if
+/// this call comes back — and the stop is the graceful rung, `SIGTERM`
+/// first. A ceiling that reached straight for `SIGKILL` would land mid-tool,
+/// which invariant 6 exists to forbid.
+#[test]
+fn a_run_that_outlives_the_ceiling_is_stopped_gracefully_and_the_watch_returns() {
+    let (dir, registry) = temp_registry("ceiling");
+    let trap_ready = dir.join("trap-ready");
+    let saw_term = dir.join("saw-term");
+    // The group signal reaches `sleep`, which dies on it; `sh` then runs the
+    // trap and exits. The marker is proof the stop began as a request.
+    let run = spawn_sh(
+        &registry,
+        "ceiling",
+        // Quoted, because the registry dir's name embeds a `ThreadId(…)`
+        // whose parentheses are sh syntax bare.
+        &format!(
+            "trap 'touch \"{}\"' TERM; touch \"{}\"; sleep 120",
+            saw_term.display(),
+            trap_ready.display()
+        ),
+    );
+    let id = run.id.clone();
+    // Waited for BEFORE the bounded watch, or a loaded machine can fire the
+    // ceiling at a child that has not installed its trap yet — which dies on
+    // the default TERM disposition and reads as a kill (#1721's window, one
+    // rung up).
+    assert!(
+        eventually(Duration::from_secs(10), || trap_ready.is_file()),
+        "precondition: the child must be trapping TERM before the ceiling may fire"
+    );
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let watched = watch(rt, &registry, run, Some(Duration::from_millis(250))).expect("watch");
+
+    assert_eq!(
+        watched,
+        Watched::CeilingReached,
+        "a watch that outlives its ceiling must say so, or the sweep cannot report it"
+    );
+    assert!(
+        eventually(Duration::from_secs(10), || saw_term.is_file()),
+        "the ceiling must ask the run to stop before anything harder"
+    );
+    // Recorded as deliberate, exactly as a Ctrl-C or `daemon stop` is: a
+    // ceiling stop nobody watched must not age into the registry as a crash.
+    assert_eq!(
+        registry.get(&id).map(|r| r.status),
+        Some(SessionStatus::Cancelled)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The ceiling must not misfire: a run that ends on its own beats a ceiling
+/// it never reaches, and the watch reports it finished rather than stopped.
+#[test]
+fn a_run_that_finishes_under_the_ceiling_is_left_to_finish() {
+    let (dir, registry) = temp_registry("under-ceiling");
+    let run = spawn_sh(&registry, "quick", "true");
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let watched = watch(rt, &registry, run, Some(Duration::from_secs(120))).expect("watch");
+    assert_eq!(watched, Watched::Finished);
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -929,15 +929,21 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 // provider resolution, its cwd already pinned to the
                 // record's workspace by the parent's launch.
                 DaemonCmd::Resume { id } if !cli.globals.foreground => {
-                    return daemon::resume_supervised(rt()?, id.as_deref())
+                    return daemon::resume_supervised(rt()?, id.as_deref(), None)
+                        .map(|_| ())
                         .map_err(failure::CliFailure::from);
                 }
                 DaemonCmd::Resume { .. } => {}
                 // The sweep is the parent half N times over — it resolves,
                 // spawns and streams each `daemon resume <id> --foreground`
                 // child — so it stays keyless here for the same reason.
-                DaemonCmd::ResumeAll { dry_run } => {
-                    return daemon::resume_all(*dry_run, rt).map_err(failure::CliFailure::from);
+                DaemonCmd::ResumeAll { dry_run, ceiling } => {
+                    return daemon::resume_all(
+                        *dry_run,
+                        std::time::Duration::from_secs(ceiling.saturating_mul(60)),
+                        rt,
+                    )
+                    .map_err(failure::CliFailure::from);
                 }
                 _ => return daemon::run(cmd).map_err(failure::CliFailure::from),
             }

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -14,7 +14,7 @@ stella daemon attach [id]
 stella daemon logs [id] [-n LINES]
 stella daemon stop <id>
 stella daemon resume [id]
-stella daemon resume-all [--dry-run]
+stella daemon resume-all [--dry-run] [--ceiling MINUTES]
 stella daemon install [--label NAME] [--keep-alive] -- <stella args…>
 stella daemon install --resume-all [--label NAME]
 stella daemon uninstall <label>
@@ -200,6 +200,14 @@ It prints one line per supervised run, continued or skipped, with the reason:
 Waiting is not failing, so it does not spend one of the three attempts below: a run can wait across any number of reboots and still be resumable the moment you answer it.
 
 **What bounds it.** Each run gets at most **three** boot-time resumes. The count is durable (`~/.stella/services/resume-boot.json`) and is written *before* the resume is spawned, so a run that takes the machine down with it is still charged for the attempt. Past three, the run is retired from the sweep and left for `stella daemon resume <id>` by hand — a human deciding to try again is what the bound exists to require. Runs are resumed one at a time; several turns resuming at once is several models spending at once on a machine nobody is watching.
+
+**What bounds each resume.** The attempt count bounds how many *boots* a run can spend; it does not stop one resumed turn from holding *this* boot forever — a wedged tool, a provider that never returns, a model call retrying without end. So each resumed run also gets a wall-clock ceiling, **30 minutes** unless `--ceiling MINUTES` says otherwise. A run that reaches it is never killed outright — a kill at the ceiling would land mid-edit, which is worse than the stall it fixes. It is stopped exactly the way `stella daemon stop` stops one: asked with `SIGTERM`, given the grace period to abort at a safe boundary and record its own ending, killed only if it ignores that. Then the sweep says so and moves to the next run:
+
+```text
+⚠ ses-1785956826121 — did not finish within the 30-minute ceiling and was stopped at a safe boundary; the sweep continues with the runs behind it — `stella daemon list` shows where this one ended up
+```
+
+The two ways that ends need no new rules. A run that honoured the stop ended deliberately — same as a Ctrl-C — so the next sweep skips it and returns its attempts; it was merely slower than the ceiling, and `stella daemon resume <id>` by hand has no ceiling. A run so wedged it had to be killed keeps its resume point and is swept again next boot — and the attempt it was already charged (a timed-out resume **does** spend one) is exactly what retires it after three, because a run that hits the ceiling every boot is the recurring failure the attempt bound exists to stop.
 
 Everything `resume` says about a resumed turn applies here, including the honest limits above: a turn interrupted mid-pipeline resumes as a plain engine turn and says which stages it is not restoring — into the service console rather than a terminal.
 


### PR DESCRIPTION
## What & why

`resume_all` streamed each resumed run to completion with no upper bound, so any turn that never ends — a wedged tool, a provider that never returns, a model call retrying forever — stalled every id behind it, exactly as an unanswered approval used to, and just as silently. #1920 fixed the one such state visible on disk before spawning (a parked approval); this is option 2 of the pair #1698 said compose: a **per-run wall-clock ceiling** on the boot sweep — `stella daemon resume-all --ceiling MINUTES`, default 30.

The design calls the issue asked to be stated:

- **The stop path is the existing graceful one, not a second one.** Expiry never kills the child outright — a `SIGKILL` at the ceiling would land mid-edit, worse than the stall it fixes. The ceiling goes through `Supervised::interrupt_and_drain`, the same discipline as Ctrl-C and `stella daemon stop`: `SIGTERM`, the measured 8-second `STOP_GRACE` for the engine to abort at a safe boundary (invariant 6) and write its own terminal status, escalation only then. `STOP_GRACE` is untouched.
- **A timed-out run IS charged its boot attempt.** The attempt is recorded before the spawn (as every attempt already was) and deliberately not refunded. The two endings compose with the existing brakes rather than needing new ones: a child that honours the stop ends deliberately (checkpoint discarded, `Cancelled` recorded — same as any operator stop), so the next sweep skips it as ended and returns its attempts; a child so wedged it had to be killed wrote nothing, keeps its resume point, and is swept again next boot — where the charge counts against `MAX_BOOT_ATTEMPTS`. So the charge only ever persists for the genuinely wedged run, which is exactly the recurring failure the three-attempt bound exists to stop. A run that was merely slower than the ceiling is `stella daemon resume <id>`'s to continue by hand — that verb has no ceiling.
- **Nothing is quiet** (#1627's "a run silently resumed at boot is as bad as one silently lost"): the watch names the ceiling the moment it fires, and the sweep prints one operator-actionable line per stopped run (`ceiling_report`, pure and witnessed like `SkipReason::explain`).

Mechanically: `watch` gains an `Option<Duration>` ceiling and answers `Watched::{Finished, CeilingReached}`; the bounded race is `tokio::time::timeout` over the existing `follow()` future (all streaming state lives on `Supervised`, so the abandoned future drops losslessly). `resume_supervised` threads it; hand resumes pass `None`.

Also in this PR: `Tail` moved verbatim from `daemon.rs` into `daemon/console.rs`, where its readers already live. `daemon.rs` stood at 1493 lines with the ceiling in place — file-size policy says a file approaching the 1500 gate gets split, not grown. It now sits at ~1400, and no baseline entry changed.

Closes #1921

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`daemon::tests::a_run_that_outlives_the_ceiling_is_stopped_gracefully_and_the_watch_returns` — a real supervised child that traps `TERM` outlives a 250ms ceiling; the test asserts the watch *returns* (the property the sequential sweep rests on), that the child saw `SIGTERM` before anything harder (the trap's marker file), and that the stop is recorded `Cancelled` rather than aging into a crash. `a_run_that_finishes_under_the_ceiling_is_left_to_finish` pins the no-misfire half, and `boot::tests::a_ceiling_stop_names_the_ceiling_the_safe_stop_and_the_next_step` pins the console contract. On `main` these fail as the feature is genuinely absent (`watch` has no ceiling parameter and `Watched`/`ceiling_report` do not exist).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (`make gate CARGO_SCOPE="-p stella-cli"`)
- [x] Docs updated: `website/content/docs/commands/daemon.mdx` § `resume-all` (new "What bounds each resume" block + synopsis), `--help` text on `ResumeAll`, module docs in `daemon/boot.rs` (new "What stops a stalled sweep" section stating the attempt-charging decision)
- [x] CLA signed
- [x] `Closes #1921` appears both above and as a commit trailer

## Nothing left behind

While gating this, main turned out doc-red: #1920 merged a dangling intra-doc link in `boot.rs` (`ci.yml` does not run on pushes to main). The second commit here fixes it — and the same one-line fix is also open as a dedicated unbreak, #1927, so every other PR heals without waiting on this one; the two apply cleanly in either order. That commit also swaps the bounded race to the canonical `tokio::time::timeout` and teaches `describe_ceiling` to speak milliseconds rather than round a sub-second test ceiling to "0-second".

Refs #1585, #1627, #1698, #1920, #1927.
