### PR TITLE
fix(arenabench): per-seat SUT pins that round-trip TOML, and a pin race that fails closed (#2082, #2098)

### DIFF
--- a/arenabench/README.md
+++ b/arenabench/README.md
@@ -326,6 +326,19 @@ match resolves its `sut_ref` to a commit and runs the binary built from that
 commit, ignoring this variable entirely — which is how a result records which
 Stella produced it.
 
+The pin is per seat as well as per match: `sut_ref` in a template's `[match]`
+table is the default every Stella seat inherits, and a seat's own `sut_ref`
+line overrides it — two Stella builds racing the same tasks is one extra
+build, since builds are cached by commit. The pin is resolved **once per
+match** and that single observation feeds the launch, `provenance.json`
+(per-seat under `sut_seats`), and each seat's `.seat.json` launch record. A
+declared pin that cannot be satisfied — typically a branch that moved between
+the build and the launch — refuses the trial naming the drift; it never falls
+back to `STELLA_BINARY` or a `PATH` lookup, because that fallback once
+uploaded a host's native macOS build into Linux task containers (#2098). Pin
+the commit the build actually resolved to (the SUT panel pins it for you) to
+be immune to branch movement.
+
 Clearing the pin opts out of *pinning*, not out of every check. An unpinned
 match asks for whatever is current, so the arena reads the commit stamped into
 `STELLA_BINARY` itself and refuses to launch when that commit is more than

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -129,6 +129,18 @@ def _cmd_run(args: argparse.Namespace) -> int:
             print(f"  {line}", file=sys.stderr)
         return 2
 
+    # The same SUT preflight the server runs in `create_match`, which this
+    # path never consulted: #2098's reproduction entered exactly here, a
+    # template whose default `main` had moved since the build, and the match
+    # launched anyway. Refusing before any container starts is the contract.
+    from .sut import sut_problem_for
+
+    sut_problem = sut_problem_for(spec)
+    if sut_problem:
+        print("error: the match cannot run the Stella it declares:", file=sys.stderr)
+        print(f"  {sut_problem}", file=sys.stderr)
+        return 2
+
     workspace = Path(args.workspace).expanduser()
     arena = ArenaServer(workspace)
     runner: MatchRunner = arena.runner

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -198,6 +198,20 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
             else:
                 declared = _declared_env(env_raw, problems, where)
 
+        seat_sut = entry.get("sut_ref")
+        if seat_sut is not None:
+            if not isinstance(seat_sut, str):
+                problems.append(f"{where}: sut_ref must be a string git ref")
+                seat_sut = None
+            elif agent and agent != "stella":
+                # Refused at parse for the same reason `MatchSpec.validate`
+                # refuses it: a pin nothing reads is a template claiming to
+                # race a build it never runs (#2082).
+                problems.append(
+                    f"{where}: sut_ref applies only to a stella seat — "
+                    f"{agent!r} runs no Stella binary"
+                )
+
         contestants.append(
             Contestant(
                 id=str(entry.get("id") or f"seat{seat + 1}"),
@@ -207,8 +221,14 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
                 env={},  # never values from a file — see module docstring
                 color=str(entry.get("color") or ARENA_COLORS[seat % len(ARENA_COLORS)]),
                 required_env=declared,
+                sut_ref=seat_sut.strip() if isinstance(seat_sut, str) else None,
             )
         )
+
+    match_sut = match_table.get("sut_ref")
+    if match_sut is not None and not isinstance(match_sut, str):
+        problems.append("match.sut_ref must be a string git ref")
+        match_sut = None
 
     if problems:
         raise MatchTemplateError(problems)
@@ -226,6 +246,10 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
             "setup_timeout_multiplier": match_table.get("setup_timeout_multiplier", 1.0),
             "capture_snapshots": match_table.get("capture_snapshots", False),
             "snapshot_interval": match_table.get("snapshot_interval", 30.0),
+            # Absent means `main` (MatchSpec.from_json's contract), never the
+            # opt-out: a committed template that ran the project's default
+            # branch before this key existed must keep meaning that (#2082).
+            "sut_ref": match_sut,
         }
     )
     return replace(spec, contestants=tuple(contestants))
@@ -306,6 +330,11 @@ def match_to_toml_dict(spec: MatchSpec) -> dict[str, Any]:
             "setup_timeout_multiplier": spec.setup_timeout_multiplier,
             "capture_snapshots": spec.capture_snapshots,
             "snapshot_interval": spec.snapshot_interval,
+            # Written unconditionally: a template that omits the pin means
+            # `main`, and the GUI's "download this match" dropping the pin was
+            # exactly how a committed file silently ran a different Stella
+            # than the match it came from (#2082).
+            "sut_ref": spec.sut_ref,
         },
         "contestant": [
             {
@@ -313,6 +342,10 @@ def match_to_toml_dict(spec: MatchSpec) -> dict[str, Any]:
                 "name": c.name,
                 "agent": c.agent,
                 "color": c.color,
+                # The override round-trips only when the seat declared one:
+                # `None` (inherit) has no TOML spelling, and inventing one
+                # would freeze the match default into every seat.
+                **({"sut_ref": c.sut_ref} if c.sut_ref is not None else {}),
                 # The declaration round-trips; values never exist to round-trip.
                 **({"env": {"required": list(c.required_env)}} if c.required_env else {}),
                 "engine": {
@@ -373,6 +406,12 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
         "# the tests started passing and how long the agent kept going afterwards.",
         _line("capture_snapshots", spec.capture_snapshots),
         _line("snapshot_interval", spec.snapshot_interval),
+        "# Which Stella the seats under test run: a git ref, resolved to a commit",
+        "# at launch and recorded in provenance.json. Pin a full commit id for a",
+        '# result that names its own code; "" runs whatever STELLA_BINARY points',
+        "# at, recorded as unverified. A seat may override this with its own",
+        "# sut_ref line — that is how two Stella builds race the same tasks.",
+        _line("sut_ref", spec.sut_ref),
         "",
     ]
 
@@ -384,6 +423,13 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
             _line("name", contestant.name),
             _line("agent", contestant.agent),
             _line("color", contestant.color),
+        ]
+        if contestant.sut_ref is not None:
+            out += [
+                "# This seat's own Stella build, overriding [match] sut_ref.",
+                _line("sut_ref", contestant.sut_ref),
+            ]
+        out += [
             "",
             "  [contestant.engine]",
         ]

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -393,6 +393,15 @@ class Contestant:
     #: holding none of them refuses to start rather than score a silent 0.0
     #: (#1777).
     required_env: tuple[str, ...] = ()
+    #: Which Stella *this seat* runs, overriding the match-level
+    #: :attr:`MatchSpec.sut_ref`. ``None`` inherits the match default; ``""``
+    #: opts this seat out of pinning; anything else is a git ref resolved to a
+    #: commit at launch. Per-seat because a champion-vs-challenger match is two
+    #: Stella builds racing the same tasks (#2082) — builds are cached by
+    #: commit, so the second pin costs one extra build, never a rewrite. Only
+    #: meaningful on a ``stella`` seat; :meth:`MatchSpec.validate` refuses it
+    #: anywhere else rather than ignoring it in silence.
+    sut_ref: str | None = None
 
     @property
     def slug(self) -> str:
@@ -415,6 +424,7 @@ class Contestant:
             "ignored_env_keys": list(self.ignored_env),
             "required_env": list(self.required_env),
             "color": self.color,
+            "sut_ref": self.sut_ref,
         }
 
     @classmethod
@@ -459,6 +469,13 @@ class Contestant:
             ignored_env=tuple(ignored),
             required_env=tuple(
                 item for item in declared if is_credential_name(item)
+            ),
+            # Absent means *inherit the match default*, which is a different
+            # thing from the empty string's explicit opt-out — collapsing the
+            # two would turn every seat written before this field existed into
+            # one that silently accepts any binary (#2082).
+            sut_ref=(
+                None if raw.get("sut_ref") is None else str(raw["sut_ref"]).strip()
             ),
         )
 
@@ -561,6 +578,16 @@ class MatchSpec:
             ),
         )
 
+    def sut_ref_for(self, contestant: Contestant) -> str:
+        """The ref this seat's Stella is pinned to, inheritance resolved.
+
+        The one seam every consumer resolves a seat's pin through — the
+        preflight refusal, the launch, and the provenance record must all
+        answer "which Stella does seat N run" identically, or two of them can
+        disagree about what a match measured (#2082, #2098).
+        """
+        return self.sut_ref if contestant.sut_ref is None else contestant.sut_ref
+
     def validate(self) -> list[str]:
         """Every problem with this spec, so the UI can show them all at once."""
         problems: list[str] = []
@@ -575,6 +602,13 @@ class MatchSpec:
             seen.add(contestant.slug)
             if not contestant.engine.model:
                 problems.append(f"{contestant.name}: no model selected")
+            if contestant.sut_ref is not None and contestant.agent != "stella":
+                # Refused rather than ignored: a pin nothing reads would let a
+                # template claim to race a build it never runs (#2082).
+                problems.append(
+                    f"{contestant.name}: sut_ref applies only to a stella "
+                    f"seat — {contestant.agent!r} runs no Stella binary"
+                )
         return problems
 
 

--- a/arenabench/arenabench/provenance.py
+++ b/arenabench/arenabench/provenance.py
@@ -93,15 +93,47 @@ class Provenance:
     #: dates a result to whenever someone happens to read the record, which is
     #: the same reason :mod:`arenabench.registry` pins datasets by digest.
     #: Empty means genuinely unknown, never a guess — an unpinned match ran a
-    #: binary nobody can attribute, and saying so is the honest record.
+    #: binary nobody can attribute, and saying so is the honest record. When
+    #: seats pin *different* commits (:attr:`sut_seats`), no single value is
+    #: true and this stays empty — per-seat truth lives in ``sut_seats``.
     sut_commit: str = ""
     #: SHA-256 of the exact binary that ran. Two builds of one commit on
     #: different toolchains are not the same artifact, and this is what tells
-    #: them apart after the fact.
+    #: them apart after the fact. Like :attr:`sut_commit`, empty when the
+    #: seats diverge.
     sut_sha256: str = ""
+    #: Per-seat SUT identity, keyed by contestant id: ``{"name", "ref",
+    #: "commit", "sha256"}`` for every Stella seat. This is what makes a
+    #: champion-vs-challenger match recordable at all — the single fields
+    #: above assume one SUT per match, which was defect 3 of #2082. Empty for
+    #: records written before per-seat pins existed and for matches with no
+    #: Stella seat; readers fall back to the single fields then.
+    sut_seats: dict[str, dict[str, str]] = field(default_factory=dict)
     arenabench_version: str = ""
     recorded_at: float = field(default_factory=time.time)
     source: str = SOURCE_RECORDED
+
+    def _key(self, sut: str) -> str:
+        digest = (self.dataset_digest or "unknown").removeprefix("sha256:")[:8]
+        if self.harbor_version:
+            grader = f"harbor{self.harbor_version}"
+        elif self.harbor_bound:
+            grader = f"harbor?{self.harbor_bound}"
+        else:
+            grader = "harbor?"
+        return f"{self.dataset_key or 'unknown'}@{digest}/{grader}/{sut}"
+
+    @property
+    def sut_commits(self) -> tuple[str, ...]:
+        """Distinct per-seat SUT commits, sorted; the legacy single field when
+        no per-seat record exists. ``""`` members mean a seat whose commit is
+        genuinely unknown — kept, never dropped, because unknown is not zero.
+        """
+        if self.sut_seats:
+            return tuple(
+                sorted({seat.get("commit") or "" for seat in self.sut_seats.values()})
+            )
+        return (self.sut_commit,)
 
     @property
     def comparability_key(self) -> str:
@@ -111,19 +143,33 @@ class Provenance:
         a key nobody reads is a key nobody notices differing. An unknown Harbor
         keeps its bound in the key rather than collapsing to the same string as
         a measured one — the whole point is that those two are not the same.
+
+        The SUT belongs in the key for the same reason the dataset digest
+        does: two runs of different Stella revisions answer different
+        questions, and a key that hides that invites them into one average. A
+        match whose seats pin *different* commits names them all — a two-twin
+        match is its own apparatus, never averageable into a single-SUT
+        series; :meth:`comparability_key_for` is the arm-level key.
         """
-        digest = (self.dataset_digest or "unknown").removeprefix("sha256:")[:8]
-        if self.harbor_version:
-            grader = f"harbor{self.harbor_version}"
-        elif self.harbor_bound:
-            grader = f"harbor?{self.harbor_bound}"
+        commits = self.sut_commits
+        if len(commits) == 1:
+            sut = f"stella{commits[0][:8]}" if commits[0] else "stella?"
         else:
-            grader = "harbor?"
-        # The SUT belongs in the key for the same reason the dataset digest
-        # does: two runs of different Stella revisions answer different
-        # questions, and a key that hides that invites them into one average.
-        sut = f"stella{self.sut_commit[:8]}" if self.sut_commit else "stella?"
-        return f"{self.dataset_key or 'unknown'}@{digest}/{grader}/{sut}"
+            sut = "stella" + "+".join(c[:8] if c else "?" for c in commits)
+        return self._key(sut)
+
+    def comparability_key_for(self, contestant_id: str) -> str:
+        """The key for one arm of the match.
+
+        Two arms — from the same match or different ones — are comparable
+        exactly when their keys differ in nothing but the ``stella<commit>``
+        half, which is the variable under test. Everything else differing
+        (dataset digest, grader) makes them different measurements, and this
+        key is what refuses to let that difference hide (#2082).
+        """
+        seat = self.sut_seats.get(contestant_id)
+        commit = (seat.get("commit") or "") if seat else self.sut_commit
+        return self._key(f"stella{commit[:8]}" if commit else "stella?")
 
     @property
     def measured(self) -> bool:
@@ -137,6 +183,11 @@ class Provenance:
         # without having to reimplement how it is built.
         out["comparability_key"] = self.comparability_key
         out["measured"] = self.measured
+        if self.sut_seats:
+            out["comparability_key_by_seat"] = {
+                seat_id: self.comparability_key_for(seat_id)
+                for seat_id in self.sut_seats
+            }
         return out
 
     @classmethod

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -80,6 +80,11 @@ _SCRUBBED_EXACT = frozenset(
         "CLAUDE_CODE_OAUTH_TOKEN",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
+        # The pin marker `_agent_environment` sets for a pinned Stella seat
+        # (#2098). Only the runner may assert a trial is pinned: an ambient
+        # copy in the operator's shell would make the adapter fail an
+        # honestly-unpinned run closed.
+        "ARENABENCH_SUT_COMMIT",
     }
 )
 
@@ -110,6 +115,14 @@ def _provenance_for(match: Match) -> provenance.Provenance:
     Harbor is asked for its version here rather than trusted from config: the
     binary on PATH can change between one match and the next, and the record
     has to say what actually graded *these* trials.
+
+    The SUT half reads the **same pin observation the launch reads**
+    (:meth:`Match.sut_pin_for`), not a second resolution of the same ref:
+    resolving twice is how provenance once recorded a commit that was never
+    the binary actually run — ``main`` moved between the two calls (#2098).
+    Per seat, because two Stella seats may pin two builds (#2082); failure
+    leaves a seat's commit empty — unknown, never guessed, for the same
+    reason ``harbor_version`` is.
     """
     from . import __version__
 
@@ -122,17 +135,26 @@ def _provenance_for(match: Match) -> provenance.Provenance:
         # is not mistaken later for one that ran on the current Harbor.
         version, binary = None, ""
 
-    # The SUT half, resolved the same way the launch resolves it so the record
-    # names the binary that actually ran. Failure leaves both fields empty —
-    # unknown, never guessed, for the same reason `harbor_version` is.
-    sut_commit, sut_sha256 = "", ""
-    if match.spec.sut_ref:
-        try:
-            sut_commit = sut.resolve_ref(match.spec.sut_ref)
-            staged = sut.binary_for(sut_commit)
-            sut_sha256 = staged.sha256 if staged else ""
-        except sut.SutUnavailableError:
-            sut_commit = ""
+    sut_seats: dict[str, dict[str, str]] = {}
+    for contestant in match.spec.contestants:
+        if contestant.agent != "stella":
+            continue
+        pin = match.sut_pin_for(contestant)
+        sut_seats[contestant.id] = {
+            "name": contestant.name,
+            "ref": pin.ref,
+            "commit": pin.commit,
+            "sha256": pin.staged.sha256 if pin.staged else "",
+        }
+    # The single legacy fields stay filled only while they are true: one
+    # distinct identity across every Stella seat. Seats that diverge — or a
+    # pinned seat racing an unpinned one — leave them empty, and the per-seat
+    # record above is the truth.
+    identities = {(s["commit"], s["sha256"]) for s in sut_seats.values()}
+    if len(identities) == 1 and next(iter(identities))[0]:
+        sut_commit, sut_sha256 = next(iter(identities))
+    else:
+        sut_commit, sut_sha256 = "", ""
 
     return provenance.Provenance(
         dataset_key=match.spec.dataset,
@@ -143,6 +165,7 @@ def _provenance_for(match: Match) -> provenance.Provenance:
         sut_ref=match.spec.sut_ref,
         sut_commit=sut_commit,
         sut_sha256=sut_sha256,
+        sut_seats=sut_seats,
         arenabench_version=__version__,
         source=provenance.SOURCE_RECORDED,
     )
@@ -212,6 +235,24 @@ class Match:
         self._watcher = MatchWatcher(self.workspace)
         self._detections: list[Detection] = []
         self._lock = threading.Lock()
+        #: One pin observation per declared ref, for this match's lifetime.
+        self._sut_pins: dict[str, sut.ResolvedPin] = {}
+
+    def sut_pin_for(self, contestant: Contestant) -> sut.ResolvedPin:
+        """This seat's SUT pin, resolved **once per ref per match**.
+
+        Provenance and the launch both read this, which is the #2098 fix:
+        each used to call ``resolve_ref`` independently, minutes apart, and a
+        floating ref like ``main`` could mean two different commits to the
+        two of them. Cached by the declared ref rather than the seat, so two
+        seats inheriting one ref also share one observation.
+        """
+        ref = self.spec.sut_ref_for(contestant)
+        pin = self._sut_pins.get(ref)
+        if pin is None:
+            pin = sut.resolve_pin(ref)
+            self._sut_pins[ref] = pin
+        return pin
 
     # -- reading ----------------------------------------------------------
 
@@ -725,9 +766,10 @@ class MatchRunner:
                 "env keys ignored — a seat may carry credentials and endpoints "
                 "only: " + ", ".join(ignored)
             )
+        pin = match.sut_pin_for(contestant) if contestant.agent == "stella" else None
         env = _base_environment()
         env.update(seat_env)
-        env.update(self._agent_environment(contestant, run, match.spec.sut_ref))
+        env.update(self._agent_environment(contestant, run, pin))
 
         # The seat's launch record — the only artifact that can say which
         # route this job's trials were actually served by. `launch_model`
@@ -746,6 +788,13 @@ class MatchRunner:
             "launch_model": launch_model(contestant),
             "base_url": contestant.engine.base_url,
         }
+        if pin is not None:
+            # Which Stella THIS seat launched — the per-seat half of #2082.
+            # The same observation provenance recorded, so the two artifacts
+            # cannot disagree about what a floating ref meant.
+            record["sut_ref"] = pin.ref
+            record["sut_commit"] = pin.commit
+            record["sut_sha256"] = pin.staged.sha256 if pin.staged else ""
         try:
             seat_manifest_path(job_dir).write_text(
                 json.dumps(record, indent=2) + "\n", encoding="utf-8"
@@ -811,9 +860,16 @@ class MatchRunner:
         return env
 
     def _agent_environment(
-        self, contestant: Contestant, run: ContestantRun, sut_ref: str = ""
+        self,
+        contestant: Contestant,
+        run: ContestantRun,
+        pin: sut.ResolvedPin | None = None,
     ) -> dict[str, str]:
-        """Agent-specific environment, layered over the operator's ``.env``."""
+        """Agent-specific environment, layered over the operator's ``.env``.
+
+        ``pin`` is the seat's SUT pin as :meth:`Match.sut_pin_for` observed it
+        — already resolved, never re-resolved here (#2098).
+        """
         spec = resolve_agent(contestant.agent)
         env: dict[str, str] = {}
         if spec.extra_env:
@@ -858,24 +914,32 @@ class MatchRunner:
             roots.append(existing)
         env["PYTHONPATH"] = os.pathsep.join(roots)
 
-        # Which Stella actually runs. A pinned `sut_ref` resolves to a commit
-        # and the binary built from *that* commit is used; the ambient
-        # STELLA_BINARY is only the fallback for an explicitly unpinned match.
-        # `ArenaServer.create_match` has already refused a pinned match with no
-        # matching build, so reaching here with a pin means the binary exists.
-        if sut_ref:
-            try:
-                commit = sut.resolve_ref(sut_ref)
-                staged = sut.binary_for(commit)
-            except sut.SutUnavailableError:
-                staged = None
-            if staged is not None:
-                env["STELLA_BINARY"] = str(staged.path)
-                run.notes.append(
-                    f"stella {commit[:8]} ({sut_ref}) "
-                    f"sha256:{staged.sha256[:12] or 'unrecorded'}"
+        # Which Stella actually runs. A pinned seat runs the binary built from
+        # the commit its pin resolved to; the ambient STELLA_BINARY is only
+        # the fallback for an explicitly *unpinned* seat. A pin that cannot be
+        # honoured — the ref moved since the build, the resolution failed —
+        # refuses the trial outright rather than degrading into the unpinned
+        # path: `create_match`'s preflight refuses this exact condition, and
+        # the launch falling through it instead once handed the operator's
+        # native macOS dev build (via `_locate_binary`'s PATH tier) to every
+        # Linux task container (#2098).
+        if pin is not None and pin.pinned:
+            problem = sut.broken_pin_problem(pin)
+            if problem or pin.staged is None:
+                raise sut.SutUnavailableError(
+                    problem
+                    or f"no staged binary for pinned commit {pin.commit[:8]}"
                 )
-                return env
+            env["STELLA_BINARY"] = str(pin.staged.path)
+            # The pin travels with the trial: `stella_harbor._locate_binary`
+            # refuses its PATH/cwd tiers when this is set but STELLA_BINARY
+            # is lost, so a broken pin fails closed at that layer too.
+            env["ARENABENCH_SUT_COMMIT"] = pin.commit
+            run.notes.append(
+                f"stella {pin.commit[:8]} ({pin.ref}) "
+                f"sha256:{pin.staged.sha256[:12] or 'unrecorded'}"
+            )
+            return env
 
         binary = os.environ.get("STELLA_BINARY")
         if binary:

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -195,12 +195,22 @@ def match_row(match: Any) -> dict[str, Any]:
     seats = []
     for contestant in spec.contestants:
         metrics = metrics_by_seat[contestant.id]
+        # Which Stella this arm ran — per seat, because two seats may race
+        # two builds (#2082). Deliberately OUTSIDE `_seat_signature`: the SUT
+        # commit is the variable under test, and folding it into the group
+        # key would split the exact series it exists to draw. Legacy records
+        # carry no per-seat entry; the match-level commit stands in then.
+        seat_sut = ""
+        if contestant.agent == "stella":
+            recorded = (prov.sut_seats if prov else {}).get(contestant.id) or {}
+            seat_sut = recorded.get("commit", "") or sut_commit
         seats.append(
             {
                 "id": contestant.id,
                 # Display only — never part of the comparability signature.
                 "color": getattr(contestant, "color", ""),
                 **_seat_signature(contestant),
+                "sut_commit": seat_sut,
                 "outcomes": _seat_outcomes(metrics),
                 "per_task": _per_task(metrics),
             }

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -202,8 +202,10 @@ def match_row(match: Any) -> dict[str, Any]:
         # carry no per-seat entry; the match-level commit stands in then.
         seat_sut = ""
         if contestant.agent == "stella":
-            recorded = (prov.sut_seats if prov else {}).get(contestant.id) or {}
-            seat_sut = recorded.get("commit", "") or sut_commit
+            # getattr, like `color` above: records written before per-seat
+            # pins (and duck-typed stand-ins) carry no `sut_seats`.
+            recorded = (getattr(prov, "sut_seats", None) or {}).get(contestant.id)
+            seat_sut = (recorded or {}).get("commit", "") or sut_commit
         seats.append(
             {
                 "id": contestant.id,

--- a/arenabench/arenabench/sut.py
+++ b/arenabench/arenabench/sut.py
@@ -57,14 +57,18 @@ __all__ = [
     "STELLA_REPO_ENV",
     "Branch",
     "Drift",
+    "ResolvedPin",
     "StagedSut",
     "SutUnavailableError",
     "ambient_sut",
     "binary_for",
+    "broken_pin_problem",
     "drift_between",
     "embedded_commit",
     "list_branches",
+    "resolve_pin",
     "resolve_ref",
+    "staged_commits",
     "staged_for",
     "stella_repo",
     "sut_problem_for",
@@ -498,6 +502,36 @@ def binary_for(commit: str) -> StagedSut | None:
     return None
 
 
+def staged_commits() -> list[str]:
+    """Every commit with a staged binary, newest build first.
+
+    The per-commit cache directories plus the legacy path when it records a
+    commit. Used to *name* what is available when a pin cannot be satisfied —
+    "no binary for X, the nearest build is N commits behind" calls for a very
+    different reaction than "nothing has ever been built".
+    """
+    found: list[tuple[float, str]] = []
+    try:
+        children = list(sut_root().iterdir())
+    except OSError:
+        children = []
+    for child in children:
+        if not _FULL_SHA.match(child.name):
+            continue
+        staged = _staged_at(child)
+        if staged is not None:
+            found.append((staged.built_at, child.name))
+    legacy = legacy_staged()
+    if legacy is not None and _FULL_SHA.match(legacy.commit):
+        found.append((legacy.built_at, legacy.commit))
+    found.sort(reverse=True)
+    ordered: list[str] = []
+    for _, commit in found:
+        if commit not in ordered:
+            ordered.append(commit)
+    return ordered
+
+
 def drift_between(staged: str, target: str, repo: Path | None = None) -> Drift:
     """How far ``staged`` is from ``target`` in this checkout."""
     if not staged:
@@ -515,6 +549,107 @@ def drift_between(staged: str, target: str, repo: Path | None = None) -> Drift:
     except (SutUnavailableError, ValueError, IndexError):
         return Drift(staged=staged, target=target, comparable=False)
     return Drift(staged=staged, target=target, behind=behind, ahead=ahead)
+
+
+def _nearest_staged(target: str, repo: Path | None = None) -> Drift | None:
+    """The staged build nearest ``target``, as a drift, or ``None``.
+
+    "Nearest" prefers a comparable drift with the smallest total distance;
+    an incomparable one (built elsewhere, force-pushed away) is only ever the
+    answer when nothing comparable exists, because "cannot be compared" is
+    the least actionable thing a refusal can say.
+    """
+
+    def distance(drift: Drift) -> tuple[int, int]:
+        return (0, drift.behind + drift.ahead) if drift.comparable else (1, 0)
+
+    best: Drift | None = None
+    for commit in staged_commits():
+        drift = drift_between(commit, target, repo)
+        if best is None or distance(drift) < distance(best):
+            best = drift
+    return best
+
+
+@dataclass(frozen=True)
+class ResolvedPin:
+    """One observation of a SUT pin, made exactly once per match.
+
+    ``SutBuilder.start`` and the launch path used to each resolve the same
+    symbolic ref independently, minutes apart — long enough for ``main`` to
+    move between them, at which point the launch found no staged binary and
+    silently degraded to the ambient/``PATH`` tier (#2098). Resolving into a
+    value and handing *that* around is the coordination: provenance, the seat
+    launch record, and the binary actually uploaded all read this one
+    observation, so they cannot disagree about which commit a floating ref
+    meant.
+    """
+
+    #: The pin as declared. ``""`` is the explicit unpinned opt-out.
+    ref: str
+    #: The commit the ref resolved to; ``""`` when unpinned or unresolvable.
+    commit: str = ""
+    #: The staged binary for that commit, when one exists.
+    staged: StagedSut | None = None
+    #: Why resolution failed, when it did.
+    problem: str = ""
+
+    @property
+    def pinned(self) -> bool:
+        return bool(self.ref)
+
+
+def resolve_pin(ref: str) -> ResolvedPin:
+    """Resolve a declared pin to a commit and its staged binary, once.
+
+    Never raises: an unresolvable pin comes back with :attr:`ResolvedPin.problem`
+    set, so the caller decides whether that refuses a launch
+    (:func:`broken_pin_problem`) or merely records unknown (provenance).
+    """
+    ref = (ref or "").strip()
+    if not ref:
+        return ResolvedPin(ref="")
+    try:
+        commit = resolve_ref(ref)
+    except SutUnavailableError as exc:
+        return ResolvedPin(ref=ref, problem=str(exc))
+    return ResolvedPin(ref=ref, commit=commit, staged=binary_for(commit))
+
+
+def broken_pin_problem(pin: ResolvedPin) -> str | None:
+    """Why a *declared* pin cannot be satisfied — a refusal, never a fallback.
+
+    ``None`` means the pin is healthy, or there is no pin at all — the
+    unpinned posture is a different judgment (:func:`unpinned_problem`).
+    Anything else is #2098's contract: a match that declared a pin and cannot
+    honour it must refuse the trial, because the silent alternative was the
+    launch degrading to the ambient/``PATH`` tier — which once uploaded the
+    operator's native macOS build into every Linux task container.
+    """
+    if not pin.pinned:
+        return None
+    if pin.problem:
+        return (
+            f"Stella seat pinned to {pin.ref!r}, but the pin cannot be "
+            f"resolved: {pin.problem}. Refusing to fall back to an ambient "
+            "binary — clear the SUT pin to run unpinned on purpose."
+        )
+    if pin.staged is not None:
+        return None
+    nearest = _nearest_staged(pin.commit)
+    detail = (
+        f"the nearest staged build is {nearest.summary()}"
+        if nearest is not None
+        else "nothing is staged at all"
+    )
+    return (
+        f"Stella seat pinned to {pin.ref!r}, which resolved to "
+        f"{pin.commit[:8]}, but no binary is staged for that commit — "
+        f"{detail}. If {pin.ref!r} is a branch it has moved since the build; "
+        "pin the commit the build resolved to (the SUT panel and the build "
+        "record both report it), or build the new tip. Refusing rather than "
+        "falling back to an ambient binary (#2098)."
+    )
 
 
 def file_sha256(path: Path) -> str:
@@ -573,26 +708,50 @@ def sut_problem_for(spec: Any) -> str | None:
     ``None`` means "go". A string is a refusal, phrased for an operator who
     now has to do something about it.
 
-    Only matches carrying a Stella seat are checked — a Claude-Code-vs-Codex
-    contest has no system under test of ours and must not be blocked by the
-    state of a binary it never runs. An empty ``sut_ref`` opts out of *pinning*,
-    not out of every check: see :func:`unpinned_problem`.
+    Checked **per seat**: each Stella seat's effective pin — its own
+    ``sut_ref`` override when it declared one, the match-level default
+    otherwise — is judged independently, so a champion-vs-challenger match
+    refuses when *either* build is missing rather than checking one ref and
+    vouching for both (#2082). Only Stella seats are checked — a
+    Claude-Code-vs-Codex contest has no system under test of ours and must
+    not be blocked by the state of a binary it never runs. An empty effective
+    ref opts that seat out of *pinning*, not out of every check: see
+    :func:`unpinned_problem`.
     """
-    if not any(c.agent == "stella" for c in spec.contestants):
+    stella_seats = [c for c in spec.contestants if c.agent == "stella"]
+    if not stella_seats:
         return None
-    if not getattr(spec, "sut_ref", ""):
-        return unpinned_problem()
-    status = sut_status(spec.sut_ref)
-    if status["ready"]:
-        return None
-    detail = status.get("problem") or "the requested Stella build is unavailable"
-    return (
-        f"Stella seat pinned to {spec.sut_ref!r}, but {detail} "
-        "Build it from the arena's SUT panel, or run "
-        "`bench/evidence/run/build_sut.sh`. To measure an unattributable "
-        "binary on purpose, clear the SUT pin — the match is then recorded "
-        "as unverified."
-    )
+    problems: list[str] = []
+    status_by_ref: dict[str, dict[str, Any]] = {}
+    unpinned_checked = False
+    for seat in stella_seats:
+        override = getattr(seat, "sut_ref", None)
+        ref = getattr(spec, "sut_ref", "") if override is None else override
+        if not ref:
+            # One ambient binary serves every unpinned seat, so the verdict
+            # is per-machine, not per-seat — checking it once is reporting,
+            # not skipping.
+            if not unpinned_checked:
+                unpinned = unpinned_problem()
+                if unpinned:
+                    problems.append(unpinned)
+                unpinned_checked = True
+            continue
+        status = status_by_ref.get(ref)
+        if status is None:
+            status = sut_status(ref)
+            status_by_ref[ref] = status
+        if status["ready"]:
+            continue
+        detail = status.get("problem") or "the requested Stella build is unavailable"
+        problems.append(
+            f"Stella seat {seat.name!r} pinned to {ref!r}, but {detail} "
+            "Build it from the arena's SUT panel, or run "
+            "`bench/evidence/run/build_sut.sh`. To measure an unattributable "
+            "binary on purpose, clear the SUT pin — the match is then recorded "
+            "as unverified."
+        )
+    return "; ".join(problems) if problems else None
 
 
 def sut_status(ref: str = "main") -> dict[str, Any]:
@@ -642,18 +801,20 @@ def sut_status(ref: str = "main") -> dict[str, Any]:
 
     # Nothing built for the requested commit. Say what *is* there and how far
     # off it is, because "no binary" and "a binary from three days ago" call
-    # for very different reactions.
-    fallback = legacy
-    if fallback is None:
+    # for very different reactions — and when the ref is a branch that moved
+    # mid-build, the nearest per-commit build IS the drift, named so the
+    # operator can pin the commit that was actually built (#2098).
+    nearest = _nearest_staged(target, repo)
+    if nearest is None:
         out["problem"] = (
             f"no Stella binary has been built for {target[:8]}. Build one "
             "before running a Stella seat."
         )
         return out
-    drift = drift_between(fallback.commit, target, repo)
-    out["drift"] = drift.to_json()
+    out["drift"] = nearest.to_json()
     out["problem"] = (
-        f"the only staged binary is not {target[:8]}: {drift.summary()}. "
-        "Build the requested commit before running a Stella seat."
+        f"no staged binary is {target[:8]} — the nearest build is "
+        f"{nearest.summary()}. Build the requested commit before running "
+        "a Stella seat."
     )
     return out

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -844,8 +844,10 @@ class TestOfflineTaskSource:
                 return None
 
         monkeypatch.setattr("arenabench.runner.subprocess.Popen", _Fake)
+        # Explicitly unpinned: this test is about the argv shape, and a
+        # pinned seat with no staged build now refuses the launch (#2098).
         spec = MatchSpec.from_json({
-            "dataset": "terminal-bench-2.1", "tasks": ["alpha"],
+            "dataset": "terminal-bench-2.1", "tasks": ["alpha"], "sut_ref": "",
             "contestants": [{"name": "s", "agent": "stella",
                              "engine": {"api": "openrouter", "model": "x/y"}}],
         })

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -1228,3 +1228,136 @@ class TestSnapshotDetections:
         assert len(first) == 5
         assert second == first
 
+
+class TestSutPinTemplates:
+    """The SUT pin as a file: a committed match must run the Stella it names.
+
+    Before #2082 neither TOML path carried `sut_ref` at all — a committed
+    template always ran `main` no matter what the match it was downloaded
+    from had pinned, and the GUI's "download this match" silently dropped
+    the pin. Every test here is about the pin surviving the file.
+    """
+
+    def _two_pin_spec(self) -> MatchSpec:
+        return match_from_toml(
+            {
+                "match": {
+                    "name": "twins",
+                    "dataset": "terminal-bench-2.1",
+                    "tasks": ["fix-git"],
+                    "sut_ref": "branch-a",
+                },
+                "contestant": [
+                    {
+                        "id": "champ",
+                        "name": "champion",
+                        "agent": "stella",
+                        "engine": {"api": "openrouter", "model": "z-ai/glm-5.2"},
+                    },
+                    {
+                        "id": "chall",
+                        "name": "challenger",
+                        "agent": "stella",
+                        "sut_ref": "branch-b",
+                        "engine": {"api": "openrouter", "model": "z-ai/glm-5.2"},
+                    },
+                ],
+            }
+        )
+
+    def test_a_match_level_pin_reaches_the_spec(self):
+        spec = self._two_pin_spec()
+        assert spec.sut_ref == "branch-a"
+
+    def test_a_seat_override_wins_and_the_rest_inherit(self):
+        spec = self._two_pin_spec()
+        assert spec.contestants[0].sut_ref is None
+        assert spec.contestants[1].sut_ref == "branch-b"
+        assert spec.sut_ref_for(spec.contestants[0]) == "branch-a"
+        assert spec.sut_ref_for(spec.contestants[1]) == "branch-b"
+
+    def test_a_template_without_the_key_still_means_main(self):
+        """Absent must keep meaning `main`, not the opt-out: every template
+        committed before the key existed asked for the default branch."""
+        spec = match_from_toml(
+            {
+                "match": {"dataset": "terminal-bench-2.1"},
+                "contestant": [
+                    {"agent": "stella", "engine": {"model": "z-ai/glm-5.2"}}
+                ],
+            }
+        )
+        assert spec.sut_ref == "main"
+
+    def test_the_pin_round_trips_byte_stably(self):
+        """dump -> load -> dump is the identity, pins included."""
+        import tomllib
+
+        from arenabench.config import dump_match
+
+        text = dump_match(self._two_pin_spec())
+        again = match_from_toml(tomllib.loads(text))
+        assert again.sut_ref == "branch-a"
+        assert again.contestants[1].sut_ref == "branch-b"
+        assert dump_match(again) == text
+
+    def test_a_downloaded_template_no_longer_drops_the_pin(self):
+        """The GUI's "download this match" renders through dump_match; the
+        pin must be in the bytes, unconditionally."""
+        from arenabench.config import dump_match
+
+        pinned = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "sut_ref": "0123456789abcdef0123456789abcdef01234567",
+                "contestants": [
+                    {"name": "s", "agent": "stella", "engine": {"model": "m"}}
+                ],
+            }
+        )
+        assert 'sut_ref = "0123456789abcdef0123456789abcdef01234567"' in dump_match(
+            pinned
+        )
+
+    def test_a_pin_on_a_non_stella_seat_is_refused_at_parse(self):
+        from arenabench.config import MatchTemplateError
+
+        with pytest.raises(MatchTemplateError) as caught:
+            match_from_toml(
+                {
+                    "match": {"dataset": "terminal-bench-2.1"},
+                    "contestant": [
+                        {
+                            "agent": "claude-code",
+                            "sut_ref": "main",
+                            "engine": {"api": "anthropic", "model": "m"},
+                        }
+                    ],
+                }
+            )
+        assert any("only to a stella seat" in p for p in caught.value.problems)
+
+    def test_a_pin_on_a_non_stella_seat_is_refused_at_validate(self):
+        spec = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {
+                        "name": "cc",
+                        "agent": "claude-code",
+                        "sut_ref": "main",
+                        "engine": {"api": "anthropic", "model": "m"},
+                    }
+                ],
+            }
+        )
+        assert any("only to a stella seat" in p for p in spec.validate())
+
+    def test_the_seat_pin_survives_the_json_spec_record(self):
+        """`spec.json` round-trips through redacted()/from_json on restore;
+        losing the pin there would strand history without its SUT."""
+        spec = self._two_pin_spec()
+        again = MatchSpec.from_json(spec.to_json())
+        assert again.contestants[1].sut_ref == "branch-b"
+        assert again.sut_ref == "branch-a"
+

--- a/arenabench/tests/test_security.py
+++ b/arenabench/tests/test_security.py
@@ -125,8 +125,15 @@ class TestSeatEnvironmentIsScreened:
             engine=Engine(api="openrouter", model="x/y"),
             env={"ZAI_API_KEY": "zk", "PATH": "/evil/bin"},
         )
+        # Explicitly unpinned: this test is about the env screen, and a pinned
+        # seat with no staged build now refuses the launch before Popen (#2098).
         spec = MatchSpec.from_json(
-            {"dataset": "terminal-bench-2.1", "tasks": ["alpha"], "contestants": []}
+            {
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["alpha"],
+                "sut_ref": "",
+                "contestants": [],
+            }
         )
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(replace(spec, contestants=(seat,)))

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -12,14 +12,19 @@ which Stella it measured.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from arenabench import runner as runner_module
 from arenabench import sut
 from arenabench.model import MatchSpec
 from arenabench.provenance import Provenance
+from arenabench.registry import DEFAULT_REGISTRY
+from arenabench.runner import MatchRunner
+from arenabench.telemetry import seat_manifest_path
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -488,3 +493,317 @@ class TestProvenanceRecordsTheSut:
             "abc123",
             "def",
         )
+
+
+class TestProvenanceRecordsEverySeat:
+    """One match may race two Stella builds; the record must carry both (#2082)."""
+
+    SEATS = {
+        "champ": {"name": "champion", "ref": "a" * 40, "commit": "a" * 40, "sha256": "x"},
+        "chall": {"name": "challenger", "ref": "b" * 40, "commit": "b" * 40, "sha256": "y"},
+    }
+
+    def _record(self) -> Provenance:
+        return Provenance(
+            dataset_key="terminal-bench-2.1",
+            dataset_digest="sha256:7d7bdc1c",
+            harbor_version="0.6.1",
+            sut_seats=dict(self.SEATS),
+        )
+
+    def test_per_seat_records_round_trip(self):
+        again = Provenance.from_json(self._record().to_json())
+        assert again.sut_seats == self.SEATS
+
+    def test_a_two_twin_match_names_both_commits_in_its_key(self):
+        key = self._record().comparability_key
+        assert "a" * 8 in key and "b" * 8 in key, (
+            "a key naming one commit invites a two-twin match into a "
+            "single-SUT average"
+        )
+
+    def test_arm_level_keys_differ_only_in_the_sut_half(self):
+        record = self._record()
+        champ = record.comparability_key_for("champ")
+        chall = record.comparability_key_for("chall")
+        assert champ != chall
+        assert champ.rsplit("/", 1)[0] == chall.rsplit("/", 1)[0], (
+            "two arms of one match share the whole apparatus; only the "
+            "stella<commit> half may differ"
+        )
+        assert champ.endswith(f"stella{'a' * 8}")
+        assert chall.endswith(f"stella{'b' * 8}")
+
+    def test_a_legacy_record_keeps_its_single_field_key(self):
+        legacy = Provenance(
+            dataset_key="terminal-bench-2.1",
+            dataset_digest="sha256:7d7bdc1c",
+            harbor_version="0.6.1",
+            sut_commit="6c345532aaaa",
+        )
+        assert "stella6c345532" in legacy.comparability_key
+        assert legacy.comparability_key_for("anything").endswith("stella6c345532")
+
+
+def _stub_harbor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The same three answers `test_arena._fake_harbor` stubs, for `_launch`."""
+    monkeypatch.setattr(
+        "arenabench.harbor.harbor_bin", lambda dataset_key=None: "/usr/bin/harbor"
+    )
+    monkeypatch.setattr(
+        "arenabench.harbor.harbor_version", lambda binary=None: "0.20.0"
+    )
+    monkeypatch.setattr(
+        "arenabench.harbor.supports_agent_import_path", lambda binary=None: False
+    )
+
+
+def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Stub the launch subprocess and capture every (command, env) handed to it."""
+    captured: list[dict] = []
+
+    class _Fake:
+        def __init__(self, command, **kwargs):
+            captured.append({"command": command, "env": kwargs.get("env") or {}})
+            self.returncode = None
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("arenabench.runner.subprocess.Popen", _Fake)
+    return captured
+
+
+class TestTwoSeatsRaceTwoBuilds:
+    """#2082: a champion-vs-challenger match is two Stella builds on one grid."""
+
+    def _stage(self, commit: str) -> Path:
+        directory = sut.sut_root() / commit
+        directory.mkdir(parents=True, exist_ok=True)
+        binary = directory / "stella"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        (directory / "sut_commit.txt").write_text(commit)
+        (directory / "binary_sha256.txt").write_text(f"sha-of-{commit[:8]}")
+        return binary
+
+    def _two_seat_spec(self, ref_a: str, ref_b: str) -> MatchSpec:
+        return MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["fix-git"],
+                "sut_ref": ref_a,
+                "contestants": [
+                    {
+                        "id": "champ",
+                        "name": "champion",
+                        "agent": "stella",
+                        "engine": {"api": "openrouter", "model": "m"},
+                    },
+                    {
+                        "id": "chall",
+                        "name": "challenger",
+                        "agent": "stella",
+                        "sut_ref": ref_b,
+                        "engine": {"api": "openrouter", "model": "m"},
+                    },
+                ],
+            }
+        )
+
+    def test_each_seats_pin_is_checked_independently(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        unbuilt = _git(repo, "rev-parse", "refs/heads/main")
+        self._stage(head)
+        problem = sut.sut_problem_for(self._two_seat_spec(head, unbuilt))
+        assert problem is not None
+        assert "challenger" in problem, "the refusal must name the seat"
+        assert "champion" not in problem, (
+            "the seat whose build exists must not be blamed for the one whose "
+            "build does not"
+        )
+
+    def test_both_builds_present_permit_the_launch(self, repo: Path):
+        head = _git(repo, "rev-parse", "origin/main")
+        other = _git(repo, "rev-parse", "refs/heads/main")
+        self._stage(head)
+        self._stage(other)
+        assert sut.sut_problem_for(self._two_seat_spec(head, other)) is None
+
+    def test_two_seats_launch_two_binaries_and_record_them(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Verify (#2082): two pinned refs launch two STELLA_BINARY values,
+        provable from the `.seat.json` launch records."""
+        head = _git(repo, "rev-parse", "origin/main")
+        other = _git(repo, "rev-parse", "refs/heads/main")
+        binary_a = self._stage(head)
+        binary_b = self._stage(other)
+        _stub_harbor(monkeypatch)
+        captured = _capture_popen(monkeypatch)
+
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._two_seat_spec(head, other))
+        runs = {
+            contestant.id: runner._launch(match, contestant)
+            for contestant in match.spec.contestants
+        }
+
+        assert captured[0]["env"]["STELLA_BINARY"] == str(binary_a)
+        assert captured[1]["env"]["STELLA_BINARY"] == str(binary_b)
+
+        records = {
+            seat_id: json.loads(
+                seat_manifest_path(run.job_dir).read_text(encoding="utf-8")
+            )
+            for seat_id, run in runs.items()
+        }
+        assert records["champ"]["sut_commit"] == head
+        assert records["chall"]["sut_commit"] == other
+        assert records["champ"]["sut_sha256"] != records["chall"]["sut_sha256"]
+
+    def test_provenance_records_both_commits(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        head = _git(repo, "rev-parse", "origin/main")
+        other = _git(repo, "rev-parse", "refs/heads/main")
+        self._stage(head)
+        self._stage(other)
+        _stub_harbor(monkeypatch)
+
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._two_seat_spec(head, other))
+        record = runner_module._provenance_for(match)
+
+        assert record.sut_seats["champ"]["commit"] == head
+        assert record.sut_seats["chall"]["commit"] == other
+        assert head[:8] in record.comparability_key
+        assert other[:8] in record.comparability_key
+        # No single match-level commit is true of a diverged match.
+        assert record.sut_commit == ""
+
+
+class TestAPinIsObservedOnce:
+    """#2098: the two halves of a pin must see one value of a floating ref.
+
+    `SutBuilder.start` and `_agent_environment` each called `resolve_ref`
+    independently, minutes apart; when `main` moved between the calls the
+    launch found no staged binary and silently degraded to the ambient/PATH
+    tier — which uploaded the operator's native macOS build into Linux task
+    containers. The reproduction is pinned here with a resolver that moves
+    the ref between calls, exactly as the real repository did.
+    """
+
+    def _stage(self, commit: str) -> Path:
+        directory = sut.sut_root() / commit
+        directory.mkdir(parents=True, exist_ok=True)
+        binary = directory / "stella"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        (directory / "sut_commit.txt").write_text(commit)
+        (directory / "binary_sha256.txt").write_text("deadbeef")
+        return binary
+
+    def _stella_spec(self, ref: str) -> MatchSpec:
+        return MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["fix-git"],
+                "sut_ref": ref,
+                "contestants": [
+                    {
+                        "id": "st",
+                        "name": "seat",
+                        "agent": "stella",
+                        "engine": {"api": "openrouter", "model": "m"},
+                    }
+                ],
+            }
+        )
+
+    def _advance_origin(self, repo: Path) -> None:
+        origin = repo.parent / "origin"
+        (origin / "a.txt").write_text("moved")
+        _git(origin, "commit", "-qam", "moved while building")
+        _git(repo, "fetch", "-q", "origin")
+
+    def test_a_commit_pin_survives_the_branch_moving(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Verify (c): built, origin advanced, pinned to the built commit —
+        the match runs the original binary, unaffected by the drift."""
+        built = _git(repo, "rev-parse", "origin/main")
+        binary = self._stage(built)
+        self._advance_origin(repo)
+        _stub_harbor(monkeypatch)
+        captured = _capture_popen(monkeypatch)
+
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._stella_spec(built))
+        run = runner._launch(match, match.spec.contestants[0])
+
+        assert run.error == ""
+        assert captured[0]["env"]["STELLA_BINARY"] == str(binary)
+        assert captured[0]["env"]["ARENABENCH_SUT_COMMIT"] == built
+
+    def test_a_drifted_branch_pin_refuses_rather_than_falling_through(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Verify (d): built, origin advanced, pinned to the bare branch —
+        refuse naming the drift; never launch on the ambient/PATH tier."""
+        built = _git(repo, "rev-parse", "origin/main")
+        self._stage(built)
+        self._advance_origin(repo)
+        _stub_harbor(monkeypatch)
+        captured = _capture_popen(monkeypatch)
+        # An ambient binary is available; falling through to it is the bug.
+        decoy = tmp_path / "ambient-stella"
+        decoy.write_text("#!/bin/sh\n")
+        monkeypatch.setenv(sut.STELLA_BINARY_ENV, str(decoy))
+
+        preflight = sut.sut_problem_for(self._stella_spec("main"))
+        assert preflight is not None
+        assert "behind" in preflight, "the refusal must name the drift"
+
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._stella_spec("main"))
+        with pytest.raises(sut.SutUnavailableError) as refusal:
+            runner._launch(match, match.spec.contestants[0])
+        assert "moved since the build" in str(refusal.value)
+        assert built[:8] in str(refusal.value)
+        assert captured == [], "a refused trial must launch nothing at all"
+
+    def test_provenance_and_launch_read_the_same_observation(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The mechanism itself: a resolver that moves the ref between calls
+        must not be able to hand provenance one commit and the launch another.
+        """
+        built = _git(repo, "rev-parse", "origin/main")
+        moved = _git(repo, "rev-parse", "refs/heads/main")
+        binary = self._stage(built)
+        _stub_harbor(monkeypatch)
+        captured = _capture_popen(monkeypatch)
+
+        calls: list[str] = []
+
+        def moving(ref: str, repo_path=None):
+            calls.append(ref)
+            # First observation: the built tip. Every later one: the ref has
+            # moved — exactly the 2026-08-07 reproduction.
+            return built if len(calls) == 1 else moved
+
+        monkeypatch.setattr(sut, "resolve_ref", moving)
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._stella_spec("main"))
+        match.provenance = runner_module._provenance_for(match)
+        run = runner._launch(match, match.spec.contestants[0])
+
+        assert run.error == ""
+        recorded = match.provenance.sut_seats["st"]["commit"]
+        launched = captured[0]["env"]["ARENABENCH_SUT_COMMIT"]
+        assert recorded == launched == built, (
+            "provenance and the launch observed different values of one "
+            "floating ref — the exact #2098 race"
+        )
+        assert captured[0]["env"]["STELLA_BINARY"] == str(binary)

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -559,10 +559,16 @@ def _stub_harbor(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
-    """Stub the launch subprocess and capture every (command, env) handed to it."""
-    captured: list[dict] = []
+    """Capture every (command, env) the *launch* hands Popen.
 
-    class _Fake:
+    Only the stubbed Harbor binary is intercepted: `arenabench.runner` imports
+    the shared ``subprocess`` module, so a blanket patch would also break the
+    real ``git`` subprocesses the pin resolution runs mid-launch.
+    """
+    captured: list[dict] = []
+    real_popen = subprocess.Popen
+
+    class _Recorder:
         def __init__(self, command, **kwargs):
             captured.append({"command": command, "env": kwargs.get("env") or {}})
             self.returncode = None
@@ -570,7 +576,12 @@ def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
         def poll(self):
             return None
 
-    monkeypatch.setattr("arenabench.runner.subprocess.Popen", _Fake)
+    def dispatch(command, **kwargs):
+        if command and command[0] == "/usr/bin/harbor":
+            return _Recorder(command, **kwargs)
+        return real_popen(command, **kwargs)
+
+    monkeypatch.setattr("arenabench.runner.subprocess.Popen", dispatch)
     return captured
 
 

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -822,7 +822,16 @@ def _locate_binary() -> Path:
     ``PATH``, then ``./target/release/stella`` walking up from the current
     working directory. Never imported at module load — only ``install`` calls
     this, so importing the adapter never requires Stella to be present.
+
+    A trial whose environment carries ``ARENABENCH_SUT_COMMIT`` was *pinned*
+    to a commit by its launcher, and the launcher always sets ``STELLA_BINARY``
+    beside it. Reaching the ``PATH``/cwd tiers with the pin present is
+    therefore always a broken pin, and it fails closed: those tiers exist for
+    genuinely unpinned development runs, and falling through them once
+    uploaded the operator's native macOS arm64 build into every Linux task
+    container (#2098).
     """
+    pinned = os.environ.get("ARENABENCH_SUT_COMMIT")
     explicit = os.environ.get("STELLA_BINARY")
     if explicit:
         binary = Path(explicit)
@@ -831,6 +840,15 @@ def _locate_binary() -> Path:
                 f"STELLA_BINARY={explicit!r} does not point at a file"
             )
         return binary
+    if pinned:
+        raise FileNotFoundError(
+            f"this trial is pinned to Stella commit {pinned[:12]} "
+            "(ARENABENCH_SUT_COMMIT) but STELLA_BINARY is not set — a broken "
+            "pin fails closed. Refusing to fall back to `stella` on PATH or "
+            "a cwd walk: an ambient binary has no relation to the pinned "
+            "commit, and that fallback once uploaded a host's native macOS "
+            "build into Linux task containers (#2098)."
+        )
 
     on_path = _cached_binary(_BINARY_NAME)
     if on_path is not None:

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -92,6 +92,7 @@ from .exit_cause import (
     probe_sigkill_cause,
 )
 from .git_baseline import ensure_git, run_git_baseline
+from .locate import locate_binary as _locate_binary
 from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
@@ -134,8 +135,8 @@ except ImportError:  # pragma: no cover - depends on the installed Harbor versio
         return fn
 
 
-# Installation paths (inside the task container).
-_BINARY_NAME = "stella"
+# Installation paths (inside the task container). The binary's name (and how
+# it is located on the host) lives in ``.locate``.
 _INSTALL_PATH = "/usr/local/bin/stella"
 _REMOTE_TMP = "/tmp/stella-upload"
 
@@ -746,17 +747,6 @@ async def _secure_exec_with_credential_fd(
             wire[index] = 0
 
 
-def _cached_binary(name: str) -> Path | None:
-    """Return the first executable named ``name`` found on ``PATH``, or None."""
-    for path in os.environ.get("PATH", "").split(os.pathsep):
-        if not path:
-            continue
-        candidate = Path(path) / name
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return candidate
-    return None
-
-
 def _sha256_file(path: Path) -> str:
     """Return the full SHA-256 digest of a host binary."""
     digest = hashlib.sha256()
@@ -813,63 +803,6 @@ def _embedded_source_commit(version_text: str) -> str | None:
     """Extract the full compile-time STELLA_BUILD_GIT_SHA from `--version`."""
     match = re.search(r"-dev\.([0-9a-fA-F]{40})(?:\s|$)", version_text)
     return match.group(1).lower() if match is not None else None
-
-
-def _locate_binary() -> Path:
-    """Find the Stella binary on the host.
-
-    Resolution order: explicit ``STELLA_BINARY`` env var, then ``stella`` on
-    ``PATH``, then ``./target/release/stella`` walking up from the current
-    working directory. Never imported at module load — only ``install`` calls
-    this, so importing the adapter never requires Stella to be present.
-
-    A trial whose environment carries ``ARENABENCH_SUT_COMMIT`` was *pinned*
-    to a commit by its launcher, and the launcher always sets ``STELLA_BINARY``
-    beside it. Reaching the ``PATH``/cwd tiers with the pin present is
-    therefore always a broken pin, and it fails closed: those tiers exist for
-    genuinely unpinned development runs, and falling through them once
-    uploaded the operator's native macOS arm64 build into every Linux task
-    container (#2098).
-    """
-    pinned = os.environ.get("ARENABENCH_SUT_COMMIT")
-    explicit = os.environ.get("STELLA_BINARY")
-    if explicit:
-        binary = Path(explicit)
-        if not binary.is_file():
-            raise FileNotFoundError(
-                f"STELLA_BINARY={explicit!r} does not point at a file"
-            )
-        return binary
-    if pinned:
-        raise FileNotFoundError(
-            f"this trial is pinned to Stella commit {pinned[:12]} "
-            "(ARENABENCH_SUT_COMMIT) but STELLA_BINARY is not set — a broken "
-            "pin fails closed. Refusing to fall back to `stella` on PATH or "
-            "a cwd walk: an ambient binary has no relation to the pinned "
-            "commit, and that fallback once uploaded a host's native macOS "
-            "build into Linux task containers (#2098)."
-        )
-
-    on_path = _cached_binary(_BINARY_NAME)
-    if on_path is not None:
-        return on_path
-
-    cwd = Path.cwd()
-    while True:
-        candidate = cwd / "target" / "release" / _BINARY_NAME
-        if candidate.is_file():
-            return candidate
-        if cwd == cwd.parent:  # reached filesystem root
-            break
-        cwd = cwd.parent
-
-    raise FileNotFoundError(
-        f"cannot find the {_BINARY_NAME!r} binary. For development, build "
-        "with `cargo build --release -p stella-cli` (produces "
-        "./target/release/stella) or put it on PATH. For a claim run, use "
-        "the README's full-SHA-stamped x86_64 Linux build and set "
-        "STELLA_BINARY=/path/to/stella."
-    )
 
 
 def _sum_step_usage(events: list[Any]) -> dict[str, int]:

--- a/bench/harbor_adapter/stella_harbor/locate.py
+++ b/bench/harbor_adapter/stella_harbor/locate.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Resolving which Stella binary a trial uploads — and when not to.
+
+Split out of ``__init__`` (which is closed to growth under the repository's
+file-size ratchet) when the broken-pin refusal landed. Deliberately
+package-import-free so the module can never participate in an import cycle
+with the adapter root.
+
+The resolution order is a deliberate gradient from explicit to ambient:
+``STELLA_BINARY``, then ``stella`` on ``PATH``, then ``./target/release/stella``
+walking up from the current working directory. The ambient tiers exist for
+unpinned development runs and stay (#2051 tracks their visibility); what must
+never happen is a *pinned* trial reaching them — see :func:`locate_binary`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: The binary's name, both on the host and installed inside the container.
+BINARY_NAME = "stella"
+
+
+def _cached_binary(name: str) -> Path | None:
+    """Return the first executable named ``name`` found on ``PATH``, or None."""
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        if not path:
+            continue
+        candidate = Path(path) / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def locate_binary() -> Path:
+    """Find the Stella binary on the host.
+
+    Resolution order: explicit ``STELLA_BINARY`` env var, then ``stella`` on
+    ``PATH``, then ``./target/release/stella`` walking up from the current
+    working directory. Never imported at module load — only ``install`` calls
+    this, so importing the adapter never requires Stella to be present.
+
+    A trial whose environment carries ``ARENABENCH_SUT_COMMIT`` was *pinned*
+    to a commit by its launcher, and the launcher always sets ``STELLA_BINARY``
+    beside it. Reaching the ``PATH``/cwd tiers with the pin present is
+    therefore always a broken pin, and it fails closed: those tiers exist for
+    genuinely unpinned development runs, and falling through them once
+    uploaded the operator's native macOS arm64 build into every Linux task
+    container (#2098).
+    """
+    pinned = os.environ.get("ARENABENCH_SUT_COMMIT")
+    explicit = os.environ.get("STELLA_BINARY")
+    if explicit:
+        binary = Path(explicit)
+        if not binary.is_file():
+            raise FileNotFoundError(
+                f"STELLA_BINARY={explicit!r} does not point at a file"
+            )
+        return binary
+    if pinned:
+        raise FileNotFoundError(
+            f"this trial is pinned to Stella commit {pinned[:12]} "
+            "(ARENABENCH_SUT_COMMIT) but STELLA_BINARY is not set — a broken "
+            "pin fails closed. Refusing to fall back to `stella` on PATH or "
+            "a cwd walk: an ambient binary has no relation to the pinned "
+            "commit, and that fallback once uploaded a host's native macOS "
+            "build into Linux task containers (#2098)."
+        )
+
+    on_path = _cached_binary(BINARY_NAME)
+    if on_path is not None:
+        return on_path
+
+    cwd = Path.cwd()
+    while True:
+        candidate = cwd / "target" / "release" / BINARY_NAME
+        if candidate.is_file():
+            return candidate
+        if cwd == cwd.parent:  # reached filesystem root
+            break
+        cwd = cwd.parent
+
+    raise FileNotFoundError(
+        f"cannot find the {BINARY_NAME!r} binary. For development, build "
+        "with `cargo build --release -p stella-cli` (produces "
+        "./target/release/stella) or put it on PATH. For a claim run, use "
+        "the README's full-SHA-stamped x86_64 Linux build and set "
+        "STELLA_BINARY=/path/to/stella."
+    )

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -80,6 +80,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/git_baseline.py",
     "bench/harbor_adapter/stella_harbor/host_attestation.py",
     "bench/harbor_adapter/stella_harbor/live_feed.py",
+    "bench/harbor_adapter/stella_harbor/locate.py",
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -37,7 +37,6 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     HOST_CREDENTIAL_BUNDLE_FD_ENV,
     StellaAgent,
     _benchmark_engine_posture,
-    _cached_binary,
     _extract_metrics,
     _is_truthy,
     _load_json_object,
@@ -54,6 +53,7 @@ from stella_harbor.credential_bundle import (  # noqa: E402
     HOST_CREDENTIAL_SOURCE,
     create_anonymous_credential_bundle,
 )
+from stella_harbor.locate import _cached_binary  # noqa: E402
 
 
 def _bare_agent() -> StellaAgent:

--- a/bench/harbor_adapter/tests/test_locate_binary.py
+++ b/bench/harbor_adapter/tests/test_locate_binary.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""A broken SUT pin fails closed at binary resolution (#2098).
+
+``_locate_binary``'s ``PATH`` and cwd-walk tiers exist for genuinely unpinned
+development runs and stay (#2051 covers their visibility separately). What
+must never happen is a *pinned* trial reaching them: on 2026-08-07 a match
+pinned to ``main`` lost its staged binary to the ref moving mid-build, the
+launcher fell through without setting ``STELLA_BINARY``, and the ``PATH``
+tier uploaded the operator's native macOS arm64 build into every Linux task
+container — seven trials dead on ``Exec format error``, silently at every
+layer.
+
+The launcher (arenabench's runner) sets ``ARENABENCH_SUT_COMMIT`` beside
+``STELLA_BINARY`` for every pinned trial, so the pin marker present without
+the explicit binary is *always* a broken pin. These tests plant working
+binaries on both ambient tiers and assert they are never reached while the
+marker is set — the fallback would succeed, which is exactly why it must not
+be attempted.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from stella_harbor import _locate_binary
+
+
+@pytest.fixture
+def ambient_tiers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A ``stella`` on PATH and one at ``./target/release``, both resolvable.
+
+    Both tiers would succeed, so any test that still fails proves the tier
+    was refused rather than merely missing.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    on_path = bin_dir / "stella"
+    on_path.write_text("#!/bin/sh\n")
+    on_path.chmod(0o755)
+
+    project = tmp_path / "project"
+    (project / "target" / "release").mkdir(parents=True)
+    walked = project / "target" / "release" / "stella"
+    walked.write_text("#!/bin/sh\n")
+    walked.chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("STELLA_BINARY", raising=False)
+    monkeypatch.delenv("ARENABENCH_SUT_COMMIT", raising=False)
+    return on_path
+
+
+class TestBrokenPinFailsClosed:
+    def test_a_pin_without_stella_binary_never_reaches_path_or_cwd_tiers(
+        self, ambient_tiers: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The #2098 regression witness: pin marker set, explicit binary lost,
+        two working fallbacks available — refuse anyway."""
+        monkeypatch.setenv("ARENABENCH_SUT_COMMIT", "a" * 40)
+        with pytest.raises(FileNotFoundError) as refusal:
+            _locate_binary()
+        message = str(refusal.value)
+        assert "pinned" in message
+        assert "fails closed" in message
+        assert ("a" * 12) in message, "the refusal must name the pinned commit"
+
+    def test_an_explicit_binary_satisfies_a_pinned_trial(
+        self, ambient_tiers: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        staged = tmp_path / "staged-stella"
+        staged.write_text("#!/bin/sh\n")
+        staged.chmod(0o755)
+        monkeypatch.setenv("ARENABENCH_SUT_COMMIT", "a" * 40)
+        monkeypatch.setenv("STELLA_BINARY", str(staged))
+        assert _locate_binary() == staged
+
+    def test_a_pinned_trial_whose_binary_path_is_gone_still_refuses(
+        self, ambient_tiers: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A dangling STELLA_BINARY on a pinned trial is the same broken pin —
+        the existing explicit-tier error already refuses it; pin or no pin,
+        it must not degrade to the ambient tiers."""
+        monkeypatch.setenv("ARENABENCH_SUT_COMMIT", "a" * 40)
+        monkeypatch.setenv("STELLA_BINARY", str(tmp_path / "deleted-stella"))
+        with pytest.raises(FileNotFoundError):
+            _locate_binary()
+
+
+class TestUnpinnedFallbackSurvives:
+    """#2098's constraint: only a broken *pin* fails closed. The ambient
+    tiers stay for unpinned development runs — removing them is explicitly
+    out of scope (#2051 tracks their visibility)."""
+
+    def test_an_unpinned_run_still_resolves_from_path(self, ambient_tiers: Path):
+        assert _locate_binary() == ambient_tiers

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2199 bench/harbor_adapter/stella_harbor/__init__.py
-4294 bench/harbor_adapter/stella_harbor/secure_launcher.py
+2150 bench/harbor_adapter/stella_harbor/__init__.py
+4295 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2335 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8272 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
## What & why

One PR closes both issues because they share one seam and #2098's own text says so: "once a per-contestant `sut_ref` round-trips, launching against an already-resolved commit rather than a re-resolved ref is a small extension of the same change." The seam is *how a match knows which Stella a seat runs*; #2082 makes that answer per-seat and file-durable, #2098 makes it a single observation that fails closed.

**#2082 — per-seat pins that round-trip TOML:**
- `Contestant.sut_ref` (`arenabench/arenabench/model.py`): `None` inherits the match default, `""` opts the seat out, anything else is the seat's own ref. `MatchSpec.sut_ref_for()` is the one seam every consumer resolves through. A pin on a non-Stella seat is refused at parse and at `validate()` rather than ignored.
- `config.py` reads `[match] sut_ref` plus a per-seat override and writes both back (`match_to_toml_dict`, `dump_match` — the match-level key is written unconditionally, so the GUI's "download this match" no longer drops the pin). `dump -> load -> dump` is byte-stable, pins included.
- `provenance.py` gains `sut_seats` (per-contestant `ref`/`commit`/`sha256`). The match-level `comparability_key` names every distinct commit (`stellaAAAA+BBBB`), so a two-twin match can never be averaged into a single-SUT series; `comparability_key_for(seat)` is the arm-level key, differing from a comparable arm's in nothing but the `stella<commit>` half. The legacy single `sut_commit`/`sut_sha256` stay filled only while they are true (one identity across all Stella seats). `series.py` rows expose each arm's own `sut_commit` (outside the group key — the SUT is the variable under test).
- `sut_problem_for` judges each Stella seat's effective ref independently and names the seat it refuses for.

**#2098 — a pin is observed once and fails closed:**
- `Match.sut_pin_for()` (`runner.py`) resolves each declared ref **once per match** (`sut.resolve_pin` -> `ResolvedPin`); `_provenance_for`, the launch env, and each seat's `.seat.json` record (new `sut_ref`/`sut_commit`/`sut_sha256` fields) all read that one observation — the two halves of a pin can no longer see two values of one floating ref.
- `_agent_environment` with a pinned seat and no staged binary now **raises** (`sut.broken_pin_problem`), naming the resolved commit and the nearest staged build's drift ("if 'main' is a branch it has moved since the build; pin the commit the build resolved to") — never falls through to ambient `STELLA_BINARY` or the adapter's PATH tier. `sut_status`'s nothing-built branch names the nearest per-commit build's drift too, so the create-preflight refusal says the same thing.
- `arenabench run` (`cli.py`) gains the same `sut_problem_for` preflight `create_match` already had — the exact path the 2026-08-07 reproduction entered through.
- Belt and braces: a pinned trial's env carries `ARENABENCH_SUT_COMMIT`, and `stella_harbor`'s binary locator refuses its PATH/cwd tiers when the marker is present without `STELLA_BINARY`. The locator moved to `stella_harbor/locate.py` (`__init__.py` is a grandfathered god file closed to growth; the split ratchets its ceiling down 2199 -> 2150). The unpinned PATH fallback is untouched — only a broken pin fails closed (#2051 tracks unpinned visibility separately).

Constraints honoured: `~/.arenabench/sut/` layout and the one-at-a-time `SutBuilder` are unchanged; `ui/` is untouched and keeps its pin-the-built-commit semantics (per-seat GUI exposure is filed as #2137).

Behavior notes for review: a match with no Stella seat no longer records a resolved `sut_commit` in provenance (it has no SUT of ours); a pinned Stella seat on a host with no configured checkout now refuses at launch instead of silently running ambient — `sut_ref = ""` is the documented opt-out, and two argv-shape tests were updated to declare it.

Closes #2082
Closes #2098

Refs #2051, #2016, #2020, #2081
Refs #2137, #2138 (follow-ups filed from this work)

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Spot-checked by reverting `arenabench/arenabench/` + `bench/harbor_adapter/stella_harbor/` to the branch point (8b266fc6) with the new tests kept, all confirmed failing there and passing here:
- `tests/test_sut.py::TestAPinIsObservedOnce::test_a_drifted_branch_pin_refuses_rather_than_falling_through` — old code: no refusal, no drift named (`AssertionError: the refusal must name the drift`).
- `tests/test_sut.py::TestAPinIsObservedOnce::test_provenance_and_launch_read_the_same_observation` — old code resolves the ref twice and the two observations diverge (`AttributeError: 'Provenance' object has no attribute 'sut_seats'`; env carries no pinned binary).
- `tests/test_sut.py::TestTwoSeatsRaceTwoBuilds::test_two_seats_launch_two_binaries_and_record_them` — old code launches both seats on one binary.
- `tests/test_arena.py::TestSutPinTemplates::test_the_pin_round_trips_byte_stably` / `test_a_match_level_pin_reaches_the_spec` — old code loads `'main'`, not the pinned ref.
- `bench/harbor_adapter/tests/test_locate_binary.py::TestBrokenPinFailsClosed::test_a_pin_without_stella_binary_never_reaches_path_or_cwd_tiers` — old code: `DID NOT RAISE` (the PATH tier resolved a planted binary).

## The gate

- [x] `cd arenabench && uv run --with pytest --no-project pytest` — 393 passed (what `bench.yml` runs)
- [x] `cd bench/harbor_adapter && uv sync --locked && uv run --no-sync pytest` — 487 passed, 1 skipped
- [x] `scripts/check-file-size.sh` green (baseline diff is its own commit: `__init__.py` 2199 -> 2150, `secure_launcher.py` 4294 -> 4295 for the one irreducible `_FIXED_ADAPTER_SOURCE_PATHS` registration line)
- [x] No Rust touched — cargo fmt/clippy/test unaffected by this diff
- [x] Docs updated: `arenabench/README.md` SUT section documents per-seat pins and the fail-closed posture
- [x] `Closes #N` appears both above and as commit trailers (on the final commit)

Not verified locally: a live end-to-end match (real `cargo zigbuild` SUT builds, Docker containers, a real Harbor run) — the drift/launch/refusal mechanics are exercised through the suite's synthetic git-fixture path (`tests/test_sut.py`) exactly like the neighbouring SUT tests, and the launch assertions read the same `.seat.json`/env the real path writes. The GUI is deliberately untouched; its per-seat exposure and its wizard round-trip gap are #2137.

## Nothing left behind

- #2137 — arenabench UI: expose the per-seat SUT pin (and fix the wizard parse->state->create round trip that drops a seat override).
- #2138 — `SutBuilder.start` drops a second requested ref while a build is running; a twin match needs two builds queued behind one another.

## Summary by Sourcery

Introduce per-seat SUT pinning that round-trips through JSON/TOML and provenance, and ensure pinned Stella builds are resolved once per match and fail closed instead of falling back to ambient binaries.

New Features:
- Add per-contestant sut_ref overrides and a sut_ref_for helper so matches can pin Stella independently per seat.
- Record per-seat SUT identity in provenance and expose per-seat sut_commit in series output to support multi-SUT matches.
- Extend match/TOML config handling and CLI run preflight to support and validate per-seat and match-level SUT pins.

Bug Fixes:
- Ensure a pinned SUT ref is resolved exactly once per match and reused for launch and provenance, preventing races where a floating ref moves between resolutions (#2098).
- Make pinned seats without a matching staged binary fail closed with clear drift reporting, rather than silently degrading to ambient/STELLA_BINARY/PATH fallbacks.
- Prevent sut_ref pins on non-Stella seats by rejecting them at template parse and spec validation, avoiding misleading templates that claim to pin a SUT they never run.
- Ensure matches with no Stella seats or with diverging per-seat commits produce honest provenance, leaving legacy aggregate SUT fields empty when no single value is true.

Enhancements:
- Refine sut preflight checks to operate per Stella seat and reuse ref-based status, improving error reporting for multi-seat matches (#2082).
- Improve sut_status and drift reporting by finding the nearest staged commit and describing its relationship to the requested target.
- Add detailed comparability keys per seat, incorporating SUT identity so multi-SUT matches cannot be averaged into single-SUT series.
- Update runner launch records and environment to carry per-seat SUT pin details and a commit marker used downstream by Harbor.
- Refactor Harbor adapter binary location logic into a dedicated module that enforces fail-closed behavior for broken pins while preserving unpinned PATH/cwd fallbacks.

Documentation:
- Update README SUT section to document per-seat pins, single-observation pin resolution, and fail-closed behavior for broken pins.

Tests:
- Add comprehensive tests covering per-seat provenance recording, two-seat matches launching distinct binaries, pin round-tripping via JSON/TOML, and validation of non-Stella pins.
- Add regression tests ensuring a pinned branch that has drifted refuses with a clear message and that launch and provenance share a single pin observation.
- Add Harbor adapter tests verifying that pinned trials without STELLA_BINARY fail closed at binary resolution while unpinned PATH-based fallback remains available.