### PR TITLE
docs(claude): a bench conclusion comes from the trace, never a surface signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,29 @@
     cannot have both, state which one you are giving up and why, and let a
     human choose. Deciding it silently is how a reference implementation
     stops being one.
+- **A bench conclusion comes from the trace, never from a surface signal.**
+  The measurement machinery is younger than the thing it measures, and its
+  summary layer is a set of projections that each have their own bugs. On
+  2026-08-07 every surface reading was wrong, in a different direction each
+  time: a 5/5 → 3/5 "regression" was a flaky task that also fails on the old
+  binary; a trial showing `✗ failed` had scored reward 1.0 (the verdict cell is
+  either/or, so it *hides* the exception when a task passes); a
+  `WITNESS CONFIRMED` was a false proof off a `ModuleNotFoundError`; and "no
+  witness authored" had three stacked structural causes, each concealed by the
+  one above it. So:
+  - **Open `stella-events.jsonl` before claiming anything.** It is ground
+    truth; the UI and `result.json` are projections of it. Census
+    `(role, model)` from `step_usage` before believing a claim about which
+    model ran; join `tool_start` → `tool_result` for real tool wall clock;
+    read the **full** `proof` reason strings, because they are truncated
+    everywhere else and the truncated half is usually the part that matters.
+  - **Run the cheap control before any bisect.** Re-run the failing task alone
+    on the *old* SUT. One trial either establishes the regression or ends the
+    investigation — and it is how the 11-commit bisect above got cancelled.
+  - **A five-task solve rate cannot resolve anything smaller than a
+    catastrophe.** Treat it as a guardrail; the mechanism metrics are the
+    measurement. Comparisons need repeats per task, and any two runs differing
+    by more than one commit are confounded and must be reported as such.
 - **AGENTS.md is the orientation document.** Commands, architectural
   invariants, workspace routing, testing approach, and gotchas all live there
   (imported above). When this file and AGENTS.md disagree, AGENTS.md wins —


### PR DESCRIPTION
Adds one rule to CLAUDE.md's hard-rules block.

## Why

On 2026-08-07 every surface reading of a bench run was wrong, each in a different direction:

- a **5/5 → 3/5 "regression"** was a flaky task that also fails on the *old* binary (150 steps, $1.93, same SUT that passed at 79 steps) — an 11-commit bisect was cancelled one step from starting
- a trial displaying a failure mark had **scored reward 1.0** — the verdict cell is either/or, so it hides the exception when a task passes (#2066)
- a **`WITNESS CONFIRMED`** was a false proof off a `ModuleNotFoundError` from a missing build artifact (#2067)
- **"no witness authored"** had three stacked structural causes, each concealed by the one above it (#2023 → #2064 → #2067)

The measurement machinery is younger than the thing it measures, and its summary layer is a set of projections that each carry their own bugs.

## What the rule says

Three habits, each of which would have caught one of the above:

1. **Open `stella-events.jsonl` before claiming anything** — it is ground truth; the UI and `result.json` are projections. Census `(role, model)` from `step_usage`, join `tool_start` → `tool_result` for real tool wall clock, and read the **full** proof reason strings, since they are truncated everywhere else and the truncated half is usually the part that matters.
2. **Run the cheap control before any bisect** — re-run the failing task alone on the old SUT. One trial either establishes the regression or ends the investigation.
3. **A five-task solve rate cannot resolve anything smaller than a catastrophe** — guardrail, not measurement. Comparisons need repeats per task, and two runs differing by more than one commit are confounded and must be reported as such.

## Verification

Docs-only; no witness test applies. `CLAUDE.md` is prose and carries no gate beyond the docs guards.

Refs #2066, #2067

## Summary by Sourcery

Documentation:
- Document a new hard rule in CLAUDE.md that bench conclusions must come from trace-level data, including guidance on using stella-events, control runs, and solve-rate limits for reliable measurement.