### PR TITLE
bench: a benchmarked slug's inherited timeout is a decision, never a silence

### DIFF
--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -222,6 +222,49 @@ _SUB_CEILING_RATIONALE: dict[str, str] = {
 # 16384 -> 32000 -> 64000 each moved one ceiling while the others held.
 _MODEL_TIMEOUT_BY_SLUG = {"claude-fable-5": 1_572}
 
+#: What "no row above" actually runs under: the engine seeds
+#: ``model_timeout: Some(Duration::from_secs(816))`` in
+#: ``crates/stella-core/src/driver.rs``, and it bounds IDLE SILENCE between
+#: stream fragments, never elapsed time — a generation that keeps streaming
+#: is never cut by it. Named here because #2021 was filed, implemented, and
+#: reverted on the belief that an absent row meant "no ceiling"; the number
+#: a reader needs was findable only in the Rust tree. A parity test pins
+#: this against the driver's literal.
+_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS = 816
+
+# A benchmarked slug with NO `_MODEL_TIMEOUT_BY_SLUG` row inherits the 816s
+# engine default — and that inherit must read as a decision, not an omission
+# (#2070). Same pattern as `_SUB_CEILING_RATIONALE` above: every silence is
+# written down with its reason, so the next slug added to
+# `_BENCHMARKED_SLUGS` fails the suite until someone decides. Deliberately
+# NOT a posture row: writing `model_timeout_secs: 816` explicitly was
+# implemented, measured as a behavioural no-op, and reverted (#2021's
+# refutation), because it changes the registered posture digest in exchange
+# for nothing. These sentences cost no digest.
+_INHERITED_TIMEOUT_RATIONALE: dict[str, str] = {
+    "claude-sonnet-5": (
+        "Inherits the 816s idle-silence default. As the head-to-head worker "
+        "its 64,000-token cap takes ~756s to fill at the registered "
+        "84.66 tok/s, and the silence ceiling only cuts a stream that has "
+        "STOPPED producing — no measured Sonnet call has stalled anywhere "
+        "near 816s of silence. Writing 816 as a posture row would invalidate "
+        "the registered digest (c8536200…) for zero behaviour change."
+    ),
+    "kimi-k3": (
+        "Inherits the 816s idle-silence default. Booked as arm B's VERIFIER: "
+        "it emits a verdict, not a solution, so neither the cap nor the "
+        "timeout has ever bound — and this model has no observed token rate "
+        "to derive a bespoke ceiling from. A manufactured row is exactly the "
+        "cap-without-timeout mismatch the table above exists to prevent."
+    ),
+    "claude-haiku-4.5": (
+        "Inherits the 816s idle-silence default. Booked as the TRIAGE "
+        "author: a short classification at effort low / reasoning off, "
+        "finished in seconds — the ceiling is three orders of magnitude "
+        "above anything this role produces."
+    ),
+}
+
 
 def _model_slug(model: str) -> str:
     """The bare model name, with any provider or gateway prefix stripped."""

--- a/bench/harbor_adapter/tests/test_timeout_rationale.py
+++ b/bench/harbor_adapter/tests/test_timeout_rationale.py
@@ -1,0 +1,108 @@
+"""Every benchmarked slug's model timeout is a decision, never a silence
+(#2070, promised in #2021's refutation).
+
+`default_model_timeout()` returning ``None`` means "inherit the engine's
+816s idle-silence default" — correct behaviour, but until now
+indistinguishable from forgetting: the next slug added to
+`_BENCHMARKED_SLUGS` inherited with zero friction, and the inherited number
+was findable only in the Rust tree (which is how #2021 was filed on a false
+premise). These tests make the inherit explicit and pin the 816 against the
+driver's own literal.
+
+Its own file rather than more length on ``test_posture.py``: two open PRs
+append to that file's tail, and a third would guarantee a textual conflict.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from stella_harbor import _benchmark_engine_posture  # noqa: E402
+
+# Internals of the posture's ceiling policy, imported from the module like
+# test_posture.py imports its siblings.
+from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    _BENCHMARKED_SLUGS,
+    _ENGINE_DEFAULT_MODEL_TIMEOUT_SECS,
+    _INHERITED_TIMEOUT_RATIONALE,
+    _MODEL_TIMEOUT_BY_SLUG,
+    default_model_timeout,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DRIVER_RS = _REPO_ROOT / "crates" / "stella-core" / "src" / "driver.rs"
+
+
+class TestInheritedTimeoutRationale:
+    def test_every_benchmarked_slug_decides_its_timeout(self) -> None:
+        """Explicit row XOR documented inherit — never neither, never both.
+
+        Neither = the omission #2070 exists to prevent: the next slug added
+        to `_BENCHMARKED_SLUGS` fails here until someone decides. Both = a
+        stale rationale left behind after a real row was added, which would
+        document an inherit that no longer happens.
+        """
+        for slug in sorted(_BENCHMARKED_SLUGS):
+            has_row = slug in _MODEL_TIMEOUT_BY_SLUG
+            has_rationale = bool(_INHERITED_TIMEOUT_RATIONALE.get(slug, "").strip())
+            assert has_row != has_rationale, (
+                f"{slug}: a benchmarked slug needs exactly one of a "
+                "`_MODEL_TIMEOUT_BY_SLUG` row or an "
+                "`_INHERITED_TIMEOUT_RATIONALE` sentence — "
+                f"row={has_row}, rationale={has_rationale}. An undecided "
+                "timeout looks deliberate and is not."
+            )
+
+    def test_rationales_name_the_number_they_inherit(self) -> None:
+        """A rationale that omits the 816 re-creates the original problem:
+        a reader who cannot learn what the slug actually runs under."""
+        for slug, rationale in _INHERITED_TIMEOUT_RATIONALE.items():
+            assert str(_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS) in rationale, (
+                f"{slug}: the rationale must name the inherited "
+                f"{_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS}s default"
+            )
+            assert default_model_timeout(slug) is None, (
+                f"{slug}: carries an inherit rationale but resolves an "
+                "explicit timeout — the rationale is stale"
+            )
+
+    def test_the_816_matches_the_engine_default_in_driver_rs(self) -> None:
+        """The documented number pins against the driver's literal — the
+        `TestOutputCeilingParity` discipline, so the two cannot drift while
+        both look deliberate. The path is a literal in this file; a crate
+        move is fixed here."""
+        try:
+            source = _DRIVER_RS.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise AssertionError(
+                f"cannot read the engine default at {_DRIVER_RS}: "
+                f"{exc.strerror}. That path is a literal in this file — if "
+                "the crate moved, update `_DRIVER_RS` to match."
+            ) from exc
+        match = re.search(
+            r"model_timeout:\s*Some\(Duration::from_secs\((\d+)\)\)", source
+        )
+        assert match is not None, (
+            "could not find the engine's `model_timeout` default in "
+            f"{_DRIVER_RS} — the seeding moved or was renamed; repoint the "
+            "regex in this test"
+        )
+        assert int(match.group(1)) == _ENGINE_DEFAULT_MODEL_TIMEOUT_SECS, (
+            "the engine default changed: update "
+            "`_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS` and every rationale that "
+            "names it, in the same PR"
+        )
+
+    def test_the_emitted_posture_is_untouched(self) -> None:
+        """Zero digest cost is the constraint the whole change lives under
+        (#2021's refutation): the sentences are module constants, and the
+        Sonnet posture still emits no `model_timeout_secs` key."""
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            "openrouter/anthropic/claude-sonnet-5"
+        )
+        assert "model_timeout_secs" not in posture


### PR DESCRIPTION
## What

Fulfils the omission-proofing half promised in #2021's refutation (#2070). `default_model_timeout()` returning `None` correctly means "inherit the engine's 816s idle-silence default" — but nothing distinguished that deliberate inherit from forgetting, and the inherited number was findable only in `crates/stella-core/src/driver.rs`, which is exactly how #2021 got filed on the false premise that "no row" meant "no ceiling".

## How

- `_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS = 816` names the inherited number in `posture.py` itself, with the load-bearing semantics stated (bounds idle silence between stream fragments, never elapsed time).
- `_INHERITED_TIMEOUT_RATIONALE` carries one sentence per benchmarked slug without a `_MODEL_TIMEOUT_BY_SLUG` row — the `_SUB_CEILING_RATIONALE` pattern, so every silence is written down with its reason (Sonnet: the ceiling only cuts a stalled stream and no measured call came near it; kimi-k3: verifier role, no observed token rate to derive from; haiku: triage classification finished in seconds).
- **Zero digest cost is the constraint**: everything is module constants; the emitted posture is byte-identical (`model_timeout_secs` still absent from the Sonnet posture, asserted), so the registered `c8536200…` digest in READINESS.md / `preflight_effort.sh` / test_posture is untouched. Writing the row instead was implemented, measured as a behavioural no-op, and reverted — that history is in the table comment.

## Tests (new file `test_timeout_rationale.py` — deliberately not `test_posture.py`, whose tail two open PRs (#2079's branch, and this repo's append-heavy history) already contend for)

- **Explicit row XOR documented rationale** for every `_BENCHMARKED_SLUGS` member — the next slug added fails until someone decides (the issue's done-when), and a rationale left stale after a real row lands also fails.
- Rationales must name the inherited number, and must not shadow an explicit row.
- The 816 **pins against `driver.rs`'s literal** (regex over `model_timeout: Some(Duration::from_secs(N))`) — the `TestOutputCeilingParity` discipline, path-literal brittleness stated in the failure message.
- The Sonnet posture shape is unchanged.

Suite: 50 passed (`test_timeout_rationale.py` + `test_posture.py`).

Closes #2070
Refs #2021, #2033

## Summary by Sourcery

Document the engine’s inherited model timeout for benchmarked slugs and enforce that each slug’s timeout is an explicit, justified decision without changing the existing posture digest.

New Features:
- Introduce module constants describing the engine’s default model timeout and per-slug rationales for inherited timeouts.
- Add a dedicated test suite to ensure all benchmarked slugs either have an explicit timeout row or a documented inherit and that the documented default matches the engine’s literal value.

Tests:
- Add tests that require each benchmarked slug to have exactly one of an explicit timeout row or an inherited-timeout rationale and that inherited rationales name the engine default.
- Add a test that verifies the documented default timeout value matches the `driver.rs` engine default and that the emitted Sonnet posture remains unchanged.