### PR TITLE
fix(stella-tools): supply a git author when the repo configures none

### DIFF
--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -199,6 +199,29 @@ impl GitCli {
         }
     }
 
+    /// `-c` overrides supplying an author, or empty when the repository
+    /// already resolves one.
+    ///
+    /// A fresh container configures no git identity at any scope, so `git
+    /// commit` exits 128 with "Author identity unknown" and the agent can
+    /// never commit at all — three failures in one benchmark cycle, and the
+    /// cost is larger than the failed calls: the model then spent turns
+    /// theorising that its work went ungraded *because* it was uncommitted,
+    /// a theory this defect made impossible to disprove (#2059).
+    ///
+    /// Conditional rather than unconditional, and passed inline rather than
+    /// written into the repository's config: committing as Stella on a
+    /// developer's own repository would be its own bug, so this only rescues
+    /// the case where git refuses outright. The probe tolerates a non-zero
+    /// exit because `--get` of an unset key exits 1 — that is the answer,
+    /// not a failure.
+    async fn commit_identity(root: &Path) -> Vec<&'static str> {
+        match Self::git(root, "repo_commit", &["config", "--get", "user.email"]).await {
+            Ok((0, email)) if !email.trim().is_empty() => Vec::new(),
+            _ => vec!["-c", "user.name=Stella", "-c", "user.email=stella@localhost"],
+        }
+    }
+
     /// [`Self::git_ok`] for output that is PARSED rather than shown: on success
     /// it yields **stdout alone**.
     ///
@@ -392,28 +415,6 @@ impl RepoBackend for GitCli {
             }
         }
         Ok(None)
-    }
-
-    /// `-c` overrides supplying an author, or empty when the repository
-    /// already resolves one.
-    ///
-    /// A fresh container configures no git identity at any scope, so `git
-    /// commit` exits 128 with "Author identity unknown" and the agent can
-    /// never commit at all — three failures in one benchmark cycle, plus the
-    /// turns the model then spent theorising that its work went ungraded
-    /// *because* it was uncommitted, which it could not disprove (#2059).
-    ///
-    /// Conditional rather than unconditional, and passed inline rather than
-    /// written into the repo's config: committing as Stella on a developer's
-    /// own repository would be its own bug, so this only rescues the case
-    /// where git refuses outright. The probe tolerates a non-zero exit
-    /// because `--get` of an unset key exits 1 — that is the answer, not a
-    /// failure.
-    async fn commit_identity(root: &Path) -> Vec<&'static str> {
-        match Self::git(root, "repo_commit", &["config", "--get", "user.email"]).await {
-            Ok((0, email)) if !email.trim().is_empty() => Vec::new(),
-            _ => vec!["-c", "user.name=Stella", "-c", "user.email=stella@localhost"],
-        }
     }
 
     async fn commit_paths(

--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -216,8 +216,18 @@ impl GitCli {
     /// exit because `--get` of an unset key exits 1 — that is the answer,
     /// not a failure.
     async fn commit_identity(root: &Path) -> Vec<&'static str> {
-        match Self::git(root, "repo_commit", &["config", "--get", "user.email"]).await {
-            Ok((0, email)) if !email.trim().is_empty() => Vec::new(),
+        // `git commit` needs BOTH a name and an email; a config with only one
+        // set (or a name git cannot derive from the container's passwd entry)
+        // still exits 128 with "empty ident name ... not allowed", so probe
+        // both keys and inject the overrides unless both already resolve.
+        let name = Self::git(root, "repo_commit", &["config", "--get", "user.name"]).await;
+        let email = Self::git(root, "repo_commit", &["config", "--get", "user.email"]).await;
+        match (name, email) {
+            (Ok((0, name)), Ok((0, email)))
+                if !name.trim().is_empty() && !email.trim().is_empty() =>
+            {
+                Vec::new()
+            }
             _ => vec!["-c", "user.name=Stella", "-c", "user.email=stella@localhost"],
         }
     }

--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -394,6 +394,28 @@ impl RepoBackend for GitCli {
         Ok(None)
     }
 
+    /// `-c` overrides supplying an author, or empty when the repository
+    /// already resolves one.
+    ///
+    /// A fresh container configures no git identity at any scope, so `git
+    /// commit` exits 128 with "Author identity unknown" and the agent can
+    /// never commit at all — three failures in one benchmark cycle, plus the
+    /// turns the model then spent theorising that its work went ungraded
+    /// *because* it was uncommitted, which it could not disprove (#2059).
+    ///
+    /// Conditional rather than unconditional, and passed inline rather than
+    /// written into the repo's config: committing as Stella on a developer's
+    /// own repository would be its own bug, so this only rescues the case
+    /// where git refuses outright. The probe tolerates a non-zero exit
+    /// because `--get` of an unset key exits 1 — that is the answer, not a
+    /// failure.
+    async fn commit_identity(root: &Path) -> Vec<&'static str> {
+        match Self::git(root, "repo_commit", &["config", "--get", "user.email"]).await {
+            Ok((0, email)) if !email.trim().is_empty() => Vec::new(),
+            _ => vec!["-c", "user.name=Stella", "-c", "user.email=stella@localhost"],
+        }
+    }
+
     async fn commit_paths(
         &self,
         root: &Path,
@@ -406,7 +428,8 @@ impl RepoBackend for GitCli {
         Self::git_ok(root, "repo_commit", &add).await?;
         // Pathspec-limited commit: exactly the named paths land, whatever
         // else may sit in the index stays uncommitted.
-        let mut commit = vec!["commit", "-m", message, "--"];
+        let mut commit = Self::commit_identity(root).await;
+        commit.extend(["commit", "-m", message, "--"]);
         commit.extend(&path_refs);
         Self::git_ok(root, "repo_commit", &commit).await?;
         let summary = Self::git_ok(root, "repo_commit", &["log", "-1", "--oneline"]).await?;


### PR DESCRIPTION
Draft — **the witness test is not written yet**. See "What is missing" below; do not merge until it is.

## Problem

`repo_commit` runs `git commit` without supplying an author. A fresh task container configures no git identity at any scope, so the commit exits 128 with "Author identity unknown" and **the agent can never commit at all**.

Measured three times in arenabench cycle `4bed110003d8` (SUT `6a41889a`), and the cost is larger than the three failed calls. In `portfolio-optimization` the model then spent turns on this theory:

> possibly one that expects my changes to be committed to git, since repo_status shows everything is still uncommitted. That could explain why the grading process keeps failing even though my own verification passed.

That theory is wrong, and the defect made it impossible for the agent to disprove.

The harbor adapter already gets this right for its own baseline commit (`git -c user.name=stella-harbor -c user.email=... commit`), so the two disagreed about how to commit inside the same container.

## Change

`GitCli::commit_identity` probes `git config --get user.email` and returns `-c` overrides only when nothing resolves. Two deliberate choices:

- **Conditional**, so a developer's own identity is never overridden — committing as Stella on someone's real repository would be its own bug.
- **Inline `-c`**, so nothing is written into the repository's config.

The probe uses `Self::git` rather than `Self::git_ok` because `--get` of an unset key exits 1: that is the answer, not a failure.

## What is missing

A witness test. The obstacle is environment isolation: `git config --get user.email` falls through local → global → system, and a developer machine resolves a global identity, so a plain temp repo does not reproduce the container's state.

The tractable route, which needs no process-global env mutation: set the repo's local `user.email` to the **empty string**. `--get` then exits 0 with empty output, which takes the same fallback branch, and git refuses the commit without the override. That is a genuine fail-on-main / pass-on-this-branch witness.

`crates/stella-tools/src/repo.rs`'s existing `config_identity` test helper is the shape to copy.

## Verification so far

`cargo check -p stella-tools` is clean. The full gate has **not** been run.

Closes #2059

## Summary by Sourcery

Ensure git commits from stella-tools succeed even when the environment lacks a configured author identity by conditionally injecting a default commit identity.

Bug Fixes:
- Prevent repo_commit from failing with 'Author identity unknown' in fresh containers without git user configuration.

Enhancements:
- Add a helper to probe git user.email and supply inline -c commit identity overrides only when no author is configured.