### PR TITLE
fix(website): stop the landing page claiming to be documentation in its title

### DIFF
--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -10,12 +10,20 @@ import { REPO_URL, SITE_URL } from "@/lib/site";
 // The root layout's metadata is titled/described for the docs section it
 // mostly serves ("stella — docs"); the landing page is the one route that
 // needs its own voice instead of inheriting that.
+//
+// Which is why the title below is `absolute`. A plain string here is still
+// run through the root layout's `template: "%s — stella docs"`, so the front
+// page shipped as "stella — the terminal agent that proves its work finished
+// — stella docs": 71 characters, past the ~60 a search result renders, and the
+// part that got cut was the proposition. It also disagreed with the Open Graph
+// and Twitter titles right below it, which are NOT template-expanded — the tab
+// said one thing and every shared card said another.
 const HOME_TITLE = "stella — the terminal agent that proves its work finished";
 const HOME_DESCRIPTION =
   "A terminal coding agent that runs on the API keys you already have, speaks ten providers' own protocols, and ends a run only when a second model has confirmed the goal from evidence.";
 
 export const metadata: Metadata = {
-  title: HOME_TITLE,
+  title: { absolute: HOME_TITLE },
   description: HOME_DESCRIPTION,
   alternates: { canonical: SITE_URL },
   openGraph: {

--- a/website/src/lib/metadata.test.ts
+++ b/website/src/lib/metadata.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * Guards the title-template trap in `src/app/layout.tsx`.
+ *
+ *   pnpm test
+ *
+ * ## The trap
+ *
+ * The root layout declares a title template for the docs tree it mostly serves:
+ *
+ *     title: { default: "stella — docs", template: "%s — stella docs" }
+ *
+ * A template applies to every descendant route that sets a **plain string**
+ * title. So a page outside `/docs` that writes `title: "stella — releases"`
+ * silently ships as `stella — releases — stella docs`, and nothing anywhere
+ * fails. Opting out means `title: { absolute: … }`.
+ *
+ * This has now bitten twice — the landing page shipped at 71 characters with
+ * the proposition in the part a search result truncates, and /releases shipped
+ * saying "docs" twice about a page that is not documentation. Both also
+ * disagreed with their own `openGraph.title` and `twitter.title`, which are NOT
+ * template-expanded: the tab said one thing and every shared card another.
+ *
+ * A third occurrence is a matter of someone adding a route, so this asserts the
+ * rule instead of trusting it. The check is static — it reads the route files
+ * rather than importing them, because importing a page pulls in React, the
+ * component tree, and fumadocs to inspect one exported object.
+ */
+
+const APP_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "app");
+
+/** Every `page.tsx` under `src/app`, as repo-relative paths. */
+function pageFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) pageFiles(path, found);
+    else if (entry.name === "page.tsx") found.push(path);
+  }
+  return found;
+}
+
+test("every non-docs page opts out of the docs title template", () => {
+  const offenders: string[] = [];
+  let inspected = 0;
+
+  for (const file of pageFiles(APP_DIR)) {
+    // Match on the path RELATIVE to src/app, never the absolute one: a checkout
+    // that happens to live under any directory called `docs` would otherwise
+    // skip every page and report green — a guard silently covering less than it
+    // claims, which is the failure mode this repo has already been bitten by
+    // twice in check-file-size.sh.
+    const route = relative(APP_DIR, file);
+
+    // The docs tree is what the template is FOR — `/docs/[[...slug]]` should
+    // inherit it, and does, by building its title from page frontmatter.
+    if (route === "docs/page.tsx" || route.startsWith("docs/")) continue;
+
+    const source = readFileSync(file, "utf8");
+
+    // Only pages that declare metadata at all are in scope; a page with no
+    // `metadata` export inherits the layout's `default`, which is a separate
+    // (and correct) mechanism.
+    if (!/export const metadata/.test(source)) continue;
+
+    // Find the `title:` inside the metadata object. `{ absolute: …}` opts out;
+    // a bare string or an identifier does not.
+    const title = source.match(/export const metadata[\s\S]*?\btitle:\s*([^\n]+)/);
+    if (!title) continue;
+
+    inspected += 1;
+    if (!/\{\s*absolute:/.test(title[1])) {
+      offenders.push(`${route} -> title: ${title[1].trim()}`);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    "these routes sit outside /docs but take a plain-string title, so the root " +
+      'layout appends " — stella docs" to them. Use `title: { absolute: … }`.',
+  );
+
+  // A rule that matched nothing is indistinguishable from a rule that passed,
+  // and this one has to survive a route being renamed or moved. Assert it
+  // actually looked at something.
+  assert.ok(
+    inspected > 0,
+    "no non-docs page with a metadata export was found — the walk or the skip is wrong, not the site",
+  );
+});
+
+test("the root layout still declares the template this guard is about", () => {
+  // If the template is ever removed, the rule above becomes noise rather than
+  // a guard — and a test that passes for the wrong reason is worse than none.
+  // This fails loudly so the pair is re-thought together.
+  const layout = readFileSync(join(APP_DIR, "layout.tsx"), "utf8");
+  assert.match(
+    layout,
+    /template:\s*"%s — stella docs"/,
+    "the root title template changed; re-check whether the absolute-title rule above still applies",
+  );
+});


### PR DESCRIPTION
Closes #2043.

## The bug

The front page shipped as:

```
stella — the terminal agent that proves its work finished — stella docs
```

71 characters — past the ~60 a search result renders, so the part that got cut
was the proposition. On the one page that is emphatically **not** documentation.

The root layout declares `template: "%s — stella docs"` for the docs tree it
mostly serves, and a title template applies to **every descendant route that
sets a plain string title**. The landing page set one. The comment directly
above it already said "the landing page is the one route that needs its own
voice instead of inheriting that" — the intent was right; the code did not
implement it.

It also disagreed with its own `openGraph.title` and `twitter.title`, which are
**not** template-expanded: the browser tab said one thing and every shared card
said another. `title: { absolute: … }` fixes both at once.

Verified against a local production build:

| Route | Before | After |
|---|---|---|
| `/` | `stella — … work finished — stella docs` | `stella — … work finished` |
| `/releases` | *(fixed in #2042)* | `stella — releases` |
| `/docs/accessibility` | `Accessibility — stella docs` | unchanged — correct |

`og:title` and `twitter:title` on `/` now match the tab exactly.

## The guard

This trap has now bitten **twice** — `/releases` shipped saying "docs" twice
about a page that is not docs, fixed in #2042 — and **nothing fails when it
does.** It will bite again the next time someone adds a route outside `/docs`.

So `website/src/lib/metadata.test.ts` asserts the rule rather than trusting it:
every `page.tsx` outside `src/app/docs/` that exports metadata must opt out with
`{ absolute: … }`.

**Witness-checked** — revert the one-line fix and it fails, naming the file:

```
AssertionError: these routes sit outside /docs but take a plain-string title,
so the root layout appends " — stella docs" to them. Use `title: { absolute: … }`.
+ [ '(home)/page.tsx -> title: HOME_TITLE,' ]
```

It reads the route files statically rather than importing them — importing a
page pulls in React, the component tree and fumadocs to inspect one exported
object. Two details are deliberate, both lessons from `check-file-size.sh`'s
history of covering less than it claimed:

- the docs skip matches the path **relative to `src/app`**, so a checkout living
  under some directory called `docs` cannot silently skip every page and report
  green;
- it asserts it **inspected at least one file**, because a rule that matched
  nothing is indistinguishable from a rule that passed.

A second case pins the root template itself, so if that is ever removed the pair
gets re-thought together instead of leaving a guard that passes for the wrong
reason.

## Verification

- `pnpm test` — 12 pass (10 changelog parser from #2042, 2 new here)
- `pnpm typecheck`, `pnpm build` — clean
- `make guards-fast` — clean
- Titles checked on a local production server for all three route kinds (table above)

## Summary by Sourcery

Ensure non-docs pages opt out of the shared docs title template and align the landing page title across metadata.

Bug Fixes:
- Prevent the landing page title from inheriting the docs title template so it no longer ends with “— stella docs” or conflicts with social metadata titles.

Tests:
- Add a metadata guard test that statically scans page.tsx files to ensure non-docs routes use absolute titles and that the root layout still declares the expected title template.