### PR TITLE
fix(stella-cli): unbreak main — unresolved SkipReason doc link in daemon::boot

### DIFF
--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -56,8 +56,9 @@
 //!   the checkpoint on every terminal path, abort included, so a policy stop
 //!   retracts its resume point on the way out. A row written by a build that
 //!   predates #1653 — where a policy stop really did store `Error` — is
-//!   therefore filtered by [`SkipReason::NoResumePoint`] anyway, without this
-//!   module having to trust its status.
+//!   therefore filtered by `SkipReason::NoResumePoint` anyway (named, not
+//!   linked: this module is private, so rustdoc cannot resolve it), without
+//!   this module having to trust its status.
 //! - **The attempt bound still applies.** An `Error` that resumes into
 //!   another `Error` is counted like any other continuation and retired
 //!   after `MAX_BOOT_ATTEMPTS`.


### PR DESCRIPTION
## What & why

`main`'s workspace doc gate is red: `crates/stella-cli/src/daemon/boot.rs`'s module doc intra-doc-links `SkipReason::NoResumePoint`, but `daemon::boot` is a **private** module and `SkipReason` is `pub(super)`, so rustdoc resolves nothing and `rustdoc::broken_intra_doc_links` fails under `-D warnings`.

The link landed in #1939 and was invisible until now, which is the part worth recording: `cargo doc` bails on the first crate that fails, so `stella-store`'s private-link error (fixed in #1965) masked this one entirely. Fixing one rustdoc break surfaces the next one down — expect to iterate, not to assume the first fix was the last.

The fix is the same shape as #1965's: name the item in prose rather than link something rustdoc cannot see, with a parenthetical saying why.

## The witness

- [ ] No witness needed (docs) — because: this is a doc-comment-only change, and the gate itself is the check. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` exits **101** on `main` and **0** with this change, verified by exit code rather than by reading output.

## The gate

- [x] `cargo doc --workspace --no-deps` under `-D warnings` (exit 0, the whole workspace — re-run after the fix to confirm nothing further was masked)
- [x] `cargo fmt --check`
- [x] CLA signed

Refs #1939, #1965.

## Summary by Sourcery

Documentation:
- Clarify daemon boot module documentation by naming SkipReason::NoResumePoint in text instead of using an intra-doc link that rustdoc cannot resolve.