### PR TITLE
fix(stella-protocol): unbreak main — resolve the CompactionRewrite doc link

### DIFF
--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -542,7 +542,7 @@ pub enum AgentEvent {
         /// The replacement bytes each in-place rewrite left behind, one entry
         /// per digest — what lets reconstruction resolve a compacted block to
         /// the bytes the model received rather than the pre-compaction output
-        /// under the same `call_id` (#1667); see [`CompactionRewrite`].
+        /// under the same `call_id` (#1667); see [`crate::CompactionRewrite`].
         /// `serde(default)` — absent on journals written before rewrites were
         /// journaled, whose compacted blocks surface as digest mismatches.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## What

The gate's `doc-warnings` step (`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`) fails on `main` at 6c345532:

```
error: unresolved link to `CompactionRewrite`
   --> crates/stella-protocol/src/event.rs:545:53
    |
545 |         /// under the same `call_id` (#1667); see [`CompactionRewrite`].
    |                                                     ^^^^^^^^^^^^^^^^^ no item named `CompactionRewrite` in scope
```

The type reaches this scope only through its `crate`-level re-export (`lib.rs`), so the bare name resolves to nothing. The field's own type annotation two lines below already spells the working path (`Vec<crate::CompactionRewrite>`); the doc link now matches it. One line, no behavior.

`event.rs` is a grandfathered god file closed to growth — this is a same-line edit, so it does not grow.

## Why it surfaced only now

Layered masking, the shape #1965 records: rustdoc stops at the first crate that fails to document, so each fix reveals the next layer down. `stella-cli` was fixed in #1970; `stella-protocol` is the layer underneath, and it is the deepest — with this applied, `cargo doc --workspace --no-deps` is **clean workspace-wide**.

## Scope — this is one of four independent red gates on main

Verified on `origin/main` at 6c345532 and deliberately **not** bundled, since each already has an owner:

| Gate | Status |
|---|---|
| `doc-warnings` (rustdoc) | **this PR** — nothing else covers it |
| `format-check` (missing trailing newline in `event/tests.rs`) | #2005 |
| `file-size` (baseline skew: `driver.rs` +1, `pipeline/tests.rs` +1) | #2003 |
| `lint` (dead `spend` local) | #2000 |

**Main is green on none of these individually — all four must land.** #2000 also touches `crates/stella-protocol/src/event.rs`, but a different region, so the two should not textually conflict.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — **clean** (fails on main without this)
- `cargo test -p stella-protocol` — 0 failures
- `cargo clippy -p stella-protocol --all-targets -- -D warnings` — clean

No witness test: a rustdoc-only fix, per the repo's pure-docs exemption. The reproduction above is the evidence.

## Summary by Sourcery

Bug Fixes:
- Correct the CompactionRewrite documentation link in AgentEvent to reference the crate-level type and restore successful rustdoc generation.