### PR TITLE
fix(bench): unbreak main — split the harbor adapter's exec-stream release and telemetry export

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -46,9 +46,7 @@ or arbitrary Harbor agent extras abort a claim run.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import hashlib
-import inspect
 import json
 import math
 import os
@@ -117,6 +115,8 @@ from .posture import (
     resolve_triage_model,
     resolve_worker_effort,
 )
+from .stream_release import communicate_with_release, journal_reports_completion
+from .telemetry_export import PRIVATE_TELEMETRY_DIR, export_private_telemetry
 from .turn_budget import (
     TURN_BUDGET_ENV as _TURN_BUDGET_ENV,
 )
@@ -145,14 +145,6 @@ _REMOTE_TMP = "/tmp/stella-upload"
 # Filenames written under ``self.logs_dir`` (host side) for durability/debug.
 _RUN_JSON_NAME = "stella-run.json"
 _RUN_STDOUT_NAME = "stella-run.stdout.txt"
-#: Host-side directory (under the trial's ``agent/`` logs) receiving the
-#: container's ``.stella/private/`` telemetry before teardown.
-_PRIVATE_TELEMETRY_DIR = "telemetry"
-#: Container-side private state worth surviving the container: the SQLite
-#: store `stella observe` and `stella usage sync` read, the reflection log
-#: skill mining feeds on, and episodic context. SQLite WAL/SHM sidecars ride
-#: along when present so an uncheckpointed database stays openable.
-_PRIVATE_TELEMETRY_FILES = ("store.db", "reflections.jsonl", "context.db")
 _RUN_STDERR_NAME = "stella-run.stderr.txt"
 _STREAM_EVENTS_NAME = "stella-events.jsonl"
 _STREAM_EVENTS_PATH = f"/logs/agent/{_STREAM_EVENTS_NAME}"
@@ -616,90 +608,6 @@ async def _probe_sigkill_cause(environment: BaseEnvironment) -> dict[str, Any]:
     )
 
 
-#: How often the completion probe is consulted while the exec stream is open.
-_STREAM_PROBE_POLL_SECONDS = 5.0
-#: How long a proven-finished stream may still end on its own before the
-#: client is terminated. Generous enough for an ordinary EOF racing the probe,
-#: short enough that a held stream costs seconds rather than the agent budget.
-_STREAM_PROBE_GRACE_SECONDS = 10.0
-
-#: Rides in ``ExecResult.stderr`` when the stream was released, so the fact
-#: lands in the trial's stderr log through the existing write path.
-_STREAM_RELEASED_NOTE = (
-    "stella-harbor: exec stream released after the journal's terminal event; "
-    "a process the agent left running held the stream open past Stella's "
-    "exit (#2122)"
-)
-
-
-async def _communicate_with_completion_probe(
-    process: asyncio.subprocess.Process,
-    wire: bytes | bytearray,
-    completion_probe: Callable[[], bool] | None,
-    *,
-    poll_seconds: float = _STREAM_PROBE_POLL_SECONDS,
-    grace_seconds: float = _STREAM_PROBE_GRACE_SECONDS,
-    drain_seconds: float = 5.0,
-) -> tuple[bytes, bool]:
-    """``communicate()``, released early once the run is proven finished.
-
-    ``docker compose exec``'s output stream reaches EOF only when every fd
-    holder inside the container lets go. A daemon the agent legitimately
-    started — ``sshd``, ``nginx``; several Terminal-Bench tasks require one —
-    inherits the stream and holds it open past Stella's exit, so a plain
-    ``communicate()`` outlives a *finished* trial until Harbor's agent
-    timeout kills it (#2122). The probe consults evidence outside the
-    stream (the durable journal on the host side); only a probe that proves
-    completion releases the wait. The stream is granted ``grace_seconds`` to
-    end on its own, then the **client** process is terminated — nothing in
-    the container is touched, so daemons the verifier will probe stay up.
-
-    Returns the captured stdout and whether the wait was released by the
-    probe rather than by stream EOF. A run that never proves completion is
-    deliberately NOT released: a hung pipeline must stay visible as a
-    timeout, not be dressed up as a finished trial (#2110 stays loud).
-    """
-    communicate = asyncio.ensure_future(process.communicate(input=wire))
-
-    async def _finish(released: bool) -> tuple[bytes, bool]:
-        stdout_bytes, _ = await communicate
-        return stdout_bytes, released
-
-    try:
-        if completion_probe is None:
-            return await _finish(False)
-        while True:
-            done, _ = await asyncio.wait({communicate}, timeout=poll_seconds)
-            if done:
-                return await _finish(False)
-            if not completion_probe():
-                continue
-            done, _ = await asyncio.wait({communicate}, timeout=grace_seconds)
-            if done:
-                return await _finish(False)
-            # The client may itself have exited already (only a grandchild
-            # holds the pipe); a signal to a reaped pid is not an error here.
-            with contextlib.suppress(ProcessLookupError):
-                process.terminate()
-            done, _ = await asyncio.wait({communicate}, timeout=drain_seconds)
-            if not done:
-                with contextlib.suppress(ProcessLookupError):
-                    process.kill()
-                done, _ = await asyncio.wait({communicate}, timeout=drain_seconds)
-            if done:
-                return await _finish(True)
-            # Nothing left to signal and the pipe is still held (an orphan
-            # shares our read end). Stop reading; the journal carries the
-            # run's truth and the caller's cleanup owns the process.
-            communicate.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await communicate
-            return b"", True
-    except BaseException:
-        communicate.cancel()
-        raise
-
-
 async def _secure_exec_with_credential_fd(
     environment: BaseEnvironment,
     *,
@@ -820,36 +728,7 @@ async def _secure_exec_with_credential_fd(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        try:
-            stdout_bytes, released = await _communicate_with_completion_probe(
-                process, wire, completion_probe
-            )
-        except BaseException:
-            if process.returncode is None:
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except TimeoutError:
-                    process.kill()
-                    await process.wait()
-            raise
-        stdout = stdout_bytes.decode(errors="replace") if stdout_bytes else None
-        if released:
-            # The client was terminated by the release, so its return code is
-            # the signal, not Stella's. The journal — which the caller already
-            # treats as the source of truth over captured stdout — proved the
-            # run finished; the note lands in the trial's stderr log so the
-            # release is auditable rather than silent.
-            return ExecResult(
-                stdout=stdout,
-                stderr=_STREAM_RELEASED_NOTE,
-                return_code=0,
-            )
-        return ExecResult(
-            stdout=stdout,
-            stderr=None,
-            return_code=process.returncode or 0,
-        )
+        return await communicate_with_release(process, wire, completion_probe)
     finally:
         for index in range(len(wire)):
             wire[index] = 0
@@ -1516,16 +1395,6 @@ class StellaAgent(BaseInstalledAgent):
         # those values into `docker compose exec -e` argv. The secure runner
         # feeds one selected key through an anonymous stdin pipe and invokes
         # Stella directly, leaving neither a shell parent nor a tee process.
-        def _journal_reports_terminal_event() -> bool:
-            # The durable journal is host-visible while the run is live (it is
-            # what the arena streams), so Stella's own terminal `complete`
-            # event — the last line the pipeline writes before exiting — can
-            # prove the run finished even when the exec stream cannot EOF. A
-            # tail scan is enough: the event is terminal, and the compact
-            # serde encoding is byte-stable.
-            stream = self._read_log(_STREAM_EVENTS_NAME)
-            return bool(stream) and '"type":"complete"' in stream[-4096:]
-
         result = await _secure_exec_with_credential_fd(
             environment,
             command=command,
@@ -1534,7 +1403,9 @@ class StellaAgent(BaseInstalledAgent):
             verifier=verifier,
             expected_posture_json=self._engine_posture_json,
             posture_builder=self._build_engine_posture,
-            completion_probe=_journal_reports_terminal_event,
+            completion_probe=lambda: journal_reports_completion(
+                self._read_log(_STREAM_EVENTS_NAME)
+            ),
         )
 
         stdout = getattr(result, "stdout", None)
@@ -2212,44 +2083,11 @@ class StellaAgent(BaseInstalledAgent):
     async def _export_private_telemetry(self, environment: BaseEnvironment) -> None:
         """Pull the trial's ``.stella/private/`` telemetry out before teardown.
 
-        The container is deleted with everything Stella recorded inside it:
-        the SQLite store that ``stella observe`` and ``stella usage sync``
-        read, and the reflections that skill mining feeds on. Only the event
-        journal survived, and it is a projection — so bench runs contributed
-        nothing to local telemetry, skill mining, or the tool foundry. This
-        copies each private file (plus any SQLite ``-wal``/``-shm`` sidecar)
-        into the trial's ``agent/telemetry/`` directory on the host.
-
-        Best-effort by contract: a graded trial is never failed over a
-        telemetry export, so every probe and download failure is skipped, and
-        harbor API variance (sync vs async file helpers) is absorbed.
+        Best-effort by contract — see :mod:`stella_harbor.telemetry_export`.
         """
-        target_dir = self._log_path(_PRIVATE_TELEMETRY_DIR)
-        if target_dir is None:
-            return
-        workdir = (
-            getattr(getattr(environment, "task_env_config", None), "workdir", None)
-            or "/app"
-        )
-
-        async def _call(method: Any, *args: Any) -> Any:
-            result = method(*args)
-            if inspect.isawaitable(result):
-                result = await result
-            return result
-
-        for base in _PRIVATE_TELEMETRY_FILES:
-            for name in (base, f"{base}-wal", f"{base}-shm"):
-                source = f"{workdir}/.stella/private/{name}"
-                try:
-                    if not await _call(environment.is_file, source):
-                        continue
-                    target_dir.mkdir(parents=True, exist_ok=True)
-                    await _call(
-                        environment.download_file, source, target_dir / name
-                    )
-                except Exception:  # noqa: BLE001 — export never fails a trial
-                    continue
+        target_dir = self._log_path(PRIVATE_TELEMETRY_DIR)
+        if target_dir is not None:
+            await export_private_telemetry(environment, target_dir)
 
     def _write_log(self, name: str, content: str | None) -> None:
         """Persist ``content`` under ``logs_dir`` without clobbering — or

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -84,6 +84,8 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",
+    "bench/harbor_adapter/stella_harbor/stream_release.py",
+    "bench/harbor_adapter/stella_harbor/telemetry_export.py",
     "bench/harbor_adapter/stella_harbor/turn_budget.py",
 )
 _FIXED_READINESS_SOURCE_PATHS = (

--- a/bench/harbor_adapter/stella_harbor/stream_release.py
+++ b/bench/harbor_adapter/stella_harbor/stream_release.py
@@ -1,0 +1,150 @@
+"""Releasing the exec stream when a task daemon outlives Stella (#2122).
+
+``docker compose exec``'s output stream reaches EOF only when every fd holder
+inside the container lets go. A daemon the agent legitimately started —
+``sshd``, ``nginx``; several Terminal-Bench tasks require one — inherits the
+stream and holds it open past Stella's exit, so a plain ``communicate()``
+outlives a *finished* trial until Harbor's agent timeout kills it.
+
+The release therefore consults evidence from outside the stream: Stella's own
+durable journal, which is host-visible while the run is live. Only a probe
+that proves completion releases the wait. A run that never proves completion
+is deliberately NOT released — a hung pipeline must stay visible as a timeout
+rather than be dressed up as a finished trial (#2110 stays loud).
+
+Nothing inside the container is ever signalled: only the **client** process is
+terminated, so daemons the verifier will probe stay up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+
+from harbor.environments.base import ExecResult
+
+#: How often the completion probe is consulted while the exec stream is open.
+_STREAM_PROBE_POLL_SECONDS = 5.0
+#: How long a proven-finished stream may still end on its own before the
+#: client is terminated. Generous enough for an ordinary EOF racing the probe,
+#: short enough that a held stream costs seconds rather than the agent budget.
+_STREAM_PROBE_GRACE_SECONDS = 10.0
+#: Bytes of the journal's tail scanned for the terminal event. The event is
+#: terminal and the compact serde encoding is byte-stable, so a tail scan is
+#: both sufficient and bounded against a journal that grows all run.
+_JOURNAL_TAIL_BYTES = 4096
+
+#: Rides in ``ExecResult.stderr`` when the stream was released, so the fact
+#: lands in the trial's stderr log through the existing write path.
+STREAM_RELEASED_NOTE = (
+    "stella-harbor: exec stream released after the journal's terminal event; "
+    "a process the agent left running held the stream open past Stella's "
+    "exit (#2122)"
+)
+
+
+def journal_reports_completion(stream: str | None) -> bool:
+    """Whether the durable journal carries Stella's terminal ``complete`` event.
+
+    The journal is host-visible while the run is live (it is what the arena
+    streams), so the last line the pipeline writes before exiting can prove
+    the run finished even when the exec stream cannot EOF.
+    """
+    return bool(stream) and '"type":"complete"' in stream[-_JOURNAL_TAIL_BYTES:]
+
+
+async def communicate_with_completion_probe(
+    process: asyncio.subprocess.Process,
+    wire: bytes | bytearray,
+    completion_probe: Callable[[], bool] | None,
+    *,
+    poll_seconds: float = _STREAM_PROBE_POLL_SECONDS,
+    grace_seconds: float = _STREAM_PROBE_GRACE_SECONDS,
+    drain_seconds: float = 5.0,
+) -> tuple[bytes, bool]:
+    """``communicate()``, released early once the run is proven finished.
+
+    The probe consults evidence outside the stream (see the module docstring);
+    the stream is granted ``grace_seconds`` to end on its own, then the client
+    process is terminated.
+
+    Returns the captured stdout and whether the wait was released by the probe
+    rather than by stream EOF.
+    """
+    communicate = asyncio.ensure_future(process.communicate(input=wire))
+
+    async def _finish(released: bool) -> tuple[bytes, bool]:
+        stdout_bytes, _ = await communicate
+        return stdout_bytes, released
+
+    try:
+        if completion_probe is None:
+            return await _finish(False)
+        while True:
+            done, _ = await asyncio.wait({communicate}, timeout=poll_seconds)
+            if done:
+                return await _finish(False)
+            if not completion_probe():
+                continue
+            done, _ = await asyncio.wait({communicate}, timeout=grace_seconds)
+            if done:
+                return await _finish(False)
+            # The client may itself have exited already (only a grandchild
+            # holds the pipe); a signal to a reaped pid is not an error here.
+            with contextlib.suppress(ProcessLookupError):
+                process.terminate()
+            done, _ = await asyncio.wait({communicate}, timeout=drain_seconds)
+            if not done:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                done, _ = await asyncio.wait({communicate}, timeout=drain_seconds)
+            if done:
+                return await _finish(True)
+            # Nothing left to signal and the pipe is still held (an orphan
+            # shares our read end). Stop reading; the journal carries the
+            # run's truth and the caller's cleanup owns the process.
+            communicate.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await communicate
+            return b"", True
+    except BaseException:
+        communicate.cancel()
+        raise
+
+
+async def communicate_with_release(
+    process: asyncio.subprocess.Process,
+    wire: bytes | bytearray,
+    completion_probe: Callable[[], bool] | None,
+) -> ExecResult:
+    """Wait on the exec client and fold the outcome into an ``ExecResult``.
+
+    Wraps :func:`communicate_with_completion_probe` with the teardown a caller
+    must not skip, and with the result a release implies: the client was
+    terminated by the release, so its return code is the signal, not Stella's.
+    The journal — which the caller already treats as the source of truth over
+    captured stdout — proved the run finished, and the note rides in stderr so
+    the release lands in the trial's log rather than being silent.
+    """
+    try:
+        stdout_bytes, released = await communicate_with_completion_probe(
+            process, wire, completion_probe
+        )
+    except BaseException:
+        if process.returncode is None:
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+        raise
+    stdout = stdout_bytes.decode(errors="replace") if stdout_bytes else None
+    if released:
+        return ExecResult(stdout=stdout, stderr=STREAM_RELEASED_NOTE, return_code=0)
+    return ExecResult(
+        stdout=stdout,
+        stderr=None,
+        return_code=process.returncode or 0,
+    )

--- a/bench/harbor_adapter/stella_harbor/telemetry_export.py
+++ b/bench/harbor_adapter/stella_harbor/telemetry_export.py
@@ -1,0 +1,65 @@
+"""Pulling a trial's ``.stella/private/`` telemetry out before teardown (#2109).
+
+A Harbor trial's container is deleted with everything Stella recorded inside
+it: the SQLite store ``stella observe`` and ``stella usage sync`` read, the
+reflections that skill mining feeds on, and episodic context. Only the event
+journal survived, and it is a projection — so bench runs contributed nothing
+to local telemetry, skill mining, or the tool foundry.
+
+Best-effort by contract: a graded trial is never failed over a telemetry
+export, so every probe and download failure is skipped, and Harbor API
+variance (sync vs async file helpers) is absorbed.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+from harbor.environments.base import BaseEnvironment
+
+#: Host-side directory (under the trial's ``agent/`` logs) receiving the
+#: container's ``.stella/private/`` telemetry before teardown.
+PRIVATE_TELEMETRY_DIR = "telemetry"
+#: Container-side private state worth surviving the container: the SQLite
+#: store `stella observe` and `stella usage sync` read, the reflection log
+#: skill mining feeds on, and episodic context. SQLite WAL/SHM sidecars ride
+#: along when present so an uncheckpointed database stays openable.
+PRIVATE_TELEMETRY_FILES = ("store.db", "reflections.jsonl", "context.db")
+#: Used when Harbor's task environment config names no working directory.
+_DEFAULT_WORKDIR = "/app"
+
+
+async def _call(method: Any, *args: Any) -> Any:
+    """Invoke a Harbor file helper that may be either sync or async."""
+    result = method(*args)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+async def export_private_telemetry(
+    environment: BaseEnvironment, target_dir: Path
+) -> None:
+    """Copy the container's private telemetry into ``target_dir`` on the host.
+
+    Each entry of :data:`PRIVATE_TELEMETRY_FILES` is pulled together with any
+    SQLite ``-wal``/``-shm`` sidecar beside it. ``target_dir`` is created only
+    once a file is actually found, so a trial that recorded nothing leaves no
+    empty directory behind.
+    """
+    workdir = (
+        getattr(getattr(environment, "task_env_config", None), "workdir", None)
+        or _DEFAULT_WORKDIR
+    )
+    for base in PRIVATE_TELEMETRY_FILES:
+        for name in (base, f"{base}-wal", f"{base}-shm"):
+            source = f"{workdir}/.stella/private/{name}"
+            try:
+                if not await _call(environment.is_file, source):
+                    continue
+                target_dir.mkdir(parents=True, exist_ok=True)
+                await _call(environment.download_file, source, target_dir / name)
+            except Exception:  # noqa: BLE001 — export never fails a trial
+                continue

--- a/bench/harbor_adapter/tests/test_stream_release.py
+++ b/bench/harbor_adapter/tests/test_stream_release.py
@@ -19,7 +19,9 @@ import pytest
 
 pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
 
-from stella_harbor import _communicate_with_completion_probe  # noqa: E402
+from stella_harbor.stream_release import (  # noqa: E402
+    communicate_with_completion_probe,
+)
 
 
 async def _spawn(script: str) -> asyncio.subprocess.Process:
@@ -46,7 +48,7 @@ class TestStreamRelease:
 
         async def scenario() -> tuple[bytes, bool]:
             process = await _spawn("echo held; exec sleep 30")
-            return await _communicate_with_completion_probe(
+            return await communicate_with_completion_probe(
                 process,
                 b"",
                 lambda: True,
@@ -72,7 +74,7 @@ class TestStreamRelease:
 
         async def scenario() -> tuple[bytes, bool]:
             process = await _spawn("sleep 30 & echo held")
-            return await _communicate_with_completion_probe(
+            return await communicate_with_completion_probe(
                 process,
                 b"",
                 lambda: True,
@@ -90,7 +92,7 @@ class TestStreamRelease:
 
         async def scenario() -> tuple[bytes, bool]:
             process = await _spawn("sleep 0.3; echo done")
-            return await _communicate_with_completion_probe(
+            return await communicate_with_completion_probe(
                 process,
                 b"",
                 lambda: True,
@@ -109,7 +111,7 @@ class TestStreamRelease:
 
         async def scenario() -> tuple[bytes, bool]:
             process = await _spawn("echo eof")
-            return await _communicate_with_completion_probe(
+            return await communicate_with_completion_probe(
                 process,
                 b"",
                 lambda: False,
@@ -127,7 +129,7 @@ class TestStreamRelease:
 
         async def scenario() -> tuple[bytes, bool]:
             process = await _spawn("cat")
-            return await _communicate_with_completion_probe(
+            return await communicate_with_completion_probe(
                 process,
                 b"echoed\n",
                 None,

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,7 +8,7 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 2150 bench/harbor_adapter/stella_harbor/__init__.py
-4295 bench/harbor_adapter/stella_harbor/secure_launcher.py
+4297 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2335 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8272 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
**main is red.** #2136 merged at 9ad88824 with its `file size ratchet` check
failing — that check is not in the required set, and `enforce_admins` is off, so
auto-merge landed it. `bench/harbor_adapter/stella_harbor/__init__.py` is 2312
lines against its recorded ceiling of 2150 (+162), which fails
`scripts/check-file-size.sh` for every PR branched off main since.

This is the repair #2136 needed, applied on top of main.

## The fix

`__init__.py` sat *exactly* at its 2150-line ceiling before #2136, so the two
features that PR added had nowhere to go. Per AGENTS.md ("plan around god
files, never into them"), the new logic moves into the sibling modules #2136's
own tests are already named after:

- **`stream_release.py`** — the completion probe, the release constants, and
  the `ExecResult` a release implies. It also takes over the client teardown
  that wrapped the same wait, so everything about waiting on the exec client
  now lives in one module instead of straddling two.
- **`telemetry_export.py`** — the private-telemetry pull and its file list.
  `StellaAgent._export_private_telemetry` stays as the thin binding that
  resolves the host log path (which is what the tests call).

`__init__.py` is back to 2150 and **its ceiling is untouched**.

## The one baseline line

Both modules are registered in `_FIXED_ADAPTER_SOURCE_PATHS` — the paid claim
launcher byte-compares the running adapter tree against the published commit,
and `test_secure_launcher.py` asserts the on-disk module set equals that tuple,
so registration is mandatory, not optional. That is +2 lines in
`secure_launcher.py`, which also sits exactly at its ceiling, so its baseline
entry moves 4295 → 4297. That is the documented irreducible case (a required
registration entry in an already-oversized file), and it is the only ceiling
raised.

## Verification

- `scripts/check-file-size.sh` → OK (was FAILED on main)
- `scripts/check-god-files.sh`, `scripts/check-left-behind.sh` → OK
- `bench/harbor_adapter` pytest: **496 passed, 1 skipped** (includes the 230
  `test_secure_launcher.py` + `test_adapter.py` tests the registration touches,
  and #2136's own `test_stream_release.py` / `test_telemetry_export.py`)

No behavior change: the moved code is verbatim apart from dropping the leading
underscore on names that are now a module's public surface.
`test_stream_release.py` imports `communicate_with_completion_probe` from its
new home; no test was deleted or renamed.

Refs #2122
Refs #2109

## Summary by Sourcery

Split the harbor adapter’s exec-stream release handling and telemetry export into dedicated modules and wire the main adapter and secure launcher to use them, restoring the file-size baseline so bench passes again.

Bug Fixes:
- Restore passing file-size checks on main by moving harbor adapter logic out of the oversized __init__ and updating the baseline for secure_launcher and new modules.

Enhancements:
- Extract exec stream release logic, including journal completion probing and ExecResult construction, into a standalone stream_release module.
- Extract private telemetry export behavior into a dedicated telemetry_export module with clearer configuration for directories and files.

Build:
- Adjust file-size baseline configuration to account for the new harbor adapter modules and the secure_launcher ceiling shift.

Tests:
- Update stream release tests to import and exercise the new public functions from the stream_release module rather than the adapter package root.