### PR TITLE
fix(gate): regenerate the file-size baseline — main is red on command_deck.rs

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2270 crates/stella-cli/src/agent.rs
 1752 crates/stella-cli/src/agent/tests.rs
-4566 crates/stella-cli/src/command_deck.rs
+4567 crates/stella-cli/src/command_deck.rs
 1507 crates/stella-cli/src/fleet_cmd.rs
 1891 crates/stella-core/src/bus.rs
 2572 crates/stella-core/src/driver.rs
@@ -33,7 +33,7 @@
 1916 crates/stella-store/src/usage.rs
 2181 crates/stella-tools/src/registry.rs
 1839 crates/stella-tools/src/scripts.rs
-1531 crates/stella-tui/src/deck_render.rs
+1529 crates/stella-tui/src/deck_render.rs
 4006 crates/stella-tui/src/deck_ui.rs
 1665 crates/stella-tui/src/views/engine.rs
 1611 crates/stella-tui/src/views/session.rs


### PR DESCRIPTION
**`main` is red.** `make file-size` fails at `6a41889a`:

```
crates/stella-cli/src/command_deck.rs grew to 4567 lines, over its baseline ceiling of 4566 (+1)
```

Every open PR inherits this, so it wants merging ahead of anything else.

## Cause — retightening skew, not real growth

Nobody added 55 lines to `command_deck.rs`. #2034 regenerated the baseline and ratcheted that entry **down** from 4621 to 4566 (its size at that moment). A parallel PR that grew the file by one line was written against the old 4621 entry, so its own gate was green. Both landed, and the sum is red.

`ci.yml` does not run on a push to `main` (#1986), so nothing reported it — the next PR to run the gate would have looked like the culprit.

That retightening was mine, in #2034. Filing this rather than leaving it for whoever hits it next.

## Fix

`make file-size-update`. Regenerated, not hand-edited: the baseline is generated and gate-enforced, so it is the only copy that can stay correct, and hand-editing one entry is how the last limit died.

The regeneration also picks up `deck_render.rs`'s earned ratchet-down (1531 → 1529). That carries the *same* collision risk in the other direction, and there is no way to take the fix without it. The mitigation is merging this quickly rather than editing one line by hand — please do not let it sit.

## Verified

`make file-size` — `OK — 1139 files, none over 1500 lines except 30 grandfathered (none grew)`.

No source file changes; baseline only.

## Summary by Sourcery

Build:
- Regenerate scripts/file-size-baseline.txt so the file-size check passes with the latest line counts.