### PR TITLE
fix(stella-pipeline): bound the witness_repair turn in wall clock

### DIFF
--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -14,6 +14,13 @@ use crate::LineMutation;
 /// in that module, beside the only tests that script them.
 mod flip_halt_arming;
 
+/// The witness repair wall-clock bound (#2141) — a child module for the same
+/// two reasons `flip_halt_arming` is: it reaches the shared fakes through
+/// this file's own `use super::*`, and the already-oversized `tests.rs` does
+/// not grow another module declaration. The stalling provider it needs lives
+/// there, beside the only test that scripts it.
+mod witness_repair_bound;
+
 /// #860 acceptance: a baseline that TIMES OUT observed no failing assertion,
 /// so a candidate whose suite then passes has no fail→pass flip — the run
 /// must escalate to the model verifier, never credit `DeterministicPass`. Before

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/witness_repair_bound.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/witness_repair_bound.rs
@@ -1,0 +1,171 @@
+//! The witness repair wall-clock bound (#2141) — the end-to-end witness and
+//! the stalling provider only it scripts.
+//!
+//! The defect this pins: the witness stage's repair rung issued its engine
+//! turn with no bound of its own, and a reasoning-heavy repair model that
+//! never stops streaming is invisible to every idle-based timeout — observed
+//! as one 965-second, 36k-token `witness_repair` call that rode a
+//! Terminal-Bench trial into the harness kill, discarding the whole
+//! verification record of work the fast worker had already finished. The fix
+//! is a stage latency ceiling in the shape the triage and research stages
+//! already use: derive a bound from the run's remaining declared clock, drop
+//! the in-flight turn past it, and degrade honestly to
+//! `WitnessUnavailable` so verify/verdict proceed with what they have.
+
+use super::*;
+
+/// The one sentence only the repair prompt carries
+/// ([`crate::witness::witness_repair_prompt`]) — how this provider
+/// recognizes the repair call without depending on call order, so the test
+/// stays correct whether the bound trips in flight or refuses pre-dispatch.
+const REPAIR_PROMPT_MARKER: &str = "witness test PASSED on the current, unmodified code";
+
+/// A provider that answers every call from its ordered script EXCEPT the
+/// witness repair call, which never resolves — #2141's runaway reasoning
+/// stream, which keeps producing and therefore never goes idle. Only a
+/// wall-clock bound can end it.
+struct StallsOnRepair {
+    script: TokioMutex<VecDeque<CompletionResult>>,
+}
+
+impl StallsOnRepair {
+    fn new(script: Vec<CompletionResult>) -> Self {
+        Self {
+            script: TokioMutex::new(script.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for StallsOnRepair {
+    fn id(&self) -> &str {
+        "stalls-on-repair"
+    }
+    async fn complete_ref(
+        &self,
+        req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        if req
+            .messages
+            .iter()
+            .any(|message| message.content.contains(REPAIR_PROMPT_MARKER))
+        {
+            std::future::pending::<()>().await;
+        }
+        let next = self.script.lock().await.pop_front();
+        next.ok_or_else(|| ProviderError::Terminal("scripted provider exhausted".into()))
+    }
+}
+
+/// A resolver handing the stalling provider to every role — the same
+/// single-model wiring `OneProvider` gives the scripted one.
+struct StallingResolver<'p>(&'p StallsOnRepair);
+impl ProviderResolver for StallingResolver<'_> {
+    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
+        Some(self.0)
+    }
+}
+
+/// #2141's witness: a witness repair whose model streams forever cannot
+/// spend the run's clock — the turn is dropped at its derived bound and the
+/// stage degrades honestly, on the rail, while the run still reaches a
+/// verdict. On `main` the repair turn is unbounded, nothing above it ends a
+/// stream that never goes idle, and this test times out.
+#[tokio::test]
+async fn a_stalled_witness_repair_is_bounded_and_degrades_honestly() {
+    let provider = StallsOnRepair::new(vec![
+        // Triage, then the worker's execute turn.
+        text_result("single"),
+        text_result("done"),
+        // The witness author names a command that will PASS on the pristine
+        // baseline — the one precondition that reaches the repair rung.
+        text_result("TEST_COMMAND: cargo test --test witness always_green -- --exact"),
+        // The unauthored ladder's verdict, reachable only past the bound.
+        text_result("PASS looks right"),
+    ]);
+    let resolver = StallingResolver(&provider);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    // The authored command passes on the unmodified baseline, so the stage
+    // asks for the one bounded repair — and the repair model stalls.
+    let baseline = FakeWorkspace::new(1, vec![true], Ok(vec![]), log.clone());
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
+    let session_runner = NeverRunner;
+    let session_status = NeverRepoStatus;
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &session_status,
+            touches: &NoFileTouches,
+            diagnostics: &session_runner,
+            tests: &session_runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(&port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            // A short declared allowance derives a sub-second repair bound
+            // (`witness_repair_bound` grants half of what remains), so the
+            // trip is observable in test time without faking clocks. Should
+            // a slow machine exhaust it before the repair dispatches, the
+            // pre-dispatch refusal degrades with the same honesty — the
+            // assertions below hold on either path.
+            run_budget: Some(Duration::from_millis(400)),
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    // The outer timeout is the DETECTOR, not the bound under test: with the
+    // repair unbounded, the stalled stream holds `run` open until an
+    // external kill — the exact #2141 failure — and this is what fails
+    // instead of hanging the suite.
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(30),
+        pipeline.run("Fix the retry bug", &mut messages, &mut budget),
+    )
+    .await
+    .expect(
+        "the witness repair turn must be bounded — unbounded, a stalled \
+         repair stream spends the whole trial (#2141)",
+    )
+    .expect("a bounded repair is a degradation, never a run-ending error");
+
+    assert!(
+        !matches!(outcome.status, PipelineStatus::Aborted { .. }),
+        "the pipeline proceeds to verify/verdict with what it has: {outcome:?}"
+    );
+    let events = drain(&mut rx);
+    let on_the_rail = events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Proof {
+                step: ProofStep::WitnessUnavailable { reason }
+            } if reason.contains("witness repair") && reason.contains("wall-clock")
+        )
+    });
+    assert!(
+        on_the_rail,
+        "the breach is recorded on the rail as an honest degradation, \
+         never ridden into an external timeout: {events:?}"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -70,6 +70,34 @@ fn witness_baseline_symptom(baseline_output: &str) -> Option<&'static str> {
     }
 }
 
+/// The static wall-clock ceiling on the witness repair engine turn (#2141).
+///
+/// Sized from the trace that motivated it: a legitimate authoring turn
+/// settles in about a minute, while the one unbounded repair observed on
+/// Terminal-Bench ran a single reasoning-heavy call for 965 seconds — more
+/// than half the trial's whole allowance — and was still streaming when the
+/// harness killed the trial. Five minutes is generous headroom above every
+/// observed legitimate repair, and still leaves a bounded trial most of its
+/// clock for the work the repair is only scaffolding for.
+const WITNESS_REPAIR_CEILING: Duration = Duration::from_secs(300);
+
+/// The wall clock one witness repair turn may spend (#2141): the static
+/// ceiling, tightened to half the run's remaining declared allowance when
+/// the caller declared one ([`PipelineConfig::run_budget`]).
+///
+/// Half, not all: the repair buys scaffolding, and whatever it consumes must
+/// leave the verification of the real work at least as much room as the
+/// scaffolding got. `None` remaining — nobody is measuring — falls back to
+/// the ceiling alone, so the bound exists on every configuration rather than
+/// only under a bench harness. Pure so the derivation is testable apart from
+/// the stage.
+fn witness_repair_bound(remaining_run_budget: Option<Duration>) -> Duration {
+    match remaining_run_budget {
+        Some(remaining) => WITNESS_REPAIR_CEILING.min(remaining / 2),
+        None => WITNESS_REPAIR_CEILING,
+    }
+}
+
 /// Candidate-bound hook execution: both the hook process and the engine's
 /// payload use the isolated root, never the session root.
 pub(super) struct BoundHookRunner<'a> {
@@ -194,6 +222,16 @@ impl<'a> Pipeline<'a> {
             self.engine_config_for(surface),
             &self.config.role_overrides.verifier,
         )
+    }
+
+    /// What remains of the run's declared wall-clock allowance
+    /// ([`PipelineConfig::run_budget`]), measured from the pipeline's start.
+    /// `None` when the caller declared no deadline — the same "nobody is
+    /// measuring" reading the repair gate gives its clock axis.
+    fn remaining_run_budget(&self) -> Option<Duration> {
+        self.config
+            .run_budget
+            .map(|budget| budget.saturating_sub(self.started.elapsed()))
     }
 
     pub(super) fn engine_config_for(&self, surface: CandidateSurface<'_>) -> EngineConfig {
@@ -403,6 +441,23 @@ impl<'a> Pipeline<'a> {
             first_baseline.stdout_tail, first_baseline.stderr_tail
         );
         if first_baseline.passed() {
+            // #2141: the "one bounded repair" is bounded in wall clock too,
+            // not just in attempts. A reasoning-heavy repair model at ~37
+            // tok/s once spent 965 seconds — still mid-stream — on a call
+            // whose whole purpose is to salvage scaffolding, and rode the
+            // trial into an external kill that discarded the entire
+            // verification record. The engine's own `model_timeout` cannot
+            // catch this shape: it measures idle gaps, and a runaway
+            // reasoning stream never goes idle. Checked before dispatch so a
+            // run that is already out of clock degrades for free.
+            let repair_bound = witness_repair_bound(self.remaining_run_budget());
+            if repair_bound.is_zero() {
+                return Err(WitnessAbort::degradable(
+                    "no wall-clock room remains for a witness repair; the executed change \
+                     stands unproven"
+                        .to_string(),
+                ));
+            }
             messages.push(CompletionMessage::user(witness_repair_prompt(&command)));
             let mut repair_engine = Engine::with_sleeper(
                 author.provider,
@@ -412,24 +467,43 @@ impl<'a> Pipeline<'a> {
             )
             .with_call_role(stella_protocol::ModelCallRole::WitnessRepair);
             repair_engine = self.attach(repair_engine);
-            let repaired = match self
-                .run_engine_turn(
-                    &repair_engine,
-                    &mut messages,
-                    spend.budget,
-                    &mut discarded_signals,
-                    // Witness repair, same reasoning as the author turn.
-                    None,
-                )
-                .await
-            {
-                TurnOutcome::Completed { text, cost_usd } => {
+            let repair_turn = self.run_engine_turn(
+                &repair_engine,
+                &mut messages,
+                spend.budget,
+                &mut discarded_signals,
+                // Witness repair, same reasoning as the author turn.
+                None,
+            );
+            // The expiry drops the in-flight turn, the same posture as the
+            // triage and research ceilings — and safe here for the same
+            // reasons a hard drop is documented as the last resort in
+            // `stella_core::step::CancelToken` (a token cancel only lands at
+            // a step boundary, which a single runaway generation never
+            // reaches): the turn's only durable effects live in the
+            // authoring snapshot, which every exit path below discards; the
+            // transcript it may leave mid-pair is `messages`, which nothing
+            // reads after this turn; and the abandoned call is not silent in
+            // accounting — the engine's `CancelUsageGuard` leaves its
+            // `UsageIncomplete { Cancelled }` envelope (its provider-side
+            // spend is unknowable once the response never lands). The budget
+            // guard itself is untouched, so invariant 6 — budget aborts at
+            // safe boundaries only — is unaffected: this is a stage latency
+            // ceiling, not a budget stop.
+            let repaired = match tokio::time::timeout(repair_bound, repair_turn).await {
+                Err(_elapsed) => {
+                    return Err(WitnessAbort::degradable(format!(
+                        "witness repair exceeded its wall-clock bound ({repair_bound:?}); \
+                         the executed change stands unproven"
+                    )));
+                }
+                Ok(TurnOutcome::Completed { text, cost_usd }) => {
                     *spend.total += cost_usd;
                     text
                 }
-                TurnOutcome::Aborted {
+                Ok(TurnOutcome::Aborted {
                     reason, cost_usd, ..
-                } => {
+                }) => {
                     *spend.total += cost_usd;
                     // Degradable for the same #1789 reason as the author
                     // turn's budget arm above.
@@ -755,6 +829,32 @@ mod tests {
                 "thread 'witness' panicked at 'assertion failed: `(left == right)`'"
             ),
             None
+        );
+    }
+
+    /// #2141's derivation half: the repair bound exists on every
+    /// configuration (no declared run budget still yields the static
+    /// ceiling), tightens to half the remaining allowance when that is the
+    /// smaller number, and collapses to zero — the pre-dispatch refusal —
+    /// when the run's clock is spent.
+    #[test]
+    fn the_repair_bound_is_the_ceiling_tightened_by_remaining_clock() {
+        assert_eq!(witness_repair_bound(None), WITNESS_REPAIR_CEILING);
+        assert_eq!(
+            witness_repair_bound(Some(Duration::from_secs(3600))),
+            WITNESS_REPAIR_CEILING,
+            "a roomy run budget must not widen the static ceiling"
+        );
+        assert_eq!(
+            witness_repair_bound(Some(Duration::from_secs(120))),
+            Duration::from_secs(60),
+            "a tight run budget halves: verification must keep at least the \
+             room the scaffolding spends"
+        );
+        assert_eq!(
+            witness_repair_bound(Some(Duration::ZERO)),
+            Duration::ZERO,
+            "a spent clock buys no repair call at all"
         );
     }
 


### PR DESCRIPTION
## What & why

A single `witness_repair` model call could consume a trial's entire remaining wall clock: a reasoning-heavy repair model that never stops streaming is invisible to every idle-based timeout (`EngineConfig::model_timeout` measures silence between stream fragments, #1211), and the repair rung issued its engine turn with no bound of its own. Observed on Terminal-Bench (match `293dc7b9c0e6`, trial `stella-kimi-k3/nginx-request-logging__aHW7kgt`): one 965-second, 36,224-token `witness_repair` call rode the trial into the harness kill and discarded the whole verification record of work the worker had finished in 125s.

The repair turn now runs under a **stage latency ceiling**, the exact shape the pipeline's triage and research stages already use (the named exemplars — `triage_latency_ceiling` drops the in-flight call and falls through; `research_latency_ceiling` cancels a child past it and degrades to a missing finding):

- **Pure derivation** — `witness_repair_bound` in `crates/stella-pipeline/src/pipeline/witness_stage.rs`: the smaller of a 300s static ceiling and **half** the run's remaining declared allowance (`PipelineConfig::run_budget`, measured from `Pipeline::new` — the repair gate's clock axis). Half, because the repair buys scaffolding and verification of the real work must keep at least as much room as the scaffolding spends. No declared budget still yields the static ceiling, so the bound exists on every configuration.
- **Pre-dispatch refusal** — a spent clock degrades for free before the call is bought (`repair_bound.is_zero()`).
- **Enforcement** — `tokio::time::timeout` around the repair `run_engine_turn`; on expiry the turn is dropped and the stage returns the existing degradable abort, which records `ProofStep::WitnessUnavailable` on the rail (both channels, via `Pipeline::unproven`) and lets the run proceed to verify/verdict with what it has — exactly the issue's definition of done.

Safety of the hard drop (documented at the call site): the turn's only durable effects live in the authoring snapshot, which every exit path discards; `messages` is dead after this turn, so the unpaired-`tool_use` hazard of a drop cannot reach a later provider call; the abandoned call is not silent in accounting — the engine's `CancelUsageGuard` leaves its `UsageIncomplete { Cancelled }` envelope (same posture as the triage ceiling's documented expiry). The budget guard is untouched: this is a latency ceiling, not a budget stop, so invariant 6 (budget aborts at safe boundaries only) is unaffected.

Closes #2141

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`pipeline::tests::verification_hardening::witness_repair_bound::a_stalled_witness_repair_is_bounded_and_degrades_honestly` — a scripted provider stalls forever on exactly the repair call (recognized by the repair prompt's own wording, so the test holds whether the bound trips in flight or refuses pre-dispatch). Verified the flip the artisanal way: with `crates/stella-pipeline/src/pipeline/witness_stage.rs` checked out from `origin/main` (tests kept), the test **fails** — `panicked: the witness repair turn must be bounded — unbounded, a stalled repair stream spends the whole trial (#2141): Elapsed(())` after the 30s detector timeout; restored, it **passes** in 0.20s. The derivation is pinned separately by `pipeline::witness_stage::tests::the_repair_bound_is_the_ceiling_tightened_by_remaining_clock`.

## The gate

- [x] `cargo fmt --check` (crate)
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo test -p stella-pipeline` (634 tests green; full workspace left to CI)
- [x] Docs updated where behavior changed (doc comments at the derivation, the call site, and the test module)
- [x] CLA signed
- [x] `Closes #2141` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2149 — the witness **author** turn has the identical unbounded shape; written as a handoff naming the mechanism this PR introduced. Refs #2021 (the general single-call wall-clock gap at the bench-posture level) and #1211.

## Ground-rule check

- [x] No I/O added to `stella-core` (untouched); no new deps — `tokio::time::timeout` is already how this crate's triage/recall/research ceilings are enforced
- [x] No new outbound network calls

## Anything reviewers should know?

- **God files respected**: `pipeline.rs` and `pipeline/tests.rs` gain zero lines. Logic lives in the `witness_stage.rs` sibling; the e2e test is a child module of `tests/verification_hardening.rs` (the `flip_halt_arming` pattern, and that file carries the module-placement justification).
- **Exemplars followed**: the pipeline's own `triage_latency_ceiling` / `research_latency_ceiling` (drop in-flight, degrade honestly, `UsageIncomplete` accounting posture) and the repair gate's clock axis (`run_budget` measured from `Pipeline::new`, #1479/#1507) for where the derived bound's inputs come from.
- **Deliberately not done**: tightening the repair call's `effort`/`max_output_tokens` (the issue lists it as a non-exclusive direction). The verifier-role shaping (#1785) stays operator-authoritative; a hard token ceiling risks cutting legitimate reasoning models where the wall-clock bound already guarantees the safety property the issue's definition of done asks for.
- The dropped turn's provider-side partial spend cannot reach `total_cost_usd` (the response never lands); it is visible as the `UsageIncomplete { Cancelled }` envelope — the same documented tradeoff as the triage ceiling.

## Summary by Sourcery

Bound the witness repair stage to a derived wall-clock ceiling so stalled repair calls cannot consume an entire trial and instead degrade cleanly to an unproven witness.

Bug Fixes:
- Prevent a runaway witness repair model call from spending the full trial wall clock by enforcing a per-turn latency ceiling and degrading to a WitnessUnavailable outcome on expiry.

Enhancements:
- Derive a witness repair wall-clock bound from a static ceiling tightened by the remaining run budget and expose a helper for computing remaining pipeline wall-clock allowance.
- Add an end-to-end verification hardening test and supporting stalling provider module to assert that stalled witness repair calls are bounded and recorded as honest degradations.

Tests:
- Introduce a unit test for the witness repair bound derivation and an end-to-end test that exercises the new wall-clock ceiling with a provider that stalls on the repair call.