### PR TITLE
test(bench): unbreak main — the merged freshness fixture grew its history twice

### DIFF
--- a/bench/harbor_adapter/tests/test_freshness.py
+++ b/bench/harbor_adapter/tests/test_freshness.py
@@ -109,10 +109,10 @@ def _seed(root: Path, commits: int) -> Path:
     _git(origin, "init", "-q", "--initial-branch=main")
     _git(origin, "config", "user.email", "t@example.com")
     _git(origin, "config", "user.name", "t")
-    # Both `commit` and `fetch` may spawn a *detached* `git maintenance run
-    # --auto` behind the porcelain — the one thing in this fixture that runs
-    # concurrently with it and varies run to run. A test repo does its own
-    # housekeeping never, so switch it off rather than race it (#2080).
+    # `commit` may spawn a *detached* `git maintenance run --auto` behind the
+    # porcelain — the one thing in this fixture that runs concurrently with it
+    # and varies run to run. A test repo does its own housekeeping never, so
+    # switch it off rather than race it (#2080).
     _git(origin, "config", "maintenance.auto", "false")
     _git(origin, "config", "gc.auto", "0")
     _git(origin, "commit", "-q", "--allow-empty", "-m", "base")
@@ -125,9 +125,6 @@ def _seed(root: Path, commits: int) -> Path:
     _git(work, "config", "user.name", "t")
     _git(work, "config", "maintenance.auto", "false")
     _git(work, "config", "gc.auto", "0")
-    for index in range(1, commits + 1):
-        _git(origin, "commit", "-q", "--allow-empty", "-m", f"c{index}")
-    _git(work, "fetch", "-q", "origin")
     return work
 
 


### PR DESCRIPTION
## What

`main` is currently red in the `harbor_adapter` pytest suite — 5 failures in `bench/harbor_adapter/tests/test_freshness.py`, every one the shape `assert 582 == 291`. This PR removes the duplication that caused it.

## How it happened

Three PRs fixed the #2080 fetch flake in the same hour, each green in isolation:

- **#2075** (ride-along): grew origin's full history *before* the single clone and removed the fetch — the suite's only multi-process git step.
- **#2092**: reworked `_git` to surface git's stderr.
- **#2093**: reworked `_git` again, kept the grow-*after*-clone loop plus the fetch, and disabled git's detached background maintenance (`maintenance.auto` / `gc.auto`) as the race theory for the 128.

The merge kept **both** history-growing structures: the merged `_seed` runs the 291-commit loop twice, so `origin/main` ends 582 commits ahead of the base the tests name as `STALE_DISTANCE = 291`. Nothing had caught it yet: the push-triggered `bench`/`ci` runs for these merges were still sitting in the Actions queue, and each PR's own pre-merge checks tested a tree without the other's change — only the *combination* is wrong. This is the additive sibling of the #1976 deleted-test shape: the guard sees a test that vanished, but not a fixture loop that doubled.

## The fix

One growth loop, before the single clone — matching the `_seed` docstring that survived the merge ("Origin's whole history exists before the one `clone`, so the fixture never fetches"). #2093's maintenance/gc hardening stays on both repos, its `TestGitHelper` coverage stays, and the now-purposeless `fetch` (plus its stale "commit and fetch" comment half) goes.

## Verified

- At `447f3393` (main's tip): `uv run --no-sync pytest -q tests/test_freshness.py` → **5 failed, 31 passed** (`test_counts_commits_behind_the_reference`, `test_the_stale_binary_is_refused`, `test_the_documented_witness`, `test_an_explicit_limit_is_honoured`, `test_json_carries_the_numbers`).
- With this change: full suite `uv run --no-sync pytest -q` → **483 passed, 1 skipped**.

The fail→pass flip on the same assertions is the witness.

Refs #2075, #2092, #2093, #2080

## Summary by Sourcery

Fix harbor_adapter freshness test fixture to avoid duplicating history growth and restore main to green.

Bug Fixes:
- Ensure the harbor_adapter freshness fixture only grows origin history once so commit count expectations match.
- Remove an unnecessary fetch from the freshness fixture to prevent inconsistent stale-distance calculations.
