### PR TITLE
refactor(stella-observatory): one char-boundary clipper, not three (#1999)

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -294,7 +294,11 @@ Adding an API route:
    [`src/global.rs`](src/global.rs) for `usage.db`,
    [`src/fsview.rs`](src/fsview.rs) for files,
    [`src/codegraph.rs`](src/codegraph.rs) for the graph. Degrade a missing
-   file or table to an empty payload; do not return an error.
+   file or table to an empty payload; do not return an error. Clip long text
+   through `db::truncate` — the crate's one clipper, so the ellipsis, the
+   char-not-byte count and `max` excluding the ellipsis stay one decision
+   rather than a per-module one (#1999). The clip *lengths* are per-surface;
+   the clip *shape* is not.
 2. Add the arm to the `match route` in `respond` (`src/lib.rs:148`). Take
    filters via `query_param`, never by splitting the query string yourself.
 3. Add the path to `empty_workspace_degrades_to_empty_payloads_not_errors`'s

--- a/crates/stella-observatory/src/context_db.rs
+++ b/crates/stella-observatory/src/context_db.rs
@@ -41,7 +41,7 @@ use stella_core::context_record::{
     SelectionHealthPolicy, fold_selection_health,
 };
 
-use crate::db::{DbError, collect_rows, is_missing_schema, open_read_only};
+use crate::db::{DbError, collect_rows, is_missing_schema, open_read_only, truncate};
 
 /// Ledger revisions read per record kind, newest first in append order —
 /// mirrors `stella proposals`' own `READ_LIMIT`
@@ -354,14 +354,4 @@ fn health_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
             })
         })
         .collect())
-}
-
-/// Cap a string at `max` chars on a char boundary, appending an ellipsis.
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(max).collect();
-    out.push('…');
-    out
 }

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -223,7 +223,7 @@ impl Observatory {
                 Ok(json!({
                     "id": r.get::<_, i64>(0)?,
                     "kind": r.get::<_, String>(1)?,
-                    "prompt": truncate(r.get::<_, String>(2)?, 160),
+                    "prompt": truncate(&r.get::<_, String>(2)?, 160),
                     "provider": r.get::<_, String>(3)?,
                     "model": r.get::<_, String>(4)?,
                     "outcome": r.get::<_, Option<String>>(5)?,
@@ -920,12 +920,12 @@ impl Observatory {
                     "kind": r.get::<_, Option<String>>(1)?,
                     "outcome": r.get::<_, Option<String>>(2)?,
                     "model": r.get::<_, Option<String>>(3)?,
-                    "prompt": truncate(r.get::<_, Option<String>>(4)?.unwrap_or_default(), 140),
+                    "prompt": truncate(&r.get::<_, Option<String>>(4)?.unwrap_or_default(), 140),
                     "delivered": r.get::<_, Option<i64>>(5)?,
                     "self_rating": r.get::<_, Option<i64>>(6)?,
-                    "what_went_well": truncate(r.get::<_, String>(7)?, 280),
-                    "what_to_improve": truncate(r.get::<_, String>(8)?, 280),
-                    "critique": truncate(r.get::<_, String>(9)?, 280),
+                    "what_went_well": truncate(&r.get::<_, String>(7)?, 280),
+                    "what_to_improve": truncate(&r.get::<_, String>(8)?, 280),
+                    "critique": truncate(&r.get::<_, String>(9)?, 280),
                     "recorded_at": r.get::<_, String>(10)?,
                 }))
             },
@@ -1060,7 +1060,7 @@ impl Observatory {
                 Ok(json!({
                     "id": r.get::<_, i64>(0)?,
                     "kind": r.get::<_, String>(1)?,
-                    "prompt": truncate(r.get::<_, String>(2)?, 160),
+                    "prompt": truncate(&r.get::<_, String>(2)?, 160),
                     "provider": r.get::<_, String>(3)?,
                     "model": r.get::<_, String>(4)?,
                     "started_at": r.get::<_, String>(5)?,
@@ -1256,7 +1256,7 @@ fn journal_entry(row: Value, full: bool) -> Value {
 pub(crate) fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
     let clipped = !full && body.chars().count() > JOURNAL_BODY_CLIP;
     entry["body"] = if clipped {
-        json!(truncate(body.to_owned(), JOURNAL_BODY_CLIP))
+        json!(truncate(body, JOURNAL_BODY_CLIP))
     } else {
         json!(body)
     };
@@ -1273,7 +1273,7 @@ fn rules_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
         |r| {
             Ok(json!({
                 "rule_id": r.get::<_, String>(0)?,
-                "contents": truncate(r.get::<_, String>(1)?, 240),
+                "contents": truncate(&r.get::<_, String>(1)?, 240),
                 "source": r.get::<_, String>(2)?,
                 "created_at": r.get::<_, String>(3)?,
             }))
@@ -1410,9 +1410,9 @@ pub(crate) fn merge(base: &mut Value, extra: Value) {
 }
 
 /// Cap a string at `max` chars on a char boundary, appending an ellipsis.
-fn truncate(s: String, max: usize) -> String {
+pub(crate) fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
-        return s;
+        return s.to_owned();
     }
     let mut out: String = s.chars().take(max).collect();
     out.push('…');

--- a/crates/stella-observatory/src/sessions.rs
+++ b/crates/stella-observatory/src/sessions.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::Connection;
 use serde_json::{Value, json};
 
-use crate::db::{DbError, is_missing_schema, merge};
+use crate::db::{DbError, is_missing_schema, merge, truncate};
 
 /// Sessions returned by [`sessions`]. Same shape of reasoning as
 /// `MAX_LISTED_EXECUTIONS`: the page re-fetches the list on every refresh, so
@@ -343,19 +343,9 @@ fn first_prompts(conn: &Connection) -> Result<BTreeMap<String, String>, DbError>
     let mut out = BTreeMap::new();
     for row in mapped {
         let (id, prompt) = row?;
-        out.insert(id, clip(prompt, 140));
+        out.insert(id, truncate(&prompt, 140));
     }
     Ok(out)
-}
-
-/// Cap a string at `max` chars on a char boundary, appending an ellipsis.
-fn clip(s: String, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s;
-    }
-    let mut out: String = s.chars().take(max).collect();
-    out.push('…');
-    out
 }
 
 /// The `/api/sessions` payload: every session of this workspace, registry
@@ -852,7 +842,7 @@ fn session_turns(conn: &Connection, id: &str) -> Result<Vec<Value>, DbError> {
     // multi-kilobyte goal; the drawer shows the full text.
     for row in &mut out {
         if let Some(prompt) = row.get("prompt").and_then(Value::as_str) {
-            let clipped = clip(prompt.to_string(), 240);
+            let clipped = truncate(prompt, 240);
             row["prompt"] = json!(clipped);
         }
     }


### PR DESCRIPTION
## What & why

`crates/stella-observatory` carried **three byte-identical** char-boundary
truncate-with-ellipsis helpers under two names:

| | signature | call sites |
|---|---|---|
| `src/db.rs::truncate` | `(String, usize)` | 8 |
| `src/sessions.rs::clip` | `(String, usize)` | 2 (pre-existing) |
| `src/context_db.rs::truncate` | `(&str, usize)` | 3 (added by #1943 / #1871) |

They had not drifted, which is exactly why this is the moment: the ellipsis
character, chars-not-bytes, and whether `max` excludes the ellipsis are silent
UI-consistency decisions that were being made in three places. The two
duplications this crate actually consolidated before (the unified differ into
`stella-diff`, the self-driving fold into `stella-core`) were both consolidated
*after* the copies started disagreeing.

`db::truncate` is promoted to `pub(crate)` and takes `&str` rather than
`String`. `db` is already the module the other two import `collect_rows` /
`is_missing_schema` / `merge` from, so **no new seam appears**. The borrowed
signature is what makes the fold free rather than costly: `context_db` clips
borrowed struct fields (`proposal.body`, `event.reason`), which an owned
signature would force to clone. Two call sites shed a `to_owned()` /
`to_string()` that existed only to feed the owned signature
(`db.rs::set_journal_body`, `sessions.rs`'s prompt clip). The eight `db.rs`
sites take a `&` on an already-owned temporary.

Net: **−20 lines**, one clipper instead of three.

Closes #1999

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: the three
      bodies were byte-identical, so there is no behavior to witness. The
      check the issue specifies is the existing suite staying green — in
      particular the golden route payloads in `tests/schema_conformance.rs`,
      which would move if any clip changed shape. **96 tests pass**
      (80 + 4 + 12), none changed.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green)
- [x] `cargo clippy -p stella-observatory --all-targets -- -D warnings` (exit 0)
- [x] `cargo test -p stella-observatory` (exit 0 — 96 passed, 0 failed)
- [x] Docs updated where behavior/flags changed — the README's *Extending it*
      recipe now carries the "clip through `db::truncate`" rule
- [x] CLA signed
- [x] `Closes #1999` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: **#2026** — the crate has a **fourth** copy of this clipper, in
      JavaScript (`src/assets/index.html:1064`), and unlike the three Rust ones
      it **has already drifted**. It counts `String.prototype.length` (UTF-16
      code units) and cuts with `slice`, so it can split a surrogate pair and
      emit a lone surrogate that the DOM renders as `�`. Verified by
      execution, not inspection: `isWellFormed()` returns `false` for the
      current implementation at the boundary case and `true` at every `n` for
      the proposed fix. Deliberately out of scope here — this PR's constraint
      is that it must not conflate the clip *shape* with anything else, and
      #2026 is a page change with its own verification story (no JS harness
      exists in this crate).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**`db.rs` is 1420 lines before and after — deliberately exactly flat.** The
issue constrains that file not to grow (it sits ~80 lines under the 1500
ratchet). My first draft added an eight-line doc comment on the promoted
helper explaining that it is now the crate's only clipper; that grew `db.rs`
to 1427, so I reverted it to the original single line and put the rule in the
README's *Extending it* recipe instead. That is the better home regardless:
someone about to write a fourth copy is reading the extension recipe or their
own module, not the bottom of `db.rs`.

One rejected alternative: keeping the `String` signature. It avoids an
allocation on the short path for the eight `db.rs` sites (which pass owned
`String`s), but forces `context_db`'s three borrowed sites to clone
unconditionally — so it is 1 allocation worse for borrowed callers on *both*
paths and 1 better for owned callers on the short path only. On payloads that
are about to be `serde_json`-serialized over HTTP, that is noise, and `&str`
is the signature the issue specifies.

Per the issue's explicit constraint, the differing clip **lengths**
(140 / 160 / 200 / 240 / 280) are untouched — they are deliberate per-surface
choices and folding them into this diff would make it unreviewable.

## Summary by Sourcery

Consolidate character-boundary string truncation into a single shared helper in the db module while preserving existing clipping behavior across call sites.

Enhancements:
- Expose a single pub(crate) truncate(&str, max) helper in db and update all Rust callers to use it, avoiding duplicate implementations and unnecessary allocations.
- Adjust db and sessions code to pass string slices to the shared truncation helper, keeping API payload shapes and clip lengths unchanged.

Documentation:
- Document in the stella-observatory README that all long-text clipping should go through db::truncate, clarifying that clip shape is centralized while clip lengths remain per-surface.