### PR TITLE
fix(arenabench): a finished SUT build pins its own commit, not the branch it came from

### DIFF
--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -228,6 +228,62 @@ class TestLaunchRefusal:
         assert MatchSpec.from_json({"name": "m", "dataset": "d"}).sut_ref == "main"
 
 
+class TestACommitPinSurvivesAMovingBranch:
+    """Why a finished build pins its own commit rather than the branch.
+
+    Observed while building this: a release cross-compile of Stella took 40
+    minutes, and ``origin/main`` moved 10 commits while it ran. On a repo that
+    active, "the binary must equal origin/main" is unsatisfiable by
+    construction — the build is slower than the interval between merges.
+
+    The fix is emphatically *not* to loosen the check; a tolerance is how the
+    291-commit drift survived in the first place. It is that a branch is how
+    you reach for something fresh, and the commit it resolved to is what you
+    actually ran and must record.
+    """
+
+    def _stage(self, commit: str) -> None:
+        directory = sut.sut_root() / commit
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "stella").write_text("#!/bin/sh\n")
+        (directory / "sut_commit.txt").write_text(commit)
+        (directory / "binary_sha256.txt").write_text("deadbeef")
+
+    def test_a_commit_pin_stays_ready_when_the_branch_moves_on(self, repo: Path):
+        built = _git(repo, "rev-parse", "origin/main")
+        self._stage(built)
+        assert sut.sut_status(built)["ready"]
+
+        # The branch advances, exactly as it does mid-build.
+        origin = repo.parent / "origin"
+        (origin / "a.txt").write_text("four")
+        _git(origin, "commit", "-qam", "fourth")
+        _git(repo, "fetch", "-q", "origin")
+
+        assert sut.sut_status(built)["ready"], (
+            "a commit pin names a fixed artifact; a branch moving cannot "
+            "invalidate what was already built and measured"
+        )
+        assert not sut.sut_status("main")["ready"], (
+            "the branch pin must go unready, or the guard would be tolerating "
+            "exactly the drift it exists to catch"
+        )
+
+    def test_a_commit_pin_is_recorded_verbatim(self, repo: Path):
+        built = _git(repo, "rev-parse", "origin/main")
+        spec = MatchSpec.from_json(
+            {
+                "name": "m",
+                "dataset": "d",
+                "sut_ref": built,
+                "contestants": [
+                    {"name": "s", "agent": "stella", "engine": {"model": "m"}}
+                ],
+            }
+        )
+        assert spec.sut_ref == built
+
+
 class TestProvenanceRecordsTheSut:
     """A result set that cannot name its SUT is not comparable to another."""
 

--- a/arenabench/ui/components/setup/sut-panel.tsx
+++ b/arenabench/ui/components/setup/sut-panel.tsx
@@ -69,14 +69,20 @@ export function SutPanel({
         setBuild(next);
         if (next.done) {
           setBusy(false);
-          if (next.status === "done") refresh(sutRef);
+          // Pin the commit that was *built*, not the branch it came from.
+          // A release cross-compile takes longer than the interval between
+          // merges on an active repo — measured here, `origin/main` moved 10
+          // commits during a 40-minute build — so a match that re-resolved
+          // the branch at launch could never be satisfied. Branch is how you
+          // reach for something fresh; the commit is what you actually ran.
+          if (next.status === "done" && next.commit) onChangeRef(next.commit);
         }
       } catch {
         /* a dropped poll is not a failed build; the next tick retries */
       }
     }, 3000);
     return () => clearInterval(timer);
-  }, [build, sutRef, refresh]);
+  }, [build, onChangeRef]);
 
   const startBuild = React.useCallback(async () => {
     setError(null);
@@ -86,16 +92,20 @@ export function SutPanel({
       setBuild(started);
       if (started.done) {
         setBusy(false);
-        if (started.status === "done") refresh(sutRef);
+        if (started.status === "done" && started.commit) onChangeRef(started.commit);
       }
     } catch (err) {
       setError(String(err));
       setBusy(false);
     }
-  }, [sutRef, refresh]);
+  }, [sutRef, onChangeRef]);
 
   const pinned = sutRef !== "";
   const ready = pinned && !!status?.ready;
+  /** A pin that is an exact commit rather than a branch name. */
+  const pinnedCommit = /^[0-9a-f]{40}$/.test(sutRef);
+  /** Which branch the pinned commit was built from, when this session built it. */
+  const buildRef = build?.commit === sutRef ? build?.ref : "";
 
   return (
     <div className="flex flex-col gap-3">
@@ -109,6 +119,16 @@ export function SutPanel({
           onChange={(event) => onChangeRef(event.target.value)}
           className="min-w-[240px] rounded-[7px] border border-line bg-panel px-2 py-1.5 font-mono text-[12px]"
         >
+          {/* A pin can be an exact commit rather than a branch — that is what
+              a finished build leaves behind. Without an option carrying that
+              value the select renders blank and looks unset, which is the one
+              thing this panel must never do. */}
+          {pinnedCommit && (
+            <option value={sutRef}>
+              commit {sutRef.slice(0, 8)}
+              {buildRef ? ` (built from ${buildRef})` : ""}
+            </option>
+          )}
           {branches.map((branch) => (
             <option key={branch.ref} value={branch.name}>
               {branch.name}


### PR DESCRIPTION
## What & why

Follow-up to #2016, from running the thing it added against the real repository.

**A release cross-compile of Stella took 40 minutes, and `origin/main` moved 10
commits while it ran.** So the binary #2016 built was already stale by its own
guard's standard the moment it finished, and a match pinned to the branch `main`
could never be satisfied — not because anything was wrong, but because on a repo
this active the build is slower than the interval between merges.

That makes "the binary must equal `origin/main`" unsatisfiable by construction.

**The fix is emphatically not to loosen the check.** A tolerance is exactly how
the original 291-commit drift survived unnoticed. The fix is to be precise about
what a pin means:

- a **branch** is how you reach for something fresh;
- the **commit** it resolved to is what you actually ran, and what must be
  recorded.

So a completed build switches the pin to its own commit. The match then names a
fixed artifact, which a branch moving on cannot invalidate, and the record says
exactly which Stella produced the numbers.

The picker also grows an option carrying that commit. A `<select>` whose value
matches none of its options renders blank and reads as unset — the one thing
this panel must never do, since its entire job is stating which binary will run.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`TestACommitPinSurvivesAMovingBranch` in `arenabench/tests/test_sut.py`: the
fixture's origin advances mid-test, exactly as it does mid-build. The commit pin
stays ready; the branch pin correctly does not. Both halves are asserted,
because a change that made the branch pin tolerant would pass a one-sided test
while reintroducing the bug #2016 exists to prevent.

**Verified end to end against the real rig**, not only in the fixture: a
`cargo zigbuild` of `origin/main` ran to completion (2387s), produced
`ELF 64-bit x86-64, GNU/Linux, stripped` with a highest required symbol version
of `GLIBC_2.17` — so genuinely portable into every task image — and a match
pinned to that commit launches with the seat note:

```
stella 6c345532 (6c3455326adfb04c0b3dcb35aad192c0f78b6e33) sha256:1c658620d783
```

while the same match pinned to `main` is still correctly refused.

## The gate

- [x] `arenabench` suite — 28 tests in `test_sut.py`, full suite green
- [x] `npm run typecheck` in `arenabench/ui` — clean
- [x] `npm run build` — exports and syncs to `arenabench/web/`
- N/A `cargo fmt` / `clippy` / `test` — no Rust in this change

## Nothing left behind

- The auto-pin happens in the panel, so it is UI logic with no test behind it —
  `arenabench/ui` still has no test harness (#1751). The *property* it depends
  on (a commit pin outliving a moving branch) is pinned in Python; the wiring
  that calls it is not.
- Carried over from #2016 and unchanged: the build log lives in memory only, and
  a missing `cargo-zigbuild`/`zig` surfaces as a build failure rather than a
  preflight.

## Summary by Sourcery

Ensure SUT builds pin and display the exact commit they were built from rather than the originating branch, so branch movement cannot invalidate completed artifacts.

Bug Fixes:
- Keep commit-based SUT pins ready even when the tracked branch advances, preventing guard checks from failing purely due to branch movement.

Enhancements:
- Update the SUT setup panel to automatically repin to the built commit on successful builds and to show commit pins explicitly in the selector, including provenance to the source branch when available.

Tests:
- Add a witness test that verifies commit pins remain valid while branch pins correctly go unready when the underlying branch moves, and that commit pins are recorded verbatim in match specs.