### PR TITLE
fix(ci): unbreak the file-size guard's self-test, and give the ratchet its own status context (#1800)

### DIFF
--- a/.github/workflows/file-size.yml
+++ b/.github/workflows/file-size.yml
@@ -1,0 +1,63 @@
+name: file-size
+
+# The 1500-line ratchet as its own status context (#1800).
+#
+# `file-size` already runs inside ci.yml's required "fmt + clippy + test" job,
+# which is correct but expensive: that job compiles and tests the workspace, so
+# requiring it is requiring an hour. This workflow runs the same guard in
+# seconds with no toolchain at all, which is what makes it *requirable on its
+# own* — the cheapest of the three fixes #1800 lists, and the one that does not
+# need admin to write the code for.
+#
+# Why that matters here specifically. Three separate god files landed on `main`
+# over their ceiling in a single day, and each one turned EVERY open PR red —
+# including PRs touching none of the affected crates. #1757 burned a full CI
+# cycle and a merge round-trip on `deck.rs` alone, having touched no
+# `stella-tui` file. The guard fires for the next person rather than the author,
+# and the cost is paid by everyone at once.
+#
+# **Making this required is still a repository setting**, and this workflow does
+# not perform it — it only makes the switch cheap to flip, by giving branch
+# protection a context that costs seconds rather than an hour. See #1800 and
+# #1645; `enforce_admins: true` is the broader fix that closes the same hole for
+# every gate step.
+#
+# No paths-ignore, deliberately: the ratchet covers Rust, Python and shell
+# across the whole tree, and ci.yml's filters exist to keep prose off the Rust
+# gate — a distinction this job does not need, because it has no Rust gate.
+
+on:
+  pull_request:
+  merge_group:
+
+# Reads the repository and nothing else.
+permissions:
+  contents: read
+
+concurrency:
+  group: file-size-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  file-size:
+    name: file size ratchet
+    runs-on: ubuntu-latest
+    steps:
+      # Full history is not needed — the guard reads the working tree and the
+      # committed baseline, never a diff against the base.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # The guard's own tests first: they are hermetic and they are what proves
+      # it can still FAIL. A ratchet that has quietly become incapable of
+      # failing reports green forever, which is worse than not having one.
+      - name: guard self-test
+        run: ./scripts/test-file-size.sh
+
+      - name: file-size ratchet
+        run: ./scripts/check-file-size.sh
+
+      # The three prose copies of the god-file list must agree with the
+      # baseline, or a file that left the list stays named as one. Same tier,
+      # same cost, and the two failures are always fixed in one commit.
+      - name: god-file lists agree
+        run: ./scripts/check-god-files.sh

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -158,7 +158,7 @@ if [ -n "$report" ]; then
   echo "$report" | awk '
     /^NEWOVER$/  { print ""; print "These files crossed the limit and are NOT grandfathered — split them into"; print "submodules. Do not add a baseline entry: the baseline only covers files"; print "that predate the guard, and this is the rule that stops the tree getting"; print "worse."; next }
     /^GREW$/     { print ""; print "These grandfathered files grew past their recorded ceiling. If the growth is"; print "irreducible (a subcommand or module declaration in an already-oversized"; print "lib.rs/main.rs), run \"make file-size-update\" and commit the baseline diff so"; print "the increase is visible in review. If it is not irreducible, put the new code"; print "in its own module instead."; next }
-    /^OBSOLETE$/ { print ""; print "Obsolete baseline entries (the file is now under the limit). Run"; print "\"make file-size-update\" to retire them — an exemption must not outlive"; print "the problem it covered."; next }
+    /^OBSOLETE$/ { print ""; print "Obsolete baseline entries (the file is now under the limit). Run"; print "\"make file-size-update\" to retire them — an exemption must not outlive"; print "the problem it covered."; print ""; print "A file leaving the baseline also leaves the god-file list, so the same"; print "commit must drop it from the per-crate table in AGENTS.md AND from the"; print "\"God files\" section of that crate README, or \"make god-files\" fails"; print "next. All three copies are cross-checked, and the baseline wins."; next }
     /^STALE$/    { print ""; print "Stale baseline entries. Run \"make file-size-update\"."; next }
     { print }
   ' >&2
@@ -169,6 +169,13 @@ tracked=$(git ls-files "${RATCHET_PATHSPECS[@]}" | wc -l | tr -d ' ')
 # The verdict is already decided; the write is best-effort. SIGPIPE is ignored
 # and the write's failure discarded, so a reader that closed the pipe
 # (`| head -1`, `| true`) cannot turn a green verdict into a failure (#1815).
-grandfathered=$(grep -cv '^#' "$baseline")
+# `|| true`: `grep -c` exits 1 when the count is ZERO, and this runs under
+# `set -e`. An empty baseline — every god file split, which is the goal — would
+# otherwise abort the guard here, AFTER the verdict was decided, printing
+# nothing and exiting non-zero. A clean tree reported as a failure with no
+# message is the worst reading of a green result, and it is why every case in
+# `scripts/test-file-size.sh` (which plants an empty baseline by design) was
+# red (#1800).
+grandfathered=$(grep -cv '^#' "$baseline" || true)
 trap '' PIPE
 echo "check-file-size: OK — $tracked Rust/Python/shell files, none over $LIMIT lines except $grandfathered grandfathered (none grew)." || true


### PR DESCRIPTION
fix(ci): unbreak the file-size guard's self-test, and give the ratchet its own status context

Three things, all of them #1800's item 2 option 3 or the road to its option 1.

## 1. The guard aborts silently on an empty baseline

`grep -c` exits **1** when the count is zero, and `check-file-size.sh` runs
under `set -e`. So a baseline with no entries — every god file split, which is
the *goal* state — aborted the script at the last line, AFTER the verdict was
decided, printing nothing and exiting non-zero.

A clean tree reported as a failure with no message is the worst possible
reading of a green result, and it is why every case in
`scripts/test-file-size.sh` was red: that suite plants an empty baseline by
design.

    before:  passed 0, failed 7
    after:   passed 7, failed 0

The whole-repo run never showed it, because this repository's baseline has 31
entries and `grep -c` therefore exits 0.

## 2. The self-test had rotted, unnoticed, to 0/7

Its header says it is deliberately not in `make gate` — the same posture as
`make impacted-test`. The cost of that is exactly what happened: nobody ran it,
so nobody learned the guard had a silent-abort path.

A guard that cannot be shown to FAIL is indistinguishable from one that always
passes, which is the failure that suite was written to prevent (#825, #1563)
and the one it then suffered itself. The new workflow runs it before the guard,
so it can no longer rot invisibly.

While fixing this I put an apostrophe into the awk message block and got
`awk: non-terminated string` — the awk program is single-quoted shell, so
`AGENTS.md's` closes it. Caught by the very suite bug 1 had disabled, which is
the argument for this change in one line.

## 3. `file-size` as its own status context

`.github/workflows/file-size.yml` runs the ratchet, its self-test, and
`god-files` in seconds with **no toolchain**.

`file-size` already runs inside ci.yml's required "fmt + clippy + test" job.
That is correct and expensive: requiring that job means requiring an hour of
compile and test. This workflow makes the same guard *requirable on its own* —
which is #1800's first fix ("make `file-size` a required status check") reduced
to flipping one switch instead of adopting an hour-long context.

**It does not make anything required.** That is a repository setting and needs
admin; this only makes the switch cheap. Stated plainly in the workflow header
so nobody reads the file and concludes the hole is closed.

Why it matters here: three separate god files landed over their ceiling in a
single day, and each turned EVERY open PR red — #1757 burned a full CI cycle
and a merge round-trip on `deck.rs` having touched no `stella-tui` file at all.
The guard fires for the next person rather than the author, and everyone pays
at once.

## 4. The OBSOLETE message names the two other files to edit

A file leaving the baseline also leaves the god-file list, so the same commit
must drop it from AGENTS.md and the crate README or `make god-files` fails
next. The message now says so. This is #1800's option 3 — "fail with the exact
invocation and the lines that must change, so the fix is one paste rather than
a hunt" — and it is the friction I hit myself taking `media.rs` off the list in
PR #1914.

## What this does not close

#1800 stays open. Its item 1 (the two named files) is already done and in fact
retightened — `driver.rs` and `registry.rs` are under their ceilings and
`check-file-size.sh` reports OK. Its item 2 options 1 and 2 (`file-size`
required, `enforce_admins: true`) are branch-protection settings only an admin
can make, and #1645 owns the broader one.

`./scripts/test-file-size.sh` — 7 passed, 0 failed. `check-file-size`,
`check-god-files`, `check-action-pins` (64 refs), `shellcheck` and
`check-no-scratch` all clean.

Refs #1800, #1645, #1563, #825

## Summary by Sourcery

Add a dedicated CI workflow for the file-size ratchet and harden its guard behavior and messaging.

Bug Fixes:
- Prevent the file-size guard from aborting with a failure on an empty baseline by tolerating zero-count grep results.
- Clarify the obsolete-baseline message to explain required updates to AGENTS.md and crate READMEs when removing a god file from the baseline.

CI:
- Introduce a lightweight `file-size` GitHub Actions workflow that runs the guard’s self-test, the file-size ratchet, and the god-file list consistency check as an independent status context.