### PR TITLE
chore(arenabench,bench): dedupe LIVENESS_NAMES; surface git stderr in the freshness fixtures

### DIFF
--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -94,20 +94,6 @@ LIVENESS_NAMES: tuple[str, ...] = (
     "agent/sessions",
 )
 
-#: Per-trial paths written incrementally *while the agent runs*, probed —
-#: never read — for liveness. Stella appends its event stream per event;
-#: Harbor appends ``trial.log`` as the trial progresses; a Claude Code arm
-#: tees its stdout to ``claude-code.txt`` and appends session transcripts
-#: under ``sessions/``. Deliberately an allowlist rather than the directory
-#: tree: the verifier and the arena write into the same trial directory, and
-#: their activity must not read as the agent's pulse (#1571).
-LIVENESS_NAMES: tuple[str, ...] = (
-    EVENTS_NAME,
-    "trial.log",
-    "agent/claude-code.txt",
-    "agent/sessions",
-)
-
 
 def seat_manifest_path(job_dir: Path) -> Path:
     """Where the runner records a job's seat launch data.

--- a/bench/harbor_adapter/tests/test_freshness.py
+++ b/bench/harbor_adapter/tests/test_freshness.py
@@ -61,9 +61,18 @@ STALE_DISTANCE = 291
 
 
 def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
-    ).stdout.strip()
+    """Run git in `repo`, surfacing stderr when it fails.
+
+    `check=True` alone raises a `CalledProcessError` whose repr names only
+    the exit status — a CI run died here with a bare "exit status 128" and
+    the reason (git's stderr) was captured and then thrown away, leaving
+    nothing to diagnose from. The assertion carries it instead.
+    """
+    proc = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True)
+    assert proc.returncode == 0, (
+        f"git {' '.join(args)} in {repo} exited {proc.returncode}:\n{proc.stderr}"
+    )
+    return proc.stdout.strip()
 
 
 def _stamp(commit: str) -> bytes:


### PR DESCRIPTION
Two small residues found while chasing a CI failure on #2075:

- **`telemetry.py` defined `LIVENESS_NAMES` twice** — identical doc comment and tuple, back to back (the keep-both-sides merge shape). Python rebinds silently so nothing failed, but the next editor changes one copy and position decides which wins. One copy remains.
- **`test_freshness.py`'s `_git` helper ate its own diagnostics**: `check=True` + `capture_output=True` raises a `CalledProcessError` that names only the exit status while git's stderr — the reason — was captured and thrown away. Run `31221793621` died there with a bare `exit status 128` on a *local* fetch; the rerun was green, and the cause is unknowable precisely because the message was eaten. The helper now asserts with stderr in the failure text, so the next occurrence names itself instead of costing another blind investigation.

No behavior change in either file's production semantics: the surviving `LIVENESS_NAMES` is byte-identical to both copies, and `_git` still fails the test on any non-zero exit. Verified: `pytest tests/test_freshness.py` 35 passed; `pytest tests/test_telemetry.py` 45 passed.

Refs #2075

## Summary by Sourcery

Deduplicate liveness path constants in telemetry and improve git helper diagnostics in freshness tests to surface stderr on failures.

Enhancements:
- Remove the redundant LIVENESS_NAMES definition in telemetry so the liveness allowlist is declared only once.

Tests:
- Update the test freshness git helper to assert on non-zero exit codes and include git stderr in failure messages for easier CI diagnosis.