### PR TITLE
refactor(bench): move the harbor adapter's metrics cluster to its own module (#2161)

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import math
 import os
 import re
 import shlex
@@ -93,6 +92,12 @@ from .exit_cause import (
 )
 from .git_baseline import ensure_git, run_git_baseline
 from .locate import locate_binary as _locate_binary
+from .metrics import (
+    _extract_metrics,
+    _load_json_object,
+    _sum_step_usage,  # noqa: F401 — re-exported for tests/test_adapter.py
+    _valid_nonnegative_number,
+)
 from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
@@ -790,164 +795,6 @@ def _embedded_source_commit(version_text: str) -> str | None:
     """Extract the full compile-time STELLA_BUILD_GIT_SHA from `--version`."""
     match = re.search(r"-dev\.([0-9a-fA-F]{40})(?:\s|$)", version_text)
     return match.group(1).lower() if match is not None else None
-
-
-def _sum_step_usage(events: list[Any]) -> dict[str, int]:
-    """Aggregate token usage across a turn's ``step_usage`` events.
-
-    Each committed model call emits one ``{"type": "step_usage", ...}`` event
-    carrying the normalized usage envelope (stella-protocol ``AgentEvent``).
-    Summing them yields the turn totals. Fully defensive: an unexpected shape
-    contributes nothing rather than raising.
-    """
-    totals = {"input": 0, "output": 0, "cache": 0}
-    for event in events:
-        if not isinstance(event, dict) or event.get("type") != "step_usage":
-            continue
-        for src, dst in (
-            ("input_tokens", "input"),
-            ("output_tokens", "output"),
-            ("cached_input_tokens", "cache"),
-        ):
-            value = event.get(src)
-            if isinstance(value, (int, float)):
-                totals[dst] += int(value)
-    return totals
-
-
-def _valid_nonnegative_number(value: Any) -> bool:
-    """Return whether ``value`` is finite, numeric, and non-negative."""
-    return (
-        not isinstance(value, bool)
-        and isinstance(value, (int, float))
-        and math.isfinite(float(value))
-        and value >= 0
-    )
-
-
-def _valid_nonnegative_integer(value: Any) -> bool:
-    """Return whether ``value`` is a non-negative integer telemetry value."""
-    return _valid_nonnegative_number(value) and float(value).is_integer()
-
-
-def _extract_metrics(stdout: str | None) -> dict[str, Any]:
-    """Parse a strict Stella result envelope into a metrics dict.
-
-    Returns keys ``cost_usd`` (float | None), ``n_input_tokens`` /
-    ``n_output_tokens`` / ``n_cache_tokens`` (int | None), ``status`` /
-    ``model`` (str | None), and ``steps`` (int | None). Never raises: a
-    missing or malformed envelope yields all-None so a benchmark run is never
-    aborted by a metadata-parsing edge case.
-    """
-    empty: dict[str, Any] = {
-        "cost_usd": None,
-        "n_input_tokens": None,
-        "n_output_tokens": None,
-        "n_cache_tokens": None,
-        "status": None,
-        "model": None,
-        "steps": None,
-    }
-    if not stdout or not stdout.strip():
-        return empty
-
-    envelope = _load_json_object(stdout)
-    if envelope is None:
-        # Last resort: the envelope's total cost is a stable, greppable key
-        # even if the surrounding JSON did not parse (e.g. truncated output).
-        match = re.search(r'"cost_usd"\s*:\s*([0-9]+(?:\.[0-9]+)?)', stdout)
-        if match:
-            return {**empty, "cost_usd": float(match.group(1))}
-        return empty
-
-    metrics = dict(empty)
-    cost = envelope.get("cost_usd")
-    if _valid_nonnegative_number(cost):
-        metrics["cost_usd"] = float(cost)
-
-    status = envelope.get("status")
-    if isinstance(status, str):
-        metrics["status"] = status
-    model = envelope.get("model")
-    if isinstance(model, str):
-        metrics["model"] = model
-
-    events = envelope.get("events")
-    if isinstance(events, list):
-        step_events = [
-            e for e in events if isinstance(e, dict) and e.get("type") == "step_usage"
-        ]
-        if step_events:
-            metrics["steps"] = len(step_events)
-            totals = _sum_step_usage(step_events)
-            # A real zero is reportable, but a missing/malformed value must
-            # remain unknown. Never turn an incomplete per-call field into an
-            # apparently exact total by silently substituting zero.
-            for source, destination, metric_key in (
-                ("input_tokens", "input", "n_input_tokens"),
-                ("output_tokens", "output", "n_output_tokens"),
-                ("cached_input_tokens", "cache", "n_cache_tokens"),
-            ):
-                if all(
-                    _valid_nonnegative_integer(event.get(source))
-                    for event in step_events
-                ):
-                    metrics[metric_key] = totals[destination]
-
-    return metrics
-
-
-def _load_json_object(text: str) -> dict[str, Any] | None:
-    """Best-effort parse of a JSON object from ``text``.
-
-    Tries the whole string first. If diagnostics leaked before or after the
-    envelope, incrementally decode every complete top-level object and select
-    the candidate that most resembles Stella's result envelope. This is more
-    robust than slicing from the first ``{`` to the last ``}``: a trailing
-    diagnostic can legitimately contain its own JSON-like tool arguments.
-    Returns None on failure.
-    """
-    text = text.strip()
-    try:
-        parsed = json.loads(text)
-        return parsed if isinstance(parsed, dict) else None
-    except json.JSONDecodeError:
-        pass
-
-    decoder = json.JSONDecoder()
-    candidates: list[tuple[int, int, dict[str, Any]]] = []
-    position = 0
-    while True:
-        start = text.find("{", position)
-        if start == -1:
-            break
-        try:
-            parsed, end = decoder.raw_decode(text, start)
-        except json.JSONDecodeError:
-            position = start + 1
-            continue
-        if isinstance(parsed, dict):
-            candidates.append((_envelope_score(parsed), end - start, parsed))
-        position = max(end, start + 1)
-
-    if not candidates:
-        return None
-    # Score known envelope fields first, then prefer the larger complete object
-    # over a small JSON argument embedded in a subsequent diagnostic.
-    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
-
-
-def _envelope_score(candidate: dict[str, Any]) -> int:
-    """Rank a decoded object by its resemblance to a Stella run envelope."""
-    score = 0
-    if isinstance(candidate.get("events"), list):
-        score += 16
-    for key in ("status", "model", "text", "reason", "task_class", "verdict"):
-        if key in candidate:
-            score += 2
-    if isinstance(candidate.get("cost_usd"), (int, float)):
-        score += 4
-    return score
 
 
 def _json_dicts_from_line(line: str) -> list[dict[str, Any]]:

--- a/bench/harbor_adapter/stella_harbor/metrics.py
+++ b/bench/harbor_adapter/stella_harbor/metrics.py
@@ -1,0 +1,178 @@
+"""Metrics extraction from Stella's result envelope.
+
+The strict envelope Stella prints — and, when diagnostics leaked around it,
+the best top-level JSON object recovered from the output — is parsed here
+into the flat metrics dict Harbor records for a trial. Defensive by
+contract: a missing or malformed envelope yields all-``None`` values,
+because a benchmark run must never be aborted by a metadata-parsing edge
+case.
+
+Names stay underscore-prefixed, like :mod:`.posture`'s, and are re-exported
+through ``stella_harbor`` for the adapter and its tests: this is adapter
+machinery, not a public API.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import Any
+
+
+def _sum_step_usage(events: list[Any]) -> dict[str, int]:
+    """Aggregate token usage across a turn's ``step_usage`` events.
+
+    Each committed model call emits one ``{"type": "step_usage", ...}`` event
+    carrying the normalized usage envelope (stella-protocol ``AgentEvent``).
+    Summing them yields the turn totals. Fully defensive: an unexpected shape
+    contributes nothing rather than raising.
+    """
+    totals = {"input": 0, "output": 0, "cache": 0}
+    for event in events:
+        if not isinstance(event, dict) or event.get("type") != "step_usage":
+            continue
+        for src, dst in (
+            ("input_tokens", "input"),
+            ("output_tokens", "output"),
+            ("cached_input_tokens", "cache"),
+        ):
+            value = event.get(src)
+            if isinstance(value, (int, float)):
+                totals[dst] += int(value)
+    return totals
+
+
+def _valid_nonnegative_number(value: Any) -> bool:
+    """Return whether ``value`` is finite, numeric, and non-negative."""
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+        and value >= 0
+    )
+
+
+def _valid_nonnegative_integer(value: Any) -> bool:
+    """Return whether ``value`` is a non-negative integer telemetry value."""
+    return _valid_nonnegative_number(value) and float(value).is_integer()
+
+
+def _extract_metrics(stdout: str | None) -> dict[str, Any]:
+    """Parse a strict Stella result envelope into a metrics dict.
+
+    Returns keys ``cost_usd`` (float | None), ``n_input_tokens`` /
+    ``n_output_tokens`` / ``n_cache_tokens`` (int | None), ``status`` /
+    ``model`` (str | None), and ``steps`` (int | None). Never raises: a
+    missing or malformed envelope yields all-None so a benchmark run is never
+    aborted by a metadata-parsing edge case.
+    """
+    empty: dict[str, Any] = {
+        "cost_usd": None,
+        "n_input_tokens": None,
+        "n_output_tokens": None,
+        "n_cache_tokens": None,
+        "status": None,
+        "model": None,
+        "steps": None,
+    }
+    if not stdout or not stdout.strip():
+        return empty
+
+    envelope = _load_json_object(stdout)
+    if envelope is None:
+        # Last resort: the envelope's total cost is a stable, greppable key
+        # even if the surrounding JSON did not parse (e.g. truncated output).
+        match = re.search(r'"cost_usd"\s*:\s*([0-9]+(?:\.[0-9]+)?)', stdout)
+        if match:
+            return {**empty, "cost_usd": float(match.group(1))}
+        return empty
+
+    metrics = dict(empty)
+    cost = envelope.get("cost_usd")
+    if _valid_nonnegative_number(cost):
+        metrics["cost_usd"] = float(cost)
+
+    status = envelope.get("status")
+    if isinstance(status, str):
+        metrics["status"] = status
+    model = envelope.get("model")
+    if isinstance(model, str):
+        metrics["model"] = model
+
+    events = envelope.get("events")
+    if isinstance(events, list):
+        step_events = [
+            e for e in events if isinstance(e, dict) and e.get("type") == "step_usage"
+        ]
+        if step_events:
+            metrics["steps"] = len(step_events)
+            totals = _sum_step_usage(step_events)
+            # A real zero is reportable, but a missing/malformed value must
+            # remain unknown. Never turn an incomplete per-call field into an
+            # apparently exact total by silently substituting zero.
+            for source, destination, metric_key in (
+                ("input_tokens", "input", "n_input_tokens"),
+                ("output_tokens", "output", "n_output_tokens"),
+                ("cached_input_tokens", "cache", "n_cache_tokens"),
+            ):
+                if all(
+                    _valid_nonnegative_integer(event.get(source))
+                    for event in step_events
+                ):
+                    metrics[metric_key] = totals[destination]
+
+    return metrics
+
+
+def _load_json_object(text: str) -> dict[str, Any] | None:
+    """Best-effort parse of a JSON object from ``text``.
+
+    Tries the whole string first. If diagnostics leaked before or after the
+    envelope, incrementally decode every complete top-level object and select
+    the candidate that most resembles Stella's result envelope. This is more
+    robust than slicing from the first ``{`` to the last ``}``: a trailing
+    diagnostic can legitimately contain its own JSON-like tool arguments.
+    Returns None on failure.
+    """
+    text = text.strip()
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    decoder = json.JSONDecoder()
+    candidates: list[tuple[int, int, dict[str, Any]]] = []
+    position = 0
+    while True:
+        start = text.find("{", position)
+        if start == -1:
+            break
+        try:
+            parsed, end = decoder.raw_decode(text, start)
+        except json.JSONDecodeError:
+            position = start + 1
+            continue
+        if isinstance(parsed, dict):
+            candidates.append((_envelope_score(parsed), end - start, parsed))
+        position = max(end, start + 1)
+
+    if not candidates:
+        return None
+    # Score known envelope fields first, then prefer the larger complete object
+    # over a small JSON argument embedded in a subsequent diagnostic.
+    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
+
+
+def _envelope_score(candidate: dict[str, Any]) -> int:
+    """Rank a decoded object by its resemblance to a Stella run envelope."""
+    score = 0
+    if isinstance(candidate.get("events"), list):
+        score += 16
+    for key in ("status", "model", "text", "reason", "task_class", "verdict"):
+        if key in candidate:
+            score += 2
+    if isinstance(candidate.get("cost_usd"), (int, float)):
+        score += 4
+    return score

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -81,6 +81,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/host_attestation.py",
     "bench/harbor_adapter/stella_harbor/live_feed.py",
     "bench/harbor_adapter/stella_harbor/locate.py",
+    "bench/harbor_adapter/stella_harbor/metrics.py",
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2150 bench/harbor_adapter/stella_harbor/__init__.py
-4297 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1997 bench/harbor_adapter/stella_harbor/__init__.py
+4298 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2335 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8272 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
## Why

`bench/harbor_adapter/stella_harbor/__init__.py` sat at **exactly 2150 lines — its own ratchet ceiling, zero headroom.** Any PR adding one net line there failed `file size ratchet` before it could be reviewed on its merits. That is not hypothetical: #2136 arrived with two genuine features (exec-stream release, per-trial telemetry export) and went red on the ratchet alone.

## What

Move the metrics cluster to a new `stella_harbor/metrics.py`. It is the natural seam — `_sum_step_usage`, `_valid_nonnegative_number`, `_valid_nonnegative_integer`, `_extract_metrics`, `_load_json_object` and `_envelope_score` are one closed unit that parses Stella's result envelope and touches nothing else in the adapter.

- Moved **verbatim**; no behavior change.
- The four names the adapter and `tests/test_adapter.py` still reach for are re-exported from the package, following `.posture`'s underscore convention. `_valid_nonnegative_integer` and `_envelope_score` have no callers outside the cluster and stay private to it.
- `math` was imported solely for `_valid_nonnegative_number` and leaves with it.
- `__init__.py`: **2150 → 1997**, restoring ~150 lines of headroom.

Exemplar for the shape: this is the same move `crates/stella-core/src/driver/settlement.rs` made out of `driver.rs` — lift a closed decision-logic cluster into a sibling module, re-export what the parent still calls.

## The two gate interactions, on purpose

**`_FIXED_ADAPTER_SOURCE_PATHS`.** The new module is registered in `secure_launcher.py`. That tuple is enumerated rather than globbed precisely so an adapter file cannot execute without being byte-compared against the published commit — it fails closed, with an error naming the launcher rather than the new file. Skipping it fails ~31 tests in `test_secure_launcher.py`.

**`secure_launcher.py` 4297 → 4298.** That one added line is the registration entry above. It is the documented irreducible case (a required entry in an already-oversized file, AGENTS.md § God files) — not a ceiling raised to turn a gate green.

**The baseline diff is deliberately scoped to these two files.** A full `--update` also retightened `crates/stella-core/src/driver/tests.rs` by 297 lines, from a merge this branch had no part in. Adopting unrelated shrinkage while several stella-core PRs are in flight is the repo's most frequent red-main cause (#2004), so that hunk was dropped rather than shipped.

## Verification

```
cd bench/harbor_adapter && uv sync --locked && uv run --no-sync pytest -q
496 passed, 1 skipped in 14.79s

bash scripts/check-file-size.sh
OK — 1167 Rust/Python/shell files, none over 1500 lines except 30 grandfathered (none grew).
```

That is the same invocation as the `harbor_adapter + analyzer pytest` CI job.

**Witness test:** none — pure refactor, no behavior change, so there is no fail→pass flip to demonstrate. The moved code's existing tests passing unchanged is the evidence.

**Deleted tests:** none.

Closes #2161

## Summary by Sourcery

Extract metrics parsing logic from the harbor adapter into a dedicated module and register it with the secure launcher while maintaining existing behavior.

Enhancements:
- Move Stella result-envelope metrics parsing helpers from stella_harbor.__init__ into a new stella_harbor.metrics module and re-export required functions for adapter and test use.
- Reduce stella_harbor.__init__ file size by delegating metrics logic to the new module to restore file-size-ratchet headroom.
- Register the new metrics module in secure_launcher’s fixed adapter source paths to keep secure loading guarantees intact.