### PR TITLE
fix(stella-cli): drop imports left unused when the diagnostic impl moved out

### DIFF
--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -7,10 +7,11 @@
 //! ports.
 
 use super::*;
-use stella_pipeline::{
-    ArtifactIdentity, ArtifactKind, CmdKind, DiagnosticInvocation, DiagnosticRunner,
-    TestInvocation, TestRunner,
-};
+// `DiagnosticInvocation`/`DiagnosticRunner` are deliberately absent: the impl
+// that used them moved to `super::diagnostics`, and only this file's tests
+// still name them. They are imported per test module rather than here so a
+// non-test build does not carry an unused import.
+use stella_pipeline::{ArtifactIdentity, ArtifactKind, CmdKind, TestInvocation, TestRunner};
 
 /// Apply the cross-crate policy shared by every model/repository-controlled
 /// subprocess. Kept as a named seam so the CLI's pipeline-only spawns have a
@@ -848,6 +849,8 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
+    use stella_pipeline::{DiagnosticInvocation, DiagnosticRunner};
+
     use stella_media::{
         CostDecision, ImageRequest, MediaArtifact, MediaCapabilities, MediaError, MediaJob,
         MediaJobStatus, MediaKind, MediaProvider, MediaSpendGate, MediaSpendRequest, VideoRequest,
@@ -1364,7 +1367,7 @@ mod benchmark_tests {
 #[cfg(test)]
 mod diff_baseline_tests {
     use super::*;
-    use stella_pipeline::DiagnosticInvocation;
+    use stella_pipeline::{DiagnosticInvocation, DiagnosticRunner};
 
     fn git(root: &std::path::Path, args: &[&str]) {
         let ok = std::process::Command::new("git")


### PR DESCRIPTION
**`main` is red.** `cargo check` / `clippy` fails on the **non-test** build at `94d013c5`:

```
error: unused imports: `DiagnosticInvocation` and `DiagnosticRunner`
  --> crates/stella-cli/src/agent/tools.rs:11:46
   = note: `-D unused-imports` implied by `-D warnings`
error: could not compile `stella-cli` (bin "stella") due to 1 previous error
```

My breakage, from #2034. Fixing rather than leaving it.

## Cause

#2034 moved `impl DiagnosticRunner for GitDiagnosticRunner` out of `agent/tools.rs` into `agent/diagnostics.rs` (tools.rs had crossed the 1500-line limit). After that move, nothing **outside `cfg(test)`** in tools.rs names those two types, so the top-level import is dead in a non-test build.

## Why the local gate did not catch it — worth knowing

`make lint` runs `clippy --all-targets`, which **compiles the test cfg**. Both types are still used there (`mod tests` at 844, `mod diff_baseline_tests` at 1365), so the import reads as live and clippy is green. Only a build *without* the test targets sees the unused import — which is exactly what CI's `cargo check on the declared MSRV` job runs.

**`clippy --all-targets` is not a superset of the plain build for unused-import purposes.** A symbol used only under `cfg(test)` keeps a top-level import looking alive. Anyone extracting code out of a module wants to check both.

## Fix

Import the two types per test module instead of at the top, so the non-test build carries nothing it does not use. No behaviour change, no test change.

## Verified both ways

- `cargo clippy -p stella-cli --bin stella -- -D warnings` — the build that was failing. Clean.
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean.
- `cargo test -p stella-cli --bin stella` — 1468 pass.

## Summary by Sourcery

Resolve unused import errors in stella-cli by scoping diagnostic imports to test modules.

Bug Fixes:
- Fix non-test stella-cli build failure caused by unused DiagnosticInvocation and DiagnosticRunner imports.

Tests:
- Update test modules to import diagnostic types locally so they remain available only where used.