### PR TITLE
fix(stella-cli): parse the supervision env vars as booleans, not clap literals

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -289,7 +289,19 @@ pub(crate) struct GlobalArgs {
     /// nobody to ask. Invocations with no terminal to lose (a pipe, CI, a
     /// container) are never supervised and are unaffected either way.
     /// Env: STELLA_FOREGROUND.
-    #[arg(long, global = true, env = "STELLA_FOREGROUND", hide_short_help = true)]
+    // `action` and `value_parser` are spelled out because the inferred `bool`
+    // parser accepts only the literals `true`/`false` — and the supervisor
+    // tells its child to do the work through `STELLA_FOREGROUND=1`
+    // (`daemon::launch`), so under the inferred parser every supervised child
+    // died in argument parsing before it ran a turn (#2142).
+    #[arg(
+        long,
+        global = true,
+        env = "STELLA_FOREGROUND",
+        hide_short_help = true,
+        action = clap::ArgAction::SetTrue,
+        value_parser = parse_env_flag,
+    )]
     pub(crate) foreground: bool,
 
     /// Start the run in the background and return to the shell immediately.
@@ -304,7 +316,17 @@ pub(crate) struct GlobalArgs {
     /// The exit code is the launch's, not the run's: the run's own answer is
     /// in `stella daemon list` afterwards. `--foreground` wins if both are
     /// given. Env: STELLA_DETACH.
-    #[arg(long, global = true, env = "STELLA_DETACH", hide_short_help = true)]
+    // Same parser as `foreground`, same reason (#2142): `export
+    // STELLA_DETACH=1` is the conventional shell spelling, and the inferred
+    // parser refuses it.
+    #[arg(
+        long,
+        global = true,
+        env = "STELLA_DETACH",
+        hide_short_help = true,
+        action = clap::ArgAction::SetTrue,
+        value_parser = parse_env_flag,
+    )]
     pub(crate) detach: bool,
 }
 
@@ -1261,6 +1283,29 @@ pub enum McpCmd {
     },
     /// Show MCP tool-usage telemetry (.stella/private/store.db): calls per server/tool
     Usage,
+}
+
+/// `--foreground` / `--detach` through their environment variables
+/// (`STELLA_FOREGROUND`, `STELLA_DETACH`).
+///
+/// clap's inferred `bool` parser accepts only the literals `true`/`false`,
+/// and the environment is exactly where other spellings arrive: the
+/// supervisor's own child telegram is `STELLA_FOREGROUND=1`
+/// (`daemon::launch`), and `export STELLA_DETACH=1` is the convention a
+/// shell user reaches for. Under the inferred parser each of those died in
+/// argument parsing — for the supervised child, before it ran a turn, which
+/// made every supervised run dead on arrival (#2142). Two asymmetries are
+/// deliberate: empty reads as unset rather than erroring, because `export
+/// STELLA_FOREGROUND=` is a shell's way of saying "not set"; anything
+/// unrecognized is still refused by name, never silently read as true.
+fn parse_env_flag(raw: &str) -> Result<bool, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "t" | "yes" | "y" | "on" => Ok(true),
+        "" | "0" | "false" | "f" | "no" | "n" | "off" => Ok(false),
+        _ => Err(format!(
+            "`{raw}` is not a boolean — use 1/0, true/false, yes/no, or on/off"
+        )),
+    }
 }
 
 /// `--budget` must be a positive, finite dollar amount — a NaN or negative

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -638,6 +638,32 @@ fn detach_before_exec(command: &mut std::process::Command, lock_path: PathBuf) {
     }
 }
 
+/// The attached banner's lines, pure over the session id so what a user is
+/// told at the moment supervision engages is testable without spawning
+/// anything.
+///
+/// The last line exists because supervision is a default, not a choice the
+/// user made: the moment it first engages is the one reliable place to teach
+/// the opt-out — `--help` is where nobody looks for a flag they don't know
+/// exists (#2142).
+fn announcement(id: &str) -> [String; 3] {
+    [
+        format!(
+            "{} {} — survives this terminal closing",
+            "▸ supervised".green().bold(),
+            id.dimmed()
+        ),
+        format!(
+            "  reattach with {}",
+            format!("stella daemon attach {id}").cyan()
+        ),
+        format!(
+            "  stella is running in the background — {} runs it in this terminal instead",
+            "--foreground".cyan()
+        ),
+    ]
+}
+
 impl Supervised {
     /// The banner the terminal sees, once, before the child's first byte.
     ///
@@ -650,15 +676,9 @@ impl Supervised {
     /// (#1585) — this terminal while it stays, any `stella daemon attach`
     /// after it goes — so supervision no longer takes that answer away.
     pub(crate) fn announce(&self) {
-        eprintln!(
-            "{} {} — survives this terminal closing",
-            "▸ supervised".green().bold(),
-            self.id.dimmed()
-        );
-        eprintln!(
-            "  reattach with {}",
-            format!("stella daemon attach {}", self.id).cyan()
-        );
+        for line in announcement(&self.id) {
+            eprintln!("{line}");
+        }
     }
 
     /// Stream the child's console to this terminal until it exits, and answer

--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -90,6 +90,33 @@ fn a_terminal_run_is_supervised_and_everything_else_is_not() {
     assert!(!should_supervise(false, true, true));
 }
 
+/// **Witness (#2142).** The banner teaches the opt-out.
+///
+/// Supervision is a default, not a choice the user made, so the moment it
+/// engages is the one reliable place to say what it means — the run is in
+/// the background — and how to decline it next time: `--foreground` keeps
+/// the work in this terminal's process.
+#[test]
+fn the_attached_banner_says_background_and_names_the_foreground_opt_out() {
+    let lines = super::announcement("ses-banner");
+    assert!(
+        lines[0].contains("survives this terminal closing"),
+        "{}",
+        lines[0]
+    );
+    assert!(
+        lines[1].contains("stella daemon attach ses-banner"),
+        "{}",
+        lines[1]
+    );
+    assert!(
+        lines[2].contains("running in the background"),
+        "{}",
+        lines[2]
+    );
+    assert!(lines[2].contains("--foreground"), "{}", lines[2]);
+}
+
 /// The witness for the whole feature: a supervised run leaves the terminal's
 /// session, so the `SIGHUP` a closing window sends to that session cannot
 /// reach it.

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -510,6 +510,58 @@ fn session_flags_parse_before_subcommand() {
     assert_eq!(cli.globals.budget, Some(2.5));
 }
 
+/// **Witness (#2142).** The supervised child's env telegram parses.
+///
+/// `daemon::launch` tells its child to do the work through
+/// `STELLA_FOREGROUND=1`, and clap's inferred `bool` parser accepts only the
+/// literals `true`/`false` — so every supervised child died in argument
+/// parsing (`error: invalid value '1' for '--foreground'`) before it ran a
+/// turn, and the launching terminal streamed the corpse. The default posture
+/// on a TTY is supervision, which made this the default path. The
+/// environment is a boolean channel with more than two spellings; parse it
+/// like one, for `--detach`'s `STELLA_DETACH` identically.
+#[test]
+fn the_supervision_env_vars_accept_the_boolean_spellings_the_shell_uses() {
+    let _lock = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_FOREGROUND", "STELLA_DETACH"]);
+
+    // The exact telegram `daemon::launch` sends its child.
+    unsafe { std::env::set_var("STELLA_FOREGROUND", "1") };
+    unsafe { std::env::remove_var("STELLA_DETACH") };
+    let cli = Cli::try_parse_from(["stella", "run", "hi"])
+        .expect("the supervisor's own child telegram must parse");
+    assert!(cli.globals.foreground);
+    assert!(!cli.globals.detach);
+
+    // `0` is off, not a parse error — and the other shell spellings, both
+    // directions, on both vars.
+    unsafe { std::env::set_var("STELLA_FOREGROUND", "0") };
+    unsafe { std::env::set_var("STELLA_DETACH", "on") };
+    let cli = Cli::try_parse_from(["stella", "run", "hi"])
+        .expect("0 and on are boolean spellings, not errors");
+    assert!(!cli.globals.foreground);
+    assert!(cli.globals.detach);
+
+    // Present-but-empty is a shell's "not set", not a fatal parse error.
+    unsafe { std::env::set_var("STELLA_FOREGROUND", "") };
+    unsafe { std::env::remove_var("STELLA_DETACH") };
+    let cli = Cli::try_parse_from(["stella", "run", "hi"]).expect("empty means unset");
+    assert!(!cli.globals.foreground);
+
+    // The bare flag needs no value and beats a contradicting environment.
+    unsafe { std::env::set_var("STELLA_FOREGROUND", "0") };
+    let cli = Cli::try_parse_from(["stella", "run", "hi", "--foreground"])
+        .expect("the command line wins over the environment");
+    assert!(cli.globals.foreground);
+
+    // Garbage is still refused by name, never silently read as true.
+    unsafe { std::env::set_var("STELLA_FOREGROUND", "banana") };
+    assert!(
+        Cli::try_parse_from(["stella", "run", "hi"]).is_err(),
+        "an unrecognized spelling must be refused, not guessed at"
+    );
+}
+
 /// #1493's witness. `--output-format` is a promise about what reaches
 /// stdout, so it exists only on the commands that keep it. Under the old
 /// `global = true` declaration every invocation below parsed cleanly and


### PR DESCRIPTION
## What & why

Every supervised run was dead on arrival. Launching any long-running verb from a terminal printed the banner and then streamed a clap error from the child:

```
▸ supervised ses-1786149550194-90070 — survives this terminal closing
  reattach with stella daemon attach ses-1786149550194-90070
error: invalid value '1' for '--foreground'
  [possible values: true, false]
```

The chain: `daemon::launch` tells its child to do the work through `STELLA_FOREGROUND=1` (deliberately env, not argv — see the `detach.rs` module doc), while `cli.rs` declares `foreground: bool` with `env = "STELLA_FOREGROUND"`. clap derive infers `ArgAction::SetTrue` with the `bool` value parser, which accepts only the literals `true`/`false` — so the child died in argument parsing before running a turn, on the **default TTY path**. `--detach`/`STELLA_DETACH` carried the identical latent hazard for the conventional `export STELLA_DETACH=1`.

The fix follows clap's own documented pattern for env-backed flags (`ArgAction::SetTrue`'s docs pair it with a lenient boolean parser for exactly this reason): both flags now spell out `action = ArgAction::SetTrue` plus a shared `parse_env_flag` that reads the boolean spellings an environment actually carries — `1/0`, `true/false`, `yes/no`, `on/off`, case-insensitive; empty = unset (a shell's `export STELLA_FOREGROUND=` means "not set", and erroring there would recreate the every-invocation-dies shape this PR removes); anything unrecognized is still refused by name, never silently read as true. Exemplar for the parser shape: the existing `parse_budget`/`parse_turn_budget` neighbors in the same file.

The default posture is deliberately unchanged: a bare TTY run still supervises (`detach_forces_supervision_where_a_bare_run_would_decline_it` pins it). Since that default is a choice the user didn't make, the attached banner now teaches the opt-out — `announce` gains a third line, extracted into a pure `announcement(id)` so the contract is testable:

```
▸ supervised ses-… — survives this terminal closing
  reattach with stella daemon attach ses-…
  stella is running in the background — --foreground runs it in this terminal instead
```

The detached (`--detach`) banner already says "running in the background" and is a posture the user asked for by flag, so it is unchanged.

Closes #2142

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_supervision_env_vars_accept_the_boolean_spellings_the_shell_uses` (`crates/stella-cli/src/tests.rs`) sets the exact telegram `daemon::launch` sends (`STELLA_FOREGROUND=1`) under the crate's `test_env` lock/restore discipline and parses — on `main` this is the clap error above; here it parses with `foreground == true`. It also pins `0`/`on`/empty/flag-beats-env, and that garbage still errors. `the_attached_banner_says_background_and_names_the_foreground_opt_out` (`daemon/tests.rs`) pins the new banner line; on `main` it does not compile (`announcement` does not exist). Verified the artisanal way: `git checkout origin/main -- crates/stella-cli/src/cli.rs` + rerun → fail; restore → pass.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (scoped `-p stella-cli` locally; CI runs the workspace)
- [x] `cargo test --workspace` (scoped `-p stella-cli` locally; CI runs the workspace)
- [x] Docs updated where behavior/flags changed — `--help` text deliberately unchanged (the flags' meaning didn't move; the accepted env spellings are documented on `parse_env_flag`, and the website command docs are parity-locked to help text)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2144 — supervision has no automated end-to-end proof; a pty smoke in the self-driving harness would have caught this on day one (the `daemon/tests.rs` module doc says the e2e property is "verified by hand", and this bug is the receipt that hand-verification doesn't hold)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

`parse_env_flag`'s two asymmetries are deliberate and documented on the function: empty → `false` (unset), unrecognized → error. `FalseyValueParser` (clap's stock alternative) would silently read `STELLA_FOREGROUND=banana` as *true*; the strict-but-multilingual parser keeps refusal-by-name.

## Summary by Sourcery

Fix supervised CLI runs failing due to strict boolean env parsing and improve supervision banner messaging.

Bug Fixes:
- Allow STELLA_FOREGROUND and STELLA_DETACH to accept common shell boolean spellings so supervised children parse flags correctly instead of erroring on values like 1.
- Ensure invalid boolean env values for supervision flags are rejected explicitly rather than misinterpreted.

Enhancements:
- Introduce a shared parse_env_flag helper and wire it into foreground/detach CLI flags to align env parsing with real-world usage.
- Refactor the supervision banner into a pure announcement helper and extend it with guidance about the foreground opt-out when supervision engages.

Tests:
- Add a witness test that exercises supervision env vars across supported boolean spellings and validates precedence between flags and env.
- Add a test that asserts the attached supervision banner describes background execution and mentions the foreground opt-out flag.