### PR TITLE
fix(stella-store,repo): unbreak main — rustdoc private-link + obsolete event.rs ratchet entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,12 +424,11 @@ a plan needs and the part that rarely changes:
 | `stella-core` | `src/driver/tests.rs`, `src/driver.rs`, `src/bus.rs` |
 | `stella-model` | `src/openai.rs`, `src/zai/tests.rs`, `src/anthropic/tests.rs`, `src/zai.rs` |
 | `stella-pipeline` | `src/pipeline.rs`, `src/pipeline/tests.rs` |
-| `stella-protocol` | `src/event.rs` |
 | `stella-store` | `src/tests.rs`, `src/lib.rs`, `src/usage.rs` |
 | `stella-tools` | `src/registry.rs`, `src/scripts.rs` |
 | `stella-tui` | `src/deck_ui.rs`, `src/views/engine.rs`, `src/views/session.rs`, `src/deck_render.rs` |
 
-The other thirteen crates carry no god files — keep it that way. Each crate's
+The other fourteen crates carry no god files — keep it that way. Each crate's
 README repeats its own list under "God files — do not add lines", so the
 constraint is in view wherever planning starts.
 

--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -79,26 +79,21 @@ and the root `Cargo.toml` members list in the same PR.
 
 ## God files — do not add lines
 
-The gate's `file-size` guard (`scripts/check-file-size.sh`) enforces a
-1500-line ratchet — a NEW file over the limit is a hard failure with no
-baseline escape — and this crate has exactly one file grandfathered at a
-recorded ceiling in `scripts/file-size-baseline.txt`. It is a god file: already
-too big, closed to growth. Plan event work so no new line lands in it: new
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
+[`src/event.rs`](src/event.rs) was grandfathered here for a long time and now
+sits just under the limit, so its split discipline still applies: new
 supporting vocabulary goes in a new module re-exported from
-[`src/lib.rs`](src/lib.rs) — the crate's own precedent is
+[`src/lib.rs`](src/lib.rs) — the crate's precedent is
 [`src/ladder.rs`](src/ladder.rs), split out of `event.rs` when the ladder rung
 joined it (#1043), with the re-export keeping `stella_protocol::LadderSnapshot`
-at its old path — and types you touch there are candidates to extract, taking
-their inline round-trip tests with them. A genuinely new `AgentEvent` variant
-cannot avoid its lines in `event.rs`; offset them by extracting the variant's
-supporting types, or move the ceiling honestly as below.
-
-- [`src/event.rs`](src/event.rs)
-
-A ceiling can move only via `make file-size-update`, which lands as a
-reviewable baseline diff justified like any other change — treat it as an
-escape hatch for an irreducible line (a module declaration in an oversized
-`lib.rs`), never as a planning assumption.
+at its old path — and a genuinely new `AgentEvent` variant offsets its lines
+by extracting the variant's supporting types, taking their inline round-trip
+tests with them.
 
 ## Layout
 

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -578,8 +578,9 @@ impl WorkJournal {
     ///
     /// A turn whose predecessor was never marked (the session's first, or a
     /// mark lost to pruning) diffs against nothing: every path in its tree is
-    /// new. Reserved journal records ([`JOURNAL_DIR`]) are never workspace
-    /// paths and are filtered out.
+    /// new. Reserved journal records (the private `journal_blob_path`
+    /// namespace, `.stella-journal/`) are never workspace paths and are
+    /// filtered out.
     ///
     /// **Read-only by construction.** Both shapes are tree-to-tree plumbing
     /// (`diff-tree`, `ls-tree`) that touches neither an index nor the work

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -26,9 +26,8 @@
 2093 crates/stella-model/src/openai.rs
 1565 crates/stella-model/src/zai.rs
 1895 crates/stella-model/src/zai/tests.rs
-3573 crates/stella-pipeline/src/pipeline.rs
-2573 crates/stella-pipeline/src/pipeline/tests.rs
-2965 crates/stella-protocol/src/event.rs
+3462 crates/stella-pipeline/src/pipeline.rs
+2533 crates/stella-pipeline/src/pipeline/tests.rs
 1996 crates/stella-store/src/lib.rs
 2266 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs


### PR DESCRIPTION
## What & why

PR #1952 auto-merged seconds after its `fmt + clippy + test` job failed on the `cargo doc -D warnings` step (the merge landed at 01:03:40Z; the check concluded red in the same run), so `main` carries a public doc comment on `WorkJournal::changed_paths_at_turn` (`crates/stella-store/src/work_journal.rs`) that intra-doc-links the private `JOURNAL_DIR` const — `rustdoc::private_intra_doc_links` fails the workspace doc gate on every PR until this lands.

The fix (one hunk, cherry-picked from the fix pushed to the #1952 branch moments after its merge): name the reserved `.stella-journal/` namespace in prose instead of linking the private item.

Verified: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` exits 0 on this branch.

No witness test: doc-comment-only change; the gate itself (`doc-warnings`) is the check that flips red→green.

Refs #1870, #1952

## Summary by Sourcery

Documentation:
- Update WorkJournal::changed_paths_at_turn docs to refer to the reserved .stella-journal/ namespace in prose, removing a broken private intra-doc link that failed the rustdoc warnings gate.


## Second unbreak folded in: the file-size ratchet

Main's ratchet is independently red: `crates/stella-protocol/src/event.rs` shrank to 1454 lines on main, leaving an obsolete baseline entry the guard refuses ("an exemption must not outlive the problem it covered"). Per the guard's own instructions, this PR retires it in all three cross-checked copies: the regenerated `scripts/file-size-baseline.txt` (also picking up the pipeline ceilings' drift-tightening), AGENTS.md's god-file table (stella-protocol row dropped, the clean-crate count becomes fourteen), and the stella-protocol README (flipped to the no-god-files claim, keeping event.rs's split discipline since it sits just under the limit).

Verified locally: `check-file-size.sh` and `check-god-files.sh` both exit 0.