### PR TITLE
release:minor changelog records lines, not patches — and an interactive /releases microsite

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -166,33 +166,47 @@ jobs:
           fi
 
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      # Draft CHANGELOG entries from the diff this tag is about to release,
-      # once, into a file both sync-versions.sh call sites read (the tagged
-      # release commit below and the bot/version-sync PR after it), so the tag
-      # and main roll identical text. This is the sole author of CHANGELOG.md
-      # entries — sync-versions.sh overwrites [Unreleased] with this draft
-      # regardless of what (if anything) a PR put there, so changelog
-      # authorship lives entirely in this CI job and never in a coding agent
-      # or contributor hand-editing the file. The script prints nothing when
-      # it can't draft (no key, API failure), and sync-versions.sh then rolls
-      # [Unreleased] as-is rather than blocking the release on it.
-      - name: Draft changelog entries from the release diff
-        if: steps.ver.outputs.skip != 'true'
+      # Draft the CHANGELOG section, once, into a file both sync-versions.sh
+      # call sites read (the tagged release commit below and the
+      # bot/version-sync PR after it), so the tag and main roll identical text.
+      # This is the sole author of CHANGELOG.md entries — the roll overwrites
+      # [Unreleased] with this draft regardless of what (if anything) a PR put
+      # there, so changelog authorship lives entirely in this CI job and never
+      # in a coding agent or contributor hand-editing the file.
+      #
+      # MINOR AND MAJOR ONLY, and the range is the whole SERIES — the previous
+      # X.Y.0 tag to HEAD, not the previous tag. CHANGELOG.md records one
+      # section per minor line (scripts/changelog-roll.sh explains why: a roll
+      # per patch left 77 of 180 sections empty), so a patch release has no
+      # section to draft and does not pay for the call. Per-tag detail still
+      # ships as GitHub Release notes, which release.yml generates separately.
+      #
+      # The script prints nothing when it can't draft (no key, API failure);
+      # changelog-roll.sh then writes a releases-page pointer rather than an
+      # empty section, and the release proceeds either way.
+      - name: Draft the changelog section from the series diff
+        if: steps.ver.outputs.skip != 'true' && steps.ver.outputs.kind != 'patch'
         env:
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
           CHANGELOG_AI_MODEL: ${{ vars.RELEASE_NOTES_MODEL || 'anthropic/claude-sonnet-5' }}
         run: |
           set -euo pipefail
-          last="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
+          # The newest X.Y.0 tag opens the series this release closes. Falling
+          # back to the newest tag of any shape keeps the very first minor
+          # release (no X.Y.0 predecessor yet) from drafting the entire history.
+          last_minor="$(git tag -l 'v*.0' --sort=-v:refname | head -n1 || true)"
+          last="${last_minor:-$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)}"
+          echo "Drafting the ${{ steps.ver.outputs.tag }} section from ${last:-<no tag>}..HEAD"
           entries="${RUNNER_TEMP}/changelog-entries.md"
           ./scripts/changelog-ai.sh ${last:+"${last}..HEAD"} > "${entries}" || true
           if [ -s "${entries}" ]; then
             echo "CHANGELOG_ENTRIES_FILE=${entries}" >> "$GITHUB_ENV"
             echo "----- drafted entries -----"; cat "${entries}"
           else
-            echo "::warning::no changelog entries drafted; the roll will proceed without them."
+            echo "::warning::no changelog entries drafted; the roll will write a releases-page pointer."
           fi
 
       # Needed before the tag now: the release commit syncs Cargo.lock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2000 +1,235 @@
 # Changelog
 
-All notable changes to this project are recorded here. The format follows
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
-follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+What each **minor line** of Stella changed, in the words of someone who uses
+the CLI. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## How this file works
 
-**Every merge to main cuts a release** (see [`RELEASING.md`](RELEASING.md)),
-and **CI writes this file, not contributors or coding agents.** Don't add a
-bullet under `## [Unreleased]` in your PR — leave the section alone. The
-release job drafts the entries itself from the **released diff**
-(`scripts/changelog-ai.sh`, the same AI Gateway that writes the GitHub
-Release notes) and rolls those beneath the new version heading, replacing
-whatever was under `[Unreleased]` (normally nothing). A release whose diff
-has nothing user-facing gets a one-line `_Internal: …_` note instead of
-bullets.
+**One section per minor line — not per release.** Every merge to main cuts a
+patch release (see [`RELEASING.md`](RELEASING.md)), which is a fine way to ship
+and a terrible way to keep a record: the 0.6 line alone was 127 releases in
+eight days. Those releases are not undocumented — [the releases
+page](https://github.com/macanderson/stella/releases) carries notes for every
+single tag, generated from that tag's own diff. This file is the other half of
+the pair: the durable, curated record of what a line delivered, written for
+someone deciding whether to upgrade rather than someone bisecting a regression.
 
-Changelog authorship used to be split between hand-written PR entries and
-this drafter, with hand-written text winning whenever present. That produced
-inconsistent, sometimes-mangled entries, so the drafter is now the only
-author: one voice, always grounded in the diff rather than in whatever a PR
-happened to say about itself. If your change needs context the diff alone
-won't convey, put it in the PR description — `changelog-ai.sh` reads commit
-bodies (squash-merge PR descriptions) too, not just the code.
+**CI writes this file, not contributors or coding agents.** Don't add a bullet
+under `## [Unreleased]` in your PR — leave the section alone.
+[`scripts/changelog-ai.sh`](scripts/changelog-ai.sh) drafts the section from the
+whole series range when a minor or major release is cut, and
+[`scripts/changelog-roll.sh`](scripts/changelog-roll.sh) rolls it into place. If
+your change needs context the diff alone won't convey, put it in the PR
+description — the drafter reads commit bodies (squash-merge PR descriptions),
+not just code.
 
-Internal refactors, test-only changes, and CI work need no action from
-you — the drafter files those under the `_Internal_` line on its own.
+Internal refactors, test-only changes, and CI work need no action from you; they
+are not user-facing and do not appear here.
 
-Each GitHub Release additionally carries per-release notes generated at publish
-time from the same diff. Those are release-note prose; this file is the
-durable record, one section per version.
-
-Entries for 0.5.29 through 0.6.42 were reconstructed after the fact
-(2026-07-31) from each release's diff — the sections were rolled empty at the
-time. Versions missing from the ladder entirely (a rapid-merge race used to
-skip the roll) were re-inserted the same way.
+<!-- Sections below are generated. See scripts/changelog-roll.sh for the rules:
+     minor and major lines only, and never a heading with an empty body. -->
 
 ## [Unreleased]
 
-## [0.6.132] — 2026-08-07
-
-## [0.6.131] — 2026-08-07
-
-## [0.6.130] — 2026-08-07
-
-## [0.6.129] — 2026-08-07
-
-## [0.6.128] — 2026-08-06
-
-## [0.6.127] — 2026-08-06
-
-## [0.6.126] — 2026-08-06
-
-## [0.6.125] — 2026-08-06
-
-## [0.6.124] — 2026-08-06
-
-## [0.6.123] — 2026-08-06
-
-## [0.6.122] — 2026-08-06
-
-## [0.6.121] — 2026-08-06
-
-## [0.6.120] — 2026-08-06
-
-## [0.6.119] — 2026-08-06
-
-## [0.6.118] — 2026-08-06
-
-## [0.6.117] — 2026-08-05
-
-## [0.6.116] — 2026-08-05
-
-## [0.6.115] — 2026-08-05
-
-## [0.6.114] — 2026-08-05
-
-## [0.6.113] — 2026-08-05
-
-## [0.6.112] — 2026-08-05
-
-## [0.6.111] — 2026-08-05
-
-## [0.6.110] — 2026-08-05
-
-## [0.6.109] — 2026-08-05
-
-## [0.6.108] — 2026-08-05
-
-## [0.6.107] — 2026-08-05
-
-## [0.6.106] — 2026-08-05
-
-## [0.6.105] — 2026-08-05
-
-## [0.6.104] — 2026-08-05
-
-## [0.6.103] — 2026-08-05
-
-## [0.6.102] — 2026-08-05
-
-## [0.6.101] — 2026-08-05
-
-## [0.6.100] — 2026-08-05
-
-## [0.6.99] — 2026-08-04
-
-## [0.6.98] — 2026-08-04
-
-## [0.6.97] — 2026-08-04
-
-## [0.6.96] — 2026-08-04
-
-## [0.6.95] — 2026-08-04
-
-## [0.6.94] — 2026-08-04
-
-## [0.6.93] — 2026-08-04
-
-## [0.6.92] — 2026-08-04
-
-## [0.6.90] — 2026-08-04
-
-## [0.6.89] — 2026-08-04
-
-## [0.6.88] — 2026-08-04
+## [0.7.0] — 2026-08-07
 
 ### Changed
 
-- The A/B recall control now runs on **every** surface, not only the
-  interactive REPL's plain prompts (#1221). `stella run`, `/goal`, and the
-  Command Deck each arm it at turn start, and its schedule is counted durably
-  per workspace in `context.db` instead of per session — which is what makes a
-  one-turn-per-process surface capable of producing a control turn at all. A
-  control turn is now frameless end to end: the pipeline's recall port returns
-  nothing on it, so the planner and witness author no longer run on recalled
-  context while the turn is recorded as suppressed.
-- The control's rate is configurable as `context.retrieval.ab_recall_rate`
-  (default 10, as the compile-time constant it replaces; `0` disables the
-  experiment).
-
-### Fixed
-
-- A control turn's `[ab-control]` episode tag no longer disappears when the
-  prompt is longer than 240 characters. The tag was composed into the prompt
-  before truncation, so exactly the turns the measurement is made of were filed
-  as ordinary ones; it is now appended by the episode writer, after truncation,
-  on every surface that records an episode.
-## [0.6.87] — 2026-08-04
-
-## [0.6.86] — 2026-08-04
-
-## [0.6.85] — 2026-08-04
-
-## [0.6.84] — 2026-08-04
-
-## [0.6.83] — 2026-08-04
-
-## [0.6.82] — 2026-08-03
+- **The changelog is now one section per minor line, and reads like something a
+  person wrote.** This file had grown to 180 sections of which **77 were
+  completely empty** — a bare `## [0.6.x] — <date>` heading with nothing under
+  it. Nothing was wrong with the drafter; the composition was. A patch release
+  was cut on every merge to main and the roll fired on every one of them, while
+  the drafter degrades open by contract (no API key, no non-bot commits, or an
+  unparseable response all print nothing and succeed). When the second happened
+  the first still stamped the heading. Patch releases no longer touch this file
+  at all, and a minor release can no longer emit a heading with an empty body
+  under any failure. Per-release detail did not disappear — it ships as GitHub
+  Release notes, the surface built for "what changed in this exact build".
 
 ### Added
 
-- Bedrock is now a first-class provider everywhere the credential chain reaches,
-  not only in a shell with the standard AWS variables exported. `stella auth set
-  bedrock` stores the whole set — access key id, secret access key, optional
-  session token, and region — in `~/.stella/credentials.toml` (new
-  `[credential_fields.<provider>]` section), prompting for each or accepting
-  `--field NAME=VALUE`. `stella auth list` shows which companion values a
-  provider has stored, by name; `stella auth remove` takes them with it.
-- Secure benchmark runs can use Bedrock (#1301). The launcher's credential
-  handover carries a set of secrets instead of exactly one, still over a single
-  unlinked owner-only descriptor that never touches disk or the environment, and
-  the region rides beside it as disclosed routing rather than as a secret. Which
-  AWS credential sources are supported — and which are deliberately excluded
-  (profile files, SSO, IMDS/container roles, web-identity tokens) — is documented
-  in `bench/harbor_adapter/README.md`.
+- **Release notes have a home you can actually read:
+  [stella.oxagen.sh/releases](https://stella.oxagen.sh/releases).** Every minor
+  line as an interactive page — filter by kind (added, changed, fixed, removed,
+  security), search the full text of every entry, and expand a line to read it
+  in full. Built from this file at build time, so the site and the repository
+  cannot drift.
 
-### Changed
+## [0.6.0] — 2026-07-29 → 2026-08-06
 
-- When a model judge passes a turn and **nothing deterministic backs it up** —
-  no fail→pass flip, no test that ran green — the pipeline now spends one
-  revision asking the worker for that evidence instead of recording the pass as
-  `UNVERIFIED` on the spot (#1295). The ask is raised **only where a tracked
-  command exists to answer it**: both facts that would settle the question are
-  observations of that command, so without one the request is unanswerable
-  however well the worker responds — which is why the same feature was measured
-  as a loss and switched off the first time. Bounded to one ask per candidate,
-  paid from the existing `max_revisions` budget. Turn it off with
-  `agent_engine_config.pipeline_judge_evidence_demand = "off"`; the measurement
-  and its limits are in `bench/evidence/judge-evidence-demand-1295/`.
-
-### Fixed
-
-- Auto-detection no longer selects Bedrock when only `AWS_ACCESS_KEY_ID` is set.
-  A shell carrying an unrelated AWS key used to launch a provider that then died
-  with a SigV4 error; it now falls through to the first-run message naming
-  providers that can actually run. `--model bedrock/…` still pins it explicitly
-  and reports the named missing-credential error.
-
-## [0.6.81] — 2026-08-03
-### Removed
-
-- **The `bash` sandbox is gone (#1300).** `STELLA_BASH_SANDBOX` —
-  `workspace-write` / `restricted`, backed by `sandbox-exec` (Seatbelt) on
-  macOS and `bwrap` (bubblewrap) on Linux — has been removed along with
-  `crates/stella-tools/src/sandbox.rs`. **The variable is now inert:** it is read
-  nowhere, so a value left in a shell profile, CI job, or service unit does
-  nothing and warns about nothing. Setting it no longer fails a tool call
-  either — an unrecognized value used to be an error, and now it is ignored
-  like any other unused variable.
-
-  It confined the `bash` tool and nothing else. `build_project` and
-  `run_tests` (via `command`), `verify_done` (via `test_cmd`), `run_script`,
-  `start_process`, the `repo_*` and `ci_status` `git`/`gh` invocations, custom
-  manifest tools, and hook actions all spawned around it and always ran
-  unconfined — so "sandbox: on" read as a bound on the session while
-  delivering a bound on one tool. A half-boundary people rely on is worse than
-  a clearly absent one, which is the whole reason this is a removal and not an
-  extension.
-
-  **If you were relying on it:** run the whole `stella` process inside a
-  container (Docker, Podman, or a remote sandbox) and mount only the
-  repository you want the agent to touch. That boundary sits outside every
-  spawn path instead of on one of them, so no tool can route around it. Add
-  `--network none` for the equivalent of `restricted`, with the same cost it
-  always had — no model provider, no dependency fetches, no `git push`. See
-  [Permissions](https://stella.oxagen.sh/docs/agent-tools/permissions) and
-  `docs/spec/remote-sandboxes.md`. Nothing else changes: `bash` already ran
-  unconfined by default, and the `command.started` policy chain still gates
-  every model-authored command line before it spawns.
-
-## [0.6.80] — 2026-08-03
+The verification line. A model's opinion stopped being enough to end a run,
+the verifier stopped being allowed to grade its own work, and the pipeline
+learned to research before it plans.
 
 ### Added
 
-- The code graph now records **call sites** (#335, B1): `graph_query` and
-  `stella graph` gain two ops — `callees <symbol>` lists the recorded calls
-  inside a definition's span, and `callers <symbol>` reverse-looks-up call
-  sites by name, labeled best-effort in every answer (same-name methods
-  conflate; function-pointer and macro calls are not seen). Structural, so
-  unlike `references` it never matches comments or strings. Index-time only,
-  no new dependencies; the `code_graph_calls` table converges into existing
-  stores on the next open.
-
-- `--accessible` (env `STELLA_ACCESSIBLE=1`) runs the **Command Deck itself** so
-  a screen reader can read it — a mode on the real product, not a lesser surface
-  beside it. Every tab, gate, key, sub-agent and resume is unchanged. The deck
-  draws inline on your own screen instead of the alternate one, each completed
-  message moves into normal scrollback exactly once (and is still there after you
-  quit), animation is frozen, the GRAPH/SKILLS panes and the session work rail
-  stack into one column, the grid views (TRACES, ISSUES, TOOLS, AGENTS,
-  INSTALLED) render as labelled rows instead of aligned columns, and tab,
-  overlay and focus changes are announced. A terminal that never answers a
-  cursor-position request still gets a deck — it degrades to a full-screen draw
-  on your own screen, and says so. (#1258)
-
-- The engine now ages old tool results **during** a long turn, not only near
-  the context ceiling: results older than 8 tool-bearing steps are middle-out
-  truncated to head+tail (batched, so the provider prompt-cache prefix is
-  rewritten once per several steps, never per step). On the measured
-  head-to-head this growth pattern was the dominant share of a 6.4× input-token
-  gap. Tune or disable it with `agent_engine_config.tool_result_horizon_steps`
-  (`0` disables); the compaction trigger itself is now also settable as
-  `agent_engine_config.compaction_budget_tokens`, and both ride
-  `stella serve`'s per-turn `engine` object too. (#1285)
-- `stella usage report` now shows cache **writes** beside cache reads (the
-  cost side of the cache ledger), the Observatory's models table gained a
-  `cache %` column, and the benchmark live feed carries each trial's
-  cached/uncached input split instead of dropping it. (#1285)
-
-### Fixed
-
-- Messages the deck itself speaks are now marked `▸`, so the transcript no longer
-  reads as though the model said "conversation cleared". The rail glyph that used
-  to carry that distinction is visual, and visual distinctions do not survive
-  being read aloud. (#1258)
-
-- A turn that ends (or proceeds) holding a length-truncated partial no longer
-  retains the whole cut-off scratchpad in its transcript: the spent-allowance,
-  out-of-time, budget-abort, and truncated-with-tool-calls paths now keep the
-  same middle-elided form the continuation path always kept. What you see is
-  unchanged — only what the model re-reads (and re-pays for) every later step
-  shrinks. (#1285)
-- Prompt-cache opt-ins across every provider that needs one: the Anthropic
-  adapter's conversation-tail cache breakpoint no longer silently no-ops when
-  the last content block is an image or document (it now stamps the newest
-  stampable block); a settings-defined custom provider whose base URL points
-  at openrouter.ai now gets OpenRouter's `cache_control` + `session_id`
-  markers instead of silently running Claude with zero caching; and Bedrock's
-  cache-point gate recognizes any Anthropic-vendored model id, not only ones
-  spelling "claude". Implicit-cache providers (OpenAI, Gemini/Vertex, Z.ai,
-  xAI, DeepSeek) need no marker — their cached-token telemetry is parsed and
-  now witnessed per identity in the parity matrix. (#1285)
-## [0.6.79] — 2026-08-03
-
-## [0.6.78] — 2026-08-03
-
-## [0.6.77] — 2026-08-03
-
-## [0.6.76] — 2026-08-03
-
-## [0.6.75] — 2026-08-03
-
-## [0.6.74] — 2026-08-03
-
-## [0.6.73] — 2026-08-03
-
-### Fixed
-
-- `delete_file` now removes a **symlink itself** instead of the file it points
-  at. The path resolver canonicalizes, so deleting an in-tree symlink (a
-  vendored config, a `node_modules/.bin` entry) silently destroyed the target
-  and left the link dangling, reported as an ordinary deletion. A dangling
-  symlink is now deletable too, and the tool says which of the two it removed.
-- `apply_edits` no longer reverts a write that arrived from outside the batch.
-  When a mid-batch write failed, the rollback restored the bytes captured
-  during validation unconditionally — destroying any change a formatter,
-  watcher, or editor had made in between while still reporting a clean
-  all-or-nothing abort. Files whose bytes are no longer the batch's are left
-  alone and named in the error.
-- `RIPGREP_CONFIG_PATH` is scrubbed from tool subprocesses, alongside the
-  `GIT_CONFIG_*` family it matches. A planted `rg` config (`--max-count=1`, a
-  hiding `--glob`) silently truncated what the `grep` tool returned, and the
-  agent read the shortfall as fact.
-- `Retry-After` is honored in its HTTP-date form, not only as delta-seconds.
-  A provider behind a CDN — the deployments that actually rate-limit — had its
-  stated backoff window dropped, and the retry landed back inside it.
-
-### Changed
-
-- `stella init`'s code-graph summary reports files skipped for exceeding the
-  indexer's size ceiling, beside the existing generated-file count. The
-  exclusion was counted and surfaced nowhere, so a large file leaving the index
-  looked like a file with no symbols in it.
-
-## [0.6.72] — 2026-08-03
-
-## [0.6.71] — 2026-08-02
-
-## [0.6.70] — 2026-08-02
-
-## [0.6.69] — 2026-08-02
-
-## [0.6.68] — 2026-08-02
-
-## [0.6.67] — 2026-08-02
-
-## [0.6.66] — 2026-08-02
-
-## [0.6.65] — 2026-08-02
-
-## [0.6.64] — 2026-08-02
-
-### Added
-
-- **`stella` writes a log you can attach to a bug report.** When a run panics or
-  exits non-zero, diagnostics land in `.stella/private/crash-*.jsonl` (owner-only)
-  and the path is printed. `stella doctor --last-failure` prints the newest one.
-  The file is safe to send as-is: the record type physically cannot hold a
-  prompt, a path, or model output, so there is nothing in it to review first.
-- **`-v` / `-vv` / `-vvv`** turn on diagnostics at `info` / `debug` / `trace`.
-  Default is `warn`, human-readable on a terminal and JSONL when redirected.
-- **`--log-level <spec>`** filters per crate — `warn,stella_store=debug` is quiet
-  everywhere except where you are looking. Also settable as `STELLA_LOG`; the
-  flag wins over the variable, and both win over nothing. An unrecognised clause
-  is reported and skipped rather than being fatal. `STELLA_SERVE_LOG` keeps
-  working and now accepts the same richer grammar.
-- **`--log-file <path>`** writes JSONL to a file, created `0600`, defaulting to
-  `info`. An unwritable path is reported and the run continues.
-### Changed
-
-- **Stella now asks each model for what that model can actually emit.** The
-  engine carried one output cap (16,384 tokens) for every model on every
-  provider, and fell back to it even though each model's real ceiling was
-  already being read from models.dev, written to the `max_output_tokens`
-  column of the local model card, and read back out — then dropped when the
-  runtime catalog was assembled. `CatalogEntry` now carries the ceiling and
-  the engine uses it, in both directions: a model that can emit 64,000 gets
-  asked for 64,000, and one whose ceiling is below 16,384 stops being asked
-  for more than its provider will serve. An explicit `params.max_tokens` in
-  settings still wins, and a model the catalog has no ceiling for keeps the
-  previous default.
-
-  The symptom this fixes is truncation that looks like failure: a step that
-  spends its whole budget reasoning and is cut off before it can emit a tool
-  call does no work and reports nothing useful, and on a benchmark that is
-  scored identically to getting the answer wrong.
-
-- **`model_timeout` is 816s, up from 600s.** The old value assumed no
-  generation a caller still wants runs past ten minutes. At high effort
-  against a large output ceiling that is false — single steps producing
-  correct, complete work were measured at 624s and 756s, and a 600s bound
-  killed them after paying for them. Raising the output ceiling without this
-  only relocates the cliff, which is why earlier attempts to fix truncation
-  by raising the cap alone did not.
-
-### Fixed
-
-- **The benchmark adapter passes the turn deadline it is running under.** The
-  engine could already decline to start a length continuation it could not
-  finish, and end the turn with a truthful partial rather than being killed
-  mid-flight — but nothing told it the deadline, so the policy was inert in
-  the one place it was written for. The Harbor adapter now derives
-  `--turn-budget` per trial from Harbor's own agent timeout (via
-  `--agent-kwarg agent_timeout_sec=<seconds>`, the seam Harbor's Cline adapter
-  uses), holding back a fixed 60s so the turn ends as a result instead of a
-  kill. `STELLA_TURN_BUDGET` is accepted as a fallback and is now registered:
-  before this, exporting it did not enable the policy, it refused the run.
-
-## [0.6.62] — 2026-08-01
-
-## [0.6.61] — 2026-08-01
-
-## [0.6.60] — 2026-08-01
-
-## [0.6.59] — 2026-08-01
-
-## [0.6.58] — 2026-08-01
-- The four Context Graph Protocol crates (`contextgraph-types`,
-  `contextgraph-host`, `contextgraph-trace`, `contextgraph-conformance`) are now
-  ordinary crates.io dependencies at `=0.1.2`, declared once in the root
-  manifest, instead of git dependencies pinned by commit rev (#819). Building
-  stella from source no longer reaches out to the protocol repository, the
-  lockfile carries a checksum for each of them, and `cargo audit` / `cargo vet`
-  can see them — none of which was true of a git rev. `deny.toml`'s `allow-git`
-  exemption is removed, so the workspace now has no vetted git sources at all.
-
-## [0.6.57] — 2026-08-01
-
-## [0.6.56] — 2026-08-01
-
-## [0.6.55] — 2026-08-01
-
-## [0.6.54] — 2026-08-01
-
-## [0.6.53] — 2026-08-01
-
-## [0.6.52] — 2026-08-01
-
-## [0.6.51] — 2026-08-01
-
-## [0.6.50] — 2026-08-01
-
-## [0.6.49] — 2026-08-01
-
-## [0.6.48] — 2026-08-01
-
-## [0.6.47] — 2026-08-01
-
+- **The verdict is decided by a model that did not do the work.** Verifier
+  independence is enforced before the spend, not audited afterwards, and each
+  candidate records a `verifier_independent` fact so a run that could not get
+  an independent verifier says so instead of quietly grading itself (#1867).
+- **A pre-plan research stage.** Triage names the questions a task actually
+  turns on, and parallel read-only sub-agents answer them before the planner
+  writes anything — so the plan is built on what the repository says rather
+  than on the model's first guess (#1778).
+- **Parked waits: the agent can wait on the outside world without burning
+  model steps.** A run blocked on a CI job, a deploy, or a long build parks
+  instead of spinning, and wakes when the thing it was waiting for changes.
+  `TurnParked`/`TurnWoken` are typed wire events, and the deck draws the park
+  state rather than looking hung (#1471, #1857).
+- **Sub-agents.** The model can delegate with the `task` tool, with a pool
+  ceiling, cancellation that closes the bracket on its children, and spend that
+  settles on every exit path — panics included.
+- **`--accessible` runs the Command Deck itself under a screen reader.**
+  A mode on the real product, not a lesser surface beside it: every tab, gate,
+  key, sub-agent and resume is unchanged, the deck draws inline so completed
+  messages join normal scrollback exactly once, animation is frozen, and tab,
+  overlay and focus changes are announced (#1258).
+- **Diagnostics you can attach to a bug report.** A panicking or non-zero run
+  writes `.stella/private/crash-*.jsonl` (owner-only) and prints the path;
+  `stella doctor --last-failure` prints the newest. The record type physically
+  cannot hold a prompt, a path, or model output, so there is nothing in it to
+  review before sending. `-v`/`-vv`/`-vvv`, `--log-level <spec>` for per-crate
+  filtering, and `--log-file <path>` came with it.
+- **The Observatory grew a Sessions tab.** Session replay and inspection with
+  real per-turn git diffs, a prompt diff between turns, and the
+  self-improvement residue that `context.db` had been accumulating unseen
+  (#1870, #1871, #1876).
+- **`stella context` — kept rules become governed steering.** `keep`,
+  `promote`, `govern` and `validate`, with approvals written into a
+  hash-chained append-only ledger; a tampered ledger grants nothing.
 - **`/profile fast|balanced|pro|ultra` retunes every engine role from one
-  word.** The deck now has a posture command that picks a model *and* a
-  reasoning effort for the default, worker, judge, and triage roles at once,
-  choosing only from models your configured API keys can actually reach. Models
-  are ranked by list output price — the same capability proxy `auto_mode`
-  already uses — so the choice follows catalog refreshes instead of a hardcoded
-  table, and rows the catalog has no price for are excluded rather than read as
-  free.
-
-  Triage is held below the worker. The judge resolves two competing goals in
-  the order that gives up least: independent *and* at least as capable wins
-  outright; if nothing clears that bar, an independent model one rung down is
-  still preferred, because losing bias resistance over a single rung is
-  overcorrection; only past that does capability take over, and then the
-  confirmation reports that review is correlated with the work.
-
-  Effort is clamped to the rungs each provider actually exposes (Gemini stops
-  at `high`, Z.ai has no effort knob at all). Because clamping alone would
-  flatten the ladder — `fast` and `balanced` both reaching `low` on a two-rung
-  provider — the missing rung is bought back by preferring, *among models at
-  the same price*, one whose provider can express the requested level. It never
-  leaves the price band, so a profile cannot overspend its tier to buy a knob.
-
-  Applying a profile turns `effort_auto`, `reasoning_auto` and `auto_mode` off
-  so the levels it prints are the levels that run, and **`/profile auto`** is
-  the way back: it restores all three and drops the per-role pins. Custom
-  per-agent prompts, providers, temperatures, model pins and your
-  `allowed_models` list are left untouched throughout. Bare `/profile` shows
-  what is set and what each profile would choose right now.
-
-### Fixed
-
-- **`/model` no longer copies your project's settings into your user file.**
-  Setting the default model read the *merged* view of user + org + project
-  settings and saved the whole `agent_engine_config` block to user scope, so a
-  repo-local judge pin — or an org-managed effort ceiling — was promoted to a
-  machine-wide default that outlived the repo it came from. Both `/model` and
-  `/profile` now read the file they are about to rewrite, matching the rule
-  the tool switches already followed.
-
-- **A malformed settings file no longer costs you your engine config.** The
-  same edit path treated an unparseable file as an empty one, and then wrote
-  the whole block back — so a single key of the wrong type anywhere in
-  `settings.json` (`"enable_recap": true`, where a `Toggle` was expected)
-  silently discarded every model pin and per-agent prompt in it. A file that
-  exists but cannot be parsed is now a named error, and nothing is written.
-
-## [0.6.45] — 2026-08-01
-
-## [0.6.44] — 2026-08-01
-
-### Fixed
-
-- **A renamed witness test file now counts as tampering.** Witness artifact
-  identity used to be computed from whatever path the lookup happened to
-  reach, so a witness test renamed after sealing — but still reachable
-  through an aliased lookup — fingerprinted as the same file and kept its
-  verified standing. Identity now records the canonical location the artifact
-  was actually observed at inside the workspace, and the pinned-path equality
-  rejects a moved file as tampering. (#1077)
-
-## [0.6.43] — 2026-08-01
-
-### Changed
-
-- **Changelog entries are now drafted from the released diff.** A release
-  arriving with `[Unreleased]` empty gets its section written by
-  `scripts/changelog-ai.sh` from the diff it ships (same AI Gateway key and
-  model as the GitHub-release notes; degrade-open, hand-written entries
-  always win), and the 86 empty or missing version sections from 0.5.28
-  through 0.6.42 were reconstructed the same way. (#1076)
-- **`stella observe` wears brand kit v1.0 ("the comet").** The Observatory
-  dashboard moves to Phosphor Gold on Ink with JetBrains Mono, matching the
-  docs site's rebrand. (#1078)
-- **The docs site's front page centers on installing.** White sidebar, a
-  hero focused on the install command, and install paths that are actually
-  counted — the letter counters stay inside their glyphs. (#1074, #1075)
-
-### Fixed
-
-- **A locally-cut release's tag now points at a tree stamped with its own
-  version.** `scripts/release.sh` (the degraded, Actions-down release path)
-  reverted the version stamp before tagging, so `cargo install --git … --tag`
-  and any other from-tag source build produced a binary whose `--version`
-  reported the *previous* release — only the prebuilt tarballs were stamped
-  right. The script now cuts a release commit with `scripts/sync-versions.sh`
-  and tags that, exactly like `auto-tag.yml` (#822, #1072).
-
-## [0.6.42] — 2026-08-01
-
-### Changed
-
-- **The docs sidebar now mirrors the CLI's own help groups.** Navigation is
-  regrouped into five sections — Start / Do / Understand / Configure /
-  Reference, plus Project — and the command index adopts the six groups
-  `stella --help` prints, with summaries kept byte-identical to the CLI's.
-  No page URL changed. (#1070)
-
-## [0.6.41] — 2026-08-01
-
-### Changed
-
-- **The docs site was rebuilt on brand kit v1.0 ("the comet").**
-  stella.oxagen.sh moves from electric blue on deep space to Phosphor Gold
-  on Ink with a warm paper light mode, self-hosted JetBrains Mono as the
-  single typeface, and regenerated PWA icons, manifest, and social cards.
-  (#1063)
-
-## [0.6.40] — 2026-08-01
-
-### Fixed
-
-- **File changes made through the shell now reach the file ledger.** `bash`
-  commands like `make`, `patch`, or `echo > f` changed the tree without
-  appearing in the Files tab or the change events verification reads — in a
-  measured run, 71% of the agent's activity was invisible. Stella now
-  fingerprints the workspace around such calls and records what actually
-  changed, even when the command exits non-zero. (#1062)
-- **The judge can no longer end a run on its own word.** A model-judge
-  "done" now needs corroboration that is not another model's opinion — a
-  fail-to-pass flip or a test that ran green. Without it the turn is scored
-  UNVERIFIED, never failed. (#1062)
-
-## [0.6.39] — 2026-08-01
-
-### Added
-
-- **`stella serve` gains server-owned sessions with mid-turn controls.**
-  `POST /v1/sessions` creates a conversation the server keeps between turns
-  — one stable system prompt, shared history, and one budget that binds
-  across the whole session — and running turns can now be steered, paused,
-  and resumed through the API. An aborted turn leaves the session's history
-  exactly as it was. (#1056)
-- **`stella context promote` and `stella context govern`.** Promoting a
-  context rule to advisory or blocking now writes an approval — approver,
-  reason, and policy version — into a hash-chained, append-only ledger at
-  `.stella/rules/promotions.jsonl`. A tampered ledger grants nothing, and
-  `stella context validate` fails on it. `govern` shows or changes the
-  governance mode, including author/approver separation. (#1059)
-- **`stella calibration` reports the judge's measured false-positive
-  rate.** The new command replays the event journal, reconciles each
-  model-judge pass against the next CI verdict in the same session, and
-  prints the rate — reporting "unmeasured" rather than 0% when nothing has
-  been reconciled yet. (#1055)
-- **Trajectory trace capture behind the new `trace_capture` setting.** Off
-  by default; when on, every finished execution writes one training-ready
-  record — the exact model inputs, stages, tool activity, and cost, with
-  secrets redacted — to `.stella/private/traces.jsonl`. (#1057)
-
-### Changed
-
-- **Read-only no longer implies safe-to-run-twice.** Tool schemas carry a
-  new `speculation_safe` flag, and Stella only runs a tool ahead of time
-  when it is both read-only and marked safe — so web fetches, rate-limited
-  issue and CI reads, and MCP tools are never speculatively re-run on a
-  retry. (#1054)
-
-## [0.6.38] — 2026-08-01
-
-### Added
-
-- **A test that reacts to nothing no longer earns a fast pass.** Before
-  granting a deterministic pass on a test the agent wrote itself, Stella now
-  breaks the candidate's changed lines one at a time (up to three
-  single-line mutants) and requires the test to catch at least one. A test
-  that stays green under every mutant sends the decision to the judge
-  instead of ending the run. (#1052)
-
-## [0.6.37] — 2026-08-01
-
-### Fixed
-
-- **Colored tool output no longer leaks escape codes into the transcript.**
-  A colorized `cargo build` failure used to arrive as rows of `[0;32m`
-  residue that ate the transcript's line budget. ANSI color, hyperlink, and
-  charset sequences are now stripped once, when tool output is folded into
-  the transcript. (#1051)
-
-## [0.6.36] — 2026-08-01
+  word**, choosing only among models your configured keys can actually reach
+  and clamping effort to the rungs each provider really exposes.
+- **The code graph records call sites.** `callees <symbol>` lists the calls
+  inside a definition, `callers <symbol>` reverse-looks-them-up — structural,
+  so unlike a text search it never matches a comment or a string (#335).
 
 ### Changed
 
 - **A green test run only counts if it fixes the failure that was actually
-  failing.** Verification now parses test names from the runner's output; a
-  passing run whose complete test list no longer contains the baseline's
-  failing tests — the delete-the-failing-test trick — earns no verified
-  flip, and the refusal is recorded in the judge evidence. Output it cannot
-  parse falls back to the old exit-code behavior. (#1047)
-- **Candidate selection prefers the best-verified attempt, not just the
-  smallest.** When several candidates tie on verification rank, Stella now
-  picks the one that introduced the fewest new warnings before comparing
-  diff size. (#1047)
-
-## [0.6.35] — 2026-08-01
-
-### Added
-
-- **Terminal-Bench head-to-head results published on the docs site.** A new
-  benchmarks section reports Stella against Claude Code on the same 89
-  Terminal-Bench 2.1 tasks, same model, run concurrently on one machine:
-  Stella solved 58, Claude Code 44. Every task is on the page with per-run
-  cost, tokens, and timing, and the raw trial records ship alongside as
-  JSON. (#1037)
-
-## [0.6.34] — 2026-08-01
-
-### Added
-
-- **A fail-then-pass test flip is confirmed before it earns fast credit.**
-  When the tracked test suite flips from failing to passing, verification now
-  reruns it once just before fast-submit; a flip that does not reproduce is
-  demoted and escalates to the judge with `unstable_flip=true` instead of
-  passing deterministically. (#1033)
-- **New lint or type errors now veto a fast submit.** The pre-submit audit
-  runs the workspace's own diagnostics (cargo check, tsc, eslint, ruff) and
-  diffs against the pre-run baseline; a candidate that introduces new errors
-  goes to the judge with a three-line sample instead of submitting. Warnings
-  can join the veto via `diagnostics_veto_warnings`. (#1033)
-- **Every verdict now records why it was reached.** The ladder inputs are
-  frozen into the verdict at decision time — the oracle runs in order, flip
-  state, diff size, diagnostics delta, tamper check — and replay can render
-  exactly why a run fast-submitted, revised, or went to the judge. Judge
-  escalations carry a compact oracle trace so the judge sees why the ladder
-  was inconclusive. Older recordings report "not recorded" rather than
-  guessing. (#1035)
-
-### Changed
-
-- **A timed-out test run is infrastructure noise, not a verdict.** Command
-  outcomes are now typed (completed, timed out, infra): a timed-out baseline
-  no longer locks the oracle onto a phantom failure, and a timed-out candidate
-  suite escalates to the judge instead of burning a revision on infra noise.
-  (#1033)
-
-## [0.6.33] — 2026-07-31
-
-_Internal: new Frontier-Bench benchmark lane with its own pinned harness; no
-user-facing changes._
-
-## [0.6.32] — 2026-07-31
+  reported**, and a model judge's "done" needs corroboration that is not
+  another model's opinion — a fail→pass flip or a test that ran green. Without
+  it the turn is `UNVERIFIED`, never silently passed. A witness test that
+  survives every single-line mutant of the code it covers no longer earns a
+  fast pass either.
+- **Stella asks each model for what that model can actually emit.** The engine
+  carried one 16,384-token output cap for every model everywhere, even though
+  each model's real ceiling was already known and stored. The symptom was
+  truncation that looked like failure: a step that spends its budget reasoning
+  and is cut off before it can emit a tool call does no work. `model_timeout`
+  rose to 816s for the same reason — correct, complete single steps were
+  measured at 624s and 756s, and a 600s bound killed them after paying for them.
+- **Prompt caching actually engages on every provider that needs it.**
+  Anthropic's conversation-tail breakpoint no longer no-ops when the last block
+  is an image, a settings-defined provider pointed at OpenRouter now gets
+  OpenRouter's markers instead of running Claude with zero caching, Bedrock
+  recognises any Anthropic-vendored model id, and the cache TTL is configurable
+  — one hour for interactive work, five minutes for headless (#1839).
+- **Long turns cost less.** Tool results older than eight tool-bearing steps
+  are middle-out truncated during the turn rather than only near the context
+  ceiling, batched so the cache prefix is rewritten once per several steps.
+  On the measured head-to-head this growth pattern was the dominant share of a
+  6.4× input-token gap. `read_file`'s payload cap fell from 76% of the context
+  budget to 12% (#1285, #1842).
+- **`stella --help` is grouped by what a command is for**, and the docs sidebar
+  mirrors those groups.
 
 ### Fixed
 
-- **The model timeout now bounds silence, not how long an answer takes.** A
-  provider that streamed steadily past the deadline used to be killed
-  mid-answer and reported as a provider fault — routine for long reasoning
-  calls at high effort. The deadline now re-arms on every streamed fragment
-  and trips only when a full window passes with nothing arriving, so a
-  wedged, silent provider is still cut off exactly as before. (#1032)
+- **`delete_file` removes the symlink, not what it points at.** The resolver
+  canonicalized, so deleting an in-tree symlink silently destroyed the target
+  and left the link dangling — reported as an ordinary deletion.
+- **`apply_edits` no longer reverts a write that arrived from outside the
+  batch.** A failed mid-batch edit restored the bytes captured at validation
+  unconditionally, destroying whatever a formatter or watcher had done in
+  between while reporting a clean all-or-nothing abort.
+- **A planted `rg` config can no longer shorten what the agent sees.**
+  `RIPGREP_CONFIG_PATH` is scrubbed from tool subprocesses alongside the
+  `GIT_CONFIG_*` family; a `--max-count=1` in a config file used to truncate
+  the `grep` tool's answer, and the agent read the shortfall as fact.
+- **`Retry-After` is honoured in its HTTP-date form**, not only as
+  delta-seconds — which is the form the CDN-fronted deployments that actually
+  rate-limit tend to send, so the stated backoff was being dropped and the
+  retry landed back inside the window.
+- **File changes made through the shell reach the file ledger.** `make`,
+  `patch`, or `echo > f` changed the tree without appearing in the Files tab or
+  in the change events verification reads — in one measured run, 71% of the
+  agent's activity was invisible (#1062).
+- **A turn that called no tool can no longer report success**, and `stella run`
+  exits when the turn ends.
 
-## [0.6.31] — 2026-07-31
+### Removed
 
-### Fixed
+- **The `bash` sandbox is gone (#1300).** `STELLA_BASH_SANDBOX` is now inert:
+  read nowhere, so a stale value in a shell profile or CI job does nothing and
+  fails nothing. It confined the `bash` tool and nothing else — `build_project`,
+  `run_tests`, `verify_done`, `run_script`, `start_process`, the `git`/`gh`
+  invocations, custom tools and hook actions all spawned around it and always
+  ran unconfined. "Sandbox: on" read as a bound on the session while delivering
+  a bound on one tool, and a half-boundary people rely on is worse than a
+  clearly absent one. To get the real thing, run the whole `stella` process in a
+  container and mount only the repository it should touch; add `--network none`
+  for the equivalent of the old `restricted`.
 
-- **OpenRouter-style providers now get a reasoning-aware output ceiling.** The
-  shared Chat Completions adapter (OpenRouter, Z.ai, xAI, DeepSeek, local)
-  used to forward no output cap and let the provider's default decide, which
-  cut reasoning models off mid-thought with no tool call. With reasoning on it
-  now defaults to the same larger ceiling the Anthropic adapter picks; an
-  explicit cap is still honored verbatim, and requests with reasoning off are
-  byte-identical to before. (#1029)
+## [0.5.0] — 2026-07-23 → 2026-07-29
 
-## [0.6.30] — 2026-07-31
-
-_Internal: live side-by-side dashboard for two-arm benchmark runs; no
-user-facing changes._
-
-## [0.6.29] — 2026-07-31
-
-### Fixed
-
-- **Running out of output tokens mid-thought no longer ends the turn.** When a
-  reasoning model spent its whole output budget thinking and was cut off
-  before calling any tool, the engine treated the truncated text as a finished
-  answer. It now keeps the partial in context, nudges the model that the turn
-  is not over, and continues — up to twice per turn — so the model acts on its
-  own reasoning instead of handing in chain-of-thought as the result. (#1024)
-
-## [0.6.28] — 2026-07-31
-
-_Internal: benchmark harness fix so an empty budget means no cap; no
-user-facing changes._
-
-## [0.6.27] — 2026-07-31
-
-_Internal: benchmark harness preflight rejecting non-portable binaries before
-a run starts; no user-facing changes._
-
-## [0.6.26] — 2026-07-31
-
-### Fixed
-
-- **A turn that called no tool can no longer report success.** When every
-  evidence channel was dark, the verification ladder's abstain rung answered
-  `passed: true` — so a run that did nothing at all was reported as a pass.
-  A new `NothingAttempted` rung now counts the engine's own mutating tool
-  dispatches: zero dispatches means the turn fails and a revision is spent
-  telling the worker that describing the work is not doing it. Turns that
-  acted but left nothing observable still abstain exactly as before. (#1017)
-
-## [0.6.25] — 2026-07-31
-
-### Fixed
-
-- **`migrate config` no longer copies secrets into the committed file.** The
-  migration used to inline an API key from `.stella/settings.json` into the
-  repo-root `stella.toml` — a file meant to be committed — and the loader then
-  refused to start. It now refuses before writing, leaves nothing on disk,
-  names the JSON file the key lives in, and never echoes the secret. Private
-  user-scope keys still migrate as before, and `--dry-run` refuses the same
-  way the real run does. (#1010)
-
-## [0.6.24] — 2026-07-31
-
-_Internal: benchmark harness gained a witness-author arm and tier disclosure; no
-user-facing changes._
-
-## [0.6.23] — 2026-07-30
+The context and memory line. Recall became accountable, memories learned what
+they were about, and verification stopped paying for work it did not need.
 
 ### Added
 
-- **MCP servers show who they are, and ctrl+o opens an inspector.** A
-  configured server used to render only as its config alias ("mcp" — even
-  for a Stripe server). The tab now shows title, description, and endpoint
-  drawn from the install card and the live handshake, with a full detail
-  view on ctrl+o. (#1006)
-
-### Changed
-
-- **SETTINGS navigates like AGENTS.** Instead of two half-width editors that
-  truncated their content at ordinary widths, ←/→ switches between
-  full-width AGENTS and TOOLS panes, and `e` edits whichever pane you are
-  on. (#1004)
-
-### Fixed
-
-- **`stella serve`: a failed write is a disconnect, not a dead turn.** When
-  a client's connection dropped mid-stream the whole turn was torn down, so
-  a reconnect got "unknown turn"; the turn now survives and the reconnect
-  replays the frames it missed. (#1005)
-
-## [0.6.22] — 2026-07-30
-
-### Changed
-
-- **The SETTINGS tab navigates like the AGENTS tab.** It used to draw both
-  config editors side by side, splitting the terminal in half: on any ordinary
-  width the agents editor truncated its values (`allowed_models` ended in an
-  ellipsis after two entries) and the tools editor truncated the reason a tool
-  was switched off — and the tab read as two things at once. The two editors
-  are now the two panes of a secondary nav, **AGENTS | TOOLS**, walked with
-  **←/→** exactly like EXECUTIONS | INSTALLED AGENTS. One pane is on screen at
-  a time and it fills the tab. **`e` edits whichever pane you are on**; the
-  editor it opens is unchanged, down to the last key, and its Esc still hands
-  the keyboard back. `t` still jumps straight to the tool switches from either
-  pane. Because a focused editor owns the keyboard, ←/→ can only move the nav
-  from browse state — never out from under an open edit.
-
-## [0.6.21] — 2026-07-30
-
-### Added
-
-- **`stella config` prints the wiring for all four engine roles.** It used
-  to report only the session's own model; it now shows driver, worker,
-  judge, and triage — provider, model, effort, thinking — plus the exact
-  settings key that decided each, so "I changed the key and nothing
-  happened" becomes visible instead of mysterious. (#997)
-
-### Changed
-
-- **`stella --help` is grouped by what a command is for.** The front page
-  used to open with fifteen lines of internal notes and 33 paragraph-length
-  summaries; it now opens with the usage line and a one-line-per-command
-  index under six purpose headings. (#999)
-
-## [0.6.20] — 2026-07-30
-
-_Internal: docs pages for arena/telemetry commands plus lockfile sync; no
-user-facing changes._
-
-## [0.6.19] — 2026-07-30
-
-### Added
-
-- **`stella serve` streams are resumable, and the wire format is published.**
-  A client that loses its SSE connection mid-turn can reconnect and replay
-  the frames it missed; the event format now ships as committed JSON Schema
-  and TypeScript definitions kept in lockstep with the code. (#987)
-
-### Fixed
-
-- **A prompt typed right after "done" stays in this conversation.** The deck
-  painted "done" before the turn had fully settled, so a follow-up typed in
-  that window spawned a separate agent that could not see the conversation.
-  Pasting a screenshot at a text-only model also no longer kills the turn.
-  (#986)
-- **Cancelling a turn stops its sub-agents — and still counts their spend.**
-  Children of a cancelled parent used to keep running unnoticed. Worker
-  lanes and fleet workers also advertised the `task` tool while always
-  refusing it; delegation now works there. (#988)
-
-## [0.6.18] — 2026-07-30
-
-### Added
-
-- **Sub-agents: the model can delegate with the new `task` tool.** A child
-  turn runs with a budget carved from the parent's real headroom, a capped
-  report size, and a recursion limit; its spend moves the HUD and can abort
-  the parent at the next step boundary. Pause and stop reach the children
-  too, so Esc no longer ends the parent while its children keep spending.
-  (#976, #983, #984)
-- **`stella inspect --diff` shows what the context engine actually added.**
-  Instead of re-reading a full reconstructed prompt, you get a unified diff
-  of a step against the previous call, the first call of the session, or
-  your prompt exactly as submitted. (#982)
-
-### Changed
-
-- **Startup notices are a transient dialog, not transcript rows.** Trust
-  warnings and code-graph progress no longer land in the transcript looking
-  like the agent said them; a formatted dialog shows them and dismisses on
-  any key or on its own after 3 seconds. (#979)
-
-### Fixed
-
-- **The verifier abstains when it cannot see, instead of failing you.** When
-  its evidence channels went dark it reported "the file likely does not
-  exist" about files that were there; it now says it could not verify, and
-  the file-change count it reads matches what the recorder counted. (#981)
-
-### Security
-
-- **A repository's rule file can no longer disarm your guards.** A cloned
-  repo could ship a record reusing the lineage id of your user-level hard
-  guard and silently replace it, or self-attest its way to an armed deny.
-  User-tier guards now stay armed, and your approvals no longer transfer to
-  whatever record later claims that lineage. (#978)
-
-## [0.6.17] — 2026-07-30
-
-### Fixed
-
-- **Receipts count tokens one way, and old runs are corrected to match.** A
-  context block's `token_cost` was counted in characters while the same
-  receipt's `estimated_input_tokens` was counted in UTF-8 bytes, so a single
-  receipt held two numbers for the same content that only agreed for ASCII. If
-  you work in Japanese, Chinese, or any script that is not one byte per
-  character — or your tool output contains emoji — a manifest's summed
-  `token_cost` read up to 4x below the step it belonged to, and the size of the
-  error depended on your language. Both numbers now come from one shared
-  function counting UTF-8 bytes, the unit the Context Graph Protocol already
-  specifies. Opening a workspace migrates its store (schema v19): every block
-  already recorded is **recounted from its own preimage**, so past runs are
-  corrected rather than reinterpreted, and `stella inspect` needs no knowledge
-  that the old rule ever existed. Blocks whose preimage the store no longer
-  holds — the reconstruction gaps `stella inspect` already declines to vouch
-  for — record no cost at all rather than keeping a number in the retired unit.
-  The compiled frame's schema version moves to `1.1` accordingly, so frame
-  hashes minted under the two rules cannot collide. ([#925])
-
-[#925]: https://github.com/macanderson/stella/issues/925
-
-## [0.6.16] — 2026-07-30
-
-_Internal: dependabot bump of a CodeQL CI action; no
-user-facing changes._
-
-## [0.6.15] — 2026-07-30
-
-### Fixed
-
-- **`stella run` exits when the turn ends.** Registry-held clones of the
-  event channel kept it open, so the process printed its final answer and
-  then hung instead of returning to the shell. (#970)
-
-## [0.6.14] — 2026-07-30
-
-### Added
-
-- **The `stella context` suite: kept rules become governed steering.**
-  Proposals extracted by `stella ingest` can now be reviewed (`context
-  review`), decided (`keep`/`edit`/`ignore`), listed, explained (`context
-  explain <handle>`), and turned into a PR (`context propose`); kept records
-  render into the prompt, and a record whose truth probe is refuted stops
-  steering. Works offline end to end, no API key. (#957)
-
-### Fixed
-
-- **Mid-turn steering reaches every best-of-N candidate.** Typed guidance
-  used to be consumed by candidate 1 alone, so when the judge picked a
-  different candidate your words were missing from the winning transcript.
-  Every candidate now sees every steer, and the fan-out is narrated live
-  ("candidate 2/3 won"). (#959)
-
-## [0.6.13] — 2026-07-30
-
-### Added
-
-- **An OpenRouter key now sets up a whole default posture.** Instances with
-  an OpenRouter key default to Kimi K3 at `xhigh` effort as the driver, Opus
-  5 as judge, and GLM 5.2 as triage — layered underneath your settings, so
-  anything you set yourself still wins. OpenRouter's `xhigh`/`max` effort
-  levels also stopped being silently downgraded to `high`. (#952)
-- **`stella context validate` re-checks kept rules against the tree.** It
-  re-runs each context record's truth probe on demand and reports which
-  claims went stale (CLAUDE.md says Node 20, `.nvmrc` moved to 22);
-  `--strict` exits non-zero so a stale rule can fail CI. (#947)
-
-### Changed
-
-- **No single keystroke approves a plan anymore.** On the plan scope card,
-  `a`/`t`/`x` committed on the first letter typed into an empty composer, so
-  a note starting "also do X" silently approved the plan. Every answer is now
-  typed and sent with Enter, and Esc closes the card even mid-note. (#951)
-
-### Fixed
-
-- **The SELF-IMPROVE tab shows self-reviews and learned skills.** Self
-  ratings were never produced (the only writer hardcoded them to null), and
-  the learned-skills counter watched a directory nothing writes to — both
-  panels could only ever show zero or a dash. (#945)
-
-## [0.6.12] — 2026-07-30
-
-### Changed
-
-- **Memory only records what a fresh look at the repo would not reveal.** The
-  reflection prompt used to invite facts like file locations and module names
-  — cheaper to grep than to carry. It now asks what surprised the agent,
-  names the worthless categories, and makes "nothing worth keeping" a valid
-  answer. (#944)
-
-### Fixed
-
-- **Restated lessons no longer pile up.** Paraphrases of a fact the store
-  already held were kept without limit — one live store held 23 memories for
-  six distinct facts — crowding other lessons out of the recall budget.
-  Near-duplicates are now collapsed before they are written. (#944)
-
-## [0.6.11] — 2026-07-30
-
-### Added
-
-- **`stella observe` now updates live and survives crashes.** Tool calls used
-  to appear only after a turn finished, and were lost forever if the process
-  died mid-turn. Counts now land as each event is written, unfinished turns
-  are repaired on the next open, and the dashboard streams changes over an
-  SSE endpoint (`/api/v1/live`) at ~250 ms latency instead of polling every
-  5 seconds. (#908)
-
-### Changed
-
-- **One visual identity across every surface.** The terminal palette, docs
-  site, and Observatory dashboard now share the electric blue + gold scheme
-  from a single normative brand spec; the vermilion cursor, terminal-green
-  theme, and the launch cinematic are retired. (#912, #937)
-
-### Fixed
-
-- **Multi-line edits on CRLF files work now.** `read_file` stripped `\r` from
-  what it showed the model, so a needle copied from that render never matched
-  the file on disk and the error blamed whitespace. `glob` and `grep` also
-  stopped silently skipping dotfiles like `.github/`. (#937)
-- **The Files tab now shows `apply_edits` batch edits.** Batch edits emitted
-  no file-change events, so any turn that used the recommended batch tool
-  showed an empty Files tab and no inline diffs. (#846)
-- **`stella inspect` prints tool results as readable text.** Results were
-  serialized as escaped JSON — file contents and command output became one
-  long line of `\n` and `\"` — and are now printed directly, with errors
-  prefixed `error:`.
-
-## [0.6.10] — 2026-07-30
-
-### Added
-
-- **Witness tests that could not have failed meaningfully are rejected.** A
-  witness with no assertions, one asserting only over constants, or a bare
-  `#[should_panic]` is refused at authoring time with a named reason, so the
-  author revises immediately instead of a vacuous test flipping the verdict
-  green. (#906)
-
-### Fixed
-
-- **Typing at a scope review card answers the review instead of spawning a
-  side agent.** A typed reply like "ok" used to become a parallel session
-  while the review sat unanswered, and Esc then aborted the turn. A pending
-  gate now owns the next submission, with plain words mapped to approve,
-  trim, or abort — in both the deck and the single-session REPL. (#907)
-- **`/files` and the diff pane no longer show `+0 -0` for edited files.**
-  File-change events now come from the one recorder that measures the real
-  before/after diff, so bulk edits via `apply_edits` and changes made in
-  worker lanes are counted instead of being invisible or zeroed. (#903)
-
-## [0.6.9] — 2026-07-30
-
-### Added
-
-- **A live PROOF rail shows verification beside the work.** A pinned card
-  under the transcript tracks warrant, witness, oracle, tamper, and verdict
-  while the turn runs, and every row resolves on every path — a waived
-  witness, an aborted turn, or a run that never reached verification says so
-  explicitly instead of hanging on "pending". (#880, #901)
-- **Custom commands can be written in TOML, with Claude Code parity.**
-  `.stella/commands/*.toml` loads beside markdown, both formats honor
-  `argument-hint`, `allowed-tools`, `model`, `disable-model-invocation`, and
-  `$1`–`$9` positional arguments, subdirectories become `/namespace:name`
-  commands, and `stella commands convert` translates markdown to TOML. (#882)
-- **`stella ingest <doc>` now actually extracts documents.** It used to print
-  a placeholder; a markdown file is now split into atomic claims, each
-  written as a reviewable proposal under `.stella/proposals/` — never
-  published directly, with embedded commands quarantined and command or
-  network probes refused for imported content. (#881)
-- **A mid-turn prompt announces the agent it became.** Typing while a turn is
-  running spawns a parallel `req:<n>` worker, but the transcript used to say
-  nothing about it. Each spawn now prints a notice naming the lane, echoing
-  the prompt, confirming the lead turn keeps running, and explaining how to
-  navigate to it and back. (#898)
-
-## [0.6.8] — 2026-07-30
-
-### Fixed
-
-- The transcript no longer eats underscores in identifiers. `tool_use_id`
-  rendered as "tooluseid" with an italic "use", because the markdown renderer
-  accepted `_` as an emphasis delimiter mid-word — so every `snake_case` field
-  and API property name in an agent's prose was silently rewritten. `_` now
-  only delimits emphasis on a word boundary (CommonMark's intraword rule), and
-  `__` is always literal so `__init__` and `__all__` survive too. `_emphasis_`
-  and `**bold**` are unchanged.
-
-## [0.6.7] — 2026-07-30
-
-### Fixed
-
-- **A diff probe that fails can no longer pass verification as "nothing
-  changed".** When the machinery could not read the working tree — for
-  example a candidate outside a git repository — the empty diff used to
-  self-certify a passing "no behavior changed" verdict with no witness test.
-  A failed probe is now treated as a failure and escalates to review. (#857)
-
-## [0.6.6] — 2026-07-30
-
-### Added
-
-- **`stella-serve` answers `--version` and `--help`.** Both used to exit with
-  "unknown argument", so a host embedding the server could not record which
-  release it verified its wire contract against. `--help` also documents
-  every `STELLA_SERVE_*` environment variable the binary reads. (#856)
-
-## [0.6.5] — 2026-07-29
-
-### Fixed
-
-- **Creating an agent or skill from a prompt now reports what it made.** The
-  create dialog used to close the instant it dispatched, leaving no sign the
-  draft was running, finished, or failed. It now shows a spinner while the
-  draft runs, opens the new definition's detail view on success, and shows
-  the error on failure; Esc hides the dialog without losing the run. (#854)
-
-## [0.6.4] — 2026-07-29
-
-### Changed
-
-- **A collapsed live thought follows its newest text instead of freezing on
-  its first line.** While the model is still thinking, the preview window
-  tracks the tail of the thought; once it settles, it reverts to showing the
-  head. The preview is also budgeted in screen rows, so one long wrapped
-  paragraph no longer fills the pane. (#851)
-
-## [0.6.3] — 2026-07-29
-
-### Added
-
-- **The ultra-audit skill now ships in the repo.** Previously a machine-local
-  skill, it lives at `.stella/skills/ultra-audit/` and is renamed from
-  `/ultraudit` to `/ultra-audit`. Audit score history keeps its old keys, so
-  past and future audit rounds stay comparable. (#850)
-
-## [0.6.2] — 2026-07-29
-
-### Added
-
-- **New `stella tune` command A/B tests the worker effort setting.** `stella
-  tune effort` compares a baseline and a candidate loop-bench run and reports
-  which effort level won; with `--promote` it writes the winner to settings
-  only on a statistically confident win. `stella tune rollback` reverts the
-  last promotion exactly, and `stella tune status` shows the ledger. (#848)
-
-## [0.6.1] — 2026-07-29
-
-### Added
-
-- **Stella now notices repeated shell patterns and proposes a tool for
-  them.** When the same command shape keeps being rebuilt by hand with
-  different values, a suggestion with a parameterized command template
-  appears in `/inbox`, at most once per shape. It is a proposal only —
-  nothing is authored or installed. (#845)
-
-## [0.6.0] — 2026-07-29
-
-_Internal: minor-version cut vehicle isolating flaky grep temp-dir tests; no
-user-facing changes._
-
-## [0.5.77] — 2026-07-29
-
-### Added
-
-- **New `/theme` command switches the deck between light and dark.** Two
-  themes ship — `stella-dark` (terminal green on black, the default) and
-  `stella-light` (ember red-orange on paper white). The switch applies on the
-  next frame and persists to `ui.theme` in user settings, so the deck starts
-  already themed. (#839)
-
-### Changed
-
-- **The deck's accent color is now terminal green instead of sky blue.**
-  Orange is retired from the dark theme: code spans render in a calm sage and
-  warnings in amber. Light mode also fills the base foreground, so prose
-  renders as ink on paper instead of relying on the terminal's default. (#839)
-
-## [0.5.76] — 2026-07-29
-
-### Added
-
-- **`/model` slash command.** Set the persisted default model straight from
-  the prompt: `/model` shows the saved default, the live session model, and
-  the pickable list; `/model <provider/slug>` validates the spec and saves
-  it, with the same semantics as the SETTINGS tab. (#829)
-- **The prompt animates while a turn is in flight.** The `>>>` chevrons chase
-  left to right while the agent is working and sit still when idle or under
-  `--no-anim`. (#829)
-
-### Fixed
-
-- **New lessons no longer vanish once the memory ledger grows.** Standings,
-  retirements, decisions, and observation mining read the oldest 5,000 ledger
-  rows, so past that bound every new promotion, retirement, or lesson was
-  invisible forever; the folds now read the newest window. (#838)
-
-### Security
-
-- **Session exports redact secrets.** `stella export` wrote prompts, tool
-  arguments, and touched-file telemetry verbatim into the ZIP and dashboard,
-  so a key that ever reached telemetry left the machine in plaintext; every
-  string value is now passed through secret redaction before export. (#840)
-
-## [0.5.75] — 2026-07-29
-
-### Fixed
-
-- **Provider 5xx responses are retried instead of failing the turn.** A
-  server-side error from the model provider used to be a hard failure; it is
-  now treated as a transport error eligible for retry. (#815)
-- **Code fences and wide characters render correctly in the TUI.** Fenced
-  code blocks now follow CommonMark fence-length and closing rules (nested
-  fences render right), and double-width glyphs no longer overflow
-  fixed-width layouts. (#815)
-- **Cancelled tool subprocesses are actually killed.** Kill-on-drop is now
-  propagated through process execution, so cancelling a run no longer leaks
-  child processes. (#815)
-
-## [0.5.74] — 2026-07-29
-
-### Fixed
-
-- **`!` shell commands show their output in the transcript.** Typing `! pwd`
-  ran the command but sent the output to a hidden lane the screen never
-  draws, so it looked like nothing happened. Output now appears inline in the
-  focused transcript, and a `!` command no longer flips an idle agent's
-  status or counters. (#814)
-
-## [0.5.73] — 2026-07-28
-
-### Added
-
-- **The context graph resolves Rust `use` paths to files.** Asking
-  `graph_query` for a Rust file's importers now returns the real dependent
-  set instead of a canned apology, and `run_tests` with scope "impacted"
-  narrows a Rust change to the owning crates (`cargo test -p ...`) instead of
-  loudly running the full suite. (#810)
-
-### Changed
-
-- **`apply_edits` batches pass the storage gate instead of being refused.**
-  The gate used to blanket-refuse schema files inside a batch; it now
-  simulates each touched file with the batch's composed edits and judges
-  exactly the bytes that would be written, so legitimate multi-hunk schema
-  work keeps the transactional path. (#810)
-
-## [0.5.72] — 2026-07-28
-
-### Added
-
-- **New `stella scoreboard` command.** Shows what each unit of work cost and
-  whether anyone said it was good: model calls, characters you typed,
-  follow-ups and interrupts, plus the verdict a merged or closed pull request
-  implies. Unrated work is counted but never averaged in as good. Reads local
-  state only; no model judges anything. (#811)
-
-## [0.5.71] — 2026-07-28
-
-_Internal: contributor dev-env scripts de-branded and renamed; agent wiring
-made opt-in; no user-facing changes._
-
-## [0.5.70] — 2026-07-28
-
-### Added
-
-- **New `stella ingest` command.** Scans workspace markdown (AGENTS.md,
-  CLAUDE.md, or any file you name) and tiers it for turning into steering
-  records: offer by default, offer with a look, find but don't offer, or
-  skip. Superseded and retired docs are surfaced but never offered as live
-  guidance. Local files only; no API key needed. (#805)
-
-### Fixed
-
-- **Git chatter on stderr no longer corrupts parsed values.** Branch names
-  and status were read from a merged stdout+stderr stream, so an advice hint
-  or GIT_TRACE line could turn a push into "fatal: invalid refspec". The
-  parsing reads now use stdout alone; displayed output keeps both streams.
-  (#801)
-- **A malformed zai stream frame can no longer pass as a successful empty
-  turn.** The decoder dropped any frame it could not parse, which ended the
-  turn as if the model had nothing left to do. A type-mismatched frame now
-  fails loudly, and frames with a missing tool-call index or an explicit
-  null tool_calls are tolerated instead of dropped. (#802)
-
-## [0.5.69] — 2026-07-28
-
-### Added
-
-- **Opt-in cloud telemetry sync.** `stella cloud sync` drains usage telemetry
-  over HTTPS to a configured hub, a status view reports the drain state, and
-  logout deregisters the machine. Nothing is sent unless a hub is configured.
-  (#800)
-
-### Changed
-
-- **Memories whose file anchors vanished retire themselves.** Validation now
-  detects a memory whose anchor files are gone and retires it without waiting
-  for a human ruling; validate reports the status as `anchors-missing`. (#800)
-- **Recalled context and tool output are bounded.** Recalled frames cap at
-  4k characters each and 20k total with visible truncation markers,
-  `web_fetch` output clamps at 120k instead of 400k, and clipboard pastes are
-  written private (0600) and pruned to the newest 100. (#800)
-
-### Security
-
-- **Command approval now covers every command-composing tool.** run_lint,
-  format_code, diagnostics, the repo_* family, screenshot, ci_status, and
-  start_work_on_issue used to run without passing the `command.started` gate;
-  each now reports the exact line it would run, and a `run_script`
-  approve-then-swap race is closed. (#800)
-
-## [0.5.68] — 2026-07-28
-
-_Internal: contributor worktree environment scripts plus demo-video and docs
-refresh; no user-facing changes._
-
-## [0.5.67] — 2026-07-28
-
-_Internal: tag-only release; no commits between the two tags; no
-user-facing changes._
-
-## [0.5.66] — 2026-07-28
-
-### Fixed
-
-- **A "just chat" misread no longer swallows real work.** Requests like
-  "organize my documents folder" were classified as small talk and answered
-  with a tool-less reply that reported the task complete having done nothing.
-  Any message asking to explore, organize, rename, or sort files now enters
-  the work pipeline. (#794)
-- **`stella serve` can no longer deadlock or cancel a live turn during
-  cleanup.** Reclaiming abandoned turns took locks in an order nothing
-  enforced, and a turn-id collision silently replaced — and cancelled — a
-  turn still in use. Reclamation now skips contended entries, and a colliding
-  registration is refused instead of overwriting. (#793)
-
-## [0.5.65] — 2026-07-28
-
-### Added
-
-- **Claude extended thinking works on Bedrock.** The Bedrock adapter now
-  passes the thinking switch and budget through Converse's model-specific
-  passthrough field, so a reasoning budget set on a Claude-on-Bedrock model
-  actually reaches it; with reasoning off the request body is unchanged.
-  (#780)
-
-### Changed
-
-- **The default look is now electric blue on jet black.** Navy-tinted
-  surfaces and the last gold accent are retired everywhere — TUI palette and
-  theme, splash and init cinematics, the HTML session export, and the
-  observatory dashboard. The `/color` default is `electric`; `sky`, `azure`,
-  and `cyan` still resolve as aliases. (#780)
-
-### Fixed
-
-- **The serve live-turn cap is no longer a one-way latch.** A turn that
-  finished but was never streamed held its slot forever, so a busy host
-  drifted toward answering everything with `429`. Finished-but-unstreamed
-  turns are now reclaimed under pressure, and the two colliding rewrites of
-  the serve and observatory code are reconciled so both keep working. (#790)
-
-## [0.5.64] — 2026-07-28
-
-_Internal: CI workflow now runs every gate despite earlier failures; no
-user-facing changes._
-
-## [0.5.63] — 2026-07-28
-
-_Internal: demo-recording scripts, a CI workflow, and a demo video; no
-user-facing changes._
-
-## [0.5.62] — 2026-07-28
-
-### Changed
-
-- **`stella serve` now bounds what one host will absorb.** At most 32 live
-  turns — the 33rd gets `429` with `Retry-After: 5` — a 30-second read
-  timeout on requests, and a 64 KiB header / 8 MiB body cap. An oversized or
-  malformed request now gets a clear `413`/`400`/`408` instead of silently
-  parking the engine step it would have answered. (#779)
-
-### Security
-
-- **Serve turn ids are no longer guessable.** Ids were sequential (`turn-0`,
-  `turn-1`, …), so a single id leaked in a log or proxy trace made every
-  other live turn addressable. Turn ids are now 128 random bits. (#779)
-
-## [0.5.61] — 2026-07-27
-
-### Added
-
-- **Memories anchor to the files they are about — and a deleted file ends the
-  anchor.** Reflection now records which files a lesson concerns, and `stella
-  memory validate` reports anchors pointing at files that no longer exist;
-  `--end-stale` marks them as no longer holding, so recall stops surfacing
-  memories about files that are gone. History is kept: the memory was true,
-  then the world changed. (#777)
-
-## [0.5.60] — 2026-07-27
-
-- `--model` now actually pins the model on the pipeline path. A configured
-  `pipeline_worker_model` (or `agents.worker.*`) used to be applied on top of
-  the flag, so `stella --model z-ai/glm-4.7-flash run "…"` silently executed —
-  and billed for — whatever the settings file named instead. The flag now
-  outranks those settings for the worker role, and when it suppresses one the
-  run says so on stderr rather than dropping it silently. An explicitly
-  configured **judge or triage** is unchanged: `--model` says nothing about
-  those roles, so cross-family setups keep working.
-- The `--output-format json` envelope's `model` key now reports the model that
-  **actually ran** the worker turns, not the one that was requested. When those
-  differed, the envelope named a model that never ran a turn and never billed a
-  cent while `cost_usd` sat right beside it — backwards for the spend
-  attribution the key exists to serve. The text cost summary and the
-  `stream-json` terminal `Complete` frame carried the same stale value and are
-  fixed with it.
-- Short work costs less. A greeting no longer pays for a triage model call: the
-  conversational route was always resolved deterministically, but the paid
-  classification went out first and could not change the answer. `hi` now costs
-  one model call instead of two, and can no longer stall behind a wedged triage
-  provider.
-- A change with nothing to prove no longer buys a review call to be told so.
-  Verification now reads the **diff** — docs-only, tests-only, config-only,
-  comments-only, or a pure removal completes with a **stated reason** recorded
-  on the verdict, rather than escalating because no test flipped. Anything
-  mixed or unreadable still buys the test. Removals and test-only changes keep
-  their independent reviewer, because deleting the wrong thing is a mistake a
-  reader catches and no test would have. Design:
-  `docs/spec/witness-protocol.md` §7.
-- Verification cost is now fully demand-driven: a change with nothing to prove
-  no longer pays for a **witness test** either. Authoring runs after execution
-  and only when the diff warrants it, so a docs or comment edit dispatches no
-  author call at all — previously it bought one before any work existed, then
-  discovered the change was prose. The author still never sees the
-  implementation (it works in a pristine pre-execution snapshot), so a witness
-  proves the same thing it always did. A witness that cannot be produced now
-  leaves the completed work alone instead of discarding the candidate and
-  re-running the task. Design: `docs/spec/witness-protocol.md` §7.3.
-
-- The pipeline no longer replays raw test-runner output into a worker's
-  revision prompt. A deterministic verification failure is now disclosed
-  through a **feedback airlock** at one of four grains (`L0`–`L3`), tightening
-  automatically when the same failure repeats, and model-authored text coming
-  back inbound (distress guidance, judge reasoning) is scrubbed against the
-  sealed material before it can reach the worker. Operator-facing output is
-  unchanged — `stella` still shows you the real failure; only the model's
-  prompt is redacted. Design: `docs/spec/witness-protocol.md`.
-
-## [0.5.59] — 2026-07-27
-
-### Added
-
-- **Verification failures now cross a feedback airlock before reaching the
-  worker.** The raw test-runner tail — exact assertions, runtime values, the
-  failing test's identity — used to be replayed into every revision prompt,
-  making special-casing cheaper than fixing. The worker now gets a redacted
-  brief that steps down in detail as the same failure repeats; the operator's
-  verdict keeps the full runner output. (#765)
-
-### Changed
-
-- **A witness test is only written when the diff warrants one.** Authoring
-  moved after execution and behind the warrant, so a change with nothing to
-  prove — a docs edit, say — no longer pays a model turn to write a test.
-  The author still sees the pre-execution tree, so the test cannot simply
-  restate the implementation. (#770)
-- **Reflection learns your codebase, not itself.** The old prompts asked what
-  the agent should do differently and reliably got self-critique back — 8 of
-  10 stored memories were about the agent. Both prompts now lead with what
-  was learned about the codebase, success counts as a learning signal, and
-  domain facts are ranked apart from process notes at recall. (#768)
-
-### Fixed
-
-- **The adaptive-context lifecycle no longer runs to nothing on headless or
-  untrusted workspaces.** A workspace without project trust skipped all
-  learning, not just skill-file writes; lesson parsing broke on models that
-  narrate before answering, recording zero lessons; and an unreadable
-  reflection looked identical to "nothing to learn". All three are fixed, and
-  the reflection output cap rises from 512 to 2048 tokens. (#766)
-- **`--model` now outranks `pipeline_worker_model`.** The config file's
-  worker model silently overrode the flag, while the JSON envelope reported
-  the model you asked for rather than the one that ran and billed. The flag
-  now wins, the run says what it suppressed, and the envelope reports what
-  actually ran. (#769)
-
-## [0.5.58] — 2026-07-27
-
-### Added
-
-- **`stella doctor` gained a fleet-ledger check.** It now reports rows in
-  `fleet.db` that name a run no longer on record. Report-only by design:
-  `--repair` will not delete fleet history. (#764)
-
-### Fixed
-
-- **Concurrent workspace opens no longer collide.** Several `stella`
-  processes hitting one fresh workspace could fail with "database is locked"
-  or a UNIQUE-constraint error; four races on the store-open path are closed,
-  and five parallel `stella init` runs now all succeed. (#764)
-- **The docs and the system prompt stopped claiming bash is opt-in.** The
-  shell and key-free web tools have been registered by default for several
-  releases, but the README, the threat model, and the prompt the model reads
-  every turn still said the opposite; all now describe the real tool surface.
-  (#764)
-
-## [0.5.57] — 2026-07-27
-
-### Added
-
-- **Dropped MCP tools are now visible.** A server advertising more than 256
-  tools silently lost everything past the cap, and a missing tool looks
-  exactly like one the model chose not to call. The deck's MCP tab now shows
-  `N dropped past cap` per server plus a session total in the tab title, and
-  text mode prints the same notice. (#760)
-
-## [0.5.56] — 2026-07-27
-
-### Changed
-
-- **The transcript is now bright sky on true black.** Gold on navy is gone;
-  the accent is spent on exactly one thing — the name of the tool being
-  called — stage markers render as section rules instead of one-word rows,
-  and system notes split into loud (errors, gates, questions) and quiet
-  (bookkeeping). (#752)
-- **Cost prints once per turn.** The budget gauge used to print a fresh spend
-  row after every model call, and the figure was a session running total, not
-  the turn's cost. The live turn cost now updates in place under the
-  composer, and the settled cost lands once at completion with the model that
-  ran. (#752)
-
-### Fixed
-
-- **The SESSION tab no longer renders raw ANSI color codes.** Its HUD and
-  scope card carried 312 cells of literal cyan escape codes, and the
-  scope-review card — the one card that halts the session — was bordered in
-  the brand color like decoration; it is now warning-colored. (#752)
-
-## [0.5.55] — 2026-07-27
-
-### Added
-
-- **Chain-of-thought now streams into the transcript.** An earlier fix
-  stopped reasoning from being pasted into the answer text, which also meant
-  thinking on tool-calling turns was dropped entirely. It now streams on its
-  own dimmed channel, collapsed to a one-line live tail, with `ctrl+r` to
-  expand — for OpenRouter/GLM reasoning and for direct-Anthropic thinking
-  deltas, which were previously discarded. (#756)
-
-## [0.5.54] — 2026-07-27
-
-### Added
-
-- **Memories that stop helping are now retired — reversibly.** Each turn's
-  recalled context is recorded together with whether it was actually cited
-  and helped, and a memory that repeatedly fails drops out of automatic
-  selection with its reasons on record. New commands `stella memory retired`,
-  `stella memory retire <id> --reason`, and `stella memory reaffirm <id>`
-  list, retire, and restore them — nothing is ever deleted. (#751)
-
-## [0.5.53] — 2026-07-27
-
-### Fixed
-
-- **Large plans no longer dead-end the Command Deck.** Scope review ran
-  headless inside the deck, so any plan past the thresholds (over 5 steps, 8
-  files, or $1.00) aborted with advice naming a setting the deck never reads.
-  The approval card now actually raises: approve, trim to the largest safe
-  prefix, or cancel, and the turn waits for your answer. (#750)
-- **Chain-of-thought no longer replaces the answer on OpenRouter.** Anthropic
-  models routed through OpenRouter stream empty content beside reasoning on
-  every tool-calling turn, and the blank-turn fallback published the model's
-  private deliberation as the reply. A turn that called a tool is no longer
-  treated as blank. (#750)
-- **Transient gateway errors are retried again.** OpenRouter reports the
-  upstream status only in a numeric `code` field the error parser never read,
-  so 502s classified as fatal and the configured retries never ran; 429 now
-  classifies as rate limiting too. A stream that died before its usage frame
-  also no longer misreports as "store write failed". (#750)
-
-## [0.5.52] — 2026-07-26
-
-### Changed
-
-- **The adaptive-context lifecycle is now on by default.** Decomposed recall,
-  frame identity, recall telemetry, the typed learning loop, and the proposals
-  ledger now run with no configuration at all — a workspace with no settings
-  file gets them too. An explicit `"enabled": false` under `context.lifecycle`
-  restores the old behavior wholesale, and an unreadable or malformed settings
-  file leaves the lifecycle off rather than overriding a possible opt-out.
-  (#746)
-
-## [0.5.51] — 2026-07-26
-
-### Added
-
-- **The accountable context frame, behind `context.lifecycle.enabled`
-  (default off).** Each step's manifest gains a deterministic frame identity
-  hash, recall decomposes into one labeled block per recalled memory instead
-  of one blob, recall telemetry fires from every entry point (one-shot, REPL,
-  `/goal`, and the deck — previously only the pipeline reported), and `stella
-  inspect` grows a FRAME column. (#738)
-
-## [0.5.50] — 2026-07-26
-
-### Added
-
-- **`stella proposals` — review what the learning loop wants to keep.** The
-  new typed adaptive loop (behind `context.lifecycle.enabled`, default off)
-  records observations in an append-only ledger and induces skill proposals;
-  the command lists each with its supporting evidence and takes Keep, Edit, or
-  Ignore, every decision recorded as a replayable event. Works offline with no
-  API key. (#736)
-- **The whole documentation as one pasteable file.** `docs/llms.txt` carries
-  all 78 doc pages as a single Markdown file, generated from the docs site so
-  it cannot drift, for dropping into a model's context whole. (#741)
-
-### Fixed
-
-- **Auto-created skills can no longer overwrite a hand-edited skill file.**
-  The no-clobber guard checked the list of loaded skills instead of the files
-  on disk, so a skill disabled from the SKILLS tab could be silently replaced
-  by a freshly mined one — with no backup. The guard now checks the directory
-  itself. (#742)
-
-## [0.5.49] — 2026-07-26
-
-### Added
-
-- **`stella memory compact` reclaims the space old edits strand.** Every
-  memory edit or forget left its old vector (about 1 KiB each) behind forever;
-  compact deletes orphaned vectors and stale junctions while keeping edges and
-  revisions, so point-in-time queries and `memory restore` still answer
-  identically. (#735)
-- **An optional similarity index speeds up recall on large stores.** `stella
-  memory index` builds a deterministic IVF index over the workspace's vectors;
-  with `context.retrieval.ann_enabled` on, recall probes clusters instead of
-  scoring every vector, and every result reports which scan actually ran. Off
-  by default, and recall falls back to the exact scan when the index drifts.
-  (#735)
-
-## [0.5.48] — 2026-07-26
-
-### Fixed
-
-- **The `enable_recap` setting was silently ignored.** The settings merge
-  dropped the key while copying every other one, so `"enable_recap": "on"`
-  parsed cleanly and then did nothing; it now reaches the runtime. Found in a
-  docs-against-source audit that also fixed the documented (and broken)
-  `--model openrouter/auto` form — the working spelling is
-  `openrouter/openrouter/auto`. (#734)
-
-## [0.5.47] — 2026-07-26
-
-### Performance
-
-- **Context blocks are hashed once per turn, not once per step.** Block ids
-  and digests are now memoized and invalidated only when compaction or the
-  overflow summarizer rewrites the transcript, so hashing grows linearly with
-  a turn instead of with its square — an 8-step turn drops from 188 hash
-  passes to 44, and the gap widens on longer turns. (#732)
-
-## [0.5.46] — 2026-07-26
-
-### Added
-
-- **`stella memory edit <id> <text>` revises a memory instead of forking it.**
-  Editing used to create a second live memory while the old one stayed
-  citable; memories now have a durable lineage, so an edit updates one record,
-  recall serves only the new text, and the old wording stays readable as
-  history. `stella memory validate` reports duplicate pairs old edits left
-  behind. (#729)
-- **The retrieval tuning knobs are now real settings.** The
-  `context.retrieval` block in settings.json configures the ranking constants
-  and per-query budgets that were hard-coded; defaults are exactly the shipped
-  values, and out-of-range values are clamped rather than failing the turn.
-  (#729)
-
-### Fixed
-
-- **Forgetting a memory now actually keeps it out of the model's context.**
-  `stella memory forget` only filtered at the final projection step, after the
-  budget was already spent on the forgotten memory — and workspace memory
-  files pasted into the system prompt were never filtered at all. Suppression
-  now applies in the retrieval plane and on the system prompt. (#729)
-- **The overflow error no longer recommends a command that does not exist.**
-  Hitting the output-token limit advised "run /compact to shrink the context";
-  `/compact` was never a command, and compaction already runs automatically
-  every step. The message is corrected. (#729)
-
-## [0.5.45] — 2026-07-26
-
-### Performance
-
-- **Memory recall no longer reads the whole corpus every turn.** Ranking now
-  runs over metadata, with bodies and vectors fetched only for the few
-  candidates that can become frames, and the pass runs on a blocking thread —
-  recall stops getting slower as a workspace ages, and the recall timeouts can
-  actually fire. (#725)
-- **Fewer repeated passes over the transcript each step.** Redundant token
-  walks and transcript copies inside the agent loop were removed, cutting
-  per-step work that grew with the length of a turn. (#725)
-
-## [0.5.44] — 2026-07-26
-
-### Added
-
-- **Find-in-page search for the session transcript.** `ctrl+f` opens an
-  incremental, case-insensitive search bar that jumps between matches, and it
-  searches full tool output rather than the drawn preview — a hit inside
-  ninety collapsed lines is still found, and landing on it unfolds it. (#722)
-- **Jump to failures and fold finished turns.** `ctrl+n`/`ctrl+p` cycle
-  through failed steps (including rejected judge verdicts and unmet goals),
-  and `ctrl+z` folds a finished turn to one summary line with a red `N failed`
-  marker when something inside it broke. (#722)
-
-## [0.5.43] — 2026-07-26
-
-### Added
-
-- **Every tool now ships turned on, switchable from one settings map.** Bash
-  and the web tools no longer need per-capability flags; a `"tools"` map in
-  settings.json takes any tool name, group name, or `*` mapped to on/off, and
-  covers MCP and custom tools too. `stella tools` now names the exact key that
-  switched a tool off. (#710)
-- **A tools on/off editor in the TUI SETTINGS tab.** Every tool in the live
-  session — including MCP and custom tools — is listed by group; toggle with
-  space, save to user or project scope, and org-managed denials render locked
-  instead of offering a switch that would not work. (#710)
-
-### Fixed
-
-- **Disabled tools could still run in process-free sessions.** The interactive
-  REPL and `--no-pipeline` one-shot skipped the tool-policy gate when
-  process-free authority was active, so a tool switched off in settings could
-  still be called there. The policy is now enforced on that path like every
-  other. (#710)
-
-## [0.5.42] — 2026-07-26
-
-_Internal: version-sync release re-tagging an already-shipped docs commit; no
-user-facing changes._
-
-## [0.5.41] — 2026-07-26
-
-### Changed
-
-- **The session transcript was redesigned for reading.** Labels used to be
-  right-aligned into column 22, so the scannable left edge jittered on every
-  row and a fifth of the pane went to chrome. Rows now open on a fixed
-  left-edge rail of status glyphs, spacing follows block structure, collapsed
-  output previews the first failing line instead of line 1, and diff
-  truncation is hunk-aware with one-token edits highlighted. (#719)
-
-### Fixed
-
-- **Every edit to a file keeps its diff in the transcript.** Only the latest
-  diff per file was retained, so a session that touched one file five times
-  showed four edit rows with nothing under them; each path now remembers its
-  recent diffs per edit. (#719)
-
-## [0.5.40] — 2026-07-26
-
-### Changed
-
-- `stella storage prune` is now an alias for `stella stats prune` — same flags,
-  same engine. Both verbs landed in parallel (#704 and #707) as rival
-  implementations of #616's `store.db` retention, against two different store
-  engines and with different flag spellings. #707's engine won and replaced the
-  other's module, which left `storage prune` wired to code that no longer
-  existed. The verb is kept and re-pointed at the surviving engine, so
-  retention stays discoverable from both `stats` and `storage`.
-
-  Two flag/behaviour changes for anyone who used `storage prune` in the window
-  it existed: the ceiling flag is `--max-rows` (was `--max-executions`), and the
-  guard is on un-replicated telemetry rather than on in-flight turns and pending
-  enterprise exports.
-
-## [0.5.39] — 2026-07-26
-
-### Changed
-
-- **Agent edits keep your file's identity.** `write_file`, `edit_file`,
-  `apply_edits` and `save_memory` used to rename a temp file over the target,
-  which replaced the inode and dropped the mode, the owner, hard links, and
-  any editor watching the file. They now write in place, and Stella's own
-  state files all go through one atomic, fsync-backed write helper. (#699)
-
-### Fixed
-
-- **Rule guards now cover the edit path the model is steered toward.**
-  `guard-tool: Edit` guards `apply_edits` (previously only `edit_file`), a
-  guard key with a blank value no longer counts as an enforced guard, and
-  `guard-deny-path` checks every path in a multi-file edit instead of letting
-  one call walk past it. (#700)
-- **Interrupted runs clean up after themselves.** A dropped or cancelled turn
-  used to leave `/tmp` shadow directories, stale `.git/worktrees`
-  registrations, leaked MCP request slots and orphaned process groups behind.
-  Each now has a synchronous guard or a start-of-run prune that reclaims
-  it. (#698)
-
-## [0.5.38] — 2026-07-26
-
-### Added
-
-- **`stella serve` can read its bearer token from a file.**
-  `STELLA_SERVE_TOKEN_FILE` is supported and wins over the inline variable —
-  an unreadable or empty file is an error, never a silent fallback — a token
-  under 32 characters warns at startup, and failed auth responses are
-  rate-limited. (#696)
-
-### Fixed
-
-- **The MCP OAuth callback no longer decides CSRF on a partial read.** The
-  `state` check used to run against whatever a single 8 KiB read happened to
-  contain, so a request split mid-`state` was judged on half its input. The
-  request head is now read to completion, with oversized heads refused. (#696)
-
-### Security
-
-- **Secrets are wiped from memory when dropped.** API keys, auth prompts,
-  signing seeds and the in-memory credentials table now zero their plaintext
-  on drop, files Stella creates are written owner-only, and a group- or
-  world-readable `credentials.toml` earns a launch warning — never a silent
-  chmod of a file Stella did not create. (#696)
-
-## [0.5.37] — 2026-07-26
-
-### Security
-
-- **More credentials are scrubbed from subprocess environments.** Variables
-  ending in `_SECRET_KEY`, `_PRIVATE_KEY`, `_ACCESS_KEY`, `_APIKEY`,
-  `_CREDENTIALS`, `_CREDENTIAL` and `_PAT` no longer reach model-controlled
-  subprocesses, and git-behavior variables (`GIT_SSH_COMMAND`,
-  `GIT_CONFIG_*`, `SSH_AUTH_SOCK`, ...) are stripped from every git spawn. A
-  new `STELLA_SUBPROCESS_ENV_ALLOW` list re-admits exact names when a tool
-  genuinely needs one. (#695)
-- **The SVG sanitizer closes the `data:` URI gap.** The old check looked for
-  `//` in attribute values, so `fill="url(data:...)"` sailed through and the
-  `style` attribute was never inspected. URL-capable attributes (including
-  `cursor` and the CSS image-valued families) now get a real scheme test,
-  and the `style` attribute is dropped outright. (#695)
-
-## [0.5.36] — 2026-07-26
-
-### Added
-
-- **Pause, resume and stop tasks from the fleet dashboard.** With a task
-  focused, `[p]` pauses it, `[r]` resumes it, and `[x]` pressed twice stops
-  it (any other key disarms, so the stop can never land on the wrong task).
-  Only tasks with a live worker accept the verbs, and the grid marks paused
-  and stopping states. (#691)
-
-## [0.5.35] — 2026-07-26
-
-### Added
-
-- **`stella doctor` diagnoses and repairs a corrupt local store.** A corrupt
-  `.stella/private/store.db` used to produce an error and nothing else. The
-  new command runs a named integrity check with a clear pass/fail, and
-  `--repair` quarantines the corrupt file (rename plus salvage copy, never a
-  delete) so the next session starts on a fresh store. (#685)
-- **`stella serve` turns can be cancelled and no longer hang forever.** A new
-  `POST /v1/turns/{id}/cancel` endpoint unwinds a running turn while still
-  delivering its terminal frame, and reverse requests to the client get a
-  deadline (300s default, per-turn overridable, clamped to 1h) instead of an
-  unbounded wait on a silent client. (#685)
-
-### Fixed
-
-- **An MCP server that fails every call no longer reports as Live.** Connect
-  health and call health are now tracked separately, so a server that accepts
-  connections but drops every tools/call backs off and escalates instead of
-  looking healthy forever — and a crashed server's last stderr lines now ride
-  the error message instead of being thrown away. (#685)
-- **Code-graph index failures stop printing over the TUI frame.** The warning
-  used to go straight to stderr, painting raw text across the rendered
-  screen. It now returns inside the tool output itself, and impact analysis
-  stands down to running the full suite rather than silently narrowing off a
-  possibly stale graph. (#685)
-
-## [0.5.34] — 2026-07-26
-
-### Changed
-
-- Every `--output-format json|stream-json` summary now leads with
-  `schema_version` instead of burying it mid-object. Two of the three envelopes
-  were built with `serde_json::json!`, which emits a sorted map; they are now
-  structs, so the version is the first key a reader sees. Key order remains
-  outside the contract — consumers must keep reading by key, not position.
-
-## [0.5.33] — 2026-07-25
-
-### Added
-
-- **Machine-readable summaries declare a `schema_version`.** Every envelope
-  `--output-format json|stream-json` can emit — the pipeline summary, the
-  `--no-pipeline` summary, and the pre-flight error — now carries
-  `schema_version: 1`, bumped only on breaking changes, so scripts can pin
-  the shape safely. (#679)
-
-### Fixed
-
-- **Unsupported attachments degrade instead of crashing the process.** In the
-  zai, anthropic, openai and bedrock adapters, an attachment type outside a
-  provider's capabilities could hit an `unreachable!()` that aborts the run
-  mid-turn. It now becomes a text note naming what arrived and which dialect
-  could not carry it. (#676)
-- **One bad timestamp no longer blanks the dashboard's activity tab.** A run
-  whose start time SQLite could not parse failed the whole daily rollup.
-  Such runs are now reported in a visible "undated" bucket instead of being
-  dropped or faked onto the earliest day. (#682)
-
-### Performance
-
-- **Roughly 1,000 tokens shaved off every model call.** Both static system
-  prompts opened with a hand-maintained tool catalogue that restated what the
-  tool schemas in the same cached prefix already say; the duplicate lines are
-  gone, keeping only the cross-tool guidance schemas cannot carry. (#678)
-
-## [0.5.32] — 2026-07-26
-
-### Added
-
-- `--output-format json|stream-json` summaries now declare `schema_version`
-  (currently `1`). Every envelope carries it — the pipeline summary, the
-  `--no-pipeline` summary, and the pre-flight error envelope — and all three
-  always declare the same value. The bump rule is documented in
-  [Scripting & automation](https://stella.oxagen.sh/docs/scripting#the-envelope-contract):
-  it increments only when a key is removed, renamed, retyped, or changes
-  meaning, never when a key is added, so consumers must keep ignoring
-  unrecognized keys.
-
-## [0.5.31] — 2026-07-26
-
-### Added
-
-- **`stella memory forget` and `stella memory restore`.** The only way to
-  remove a memory used to be citing it untruthful twice to trip quarantine.
-  Forget is now one command, backed by a tombstone that also stops the same
-  lesson from being re-recorded or re-entering as a mined skill; restore
-  takes it back. (#671)
-
-### Changed
-
-- **The event stream tolerates events from newer versions of Stella.** An
-  unrecognized event `"type"` used to be a hard deserialization error, so the
-  vocabulary could never grow without breaking readers. Unknown types now
-  decode with their payload preserved: older binaries skip them, and proxies
-  or recorders can forward them intact. (#672)
-
-### Fixed
-
-- **Authored witness tests stay out of your working tree.** Adopting a
-  winning candidate used to copy its one-run witness test into the project's
-  real test suite, where the runner picked it up forever and nobody ever
-  reviewed it. The witness is now withheld at adoption unless you explicitly
-  pass `stella run --keep-witness`. (#670)
-
-## [0.5.30] — 2026-07-26
-
-### Fixed
-
-- **`stella memory validate` now catches memories that name bare filenames.**
-  A memory saying "in foo_test.rs" with no directory was reported as having no
-  file anchors and never checked against the tree, so lore about deleted files
-  kept being recalled on every turn. Bare filenames now resolve against a
-  workspace filename index, and the rotten ones get flagged as stale. (#669)
-
-## [0.5.29] — 2026-07-26
-
-### Fixed
-
-- **Asking Stella to delete a file no longer plants a failing test.** A plain
-  deletion request ("remove foo.rs") was routed through witness authoring,
-  which invented a test whose whole body was a panic and left it in the test
-  tree, where later runs burned turns trying to satisfy it. Bare deletions now
-  skip the authored witness; the verify ladder and the judge still run. (#668)
-
-## [0.5.28] — 2026-07-25
-
-### Added
-
+- **The accountable context frame.** The adaptive-context lifecycle went from
+  opt-in to on by default: what the context engine adds to a turn is recorded,
+  inspectable with `stella inspect --diff`, and reviewable — `stella proposals`
+  shows what the learning loop wants to keep before it keeps it.
+- **Memories anchor to the files they are about**, and a deleted file ends the
+  memory's life rather than leaving it to steer future turns from a tree that
+  no longer exists. `stella memory forget`/`restore`/`edit`/`compact` round out
+  the lifecycle, and memories that stop helping retire themselves — reversibly.
+- **`stella scoreboard`, `stella ingest`, and a `stella doctor` that repairs.**
+  Doctor diagnoses and repairs a corrupt local store and checks the fleet
+  ledger; ingest extracts documents into the context plane.
+- **Machine-readable output grew a contract.** `--output-format json` and
+  `stream-json` summaries declare a `schema_version`, and the event stream
+  tolerates events emitted by newer versions of Stella.
 - **Release artifacts carry build provenance, and the installer checks it.**
-  Every release tarball and its `SHA256SUMS` are attested with a Sigstore
-  bundle bound to the CI workflow that built them; `install.sh` verifies the
-  attestation when `gh` is available, and `STELLA_REQUIRE_PROVENANCE=1` makes
-  a missing or failed attestation a hard refusal instead of an info line.
-  (#657)
-- **This changelog.** `CHANGELOG.md` starts here, rolled on every release.
-  (#656)
+- **This changelog.**
+
+### Changed
+
+- **Verification is demand-driven.** A change with nothing to prove no longer
+  buys a review call to be told so, a witness test is only written when the
+  diff warrants one, and a greeting no longer pays for a triage model call.
+- **Verification failures cross a feedback airlock** before reaching the worker,
+  instead of raw test-runner output being replayed into its context.
+- **Every built-in tool ships turned on**, switchable from one settings map and
+  from a tools editor in the TUI SETTINGS tab.
+- **Reflection learns your codebase, not itself**, and memory only records what
+  a fresh look at the repository would not reveal.
 
 ### Fixed
 
-- **Nine correctness P0s from the backlog triage.** Among them: the
-  runaway-loop guard was silently off for Gemini and Vertex (their recycled
-  tool-call ids poisoned the detector's identity key), deeply nested SQL
-  could overflow the stack and abort the process mid-turn, and the
-  config-redirect route around the dotenv deny-list is closed. (#658, #647)
+- **Cancelled tool subprocesses are actually killed**, and interrupted runs
+  clean up after themselves.
+- **`stella serve` can no longer deadlock or cancel a live turn** during a
+  concurrent request, and its live-turn cap stopped being a one-way latch.
+- **Chain-of-thought no longer replaces the answer on OpenRouter**, and
+  provider 5xx responses are retried instead of failing the turn.
+- **Agent edits keep your file's identity** — inode, permissions and all —
+  and every edit keeps its diff in the transcript.
 
-## Before 0.5.27
+### Security
 
-This file was introduced at 0.5.27. Earlier releases are recorded only in their
-generated GitHub Release notes, at
-<https://github.com/macanderson/stella/releases>. No attempt has been made to
-reconstruct them here — a hand-written history of releases nobody curated at the
-time would be a guess presented as a record.
+- **Secrets are wiped from memory when dropped**, redacted from session
+  exports, and scrubbed more thoroughly from subprocess environments.
+- **Command approval covers every command-composing tool**, not only `bash`.
+- **`stella serve` turn ids are no longer guessable**, and the SVG sanitizer
+  closes the `data:` URI gap.
+
+## Earlier releases
+
+0.4.0 and earlier predate this file. Their notes are on
+[the releases page](https://github.com/macanderson/stella/releases), generated
+per tag from each release's own diff.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,25 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 **One section per minor line — not per release.** Every merge to main cuts a
 patch release (see [`RELEASING.md`](RELEASING.md)), which is a fine way to ship
 and a terrible way to keep a record: the 0.6 line alone was 127 releases in
-eight days. Those releases are not undocumented — [the releases
+nine days. Those releases are not undocumented — [the releases
 page](https://github.com/macanderson/stella/releases) carries notes for every
 single tag, generated from that tag's own diff. This file is the other half of
-the pair: the durable, curated record of what a line delivered, written for
-someone deciding whether to upgrade rather than someone bisecting a regression.
+the pair: the durable, curated record, written for someone deciding whether to
+upgrade rather than someone bisecting a regression.
 
-**CI writes this file, not contributors or coding agents.** Don't add a bullet
-under `## [Unreleased]` in your PR — leave the section alone.
+**A section covers everything since the previous section's version.** Because
+only minor and major lines are listed, `[0.7.0]` means "what you get moving
+from 0.6.0 to 0.7.0" — the whole 0.6 line, not the single release that opened
+it. That is also exactly the range CI drafts it from.
+
+**CI writes this file, not contributors or coding agents.** Leave the
+`[Unreleased]` section alone in your PR rather than adding a bullet to it. (The
+exception is a release PR that deliberately writes its own section: the roll is
+idempotent and never overwrites or duplicates a version that already has one.)
 [`scripts/changelog-ai.sh`](scripts/changelog-ai.sh) drafts the section from the
-whole series range when a minor or major release is cut, and
+series range when a minor or major release is cut, and
 [`scripts/changelog-roll.sh`](scripts/changelog-roll.sh) rolls it into place. If
-your change needs context the diff alone won't convey, put it in the PR
+your change needs context the diff alone will not convey, put it in the PR
 description — the drafter reads commit bodies (squash-merge PR descriptions),
 not just code.
 
@@ -34,19 +41,10 @@ are not user-facing and do not appear here.
 
 ## [0.7.0] — 2026-08-07
 
-### Changed
-
-- **The changelog is now one section per minor line, and reads like something a
-  person wrote.** This file had grown to 180 sections of which **77 were
-  completely empty** — a bare `## [0.6.x] — <date>` heading with nothing under
-  it. Nothing was wrong with the drafter; the composition was. A patch release
-  was cut on every merge to main and the roll fired on every one of them, while
-  the drafter degrades open by contract (no API key, no non-bot commits, or an
-  unparseable response all print nothing and succeed). When the second happened
-  the first still stamped the heading. Patch releases no longer touch this file
-  at all, and a minor release can no longer emit a heading with an empty body
-  under any failure. Per-release detail did not disappear — it ships as GitHub
-  Release notes, the surface built for "what changed in this exact build".
+Everything since 0.6.0 — 127 patch releases over nine days, plus the release-
+notes overhaul below. The verification line: a model's opinion stopped being
+enough to end a run, the verifier stopped being allowed to grade its own work,
+and the pipeline learned to research before it plans.
 
 ### Added
 
@@ -56,15 +54,6 @@ are not user-facing and do not appear here.
   security), search the full text of every entry, and expand a line to read it
   in full. Built from this file at build time, so the site and the repository
   cannot drift.
-
-## [0.6.0] — 2026-07-29 → 2026-08-06
-
-The verification line. A model's opinion stopped being enough to end a run,
-the verifier stopped being allowed to grade its own work, and the pipeline
-learned to research before it plans.
-
-### Added
-
 - **The verdict is decided by a model that did not do the work.** Verifier
   independence is enforced before the spend, not audited afterwards, and each
   candidate records a `verifier_independent` fact so a run that could not get
@@ -108,6 +97,17 @@ learned to research before it plans.
 
 ### Changed
 
+- **The changelog is now one section per minor line, and reads like something a
+  person wrote.** This file had grown to 180 sections of which **77 were
+  completely empty** — a bare `## [0.6.x] — <date>` heading with nothing under
+  it. Nothing was wrong with the drafter; the composition was. A patch release
+  was cut on every merge to main and the roll fired on every one of them, while
+  the drafter degrades open by contract (no API key, no non-bot commits, or an
+  unparseable response all print nothing and succeed). When the second happened
+  the first still stamped the heading. Patch releases no longer touch this file
+  at all, and a minor release can no longer emit a heading with an empty body
+  under any failure. Per-release detail did not disappear — it ships as GitHub
+  Release notes, the surface built for "what changed in this exact build".
 - **A green test run only counts if it fixes the failure that was actually
   reported**, and a model judge's "done" needs corroboration that is not
   another model's opinion — a fail→pass flip or a test that ran green. Without
@@ -173,10 +173,11 @@ learned to research before it plans.
   container and mount only the repository it should touch; add `--network none`
   for the equivalent of the old `restricted`.
 
-## [0.5.0] — 2026-07-23 → 2026-07-29
+## [0.6.0] — 2026-07-29
 
-The context and memory line. Recall became accountable, memories learned what
-they were about, and verification stopped paying for work it did not need.
+Everything since 0.5.0 — the context and memory line. Recall became
+accountable, memories learned what they were about, and verification stopped
+paying for work it did not need.
 
 ### Added
 
@@ -230,6 +231,6 @@ they were about, and verification stopped paying for work it did not need.
 
 ## Earlier releases
 
-0.4.0 and earlier predate this file. Their notes are on
+0.5.0 and earlier predate this file. Their notes are on
 [the releases page](https://github.com/macanderson/stella/releases), generated
 per tag from each release's own diff.

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,10 @@ file-size-test: ## Test which languages the file-size ratchet actually watches (
 guard-sigpipe-test: ## Test that the gate guards survive a reader that closes their pipe early (#1815; hermetic; not part of `gate`)
 	./scripts/test-guard-sigpipe.sh
 
+.PHONY: changelog-roll-test
+changelog-roll-test: ## Test which releases get a CHANGELOG.md section (hermetic; not part of `gate`)
+	./scripts/test-changelog-roll.sh
+
 .PHONY: releases-published
 releases-published: ## Assert every v* tag older than the grace window has a published release (#1464)
 	@./scripts/check-releases-published.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,7 +71,8 @@ was structurally guaranteed to fill with noise no matter how good the drafter
 got, so the roll stopped firing on patches — where the per-tag detail already
 had a home in the GitHub Release notes above.
 
-The roll is deliberately non-fatal, and can no longer produce an empty section:
+The roll is deliberately non-fatal, and can no longer produce an empty or a
+duplicate section:
 
 - A missing `CHANGELOG.md`, or one with no `## [Unreleased]` heading, logs a
   warning and continues. A bookkeeping slip must never be the reason a release
@@ -80,6 +81,12 @@ The roll is deliberately non-fatal, and can no longer produce an empty section:
   roll writes a pointer to the releases page rather than a heading with an
   empty body — the failure mode above, which would otherwise recur once per
   line.
+- **It is idempotent.** If the version already has a section, the roll leaves
+  the file alone. That matters because it runs at two call sites per release,
+  and because a maintainer may have written the section by hand in the release
+  PR — a minor release is a considered event, and "CI writes this file" exists
+  to stop per-PR bullets accumulating in inconsistent voices, not to overwrite
+  a section someone sat down and wrote. Whoever got there first wins.
 
 `make changelog-roll-test` (hermetic, not part of `make gate`) pins both rules.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,9 +33,10 @@ main and does everything — no manual steps:
    pass. Its commit carries `[skip release]`, so the sync itself never cuts a
    release. If a sync PR is ever left open (red check, race with another
    merge), the next release supersedes it automatically — no cleanup needed.
-   The same PR **rolls [`CHANGELOG.md`](CHANGELOG.md)**: whatever sits under
-   `## [Unreleased]` moves beneath a new version heading, and `[Unreleased]`
-   is left empty for the next change.
+   On a **minor or major** release the same PR also **rolls
+   [`CHANGELOG.md`](CHANGELOG.md)**: whatever sits under `## [Unreleased]`
+   moves beneath a new version heading, and `[Unreleased]` is left empty for
+   the next line. A patch release does not touch that file — see below.
 
 Manual version bumps are therefore only needed for the hand-cut flows below.
 
@@ -43,27 +44,44 @@ Manual version bumps are therefore only needed for the hand-cut flows below.
 
 Two things, and they are not the same thing:
 
-- **[`CHANGELOG.md`](CHANGELOG.md)** — the durable record, one section per
-  version, and **CI writes it, not PRs.** `auto-tag.yml` drafts the section
-  for every release from the **released diff**
-  ([`scripts/changelog-ai.sh`](scripts/changelog-ai.sh), the same AI Gateway
-  key and model as the release notes) and injects it before the roll, at both
-  roll sites (the tagged release commit and the version-sync PR), so the tag
-  and main record identical text. The draft **replaces** whatever sits under
-  `[Unreleased]` — contributors and coding agents should leave that section
-  alone rather than hand-write entries in a PR; a split between hand-written
-  and drafted entries is what used to make this file inconsistent. A release
-  whose diff has nothing user-facing gets a one-line `_Internal: …_` note. If
-  the AI Gateway key is unset or the call fails, the roll proceeds with
-  whatever was already under `[Unreleased]` (normally nothing) exactly as
-  before — drafting is best-effort, never release-blocking.
+- **[`CHANGELOG.md`](CHANGELOG.md)** — the durable curated record, **one
+  section per minor line**, and **CI writes it, not PRs.** When a minor or
+  major release is cut, `auto-tag.yml` drafts the section from the whole
+  **series** diff — the previous `X.Y.0` tag to this one
+  ([`scripts/changelog-ai.sh`](scripts/changelog-ai.sh), the same AI Gateway key
+  and model as the release notes) — and
+  [`scripts/changelog-roll.sh`](scripts/changelog-roll.sh) injects it at both
+  roll sites (the tagged release commit and the version-sync PR), so the tag and
+  main record identical text. The draft **replaces** whatever sits under
+  `[Unreleased]`: contributors and coding agents should leave that section alone
+  rather than hand-write entries in a PR, because a split between hand-written
+  and drafted entries is what used to make this file inconsistent.
 - **GitHub Release notes** — generated at publish time by `release.yml` from
-  the commit range. Release-note prose, not a curated record, and not
-  something to edit by hand.
+  the commit range, **for every tag including patches**. Release-note prose, not
+  a curated record, and not something to edit by hand.
 
-The changelog roll is deliberately non-fatal. If `CHANGELOG.md` is missing or
-has no `## [Unreleased]` heading, `auto-tag.yml` logs a warning and continues —
-a bookkeeping slip must never be the reason a release fails to ship.
+**A patch release records nothing in `CHANGELOG.md`.** This is the important
+half of the split, and it is enforced in `changelog-roll.sh` rather than trusted
+to a caller. Every merge to main cuts a patch, so the roll used to fire ~130
+times per minor line; `changelog-ai.sh` degrades open by contract (no API key,
+no non-bot commits, or an unparseable response all print nothing and exit 0),
+but the roll ran regardless and stamped a bare `## [0.6.x] — <date>` heading
+with nothing under it. The file reached 180 sections of which 77 were empty. It
+was structurally guaranteed to fill with noise no matter how good the drafter
+got, so the roll stopped firing on patches — where the per-tag detail already
+had a home in the GitHub Release notes above.
+
+The roll is deliberately non-fatal, and can no longer produce an empty section:
+
+- A missing `CHANGELOG.md`, or one with no `## [Unreleased]` heading, logs a
+  warning and continues. A bookkeeping slip must never be the reason a release
+  fails to ship.
+- If the draft fails on a minor release **and** `[Unreleased]` is empty, the
+  roll writes a pointer to the releases page rather than a heading with an
+  empty body — the failure mode above, which would otherwise recur once per
+  line.
+
+`make changelog-roll-test` (hermetic, not part of `make gate`) pins both rules.
 
 ## One-time setup
 

--- a/scripts/changelog-ai.sh
+++ b/scripts/changelog-ai.sh
@@ -37,23 +37,60 @@ fi
 
 model="${CHANGELOG_AI_MODEL:-anthropic/claude-sonnet-5}"
 
+# A SERIES range — the whole minor line, which is what a section is drafted
+# from now — spans hundreds of commits, and its raw diff is far past anything a
+# 100,000-character window represents fairly: truncating it hands the model
+# whatever git happened to emit first and silently drops the rest, so the
+# section would describe the start of the range rather than the important part
+# of it. Above the threshold the diff is dropped entirely and the draft leans on
+# commit subjects and bodies — which in this repository are conventional-commit
+# titles carrying the PR number and a real sentence, a better signal per token
+# than a truncated hunk — with the subject and body caps widened to match.
+# Below it a single release's diff still fits, and the diff still wins: commit
+# messages describe intent, the diff is what shipped.
+commit_count="$(git rev-list --no-merges --count ${range:+"$range"} 2>/dev/null || echo 0)"
+if [ "${commit_count}" -gt 60 ]; then
+  scope="series"
+  subject_cap=600
+  body_cap=1200
+  echo "changelog-ai: ${commit_count} commits in '${range:-<all>}'; drafting a series section from subjects and diffstat." >&2
+else
+  scope="release"
+  subject_cap=100
+  body_cap=400
+fi
+
 # The release's real content: everything in the range except the release
 # machinery's own commits (the "stella X.Y.Z" stamp and the version-sync PR).
 bot_re='^(stella [0-9]|chore\(release\): sync versions)'
-commits="$(git log --no-merges --format='%s' ${range:+"$range"} | grep -Ev "$bot_re" | head -n 100 || true)"
+commits="$(git log --no-merges --format='%s' ${range:+"$range"} | grep -Ev "$bot_re" | head -n "$subject_cap" || true)"
 if [ -z "$commits" ]; then
   echo "changelog-ai: no non-bot commits in range '${range:-<all>}'; printing nothing." >&2
   exit 0
 fi
 
-bodies="$(git log --no-merges --format='--- %s%n%b' ${range:+"$range"} | head -n 400 || true)"
+bodies="$(git log --no-merges --format='--- %s%n%b' ${range:+"$range"} | head -n "$body_cap" || true)"
 stat="$(git diff --stat ${range:+"$range"} -- ':(exclude)Cargo.lock' | tail -n 100 || true)"
-diff="$(git diff ${range:+"$range"} -- ':(exclude)Cargo.lock' ':(exclude)website/pnpm-lock.yaml' 2>/dev/null | head -c 100000 || true)"
+
+if [ "$scope" = series ]; then
+  diff=""
+else
+  diff="$(git diff ${range:+"$range"} -- ':(exclude)Cargo.lock' ':(exclude)website/pnpm-lock.yaml' 2>/dev/null | head -c 100000 || true)"
+fi
+
+# The shared half of the instruction — voice, format, and what counts as
+# user-facing — is identical either way; only the scope sentence differs.
+common='Keep a Changelog format: "### Added" / "### Changed" / "### Fixed" / "### Removed" / "### Security" headings (only the ones that apply, in that order), each bullet starting with a bold lead claim, then one or two plain sentences saying what a user of the CLI would notice — concrete, everyday words, wrapped at 80 columns, ending with the PR reference like (#1234) when the commit subject carries one. Tests, CI workflows, gates and baselines, bench-harness internals, and refactors are not user-facing. Output ONLY the section body markdown - no version heading, no preamble, no code fences.'
+
+if [ "$scope" = series ]; then
+  intro="Write the CHANGELOG.md section body for one MINOR RELEASE LINE of \"stella\", a Rust coding-agent CLI — the whole series of releases listed below, summarized as one section a reader upgrading across it would want. ${common} 8-16 bullets total: group the work into themes, lead with the changes that alter what the tool does, and drop everything routine. Base every claim on the commit subjects and bodies below."
+else
+  intro="Write the CHANGELOG.md section body for one release of \"stella\", a Rust coding-agent CLI. ${common} 1-3 bullets total; pick the biggest user-visible changes and drop the rest. Base every claim on the diff below — commit messages describe intent, the diff is what shipped. If the release contains nothing user-facing, output exactly one line instead: _Internal: <six-to-twelve-word summary>; no user-facing changes._"
+fi
 
 # shellcheck disable=SC2016  # the format string's backticks are literal markdown
 prompt="$(printf '%s\n\n## Commit subjects\n%s\n\n## Commit bodies (squash-merge PR descriptions)\n%s\n\n## Files changed\n%s\n\n## Diff (truncated)\n```diff\n%s\n```\n' \
-  'Write the CHANGELOG.md section body for one release of "stella", a Rust coding-agent CLI. Keep a Changelog format: "### Added" / "### Changed" / "### Fixed" / "### Removed" / "### Security" headings (only the ones that apply, in that order), each bullet starting with a bold lead claim, then one or two plain sentences saying what a user of the CLI would notice — concrete, everyday words, wrapped at 80 columns, ending with the PR reference like (#1234) when the commit subject carries one. 1-3 bullets total; pick the biggest user-visible changes and drop the rest. Base every claim on the diff below — commit messages describe intent, the diff is what shipped. Tests, CI workflows, gates and baselines, bench-harness internals, and refactors are not user-facing: if the release contains nothing user-facing, output exactly one line instead: _Internal: <six-to-twelve-word summary>; no user-facing changes._ Output ONLY the section body markdown - no version heading, no preamble, no code fences.' \
-  "$commits" "$bodies" "$stat" "$diff")"
+  "$intro" "$commits" "$bodies" "$stat" "$diff")"
 
 payload="$(jq -n --arg m "$model" --arg c "$prompt" \
   '{model:$m, messages:[{role:"user",content:$c}], temperature:0.2}')"

--- a/scripts/changelog-roll.sh
+++ b/scripts/changelog-roll.sh
@@ -65,6 +65,21 @@ if [ ! -f "${changelog}" ] || ! grep -q '^## \[Unreleased\]' "${changelog}"; the
   exit 0
 fi
 
+# Idempotent: if this version already has a section, leave the file alone.
+#
+# Two cases reach here, and neither wants a second heading. The roll runs at
+# TWO call sites per release (the tagged release commit and the bot/version-sync
+# PR), so a re-run or a retry must not stack headings. And a maintainer may have
+# written the section deliberately in the release PR itself — a minor release is
+# a considered event, and the "CI writes this file" rule exists to stop
+# per-PR bullets accumulating in inconsistent voices, not to overwrite a section
+# someone sat down and wrote. Whoever got there first wins; the roll never
+# duplicates.
+if grep -q "^## \[${version}\]" "${changelog}"; then
+  echo "changelog-roll: ${changelog} already has a [${version}] section; leaving it alone."
+  exit 0
+fi
+
 # Replace whatever sits under [Unreleased] with $1's contents.
 inject_entries() {
   ENTRIES_FILE="$1" perl -0777 -pi -e '

--- a/scripts/changelog-roll.sh
+++ b/scripts/changelog-roll.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Roll CHANGELOG.md's `[Unreleased]` section under a new version heading.
+#
+# Usage: NEW_VERSION=0.7.0 [RELEASE_DATE=2026-08-07] \
+#          [CHANGELOG_ENTRIES_FILE=<path>] scripts/changelog-roll.sh [<file>]
+#
+# Split out of scripts/sync-versions.sh so it can be tested without standing up
+# a Cargo workspace (scripts/test-changelog-roll.sh, `make changelog-roll-test`).
+# sync-versions.sh calls it at both of its call sites — the tagged release
+# commit and the bot/version-sync PR — so the tag and main roll identical text.
+#
+# ## The rule: minor and major lines only
+#
+# Every merge to main cuts a patch release, so this roll used to fire ~130
+# times per minor line. scripts/changelog-ai.sh degrades open by contract (no
+# API key, no non-bot commits, or a response that does not look like changelog
+# markdown all print nothing and exit 0), but the roll ran regardless —
+# depositing a bare `## [0.6.x] — <date>` heading with nothing under it. That is
+# how CHANGELOG.md reached 180 sections of which 77 were empty: the file was
+# structurally guaranteed to fill with noise no matter how good the drafter got.
+#
+# So a patch release does not touch this file at all. Its detail is not lost —
+# release.yml publishes GitHub Release notes for every tag, which is the surface
+# built for "what changed in this exact build". CHANGELOG.md is the curated
+# durable record: one section per minor line, drafted once from the whole series
+# range. RELEASING.md § "What records a change" documents the split.
+#
+# ## The second rule: never emit a heading with nothing under it
+#
+# A minor release whose draft failed would otherwise reproduce the original
+# defect once per line. When the drafter degrades open AND `[Unreleased]` is
+# empty, this writes a pointer to the releases page instead — truthful, because
+# the per-tag detail genuinely does exist there. A bare heading is never an
+# acceptable output of this script.
+#
+# Deliberately tolerant everywhere else: a missing file or a missing
+# `[Unreleased]` heading is a warning, not a failure. A changelog bookkeeping
+# slip must never be the reason a release fails to ship.
+#
+# perl, not `sed -i "0,/re/"`: that address form is GNU-only and SILENTLY
+# no-ops on BSD sed (macOS).
+set -euo pipefail
+
+version="${NEW_VERSION:?set NEW_VERSION to the bare semver, e.g. 0.7.0}"
+export NEW_VERSION
+changelog="${1:-CHANGELOG.md}"
+
+# The releases page carries every tag's notes; the fallback body points there.
+releases_url="https://github.com/macanderson/stella/releases"
+
+# Checking the patch component here — rather than trusting a caller to pass the
+# bump kind — keeps the rule true at both call sites with no third place to
+# drift.
+case "${version}" in
+  *.*.0) ;;
+  *)
+    echo "changelog-roll: ${version} is a patch release; CHANGELOG.md records minor and major lines only."
+    exit 0
+    ;;
+esac
+
+if [ ! -f "${changelog}" ] || ! grep -q '^## \[Unreleased\]' "${changelog}"; then
+  echo "::warning::${changelog} missing or has no [Unreleased] heading; skipping the roll."
+  exit 0
+fi
+
+# Replace whatever sits under [Unreleased] with $1's contents.
+inject_entries() {
+  ENTRIES_FILE="$1" perl -0777 -pi -e '
+    open my $fh, "<", $ENV{ENTRIES_FILE} or die "cannot open $ENV{ENTRIES_FILE}: $!";
+    my $entries = do { local $/; <$fh> };
+    close $fh;
+    $entries =~ s/\s+\z//;
+    s/^## \[Unreleased\]\n.*?(?=^## \[|\z)/"## [Unreleased]\n\n" . $entries . "\n\n"/mse;
+  ' "${changelog}"
+}
+
+unreleased_body="$(awk '/^## \[Unreleased\]$/{f=1;next} /^## \[/{f=0} f' "${changelog}" | tr -d '[:space:]')"
+
+if [ -n "${CHANGELOG_ENTRIES_FILE:-}" ] && [ -s "${CHANGELOG_ENTRIES_FILE}" ]; then
+  # The CI draft is authoritative: it REPLACES whatever already sits under
+  # [Unreleased], hand-written or not. Changelog authorship lives in the release
+  # job, not in feature PRs, so entries stay in one voice instead of whatever a
+  # contributor or coding agent happened to type.
+  inject_entries "${CHANGELOG_ENTRIES_FILE}"
+  echo "changelog-roll: CI-drafted entries written for ${version}."
+elif [ -z "${unreleased_body}" ]; then
+  fallback="$(mktemp)"
+  printf '_The draft for this section could not be generated. Per-release notes for\nevery tag in this line are published on the [releases page](%s)._\n' \
+    "${releases_url}" > "${fallback}"
+  inject_entries "${fallback}"
+  rm -f "${fallback}"
+  echo "::warning::no entries drafted for ${version}; wrote a releases-page pointer rather than an empty section."
+else
+  echo "::warning::no entries drafted for ${version}; rolling the existing [Unreleased] body as-is."
+fi
+
+# Inserting *after* the heading (rather than renaming it) is what carries the
+# section's content down into the new version's section.
+RELEASE_DATE="${RELEASE_DATE:-$(date -u +%F)}" \
+  perl -pi -e 's/^## \[Unreleased\]$/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] — $ENV{RELEASE_DATE}/' "${changelog}"
+
+grep -q "^## \[${version}\] " "${changelog}" \
+  || echo "::warning::${changelog} roll did not take for ${version}"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -16,9 +16,9 @@
 #   - the workspace-member entries in Cargo.lock (`cargo update --workspace`;
 #     registry and git pins are untouched)
 #   - packaging/homebrew/stella.rb (build-from-source formula tag + version)
-#   - CHANGELOG.md: the `[Unreleased]` section rolls under the new version.
-#     Deliberately tolerant — a missing file or heading is a warning, not a
-#     failure, because a changelog bookkeeping slip must never stop a release.
+#   - CHANGELOG.md, via scripts/changelog-roll.sh — on a MINOR or MAJOR
+#     release only. A patch release does not touch that file; see the rationale
+#     in changelog-roll.sh's header and RELEASING.md § "What records a change".
 #
 # perl, not `sed -i "0,/re/"`: that address form is GNU-only and SILENTLY
 # no-ops on BSD sed (macOS).
@@ -37,40 +37,9 @@ cargo update --workspace
 perl -pi -e 's/tag: "v[^"]*"/tag: "v$ENV{NEW_VERSION}"/; s/^  version "[^"]*"/  version "$ENV{NEW_VERSION}"/' \
   packaging/homebrew/stella.rb
 
-if [ -f CHANGELOG.md ] && grep -q '^## \[Unreleased\]' CHANGELOG.md; then
-  # CI drafts every release's changelog section from the release diff
-  # (scripts/changelog-ai.sh, invoked once by auto-tag.yml and handed to both
-  # sync-versions.sh call sites via CHANGELOG_ENTRIES_FILE, so the tag and
-  # main roll identical text). The draft is authoritative: it REPLACES
-  # whatever already sits under [Unreleased], hand-written or not — changelog
-  # authorship lives in the release job, not in feature PRs, so entries stay
-  # in one consistent voice instead of whatever a contributor or coding agent
-  # happened to type. Injection lives here, not in the workflow, because this
-  # script runs at two call sites (the tagged release commit and the
-  # bot/version-sync PR) and the tag and main must roll identical text — one
-  # script, two call sites, no drift (#786).
-  if [ -n "${CHANGELOG_ENTRIES_FILE:-}" ] && [ -s "${CHANGELOG_ENTRIES_FILE}" ]; then
-    # An explicit lexical filehandle, not `local @ARGV; <>`: -pi's own
-    # in-place magic already drives @ARGV/<> to iterate CHANGELOG.md, and
-    # reassigning @ARGV mid-script (even locally) to slurp a second file
-    # collides with that and corrupts the edit.
-    ENTRIES_FILE="${CHANGELOG_ENTRIES_FILE}" perl -0777 -pi -e '
-      open my $fh, "<", $ENV{ENTRIES_FILE} or die "cannot open $ENV{ENTRIES_FILE}: $!";
-      my $entries = do { local $/; <$fh> };
-      close $fh;
-      $entries =~ s/\s+\z//;
-      s/^## \[Unreleased\]\n.*?(?=^## \[|\z)/"## [Unreleased]\n\n" . $entries . "\n\n"/mse;
-    ' CHANGELOG.md
-    echo "sync-versions: CI-drafted changelog entries written for ${version}."
-  else
-    echo "::warning::no changelog entries drafted (AI Gateway unset or the call failed); rolling [Unreleased] as-is."
-  fi
-  # Inserting *after* the heading (rather than renaming it) is what carries
-  # the section's content down into the new version's section.
-  RELEASE_DATE="${RELEASE_DATE:-$(date -u +%F)}" \
-    perl -pi -e 's/^## \[Unreleased\]$/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] — $ENV{RELEASE_DATE}/' CHANGELOG.md
-  grep -q "^## \[${version}\] " CHANGELOG.md \
-    || echo "::warning::CHANGELOG.md roll did not take for ${version}"
-else
-  echo "::warning::CHANGELOG.md missing or has no [Unreleased] heading; skipping the roll."
-fi
+# CHANGELOG.md is rolled by a sibling script, not inlined here: the roll has
+# rules of its own (minor/major only, never a heading with an empty body) that
+# deserve a direct test, and testing them through this script would mean
+# standing up a throwaway Cargo workspace for `cargo update` above.
+# scripts/test-changelog-roll.sh covers it; `make changelog-roll-test` runs it.
+"$(dirname "$0")/changelog-roll.sh" CHANGELOG.md

--- a/scripts/test-changelog-roll.sh
+++ b/scripts/test-changelog-roll.sh
@@ -136,5 +136,21 @@ check "the hand-written note rolled under 0.9.0" \
 check "the fallback pointer was NOT written" \
   "$(grep -c 'could not be generated' "$f")" "0"
 
+# ── C6: idempotent — an existing section for this version is never duplicated ─
+printf '\nC6  a version that already has a section is left alone\n'
+f="$(changelog_with c6)"
+# Plant the section the roll is about to write, as a release PR or a first
+# invocation at the other call site would have.
+perl -0777 -pi -e 's/^## \[Unreleased\]\n/## [Unreleased]\n\n## [1.0.0] — 2026-08-07\n\n### Added\n\n- hand-written\n/ms' "$f"
+printf '### Added\n\n- **CI draft.** Would have replaced it.\n' >"$TMP/c6-entries.md"
+out="$(roll "$f" 1.0.0 "$TMP/c6-entries.md")"
+check "exactly one 1.0.0 heading exists" "$(grep -c '^## \[1.0.0\]' "$f")" "1"
+check "the existing body survives" "$(grep -c '^- hand-written$' "$f")" "1"
+check "the CI draft was not written" "$(grep -c 'CI draft' "$f")" "0"
+case "$out" in
+  *"already has a"*) ok "the skip is logged" ;;
+  *) no "the skip is logged" "$out" "an 'already has a [1.0.0] section' notice" ;;
+esac
+
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/test-changelog-roll.sh
+++ b/scripts/test-changelog-roll.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Tests for check scripts/changelog-roll.sh — WHICH RELEASES GET A SECTION.
+#
+#   ./scripts/test-changelog-roll.sh
+#
+# Run it after touching that script. Not part of `make gate`: it is hermetic
+# and cheap, the same posture as `make file-size-test`.
+#
+# ── Why this suite exists ────────────────────────────────────────────────────
+#
+# CHANGELOG.md reached 180 sections of which 77 were completely empty — a bare
+# `## [0.6.x] — <date>` with nothing under it. Two facts composed into that:
+#
+#   1. auto-tag.yml cuts a PATCH release on every merge to main (127 tags in
+#      the 0.6 line alone), and the roll fired on every one of them.
+#   2. scripts/changelog-ai.sh degrades open BY CONTRACT — no API key, no
+#      non-bot commits, or a response that does not look like changelog
+#      markdown all print nothing and exit 0.
+#
+# When (2) fired, (1) still stamped the heading. Neither script was individually
+# wrong; the composition was. Both halves of the fix are asserted here, because
+# both are invisible from the script's own output — a run that stamps an empty
+# heading and a run that correctly skips print nothing alarming either way.
+#
+# C1/C2 pin rule one (patches record nothing). C3/C4 pin rule two (a minor
+# release never emits a heading with an empty body, even when the drafter
+# degraded). C5 pins that a hand-written [Unreleased] is still honored, so the
+# fallback cannot eat real content.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/changelog-roll.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+ok() {
+  pass=$((pass + 1))
+  printf '  ok    %s\n' "$1"
+}
+no() {
+  fail=$((fail + 1))
+  printf '  FAIL  %s\n' "$1"
+  printf '        want: %s\n        got:  %s\n' "$3" "$2"
+}
+check() {
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "$2" "$3"; fi
+}
+
+# A CHANGELOG.md with $1 as the [Unreleased] body. Echoes its path.
+changelog_with() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir"
+  {
+    printf '# Changelog\n\n## [Unreleased]\n'
+    printf '%s' "${2:-}"
+    printf '\n## [0.6.0] — 2026-07-16\n\n### Added\n\n- something older\n'
+  } >"$dir/CHANGELOG.md"
+  printf '%s/CHANGELOG.md' "$dir"
+}
+
+# Body of the section headed $2 in file $1, whitespace stripped.
+section_body() {
+  awk -v want="$2" '
+    $0 ~ "^## \\[" want "\\]" { f = 1; next }
+    /^## \[/ { f = 0 }
+    f
+  ' "$1" | tr -d '[:space:]'
+}
+
+roll() {
+  local file="$1" version="$2" entries="${3:-}"
+  NEW_VERSION="$version" RELEASE_DATE=2026-08-07 CHANGELOG_ENTRIES_FILE="$entries" \
+    "$SCRIPT" "$file" 2>&1
+}
+
+# ── C1: a patch release leaves the file byte-identical ───────────────────────
+printf '\nC1  patch release records nothing\n'
+f="$(changelog_with c1)"
+before="$(cat "$f")"
+out="$(roll "$f" 0.6.132)"
+check "CHANGELOG.md is byte-identical" "$(cat "$f")" "$before"
+case "$out" in
+  *"records minor and major lines only"*) ok "the skip is logged" ;;
+  *) no "the skip is logged" "$out" "a 'minor and major lines only' notice" ;;
+esac
+
+# ── C2: a patch release does not stamp a heading even with entries drafted ───
+printf '\nC2  patch release ignores drafted entries\n'
+f="$(changelog_with c2)"
+printf '### Added\n\n- **A thing.** It happened.\n' >"$TMP/c2-entries.md"
+roll "$f" 0.6.133 "$TMP/c2-entries.md" >/dev/null
+check "no 0.6.133 heading exists" "$(grep -c '^## \[0.6.133\]' "$f")" "0"
+check "[Unreleased] is still empty" "$(section_body "$f" Unreleased)" ""
+
+# ── C3: a minor release rolls the drafted entries under a new heading ────────
+printf '\nC3  minor release rolls the draft\n'
+f="$(changelog_with c3)"
+printf '### Added\n\n- **A new thing.** It does things.\n' >"$TMP/c3-entries.md"
+roll "$f" 0.7.0 "$TMP/c3-entries.md" >/dev/null
+check "the 0.7.0 heading is created once" "$(grep -c '^## \[0.7.0\] — 2026-08-07$' "$f")" "1"
+check "the drafted bullet landed under it" \
+  "$(grep -c '^- \*\*A new thing\.\*\* It does things\.$' "$f")" "1"
+check "[Unreleased] is left behind, empty" "$(section_body "$f" Unreleased)" ""
+check "the older section survives" "$(grep -c '^## \[0.6.0\] — 2026-07-16$' "$f")" "1"
+
+# ── C4: THE REGRESSION. Minor + degraded drafter must not leave a bare heading ─
+printf '\nC4  minor release with no draft writes a pointer, not an empty section\n'
+f="$(changelog_with c4)"
+roll "$f" 0.8.0 "" >/dev/null
+check "the 0.8.0 heading is still created" "$(grep -c '^## \[0.8.0\] — 2026-08-07$' "$f")" "1"
+if [ -n "$(section_body "$f" 0.8.0)" ]; then
+  ok "the section has a body (not the 77-empty-headings shape)"
+else
+  no "the section has a body" "an empty section" "a releases-page pointer"
+fi
+check "the pointer names the releases page" \
+  "$(grep -c 'github.com/macanderson/stella/releases' "$f")" "1"
+
+# ── C5: a hand-written [Unreleased] survives a degraded draft ────────────────
+printf '\nC5  hand-written [Unreleased] is not eaten by the fallback\n'
+f="$(changelog_with c5 '
+### Fixed
+
+- a hand-written note
+')"
+roll "$f" 0.9.0 "" >/dev/null
+check "the hand-written note rolled under 0.9.0" \
+  "$(awk '/^## \[0.9.0\]/{f=1;next} /^## \[/{f=0} f' "$f" | grep -c 'a hand-written note')" "1"
+check "the fallback pointer was NOT written" \
+  "$(grep -c 'could not be generated' "$f")" "0"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/website/README.md
+++ b/website/README.md
@@ -26,6 +26,13 @@ layers, in order:
 Do not put a hex literal in `global.css` or a component — add a token to
 `tokens.css` and reference it, so the site and the kit cannot drift.
 
+**A route used by exactly one page may keep its own stylesheet** beside it,
+imported from that route's layout — `src/app/releases/releases.css` is the
+pattern. It buys the same thing `global.css` does (one stylesheet per page, not
+a `<style>` tag per component) without growing a sitewide file with rules
+nothing else can use. The token rule above still applies: no hex literals
+anywhere, and a `--rl-`-style prefix so the selectors cannot collide.
+
 **Brand assets are copies of the kit, not originals.** Every SVG under
 `public/brand/` mirrors `docs/brand/logo/svg/`; `public/icons/*`,
 `src/app/favicon.ico`, `src/app/icon.svg`, and `src/app/apple-icon.png` mirror
@@ -83,7 +90,7 @@ content/docs/            # all documentation (MDX + meta.json ordering)
   extensions.mdx         # the extension event bus
   scripting.mdx          # headless JSON output for CI
   showcase.mdx           # teams shipping with Stella (Oxagen, …)
-  release-notes.mdx      # what's new, per minor release
+  release-notes.mdx      # where release notes live (points at /releases)
   donate.mdx             # how to support the project
 
 src/app/                 # Next.js App Router

--- a/website/content/docs/release-notes.mdx
+++ b/website/content/docs/release-notes.mdx
@@ -1,284 +1,45 @@
 ---
 title: Release notes
-description: What's new in stella, per minor release — the user-facing changes behind each version, with the commit-level changelog linked on its GitHub Release.
+description: Where stella's release notes live — the per-line changelog at /releases, and the per-tag notes on GitHub.
 ---
 
-stella follows [semantic versioning](https://semver.org). Every merge to `main`
-cuts a release and publishes prebuilt binaries plus a Homebrew formula, so
-`brew upgrade stella` always tracks the latest build.
+Release notes live in two places, and which one you want depends on the
+question you are asking.
 
-This page is organized **by minor release**, and it is a summary rather than a
-changelog: the patch releases within a line ship continuously and are not
-itemized here. For what changed in one specific tag, read that tag's
-[GitHub Release](https://github.com/macanderson/stella/releases) — every one
-carries its full commit-level log.
+## What changed in the line I am upgrading across
 
-## 0.6.x — since 0.6.0
+**[stella.oxagen.sh/releases](/releases)** — one section per **minor line**,
+searchable, filterable by kind. This is the curated record: what a line
+delivered, written for someone deciding whether to upgrade.
 
-The patch releases in this line are not itemized (see the note above), but several
-of them added surface worth knowing about. Current release: **0.6.44**.
+It is generated from [`CHANGELOG.md`](https://github.com/macanderson/stella/blob/main/CHANGELOG.md)
+at build time, so the page and the repository cannot drift.
 
-### The PROOF rail — the verification, beside the work, live
+## What changed in this exact build
 
-The deck grew a rail that answers one question continuously: *right now, is this run
-proving what it is doing?* It folds live from the turn's proof events — what assurance
-triage decided to buy, whether the warrant judged the diff to need a test, the witness
-that was authored and pinned, and the oracle's baseline-versus-candidate result.
+**[The releases page on GitHub](https://github.com/macanderson/stella/releases)**
+— notes for every tag, generated from that tag's own diff.
 
-It is a panel rather than transcript rows on purpose. Proof is a small state machine
-whose *current* value matters and whose history does not; rendered as scrolling lines
-the answer is buried under whatever the worker printed since.
+Every merge to `main` cuts a patch release (the 0.6 line was 127 of them in
+eight days), so this is the surface to reach for when you are bisecting a
+regression or want the commit-level log for one version.
 
-The rail carries one invariant: **once a turn has ended, no row may read `pending`**.
-A surface that reports only when things go well is one you cannot trust when they do
-not, and `pending` on a finished turn is silence wearing the costume of progress. That
-is held in the fold rather than by asking eighteen terminal exits to each remember to
-report.
+<Callout title="Why this page is not the changelog">
+It used to be — a hand-maintained copy of the same notes, which is exactly why
+it stopped being one. It sat on "Current release: 0.6.44" while the tree was on
+0.6.131. A second copy of a record that changes every day is a copy that is
+wrong every day; `/releases` renders the repository's own file instead.
+</Callout>
 
-A related fix made the same honesty hold for the file counts beside it: `FileChange`
-now comes from the single recorder that actually measures a touch, so counts ride the
-event instead of being re-derived from diff text.
+## How a section gets written
 
-### `stella ingest` — your markdown becomes reviewable records
+Contributors and coding agents do not write changelog entries — CI does, so the
+file keeps one voice instead of whatever each PR happened to say about itself.
+When a minor or major release is cut,
+[`scripts/changelog-ai.sh`](https://github.com/macanderson/stella/blob/main/scripts/changelog-ai.sh)
+drafts the section from the whole series diff and
+[`scripts/changelog-roll.sh`](https://github.com/macanderson/stella/blob/main/scripts/changelog-roll.sh)
+rolls it into place under the new version heading.
 
-[`stella ingest`](/docs/commands/ingest) reads markdown you already wrote and turns it
-into context-record proposals. With no arguments it scans and classifies what the
-workspace contains; name a document and one model call splits it into atomic claims,
-each mapped to a record, run through a **deterministic safety gate**, probed for
-staleness, and written to `.stella/proposals/` as reviewable TOML.
-
-The gate is the point: the model is asked to surface executable content, but nothing
-downstream trusts that it did. Atomicity and quarantine are re-decided by a pure
-function that cannot be talked out of a rule by a cleverly-worded document.
-
-### Custom commands: TOML, parity fields, and namespaces
-
-[Custom commands](/docs/agent-tools/commands) can now be authored as TOML as well as
-markdown-with-frontmatter. The formats carry exactly the same fields, so TOML is a
-spelling rather than a feature tier — but a `prompt` key needs no frontmatter fence,
-and `allowed-tools` becomes a typed array.
-
-Alongside it: the full parity field set (`argument-hint`, `allowed-tools`, `model`,
-`disable-model-invocation`), namespaced commands via a subdirectory
-(`commands/vercel/deploy.toml` → `/vercel:deploy`), and
-[`stella commands`](/docs/commands/commands) to list what a workspace offers or convert
-markdown definitions in place.
-
-### A mid-turn prompt says what it became
-
-Typing while a turn runs is no longer ambiguous. Only a message prefixed `>` steers the
-running turn; a plain prompt becomes its own sub-session — and the deck now **says so**
-instead of leaving you to guess whether your text landed. The previously-reported "turn
-blew up" symptom was UI silence, not a broken turn.
-
-One exception is deliberate: while a gate card is pending, the gate owns the submission,
-so your keystrokes answer the card rather than starting anything.
-
-### Self-tuning, on evidence
-
-[`stella tune`](/docs/commands/tune) A/Bs one policy knob — the worker's reasoning
-effort — over two loop-bench runs, and promotes the winner **only** when it confidently
-wins, with a `--min-samples` floor and a reversible rollback record. Without
-`--promote` it reports and records the receipt but changes nothing.
-
-### `stella scoreboard` — and nothing grading its own homework
-
-[`stella scoreboard`](/docs/commands/scoreboard) reports four numbers per unit of work:
-model calls, characters a person had to type, follow-ups, and the verdict a merged or
-closed pull request implies. The store *does* carry a model self-rating field and the
-scoreboard deliberately ignores it. An open or draft PR is not counted as a verdict at
-all, because work still in flight has not been judged.
-
-### Telemetry, witness, and the terminal
-
-- **Live tool-call projection, crash recovery, and a real streaming telemetry API.**
-- **Witness assertion-density screen** — a witness that asserts nothing is no longer
-  accepted as proof — plus impacted-test selection that provably narrows across crates.
-- **A blind diff probe no longer completes as "nothing changed"**, which is what made
-  the warrant's guard inert on candidates that emitted no file events.
-- **A live thought follows its tail** instead of freezing on its first line; a `create`
-  reports what it made instead of vanishing; the Files tab populates for batched
-  `apply_edits`; and the markdown renderer stopped eating underscores in identifiers.
-- **`stella-serve`** gained `--version`/`--help` and a corrected as-built route table.
-
-### Brand: one identity, written down
-
-`docs/brand/BRAND.md` is now the normative source for stella's visual identity —
-electric blue and gold on deep space — and the terminal palette, the brand assets, the
-docs site tokens, and the Observatory dashboard all mirror it. Four surfaces had drifted
-to three different identities, and the drift was possible because nothing was normative.
-Retired in the same pass: the vermilion "ember" block cursor, the terminal-green dark
-theme, and the `--stella-sky*` token names they shipped under.
-
-## 0.6.0
-
-The `0.6.x` line opens with the feature the `0.5.x` series was building toward: **stella now learns from working in your codebase, and shows its work.** The adaptive context lifecycle is complete and on by default. Alongside it, this release gathers a large security and reliability pass, streaming on every provider that supports it, a rebuilt transcript, and a relicense.
-
-### Adaptive context — the loop closes
-
-stella has always recalled memories. What it could not do was tell you *why* a memory was chosen, whether it helped, or stop selecting one that never did. All four phases of that work landed in this line.
-
-- **Every turn is accountable.** The step manifest is now a compiled context frame with a deterministic identity and a content hash, and recall is decomposed into one block per item instead of a single undifferentiated blob. For any past turn you can see exactly which memories entered it, in what order, at what token cost, and where each came from.
-- **`stella inspect`** reconstructs the exact message array any past model call was sent, verified against the digests taken at emission, and reports coverage gaps and digest mismatches separately rather than papering over them. `Ctrl-G` opens the same view inside the deck.
-- **Proposals are typed, governed, and reviewable.** What the loop wants to make durable now lands in an append-only ledger with the evidence behind it. `stella proposals list / keep / edit / ignore` is the review surface; every decision is an immutable event, so the history replays exactly and Ignore is reversible rather than permanent. A proposal must recur across **distinct tasks**, not merely many times in one.
-- **Context that stops helping gets retired — reversibly.** Selection health is derived from immutable use and feedback records and rebuilds exactly; nothing is a stored counter that can drift. `stella memory retire` / `reaffirm` / `retired` manage it. A retired memory is excluded from automatic recall but stays explicitly retrievable by id, and **nothing is ever deleted**.
-- **The agent cannot talk itself into forgetting.** Citation feedback is recorded as `agent_self_report` and, by design, may inform selection health but never drive retirement — a self-report that can retire its own subject is self-reinforcing, because a model that misreads a memory reports it unhelpful, retires it, and destroys the evidence that the reading was wrong. Retirement requires a human or a deterministic source.
-- **`stella memory` grew a full lifecycle:** `forget` / `restore` / `forgotten` (a tombstone that survives re-learning, because the reflection loop re-mines paraphrases), `edit` (a new revision of the same id, so recall stops serving the old words), `compact`, and `index`.
-
-`context.lifecycle.enabled: false` in `settings.json` restores every pre-adaptive behavior wholesale.
-
-### Retrieval got much faster and much more relevant
-
-- **Recall no longer loads the whole corpus to answer a five-frame query.** It is two-phase: corpus-wide passes read a body-free projection computed in SQL, and bodies, vectors and domain tags are fetched only for the handful of rows that can still become frames. Ranking output is unchanged by construction — only what it costs to produce it.
-- **Recency stopped hijacking recall.** It was fused at full weight, so the newest rows could take every slot regardless of the query — one run's leftovers were being handed to the next, unrelated run.
-- **~1,000 tokens off every model call.** Both system prompts opened with a hand-maintained tool catalogue restating what each tool's generated schema already carries, shown to the model twice on every call for the life of the session.
-- **The cached system prefix is byte-stable again.** Relative ages ("2 hours ago") and draft lines naming a live pid made the ~15–20k-token prefix change every call, missing the provider prompt cache *and* paying the cache-write premium on the whole thing.
-- Context blocks are hashed once per turn rather than once per step, and an optional IVF approximate-similarity index is available behind `stella memory index`.
-
-### Every tool ships on
-
-`bash` and the key-free web tools are now registered in every session. The `"tools"` block in `settings.json` became an open map — any tool, group, or `*` → `on`/`off` — covering MCP and custom tools too, with a matching editor in the deck's SETTINGS tab. `stella tools` names the key that withheld each tool. Org-managed denials render locked.
-
-### Providers
-
-- **Streaming now works on OpenAI, Gemini and Vertex.** Only Anthropic and zai implemented the observed-completion path; everywhere else the deck rendered nothing until the whole turn finished.
-- **Bedrock stopped burning four paid generations per turn** — a shared per-read timeout was bounding the entire unary generation, so anything slower failed as retryable and was reissued three more times.
-- Transient gateway 5xx are retried again (OpenRouter reports upstream status in a field the error type wasn't reading, so a retryable 502 classified as terminal), a truncated Gemini/Vertex stream is retried rather than committed as a silently half-complete answer, and per-turn cost is priced against the right provider.
-- **Chain-of-thought is no longer published as the answer** on tool-calling turns via OpenRouter.
-
-### Terminal UI
-
-- **The transcript was rebuilt for reading.** Rows open on a fixed-width rail — `●` call, `⎿` result, `✗` failure, `▌` prompt — giving back 18 columns the old right-aligned tags spent on chrome. Collapsed output anchors on the first failing line rather than line 1, and a failure never collapses to one line. System notes split into *loud* (errors, gates, questions — a scan should stop on them) and *quiet* (recall, memory, compaction — bookkeeping), stages render as section rules rather than rows carrying one word, and the budget gauge prints the turn's cost once instead of a fresh `spend` row after every model call.
-- **Navigation:** `Ctrl-F` incremental find that searches the *full* tool output rather than the drawn preview, `Ctrl-N`/`Ctrl-P` to jump between failures, `Ctrl-Z` to fold a finished turn to one line.
-- **The deck prompts on large plans instead of dead-ending.** Scope review was hardcoded headless with an always-abort gate, and the advice it printed named a key only `stella run` reads. `Trim` keeps the largest prefix under the thresholds and says what it dropped.
-- **Live fleet dashboard** with supervisor verbs — pause, resume, and stop the focused task, with stop requiring two keystrokes.
-- **A new palette: bright sky on true black.** Four rival palettes collapsed into one system with WCAG-AA contrast contracts enforced at build time. The ground is neutral on purpose — a pale blue accent on a blue-tinted ground loses the separation that makes it read as a signal — and the accent is spent on exactly one thing in the transcript: the name of the tool being called, since those names are the index to the whole scrollback. A palette-law test rejects any categorical hue that sits within confusable distance of the accent, which moved azure to amber and the old glacier blue to teal. `/color` offers `sky` (the default), `azure`, `violet`, `magenta` and `mint`; `cyan` is kept as an alias so an existing `/color cyan` still resolves.
-
-### Security
-
-- **`git clone && stella` is no longer arbitrary code execution.** A repo's `.env` could set `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, `BASH_ENV`, `GIT_SSH_COMMAND` or a redirected `PATH`. Loader, interpreter and config-redirect names are refused from project `.env` files and printed on stderr; a live shell env still wins, so `LD_PRELOAD=… stella …` works when a human means it.
-- **Ambient authority scrubbed from model-controlled subprocesses**, including git's config/SSH/proxy hooks and `SSH_AUTH_SOCK`. Escape hatch: `STELLA_SUBPROCESS_ENV_ALLOW`.
-- Secrets are zeroized on drop and no longer dumpable via `{:?}`; files stella creates are owner-only; `run_tests`' `filter` is quoted per token, closing a command-injection path; a stored-XSS hole in the exported dashboard is closed; MCP servers are bounded on every axis (an MCP server streaming without a newline used to OOM-kill stella).
-- **Releases carry build-provenance attestation** covering both the tarballs and `SHA256SUMS`, and `install.sh` verifies it. A *contradicted* attestation always aborts; set `STELLA_REQUIRE_PROVENANCE=1` to make *unverifiable* abort too.
-- A new [threat model](https://github.com/macanderson/stella/blob/main/docs/spec/threat-model.md) records nine residual risks — including that "bash is off" was never the same claim as "the agent cannot run code."
-
-### Reliability
-
-- **Cancelling a turn actually kills the work.** Esc, the tool-timeout backstop and a fleet stop now kill the process group; before, the child kept running and kept editing your tree. Ctrl-C works headlessly for the first time, with exit codes **130** / **143**.
-- **Source writes survive a crash.** `write_file`, `edit_file`, `apply_edits` and `save_memory` used to truncate the target directly, so a crash mid-write left your file truncated with the replacement nowhere. Writes are now durable and in-place, preserving mode, owner and hard links.
-- **Loop detection works during compaction again** — its evidence was keyed off tool-result content compaction had already replaced, so the primary stuck-turn defense was off exactly when it was needed. On Gemini and Vertex it was effectively off entirely, because their per-step `call_{ordinal}` ids made three different outputs compare equal.
-- A crashed fleet run no longer wedges a workspace with a lock naming a dead run id; media downloads, SSE buffers and tool output are all bounded; deeply nested sources no longer crash the indexer; sessions survive a power cut.
-- **New default ceilings:** 10 minutes per model call, 15 minutes per tool dispatch, 5 seconds for recall.
-
-### Retention & cost
-
-- **`stella stats prune`** gives `store.db` a retention path — it holds full prompts, event payloads, tool arguments and context blocks and previously had none across 21 tables. `stella usage prune` bounds the hub. Both support `--dry-run`.
-- **Cache-write tokens are now priced.** They were reported end-to-end and priced at $0 by nothing, understating the budget meter and every receipt. **Reported costs go up for identical workloads** — a correction, not a price change.
-- Every JSON envelope leads with `schema_version`, and `AgentEvent` gained an `Unknown` variant so an older binary no longer fails a whole stream on one unrecognized event.
-
-### Docs
-
-A mobile-first overhaul turned reference tables into card grids and added diagrams for the credential chain, settings cascade, permission gate and telemetry flow. Building it surfaced three real defects, fixed in the same pass — `--model openrouter/auto` was documented and broken, `enable_recap` never reached the runtime, and one flag's help described the opposite of what it did. New: a `stella doctor` page, `CHANGELOG.md`, and a README per crate.
-
-### Licensing
-
-stella is relicensed from `MIT OR Apache-2.0` to **`AGPL-3.0-only`**, dual-licensed with commercial licenses from Oxagen, Inc. Two carve-outs worth stating plainly: **using stella to write proprietary code does not make that code AGPL**, and **releases up to v0.5.14 remain perpetually available under MIT/Apache**, including the right to fork from that point. Contributions now require a CLA. The Context Graph Protocol stays Apache-2.0.
-
-### Upgrading — what changes under you
-
-1. **`bash` and the key-free web tools are on by default.** Turn off with `"tools": {"bash": "off"}`.
-2. **The adaptive context lifecycle is on by default.** `"context": {"lifecycle": {"enabled": false}}` restores previous behavior.
-3. **Reported costs rise** for identical workloads, because cache-write tokens are now priced.
-4. **Witness test files are no longer written into your tree.** `stella run --keep-witness` restores it.
-5. **The deck now blocks on an approval card** for plans over 5 steps / 8 files / $1.00, where it previously aborted.
-6. **`OXAGEN_DEBUG` / `OXAGEN_MEDIA_LIVE` are renamed** to `STELLA_*`. The old names still work **for this release only**.
-7. **Extension deny policies now bite** on `build_project`, `run_tests`, `verify_done` and `send_stdin`, which previously bypassed them.
-8. **Downgrading is refused, not silently misread** — `context.db`, `codegraph.db` and the media journal now decline to open a schema newer than the binary knows.
-9. **The TUI palette is bright sky on true black**, and the default accent is `sky`. `/color cyan` still resolves, as an alias. *(Superseded later in the `0.6.x` line — the deck's themes are now `stella-dark` and `stella-light`, electric blue on deep space. `/color` still sets the plain REPL's accent from the same list.)*
-
-```bash
-# Homebrew (macOS / Linux)
-brew upgrade stella
-
-# From a release tarball — pick your target
-# https://github.com/macanderson/stella/releases/latest
-```
-
-Prebuilt binaries are published for `aarch64`/`x86_64` macOS and Linux. Verify a download against the `SHA256SUMS` attached to the release.
-
-## 0.5.0
-
-The first minor release of the `0.5.x` line. It gathers the stabilization and
-feature work that accumulated across the `0.4.x` patch series into one coherent
-step: a smarter edit path, graph-aware tooling, a durable context engine, and
-fleet-scale telemetry.
-
-### Editing & tools
-
-- **read→edit drift oracle.** `edit_file` now keeps a per-file record of the
-  content the model last *saw* (via a read, or its own successful write). When
-  an edit's `old_string` no longer matches, stella distinguishes an
-  out-of-band change to the file from a genuine not-found, echoes the current
-  content, and lets the model recover — instead of blindly retrying a stale
-  edit.
-- **`apply_edits` — transactional multi-file edits.** A new tool applies a batch
-  of edits across many files atomically, with a dry-run preflight that reports
-  exactly what would change before anything is written. Either the whole batch
-  applies or none of it does.
-- **`run_tests scope:"impacted"`.** Test selection is now graph-driven: stella
-  walks the tree-sitter code graph from your changes to the tests that actually
-  exercise them, so a focused change runs a focused suite.
-- **graph-derived planner context.** The planner localizes a goal to the
-  relevant files deterministically from the code graph, giving each turn a
-  tighter, more relevant working set.
-
-### Context engine
-
-- **Adaptive-context baseline (Phase 0 & 1).** The foundation of stella's
-  durable memory: a typed record taxonomy with scope and temporal axes, and
-  canonical JCS hashing for stable content identity. Context receipts now emit
-  **typed decision events** (loop-detection, budget, retry, and policy
-  decisions) as parseable twins of the prose the agent already narrates, bridged
-  into the policy-plane journal.
-- **compaction preserves the prompt-cache prefix.** When compaction dedupes
-  repeated blocks it now keeps the *earliest* copy, so the stable prefix the
-  provider's prompt cache keys on survives — fewer cache misses, lower bills.
-
-### Fleet & telemetry
-
-- **Observatory: org / hub telemetry dashboard.** A new view aggregates
-  telemetry across an organization's agents and workspaces, with hub-and-spoke
-  scoping for org / workspace / repo.
-- **Benchmark harnesses.** `loop-bench` (a cheap turn-loop + context-query
-  correctness harness) and the **stella arena** arena-bench adapter, which
-  records runs as ContextGraph traces.
-
-### Terminal UI
-
-- **Syntax highlighting in edit mode.** Markdown and TOML are now highlighted
-  when editing skills and agents in the TUI.
-- **Interactive Command Deck.** The docs landing page gained an interactive
-  Command Deck with animated terminals.
-
-### Fixes
-
-- Loop detection now sees through `read_file`'s session-tally footer, so
-  legitimate re-reads are no longer misread as a loop.
-- The conversational fast path no longer authors a witness test for a bare
-  greeting like `hi`.
-- Exhaustive TUI event matches handle `SpeculationDiscarded` cleanly, unbreaking
-  the clippy gate.
-
-### Install & upgrade
-
-```bash
-# Homebrew (macOS / Linux)
-brew install macanderson/tap/stella
-brew upgrade stella
-
-# From a release tarball — pick your target
-# https://github.com/macanderson/stella/releases/latest
-```
-
-Prebuilt binaries are published for `aarch64`/`x86_64` macOS and Linux. Verify a
-download against the `SHA256SUMS` attached to the release.
+If your change needs context the diff alone will not convey, put it in the pull
+request description: the drafter reads commit bodies, not just code.

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,8 @@
     "build": "NODE_ENV=production next build",
     "start": "next start --port 3400",
     "postinstall": "fumadocs-mdx",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@upstash/redis": "^1.38.0",

--- a/website/src/app/releases/layout.tsx
+++ b/website/src/app/releases/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import { baseOptions } from "@/lib/layout.shared";
+import "./releases.css";
+
+/**
+ * Chrome for /releases: the standard nav bar, present from first paint.
+ *
+ * Deliberately NOT the home page's `HomeChrome`, which hides the bar until the
+ * reader scrolls — that exists because the hero there carries its own large
+ * animated lockup in the corner the nav's logo would occupy, and two lockups
+ * would compete. This page's hero is type, so there is nothing to compete with
+ * and no reason to make a reader scroll to find their way back to the docs.
+ */
+export default function Layout({ children }: { children: ReactNode }) {
+  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+}

--- a/website/src/app/releases/page.tsx
+++ b/website/src/app/releases/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { ReleasesBrowser } from "./releases-browser";
+import { getReleases } from "@/lib/changelog.server";
+import { REPO_URL, SITE_URL } from "@/lib/site";
+
+/**
+ * /releases — the release-notes microsite.
+ *
+ * A server component: `getReleases()` reads the repository's CHANGELOG.md at
+ * build time and hands the parsed result to `<ReleasesBrowser>` for search and
+ * filtering. Nothing about the notes is duplicated here, so the page cannot
+ * fall behind the repository the way the hand-maintained docs page it replaces
+ * did (it sat on "Current release: 0.6.44" while the tree was on 0.6.131).
+ *
+ * Statically rendered — the data changes only when the repository does, which
+ * is to say only at deploy time. There is no revalidation window because there
+ * is nothing to revalidate against.
+ */
+
+const TITLE = "stella — releases";
+const DESCRIPTION =
+  "What each minor line of stella changed, in the words of someone who uses the CLI. Search every change, filter by kind, and read the line you are upgrading across.";
+const URL = `${SITE_URL}/releases`;
+
+export const metadata: Metadata = {
+  // `absolute` because the root layout's template is `%s — stella docs`, which
+  // is right for the docs tree and wrong here: this page is not documentation,
+  // and "stella — releases — stella docs" says the word twice to say less.
+  title: { absolute: TITLE },
+  description: DESCRIPTION,
+  alternates: { canonical: URL },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: URL,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+};
+
+export default function ReleasesPage() {
+  const releases = getReleases();
+  const latest = releases[0];
+
+  return (
+    <main className="rl-page">
+      <header className="rl-hero">
+        <p className="rl-eyebrow">changelog</p>
+        <h1 className="rl-title">releases</h1>
+        <p className="rl-lede">
+          What each <strong>minor line</strong> changed, written for someone
+          deciding whether to upgrade. Every merge to <code>main</code> cuts a
+          patch release — the 0.6 line was 127 of them in eight days — so those
+          are recorded per tag on the{" "}
+          <a href={`${REPO_URL}/releases`} target="_blank" rel="noreferrer">
+            releases page
+          </a>{" "}
+          rather than itemized here.
+        </p>
+        {latest ? (
+          <p className="rl-latest">
+            <span className="rl-latest-dot" aria-hidden="true" />
+            latest line <strong>{latest.version}</strong>
+            {latest.date ? <span className="rl-latest-date"> · {latest.date}</span> : null}
+          </p>
+        ) : null}
+      </header>
+
+      <ReleasesBrowser releases={releases} />
+
+      <footer className="rl-foot">
+        <p>
+          Notes are drafted from each line&rsquo;s own diff by{" "}
+          <a
+            href={`${REPO_URL}/blob/main/scripts/changelog-ai.sh`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <code>changelog-ai.sh</code>
+          </a>{" "}
+          and rolled into{" "}
+          <a
+            href={`${REPO_URL}/blob/main/CHANGELOG.md`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <code>CHANGELOG.md</code>
+          </a>
+          , which is what this page renders.
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/website/src/app/releases/releases-browser.tsx
+++ b/website/src/app/releases/releases-browser.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useDeferredValue, useId, useMemo, useState } from "react";
+import { InlineMarkdown } from "@/components/inline-markdown";
+import { CHANGE_KINDS, type ChangeKind, type Release } from "@/lib/changelog";
+import { REPO_URL } from "@/lib/site";
+
+/**
+ * The interactive half of /releases: search, filter by kind, expand a line.
+ *
+ * All state is client-side over data the server already parsed — the whole
+ * changelog is a few dozen entries, so filtering it is a `filter()` per
+ * keystroke rather than anything that needs a request. Sending it once and
+ * querying it locally is what makes the search feel instant; paginating it
+ * would add latency to a dataset that fits in a single response.
+ *
+ * `useDeferredValue` on the query keeps typing responsive if the list ever
+ * grows past what a synchronous re-render can absorb: React renders the stale
+ * list at high priority and the fresh one at low, so keystrokes never queue
+ * behind a filter pass.
+ *
+ * ## Why the filter is on entries, not releases
+ *
+ * A reader searching "cache" wants the four bullets that mention caching, not
+ * the three releases that contain them. So the query filters ENTRIES, a release
+ * disappears when none of its entries survive, and the surviving entries are
+ * the only ones drawn — the release card becomes a heading over its own hits.
+ * Result counts are stated in entries for the same reason.
+ */
+
+/**
+ * Per-kind accent. Hue is never the only cue — each chip and rail also carries
+ * the kind's word — because the brand kit's one-color law makes functional hue
+ * a supporting signal, not the message. `security` deliberately borrows the
+ * danger token: it is the one kind a reader must not skim past.
+ */
+const KIND_TOKEN: Record<ChangeKind, string> = {
+  Added: "var(--stella-gold)",
+  Changed: "var(--stella-gold-600)",
+  Fixed: "var(--stella-success)",
+  Removed: "var(--stella-neutral-500)",
+  Security: "var(--stella-danger)",
+};
+
+/** A version as a URL fragment: `0.7.0` -> `v0-7-0`. */
+function anchorFor(version: string): string {
+  return `v${version.replace(/\./g, "-")}`;
+}
+
+interface FilteredRelease {
+  release: Release;
+  entries: Release["entries"];
+}
+
+export function ReleasesBrowser({ releases }: { releases: Release[] }) {
+  const [rawQuery, setRawQuery] = useState("");
+  const [kinds, setKinds] = useState<ReadonlySet<ChangeKind>>(new Set());
+  // A release is open unless the reader collapsed it. Tracking the CLOSED set
+  // (rather than the open one) is what makes "everything expanded" the default
+  // without seeding state from props — which would go stale if `releases` ever
+  // changed under a client-side navigation.
+  const [closed, setClosed] = useState<ReadonlySet<string>>(new Set());
+
+  const query = useDeferredValue(rawQuery);
+  const searchId = useId();
+
+  /** Total entries per kind across every release — the chip counts. */
+  const totals = useMemo(() => {
+    const counts = new Map<ChangeKind, number>();
+    for (const release of releases) {
+      for (const entry of release.entries) {
+        counts.set(entry.kind, (counts.get(entry.kind) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [releases]);
+
+  const filtered = useMemo<FilteredRelease[]>(() => {
+    const needle = query.trim().toLowerCase();
+    const result: FilteredRelease[] = [];
+    for (const release of releases) {
+      const entries = release.entries.filter(
+        (entry) =>
+          (kinds.size === 0 || kinds.has(entry.kind)) &&
+          (needle === "" || entry.haystack.includes(needle)),
+      );
+      if (entries.length > 0) result.push({ release, entries });
+    }
+    return result;
+  }, [releases, query, kinds]);
+
+  const shown = filtered.reduce((n, r) => n + r.entries.length, 0);
+  const total = releases.reduce((n, r) => n + r.entries.length, 0);
+  const isFiltered = shown !== total;
+
+  const toggleKind = (kind: ChangeKind) => {
+    setKinds((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  };
+
+  const toggleOpen = (version: string) => {
+    setClosed((prev) => {
+      const next = new Set(prev);
+      if (next.has(version)) next.delete(version);
+      else next.add(version);
+      return next;
+    });
+  };
+
+  const reset = () => {
+    setRawQuery("");
+    setKinds(new Set());
+  };
+
+  return (
+    <div className="rl-browser">
+      <div className="rl-controls">
+        <div className="rl-search">
+          <label className="rl-search-label" htmlFor={searchId}>
+            search releases
+          </label>
+          <input
+            id={searchId}
+            className="rl-search-input"
+            type="search"
+            value={rawQuery}
+            onChange={(event) => setRawQuery(event.target.value)}
+            placeholder="cache, witness, sandbox, #1867…"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+
+        <div className="rl-chips" role="group" aria-label="filter by kind">
+          {CHANGE_KINDS.filter((kind) => totals.has(kind)).map((kind) => {
+            const active = kinds.has(kind);
+            return (
+              <button
+                key={kind}
+                type="button"
+                className="rl-chip"
+                data-active={active}
+                aria-pressed={active}
+                onClick={() => toggleKind(kind)}
+                style={{ "--rl-kind": KIND_TOKEN[kind] } as React.CSSProperties}
+              >
+                <span className="rl-chip-dot" aria-hidden="true" />
+                {kind.toLowerCase()}
+                <span className="rl-chip-count">{totals.get(kind)}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* aria-live so a screen reader hears the count change as the query is
+            typed; the visual count is the same node, never a parallel one. */}
+        <p className="rl-count" role="status" aria-live="polite">
+          {shown === 0
+            ? "no matching changes"
+            : `${shown} change${shown === 1 ? "" : "s"}${isFiltered ? ` of ${total}` : ""}`}
+          {isFiltered ? (
+            <button type="button" className="rl-reset" onClick={reset}>
+              clear
+            </button>
+          ) : null}
+        </p>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="rl-empty">
+          Nothing matches <strong>{rawQuery}</strong>. Older lines are on the{" "}
+          <a href={`${REPO_URL}/releases`} target="_blank" rel="noreferrer">
+            releases page
+          </a>
+          .
+        </p>
+      ) : (
+        <ol className="rl-timeline">
+          {filtered.map(({ release, entries }) => {
+            const open = !closed.has(release.version);
+            const anchor = anchorFor(release.version);
+            return (
+              <li key={release.version} className="rl-release" id={anchor}>
+                <div className="rl-release-head">
+                  <button
+                    type="button"
+                    className="rl-disclosure"
+                    aria-expanded={open}
+                    aria-controls={`${anchor}-body`}
+                    onClick={() => toggleOpen(release.version)}
+                  >
+                    <span className="rl-marker" aria-hidden="true" />
+                    <span className="rl-version">{release.version}</span>
+                    {release.date ? (
+                      <span className="rl-date">{release.date}</span>
+                    ) : null}
+                    <span className="rl-meter" aria-hidden="true">
+                      {CHANGE_KINDS.filter((k) => release.counts[k]).map((k) => (
+                        <span
+                          key={k}
+                          className="rl-meter-seg"
+                          style={
+                            {
+                              "--rl-kind": KIND_TOKEN[k],
+                              flexGrow: release.counts[k],
+                            } as React.CSSProperties
+                          }
+                        />
+                      ))}
+                    </span>
+                    <span className="rl-toggle" aria-hidden="true">
+                      {open ? "−" : "+"}
+                    </span>
+                  </button>
+                  <a
+                    className="rl-tag"
+                    href={`${REPO_URL}/releases/tag/v${release.version}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    v{release.version} on GitHub
+                  </a>
+                </div>
+
+                <div id={`${anchor}-body`} className="rl-release-body" hidden={!open}>
+                  {release.summary ? (
+                    <p className="rl-summary">
+                      <InlineMarkdown text={release.summary} query={query} />
+                    </p>
+                  ) : null}
+
+                  <ul className="rl-entries">
+                    {entries.map((entry, i) => (
+                      <li
+                        key={`${entry.kind}-${i}`}
+                        className="rl-entry"
+                        style={
+                          { "--rl-kind": KIND_TOKEN[entry.kind] } as React.CSSProperties
+                        }
+                      >
+                        <span className="rl-kind">{entry.kind.toLowerCase()}</span>
+                        <div className="rl-entry-text">
+                          {entry.lead ? (
+                            <strong className="rl-lead">
+                              <InlineMarkdown text={entry.lead} query={query} />
+                            </strong>
+                          ) : null}{" "}
+                          <InlineMarkdown text={entry.body} query={query} />
+                          {entry.refs.length > 0 ? (
+                            <span className="rl-refs">
+                              {entry.refs.map((ref) => (
+                                <a
+                                  key={ref}
+                                  href={`${REPO_URL}/pull/${ref}`}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="rl-ref"
+                                >
+                                  #{ref}
+                                </a>
+                              ))}
+                            </span>
+                          ) : null}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/website/src/app/releases/releases.css
+++ b/website/src/app/releases/releases.css
@@ -1,0 +1,457 @@
+/**
+ * Releases microsite (`rl-`) — styles for src/app/releases/.
+ *
+ * Imported once from this route's layout, so the whole page ships one
+ * stylesheet no matter how many entries it draws — the same reason the docs
+ * card primitives keep their styles out of the component. It lives beside the
+ * route instead of inside `global.css` because it is used by exactly one route
+ * and `global.css` is already sitewide chrome plus the docs card system;
+ * a fourth unrelated concern in there earns its own file.
+ *
+ * Colour discipline, from the brand kit: **gold is the signal, never the
+ * surface.** The page ground and the entry rows are the plain theme ground;
+ * gold appears on the version numeral, the timeline marker, the focus ring and
+ * the search hit — the things a reader is actually hunting for. Per-kind hue
+ * arrives through one `--rl-kind` custom property set inline by the component,
+ * so adding a kind needs no rule here. Hue is never the only cue: every chip
+ * and every entry also carries the kind's word.
+ *
+ * Every value is a token from tokens.css or a fumadocs `--color-fd-*` alias —
+ * no hex literals — so the page inverts with the theme.
+ */
+
+.rl-page {
+  max-width: 62rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.25rem 6rem;
+}
+
+/* ── hero ─────────────────────────────────────────────────────────────────── */
+
+.rl-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--stella-muted-fg);
+  margin: 0 0 0.5rem;
+}
+
+/* lowercase always — the brand kit's rule. There is no text-transform here
+ * because the string is already lowercase in the markup, which keeps it
+ * lowercase when it is copied, read aloud, or indexed. */
+.rl-title {
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+  margin: 0;
+}
+
+.rl-lede {
+  max-width: 46rem;
+  margin: 1.25rem 0 0;
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--stella-muted-fg);
+}
+.rl-lede strong {
+  color: var(--color-fd-foreground);
+  font-weight: 600;
+}
+.rl-lede code,
+.rl-foot code {
+  font-size: 0.9em;
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+  background: var(--color-fd-muted);
+}
+.rl-lede a,
+.rl-foot a {
+  color: var(--stella-accent-text);
+}
+
+.rl-latest {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 1.5rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--stella-muted-fg);
+}
+.rl-latest strong {
+  color: var(--stella-accent-text);
+  font-weight: 700;
+}
+.rl-latest-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--stella-gold);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--stella-gold) 22%, transparent);
+}
+
+/* ── controls ─────────────────────────────────────────────────────────────── */
+
+.rl-controls {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 2.75rem 0 0;
+  padding: 0.875rem 0;
+  /* An opaque ground by default: the timeline must not scroll visibly through
+   * the bar. The translucent treatment is an enhancement, not the base. */
+  background: var(--color-fd-background);
+  border-bottom: 1px solid var(--color-fd-border);
+}
+@supports (backdrop-filter: blur(1px)) {
+  .rl-controls {
+    background: color-mix(in srgb, var(--color-fd-background) 88%, transparent);
+    backdrop-filter: blur(8px);
+  }
+}
+
+.rl-search {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+/* Visually hidden, not removed: the input needs a programmatic label, and a
+ * placeholder is not one — it disappears the moment you type. */
+.rl-search-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.rl-search-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--color-fd-foreground);
+  background: var(--color-fd-card);
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.5rem;
+}
+.rl-search-input::placeholder {
+  color: var(--stella-muted-fg);
+}
+.rl-search-input:focus-visible {
+  outline: 2px solid var(--stella-accent-text);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.rl-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+.rl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  line-height: 1;
+  color: var(--stella-muted-fg);
+  background: transparent;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    color var(--stella-duration-fast) var(--stella-ease-arrive),
+    border-color var(--stella-duration-fast) var(--stella-ease-arrive),
+    background-color var(--stella-duration-fast) var(--stella-ease-arrive);
+}
+.rl-chip:hover {
+  color: var(--color-fd-foreground);
+  border-color: var(--stella-muted-fg);
+}
+.rl-chip[data-active="true"] {
+  color: var(--color-fd-foreground);
+  border-color: var(--rl-kind);
+  background: color-mix(in srgb, var(--rl-kind) 12%, transparent);
+}
+.rl-chip:focus-visible {
+  outline: 2px solid var(--stella-accent-text);
+  outline-offset: 2px;
+}
+.rl-chip-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--rl-kind);
+}
+.rl-chip-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--stella-muted-fg);
+}
+
+.rl-count {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--stella-muted-fg);
+  font-variant-numeric: tabular-nums;
+}
+.rl-reset {
+  margin-left: 0.5rem;
+  padding: 0;
+  font: inherit;
+  color: var(--stella-accent-text);
+  background: none;
+  border: none;
+  border-bottom: 1px solid currentColor;
+  cursor: pointer;
+}
+
+/* ── timeline ─────────────────────────────────────────────────────────────── */
+
+.rl-empty {
+  margin: 3rem 0;
+  color: var(--stella-muted-fg);
+}
+.rl-empty a {
+  color: var(--stella-accent-text);
+}
+
+.rl-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* The rail: one hairline down the left of every release, with the marker
+ * sitting on it. Drawn as a border on each list item rather than a
+ * pseudo-element on the container so it breaks correctly when a release is
+ * filtered out of the middle of the list. `position: relative` anchors the
+ * marker, which is absolutely positioned onto the rail. */
+.rl-release {
+  position: relative;
+  border-left: 1px solid var(--color-fd-border);
+  padding: 2.25rem 0 0 1.75rem;
+  margin-left: 0.5rem;
+}
+.rl-release:last-child {
+  padding-bottom: 1rem;
+}
+
+.rl-release-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.rl-disclosure {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  flex: 1 1 auto;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.rl-disclosure:focus-visible {
+  outline: 2px solid var(--stella-accent-text);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+/* Sits ON the rail: half the marker's width, plus the rail's own, back from
+ * the content edge. The ring is the page ground, so the rail appears to pass
+ * behind the dot rather than through it. */
+.rl-marker {
+  position: absolute;
+  left: calc(-0.3125rem - 1px);
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  background: var(--stella-gold);
+  box-shadow: 0 0 0 4px var(--color-fd-background);
+}
+
+.rl-version {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--stella-accent-text);
+}
+.rl-date {
+  font-size: 0.8125rem;
+  color: var(--stella-muted-fg);
+  font-variant-numeric: tabular-nums;
+}
+
+/* A proportional bar of the release's kinds — shape for "this line was mostly
+ * fixes", taken in before a word is read. Decorative: every count it encodes
+ * is also stated by the entries below, so it is aria-hidden in the markup. */
+.rl-meter {
+  display: flex;
+  flex: 0 1 8rem;
+  gap: 2px;
+  height: 3px;
+  margin-left: auto;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.rl-meter-seg {
+  background: var(--rl-kind);
+  border-radius: 2px;
+}
+
+.rl-toggle {
+  width: 1rem;
+  text-align: center;
+  font-size: 1.125rem;
+  color: var(--stella-muted-fg);
+}
+.rl-tag {
+  font-size: 0.75rem;
+  color: var(--stella-muted-fg);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+.rl-tag:hover {
+  color: var(--stella-accent-text);
+  border-bottom-color: currentColor;
+}
+
+.rl-release-body {
+  margin-top: 1.25rem;
+}
+.rl-summary {
+  max-width: 44rem;
+  margin: 0 0 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--stella-muted-fg);
+}
+
+/* ── entries ──────────────────────────────────────────────────────────────── */
+
+.rl-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.125rem;
+}
+.rl-entry {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 0.875rem;
+  align-items: baseline;
+  padding-left: 0.875rem;
+  border-left: 2px solid var(--rl-kind);
+}
+
+/* The colour is the supporting cue; this word is the actual label, which is
+ * what keeps an entry classified with hue removed entirely. */
+.rl-kind {
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--rl-kind);
+}
+
+.rl-entry-text {
+  max-width: 44rem;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--stella-muted-fg);
+}
+.rl-lead {
+  color: var(--color-fd-foreground);
+  font-weight: 600;
+}
+.rl-code {
+  font-size: 0.9em;
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+  background: var(--color-fd-muted);
+  color: var(--color-fd-foreground);
+}
+.rl-link {
+  color: var(--stella-accent-text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.rl-refs {
+  display: inline-flex;
+  gap: 0.375rem;
+  margin-left: 0.375rem;
+}
+.rl-ref {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--stella-muted-fg);
+  text-decoration: none;
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.25rem;
+}
+.rl-ref:hover {
+  color: var(--stella-accent-text);
+  border-color: currentColor;
+}
+
+/* The search hit. Gold at low alpha rather than the browser's default yellow,
+ * which is the one colour on the page belonging to no theme. */
+.rl-hit {
+  background: color-mix(in srgb, var(--stella-gold) 30%, transparent);
+  color: inherit;
+  border-radius: 0.15rem;
+  padding: 0 0.1em;
+}
+
+/* ── footer ───────────────────────────────────────────────────────────────── */
+
+.rl-foot {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-fd-border);
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  color: var(--stella-muted-fg);
+}
+
+/* ── narrow screens ───────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .rl-page {
+    padding-top: 2.25rem;
+  }
+  /* The kind label moves above the prose: at 380px a 5.5rem gutter leaves the
+   * text column too narrow to read, and the label is short enough that a line
+   * of its own costs less than the column it was taking. */
+  .rl-entry {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+  .rl-meter {
+    flex-basis: 4rem;
+  }
+  .rl-controls {
+    gap: 0.5rem;
+  }
+}
+
+/* The chip transitions are the only animation on this page, and they are pure
+ * affordance — nothing is lost by dropping them. */
+@media (prefers-reduced-motion: reduce) {
+  .rl-chip {
+    transition: none;
+  }
+}

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -14,9 +14,27 @@
  */
 import type { MetadataRoute } from "next";
 import { source } from "@/lib/source";
+import { getReleases } from "@/lib/changelog.server";
 import { SITE_URL } from "@/lib/site";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The date of the newest release section, for /releases' `lastModified`.
+ *
+ * A changelog date is either `YYYY-MM-DD` or a `start → end` span; the last
+ * 10-character date in the string is the one that says when the line stopped
+ * moving. Returns undefined if the heading carries no parseable date, so the
+ * field is omitted rather than guessed — the same "no claim beats a false
+ * claim" rule the docs rows follow.
+ */
+function releasesLastModified(): Date | undefined {
+  const [latest] = getReleases();
+  const dates = latest?.date.match(/\d{4}-\d{2}-\d{2}/g);
+  if (!dates?.length) return undefined;
+  const parsed = new Date(`${dates[dates.length - 1]}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
 
 /**
  * The `last-modified` plugin is registered in source.config.ts only when the
@@ -75,6 +93,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: homeLastModified,
       changeFrequency: changeFrequency(homeLastModified),
       priority: 1,
+    },
+    {
+      // /releases is a React route rendered from CHANGELOG.md, so no per-file
+      // MDX date reaches this map. Its content changes on exactly the cadence
+      // the newest release does, and the newest release's date is parsed
+      // rather than guessed — a real date, like every other row here.
+      url: `${SITE_URL}/releases`,
+      lastModified: releasesLastModified(),
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
     },
     ...docs,
   ];

--- a/website/src/components/inline-markdown.tsx
+++ b/website/src/components/inline-markdown.tsx
@@ -1,0 +1,126 @@
+import { Fragment, type ReactNode } from "react";
+
+/**
+ * Render the inline marks that appear inside a changelog entry, as JSX.
+ *
+ * The alternative — running a markdown library and injecting its HTML string —
+ * would mean `dangerouslySetInnerHTML` on text that, while ours today, is
+ * written by a model in CI (`scripts/changelog-ai.sh`). Returning React nodes
+ * makes an injected `<script>` structurally impossible rather than
+ * conventionally unlikely, which is the right posture for machine-authored
+ * prose no human is required to read before it deploys.
+ *
+ * Three marks, matching what the drafter's prompt tells it to emit:
+ *
+ *   `code`            -> <code>
+ *   **bold**          -> <strong>
+ *   [text](https://…) -> <a>, external only
+ *
+ * Anything else — underscores, nested emphasis, images, reference links — is
+ * left as literal text. That is deliberate: an entry is one or two sentences of
+ * plain prose by contract, and silently supporting more marks would invite
+ * entries that depend on them and then render wrong somewhere else (the same
+ * text also ships as a plain-text GitHub release body).
+ *
+ * ## The search-term highlight
+ *
+ * `highlight` wraps case-insensitive matches of a query in `<mark>`. It runs
+ * over the *text* segments only, after the marks are split out, so a query
+ * matching `code` cannot break a `<code>` element in half — the split is
+ * structural, not string-level.
+ */
+
+/** `code`, **bold**, or [text](url) — alternatives ordered longest-first. */
+const INLINE = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\(https?:\/\/[^)]+\))/g;
+const LINK = /^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/;
+
+/** Escape a user-typed query for use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Split `text` on case-insensitive occurrences of `query`, wrapping each hit in
+ * `<mark>`. Returns the string unchanged when there is no query, so the common
+ * (unfiltered) render allocates nothing.
+ */
+function highlight(text: string, query: string, keyPrefix: string): ReactNode {
+  if (!query) return text;
+  const pattern = new RegExp(`(${escapeRegExp(query)})`, "ig");
+  const parts = text.split(pattern);
+  if (parts.length === 1) return text;
+  return parts.map((part, i) =>
+    // split() with one capture group alternates [text, hit, text, hit, …], so
+    // odd indices are exactly the matches — no second comparison needed.
+    i % 2 === 1 ? (
+      <mark key={`${keyPrefix}-m${i}`} className="rl-hit">
+        {part}
+      </mark>
+    ) : (
+      <Fragment key={`${keyPrefix}-t${i}`}>{part}</Fragment>
+    ),
+  );
+}
+
+export function InlineMarkdown({
+  text,
+  query = "",
+}: {
+  text: string;
+  /** Search term to highlight, if any. */
+  query?: string;
+}): ReactNode {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let index = 0;
+
+  for (const match of text.matchAll(INLINE)) {
+    const at = match.index ?? 0;
+    if (at > cursor) {
+      nodes.push(highlight(text.slice(cursor, at), query, `p${index}`));
+    }
+
+    const token = match[0];
+    if (token.startsWith("`")) {
+      nodes.push(
+        <code key={`c${index}`} className="rl-code">
+          {token.slice(1, -1)}
+        </code>,
+      );
+    } else if (token.startsWith("**")) {
+      nodes.push(
+        <strong key={`b${index}`}>
+          {highlight(token.slice(2, -2), query, `b${index}`)}
+        </strong>,
+      );
+    } else {
+      const link = token.match(LINK);
+      // The regex only matches well-formed links, so `link` is non-null here;
+      // the fallback keeps this total rather than asserting.
+      nodes.push(
+        link ? (
+          <a
+            key={`a${index}`}
+            href={link[2]}
+            target="_blank"
+            rel="noreferrer"
+            className="rl-link"
+          >
+            {highlight(link[1], query, `a${index}`)}
+          </a>
+        ) : (
+          <Fragment key={`x${index}`}>{token}</Fragment>
+        ),
+      );
+    }
+
+    cursor = at + token.length;
+    index += 1;
+  }
+
+  if (cursor < text.length) {
+    nodes.push(highlight(text.slice(cursor), query, `p${index}`));
+  }
+
+  return <>{nodes}</>;
+}

--- a/website/src/lib/changelog.server.ts
+++ b/website/src/lib/changelog.server.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseChangelog, type Release } from "./changelog";
+
+/**
+ * The I/O half of the changelog reader: find CHANGELOG.md and read it.
+ *
+ * Split from `changelog.ts` because that module is imported by the client
+ * component too, and a `node:fs` anywhere in a client graph fails the Turbopack
+ * build outright ("the chunking context does not support external modules").
+ * That failure IS the guard — importing this from a client component cannot
+ * reach production — so the `server-only` package would add a dependency to
+ * restate an error the bundler already raises. The `.server` suffix is the
+ * reminder; the build is the enforcement.
+ *
+ * The page that calls this is statically rendered, so this runs at build time —
+ * which is what keeps the site and the repository from drifting: there is no
+ * second copy of the release notes to forget to update. The hand-maintained MDX
+ * page this replaced had been stuck on "Current release: 0.6.44" while the tree
+ * was on 0.6.131.
+ */
+
+/**
+ * The repo root, derived from this module's own location, so the path survives
+ * being built from any working directory (Vercel builds from `website/`,
+ * `pnpm dev` from wherever you launched it). `import.meta.url` rather than
+ * `process.cwd()` for exactly that reason.
+ */
+function changelogPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "..", "..", "CHANGELOG.md");
+}
+
+/**
+ * Every release in CHANGELOG.md, newest first (the file's own order, which the
+ * roll maintains by inserting at the top).
+ *
+ * Deliberately uncached: this is evaluated once per build for a static route,
+ * so a cache would buy nothing and a stale-cache bug on the one page whose
+ * whole point is freshness would cost more than the read.
+ */
+export function getReleases(): Release[] {
+  return parseChangelog(readFileSync(changelogPath(), "utf8"));
+}

--- a/website/src/lib/changelog.test.ts
+++ b/website/src/lib/changelog.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseChangelog } from "./changelog.ts";
+
+/**
+ * Tests for the CHANGELOG.md parser behind /releases.
+ *
+ *   pnpm test          (from website/)
+ *
+ * Node's built-in runner, with its native TypeScript stripping — the parser is
+ * a pure function over a string, so a test framework would be a dependency
+ * bought to call one function.
+ *
+ * ## Why this file exists
+ *
+ * The parser's input is written by a model in CI (`scripts/changelog-ai.sh`),
+ * and every way it can go wrong is SILENT: a heading shape it stops matching
+ * makes a release vanish from the page, and a bullet shape it stops matching
+ * makes entries vanish from a release. Both render as a page that looks
+ * completely fine and is missing things. Nothing else in the build fails.
+ *
+ * So the cases below are the shapes the drafter is instructed to emit, plus
+ * the three non-release headings that live in the same file and must never be
+ * rendered as releases.
+ */
+
+const SAMPLE = `# Changelog
+
+Preamble prose that is not a release.
+
+## How this file works
+
+Instructions to contributors. Not release notes.
+
+## [Unreleased]
+
+## [0.7.0] — 2026-08-07
+
+### Changed
+
+- **A bold lead claim.** One sentence of prose that wraps
+  across two source lines (#1234).
+
+### Added
+
+- A bullet with no bold lead at all.
+
+## [0.6.0] — 2026-07-29 → 2026-08-06
+
+A lead paragraph describing the line.
+
+### Fixed
+
+- **Something broke.** It does not any more (#100, #200).
+- **A second fix.** With \`code\` and a [link](https://example.com).
+
+### Removed
+
+- **A thing is gone.** And is not coming back.
+
+## Earlier releases
+
+0.4.0 and earlier predate this file.
+`;
+
+test("parses every release heading, and only release headings", () => {
+  const releases = parseChangelog(SAMPLE);
+  assert.deepEqual(
+    releases.map((r) => r.version),
+    ["0.7.0", "0.6.0"],
+    "Unreleased, the preamble, 'How this file works' and 'Earlier releases' must not appear",
+  );
+});
+
+test("keeps the date tail verbatim, including a span", () => {
+  const [latest, previous] = parseChangelog(SAMPLE);
+  assert.equal(latest.date, "2026-08-07");
+  assert.equal(previous.date, "2026-07-29 → 2026-08-06");
+});
+
+test("drops a release with no entries rather than rendering an empty card", () => {
+  // The roll cannot produce this any more (scripts/changelog-roll.sh refuses),
+  // but the page must not depend on that: this file outlives that script.
+  const releases = parseChangelog("## [Unreleased]\n\n## [9.9.9] — 2026-01-01\n");
+  assert.deepEqual(releases, []);
+});
+
+test("splits a bold lead from its body, and joins wrapped lines", () => {
+  const [latest] = parseChangelog(SAMPLE);
+  const entry = latest.entries[0];
+  assert.equal(entry.kind, "Changed");
+  assert.equal(entry.lead, "A bold lead claim.");
+  assert.equal(
+    entry.body,
+    "One sentence of prose that wraps across two source lines (#1234).",
+    "the 80-column wrap must collapse to one paragraph, with single spaces",
+  );
+});
+
+test("handles a bullet with no bold lead", () => {
+  const [latest] = parseChangelog(SAMPLE);
+  const entry = latest.entries[1];
+  assert.equal(entry.kind, "Added");
+  assert.equal(entry.lead, "");
+  assert.equal(entry.body, "A bullet with no bold lead at all.");
+});
+
+test("extracts every PR reference, deduplicated", () => {
+  const [, previous] = parseChangelog(SAMPLE);
+  assert.deepEqual(previous.entries[0].refs, ["100", "200"]);
+  assert.deepEqual(previous.entries[1].refs, []);
+});
+
+test("counts entries per kind, omitting kinds with none", () => {
+  const [, previous] = parseChangelog(SAMPLE);
+  assert.deepEqual(previous.counts, { Fixed: 2, Removed: 1 });
+});
+
+test("captures the lead paragraph before the first kind heading", () => {
+  const [latest, previous] = parseChangelog(SAMPLE);
+  assert.equal(previous.summary, "A lead paragraph describing the line.");
+  assert.equal(latest.summary, "", "a release with no lead paragraph gets an empty one");
+});
+
+test("lowercases the haystack so search does no work per keystroke", () => {
+  const [latest] = parseChangelog(SAMPLE);
+  assert.ok(latest.entries[0].haystack.includes("a bold lead claim"));
+  assert.equal(
+    latest.entries[0].haystack,
+    latest.entries[0].haystack.toLowerCase(),
+  );
+});
+
+test("ignores an unknown ### heading rather than inventing a kind", () => {
+  const releases = parseChangelog(
+    "## [1.0.0] — 2026-01-01\n\n### Deprecated\n\n- orphaned\n\n### Fixed\n\n- **Real.** Kept.\n",
+  );
+  assert.deepEqual(
+    releases[0].entries.map((e) => e.kind),
+    ["Fixed"],
+    "a bullet under a heading that is not a Keep-a-Changelog kind is dropped, not miscategorised",
+  );
+});

--- a/website/src/lib/changelog.ts
+++ b/website/src/lib/changelog.ts
@@ -1,0 +1,223 @@
+/**
+ * Parse CHANGELOG.md into the shape /releases renders. **Pure — no I/O.**
+ *
+ * Reading the file lives in `changelog.server.ts`; this module is imported by
+ * the client component too (for `CHANGE_KINDS` and the types), and a single
+ * `node:fs` import anywhere in that graph fails the build with "the chunking
+ * context does not support external modules". Which is the bundler enforcing
+ * the same split the Rust side of this repository states as invariant #2:
+ * decision logic is pure functions over owned data, and anything that touches
+ * the filesystem is a separate layer. Keeping the parser pure is also what
+ * lets it be tested against a fixture string with no tmpdir.
+ *
+ * ## What it expects
+ *
+ * The subset of Keep a Changelog that `scripts/changelog-roll.sh` actually
+ * produces, and nothing more:
+ *
+ *   ## [0.7.0] — 2026-08-07          <- a release, optionally a date or range
+ *   <optional lead paragraph>
+ *   ### Added                        <- a kind
+ *   - **Bold lead claim.** Prose.    <- an entry
+ *
+ * `## [Unreleased]` and any non-version `##` heading (the "How this file works"
+ * preamble, the "Earlier releases" footer) are skipped: they are instructions
+ * to contributors, not release notes, and rendering them on a marketing page
+ * would be noise. A release with no entries cannot occur any more — the roll
+ * refuses to emit one — but it is dropped here too rather than trusted, because
+ * this parser outlives any one version of that script.
+ *
+ * ## Why a hand-rolled parser and not a markdown library
+ *
+ * The whole grammar is four line shapes, all anchored at column zero, and the
+ * output feeds a bespoke component tree rather than an HTML string. A markdown
+ * AST would be a dependency and a traversal to arrive at the same four cases.
+ * Inline markdown *within* an entry is left as text here and rendered by
+ * `<InlineMarkdown>` at the leaf, which is where it can become JSX instead of
+ * an HTML string — so the page never needs `dangerouslySetInnerHTML`.
+ */
+
+/**
+ * The Keep a Changelog kinds, in the order the drafter is instructed to emit
+ * them — which is also the order they read best: what you gained, what moved
+ * under you, what stopped hurting, what went away, what was dangerous.
+ *
+ * Declared as a const tuple so `ChangeKind` is the union of exactly these and
+ * the filter UI can iterate the same list it validates against.
+ */
+export const CHANGE_KINDS = [
+  "Added",
+  "Changed",
+  "Fixed",
+  "Removed",
+  "Security",
+] as const;
+
+export type ChangeKind = (typeof CHANGE_KINDS)[number];
+
+/** One bullet: a bold lead claim (optional) and the prose after it. */
+export interface ChangeEntry {
+  kind: ChangeKind;
+  /** The `**bold**` opener, without its asterisks. Empty when the bullet has none. */
+  lead: string;
+  /** Everything after the lead, as raw markdown-ish text. */
+  body: string;
+  /** Lowercased `lead + body`, precomputed so search does no work per keystroke. */
+  haystack: string;
+  /** PR numbers cited as `(#1234)`, in order of appearance, deduplicated. */
+  refs: string[];
+}
+
+/** One `## [x.y.z]` section. */
+export interface Release {
+  /** The bare version, e.g. `0.7.0`. */
+  version: string;
+  /** The `— …` tail of the heading: a date, or a `start → end` span. */
+  date: string;
+  /** The prose between the heading and the first `###`, if any. */
+  summary: string;
+  entries: ChangeEntry[];
+  /** Entry counts by kind, for the per-release meter. Zero-count kinds omitted. */
+  counts: Partial<Record<ChangeKind, number>>;
+}
+
+const KIND_SET = new Set<string>(CHANGE_KINDS);
+
+/**
+ * `## [0.7.0] — 2026-08-07` / `## [0.6.0] — 2026-07-29 → 2026-08-06`.
+ * The date tail is optional so a section is still parsed if the roll ever
+ * writes one without a date; better a release with a blank date than a release
+ * silently missing from the page.
+ */
+const RELEASE_HEADING = /^## \[(\d+\.\d+\.\d+)\](?:\s*[—-]\s*(.+))?$/;
+const KIND_HEADING = /^### (\w+)\s*$/;
+const BULLET = /^- (.*)$/;
+const LEAD = /^\*\*(.+?)\*\*\s*/;
+const PR_REF = /\(#(\d+)\)/g;
+
+/**
+ * Collapse a bullet's continuation lines into one paragraph.
+ *
+ * CHANGELOG.md is hard-wrapped at 80 columns, so nearly every bullet spans
+ * several source lines. Joining with a space is right for prose; the drafter is
+ * instructed to emit prose, and a bullet containing a code block would be
+ * outside the grammar this page renders anyway.
+ */
+function joinWrapped(lines: string[]): string {
+  return lines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function toEntry(kind: ChangeKind, raw: string): ChangeEntry {
+  const leadMatch = raw.match(LEAD);
+  const lead = leadMatch ? leadMatch[1].trim() : "";
+  const body = leadMatch ? raw.slice(leadMatch[0].length).trim() : raw.trim();
+
+  const refs = [...raw.matchAll(PR_REF)].map((m) => m[1]);
+
+  return {
+    kind,
+    lead,
+    body,
+    haystack: `${lead} ${body}`.toLowerCase(),
+    refs: [...new Set(refs)],
+  };
+}
+
+/** Parse changelog markdown into releases, newest first (the file's own order). */
+export function parseChangelog(markdown: string): Release[] {
+  const releases: Release[] = [];
+
+  let release: Release | null = null;
+  let kind: ChangeKind | null = null;
+  let bullet: string[] | null = null;
+  let summary: string[] = [];
+
+  /** Close the bullet under construction, if any. */
+  const flushBullet = () => {
+    if (release && kind && bullet) {
+      const text = joinWrapped(bullet);
+      if (text) release.entries.push(toEntry(kind, text));
+    }
+    bullet = null;
+  };
+
+  /** Close the release under construction, dropping it if it has no entries. */
+  const flushRelease = () => {
+    flushBullet();
+    if (release) {
+      release.summary = joinWrapped(summary);
+      if (release.entries.length > 0) {
+        for (const entry of release.entries) {
+          release.counts[entry.kind] = (release.counts[entry.kind] ?? 0) + 1;
+        }
+        releases.push(release);
+      }
+    }
+    release = null;
+    kind = null;
+    summary = [];
+  };
+
+  for (const line of markdown.split("\n")) {
+    const heading = line.match(RELEASE_HEADING);
+    if (heading) {
+      flushRelease();
+      release = {
+        version: heading[1],
+        date: (heading[2] ?? "").trim(),
+        summary: "",
+        entries: [],
+        counts: {},
+      };
+      continue;
+    }
+
+    // Any other `## ` ends the current release: `[Unreleased]`, the preamble,
+    // the "Earlier releases" footer. None of them are release notes.
+    if (line.startsWith("## ")) {
+      flushRelease();
+      continue;
+    }
+
+    if (!release) continue;
+
+    const kindHeading = line.match(KIND_HEADING);
+    if (kindHeading && KIND_SET.has(kindHeading[1])) {
+      flushBullet();
+      kind = kindHeading[1] as ChangeKind;
+      continue;
+    }
+
+    const bulletStart = line.match(BULLET);
+    if (bulletStart) {
+      flushBullet();
+      bullet = [bulletStart[1]];
+      continue;
+    }
+
+    if (bullet) {
+      // A blank line ends a bullet; an indented line continues it. A bullet's
+      // own body can contain blank-line-separated paragraphs in this file, so
+      // an indented line after a blank one re-opens the same bullet rather than
+      // starting a new one — hence the check on `line.startsWith(" ")` instead
+      // of treating every blank line as terminal.
+      if (line.trim() === "") continue;
+      if (line.startsWith("  ")) {
+        bullet.push(line);
+        continue;
+      }
+      flushBullet();
+    }
+
+    // Prose before the first `###` is the release's lead paragraph.
+    if (!kind && line.trim()) summary.push(line);
+  }
+
+  flushRelease();
+  return releases;
+}

--- a/website/src/lib/changelog.ts
+++ b/website/src/lib/changelog.ts
@@ -93,7 +93,15 @@ const RELEASE_HEADING = /^## \[(\d+\.\d+\.\d+)\](?:\s*[—-]\s*(.+))?$/;
 const KIND_HEADING = /^### (\w+)\s*$/;
 const BULLET = /^- (.*)$/;
 const LEAD = /^\*\*(.+?)\*\*\s*/;
-const PR_REF = /\(#(\d+)\)/g;
+
+/**
+ * A PR or issue citation, matched anywhere in the bullet rather than only as a
+ * trailing `(#1234)`. Entries routinely cite several at once — `(#1285, #1842)`,
+ * `(#1870, #1871, #1876)`, `(#335, B1)` — and an anchored `\(#(\d+)\)` silently
+ * matched NONE of those, which is exactly the kind of quiet under-reporting a
+ * page like this must not do.
+ */
+const PR_REF = /#(\d+)\b/g;
 
 /**
  * Collapse a bullet's continuation lines into one paragraph.

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -17,6 +17,11 @@
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "noEmit": true,
+    // The *.test.ts files run under `node --test`, whose native TypeScript
+    // stripping resolves real filesystem paths and so requires the .ts
+    // extension on relative imports. Safe because nothing is emitted here:
+    // tsc only typechecks, and Next/Turbopack does the building.
+    "allowImportingTsExtensions": true,
     "incremental": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## What this is

Two things that turned out to be one thing: **stop generating a bad changelog**,
and **give release notes a surface worth reading**.

`CHANGELOG.md` had grown to **180 sections, 77 of them completely empty** — a
bare `## [0.6.x] — <date>` heading with nothing underneath. Neither script
involved was individually wrong; the composition was:

1. `auto-tag.yml` cuts a **patch release on every merge to main** — 127 tags in
   the 0.6 line alone, over nine days — and `sync-versions.sh` rolled
   `[Unreleased]` under a new heading on **every one of them**.
2. `changelog-ai.sh` **degrades open by contract**: no API key, no non-bot
   commits, or a response that doesn't look like changelog markdown all print
   nothing and exit 0.

When (2) fired, (1) stamped the heading anyway. No amount of improving the
drafter fixes that shape — the roll has to stop firing on patches.

## The rule

`CHANGELOG.md` now records **one section per minor line**, drafted once from the
whole series range. **A patch release does not touch the file at all.**
Per-release detail did not disappear: `release.yml` already publishes GitHub
Release notes for every tag from that tag's own diff, which is the surface built
for "what changed in this exact build". `RELEASING.md`'s two-surface split now
describes what the code actually does.

A section means **"what you get by upgrading to this version"** — everything
since the previously listed version. With only minors listed, `[0.7.0]` covers
`v0.6.0..v0.7.0`, the whole 0.6 line. That is also exactly the range CI drafts
it from, so the file and the machinery cannot disagree.

### Machinery

- **`scripts/changelog-roll.sh`** (new) owns the roll, split out of
  `sync-versions.sh` so it is testable without standing up a Cargo workspace for
  the `cargo update` above it. Three rules:
  - minor and major only;
  - **never a heading with an empty body** — when the drafter degrades open and
    `[Unreleased]` is empty it writes a releases-page pointer, rather than
    reproducing the original defect once per line;
  - **idempotent** — an existing section for the version is left alone. The roll
    runs at two call sites per release, and a release PR may write its own
    section (this one does).
- **`scripts/test-changelog-roll.sh`** + `make changelog-roll-test` (new,
  hermetic, not in `gate`): **17 assertions**. Witness-checked — run against
  main's inlined behavior, **5 fail**, including one whose diff shows the empty
  `## [0.6.132] — 2026-08-07` heading being produced.
- **`auto-tag.yml`** drafts only for a minor/major bump, from the previous
  `X.Y.0` tag rather than the previous tag.
- **`changelog-ai.sh`** gains a series mode: above 60 commits it drops the raw
  diff (truncating a 737-commit diff to 100 KB describes the *start* of the
  range, not the important part of it) and leans on conventional-commit subjects
  and PR bodies, with the caps widened and an 8–16 bullet target.

`CHANGELOG.md` itself: **1998 lines and 180 sections → 236 lines and 2 curated
sections, zero empty.** The 0.6 line's previously unrecorded tail — verifier
independence, the research stage, parked waits, sub-agents, the Observatory
Sessions tab — is written down for the first time.

## The microsite — `/releases`

`website/src/app/releases/` renders `CHANGELOG.md` as an interactive page:
search across every entry, filter by kind, expand a line, deep-link a version.
Parsed at **build time from the repository's own file**, so the site cannot
drift — the hand-maintained docs page it replaces sat on "Current release:
0.6.44" while the tree was on 0.6.131. That page becomes a pointer, so there is
one authority.

Two design notes worth review:

- The parser is split **pure / impure** (`changelog.ts` / `changelog.server.ts`)
  because the client component needs the types, and a single `node:fs` in that
  graph fails the Turbopack build outright. That is the bundler enforcing the
  same boundary the Rust side states as **invariant #2**.
- Inline marks render as **JSX, not injected HTML**. The prose is machine-authored
  in CI, so returning React nodes makes an injected `<script>` structurally
  impossible rather than conventionally unlikely — no `dangerouslySetInnerHTML`.

Exemplar for the page shape: the existing docs card primitives
(`website/src/components/cards.tsx`) — one stylesheet under a prefix, every
colour a token, hue never the only cue.

## Witness

Not a pure refactor, so it carries tests:

| Suite | What it pins | Result |
|---|---|---|
| `make changelog-roll-test` | which releases get a section; no empty body; idempotence | 17 pass; **5 fail on main's behavior** |
| `pnpm test` (website) | the parser's accepted shapes | 10 pass |

The parser suite earned itself immediately: it caught that PR citations were
matched only as a trailing `(#1234)`, so entries citing several at once —
`(#1870, #1871, #1876)`, `(#1471, #1857)`, `(#1285, #1842)` — surfaced **none**
of them. The page rendered **7 of the 14** references the file carries and
looked completely fine doing it. Now 14.

## Verification run

- `make guards-fast` — clean (all 25 guards, `fmt --check`)
- `make changelog-roll-test` — 17/17
- `pnpm typecheck`, `pnpm build`, `pnpm test` — clean; `/releases` prerenders static
- `make doc-links` — 250 citations resolve
- `/releases`, `/docs/release-notes` and `sitemap.xml` checked against a local
  production server

## Not done here

- The home page has the same `<title>` template defect this PR fixes for
  `/releases` ("… — stella docs" appended to a page that is not docs). Left
  alone because changing the landing page's title is an SEO decision of its own
  — filed separately.
- Interactivity (search, filters, disclosure) was verified by build, types and
  server-rendered markup, **not** in a live browser — the browser extension was
  not connected in this environment. Worth a click-through before merge.

## Cutting 0.7.0

The title of this PR starts with `release:minor`, which is what `auto-tag.yml`
reads to bump `0.6.x → 0.7.0` on merge. The `[0.7.0]` section is already
written; the roll's new idempotence is what keeps CI from adding a second one.

## Summary by Sourcery

Record changelog entries per minor line instead of per patch and expose them via a new interactive /releases microsite, updating release automation and tests to enforce the new rules.

New Features:
- Add a /releases page that renders CHANGELOG.md as an interactive, searchable, filterable releases microsite.
- Introduce a changelog parser library and tests to turn CHANGELOG.md into structured data for the website.
- Add a dedicated changelog-roll test target to validate which releases receive sections and prevent empty headings.

Bug Fixes:
- Prevent release automation from emitting empty changelog sections when drafting fails and avoid duplicating existing version headings.
- Ensure sitemap metadata correctly reflects the /releases page’s last modified date and fix incorrect title templating for non-docs pages.

Enhancements:
- Restructure CHANGELOG.md to summarize one section per minor line with curated entries and tighten its contributor guidance.
- Refactor release tooling so changelog rolling is handled by a standalone script that only runs for minor/major releases and is idempotent.
- Improve changelog AI drafting to handle long series ranges by switching from raw diffs to commit subjects and bodies when appropriate.
- Document the split between per-line changelog entries and per-tag GitHub release notes in RELEASING.md and the docs site.
- Update website build, typechecking, and testing configuration (including TS extension imports and test runner wiring) to support the new releases microsite.

Documentation:
- Replace the hand-maintained release-notes docs page with an explainer that points to the /releases microsite and GitHub Releases, aligning documentation with actual automation.

Tests:
- Add a hermetic bash test suite for the changelog roll script to pin behavior around minor vs patch releases, empty-body avoidance, and idempotence.
- Add Node-based unit tests for the changelog parser to ensure all expected heading and entry shapes are correctly handled.