### PR TITLE
feat(stella-observatory): surface context.db's self-improvement plane (#1871)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "sha2 0.11.0",
+ "stella-context",
  "stella-core",
  "stella-diff",
  "stella-home",

--- a/crates/stella-observatory/Cargo.toml
+++ b/crates/stella-observatory/Cargo.toml
@@ -61,3 +61,9 @@ tokio = { workspace = true, features = ["net", "rt-multi-thread"] }
 # on a user's dashboard. See tests/schema_conformance.rs.
 stella-store = { path = "../stella-store" }
 stella-protocol = { path = "../stella-protocol" }
+# The second real-schema gate (#1871), same bargain as stella-store above:
+# production reads context.db with hand-written SQL over SQLITE_OPEN_READ_ONLY,
+# and the test builds the file through ContextStore's real migration path so a
+# renamed ledger or episode column fails at `cargo test` rather than on a
+# user's dashboard.
+stella-context = { path = "../stella-context" }

--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -61,7 +61,7 @@ Only [`stella-cli`](../stella-cli) depends on it: `run_observe`
 preflights the private store paths and calls `serve` (`--port`, default `7787`; `0` picks a
 free one). This crate builds no binary —
 [`examples/serve.rs`](examples/serve.rs) is the dev harness. It reads two tiers:
-`<root>/.stella/private/{store,fleet,codegraph}.db` per workspace, and
+`<root>/.stella/private/{store,fleet,codegraph,context}.db` per workspace, and
 `~/.stella/usage.db`, the cross-project hub.
 
 ## Layout
@@ -71,6 +71,7 @@ free one). This crate builds no binary —
 | [`src/lib.rs`](src/lib.rs) | The HTTP responder: the route table, the `Host` and head-cap gates, the CSP, `serve`. Open it to add a route or to touch anything security-relevant. |
 | [`src/db.rs`](src/db.rs) | Every query against `.stella/private/store.db` and `fleet.db`. Open it when a panel needs a new aggregate; the SQL deliberately mirrors `stella stats` semantics (resolved = outcome `completed`, `off-grid` = provider `local`). |
 | [`src/sent_context.rs`](src/sent_context.rs) | `/api/execution-context`: the receipt queries (`step_receipt`, `step_manifest`, `context_blocks`) and the fold that rebuilds the messages one model call was sent, with the digest-verification verdict. Kept out of `src/db.rs` so that file stays clear of the 1500-line ratchet. |
+| [`src/context_db.rs`](src/context_db.rs) | `/api/context-lifecycle` (#1871): the self-improvement plane read out of `.stella/private/context.db` — the promotion audit trail (`context_records` folded by lineage in append order), current episodes, and selection health. Record bodies deserialize through `stella-core`'s own `context_record` types and the health fold is the CLI's `fold_selection_health`, linked rather than copied. |
 | [`src/context_diff.rs`](src/context_diff.rs) | `/api/execution-context-diff` (#1511): `stella inspect --diff`, served — the unified diff between one call's reconstruction and its resolved baseline (`prev`/`first`/`prompt`, same-role, whole-session). The differ itself is the `stella-diff` leaf crate. |
 | [`src/sessions.rs`](src/sessions.rs) | The sessions plane: the `~/.stella/sessions/` registry (with the read-time pid-liveness downgrade) merged with per-session store rollups (`/api/sessions`, `/api/session`), plus the per-execution behavioural-tendencies fold (`/api/execution-tendencies`). |
 | [`src/global.rs`](src/global.rs) | The user-tier view over `~/.stella/usage.db`: the project switcher (`/api/projects`, `?project=`) and the hub-telemetry drill (org → workspace → repo → project). |

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -642,6 +642,30 @@ footer b{color:var(--text-2);font-weight:600}
         <div class="scroll-y-tall" id="imp-learned" tabindex="0"></div>
       </div>
     </div>
+    <div class="grid cols-2e">
+      <div class="card">
+        <div class="kick">Promotion audit trail · context.db</div>
+        <h2>Proposals &amp; their standing</h2>
+        <div class="scroll-y-tall" id="imp-proposals" tabindex="0"></div>
+      </div>
+      <div class="card">
+        <div class="kick">Governance decisions · newest first</div>
+        <h2>Promotion events</h2>
+        <div class="scroll-y-tall" id="imp-events" tabindex="0"></div>
+      </div>
+    </div>
+    <div class="grid cols-2e">
+      <div class="card">
+        <div class="kick">Episodic memory · current revisions</div>
+        <h2>Episodes</h2>
+        <div class="scroll-y-tall" id="imp-episodes" tabindex="0"></div>
+      </div>
+      <div class="card">
+        <div class="kick">Is injected context earning its tokens?</div>
+        <h2>Selection health</h2>
+        <div class="scroll-y-tall" id="imp-health" tabindex="0"></div>
+      </div>
+    </div>
   </section>
 
   <!-- ══ CONFIG ════════════════════════════════════════════════════════ -->
@@ -1793,6 +1817,98 @@ function renderImprove(skills) {
     : `<div class="empty">none yet — when a lesson recurs across turns, stella writes it into
        <code>.stella/skills/</code> and starts using it in future runs</div>`;
 }
+/* The self-improvement lifecycle read out of context.db (#1871): the
+   promotion audit trail (observation → proposal → promotion event), episodic
+   memory, and selection health. Lazily fetched with the tab rather than on
+   the 5 s poll — the ledger is append-only and slow-moving. */
+const LIFECYCLE_BADGE = {
+  eligible:       ["◆", "accent"], collecting: ["○", "dim"],
+  ignored:        ["✕", "dim"],    proposed:   ["◆", "accent"],
+  auto_activated: ["✓", "ok"],     confirmed:  ["✓", "ok"],
+  published:      ["✓", "ok"],     rejected:   ["✕", "bad"],
+  retired:        ["⊘", "warn"],   reverted:   ["↩", "warn"],
+};
+function lifecycleBadge(status) {
+  const [glyph, cls] = pick(LIFECYCLE_BADGE, status, ["·", "dim"]);
+  return `<span class="badge ${cls}">${glyph} ${esc(String(status ?? ""))}</span>`;
+}
+const EPISODE_OUTCOME = {
+  success: ["ok", "✓ success"], failure: ["bad", "✕ failure"],
+  partial: ["warn", "◌ partial"], aborted: ["bad", "✕ aborted"],
+};
+function renderLifecycle(d) {
+  if (!changed("lifecycle", d)) return;
+  const proposals = d.proposals ?? [];
+  $("imp-proposals").innerHTML = proposals.length
+    ? proposals.map(p => `<div class="feed-item">
+        <b>${esc(p.candidate_id)}</b> ${lifecycleBadge(p.status)}
+        <span class="chip">${esc(p.kind)}</span>
+        <span class="when">${ago(p.observed_at)}</span>
+        <div>${esc(p.body || p.title || "")}</div>
+        <div class="when">${fmtInt(p.distinct_tasks)} distinct task(s) ·
+          ${fmtInt(p.occurrences)} observation(s) · confidence ${fmtInt(p.confidence)}</div>
+      </div>`).join("")
+    : `<div class="empty">No proposals in the ledger.<br>
+       When a lesson recurs across distinct tasks, the loop files a durable
+       proposal into <code>.stella/private/context.db</code> — the audit trail
+       behind every learned skill and promoted rule.</div>`;
+
+  const events = d.events ?? [];
+  $("imp-events").innerHTML = events.length
+    ? events.map(e => `<div class="feed-item">
+        ${lifecycleBadge(e.action)} <b>${esc(e.candidate_id ?? e.proposal_lineage_id)}</b>
+        <span class="chip">${esc(e.actor)}</span>${e.enforcement
+          ? ` <span class="chip">${esc(e.enforcement)}</span>` : ""}
+        <span class="when">${ago(e.occurred_at)}</span>
+        <div>${esc(e.reason || "")}</div></div>`).join("")
+    : `<div class="empty">No governance decisions recorded.<br>
+       Keep, Edit and Ignore from <code>stella proposals</code> — and the
+       loop's own auto-activations and retirements — replay from here.</div>`;
+
+  const episodes = d.episodes ?? [];
+  $("imp-episodes").innerHTML = episodes.length
+    ? `<table><thead><tr><th scope="col">episode</th><th scope="col">outcome</th>
+        <th scope="col" class="num">files</th><th scope="col" class="num">salience</th>
+        <th scope="col" class="num">ended</th></tr></thead><tbody>` +
+      episodes.map(ep => {
+        const files = Array.isArray(ep.files_touched) ? ep.files_touched : [];
+        const [cls, label] = pick(EPISODE_OUTCOME, ep.outcome, ["dim", String(ep.outcome ?? "")]);
+        return `<tr>
+        <td class="main">${esc(ep.summary)}</td>
+        <td><span class="badge ${cls}">${esc(label)}</span></td>
+        <td class="num" title="${esc(files.join("\n"))}">${fmtInt(files.length)}</td>
+        <td class="num">${num(ep.salience).toFixed(2)}</td>
+        <td class="num">${ago(ep.ended_at)}</td></tr>`;
+      }).join("") + `</tbody></table>`
+    : `<div class="empty">No episodes recorded.<br>
+       Each turn's story — what was asked, what was touched, how it ended —
+       lands in episodic memory for future recall.</div>`;
+
+  const health = d.selection_health ?? [];
+  const pol = d.health_policy ?? {};
+  $("imp-health").innerHTML = health.length
+    ? `<table><thead><tr><th scope="col">record</th><th scope="col" class="num">uses</th>
+        <th scope="col" class="num">tasks</th><th scope="col" class="num">assessed</th>
+        <th scope="col" class="num">helpful</th><th scope="col" class="num">not helpful</th>
+        <th scope="col">standing</th></tr></thead><tbody>` +
+      health.map(h => `<tr>
+        <td class="main" title="${esc(h.context_record_id)}">${esc(h.context_record_id)}</td>
+        <td class="num">${fmtInt(h.uses)}</td>
+        <td class="num">${fmtInt(h.distinct_tasks)}</td>
+        <td class="num">${fmtInt(h.assessed_uses)}</td>
+        <td class="num">${fmtInt(h.helpful)}</td>
+        <td class="num">${fmtInt(h.not_helpful)}</td>
+        <td>${h.failing ? `<span class="badge bad">✕ failing</span>`
+            : h.attributable ? `<span class="badge ok">✓ earning</span>`
+            : `<span class="badge dim">○ unassessed</span>`}</td></tr>`).join("") +
+      `</tbody></table>
+      <div class="when" style="margin-top:6px">shipped defaults: failing =
+        ≥${fmtInt(pol.min_attributable_uses ?? 5)} assessed uses with
+        ≥${pct(pol.not_helpful_ratio_threshold ?? 0.8)} judged not helpful</div>`
+    : `<div class="empty">Nothing assessed yet.<br>
+       Every time recalled context is judged for whether it helped, the verdict
+       lands here — which injected records are earning their tokens.</div>`;
+}
 function renderRatingsChart(ratings) {
   const el = $("ch-ratings");
   const pts = ratings.filter(r => r.self_rating != null);
@@ -2725,10 +2841,13 @@ async function loadTab(tab, force) {
       lazyCache[key] = data;
       renderMemoryTab(data[0], data[1], data[2]);
     } else if (tab === "improve") {
-      const data = cached ?? await api("/api/skills");
-      lazyCache[`skills:${state.project}`] = data;
+      const data = cached ?? await Promise.all([
+        api("/api/skills"), api("/api/context-lifecycle"),
+      ]);
+      lazyCache[`skills:${state.project}`] = data[0];
       lazyCache[key] = data;
-      renderImprove(data ?? []);
+      renderImprove(data[0] ?? []);
+      renderLifecycle(data[1] ?? {});
     } else if (tab === "sessions") {
       // Never cached, same reasoning as self-driving: a session's liveness
       // (live / needs-input / crashed) is the point of the list, and the

--- a/crates/stella-observatory/src/context_db.rs
+++ b/crates/stella-observatory/src/context_db.rs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Read-only view over `.stella/private/context.db`'s self-improvement plane
+//! (#1871): the promotion audit trail, episodic memory, and selection health.
+//!
+//! The Self-improve tab shows the skills a session *used*; this module shows
+//! the lifecycle that *created* them — the append-only `context_records`
+//! ledger (observation → `record_proposal` → `promotion_event`, context.db v8,
+//! `crates/stella-context/src/store/schema.rs::migrate_v8`), the `episode`
+//! rows recall ranks, and the use/feedback records selection health is folded
+//! from.
+//!
+//! Two boundaries hold, same as everywhere else in this crate:
+//!
+//! - **The file is opened `SQLITE_OPEN_READ_ONLY` and never migrated.** A
+//!   missing file, table, or column is a state — each section degrades to an
+//!   empty payload and fills in the moment a session migrates the store.
+//! - **Folds are linked, never copied.** Record bodies deserialize through
+//!   `stella_core::context_record`'s own types, and selection health goes
+//!   through the same `fold_selection_health` the CLI runs — pure decision
+//!   logic over owned data (invariant 2), the same bargain that lets this
+//!   crate link the self-driving fold. What *is* re-implemented here is the
+//!   SQL itself, because the write side (`stella-context`) runs migrations on
+//!   open and an observer must never mutate what it observes; the
+//!   schema-conformance suite builds a real `context.db` through that crate's
+//!   migration path to prove these queries stay resolvable.
+//!
+//! Episode ↔ execution linkage is deliberately absent: the only tie is a
+//! summary-tag convention (see `crates/stella-cli/src/memory.rs`, the #1042
+//! trace-pointer note), so episodes render as they are rather than through an
+//! invented join.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+use rusqlite::Connection;
+use serde_json::{Value, json};
+use stella_core::context_record::{
+    ContextUse, ContextUseFeedback, PromotionAction, PromotionEventRecord, ProposalRecord,
+    SelectionHealthPolicy, fold_selection_health,
+};
+
+use crate::db::{DbError, collect_rows, is_missing_schema, open_read_only};
+
+/// Ledger revisions read per record kind, newest first in append order —
+/// mirrors `stella proposals`' own `READ_LIMIT`
+/// (`crates/stella-cli/src/proposals_cmd.rs`), so the dashboard folds the same
+/// window the CLI folds.
+const RECORD_READ_LIMIT: usize = 2_000;
+
+/// Use/feedback records read for the selection-health fold — mirrors the
+/// CLI's `HEALTH_READ_LIMIT` (`crates/stella-cli/src/memory/uses.rs`). This is
+/// the largest read here, and it runs on the lazily-fetched tab, never the 5 s
+/// poll.
+const USE_READ_LIMIT: usize = 20_000;
+
+/// Newest episodes listed. Episodic memory grows without bound; the tab wants
+/// the recent window, not the corpus.
+const MAX_LISTED_EPISODES: usize = 100;
+
+/// Newest promotion events on the timeline.
+const MAX_LISTED_EVENTS: usize = 100;
+
+/// Selection-health rows returned, worst standing first.
+const MAX_HEALTH_ROWS: usize = 50;
+
+/// The promotion gate `stella proposals` displays eligibility against
+/// (`proposals_cmd::list` calls `is_eligible(3, 3)`), mirrored so the two
+/// surfaces can never disagree about what "eligible" means.
+const MIN_DISTINCT_TASKS: u32 = 3;
+/// See [`MIN_DISTINCT_TASKS`].
+const MIN_OBSERVATIONS: u32 = 3;
+
+/// The self-improvement lifecycle payload for `/api/context-lifecycle`.
+pub(crate) fn self_improvement(root: &Path) -> Result<Value, DbError> {
+    let db = root.join(".stella").join("private").join("context.db");
+    let Some(conn) = open_read_only(&db) else {
+        return Ok(empty_payload(false));
+    };
+
+    let counts = collect_rows(
+        &conn,
+        "SELECT record_kind, count(*) FROM context_records
+         GROUP BY record_kind ORDER BY record_kind ASC",
+        |r| {
+            Ok(json!({
+                "kind": r.get::<_, String>(0)?,
+                "records": r.get::<_, i64>(1)?,
+            }))
+        },
+    )?;
+
+    let proposals = proposal_rows(&conn)?;
+    let events = event_rows(&conn)?;
+    let episodes = episode_rows(&conn)?;
+    let health = health_rows(&conn)?;
+    let policy = SelectionHealthPolicy::default();
+
+    Ok(json!({
+        "present": true,
+        "counts": counts,
+        "proposals": proposals,
+        "events": events,
+        "episodes": episodes,
+        "selection_health": health,
+        // The thresholds the fold above ran with. The CLI reads tuned values
+        // out of the settings scope chain; the dashboard runs the shipped
+        // defaults and says so, rather than silently presenting a verdict
+        // computed under thresholds the reader cannot see.
+        "health_policy": {
+            "min_attributable_uses": policy.min_attributable_uses,
+            "not_helpful_ratio_threshold": policy.not_helpful_ratio_threshold,
+            "min_attribution_confidence": policy.min_attribution_confidence,
+        },
+    }))
+}
+
+/// The payload shape with nothing in it. Same key set as the populated branch
+/// so a client indexing a section never finds the key missing — the lesson
+/// `Observatory::cursor` already carries.
+fn empty_payload(present: bool) -> Value {
+    let policy = SelectionHealthPolicy::default();
+    json!({
+        "present": present,
+        "counts": [],
+        "proposals": [],
+        "events": [],
+        "episodes": [],
+        "selection_health": [],
+        "health_policy": {
+            "min_attributable_uses": policy.min_attributable_uses,
+            "not_helpful_ratio_threshold": policy.not_helpful_ratio_threshold,
+            "min_attribution_confidence": policy.min_attribution_confidence,
+        },
+    })
+}
+
+/// The newest `limit` `(record_id, body)` pairs of one ledger kind, returned
+/// in ascending append order.
+///
+/// Append order (`rowid`), not `observed_at`: the ledger is append-only and
+/// never updated or deleted from, so `rowid` is its insertion sequence, and a
+/// last-write-wins fold over `observed_at` would order two same-second
+/// decisions by content hash — the deterministic wrong answer
+/// `stella-context`'s `records_of_kind_newest_in_append_order` documents.
+fn kind_rows(
+    conn: &Connection,
+    kind: &str,
+    limit: usize,
+) -> Result<Vec<(String, String)>, DbError> {
+    let mut stmt = match conn.prepare(
+        "SELECT record_id, body FROM context_records
+         WHERE record_kind = ?1 ORDER BY rowid DESC LIMIT ?2",
+    ) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mapped = stmt.query_map(rusqlite::params![kind, limit as i64], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })?;
+    let mut rows = mapped.collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.reverse();
+    Ok(rows)
+}
+
+/// Every promotion event in the window, parsed. Ascending append order — the
+/// replay order the decision fold requires.
+fn parsed_events(conn: &Connection) -> Result<Vec<PromotionEventRecord>, DbError> {
+    Ok(kind_rows(conn, "promotion_event", RECORD_READ_LIMIT)?
+        .into_iter()
+        .filter_map(|(_, body)| serde_json::from_str::<PromotionEventRecord>(&body).ok())
+        .collect())
+}
+
+/// Current proposals with their decision standing and their own slice of the
+/// promotion-event log — the `context_records` lineage fold, one entry per
+/// proposal lineage.
+fn proposal_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
+    // Newest revision per lineage: ascending append order means a later
+    // revision overwrites its predecessor in the map, exactly as
+    // `proposals_cmd::current_proposals` folds.
+    let mut latest: BTreeMap<String, ProposalRecord> = BTreeMap::new();
+    for (_, body) in kind_rows(conn, "record_proposal", RECORD_READ_LIMIT)? {
+        if let Ok(proposal) = serde_json::from_str::<ProposalRecord>(&body) {
+            latest.insert(proposal.lineage_id.clone(), proposal);
+        }
+    }
+    let events = parsed_events(conn)?;
+    // Last write wins — the whole governance state machine: an ignored
+    // proposal later kept has been kept, and both acts remain readable.
+    let mut decided: HashMap<String, PromotionAction> = HashMap::new();
+    let mut per_lineage: HashMap<String, Vec<&PromotionEventRecord>> = HashMap::new();
+    for event in &events {
+        decided.insert(event.proposal_lineage_id.clone(), event.action);
+        per_lineage
+            .entry(event.proposal_lineage_id.clone())
+            .or_default()
+            .push(event);
+    }
+
+    let mut proposals: Vec<&ProposalRecord> = latest.values().collect();
+    proposals.sort_by(|a, b| {
+        b.observed_at
+            .cmp(&a.observed_at)
+            .then_with(|| a.candidate_id.cmp(&b.candidate_id))
+    });
+    Ok(proposals
+        .into_iter()
+        .map(|proposal| {
+            // The displayed status is derived, never stored — the same
+            // derivation `stella proposals` prints, minus the colors.
+            let status = match decided.get(&proposal.lineage_id) {
+                Some(PromotionAction::Rejected) => "ignored".to_string(),
+                Some(action) => action.as_str().to_string(),
+                None if proposal.is_eligible(MIN_DISTINCT_TASKS, MIN_OBSERVATIONS) => {
+                    "eligible".to_string()
+                }
+                None => "collecting".to_string(),
+            };
+            let lineage_events: Vec<Value> = per_lineage
+                .get(&proposal.lineage_id)
+                .map(|events| events.iter().map(|e| event_json(e, None)).collect())
+                .unwrap_or_default();
+            json!({
+                "lineage_id": proposal.lineage_id,
+                "candidate_id": proposal.candidate_id,
+                "kind": proposal.proposal_kind.as_str(),
+                "title": proposal.title,
+                "body": truncate(&proposal.body, 240),
+                "status": status,
+                "distinct_tasks": proposal.score.distinct_tasks,
+                "occurrences": proposal.score.occurrences,
+                "salient": proposal.score.salient,
+                "confidence": proposal.confidence.get(),
+                "supporting_observations": proposal.supporting_observations,
+                "observed_at": proposal.observed_at,
+                "events": lineage_events,
+            })
+        })
+        .collect())
+}
+
+/// The promotions timeline: the newest events, newest first, each carrying the
+/// candidate its proposal lineage currently names (when the proposal is still
+/// inside the read window).
+fn event_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
+    let mut titles: HashMap<String, (String, String)> = HashMap::new();
+    for (_, body) in kind_rows(conn, "record_proposal", RECORD_READ_LIMIT)? {
+        if let Ok(proposal) = serde_json::from_str::<ProposalRecord>(&body) {
+            titles.insert(
+                proposal.lineage_id.clone(),
+                (proposal.candidate_id, proposal.title),
+            );
+        }
+    }
+    let mut events = parsed_events(conn)?;
+    events.reverse();
+    Ok(events
+        .iter()
+        .take(MAX_LISTED_EVENTS)
+        .map(|event| event_json(event, titles.get(&event.proposal_lineage_id)))
+        .collect())
+}
+
+/// One promotion event, shaped for the page.
+fn event_json(event: &PromotionEventRecord, named: Option<&(String, String)>) -> Value {
+    json!({
+        "occurred_at": event.occurred_at,
+        "action": event.action.as_str(),
+        "actor": event.actor.as_str(),
+        "reason": truncate(&event.reason, 200),
+        "proposal_lineage_id": event.proposal_lineage_id,
+        "enforcement": event.enforcement.map(|e| e.as_str()),
+        "candidate_id": named.map(|(candidate, _)| candidate.as_str()),
+        "title": named.map(|(_, title)| title.as_str()),
+    })
+}
+
+/// The newest episodes, newest first. Superseded revisions are excluded — the
+/// tab shows current episodic memory, and history stays queryable where it
+/// lives.
+///
+/// `superseded_at` arrived with context.db v8; on an older file the whole
+/// query degrades to an empty list and fills in after the next migration,
+/// like every other missing-schema state here.
+fn episode_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
+    collect_rows(
+        conn,
+        &format!(
+            "SELECT summary, files_touched, outcome, salience, started_at, ended_at
+             FROM episode WHERE superseded_at IS NULL
+             ORDER BY ended_at DESC, id DESC LIMIT {MAX_LISTED_EPISODES}"
+        ),
+        |r| {
+            let files: Value =
+                serde_json::from_str(&r.get::<_, String>(1)?).unwrap_or_else(|_| json!([]));
+            Ok(json!({
+                "summary": truncate(&r.get::<_, String>(0)?, 240),
+                "files_touched": files,
+                "outcome": r.get::<_, String>(2)?,
+                "salience": r.get::<_, f64>(3)?,
+                "started_at": r.get::<_, String>(4)?,
+                "ended_at": r.get::<_, String>(5)?,
+            }))
+        },
+    )
+}
+
+/// Selection health, folded from the ledger's use/feedback records through the
+/// same pure fold the CLI runs, worst standing first.
+fn health_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
+    let uses: Vec<(String, ContextUse)> = kind_rows(conn, "context_use", USE_READ_LIMIT)?
+        .into_iter()
+        .filter_map(|(record_id, body)| {
+            serde_json::from_str::<ContextUse>(&body)
+                .ok()
+                .map(|body| (record_id, body))
+        })
+        .collect();
+    let feedback: Vec<ContextUseFeedback> =
+        kind_rows(conn, "context_use_feedback", USE_READ_LIMIT)?
+            .into_iter()
+            .filter_map(|(_, body)| serde_json::from_str::<ContextUseFeedback>(&body).ok())
+            .collect();
+    let mut health = fold_selection_health(&uses, &feedback, SelectionHealthPolicy::default());
+    health.sort_by(|a, b| {
+        b.failing
+            .cmp(&a.failing)
+            .then_with(|| {
+                b.not_helpful_ratio
+                    .partial_cmp(&a.not_helpful_ratio)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| b.uses.cmp(&a.uses))
+            .then_with(|| a.context_record_id.cmp(&b.context_record_id))
+    });
+    Ok(health
+        .iter()
+        .take(MAX_HEALTH_ROWS)
+        .map(|row| {
+            json!({
+                "context_record_id": row.context_record_id,
+                "uses": row.uses,
+                "distinct_tasks": row.distinct_tasks,
+                "assessed_uses": row.assessed_uses,
+                "helpful": row.helpful,
+                "not_helpful": row.not_helpful,
+                "neutral": row.neutral,
+                "not_helpful_ratio": row.not_helpful_ratio,
+                "attributable": row.attributable,
+                "failing": row.failing,
+            })
+        })
+        .collect())
+}
+
+/// Cap a string at `max` chars on a char boundary, appending an ellipsis.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('…');
+    out
+}

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -1218,7 +1218,7 @@ struct ToolAgg {
 }
 
 /// Open a SQLite file strictly read-only; `None` when it doesn't exist.
-fn open_read_only(path: &Path) -> Option<Connection> {
+pub(crate) fn open_read_only(path: &Path) -> Option<Connection> {
     if !path.exists() {
         return None;
     }
@@ -1236,7 +1236,7 @@ fn open_read_only(path: &Path) -> Option<Connection> {
 
 /// Run a query collecting every row; a missing table degrades to `[]` so a
 /// dashboard section renders empty instead of failing the whole page.
-fn collect_rows<F>(conn: &Connection, sql: &str, map: F) -> Result<Vec<Value>, DbError>
+pub(crate) fn collect_rows<F>(conn: &Connection, sql: &str, map: F) -> Result<Vec<Value>, DbError>
 where
     F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<Value>,
 {

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -2,7 +2,8 @@
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
 //! The stella Observatory — a local, loopback-only dashboard over the
-//! workspace's own telemetry (`.stella/private/store.db`, `.stella/private/fleet.db`).
+//! workspace's own telemetry (`.stella/private/store.db`,
+//! `.stella/private/fleet.db`, `.stella/private/context.db`).
 //!
 //! Design constraints, in order:
 //!

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -43,6 +43,7 @@
 
 mod accept;
 mod codegraph;
+mod context_db;
 mod context_diff;
 mod db;
 mod fsview;
@@ -364,6 +365,11 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
                 "ratings": ratings,
             })
         }),
+        // The self-improvement lifecycle behind those skills (#1871): the
+        // promotion audit trail, episodic memory, and selection health, read
+        // straight out of `.stella/private/context.db` — the one store the
+        // dashboard never looked at.
+        "/api/context-lifecycle" => context_db::self_improvement(root),
         // self-driving is machine-scoped, not workspace-scoped: the list answers
         // "what is my agent doing anywhere", and the workspace root only marks
         // which loop belongs to the project this tab is pointed at.

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -36,6 +36,12 @@
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
+use stella_context::{ContextDelta, ContextStore, EpisodeInput, LedgerAppend};
+use stella_core::context_record::{
+    Confidence, ObservationRecord, PromotionAction, PromotionActor, PromotionEventRecord,
+    ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus,
+    lifecycle::ObservationSource,
+};
 use stella_observatory::respond;
 use stella_protocol::{
     AgentEvent, ContextFrameRef, ProviderShare, TaskItem, TaskStatus, ToolCall, ToolOutput,
@@ -108,6 +114,10 @@ const ROUTES: &[(&str, Option<&str>)] = &[
     ("/api/explorations", None),
     ("/api/rules", Some("/db/0/rule_id")),
     ("/api/reflections", Some("/ratings/0/execution_id")),
+    // Empty in a store-only fixture: the lifecycle reads context.db, which
+    // this workspace deliberately does not build. Its own real-schema gate is
+    // `context_lifecycle_returns_the_promotion_lineage` below (#1871).
+    ("/api/context-lifecycle", None),
 ];
 
 /// One tool call's full event round-trip — the announcement and its result.
@@ -935,4 +945,250 @@ fn context_diff_names_the_moved_line_and_reports_identity_honestly() {
         "prev on a first call resolves: {first}"
     );
     assert_eq!(first["base_label"], "prompt as submitted", "{first}");
+}
+
+/// One ledger append through the real write API, with the record's own
+/// identity, hash and timestamps — the shape every production writer uses
+/// (`crates/stella-cli/src/memory/observations.rs::append_observation` et al).
+fn append_lifecycle<T: serde::Serialize>(
+    store: &ContextStore,
+    kind: &str,
+    record_id: &str,
+    lineage_id: &str,
+    record_hash: &str,
+    schema_version: &str,
+    record: &T,
+    observed_at: &str,
+) {
+    let body = serde_json::to_string(record).expect("record json");
+    store
+        .append_record(LedgerAppend {
+            record_id,
+            lineage_id,
+            record_kind: kind,
+            record_hash,
+            schema_version,
+            body: &body,
+            observed_at,
+            supersedes: None,
+        })
+        .expect("ledger append");
+}
+
+/// The candidate the seeded proposal names — what the promotions timeline
+/// must echo back.
+const CANDIDATE_ID: &str = "grep-first-abc12345";
+
+/// Build a workspace whose `context.db` came from the **real** migration path
+/// (`ContextStore::open`), seeded through the real write APIs (#1871): a full
+/// observation → proposal → promotion-event lineage, plus one episode through
+/// the writeback path.
+///
+/// The second half of the bargain `real_store_workspace` documents for
+/// `store.db`: production reads this file with hand-written SQL over a
+/// read-only handle, so only a database built by `stella-context`'s own
+/// migrations can prove those queries still resolve.
+fn real_context_workspace() -> (tempfile::TempDir, String, String) {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let private = dir.path().join(".stella").join("private");
+    std::fs::create_dir_all(&private).expect("private dir");
+    let store = ContextStore::open(private.join("context.db"))
+        .expect("ContextStore::open runs the real migrations");
+
+    let observation = ObservationRecord::new(
+        ObservationSource::ReflectionLesson,
+        "reflection:1700000000",
+        "task-1",
+        "grep before you guess",
+        Vec::new(),
+        false,
+        "2026-08-01T12:00:00Z",
+    )
+    .expect("observation");
+    append_lifecycle(
+        &store,
+        "observation",
+        &observation.record_id,
+        &observation.lineage_id,
+        &observation.record_hash,
+        &observation.schema_version,
+        &observation,
+        &observation.observed_at,
+    );
+
+    let proposal = ProposalRecord::new(
+        RecordProposalKind::Knowledge,
+        RecordProposalStatus::Eligible,
+        CANDIDATE_ID,
+        "Grep before you guess",
+        "Search the tree before assuming a symbol's location.",
+        Vec::new(),
+        vec![observation.record_id.clone()],
+        ProposalScore {
+            occurrences: 4,
+            distinct_tasks: 3,
+            salient: true,
+            rank: 0.9,
+        },
+        Confidence::new(90).expect("confidence"),
+        "2026-08-01T12:05:00Z",
+    )
+    .expect("proposal");
+    append_lifecycle(
+        &store,
+        "record_proposal",
+        &proposal.record_id,
+        &proposal.lineage_id,
+        &proposal.record_hash,
+        &proposal.schema_version,
+        &proposal,
+        &proposal.observed_at,
+    );
+
+    let event = PromotionEventRecord::new(
+        proposal.lineage_id.clone(),
+        PromotionAction::Confirmed,
+        PromotionActor::User,
+        None,
+        None,
+        "kept from review",
+        "2026-08-01T12:10:00Z",
+    )
+    .expect("promotion event");
+    append_lifecycle(
+        &store,
+        "promotion_event",
+        &event.record_id,
+        &event.lineage_id,
+        &event.record_hash,
+        &event.schema_version,
+        &event,
+        &event.occurred_at,
+    );
+
+    // One episode through the real writeback path. The embed decision runs on
+    // the store's built-in hash embedder — nothing leaves the process.
+    tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(async {
+            store
+                .upsert(ContextDelta::new().with_episode(EpisodeInput::new(
+                    "added the parser fix",
+                    "2026-08-01T12:00:00Z",
+                    "2026-08-01T12:20:00Z",
+                )))
+                .await
+                .expect("episode upsert");
+        });
+
+    (dir, proposal.lineage_id.clone(), observation.record_id.clone())
+}
+
+/// The #1871 witness: the route folds the seeded observation → proposal →
+/// promotion-event lineage back out of a real-migration `context.db`. Fails
+/// on main (the route is absent), and fails if any ledger or episode column
+/// this crate reads is renamed in `stella-context`.
+#[test]
+fn context_lifecycle_returns_the_promotion_lineage() {
+    let (workspace, proposal_lineage, observation_id) = real_context_workspace();
+
+    let body = respond(workspace.path(), "/api/context-lifecycle").body;
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    assert!(v.get("error").is_none(), "{v}");
+    assert_eq!(v["present"], true, "{v}");
+
+    let proposal = &v["proposals"][0];
+    assert_eq!(proposal["lineage_id"], proposal_lineage.as_str(), "{v}");
+    assert_eq!(proposal["candidate_id"], CANDIDATE_ID, "{v}");
+    assert_eq!(
+        proposal["status"], "confirmed",
+        "the decision standing is replayed from the event log, not stored: {v}"
+    );
+    assert_eq!(
+        proposal["supporting_observations"][0],
+        observation_id.as_str(),
+        "the lineage reaches back to its evidence: {v}"
+    );
+    assert_eq!(
+        proposal["events"][0]["action"], "confirmed",
+        "the proposal carries its own slice of the audit trail: {v}"
+    );
+
+    assert_eq!(v["events"][0]["action"], "confirmed", "{v}");
+    assert_eq!(
+        v["events"][0]["candidate_id"], CANDIDATE_ID,
+        "the timeline names the candidate its lineage points at: {v}"
+    );
+
+    assert_eq!(v["episodes"][0]["outcome"], "success", "{v}");
+    assert_eq!(v["episodes"][0]["summary"], "added the parser fix", "{v}");
+
+    let kinds: Vec<&str> = v["counts"]
+        .as_array()
+        .expect("counts")
+        .iter()
+        .filter_map(|c| c["kind"].as_str())
+        .collect();
+    for kind in ["observation", "record_proposal", "promotion_event"] {
+        assert!(kinds.contains(&kind), "counts missing {kind}: {v}");
+    }
+}
+
+/// Missing is a state: a workspace that has never built a context plane
+/// answers with the full (empty) payload shape, never a 500 and never a
+/// missing key.
+#[test]
+fn a_workspace_with_no_context_db_degrades_to_an_empty_lifecycle() {
+    let workspace = real_store_workspace();
+    let response = respond(workspace.path(), "/api/context-lifecycle");
+    assert_eq!(
+        response.status,
+        "200 OK",
+        "body: {}",
+        String::from_utf8_lossy(&response.body)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&response.body).expect("json");
+    assert_eq!(v["present"], false, "{v}");
+    for key in ["counts", "proposals", "events", "episodes", "selection_health"] {
+        assert_eq!(v[key], serde_json::json!([]), "{key} must be empty: {v}");
+    }
+}
+
+/// The read-only observer never migrates, so it can be pointed at a
+/// `context.db` older than the v8 lifecycle ledger — same hazard the pre-v18
+/// store test above covers. The ledger sections degrade to empty and the
+/// episode list (whose v8 columns are also gone) degrades with them; nothing
+/// 500s, and everything fills in after the next session migrates the file.
+#[test]
+fn a_context_db_older_than_v8_degrades_to_empty_ledger_sections() {
+    let (workspace, _, _) = real_context_workspace();
+    {
+        let raw =
+            rusqlite::Connection::open(workspace.path().join(".stella/private/context.db"))
+                .expect("open");
+        // Rebuild the pre-v8 shape honestly: no ledger table, no lineage
+        // columns on `episode`. Dropping the whole table also drops its
+        // append-only triggers, exactly as a pre-v8 file never had them.
+        raw.execute_batch(
+            "DROP TABLE context_records;
+             DROP INDEX IF EXISTS idx_episode_lineage;
+             ALTER TABLE episode DROP COLUMN lineage_id;
+             ALTER TABLE episode DROP COLUMN superseded_at;
+             PRAGMA user_version = 7;",
+        )
+        .expect("roll the schema back");
+    }
+
+    let response = respond(workspace.path(), "/api/context-lifecycle");
+    assert_eq!(
+        response.status,
+        "200 OK",
+        "a pre-v8 context.db must degrade, not 500 — body: {}",
+        String::from_utf8_lossy(&response.body)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&response.body).expect("json");
+    assert_eq!(v["present"], true, "the file exists and is reported: {v}");
+    for key in ["counts", "proposals", "events", "episodes", "selection_health"] {
+        assert_eq!(v[key], serde_json::json!([]), "{key} must be empty: {v}");
+    }
 }

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -950,17 +950,17 @@ fn context_diff_names_the_moved_line_and_reports_identity_honestly() {
 /// One ledger append through the real write API, with the record's own
 /// identity, hash and timestamps — the shape every production writer uses
 /// (`crates/stella-cli/src/memory/observations.rs::append_observation` et al).
-fn append_lifecycle<T: serde::Serialize>(
+#[allow(clippy::too_many_arguments)] // mirrors LedgerAppend's own field list
+fn append_lifecycle(
     store: &ContextStore,
     kind: &str,
     record_id: &str,
     lineage_id: &str,
     record_hash: &str,
     schema_version: &str,
-    record: &T,
+    body: &str,
     observed_at: &str,
 ) {
-    let body = serde_json::to_string(record).expect("record json");
     store
         .append_record(LedgerAppend {
             record_id,
@@ -968,7 +968,7 @@ fn append_lifecycle<T: serde::Serialize>(
             record_kind: kind,
             record_hash,
             schema_version,
-            body: &body,
+            body,
             observed_at,
             supersedes: None,
         })
@@ -1012,7 +1012,7 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
         &observation.lineage_id,
         &observation.record_hash,
         &observation.schema_version,
-        &observation,
+        &serde_json::to_string(&observation).expect("record json"),
         &observation.observed_at,
     );
 
@@ -1041,7 +1041,7 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
         &proposal.lineage_id,
         &proposal.record_hash,
         &proposal.schema_version,
-        &proposal,
+        &serde_json::to_string(&proposal).expect("record json"),
         &proposal.observed_at,
     );
 
@@ -1062,7 +1062,7 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
         &event.lineage_id,
         &event.record_hash,
         &event.schema_version,
-        &event,
+        &serde_json::to_string(&event).expect("record json"),
         &event.occurred_at,
     );
 
@@ -1081,7 +1081,11 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
                 .expect("episode upsert");
         });
 
-    (dir, proposal.lineage_id.clone(), observation.record_id.clone())
+    (
+        dir,
+        proposal.lineage_id.clone(),
+        observation.record_id.clone(),
+    )
 }
 
 /// The #1871 witness: the route folds the seeded observation → proposal →
@@ -1149,7 +1153,13 @@ fn a_workspace_with_no_context_db_degrades_to_an_empty_lifecycle() {
     );
     let v: serde_json::Value = serde_json::from_slice(&response.body).expect("json");
     assert_eq!(v["present"], false, "{v}");
-    for key in ["counts", "proposals", "events", "episodes", "selection_health"] {
+    for key in [
+        "counts",
+        "proposals",
+        "events",
+        "episodes",
+        "selection_health",
+    ] {
         assert_eq!(v[key], serde_json::json!([]), "{key} must be empty: {v}");
     }
 }
@@ -1163,9 +1173,8 @@ fn a_workspace_with_no_context_db_degrades_to_an_empty_lifecycle() {
 fn a_context_db_older_than_v8_degrades_to_empty_ledger_sections() {
     let (workspace, _, _) = real_context_workspace();
     {
-        let raw =
-            rusqlite::Connection::open(workspace.path().join(".stella/private/context.db"))
-                .expect("open");
+        let raw = rusqlite::Connection::open(workspace.path().join(".stella/private/context.db"))
+            .expect("open");
         // Rebuild the pre-v8 shape honestly: no ledger table, no lineage
         // columns on `episode`. Dropping the whole table also drops its
         // append-only triggers, exactly as a pre-v8 file never had them.
@@ -1188,7 +1197,13 @@ fn a_context_db_older_than_v8_degrades_to_empty_ledger_sections() {
     );
     let v: serde_json::Value = serde_json::from_slice(&response.body).expect("json");
     assert_eq!(v["present"], true, "the file exists and is reported: {v}");
-    for key in ["counts", "proposals", "events", "episodes", "selection_health"] {
+    for key in [
+        "counts",
+        "proposals",
+        "events",
+        "episodes",
+        "selection_health",
+    ] {
         assert_eq!(v[key], serde_json::json!([]), "{key} must be empty: {v}");
     }
 }


### PR DESCRIPTION
## What & why

The dashboard's Self-improve tab showed the skills a session *used* but nothing read `.stella/private/context.db`, where the self-improvement machinery leaves its audit trail. This PR adds a read-only `context_db` module and a `/api/context-lifecycle` route surfacing:

- **The promotion audit trail** — `record_proposal` revisions folded newest-per-lineage in append order, each carrying its decision standing replayed last-write-wins from the `promotion_event` log (the exact derivation `stella proposals` prints: `ignored` / action / `eligible(3,3)` / `collecting`), its supporting observation ids, and its own slice of the event log. Plus a newest-first promotion-events timeline naming each event's candidate.
- **Episodes** — current (unsuperseded) episodic memory: summary, files touched, outcome, salience, window. Episode↔execution linkage is deliberately *not* invented — the only tie is the summary-tag convention (#1042 note), so episodes render as they are.
- **Selection health** — `context_use`/`context_use_feedback` folded through `stella_core::context_record::fold_selection_health` (linked, not copied — the same bargain as the self-driving fold, #1613) under the shipped default policy, which the payload names explicitly.

All reads are `SQLITE_OPEN_READ_ONLY` with the crate's standard missing-file/table/column degradation: a fresh workspace, a store-only workspace, and a pre-v8 `context.db` all render empty sections instead of 500ing.

**Exemplar:** the module mirrors `src/db.rs`' read-only idiom and the #827 schema-conformance-gate structure; record bodies deserialize through `stella-core`'s own `context_record` types so a field rename fails at compile time rather than at runtime.

`stella-context` joins `tests/schema_conformance.rs` as a **dev**-dependency (same bargain as `stella-store` there): the suite builds `context.db` through `ContextStore::open`'s real migration path and seeds through the real write APIs (`ObservationRecord::new` → `append_record`, `ProposalRecord::new`, `PromotionEventRecord::new`, and an episode through the async `upsert` writeback), so the hand-written SQL is pinned to the real schema.

Closes #1871

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`context_lifecycle_returns_the_promotion_lineage` seeds an observation → proposal → promotion-event lineage via the real write API and asserts the route folds it back (status replayed from the event log, evidence ids intact, timeline names the candidate). On `main` the route is absent (404 → non-200), so the test fails there. Two degradation tests ride along: no `context.db` at all, and a file rolled back to the pre-v8 shape (ledger table dropped, v8 episode columns dropped).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (scoped run locally; CI runs the workspace)
- [x] `cargo test --workspace` (scoped `-p stella-observatory` locally, 11/11 incl. the new gate; CI runs the workspace)
- [x] Docs updated where behavior/flags changed (crate README layout table + tier list, lib.rs module doc)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- The dashboard computes selection health under the **shipped default** `SelectionHealthPolicy` and says so in the payload; the CLI can run settings-tuned thresholds. Surfacing the tuned values would mean mirroring the 3-scope settings merge in the observatory — noted in the payload as `health_policy` rather than silently diverging. Filed as #1944.

## Summary by Sourcery

Expose the self-improvement lifecycle stored in .stella/private/context.db through a new read-only API and dashboard views, backed by schema-conformance tests using the real stella-context migration path.

New Features:
- Add a /api/context-lifecycle endpoint that surfaces promotion audit trail data, episodic memory, and selection health from context.db.
- Extend the Self-improve tab with panels for proposals, promotion events, episodes, and selection health rendered from the new lifecycle API.

Enhancements:
- Introduce a dedicated context_db module that reads context.db via the crate’s standard read-only helpers and mirrors CLI selection-health and proposal-fold semantics.
- Export shared read-only DB helpers so other modules can reuse the existing SQLite access pattern.

Build:
- Add stella-context as a dev-dependency so tests can build and seed context.db through the real migration and write APIs.

Documentation:
- Update stella-observatory documentation to describe context.db as an observed telemetry source and document the new context_db module and route.

Tests:
- Add a schema-conformance witness test that seeds a real context.db via stella-context and asserts /api/context-lifecycle returns the expected promotion lineage and counts.
- Add degradation tests ensuring workspaces with no context.db or pre-v8 schemas return empty lifecycle payloads without failing.
