### PR TITLE
feat(stella-cli): carry reward labels and verified prompt_messages in dataset export (#2083)

### DIFF
--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -483,8 +483,7 @@ fn extract(
         for execution in &batch {
             cursor = execution.execution_id;
             scanned += 1;
-            let Some(record) =
-                accepted_record(store, execution, repo, args, policy, &mut counts)?
+            let Some(record) = accepted_record(store, execution, repo, args, policy, &mut counts)?
             else {
                 continue;
             };

--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -26,10 +26,26 @@
 //! `goal_met`, `goal_unmet`, `verification_failed`, `aborted`, `cancelled`,
 //! `failed`, `error`, `interrupted` — and `AgentEvent::Verdict`. So the
 //! predicate is named ([`is_accepted`]), documented, and echoed **verbatim**
-//! into the manifest, rather than left implicit in a `WHERE` clause. No
-//! numeric reward is invented: nothing in the tree maps a ladder decision to
-//! a reward scalar yet (#1043 is open), so the raw verdict is emitted and
-//! scoring is left to whoever gets there.
+//! into the manifest, rather than left implicit in a `WHERE` clause.
+//!
+//! ## Rewards and transcripts (#2083)
+//!
+//! Two things #872 shipped without now exist in tree and are carried. The
+//! verdict → scalar mapping (#1043, [`stella_pipeline::reward`]) labels each
+//! record from the journal's settled verdict under the workspace's resolved
+//! [`RewardPolicy`] — and the policy rides on every label, so records from
+//! differently-weighted workspaces stay comparable. And the receipts plane
+//! rebuilds any model call byte-exactly
+//! ([`stella_store::Store::reconstruct_call`] — the same source `trace.rs`
+//! reads, so SFT pairs need no other source), so each record carries every
+//! call's exact `prompt_messages`, admitted only when the reconstruction
+//! digest-verifies. An execution that cannot vouch for its own transcripts —
+//! no recorded call at all, or any call short of
+//! [`stella_store::Reconstruction::is_verified`] — is excluded under the
+//! default filter and **counted** in the manifest, the same named-predicate
+//! discipline as the rest of the acceptance rule. The raw verdict is still
+//! emitted beside the label, so a reader can re-derive a label under other
+//! weights without trusting this one.
 //!
 //! ## What a "diff" can honestly be here
 //!
@@ -61,12 +77,18 @@ use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use stella_core::redact::{PLACEHOLDER, redact_secrets};
+use stella_pipeline::reward::{RewardLabel, RewardPolicy, Settlement, TrajectoryCost, label};
 use stella_protocol::AgentEvent;
-use stella_store::{FinishedExecution, Store};
+use stella_store::{FinishedExecution, RecordedCall, Store};
 
 /// Bump when [`DatasetRecord`]'s shape changes incompatibly, so a reader can
 /// refuse a dataset it does not understand instead of misparsing it.
-pub const DATASET_SCHEMA_VERSION: u32 = 1;
+///
+/// `2` (#2083) added the per-call verified transcripts ([`DatasetRecord::calls`])
+/// and the reward label ([`DatasetRecord::reward`], #1043), and tightened the
+/// default filter to transcript-verified executions — so a v1 dataset is not
+/// comparable to a v2 one even where the shared fields agree.
+pub const DATASET_SCHEMA_VERSION: u32 = 2;
 
 /// The dataset file written under `--output`.
 pub const DATASET_FILE: &str = "dataset.jsonl";
@@ -98,6 +120,12 @@ const SCAN_BATCH: u32 = 500;
 /// That is off by default because most executions never reach a verifier at all
 /// (the deterministic ladder can fast-submit), so requiring it would silently
 /// shrink the dataset to the subset that escalated.
+///
+/// This is the journal half of the stated predicate. The transcript half —
+/// every recorded model call reconstructing digest-verified — needs the
+/// receipts plane rather than the fold, so [`accepted_record`] applies it via
+/// [`verified_transcripts`] after this returns true, and the manifest counts
+/// what it excludes.
 fn is_accepted(outcome: &str, fold: &JournalFold, require_verdict: bool) -> bool {
     ACCEPTED_OUTCOMES.contains(&outcome)
         && !fold.changes.is_empty()
@@ -109,7 +137,9 @@ fn is_accepted(outcome: &str, fold: &JournalFold, require_verdict: bool) -> bool
 /// without reading this file.
 fn acceptance_predicate(require_verdict: bool) -> String {
     let base = format!(
-        "executions.outcome in {{{}}} AND at least one mutating file_change event",
+        "executions.outcome in {{{}}} AND at least one mutating file_change event \
+         AND at least one recorded model call, every one reconstructing \
+         digest-verified (Reconstruction::is_verified)",
         ACCEPTED_OUTCOMES.join(", ")
     );
     if require_verdict {
@@ -169,6 +199,8 @@ pub enum DatasetCmd {
 /// Every field is always present — no `skip_serializing_if` anywhere — so
 /// each line of the dataset carries the same keys and a consumer never has to
 /// distinguish "absent" from "not applicable". Absence is spelled `null`.
+/// (Inside [`RewardLabel`] the pipeline's own wire shape applies; that type
+/// belongs to `stella-pipeline` and is carried verbatim.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatasetRecord {
     pub schema: u32,
@@ -199,16 +231,50 @@ pub struct DatasetRecord {
     // ---- the trajectory ---------------------------------------------------
     /// The prompt as submitted, before the context engine expanded it.
     pub prompt: String,
+    /// Every model call, in wire order, each with the exact messages it was
+    /// sent — reconstructed from the receipts plane and digest-verified
+    /// before admission (#2083). Never empty: an execution whose transcripts
+    /// do not all verify is excluded by the default filter, not exported
+    /// with a gap here.
+    pub calls: Vec<DatasetCall>,
     /// Every tool invocation, in journal order.
     pub tool_calls: Vec<DatasetToolCall>,
     /// Every mutating file change, in journal order.
     pub changes: Vec<DatasetChange>,
     /// The last verifier verdict, when the turn reached one.
     pub verdict: Option<DatasetVerdict>,
+    /// The training label the settled verdict earned (#1043), computed under
+    /// the workspace's resolved [`RewardPolicy`] (stamped on the label, so
+    /// the scalar is interpretable outside this workspace). `None` when the
+    /// journal holds no verdict at all: there is no proof or ladder evidence
+    /// to derive a label from, and synthesizing a discard under a policy the
+    /// run never saw would claim more than the store knows.
+    pub reward: Option<RewardLabel>,
     /// Whether redaction actually replaced something anywhere in this record.
     /// Recorded so "this was redacted" is a visible fact rather than an
     /// assumption (the `stella_core::redact` posture).
     pub redacted: bool,
+}
+
+/// One model call: who was called, in which role, and exactly what it saw.
+///
+/// The transcript half of the record. Each entry of `prompt_messages` is a
+/// full serialized [`stella_protocol::CompletionMessage`] (role, content,
+/// tool calls with arguments, tool results) rebuilt by
+/// [`stella_store::Store::reconstruct_call`] — so an SFT pair needs no other
+/// source — and admitted only when the reconstruction digest-verifies, so an
+/// unvouched transcript never reaches a dataset silently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatasetCall {
+    pub turn_instance: u32,
+    pub step: u64,
+    pub call_seq: u64,
+    /// `ModelCallRole` as its wire token ("worker", "verifier", …).
+    pub role: String,
+    pub provider: String,
+    pub model: String,
+    /// The exact messages this call was sent, in wire order.
+    pub prompt_messages: Vec<serde_json::Value>,
 }
 
 /// One tool invocation: what the model asked for and what came back.
@@ -251,8 +317,9 @@ pub struct DatasetChange {
     pub diff_truncated: bool,
 }
 
-/// A verifier verdict, carried raw. No reward scalar is derived from it: nothing
-/// in the tree maps a ladder decision onto one yet (#1043).
+/// A verifier verdict, carried raw beside the label #1043 derives from it
+/// ([`DatasetRecord::reward`]) — so a reader can re-derive a label under
+/// different weights without trusting this export's.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatasetVerdict {
     pub passed: bool,
@@ -294,7 +361,12 @@ pub struct DatasetFilter {
     pub executions_scanned: u64,
     /// Of those, how many fell inside the `since`/`until` window.
     pub executions_in_window: u64,
-    /// Of those, how many the predicate accepted. Equals `records`.
+    /// Of the executions the outcome-and-change half of the predicate
+    /// accepted, how many were excluded because their transcripts did not
+    /// verify: no recorded model call at all, or some call's reconstruction
+    /// short of [`stella_store::Reconstruction::is_verified`] (#2083).
+    pub executions_transcripts_unverified: u64,
+    /// Of those, how many the whole predicate accepted. Equals `records`.
     pub executions_accepted: u64,
 }
 
@@ -341,8 +413,15 @@ fn run_export(args: &ExportArgs) -> Result<(), String> {
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let store = open_readonly_store(&workspace_root)?;
     let repo = stella_store::identity::TelemetryScope::resolve(&workspace_root).repo_id;
+    // The same resolution the runtime labels traces under (settings `reward`
+    // block, defaults where absent), so a dataset label and a trace label of
+    // the same execution agree — and a refused weight fails here, loudly,
+    // before any record is written under it.
+    let policy = crate::settings::Settings::load(&workspace_root)
+        .and_then(|settings| settings.reward_policy())
+        .map_err(|e| format!("cannot resolve the reward policy: {e}"))?;
 
-    let (records, filter) = extract(&store, &repo, args)?;
+    let (records, filter) = extract(&store, &repo, args, &policy)?;
     let manifest = DatasetManifest {
         schema: DATASET_SCHEMA_VERSION,
         format: args.format.wire().to_string(),
@@ -388,9 +467,11 @@ fn extract(
     store: &Store,
     repo: &str,
     args: &ExportArgs,
+    policy: &RewardPolicy,
 ) -> Result<(Vec<DatasetRecord>, DatasetFilter), String> {
     let mut records: Vec<DatasetRecord> = Vec::new();
-    let (mut scanned, mut in_window) = (0u64, 0u64);
+    let mut scanned = 0u64;
+    let mut counts = ScanCounts::default();
     let mut cursor = 0i64;
     loop {
         let batch = store
@@ -402,7 +483,8 @@ fn extract(
         for execution in &batch {
             cursor = execution.execution_id;
             scanned += 1;
-            let Some(record) = accepted_record(store, execution, repo, args, &mut in_window)?
+            let Some(record) =
+                accepted_record(store, execution, repo, args, policy, &mut counts)?
             else {
                 continue;
             };
@@ -419,10 +501,23 @@ fn extract(
         until: args.until.clone(),
         require_verdict: args.require_verdict,
         executions_scanned: scanned,
-        executions_in_window: in_window,
+        executions_in_window: counts.in_window,
+        executions_transcripts_unverified: counts.transcripts_unverified,
         executions_accepted: records.len() as u64,
     };
     Ok((records, filter))
+}
+
+/// What the fold counts beyond the records it keeps — the manifest's
+/// accounting of the executions each stage of the filter turned away.
+#[derive(Default)]
+struct ScanCounts {
+    /// Executions the `since`/`until` window admitted.
+    in_window: u64,
+    /// Executions the outcome-and-change predicate accepted whose transcripts
+    /// then failed to verify — see
+    /// [`DatasetFilter::executions_transcripts_unverified`].
+    transcripts_unverified: u64,
 }
 
 /// One execution's record, or `None` when the window or the predicate excludes
@@ -432,7 +527,8 @@ fn accepted_record(
     execution: &FinishedExecution,
     repo: &str,
     args: &ExportArgs,
-    in_window: &mut u64,
+    policy: &RewardPolicy,
+    counts: &mut ScanCounts,
 ) -> Result<Option<DatasetRecord>, String> {
     let id = execution.execution_id;
     let Some(summary) = store
@@ -450,7 +546,7 @@ fn accepted_record(
     ) {
         return Ok(None);
     }
-    *in_window += 1;
+    counts.in_window += 1;
 
     let journal = store
         .execution_events(id)
@@ -459,6 +555,19 @@ fn accepted_record(
     if !is_accepted(&execution.outcome, &fold, args.require_verdict) {
         return Ok(None);
     }
+
+    // The transcript half of the predicate, checked only for otherwise-
+    // accepted executions: reconstruction reads the whole receipts plane, and
+    // the count the manifest wants is "accepted but unvouched", not "never
+    // eligible anyway".
+    let receipts = store
+        .recorded_calls(id)
+        .map_err(|e| format!("cannot read receipts for execution {id}: {e}"))?;
+    let Some(calls) = verified_transcripts(store, id, &receipts)? else {
+        counts.transcripts_unverified += 1;
+        return Ok(None);
+    };
+    let reward = reward_label(&fold, receipts.len(), summary.cost_usd, policy);
 
     let record = DatasetRecord {
         schema: DATASET_SCHEMA_VERSION,
@@ -473,12 +582,93 @@ fn accepted_record(
         outcome: execution.outcome.clone(),
         cost_usd: summary.cost_usd,
         prompt: summary.prompt,
+        calls,
         tool_calls: fold.tool_calls,
         changes: fold.changes,
         verdict: fold.verdict,
+        reward,
         redacted: false,
     };
     Ok(Some(redact_after_assembly(&record)?))
+}
+
+/// Every recorded call's exact prompt transcript, digest-verified — or `None`
+/// when this execution cannot vouch for its own: it recorded no model call at
+/// all, or some call's reconstruction fell short of
+/// [`stella_store::Reconstruction::is_verified`]. `None` is an exclusion the
+/// manifest counts, never a silent downgrade to an unverified transcript.
+fn verified_transcripts(
+    store: &Store,
+    execution_id: i64,
+    receipts: &[RecordedCall],
+) -> Result<Option<Vec<DatasetCall>>, String> {
+    if receipts.is_empty() {
+        return Ok(None);
+    }
+    let mut calls = Vec::with_capacity(receipts.len());
+    for receipt in receipts {
+        let reconstruction = store
+            .reconstruct_call(
+                execution_id,
+                receipt.turn_instance,
+                receipt.step,
+                receipt.call_seq,
+            )
+            .map_err(|e| {
+                format!(
+                    "cannot reconstruct execution {execution_id} turn {} step {} call {}: {e}",
+                    receipt.turn_instance, receipt.step, receipt.call_seq
+                )
+            })?;
+        if !reconstruction.is_verified() {
+            return Ok(None);
+        }
+        let mut prompt_messages = Vec::with_capacity(reconstruction.messages.len());
+        for message in &reconstruction.messages {
+            prompt_messages.push(
+                serde_json::to_value(message)
+                    .map_err(|e| format!("cannot serialize a reconstructed message: {e}"))?,
+            );
+        }
+        calls.push(DatasetCall {
+            turn_instance: receipt.turn_instance,
+            step: receipt.step,
+            call_seq: receipt.call_seq,
+            role: receipt.call_role.clone(),
+            provider: receipt.provider.clone(),
+            model: receipt.model.clone(),
+            prompt_messages,
+        });
+    }
+    Ok(Some(calls))
+}
+
+/// The record's training label, when the journal holds anything to derive one
+/// from.
+///
+/// `None` exactly when no `Verdict` event reached the journal. Everything
+/// else — an abstention, a pre-rung verdict, an invalid policy — labels
+/// through [`stella_pipeline::reward::label`], which marks what it cannot
+/// score rather than dropping it. Steps count every recorded call (every
+/// role, not just the worker's) and revisions the verdicts beyond the
+/// settling one — the same fold `trace.rs` applies, so a dataset label and a
+/// trace label of one execution agree.
+fn reward_label(
+    fold: &JournalFold,
+    steps: usize,
+    cost_usd: f64,
+    policy: &RewardPolicy,
+) -> Option<RewardLabel> {
+    let settlement = fold.settlement?;
+    Some(label(
+        settlement,
+        TrajectoryCost {
+            steps: u32::try_from(steps).unwrap_or(u32::MAX),
+            cost_usd,
+            revisions: fold.verdicts.saturating_sub(1),
+        },
+        policy,
+    ))
 }
 
 /// Half-open `[since, until)` on the timestamp string. Both bounds are
@@ -495,6 +685,13 @@ struct JournalFold {
     changes: Vec<DatasetChange>,
     verdict: Option<DatasetVerdict>,
     turn_instance: u32,
+    /// The last verdict's [`Settlement`] — the one that settled the turn;
+    /// earlier verdicts are the revision rounds counted below.
+    settlement: Option<Settlement>,
+    /// Verdicts the journal holds. `saturating_sub(1)` is the revision count
+    /// the reward's shaping prices (see [`TrajectoryCost::revisions`] for
+    /// what that over-counts and why the direction is safe).
+    verdicts: u32,
 }
 
 fn fold_journal(events: &[stella_store::SessionEventRecord]) -> JournalFold {
@@ -559,6 +756,10 @@ fn fold_journal(events: &[stella_store::SessionEventRecord]) -> JournalFold {
                     deterministic: evidence.deterministic,
                     summary: evidence.summary.clone(),
                 });
+                // Overwritten on every verdict so the last one wins: that is
+                // the settlement, and the earlier ones are revision rounds.
+                fold.settlement = Some(Settlement::from_evidence(*passed, evidence));
+                fold.verdicts = fold.verdicts.saturating_add(1);
             }
             _ => {}
         }
@@ -772,13 +973,21 @@ fn report(
         filter.executions_in_window,
     );
     println!("  accepted when: {}", filter.acceptance_predicate);
+    if filter.executions_transcripts_unverified > 0 {
+        println!(
+            "  {} otherwise-accepted turn(s) excluded: transcripts not digest-verified",
+            filter.executions_transcripts_unverified
+        );
+    }
     println!("  {}", dataset_path.display().to_string().cyan());
     println!("  {}", manifest_path.display().to_string().cyan());
     if records.is_empty() {
         println!(
             "\nNothing matched. Turns qualify only once they have settled with a \
-             success outcome AND changed a file; a read-only or aborted turn is \
-             recorded but is not a trajectory to distil from."
+             success outcome, changed a file, AND can prove what each model call \
+             saw (every recorded call reconstructing digest-verified); a \
+             read-only, aborted, or unvouched turn is recorded but is not a \
+             trajectory to distil from."
         );
         return;
     }

--- a/crates/stella-cli/src/dataset_cmd/tests.rs
+++ b/crates/stella-cli/src/dataset_cmd/tests.rs
@@ -1,11 +1,16 @@
 //! Unit cover for the dataset fold: the acceptance predicate, the journal
-//! pass, the truncation inference, and the post-assembly redaction.
+//! pass, the reward labelling (#2083), the truncation inference, and the
+//! post-assembly redaction.
 //!
 //! The end-to-end witness — the real binary against a seeded workspace, both
 //! output files, byte-identity — lives in `tests/dataset_export_cli.rs`.
 
 use super::*;
-use stella_protocol::{FileChangeKind, ModelCallRole, ToolCall, ToolOutput, VerdictEvidence};
+use stella_pipeline::reward::DiscardReason;
+use stella_protocol::{
+    FileChangeKind, LadderRung, LadderSnapshot, ModelCallRole, ToolCall, ToolOutput,
+    VerdictEvidence,
+};
 use stella_store::SessionEventRecord;
 
 fn journal(events: Vec<AgentEvent>) -> Vec<SessionEventRecord> {
@@ -191,6 +196,93 @@ fn require_verdict_demands_a_passing_judgement() {
     assert!(acceptance_predicate(true).contains("verdict"));
 }
 
+/// A `Verdict` event whose evidence names a rung — or none, for the
+/// pre-#1043 shape a reader must not guess about.
+fn ladder_verdict(passed: bool, rung: Option<LadderRung>) -> AgentEvent {
+    AgentEvent::Verdict {
+        passed,
+        evidence: VerdictEvidence {
+            summary: "verifier prose that must never reach a label".into(),
+            deterministic: matches!(rung, Some(LadderRung::SubmitFast | LadderRung::Revise)),
+            evidence_refs: Vec::new(),
+            ladder: rung.map(|rung| {
+                Box::new(LadderSnapshot {
+                    rung: Some(rung),
+                    tracked_command: None,
+                    oracle_trace: Vec::new(),
+                    flip_achieved: false,
+                    unstable_flip: false,
+                    flip_refused_different_failure: false,
+                    touched_tests_passed: None,
+                    test_infra: None,
+                    diff_lines: 0,
+                    diff_budget: 0,
+                    diff_available: false,
+                    file_change_events: 0,
+                    mutating_actions: 0,
+                    new_diag_errors: 0,
+                    new_diag_warnings: 0,
+                    witness_intact: None,
+                    witness_mutation: None,
+                    diff_coverage: None,
+                    verifier_independent: None,
+                })
+            }),
+        },
+    }
+}
+
+/// The issue's own table (#2083 ⇢ #1043): a deterministic flip earns +1.0, a
+/// tampered/red-test settlement −1.0, and the policy rides on the label.
+#[test]
+fn a_flip_labels_plus_one_and_a_red_settlement_minus_one() {
+    let policy = RewardPolicy::default();
+
+    let mut events = edit_events();
+    events.push(ladder_verdict(true, Some(LadderRung::SubmitFast)));
+    let flip = fold_journal(&journal(events));
+    let flipped = reward_label(&flip, 1, 0.0, &policy).expect("a settled verdict labels");
+    assert_eq!(flipped.rung, Some(LadderRung::SubmitFast));
+    assert_eq!(flipped.outcome, Some(1.0));
+    assert!(flipped.is_scored());
+
+    let mut events = edit_events();
+    events.push(ladder_verdict(false, Some(LadderRung::Revise)));
+    let red = fold_journal(&journal(events));
+    let labelled = reward_label(&red, 1, 0.0, &policy).expect("a settled verdict labels");
+    assert_eq!(labelled.rung, Some(LadderRung::Revise));
+    assert_eq!(labelled.outcome, Some(-1.0));
+    assert_eq!(labelled.policy, policy, "the policy travels with the label");
+}
+
+/// No verdict, no label: `null` states "nothing to derive from" rather than
+/// synthesizing a discard under a policy the run never saw.
+#[test]
+fn a_journal_with_no_verdict_earns_no_label() {
+    let fold = fold_journal(&journal(edit_events()));
+    assert_eq!(reward_label(&fold, 1, 0.0, &RewardPolicy::default()), None);
+}
+
+/// The last verdict settles, earlier ones are revision rounds, and a
+/// rung-less verdict is marked unknown rather than guessed at.
+#[test]
+fn the_last_verdict_settles_and_a_rungless_one_is_marked_not_guessed() {
+    let mut events = edit_events();
+    events.push(ladder_verdict(false, Some(LadderRung::Revise)));
+    events.push(ladder_verdict(true, Some(LadderRung::SubmitFast)));
+    let fold = fold_journal(&journal(events));
+    let labelled = reward_label(&fold, 2, 0.0, &RewardPolicy::default()).expect("settled");
+    assert_eq!(labelled.rung, Some(LadderRung::SubmitFast));
+    assert_eq!(labelled.cost.revisions, 1);
+
+    let mut events = edit_events();
+    events.push(ladder_verdict(true, None));
+    let fold = fold_journal(&journal(events));
+    let unknown = reward_label(&fold, 1, 0.0, &RewardPolicy::default()).expect("still a record");
+    assert_eq!(unknown.reward, None);
+    assert_eq!(unknown.discard, Some(DiscardReason::RungUnknown));
+}
+
 /// The half-open window, on the timestamp form SQLite actually writes.
 #[test]
 fn the_date_window_is_half_open_and_accepts_a_bare_date() {
@@ -238,6 +330,18 @@ fn redaction_runs_after_assembly_over_every_string_leaf() {
         outcome: "completed".into(),
         cost_usd: 0.01,
         prompt: "rotate ghp_0123456789abcdef0123456789abcdef012345".into(),
+        calls: vec![DatasetCall {
+            turn_instance: 0,
+            step: 0,
+            call_seq: 0,
+            role: "worker".into(),
+            provider: "zai".into(),
+            model: "glm-5.2".into(),
+            prompt_messages: vec![serde_json::json!({
+                "role": "user",
+                "content": "deploy with AKIAIOSFODNN7EXAMPLE",
+            })],
+        }],
         tool_calls: vec![DatasetToolCall {
             seq: 1,
             turn_instance: 0,
@@ -250,6 +354,7 @@ fn redaction_runs_after_assembly_over_every_string_leaf() {
         }],
         changes: Vec::new(),
         verdict: None,
+        reward: None,
         redacted: false,
     };
 
@@ -273,8 +378,16 @@ fn redaction_runs_after_assembly_over_every_string_leaf() {
     // Serializing the STRUCT (not the intermediate Value) pins the key order
     // to the declaration order, whatever `serde_json::Map` happens to be.
     assert!(
-        line.starts_with(r#"{"schema":1,"execution_id":1,"session_id":"ses-fixture""#),
+        line.starts_with(r#"{"schema":2,"execution_id":1,"session_id":"ses-fixture""#),
         "declaration order is the wire order: {line}"
+    );
+    // The transcript is a string leaf like any other: the key planted in
+    // `prompt_messages` is gone too, because redaction runs over the whole
+    // assembled tree rather than field-by-field.
+    let messages = serde_json::to_string(&redacted.calls[0].prompt_messages).expect("serialize");
+    assert!(
+        !messages.contains("AKIAIOSFODNN7EXAMPLE") && messages.contains(PLACEHOLDER),
+        "a secret inside a reconstructed message survived: {messages}"
     );
 }
 
@@ -295,9 +408,11 @@ fn a_clean_record_is_not_reported_as_redacted() {
         outcome: "completed".into(),
         cost_usd: 0.0,
         prompt: "fix the failing test".into(),
+        calls: Vec::new(),
         tool_calls: Vec::new(),
         changes: Vec::new(),
         verdict: None,
+        reward: None,
         redacted: false,
     };
     assert!(!redact_after_assembly(&record).expect("redact").redacted);

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -305,7 +305,10 @@ fn seeded_workspace() -> (tempfile::TempDir, i64, i64) {
     store
         .record_step_manifest(
             tampered,
-            &worker_manifest(vec![manifest_entry("blk_sys", 0), manifest_entry("blk_goal", 1)]),
+            &worker_manifest(vec![
+                manifest_entry("blk_sys", 0),
+                manifest_entry("blk_goal", 1),
+            ]),
         )
         .expect("manifest");
     store

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -551,7 +551,7 @@ fn the_date_window_and_require_verdict_are_reported_as_applied() {
     let manifest: serde_json::Value =
         serde_json::from_slice(&read(dir.path(), "future", "manifest.json")).expect("json");
     assert_eq!(manifest["records"], 0);
-    assert_eq!(manifest["filter"]["executions_scanned"], 2);
+    assert_eq!(manifest["filter"]["executions_scanned"], 4);
     assert_eq!(manifest["filter"]["executions_in_window"], 0);
     assert_eq!(manifest["filter"]["since"], "2099-01-01");
     assert_eq!(manifest["execution_id_range"], serde_json::Value::Null);
@@ -563,7 +563,10 @@ fn the_date_window_and_require_verdict_are_reported_as_applied() {
     export(&dir, "judged", &["--require-verdict"]);
     let manifest: serde_json::Value =
         serde_json::from_slice(&read(dir.path(), "judged", "manifest.json")).expect("json");
-    assert_eq!(manifest["records"], 1, "the fixture's verdict passed");
+    assert_eq!(
+        manifest["records"], 1,
+        "only the flip's PASSING verdict qualifies — the tampered turn's failed one does not"
+    );
     assert!(
         manifest["filter"]["acceptance_predicate"]
             .as_str()

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -1,19 +1,23 @@
-//! End-to-end witness for `stella dataset export` (#872): drive the real
-//! binary against a seeded workspace and check the four things the issue
-//! actually asks for — the two files, the redaction of a planted key in both
-//! a prompt and a tool argument, the provenance stamp, and byte-identity
-//! across runs.
+//! End-to-end witness for `stella dataset export` (#872, extended by #2083):
+//! drive the real binary against a seeded workspace and check what the issues
+//! actually ask for — the two files, the redaction of a planted key in a
+//! prompt, a tool argument, AND a reconstructed transcript, the provenance
+//! stamp, the reward labels with their policy, the transcript-verification
+//! gate with its manifest count, and byte-identity across runs.
 //!
 //! Every assertion here fails on the pre-#872 tree, where the subcommand does
-//! not parse at all (clap exits 2 with "unrecognized subcommand").
+//! not parse at all (clap exits 2 with "unrecognized subcommand"); the #2083
+//! assertions fail on the pre-#2083 tree, where records carry no `calls` or
+//! `reward` and the unvouched execution is exported instead of counted.
 
 use std::path::Path;
 use std::process::Command;
 
 use stella_protocol::{
-    AgentEvent, FileChangeKind, ModelCallRole, ToolCall, ToolOutput, VerdictEvidence,
+    AgentEvent, FileChangeKind, LadderRung, LadderSnapshot, ModelCallRole, ToolCall, ToolOutput,
+    VerdictEvidence,
 };
-use stella_store::Store;
+use stella_store::{ContextBlockRow, ManifestBlockRow, StepManifestRow, Store};
 
 /// A GitHub PAT shape planted in the user's prompt.
 const PROMPT_SECRET: &str = "ghp_016C7e4a9b2d3f5081726354ABCDabcd1234";
@@ -21,24 +25,153 @@ const PROMPT_SECRET: &str = "ghp_016C7e4a9b2d3f5081726354ABCDabcd1234";
 /// alone would not cover.
 const ARG_SECRET: &str = "AKIAIOSFODNN7EXAMPLE";
 
-/// A workspace whose store holds one ACCEPTED turn (settled `completed`, with
-/// a mutating file change) and one rejected one (`aborted`), so the filter has
-/// something to exclude as well as something to keep.
-fn seeded_workspace() -> (tempfile::TempDir, i64) {
+/// `sha256:<hex>` over `content` — the digest form the receipts plane records
+/// and reconstruction re-checks.
+fn digest(content: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let hex: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    format!("sha256:{hex}")
+}
+
+/// A block whose content the receipt carries locally (system prefix, goal).
+fn gap_block(block_id: &str, kind: &str, content: &str) -> ContextBlockRow {
+    ContextBlockRow {
+        block_id: block_id.into(),
+        kind: kind.into(),
+        origin_turn: 0,
+        origin_step: 0,
+        call_id: None,
+        memory_id: None,
+        token_cost: Some(10),
+        content_digest: digest(content),
+        citation_label: None,
+        content: Some(content.into()),
+    }
+}
+
+/// A block that resolves from the journal by `call_id` and must re-hash to
+/// its recorded digest.
+fn journal_block(block_id: &str, kind: &str, call_id: &str, content: &str) -> ContextBlockRow {
+    ContextBlockRow {
+        block_id: block_id.into(),
+        kind: kind.into(),
+        origin_turn: 0,
+        origin_step: 0,
+        call_id: Some(call_id.into()),
+        memory_id: None,
+        token_cost: Some(10),
+        content_digest: digest(content),
+        citation_label: None,
+        content: None,
+    }
+}
+
+fn manifest_entry(block_id: &str, message_index: u64) -> ManifestBlockRow {
+    ManifestBlockRow {
+        block_id: block_id.into(),
+        cache_zone: "cacheable".into(),
+        token_cost: Some(10),
+        resident_since_step: 0,
+        message_index,
+        call_id: None,
+    }
+}
+
+/// The worker call's receipt at (turn 0, step 0, call_seq 0).
+fn worker_manifest(blocks: Vec<ManifestBlockRow>) -> StepManifestRow {
+    StepManifestRow {
+        turn_instance: 0,
+        step: 0,
+        call_seq: 0,
+        provider: "zai".into(),
+        model: "glm-5.2".into(),
+        call_role: "worker".into(),
+        effective_budget_tokens: 1000,
+        calibration_factor: 1.0,
+        estimated_input_tokens: 40,
+        compiled_frame_id: None,
+        frame_hash: None,
+        blocks,
+    }
+}
+
+/// Ladder evidence naming the rung a verdict settled on — what the reward
+/// label is derived from (#1043).
+fn ladder(rung: LadderRung) -> Option<Box<LadderSnapshot>> {
+    Some(Box::new(LadderSnapshot {
+        rung: Some(rung),
+        tracked_command: None,
+        oracle_trace: Vec::new(),
+        flip_achieved: matches!(rung, LadderRung::SubmitFast),
+        unstable_flip: false,
+        flip_refused_different_failure: false,
+        touched_tests_passed: None,
+        test_infra: None,
+        diff_lines: 2,
+        diff_budget: 100,
+        diff_available: true,
+        file_change_events: 1,
+        mutating_actions: 1,
+        new_diag_errors: 0,
+        new_diag_warnings: 0,
+        witness_intact: None,
+        witness_mutation: None,
+        diff_coverage: None,
+        verifier_independent: None,
+    }))
+}
+
+/// A workspace whose store holds four settled executions, one per filter arm:
+///
+/// - `flipped`: accepted — `completed`, a mutating change, a digest-verified
+///   worker transcript, and a `SubmitFast` verdict (the deterministic flip,
+///   reward outcome +1.0);
+/// - `tampered`: accepted — same shape, but the verdict settled `Revise`
+///   with `passed: false` (the tampered/red-test arm, reward outcome −1.0);
+/// - one `aborted` turn, excluded by outcome;
+/// - one `completed` turn whose only receipt cites a block with no journal
+///   preimage, so its reconstruction cannot verify: excluded by the
+///   transcript gate and counted in the manifest.
+///
+/// A project-scope `.stella/settings.json` pins the default reward weights
+/// explicitly, so the labels asserted below cannot drift with whatever the
+/// developer's user-scope settings say.
+fn seeded_workspace() -> (tempfile::TempDir, i64, i64) {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
+    std::fs::write(
+        dir.path().join(".stella").join("settings.json"),
+        r#"{"reward":{"deterministic_weight":1.0,"verifier_weight":0.5,"per_step":0.02,"per_usd":0.5,"per_revision":0.1}}"#,
+    )
+    .expect("settings");
 
-    let accepted = store
-        .begin_execution(
-            "run",
-            &format!("rotate the deploy key {PROMPT_SECRET}"),
-            "zai",
-            "glm-5.2",
-        )
+    let prompt = format!("rotate the deploy key {PROMPT_SECRET}");
+    let flipped = store
+        .begin_execution("run", &prompt, "zai", "glm-5.2")
         .expect("execution");
     store
-        .set_execution_session(accepted, "ses-fixture")
+        .set_execution_session(flipped, "ses-fixture")
         .expect("session");
+
+    let call = ToolCall {
+        call_id: "c1".into(),
+        name: "edit".into(),
+        input: serde_json::json!({
+            "path": "src/lib.rs",
+            "new_string": format!("const KEY: &str = \"{ARG_SECRET}\";"),
+        }),
+    };
+    let output = ToolOutput::Ok {
+        content: "edited src/lib.rs".into(),
+    };
+    let call_json = serde_json::to_string(&call).expect("call json");
+    let output_json = serde_json::to_string(&output).expect("output json");
 
     let events = [
         AgentEvent::StepManifest {
@@ -54,21 +187,10 @@ fn seeded_workspace() -> (tempfile::TempDir, i64) {
             estimated_input_tokens: 10,
             compiled_frame: None,
         },
-        AgentEvent::ToolStart {
-            call: ToolCall {
-                call_id: "c1".into(),
-                name: "edit".into(),
-                input: serde_json::json!({
-                    "path": "src/lib.rs",
-                    "new_string": format!("const KEY: &str = \"{ARG_SECRET}\";"),
-                }),
-            },
-        },
+        AgentEvent::ToolStart { call: call.clone() },
         AgentEvent::ToolResult {
             call_id: "c1".into(),
-            output: ToolOutput::Ok {
-                content: "edited src/lib.rs".into(),
-            },
+            output: output.clone(),
             duration_ms: 5,
             speculated: false,
         },
@@ -85,17 +207,41 @@ fn seeded_workspace() -> (tempfile::TempDir, i64) {
                 summary: "the touched tests are green".into(),
                 deterministic: true,
                 evidence_refs: Vec::new(),
-                ladder: None,
+                ladder: ladder(LadderRung::SubmitFast),
             },
         },
     ];
     for (seq, event) in events.iter().enumerate() {
         store
-            .record_event(accepted, seq as u64, event)
+            .record_event(flipped, seq as u64, event)
             .expect("event");
     }
+    // The receipt: what the worker call saw, digest-verified on reconstruction.
+    // The tool round-trip resolves from the journal events above; the system
+    // prefix and goal carry their content locally, like real gap blocks.
+    for block in [
+        gap_block("blk_sys", "system_prefix", "you are a careful engineer"),
+        gap_block("blk_goal", "user_goal", &prompt),
+        journal_block("blk_call", "tool_call", "c1", &call_json),
+        journal_block("blk_res", "tool_result", "c1", &output_json),
+    ] {
+        store
+            .record_context_block(flipped, &block)
+            .expect("context block");
+    }
     store
-        .finish_execution(accepted, "completed", 0.01)
+        .record_step_manifest(
+            flipped,
+            &worker_manifest(vec![
+                manifest_entry("blk_sys", 0),
+                manifest_entry("blk_goal", 1),
+                manifest_entry("blk_call", 2),
+                manifest_entry("blk_res", 3),
+            ]),
+        )
+        .expect("manifest");
+    store
+        .finish_execution(flipped, "completed", 0.01)
         .expect("finish");
 
     // A turn that changed a file but did not land: settled, and excluded.
@@ -119,7 +265,95 @@ fn seeded_workspace() -> (tempfile::TempDir, i64) {
         .finish_execution(rejected, "aborted", 0.02)
         .expect("finish");
 
-    (dir, accepted)
+    // A settled success whose witness was tampered with: the ladder refused
+    // the flip and settled Revise/failed. Accepted by the outcome-and-change
+    // predicate, exported, and labelled −1.0.
+    let tampered = store
+        .begin_execution("run", "make the witness pass", "zai", "glm-5.2")
+        .expect("execution");
+    let tampered_events = [
+        AgentEvent::FileChange {
+            path: "tests/witness.rs".into(),
+            kind: FileChangeKind::Modified,
+            added: 2,
+            removed: 0,
+            diff: None,
+        },
+        AgentEvent::Verdict {
+            passed: false,
+            evidence: VerdictEvidence {
+                summary: "the worker modified the witness files".into(),
+                deterministic: true,
+                evidence_refs: Vec::new(),
+                ladder: ladder(LadderRung::Revise),
+            },
+        },
+    ];
+    for (seq, event) in tampered_events.iter().enumerate() {
+        store
+            .record_event(tampered, seq as u64, event)
+            .expect("event");
+    }
+    for block in [
+        gap_block("blk_sys", "system_prefix", "you are a careful engineer"),
+        gap_block("blk_goal", "user_goal", "make the witness pass"),
+    ] {
+        store
+            .record_context_block(tampered, &block)
+            .expect("context block");
+    }
+    store
+        .record_step_manifest(
+            tampered,
+            &worker_manifest(vec![manifest_entry("blk_sys", 0), manifest_entry("blk_goal", 1)]),
+        )
+        .expect("manifest");
+    store
+        .finish_execution(tampered, "completed", 0.02)
+        .expect("finish");
+
+    // A settled success whose only receipt cites a tool result with no
+    // journal preimage: reconstruction reports it unresolved, so the
+    // execution cannot vouch for what its model saw. Absent from the
+    // dataset, counted in the manifest.
+    let unvouched = store
+        .begin_execution("run", "an unprovable transcript", "zai", "glm-5.2")
+        .expect("execution");
+    store
+        .record_event(
+            unvouched,
+            0,
+            &AgentEvent::FileChange {
+                path: "src/lib.rs".into(),
+                kind: FileChangeKind::Modified,
+                added: 1,
+                removed: 0,
+                diff: None,
+            },
+        )
+        .expect("event");
+    store
+        .record_context_block(
+            unvouched,
+            &journal_block(
+                "blk_orphan",
+                "tool_result",
+                "missing",
+                "{\"ok\":{\"content\":\"x\"}}",
+            ),
+        )
+        .expect("context block");
+    store
+        .record_step_manifest(
+            unvouched,
+            &worker_manifest(vec![manifest_entry("blk_orphan", 0)]),
+        )
+        .expect("manifest");
+    store
+        .finish_execution(unvouched, "completed", 0.01)
+        .expect("finish");
+
+    (dir, flipped, tampered)
 }
 
 fn export(dir: &tempfile::TempDir, out: &str, extra: &[&str]) -> String {
@@ -149,26 +383,28 @@ fn read(dir: &Path, out: &str, file: &str) -> Vec<u8> {
     std::fs::read(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 
-/// The acceptance shape of #872: two files, one record per accepted turn, the
-/// full provenance stamp, and the trajectory the issue describes.
+/// The acceptance shape of #872 + #2083: two files, one record per accepted
+/// turn, the full provenance stamp, the trajectory, the verified transcript,
+/// and the reward labels the issues describe.
 #[test]
 fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
-    let (dir, accepted) = seeded_workspace();
+    let (dir, flipped, tampered) = seeded_workspace();
     let summary = export(&dir, "out", &[]);
     assert!(
-        summary.contains("1 accepted turn(s) from 2 settled execution(s)"),
+        summary.contains("2 accepted turn(s) from 4 settled execution(s)"),
         "the summary reports what it kept and what it read: {summary}"
     );
 
     let jsonl = String::from_utf8(read(dir.path(), "out", "dataset.jsonl")).expect("utf8");
     assert_eq!(
         jsonl.lines().count(),
-        1,
-        "the aborted execution is excluded: {jsonl}"
+        2,
+        "the aborted and the unvouched executions are excluded: {jsonl}"
     );
-    let record: serde_json::Value = serde_json::from_str(jsonl.lines().next().unwrap()).unwrap();
+    let mut lines = jsonl.lines();
+    let record: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
 
-    assert_eq!(record["execution_id"], accepted);
+    assert_eq!(record["execution_id"], flipped);
     assert_eq!(record["session_id"], "ses-fixture");
     assert!(
         record["repo"].as_str().is_some_and(|r| !r.is_empty()),
@@ -194,21 +430,64 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
     assert_eq!(record["verdict"]["passed"], true);
     assert_eq!(record["verdict"]["deterministic"], true);
 
-    // The manifest states the rule that produced the selection.
+    // #2083: the verified transcript. One worker call, non-empty
+    // prompt_messages, and the exact message sequence the receipt recorded —
+    // with the planted prompt secret redacted inside it.
+    assert_eq!(record["calls"].as_array().map(Vec::len), Some(1));
+    let call = &record["calls"][0];
+    assert_eq!(call["role"], "worker");
+    assert_eq!(call["turn_instance"], 0);
+    assert_eq!(call["call_seq"], 0);
+    let messages = call["prompt_messages"].as_array().expect("messages");
+    assert_eq!(messages.len(), 4, "system, goal, tool call, tool result");
+    assert_eq!(messages[0]["role"], "system");
+    assert_eq!(messages[1]["role"], "user");
+    let goal = messages[1]["content"].as_str().expect("goal content");
+    assert!(
+        goal.starts_with("rotate the deploy key") && goal.contains("[redacted]"),
+        "the transcript is the reconstructed goal, secret-redacted: {goal}"
+    );
+
+    // #2083: the reward label — the deterministic flip earns +1.0, and the
+    // policy it was computed under rides on the label.
+    assert_eq!(record["reward"]["rung"], "submit_fast");
+    assert_eq!(record["reward"]["outcome"], 1.0);
+    assert_eq!(record["reward"]["policy"]["outcome"]["deterministic"], 1.0);
+    let reward = record["reward"]["reward"].as_f64().expect("scored");
+    // outcome 1.0 − 0.02·1 step − 0.5·$0.01 − 0 revisions.
+    assert!(
+        (reward - 0.975).abs() < 1e-9,
+        "the composite reward prices the effort: {reward}"
+    );
+
+    // The tampered-witness turn is the second record: same acceptance, the
+    // negative label.
+    let negative: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+    assert_eq!(negative["execution_id"], tampered);
+    assert_eq!(negative["reward"]["rung"], "revise");
+    assert_eq!(negative["reward"]["outcome"], -1.0);
+    assert_eq!(negative["verdict"]["passed"], false);
+
+    // The manifest states the rule that produced the selection — including
+    // the transcript gate — and counts what that gate excluded.
     let manifest: serde_json::Value =
         serde_json::from_slice(&read(dir.path(), "out", "manifest.json")).expect("manifest json");
-    assert_eq!(manifest["records"], 1);
-    assert_eq!(manifest["filter"]["executions_scanned"], 2);
-    assert_eq!(manifest["filter"]["executions_accepted"], 1);
+    assert_eq!(manifest["records"], 2);
+    assert_eq!(manifest["filter"]["executions_scanned"], 4);
+    assert_eq!(manifest["filter"]["executions_transcripts_unverified"], 1);
+    assert_eq!(manifest["filter"]["executions_accepted"], 2);
     assert_eq!(
         manifest["filter"]["acceptance_predicate"],
-        "executions.outcome in {completed, goal_met} AND at least one mutating file_change event"
+        "executions.outcome in {completed, goal_met} AND at least one mutating \
+         file_change event AND at least one recorded model call, every one \
+         reconstructing digest-verified (Reconstruction::is_verified)"
     );
     assert_eq!(
         manifest["redaction"]["function"],
         "stella_core::redact::redact_secrets"
     );
-    assert_eq!(manifest["execution_id_range"][0], accepted);
+    assert_eq!(manifest["execution_id_range"][0], flipped);
+    assert_eq!(manifest["execution_id_range"][1], tampered);
 }
 
 /// The redaction criterion, stated exactly as #872 states it: a synthetic API
@@ -217,7 +496,7 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
 /// detail can hide a leak.
 #[test]
 fn a_planted_key_in_the_prompt_or_a_tool_argument_never_reaches_the_output() {
-    let (dir, _) = seeded_workspace();
+    let (dir, _, _) = seeded_workspace();
     export(&dir, "out", &[]);
 
     for file in ["dataset.jsonl", "manifest.json"] {
@@ -249,7 +528,7 @@ fn a_planted_key_in_the_prompt_or_a_tool_argument_never_reaches_the_output() {
 /// files. Run twice into different directories and compare the bytes.
 #[test]
 fn the_same_store_and_filter_export_byte_identical_files() {
-    let (dir, _) = seeded_workspace();
+    let (dir, _, _) = seeded_workspace();
     export(&dir, "first", &[]);
     export(&dir, "second", &[]);
 
@@ -266,7 +545,7 @@ fn the_same_store_and_filter_export_byte_identical_files() {
 /// rule rather than the default one.
 #[test]
 fn the_date_window_and_require_verdict_are_reported_as_applied() {
-    let (dir, _) = seeded_workspace();
+    let (dir, _, _) = seeded_workspace();
 
     export(&dir, "future", &["--since", "2099-01-01"]);
     let manifest: serde_json::Value =
@@ -301,7 +580,7 @@ fn the_date_window_and_require_verdict_are_reported_as_applied() {
 fn the_dataset_and_its_directory_are_owner_only() {
     use std::os::unix::fs::PermissionsExt;
 
-    let (dir, _) = seeded_workspace();
+    let (dir, _, _) = seeded_workspace();
     export(&dir, "out", &[]);
 
     let out = dir.path().join("out");


### PR DESCRIPTION
## What & why

`stella dataset export` (#872) predated two things that now exist, and its own header comment still claimed no reward mapping exists in tree. This PR closes both gaps (schema v2):

- **Reward labels.** Each record carries `reward: Option<RewardLabel>` folded from the journal's settled verdict via `stella_pipeline::reward` (#1043) — flip = +1.0, red/tampered settlement = −1.0, model verdict = ±0.5, abstentions marked as discards — under the workspace's resolved `RewardPolicy` (`Settings::reward_policy()`, the same resolution trace capture uses), with the policy stamped on every label. `null` exactly when the journal holds no verdict at all: there is no proof/ladder evidence to derive from, and synthesizing a discard under a policy the run never saw would claim more than the store knows. The raw verdict stays beside the label so a reader can re-derive under other weights.
- **Verified prompt transcripts.** Each record carries `calls: Vec<DatasetCall>` — every recorded model call with its exact `prompt_messages` rebuilt by `Store::reconstruct_call` (the same source `trace.rs` uses "so SFT pairs need no other source"), admitted only when the reconstruction digest-verifies (`Reconstruction::is_verified`). Transcripts pass through `redact_secrets` with the rest of the record, because redaction runs AFTER assembly over the whole tree (the existing writer contract — no new field can route around it).
- **The gate is named and counted.** An execution that cannot vouch for its transcripts — no recorded call, or any call unverified — is excluded under the default filter and counted in `manifest.json` (`filter.executions_transcripts_unverified`); the tightened acceptance predicate is stated verbatim in the manifest, same named-predicate discipline as before.
- `DATASET_SCHEMA_VERSION` 1 → 2; the stale header comment ("nothing in the tree maps a ladder decision to a reward scalar yet") is corrected.
- Determinism preserved: nothing new reads a clock; reconstruction and labelling are pure folds over the store, and the byte-identity test still passes over the richer records.

Phase 0 of doc:self-driving-foundry.

Closes #2083
Refs #2081, #872, #1043, #1046

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Checked the artisanal way: with `origin/main`'s `dataset_cmd.rs` restored under the new integration tests, `export_writes_one_record_per_accepted_turn_with_its_provenance` fails with `3 accepted turn(s) from 4 settled execution(s)` — main exports the unvouched execution instead of excluding and counting it, emits the old predicate string, and its records carry no `calls`/`reward` (assertions read `null`). The unit-test witnesses (`a_flip_labels_plus_one_and_a_red_settlement_minus_one`, `a_journal_with_no_verdict_earns_no_label`, `the_last_verdict_settles_and_a_rungless_one_is_marked_not_guessed`) fail to **compile** on main because `reward_label`, `DatasetCall`, and the fold's `settlement` do not exist — a valid witness for an additive schema change; the behavioral halves (negative label on the tampered/`Revise` settlement, exclusion counting, `--require-verdict` rejecting the failed verdict) are genuine runtime assertions in `dataset_export_cli.rs`.

The integration fixture pins the reward weights in project-scope `.stella/settings.json` so the asserted labels cannot drift with a developer's user-scope `reward` block (the project scope wins per-field, and the reward section is honored from an untrusted project scope by design — `settings/merge.rs`).

## The gate

- [x] `cargo fmt --check` (via `cargo fmt -p stella-cli`; clean)
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` (clean; workspace clippy left to CI per the no-heavy-local-builds operating rule)
- [x] `cargo test -p stella-cli --bin stella dataset_cmd` (13 passed) and `cargo test -p stella-cli --test dataset_export_cli` (5 passed); `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps` clean. The full workspace suite is CI's to prove.
- [x] Docs updated where behavior changed (module header, schema-version doc, predicate/manifest docs, summary output)
- [x] CLA signed
- [x] `Closes #2083` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2123 — the logical next step this PR's wording implies: a non-default, explicitly-marked path for executions that cannot prove their transcripts (a pre-receipts store now exports zero records by design; the manifest counts them but nothing can export them).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — `stella-pipeline`, `stella-store`, and `sha2` were already dependencies of `stella-cli` (trace.rs consumes `stella_pipeline::reward` the same way)
- [x] No new outbound network calls
- [x] No new cross-boundary types: `RewardLabel`/`RewardPolicy` are existing serde-derived `stella-pipeline` types, and every export round-trips them through `redact_after_assembly` (serialize → redact → deserialize) on the write path itself

## Anything reviewers should know?

- Exemplar for the shape: the exporter now mirrors `trace.rs`'s discipline exactly — same `Settlement::from_evidence` fold, same steps/revisions accounting, same reconstruct-then-redact order — so a dataset label and a trace label of one execution agree by construction.
- `stella dataset export` now loads settings (for the reward policy), so a malformed settings file fails the export with a named error where it previously read no settings at all. That matches the reward module's stated posture: refused, not clamped — a bad weight must not silently mislabel training data.
- The transcript gate is deliberately checked only for otherwise-accepted executions, so the manifest's count means "accepted but unvouched", not "never eligible anyway".

## Summary by Sourcery

Extend `stella dataset export` to embed verified model call transcripts and reward labels in exported records, tighten the default acceptance filter to exclude executions with unverified transcripts while counting them in the manifest, and bump the dataset schema version accordingly.

New Features:
- Include per-call reconstructed and digest-verified model prompt transcripts in dataset export records.
- Attach per-execution reward labels derived from settled verdicts under the workspace’s resolved reward policy to each dataset record.

Enhancements:
- Update the dataset schema version and documentation to describe the new reward and transcript fields and stricter acceptance predicate.
- Load and apply workspace settings to resolve the reward policy for consistent labelling between traces and exports.

Tests:
- Expand end-to-end dataset export tests to cover verified transcripts, reward labelling, manifest accounting for excluded executions, and deterministic output.
- Add unit tests for reward label derivation, verdict settlement handling, rungless verdict discard tagging, and redaction over reconstructed transcripts.