### PR TITLE
fix(stella-pipeline): unbreak main — three parallel-merge collisions in one round

### DIFF
--- a/crates/stella-pipeline/src/management_prompt/tests.rs
+++ b/crates/stella-pipeline/src/management_prompt/tests.rs
@@ -36,9 +36,10 @@ const SHARED_MANAGEMENT_PREAMBLE: &str = "";
 /// family. Completeness is not compiler-checked here — that job belongs to
 /// the exhaustive match in [`management_system_block`], which forces a new
 /// variant to declare its prefix posture before this array matters.
-const ALL_ROLES: [ModelCallRole; 14] = [
+const ALL_ROLES: [ModelCallRole; 15] = [
     ModelCallRole::Unknown,
     ModelCallRole::Triage,
+    ModelCallRole::Research,
     ModelCallRole::Plan,
     ModelCallRole::PlanRepair,
     ModelCallRole::WitnessAuthor,
@@ -82,8 +83,12 @@ fn management_system_block(role: ModelCallRole) -> Option<String> {
         // adopt the split these arms move to `Some(...)` and the roles join
         // the parity witness automatically.
         ModelCallRole::Plan | ModelCallRole::PlanRepair => None,
-        // Never dispatched through the management chokepoint.
+        // Never dispatched through the management chokepoint. `Research`
+        // (#1778) runs as an engine sub-agent turn, so its system prompt
+        // rides its `SubAgentSpec` rather than this family — the same
+        // grouping, for the same reason, that `raw_usage.rs` gives it.
         ModelCallRole::Unknown
+        | ModelCallRole::Research
         | ModelCallRole::WitnessAuthor
         | ModelCallRole::WitnessRepair
         | ModelCallRole::AgentAuthor

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1462,8 +1462,7 @@ impl<'a> Pipeline<'a> {
         research: &[ResearchFinding],
         repo_structure: &str,
         revision: Option<&str>,
-        budget: &mut BudgetGuard,
-        total: &mut f64,
+        spend: &mut Spend<'_>,
     ) -> Result<Vec<PlanStep>, PipelineBudgetAbort> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Plan,
@@ -1491,8 +1490,8 @@ impl<'a> Pipeline<'a> {
                     overrides: &worker_overrides,
                     timeout: self.config.engine.model_timeout,
                 },
-                budget,
-                total,
+                spend.budget,
+                spend.total,
             )
             .await
         {
@@ -1516,8 +1515,8 @@ impl<'a> Pipeline<'a> {
                     overrides: &worker_overrides,
                     timeout: self.config.engine.model_timeout,
                 },
-                budget,
-                total,
+                spend.budget,
+                spend.total,
             )
             .await
         {

--- a/crates/stella-pipeline/src/pipeline/scope_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/scope_stage.rs
@@ -31,6 +31,11 @@ impl Pipeline<'_> {
         let repo_structure = self.repo.structure_summary().await;
         let mut revision: Option<String> = None;
         let mut spent_revisions = 0usize;
+        // Built once and reborrowed per re-plan: the two halves travel
+        // together everywhere else in the crate, and bundling them is what
+        // keeps `plan_stage` structurally inside the argument limit rather
+        // than behind an `#[allow]`.
+        let mut spend = Spend { budget, total };
 
         loop {
             let plan = match self
@@ -40,8 +45,7 @@ impl Pipeline<'_> {
                     research,
                     &repo_structure,
                     revision.as_deref(),
-                    budget,
-                    total,
+                    &mut spend,
                 )
                 .await
             {

--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -453,8 +453,10 @@ async fn a_late_plan_is_abandoned_and_falls_back_to_the_single_step_plan() {
             &[],
             "",
             None,
-            &mut budget,
-            &mut total,
+            &mut Spend {
+                budget: &mut budget,
+                total: &mut total,
+            },
         )
         .await
         .expect("a wedged planner is never a run-ending failure");

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/flip_halt_arming.rs
@@ -1,15 +1,143 @@
-//! FlipHalt arming on the authored-witness path (#1793).
+//! FlipHalt arming in revise turns, on both paths (#1793).
 //!
 //! The mid-turn early stop used to be armed only from a configured
-//! `--test-command` baseline, so on the authored-witness path — the default
-//! for every run without a configured command — a revision kept running to
-//! its step and loop caps after the witness had already flipped. This pins
-//! the repair: `witness_on_demand` arms the latch the moment the witness's
-//! failing baseline is credited into the oracle, and the revision receives
-//! it (unfired) through the same `run_engine_turn` seam the execute turn
-//! uses.
+//! `--test-command` baseline, and `revise_turn` passed no latch at all. So on
+//! the authored-witness path — the default for every run without a configured
+//! command — a revision kept running to its step and loop caps after the
+//! witness had already flipped, and even a configured-command run's revisions
+//! did the same. This pins both repairs: `witness_on_demand` arms the latch
+//! the moment the witness's failing baseline is credited into the oracle, and
+//! a revision receives it (unfired) through the same `run_engine_turn` seam
+//! the execute turn uses.
+//!
+//! Both witnesses and the two doubles they need live here rather than in the
+//! parent: `verification_hardening.rs` is close enough to the 1500-line
+//! ceiling that it cannot hold them, and these are the only users.
 
 use super::*;
+
+/// A shell double whose every command "passes": the output carries the
+/// trailing exit-0 marker [`crate::flip_halt::exit_status`] parses. What
+/// [`EmptyTools`] can never express — a worker *observing* the tracked test
+/// succeed through a tool result.
+struct PassingShell;
+#[async_trait]
+impl ToolExecutor for PassingShell {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a shell command".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: "1 passed\n[exit code: 0]".into(),
+        }
+    }
+}
+
+/// A completion that runs `command` through the shell — the observation the
+/// flip halt correlates by `call_id` and scores against the tracked test.
+fn shell_call_result(command: &str) -> CompletionResult {
+    CompletionResult {
+        tool_calls: vec![ToolCall {
+            call_id: format!("call-shell-{command}"),
+            name: "bash".into(),
+            input: serde_json::json!({ "command": command }),
+        }],
+        ..text_result("")
+    }
+}
+
+/// #1793 witness (configured-command side): a revision that observes the
+/// tracked test go fail→pass halts at that step boundary instead of running
+/// on. The provider is scripted with steps BEYOND the flip; consuming them
+/// is exactly the waste `flip_halt` exists to stop, so the call count is the
+/// assertion.
+#[tokio::test]
+async fn a_revision_halts_at_the_step_where_the_tracked_test_flips() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        // Execute turn: acts, but the suite still fails afterwards.
+        text_result("done"),
+        // Revision, step 1: re-run the tracked test — it now passes.
+        shell_call_result("cargo test -p x"),
+        // Steps the revision would burn WITHOUT the halt. They must never be
+        // consumed: the goal was met at the step above.
+        shell_call_result("cargo test -p x"),
+        text_result("revision done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    // Baseline fails (arms the halt), post-execute fails (forces the
+    // revision), post-revise passes (the flip), confirmation passes (#859).
+    let runner = ScriptedRunner::scripted(
+        vec![
+            TestScript::Fail,
+            TestScript::Fail,
+            TestScript::Pass,
+            TestScript::Pass,
+        ],
+        "@@ -1 +1 @@\n-old\n+new",
+    );
+    let tools = PassingShell;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(verdict.passed, "the flip was confirmed: {verdict:?}");
+    assert_eq!(
+        provider.prompts().len(),
+        3,
+        "triage, execute, one revision step — the revision must halt at the \
+         boundary where the tracked test flipped, not spend the scripted \
+         steps beyond it"
+    );
+}
 
 /// #1793 witness (authored side): after `witness_on_demand` seeds a failing
 /// witness, a revision that observes the witness command pass halts at that


### PR DESCRIPTION
## What & why

`main` is red at 43402ae4: `cargo test -p stella-pipeline` fails to compile
with three errors, and `cargo clippy -p stella-pipeline --all-targets` fails a
fourth. Until this lands every PR against `main` inherits a red gate, so this
is deliberately narrow — no behavior change, nothing but the repairs.

Three independent parallel-merge collisions from the same round of merges.
None was visible to the CI of the PR that caused it, because each PR was green
against the `main` it branched from.

### 1. Clobbered flip-halt test doubles (#1945 vs #1951)

#1945 added `mod flip_halt_arming;` to
`pipeline/tests/verification_hardening.rs` **together with** the two doubles
the child module uses — `PassingShell` and `shell_call_result` — plus the
configured-command witness `a_revision_halts_at_the_step_where_the_tracked_test_flips`.

#1951 then rewrote that file from a pre-#1945 base. It deleted all three, and
left the `mod flip_halt_arming;` line standing — so the child module referenced
two symbols that no longer existed:

```
error[E0425]: cannot find value `PassingShell` in this scope
error[E0425]: cannot find function `shell_call_result` in this scope
```

Restored **into `flip_halt_arming.rs` itself** rather than back into the
parent, for two reasons: `verification_hardening.rs` is 1434 lines against the
1500 ceiling and cannot hold them, and the child module is their only user.
Both #1793 witnesses — the configured-command side and the authored-witness
side — now sit in one module, which is where a reader looking for "how is the
flip halt witnessed" would expect them.

### 2. `ModelCallRole::Research` not covered (#1778)

#1778 added the `Research` variant. `management_prompt/tests.rs` holds a
**deliberately** exhaustive `match` over `ModelCallRole` — its doc says a new
role "must declare its prefix posture here, not escape the family witness by
omission" — which #1778's CI never compiled against.

```
error[E0004]: non-exhaustive patterns: `ModelCallRole::Research` not covered
```

`Research` runs as an engine sub-agent turn (`research_stage.rs` builds a
`SubAgentSpec` carrying `RESEARCH_SYSTEM_PROMPT`), never through the management
chokepoint — so it joins the never-dispatched arm returning `None`. That is the
same grouping, with the same stated reasoning, that `raw_usage.rs` already
gives it. Added to `ALL_ROLES` as well, since that array is documented as
"every role the crate can dispatch".

### 3. `plan_stage` over the argument limit (#1778)

#1778 also added `research: &[ResearchFinding]` to `plan_stage`, taking it to 8
arguments against clippy's limit of 7. The gate runs clippy at `-D warnings`.

Fixed structurally rather than with an `#[allow]`: `budget` and `total` are
exactly the pair the crate's own `Spend` envelope bundles
(`pipeline/stage_budget.rs`), they travel together everywhere else, and
`verifier()` already took this shape in #1951. `plan_stage` now takes `Spend`;
`plan_with_review` — which uses the two for nothing but that call — builds one
before its re-plan loop and reborrows it per iteration. 8 arguments become 7
and the meaning is unchanged.

## The witness

- [ ] This PR includes a witness test

Deliberately none, and this is the case the template's "explain how you
verified instead" is for: a repair to a **broken build** is witnessed by the
build. The evidence is that `cargo test -p stella-pipeline` does not compile on
`main` and compiles here, which no test inside that crate could express — a
test that cannot be built cannot fail informatively.

The two witnesses #1951 deleted are restored verbatim and do run again, so
#1793's coverage returns with this PR rather than being re-asserted by it.

## The gate

Run on this branch, from the worktree:

- `cargo test -p stella-pipeline` — 583 + 5 + 2 + 5 + 6 + 4 = **605 passed, 0
  failed** (on `main`: does not compile)
- `cargo clippy -p stella-pipeline --all-targets` — clean (on `main`: 1 warning
  = 1 error under the gate's `-D warnings`)
- `cargo fmt --check -p stella-pipeline` — clean
- `cargo check --all-targets` on `stella-protocol`, `stella-core`, `stella-tui`,
  `stella-serve`, `stella-cli` — clean, confirming `stella-pipeline` was the
  only crate the new enum variant broke
- `scripts/check-file-size.sh` — OK, none grew
- `scripts/check-god-files.sh` — OK
- `scripts/check-left-behind.sh` — OK, 0 grandfathered

The full workspace suite is left to CI.

## Nothing left behind

Two follow-ups worth tracking, neither fixable inside an unbreak PR:

1. **The clobber in #2 is a recurring shape, not an accident.** A PR that
   rewrites a test file from a stale base silently drops whatever landed
   underneath it, and the only thing that caught it here was a `mod`
   declaration surviving. I will file an issue for it rather than leave the
   observation in this description.
2. `ALL_ROLES` in `management_prompt/tests.rs` is a hand-maintained array whose
   own doc admits completeness "is not compiler-checked here". It stayed
   correct this time only because the neighbouring `match` is exhaustive.
   Worth a `strum`-style derive or a const assertion; also going in the issue.

## Summary by Sourcery

Repair stella-pipeline so it builds and passes clippy again by resolving recent merge collisions in tests, enum handling, and pipeline budgeting signatures.

Bug Fixes:
- Restore the flip-halt verification witnesses and their test doubles so the flip_halt_arming tests compile and run again.
- Handle the ModelCallRole::Research variant consistently in management_prompt tests, including matching and ALL_ROLES coverage.
- Refactor plan_stage to accept a Spend bundle instead of separate budget and total parameters to satisfy clippy's argument limit without changing behavior.

Tests:
- Reinstate the configured-command flip-halt witness test alongside the authored-witness test to fully exercise FlipHalt arming behavior across both paths.