### PR TITLE
fix(stella-pipeline): bound the witness author/repair output, never the whole trial

### DIFF
--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -34,6 +34,49 @@ async fn runner_availability(tests: &dyn TestRunner) -> Vec<String> {
         .collect()
 }
 
+/// Per-call output ceiling for the witness author and repair turns (#2141,
+/// #2149).
+///
+/// A witness test is a short script and its authoring reply is a marker line
+/// plus that script; the largest legitimate authoring call observed on a
+/// settled flip was under 2k output tokens. Left uncapped, the turn inherits
+/// the worker's ceiling (131k on a measured run), and a reasoning-heavy model
+/// spent it: one `witness_repair` call streamed 36,224 output tokens over
+/// 965 seconds and rode a solved trial into Harbor's agent timeout, taking
+/// the whole verification record with it. This bounds each such call to a
+/// value comfortably above legitimate need yet far below that runaway; a call
+/// that exceeds it truncates and degrades honestly through the existing
+/// no-marker path, which frees the budget instead of consuming it. It only
+/// ever *lowers* a higher ceiling — an operator's tighter `max_output_tokens`
+/// still wins.
+///
+/// This is the **token** axis, and it composes with — never replaces — the
+/// **wall-clock** axis [`witness_repair_bound`] applies to the repair turn:
+/// a cap on emitted tokens cannot end a call that stalls without emitting
+/// any, and a latency ceiling cannot stop a fast runaway from spending the
+/// budget it was granted. Both are needed, and each turn should keep the
+/// bounds it has. The repair rung carries both today; the author rung still
+/// wants the wall-clock half (#2149).
+///
+/// Sized well clear of the reasoning budget that starves the 512/1024-token
+/// role caps in #2128 — reasoning is billed against this same ceiling, so a
+/// value near legitimate output alone would trade a runaway for a silently
+/// empty authoring reply.
+const WITNESS_MAX_OUTPUT_TOKENS: u32 = 16_384;
+
+/// Lower `config.max_output_tokens` to at most [`WITNESS_MAX_OUTPUT_TOKENS`],
+/// leaving a stricter operator value untouched. Pure so the min-not-raise
+/// contract is testable without a pipeline.
+fn bound_witness_output_tokens(mut config: EngineConfig) -> EngineConfig {
+    let bounded = config
+        .max_output_tokens
+        .map_or(WITNESS_MAX_OUTPUT_TOKENS, |existing| {
+            existing.min(WITNESS_MAX_OUTPUT_TOKENS)
+        });
+    config.max_output_tokens = Some(bounded);
+    config
+}
+
 /// Overlay one role's request shaping onto an engine config — the pure half
 /// of [`Pipeline::witness_engine_config`], so the field-by-field flow is
 /// testable without a pipeline. Only the knobs `EngineConfig` itself carries
@@ -218,10 +261,13 @@ impl<'a> Pipeline<'a> {
     /// It stays scoped to the raw verdict/guidance calls
     /// (`metered_raw_call`).
     pub(super) fn witness_engine_config(&self, surface: CandidateSurface<'_>) -> EngineConfig {
-        apply_role_shaping(
+        // The output ceiling (#2141) is applied *after* role shaping so it
+        // caps whatever the verifier overrides resolved to — an override can
+        // lower the bound but never raise it back above the witness ceiling.
+        bound_witness_output_tokens(apply_role_shaping(
             self.engine_config_for(surface),
             &self.config.role_overrides.verifier,
-        )
+        ))
     }
 
     /// What remains of the run's declared wall-clock allowance
@@ -890,5 +936,39 @@ mod tests {
         let untouched = apply_role_shaping(worker.clone(), &RoleCallOverrides::default());
         assert_eq!(untouched.temperature, worker.temperature);
         assert_eq!(untouched.max_output_tokens, worker.max_output_tokens);
+    }
+
+    /// #2141's witness: the witness author/repair output ceiling lowers a
+    /// too-high or absent `max_output_tokens` to the bound, and never raises
+    /// a stricter operator value. On `main` the turn inherits the worker's
+    /// ceiling and a single reasoning-heavy repair call can spend the whole
+    /// trial budget.
+    #[test]
+    fn the_witness_output_ceiling_only_ever_lowers() {
+        // The worker's 131k ceiling — the measured runaway's headroom — is
+        // brought down to the witness bound.
+        let from_worker = bound_witness_output_tokens(EngineConfig {
+            max_output_tokens: Some(131_072),
+            ..EngineConfig::default()
+        });
+        assert_eq!(
+            from_worker.max_output_tokens,
+            Some(WITNESS_MAX_OUTPUT_TOKENS)
+        );
+
+        // An absent ceiling (provider default) is given the bound outright.
+        let from_none = bound_witness_output_tokens(EngineConfig {
+            max_output_tokens: None,
+            ..EngineConfig::default()
+        });
+        assert_eq!(from_none.max_output_tokens, Some(WITNESS_MAX_OUTPUT_TOKENS));
+
+        // A stricter operator value stands — the bound is a ceiling, not a
+        // floor.
+        let from_stricter = bound_witness_output_tokens(EngineConfig {
+            max_output_tokens: Some(2_048),
+            ..EngineConfig::default()
+        });
+        assert_eq!(from_stricter.max_output_tokens, Some(2_048));
     }
 }


### PR DESCRIPTION
Refs #2149 · Refs #2141

## The bug

The witness author and repair turns build their engine from `witness_engine_config`, which inherits the worker's `max_output_tokens` — 131k on a measured run. Uncapped, a reasoning-heavy model spent it: in match `293dc7b9c0e6` (the same match that produced the **first deterministic witness flip on Terminal-Bench**), the kimi-k3 arm's single `witness_repair` call streamed **36,224 output tokens over 965 seconds**, riding an already-solved trial into Harbor's 900→1800s agent timeout and discarding the entire verification record. The glm arm, whose repair stayed short, settled its flip in the same match — so the machinery works; this was the last unbounded step.

## The fix

`witness_engine_config` now lowers `max_output_tokens` to `WITNESS_MAX_OUTPUT_TOKENS` (16,384) **after** role shaping, so:
- an operator's stricter verifier `max_output_tokens` still wins (min, never raise);
- a too-high or absent ceiling is brought down to the bound;
- a call that exceeds it truncates and degrades through the existing no-marker path (`witness repair produced no TEST_COMMAND line` → degradable), **freeing the budget instead of consuming it** — the honest-degradation outcome the issue asks for.

16k is over 8× the largest legitimate authoring call observed on a settled flip (<2k) and less than half the runaway. Bounds both author and repair because both build from the one config method. It also sits well clear of the reasoning budget that starves the 512/1024-token role caps in #2128 — reasoning bills against this same ceiling, so a value near legitimate output alone would trade a runaway for a silently empty authoring reply.

## Reconciled with #2151 — two axes, neither subsumes the other

This branch forked **before** #2151 (`7b5155db`) merged, and both edit `crates/stella-pipeline/src/pipeline/witness_stage.rs`. They are complementary, and the branch has been rebased onto current `main` so both survive:

| Axis | Mechanism | Covers | From |
|---|---|---|---|
| **Wall clock** | `witness_repair_bound` — min(300s static ceiling, half the remaining `PipelineConfig::run_budget`), checked pre-dispatch and enforced with `tokio::time::timeout`, degrading to `ProofStep::WitnessUnavailable` | the **repair** turn | #2151 (on `main`) |
| **Output tokens** | `bound_witness_output_tokens` / `WITNESS_MAX_OUTPUT_TOKENS` — a min-not-raise per-call ceiling applied after role shaping | the **author** *and* **repair** turns | this PR |

A token cap cannot end a call that stalls without emitting tokens; a latency ceiling cannot stop a fast runaway from spending the budget it was granted. `WITNESS_MAX_OUTPUT_TOKENS`' doc comment now states the split so a later maintainer cannot read one as superseding the other. No test or line from #2151 was removed — see the evidence below.

## Witness

`pipeline::witness_stage::tests::the_witness_output_ceiling_only_ever_lowers`: 131k→16k, None→16k, 2k stays 2k. References `bound_witness_output_tokens`/`WITNESS_MAX_OUTPUT_TOKENS`, absent on `main`, so it cannot compile there.

Coexistence evidence after the rebase — the full `stella-pipeline` lib suite is green (**613 passed, 0 failed**), including all three:

- `pipeline::witness_stage::tests::the_witness_output_ceiling_only_ever_lowers` — this PR ✅
- `pipeline::witness_stage::tests::the_repair_bound_is_the_ceiling_tightened_by_remaining_clock` — #2151 ✅
- `pipeline::tests::verification_hardening::witness_repair_bound::a_stalled_witness_repair_is_bounded_and_degrades_honestly` — #2151's end-to-end stalling-provider witness ✅

`cargo fmt -p stella-pipeline --check` and `cargo clippy -p stella-pipeline --all-targets` are both clean.

**No tests were deleted by this PR.**

## Why `Refs #2149`, not `Closes`

#2149 asks for a **wall-clock** bound on the author turn — a `witness_repair_bound`-shaped ceiling around the author's `run_engine_turn`, proven by a stalling-provider witness test. This PR bounds the author's *tokens per call*, which kills the specific runaway-stream shape but is not that bound: the author turn is multi-step (probe → write artifact → reply), so N calls each capped at 16k still have unbounded elapsed time, and a provider that stalls without emitting is untouched by a token cap. **#2149 stays open** for the wall-clock half.

#2141 is already closed by #2151 (the repair rung's wall-clock bound); this is its token half, so it is referenced, not re-closed.

Refs #2089 (this unblocks a clean 2/2 flip match), #2109/#2122 (the harness fixes that got the witness stage this far), #2128 (the role-cap/reasoning-budget interaction this ceiling is sized against), #2021 (the general single-call wall-clock gap).

Exemplar: mirrors the min-not-raise ceiling discipline in `apply_role_shaping`'s neighbor knobs.

Refs #2165 — the wiring-coverage gap this PR leaves behind: the ceiling is proven as a pure function, but nothing fails if its call site in `witness_engine_config` is deleted. Filed as a handoff rather than grown into this PR.
