### PR TITLE
feat(stella-cli): scope delivery to the prompt actually sent, not the inferred project

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -43,11 +43,29 @@ macro_rules! tool_steering {
     };
 }
 
+/// The scope contract shared by both static prompts: the unit of delivery is
+/// the prompt actually sent, never the larger project inferred around it.
+/// Born from a real bench run — a worker that saw "Step 1/9" implemented all
+/// nine steps up front with invented specifics (deploy paths, hook mechanism),
+/// then spent every remaining turn discovering the real steps contradicted its
+/// guesses: stale hook targets, an nginx vhost pointing at directories it had
+/// itself deleted. One shared literal, embedded verbatim by both prompts,
+/// same as `tool_steering!` and for the same anti-drift reason (#450).
+macro_rules! scope_discipline {
+    () => {
+        r#"Scope: the deliverable is what THIS prompt asks for, not the larger project you infer around it. A prompt that marks itself one step of a longer sequence ("Step 1/9") delivers only that step's spec — later steps' real specifics (paths, names, mechanisms) arrive with their own prompts, and any version you invent now is a guess their spec will contradict, turning those steps into rework. Read ahead freely; build ahead never: complete the delivered step, verify it, and stop."#
+    };
+}
+
 pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"You are Stella, a fast terminal coding agent. You help the user with software engineering tasks by reading files, writing code, running commands, and searching the codebase.
 
 "#,
     tool_steering!(),
+    r#"
+
+"#,
+    scope_discipline!(),
     r#"
 
 Rules:
@@ -68,6 +86,10 @@ pub(crate) const PIPELINE_SYSTEM_PROMPT: &str = concat!(
 
 "#,
     tool_steering!(),
+    r#"
+
+"#,
+    scope_discipline!(),
     r#"
 
 Methodology (always follow in order):
@@ -505,6 +527,23 @@ mod tests {
             assert!(
                 prompt.contains(shared),
                 "{label} does not embed the shared steering block verbatim"
+            );
+        }
+    }
+
+    /// Witness for the front-run defect: a bench worker that saw "Step 1/9"
+    /// implemented all nine steps immediately with invented specifics, then
+    /// spent every later turn reconciling the real steps against its guesses
+    /// (stale hook paths, an nginx vhost aimed at directories it had deleted).
+    /// Neither prompt carried any scope contract at all; pin the shared
+    /// literal verbatim in both so a trim cannot quietly reopen the hole.
+    #[test]
+    fn both_prompts_scope_delivery_to_the_prompt_actually_sent() {
+        let shared = scope_discipline!();
+        for (label, prompt) in PROMPTS {
+            assert!(
+                prompt.contains(shared),
+                "{label} does not embed the shared scope-discipline block verbatim"
             );
         }
     }


### PR DESCRIPTION
## What

Adds a shared `scope_discipline!()` literal to both static system prompts (`SYSTEM_PROMPT` and `PIPELINE_SYSTEM_PROMPT` in `crates/stella-cli/src/agent/prompt.rs`): the deliverable is what the delivered prompt asks for — a prompt that marks itself one step of a longer sequence ("Step 1/9") delivers only that step's spec; read ahead freely, build ahead never.

## Why

Observed on a real TB2.1 `git-multibranch` run (match `bbc9ea944037`, worker `claude-sonnet-5`): the task arrives as nine sequential step prompts, and on "Step 1/9" the worker implemented all nine steps immediately with invented specifics — `/var/www/deploy/{main,dev}` deploy paths and a `GIT_WORK_TREE` hook, where the real step specs later mandated `/var/www/{main,dev}` and `git archive`. Every remaining turn was either redundant re-verification (steps 2, 3, 6 changed nothing) or rework reconciling the guesses (steps 4, 5, 7 — including a window where the nginx vhost pointed at directories the worker had itself deleted). Roughly half the run's spend was this redundancy/rework. Neither prompt carried any scope contract.

## How

Follows the exemplar already in the file: `tool_steering!()` (#450) — one shared literal embedded verbatim by both prompts so the copies cannot drift, kept a compile-time `concat!` so the byte-stable prefix property (invariant 7, L-E8) is preserved. Static text only; the prompt-cache golden fixtures assert zone structure, not prompt bytes, and are unaffected.

## Witness

`both_prompts_scope_delivery_to_the_prompt_actually_sent` — asserts both prompts embed the shared literal verbatim. Checked the artisanal way: with the two embeddings stripped (macro and test kept), the test fails; with the change, the full `agent::prompt` module passes (6/6). `cargo fmt --check` and `cargo clippy -p stella-cli --all-targets -- -D warnings` are clean.

## Residue (nothing left behind)

Findings from the same transcript, filed rather than fixed here:
- #1956 — `graph_query` tip footer misfires on non-code shell output
- #1957 — worker accepts failed measurements as evidence (exit-0 pipelines masking `fatal:`)
- #1958 — verification proportionality: mutating e2e + destructive reset-to-pristine on no-op turns

## Summary by Sourcery

Clarify the system prompt’s scope contract so agents deliver only what the current prompt requests rather than the broader inferred project.

New Features:
- Add a shared scope_discipline! macro that defines a scope contract for agent behavior across system prompts.

Enhancements:
- Embed the shared scope-discipline text into both SYSTEM_PROMPT and PIPELINE_SYSTEM_PROMPT to keep delivery scope consistent and prevent prompt drift.

Tests:
- Add a test ensuring all prompts include the shared scope-discipline block verbatim to guard against future regressions.