### PR TITLE
feat(arenabench): scale-to-zero AWS infrastructure for cloud matches

### DIFF
--- a/arenabench/infra/README.md
+++ b/arenabench/infra/README.md
@@ -146,10 +146,11 @@ frontier baselines — specifically Opus 5.
    champion and against Claude Code / Opus 5 arms; trials run on
    `arenabench-measure`, traces (`stella-events.jsonl`, trajectories,
    recordings, `results.json`) land under `runs/`.
-3. **Dataset export**: `arenabench datasets` compiles traces into training
-   corpora under `datasets/` — the witness stage's **oracle flip**
-   (fail→pass, tamper-excluded) is the reward signal that separates verified
-   solutions from claimed ones.
+3. **Dataset export** (to be built; tracked as a follow-up issue): a
+   trace→corpus exporter compiles `runs/` into training data under
+   `datasets/` — the witness stage's **oracle flip** (fail→pass,
+   tamper-excluded) is the reward signal that separates verified solutions
+   from claimed ones.
 4. **Tune**: fine-tuning jobs run on the `arenabench-tune` GPU queue
    (g6e/g6/g5, zero idle cost; blocked on the GPU quota above). The tuned
    open-weight model is served OpenAI-compatibly and seated as just another

--- a/arenabench/infra/README.md
+++ b/arenabench/infra/README.md
@@ -1,0 +1,163 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ArenaBench cloud infrastructure
+
+Scale-to-zero AWS infrastructure for running ArenaBench matches as short,
+serious bursts — 12 agents at 12-task concurrency if asked — while billing
+nothing when idle. One CloudFormation template (`core.yaml`) is the whole
+control plane; the web app lives on Vercel (arenabench.org) and reaches AWS
+through an OIDC-assumed role, never long-lived keys.
+
+**Standalone by design.** ArenaBench is being ejected from the stella
+monorepo. Nothing here assumes that monorepo: the system under test (SUT) is
+always fetched by **git URL + ref**, the runner image locates the package via
+a `PkgPath` parameter (`arenabench` today, `.` post-ejection), and stella is
+just the first entry in the agent roster — Claude Code is the required day-1
+comparison arm, anything else is a seat in a match TOML.
+
+## Architecture
+
+```
+arenabench.org (Vercel, Next.js)          AWS account 578673726240, us-east-1
+┌─────────────────────────────┐
+│ Auth.js magic-link login    │   OIDC    ┌──────────────────────────────────┐
+│ (Resend; allowlist:         ├──────────►│ role arenabench-vercel-web       │
+│  mac@macanderson.com)       │           └───────┬──────────────────────────┘
+└─────────────────────────────┘                   │ SubmitJob / StartBuild /
+                                                  │ DynamoDB / S3 / logs
+        ┌─────────────────────────────────────────┼─────────────────────────┐
+        │                                         ▼                         │
+        │  CodeBuild arenabench-sut-build   AWS Batch queues                │
+        │  (any git ref → zigbuild →        measure (on-demand, minv 0)     │
+        │   s3://…/binaries/<ref>/<sha>)    burst (spot)   tune (GPU)       │
+        │                                         │                         │
+        │  CodeBuild arenabench-runner-image      ▼                         │
+        │  (repo → ECR arenabench/runner)   runner container (privileged)   │
+        │                                   dockerd-in-docker → harbor task │
+        │                                   containers, `arenabench run`    │
+        │                                         │                         │
+        │      S3 arenabench-artifacts-*  ◄───────┘  DynamoDB `arenabench`  │
+        │      binaries/ runs/ datasets/             run + trial metadata   │
+        └───────────────────────────────────────────────────────────────────┘
+```
+
+Idle cost is storage only (S3/ECR/DynamoDB — cents). Batch compute
+environments sit at `minvCpus: 0`: EC2 exists only while jobs are queued,
+and there is deliberately **no NAT gateway** — instances live in default-VPC
+public subnets behind an ingress-free security group, because a NAT bills
+hourly around the clock.
+
+## Runbook
+
+Deploy / update (idempotent):
+
+```bash
+aws cloudformation deploy \
+  --template-file arenabench/infra/core.yaml \
+  --stack-name arenabench-core \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides VpcId=<default-vpc> \
+      'SubnetIds=<subnet-1>,<subnet-2>,...'
+```
+
+Build the Stella binary — tip of `main` by default, any branch on request:
+
+```bash
+aws codebuild start-build --project-name arenabench-sut-build            # main
+aws codebuild start-build --project-name arenabench-sut-build \
+  --environment-variables-override name=GIT_REF,value=my-branch,type=PLAINTEXT
+```
+
+Artifacts land at `s3://<bucket>/binaries/<ref>/<sha>/stella` with a
+`manifest.json` (+ per-ref `latest.json`), built with `cargo zigbuild
+--locked` at glibc floor 2.17 — the same recipe as `sut_build.py`, so the
+binary runs in any reasonable task container.
+
+Rebuild the runner image after changing `runner/`:
+
+```bash
+aws codebuild start-build --project-name arenabench-runner-image
+```
+
+Prove the substrate end to end (scales 0 → 1 instance → 0):
+
+```bash
+aws batch submit-job --job-name smoke \
+  --job-queue arenabench-measure --job-definition arenabench-trial
+```
+
+Run a match: upload an `arenabench.toml` to S3, then submit with overrides —
+
+```bash
+aws s3 cp match.toml s3://<bucket>/runs/<run-id>/match.toml
+aws batch submit-job --job-name <run-id> \
+  --job-queue arenabench-measure --job-definition arenabench-trial \
+  --container-overrides '{
+    "command": ["run"],
+    "resourceRequirements": [{"type":"VCPU","value":"4"},{"type":"MEMORY","value":"15360"}],
+    "environment": [
+      {"name":"RUN_ID","value":"<run-id>"},
+      {"name":"MATCH_S3_URI","value":"s3://<bucket>/runs/<run-id>/match.toml"},
+      {"name":"SUT_S3_URI","value":"s3://<bucket>/binaries/main/<sha>/stella"},
+      {"name":"SUT_COMMIT","value":"<sha>"}
+    ]}'
+```
+
+The 12×12 shape is 144 such submissions (or one array job of size 144) —
+Batch packs instances up to the queue's compute-environment ceiling and
+tears everything down when the queue drains. Provider API keys are read at
+trial start from SSM parameters under `/arenabench/` (SecureString;
+`/arenabench/anthropic_api_key` → `ANTHROPIC_API_KEY`, etc.).
+
+### Quotas (account limits, not template limits)
+
+| Quota | At deploy time | Needed for 12×12 | Fix |
+|---|---|---|---|
+| EC2 on-demand Standard vCPU (`L-1216C47A`) | 64 | ~288 (+headroom → 384) | service-quotas increase |
+| EC2 Spot Standard vCPU (`L-34B43A08`) | 32 | burst queue only | as needed |
+| EC2 G/VT (GPU) vCPU (`L-DB2E81BA`) | 0 | tuning loop | must raise before `arenabench-tune` can place jobs |
+
+Under-quota bursts do not fail — Batch queues trials and works through them
+at whatever capacity the quota allows.
+
+## Web plane: arenabench.org
+
+The Next.js app (evolving `../ui/`) deploys to Vercel with arenabench.org
+attached; server routes assume `arenabench-vercel-web` via Vercel's OIDC
+federation (`AWS_ROLE_ARN` env var — no AWS keys in Vercel). The trust
+policy accepts the `arena` and `arenabench` project slugs in team `oxagen`.
+
+Auth is built like a real SaaS but gated to one user while testing:
+Auth.js v5 with the Resend email provider (passwordless magic links) and a
+database session adapter; sign-in is refused unless the address appears in
+`ALLOWED_EMAILS` (currently `mac@macanderson.com`). Adding a teammate later
+is an env change; adding OAuth providers later is additive, not a rework.
+Every page and API route sits behind the session middleware.
+
+## Self-tuning roadmap (the Opus 5 target)
+
+The loop this infrastructure is built to host: Stella branches itself, digital
+clones compete, and the traces train an open-weight model until it beats
+frontier baselines — specifically Opus 5.
+
+1. **Branch → build**: each candidate branch becomes a binary via
+   `arenabench-sut-build` (`GIT_REF=<branch>`), content-addressed in S3.
+2. **Clone vs. clone**: matches seat candidate binaries against the current
+   champion and against Claude Code / Opus 5 arms; trials run on
+   `arenabench-measure`, traces (`stella-events.jsonl`, trajectories,
+   recordings, `results.json`) land under `runs/`.
+3. **Dataset export**: `arenabench datasets` compiles traces into training
+   corpora under `datasets/` — the witness stage's **oracle flip**
+   (fail→pass, tamper-excluded) is the reward signal that separates verified
+   solutions from claimed ones.
+4. **Tune**: fine-tuning jobs run on the `arenabench-tune` GPU queue
+   (g6e/g6/g5, zero idle cost; blocked on the GPU quota above). The tuned
+   open-weight model is served OpenAI-compatibly and seated as just another
+   contestant — closing the loop at step 2.
+
+## Teardown
+
+```bash
+aws s3 rm s3://arenabench-artifacts-<account>/ --recursive   # bucket must be empty
+aws cloudformation delete-stack --stack-name arenabench-core
+```

--- a/arenabench/infra/README.md
+++ b/arenabench/infra/README.md
@@ -8,10 +8,10 @@ nothing when idle. One CloudFormation template (`core.yaml`) is the whole
 control plane; the web app lives on Vercel (arenabench.org) and reaches AWS
 through an OIDC-assumed role, never long-lived keys.
 
-**Standalone by design.** ArenaBench is being ejected from the stella
+**Standalone by design.** ArenaBench is being ejected from the Stella
 monorepo. Nothing here assumes that monorepo: the system under test (SUT) is
 always fetched by **git URL + ref**, the runner image locates the package via
-a `PkgPath` parameter (`arenabench` today, `.` post-ejection), and stella is
+a `PkgPath` parameter (`arenabench` today, `.` post-ejection), and Stella is
 just the first entry in the agent roster — Claude Code is the required day-1
 comparison arm, anything else is a seat in a match TOML.
 

--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -551,6 +551,17 @@ Resources:
         Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/arenabench/runner:latest
         JobRoleArn: !GetAtt TrialJobRole.Arn
         Privileged: true
+        # The inner dockerd cannot stack overlayfs on the container's own
+        # overlay root (EINVAL); it needs a data root on a real filesystem.
+        # The entrypoint carves a per-job subdirectory under this host
+        # volume so concurrent trials on one instance never share storage.
+        Volumes:
+          - Name: dind-scratch
+            Host:
+              SourcePath: /var/lib/arenabench-scratch
+        MountPoints:
+          - SourceVolume: dind-scratch
+            ContainerPath: /scratch
         ResourceRequirements:
           - Type: VCPU
             Value: "2"

--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -31,7 +31,7 @@ Parameters:
     Default: arenabench
     Description: >-
       Path of the ArenaBench package inside InfraGitUrl's repo. "arenabench"
-      while ArenaBench lives inside the stella monorepo; "." after ejection.
+      while ArenaBench lives inside the Stella monorepo; "." after ejection.
   VercelTeamSlug:
     Type: String
     Default: oxagen

--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -1,0 +1,686 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  ArenaBench core infrastructure: scale-to-zero benchmark compute (AWS Batch),
+  SUT binary builds from any git ref (CodeBuild), artifact/trace storage (S3),
+  run metadata (DynamoDB), and the OIDC role the Vercel web app assumes.
+  Designed for ArenaBench as a standalone repository: the system under test is
+  always fetched by git URL + ref, never by local path.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC for Batch compute instances (default VPC is fine).
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: >-
+      Public subnets for Batch instances. Public-subnet egress is deliberate:
+      a NAT gateway would bill hourly while idle, which violates the
+      scale-to-zero posture. The security group allows no ingress.
+  SutGitUrl:
+    Type: String
+    Default: https://github.com/macanderson/stella.git
+    Description: Default git remote for SUT (system under test) binary builds.
+  InfraGitUrl:
+    Type: String
+    Default: https://github.com/macanderson/stella.git
+    Description: >-
+      Git remote holding the ArenaBench package and this infra directory.
+      After ejection, point this at the standalone arenabench repository.
+  PkgPath:
+    Type: String
+    Default: arenabench
+    Description: >-
+      Path of the ArenaBench package inside InfraGitUrl's repo. "arenabench"
+      while ArenaBench lives inside the stella monorepo; "." after ejection.
+  VercelTeamSlug:
+    Type: String
+    Default: oxagen
+  VercelThumbprint:
+    Type: String
+    Default: 91d89f33169baa11a2e810804f8d25f5639aa440
+    Description: SHA-1 thumbprint of oidc.vercel.com's TLS certificate.
+  OnDemandMaxvCpus:
+    Type: Number
+    Default: 384
+    Description: >-
+      Ceiling for the measurement compute environment. 12 agents x 12-task
+      concurrency at 2 vCPU per trial is 288 vCPU; 384 leaves headroom.
+      The account's EC2 on-demand vCPU quota is the real limit.
+  SpotMaxvCpus:
+    Type: Number
+    Default: 256
+  GpuMaxvCpus:
+    Type: Number
+    Default: 64
+  SutBuildComputeType:
+    Type: String
+    Default: BUILD_GENERAL1_LARGE
+    AllowedValues:
+      - BUILD_GENERAL1_MEDIUM
+      - BUILD_GENERAL1_LARGE
+      - BUILD_GENERAL1_2XLARGE
+  LogRetentionDays:
+    Type: Number
+    Default: 30
+
+Resources:
+  # ---------------------------------------------------------------- storage
+  ArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub arenabench-artifacts-${AWS::AccountId}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: abort-incomplete-multipart
+            Status: Enabled
+            Prefix: ""
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+          - Id: expire-build-cache
+            Status: Enabled
+            Prefix: cache/
+            ExpirationInDays: 30
+
+  RunsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: arenabench
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: PK
+          AttributeType: S
+        - AttributeName: SK
+          AttributeType: S
+        - AttributeName: GSI1PK
+          AttributeType: S
+        - AttributeName: GSI1SK
+          AttributeType: S
+      KeySchema:
+        - AttributeName: PK
+          KeyType: HASH
+        - AttributeName: SK
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: GSI1
+          KeySchema:
+            - AttributeName: GSI1PK
+              KeyType: HASH
+            - AttributeName: GSI1SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: true
+
+  RunnerRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: arenabench/runner
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "expire untagged images after 14 days",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 14
+                },
+                "action": { "type": "expire" }
+              }
+            ]
+          }
+
+  BatchLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /arenabench/batch
+      RetentionInDays: !Ref LogRetentionDays
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /arenabench/build
+      RetentionInDays: !Ref LogRetentionDays
+
+  # ------------------------------------------------------------- codebuild
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: arenabench-codebuild
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: arenabench-codebuild
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub ${BuildLogGroup.Arn}:*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt ArtifactsBucket.Arn
+                  - !Sub ${ArtifactsBucket.Arn}/*
+              - Effect: Allow
+                Action: ecr:GetAuthorizationToken
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:CompleteLayerUpload
+                  - ecr:InitiateLayerUpload
+                  - ecr:PutImage
+                  - ecr:UploadLayerPart
+                  - ecr:BatchGetImage
+                  - ecr:GetDownloadUrlForLayer
+                Resource: !GetAtt RunnerRepository.Arn
+
+  # Builds the SUT binary from any git ref (default: tip of main) and drops
+  # it in S3 under binaries/<ref>/<sha>/stella, mirroring sut_build.py's
+  # zigbuild recipe so the artifact is glibc-2.17 portable.
+  SutBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: arenabench-sut-build
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      TimeoutInMinutes: 90
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Cache:
+        Type: S3
+        Location: !Sub ${ArtifactsBucket}/cache/sut-build
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Ref BuildLogGroup
+          StreamName: sut-build
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref SutBuildComputeType
+        Image: aws/codebuild/standard:7.0
+        EnvironmentVariables:
+          - Name: GIT_URL
+            Value: !Ref SutGitUrl
+          - Name: GIT_REF
+            Value: main
+          - Name: ARTIFACTS_BUCKET
+            Value: !Ref ArtifactsBucket
+          - Name: TARGET_TRIPLE
+            Value: x86_64-unknown-linux-gnu
+          - Name: GLIBC_FLOOR
+            Value: "2.17"
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              commands:
+                - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+                - pip3 install --quiet cargo-zigbuild
+            build:
+              commands:
+                - export PATH="$HOME/.cargo/bin:$PATH"
+                - git clone --filter=blob:none "$GIT_URL" /tmp/sut-src
+                - cd /tmp/sut-src && git checkout "$GIT_REF"
+                - export SHA="$(git rev-parse HEAD)"
+                - export REF_SAFE="$(printf '%s' "$GIT_REF" | tr '/' '-')"
+                - TOOLCHAIN="$(sed -n 's/^channel *= *"\(.*\)"/\1/p' rust-toolchain.toml)"
+                - rustup toolchain install "$TOOLCHAIN" --profile minimal
+                - rustup default "$TOOLCHAIN"
+                - rustup target add "$TARGET_TRIPLE"
+                - export CARGO_TARGET_DIR=/root/target
+                - export STELLA_BUILD_GIT_SHA="$SHA"
+                - cargo zigbuild --release --locked --target "$TARGET_TRIPLE.$GLIBC_FLOOR" -p stella-cli --bin stella
+            post_build:
+              commands:
+                - cd /tmp/sut-src
+                - BIN="/root/target/$TARGET_TRIPLE/release/stella"
+                - test -f "$BIN"
+                - BSHA="$(sha256sum "$BIN" | cut -d' ' -f1)"
+                - aws s3 cp "$BIN" "s3://$ARTIFACTS_BUCKET/binaries/$REF_SAFE/$SHA/stella"
+                - printf '{"git_ref":"%s","commit":"%s","sha256":"%s","glibc_floor":"%s","built_at":"%s"}\n' "$GIT_REF" "$SHA" "$BSHA" "$GLIBC_FLOOR" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /tmp/manifest.json
+                - aws s3 cp /tmp/manifest.json "s3://$ARTIFACTS_BUCKET/binaries/$REF_SAFE/$SHA/manifest.json"
+                - aws s3 cp /tmp/manifest.json "s3://$ARTIFACTS_BUCKET/binaries/$REF_SAFE/latest.json"
+          cache:
+            paths:
+              - /root/.cargo/**/*
+              - /root/target/**/*
+
+  # Builds the trial runner image (docker-in-docker + arenabench + agent
+  # CLIs) from the repo's infra/runner/Dockerfile and pushes it to ECR.
+  RunnerImageProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: arenabench-runner-image
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      TimeoutInMinutes: 45
+      Artifacts:
+        Type: NO_ARTIFACTS
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Ref BuildLogGroup
+          StreamName: runner-image
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: aws/codebuild/standard:7.0
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: GIT_URL
+            Value: !Ref InfraGitUrl
+          - Name: GIT_REF
+            Value: main
+          - Name: PKG_PATH
+            Value: !Ref PkgPath
+          - Name: ECR_URI
+            Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/arenabench/runner
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - aws ecr get-login-password | docker login --username AWS --password-stdin "${ECR_URI%%/*}"
+            build:
+              commands:
+                - git clone --filter=blob:none "$GIT_URL" /tmp/src
+                - cd /tmp/src && git checkout "$GIT_REF"
+                - export SHA="$(git rev-parse HEAD)"
+                - docker build -f "$PKG_PATH/infra/runner/Dockerfile" --build-arg "PKG_PATH=$PKG_PATH" -t "$ECR_URI:latest" -t "$ECR_URI:$SHA" .
+            post_build:
+              commands:
+                - docker push "$ECR_URI:latest"
+                - docker push "$ECR_URI:$SHA"
+
+  # ------------------------------------------------------------------ batch
+  BatchSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: ArenaBench Batch instances — egress only, no ingress.
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Project
+          Value: arenabench
+
+  EcsInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: arenabench-ecs-instance
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  EcsInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: arenabench-ecs-instance
+      Roles:
+        - !Ref EcsInstanceRole
+
+  # 200 GB gp3 root: each instance hosts up to a dozen docker-in-docker
+  # trials, and task images plus recordings need real scratch space.
+  InstanceLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: arenabench-batch-instance
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              VolumeSize: 200
+              VolumeType: gp3
+              DeleteOnTermination: true
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Project
+                Value: arenabench
+
+  OnDemandComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName: arenabench-ondemand
+      Type: MANAGED
+      State: ENABLED
+      ComputeResources:
+        Type: EC2
+        AllocationStrategy: BEST_FIT_PROGRESSIVE
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: !Ref OnDemandMaxvCpus
+        InstanceTypes:
+          - m6i
+          - c6i
+        Subnets: !Ref SubnetIds
+        SecurityGroupIds:
+          - !Ref BatchSecurityGroup
+        InstanceRole: !GetAtt EcsInstanceProfile.Arn
+        LaunchTemplate:
+          LaunchTemplateId: !Ref InstanceLaunchTemplate
+          Version: !GetAtt InstanceLaunchTemplate.LatestVersionNumber
+        Ec2Configuration:
+          - ImageType: ECS_AL2023
+        Tags:
+          Project: arenabench
+
+  SpotComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName: arenabench-spot
+      Type: MANAGED
+      State: ENABLED
+      ComputeResources:
+        Type: SPOT
+        AllocationStrategy: SPOT_PRICE_CAPACITY_OPTIMIZED
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: !Ref SpotMaxvCpus
+        InstanceTypes:
+          - m6i
+          - c6i
+        Subnets: !Ref SubnetIds
+        SecurityGroupIds:
+          - !Ref BatchSecurityGroup
+        InstanceRole: !GetAtt EcsInstanceProfile.Arn
+        LaunchTemplate:
+          LaunchTemplateId: !Ref InstanceLaunchTemplate
+          Version: !GetAtt InstanceLaunchTemplate.LatestVersionNumber
+        Ec2Configuration:
+          - ImageType: ECS_AL2023
+        Tags:
+          Project: arenabench
+
+  # GPU capacity for the tuning loop. Provisioned at zero idle cost; the
+  # account's G/VT vCPU quota (0 at deploy time) must be raised before jobs
+  # placed here can start.
+  GpuComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName: arenabench-gpu
+      Type: MANAGED
+      State: ENABLED
+      ComputeResources:
+        Type: EC2
+        AllocationStrategy: BEST_FIT_PROGRESSIVE
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: !Ref GpuMaxvCpus
+        InstanceTypes:
+          - g6e
+          - g6
+          - g5
+        Subnets: !Ref SubnetIds
+        SecurityGroupIds:
+          - !Ref BatchSecurityGroup
+        InstanceRole: !GetAtt EcsInstanceProfile.Arn
+        LaunchTemplate:
+          LaunchTemplateId: !Ref InstanceLaunchTemplate
+          Version: !GetAtt InstanceLaunchTemplate.LatestVersionNumber
+        Ec2Configuration:
+          - ImageType: ECS_AL2023_NVIDIA
+        Tags:
+          Project: arenabench
+
+  # Measured comparisons run on-demand only: a spot interruption mid-trial
+  # is a confound, not a saving.
+  MeasureQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: arenabench-measure
+      State: ENABLED
+      Priority: 100
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref OnDemandComputeEnvironment
+
+  BurstQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: arenabench-burst
+      State: ENABLED
+      Priority: 50
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref SpotComputeEnvironment
+
+  TuneQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: arenabench-tune
+      State: ENABLED
+      Priority: 10
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref GpuComputeEnvironment
+
+  TrialJobRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: arenabench-trial-job
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: arenabench-trial-job
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !GetAtt ArtifactsBucket.Arn
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub ${ArtifactsBucket.Arn}/*
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !GetAtt RunsTable.Arn
+                  - !Sub ${RunsTable.Arn}/index/*
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/arenabench/*
+
+  TrialJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      JobDefinitionName: arenabench-trial
+      Type: container
+      PlatformCapabilities:
+        - EC2
+      RetryStrategy:
+        Attempts: 1
+      Timeout:
+        AttemptDurationSeconds: 10800
+      ContainerProperties:
+        Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/arenabench/runner:latest
+        JobRoleArn: !GetAtt TrialJobRole.Arn
+        Privileged: true
+        ResourceRequirements:
+          - Type: VCPU
+            Value: "2"
+          - Type: MEMORY
+            Value: "7168"
+        Command:
+          - smoke
+        Environment:
+          - Name: ARTIFACTS_BUCKET
+            Value: !Ref ArtifactsBucket
+          - Name: ARENABENCH_TABLE
+            Value: !Ref RunsTable
+          - Name: AWS_DEFAULT_REGION
+            Value: !Ref AWS::Region
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref BatchLogGroup
+            awslogs-region: !Ref AWS::Region
+            awslogs-stream-prefix: trial
+
+  # ----------------------------------------------------------- vercel oidc
+  VercelOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: !Sub https://oidc.vercel.com/${VercelTeamSlug}
+      ClientIdList:
+        - !Sub https://vercel.com/${VercelTeamSlug}
+      ThumbprintList:
+        - !Ref VercelThumbprint
+
+  VercelWebRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: arenabench-vercel-web
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !GetAtt VercelOidcProvider.Arn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                !Sub "oidc.vercel.com/${VercelTeamSlug}:aud": !Sub https://vercel.com/${VercelTeamSlug}
+              StringLike:
+                !Sub "oidc.vercel.com/${VercelTeamSlug}:sub":
+                  - !Sub owner:${VercelTeamSlug}:project:arena:*
+                  - !Sub owner:${VercelTeamSlug}:project:arenabench:*
+      Policies:
+        - PolicyName: arenabench-vercel-web
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: batch:SubmitJob
+                Resource:
+                  - !Ref MeasureQueue
+                  - !Ref BurstQueue
+                  - !Ref TuneQueue
+                  - !Ref TrialJobDefinition
+              - Effect: Allow
+                Action:
+                  - batch:DescribeJobs
+                  - batch:ListJobs
+                  - batch:TerminateJob
+                  - batch:DescribeJobQueues
+                  - batch:DescribeComputeEnvironments
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:StopBuild
+                  - codebuild:BatchGetBuilds
+                Resource:
+                  - !GetAtt SutBuildProject.Arn
+                  - !GetAtt RunnerImageProject.Arn
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !GetAtt ArtifactsBucket.Arn
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub ${ArtifactsBucket.Arn}/*
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:BatchWriteItem
+                Resource:
+                  - !GetAtt RunsTable.Arn
+                  - !Sub ${RunsTable.Arn}/index/*
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                  - ssm:PutParameter
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/arenabench/*
+              - Effect: Allow
+                Action:
+                  - logs:GetLogEvents
+                  - logs:FilterLogEvents
+                Resource:
+                  - !Sub ${BatchLogGroup.Arn}:*
+                  - !Sub ${BuildLogGroup.Arn}:*
+
+Outputs:
+  ArtifactsBucketName:
+    Value: !Ref ArtifactsBucket
+  RunsTableName:
+    Value: !Ref RunsTable
+  RunnerImageUri:
+    Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/arenabench/runner:latest
+  MeasureQueueArn:
+    Value: !Ref MeasureQueue
+  BurstQueueArn:
+    Value: !Ref BurstQueue
+  TuneQueueArn:
+    Value: !Ref TuneQueue
+  TrialJobDefinitionArn:
+    Value: !Ref TrialJobDefinition
+  SutBuildProjectName:
+    Value: !Ref SutBuildProject
+  RunnerImageProjectName:
+    Value: !Ref RunnerImageProject
+  VercelWebRoleArn:
+    Description: Role the Vercel app assumes via OIDC (AWS_ROLE_ARN env var).
+    Value: !GetAtt VercelWebRole.Arn

--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -326,7 +326,7 @@ Resources:
   BatchSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: ArenaBench Batch instances — egress only, no ingress.
+      GroupDescription: ArenaBench Batch instances - egress only, no ingress.
       VpcId: !Ref VpcId
       SecurityGroupEgress:
         - IpProtocol: "-1"
@@ -586,20 +586,30 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: arenabench-vercel-web
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !GetAtt VercelOidcProvider.Arn
-            Action: sts:AssumeRoleWithWebIdentity
-            Condition:
-              StringEquals:
-                !Sub "oidc.vercel.com/${VercelTeamSlug}:aud": !Sub https://vercel.com/${VercelTeamSlug}
-              StringLike:
-                !Sub "oidc.vercel.com/${VercelTeamSlug}:sub":
-                  - !Sub owner:${VercelTeamSlug}:project:arena:*
-                  - !Sub owner:${VercelTeamSlug}:project:arenabench:*
+      # Rendered as a Sub'd JSON string because the condition keys embed the
+      # team slug, and CloudFormation forbids intrinsics in mapping keys.
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Federated": "${VercelOidcProvider.Arn}" },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "oidc.vercel.com/${VercelTeamSlug}:aud": "https://vercel.com/${VercelTeamSlug}"
+                },
+                "StringLike": {
+                  "oidc.vercel.com/${VercelTeamSlug}:sub": [
+                    "owner:${VercelTeamSlug}:project:arena:*",
+                    "owner:${VercelTeamSlug}:project:arenabench:*"
+                  ]
+                }
+              }
+            }
+          ]
+        }
       Policies:
         - PolicyName: arenabench-vercel-web
           PolicyDocument:

--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -10,7 +10,9 @@
 # monorepo, "." once it is ejected into its own repository.
 ARG PKG_PATH=arenabench
 
-FROM ubuntu:24.04
+# ECR Public mirror of the official image: Docker Hub rate-limits anonymous
+# pulls from CodeBuild's shared egress IPs (429s), ECR Public does not.
+FROM public.ecr.aws/docker/library/ubuntu:24.04
 ARG PKG_PATH
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -1,0 +1,56 @@
+# ArenaBench trial runner.
+#
+# One container = one trial slot on AWS Batch: it boots its own dockerd
+# (privileged docker-in-docker, so harbor task containers are fully isolated
+# per trial), stages a prebuilt SUT binary the way sut_build.py would, and
+# runs `arenabench run` against a match TOML fetched from S3.
+#
+# Build context is the repository root. PKG_PATH locates the ArenaBench
+# package inside it: "arenabench" while ArenaBench lives in the stella
+# monorepo, "." once it is ejected into its own repository.
+ARG PKG_PATH=arenabench
+
+FROM ubuntu:24.04
+ARG PKG_PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git jq unzip gnupg procps \
+        python3 python3-pip ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker engine from the official repository — the trial hosts its own
+# dockerd, so harbor's `docker compose` task stacks work unmodified.
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 22 + Claude Code: the required day-1 comparison agent.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2 for S3 artifact sync, SSM credential fetch, DynamoDB status.
+RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# ArenaBench itself. Stdlib-only by contract, so this install is dependency
+# free; the pre-built web client ships inside the package.
+COPY ${PKG_PATH}/pyproject.toml /opt/arenabench/pyproject.toml
+COPY ${PKG_PATH}/README.md /opt/arenabench/README.md
+COPY ${PKG_PATH}/LICENSE /opt/arenabench/LICENSE
+COPY ${PKG_PATH}/arenabench /opt/arenabench/arenabench
+RUN python3 -m pip install --break-system-packages /opt/arenabench
+
+COPY ${PKG_PATH}/infra/runner/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["smoke"]

--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -6,7 +6,7 @@
 # runs `arenabench run` against a match TOML fetched from S3.
 #
 # Build context is the repository root. PKG_PATH locates the ArenaBench
-# package inside it: "arenabench" while ArenaBench lives in the stella
+# package inside it: "arenabench" while ArenaBench lives in the Stella
 # monorepo, "." once it is ejected into its own repository.
 ARG PKG_PATH=arenabench
 

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ArenaBench Batch runner entrypoint.
+#
+# Modes (first argument, default "smoke"):
+#   smoke  — prove the trial substrate works end to end: dockerd boots,
+#            a container runs, S3 and DynamoDB are reachable. Cheap enough
+#            to run after every infra change.
+#   run    — execute one match: fetch MATCH_S3_URI (an arenabench.toml),
+#            optionally stage a prebuilt SUT binary from SUT_S3_URI in the
+#            layout sut_build.py produces, run `arenabench run`, then sync
+#            all artifacts (events, results, recordings) to S3 and record
+#            the outcome in DynamoDB.
+#
+# Required environment (from the Batch job definition / submit-time overrides):
+#   ARTIFACTS_BUCKET, ARENABENCH_TABLE, AWS_DEFAULT_REGION   (job definition)
+#   run mode: RUN_ID, MATCH_S3_URI; optionally SUT_S3_URI + SUT_COMMIT.
+#
+# Provider credentials are read from SSM Parameter Store: every parameter
+# under /arenabench/ is exported, upper-cased, into the environment
+# (e.g. /arenabench/anthropic_api_key -> ANTHROPIC_API_KEY).
+set -euo pipefail
+
+MODE="${1:-smoke}"
+JOB_ID="${AWS_BATCH_JOB_ID:-local-$$}"
+
+log() { printf '[runner] %s\n' "$*"; }
+
+start_dockerd() {
+    log "starting dockerd"
+    dockerd >/var/log/dockerd.log 2>&1 &
+    for _ in $(seq 1 60); do
+        if docker info >/dev/null 2>&1; then
+            log "dockerd is up"
+            return 0
+        fi
+        sleep 1
+    done
+    log "dockerd failed to start; tail of log:"
+    tail -50 /var/log/dockerd.log || true
+    return 1
+}
+
+export_ssm_credentials() {
+    # Missing credentials are not fatal here: `arenabench run` itself
+    # refuses a seat whose declared credentials are absent, which is the
+    # better error surface.
+    local pairs
+    if ! pairs=$(aws ssm get-parameters-by-path \
+        --path /arenabench --with-decryption \
+        --query 'Parameters[].[Name,Value]' --output text 2>/dev/null); then
+        log "no SSM credentials readable; continuing"
+        return 0
+    fi
+    while IFS=$'\t' read -r name value; do
+        [ -n "$name" ] || continue
+        local key
+        key=$(basename "$name" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9_\n' '_')
+        export "$key=$value"
+        log "exported credential $key"
+    done <<<"$pairs"
+}
+
+ddb_put_status() {
+    local status="$1" detail="$2"
+    aws dynamodb put-item --table-name "$ARENABENCH_TABLE" --item "{
+        \"PK\": {\"S\": \"RUN#${RUN_ID:-smoke}\"},
+        \"SK\": {\"S\": \"JOB#${JOB_ID}\"},
+        \"GSI1PK\": {\"S\": \"JOB\"},
+        \"GSI1SK\": {\"S\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"},
+        \"status\": {\"S\": \"${status}\"},
+        \"detail\": {\"S\": \"${detail}\"},
+        \"mode\": {\"S\": \"${MODE}\"}
+    }" >/dev/null 2>&1 || log "dynamodb status write failed (non-fatal)"
+}
+
+stage_sut() {
+    # Reconstruct the finished-build layout sut_build.py stages, so
+    # arenabench's binary_for() accepts the prebuilt binary as done.
+    : "${SUT_COMMIT:?SUT_S3_URI requires SUT_COMMIT}"
+    local dest="$HOME/.arenabench/sut/$SUT_COMMIT"
+    mkdir -p "$dest"
+    aws s3 cp "$SUT_S3_URI" "$dest/stella"
+    chmod 0755 "$dest/stella"
+    printf '%s\n' "$SUT_COMMIT" >"$dest/sut_commit.txt"
+    sha256sum "$dest/stella" | cut -d' ' -f1 >"$dest/binary_sha256.txt"
+    log "staged SUT $SUT_COMMIT ($(cut -c1-12 "$dest/binary_sha256.txt"))"
+}
+
+case "$MODE" in
+smoke)
+    start_dockerd
+    docker run --rm public.ecr.aws/docker/library/hello-world:latest
+    log "inner container ran"
+    printf '{"job":"%s","at":"%s"}\n' "$JOB_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >/tmp/heartbeat.json
+    aws s3 cp /tmp/heartbeat.json "s3://$ARTIFACTS_BUCKET/runs/_smoke/$JOB_ID.json"
+    log "s3 write ok"
+    RUN_ID="smoke" ddb_put_status "done" "smoke passed"
+    log "SMOKE OK"
+    ;;
+run)
+    : "${RUN_ID:?}" "${MATCH_S3_URI:?}"
+    start_dockerd
+    export_ssm_credentials
+    [ -n "${SUT_S3_URI:-}" ] && stage_sut
+    ddb_put_status "running" "$MATCH_S3_URI"
+
+    mkdir -p /work/ws
+    aws s3 cp "$MATCH_S3_URI" /work/match.toml
+    rc=0
+    arenabench run /work/match.toml \
+        --workspace /work/ws \
+        --results /work/results.json \
+        --progress || rc=$?
+
+    log "arenabench run exited $rc; syncing artifacts"
+    aws s3 sync /work/ws "s3://$ARTIFACTS_BUCKET/runs/$RUN_ID/$JOB_ID/ws" --only-show-errors || true
+    [ -f /work/results.json ] &&
+        aws s3 cp /work/results.json "s3://$ARTIFACTS_BUCKET/runs/$RUN_ID/$JOB_ID/results.json"
+    [ -d "$HOME/.arenabench/matches" ] &&
+        aws s3 sync "$HOME/.arenabench/matches" "s3://$ARTIFACTS_BUCKET/runs/$RUN_ID/$JOB_ID/matches" --only-show-errors || true
+
+    if [ "$rc" -eq 0 ]; then
+        ddb_put_status "done" "exit 0"
+    else
+        ddb_put_status "failed" "exit $rc"
+    fi
+    exit "$rc"
+    ;;
+*)
+    log "unknown mode: $MODE (expected smoke|run)"
+    exit 2
+    ;;
+esac

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -25,9 +25,28 @@ JOB_ID="${AWS_BATCH_JOB_ID:-local-$$}"
 
 log() { printf '[runner] %s\n' "$*"; }
 
+cleanup_dockerd() {
+    kill "${DOCKERD_PID:-0}" 2>/dev/null || true
+    wait "${DOCKERD_PID:-0}" 2>/dev/null || true
+    [ -n "${JOB_SLUG:-}" ] && rm -rf "/scratch/$JOB_SLUG" 2>/dev/null || true
+}
+
 start_dockerd() {
-    log "starting dockerd"
-    dockerd >/var/log/dockerd.log 2>&1 &
+    # Overlayfs cannot nest: with /var/lib/docker on the container's own
+    # overlay root, the inner dockerd's mounts fail with EINVAL. The job
+    # definition mounts a host-path volume at /scratch; a per-job
+    # subdirectory there gives each concurrent trial its own storage on a
+    # real filesystem, cleaned up on exit to free the shared instance disk.
+    local data_root=/var/lib/docker
+    if [ -d /scratch ]; then
+        JOB_SLUG=$(printf '%s' "$JOB_ID" | tr -c 'A-Za-z0-9_-' '_')
+        data_root="/scratch/$JOB_SLUG/docker"
+        mkdir -p "$data_root"
+        trap 'cleanup_dockerd' EXIT
+    fi
+    log "starting dockerd (data-root $data_root)"
+    dockerd --data-root "$data_root" >/var/log/dockerd.log 2>&1 &
+    DOCKERD_PID=$!
     for _ in $(seq 1 60); do
         if docker info >/dev/null 2>&1; then
             log "dockerd is up"


### PR DESCRIPTION
## What & why

Provisions ArenaBench's cloud substrate on AWS as infrastructure-as-code
(`arenabench/infra/`), replacing the always-on EC2 rig (stopped 2026-08-07
after a >$1000/month projection) with a **scale-to-zero** design: nothing
bills while idle, and bursts scale to the 12-agents x 12-task-concurrency
shape on request.

One CloudFormation template (`core.yaml`) is the whole control plane:

- **AWS Batch** queues `arenabench-measure` (on-demand — measured runs
  only), `arenabench-burst` (spot), `arenabench-tune` (GPU, for the tuning
  loop) — all compute environments at `minvCpus: 0`, no NAT gateway by
  design (a NAT bills hourly while idle).
- **CodeBuild `arenabench-sut-build`** — builds the Stella binary from
  **any git ref** (default: tip of `main`) with `cargo zigbuild --locked`
  at glibc floor 2.17, the exact `sut_build.py` recipe, into
  `s3://arenabench-artifacts-<acct>/binaries/<ref>/<sha>/stella` +
  manifests.
- **CodeBuild `arenabench-runner-image`** — builds the privileged
  docker-in-docker trial runner (arenabench + Claude Code + AWS CLI) into
  ECR. The entrypoint speaks arenabench's real interfaces: `arenabench run`
  for matches, and it stages prebuilt SUT binaries in `sut_build.py`'s
  finished-build layout (`sut/<commit>/stella` + sidecars) so `binary_for`
  accepts them.
- **S3 + DynamoDB** for artifacts/traces and run metadata; **SSM
  `/arenabench/*`** SecureStrings for provider credentials; **IAM OIDC
  role `arenabench-vercel-web`** so the arenabench.org app on Vercel
  assumes a scoped role with zero long-lived keys.

**Standalone by design**: ArenaBench is being ejected from this monorepo
soon. The SUT is fetched by git URL + ref (never a local path), the runner
Dockerfile takes a `PKG_PATH` build-arg (`arenabench` now, `.`
post-ejection), and nothing here references the stella workspace.

## The witness

- [x] No witness needed (infra + docs; no Rust code changed) — because:
  the artifact is a CloudFormation template, and its proof is the deployed
  system, exercised for real on 2026-08-07:
  - Stack `arenabench-core` reached CREATE_COMPLETE in us-east-1
    (account 578673726240).
  - `arenabench-sut-build` built tip of `main` (`ebbbe510`) in ~8 min to
    `s3://arenabench-artifacts-578673726240/binaries/main/ebbbe510…/stella`
    (34 MB, zigbuild glibc-2.17) + manifest + `latest.json`.
  - `arenabench-runner-image` pushed to ECR `arenabench/runner:latest`.
  - Smoke Batch job `96cec9b8-2717-4b55-9ca9-1d4c1d6a2740` on
    `arenabench-measure`: RUNNABLE → an m6i.large scaled up **from zero**
    → privileged runner booted its inner dockerd on the /scratch host
    volume → ran a nested container → wrote the S3 heartbeat
    (`runs/_smoke/96cec9b8….json`) → wrote the DynamoDB row
    (`RUN#smoke / JOB#96cec9b8… = done, "smoke passed"`) → exit 0 →
    instance reaped by Batch (scale back to zero).

## The gate

- [x] `cargo fmt --check` / clippy / tests — unaffected (no Rust touched);
      guards-fast rung applies (docs + non-crate files only)
- [x] Docs updated (arenabench/infra/README.md is the runbook)
- [x] CLA signed

## Nothing left behind

- [x] Filed: #2099 (Batch cloud executor wiring), #2100 (arenabench.org
  web app + magic-link auth), #2101 (durable Claude Code credential —
  seeded OAuth token rotates stale). Commented the provisioned substrate
  into epic #2081 (foundry loop); linked constraints #2082/#2083 there.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new Rust deps
- [x] No new outbound network calls from Stella itself (the infra is
      ArenaBench's, not the agent's)

## Anything reviewers should know?

- Two deploy-blocking gotchas are baked into comments: CloudFormation
  forbids intrinsics in YAML mapping keys (the OIDC trust doc is a Sub'd
  JSON string instead), and EC2 `GroupDescription` rejects non-ASCII.
- The first runner-image build must run with
  `GIT_REF=worktree-arenabench-aws-infra` (this branch) until this PR
  merges, because the Dockerfile doesn't exist on `main` yet; after merge
  the default is correct.
- Account quotas, not the template, bound burst width: on-demand vCPU is
  64 with an open case for 256 (AWS allows one open request per quota);
  GPU (G/VT) is 0 with 96 requested — `arenabench-tune` cannot place jobs
  until that lands. Under-quota bursts queue rather than fail.
- Provider credentials were seeded into SSM SecureStrings
  (`/arenabench/openrouter_api_key`, `/arenabench/claude_code_oauth_token`)
  from the operator's local credentials file; values never entered the
  repo. #2101 covers the rotation hazard.

## Summary by Sourcery

Introduce ArenaBench AWS infrastructure as code to provide a scale-to-zero cloud substrate for running benchmarks via AWS Batch, CodeBuild, and Vercel OIDC integration.

New Features:
- Add a CloudFormation template that provisions ArenaBench core infrastructure including AWS Batch queues, compute environments, storage, and IAM roles for scale-to-zero benchmark execution.
- Introduce CodeBuild projects for building SUT binaries from arbitrary git refs and for building/publishing the ArenaBench runner Docker image to ECR.
- Add an AWS Batch trial job definition and privileged runner container that executes ArenaBench matches, stages prebuilt SUT binaries, and syncs artifacts and metadata to S3 and DynamoDB.
- Provide an IAM OIDC role and provider configuration so the arenabench.org Vercel app can assume a scoped AWS role without long-lived credentials.
- Document the ArenaBench cloud architecture, deployment runbook, quotas, and teardown steps in a dedicated infra README.