### PR TITLE
fix(stella-cli): void any measurement whose producing command errored

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -57,6 +57,23 @@ macro_rules! scope_discipline {
     };
 }
 
+/// The evidence contract shared by both static prompts: a number produced by
+/// a command chain that errored is not a measurement. Born from a real TB2.1
+/// bench trace (`git-multibranch`, #1957): a timing read came back EMPTY
+/// because `bc` was not installed (`bc: command not found` on stderr) and the
+/// worker concluded "well under 3 seconds" anyway; a probe printed
+/// `archive+extract time: 70 ms` over a stderr carrying `fatal: detected
+/// dubious ownership` then `tar: This does not look like a tar archive` —
+/// 70 ms was the time to FAIL, cited as proof the hook is fast. Both slipped
+/// through because the compound command exited 0. One shared literal,
+/// embedded verbatim by both prompts, same as `tool_steering!` and for the
+/// same anti-drift reason (#450).
+macro_rules! measurement_discipline {
+    () => {
+        r#"Measurements: a number you cite as evidence is VOID if any command in the chain that produced it reported an error — a `command not found`, a `fatal:`, an empty capture, a failure on stderr — even when the overall exit code is 0 (a pipeline's exit code is its last command's, and a failed command substitution does not propagate). An errored probe measured the time to fail, not the thing you named. Fix the error and re-measure, or report the quantity as unmeasured; never cite the number."#
+    };
+}
+
 pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"You are Stella, a fast terminal coding agent. You help the user with software engineering tasks by reading files, writing code, running commands, and searching the codebase.
 
@@ -66,6 +83,10 @@ pub(crate) const SYSTEM_PROMPT: &str = concat!(
 
 "#,
     scope_discipline!(),
+    r#"
+
+"#,
+    measurement_discipline!(),
     r#"
 
 Rules:
@@ -90,6 +111,10 @@ pub(crate) const PIPELINE_SYSTEM_PROMPT: &str = concat!(
 
 "#,
     scope_discipline!(),
+    r#"
+
+"#,
+    measurement_discipline!(),
     r#"
 
 Methodology (always follow in order):
@@ -544,6 +569,32 @@ mod tests {
             assert!(
                 prompt.contains(shared),
                 "{label} does not embed the shared scope-discipline block verbatim"
+            );
+        }
+    }
+
+    /// Witness for the voided-measurement defect (#1957): in a TB2.1
+    /// `git-multibranch` run the worker twice accepted a broken measurement
+    /// because the compound command exited 0 — a timing read that came back
+    /// empty (`bc: command not found` on stderr) became "well under 3
+    /// seconds", and a probe's `archive+extract time: 70 ms` was cited as
+    /// proof a hook is fast while its stderr carried `fatal: detected
+    /// dubious ownership` then `tar: This does not look like a tar archive`,
+    /// so 70 ms was the time to fail. Neither prompt said a word about
+    /// invalidating such evidence; pin the shared literal verbatim in both,
+    /// plus its "unmeasured" escape hatch so the assertion cannot pass
+    /// vacuously against an emptied literal.
+    #[test]
+    fn both_prompts_void_measurements_whose_producing_command_errored() {
+        let shared = measurement_discipline!();
+        assert!(
+            shared.contains("unmeasured"),
+            "the shared literal must offer the honest alternative to citing a broken number"
+        );
+        for (label, prompt) in PROMPTS {
+            assert!(
+                prompt.contains(shared),
+                "{label} does not embed the shared measurement-discipline block verbatim"
             );
         }
     }


### PR DESCRIPTION
## What & why

In the TB2.1 `git-multibranch` trace behind #1957, the worker twice accepted a broken measurement as evidence because the compound command exited 0: a timing read that came back empty (`bc: command not found` on stderr) became "well under 3 seconds", and a probe's `archive+extract time: 70 ms` was cited as proof a hook is fast while its stderr carried `fatal: detected dubious ownership` then `tar: This does not look like a tar archive` — 70 ms was the time to fail. Both violate "correctness is demonstrated or it is not claimed", and neither static prompt said a word about invalidating such evidence.

This adds a third shared-literal block, `measurement_discipline!`, to `crates/stella-cli/src/agent/prompt.rs`: a cited number is VOID if any command in the producing chain reported an error — even at overall exit 0, since a pipeline's exit code is its last command's and a failed command substitution does not propagate — and the honest moves are re-measure or report the quantity as unmeasured. It is embedded verbatim in both `SYSTEM_PROMPT` and `PIPELINE_SYSTEM_PROMPT` through the existing `concat!` chains, exactly as `tool_steering!` and `scope_discipline!` are: a macro rather than a `const` because `concat!` takes only literals, and compile-time concatenation preserves the byte-stable prompt-cache prefix (L-E8). One shared literal is the same anti-drift choice those two blocks made (#450), following the pattern PR #1955 established.

Closes #1957
Refs #450, #1955

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`both_prompts_void_measurements_whose_producing_command_errored` pins the shared literal verbatim in both prompts via the module's `PROMPTS` array, same shape as `both_prompts_scope_delivery_to_the_prompt_actually_sent`. On `main` it fails at compile time — `measurement_discipline!` does not exist there — which is a valid witness for an additive prompt block; and the test additionally asserts the distinctive substring `"unmeasured"` is inside the shared literal itself, so it cannot pass vacuously against an emptied literal.

## The gate

- [x] `cargo fmt` (via `cargo fmt -p stella-cli`)
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli --bin stella agent::prompt::tests` — 7 passed (all four shared-literal/steering guards plus the two memory-suppression witnesses)
- [x] Docs: the macro's doc comment records the defect, matching its two siblings
- [x] CLA signed
- [x] `Closes #1957` appears both above and as a commit trailer

Workspace-wide fmt/clippy/test left to CI per operator build policy on this machine (narrow scope only); the touched surface is fully covered by the runs above.

## Nothing left behind

- [x] Filed: #2125 — the verifier-side half. The issue's "and/or pipeline verify-stage guidance" was inspected: `VERIFIER_INSTRUCTIONS`/`GUIDANCE_INSTRUCTIONS` (`crates/stella-pipeline/src/verify.rs`) address the reviewer model, which never sees the worker's tool stderr (verifier ≠ worker, L-E11) — a rule there would reference a signal absent from its inputs. Making it real means extending the deterministic evidence (`LadderInputs`) with an errored-command projection, which is a design change, not a one-literal addition; #2125 is the handoff for that.

## Ground-rule check

- [ ] ~~No I/O added to `stella-core`~~ — not touched; no new deps
- [ ] ~~No new outbound network calls~~ — none
- [ ] ~~New cross-boundary types~~ — none

## Anything reviewers should know?

The block costs ~90 tokens per call in both prompts, sitting inside the cached prefix. Placement is after `scope_discipline!()` with the identical `"\n\n"` separator shape, so the prefix stays byte-stable per build.

## Summary by Sourcery

Clarify the agent prompts so that any measurement produced by an errored command chain is treated as invalid and must not be cited as evidence.

Enhancements:
- Add a shared measurement discipline prompt block that defines when numeric evidence is void due to command errors and instructs agents to re-measure or report quantities as unmeasured instead.
- Embed the new shared measurement discipline block into both system prompts to keep their behavior consistent and prevent prompt drift.

Tests:
- Add a witness test that verifies the measurement discipline literal contains the expected guidance and is embedded verbatim in all defined prompts.