### PR TITLE
feat(arenabench): AWS Batch cloud executor — arenabench cloud run|status|fetch (#2099)

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -753,6 +753,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     watch_parser.set_defaults(func=_cmd_watch)
 
+    # The AWS Batch executor registers its own verb tree; everything cloud
+    # lives in .cloud (boto3 stays a lazy, optional import there).
+    from .cloud import register_cli as _register_cloud_cli
+
+    _register_cloud_cli(subparsers)
+
     args = parser.parse_args(argv)
     _configure_logging(args.verbose)
     return int(args.func(args))

--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -1,0 +1,954 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Submitting a match to the AWS Batch cloud substrate (``arenabench cloud``).
+
+``arenabench/infra/core.yaml`` provisions scale-to-zero capacity — queues
+``arenabench-measure`` (on-demand) and ``arenabench-burst`` (spot), job
+definition ``arenabench-trial``, the runner image, an artifacts bucket and a
+DynamoDB status table — and the runner entrypoint
+(``arenabench/infra/runner/entrypoint.sh``) speaks a fixed contract:
+``RUN_ID``, ``MATCH_S3_URI``, optionally ``SUT_S3_URI`` + ``SUT_COMMIT``,
+command ``["run"]``. This module is the submit side of that contract, so a
+cloud run is one CLI verb rather than a hand-written ``aws batch submit-job``.
+
+**Decisions are pure functions; AWS calls are a thin adapter.** Queue
+selection, trial fan-out, env assembly, credential refusal, and progress
+derivation all operate on plain data and are tested without any AWS client
+(``tests/test_cloud.py`` exercises the adapter against recorded-call fakes).
+That is the same ports-not-concretions split the rest of the tree holds, and
+it is what lets this file stay stdlib-only at import time: ``boto3`` is
+imported lazily inside :func:`_boto3`, so everything else in ArenaBench keeps
+working without it (``pip install 'arenabench[cloud]'`` adds it).
+
+**One Batch job per trial.** The runner executes one whole match TOML per
+container, so the fan-out happens here: a match naming N tasks and M seats
+becomes ``attempts x N x M`` sliced match TOMLs uploaded under
+``runs/<run-id>/trials/``, each submitted as its own job. A Batch array job
+cannot vary ``MATCH_S3_URI`` per child without entrypoint changes, so
+individual submissions are the shape the contract supports today. Batch packs
+them onto instances up to the account's vCPU quota; **excess trials queue in
+``RUNNABLE`` and that is progress, not a hang** — the watcher prints the
+queued count and says so, because a 144-trial submission on a 64-vCPU quota
+spends most of its life there by design.
+
+**Measured comparisons ride on-demand only.** ``arenabench-burst`` is spot,
+and a spot interruption mid-trial is a confound no scoreboard should carry;
+:func:`select_queue` routes there only when the caller explicitly marks the
+work as non-measurement (``--burst``).
+
+**Unauthenticated seats are refused at submit time.** In the cloud, provider
+credentials come from SSM parameters under ``/arenabench/`` (exported by the
+entrypoint, upper-cased basename); a seat none of whose declared names will
+exist in the trial environment would burn a container to score a ``0.0``
+indistinguishable from a real loss — the same contract #1777/#1827 enforce on
+the local path, applied before any job is submitted.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from .model import MatchSpec, slugify
+
+__all__ = [
+    "BURST_QUEUE",
+    "CloudError",
+    "CloudExecutor",
+    "JOB_DEFINITION",
+    "MEASURE_QUEUE",
+    "Progress",
+    "SutBinary",
+    "TrialPlan",
+    "job_name",
+    "plan_trials",
+    "progress_from_states",
+    "ref_safe",
+    "refused_seats",
+    "register_cli",
+    "select_queue",
+    "slice_spec",
+    "ssm_env_name",
+    "sut_seats",
+    "trial_environment",
+]
+
+#: The provisioned resource names, mirrored from ``infra/core.yaml``. Constants
+#: rather than settings: they are the stack's contract, and an operator able to
+#: retarget them from a flag is an operator submitting to a stack this module
+#: has never been tested against.
+MEASURE_QUEUE = "arenabench-measure"
+BURST_QUEUE = "arenabench-burst"
+JOB_DEFINITION = "arenabench-trial"
+SUT_BUILD_PROJECT = "arenabench-sut-build"
+TABLE_NAME = "arenabench"
+SSM_PREFIX = "/arenabench"
+
+#: Per-trial container size, mirrored from the infra README's runbook. One
+#: trial is one privileged docker-in-docker container running a harbor task
+#: stack; 4 vCPU / 15 GiB is the shape the compute environment packs.
+TRIAL_VCPUS = 4
+TRIAL_MEMORY_MB = 15360
+
+#: ``describe_jobs`` accepts at most this many ids per call.
+_DESCRIBE_CHUNK = 100
+
+#: Batch job states that mean "waiting for capacity". A quota-limited account
+#: parks most of a large submission here; surfacing the count is what keeps a
+#: 144-trial run from looking like a hang.
+_QUEUED_STATES = frozenset({"SUBMITTED", "PENDING", "RUNNABLE"})
+_RUNNING_STATES = frozenset({"STARTING", "RUNNING"})
+
+
+class CloudError(RuntimeError):
+    """A cloud submission could not proceed; the message says why."""
+
+
+def _boto3() -> Any:
+    """Import boto3 on first use, with an actionable error when absent.
+
+    ArenaBench is stdlib-only by contract (see ``pyproject.toml``); the AWS
+    SDK is the one optional extra, pulled in only by the ``cloud`` verbs.
+    """
+    try:
+        import boto3
+    except ImportError as exc:  # pragma: no cover — exercised only without boto3
+        raise CloudError(
+            "cloud execution needs boto3 — install it with: "
+            "pip install 'arenabench[cloud]'"
+        ) from exc
+    return boto3
+
+
+# --------------------------------------------------------------------------
+# pure decisions
+# --------------------------------------------------------------------------
+
+
+def ref_safe(ref: str) -> str:
+    """A git ref as it appears in the S3 ``binaries/`` prefix.
+
+    Mirrors the CodeBuild spec's ``tr '/' '-'`` exactly — ``feature/x`` builds
+    land under ``binaries/feature-x/``, so resolving the same ref must apply
+    the same fold.
+    """
+    return ref.replace("/", "-")
+
+
+def ssm_env_name(parameter_name: str) -> str:
+    """The environment variable a ``/arenabench/*`` parameter becomes.
+
+    Mirrors the entrypoint's export exactly: basename, upper-cased, with
+    every character outside ``[A-Z0-9_]`` folded to ``_``
+    (``/arenabench/anthropic_api_key`` → ``ANTHROPIC_API_KEY``). The refusal
+    check below is only honest if this transform and the runner's agree.
+    """
+    base = parameter_name.rsplit("/", 1)[-1].upper()
+    return "".join(ch if (ch.isascii() and (ch.isalnum() or ch == "_")) else "_"
+                   for ch in base)
+
+
+def select_queue(burst: bool) -> str:
+    """Which job queue a submission goes to.
+
+    Measured comparisons go to the on-demand queue, always: the burst queue is
+    spot capacity, and a spot interruption mid-trial invalidates the trial in
+    a way that scores as an agent loss. ``burst=True`` is the caller's
+    explicit statement that this work is not a measurement.
+    """
+    return BURST_QUEUE if burst else MEASURE_QUEUE
+
+
+@dataclass(frozen=True)
+class TrialPlan:
+    """One Batch job's slice of the match grid.
+
+    ``task`` is ``None`` for a whole-dataset seat: a match that names no tasks
+    cannot be fanned out per task from here (the task list is only enumerated
+    by Harbor inside the container), so each seat runs its full dataset as one
+    job instead.
+    """
+
+    index: int
+    contestant_id: str
+    contestant_slug: str
+    task: str | None
+    attempt: int
+
+    @property
+    def label(self) -> str:
+        """Stable, filesystem- and jobname-safe identity for this trial."""
+        parts = [f"{self.index:03d}", self.contestant_slug]
+        if self.task is not None:
+            parts.append(slugify(self.task))
+        if self.attempt > 1:
+            parts.append(f"a{self.attempt}")
+        return "-".join(parts)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "contestant_id": self.contestant_id,
+            "contestant_slug": self.contestant_slug,
+            "task": self.task,
+            "attempt": self.attempt,
+            "label": self.label,
+        }
+
+
+def plan_trials(spec: MatchSpec) -> tuple[TrialPlan, ...]:
+    """Fan a match out into per-trial Batch submissions.
+
+    With tasks named, the grid is ``attempts x tasks x contestants`` — the
+    12-agents-at-12-tasks shape is 144 plans, one job each, and Batch queues
+    whatever the vCPU quota cannot place. With no tasks named the fan-out is
+    per contestant only, each seat running its whole dataset inside one job
+    (attempts and concurrency preserved in the slice).
+    """
+    plans: list[TrialPlan] = []
+    index = 0
+    if spec.tasks:
+        for attempt in range(1, spec.attempts + 1):
+            for task in spec.tasks:
+                for contestant in spec.contestants:
+                    plans.append(
+                        TrialPlan(
+                            index=index,
+                            contestant_id=contestant.id,
+                            contestant_slug=contestant.slug,
+                            task=task,
+                            attempt=attempt,
+                        )
+                    )
+                    index += 1
+    else:
+        for contestant in spec.contestants:
+            plans.append(
+                TrialPlan(
+                    index=index,
+                    contestant_id=contestant.id,
+                    contestant_slug=contestant.slug,
+                    task=None,
+                    attempt=1,
+                )
+            )
+            index += 1
+    return tuple(plans)
+
+
+def slice_spec(spec: MatchSpec, plan: TrialPlan) -> MatchSpec:
+    """The one-trial match a plan's Batch job actually runs.
+
+    A per-task slice pins one task, one seat, one attempt at concurrency 1 —
+    the container is the unit of isolation, so the slice must not fan out
+    again inside it. A whole-dataset slice (``plan.task is None``) keeps the
+    match's own attempts/concurrency, because that job *is* the seat's whole
+    run. ``sut_ref`` is match-level today (#2082) and ``dump_match`` does not
+    carry it; in the cloud the binary rides the ``SUT_S3_URI``/``SUT_COMMIT``
+    env contract instead, staged by the entrypoint before the run starts.
+    """
+    contestant = next(c for c in spec.contestants if c.id == plan.contestant_id)
+    if plan.task is None:
+        return replace(spec, contestants=(contestant,))
+    return replace(
+        spec,
+        tasks=(plan.task,),
+        contestants=(contestant,),
+        attempts=1,
+        concurrency=1,
+    )
+
+
+@dataclass(frozen=True)
+class SutBinary:
+    """A prebuilt SUT artifact resolved from ``binaries/<ref>/latest.json``."""
+
+    ref: str
+    commit: str
+    uri: str
+
+
+def trial_environment(
+    run_id: str, match_uri: str, sut: SutBinary | None
+) -> list[dict[str, str]]:
+    """The exact environment the runner entrypoint contracts for.
+
+    Names are the entrypoint's, verbatim: ``RUN_ID`` and ``MATCH_S3_URI``
+    always; ``SUT_S3_URI`` + ``SUT_COMMIT`` as a pair when a prebuilt binary
+    is staged (the entrypoint refuses one without the other).
+    """
+    env = [
+        {"name": "RUN_ID", "value": run_id},
+        {"name": "MATCH_S3_URI", "value": match_uri},
+    ]
+    if sut is not None:
+        env.append({"name": "SUT_S3_URI", "value": sut.uri})
+        env.append({"name": "SUT_COMMIT", "value": sut.commit})
+    return env
+
+
+def job_name(run_id: str, plan: TrialPlan) -> str:
+    """A Batch job name: alphanumeric start, ``[A-Za-z0-9_-]``, max 128."""
+    raw = f"{run_id}-{plan.label}"
+    cleaned = "".join(
+        ch if (ch.isascii() and (ch.isalnum() or ch in "-_")) else "-" for ch in raw
+    ).strip("-_")
+    if not cleaned or not cleaned[0].isalnum():
+        cleaned = "t" + cleaned
+    return cleaned[:128]
+
+
+def sut_seats(spec: MatchSpec) -> list[str]:
+    """The seats that run the Stella binary under test.
+
+    These are the seats a cloud run must stage a prebuilt SUT for: no Stella
+    checkout or toolchain exists inside the runner, so an unpinned match with
+    a Stella seat would launch a container guaranteed to have no binary.
+    """
+    return [c.name for c in spec.contestants if c.agent == "stella"]
+
+
+def refused_seats(
+    needed: Mapping[str, list[str]],
+    seat_env: Mapping[str, Mapping[str, str]],
+    available: Iterable[str],
+) -> dict[str, list[str]]:
+    """Seats whose credentials will not exist in the trial environment.
+
+    ``needed`` maps contestant id → candidate variable names (alternatives,
+    not a conjunction — same contract as
+    :func:`~.credentials.missing_required_credentials`); ``available`` is the
+    set of names the SSM export will provide. A seat is credentialled if any
+    candidate is available from SSM or already held in its own env; anything
+    else must be refused at submit time, because a cloud trial that launches
+    unauthenticated burns a container to score a ``0.0`` indistinguishable
+    from a real loss (#1827).
+    """
+    provided = set(available)
+    out: dict[str, list[str]] = {}
+    for contestant_id, candidates in needed.items():
+        if not candidates:
+            continue
+        held = seat_env.get(contestant_id, {})
+        if any(name in provided or held.get(name) for name in candidates):
+            continue
+        out[contestant_id] = list(candidates)
+    return out
+
+
+@dataclass(frozen=True)
+class Progress:
+    """Counts of a run's Batch jobs by coarse state."""
+
+    queued: int
+    running: int
+    succeeded: int
+    failed: int
+
+    @property
+    def total(self) -> int:
+        return self.queued + self.running + self.succeeded + self.failed
+
+    @property
+    def done(self) -> bool:
+        return self.queued == 0 and self.running == 0
+
+    def to_line(self, elapsed: float) -> str:
+        """One progress line; the queued count is always spelled out."""
+        return (
+            f"[{elapsed / 60:6.1f}m] queued {self.queued:>3}  "
+            f"running {self.running:>3}  ok {self.succeeded:>3}  "
+            f"failed {self.failed:>3}  ({self.total} trials)"
+        )
+
+
+def progress_from_states(states: Iterable[str]) -> Progress:
+    """Fold Batch job states into the four counts an operator watches.
+
+    ``SUBMITTED``/``PENDING``/``RUNNABLE`` are all "queued" — ``RUNNABLE`` is
+    where a quota-limited account parks the overflow, and it must read as
+    progress rather than as a hang.
+    """
+    queued = running = succeeded = failed = 0
+    for state in states:
+        if state in _QUEUED_STATES:
+            queued += 1
+        elif state in _RUNNING_STATES:
+            running += 1
+        elif state == "SUCCEEDED":
+            succeeded += 1
+        else:
+            failed += 1
+    return Progress(queued=queued, running=running, succeeded=succeeded, failed=failed)
+
+
+# --------------------------------------------------------------------------
+# the AWS adapter
+# --------------------------------------------------------------------------
+
+
+class CloudExecutor:
+    """Thin adapter over the AWS clients the cloud verbs need.
+
+    Every decision above happens before a method here is called; this class
+    only moves bytes. ``clients`` injects recorded-call fakes in tests — when
+    a service is missing from the mapping, a real boto3 client is built
+    lazily, so importing and testing this module never requires boto3.
+    """
+
+    def __init__(
+        self,
+        *,
+        region: str | None = None,
+        bucket: str | None = None,
+        clients: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._region = region
+        self._bucket = bucket
+        self._clients: dict[str, Any] = dict(clients or {})
+
+    def _client(self, service: str) -> Any:
+        if service not in self._clients:
+            kwargs = {"region_name": self._region} if self._region else {}
+            self._clients[service] = _boto3().client(service, **kwargs)
+        return self._clients[service]
+
+    # -- identity ----------------------------------------------------------
+
+    def bucket(self) -> str:
+        """The artifacts bucket, derived from the account id unless pinned."""
+        if self._bucket is None:
+            account = self._client("sts").get_caller_identity()["Account"]
+            self._bucket = f"arenabench-artifacts-{account}"
+        return self._bucket
+
+    # -- credentials -------------------------------------------------------
+
+    def available_credentials(self) -> set[str]:
+        """Environment names the runner's SSM export will provide.
+
+        Names only, never values (``WithDecryption=False``): the submit-time
+        question is "will this variable exist in the trial", and the secret
+        itself has no business transiting the operator's machine.
+        """
+        ssm = self._client("ssm")
+        names: set[str] = set()
+        token: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {"Path": SSM_PREFIX, "WithDecryption": False}
+            if token:
+                kwargs["NextToken"] = token
+            page = ssm.get_parameters_by_path(**kwargs)
+            names.update(
+                ssm_env_name(p["Name"]) for p in page.get("Parameters", [])
+            )
+            token = page.get("NextToken")
+            if not token:
+                return names
+
+    # -- the SUT -----------------------------------------------------------
+
+    def resolve_sut(
+        self,
+        ref: str,
+        *,
+        build_missing: bool = True,
+        poll_interval: float = 15.0,
+        sleep: Callable[[float], None] = time.sleep,
+        out: Callable[[str], None] = print,
+    ) -> SutBinary:
+        """The prebuilt binary for ``ref``, building it first when absent.
+
+        Reads ``binaries/<ref>/latest.json`` (written by the
+        ``arenabench-sut-build`` CodeBuild project alongside each artifact);
+        on a miss, starts that project with a ``GIT_REF`` override and polls
+        until the build settles. The manifest's ``commit`` is what the trial
+        records as its SUT identity, so it comes from the build, never from a
+        local git resolution that could disagree with what was compiled.
+        """
+        manifest = self._latest_manifest(ref)
+        if manifest is None:
+            if not build_missing:
+                raise CloudError(f"no prebuilt SUT for ref {ref!r} and building is off")
+            self._build_sut(ref, poll_interval=poll_interval, sleep=sleep, out=out)
+            manifest = self._latest_manifest(ref)
+            if manifest is None:
+                raise CloudError(
+                    f"SUT build for {ref!r} succeeded but wrote no "
+                    f"binaries/{ref_safe(ref)}/latest.json"
+                )
+        commit = str(manifest.get("commit") or "")
+        if not commit:
+            raise CloudError(f"binaries/{ref_safe(ref)}/latest.json names no commit")
+        uri = f"s3://{self.bucket()}/binaries/{ref_safe(ref)}/{commit}/stella"
+        return SutBinary(ref=ref, commit=commit, uri=uri)
+
+    def _latest_manifest(self, ref: str) -> dict[str, Any] | None:
+        s3 = self._client("s3")
+        key = f"binaries/{ref_safe(ref)}/latest.json"
+        try:
+            body = s3.get_object(Bucket=self.bucket(), Key=key)["Body"].read()
+        except s3.exceptions.NoSuchKey:
+            return None
+        try:
+            manifest = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise CloudError(f"{key} is not valid JSON: {exc}") from exc
+        return manifest if isinstance(manifest, dict) else None
+
+    def _build_sut(
+        self,
+        ref: str,
+        *,
+        poll_interval: float,
+        sleep: Callable[[float], None],
+        out: Callable[[str], None],
+    ) -> None:
+        codebuild = self._client("codebuild")
+        started = codebuild.start_build(
+            projectName=SUT_BUILD_PROJECT,
+            environmentVariablesOverride=[
+                {"name": "GIT_REF", "value": ref, "type": "PLAINTEXT"}
+            ],
+        )
+        build_id = started["build"]["id"]
+        out(f"sut: no artifact for {ref!r}; building via {SUT_BUILD_PROJECT} ({build_id})")
+        while True:
+            build = codebuild.batch_get_builds(ids=[build_id])["builds"][0]
+            status = build["buildStatus"]
+            if status == "SUCCEEDED":
+                out(f"sut: build {build_id} succeeded")
+                return
+            if status != "IN_PROGRESS":
+                raise CloudError(f"SUT build {build_id} for {ref!r} ended {status}")
+            sleep(poll_interval)
+
+    # -- submission --------------------------------------------------------
+
+    def submit_run(
+        self,
+        spec: MatchSpec,
+        plans: Iterable[TrialPlan],
+        *,
+        run_id: str,
+        queue: str,
+        sut: SutBinary | None,
+        vcpus: int = TRIAL_VCPUS,
+        memory_mb: int = TRIAL_MEMORY_MB,
+    ) -> list[dict[str, Any]]:
+        """Upload the match and its slices, then submit one job per plan.
+
+        Returns the submitted job records (also persisted to
+        ``runs/<run-id>/jobs.json`` so ``cloud status`` / ``cloud fetch`` — or
+        another machine entirely — can find the run again without this
+        process's memory).
+        """
+        from .config import dump_match
+
+        s3 = self._client("s3")
+        batch = self._client("batch")
+        bucket = self.bucket()
+        prefix = f"runs/{run_id}"
+
+        s3.put_object(
+            Bucket=bucket,
+            Key=f"{prefix}/match.toml",
+            Body=dump_match(spec).encode("utf-8"),
+        )
+
+        jobs: list[dict[str, Any]] = []
+        for plan in plans:
+            key = f"{prefix}/trials/{plan.label}/match.toml"
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=dump_match(slice_spec(spec, plan)).encode("utf-8"),
+            )
+            submitted = batch.submit_job(
+                jobName=job_name(run_id, plan),
+                jobQueue=queue,
+                jobDefinition=JOB_DEFINITION,
+                containerOverrides={
+                    "command": ["run"],
+                    "resourceRequirements": [
+                        {"type": "VCPU", "value": str(vcpus)},
+                        {"type": "MEMORY", "value": str(memory_mb)},
+                    ],
+                    "environment": trial_environment(
+                        run_id, f"s3://{bucket}/{key}", sut
+                    ),
+                },
+            )
+            jobs.append({"id": submitted["jobId"], **plan.to_json()})
+
+        record = {
+            "run_id": run_id,
+            "queue": queue,
+            "job_definition": JOB_DEFINITION,
+            "sut": None if sut is None else {
+                "ref": sut.ref, "commit": sut.commit, "uri": sut.uri,
+            },
+            "jobs": jobs,
+        }
+        s3.put_object(
+            Bucket=bucket,
+            Key=f"{prefix}/jobs.json",
+            Body=json.dumps(record, indent=2).encode("utf-8"),
+        )
+        return jobs
+
+    def load_jobs(self, run_id: str) -> dict[str, Any]:
+        """The persisted submission record for a run id."""
+        s3 = self._client("s3")
+        key = f"runs/{run_id}/jobs.json"
+        try:
+            body = s3.get_object(Bucket=self.bucket(), Key=key)["Body"].read()
+        except s3.exceptions.NoSuchKey:
+            raise CloudError(
+                f"no submission record at s3://{self.bucket()}/{key} — "
+                "was this run submitted with `arenabench cloud run`?"
+            ) from None
+        return json.loads(body.decode("utf-8"))
+
+    # -- progress ----------------------------------------------------------
+
+    def job_states(self, job_ids: Iterable[str]) -> dict[str, str]:
+        """Current Batch state per job id, in describe chunks of 100."""
+        batch = self._client("batch")
+        ids = list(job_ids)
+        states: dict[str, str] = {}
+        for start in range(0, len(ids), _DESCRIBE_CHUNK):
+            chunk = ids[start : start + _DESCRIBE_CHUNK]
+            for job in batch.describe_jobs(jobs=chunk)["jobs"]:
+                states[job["jobId"]] = job["status"]
+        return states
+
+    def watch(
+        self,
+        jobs: list[dict[str, Any]],
+        *,
+        poll_interval: float = 15.0,
+        sleep: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+        out: Callable[[str], None] = print,
+    ) -> dict[str, str]:
+        """Poll until every job settles, printing transitions and counts.
+
+        No busy-waiting: one ``describe_jobs`` sweep per interval. The first
+        time trials sit queued, one explanatory line says why — a
+        quota-limited account is *supposed* to park the overflow in
+        ``RUNNABLE`` and drain it as capacity frees.
+        """
+        labels = {job["id"]: job["label"] for job in jobs}
+        started = clock()
+        previous: dict[str, str] = {}
+        quota_note_shown = False
+        while True:
+            states = self.job_states(labels.keys())
+            for job_id, state in states.items():
+                before = previous.get(job_id)
+                if before is not None and before != state:
+                    out(f"  {labels[job_id]}: {before} -> {state}")
+            previous = states
+            progress = progress_from_states(states.values())
+            out(progress.to_line(clock() - started))
+            if progress.queued and not quota_note_shown:
+                out(
+                    f"  note: {progress.queued} trial(s) queued — Batch holds "
+                    "them in RUNNABLE while the account vCPU quota is spent "
+                    "and drains the backlog as capacity frees. Queued is "
+                    "progress, not a hang."
+                )
+                quota_note_shown = True
+            if progress.done:
+                return states
+            sleep(poll_interval)
+
+    def run_rows(self, run_id: str) -> list[dict[str, str]]:
+        """The DynamoDB status rows the runner wrote for this run."""
+        dynamodb = self._client("dynamodb")
+        rows: list[dict[str, str]] = []
+        kwargs: dict[str, Any] = {
+            "TableName": TABLE_NAME,
+            "KeyConditionExpression": "PK = :pk",
+            "ExpressionAttributeValues": {":pk": {"S": f"RUN#{run_id}"}},
+        }
+        while True:
+            page = dynamodb.query(**kwargs)
+            for item in page.get("Items", []):
+                rows.append(
+                    {
+                        "job": item.get("SK", {}).get("S", "").removeprefix("JOB#"),
+                        "status": item.get("status", {}).get("S", ""),
+                        "detail": item.get("detail", {}).get("S", ""),
+                    }
+                )
+            last = page.get("LastEvaluatedKey")
+            if not last:
+                return rows
+            kwargs["ExclusiveStartKey"] = last
+
+    # -- results -----------------------------------------------------------
+
+    def fetch_results(
+        self,
+        run_id: str,
+        jobs: list[dict[str, Any]],
+        dest: Path,
+        *,
+        artifacts: bool = False,
+        out: Callable[[str], None] = print,
+    ) -> int:
+        """Download each trial's ``results.json`` (and, opted in, everything).
+
+        ``results.json`` per job is the default because it is the scoreboard;
+        the full artifact tree (events, recordings, workspaces) can be
+        gigabytes, so ``artifacts=True`` is a choice, not a side effect.
+        Returns the number of results files downloaded.
+        """
+        s3 = self._client("s3")
+        bucket = self.bucket()
+        fetched = 0
+        for job in jobs:
+            key = f"runs/{run_id}/{job['id']}/results.json"
+            try:
+                body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            except s3.exceptions.NoSuchKey:
+                out(f"  {job['label']}: no results.json (trial did not finish?)")
+                continue
+            target = dest / job["label"] / "results.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(body)
+            fetched += 1
+        if artifacts:
+            fetched += self._fetch_prefix(f"runs/{run_id}/", dest, out=out)
+        return fetched
+
+    def _fetch_prefix(
+        self, prefix: str, dest: Path, *, out: Callable[[str], None]
+    ) -> int:
+        s3 = self._client("s3")
+        bucket = self.bucket()
+        count = 0
+        kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+        while True:
+            page = s3.list_objects_v2(**kwargs)
+            for entry in page.get("Contents", []):
+                key = entry["Key"]
+                relative = key.removeprefix(prefix)
+                if not relative or relative.endswith("/"):
+                    continue
+                target = dest / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(
+                    s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+                )
+                count += 1
+            if not page.get("IsTruncated"):
+                out(f"  artifacts: {count} object(s) under s3://{bucket}/{prefix}")
+                return count
+            kwargs["ContinuationToken"] = page["NextContinuationToken"]
+
+
+# --------------------------------------------------------------------------
+# CLI verbs
+# --------------------------------------------------------------------------
+
+
+def _new_run_id() -> str:
+    return time.strftime("r%Y%m%d-%H%M%S-") + uuid.uuid4().hex[:6]
+
+
+def _cmd_cloud_run(args: Any, executor: CloudExecutor | None = None) -> int:
+    """``arenabench cloud run match.toml --ref main`` — submit, watch, fetch."""
+    import sys
+
+    from .config import MatchTemplateError, load_match, required_env
+
+    try:
+        spec = load_match(Path(args.template).expanduser())
+    except MatchTemplateError as exc:
+        for problem in exc.problems:
+            print(f"error: {problem}", file=sys.stderr)
+        return 2
+
+    executor = executor or CloudExecutor(region=args.region, bucket=args.bucket)
+
+    # Refusal before any upload or submission: a seat whose declared
+    # credentials will not exist in the trial environment must not launch.
+    needed = required_env(spec)
+    seat_env = {c.id: c.env for c in spec.contestants}
+    refused = refused_seats(needed, seat_env, executor.available_credentials())
+    if refused:
+        names = {c.id: c.name for c in spec.contestants}
+        print(
+            "error: seat(s) have no credentials in SSM under "
+            f"{SSM_PREFIX}/ — refusing to submit:",
+            file=sys.stderr,
+        )
+        for contestant_id, candidates in refused.items():
+            print(
+                f"  {names.get(contestant_id, contestant_id)}: "
+                f"any of {', '.join(candidates)}",
+                file=sys.stderr,
+            )
+        print(
+            f"  (aws ssm put-parameter --name '{SSM_PREFIX}/<key_name>' "
+            "--type SecureString --value ... to add one)",
+            file=sys.stderr,
+        )
+        return 2
+
+    ref = args.ref if args.ref is not None else spec.sut_ref
+    sut: SutBinary | None = None
+    if ref:
+        sut = executor.resolve_sut(ref)
+    elif sut_seats(spec):
+        print(
+            "error: this match seats Stella "
+            f"({', '.join(sut_seats(spec))}) but pins no SUT ref; the cloud "
+            "runner has no local binary to fall back to. Pass --ref.",
+            file=sys.stderr,
+        )
+        return 2
+
+    run_id = args.run_id or _new_run_id()
+    queue = select_queue(args.burst)
+    plans = plan_trials(spec)
+
+    print(f"run       : {run_id}")
+    print(f"match     : {spec.name}")
+    print(f"queue     : {queue}" + ("  (spot — not for measured comparisons)"
+                                    if args.burst else ""))
+    if sut is not None:
+        print(f"sut       : {sut.commit[:12]} ({sut.ref})")
+    grid = "per-seat whole-dataset" if not spec.tasks else (
+        f"{spec.attempts} attempt(s) x {len(spec.tasks)} task(s) x "
+        f"{len(spec.contestants)} seat(s)"
+    )
+    print(f"trials    : {len(plans)}  [{grid}]")
+
+    jobs = executor.submit_run(
+        spec, plans, run_id=run_id, queue=queue, sut=sut,
+        vcpus=args.vcpus, memory_mb=args.memory_mb,
+    )
+    print(f"submitted : {len(jobs)} job(s) to {queue}")
+    print(f"record    : s3://{executor.bucket()}/runs/{run_id}/jobs.json")
+
+    if args.no_wait:
+        print(f"not waiting; follow with: arenabench cloud status {run_id}")
+        return 0
+
+    states = executor.watch(jobs, poll_interval=args.poll)
+    final = progress_from_states(states.values())
+    print(f"\nfinished: {final.succeeded} succeeded, {final.failed} failed")
+    for row in executor.run_rows(run_id):
+        print(f"  ddb {row['job']}: {row['status']}  {row['detail']}")
+
+    if not args.no_fetch:
+        dest = Path(args.out or f"arenabench-cloud/{run_id}").expanduser()
+        fetched = executor.fetch_results(
+            run_id, jobs, dest, artifacts=args.artifacts
+        )
+        print(f"results   : {fetched} file(s) -> {dest}")
+    return 0 if final.failed == 0 else 1
+
+
+def _cmd_cloud_status(args: Any, executor: CloudExecutor | None = None) -> int:
+    """``arenabench cloud status <run-id>`` — one snapshot, or follow."""
+    executor = executor or CloudExecutor(region=args.region, bucket=args.bucket)
+    record = executor.load_jobs(args.run_id)
+    jobs = record["jobs"]
+    print(f"run   : {record['run_id']}  ({len(jobs)} trials on {record['queue']})")
+    if args.follow:
+        states = executor.watch(jobs, poll_interval=args.poll)
+    else:
+        states = executor.job_states([job["id"] for job in jobs])
+        print(progress_from_states(states.values()).to_line(0.0))
+    for row in executor.run_rows(args.run_id):
+        print(f"  ddb {row['job']}: {row['status']}  {row['detail']}")
+    final = progress_from_states(states.values())
+    return 0 if final.failed == 0 else 1
+
+
+def _cmd_cloud_fetch(args: Any, executor: CloudExecutor | None = None) -> int:
+    """``arenabench cloud fetch <run-id>`` — pull results (and artifacts)."""
+    executor = executor or CloudExecutor(region=args.region, bucket=args.bucket)
+    record = executor.load_jobs(args.run_id)
+    dest = Path(args.out or f"arenabench-cloud/{args.run_id}").expanduser()
+    fetched = executor.fetch_results(
+        args.run_id, record["jobs"], dest, artifacts=args.artifacts
+    )
+    print(f"results   : {fetched} file(s) -> {dest}")
+    return 0
+
+
+def _common_aws_arguments(parser: Any) -> None:
+    parser.add_argument("--region", help="AWS region (default: the SDK's chain)")
+    parser.add_argument(
+        "--bucket",
+        help="artifacts bucket (default: arenabench-artifacts-<account-id>)",
+    )
+
+
+def register_cli(subparsers: Any) -> None:
+    """Attach the ``cloud`` verb tree to the main CLI's subparsers."""
+    cloud = subparsers.add_parser(
+        "cloud", help="run matches on the AWS Batch substrate (needs boto3)"
+    )
+    verbs = cloud.add_subparsers(dest="cloud_command", required=True)
+
+    run = verbs.add_parser(
+        "run", help="submit a match to Batch, stream progress, fetch results"
+    )
+    run.add_argument("template", help="path to an arenabench.toml")
+    run.add_argument(
+        "--ref",
+        help="git ref of the Stella SUT to run (default: the match's sut_ref); "
+             "built via CodeBuild first if no artifact exists",
+    )
+    run.add_argument("--run-id", help="run identifier (default: generated)")
+    run.add_argument(
+        "--burst",
+        action="store_true",
+        help="submit to the spot queue — for non-measurement work ONLY; spot "
+             "interruption invalidates a measured comparison",
+    )
+    run.add_argument("--poll", type=float, default=15.0,
+                     help="seconds between progress polls")
+    run.add_argument("--vcpus", type=int, default=TRIAL_VCPUS,
+                     help=f"vCPUs per trial container (default: {TRIAL_VCPUS})")
+    run.add_argument(
+        "--memory-mb", type=int, default=TRIAL_MEMORY_MB,
+        help=f"memory per trial container in MiB (default: {TRIAL_MEMORY_MB})",
+    )
+    run.add_argument("--no-wait", action="store_true",
+                     help="submit and exit; follow later with `cloud status`")
+    run.add_argument("--no-fetch", action="store_true",
+                     help="do not download results when the run finishes")
+    run.add_argument("--artifacts", action="store_true",
+                     help="also download the full artifact tree (can be large)")
+    run.add_argument("--out", help="local directory for downloaded results")
+    _common_aws_arguments(run)
+    run.set_defaults(func=_cmd_cloud_run)
+
+    status = verbs.add_parser("status", help="progress of a submitted cloud run")
+    status.add_argument("run_id")
+    status.add_argument("--follow", action="store_true",
+                        help="keep polling until every trial settles")
+    status.add_argument("--poll", type=float, default=15.0)
+    _common_aws_arguments(status)
+    status.set_defaults(func=_cmd_cloud_status)
+
+    fetch = verbs.add_parser("fetch", help="download a cloud run's results")
+    fetch.add_argument("run_id")
+    fetch.add_argument("--artifacts", action="store_true",
+                       help="also download the full artifact tree (can be large)")
+    fetch.add_argument("--out", help="local directory for downloaded results")
+    _common_aws_arguments(fetch)
+    fetch.set_defaults(func=_cmd_cloud_fetch)

--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -58,10 +58,10 @@ from .model import MatchSpec, slugify
 
 __all__ = [
     "BURST_QUEUE",
-    "CloudError",
-    "CloudExecutor",
     "JOB_DEFINITION",
     "MEASURE_QUEUE",
+    "CloudError",
+    "CloudExecutor",
     "Progress",
     "SutBinary",
     "TrialPlan",

--- a/arenabench/infra/README.md
+++ b/arenabench/infra/README.md
@@ -109,6 +109,19 @@ tears everything down when the queue drains. Provider API keys are read at
 trial start from SSM parameters under `/arenabench/` (SecureString;
 `/arenabench/anthropic_api_key` → `ANTHROPIC_API_KEY`, etc.).
 
+`arenabench cloud run` automates all of the above — per-trial slice upload,
+SUT resolution from `binaries/<ref>/latest.json` (building via
+`arenabench-sut-build` on a miss), submit-time refusal of seats with no SSM
+credentials, one job per trial, progress streaming (queued trials surface as
+progress, not a hang), and results download:
+
+```bash
+pip install 'arenabench[cloud]'
+arenabench cloud run match.toml --ref main        # submit + watch + fetch
+arenabench cloud status <run-id> [--follow]       # from any machine
+arenabench cloud fetch <run-id> [--artifacts]
+```
+
 ### Quotas (account limits, not template limits)
 
 | Quota | At deploy time | Needed for 12×12 | Fix |

--- a/arenabench/pyproject.toml
+++ b/arenabench/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest>=8", "ruff>=0.6"]
+# Only the `arenabench cloud` verbs (AWS Batch submission) need the AWS SDK;
+# everything else stays stdlib-only. cloud.py imports it lazily, so the rest
+# of the package works without this extra installed.
+cloud = ["boto3>=1.34"]
 
 [project.scripts]
 arenabench = "arenabench.cli:main"

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -57,7 +57,7 @@ BUCKET = f"arenabench-artifacts-{ACCOUNT}"
 # --------------------------------------------------------------------------
 
 
-class _NoSuchKey(Exception):
+class _NoSuchKeyError(Exception):
     pass
 
 
@@ -65,17 +65,20 @@ class FakeS3:
     def __init__(self, objects: dict[str, bytes] | None = None) -> None:
         self.objects: dict[str, bytes] = dict(objects or {})
         self.calls: list[tuple] = []
-        self.exceptions = SimpleNamespace(NoSuchKey=_NoSuchKey)
+        # boto3 spells it NoSuchKey; the adapter catches it by that name.
+        self.exceptions = SimpleNamespace(NoSuchKey=_NoSuchKeyError)
 
-    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **_: object) -> dict:
+    # The keyword casing is the AWS SDK's, not PEP 8's: the adapter calls
+    # with Bucket=/Key=/Body=, so the fakes must accept those spellings.
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **_: object) -> dict:  # noqa: N803
         self.calls.append(("put_object", Bucket, Key))
         self.objects[Key] = Body
         return {}
 
-    def get_object(self, *, Bucket: str, Key: str) -> dict:
+    def get_object(self, *, Bucket: str, Key: str) -> dict:  # noqa: N803
         self.calls.append(("get_object", Bucket, Key))
         if Key not in self.objects:
-            raise _NoSuchKey(Key)
+            raise _NoSuchKeyError(Key)
         return {"Body": io.BytesIO(self.objects[Key])}
 
     def list_objects_v2(self, **kwargs: object) -> dict:
@@ -459,7 +462,7 @@ class TestSubmitContract:
         return s3, batch, jobs
 
     def test_one_job_per_trial_with_the_entrypoint_env_contract(self) -> None:
-        s3, batch, jobs = self._submit(_spec())
+        _s3, batch, _jobs = self._submit(_spec())
         assert len(batch.submitted) == 4  # 2 tasks x 2 seats
         match_uris = set()
         for submitted in batch.submitted:

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -1,0 +1,710 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The cloud executor's submit contract, pinned (#2099).
+
+The AWS Batch substrate (``arenabench/infra/``) speaks one contract — the
+runner entrypoint's env names, the provisioned queue and job-definition
+names, the SSM credential export — and every test here proves the executor
+speaks exactly that contract, against recorded-call fakes rather than AWS.
+The decisions (queue selection, trial fan-out, env assembly, refusal on
+missing credentials, progress derivation) are pure functions exercised
+directly; the boto3 adapter is exercised through fakes that record every
+call, so a drifted parameter name fails here instead of in a container that
+billed real compute first.
+
+These tests are the witness for #2099: none of them can pass on a tree
+without ``arenabench/arenabench/cloud.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import tomllib
+from types import SimpleNamespace
+
+import pytest
+
+from arenabench.cloud import (
+    BURST_QUEUE,
+    JOB_DEFINITION,
+    MEASURE_QUEUE,
+    CloudError,
+    CloudExecutor,
+    _cmd_cloud_run,
+    job_name,
+    plan_trials,
+    progress_from_states,
+    ref_safe,
+    refused_seats,
+    select_queue,
+    slice_spec,
+    ssm_env_name,
+    sut_seats,
+    trial_environment,
+)
+from arenabench.config import match_from_toml
+from arenabench.model import Contestant, Engine, MatchSpec
+
+ACCOUNT = "123456789012"
+BUCKET = f"arenabench-artifacts-{ACCOUNT}"
+
+
+# --------------------------------------------------------------------------
+# recorded-call fakes — small on purpose; moto would be a heavyweight
+# dependency for what is a handful of parameter-shape assertions
+# --------------------------------------------------------------------------
+
+
+class _NoSuchKey(Exception):
+    pass
+
+
+class FakeS3:
+    def __init__(self, objects: dict[str, bytes] | None = None) -> None:
+        self.objects: dict[str, bytes] = dict(objects or {})
+        self.calls: list[tuple] = []
+        self.exceptions = SimpleNamespace(NoSuchKey=_NoSuchKey)
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **_: object) -> dict:
+        self.calls.append(("put_object", Bucket, Key))
+        self.objects[Key] = Body
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict:
+        self.calls.append(("get_object", Bucket, Key))
+        if Key not in self.objects:
+            raise _NoSuchKey(Key)
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def list_objects_v2(self, **kwargs: object) -> dict:
+        self.calls.append(("list_objects_v2", kwargs.get("Prefix")))
+        prefix = str(kwargs.get("Prefix") or "")
+        keys = sorted(k for k in self.objects if k.startswith(prefix))
+        return {
+            "Contents": [{"Key": k} for k in keys],
+            "IsTruncated": False,
+        }
+
+
+class FakeBatch:
+    """Records submissions; serves job states from a per-sweep script."""
+
+    def __init__(self, state_script: list[dict[str, str]] | None = None) -> None:
+        self.submitted: list[dict] = []
+        self.describe_calls: list[list[str]] = []
+        self.state_script = list(state_script or [])
+        self._counter = 0
+
+    def submit_job(self, **kwargs: object) -> dict:
+        self.submitted.append(kwargs)
+        self._counter += 1
+        return {"jobId": f"job-{self._counter:03d}", "jobName": kwargs["jobName"]}
+
+    def describe_jobs(self, *, jobs: list[str]) -> dict:
+        self.describe_calls.append(list(jobs))
+        states = self.state_script[0] if self.state_script else {}
+        return {"jobs": [{"jobId": j, "status": states.get(j, "SUCCEEDED")} for j in jobs]}
+
+    def advance(self) -> None:
+        if len(self.state_script) > 1:
+            self.state_script.pop(0)
+
+
+class FakeSsm:
+    def __init__(self, parameters: list[str]) -> None:
+        self.parameters = parameters
+        self.calls: list[dict] = []
+
+    def get_parameters_by_path(self, **kwargs: object) -> dict:
+        self.calls.append(dict(kwargs))
+        # Two pages, to prove the paginator loop follows NextToken.
+        first, rest = self.parameters[:1], self.parameters[1:]
+        if "NextToken" not in kwargs:
+            page = {"Parameters": [{"Name": n} for n in first]}
+            if rest:
+                page["NextToken"] = "page-2"
+            return page
+        return {"Parameters": [{"Name": n} for n in rest]}
+
+
+class FakeCodeBuild:
+    def __init__(self, statuses: list[str]) -> None:
+        self.statuses = list(statuses)
+        self.started: list[dict] = []
+        self.polls = 0
+
+    def start_build(self, **kwargs: object) -> dict:
+        self.started.append(dict(kwargs))
+        return {"build": {"id": "arenabench-sut-build:1234"}}
+
+    def batch_get_builds(self, *, ids: list[str]) -> dict:
+        status = self.statuses[min(self.polls, len(self.statuses) - 1)]
+        self.polls += 1
+        return {"builds": [{"id": ids[0], "buildStatus": status}]}
+
+
+class FakeSts:
+    def get_caller_identity(self) -> dict:
+        return {"Account": ACCOUNT}
+
+
+class FakeDynamo:
+    def __init__(self, pages: list[dict]) -> None:
+        self.pages = list(pages)
+        self.calls: list[dict] = []
+
+    def query(self, **kwargs: object) -> dict:
+        self.calls.append(dict(kwargs))
+        return self.pages[min(len(self.calls) - 1, len(self.pages) - 1)]
+
+
+def _executor(**clients: object) -> CloudExecutor:
+    defaults: dict[str, object] = {"sts": FakeSts()}
+    defaults.update(clients)
+    return CloudExecutor(clients=defaults)
+
+
+# --------------------------------------------------------------------------
+# spec helpers
+# --------------------------------------------------------------------------
+
+
+def _seat(seat_id: str, agent: str = "stella", api: str = "openrouter") -> Contestant:
+    return Contestant(
+        id=seat_id,
+        name=seat_id,
+        agent=agent,
+        engine=Engine(api=api, model="z-ai/glm-5.2"),
+        required_env=("OPENROUTER_API_KEY",),
+    )
+
+
+def _spec(
+    tasks: tuple[str, ...] = ("task-a", "task-b"),
+    seats: tuple[Contestant, ...] | None = None,
+    attempts: int = 1,
+) -> MatchSpec:
+    return MatchSpec(
+        id="m1",
+        name="cloud match",
+        dataset="terminal-bench-2.1",
+        tasks=tasks,
+        contestants=seats or (_seat("stella"), _seat("cc", agent="claude-code")),
+        attempts=attempts,
+    )
+
+
+SUT = None  # filled per-test via resolve_sut or built directly
+
+
+def _sut():
+    from arenabench.cloud import SutBinary
+
+    commit = "c" * 40
+    return SutBinary(
+        ref="main", commit=commit, uri=f"s3://{BUCKET}/binaries/main/{commit}/stella"
+    )
+
+
+# --------------------------------------------------------------------------
+# pure decisions
+# --------------------------------------------------------------------------
+
+
+class TestSsmEnvName:
+    """The refusal check is honest only if this transform matches the
+    entrypoint's export (basename | upper | non-[A-Z0-9_] -> '_')."""
+
+    def test_matches_the_entrypoint_export(self) -> None:
+        assert ssm_env_name("/arenabench/anthropic_api_key") == "ANTHROPIC_API_KEY"
+
+    def test_folds_hyphens_like_tr_c(self) -> None:
+        assert ssm_env_name("/arenabench/zai-api-key") == "ZAI_API_KEY"
+
+    def test_takes_the_basename_of_a_nested_parameter(self) -> None:
+        assert ssm_env_name("/arenabench/team/openrouter_api_key") == (
+            "OPENROUTER_API_KEY"
+        )
+
+
+class TestRefSafe:
+    def test_mirrors_the_codebuild_slash_fold(self) -> None:
+        assert ref_safe("feature/x") == "feature-x"
+        assert ref_safe("main") == "main"
+
+
+class TestSelectQueue:
+    """Measured comparisons ride on-demand only; spot interruption is a
+    confound, so the burst queue takes only explicitly non-measurement work."""
+
+    def test_measured_goes_to_the_on_demand_queue(self) -> None:
+        assert select_queue(False) == MEASURE_QUEUE == "arenabench-measure"
+
+    def test_burst_is_the_explicit_opt_out(self) -> None:
+        assert select_queue(True) == BURST_QUEUE == "arenabench-burst"
+
+
+class TestPlanTrials:
+    def test_the_12x12_shape_is_144_submissions(self) -> None:
+        """The array-sizing half of the witness: 12 agents x 12 tasks fans
+        into exactly 144 per-trial jobs, one container each."""
+        seats = tuple(_seat(f"agent{i:02d}") for i in range(12))
+        tasks = tuple(f"task{i:02d}" for i in range(12))
+        plans = plan_trials(_spec(tasks=tasks, seats=seats))
+        assert len(plans) == 144
+        assert len({p.label for p in plans}) == 144
+        assert [p.index for p in plans] == list(range(144))
+
+    def test_attempts_multiply_the_grid(self) -> None:
+        plans = plan_trials(_spec(attempts=2))
+        assert len(plans) == 2 * 2 * 2
+        assert {p.attempt for p in plans} == {1, 2}
+
+    def test_no_named_tasks_fans_per_seat_only(self) -> None:
+        """The task list of a whole-dataset match is only known to Harbor
+        inside the container, so the fan-out is one job per seat."""
+        plans = plan_trials(_spec(tasks=()))
+        assert len(plans) == 2
+        assert all(p.task is None for p in plans)
+
+
+class TestSliceSpec:
+    def test_a_task_slice_is_one_cell_of_the_grid(self) -> None:
+        spec = _spec(attempts=3)
+        plan = plan_trials(spec)[0]
+        sliced = slice_spec(spec, plan)
+        assert sliced.tasks == (plan.task,)
+        assert [c.id for c in sliced.contestants] == [plan.contestant_id]
+        assert sliced.attempts == 1
+        assert sliced.concurrency == 1
+        assert sliced.dataset == spec.dataset
+
+    def test_a_whole_dataset_slice_keeps_the_matchs_own_shape(self) -> None:
+        spec = _spec(tasks=(), attempts=3)
+        sliced = slice_spec(spec, plan_trials(spec)[0])
+        assert sliced.tasks == ()
+        assert sliced.attempts == 3
+        assert len(sliced.contestants) == 1
+
+
+class TestTrialEnvironment:
+    """The env names are the entrypoint's contract, verbatim."""
+
+    def test_the_exact_names_the_entrypoint_speaks(self) -> None:
+        env = trial_environment("r1", f"s3://{BUCKET}/runs/r1/t/match.toml", _sut())
+        assert [e["name"] for e in env] == [
+            "RUN_ID",
+            "MATCH_S3_URI",
+            "SUT_S3_URI",
+            "SUT_COMMIT",
+        ]
+        values = {e["name"]: e["value"] for e in env}
+        assert values["RUN_ID"] == "r1"
+        assert values["SUT_COMMIT"] == "c" * 40
+        assert values["SUT_S3_URI"].endswith("/stella")
+
+    def test_no_sut_means_no_sut_pair(self) -> None:
+        """SUT_S3_URI requires SUT_COMMIT in the entrypoint; they travel as a
+        pair or not at all."""
+        env = trial_environment("r1", "s3://b/k", None)
+        assert [e["name"] for e in env] == ["RUN_ID", "MATCH_S3_URI"]
+
+
+class TestJobName:
+    def test_batch_charset_and_length(self) -> None:
+        plan = plan_trials(_spec())[0]
+        name = job_name("r.2026/08.07_x", plan)
+        assert name[0].isalnum()
+        assert len(name) <= 128
+        assert all(c.isalnum() or c in "-_" for c in name)
+
+
+class TestRefusedSeats:
+    """A seat with no credentials in the trial environment must be refused at
+    submit time (#1827) — never launched to score a silent 0.0."""
+
+    def test_a_seat_with_nothing_available_is_refused(self) -> None:
+        refused = refused_seats(
+            {"stella": ["OPENROUTER_API_KEY", "ZAI_API_KEY"]}, {}, set()
+        )
+        assert refused == {"stella": ["OPENROUTER_API_KEY", "ZAI_API_KEY"]}
+
+    def test_any_one_candidate_in_ssm_credentials_the_seat(self) -> None:
+        """The candidate names are alternatives, not a conjunction."""
+        refused = refused_seats(
+            {"stella": ["OPENROUTER_API_KEY", "ZAI_API_KEY"]},
+            {},
+            {"ZAI_API_KEY"},
+        )
+        assert refused == {}
+
+    def test_a_seat_holding_its_own_value_is_credentialled(self) -> None:
+        refused = refused_seats(
+            {"stella": ["OPENROUTER_API_KEY"]},
+            {"stella": {"OPENROUTER_API_KEY": "sk-or"}},
+            set(),
+        )
+        assert refused == {}
+
+    def test_a_seat_declaring_nothing_is_never_refused(self) -> None:
+        assert refused_seats({"free": []}, {}, set()) == {}
+
+
+class TestProgress:
+    """A quota-limited account parks the overflow in RUNNABLE; that must read
+    as progress, not as a hang."""
+
+    def test_runnable_counts_as_queued(self) -> None:
+        progress = progress_from_states(
+            ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING",
+             "SUCCEEDED", "FAILED"]
+        )
+        assert (progress.queued, progress.running) == (3, 2)
+        assert (progress.succeeded, progress.failed) == (1, 1)
+        assert not progress.done
+
+    def test_the_line_spells_out_the_queued_count(self) -> None:
+        progress = progress_from_states(["RUNNABLE"] * 120 + ["RUNNING"] * 24)
+        line = progress.to_line(190.0)
+        assert "queued 120" in line
+        assert "running  24" in line
+        assert "(144 trials)" in line
+
+    def test_done_only_when_nothing_is_pending(self) -> None:
+        assert progress_from_states(["SUCCEEDED", "FAILED"]).done
+        assert not progress_from_states(["SUCCEEDED", "RUNNABLE"]).done
+
+
+class TestSutSeats:
+    def test_names_the_stella_seats(self) -> None:
+        assert sut_seats(_spec()) == ["stella"]
+        assert sut_seats(_spec(seats=(_seat("cc", agent="claude-code"),))) == []
+
+
+# --------------------------------------------------------------------------
+# the adapter, against recorded calls
+# --------------------------------------------------------------------------
+
+
+class TestAvailableCredentials:
+    def test_names_only_and_paginated(self) -> None:
+        ssm = FakeSsm(["/arenabench/anthropic_api_key", "/arenabench/zai-api-key"])
+        names = _executor(ssm=ssm).available_credentials()
+        assert names == {"ANTHROPIC_API_KEY", "ZAI_API_KEY"}
+        assert len(ssm.calls) == 2, "NextToken page was not followed"
+        for call in ssm.calls:
+            assert call["Path"] == "/arenabench"
+            assert call["WithDecryption"] is False, "values must never transit"
+
+
+class TestResolveSut:
+    def test_reads_the_per_ref_latest_manifest(self) -> None:
+        commit = "a" * 40
+        s3 = FakeS3(
+            {
+                "binaries/feature-x/latest.json": json.dumps(
+                    {"git_ref": "feature/x", "commit": commit}
+                ).encode()
+            }
+        )
+        sut = _executor(s3=s3).resolve_sut("feature/x")
+        assert sut.commit == commit
+        assert sut.uri == f"s3://{BUCKET}/binaries/feature-x/{commit}/stella"
+
+    def test_a_missing_ref_triggers_a_codebuild_build_first(self) -> None:
+        """The build is started with the GIT_REF override the project
+        contracts for, polled to completion, then the manifest is re-read."""
+        commit = "b" * 40
+        s3 = FakeS3()
+        codebuild = FakeCodeBuild(["IN_PROGRESS", "SUCCEEDED"])
+        slept: list[float] = []
+
+        def sleep(seconds: float) -> None:
+            slept.append(seconds)
+            # The build "finishes": its artifact appears in S3.
+            s3.objects["binaries/main/latest.json"] = json.dumps(
+                {"git_ref": "main", "commit": commit}
+            ).encode()
+
+        sut = _executor(s3=s3, codebuild=codebuild).resolve_sut(
+            "main", sleep=sleep, out=lambda _line: None
+        )
+        assert sut.commit == commit
+        (started,) = codebuild.started
+        assert started["projectName"] == "arenabench-sut-build"
+        assert started["environmentVariablesOverride"] == [
+            {"name": "GIT_REF", "value": "main", "type": "PLAINTEXT"}
+        ]
+        assert slept, "polling must sleep between sweeps, not busy-wait"
+
+    def test_a_failed_build_is_an_error_not_a_submission(self) -> None:
+        codebuild = FakeCodeBuild(["FAILED"])
+        with pytest.raises(CloudError, match="FAILED"):
+            _executor(s3=FakeS3(), codebuild=codebuild).resolve_sut(
+                "main", sleep=lambda _s: None, out=lambda _line: None
+            )
+
+
+class TestSubmitContract:
+    """The centerpiece witness: what actually goes over the wire per trial."""
+
+    def _submit(self, spec: MatchSpec, queue: str = MEASURE_QUEUE):
+        s3, batch = FakeS3(), FakeBatch()
+        executor = _executor(s3=s3, batch=batch)
+        jobs = executor.submit_run(
+            spec, plan_trials(spec), run_id="r1", queue=queue, sut=_sut()
+        )
+        return s3, batch, jobs
+
+    def test_one_job_per_trial_with_the_entrypoint_env_contract(self) -> None:
+        s3, batch, jobs = self._submit(_spec())
+        assert len(batch.submitted) == 4  # 2 tasks x 2 seats
+        match_uris = set()
+        for submitted in batch.submitted:
+            assert submitted["jobQueue"] == "arenabench-measure"
+            assert submitted["jobDefinition"] == JOB_DEFINITION == "arenabench-trial"
+            overrides = submitted["containerOverrides"]
+            assert overrides["command"] == ["run"]
+            env = {e["name"]: e["value"] for e in overrides["environment"]}
+            assert set(env) == {"RUN_ID", "MATCH_S3_URI", "SUT_S3_URI", "SUT_COMMIT"}
+            assert env["RUN_ID"] == "r1"
+            assert env["MATCH_S3_URI"].startswith(f"s3://{BUCKET}/runs/r1/trials/")
+            match_uris.add(env["MATCH_S3_URI"])
+            resources = {
+                r["type"]: r["value"] for r in overrides["resourceRequirements"]
+            }
+            assert resources == {"VCPU": "4", "MEMORY": "15360"}
+        assert len(match_uris) == 4, "every trial must get its own slice"
+
+    def test_uploads_the_match_the_slices_and_the_submission_record(self) -> None:
+        s3, _batch, jobs = self._submit(_spec())
+        assert "runs/r1/match.toml" in s3.objects
+        record = json.loads(s3.objects["runs/r1/jobs.json"])
+        assert record["queue"] == "arenabench-measure"
+        assert record["sut"]["commit"] == "c" * 40
+        assert [j["id"] for j in record["jobs"]] == [j["id"] for j in jobs]
+
+    def test_each_slice_parses_back_to_one_cell(self) -> None:
+        spec = _spec()
+        s3, batch, _jobs = self._submit(spec)
+        env = {
+            e["name"]: e["value"]
+            for e in batch.submitted[0]["containerOverrides"]["environment"]
+        }
+        key = env["MATCH_S3_URI"].removeprefix(f"s3://{BUCKET}/")
+        sliced = match_from_toml(tomllib.loads(s3.objects[key].decode()))
+        assert len(sliced.tasks) == 1
+        assert len(sliced.contestants) == 1
+        assert sliced.attempts == 1
+        assert sliced.concurrency == 1
+
+    def test_burst_submissions_go_to_the_spot_queue(self) -> None:
+        _s3, batch, _jobs = self._submit(_spec(), queue=select_queue(True))
+        assert all(s["jobQueue"] == "arenabench-burst" for s in batch.submitted)
+
+
+class TestJobStates:
+    def test_describes_in_chunks_of_100(self) -> None:
+        """A 144-trial run cannot fit one describe_jobs call; the sweep must
+        chunk, and every id must be covered exactly once."""
+        batch = FakeBatch([{}])
+        ids = [f"job-{i:03d}" for i in range(144)]
+        states = _executor(batch=batch).job_states(ids)
+        assert len(states) == 144
+        assert len(batch.describe_calls) == 2
+        assert all(len(chunk) <= 100 for chunk in batch.describe_calls)
+
+
+class TestWatch:
+    def test_streams_transitions_and_surfaces_the_queued_backlog(self) -> None:
+        jobs = [
+            {"id": "job-001", "label": "000-stella-task-a"},
+            {"id": "job-002", "label": "001-cc-task-a"},
+            {"id": "job-003", "label": "002-stella-task-b"},
+        ]
+        script = [
+            {"job-001": "RUNNABLE", "job-002": "RUNNABLE", "job-003": "RUNNABLE"},
+            {"job-001": "RUNNING", "job-002": "RUNNING", "job-003": "RUNNABLE"},
+            {"job-001": "SUCCEEDED", "job-002": "SUCCEEDED", "job-003": "SUCCEEDED"},
+        ]
+        batch = FakeBatch(script)
+        lines: list[str] = []
+        slept: list[float] = []
+
+        def sleep(seconds: float) -> None:
+            slept.append(seconds)
+            batch.advance()
+
+        ticks = iter(range(0, 1000, 10))
+        states = _executor(batch=batch).watch(
+            jobs,
+            poll_interval=7.5,
+            sleep=sleep,
+            clock=lambda: float(next(ticks)),
+            out=lines.append,
+        )
+        assert set(states.values()) == {"SUCCEEDED"}
+        assert slept == [7.5, 7.5], "one sleep per sweep, none after settling"
+        text = "\n".join(lines)
+        assert "queued   3" in text
+        assert "Queued is progress, not a hang" in text
+        assert text.count("not a hang") == 1, "the quota note prints once"
+        assert "000-stella-task-a: RUNNABLE -> RUNNING" in text
+        assert "002-stella-task-b: RUNNABLE -> SUCCEEDED" in text
+
+
+class TestRunRows:
+    def test_reads_the_runner_status_items_across_pages(self) -> None:
+        pages = [
+            {
+                "Items": [
+                    {
+                        "PK": {"S": "RUN#r1"},
+                        "SK": {"S": "JOB#job-001"},
+                        "status": {"S": "done"},
+                        "detail": {"S": "exit 0"},
+                    }
+                ],
+                "LastEvaluatedKey": {"PK": {"S": "RUN#r1"}},
+            },
+            {
+                "Items": [
+                    {
+                        "PK": {"S": "RUN#r1"},
+                        "SK": {"S": "JOB#job-002"},
+                        "status": {"S": "failed"},
+                        "detail": {"S": "exit 1"},
+                    }
+                ]
+            },
+        ]
+        dynamo = FakeDynamo(pages)
+        rows = _executor(dynamodb=dynamo).run_rows("r1")
+        assert rows == [
+            {"job": "job-001", "status": "done", "detail": "exit 0"},
+            {"job": "job-002", "status": "failed", "detail": "exit 1"},
+        ]
+        first = dynamo.calls[0]
+        assert first["TableName"] == "arenabench"
+        assert first["ExpressionAttributeValues"] == {":pk": {"S": "RUN#r1"}}
+
+
+class TestFetchResults:
+    def test_downloads_each_trials_results_json(self, tmp_path) -> None:
+        s3 = FakeS3({"runs/r1/job-001/results.json": b'{"ok": true}'})
+        jobs = [
+            {"id": "job-001", "label": "000-stella-task-a"},
+            {"id": "job-002", "label": "001-cc-task-a"},
+        ]
+        notes: list[str] = []
+        fetched = _executor(s3=s3).fetch_results(
+            "r1", jobs, tmp_path, out=notes.append
+        )
+        assert fetched == 1
+        assert (tmp_path / "000-stella-task-a" / "results.json").read_bytes() == (
+            b'{"ok": true}'
+        )
+        assert any("001-cc-task-a" in note for note in notes), (
+            "a missing results.json must be said out loud, not skipped silently"
+        )
+
+
+# --------------------------------------------------------------------------
+# the CLI path
+# --------------------------------------------------------------------------
+
+TEMPLATE = """\
+[match]
+name = "cloud smoke"
+dataset = "terminal-bench-2.1"
+tasks = ["task-a"]
+
+[[contestant]]
+id = "stella"
+agent = "stella"
+
+  [contestant.engine]
+  api = "openrouter"
+  model = "z-ai/glm-5.2"
+
+  [contestant.env]
+  required = ["OPENROUTER_API_KEY"]
+"""
+
+
+def _run_args(template, **overrides) -> argparse.Namespace:
+    defaults = dict(
+        template=str(template),
+        ref=None,
+        run_id="r-test",
+        burst=False,
+        poll=0.0,
+        vcpus=4,
+        memory_mb=15360,
+        no_wait=True,
+        no_fetch=True,
+        artifacts=False,
+        out=None,
+        region=None,
+        bucket=None,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestCloudRunCommand:
+    def test_a_seat_without_ssm_credentials_is_refused_before_any_submit(
+        self, tmp_path, capsys
+    ) -> None:
+        """The refusal half of the witness: nothing is uploaded and no job is
+        submitted when a seat's declared credentials will not exist in the
+        trial environment (#1827)."""
+        template = tmp_path / "match.toml"
+        template.write_text(TEMPLATE, encoding="utf-8")
+        s3, batch = FakeS3(), FakeBatch()
+        executor = _executor(s3=s3, batch=batch, ssm=FakeSsm([]))
+
+        rc = _cmd_cloud_run(_run_args(template), executor=executor)
+
+        assert rc == 2
+        assert batch.submitted == [], "a refused match must submit nothing"
+        assert s3.calls == [], "a refused match must upload nothing"
+        err = capsys.readouterr().err
+        assert "OPENROUTER_API_KEY" in err
+        assert "refusing to submit" in err
+
+    def test_a_credentialled_match_submits_with_the_matchs_own_ref(
+        self, tmp_path, capsys, monkeypatch
+    ) -> None:
+        """End to end through the CLI glue: SSM credentials present, the SUT
+        resolved from the match's default ref (main), one job per trial."""
+        monkeypatch.delenv("ARENABENCH_STELLA_REPO", raising=False)
+        commit = "d" * 40
+        template = tmp_path / "match.toml"
+        template.write_text(TEMPLATE, encoding="utf-8")
+        s3 = FakeS3(
+            {
+                "binaries/main/latest.json": json.dumps(
+                    {"git_ref": "main", "commit": commit}
+                ).encode()
+            }
+        )
+        batch = FakeBatch()
+        executor = _executor(
+            s3=s3, batch=batch, ssm=FakeSsm(["/arenabench/openrouter_api_key"])
+        )
+
+        rc = _cmd_cloud_run(_run_args(template), executor=executor)
+
+        assert rc == 0
+        (submitted,) = batch.submitted
+        env = {
+            e["name"]: e["value"]
+            for e in submitted["containerOverrides"]["environment"]
+        }
+        assert env["SUT_COMMIT"] == commit
+        assert env["RUN_ID"] == "r-test"
+        assert "runs/r-test/jobs.json" in s3.objects
+        assert "cloud status r-test" in capsys.readouterr().out


### PR DESCRIPTION
## What & why

`arenabench cloud run <match.toml> --ref main` — the submit side of the AWS Batch substrate `arenabench/infra/` provisions. Until now a cloud run meant hand-writing `aws batch submit-job` calls against the contract documented in the infra runbook; this PR makes it one CLI verb. New module `arenabench/arenabench/cloud.py` plus `arenabench cloud run|status|fetch`:

1. Uploads the match TOML and one **sliced** match TOML per trial to `s3://arenabench-artifacts-<acct>/runs/<run-id>/` (the runner executes one whole TOML per container, so the fan-out happens at submit: `attempts × tasks × contestants` slices — the 12×12 shape is 144 jobs; a match naming no tasks fans per seat).
2. Resolves the SUT from `binaries/<ref>/latest.json`; on a miss, starts the `arenabench-sut-build` CodeBuild project with the `GIT_REF` override and polls it to completion before submitting.
3. Submits one `arenabench-trial` job per trial with **exactly** the env contract `infra/runner/entrypoint.sh` speaks: `RUN_ID`, `MATCH_S3_URI`, `SUT_S3_URI`, `SUT_COMMIT`, command `["run"]`, 4 vCPU / 15360 MiB.
4. **Refuses unauthenticated seats at submit time**: a seat none of whose declared credential names will exist in the SSM `/arenabench/` export (name transform mirrors the entrypoint's) is refused before any upload or submission — same direction as #1827/#1777.
5. Streams progress by polling Batch job states (chunked `describe_jobs`), printing per-trial transitions plus queued/running/ok/failed counts. `RUNNABLE` — where a quota-limited account (on-demand vCPU 64) parks the overflow — is surfaced as an explicit queued count with a one-time explanatory note, so a 144-trial submission reads as progress, not a hang. DynamoDB `RUN#<run-id>` status rows are read into the final summary and `cloud status`.
6. Downloads each trial's `runs/<run-id>/<job>/results.json` (full artifact tree behind `--artifacts` — it can be gigabytes, so it is a choice, not a side effect). `runs/<run-id>/jobs.json` persists the submission record so `cloud status`/`cloud fetch` work from any machine, or after the submitting process dies.

**Queue rules:** measured comparisons go to `arenabench-measure` only. `--burst` (spot) is an explicit non-measurement opt-out — spot interruption is a confound — and the CLI labels it as such when selected.

**Design:** every decision — queue selection, trial fan-out/array sizing, env assembly, credential refusal, progress derivation — is a pure function over plain data, tested with no AWS client at all; the boto3 calls are a thin `CloudExecutor` adapter exercised through in-repo recorded-call fakes (ports, not concretions — moto was deliberately not added; it is a heavyweight dependency for what is parameter-shape assertions).

**New dependency (justification):** `boto3`, as an *optional* extra `[project.optional-dependencies] cloud` only. ArenaBench stays stdlib-only by contract: `cloud.py` imports boto3 lazily inside the adapter, so every other verb — and the whole test suite, including the new one — runs without it.

Closes #2099

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`arenabench/tests/test_cloud.py` (37 tests) fails trivially on `main` because `arenabench/arenabench/cloud.py` does not exist — and non-trivially it pins the submit contract end to end:

- **Env names**: each submitted job carries exactly `RUN_ID`, `MATCH_S3_URI`, `SUT_S3_URI`, `SUT_COMMIT` and command `["run"]`; the SUT pair travels together or not at all; the SSM name transform (`/arenabench/anthropic_api_key` → `ANTHROPIC_API_KEY`, `tr -c` fold included) matches the entrypoint's.
- **Queue selection**: measured → `arenabench-measure`; `--burst` → `arenabench-burst`, never the other way.
- **Array sizing**: 12 seats × 12 tasks fans into exactly 144 unique per-trial submissions with distinct slice URIs; attempts multiply the grid; `describe_jobs` sweeps chunk at 100; each uploaded slice parses back (`tomllib` + `match_from_toml`) to one task × one seat × one attempt at concurrency 1.
- **Refusal**: a seat with no declared credential in SSM exits 2 with **zero** S3 calls and **zero** Batch calls recorded.
- **Progress**: `RUNNABLE` counts as queued, the line spells the queued count out, the quota note prints exactly once, and the watcher sleeps between sweeps (injected clock/sleep — no real waiting in tests).

**Verification honesty:** this session had no AWS access, deliberately. The recorded-call fakes and pure-function tests *are* the verification of this PR; the first real-AWS acceptance run (144-trial queue-through on the quota-limited account) is tracked as #2112 and is named there as the remaining, undelivered half of the issue's definition of done.

## The gate

- [x] `cargo fmt --check` / clippy / `cargo test` — no Rust touched (Python-only change; `uv run --with pytest --no-project pytest -q` in `arenabench/` is green, which is exactly what CI's `bench.yml` runs; `ruff check` clean on the changed files)
- [x] Docs updated where behavior changed (`arenabench/infra/README.md` runbook now points at the verbs)
- [x] CLA signed
- [x] `Closes #2099` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2112 (first real-AWS acceptance run — the operational half of the DoD this session could not verify), #2113 (array-job submission mode: one `submit_job` of size N needs the entrypoint to learn `AWS_BATCH_JOB_ARRAY_INDEX` + a runner-image rebuild; per-trial submission is the shape today's contract supports, which is why this PR chose it)

## Anything reviewers should know?

- **Per-seat SUT refs are out of scope on purpose** (`Refs #2082`): `sut_ref` is match-level today and a parallel session owns that fix; this PR takes a single `--ref` for the whole match (default: the match's `sut_ref`).
- **In-container pickup of the staged binary rides on #2082/#2098.** This executor stages the SUT race-free (`SUT_S3_URI`/`SUT_COMMIT` resolved once from `latest.json` at submit — never a launch-time re-resolution), and the entrypoint stages it in the `binary_for()` layout. But inside the container `runner.py` still resolves `spec.sut_ref` via git against a Stella checkout the runner image does not have — the exact wiring #2098 documents and the parallel session on #2082/#2098 is fixing. Named here rather than worked around, to keep the two PRs from colliding on `runner.py`/`sut.py`.
- Diff is confined to new files (`cloud.py`, `test_cloud.py`) plus minimal wiring (2-line registration in `cli.py`, the `[cloud]` extra in `pyproject.toml`, a runbook paragraph) for the same reason.
- `Refs #1584, #1707, #1773, #1827` — container budget, hosted match browsing, and Docker preflight are adjacent but untouched (preflight is moot in cloud: dockerd is guaranteed by the job definition); the credential refusal follows #1827's direction.

## Summary by Sourcery

Add an AWS Batch–backed cloud execution path to ArenaBench, exposing it via new `arenabench cloud` CLI verbs and wiring it into the existing CLI and optional dependencies.

New Features:
- Introduce an AWS Batch cloud executor (`CloudExecutor`) that uploads match specs, submits one Batch job per trial, tracks progress, and fetches results for cloud runs.
- Add `arenabench cloud run|status|fetch` CLI commands to submit matches to AWS Batch, stream and follow status, and download trial results and artifacts.
- Support resolving and optionally building SUT binaries from S3 (`binaries/<ref>/latest.json`) via CodeBuild before cloud submission, and enforce submit-time refusal of seats lacking required SSM credentials.

Enhancements:
- Document the new `arenabench cloud` workflow and usage in the infra README, replacing manual `aws batch submit-job` steps.
- Add an optional `cloud` extra that brings in `boto3`, keeping the core ArenaBench package stdlib-only by lazily importing AWS SDK usage in the cloud module.

Tests:
- Add a comprehensive `test_cloud.py` suite using lightweight recorded-call fakes to pin the AWS contract (SSM export mapping, queue selection, fan-out sizing, env layout, progress folding, DynamoDB rows, and result fetching) without requiring real AWS access.