### PR TITLE
test(stella-pipeline): pin the shared management system-prefix structure (#1855)

### DIFF
--- a/crates/stella-pipeline/src/management_prompt.rs
+++ b/crates/stella-pipeline/src/management_prompt.rs
@@ -77,3 +77,6 @@ impl ManagementPrompt {
         format!("{}\n\n{}", self.instructions, self.payload)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-pipeline/src/management_prompt/tests.rs
+++ b/crates/stella-pipeline/src/management_prompt/tests.rs
@@ -62,11 +62,7 @@ const ALL_ROLES: [ModelCallRole; 14] = [
 fn management_system_block(role: ModelCallRole) -> Option<String> {
     let ctx = DiffContext::default();
     match role {
-        ModelCallRole::Triage => Some(
-            triage_prompt("goal", "src/lib.rs")
-                .instructions
-                .to_string(),
-        ),
+        ModelCallRole::Triage => Some(triage_prompt("goal", "src/lib.rs").instructions.to_string()),
         ModelCallRole::Verdict => Some(
             verifier_prompt("goal", "+a\n", "no flip", &ctx)
                 .instructions

--- a/crates/stella-pipeline/src/management_prompt/tests.rs
+++ b/crates/stella-pipeline/src/management_prompt/tests.rs
@@ -1,0 +1,175 @@
+//! Cross-role witnesses for the management system-prefix structure
+//! (#1434, #1855).
+//!
+//! The per-role halves live beside their builders — `verify/tests.rs` pins
+//! the verdict and guidance instruction blocks byte-stable across calls,
+//! `triage/tests.rs` keeps volatile evidence out of the triage block. What
+//! no per-role test can see is the FAMILY property #1855 turns on: whether
+//! the roles' system blocks open with one byte-identical preamble a
+//! provider prompt cache could serve across roles. This module declares
+//! that shared preamble and holds every management system block to it,
+//! parity-style (declared, not assumed — the invariant-8 shape): the
+//! declaration must equal what the blocks actually share, so a preamble
+//! authored but adopted by only some roles, and accidental sharing grown
+//! without being declared, both fail here by name.
+
+use stella_protocol::{MessageRole, ModelCallRole};
+
+use super::ManagementPrompt;
+use crate::pipeline::CONVERSATIONAL_SYSTEM_PROMPT;
+use crate::triage::triage_prompt;
+use crate::verify::diff_render::DiffContext;
+use crate::verify::{guidance_prompt, verifier_prompt};
+
+/// The preamble every management system block is declared to open with,
+/// byte-for-byte.
+///
+/// Empty is the measured truth today (#1855): no shared preamble has been
+/// authored, the fixed blocks are disjoint, and none clears a provider's
+/// minimum cacheable prefix on its own (see the `management_prompt` module
+/// docs). When #1855 option 1 authors the shared preamble, updating this
+/// constant is the whole adoption contract — the parity witness below then
+/// refuses any role that does not open with it.
+const SHARED_MANAGEMENT_PREAMBLE: &str = "";
+
+/// Every [`ModelCallRole`] the crate can dispatch, for enumerating the
+/// family. Completeness is not compiler-checked here — that job belongs to
+/// the exhaustive match in [`management_system_block`], which forces a new
+/// variant to declare its prefix posture before this array matters.
+const ALL_ROLES: [ModelCallRole; 14] = [
+    ModelCallRole::Unknown,
+    ModelCallRole::Triage,
+    ModelCallRole::Plan,
+    ModelCallRole::PlanRepair,
+    ModelCallRole::WitnessAuthor,
+    ModelCallRole::WitnessRepair,
+    ModelCallRole::Worker,
+    ModelCallRole::DistressGuidance,
+    ModelCallRole::Verdict,
+    ModelCallRole::AgentAuthor,
+    ModelCallRole::SkillAuthor,
+    ModelCallRole::DomainInference,
+    ModelCallRole::Reflection,
+    ModelCallRole::Summarization,
+];
+
+/// The system block a role dispatches through the management chokepoint
+/// (`metered_raw_call`), or `None` where the role sends no system message.
+///
+/// Exhaustive over [`ModelCallRole`] for the same reason `management_bounds`
+/// is: a new role routed through the chokepoint must declare its prefix
+/// posture here, not escape the family witness by omission.
+fn management_system_block(role: ModelCallRole) -> Option<String> {
+    let ctx = DiffContext::default();
+    match role {
+        ModelCallRole::Triage => Some(
+            triage_prompt("goal", "src/lib.rs")
+                .instructions
+                .to_string(),
+        ),
+        ModelCallRole::Verdict => Some(
+            verifier_prompt("goal", "+a\n", "no flip", &ctx)
+                .instructions
+                .to_string(),
+        ),
+        ModelCallRole::DistressGuidance => Some(
+            guidance_prompt("goal", "+a\n", "red twice", &ctx)
+                .instructions
+                .to_string(),
+        ),
+        // The conversational fast path is the only raw `Worker` dispatch.
+        ModelCallRole::Worker => Some(CONVERSATIONAL_SYSTEM_PROMPT.to_string()),
+        // Plan and PlanRepair ride the chokepoint as a single user message
+        // with no system block at all: their fixed instructions are
+        // interpolated into the volatile payload — the pre-#1434 shape,
+        // structurally uncacheable. Recorded as a gap on #1855; when they
+        // adopt the split these arms move to `Some(...)` and the roles join
+        // the parity witness automatically.
+        ModelCallRole::Plan | ModelCallRole::PlanRepair => None,
+        // Never dispatched through the management chokepoint.
+        ModelCallRole::Unknown
+        | ModelCallRole::WitnessAuthor
+        | ModelCallRole::WitnessRepair
+        | ModelCallRole::AgentAuthor
+        | ModelCallRole::SkillAuthor
+        | ModelCallRole::DomainInference
+        | ModelCallRole::Reflection
+        | ModelCallRole::Summarization => None,
+    }
+}
+
+/// The `(role, system block)` pairs for every role that carries one.
+fn management_system_blocks() -> Vec<(ModelCallRole, String)> {
+    ALL_ROLES
+        .into_iter()
+        .filter_map(|role| management_system_block(role).map(|block| (role, block)))
+        .collect()
+}
+
+/// The longest common prefix of two strings, on `char` boundaries.
+fn common_prefix<'a>(a: &'a str, b: &str) -> &'a str {
+    let end = a
+        .char_indices()
+        .zip(b.chars())
+        .find(|((_, ca), cb)| ca != cb)
+        .map(|((i, _), _)| i)
+        .unwrap_or_else(|| a.len().min(b.len()));
+    &a[..end]
+}
+
+/// The wire shape every management prompt serializes to: exactly one system
+/// block carrying the fixed instructions, then the volatile payload as the
+/// user message. This order is what puts the stable bytes where a provider
+/// adapter's cache plumbing can mark them (#1434).
+#[test]
+fn the_wire_shape_is_one_system_block_then_the_payload() {
+    let msgs = ManagementPrompt {
+        instructions: "fixed",
+        payload: "volatile".to_string(),
+    }
+    .into_messages();
+    assert_eq!(msgs.len(), 2);
+    assert!(matches!(msgs[0].role, MessageRole::System));
+    assert_eq!(msgs[0].content, "fixed");
+    assert!(matches!(msgs[1].role, MessageRole::User));
+    assert_eq!(msgs[1].content, "volatile");
+}
+
+/// Every management system block opens with the declared shared preamble.
+/// Vacuously green while the preamble is empty; the moment #1855 option 1
+/// authors it, this is the assertion that refuses a role left behind.
+#[test]
+fn every_management_system_block_opens_with_the_declared_preamble() {
+    for (role, block) in management_system_blocks() {
+        assert!(
+            block.starts_with(SHARED_MANAGEMENT_PREAMBLE),
+            "{role:?}'s system block must open with the declared shared preamble"
+        );
+    }
+}
+
+/// The declaration is exact, not a lower bound: the longest common prefix
+/// the family actually shares equals [`SHARED_MANAGEMENT_PREAMBLE`]. Today
+/// both sides are empty — the measured #1855 problem, stated as a test.
+/// This fails in both interesting directions: an authored preamble the
+/// constant does not record (the option-1 PR must update the declaration in
+/// the same change), and sharing that grows by accident (cache-relevant
+/// bytes appearing without being declared).
+#[test]
+fn the_declared_preamble_is_exactly_what_the_family_shares() {
+    let blocks = management_system_blocks();
+    assert!(
+        blocks.len() >= 2,
+        "the family witness needs at least two roles to compare"
+    );
+    let lcp = blocks[1..]
+        .iter()
+        .fold(blocks[0].1.as_str(), |acc, (_, block)| {
+            common_prefix(acc, block)
+        });
+    assert_eq!(
+        lcp, SHARED_MANAGEMENT_PREAMBLE,
+        "the shared management preamble must be declared, not assumed: \
+         update SHARED_MANAGEMENT_PREAMBLE to the bytes the roles actually share"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -200,7 +200,7 @@ fn conversational_window(messages: &[CompletionMessage]) -> Vec<CompletionMessag
     head.iter().chain(&rest[tail..]).cloned().collect()
 }
 
-const CONVERSATIONAL_SYSTEM_PROMPT: &str = "You are Stella, a careful software engineering agent. The user's latest \
+pub(crate) const CONVERSATIONAL_SYSTEM_PROMPT: &str = "You are Stella, a careful software engineering agent. The user's latest \
      message is a greeting, small talk, or a question about you — not a coding \
      task. Reply briefly and warmly in plain prose: no tools, no code, no plan, \
      no test. Do not invent a task. If it fits, add one short line inviting \


### PR DESCRIPTION
## What

The cheap, useful-now slice of #1855: a cross-role family witness for the #1434 management-prompt split, in a new `management_prompt/tests.rs`. No prompt bytes change — option 1 (authoring the shared ≥1024-token preamble) stays open, per the issue's own constraint that it must not land unmeasured.

Three witnesses:

- **Wire shape** — `ManagementPrompt::into_messages` is exactly `[system(instructions), user(payload)]`, the order that puts stable bytes where the adapters' cache plumbing can mark them.
- **Preamble adoption** — every management system block opens with the declared `SHARED_MANAGEMENT_PREAMBLE`. Vacuously green while the preamble is empty; the assertion that refuses a role left behind once option 1 authors it.
- **Declared-not-assumed parity** — the longest common prefix the family *actually* shares must equal the declaration (empty today — the measured #1855 problem stated as a test). Fails in both directions: an authored preamble the constant does not record, and accidental sharing grown without being declared. Same declared/witnessed shape as the invariant-8 parity matrices.

The role family is enumerated by an exhaustive match over `ModelCallRole` (the `management_bounds` pattern), so a new role dispatched through the chokepoint must declare its prefix posture rather than escape the witness by omission.

## Findings recorded along the way

- **Plan/PlanRepair send no system block at all** — `build_planner_prompt` interpolates its fixed instructions into the single volatile user message, the pre-#1434 structurally-uncacheable shape. Recorded in the witness's match arms and noted on #1855.
- `CONVERSATIONAL_SYSTEM_PROMPT` widened to `pub(crate)` (one line modified, zero lines added — `pipeline.rs` is closed to growth) so the conversational fast path joins the family witness instead of duplicating its bytes.

## Verification

Pure test addition pinning current behavior — no witness-fails-on-main applies. `cargo test -p stella-pipeline` (560 lib + fixture tests) green, clippy `-D warnings` clean, rustfmt clean.

Refs #1855

## Summary by Sourcery

Add tests to pin the management prompt wire shape and shared system-prefix behavior across roles, and expose the conversational system prompt for reuse in those tests.

New Features:
- Introduce a cross-role family witness in management_prompt tests to validate shared management system-prefix structure and parity.
- Add tests ensuring ManagementPrompt serializes to a single system message followed by a user payload.

Enhancements:
- Export the conversational system prompt constant within the crate so the conversational worker path participates in the shared prefix tests.

Tests:
- Add role-enumeration tests that verify which management roles emit system blocks and that all such blocks open with the declared shared management preamble.
- Add a parity test asserting the declared shared preamble exactly matches the longest common prefix actually shared by all management system blocks.