### PR TITLE
test(stella-cli): gate the liveness-lock child on a file, not a timer

### DIFF
--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -183,7 +183,12 @@ fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
         "a running child holds its lock"
     );
     std::fs::write(&gate, b"").expect("open the child's exit gate");
-    let _ = run.child.wait();
+    let status = run.child.wait().expect("wait for child to exit");
+    assert!(
+        status.success(),
+        "child exited unsuccessfully with status {:?} (possible gate timeout or shell error)",
+        status
+    );
     assert!(
         eventually(Duration::from_secs(10), || lock_is_held(&sidecar)
             == Some(false)),

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -151,10 +151,30 @@ fn the_record_carries_the_childs_pid_not_the_supervisors() {
 /// Liveness is the lock, not the pid (see the module docs). The kernel
 /// releases it when the process dies, so this is the one liveness answer a
 /// recycled pid cannot forge.
+///
+/// The child's lifetime is gated on a file this test creates, not a timer:
+/// `pre_exec` takes the lock before `exec` and `spawn` does not return until
+/// `exec` succeeded, so "held" is certain while the child lives — but a
+/// `sleep 0.2` child raced the first assertion on a loaded runner, and the
+/// lock it had honestly released read as never held. The wait is bounded so
+/// a panic between spawn and gate cannot leak the child forever.
 #[test]
 fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
     let (dir, registry) = temp_registry("lock");
-    let mut run = spawn_sh(&registry, "lock", "sleep 0.2");
+    let gate = std::env::temp_dir().join(format!(
+        "stella-daemon-lock-gate-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_file(&gate);
+    let mut run = spawn_sh(
+        &registry,
+        "lock",
+        &format!(
+            "i=0; until [ -e '{}' ]; do i=$((i+1)); [ \"$i\" -gt 1200 ] && exit 1; sleep 0.05; done",
+            gate.display()
+        ),
+    );
     let sidecar = registry.sidecar_dir(&run.id);
 
     assert_eq!(
@@ -162,6 +182,7 @@ fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
         Some(true),
         "a running child holds its lock"
     );
+    std::fs::write(&gate, b"").expect("open the child's exit gate");
     let _ = run.child.wait();
     assert!(
         eventually(Duration::from_secs(10), || lock_is_held(&sidecar)
@@ -169,6 +190,7 @@ fn the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends() {
         "the kernel must release the lock when the process exits"
     );
 
+    let _ = std::fs::remove_file(&gate);
     let _ = std::fs::remove_dir_all(&dir);
 }
 


### PR DESCRIPTION
## What & why

`daemon::tests::the_liveness_lock_is_held_while_the_run_lives_and_free_once_it_ends` is a coin-flip on a loaded runner: it redded the required `fmt + clippy + test` job on #2106 — a PR that touches only `arenabench/web/**` and no Rust at all.

The race is the child's lifetime, not the lock. `detach_before_exec` takes the liveness lock inside `pre_exec` (fork side, before `exec`), and `Command::spawn` does not return until `exec` succeeded, so "held" is certain from the moment `spawn` returns and for as long as the child lives. But the test's child was `sleep 0.2`, and on a loaded runner more than 200 ms can pass between `exec` and the first assertion: the child dies, the kernel honestly releases the flock, and `lock_is_held` reports `Some(false)` to an assertion that reads it as "never held".

The child's lifetime is now gated on a file the test creates: it cannot exit before the held half is asserted, and it still exits naturally (no signal) once the test opens the gate — preserving the second half's subject, the kernel releasing the lock on ordinary process exit. The gate wait is bounded (60 s) so a panic between spawn and gate cannot leak the child past the test run.

Audited the module's siblings for the same shape: this was the only test that hard-asserts `Some(true)` after a timer-lived child (the others use `sleep 30`/`sleep 120` children with explicit `stop`, or assert the released side under `eventually`).

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: the change *is* a test fix. The defect is timing-dependent — it needs the runner to deschedule the test thread >200 ms inside a specific window — so a deterministic fail-on-`main` repro is not available. The observed instance is #2106's `fmt + clippy + test` failure (run 31227219433: `left: Some(false), right: Some(true)` at `daemon/tests.rs:160`), and the fix removes the timer that race needs.

## The gate

- [x] `cargo fmt --check` (ran `cargo fmt -p stella-cli`; no reflow)
- [ ] `cargo clippy` / `cargo test` — deferred to CI deliberately: heavy local builds are off-limits on this machine right now, and the diff is one test body in `stella-cli`. CI runs the identical steps on this PR.
- [x] Docs updated where behavior changed (the test's doc comment now states the lifetime-gating rationale)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The first assertion stays a hard `assert_eq!` on purpose: `eventually` cannot rescue it (a released lock cannot be re-observed as held), and softening it would hide a genuine acquisition failure. Determinism comes from the child not being *able* to exit early, not from retrying the observation.

## Summary by Sourcery

Stabilize the daemon liveness-lock test by gating the child process lifetime on a temporary file instead of a fixed sleep duration, ensuring the lock is observed as held while the child runs and released after it exits.

Documentation:
- Extend the liveness-lock test doc comment to explain the file-gated child lifetime rationale and bounded wait behavior.

Tests:
- Update the liveness-lock test to use a file-based gate for the child process instead of a short sleep, removing timing-dependent flakiness on loaded runners.