### PR TITLE
fix(stella-cli): route post-turn reflection to the cheap triage tier

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -38,8 +38,8 @@ use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::failure::CliFailure;
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
 use crate::memory::{
-    ReflectionReport, SessionMemory, inject_recall_block, should_reflect_on,
-    turn_warrants_reflection,
+    ReflectionReport, SessionMemory, inject_recall_block, reflect_routed, reflection_tail,
+    should_reflect_on, turn_warrants_reflection,
 };
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::tui;
@@ -514,7 +514,7 @@ async fn run_pipeline_one_shot(
                 name: stella_protocol::StageKind::Reflect,
             });
         }
-        let mut reflect_transcript = messages.clone();
+        let mut reflect_transcript = reflection_tail(&messages);
         if let Ok(outcome) = &result
             && !outcome.final_text.trim().is_empty()
         {
@@ -530,19 +530,19 @@ async fn run_pipeline_one_shot(
                 "(files changed this turn: {changed})"
             )));
         }
-        let mut report = m
-            .reflect_and_record(
-                &*provider,
-                &cfg.model_id,
-                &reflect_transcript,
-                format != OutputFormat::Text,
-                matches!(
-                    &result,
-                    Ok(outcome) if matches!(outcome.status, PipelineStatus::Completed)
-                ),
-                remaining_budget(&budget),
-            )
-            .await;
+        let mut report = reflect_routed(
+            m,
+            cfg,
+            &*provider,
+            &reflect_transcript,
+            format != OutputFormat::Text,
+            matches!(
+                &result,
+                Ok(outcome) if matches!(outcome.status, PipelineStatus::Completed)
+            ),
+            remaining_budget(&budget),
+        )
+        .await;
         settle_reflection_budget(&mut report, &mut budget);
         if format == OutputFormat::StreamJson {
             for event in &report.events {
@@ -1188,16 +1188,16 @@ async fn reflect_on_interactive_turn<E: std::fmt::Display>(
         && turn_warrants_reflection(&messages[turn_start..])
         && let Some(m) = memory
     {
-        let mut report = m
-            .reflect_and_record(
-                provider,
-                &cfg.model_id,
-                messages,
-                false,
-                result.is_ok(),
-                remaining_budget(budget),
-            )
-            .await;
+        let mut report = reflect_routed(
+            m,
+            cfg,
+            provider,
+            messages,
+            false,
+            result.is_ok(),
+            remaining_budget(budget),
+        )
+        .await;
         settle_reflection_budget(&mut report, budget);
         surface_reflection(&report, OutputFormat::Text);
     }

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -1053,3 +1053,60 @@ pub(crate) fn resolve_cross_family_verifier(
     .ok()?;
     Some((verifier, decision.model_ref.provider))
 }
+
+/// Resolve where post-turn reflection dispatches (#1847): the configured
+/// triage model when it is routable, else `None` — ride the worker.
+///
+/// Reflection ran on the WORKER model from the day it shipped, with a 2048
+/// output-token allowance and no effort pin, while `crate::memory`'s own
+/// module doc called it "one cheap model call". Nothing routed it to a cheap
+/// tier. The triage pin (`pipeline_triage_model`/`agents.triage.*`) is
+/// already the posture's declaration of "the cheap, fast model", so
+/// reflection rides that declaration rather than adding a second cheap-model
+/// knob the two settings could drift apart on.
+///
+/// Every miss is soft, matching [`resolve_cross_family_verifier`] and
+/// `pin_role`: no engine settings, no triage spec, an uncredentialed
+/// provider, or an adapter that will not build all yield `None`, and the
+/// caller keeps dispatching on the worker exactly as every reflection call
+/// always has. A triage spec that resolves to the session default model also
+/// yields `None` — the worker adapter already serves that exact model, and a
+/// second instance would buy only a second connection pool (the same "no
+/// duplicate adapter" rule the wiring's `pin_role` applies).
+pub(crate) fn reflection_route(
+    cfg: &Config,
+    configured: &[crate::config::ConfiguredProvider],
+) -> Option<(ModelRef, Box<dyn Provider>)> {
+    let engine = cfg.engine_settings.as_ref()?;
+    let is_provider = |id: &str| configured.iter().any(|c| c.config.id == id);
+    let spec = crate::engine_config::model_spec_for(
+        engine,
+        crate::settings::EngineAgentKind::Triage,
+        &is_provider,
+    )?;
+    let entry = configured.iter().find(|c| c.config.id == spec.provider)?;
+    // An empty slug is the "provider pin without a model" form — the
+    // provider's own default model, exactly as `pin_role` reads it.
+    let slug = if spec.model.is_empty() {
+        entry.config.default_model.to_string()
+    } else {
+        spec.model
+    };
+    let routed = ModelRef::new(entry.config.id, slug.clone());
+    if routed == ModelRef::new(cfg.provider.id, cfg.model_id.clone()) {
+        return None;
+    }
+    let provider = build_provider_parts(
+        &entry.config,
+        &slug,
+        entry.api_key.clone(),
+        entry.config.base_url.to_string(),
+        None,
+        entry.aux.clone(),
+        // One post-turn call per reflected turn: bursty within a session,
+        // so the 5-minute cache window is the right ask (#1839).
+        stella_model::CacheTtl::default(),
+    )
+    .ok()?;
+    Some((routed, provider))
+}

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -161,16 +161,16 @@ pub(crate) async fn run_raw_one_shot(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
-        let mut report = m
-            .reflect_and_record(
-                &*provider,
-                &cfg.model_id,
-                &messages,
-                format != OutputFormat::Text,
-                outcome.is_ok(),
-                crate::agent::remaining_budget(&budget),
-            )
-            .await;
+        let mut report = crate::memory::reflect_routed(
+            m,
+            cfg,
+            &*provider,
+            &messages,
+            format != OutputFormat::Text,
+            outcome.is_ok(),
+            crate::agent::remaining_budget(&budget),
+        )
+        .await;
         settle_reflection_budget(&mut report, &mut budget);
         surface_reflection(&report, format);
     }
@@ -351,16 +351,16 @@ pub async fn run_goal_cmd(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
-        let mut report = m
-            .reflect_and_record(
-                &*provider,
-                &cfg.model_id,
-                &messages,
-                false,
-                outcome.is_ok(),
-                crate::agent::remaining_budget(&budget),
-            )
-            .await;
+        let mut report = crate::memory::reflect_routed(
+            m,
+            cfg,
+            &*provider,
+            &messages,
+            false,
+            outcome.is_ok(),
+            crate::agent::remaining_budget(&budget),
+        )
+        .await;
         settle_reflection_budget(&mut report, &mut budget);
         surface_reflection(&report, OutputFormat::Text);
     }

--- a/crates/stella-cli/src/agent/tests/engine_wiring.rs
+++ b/crates/stella-cli/src/agent/tests/engine_wiring.rs
@@ -1200,3 +1200,53 @@ fn approval_capability_for_a_supervised_child_is_sidecar_in_every_format() {
     );
     assert!(!config.headless_bypass_scope_review);
 }
+
+/// #1847: post-turn reflection must dispatch on the configured cheap tier.
+///
+/// It ran on the WORKER model from the day it shipped — with `memory.rs`
+/// calling it "one cheap model call" the whole time — because no reflection
+/// pin existed anywhere in the role wiring. The route rides the triage
+/// declaration (`pipeline_triage_model`/`agents.triage.*`): the posture's one
+/// existing statement of "the cheap, fast model", so there is no second knob
+/// for the two to drift apart on.
+#[test]
+fn reflection_routes_to_the_configured_triage_model() {
+    let cfg = cfg_with_engine(
+        "zai", // session default (the worker): zai/glm-5.2
+        r#"{ "pipeline_triage_model": "deepseek/deepseek-chat" }"#,
+    );
+    let configured = vec![configured_provider("zai"), configured_provider("deepseek")];
+
+    let (model, provider) = reflection_route(&cfg, &configured)
+        .expect("a credentialed triage pin must route reflection off the worker");
+    assert_eq!(model, ModelRef::new("deepseek", "deepseek-chat"));
+    assert_eq!(
+        provider.id(),
+        "deepseek",
+        "the routed adapter must be the triage provider's, not the worker's"
+    );
+}
+
+/// Every unroutable shape rides the worker — `None`, the exact pre-#1847
+/// dispatch — because reflection is best-effort by contract and a
+/// configuration problem must never cost the turn its learning. The
+/// same-model case is deliberate rather than degenerate: the worker adapter
+/// already serves that exact model, and a duplicate instance would buy only
+/// a second connection pool.
+#[test]
+fn reflection_rides_the_worker_when_the_triage_tier_is_unroutable() {
+    // The stock posture: no engine settings at all.
+    let stock = cfg_for("zai");
+    assert!(reflection_route(&stock, &[configured_provider("zai")]).is_none());
+
+    // A triage pin whose provider has no resolvable credential.
+    let uncredentialed = cfg_with_engine(
+        "zai",
+        r#"{ "pipeline_triage_model": "deepseek/deepseek-chat" }"#,
+    );
+    assert!(reflection_route(&uncredentialed, &[configured_provider("zai")]).is_none());
+
+    // A triage pin naming the session default model itself.
+    let same_model = cfg_with_engine("zai", r#"{ "pipeline_triage_model": "zai/glm-5.2" }"#);
+    assert!(reflection_route(&same_model, &[configured_provider("zai")]).is_none());
+}

--- a/crates/stella-cli/src/command_deck/authoring.rs
+++ b/crates/stella-cli/src/command_deck/authoring.rs
@@ -106,16 +106,16 @@ pub(super) async fn record_and_reflect_turn(
         return;
     }
     let Some(memory) = memory else { return };
-    let mut report = memory
-        .reflect_and_record(
-            provider,
-            &cfg.model_id,
-            messages,
-            true,
-            true,
-            crate::agent::remaining_budget(budget),
-        )
-        .await;
+    let mut report = crate::memory::reflect_routed(
+        memory,
+        cfg,
+        provider,
+        messages,
+        true,
+        true,
+        crate::agent::remaining_budget(budget),
+    )
+    .await;
     crate::agent::settle_reflection_budget(&mut report, budget);
     forward_reflection_events(in_tx, report);
 }

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -13,7 +13,7 @@
 //! prompt ──> recall_block_reported(): registry-routed recall (crate::contextgraph) + select_skills()
 //!            └─ volatile message AFTER the byte-stable system prefix (L-E8)
 //! turn runs …
-//! outcome ─> reflect_and_record(): one cheap model call -> 0-3 lessons
+//! outcome ─> reflect_routed(): one model call on the cheap (triage) tier -> 0-3 lessons
 //!            ├─ MemoryInput::reflection(...) -> context.db (domain-tagged)
 //!            ├─ appended to .stella/private/reflections.jsonl (the mining log)
 //!            └─ mine_skill_candidates over the log -> decide_auto_creation
@@ -200,6 +200,7 @@ mod reflection;
 pub use reflection::{
     ReflectionReport, reflect_on_turn, should_reflect_on, turn_warrants_reflection,
 };
+pub(crate) use reflection::{reflect_routed, reflection_tail};
 
 /// Session-scoped memory state: the context store, the CGP host that
 /// routes every recall (workspace memory + code graph as in-process CGP

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -8,7 +8,9 @@ mod tests;
 use std::path::Path;
 
 use stella_model::provider::Provider;
-use stella_protocol::{AgentEvent, CompletionMessage, CompletionRequest, MessageRole};
+use stella_protocol::{
+    AgentEvent, CompletionMessage, CompletionRequest, MessageRole, ReasoningEffort,
+};
 use stella_store::reflection::SelfReviewRow;
 
 use super::ReflectionLesson;
@@ -44,6 +46,61 @@ pub fn should_reflect_on<E: std::fmt::Display>(result: &Result<(), E>) -> bool {
     }
 }
 
+/// How much of the transcript the reflection digest reads ([`reflect_on_turn`]
+/// takes exactly this many messages off the tail).
+const REFLECTED_TAIL_MESSAGES: usize = 12;
+
+/// The slice of `messages` worth copying for a reflection transcript.
+///
+/// A caller that appends turn context (the final answer, a files-changed
+/// note) before reflecting should clone this tail, never the whole history:
+/// [`reflect_on_turn`] digests only the last [`REFLECTED_TAIL_MESSAGES`]
+/// messages, so on a long session everything earlier was memcpy'd to be
+/// dropped (#1847's call-site nit).
+pub(crate) fn reflection_tail(messages: &[CompletionMessage]) -> Vec<CompletionMessage> {
+    messages[messages.len().saturating_sub(REFLECTED_TAIL_MESSAGES)..].to_vec()
+}
+
+/// Post-turn reflection on the cheap tier (#1847): resolve the reflection
+/// route, then run [`super::SessionMemory::reflect_and_record`] on whichever
+/// provider it lands on — the configured triage model when routable
+/// (`crate::agent::reflection_route`), else the worker this turn already ran
+/// on, exactly as every reflection call dispatched before the route existed.
+///
+/// This is the one seam all four reflecting surfaces (one-shot `run`, the
+/// REPL, `/goal`, the Command Deck) dispatch through, so the routing
+/// decision cannot be remembered by three drivers and forgotten by the
+/// fourth. Provider discovery runs per call rather than per session because
+/// reflection is already a post-turn, best-effort model call that opens the
+/// store — one credential scan is noise beside it, and it keeps this seam a
+/// drop-in for the call sites' previous direct dispatch.
+pub(crate) async fn reflect_routed(
+    memory: &mut super::SessionMemory,
+    cfg: &crate::config::Config,
+    worker: &dyn Provider,
+    transcript: &[CompletionMessage],
+    quiet: bool,
+    succeeded: bool,
+    budget_limit: Option<f64>,
+) -> ReflectionReport {
+    let routed =
+        crate::agent::reflection_route(cfg, &crate::config::discover_configured_providers());
+    let (provider, model_hint) = match &routed {
+        Some((model, provider)) => (provider.as_ref(), model.model_id.as_str()),
+        None => (worker, cfg.model_id.as_str()),
+    };
+    memory
+        .reflect_and_record(
+            provider,
+            model_hint,
+            transcript,
+            quiet,
+            succeeded,
+            budget_limit,
+        )
+        .await
+}
+
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,
@@ -59,7 +116,7 @@ pub async fn reflect_on_turn(
     let digest = transcript
         .iter()
         .rev()
-        .take(12)
+        .take(REFLECTED_TAIL_MESSAGES)
         .collect::<Vec<_>>()
         .into_iter()
         .rev()
@@ -224,7 +281,16 @@ pub async fn reflect_on_turn(
         // spent by models that were going to be cut off.
         max_output_tokens: Some(2048),
         temperature: Some(0.0),
-        effort: None,
+        // Pinned low, like every bounded management call (the pipeline's
+        // `management_bounds` pins triage the same way, and the overflow
+        // summarizer pins its own pass low): the written output contract is
+        // a three-lesson JSON array, and an unset effort leaves the
+        // provider's default reasoning allowance in force — unbounded
+        // thinking spent deciding, most turns, to return an empty list.
+        // Providers that cannot express effort drop it per their declared
+        // `ReasoningPosture` (provider-parity invariant #8), the same path
+        // every pinned management call rides.
+        effort: Some(ReasoningEffort::Low),
         tools: Vec::new(),
         reasoning: None,
         params: None,

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -21,15 +21,17 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use stella_protocol::{
     CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
-    Provider, ProviderError,
+    Provider, ProviderError, ReasoningEffort,
 };
 
-/// Records the prompt it is asked to complete, then answers with a well-formed
-/// empty result so the caller's parsing path stays on its happy road — the
-/// prompt is what is under test, not the response handling.
+/// Records the prompt it is asked to complete — and the request's dispatch
+/// shape (effort, output cap) — then answers with a well-formed empty result
+/// so the caller's parsing path stays on its happy road: the request is what
+/// is under test, not the response handling.
 #[derive(Default)]
 struct CapturingProvider {
     prompt: Mutex<String>,
+    shape: Mutex<(Option<ReasoningEffort>, Option<u32>)>,
 }
 
 #[async_trait]
@@ -49,6 +51,7 @@ impl Provider for CapturingProvider {
         {
             *self.prompt.lock().expect("prompt lock") = user.content.clone();
         }
+        *self.shape.lock().expect("shape lock") = (req.effort, req.max_output_tokens);
         Ok(CompletionResult {
             text: r#"{"lessons": []}"#.into(),
             tool_calls: vec![],
@@ -149,5 +152,38 @@ async fn a_successful_turn_is_asked_what_surprised_it() {
         !prompt.contains("where things live"),
         "the prompt is asking for file locations again, which is the \
          over-correction #944 was fixing"
+    );
+}
+
+/// #1847's request-shape half: reflection is a bounded management call.
+///
+/// `effort` was previously unset, which leaves the provider's own default
+/// reasoning allowance in force — unbounded thinking spent deciding, most
+/// turns, to return an empty list. Pinned low it matches the shape every
+/// bounded management call already has (the pipeline's `management_bounds`
+/// pins triage the same way; so does the engine's overflow summarizer). The
+/// 2048 output cap is asserted alongside because the two bounds are one
+/// dispatch contract: a short JSON lesson array, briefly reasoned.
+#[tokio::test]
+async fn reflection_dispatches_low_effort_with_its_bounded_output_cap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+    let provider = CapturingProvider::default();
+    let transcript = vec![CompletionMessage::user("fix the leak")];
+    super::reflect_on_turn(
+        &provider,
+        "capturing",
+        dir.path(),
+        &transcript,
+        &["testing".to_string()],
+        true,
+        None,
+    )
+    .await
+    .expect("the stub provider cannot fail");
+    assert_eq!(
+        *provider.shape.lock().expect("shape lock"),
+        (Some(ReasoningEffort::Low), Some(2048)),
+        "reflection must dispatch as a bounded, pinned-low management call"
     );
 }


### PR DESCRIPTION
## What & why

Post-turn reflection — lesson mining whose own prompt says most turns should return an empty list — dispatched on the **worker** provider/model with a 2048-token allowance and no effort pin, after essentially every tool-using turn, from every surface. `memory.rs` called it "one cheap model call"; nothing routed it to a cheap tier. On a frontier worker a 30-turn session paid ~$1.0–1.5 for it.

- **Routing.** All four reflecting surfaces (one-shot `run`, the REPL, `/goal`, the Command Deck) now dispatch through one seam, `reflect_routed()` (`crates/stella-cli/src/memory/reflection.rs`), which resolves `reflection_route()` (`crates/stella-cli/src/agent/engine.rs`): the configured triage model (`pipeline_triage_model`/`agents.triage.*`) when it is routable — the posture's one existing declaration of "the cheap, fast model", so there is no second knob for the two to drift apart on — else the worker, exactly as every reflection call dispatched before. Every miss is soft, mirroring `pin_role` and `resolve_cross_family_verifier`: no engine settings, no triage spec, no resolvable credential, or a failed adapter build all ride the worker; a triage spec equal to the session default deliberately builds no duplicate adapter.
- **Request shape.** `effort` is pinned `Low`, matching the shape every bounded management call already has (the pipeline's `management_bounds` pins triage the same way; so does the engine's overflow summarizer). The 2048 output cap stays — its in-code rationale (narrating models truncating away the lesson array) is unchanged and now priced on the cheap tier.
- **The clone nit** (same issue, same site): the one-shot path cloned the entire message history to append two messages when the digest reads only the last 12 — `reflection_tail()` now copies just that slice.

Exemplar followed: `resolve_cross_family_verifier` in the same file — soft-fallback role routing returning an `Option` of a built adapter, `None` meaning "reuse the worker, build nothing".

`agent.rs` (2270) and `command_deck.rs` (4567) are god files at their exact ceilings; every call-site change there is net-zero lines, and all new logic lands in `agent/engine.rs` and `memory/reflection.rs`.

Closes #1847

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Router level (`agent/tests/engine_wiring.rs`), as the issue specified:
- `reflection_routes_to_the_configured_triage_model` — a posture carrying `pipeline_triage_model` resolves reflection dispatch to that provider's adapter and model, not the worker's.
- `reflection_rides_the_worker_when_the_triage_tier_is_unroutable` — pins all three soft-fallback shapes (stock posture / uncredentialed pin / pin equal to the session default).

Request shape (`memory/reflection/tests.rs`):
- `reflection_dispatches_low_effort_with_its_bounded_output_cap` — asserts `(Some(Low), Some(2048))` on the wire request; on `main` the dispatched `effort` is `None`, so the assertion fails there.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, all guards green — file-size confirms no god file grew)
- [x] `cargo check -p stella-cli` clean
- [x] `cargo test -p stella-cli --bin stella reflection` (the touched area's unit tests; the crate's integration binaries and the full workspace suite are left to CI — linking them OOMs this 16 GB machine)
- [x] Docs updated where behavior changed (`memory.rs` dataflow doc; doc comments on the new seam)
- [x] CLA signed
- [x] `Closes #1847` appears both above and as a commit trailer

## Nothing left behind

- Filed: #2155 — the tighter fire gate, #1847's third suggestion, deliberately not shipped here: gating reflection on failure/retry/loop signals changes *learning semantics* (a failure-only gate loses the success-path "what surprised you" lessons), and the friction signals it needs (retries, loop-detector trips) are computed in the engine but not surfaced to the CLI's reflection gate today. Routing + the effort pin remove the cost problem; the gate change deserves its own design pass.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls (the routed adapter targets an already-configured, credentialed provider)

## Anything reviewers should know?

`reflect_routed` resolves the route per call (one `discover_configured_providers()` scan + one adapter build per reflected turn) rather than caching per session. Deliberate: reflection is already a post-turn, best-effort model call that opens the store — the scan is noise beside it — and threading a session-lived route through five call sites means growing two god files that are at their exact ceilings. The doc comment on the seam records the tradeoff.

## Summary by Sourcery

Route post-turn reflection through a shared seam that prefers the configured triage (cheap) tier while retaining worker fallback, and align reflection’s request shape with existing bounded management calls.

New Features:
- Introduce a unified reflect_routed seam that all CLI reflection entry points use to dispatch post-turn reflection via configured triage routing.

Enhancements:
- Add reflection_tail helper to avoid cloning full transcripts and standardize how the reflection digest window is derived.
- Update memory dataflow documentation to describe reflection as a triage-tier model call.

Tests:
- Add engine wiring tests to verify reflection routes to the triage model when possible and falls back to the worker when triage is unroutable.
- Add reflection tests asserting low reasoning effort and a bounded output cap for reflection requests.