### PR TITLE
fix(stella-pipeline): bound the oracle trace at the verifier-prompt ingress (#1787)

### DIFF
--- a/crates/stella-pipeline/src/pipeline/evidence.rs
+++ b/crates/stella-pipeline/src/pipeline/evidence.rs
@@ -25,6 +25,32 @@ fn touched_tests_status(observed: Option<bool>) -> &'static str {
     }
 }
 
+/// The most observations the trusted zone will render (#1787). The trace
+/// grows once per verification round, and the repair gate can keep granting
+/// rounds as long as a measured budget affords them — so unlike the diff,
+/// which rides under a token budget, this channel had no ceiling at all.
+/// Sized far above a normal run (baseline plus a handful of rounds) so the
+/// bound only ever bites a pathological loop.
+const MAX_ORACLE_TRACE_OBSERVATIONS: usize = 24;
+
+/// Render the oracle trace for the verifier prompt, bounded to the newest
+/// [`MAX_ORACLE_TRACE_OBSERVATIONS`] entries.
+///
+/// Newest kept, oldest dropped: the recent runs are the ones the verdict
+/// weighs, and the drop is stated in-band — the verifier must read "earlier
+/// observations exist" rather than a trace that silently starts mid-run.
+/// The stored snapshot keeps the full trace either way; only this prompt
+/// ingress is clipped (the structural-bound rule from #1932).
+fn bounded_oracle_trace(trace: &[OracleObservation]) -> String {
+    let omitted = trace.len().saturating_sub(MAX_ORACLE_TRACE_OBSERVATIONS);
+    let rendered = crate::replay::render_oracle_trace(&trace[omitted..]);
+    if omitted == 0 {
+        rendered
+    } else {
+        format!("…{omitted} earlier observation(s) omitted → {rendered}")
+    }
+}
+
 impl<'a> Pipeline<'a> {
     /// Assemble the deterministic evidence summary and the witness-stripped
     /// diff for one model-verdict round.
@@ -118,7 +144,7 @@ impl<'a> Pipeline<'a> {
             // order, and what each observed — instead of a diff cold.
             evidence_summary.push_str(&format!(
                 "; oracle_trace=[{}]",
-                crate::replay::render_oracle_trace(&snapshot.oracle_trace)
+                bounded_oracle_trace(&snapshot.oracle_trace)
             ));
         }
         if let Some(symptom) = state.witness_baseline_symptom {
@@ -157,7 +183,10 @@ impl<'a> Pipeline<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::touched_tests_status;
+    use super::{
+        MAX_ORACLE_TRACE_OBSERVATIONS, OracleObservation, ProofTree, bounded_oracle_trace,
+        touched_tests_status,
+    };
 
     #[test]
     fn touched_tests_render_names_the_unobserved_case() {
@@ -168,5 +197,48 @@ mod tests {
         assert_eq!(touched_tests_status(Some(true)), "passed");
         assert_eq!(touched_tests_status(Some(false)), "failed");
         assert_eq!(touched_tests_status(None), "unobserved");
+    }
+
+    fn trace_of(len: usize) -> Vec<OracleObservation> {
+        (0..len)
+            .map(|i| OracleObservation {
+                tree: ProofTree::Candidate,
+                // Alternate so a clipped render is distinguishable from a
+                // repeated one.
+                passed: i % 2 == 0,
+            })
+            .collect()
+    }
+
+    /// #1787's witness for the trusted-zone bound: a pathological run's
+    /// trace reaches the prompt clipped to the newest observations, with the
+    /// drop stated in-band rather than the trace silently starting mid-run.
+    #[test]
+    fn a_pathological_oracle_trace_is_clipped_with_the_drop_stated() {
+        let trace = trace_of(100);
+        let rendered = bounded_oracle_trace(&trace);
+        assert!(
+            rendered.starts_with("…76 earlier observation(s) omitted → "),
+            "{rendered}"
+        );
+        assert_eq!(
+            rendered.matches("candidate:").count(),
+            MAX_ORACLE_TRACE_OBSERVATIONS,
+            "only the newest observations are rendered: {rendered}"
+        );
+        // The newest entry survives: index 99 is odd, so it observed a fail.
+        assert!(rendered.ends_with("candidate:fail"), "{rendered}");
+    }
+
+    /// An ordinary run's trace is untouched — byte-identical to the
+    /// unbounded render, so every existing prompt (and verdict-reuse digest)
+    /// is unchanged where the bound does not bite.
+    #[test]
+    fn an_ordinary_oracle_trace_renders_unchanged() {
+        let trace = trace_of(5);
+        assert_eq!(
+            bounded_oracle_trace(&trace),
+            crate::replay::render_oracle_trace(&trace)
+        );
     }
 }


### PR DESCRIPTION
> Supersedes #1982, which was auto-closed when the branch it was stacked on
> went away. Same single commit, now rebased directly on `main`.
>
> Note: `main` currently fails `cargo clippy -p stella-pipeline` with five
> pre-existing warnings unrelated to this change (fixed in #2009), so this
> PR's clippy step inherits them until that lands.

## What & why

The last unbounded ingress into the verdict prompt, and the item #1787 folds in
at the end of its body:

> Also worth folding in: the trusted evidence summary has no length bound
> (`oracle_trace` grows per observation; the diff has a token budget, the
> trusted zone does not) — `pipeline/evidence.rs` since the extraction.

`verifier_evidence_summary` renders `oracle_trace` in full. That trace gains an
observation per verification round, and the repair gate (#1479) keeps granting
rounds for as long as a measured budget affords them — so the one channel that
grows without limit was also the one channel with no ceiling. Every other input
to that prompt is bounded: the diff has a token budget, recall frames have
`bound_recalled_frames`, and `Verdict::reasoning` got its cap in #1932.

Bounded to the newest 24 observations, with the drop **stated in-band**:

```
oracle_trace=[…76 earlier observation(s) omitted → candidate:pass → candidate:fail → …]
```

Three choices worth naming, because each has a wrong-looking alternative:

- **Newest kept, oldest dropped.** The recent runs are what the verdict weighs;
  a trace clipped from the front would hand the verifier a history that stops
  before the evidence.
- **Stated, not silent.** A trace that silently began mid-run reads as the whole
  run — the verifier would draw conclusions about a first observation that was
  not the first.
- **Clipped where the value is constructed**, not at a downstream consumer.
  That is the same "structural, not by convention" rule #1932 applied to
  `reasoning`, and it is why the stored `LadderSnapshot` and
  `verdict_provenance` are deliberately untouched: the bound is on the *prompt
  ingress*, not on the record.

24 is sized far above a normal run (a baseline plus a handful of rounds), so
the bound only ever bites a pathological loop. It is a named constant next to
its rationale rather than a literal.

## The witness

- [x] This PR includes a witness test

`a_pathological_oracle_trace_is_clipped_with_the_drop_stated` — a 100-observation
trace renders exactly 24 entries behind the `…76 earlier observation(s)
omitted →` marker, and still ends on the newest observation.

`an_ordinary_oracle_trace_renders_unchanged` is the other half, and the one
that matters for regression: a 5-observation trace is asserted **byte-identical
to `render_oracle_trace`**, main's own unbounded function, which is still
present and still used for provenance. So every prompt the bound does not bite
is unchanged to the byte — which also means no verdict-reuse digest (#1431)
moves for an ordinary run.

Honest note on "fails on main": these pin a bound that does not exist on `main`,
so the failure there is that `bounded_oracle_trace` is not defined — the same
shape as #1932's witnesses for the `reasoning` cap, and the shape any
"add a missing ceiling" change has. The behavioural claim is carried by the
second test, which compares against main's function directly rather than
against a copied expectation.

## The gate

- `cargo test -p stella-pipeline` — 585 + 5 + 2 + 5 + 6 + 4 = **607 passed, 0 failed**
- `cargo clippy -p stella-pipeline --all-targets` — clean
- `cargo fmt --check -p stella-pipeline` — clean
- `scripts/check-file-size.sh` — OK, none grew (`evidence.rs` was extracted from
  `pipeline.rs` precisely so this kind of channel can be added without touching
  a god file, and that still holds)

Full workspace left to CI.

## Nothing left behind

`Refs #1787`, deliberately not `Closes` — this is the folded-in bound only.
Item 1 (a provider-parity-aware structured verdict output path, invariant 8)
remains open and is being approached from a different angle in #1964; item 2
shipped as #1932 and item 3 as #1951.

Refs #1787

## Summary by Sourcery

Bound the oracle trace rendered in verifier evidence summaries and added tests to cover the new trusted-zone length cap.

New Features:
- Introduce a bounded oracle trace renderer for verifier prompts that limits the trusted evidence summary to the newest observations while indicating omissions in-band.

Tests:
- Add witness tests ensuring long oracle traces are clipped with an explicit omission marker and that ordinary short traces remain byte-identical to the unbounded renderer.