### PR TITLE
feat(arenabench): a trial that solved AND errored shows both facts, not just the tick

### DIFF
--- a/arenabench/ui/components/arena/stat-strip.tsx
+++ b/arenabench/ui/components/arena/stat-strip.tsx
@@ -96,6 +96,41 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
   // a fraction printed "1%".
   const solveRate = totals.judged > 0 ? (totals.passed / totals.judged) * 100 : 0;
 
+  // Incidents, counted from the cells because seat totals do not carry them.
+  // Kept strictly apart from the solve rate in BOTH directions (#2066): a
+  // trial can score the reward and then raise, and folding either number
+  // into the other hides exactly the trials most flattered by a headline
+  // rate. Timeouts split by whether the solve had already happened — the
+  // two mean opposite things (did not stop after success vs. ran out of
+  // time before it) and a merged count cannot be acted on.
+  const incidents = React.useMemo(() => {
+    let onSolved = 0;
+    let onFailed = 0;
+    let timeoutAfterSolve = 0;
+    let timeoutBeforeSolve = 0;
+    for (const row of snapshot.rows) {
+      for (const seat of seats) {
+        const cell = row.cells[seat.id];
+        if (!cell || cell.status !== "done" || !cell.failure) continue;
+        const isTimeout = /timeout/i.test(cell.failure);
+        if (cell.resolved === true) {
+          onSolved += 1;
+          if (isTimeout) timeoutAfterSolve += 1;
+        } else {
+          onFailed += 1;
+          if (isTimeout) timeoutBeforeSolve += 1;
+        }
+      }
+    }
+    return {
+      onSolved,
+      onFailed,
+      timeoutAfterSolve,
+      timeoutBeforeSolve,
+      total: onSolved + onFailed,
+    };
+  }, [snapshot.rows, seats]);
+
   // The leader line, stated only when there is a strict winner on solve rate.
   const ranked = [...seats].sort(
     (a, b) => (Number(b.totals.solve_rate) || 0) - (Number(a.totals.solve_rate) || 0),
@@ -153,6 +188,20 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
         value={`${fmtTokens(totals.tokensIn)}/${fmtTokens(totals.tokensOut)}`}
         sub="in / out"
         blurb="Input and output tokens summed across every seat."
+      />
+      <Stat
+        label="incidents"
+        value={String(incidents.total)}
+        sub={`${incidents.onSolved} on solved · ${incidents.onFailed} on failed`}
+        tone={incidents.onSolved > 0 ? "warn" : undefined}
+        blurb={
+          "Trials that raised an exception, counted apart from the solve rate in both " +
+          "directions — a trial can score the reward and then raise, and the tick alone " +
+          "hides it. An incident on a SOLVED trial means the agent kept burning budget " +
+          "after succeeding; on a failed trial it is the ordinary kind. Timeouts here: " +
+          `${incidents.timeoutAfterSolve} after the solve (did not stop when done), ` +
+          `${incidents.timeoutBeforeSolve} before it (ran out of time).`
+        }
       />
       {critical > 0 ? (
         <Stat

--- a/arenabench/ui/components/arena/task-table.tsx
+++ b/arenabench/ui/components/arena/task-table.tsx
@@ -91,6 +91,15 @@ function winnersFor(
   return won;
 }
 
+/**
+ * The verdict and the incident are two facts, not one (#2066): a trial can
+ * score the reward and then raise (`crack-7z-hash` solved at reward 1.0 and
+ * still hit `AgentTimeoutError`), and the either/or branch this used to be
+ * showed only the tick — under-reporting the incident entirely. The tick
+ * stays `text-ok` because the task DID solve (the grading is Harbor's and
+ * unchanged); the marker carries the exception in a warning tone so it is
+ * legible without implying failure.
+ */
 function Verdict({ cell }: { cell: Cell | null | undefined }) {
   if (!cell) return <span className="font-mono text-[11px] text-dim">queued</span>;
   if (cell.status !== "done") {
@@ -101,9 +110,26 @@ function Verdict({ cell }: { cell: Cell | null | undefined }) {
       </span>
     );
   }
-  return cell.resolved === true ? (
-    <span className="font-mono text-[11px] font-semibold text-ok">✓ solved</span>
-  ) : (
+  if (cell.resolved === true) {
+    if (!cell.failure) {
+      return <span className="font-mono text-[11px] font-semibold text-ok">✓ solved</span>;
+    }
+    return (
+      <span className="flex items-center gap-1">
+        <span className="font-mono text-[11px] font-semibold text-ok">✓ solved</span>
+        <Tip
+          content={
+            `Solved, then raised ${cell.failure}. The reward was scored before the ` +
+            `exception, so the solve stands — but the trial did not end cleanly ` +
+            `(for a timeout: the agent kept burning budget after succeeding).`
+          }
+        >
+          <span className="font-mono text-[11px] text-warn">⚠ incident</span>
+        </Tip>
+      </span>
+    );
+  }
+  return (
     <Tip content={cell.failure || undefined}>
       <span className="font-mono text-[11px] text-bad">✗ failed</span>
     </Tip>


### PR DESCRIPTION
## What

The verdict cell was either/or (`task-table.tsx`): `cell.failure` rendered only when the task did not solve, so a trial that scored the reward and then raised displayed as a clean `✓ solved` with nothing else. Live fixture: `crack-7z-hash__kSptNGZ` in match `3568657c2db9` — reward 1.0 **and** `AgentTimeoutError` (#2066).

## How

- **Verdict cell**: three states instead of two. `resolved && failure` keeps the `text-ok` tick — the task did solve, and the grading is Harbor's — plus a warning-tone `⚠ incident` marker whose `Tip` carries the exception type and what it means (for a timeout: budget burned after success). Clean solves and plain failures render exactly as before.
- **Stat strip**: an `incidents` tile counted from the cells, kept apart from the solve rate in both directions, sub-labelled `N on solved · M on failed`. The blurb splits timeouts by whether the solve had already happened — after-solve (did not stop when done) and before-solve (ran out of time) mean opposite things, and a merged count cannot be acted on.
- **No type changes**: `Cell.resolved`/`Cell.failure` already existed, as the issue predicted.
- `arenabench/arenabench/web/` is untracked generated output since #1606 — `ui/` is the only thing committed; `npm run build` regenerated and synced the local export.

## What is deliberately NOT changed

`telemetry.py`'s `resolved`/`failure`/`infrastructure` derivation is untouched — the solve rate is Harbor's verdict and this PR adds display only. The stat strip's solve-rate arithmetic is also untouched, so every existing match reads byte-identically (`4bed110003d8` stays 5/5, `61e01ca06fc7` stays 3/5): the change provably cannot move a number because no number-producing code changed.

## Verified

`npm run build` (next build runs the full type check) green; static export regenerated. Witnessing this in a JS test harness would require introducing one — the UI has no test runner today — so verification is the type-checked build plus the review-visible three-state branch; the live fixture named above renders the marker on the local arena.

The `timeout_after_solve`/`timeout_before_solve` split for `~/.arenabench/trace-metrics.py` is rig tooling outside this repo, noted here per the issue.

Closes #2066
Refs #2064, #2068

## Summary by Sourcery

Clarify arena trial outcomes by distinguishing clean solves, failures, and solved-with-incident cases in both the task table and statistics strip.

New Features:
- Display both a solve tick and an incident marker when a trial both solves and raises, keeping verdict and incident as separate facts in the task table.
- Add an incidents statistic to the arena stat strip that counts exception-raising trials separately from solve rate and breaks out timeouts before vs. after solve.

Enhancements:
- Compute incident counts from snapshot cells in the stat strip without altering existing solve-rate or totals logic.