### PR TITLE
fix(arenabench): fix light-mode text contrast

### DIFF
--- a/arenabench/ui/app/globals.css
+++ b/arenabench/ui/app/globals.css
@@ -43,21 +43,24 @@
   --line:       #d8d3c4;
   --line-soft:  #e4e0d3;
   --foreground: #1c1b16;
-  --muted:      #6e6a5f;
-  --dim:        #98948a;
+  --muted:      #5d5a50;
+  --dim:        #66625a;
 
-  --accent:     #a37200;   /* gold that passes contrast on light */
-  --ok:         #1c7c43;
-  --bad:        #c0343c;
-  --warn:       #8a6d00;
-  --acc-cyan:   #0b7285;
+  /* Every one of these is picked to clear 4.5:1 against --panel-2 (#e9e5da),
+     the darkest of the three light surfaces and so the binding constraint —
+     a color that passes against --background can still fail there. */
+  --accent:     #835b00;
+  --ok:         #1a713d;
+  --bad:        #b53139;
+  --warn:       #796000;
+  --acc-cyan:   #0a6c7e;
   --acc-violet: #7048a8;
-  --acc-rose:   #c2255c;
-  --acc-citron: #8a6d00;
+  --acc-rose:   #ba2358;
+  --acc-citron: #796000;
 
   /* Seat colours arrive as data (each contestant carries a hex). As fills
      they work on both schemes; as *text* on paper they need ink mixed in. */
-  --seat-fg: color-mix(in srgb, var(--seat, #a37200) 62%, #1c1b16);
+  --seat-fg: color-mix(in srgb, var(--seat, #835b00) 62%, #1c1b16);
 
   --glow-gold: 0 0 24px rgb(163 114 0 / 0.18), 0 0 96px rgb(163 114 0 / 0.08);
 }


### PR DESCRIPTION
## Summary
- Light-mode text was largely unreadable — several CSS custom properties in `arenabench/ui/app/globals.css` failed WCAG AA contrast (4.5:1) against the light surfaces.
- `--dim` (used for nearly every label, timestamp, and placeholder across the arena/trends views) was only **2.63–2.85:1**. `--accent`, `--warn`/`--acc-citron`, and the status colors (`--ok`, `--bad`, `--acc-cyan`, `--acc-rose`) also fell short, especially against `--panel-2`.
- Re-picked each token (same hue, darkened) so every one clears **4.5:1 against `--panel-2`** — the darkest of the three light surfaces (`--background`, `--panel`, `--panel-2`) and the binding constraint. Margins now run 4.79–6.5:1 across all three surfaces. `--acc-violet` already passed and is unchanged. Dark mode is untouched.

## Verification
- Computed WCAG contrast ratios for every affected token against all three light surfaces before/after (script-verified, all ≥4.5:1 after the fix).
- `npm run typecheck` — clean.
- `npm run build` — clean; confirmed the new hex values landed in the compiled CSS chunk and the dark-mode values are unchanged.

## Test plan
- [ ] Load the ArenaBench dashboard in light mode and confirm labels, timestamps, placeholders, and status text are legible
- [ ] Spot-check the transcript page and trends view, which lean heavily on `text-dim`

## Summary by Sourcery

Improve light-mode text legibility in ArenaBench by adjusting color tokens to meet WCAG AA contrast requirements against light surfaces.

Bug Fixes:
- Fix insufficient contrast for light-mode labels, timestamps, placeholders, and status text by darkening muted and dim text colors.
- Correct accent and status color tokens in light mode so they pass WCAG AA against the darkest panel surface.
- Align seat foreground color mixing with the updated light-mode accent palette to maintain readable text.