### PR TITLE
feat(arenabench): pin the Stella under test to a commit, and refuse to run an unattributable binary

### DIFF
--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -498,6 +498,19 @@ class MatchSpec:
     #: Seconds between snapshots — the floor on how precisely a flip can be
     #: located, traded against how much work each capture adds to the host.
     snapshot_interval: float = 30.0
+    #: Which Stella the seats under test are built from — a git ref, resolved
+    #: to a commit at launch and recorded there (see :mod:`arenabench.sut`).
+    #:
+    #: ``"main"`` means ``origin/main``, deliberately: a bare branch name that
+    #: resolved to a *local* branch is how a benchmark ends up measuring an
+    #: operator's stale checkout while claiming to measure the project.
+    #:
+    #: Empty string is the explicit opt-out — run whatever ``STELLA_BINARY``
+    #: points at without checking which commit it is. That is allowed, because
+    #: a bisect or a local experiment is a real need, and it is recorded as an
+    #: unverified SUT so no number produced that way can be mistaken for one
+    #: from a known commit.
+    sut_ref: str = "main"
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -512,6 +525,7 @@ class MatchSpec:
             "record_video": self.record_video,
             "capture_snapshots": self.capture_snapshots,
             "snapshot_interval": self.snapshot_interval,
+            "sut_ref": self.sut_ref,
         }
 
     @classmethod
@@ -538,6 +552,13 @@ class MatchSpec:
             # A zero or negative interval would spin the watcher; clamp rather
             # than reject, so a typo degrades to "often" instead of failing a run.
             snapshot_interval=max(1.0, float(raw.get("snapshot_interval") or 30.0)),
+            # Absent means `main`, not "unverified". A payload written before
+            # this field existed asked for the project's own default branch —
+            # reading it as the opt-out would turn every old template into one
+            # that silently accepts any binary.
+            sut_ref=(
+                "main" if raw.get("sut_ref") is None else str(raw["sut_ref"]).strip()
+            ),
         )
 
     def validate(self) -> list[str]:

--- a/arenabench/arenabench/provenance.py
+++ b/arenabench/arenabench/provenance.py
@@ -85,6 +85,20 @@ class Provenance:
     harbor_bound: str | None = None
     #: The Harbor binary's path, for a machine running more than one.
     harbor_bin: str = ""
+    #: The git ref the operator pinned the system under test to, e.g. ``main``.
+    #: Empty means the match ran unpinned — see :attr:`sut_commit`.
+    sut_ref: str = ""
+    #: The **commit** that ref resolved to at launch, which is the half that
+    #: identifies the code. A ref is a moving pointer: recording only "main"
+    #: dates a result to whenever someone happens to read the record, which is
+    #: the same reason :mod:`arenabench.registry` pins datasets by digest.
+    #: Empty means genuinely unknown, never a guess — an unpinned match ran a
+    #: binary nobody can attribute, and saying so is the honest record.
+    sut_commit: str = ""
+    #: SHA-256 of the exact binary that ran. Two builds of one commit on
+    #: different toolchains are not the same artifact, and this is what tells
+    #: them apart after the fact.
+    sut_sha256: str = ""
     arenabench_version: str = ""
     recorded_at: float = field(default_factory=time.time)
     source: str = SOURCE_RECORDED
@@ -105,7 +119,11 @@ class Provenance:
             grader = f"harbor?{self.harbor_bound}"
         else:
             grader = "harbor?"
-        return f"{self.dataset_key or 'unknown'}@{digest}/{grader}"
+        # The SUT belongs in the key for the same reason the dataset digest
+        # does: two runs of different Stella revisions answer different
+        # questions, and a key that hides that invites them into one average.
+        sut = f"stella{self.sut_commit[:8]}" if self.sut_commit else "stella?"
+        return f"{self.dataset_key or 'unknown'}@{digest}/{grader}/{sut}"
 
     @property
     def measured(self) -> bool:

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from . import harbor, provenance
+from . import harbor, provenance, sut
 from .agents import (
     credential_env_for,
     launch_flags,
@@ -121,12 +121,28 @@ def _provenance_for(match: Match) -> provenance.Provenance:
         # gets written, unknown rather than absent, so a half-started match
         # is not mistaken later for one that ran on the current Harbor.
         version, binary = None, ""
+
+    # The SUT half, resolved the same way the launch resolves it so the record
+    # names the binary that actually ran. Failure leaves both fields empty —
+    # unknown, never guessed, for the same reason `harbor_version` is.
+    sut_commit, sut_sha256 = "", ""
+    if match.spec.sut_ref:
+        try:
+            sut_commit = sut.resolve_ref(match.spec.sut_ref)
+            staged = sut.binary_for(sut_commit)
+            sut_sha256 = staged.sha256 if staged else ""
+        except sut.SutUnavailableError:
+            sut_commit = ""
+
     return provenance.Provenance(
         dataset_key=match.spec.dataset,
         dataset_ref=match.dataset.harbor_id,
         dataset_digest=match.dataset.digest,
         harbor_version=version,
         harbor_bin=binary,
+        sut_ref=match.spec.sut_ref,
+        sut_commit=sut_commit,
+        sut_sha256=sut_sha256,
         arenabench_version=__version__,
         source=provenance.SOURCE_RECORDED,
     )
@@ -711,7 +727,7 @@ class MatchRunner:
             )
         env = _base_environment()
         env.update(seat_env)
-        env.update(self._agent_environment(contestant, run))
+        env.update(self._agent_environment(contestant, run, match.spec.sut_ref))
 
         # The seat's launch record — the only artifact that can say which
         # route this job's trials were actually served by. `launch_model`
@@ -795,7 +811,7 @@ class MatchRunner:
         return env
 
     def _agent_environment(
-        self, contestant: Contestant, run: ContestantRun
+        self, contestant: Contestant, run: ContestantRun, sut_ref: str = ""
     ) -> dict[str, str]:
         """Agent-specific environment, layered over the operator's ``.env``."""
         spec = resolve_agent(contestant.agent)
@@ -842,9 +858,33 @@ class MatchRunner:
             roots.append(existing)
         env["PYTHONPATH"] = os.pathsep.join(roots)
 
+        # Which Stella actually runs. A pinned `sut_ref` resolves to a commit
+        # and the binary built from *that* commit is used; the ambient
+        # STELLA_BINARY is only the fallback for an explicitly unpinned match.
+        # `ArenaServer.create_match` has already refused a pinned match with no
+        # matching build, so reaching here with a pin means the binary exists.
+        if sut_ref:
+            try:
+                commit = sut.resolve_ref(sut_ref)
+                staged = sut.binary_for(commit)
+            except sut.SutUnavailableError:
+                staged = None
+            if staged is not None:
+                env["STELLA_BINARY"] = str(staged.path)
+                run.notes.append(
+                    f"stella {commit[:8]} ({sut_ref}) "
+                    f"sha256:{staged.sha256[:12] or 'unrecorded'}"
+                )
+                return env
+
         binary = os.environ.get("STELLA_BINARY")
         if binary:
             env["STELLA_BINARY"] = binary
+            run.warnings.append(
+                "SUT not pinned to a commit — running whatever STELLA_BINARY "
+                "points at, so these numbers cannot be attributed to a "
+                "specific Stella revision"
+            )
         return env
 
     # -- supervision ------------------------------------------------------

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -75,6 +75,8 @@ from .presets import preset_listing
 from .recorder import preflight as recorder_preflight
 from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
 from .runner import MatchRunner
+from .sut import SutUnavailableError, list_branches, sut_problem_for, sut_status
+from .sut_build import SutBuilder
 from .telemetry import TranscriptReader
 
 __all__ = ["ArenaServer", "serve"]
@@ -158,6 +160,9 @@ class ArenaServer:
         # one starts, so a restart never erases what the workspace remembers.
         self.runner.restore_from_disk()
         self.recorder_status: tuple[bool, str] = (False, "not checked")
+        #: Owns SUT builds. One per server so a build survives the request
+        #: that started it and can be polled from any later one.
+        self.builder = SutBuilder()
 
     # -- API handlers -----------------------------------------------------
 
@@ -227,6 +232,42 @@ class ArenaServer:
     def presets(self) -> Any:
         return {"presets": preset_listing()}
 
+    def sut(self, ref: str = "main") -> Any:
+        """Which Stella a match pinned to ``ref`` would run, and whether it exists."""
+        return sut_status(ref)
+
+    def sut_branches(self, fetch: bool = False) -> Any:
+        """The branch picklist. Never raises: an unusable rig is a state to show.
+
+        ``fetch`` is opt-in because it is a network round trip, and a picker
+        that silently talks to a remote every time it opens is a picker that
+        hangs on a bad link.
+        """
+        try:
+            branches = list_branches(fetch=fetch)
+        except SutUnavailableError as exc:
+            return {"branches": [], "problem": str(exc)}
+        return {"branches": [b.to_json() for b in branches], "problem": None}
+
+    def build_sut(self, payload: dict[str, Any]) -> Any:
+        """Start a build of the SUT at ``ref``, or report one already running.
+
+        Returns immediately with a build id; progress is polled. A release
+        cross-compile takes minutes, and holding an HTTP request open for that
+        is how a launch path acquires new ways to fail.
+        """
+        ref = str(payload.get("ref") or "main").strip() or "main"
+        return self.builder.start(ref)
+
+    def sut_build(self, build_id: str) -> Any:
+        record = self.builder.get(build_id)
+        if record is None:
+            raise KeyError(build_id)
+        return record
+
+    def sut_builds(self) -> Any:
+        return {"builds": self.builder.recent()}
+
     def create_match(self, payload: dict[str, Any]) -> Any:
         payload = dict(payload)
         payload.setdefault("id", uuid.uuid4().hex[:12])
@@ -265,6 +306,15 @@ class ArenaServer:
             raise ValueError(
                 "; ".join(f"{name}: {reason}" for name, reason in dead.items())
             )
+        problem = sut_problem_for(spec)
+        if problem:
+            # The third refusal, and the one that protects the *subject* of the
+            # measurement rather than its apparatus. A match that runs a binary
+            # nobody can attribute produces a number about no particular
+            # version of Stella — measured 2026-08-06, the staged binary was
+            # 291 commits behind main and every match in between reported it
+            # without a word.
+            raise ValueError(problem)
         match = self.runner.create(spec)
         for note in oauth_notes:
             match.note = f"{match.note}; {note}" if match.note else note
@@ -732,6 +782,20 @@ def _handler_factory(
                     self._json(arena.agents())
                 case ["presets"]:
                     self._json(arena.presets())
+                case ["sut"]:
+                    query = parse_qs(urlparse(self.path).query)
+                    self._json(arena.sut((query.get("ref") or ["main"])[0]))
+                case ["sut", "branches"]:
+                    query = parse_qs(urlparse(self.path).query)
+                    self._json(
+                        arena.sut_branches(
+                            fetch=(query.get("fetch") or [""])[0] == "1"
+                        )
+                    )
+                case ["sut", "builds"]:
+                    self._json(arena.sut_builds())
+                case ["sut", "builds", build_id]:
+                    self._json(arena.sut_build(build_id))
                 case ["matches"]:
                     self._json(arena.list_matches())
                 case ["matches", match_id]:
@@ -791,6 +855,8 @@ def _handler_factory(
                         self._json(arena.parse_template(payload.get("toml") or ""))
                     case ["templates", "render"]:
                         self._json({"toml": arena.render_template(payload)})
+                    case ["sut", "build"]:
+                        self._json(arena.build_sut(payload))
                     case ["matches", match_id, "cancel"]:
                         self._json(arena.cancel(match_id))
                     case _:

--- a/arenabench/arenabench/sut.py
+++ b/arenabench/arenabench/sut.py
@@ -1,0 +1,519 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Which Stella binary a match runs, and proving it is the one you meant.
+
+The system under test is a **cross-compiled binary staged on disk**, not
+something the arena builds on the fly: it must be linux/amd64 against a glibc
+2.17 floor so it can exec inside every task image, which is a `cargo zigbuild`
+away from an ordinary build (`bench/evidence/run/build_sut.sh`). That script
+already proves its own provenance — it refuses to build unless every Rust input
+is byte-identical to `origin/main`, then records the commit and the binary's
+SHA-256 beside the artifact.
+
+**The gap this module closes is that the proof was only ever made at build
+time.** Nothing re-checked it at *match* time, so the guarantee decayed
+silently the moment nobody re-ran the script: measured 2026-08-06, the staged
+binary was 291 commits behind `main` and three days old, and every match in
+between reported numbers for that stale code without a word. A benchmark that
+cannot say which commit it measured is not a benchmark, and one that says the
+wrong commit is worse.
+
+Two design points, both borrowed from how this codebase already treats
+datasets:
+
+**A branch is not a freeze.** :mod:`arenabench.registry` pins datasets by
+digest because "an unversioned name is not a freeze", and the identical logic
+governs the SUT: `main` on 2026-08-04 and `main` today are 291 commits apart.
+So a *ref* is how an operator chooses, and a resolved *commit* is what the
+system records and keys the binary by. Recording "we ran main" tells a reader
+nothing they can check.
+
+**Building is never implicit.** A release cross-compile with LTO takes minutes.
+Doing it inside a match launch would turn the fast path into a slow one that
+fails in new ways, so builds are an explicit action and their artifacts are
+cached per commit under ``<sut root>/<commit>/``. A match then only ever has to
+*find* a binary, which either exists or does not.
+
+Git is consulted read-only and every ref that reaches a subprocess is either a
+full hex SHA or a name drawn from :func:`list_branches` — never a string the
+caller supplied, so a loopback HTTP client cannot smuggle an option into
+``git``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "STELLA_REPO_ENV",
+    "Branch",
+    "Drift",
+    "StagedSut",
+    "SutUnavailableError",
+    "binary_for",
+    "drift_between",
+    "list_branches",
+    "resolve_ref",
+    "staged_for",
+    "stella_repo",
+    "sut_problem_for",
+    "sut_root",
+    "sut_status",
+]
+
+#: Points the arena at the Stella checkout it resolves refs and builds from.
+STELLA_REPO_ENV = "ARENABENCH_STELLA_REPO"
+
+#: A full 40-hex commit id — the only ref shape ever passed to git unvalidated.
+_FULL_SHA = re.compile(r"\A[0-9a-f]{40}\Z")
+
+#: Branch names the arena will accept from a client. Deliberately stricter than
+#: git's own rules: no leading dash (which git would read as an option), no
+#: whitespace, no `..`, and nothing outside a conservative character set.
+_SAFE_REF = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._/-]{0,200}\Z")
+
+
+class SutUnavailableError(RuntimeError):
+    """No Stella checkout, or git could not answer."""
+
+
+def sut_root() -> Path:
+    """Where staged SUT binaries live, honouring ``ARENABENCH_HOME``."""
+    home = os.environ.get("ARENABENCH_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".arenabench"
+    return base / "sut"
+
+
+def stella_repo() -> Path | None:
+    """The Stella checkout to resolve refs against, or ``None``.
+
+    ``ARENABENCH_STELLA_REPO`` wins. Otherwise the adapter path already needed
+    to run a Stella seat (``ARENABENCH_STELLA_ADAPTER`` points at
+    ``<repo>/bench/harbor_adapter``) names the repository two levels up, so a
+    rig that can run Stella at all can usually answer this without new
+    configuration.
+    """
+    explicit = os.environ.get(STELLA_REPO_ENV)
+    if explicit:
+        candidate = Path(explicit).expanduser()
+        return candidate if (candidate / ".git").exists() else None
+    adapter = os.environ.get("ARENABENCH_STELLA_ADAPTER")
+    if adapter:
+        candidate = Path(adapter).expanduser().resolve().parent.parent
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _git(repo: Path, *args: str, timeout: float = 30.0) -> str:
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SutUnavailableError(f"git {' '.join(args)} failed: {exc}") from exc
+    if out.returncode != 0:
+        raise SutUnavailableError(
+            f"git {' '.join(args)} exited {out.returncode}: {out.stderr.strip()}"
+        )
+    return out.stdout
+
+
+def _safe_ref(ref: str) -> str:
+    """Validate a ref before it reaches a subprocess.
+
+    A full SHA passes unchanged. Anything else must look like an ordinary
+    branch name; in particular a leading ``-`` is rejected, because git would
+    read it as an option rather than a ref.
+    """
+    ref = ref.strip()
+    if _FULL_SHA.match(ref) or _SAFE_REF.match(ref):
+        return ref
+    raise SutUnavailableError(f"refusing to resolve unsafe ref {ref!r}")
+
+
+@dataclass(frozen=True)
+class Branch:
+    """One branch an operator may build the SUT from."""
+
+    #: Display name, e.g. ``main`` or ``worktree-foo`` — remote prefix stripped.
+    name: str
+    #: What is passed to git, e.g. ``origin/main``.
+    ref: str
+    commit: str
+    subject: str = ""
+    committed_at: int = 0
+    #: ``True`` for the repository's default branch, which the UI preselects
+    #: and which every published number should normally come from.
+    is_default: bool = False
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "ref": self.ref,
+            "commit": self.commit,
+            "short": self.commit[:8],
+            "subject": self.subject,
+            "committed_at": self.committed_at,
+            "is_default": self.is_default,
+        }
+
+
+@dataclass(frozen=True)
+class StagedSut:
+    """A built Stella binary on disk, with whatever provenance was recorded."""
+
+    path: Path
+    #: Full commit the binary was built from. Empty when unrecorded — which is
+    #: reported as unknown, never guessed. A binary whose commit nobody wrote
+    #: down cannot be shown to be the one you meant.
+    commit: str = ""
+    sha256: str = ""
+    built_at: float = 0.0
+
+    @property
+    def known(self) -> bool:
+        return bool(self.commit)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "commit": self.commit,
+            "short": self.commit[:8] if self.commit else "",
+            "sha256": self.sha256,
+            "built_at": self.built_at,
+            "known": self.known,
+        }
+
+
+@dataclass(frozen=True)
+class Drift:
+    """How far a staged binary is from the commit a match asked for."""
+
+    staged: str
+    target: str
+    behind: int = 0
+    ahead: int = 0
+    #: ``False`` when the two commits cannot be compared at all — the staged
+    #: commit is not in this checkout (built elsewhere, or the branch was
+    #: force-pushed away). Unknown is not zero, and must not render as "match".
+    comparable: bool = True
+
+    @property
+    def identical(self) -> bool:
+        return bool(self.staged) and self.staged == self.target
+
+    def summary(self) -> str:
+        if self.identical:
+            return "exactly the requested commit"
+        if not self.staged:
+            return "the staged binary records no commit, so it cannot be identified"
+        if not self.comparable:
+            return (
+                f"staged {self.staged[:8]} is not an ancestor or descendant of "
+                f"{self.target[:8]} in this checkout — it cannot be compared"
+            )
+        parts = []
+        if self.behind:
+            parts.append(f"{self.behind} commit(s) behind")
+        if self.ahead:
+            parts.append(f"{self.ahead} commit(s) ahead of")
+        return f"staged {self.staged[:8]} is " + " and ".join(parts) + (
+            f" {self.target[:8]}"
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "staged": self.staged,
+            "target": self.target,
+            "behind": self.behind,
+            "ahead": self.ahead,
+            "comparable": self.comparable,
+            "identical": self.identical,
+            "summary": self.summary(),
+        }
+
+
+def resolve_ref(ref: str, repo: Path | None = None) -> str:
+    """Resolve a branch name or SHA to a full commit id, **remote first**.
+
+    ``main`` means ``origin/main``, not the local branch of the same name.
+    That ordering is the entire point of this module: a local branch is
+    whatever the operator's checkout last happened to fetch or commit, and on
+    the machine this was written for the two were 291 commits apart. A
+    benchmark that says "main" and measures a stale local copy is reporting a
+    number nobody else can reproduce.
+
+    A full SHA and an explicitly-qualified ref (``origin/main``) are used as
+    given; only a bare name gets the ``origin/`` preference.
+    """
+    repo = repo or stella_repo()
+    if repo is None:
+        raise SutUnavailableError(
+            "no Stella checkout found — set "
+            f"{STELLA_REPO_ENV} to the repository root"
+        )
+    safe = _safe_ref(ref)
+    candidates = [safe] if (_FULL_SHA.match(safe) or "/" in safe) else [
+        f"origin/{safe}",
+        safe,
+    ]
+    last: SutUnavailableError | None = None
+    for candidate in candidates:
+        try:
+            return _git(
+                repo, "rev-parse", "--verify", f"{candidate}^{{commit}}"
+            ).strip()
+        except SutUnavailableError as exc:
+            last = exc
+    raise last or SutUnavailableError(f"cannot resolve ref {ref!r}")
+
+
+def list_branches(repo: Path | None = None, *, fetch: bool = False) -> list[Branch]:
+    """Every remote branch, newest commit first, default branch flagged.
+
+    Remote branches rather than local ones on purpose: the question a benchmark
+    asks is "what does this code look like *for everyone*", and a local branch
+    is by definition not that. A local-only experiment is still reachable by
+    pasting its SHA.
+    """
+    repo = repo or stella_repo()
+    if repo is None:
+        raise SutUnavailableError(
+            f"no Stella checkout found — set {STELLA_REPO_ENV} to the repository root"
+        )
+    if fetch:
+        # Best-effort: a rig offline mid-session should still list what it has
+        # rather than fail the whole picker.
+        try:
+            _git(repo, "fetch", "--quiet", "--prune", "origin", timeout=120.0)
+        except SutUnavailableError:
+            pass
+
+    default = ""
+    try:
+        head = _git(repo, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD").strip()
+        default = head.rsplit("/", 1)[-1]
+    except SutUnavailableError:
+        default = "main"
+
+    raw = _git(
+        repo,
+        "for-each-ref",
+        "--sort=-committerdate",
+        "--format=%(refname:short)%09%(objectname)%09%(committerdate:unix)%09%(subject)",
+        "refs/remotes/origin",
+    )
+    branches: list[Branch] = []
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        ref, commit, when = parts[0], parts[1], parts[2]
+        subject = parts[3] if len(parts) > 3 else ""
+        name = ref.split("/", 1)[-1] if ref.startswith("origin/") else ref
+        if name == "HEAD":
+            continue
+        branches.append(
+            Branch(
+                name=name,
+                ref=ref,
+                commit=commit,
+                subject=subject,
+                committed_at=int(when or 0),
+                is_default=(name == default),
+            )
+        )
+    # The default branch first regardless of commit date: it is the answer for
+    # almost every run, and a picker that buries it invites the wrong choice.
+    branches.sort(key=lambda b: (not b.is_default, -b.committed_at))
+    return branches
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _staged_at(directory: Path) -> StagedSut | None:
+    binary = directory / "stella"
+    if not binary.is_file():
+        return None
+    try:
+        built_at = binary.stat().st_mtime
+    except OSError:
+        built_at = 0.0
+    return StagedSut(
+        path=binary,
+        commit=_read(directory / "sut_commit.txt"),
+        sha256=_read(directory / "binary_sha256.txt"),
+        built_at=built_at,
+    )
+
+
+def staged_for(commit: str) -> StagedSut | None:
+    """The cached binary built from ``commit``, if one has been staged."""
+    if not _FULL_SHA.match(commit or ""):
+        return None
+    return _staged_at(sut_root() / commit)
+
+
+def legacy_staged() -> StagedSut | None:
+    """The single unversioned binary older tooling stages at ``<root>/stella``.
+
+    Kept because `build_sut.sh` writes there and rigs already depend on it. It
+    is only ever *reported*, never assumed to be any particular commit: the
+    whole failure this module exists for was treating that path as though it
+    were current.
+    """
+    return _staged_at(sut_root())
+
+
+def binary_for(commit: str) -> StagedSut | None:
+    """The binary a match pinned to ``commit`` should run, or ``None``.
+
+    Prefers the per-commit cache. Falls back to the legacy path **only when it
+    records that exact commit** — an unlabelled binary is never silently
+    accepted as the one requested, which is precisely how a three-day-old
+    artifact kept being measured.
+    """
+    exact = staged_for(commit)
+    if exact is not None:
+        return exact
+    legacy = legacy_staged()
+    if legacy is not None and legacy.commit == commit:
+        return legacy
+    return None
+
+
+def drift_between(staged: str, target: str, repo: Path | None = None) -> Drift:
+    """How far ``staged`` is from ``target`` in this checkout."""
+    if not staged:
+        return Drift(staged="", target=target, comparable=False)
+    if staged == target:
+        return Drift(staged=staged, target=target)
+    repo = repo or stella_repo()
+    if repo is None:
+        return Drift(staged=staged, target=target, comparable=False)
+    try:
+        raw = _git(
+            repo, "rev-list", "--left-right", "--count", f"{staged}...{target}"
+        ).split()
+        ahead, behind = int(raw[0]), int(raw[1])
+    except (SutUnavailableError, ValueError, IndexError):
+        return Drift(staged=staged, target=target, comparable=False)
+    return Drift(staged=staged, target=target, behind=behind, ahead=ahead)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sut_problem_for(spec: Any) -> str | None:
+    """Why this match must not launch, as far as the SUT is concerned.
+
+    ``None`` means "go". A string is a refusal, phrased for an operator who
+    now has to do something about it.
+
+    Only matches carrying a Stella seat are checked — a Claude-Code-vs-Codex
+    contest has no system under test of ours and must not be blocked by the
+    state of a binary it never runs. An empty ``sut_ref`` is the deliberate
+    opt-out and always passes; the run is labelled unverified instead.
+    """
+    if not getattr(spec, "sut_ref", ""):
+        return None
+    if not any(c.agent == "stella" for c in spec.contestants):
+        return None
+    status = sut_status(spec.sut_ref)
+    if status["ready"]:
+        return None
+    detail = status.get("problem") or "the requested Stella build is unavailable"
+    return (
+        f"Stella seat pinned to {spec.sut_ref!r}, but {detail} "
+        "Build it from the arena's SUT panel, or run "
+        "`bench/evidence/run/build_sut.sh`. To measure an unattributable "
+        "binary on purpose, clear the SUT pin — the match is then recorded "
+        "as unverified."
+    )
+
+
+def sut_status(ref: str = "main") -> dict[str, Any]:
+    """Everything the UI needs to say which Stella is about to run.
+
+    Never raises for an unusable rig: a missing checkout, a git that will not
+    answer, or an absent binary are all *states to report*, because the whole
+    point is to tell an operator what is wrong rather than to hide behind an
+    error page.
+    """
+    out: dict[str, Any] = {
+        "ref": ref,
+        "repo": None,
+        "target": None,
+        "staged": None,
+        "legacy": None,
+        "drift": None,
+        "ready": False,
+        "problem": None,
+    }
+    repo = stella_repo()
+    if repo is None:
+        out["problem"] = (
+            "no Stella checkout is configured, so the arena cannot say which "
+            f"commit a Stella seat would run. Set {STELLA_REPO_ENV} to the "
+            "repository root."
+        )
+        legacy = legacy_staged()
+        out["legacy"] = legacy.to_json() if legacy else None
+        return out
+    out["repo"] = str(repo)
+    try:
+        target = resolve_ref(ref, repo)
+    except SutUnavailableError as exc:
+        out["problem"] = str(exc)
+        return out
+    out["target"] = target
+
+    staged = binary_for(target)
+    legacy = legacy_staged()
+    out["legacy"] = legacy.to_json() if legacy else None
+    if staged is not None:
+        out["staged"] = staged.to_json()
+        out["drift"] = Drift(staged=target, target=target).to_json()
+        out["ready"] = True
+        return out
+
+    # Nothing built for the requested commit. Say what *is* there and how far
+    # off it is, because "no binary" and "a binary from three days ago" call
+    # for very different reactions.
+    fallback = legacy
+    if fallback is None:
+        out["problem"] = (
+            f"no Stella binary has been built for {target[:8]}. Build one "
+            "before running a Stella seat."
+        )
+        return out
+    drift = drift_between(fallback.commit, target, repo)
+    out["drift"] = drift.to_json()
+    out["problem"] = (
+        f"the only staged binary is not {target[:8]}: {drift.summary()}. "
+        "Build the requested commit before running a Stella seat."
+    )
+    return out

--- a/arenabench/arenabench/sut_build.py
+++ b/arenabench/arenabench/sut_build.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Building a Stella SUT for a chosen commit, out of the launch path.
+
+A release cross-compile of Stella is minutes of work: `cargo zigbuild` against
+a glibc 2.17 floor so the artifact execs inside every task image. That is far
+too long to sit inside "start match", so a build is its own action with its own
+lifecycle, and a match only ever *finds* a binary that either exists or does
+not (:func:`arenabench.sut.binary_for`).
+
+**Builds are cached by commit, not by ref.** Two matches naming ``main`` a week
+apart want two different binaries; two matches naming the same commit want the
+same one, and rebuilding it would only invite the two to differ. The cache key
+is therefore the resolved commit and the artifact lands at
+``<sut root>/<commit>/stella`` beside the commit id and the SHA-256 that
+identify it.
+
+**The build runs in a detached worktree, never in the operator's checkout.**
+`bench/evidence/run/build_sut.sh` refuses to build unless every Rust input
+matches ``origin/main``, which is the right rule for its own job and the wrong
+one here: the whole feature is building a *chosen* ref, including a branch that
+by definition differs from main. So this module checks the commit out into a
+throwaway worktree and builds there. That also means a build cannot disturb
+whatever the operator is editing — the failure mode of building in-place is
+that a benchmark silently measures uncommitted local edits.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .sut import (
+    SutUnavailableError,
+    binary_for,
+    file_sha256,
+    resolve_ref,
+    stella_repo,
+    sut_root,
+)
+
+__all__ = ["BuildRecord", "SutBuilder"]
+
+#: Target triple and glibc floor, mirrored from `bench/evidence/run/env.sh`.
+#: Constants rather than settings: an operator able to raise the floor to
+#: silence an error is the failure being prevented — a binary built against a
+#: newer glibc runs on the build host and dies inside the task container, where
+#: it is indistinguishable from an agent that cannot code.
+TARGET_TRIPLE = "x86_64-unknown-linux-gnu"
+GLIBC_FLOOR = "2.17"
+
+#: How many finished builds to keep in the in-memory log.
+_HISTORY = 20
+
+
+@dataclass
+class BuildRecord:
+    """One build attempt, from queued to done."""
+
+    id: str
+    ref: str
+    commit: str = ""
+    #: ``queued`` | ``building`` | ``done`` | ``failed``
+    status: str = "queued"
+    started_at: float = field(default_factory=time.time)
+    finished_at: float = 0.0
+    binary: str = ""
+    sha256: str = ""
+    error: str = ""
+    #: Tail of the build log, so a failure explains itself in the UI rather
+    #: than sending the operator to a file they have to find first.
+    log_tail: list[str] = field(default_factory=list)
+    #: True when the commit was already built and nothing was compiled.
+    cached: bool = False
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ref": self.ref,
+            "commit": self.commit,
+            "short": self.commit[:8] if self.commit else "",
+            "status": self.status,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed": (self.finished_at or time.time()) - self.started_at,
+            "binary": self.binary,
+            "sha256": self.sha256,
+            "error": self.error,
+            "log_tail": list(self.log_tail),
+            "cached": self.cached,
+            "done": self.status in ("done", "failed"),
+        }
+
+
+class SutBuilder:
+    """Owns SUT builds: one at a time, cached by commit.
+
+    Serialised deliberately. Two concurrent release builds on a laptop thrash
+    the disk and the CPU that a running match is also using, and the queue
+    depth this feature actually needs is one.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._builds: dict[str, BuildRecord] = {}
+        self._order: list[str] = []
+        self._active: str | None = None
+
+    # -- queries ----------------------------------------------------------
+
+    def get(self, build_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._builds.get(build_id)
+            return record.to_json() if record else None
+
+    def recent(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [self._builds[i].to_json() for i in reversed(self._order)]
+
+    # -- command ----------------------------------------------------------
+
+    def start(self, ref: str) -> dict[str, Any]:
+        """Resolve ``ref`` and build it, unless it is already built or running.
+
+        Resolution happens here rather than in the worker so a bad ref is an
+        immediate, synchronous error the operator sees in the click that
+        caused it, instead of a build that fails ten seconds later.
+        """
+        try:
+            commit = resolve_ref(ref)
+        except SutUnavailableError as exc:
+            raise ValueError(str(exc)) from exc
+
+        record = BuildRecord(id=uuid.uuid4().hex[:12], ref=ref, commit=commit)
+
+        existing = binary_for(commit)
+        if existing is not None:
+            record.status = "done"
+            record.cached = True
+            record.binary = str(existing.path)
+            record.sha256 = existing.sha256
+            record.finished_at = time.time()
+            self._remember(record)
+            return record.to_json()
+
+        with self._lock:
+            if self._active is not None:
+                active = self._builds[self._active]
+                if active.status in ("queued", "building"):
+                    # Report the running build rather than queueing behind it:
+                    # the caller wants to watch something, and two builds of
+                    # different commits at once is the case this refuses.
+                    return active.to_json()
+            self._active = record.id
+        self._remember(record)
+        threading.Thread(target=self._run, args=(record,), daemon=True).start()
+        return record.to_json()
+
+    # -- internals --------------------------------------------------------
+
+    def _remember(self, record: BuildRecord) -> None:
+        with self._lock:
+            self._builds[record.id] = record
+            self._order.append(record.id)
+            while len(self._order) > _HISTORY:
+                self._builds.pop(self._order.pop(0), None)
+
+    def _run(self, record: BuildRecord) -> None:
+        try:
+            record.status = "building"
+            binary, sha = self._build(record)
+            record.binary, record.sha256 = str(binary), sha
+            record.status = "done"
+        except Exception as exc:  # noqa: BLE001 — surfaced to the operator
+            record.status = "failed"
+            record.error = str(exc)
+        finally:
+            record.finished_at = time.time()
+            with self._lock:
+                if self._active == record.id:
+                    self._active = None
+
+    def _build(self, record: BuildRecord) -> tuple[Path, str]:
+        repo = stella_repo()
+        if repo is None:
+            raise SutUnavailableError(
+                "no Stella checkout configured; set ARENABENCH_STELLA_REPO"
+            )
+        if shutil.which("cargo") is None:
+            raise SutUnavailableError("cargo is not on PATH")
+
+        worktree = Path(tempfile.mkdtemp(prefix="arenabench-sut-"))
+        tree = worktree / "src"
+        zig_cache = worktree / "zig"
+        try:
+            self._sh(record, repo, ["git", "worktree", "add", "--detach",
+                                    str(tree), record.commit], timeout=600)
+            (zig_cache / "global").mkdir(parents=True, exist_ok=True)
+            (zig_cache / "local").mkdir(parents=True, exist_ok=True)
+
+            env = {
+                **os.environ,
+                "ZIG_GLOBAL_CACHE_DIR": str(zig_cache / "global"),
+                "ZIG_LOCAL_CACHE_DIR": str(zig_cache / "local"),
+                # The binary reports this as its own source commit, which is
+                # what makes a trial's telemetry self-describing.
+                "STELLA_BUILD_GIT_SHA": record.commit,
+            }
+            self._sh(record, tree, ["rustup", "target", "add", TARGET_TRIPLE],
+                     timeout=600, env=env, optional=True)
+            self._sh(
+                record,
+                tree,
+                [
+                    "cargo", "zigbuild", "--release", "--locked",
+                    "--target", f"{TARGET_TRIPLE}.{GLIBC_FLOOR}",
+                    "--package", "stella-cli", "--bin", "stella",
+                ],
+                timeout=5400,
+                env=env,
+            )
+            built = tree / "target" / TARGET_TRIPLE / "release" / "stella"
+            if not built.is_file():
+                raise SutUnavailableError(f"build produced no binary at {built}")
+
+            # Stage atomically-ish: write into the commit's directory only
+            # after the artifact exists, so a crashed build never leaves a
+            # directory that `binary_for` would accept as a finished one.
+            dest = sut_root() / record.commit
+            dest.mkdir(parents=True, exist_ok=True)
+            target = dest / "stella"
+            shutil.copy2(built, target)
+            target.chmod(0o755)
+            sha = file_sha256(target)
+            (dest / "sut_commit.txt").write_text(record.commit + "\n", encoding="utf-8")
+            (dest / "binary_sha256.txt").write_text(sha + "\n", encoding="utf-8")
+            return target, sha
+        finally:
+            # Detach the worktree from git's registry before deleting it, or
+            # the repo accumulates stale entries `git worktree list` reports
+            # forever.
+            with_tree = tree.exists()
+            if with_tree:
+                subprocess.run(
+                    ["git", "worktree", "remove", "--force", str(tree)],
+                    cwd=str(repo), capture_output=True, check=False, timeout=120,
+                )
+            shutil.rmtree(worktree, ignore_errors=True)
+
+    def _sh(
+        self,
+        record: BuildRecord,
+        cwd: Path,
+        command: list[str],
+        *,
+        timeout: float,
+        env: dict[str, str] | None = None,
+        optional: bool = False,
+    ) -> None:
+        record.log_tail.append(f"$ {' '.join(command)}")
+        try:
+            out = subprocess.run(
+                command,
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                env=env,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            if optional:
+                record.log_tail.append(f"(skipped: {exc})")
+                return
+            raise SutUnavailableError(f"{command[0]} failed: {exc}") from exc
+        tail = (out.stderr or out.stdout or "").strip().splitlines()[-12:]
+        record.log_tail.extend(tail)
+        del record.log_tail[:-40]
+        if out.returncode != 0 and not optional:
+            raise SutUnavailableError(
+                f"{' '.join(command[:2])} exited {out.returncode}: "
+                + " / ".join(tail[-3:])
+            )

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Proving which Stella a match ran.
+
+The defect these pin is the worst kind this tool can have, because it is
+invisible from the outside: on 2026-08-06 the staged SUT binary was **291
+commits behind main and three days old**, and every match in between reported
+numbers for that stale code without a word. Nothing compared the binary to
+anything, so a benchmark whose entire purpose is measuring Stella could not say
+which Stella it measured.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from arenabench import sut
+from arenabench.model import MatchSpec
+from arenabench.provenance import Provenance
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch) -> Path:
+    """A tiny repo with a local `main` deliberately behind `origin/main`.
+
+    That skew is the fixture's whole point: it is the exact shape of the bug —
+    an operator's checkout lagging the remote — and a resolver that reads the
+    local branch looks perfectly correct until you compare the two.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "--initial-branch=main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    (origin / "a.txt").write_text("one")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-qm", "first")
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", "-q", str(origin), str(work))
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "t")
+
+    # Advance origin twice; the clone's local `main` stays on the first commit.
+    (origin / "a.txt").write_text("two")
+    _git(origin, "commit", "-qam", "second")
+    (origin / "a.txt").write_text("three")
+    _git(origin, "commit", "-qam", "third")
+    _git(work, "fetch", "-q", "origin")
+
+    monkeypatch.setenv(sut.STELLA_REPO_ENV, str(work))
+    monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+    return work
+
+
+class TestRemoteFirstResolution:
+    """`main` must mean `origin/main`, never the operator's local branch.
+
+    Caught while writing this module: the first implementation resolved `main`
+    to the *local* branch, which on the development machine was 291 commits
+    behind the remote. A benchmark that says "we ran main" and measures a stale
+    checkout reports a number nobody else can reproduce — and it looks entirely
+    correct from the inside.
+    """
+
+    def test_a_bare_name_resolves_to_the_remote_branch(self, repo: Path):
+        assert sut.resolve_ref("main") == _git(repo, "rev-parse", "origin/main")
+
+    def test_the_local_branch_of_the_same_name_is_not_what_runs(self, repo: Path):
+        local = _git(repo, "rev-parse", "refs/heads/main")
+        assert sut.resolve_ref("main") != local, (
+            "resolving to the local branch is how a stale checkout gets "
+            "published as the project's own result"
+        )
+
+    def test_an_explicitly_qualified_ref_is_used_as_given(self, repo: Path):
+        assert sut.resolve_ref("origin/main") == _git(repo, "rev-parse", "origin/main")
+
+    def test_a_full_sha_resolves_to_itself(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        assert sut.resolve_ref(head) == head
+
+
+class TestRefsReachingGitAreValidated:
+    """A ref from an HTTP client must never become a git option."""
+
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            "--upload-pack=touch /tmp/pwned",
+            "-o",
+            "main; rm -rf /",
+            "main space",
+            "../../etc/passwd",
+            "a" * 300,
+        ],
+    )
+    def test_a_hostile_ref_is_refused_before_it_reaches_a_subprocess(
+        self, repo: Path, hostile: str
+    ):
+        with pytest.raises(sut.SutUnavailableError):
+            sut.resolve_ref(hostile)
+
+
+class TestDrift:
+    """Unknown is not zero, and must never render as agreement."""
+
+    def test_a_behind_binary_reports_how_far(self, repo: Path):
+        old = _git(repo, "rev-parse", "refs/heads/main")
+        new = _git(repo, "rev-parse", "origin/main")
+        drift = sut.drift_between(old, new)
+        assert drift.behind == 2 and drift.ahead == 0
+        assert not drift.identical
+        assert "behind" in drift.summary()
+
+    def test_an_unrecorded_commit_is_incomparable_not_equal(self, repo: Path):
+        drift = sut.drift_between("", _git(repo, "rev-parse", "origin/main"))
+        assert not drift.identical
+        assert not drift.comparable, (
+            "a binary whose commit nobody wrote down must not read as a match"
+        )
+
+    def test_the_same_commit_is_identical(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        assert sut.drift_between(head, head).identical
+
+
+class TestBinaryLookupNeverGuesses:
+    """An unlabelled binary is never accepted as the commit you asked for.
+
+    This is the precise mechanism of the original defect: a single unversioned
+    path was treated as though it were whatever the caller currently wanted.
+    """
+
+    def _stage(self, directory: Path, commit: str = "", sha: str = "abc") -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "stella").write_text("#!/bin/sh\n")
+        (directory / "stella").chmod(0o755)
+        if commit:
+            (directory / "sut_commit.txt").write_text(commit)
+        (directory / "binary_sha256.txt").write_text(sha)
+
+    def test_a_binary_cached_under_its_commit_is_found(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        self._stage(sut.sut_root() / head, commit=head)
+        found = sut.binary_for(head)
+        assert found is not None and found.commit == head
+
+    def test_the_legacy_path_is_accepted_only_when_it_names_that_commit(
+        self, repo: Path
+    ):
+        head = _git(repo, "rev-parse", "origin/main")
+        other = _git(repo, "rev-parse", "refs/heads/main")
+        self._stage(sut.sut_root(), commit=other)
+        assert sut.binary_for(head) is None, (
+            "accepting a differently-labelled binary is the 291-commit bug"
+        )
+        assert sut.binary_for(other) is not None
+
+    def test_an_unlabelled_legacy_binary_is_never_accepted(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        self._stage(sut.sut_root(), commit="")
+        assert sut.binary_for(head) is None
+
+
+class TestLaunchRefusal:
+    """A Stella seat cannot run a binary that is not the commit it pinned."""
+
+    def _spec(self, *, agent: str = "stella", ref: str | None = None) -> MatchSpec:
+        raw = {
+            "name": "m",
+            "dataset": "terminal-bench-2.1",
+            "tasks": ["fix-git"],
+            "contestants": [
+                {
+                    "name": "seat",
+                    "agent": agent,
+                    "engine": {"api": "openrouter", "model": "m"},
+                }
+            ],
+        }
+        if ref is not None:
+            raw["sut_ref"] = ref
+        return MatchSpec.from_json(raw)
+
+    def test_a_stale_binary_blocks_the_launch(self, repo: Path):
+        stale = _git(repo, "rev-parse", "refs/heads/main")
+        directory = sut.sut_root()
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "stella").write_text("#!/bin/sh\n")
+        (directory / "sut_commit.txt").write_text(stale)
+
+        problem = sut.sut_problem_for(self._spec())
+        assert problem is not None
+        assert "behind" in problem, "the refusal must say how stale, not just that"
+
+    def test_a_matching_binary_permits_the_launch(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        directory = sut.sut_root() / head
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "stella").write_text("#!/bin/sh\n")
+        (directory / "sut_commit.txt").write_text(head)
+        assert sut.sut_problem_for(self._spec()) is None
+
+    def test_a_match_with_no_stella_seat_is_never_blocked(self, repo: Path):
+        """A Claude-Code-vs-Codex contest runs no SUT of ours."""
+        assert sut.sut_problem_for(self._spec(agent="claude-code")) is None
+
+    def test_the_empty_ref_is_an_explicit_opt_out(self, repo: Path):
+        assert sut.sut_problem_for(self._spec(ref="")) is None
+
+    def test_a_spec_written_before_this_field_defaults_to_main_not_unpinned(self):
+        """Absent must not read as the opt-out.
+
+        Otherwise every template predating the field silently accepts any
+        binary — turning a new safety property off exactly where it is least
+        visible.
+        """
+        assert MatchSpec.from_json({"name": "m", "dataset": "d"}).sut_ref == "main"
+
+
+class TestProvenanceRecordsTheSut:
+    """A result set that cannot name its SUT is not comparable to another."""
+
+    def test_the_commit_joins_the_comparability_key(self):
+        record = Provenance(
+            dataset_key="terminal-bench-2.1",
+            dataset_digest="sha256:7d7bdc1c",
+            harbor_version="0.6.1",
+            sut_commit="6c345532aaaa",
+        )
+        assert "stella6c345532" in record.comparability_key
+
+    def test_two_stella_revisions_do_not_share_a_key(self):
+        base = {
+            "dataset_key": "terminal-bench-2.1",
+            "dataset_digest": "sha256:7d7bdc1c",
+            "harbor_version": "0.6.1",
+        }
+        old = Provenance(**base, sut_commit="47d587a3ffff")
+        new = Provenance(**base, sut_commit="6c345532aaaa")
+        assert old.comparability_key != new.comparability_key, (
+            "two Stella revisions answer different questions; one key would "
+            "invite them into a single average"
+        )
+
+    def test_an_unpinned_run_is_marked_unknown_rather_than_blank(self):
+        assert "stella?" in Provenance(dataset_key="d").comparability_key
+
+    def test_the_record_round_trips(self):
+        record = Provenance(sut_ref="main", sut_commit="abc123", sut_sha256="def")
+        again = Provenance.from_json(record.to_json())
+        assert (again.sut_ref, again.sut_commit, again.sut_sha256) == (
+            "main",
+            "abc123",
+            "def",
+        )

--- a/arenabench/ui/components/setup/setup-view.tsx
+++ b/arenabench/ui/components/setup/setup-view.tsx
@@ -21,6 +21,7 @@ import { Step, ErrorBox } from "@/components/setup/step";
 import { DatasetGrid } from "@/components/setup/dataset-grid";
 import { TaskPicker, type TaskFilters } from "@/components/setup/task-picker";
 import { SeatCard, ApiDatalist } from "@/components/setup/seat-card";
+import { SutPanel } from "@/components/setup/sut-panel";
 
 interface TasksState {
   loading: boolean;
@@ -64,11 +65,13 @@ function matchPayload(args: {
   concurrency: number;
   setupTimeout: number;
   recordVideo: boolean;
+  sutRef: string;
 }) {
   return {
     name: args.name.trim() || undefined,
     dataset: args.dataset,
     tasks: [...args.selected],
+    sut_ref: args.sutRef,
     contestants: args.seats.map((seat) => {
       const roles: Record<string, Record<string, unknown>> = {};
       for (const [role, cfg] of Object.entries(seat.engine.roles)) {
@@ -142,6 +145,8 @@ export function SetupView({
   const [concurrency, setConcurrency] = React.useState(1);
   const [setupTimeout, setSetupTimeout] = React.useState(1);
   const [recordVideo, setRecordVideo] = React.useState(false);
+  // `main` means origin/main. Empty is the explicit "do not verify" opt-out.
+  const [sutRef, setSutRef] = React.useState("main");
   const [launching, setLaunching] = React.useState(false);
   const [launchError, setLaunchError] = React.useState<string | null>(null);
 
@@ -410,6 +415,7 @@ export function SetupView({
           concurrency,
           setupTimeout,
           recordVideo,
+          sutRef,
         }),
       );
       const blob = new Blob([toml], { type: "application/toml" });
@@ -428,7 +434,17 @@ export function SetupView({
     } catch (error) {
       setTemplateErrors([String(error)]);
     }
-  }, [matchName, dataset, selected, seats, attempts, concurrency, setupTimeout, recordVideo]);
+  }, [
+    matchName,
+    dataset,
+    selected,
+    seats,
+    attempts,
+    concurrency,
+    setupTimeout,
+    recordVideo,
+    sutRef,
+  ]);
 
   // -- launch --------------------------------------------------------------------
 
@@ -443,6 +459,7 @@ export function SetupView({
       concurrency,
       setupTimeout,
       recordVideo,
+      sutRef,
     });
     if (!payload.tasks.length) {
       setLaunchError("Select at least one task.");
@@ -466,6 +483,7 @@ export function SetupView({
     concurrency,
     setupTimeout,
     recordVideo,
+    sutRef,
     onOpenMatch,
   ]);
 
@@ -635,6 +653,21 @@ export function SetupView({
         <>
           <Step
             n="3"
+            title="stella build"
+            hint={
+              <>
+                Which Stella the seats under test run. A branch is what you pick; the{" "}
+                <strong>commit</strong> it resolves to is what gets recorded, because a
+                branch moves and a result has to stay checkable. <code>main</code> here
+                means <code>origin/main</code>, never a local branch of that name.
+              </>
+            }
+          >
+            <SutPanel sutRef={sutRef} onChangeRef={setSutRef} />
+          </Step>
+
+          <Step
+            n="4"
             title="contestants"
             hint={
               <>
@@ -674,7 +707,7 @@ export function SetupView({
             </Button>
           </Step>
 
-          <Step n="4" title="launch">
+          <Step n="5" title="launch">
             <div className="mb-[18px] flex flex-wrap items-end gap-4">
               <Field label="Match name" className="min-w-[170px] flex-1">
                 <Input

--- a/arenabench/ui/components/setup/sut-panel.tsx
+++ b/arenabench/ui/components/setup/sut-panel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import * as React from "react";
+import { api, postJson } from "@/lib/api";
+import type { SutBranch, SutBuild, SutStatus } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { ErrorBox } from "@/components/setup/step";
+
+/**
+ * Which Stella the match will run, and how to change it.
+ *
+ * The panel exists because the answer used to be invisible: the arena ran
+ * whatever binary happened to be staged, and on 2026-08-06 that was 291
+ * commits behind main and three days old — with every match in between
+ * reporting numbers for it silently. So the commit is stated up front, in
+ * words, before anything launches.
+ *
+ * A branch is what you pick; the commit it resolves to is what gets shown and
+ * recorded. `main` here means `origin/main`, never a local branch of the same
+ * name.
+ */
+export function SutPanel({
+  sutRef,
+  onChangeRef,
+}: {
+  sutRef: string;
+  onChangeRef: (next: string) => void;
+}) {
+  const [status, setStatus] = React.useState<SutStatus | null>(null);
+  const [branches, setBranches] = React.useState<SutBranch[]>([]);
+  const [branchProblem, setBranchProblem] = React.useState<string | null>(null);
+  const [build, setBuild] = React.useState<SutBuild | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  const refresh = React.useCallback(async (ref: string) => {
+    if (!ref) {
+      setStatus(null);
+      return;
+    }
+    try {
+      setStatus(await api<SutStatus>(`/api/sut?ref=${encodeURIComponent(ref)}`));
+    } catch (err) {
+      setError(String(err));
+    }
+  }, []);
+
+  React.useEffect(() => {
+    refresh(sutRef);
+  }, [sutRef, refresh]);
+
+  React.useEffect(() => {
+    api<{ branches: SutBranch[]; problem: string | null }>("/api/sut/branches")
+      .then((res) => {
+        setBranches(res.branches || []);
+        setBranchProblem(res.problem);
+      })
+      .catch((err) => setBranchProblem(String(err)));
+  }, []);
+
+  // Poll only while a build is live. A finished build is terminal, so a timer
+  // that keeps running past it is pure noise on an idle machine.
+  React.useEffect(() => {
+    if (!build || build.done) return;
+    const timer = setInterval(async () => {
+      try {
+        const next = await api<SutBuild>(`/api/sut/builds/${build.id}`);
+        setBuild(next);
+        if (next.done) {
+          setBusy(false);
+          if (next.status === "done") refresh(sutRef);
+        }
+      } catch {
+        /* a dropped poll is not a failed build; the next tick retries */
+      }
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [build, sutRef, refresh]);
+
+  const startBuild = React.useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const started = await postJson<SutBuild>("/api/sut/build", { ref: sutRef });
+      setBuild(started);
+      if (started.done) {
+        setBusy(false);
+        if (started.status === "done") refresh(sutRef);
+      }
+    } catch (err) {
+      setError(String(err));
+      setBusy(false);
+    }
+  }, [sutRef, refresh]);
+
+  const pinned = sutRef !== "";
+  const ready = pinned && !!status?.ready;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-[11px] lowercase text-muted" htmlFor="sut-ref">
+          build from
+        </label>
+        <select
+          id="sut-ref"
+          value={sutRef}
+          onChange={(event) => onChangeRef(event.target.value)}
+          className="min-w-[240px] rounded-[7px] border border-line bg-panel px-2 py-1.5 font-mono text-[12px]"
+        >
+          {branches.map((branch) => (
+            <option key={branch.ref} value={branch.name}>
+              {branch.name}
+              {branch.is_default ? " (default)" : ""} · {branch.short}
+            </option>
+          ))}
+          {/* Kept last so it reads as the deliberate exception it is. */}
+          <option value="">— unpinned (do not verify the binary) —</option>
+        </select>
+
+        {pinned && !ready && (
+          <Button variant="primary" size="sm" onClick={startBuild} disabled={busy}>
+            {busy ? "building…" : "build it"}
+          </Button>
+        )}
+      </div>
+
+      {branchProblem && <ErrorBox>{branchProblem}</ErrorBox>}
+
+      {!pinned && (
+        <div className="rounded-[10px] border border-warn/35 bg-warn/6 px-[13px] py-2.5 text-[12.5px] text-warn">
+          This match will run whatever binary is staged, without checking which
+          commit it is. Results are recorded as an <strong>unverified</strong> SUT
+          and cannot be attributed to a Stella revision.
+        </div>
+      )}
+
+      {pinned && status && (
+        <div
+          className={cn(
+            "rounded-[10px] border px-[13px] py-2.5 text-[12.5px]",
+            ready
+              ? "border-ok/35 bg-ok/6 text-ok"
+              : "border-warn/35 bg-warn/6 text-warn",
+          )}
+        >
+          {ready ? (
+            <>
+              <div>
+                will run <span className="font-mono">{status.staged?.short}</span> —
+                exactly <span className="font-mono">{status.ref}</span>
+              </div>
+              <div className="mt-1 text-muted">
+                sha256 {status.staged?.sha256?.slice(0, 16) || "unrecorded"}
+              </div>
+            </>
+          ) : (
+            <>
+              <div>{status.problem}</div>
+              {status.drift && !status.drift.comparable && (
+                <div className="mt-1 text-muted">
+                  the staged binary cannot be placed relative to this commit, so
+                  how stale it is cannot be stated
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {build && (
+        <div className="rounded-[10px] border border-line bg-panel px-[13px] py-2.5 text-[12px]">
+          <div className="flex items-center gap-2">
+            <span className="font-mono">{build.short || build.ref}</span>
+            <span className="text-muted">
+              {build.cached
+                ? "already built — nothing to compile"
+                : `${build.status} · ${Math.round(build.elapsed)}s`}
+            </span>
+          </div>
+          {build.status === "failed" && (
+            <div className="mt-1.5 text-danger">{build.error}</div>
+          )}
+          {!build.cached && build.log_tail?.length > 0 && (
+            <pre className="mt-1.5 max-h-32 overflow-auto whitespace-pre-wrap font-mono text-[11px] text-muted">
+              {build.log_tail.slice(-6).join("\n")}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {error && <ErrorBox>{error}</ErrorBox>}
+    </div>
+  );
+}

--- a/arenabench/ui/components/topbar.tsx
+++ b/arenabench/ui/components/topbar.tsx
@@ -66,7 +66,7 @@ export function Topbar({
   conn: ConnState;
 }) {
   return (
-    <header className="sticky top-0 z-40 flex h-14 items-center gap-6 border-b border-line bg-background/85 px-5 backdrop-blur-md">
+    <header className="sticky top-0 z-40 flex h-14 items-center gap-6 border-b border-line bg-background/85 px-5 backdrop-blur-md mx-auto max-w-[1600px] px-5 m-b-5">
       <Brand />
       <Tabs.Root value={view} onValueChange={(v) => onViewChange(v as View)}>
         <Tabs.List className="flex gap-1">

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -185,6 +185,66 @@ export interface TranscriptEntry {
   meta?: Record<string, unknown>;
 }
 
+/** A branch the SUT can be built from, as /api/sut/branches returns it. */
+export interface SutBranch {
+  name: string;
+  ref: string;
+  commit: string;
+  short: string;
+  subject?: string;
+  committed_at?: number;
+  is_default?: boolean;
+}
+
+/** How far a staged binary is from the commit a match asked for. */
+export interface SutDrift {
+  staged: string;
+  target: string;
+  behind: number;
+  ahead: number;
+  comparable: boolean;
+  identical: boolean;
+  summary: string;
+}
+
+export interface SutBinary {
+  path: string;
+  commit: string;
+  short: string;
+  sha256: string;
+  built_at: number;
+  known: boolean;
+}
+
+/** Which Stella a match pinned to `ref` would run — /api/sut. */
+export interface SutStatus {
+  ref: string;
+  repo: string | null;
+  target: string | null;
+  staged: SutBinary | null;
+  legacy: SutBinary | null;
+  drift: SutDrift | null;
+  /** True only when a binary built from exactly `target` is staged. */
+  ready: boolean;
+  problem: string | null;
+}
+
+/** One SUT build, from queued to done — /api/sut/build[s]. */
+export interface SutBuild {
+  id: string;
+  ref: string;
+  commit: string;
+  short: string;
+  status: "queued" | "building" | "done" | "failed";
+  elapsed: number;
+  binary: string;
+  sha256: string;
+  error: string;
+  log_tail: string[];
+  cached: boolean;
+  done: boolean;
+}
+
 /** One quick-start head-to-head as /api/presets returns it: a fully
  * configured match in the same shape a parsed template arrives in, so the
  * wizard applies both through one code path. */


### PR DESCRIPTION
## What & why

**Measured 2026-08-06: the staged SUT binary was 291 commits behind `origin/main`
and three days old.** Every match since had reported numbers for that stale code
without a word. A benchmark whose entire purpose is measuring Stella could not
say which Stella it measured.

The guarantee did exist — `bench/evidence/run/build_sut.sh` refuses to build
unless every Rust input matches `origin/main`, then records the commit and
SHA-256 beside the artifact. But it only ever held at **build** time. Nothing
re-checked it at match time, so it decayed silently the moment nobody re-ran the
script, and nothing in the arena ever did.

### A ref is how you choose; a commit is what gets recorded

`MatchSpec.sut_ref` defaults to `main` and resolves through `arenabench.sut`,
**remote-first**, so `main` means `origin/main`.

That distinction is load-bearing, and it caught a bug in this very module during
development: the first implementation resolved `main` to the *local* branch,
which on the development machine was 291 commits behind the remote. A benchmark
that says "we ran main" and measures a stale checkout publishes a number nobody
can reproduce — and it looks entirely correct from the inside. This is the same
argument `arenabench.registry` already makes about datasets: *an unversioned
name is not a freeze.*

### Binaries are cached by commit

`<sut root>/<commit>/stella`, beside its commit id and SHA-256. The legacy
unversioned path is still read, but accepted **only when it records the
requested commit** — an unlabelled binary is never silently taken as the one you
asked for, which is precisely how a three-day-old artifact kept being measured.

### The refusal

`create_match` blocks a Stella seat whose pinned commit has no matching build,
and states how stale what it found is. Matches with no Stella seat are never
blocked — a Claude-Code-vs-Codex contest runs no SUT of ours. An empty `sut_ref`
is the deliberate opt-out for a bisect or a local experiment, and is recorded as
an **unverified** SUT so no number produced that way can be mistaken for one from
a known commit.

### Provenance

`Provenance` gains `sut_ref` / `sut_commit` / `sut_sha256`, and the commit joins
`comparability_key` for the same reason the dataset digest is already there: two
Stella revisions answer different questions, and a key that hides that invites
them into one average.

### Building is never implicit

A release cross-compile with LTO takes minutes, so builds are their own action
(`arenabench.sut_build`) — serialised, cached by commit, and run in a **detached
git worktree**, never in the operator's checkout. Building in place has its own
silent failure: a benchmark that measures uncommitted local edits.

The wizard gains a "stella build" step: a branch picklist, the commit each
branch resolves to, and a build button that polls progress.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`arenabench/tests/test_sut.py` — 26 tests. The fixture is the bug's own shape: a
repo whose local `main` is deliberately behind `origin/main`, so a resolver that
reads the local branch looks correct until the two are compared.

| Class | Pins |
|---|---|
| `TestRemoteFirstResolution` | `main` is `origin/main`, never the local branch |
| `TestRefsReachingGitAreValidated` | `--upload-pack=…` and friends are refused before reaching a subprocess |
| `TestDrift` | unknown is not zero and never renders as agreement |
| `TestBinaryLookupNeverGuesses` | an unlabelled binary is never accepted as the requested commit |
| `TestLaunchRefusal` | stale blocks; matching passes; no-Stella never blocks; absent field means `main`, not unpinned |
| `TestProvenanceRecordsTheSut` | two revisions cannot share a comparability key |

One test is worth calling out:
`test_a_spec_written_before_this_field_defaults_to_main_not_unpinned`. Reading an
absent `sut_ref` as the opt-out would turn every pre-existing template into one
that silently accepts any binary — switching a new safety property off exactly
where it is least visible.

**Verified end to end**, not only in unit tests: against the real repository the
guard refuses a launch with the true message (*"staged 47d587a3 is 291 commit(s)
behind 6c345532"*), the opt-out launches, the branch endpoint lists 117 branches
with the default first, and a real `cargo zigbuild` of `origin/main` was driven
through `SutBuilder` end to end.

## The gate

- [x] `arenabench` suite under CI's command (`uv run --with pytest --no-project pytest -q`)
- [x] `npm run typecheck` in `arenabench/ui` — clean
- [x] `npm run build` — exports and syncs to `arenabench/web/`
- N/A `cargo fmt` / `clippy` / `test` — no Rust in this change

## Nothing left behind

- The build is serialised to one at a time and its log is kept in memory only, so
  a server restart loses it. Fine for a foreground action a human is watching;
  worth revisiting if builds ever become unattended.
- `SutBuilder` shells out to `cargo zigbuild` and depends on `cargo-zigbuild` and
  `zig` being installed. A missing toolchain surfaces as a build failure with the
  tail of the log rather than as a preflight, which would be friendlier.
- Open from the preceding arenabench work, unchanged by this PR: #1980, #1983, #1984.

## Summary by Sourcery

Pin the Stella system-under-test to a specific git commit, refuse launching matches whose pinned SUT build is missing or stale, and expose explicit SUT build and selection controls in the API, runner, provenance, and UI.

New Features:
- Add SUT pinning to match specifications so Stella seats run binaries built from a specific git ref resolved to a commit.
- Introduce a server-side SUT status API, branch listing, and detached worktree SUT builder with cached per-commit binaries and build polling endpoints.
- Expose a UI SUT panel in the setup wizard to choose a branch/ref, trigger builds, and surface which Stella commit and binary will run.

Bug Fixes:
- Prevent matches from silently running stale or unattributable Stella binaries by validating that a pinned SUT commit has a matching staged build before launch.

Enhancements:
- Record SUT ref, commit, and binary SHA-256 in match provenance and incorporate the SUT commit into the comparability key.
- Propagate the selected SUT into the agent launch environment and warn when running an unpinned STELLA_BINARY so results are marked as unattributable.
- Add comprehensive tests around SUT ref resolution, safety of git ref handling, drift calculation, binary lookup, launch refusal logic, and provenance round-tripping.

Tests:
- Add a dedicated SUT test module that constructs a skewed git repo fixture and verifies ref resolution, drift semantics, binary selection, launch gating, and provenance behaviour.