### PR TITLE
fix(arenabench): render AWS read failures as an outage, not an empty backend

### DIFF
--- a/arenabench/web/app/globals.css
+++ b/arenabench/web/app/globals.css
@@ -137,9 +137,18 @@ button.secondary {
   border: 1px solid var(--line);
 }
 
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .note {
   color: var(--dim);
   font-size: 12.5px;
+}
+
+.error {
+  color: var(--bad);
 }
 
 code {

--- a/arenabench/web/app/page.js
+++ b/arenabench/web/app/page.js
@@ -3,11 +3,26 @@ import { buildSutAction, smokeAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
+// An AWS read that failed must never render as an empty backend: "no
+// binaries" and "the control plane is unreachable" call for opposite
+// operator actions (build vs. wait), and both builds and smoke trials cost
+// real money. Failures are carried into the render as their own state.
+async function read(promise) {
+  try {
+    return { ok: true, value: await promise };
+  } catch (err) {
+    return { ok: false, error: String(err?.message ?? err) };
+  }
+}
+
 export default async function Home() {
-  const [refs, jobs] = await Promise.all([
-    listBinaryRefs().catch(() => []),
-    recentJobs().catch(() => []),
+  const [refsRead, jobsRead] = await Promise.all([
+    read(listBinaryRefs()),
+    read(recentJobs()),
   ]);
+  const refs = refsRead.ok ? refsRead.value : [];
+  const jobs = jobsRead.ok ? jobsRead.value : [];
+  const outage = !refsRead.ok || !jobsRead.ok;
   const manifests = await Promise.all(
     refs.slice(0, 8).map(async (ref) => ({ ref, m: await latestManifest(ref) })),
   );
@@ -29,20 +44,38 @@ export default async function Home() {
         (match execution). Until then this page is the control surface.
       </p>
 
+      {outage && (
+        <div className="panel">
+          <p className="error">
+            Control plane unreachable — the readings below are incomplete, not
+            a picture of an empty backend.
+          </p>
+          {!refsRead.ok && (
+            <p className="note">Binary listing (S3): {refsRead.error}</p>
+          )}
+          {!jobsRead.ok && (
+            <p className="note">Job history (DynamoDB): {jobsRead.error}</p>
+          )}
+        </div>
+      )}
+
       <h2>Actions</h2>
       <div className="panel">
         <form action={buildSutAction}>
           <input type="text" name="ref" placeholder="git ref (default: main)" />
-          <button type="submit">Build Stella binary</button>
+          <button type="submit" disabled={outage}>
+            Build Stella binary
+          </button>
         </form>
         <form action={smokeAction}>
-          <button type="submit" className="secondary">
+          <button type="submit" className="secondary" disabled={outage}>
             Run smoke trial
           </button>
         </form>
         <p className="note">
-          Builds take ~8 min warm-cached; a smoke trial scales Batch from
-          zero (~5 min) and back.
+          {outage
+            ? "Actions are disabled while the control plane is unreachable — a build kicked off blind costs money with no way to watch it."
+            : "Builds take ~8 min warm-cached; a smoke trial scales Batch from zero (~5 min) and back."}
         </p>
       </div>
 
@@ -68,7 +101,14 @@ export default async function Home() {
                 <td>{m ? m.sha256.slice(0, 16) : "—"}</td>
               </tr>
             ))}
-            {manifests.length === 0 && (
+            {!refsRead.ok && (
+              <tr>
+                <td colSpan={4} className="error">
+                  Binary listing unavailable — see the outage notice above.
+                </td>
+              </tr>
+            )}
+            {refsRead.ok && manifests.length === 0 && (
               <tr>
                 <td colSpan={4} className="note">
                   No binaries yet — build one above.
@@ -101,7 +141,14 @@ export default async function Home() {
                 <td>{j.detail}</td>
               </tr>
             ))}
-            {jobs.length === 0 && (
+            {!jobsRead.ok && (
+              <tr>
+                <td colSpan={5} className="error">
+                  Job history unavailable — see the outage notice above.
+                </td>
+              </tr>
+            )}
+            {jobsRead.ok && jobs.length === 0 && (
               <tr>
                 <td colSpan={5} className="note">
                   No jobs recorded yet.


### PR DESCRIPTION
The Vercel bot's review on #2106 found the home page swallowing AWS read failures with `.catch(() => [])`: a control-plane outage rendered exactly like an empty backend — "No binaries yet — build one above" — inviting an operator to trigger a spend-costing build during the very outage that made the list look empty. #2106 merged before the fix could land on its branch, so this is the follow-up against main.

- `listBinaryRefs()` / `recentJobs()` failures now carry into the render as their own state via a small `read()` wrapper: an outage banner names which read failed (S3 binary listing vs DynamoDB job history) and why.
- Both tables render an explicit `error`-classed unavailable row instead of the false empty-state; the true empty-states ("No binaries yet", "No jobs recorded yet") render only when their read actually succeeded.
- Both spend-costing action buttons (build, smoke trial) are disabled during an outage, with the note explaining why — a build kicked off blind costs money with no way to watch it.

Deliberately not widened here: `latestManifest()` still folds not-found and outage into the same `null` per ref — that fix changes per-row error routing and is filed as #2118 with the design constraint spelled out.

Verification: `npx next build` (lint + type check + full compile) green on this exact tree, run twice — once on the #2106 branch, once after the cherry-pick onto main. The app has no unit-test harness, so no witness test is practical (per the contributing carve-out for surfaces without one); the behavioral claim is two booleans routing JSX, reviewable by eye in the diff.

Refs #2106, #2118.

## Summary by Sourcery

Handle AWS control-plane read failures on the arenabench home page as explicit outages instead of silently rendering an empty backend.

Bug Fixes:
- Ensure failed S3 binary listings and DynamoDB job history reads no longer appear as legitimate empty states on the home page.

Enhancements:
- Introduce an outage banner that surfaces which control-plane reads failed and why.
- Render explicit unavailable rows in the binaries and job history tables when their respective reads fail, only showing empty-state messaging when reads succeed.
- Disable build and smoke-trial actions during control-plane outages and explain the cost and observability implications in the UI.
- Add styling for disabled buttons and error messages to visually distinguish outage states from normal operation.