### PR TITLE
test(bench): surface git's reason when a freshness fixture command fails

### DIFF
--- a/bench/harbor_adapter/tests/test_freshness.py
+++ b/bench/harbor_adapter/tests/test_freshness.py
@@ -61,9 +61,20 @@ STALE_DISTANCE = 291
 
 
 def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
-    ).stdout.strip()
+    """Run git for a fixture, carrying git's own reason on failure.
+
+    ``check=True`` alone raised a bare ``CalledProcessError`` whose message
+    names the exit status and nothing else — the ``fatal:`` line that would
+    explain a CI-only failure was captured and then discarded, which made
+    the #2080 flake structurally undiagnosable from the log.
+    """
+    proc = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} in {repo} exited {proc.returncode}: "
+            f"{proc.stderr.strip() or proc.stdout.strip() or '<no output>'}"
+        )
+    return proc.stdout.strip()
 
 
 def _stamp(commit: str) -> bytes:
@@ -90,12 +101,20 @@ def _seed(root: Path, commits: int) -> Path:
     _git(origin, "init", "-q", "--initial-branch=main")
     _git(origin, "config", "user.email", "t@example.com")
     _git(origin, "config", "user.name", "t")
+    # Both `commit` and `fetch` may spawn a *detached* `git maintenance run
+    # --auto` behind the porcelain — the one thing in this fixture that runs
+    # concurrently with it and varies run to run. A test repo does its own
+    # housekeeping never, so switch it off rather than race it (#2080).
+    _git(origin, "config", "maintenance.auto", "false")
+    _git(origin, "config", "gc.auto", "0")
     _git(origin, "commit", "-q", "--allow-empty", "-m", "base")
 
     work = root / "work"
     _git(root, "clone", "-q", str(origin), str(work))
     _git(work, "config", "user.email", "t@example.com")
     _git(work, "config", "user.name", "t")
+    _git(work, "config", "maintenance.auto", "false")
+    _git(work, "config", "gc.auto", "0")
     for index in range(1, commits + 1):
         _git(origin, "commit", "-q", "--allow-empty", "-m", f"c{index}")
     _git(work, "fetch", "-q", "origin")
@@ -119,6 +138,17 @@ def repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def base_commit(repo: Path) -> str:
     """The commit `origin/main` is exactly ``STALE_DISTANCE`` ahead of."""
     return _git(repo, "rev-list", "--max-parents=0", "origin/main")
+
+
+class TestGitHelper:
+    def test_a_failing_git_command_names_its_reason(self, tmp_path: Path) -> None:
+        """The #2080 flake was structurally undiagnosable: seventeen errors,
+        each saying only "exit status 128" because ``_git`` captured stderr
+        and then discarded it. The helper's failure must carry git's own
+        ``fatal:`` line, or the next environmental failure is equally opaque."""
+        _git(tmp_path, "init", "-q")
+        with pytest.raises(RuntimeError, match="fatal"):
+            _git(tmp_path, "rev-parse", "--verify", "no-such-ref")
 
 
 class TestEmbeddedIdentity:


### PR DESCRIPTION
## What

Fixes the structural half of the `test_freshness.py` flake (#2080): a fixture git failure now names its cause, and the fixture repos no longer race git's background maintenance.

- `_git` raises with git's own stderr in the message instead of a bare `CalledProcessError` whose text is only the exit status. The `fatal:` line that would have explained the CI-only `git fetch` exit-128 failures now lands in the log.
- The fixture repos set `maintenance.auto=false` / `gc.auto=0`. Both `commit` and `fetch` can spawn a **detached** `git maintenance run --auto` behind the porcelain — the only thing in this fixture that runs concurrently with it and varies run to run, which fits the observed coin-flip pattern (same code, same runner image `20260720.247.2`, pass at 21:26/21:49, fail at 21:15/21:48/21:54 on 2026-08-07).
- **No retries**, per the issue's explicit constraint: if the flake has a different cause, the next occurrence names it instead of being hidden.

## Witness

`TestGitHelper::test_a_failing_git_command_names_its_reason` — on the old helper the failing command raises a bare `CalledProcessError`, not the `RuntimeError` carrying git's reason, so `pytest.raises(RuntimeError, match="fatal")` fails on main and passes here. The maintenance hardening itself is deliberately not witnessed: it removes a nondeterministic race, and a test that races a detached process is the defect, not a proof.

## Evidence

- Flake on main: run 31219261747 (d8ad1ca5, 21:15Z) — per #2080.
- Flake on PRs with untouched `bench/`: run 31221391709 (PR #2078, 21:48Z; rerun of the same merge ref passed), run 31221793621 (PR #2075, 21:54Z).
- 483 passed, 1 skipped locally for `bench/harbor_adapter`.

Closes #2080

## Summary by Sourcery

Improve git fixture reliability and error visibility in bench freshness tests.

Bug Fixes:
- Ensure git helper raises errors that include git's stderr so fixture failures surface their underlying cause.
- Disable automatic git maintenance and garbage collection in fixture repositories to eliminate nondeterministic background races.

Tests:
- Add a regression test verifying that the git helper exposes git's fatal error messages on failure.