### PR TITLE
feat(arenabench): an outcome_reason taxonomy, and the trends composition panel built from it

### DIFF
--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -76,7 +76,10 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
     is still ``None`` is an infrastructure void, outside every rate.
     Timeouts split by whether the solve had already happened — after-solve
     (did not stop when done) and before-solve (ran out of time) mean
-    opposite things and are never merged.
+    opposite things and are never merged. The split consumes the
+    ``outcome_reason`` taxonomy (#2076), not a substring match: only the
+    exception the agent-budget machinery actually raises counts, so an
+    unrelated exception that merely mentions a timeout cannot inflate it.
     """
     judged = 0
     solved = 0
@@ -84,8 +87,7 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
     voids = 0
     incidents = 0
     incidents_on_solved = 0
-    timeouts_after_solve = 0
-    timeouts_before_solve = 0
+    reasons: dict[str, int] = {}
     clock_time = 0.0
     priced: float | None = 0.0
     for m in metrics.values():
@@ -95,23 +97,20 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
         clock_time += m.clock_time or 0.0
         if priced is not None:
             priced = None if m.priced_cost is None else priced + m.priced_cost
+        reason = m.outcome_reason() or "unlabelled"
+        reasons[reason] = reasons.get(reason, 0) + 1
         if m.resolved is None:
             voids += 1
             continue
-        is_timeout = "timeout" in (m.failure or "").lower()
         if m.resolved:
             solved += 1
             if m.failure:
                 incidents += 1
                 incidents_on_solved += 1
-                if is_timeout:
-                    timeouts_after_solve += 1
         else:
             failed += 1
             if m.failure:
                 incidents += 1
-                if is_timeout:
-                    timeouts_before_solve += 1
     scored = solved + failed
     return {
         "judged": judged,
@@ -121,8 +120,11 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
         "voids": voids,
         "incidents": incidents,
         "incidents_on_solved": incidents_on_solved,
-        "timeouts_after_solve": timeouts_after_solve,
-        "timeouts_before_solve": timeouts_before_solve,
+        "timeouts_after_solve": reasons.get("solved_then_timeout", 0),
+        "timeouts_before_solve": reasons.get("timeout_before_solve", 0),
+        # The composition the trends panel stacks — sorted so the payload
+        # is deterministic.
+        "outcome_reasons": dict(sorted(reasons.items())),
         "clock_time": round(clock_time, 2),
         "priced_cost": round(priced, 6) if priced is not None else None,
         # Cost per solve stays null-poisoned like every priced figure: an

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -214,6 +214,35 @@ INFRASTRUCTURE_FAILURES: frozenset[str] = frozenset(
     }
 )
 
+#: Sub-buckets of :data:`INFRASTRUCTURE_FAILURES` for the outcome taxonomy
+#: (#2076) — *why* a void voided, at the grain a trends chart can act on. A
+#: test pins their union equal to the set above, so a name added there must
+#: be bucketed here in the same change rather than silently falling into a
+#: catch-all.
+VOID_SETUP: frozenset[str] = frozenset(
+    {
+        "AgentSetupTimeoutError",
+        "EnvironmentStartTimeoutError",
+        "HealthcheckError",
+        "AddTestsDirError",
+        "DownloadVerifierDirError",
+        "MissingExtraError",
+    }
+)
+VOID_CREDENTIALS: frozenset[str] = frozenset(
+    {"AuthenticationError", "OAuthCallbackError", "RefreshTokenExpiredError"}
+)
+VOID_CANCELLED: frozenset[str] = frozenset({"CancelledError"})
+VOID_VERIFIER: frozenset[str] = frozenset(
+    {
+        "VerifierTimeoutError",
+        "VerifierOutputParseError",
+        "RewardFileNotFoundError",
+        "RewardFileEmptyError",
+        "MultimodalExportError",
+    }
+)
+
 
 @dataclass
 class TrialMetrics:
@@ -296,6 +325,51 @@ class TrialMetrics:
             return None
         return min(100.0, self.cache_read / self.tokens_in * 100.0)
 
+    def outcome_reason(self) -> str | None:
+        """One closed label for *how* this judged trial ended (#2076).
+
+        ``None`` until the trial is judged. The label ANNOTATES Harbor's
+        verdict, never overrides it: ``resolved`` is read, not recomputed,
+        and a solved trial that also raised keeps both facts as
+        ``solved_then_*`` (#2066's two-facts rule). Group A voids carry a
+        ``void_`` prefix, so "outside every rate" is mechanically
+        recognizable; Group B is agent performance. Classified from the
+        structured fields — the exception class name, the verdict, the
+        infrastructure flag — never by matching prose out of a message.
+        """
+        if self.status != "done":
+            return None
+        if self.resolved is None:
+            # Group A: judged, no verdict — not agent performance.
+            if not self.failure:
+                return "void_unjudged"
+            if self.failure in VOID_SETUP:
+                return "void_setup"
+            if self.failure in VOID_CREDENTIALS:
+                return "void_credentials"
+            if self.failure in VOID_CANCELLED:
+                return "void_cancelled"
+            if self.failure in VOID_VERIFIER:
+                return "void_verifier"
+            # The zero-spend guard's shape: an agent-named exception
+            # (NonZeroAgentExitCodeError) voided because not one token was
+            # ever observed — never a fair attempt (#1480).
+            return "void_no_fair_attempt"
+        if self.resolved:
+            if not self.failure:
+                return "solved_clean"
+            if self.failure == "AgentTimeoutError":
+                # Solved, then burned the rest of the budget: the agent did
+                # not stop when done — the opposite pathology from
+                # `timeout_before_solve`, and never merged with it.
+                return "solved_then_timeout"
+            return "solved_then_error"
+        if not self.failure:
+            return "failed_wrong_answer"
+        if self.failure == "AgentTimeoutError":
+            return "timeout_before_solve"
+        return "agent_error"
+
     def to_json(self) -> dict[str, Any]:
         return {
             "task": self.task,
@@ -304,6 +378,7 @@ class TrialMetrics:
             "resolved": self.resolved,
             "reward": self.reward,
             "failure": self.failure,
+            "outcome_reason": self.outcome_reason(),
             "infrastructure": self.infrastructure,
             "steps": self.steps,
             "tools": self.tools,

--- a/arenabench/tests/test_outcome_reason.py
+++ b/arenabench/tests/test_outcome_reason.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The outcome taxonomy (#2076): one closed label per judged trial.
+
+The label annotates Harbor's verdict, never overrides it — ``resolved`` is
+read, not recomputed — and the Group A/void half must equal exactly the
+trials the ``infrastructure`` machinery already voids: this taxonomy adds
+names, never reclassifications.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from arenabench.telemetry import (
+    INFRASTRUCTURE_FAILURES,
+    VOID_CANCELLED,
+    VOID_CREDENTIALS,
+    VOID_SETUP,
+    VOID_VERIFIER,
+    TrialMetrics,
+)
+
+_MATCHES = Path.home() / ".arenabench" / "matches"
+
+
+def _trial(
+    *,
+    status: str = "done",
+    resolved: bool | None,
+    failure: str = "",
+    infrastructure: bool = False,
+) -> TrialMetrics:
+    m = TrialMetrics(task="t", trial="t__x")
+    m.status = status
+    m.resolved = resolved
+    m.failure = failure
+    m.infrastructure = infrastructure
+    return m
+
+
+class TestVocabulary:
+    def test_void_buckets_partition_the_infrastructure_set_exactly(self) -> None:
+        """A name added to INFRASTRUCTURE_FAILURES must be bucketed in the
+        same change — and no bucket may carry a name the void machinery
+        does not actually void."""
+        buckets = (VOID_SETUP, VOID_CREDENTIALS, VOID_CANCELLED, VOID_VERIFIER)
+        union: set[str] = set()
+        for bucket in buckets:
+            assert not (union & bucket), "a failure name sits in two buckets"
+            union |= bucket
+        assert union == INFRASTRUCTURE_FAILURES
+
+    def test_group_b_labels_annotate_the_verdict(self) -> None:
+        cases = {
+            "solved_clean": _trial(resolved=True),
+            "solved_then_timeout": _trial(resolved=True, failure="AgentTimeoutError"),
+            "solved_then_error": _trial(resolved=True, failure="ValueError"),
+            "failed_wrong_answer": _trial(resolved=False),
+            "timeout_before_solve": _trial(resolved=False, failure="AgentTimeoutError"),
+            "agent_error": _trial(resolved=False, failure="NonZeroAgentExitCodeError"),
+        }
+        for expected, metrics in cases.items():
+            assert metrics.outcome_reason() == expected
+
+    def test_group_a_voids_carry_the_prefix_and_the_cause(self) -> None:
+        assert (
+            _trial(resolved=None, failure="CancelledError", infrastructure=True)
+            .outcome_reason()
+            == "void_cancelled"
+        )
+        assert (
+            _trial(resolved=None, failure="AuthenticationError", infrastructure=True)
+            .outcome_reason()
+            == "void_credentials"
+        )
+        assert (
+            _trial(resolved=None, failure="HealthcheckError", infrastructure=True)
+            .outcome_reason()
+            == "void_setup"
+        )
+        assert (
+            _trial(resolved=None, failure="VerifierTimeoutError", infrastructure=True)
+            .outcome_reason()
+            == "void_verifier"
+        )
+        # The zero-spend guard (#1480): an agent-named exception voided
+        # because not one token was observed.
+        assert (
+            _trial(
+                resolved=None,
+                failure="NonZeroAgentExitCodeError",
+                infrastructure=True,
+            ).outcome_reason()
+            == "void_no_fair_attempt"
+        )
+
+    def test_unjudged_trials_have_no_reason_yet(self) -> None:
+        assert _trial(status="running", resolved=None).outcome_reason() is None
+        assert _trial(status="pending", resolved=None).outcome_reason() is None
+
+    def test_the_reason_rides_to_json(self) -> None:
+        payload = _trial(resolved=True, failure="AgentTimeoutError").to_json()
+        assert payload["outcome_reason"] == "solved_then_timeout"
+        # The two-facts rule (#2066): the verdict and the incident both
+        # survive beside the label.
+        assert payload["resolved"] is True
+        assert payload["failure"] == "AgentTimeoutError"
+
+
+@pytest.mark.skipif(
+    not _MATCHES.is_dir(), reason="no local arenabench corpus on this machine"
+)
+class TestAgainstTheLocalCorpus:
+    """The issue's done-when, run wherever the rig's matches exist."""
+
+    def test_every_judged_trial_maps_and_voids_match_the_flag(self) -> None:
+        from arenabench.server import ArenaServer
+
+        arena = ArenaServer(_MATCHES.parent)
+        judged = 0
+        for match in arena.runner.matches.values():
+            for contestant in match.spec.contestants:
+                for m in match.metrics_for(contestant.id).values():
+                    if m.status != "done":
+                        assert m.outcome_reason() is None
+                        continue
+                    judged += 1
+                    reason = m.outcome_reason()
+                    assert reason, f"{match.spec.id}/{m.trial}: judged, no reason"
+                    # Group A == the trials the void machinery already
+                    # excludes (resolved is None on a judged trial); the
+                    # taxonomy must add names, never reclassify.
+                    assert reason.startswith("void_") == (m.resolved is None), (
+                        f"{match.spec.id}/{m.trial}: {reason} vs "
+                        f"resolved={m.resolved}"
+                    )
+        assert judged, "corpus present but nothing judged — the walk is inert"
+
+    def test_the_live_fixture_reads_solved_then_timeout(self) -> None:
+        from arenabench.server import ArenaServer
+
+        match = ArenaServer(_MATCHES.parent).runner.matches.get("3568657c2db9")
+        if match is None:
+            pytest.skip("fixture match 3568657c2db9 not on this machine")
+        for contestant in match.spec.contestants:
+            metrics = match.metrics_for(contestant.id)
+            m = metrics.get("crack-7z-hash")
+            if m is not None and m.status == "done":
+                assert m.outcome_reason() == "solved_then_timeout"
+                return
+        pytest.skip("crack-7z-hash trial not judged in the fixture match")

--- a/arenabench/tests/test_series.py
+++ b/arenabench/tests/test_series.py
@@ -112,6 +112,32 @@ class TestOutcomeCounting:
         assert outcomes["timeouts_after_solve"] == 1
         assert outcomes["timeouts_before_solve"] == 1
 
+    def test_outcome_reasons_are_counted_and_drive_the_timeout_split(self) -> None:
+        """#2076: the composition is the taxonomy's counts, and the timeout
+        split consumes the labels — not a substring match. The witness: an
+        unsolved trial whose exception merely CONTAINS 'timeout'
+        (`ReadTimeout`) is `agent_error`, where the old regex counted it as
+        a real budget timeout."""
+        seat = _seat(
+            {
+                "a": _trial("a", resolved=True),
+                "b": _trial("b", resolved=True, failure="AgentTimeoutError"),
+                "c": _trial("c", resolved=False, failure="ReadTimeout"),
+                "d": _trial("d", resolved=False, failure="AgentTimeoutError"),
+            }
+        )
+        outcomes = match_row(_match([seat]))["seats"][0]["outcomes"]
+        assert outcomes["outcome_reasons"] == {
+            "solved_clean": 1,
+            "solved_then_timeout": 1,
+            "agent_error": 1,
+            "timeout_before_solve": 1,
+        }
+        assert outcomes["timeouts_after_solve"] == 1
+        assert outcomes["timeouts_before_solve"] == 1, (
+            "ReadTimeout must not inflate the budget-timeout count"
+        )
+
     def test_voids_are_outside_every_rate_and_visible(self) -> None:
         """An infrastructure void (judged, no verdict) is not agent
         performance: excluded from solved/failed, reported as its own

--- a/arenabench/ui/components/arena/stat-strip.tsx
+++ b/arenabench/ui/components/arena/stat-strip.tsx
@@ -112,7 +112,15 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
       for (const seat of seats) {
         const cell = row.cells[seat.id];
         if (!cell || cell.status !== "done" || !cell.failure) continue;
-        const isTimeout = /timeout/i.test(cell.failure);
+        // The taxonomy label (#2076) is authoritative — only the exception
+        // the agent-budget machinery actually raises counts as a timeout.
+        // The substring test survives solely for payloads recorded before
+        // the field existed.
+        const isTimeout =
+          cell.outcome_reason != null
+            ? cell.outcome_reason === "solved_then_timeout" ||
+              cell.outcome_reason === "timeout_before_solve"
+            : /timeout/i.test(cell.failure);
         if (cell.resolved === true) {
           onSolved += 1;
           if (isTimeout) timeoutAfterSolve += 1;

--- a/arenabench/ui/components/trends/trends-view.tsx
+++ b/arenabench/ui/components/trends/trends-view.tsx
@@ -58,6 +58,7 @@ function zeroOutcomes(): SeriesOutcomes {
     incidents_on_solved: 0,
     timeouts_after_solve: 0,
     timeouts_before_solve: 0,
+    outcome_reasons: {},
     clock_time: 0,
     priced_cost: 0,
     priced_cost_per_solve: null,
@@ -75,6 +76,9 @@ function addOutcomes(into: SeriesOutcomes, from: SeriesOutcomes): void {
   into.incidents_on_solved += from.incidents_on_solved;
   into.timeouts_after_solve += from.timeouts_after_solve;
   into.timeouts_before_solve += from.timeouts_before_solve;
+  for (const [reason, count] of Object.entries(from.outcome_reasons ?? {})) {
+    into.outcome_reasons[reason] = (into.outcome_reasons[reason] ?? 0) + count;
+  }
   into.clock_time += from.clock_time;
   into.priced_cost =
     into.priced_cost === null || from.priced_cost === null
@@ -360,6 +364,112 @@ function PointTable({ group }: { group: Group }) {
 }
 
 /**
+ * The #2076 taxonomy in stack order, with its rendering. Group B only —
+ * voids are Group A, outside every rate, and are drawn *after* a gap in a
+ * dim tone rather than inside the scored stack, so composition never
+ * launders an infrastructure void into an agent outcome.
+ */
+const REASON_STYLE: Array<{ key: string; label: string; color: string; opacity: number }> = [
+  { key: "solved_clean", label: "solved clean", color: "var(--ok)", opacity: 1 },
+  { key: "solved_then_timeout", label: "solved, then timeout", color: "var(--ok)", opacity: 0.55 },
+  { key: "solved_then_error", label: "solved, then error", color: "var(--ok)", opacity: 0.3 },
+  { key: "failed_wrong_answer", label: "wrong answer", color: "var(--bad)", opacity: 1 },
+  { key: "timeout_before_solve", label: "timeout before solve", color: "var(--warn)", opacity: 0.9 },
+  { key: "agent_error", label: "agent error", color: "var(--bad)", opacity: 0.55 },
+];
+
+/**
+ * Outcome composition per point — the panel that makes a flat solve rate
+ * that is quietly changing *shape* (fewer wrong answers, more timeouts)
+ * visible. One proportional stacked bar per seat per SUT commit, scored
+ * trials only; voids follow after a gap as dim blocks with their count.
+ */
+function CompositionPanel({ group }: { group: Group }) {
+  const seats = group.rows[0].seats;
+  const keys = seatKeys(group.rows[0]);
+  return (
+    <div className="space-y-1.5">
+      <div className="text-[10px] lowercase tracking-[0.09em] text-dim">
+        outcome composition
+      </div>
+      <div className="space-y-1">
+        {group.points.map((point) =>
+          seats.map((seat, seatIndex) => {
+            const o = point.seats.get(keys[seatIndex])?.outcomes;
+            if (!o || o.judged === 0) return null;
+            const reasons = o.outcome_reasons ?? {};
+            const known = REASON_STYLE.reduce((sum, r) => sum + (reasons[r.key] ?? 0), 0);
+            const unlabelled = o.scored - known;
+            return (
+              <div
+                key={`${point.sut}:${seat.id}`}
+                className="flex items-center gap-2 font-mono text-[10.5px] text-muted"
+              >
+                <span className="w-[72px] flex-none truncate">
+                  {point.sut === "unpinned" ? "unpinned" : point.sut.slice(0, 8)}
+                </span>
+                {seats.length > 1 && (
+                  <span className="w-[88px] flex-none truncate" style={{ color: seat.color }}>
+                    {seat.name}
+                  </span>
+                )}
+                <span className="flex h-[11px] w-[260px] flex-none items-stretch overflow-hidden rounded-[3px]">
+                  {REASON_STYLE.map((style) => {
+                    const count = reasons[style.key] ?? 0;
+                    if (count === 0 || o.scored === 0) return null;
+                    return (
+                      <Tip key={style.key} content={`${style.label}: ${count}/${o.scored} scored`}>
+                        <span
+                          style={{
+                            width: `${(count / o.scored) * 100}%`,
+                            background: style.color,
+                            opacity: style.opacity,
+                          }}
+                        />
+                      </Tip>
+                    );
+                  })}
+                  {unlabelled > 0 && (
+                    <Tip content={`${unlabelled} scored trial(s) without a label — matches recorded before the taxonomy existed`}>
+                      <span
+                        style={{
+                          width: `${(unlabelled / Math.max(1, o.scored)) * 100}%`,
+                          background: "var(--dim)",
+                          opacity: 0.35,
+                        }}
+                      />
+                    </Tip>
+                  )}
+                </span>
+                {o.voids > 0 && (
+                  <Tip content={`${o.voids} infrastructure void(s) — outside every rate, never part of the composition`}>
+                    <span className="text-dim">∅ {o.voids}</span>
+                  </Tip>
+                )}
+              </div>
+            );
+          }),
+        )}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-dim">
+        {REASON_STYLE.map((style) => (
+          <span key={style.key} className="inline-flex items-center gap-1">
+            <span
+              className="inline-block size-[8px] rounded-[2px]"
+              style={{ background: style.color, opacity: style.opacity }}
+            />
+            {style.label}
+          </span>
+        ))}
+        <span className="inline-flex items-center gap-1">
+          <span className="text-dim">∅</span> void (excluded from rates)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
  * One task's verdicts pooled at one point. All-same renders a glyph;
  * disagreement renders the fraction — which is the flaky-task signature
  * (git-multibranch's PASS FAIL FAIL FAIL was invisible until this grid).
@@ -488,6 +598,7 @@ function GroupCard({ group }: { group: Group }) {
           span many SUT commits, so a step between them is not a one-change delta.
         </p>
         <PointTable group={group} />
+        <CompositionPanel group={group} />
         <TaskGrid group={group} />
       </div>
     </section>

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -169,6 +169,9 @@ export interface SeriesOutcomes {
   incidents_on_solved: number;
   timeouts_after_solve: number;
   timeouts_before_solve: number;
+  /** The #2076 taxonomy: closed label -> count. `void_*` labels are Group A
+   *  (outside every rate); the rest are agent performance. */
+  outcome_reasons: Record<string, number>;
   clock_time: number;
   priced_cost: number | null;
   priced_cost_per_solve: number | null;

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -132,6 +132,9 @@ export interface Cell {
   status: string;
   resolved: boolean | null;
   failure?: string | null;
+  /** The #2076 taxonomy label; null until judged. Absent only in payloads
+   *  recorded before the field existed. */
+  outcome_reason?: string | null;
   age_s?: number | null;
   steps: number;
   tools: number;


### PR DESCRIPTION
## What

Every judged trial now carries one label from a closed vocabulary (#2076), and the trends view gains the composition panel #2068 deferred — the chart that makes a flat solve rate that is quietly changing *shape* (fewer wrong answers, more timeouts) visible.

## Taxonomy (`telemetry.py`)

`TrialMetrics.outcome_reason()`, serialized in `to_json()`. Derived from **structured fields** — the exception class name, Harbor's verdict, the infrastructure flag — never by matching prose:

- **Group A, `void_*`** (outside every rate, mechanically recognizable by prefix): `void_setup` / `void_credentials` / `void_cancelled` / `void_verifier` sub-bucket `INFRASTRUCTURE_FAILURES` — **a test pins the buckets' union equal to that set**, so a name added there must be bucketed in the same change — plus `void_no_fair_attempt` for the #1480 zero-spend shape and `void_unjudged`.
- **Group B**: `solved_clean`, `solved_then_timeout`, `solved_then_error`, `failed_wrong_answer`, `timeout_before_solve`, `agent_error`. The label *annotates* the verdict, never overrides it — `resolved` is read, not recomputed, and solved-with-incident keeps both facts (#2066's rule).

## Consumers

- `series.py` counts `outcome_reasons` per seat and derives the timeout split **from the labels instead of a substring match** — witnessed: an unsolved `ReadTimeout` no longer inflates the budget-timeout count. The aggregate keys the existing charts consume are unchanged.
- The trends card's **composition panel**: one proportional stacked bar per seat per SUT commit over scored trials, closed Group B vocabulary with a legend; voids render *after* the bar as a dim count — never inside the stack, so composition cannot launder an infrastructure void into an agent outcome. Pre-taxonomy trials render as an explicit `unlabelled` remainder.
- The stat strip's `/timeout/i` regex became a taxonomy consumer (substring kept only for payloads recorded before the field existed).

## Verified

- `pytest`: `test_outcome_reason.py` (vocabulary partition, Group B table, void prefixes, to_json ride-along) + `test_series.py` + `test_telemetry.py` + `test_arena.py` — all green on this branch rebased onto current `main` (i.e. on top of the #2092/#2093 conflict resolutions; the LIVENESS_NAMES dedupe and the taxonomy coexist, one definition each).
- **Against the live corpus** (skipped where absent): every judged trial in `~/.arenabench/matches` maps to exactly one reason; `void_` equals resolved-is-None everywhere — no silent reclassification; and `crack-7z-hash` in match `3568657c2db9` reads `solved_then_timeout` — the issue's named fixture.
- `npm run build` (full type check) passed on identical UI sources; the rebase touched no UI file.

Closes #2076
Refs #2068, #2066, #1480

## Summary by Sourcery

Introduce a closed outcome taxonomy for judged trials and surface it in trends and stats views to make outcome composition and timeout splits explicit and reliable.

New Features:
- Add an outcome_reason label to each judged trial and expose it in telemetry JSON and UI types.
- Render an outcome composition panel in the trends view, showing stacked outcome categories per seat and SUT commit.

Bug Fixes:
- Derive timeout-before/after-solve counts from structured outcome_reason labels instead of substring-matching failure messages, preventing spurious timeout inflation.
- Align stat strip timeout counting with the new taxonomy so only true agent-budget timeouts are treated as such.

Enhancements:
- Partition infrastructure failure causes into named void_* buckets that are mechanically tied to the existing INFRASTRUCTURE_FAILURES set.
- Record and aggregate outcome_reason counts per seat to feed composition charts while keeping deterministic payload ordering.

Tests:
- Add outcome_reason-focused tests covering taxonomy vocabulary, void bucket partitioning, JSON serialization, and live corpus consistency checks.
- Extend series tests to verify outcome_reason-driven timeout splits and outcome composition counts.