### PR TITLE
fix(stella-cli): unbreak main — broken intra-doc link in #1698's boot guard

### DIFF
--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -127,7 +127,7 @@ pub(super) struct BootCandidate {
     /// Whether the workspace the turn must continue in still exists.
     pub(super) workspace_exists: bool,
     /// Whether the run left an unanswered approval request in its sidecar
-    /// ([`supervised::APPROVAL_REQUEST`]).
+    /// ([`stella_store::supervised::APPROVAL_REQUEST`]).
     ///
     /// Such a run does not fail on resume — it *parks*, waiting for a human
     /// who is not there. The sweep resumes one run at a time and streams each


### PR DESCRIPTION
fix(stella-cli): unbreak main — a broken intra-doc link in #1698's boot guard

`main` fails the gate's `doc-warnings` step:

    error: could not document `stella-cli`
      --> crates/stella-cli/src/daemon/boot.rs:130
       |
       |     /// ([`supervised::APPROVAL_REQUEST`]).
       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `supervised` in scope
       |
       = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`

`boot.rs` imports `stella_store::{SessionRecord, SessionRegistry, SessionStatus}`
but not the `supervised` module, so the shortened path does not resolve. Fully
qualified, it does.

This is mine, from PR #1920 (#1698). I ran `cargo test`, clippy, `fmt --check`
and four guard scripts on that branch and reported them — but not
`RUSTDOCFLAGS="-D warnings" cargo doc`, which is a separate gate step, and the
one this needed.

It reached `main` because the required checks never ran: every `ci.yml` run
since 19:03 is still `queued` (#1899), so the branch merged on stale/absent
contexts. That is #1645's failure mode arriving by a different road — not a red
check that was overridden, but no check at all.

Verified: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` exits 0.
`cargo test -p stella-cli --bin stella boot` — 24 passed.

## Summary by Sourcery

Bug Fixes:
- Correct a broken intra-doc link in the stella-cli boot module that caused rustdoc to fail with `-D warnings`.