### PR TITLE
feat(arenabench): arenabench.org web app v0 — on-brand, gated, live

### DIFF
--- a/arenabench/web/.gitignore
+++ b/arenabench/web/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.vercel/
+.vercel
+.env*

--- a/arenabench/web/README.md
+++ b/arenabench/web/README.md
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ArenaBench web (v0)
+
+The arenabench.org control-plane app: a server-rendered Next.js dashboard
+over the AWS substrate provisioned by `../infra/core.yaml`. It lists built
+Stella binaries, shows recent trial jobs, and can trigger a binary build
+from any git ref or a smoke trial — all through the Vercel OIDC-assumed
+role `arenabench-vercel-web`, so no AWS keys exist in Vercel.
+
+**Auth posture (v0)**: the deployment sits behind Vercel Authentication
+(team members only) as an interim wall. The real login — passwordless
+magic links via Resend, allowlisted to `ALLOWED_EMAILS`, built SaaS-shaped
+on Auth.js — is #2100, and replaces the interim wall rather than stacking
+on it. The Claude Code credential lifecycle (connect/verify/renew from the
+UI) is #2101.
+
+Environment (all optional — defaults target the deployed stack):
+
+| Variable | Default |
+| --- | --- |
+| `AWS_ROLE_ARN` | `arn:aws:iam::578673726240:role/arenabench-vercel-web` |
+| `ARTIFACTS_BUCKET` | `arenabench-artifacts-578673726240` |
+| `ARENABENCH_TABLE` | `arenabench` |
+
+Deploy: the Vercel project is `arenabench` (team `oxagen`); OIDC sub claims
+for this project are already trusted by the role. Attach `arenabench.org`
+in the project's domain settings.

--- a/arenabench/web/app/actions.js
+++ b/arenabench/web/app/actions.js
@@ -1,0 +1,15 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { startSutBuild, submitSmoke } from "../lib/aws";
+
+export async function buildSutAction(formData) {
+  const ref = String(formData.get("ref") || "main").trim() || "main";
+  await startSutBuild(ref);
+  revalidatePath("/");
+}
+
+export async function smokeAction() {
+  await submitSmoke();
+  revalidatePath("/");
+}

--- a/arenabench/web/app/globals.css
+++ b/arenabench/web/app/globals.css
@@ -1,0 +1,147 @@
+/* ArenaBench brand tokens — docs/brand/brand-guidelines.html (Comet kit).
+   Dark is the default (matching `arenabench serve`); light is the paper
+   palette the ArenaBench UI itself ships in ui/app/globals.css. */
+:root {
+  color-scheme: dark;
+  --bg: #0b0b0c;
+  --panel: #131315;
+  --line: #232327;
+  --text: #f4f1ea;
+  --dim: #9b9890;
+  --accent: #ffb000;
+  --ok: #4fbf72;
+  --bad: #e0565e;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --bg: #f2efe7;
+    --panel: #faf8f2;
+    --line: #d8d3c4;
+    --text: #1c1b16;
+    --dim: #6e6a5f;
+    --accent: #a37200;
+    --ok: #1c7c43;
+    --bad: #c0343c;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+main {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+}
+
+h1 {
+  font-size: 22px;
+  letter-spacing: 0.04em;
+}
+
+h1 .gold {
+  color: var(--accent);
+}
+
+h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+  margin: 36px 0 10px;
+}
+
+a {
+  color: var(--accent);
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+th {
+  text-align: left;
+  color: var(--dim);
+  font-weight: 500;
+  padding: 4px 12px 8px 0;
+}
+
+td {
+  padding: 5px 12px 5px 0;
+  border-top: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+.status-done,
+.status-SUCCEEDED {
+  color: var(--ok);
+}
+
+.status-failed,
+.status-FAILED {
+  color: var(--bad);
+}
+
+form {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin-right: 18px;
+}
+
+input[type="text"] {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 7px 10px;
+  font: inherit;
+  width: 220px;
+}
+
+button {
+  background: var(--accent);
+  color: var(--bg);
+  border: 0;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--line);
+}
+
+.note {
+  color: var(--dim);
+  font-size: 12.5px;
+}
+
+code {
+  color: var(--accent);
+}

--- a/arenabench/web/app/layout.js
+++ b/arenabench/web/app/layout.js
@@ -1,0 +1,17 @@
+import { JetBrains_Mono } from "next/font/google";
+import "./globals.css";
+
+const mono = JetBrains_Mono({ subsets: ["latin"] });
+
+export const metadata = {
+  title: "ArenaBench",
+  description: "Coding-agent benchmarks as a live, side-by-side contest.",
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className={mono.className}>{children}</body>
+    </html>
+  );
+}

--- a/arenabench/web/app/page.js
+++ b/arenabench/web/app/page.js
@@ -1,0 +1,116 @@
+import { listBinaryRefs, latestManifest, recentJobs } from "../lib/aws";
+import { buildSutAction, smokeAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const [refs, jobs] = await Promise.all([
+    listBinaryRefs().catch(() => []),
+    recentJobs().catch(() => []),
+  ]);
+  const manifests = await Promise.all(
+    refs.slice(0, 8).map(async (ref) => ({ ref, m: await latestManifest(ref) })),
+  );
+
+  return (
+    <main>
+      <h1>
+        Arena<span className="gold">Bench</span>{" "}
+        <span className="note">cloud — early access</span>
+      </h1>
+      <p className="note">
+        The cloud substrate is live: Stella binaries build from any git ref,
+        trials run on scale-to-zero AWS Batch, artifacts land in S3. The full
+        arena interface — scoreboard, live transcripts, recordings — arrives
+        when its API is ported onto this substrate:{" "}
+        <a href="https://github.com/macanderson/stella/issues/2100">#2100</a>{" "}
+        (login) and{" "}
+        <a href="https://github.com/macanderson/stella/issues/2099">#2099</a>{" "}
+        (match execution). Until then this page is the control surface.
+      </p>
+
+      <h2>Actions</h2>
+      <div className="panel">
+        <form action={buildSutAction}>
+          <input type="text" name="ref" placeholder="git ref (default: main)" />
+          <button type="submit">Build Stella binary</button>
+        </form>
+        <form action={smokeAction}>
+          <button type="submit" className="secondary">
+            Run smoke trial
+          </button>
+        </form>
+        <p className="note">
+          Builds take ~8 min warm-cached; a smoke trial scales Batch from
+          zero (~5 min) and back.
+        </p>
+      </div>
+
+      <h2>Built binaries</h2>
+      <div className="panel">
+        <table>
+          <thead>
+            <tr>
+              <th>ref</th>
+              <th>commit</th>
+              <th>built at</th>
+              <th>sha256</th>
+            </tr>
+          </thead>
+          <tbody>
+            {manifests.map(({ ref, m }) => (
+              <tr key={ref}>
+                <td>
+                  <code>{ref}</code>
+                </td>
+                <td>{m ? m.commit.slice(0, 12) : "—"}</td>
+                <td>{m ? m.built_at : "no manifest"}</td>
+                <td>{m ? m.sha256.slice(0, 16) : "—"}</td>
+              </tr>
+            ))}
+            {manifests.length === 0 && (
+              <tr>
+                <td colSpan={4} className="note">
+                  No binaries yet — build one above.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Recent jobs</h2>
+      <div className="panel">
+        <table>
+          <thead>
+            <tr>
+              <th>at (UTC)</th>
+              <th>run</th>
+              <th>mode</th>
+              <th>status</th>
+              <th>detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map((j) => (
+              <tr key={j.job}>
+                <td>{j.at}</td>
+                <td>{j.run}</td>
+                <td>{j.mode}</td>
+                <td className={`status-${j.status}`}>{j.status}</td>
+                <td>{j.detail}</td>
+              </tr>
+            ))}
+            {jobs.length === 0 && (
+              <tr>
+                <td colSpan={5} className="note">
+                  No jobs recorded yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/arenabench/web/app/unlock/route.js
+++ b/arenabench/web/app/unlock/route.js
@@ -1,0 +1,20 @@
+// One-time unlock: exchanges ?key=<ACCESS_KEY> for the gate cookie.
+// See middleware.js for why this interim gate exists; #2100 replaces it.
+import { NextResponse } from "next/server";
+
+export async function GET(req) {
+  const url = new URL(req.url);
+  const key = url.searchParams.get("key") ?? "";
+  if (!process.env.ACCESS_KEY || key !== process.env.ACCESS_KEY) {
+    return new NextResponse("invalid key\n", { status: 401 });
+  }
+  const res = NextResponse.redirect(new URL("/", req.url));
+  res.cookies.set("ab_key", key, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 30,
+    path: "/",
+  });
+  return res;
+}

--- a/arenabench/web/lib/aws.js
+++ b/arenabench/web/lib/aws.js
@@ -1,0 +1,94 @@
+// AWS access for the ArenaBench control plane.
+//
+// Server-side only. Credentials come from Vercel's OIDC federation: the
+// function's identity token is exchanged for the scoped role provisioned by
+// infra/core.yaml — no long-lived AWS keys exist anywhere in this app.
+import { awsCredentialsProvider } from "@vercel/functions/oidc";
+import { S3Client, GetObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { BatchClient, SubmitJobCommand } from "@aws-sdk/client-batch";
+import { CodeBuildClient, StartBuildCommand } from "@aws-sdk/client-codebuild";
+
+export const REGION = "us-east-1";
+export const BUCKET = process.env.ARTIFACTS_BUCKET ?? "arenabench-artifacts-578673726240";
+export const TABLE = process.env.ARENABENCH_TABLE ?? "arenabench";
+
+const ROLE_ARN =
+  process.env.AWS_ROLE_ARN ??
+  "arn:aws:iam::578673726240:role/arenabench-vercel-web";
+
+const credentials = awsCredentialsProvider({ roleArn: ROLE_ARN });
+
+const s3 = new S3Client({ region: REGION, credentials });
+const ddb = new DynamoDBClient({ region: REGION, credentials });
+const batch = new BatchClient({ region: REGION, credentials });
+const codebuild = new CodeBuildClient({ region: REGION, credentials });
+
+/** Refs that have at least one built binary, from the S3 prefix layout. */
+export async function listBinaryRefs() {
+  const out = await s3.send(
+    new ListObjectsV2Command({ Bucket: BUCKET, Prefix: "binaries/", Delimiter: "/" }),
+  );
+  return (out.CommonPrefixes ?? []).map((p) =>
+    p.Prefix.replace(/^binaries\//, "").replace(/\/$/, ""),
+  );
+}
+
+/** The latest build manifest for one ref, or null if none exists. */
+export async function latestManifest(ref) {
+  try {
+    const out = await s3.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: `binaries/${ref}/latest.json` }),
+    );
+    return JSON.parse(await out.Body.transformToString());
+  } catch {
+    return null;
+  }
+}
+
+/** Most recent trial/smoke jobs, newest first, from the runner's status rows. */
+export async function recentJobs(limit = 12) {
+  const out = await ddb.send(
+    new QueryCommand({
+      TableName: TABLE,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :p",
+      ExpressionAttributeValues: { ":p": { S: "JOB" } },
+      ScanIndexForward: false,
+      Limit: limit,
+    }),
+  );
+  return (out.Items ?? []).map((it) => ({
+    run: (it.PK?.S ?? "").replace(/^RUN#/, ""),
+    job: (it.SK?.S ?? "").replace(/^JOB#/, ""),
+    at: it.GSI1SK?.S ?? "",
+    status: it.status?.S ?? "",
+    detail: it.detail?.S ?? "",
+    mode: it.mode?.S ?? "",
+  }));
+}
+
+/** Kick a CodeBuild of the Stella binary from any git ref. */
+export async function startSutBuild(ref) {
+  const out = await codebuild.send(
+    new StartBuildCommand({
+      projectName: "arenabench-sut-build",
+      environmentVariablesOverride: [
+        { name: "GIT_REF", value: ref, type: "PLAINTEXT" },
+      ],
+    }),
+  );
+  return out.build?.id ?? "";
+}
+
+/** Submit a smoke job proving the Batch substrate scales from zero. */
+export async function submitSmoke() {
+  const out = await batch.send(
+    new SubmitJobCommand({
+      jobName: "smoke-web",
+      jobQueue: "arenabench-measure",
+      jobDefinition: "arenabench-trial",
+    }),
+  );
+  return out.jobId ?? "";
+}

--- a/arenabench/web/middleware.js
+++ b/arenabench/web/middleware.js
@@ -1,0 +1,22 @@
+// Interim access gate for arenabench.org.
+//
+// The Vercel plan does not offer team authentication on production
+// domains, and the page exposes spend-triggering actions, so production
+// cannot be public. Until the real login lands (#2100: Auth.js magic
+// links via Resend, allowlisted addresses), entry requires a one-time
+// visit to /unlock?key=<ACCESS_KEY>, which sets a cookie.
+import { NextResponse } from "next/server";
+
+export const config = {
+  matcher: ["/((?!_next/|favicon\\.ico|unlock).*)"],
+};
+
+export function middleware(req) {
+  const key = process.env.ACCESS_KEY;
+  if (!key) return NextResponse.next();
+  if (req.cookies.get("ab_key")?.value === key) return NextResponse.next();
+  return new NextResponse(
+    "ArenaBench is locked. Open your access link (/unlock?key=...) once to enter.\n",
+    { status: 401, headers: { "content-type": "text/plain" } },
+  );
+}

--- a/arenabench/web/next.config.mjs
+++ b/arenabench/web/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/arenabench/web/package.json
+++ b/arenabench/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "arenabench-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@aws-sdk/client-batch": "^3.650.0",
+    "@aws-sdk/client-codebuild": "^3.650.0",
+    "@aws-sdk/client-dynamodb": "^3.650.0",
+    "@aws-sdk/client-s3": "^3.650.0",
+    "@aws-sdk/credential-provider-web-identity": "^3.650.0",
+    "@vercel/functions": "^2.0.0",
+    "next": "^15.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}


### PR DESCRIPTION
## What & why

The first live face of arenabench.org: a server-rendered Next.js app
(`arenabench/web/`) deployed to Vercel project `arenabench` with the domain
attached. It is deliberately small — the control surface over the cloud
substrate #2103 provisioned — and exists so the URL is real while the full
arena interface is ported:

- Lists built Stella binaries (S3 manifests) and recent trial jobs
  (DynamoDB rows the runner writes).
- Triggers a Stella binary build from **any git ref** and a smoke Batch
  trial, through the OIDC-assumed role `arenabench-vercel-web` — zero AWS
  keys in Vercel.
- Styled from `docs/brand/brand-guidelines.html`: dark Comet palette
  (#0B0B0C / #FFB000) by default, the ArenaBench UI's paper palette in
  light mode, JetBrains Mono via next/font.
- Production is gated: `/unlock?key=<ACCESS_KEY>` sets a cookie; every
  other route 401s without it. The Vercel plan offers no team auth on
  custom production domains, and the page triggers billable actions, so it
  cannot be public. #2100's magic-link login replaces this gate.

The full ArenaBench UI (`arenabench/ui/` — scoreboard, live transcripts,
recordings) feeds from the local server's REST/SSE API; it goes live when
that API is ported onto the substrate — #2099 (execution) + #2100 (login +
hosting), where this app becomes its shell.

Refs #2100

## The witness

- [x] No witness needed (web app, no Rust) — verified live on 2026-08-07:
  https://arenabench.org returns 401 with no cookie and for a wrong key;
  the unlock link 200s and the rendered page shows live substrate data
  (binary manifest commit `ebbbe510`, the `smoke passed` DynamoDB row) —
  proving the Vercel OIDC → STS → IAM → S3/DynamoDB chain in production.

## The gate

- [x] Rust gates unaffected (no crate touched; docs/web only)
- [x] Docs: `arenabench/web/README.md` covers env, auth posture, deploy

## Nothing left behind

- [x] Filed earlier tonight and advanced here: #2099, #2100, #2101 (design
  direction for end-to-end Claude Code auth posted in-thread).

## Anything reviewers should know?

- `lib/aws.js` hardcodes account-specific defaults (role ARN, bucket,
  table) overridable by env — pragmatic for the single-account v0; they
  move to config when the app grows real settings.
- The ACCESS_KEY lives as a sensitive Vercel env var; rotating it is
  `vercel env rm/add ACCESS_KEY production` + redeploy.

## Summary by Sourcery

Introduce an initial server-rendered ArenaBench web dashboard on arenabench.org, wired to the existing AWS substrate and gated behind an access key for controlled early access.

New Features:
- Add a Next.js-based ArenaBench control-plane web app that lists built Stella binaries and recent trial jobs and exposes build and smoke actions.
- Implement server actions to trigger Stella binary CodeBuild jobs from arbitrary git refs and submit smoke trials to AWS Batch.
- Apply branded dark/light theming and JetBrains Mono typography for the ArenaBench web UI.

Enhancements:
- Add AWS integration layer using Vercel OIDC to assume an IAM role and interact with S3, DynamoDB, CodeBuild, and Batch without static credentials.
- Configure Next.js app metadata, layout, and basic project scaffolding for the ArenaBench web frontend.

Build:
- Add a standalone Next.js project configuration and package.json with AWS SDK and Vercel function dependencies for the ArenaBench web app.

Deployment:
- Add a middleware-based access gate for production, requiring a one-time /unlock flow with an ACCESS_KEY cookie for entry.

Documentation:
- Document the ArenaBench web app’s purpose, auth posture, environment configuration, and deployment setup in arenabench/web/README.md.