### PR TITLE
fix(arenabench): queue a second SUT ref behind the active build instead of dropping it

### DIFF
--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -252,11 +252,14 @@ class ArenaServer:
         return {"branches": [b.to_json() for b in branches], "problem": None}
 
     def build_sut(self, payload: dict[str, Any]) -> Any:
-        """Start a build of the SUT at ``ref``, or report one already running.
+        """Start a build of the SUT at ``ref``, queueing behind a running one.
 
         Returns immediately with a build id; progress is polled. A release
         cross-compile takes minutes, and holding an HTTP request open for that
-        is how a launch path acquires new ways to fail.
+        is how a launch path acquires new ways to fail. A request for a commit
+        already running or queued returns that build's record; a distinct
+        commit gets its own ``queued`` record rather than being dropped
+        (#2138), so a twin match can request both its refs back to back.
         """
         ref = str(payload.get("ref") or "main").strip() or "main"
         return self.builder.start(ref)

--- a/arenabench/arenabench/sut_build.py
+++ b/arenabench/arenabench/sut_build.py
@@ -70,6 +70,9 @@ class BuildRecord:
     commit: str = ""
     #: ``queued`` | ``building`` | ``done`` | ``failed``
     status: str = "queued"
+    #: When the request was accepted; reset to the moment the compile begins
+    #: when the build leaves the queue, so ``elapsed`` measures the wait while
+    #: queued and the build once it runs.
     started_at: float = field(default_factory=time.time)
     finished_at: float = 0.0
     binary: str = ""
@@ -101,11 +104,16 @@ class BuildRecord:
 
 
 class SutBuilder:
-    """Owns SUT builds: one at a time, cached by commit.
+    """Owns SUT builds: one at a time, cached by commit, FIFO beyond that.
 
-    Serialised deliberately. Two concurrent release builds on a laptop thrash
-    the disk and the CPU that a running match is also using, and the queue
-    depth this feature actually needs is one.
+    *Execution* is serialised deliberately: two concurrent release builds on a
+    laptop thrash the disk and the CPU that a running match is also using. But
+    serial execution must not mean serial *requests* — a champion-vs-challenger
+    match is two refs, and the second click used to come back as the active
+    build's record while ref B was silently never built at all (#2138). A
+    request for a distinct commit while the builder is busy therefore queues
+    behind the active build; a request for a commit already running or queued
+    returns that build's record rather than creating a twin.
     """
 
     def __init__(self) -> None:
@@ -113,6 +121,8 @@ class SutBuilder:
         self._builds: dict[str, BuildRecord] = {}
         self._order: list[str] = []
         self._active: str | None = None
+        #: Build ids waiting behind the active build, oldest first.
+        self._pending: list[str] = []
 
     # -- queries ----------------------------------------------------------
 
@@ -128,11 +138,14 @@ class SutBuilder:
     # -- command ----------------------------------------------------------
 
     def start(self, ref: str) -> dict[str, Any]:
-        """Resolve ``ref`` and build it, unless it is already built or running.
+        """Resolve ``ref`` and build it, queueing behind any active build.
 
         Resolution happens here rather than in the worker so a bad ref is an
         immediate, synchronous error the operator sees in the click that
-        caused it, instead of a build that fails ten seconds later.
+        caused it, instead of a build that fails ten seconds later. It also
+        pins *when* the ref is read: a queued build compiles the commit the
+        click meant, not whatever the branch has moved to by the time the
+        build finally runs (#2098).
         """
         try:
             commit = resolve_ref(ref)
@@ -148,45 +161,109 @@ class SutBuilder:
             record.binary = str(existing.path)
             record.sha256 = existing.sha256
             record.finished_at = time.time()
-            self._remember(record)
+            with self._lock:
+                self._remember_locked(record)
             return record.to_json()
 
         with self._lock:
+            in_flight = self._in_flight_locked(commit)
+            if in_flight is not None:
+                # This commit is already running or waiting; a second build
+                # of it could only invite the two artifacts to differ.
+                return in_flight.to_json()
+            self._remember_locked(record)
             if self._active is not None:
-                active = self._builds[self._active]
-                if active.status in ("queued", "building"):
-                    # Report the running build rather than queueing behind it:
-                    # the caller wants to watch something, and two builds of
-                    # different commits at once is the case this refuses.
-                    return active.to_json()
+                # Busy with a different commit: queue, never drop. Returning
+                # the active record here — the pre-#2138 behavior — meant the
+                # second ref of a twin match silently built nothing.
+                self._pending.append(record.id)
+                return record.to_json()
             self._active = record.id
-        self._remember(record)
         threading.Thread(target=self._run, args=(record,), daemon=True).start()
         return record.to_json()
 
     # -- internals --------------------------------------------------------
 
-    def _remember(self, record: BuildRecord) -> None:
-        with self._lock:
-            self._builds[record.id] = record
-            self._order.append(record.id)
-            while len(self._order) > _HISTORY:
-                self._builds.pop(self._order.pop(0), None)
+    def _in_flight_locked(self, commit: str) -> BuildRecord | None:
+        """The unfinished build of ``commit`` — active or queued — if any.
+
+        Caller holds ``self._lock``.
+        """
+        if self._active is not None:
+            active = self._builds.get(self._active)
+            if (
+                active is not None
+                and active.status in ("queued", "building")
+                and active.commit == commit
+            ):
+                return active
+        for build_id in self._pending:
+            queued = self._builds.get(build_id)
+            if queued is not None and queued.commit == commit:
+                return queued
+        return None
+
+    def _remember_locked(self, record: BuildRecord) -> None:
+        """Insert ``record`` into the log; caller holds ``self._lock``.
+
+        Trimming skips unfinished builds: evicting a queued id would drop the
+        request — the exact defect the queue exists to prevent (#2138) — and
+        evicting the active id would 404 every poll watching it.
+        """
+        self._builds[record.id] = record
+        self._order.append(record.id)
+        excess = len(self._order) - _HISTORY
+        if excess <= 0:
+            return
+        kept: list[str] = []
+        for build_id in self._order:
+            entry = self._builds.get(build_id)
+            unfinished = entry is not None and entry.status in ("queued", "building")
+            if excess > 0 and not unfinished:
+                self._builds.pop(build_id, None)
+                excess -= 1
+            else:
+                kept.append(build_id)
+        self._order = kept
 
     def _run(self, record: BuildRecord) -> None:
         try:
-            record.status = "building"
-            binary, sha = self._build(record)
-            record.binary, record.sha256 = str(binary), sha
-            record.status = "done"
-        except Exception as exc:  # noqa: BLE001 — surfaced to the operator
+            staged = binary_for(record.commit)
+            if staged is not None:
+                # A queued build can wait minutes, long enough for its commit
+                # to have been staged by other means; rebuilding it would only
+                # invite the two artifacts to differ.
+                record.cached = True
+                record.binary = str(staged.path)
+                record.sha256 = staged.sha256
+                record.status = "done"
+            else:
+                # The clock restarts when the compile does, so ``elapsed``
+                # reports the wait while queued and the build once it runs.
+                record.started_at = time.time()
+                record.status = "building"
+                binary, sha = self._build(record)
+                record.binary, record.sha256 = str(binary), sha
+                record.status = "done"
+        except Exception as exc:  # every failure is surfaced to the operator
             record.status = "failed"
             record.error = str(exc)
         finally:
             record.finished_at = time.time()
+            next_record: BuildRecord | None = None
             with self._lock:
                 if self._active == record.id:
                     self._active = None
+                while self._pending and next_record is None:
+                    queued = self._builds.get(self._pending.pop(0))
+                    if queued is not None and queued.status == "queued":
+                        next_record = queued
+                if next_record is not None:
+                    self._active = next_record.id
+            if next_record is not None:
+                threading.Thread(
+                    target=self._run, args=(next_record,), daemon=True
+                ).start()
 
     def _build(self, record: BuildRecord) -> tuple[Path, str]:
         repo = stella_repo()

--- a/arenabench/tests/test_sut_build.py
+++ b/arenabench/tests/test_sut_build.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The builder must never discard a requested build.
+
+The defect these pin (#2138): ``SutBuilder.start`` executes one build at a
+time by design, but while a build was running a request for a *different*
+commit came back as the active build's record — and the new request was
+dropped entirely. With per-seat pins (#2082) the natural operator flow is
+"build champion, build challenger, launch the twin match", and the second
+click silently built nothing: the caller polled record A to completion while
+ref B was never resolved into a build, so the match then refused at preflight
+for a binary nobody was ever going to stage.
+
+The builds themselves are stubbed behind a gate the test controls — the
+contract under test is queueing, not cross-compilation, and holding the gate
+closed is what makes "a second request arrives while a build is in flight" a
+state a test can occupy for as long as it needs.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from arenabench import sut, sut_build
+from arenabench.sut_build import BuildRecord, SutBuilder
+
+COMMIT_A = "a" * 40
+COMMIT_B = "b" * 40
+
+
+@pytest.fixture
+def refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """An isolated stage root, and a resolver that needs no git repository.
+
+    Resolution itself is proven by ``test_sut``; here refs map straight to
+    fixed commits so every test states which commit a click meant.
+    """
+    monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+    mapping = {"refA": COMMIT_A, "refB": COMMIT_B}
+
+    def resolve(ref: str) -> str:
+        try:
+            return mapping[ref]
+        except KeyError:
+            raise sut.SutUnavailableError(f"unknown ref {ref!r}") from None
+
+    monkeypatch.setattr(sut_build, "resolve_ref", resolve)
+    return mapping
+
+
+def _stage(commit: str) -> tuple[Path, str]:
+    """Stage a stand-in artifact exactly where a real build lands one."""
+    directory = sut.sut_root() / commit
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / "stella"
+    target.write_text("#!/bin/sh\n")
+    target.chmod(0o755)
+    sha = sut.file_sha256(target)
+    (directory / "sut_commit.txt").write_text(commit + "\n", encoding="utf-8")
+    (directory / "binary_sha256.txt").write_text(sha + "\n", encoding="utf-8")
+    return target, sha
+
+
+def _wait(predicate: Callable[[], bool], timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not reached in time")
+
+
+def _done(builder: SutBuilder, build_id: str) -> bool:
+    record = builder.get(build_id)
+    return bool(record and record["done"])
+
+
+class GatedBuilder(SutBuilder):
+    """The real builder with the cross-compile replaced by a gate.
+
+    ``_build`` stages its artifact exactly where the real one lands, so
+    ``binary_for`` sees a finished build, but blocks until the test opens the
+    gate — the in-flight state every test here is about.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate = threading.Event()
+        self.build_order: list[str] = []
+        self.fail_commits: set[str] = set()
+
+    def _build(self, record: BuildRecord) -> tuple[Path, str]:
+        self.build_order.append(record.commit)
+        assert self.gate.wait(timeout=30.0), "test gate never opened"
+        if record.commit in self.fail_commits:
+            raise sut.SutUnavailableError("cargo zigbuild exited 101 (stub)")
+        return _stage(record.commit)
+
+
+class TestASecondRefQueuesInsteadOfVanishing:
+    """The witness for #2138: two clicks, two refs, two builds."""
+
+    def test_a_distinct_commit_queues_behind_the_active_build(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        first = builder.start("refA")
+        _wait(lambda: builder.build_order == [COMMIT_A])
+
+        second = builder.start("refB")
+        assert second["id"] != first["id"], (
+            "the second request came back as the first build's record — "
+            "ref B was dropped, which is the #2138 defect"
+        )
+        assert second["ref"] == "refB"
+        assert second["commit"] == COMMIT_B
+        assert second["status"] == "queued"
+        # Execution stays strictly serial: nothing for B runs while A holds
+        # the build slot (#2082's laptop constraint stands).
+        assert builder.build_order == [COMMIT_A]
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, second["id"]))
+        assert builder.build_order == [COMMIT_A, COMMIT_B]
+        assert builder.get(first["id"])["status"] == "done"
+        assert builder.get(second["id"])["status"] == "done"
+        for commit in (COMMIT_A, COMMIT_B):
+            staged = sut.binary_for(commit)
+            assert staged is not None and staged.commit == commit, (
+                "a twin match needs both binaries staged under their own "
+                "commits"
+            )
+
+    def test_a_failed_active_build_still_promotes_the_queue(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        builder.fail_commits.add(COMMIT_A)
+        first = builder.start("refA")
+        second = builder.start("refB")
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, second["id"]))
+        assert builder.get(first["id"])["status"] == "failed"
+        assert builder.get(second["id"])["status"] == "done"
+        assert sut.binary_for(COMMIT_B) is not None, (
+            "one ref failing to compile must not strand the request behind it"
+        )
+
+
+class TestTheSameCommitNeverBuildsTwice:
+    """The dedupe half of the contract, unchanged from before the queue."""
+
+    def test_the_active_commit_dedupes_to_the_running_record(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        first = builder.start("refA")
+        again = builder.start("refA")
+        assert again["id"] == first["id"]
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, first["id"]))
+        assert builder.build_order == [COMMIT_A]
+
+    def test_a_queued_commit_dedupes_to_the_queued_record(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        builder.start("refA")
+        queued = builder.start("refB")
+        again = builder.start("refB")
+        assert again["id"] == queued["id"], (
+            "a twin of a queued build would compile the same commit twice"
+        )
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, queued["id"]))
+        assert builder.build_order == [COMMIT_A, COMMIT_B]
+
+    def test_an_already_staged_commit_returns_a_cached_record(
+        self, refs: dict[str, str]
+    ):
+        _stage(COMMIT_A)
+        builder = GatedBuilder()
+        record = builder.start("refA")
+        assert record["cached"] and record["status"] == "done"
+        assert builder.build_order == []
+
+    def test_a_queued_commit_staged_in_the_meantime_is_not_rebuilt(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        builder.start("refA")
+        _wait(lambda: builder.build_order == [COMMIT_A])
+        second = builder.start("refB")
+        # e.g. `build_sut.sh` staged the same commit while the queue waited.
+        _stage(COMMIT_B)
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, second["id"]))
+        record = builder.get(second["id"])
+        assert record["status"] == "done" and record["cached"], (
+            "rebuilding a commit that is already staged invites the two "
+            "artifacts to differ"
+        )
+        assert builder.build_order == [COMMIT_A]
+
+
+class TestHistoryTrimmingNeverDropsLiveBuilds:
+    """Trimming the finished-build log must not become a second silent drop."""
+
+    def test_a_flood_of_cached_starts_evicts_neither_active_nor_queued(
+        self, refs: dict[str, str]
+    ):
+        builder = GatedBuilder()
+        first = builder.start("refA")
+        _wait(lambda: builder.build_order == [COMMIT_A])
+        second = builder.start("refB")
+
+        # Enough finished records to trim well past the history window while
+        # A runs and B waits.
+        for index in range(sut_build._HISTORY + 5):
+            commit = f"{index:040x}"
+            refs[f"cached{index}"] = commit
+            _stage(commit)
+            assert builder.start(f"cached{index}")["cached"]
+
+        assert builder.get(first["id"]) is not None, (
+            "evicting the active build 404s every poll watching it"
+        )
+        assert builder.get(second["id"]) is not None, (
+            "evicting a queued build drops the request — the #2138 defect "
+            "wearing a different hat"
+        )
+
+        builder.gate.set()
+        _wait(lambda: _done(builder, second["id"]))
+        assert sut.binary_for(COMMIT_B) is not None
+
+
+def test_an_unresolvable_ref_is_a_synchronous_error(refs: dict[str, str]):
+    """A bad ref fails in the click that caused it, never in the worker."""
+    with pytest.raises(ValueError):
+        GatedBuilder().start("nonesuch")


### PR DESCRIPTION
## What & why

`SutBuilder.start` (`arenabench/arenabench/sut_build.py`) executes one build at a time by design, but while a build was running a request for a **different** commit returned the active build's record and discarded the new request entirely. With per-seat pins (#2082) the natural operator flow is "build champion, build challenger, launch the twin match" — and the second click silently built nothing, so the match then refused at preflight for a binary nobody was ever going to stage.

The fix follows the shape the issue specifies:

- **Execution stays strictly one-at-a-time** (#2082's laptop constraint stands). A distinct commit while busy now gets its own `queued` record in a FIFO (`_pending`) that the worker promotes when the active build finishes — **including when it fails**, so one broken ref cannot strand the request behind it.
- **The commit is still captured at `start()` time** (`BuildRecord.commit`), so a queued build compiles the commit the click meant, not what the branch has moved to by the time it runs (#2098's lesson).
- **Same-commit requests dedupe** against both the running and the queued record — no double-build of one commit.
- A queued build whose commit gets staged while it waits (e.g. `build_sut.sh`) completes as `cached` rather than rebuilding — rebuilding "would only invite the two to differ", per the module's own cache rationale.
- Two latent hazards in the same seam, both the silent drop wearing a different hat, fixed alongside: **history trimming no longer evicts an unfinished record** (evicting a queued id dropped the request; evicting the active id 404'd every poll watching it), and **the active id is now published under the same lock hold that records it**, closing a window where a concurrent `start()` could observe an active id with no record (`KeyError`).

No UI change needed: `ui/lib/types.ts` already types `status: "queued" | …` and `sut-panel.tsx` polls whatever record `start` returns until `done`. The stale `build_sut` docstring in `server.py` ("or report one already running") is updated in the same PR.

Closes #2138
Refs #2082, #2098

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`arenabench/tests/test_sut_build.py` (new — the builder had no tests; the issue asked for them beside the `test_sut.py` staging fixtures). Real builds are stubbed by a `GatedBuilder` whose `_build` stages its artifact exactly where the real one lands but blocks on a test-controlled gate — the in-flight state the defect lives in.

Flip verified the artisanal way (`git stash push -- arenabench/sut_build.py && python3 -m pytest tests/test_sut_build.py && git stash pop`): **5 of 8 fail on the old builder**, each naming its half of the defect —

- `test_a_distinct_commit_queues_behind_the_active_build` — the core #2138 drop
- `test_a_failed_active_build_still_promotes_the_queue`
- `test_a_queued_commit_dedupes_to_the_queued_record`
- `test_a_queued_commit_staged_in_the_meantime_is_not_rebuilt`
- `test_a_flood_of_cached_starts_evicts_neither_active_nor_queued` — the eviction drop

The 3 that pass on both pin deliberately preserved behavior (active-commit dedupe, cached fast-path, synchronous bad-ref error).

## The gate

- [x] `cd arenabench && python3 -m pytest tests/test_sut_build.py tests/test_sut.py` — all green (this is a Python-only change under `arenabench/`; the Rust gate is untouched and CI's bench.yml pytest job covers this tree)
- [x] `uvx ruff@0.6 check` clean on the touched files (also removed a pre-existing inert `# noqa: BLE001` on the exact line the rewrite touched; BLE was never in the select list)
- [x] Docs updated where behavior changed (`SutBuilder` class docstring, `start` docstring, `server.py::build_sut` docstring)
- [x] `Closes #2138` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2146 (arenabench's ruff config is never gated in CI — 18 pre-existing findings censused), #2147 (a queued/running SUT build cannot be cancelled — the queue this PR adds makes that gap operator-visible). #2137 (per-seat SUT pin in the UI) was already filed and is being handled separately.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (arenabench stays stdlib-only)
- [x] No new outbound network calls

## Anything reviewers should know?

- Open PR #2136 touches the bench harness (`arenabench/config.py`, `model.py`, `runner.py`, `test_arena.py`, harbor adapter) — **no file overlap** with this PR (`sut_build.py`, `server.py`, new `tests/test_sut_build.py`).
- Rejected alternative: unbounded concurrent builds (two `cargo zigbuild` runs thrash the disk/CPU a live match is using — the serialisation is deliberate, per #2082) and refusing the second request with an error (turns an operator's correct flow into a retry loop; the issue asked for a queue).
- `BuildRecord.started_at` now resets when a promoted build's compile actually begins, so the UI's `elapsed` reads as queue wait while `queued` and build time while `building` — not the sum.

## Summary by Sourcery

Introduce queued SUT builds so distinct commit requests are never dropped while preserving strictly serial execution.

New Features:
- Queue SUT build requests for distinct commits behind any active build and expose a "queued" status instead of returning the active build.
- Deduplicate build requests for the same commit across both the active and queued records to avoid duplicate compilations.
- Treat builds whose commit is already staged as cached, including when they were previously queued, so they complete without recompilation.

Enhancements:
- Prevent history trimming from evicting active or queued build records to avoid silently dropping live requests or breaking polling.
- Reset build start timestamps when compilation actually begins so elapsed time reflects queue wait separately from build time.
- Clarify builder and server docstrings to describe the queuing behavior and cached handling accurately.

Tests:
- Add a dedicated sut_build test suite using a gated builder to exercise queuing, deduplication, cached behavior, failure promotion, and history trimming semantics.