### PR TITLE
style(stella-tools): unbreak main — format the commit-identity override vec

### DIFF
--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -228,7 +228,12 @@ impl GitCli {
             {
                 Vec::new()
             }
-            _ => vec!["-c", "user.name=Stella", "-c", "user.email=stella@localhost"],
+            _ => vec![
+                "-c",
+                "user.name=Stella",
+                "-c",
+                "user.email=stella@localhost",
+            ],
         }
     }
 


### PR DESCRIPTION
## What

Formatting-only unbreak. PR #2060 merged with its `fmt + clippy + test` check **failing** at the `cargo fmt --check` step, which landed an unformatted line on main at `crates/stella-tools/src/repo.rs:228`. Because `ci.yml` does not run on pushes to main, main went silently red, and every open PR's merge-head CI now fails at fmt regardless of its own diff — #2073 and #2075 are TypeScript-only and still fail the Rust fmt gate; #2071 and #2072 inherit it too.

## How

rustfmt's preferred shape for the `vec!` (its contents exceed the macro-call width), exactly the diff CI prints. No behavior change — same elements, same order.

## Verified

`cargo fmt --all --check` is clean with this applied, and this was the **only** violation in the workspace. Note: because #2060's job died at fmt, clippy and the test suite never ran on that merge — this PR's own CI is the first full run of both on main's current content. If clippy or a test is also broken from #2060, it will surface here and should be fixed in this same PR.

Formatting-only change: no witness test per the contract's refactor/docs/CI carve-out.

## After merge

Re-run (or update-branch) the four open PRs so their merge-head CI picks up the repaired base: #2071, #2072, #2073, #2075.

Refs #2060

## Summary by Sourcery

Enhancements:
- Apply rustfmt-compliant layout to the commit-identity configuration vector in the Git CLI helper to align with workspace formatting standards.