### PR TITLE
fix(stella-pipeline): arm FlipHalt on the authored-witness path and in revise turns (#1793)

### DIFF
--- a/crates/stella-pipeline/src/flip_halt.rs
+++ b/crates/stella-pipeline/src/flip_halt.rs
@@ -43,6 +43,7 @@
 //! the work is credited is a separate question with its own, stricter,
 //! machinery.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use stella_core::driver::TurnHalt;
@@ -124,6 +125,19 @@ impl FlipHalt {
     #[must_use]
     pub fn is_flipped(&self) -> bool {
         self.flipped.load(Ordering::SeqCst)
+    }
+
+    /// The latch to hand a follow-up turn: `Some(self)` only while unfired.
+    ///
+    /// A latch that already fired belongs to the turn it stopped. A revision
+    /// dispatched after that flip was requested *despite* it — the ladder
+    /// found something else to fix (a lint regression, a refuted verdict) —
+    /// so the stale latch must not end the revision at its first step
+    /// boundary. Only a flip observed during the new turn itself may stop it,
+    /// and that is exactly what an unfired latch delivers (#1793).
+    #[must_use]
+    pub fn unfired(self: &Arc<Self>) -> Option<Arc<Self>> {
+        (!self.is_flipped()).then(|| Arc::clone(self))
     }
 
     /// Feed one finished shell call. Returns `true` if this observation
@@ -220,6 +234,21 @@ mod tests {
         let halt = FlipHalt::new("pytest -q");
         assert!(!halt.observe("pytest -q", "3 passed"));
         assert!(!halt.is_flipped());
+    }
+
+    #[test]
+    fn a_fired_latch_is_withheld_from_a_follow_up_turn() {
+        let halt = Arc::new(FlipHalt::new("pytest -q"));
+        // Unfired: the follow-up turn gets the same latch, not a copy — a
+        // flip it observes must be visible to the caller that armed it.
+        let handed = halt.unfired().expect("an unfired latch is handed on");
+        assert!(Arc::ptr_eq(&halt, &handed));
+
+        halt.observe("pytest -q", "ok\n[exit code: 0]");
+        assert!(
+            halt.unfired().is_none(),
+            "a latch that already fired must not end a later turn at its first step boundary"
+        );
     }
 
     #[test]

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -692,13 +692,13 @@ struct CandidateState {
     /// warrant (the #1701 recurrence a projection method used to guard
     /// against by hand).
     signals: ChangeSignals,
-    /// Ends the execute turn as soon as the tracked test goes fail→pass.
+    /// Ends an engine turn — execute, or a revision that gets the latch via
+    /// [`FlipHalt::unfired`] — as soon as the tracked test goes fail→pass.
     ///
-    /// `None` whenever there is nothing to watch: no configured test command,
-    /// or a baseline that was already passing (which can never flip, so a
-    /// halt on it would end turns that had work left). See
-    /// [`crate::flip_halt`] for why stopping is a separate question from
-    /// crediting.
+    /// `None` while there is nothing to watch: no failing configured-command
+    /// baseline and no authored witness yet. `witness_on_demand` arms it the
+    /// moment a witness's failing baseline is credited (#1793). See
+    /// [`crate::flip_halt`] for why stopping is separate from crediting.
     flip_halt: Option<Arc<FlipHalt>>,
     oracle: FlipOracle,
     /// The oracle's observations in the order they were made (#864) —
@@ -2960,7 +2960,7 @@ impl<'a> Pipeline<'a> {
                 &mut state.messages,
                 spend.budget,
                 &mut state.signals,
-                None,
+                state.flip_halt.as_ref().and_then(FlipHalt::unfired),
             )
             .await
         {

--- a/crates/stella-pipeline/src/pipeline/test_doubles.rs
+++ b/crates/stella-pipeline/src/pipeline/test_doubles.rs
@@ -49,7 +49,7 @@ impl RepoStatusPort for NeverRepoStatus {
 pub(super) struct FakeWorkspace {
     id: usize,
     root: String,
-    tools: EmptyTools,
+    tools: Box<dyn ToolExecutor>,
     diagnostics: ScriptedRunner,
     repo_status: SeqRepoStatus,
     adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
@@ -74,7 +74,7 @@ impl FakeWorkspace {
         Self {
             id,
             root: "/candidate/workspace".into(),
-            tools: EmptyTools,
+            tools: Box::new(EmptyTools),
             diagnostics: ScriptedRunner::new(test_results, "@@ -1 +1 @@\n-a\n+b"),
             repo_status: SeqRepoStatus::new(vec![]),
             adopt_result,
@@ -125,6 +125,15 @@ impl FakeWorkspace {
         self
     }
 
+    /// The tool executor this candidate's engine turns run against — for
+    /// scenarios where a scripted worker must *observe* something through a
+    /// tool result (e.g. the tracked test's exit status feeding the flip
+    /// halt), which the default silent [`EmptyTools`] can never carry.
+    pub(super) fn with_tools(mut self, tools: impl ToolExecutor + 'static) -> Self {
+        self.tools = Box::new(tools);
+        self
+    }
+
     /// A candidate that wrote through its isolation (#1538): the post-seal
     /// escape check will report these paths as already holding the
     /// candidate's sealed bytes in the real tree.
@@ -149,10 +158,10 @@ impl CandidateWorkspace for FakeWorkspace {
         &self.root
     }
     fn tools(&self) -> &dyn ToolExecutor {
-        &self.tools
+        self.tools.as_ref()
     }
     fn witness_tools(&self) -> &dyn ToolExecutor {
-        &self.tools
+        self.tools.as_ref()
     }
     fn diagnostics(&self) -> &dyn DiagnosticRunner {
         &self.diagnostics

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -7,6 +7,12 @@
 use super::*;
 use crate::LineMutation;
 
+/// The authored-witness arming of the mid-turn flip halt (#1793) — a child
+/// rather than a sibling module so it reaches the shared fakes through this
+/// file's own `use super::*`, and so the already-oversized `tests.rs` does
+/// not grow another module declaration.
+mod flip_halt_arming;
+
 /// #860 acceptance: a baseline that TIMES OUT observed no failing assertion,
 /// so a candidate whose suite then passes has no fail→pass flip — the run
 /// must escalate to the model verifier, never credit `DeterministicPass`. Before
@@ -1257,5 +1263,128 @@ async fn a_second_deterministic_failure_fires_guidance_even_when_not_consecutive
     assert!(
         stages(&drain(&mut rx)).contains(&StageKind::Verdict),
         "the guidance call is an honest Verifier stage in the stream"
+    );
+}
+
+/// A shell double whose every command "passes": the output carries the
+/// trailing exit-0 marker [`crate::flip_halt::exit_status`] parses. What
+/// [`EmptyTools`] can never express — a worker *observing* the tracked test
+/// succeed through a tool result.
+struct PassingShell;
+#[async_trait]
+impl ToolExecutor for PassingShell {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a shell command".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: "1 passed\n[exit code: 0]".into(),
+        }
+    }
+}
+
+/// A completion that runs `command` through the shell — the observation the
+/// flip halt correlates by `call_id` and scores against the tracked test.
+fn shell_call_result(command: &str) -> CompletionResult {
+    CompletionResult {
+        tool_calls: vec![ToolCall {
+            call_id: format!("call-shell-{command}"),
+            name: "bash".into(),
+            input: serde_json::json!({ "command": command }),
+        }],
+        ..text_result("")
+    }
+}
+
+/// #1793 witness (configured-command side): a revision that observes the
+/// tracked test go fail→pass halts at that step boundary instead of running
+/// on. The provider is scripted with steps BEYOND the flip; consuming them
+/// is exactly the waste `flip_halt` exists to stop, so the call count is the
+/// assertion.
+#[tokio::test]
+async fn a_revision_halts_at_the_step_where_the_tracked_test_flips() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        // Execute turn: acts, but the suite still fails afterwards.
+        text_result("done"),
+        // Revision, step 1: re-run the tracked test — it now passes.
+        shell_call_result("cargo test -p x"),
+        // Steps the revision would burn WITHOUT the halt. They must never be
+        // consumed: the goal was met at the step above.
+        shell_call_result("cargo test -p x"),
+        text_result("revision done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    // Baseline fails (arms the halt), post-execute fails (forces the
+    // revision), post-revise passes (the flip), confirmation passes (#859).
+    let runner = ScriptedRunner::scripted(
+        vec![
+            TestScript::Fail,
+            TestScript::Fail,
+            TestScript::Pass,
+            TestScript::Pass,
+        ],
+        "@@ -1 +1 @@\n-old\n+new",
+    );
+    let tools = PassingShell;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(verdict.passed, "the flip was confirmed: {verdict:?}");
+    assert_eq!(
+        provider.prompts().len(),
+        3,
+        "triage, execute, one revision step — the revision must halt at the \
+         boundary where the tracked test flipped, not spend the scripted \
+         steps beyond it"
     );
 }

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
@@ -45,11 +45,12 @@ async fn an_authored_witness_arms_the_revision_flip_halt() {
             vec![("tests/authority_witness.rs", "sha256:test")],
         ]));
     // Authoring baseline: the witness fails there, which is what arms it.
-    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
-        .with_repo_status(SeqRepoStatus::new(vec![
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![
             vec![],
             vec![("tests/authority_witness.rs", "sha256:test")],
-        ]));
+        ]),
+    );
     let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
     let session_runner = NeverRunner;
     let session_status = NeverRepoStatus;

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
@@ -1,0 +1,106 @@
+//! FlipHalt arming on the authored-witness path (#1793).
+//!
+//! The mid-turn early stop used to be armed only from a configured
+//! `--test-command` baseline, so on the authored-witness path — the default
+//! for every run without a configured command — a revision kept running to
+//! its step and loop caps after the witness had already flipped. This pins
+//! the repair: `witness_on_demand` arms the latch the moment the witness's
+//! failing baseline is credited into the oracle, and the revision receives
+//! it (unfired) through the same `run_engine_turn` seam the execute turn
+//! uses.
+
+use super::*;
+
+/// #1793 witness (authored side): after `witness_on_demand` seeds a failing
+/// witness, a revision that observes the witness command pass halts at that
+/// step boundary. As in the configured-command twin, the provider is
+/// scripted with steps beyond the flip and the call count is the assertion.
+#[tokio::test]
+async fn an_authored_witness_arms_the_revision_flip_halt() {
+    let witness_command = "cargo test --test authority_witness authority_witness -- --exact";
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        // Worker execute turn: one mutating call, then done — with the suite
+        // (the authored witness) still failing afterwards.
+        writing_tool_result("editing"),
+        text_result("worker done"),
+        // Witness author, in the pristine baseline snapshot.
+        writing_tool_result("authoring"),
+        text_result(&format!("TEST_COMMAND: {witness_command}")),
+        // Revision, step 1: re-run the witness — it now passes.
+        shell_call_result(witness_command),
+        // Steps the revision would burn WITHOUT the halt; never consumed.
+        writing_tool_result("more edits"),
+        text_result("revision done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Candidate: the post-execute observation fails, the post-revise one
+    // passes. Its engine turns run against a shell that reports exit 0 —
+    // the observation that must now latch the halt.
+    let candidate = FakeWorkspace::new(0, vec![false, true], Ok(vec![]), log.clone())
+        .with_tools(PassingShell)
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/authority_witness.rs", "sha256:test")],
+        ]));
+    // Authoring baseline: the witness fails there, which is what arms it.
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/authority_witness.rs", "sha256:test")],
+        ]));
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
+    let session_runner = NeverRunner;
+    let session_status = NeverRepoStatus;
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &session_status,
+            touches: &NoFileTouches,
+            diagnostics: &session_runner,
+            tests: &session_runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(&port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            max_revisions: 1,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("pipeline runs");
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert_eq!(
+        provider.prompts().len(),
+        6,
+        "triage, two worker steps, two authoring steps, ONE revision step — \
+         the revision must halt at the boundary where the authored witness \
+         flipped, not spend the scripted steps beyond it"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -661,6 +661,18 @@ impl<'a> Pipeline<'a> {
         state
             .oracle
             .observe_run(&witness.command, false, &witness.baseline_output);
+        // Arm the mid-turn early stop for the revise loop (#1793). The same
+        // rule as the configured-command arming — only a baseline observed
+        // FAILING may arm, and the observation above is exactly that (the
+        // stage cannot return an artifact whose baseline passed). Nothing can
+        // already hold this slot: authoring is only reachable when no test
+        // command is configured, and the configured-command path is the only
+        // other writer. The execute turn has already run by now, so this
+        // reaches only the revisions — which receive it through
+        // [`crate::flip_halt::FlipHalt::unfired`].
+        state.flip_halt = Some(std::sync::Arc::new(crate::flip_halt::FlipHalt::new(
+            &witness.command,
+        )));
         // The graft added an untracked file after the pre-execution snapshot
         // was taken. Enrolling it as pre-existing keeps every later diff
         // gather (each revision re-gathers) from reading the scaffolding as


### PR DESCRIPTION
## What

Two gaps in the mid-turn early stop (`flip_halt.rs`, built from a measured Terminal-Bench regression), both from #1793:

1. **Authored witnesses never armed it.** `witness_on_demand` seeded the oracle with the witness command after execution, but `state.flip_halt` stayed `None` on the authored path. Now armed at the exact point the witness's failing baseline is credited into the oracle — the same only-a-failing-baseline-may-arm rule the configured-command path applies (`witness_stage.rs`).
2. **`revise_turn` passed `None` unconditionally**, so even configured-command runs never halted a revision early. Now it hands the latch through a new `FlipHalt::unfired` — `Some` only while unfired.

`unfired` exists because the latch is permanent by design: a latch that already fired belongs to the turn it stopped. A revision dispatched *despite* an earlier flip (lint regression veto, refuted verdict) must not be ended by the stale latch at its first step boundary — the driver checks the predicate after every committed step, so a pre-fired latch would cap every such revision at one step. Only a flip observed during the revision itself may stop it.

Decision on the issue's open sub-question 2: revise turns **do** halt on a flip. The module's own rationale (stop spending once the tracked test flips) applies to a revision at least as much as to the execute turn, and no rationale for the exemption was recorded anywhere.

## Witness tests

Both fail on `main` without the fix (verified by checking out the three production files from `origin/main` and re-running — each fails on the provider-call-count assertion) and pass with it:

- `a_revision_halts_at_the_step_where_the_tracked_test_flips` (`tests/verification_hardening.rs`) — configured-command side: a revision whose shell call reports the tracked command exiting 0 halts at that step boundary; the scripted steps beyond it are never consumed.
- `an_authored_witness_arms_the_revision_flip_halt` (`tests/verification_hardening/flip_halt_arming.rs`) — authored side: after `witness_on_demand` seeds a failing witness, a revision observing the witness command pass halts the same way.
- `a_fired_latch_is_withheld_from_a_follow_up_turn` (`flip_halt.rs`) — the `unfired` contract, including that the follow-up turn gets the same latch, not a copy.

The new test module is a **child of `verification_hardening.rs`** (the `best_of_n/fanout_concurrency.rs` pattern) because `tests.rs` is at its file-size ceiling and `witness_isolation.rs` is at 1448 lines; `pipeline.rs` edits are line-neutral (the guard confirms none of the grandfathered files grew). `FakeWorkspace` gained a `with_tools` builder so a scripted candidate can observe a tool result that carries an exit status — the default `EmptyTools` returns empty content and can never feed the halt.

## Why Refs, not Closes

The issue asks for a loop-bench measurement before this is settled default behavior; that needs the bench rig. The code gaps are fixed here and the nightly loop-bench gate will observe the change — #1793 stays open for the measurement.

Checks: `cargo test -p stella-pipeline` (560 passed), `cargo clippy -p stella-pipeline --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `scripts/check-file-size.sh` OK (none grew).

Refs #1793

## Summary by Sourcery

Arm and propagate the mid-turn flip-halt latch for both configured test commands and authored witnesses so revisions stop once the tracked test or witness flips from fail to pass, and add coverage around this behavior.

Bug Fixes:
- Ensure revise turns receive an unfired FlipHalt latch so they can halt early when the tracked test flips during a revision.
- Arm flip-halt from authored witness baselines by seeding the latch when a failing witness baseline is credited into the oracle, preventing wasted revision steps after the flip.
- Prevent pre-fired flip-halt latches from affecting follow-up turns by only handing forward unfired latches.

Enhancements:
- Extend FakeWorkspace with configurable tool executors to allow tests to simulate observing tool-based test results, including exit statuses.

Tests:
- Add regression tests verifying configured-command revisions halt at the step where the tracked test flips.
- Add regression tests verifying authored witnesses arm the revision flip-halt and that fired latches are not reused in subsequent turns.