### PR TITLE
fix(arenabench): price claude-sonnet-5 and stop the solve-rate tile reading 1%

### DIFF
--- a/arenabench/arenabench/pricing.py
+++ b/arenabench/arenabench/pricing.py
@@ -126,6 +126,22 @@ PRICES: dict[str, Price] = {
     "claude-sonnet-4.5": Price(
         input=3.0, output=15.0, cache_read=0.3, cache_write=3.75
     ),
+    # List price, per Anthropic's pricing page and the Stella seed catalog
+    # (`crates/stella-model/src/catalog.rs`, the `claude-sonnet-5` row). An
+    # introductory rate ($2.00/$10.00) runs to 2026-08-31; this table carries
+    # the durable number, so costs over-state slightly until then — the safe
+    # direction, and it corrects itself without an edit.
+    "claude-sonnet-5": Price(
+        input=3.0, output=15.0, cache_read=0.3, cache_write=3.75
+    ),
+    # The same model on the OpenRouter route, which prices it at the
+    # introductory rate with no end date of its own (catalog row
+    # `openrouter/anthropic/claude-sonnet-5`, verified 2026-08-03). A route
+    # row exists exactly for this case: the seat's launch record says which
+    # rate its tokens actually billed at (#1498).
+    "openrouter/anthropic/claude-sonnet-5": Price(
+        input=2.0, output=10.0, cache_read=0.2, cache_write=2.5
+    ),
 }
 
 #: Routing prefixes that are ArenaBench's or Harbor's, never the provider's.

--- a/arenabench/tests/test_pricing.py
+++ b/arenabench/tests/test_pricing.py
@@ -130,3 +130,31 @@ class TestRoutePricing:
         )
 
 
+
+
+class TestSonnet5Pricing:
+    """The model both seats of the kvk matches actually ran (2026-08-06).
+
+    Witness: on the old table `claude-sonnet-5` had no row at all, so every
+    trial's comparable cost was None and the arena's cost tile read '—' for
+    an entire finished match.
+    """
+
+    def test_the_first_party_rate_is_the_durable_list_price(self):
+        price = price_for("claude-sonnet-5")
+        assert price is not None
+        assert (price.input, price.output) == (3.0, 15.0)
+        assert (price.cache_read, price.cache_write) == (0.3, 3.75)
+
+    def test_the_recorded_openrouter_route_prices_at_its_own_rate(self):
+        price = price_for_route("openrouter/anthropic/claude-sonnet-5")
+        assert price is not None
+        assert (price.input, price.output) == (2.0, 10.0)
+        assert (price.cache_read, price.cache_write) == (0.2, 2.5)
+
+    def test_a_recorded_id_off_the_anthropic_route_prices_at_list(self):
+        # A seat manifest that says `anthropic/claude-sonnet-5` has no route
+        # row of its own and must collapse to the bare first-party tier.
+        price = price_for_route("anthropic/claude-sonnet-5")
+        assert price is not None
+        assert price.input == 3.0

--- a/arenabench/ui/components/arena/stat-strip.tsx
+++ b/arenabench/ui/components/arena/stat-strip.tsx
@@ -91,8 +91,10 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
 
   // Solve rate over *judged* trials, not over every trial that exists: a
   // queued trial is not a failure, and dividing by it reports a rate that
-  // climbs as the match runs for no reason but arithmetic.
-  const solveRate = totals.judged > 0 ? totals.passed / totals.judged : 0;
+  // climbs as the match runs for no reason but arithmetic. Scaled to 0–100
+  // here because `fmtPct` renders, never rescales — 3/6 judged fed to it as
+  // a fraction printed "1%".
+  const solveRate = totals.judged > 0 ? (totals.passed / totals.judged) * 100 : 0;
 
   // The leader line, stated only when there is a strict winner on solve rate.
   const ranked = [...seats].sort(


### PR DESCRIPTION
## What

Two wrong numbers on the same scoreboard, reported live from the kvk matches (2026-08-06):

**Cost read '—' for a finished match.** The price table had no `claude-sonnet-5` row — the model both seats actually ran — so every trial's comparable cost was None. Added two rows sourced from the Stella seed catalog (`crates/stella-model/src/catalog.rs`, the repo's pricing authority): the durable first-party list rate ($3/$15, cache 0.30/3.75 — deliberately not the introductory rate that lapses 2026-08-31, same reasoning as the catalog row), and the OpenRouter route row ($2/$10, cache 0.20/2.50) so a seat whose launch record says `openrouter/anthropic/claude-sonnet-5` prices at the rate its tokens actually billed (#1498 discipline).

**Solve rate read '1%' when it was 50%.** `StatStrip` computed the whole-match rate as a fraction (`passed/judged` = 0.5) and handed it to `fmtPct`, which renders 0–100 without rescaling — `(0.5).toFixed(0) + '%'` is exactly the reported '1%'. Scaled to 0–100 at the call site, matching the per-seat rates the server already sends pre-scaled.

## Witness

`TestSonnet5Pricing` (3 tests) fails on main with `assert None is not None`, passes here; verified by swapping `origin/main`'s `pricing.py` in and out. Full `tests/test_pricing.py` green. The UI half is arithmetic at one call site; `tsc --noEmit` and `next build` clean (no UI test runner exists — noted).

## Summary by Sourcery

Add pricing entries for claude-sonnet-5 and correct the arena solve-rate display to match actual pass/judged percentages.

New Features:
- Support claude-sonnet-5 pricing as a first-party model and via the OpenRouter route in the arena pricing table.

Bug Fixes:
- Ensure matches using claude-sonnet-5 show a non-empty comparable cost instead of missing pricing.
- Fix the solve-rate tile to display the correct 0–100% rate by scaling the pass/judged fraction before rendering.

Tests:
- Add targeted pricing tests for claude-sonnet-5 first-party and OpenRouter routes, including route fallback to the list price.