### PR TITLE
fix(arenabench): price the kimi models, and name an unpriced one (#2108)

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -186,6 +186,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
             f"({totals['passed']}/{totals['judged']})  {cost:>9}  "
             f"(self-reported ${totals['total_cost']:.2f})"
         )
+        # A blank cost column is a finding, not a formatting detail: it went
+        # unremarked across every kimi match because "unpriced" named nothing
+        # an operator could go fix (#2108). Naming the slug turns it into a
+        # one-line edit to `pricing.PRICES`.
+        for slug in totals.get("unpriced_models") or ():
+            print(f"    !! no pricing entry for {slug} — priced cost unavailable")
         if totals["judged"] == 0:
             worst = 1
     if args.results:

--- a/arenabench/arenabench/pricing.py
+++ b/arenabench/arenabench/pricing.py
@@ -117,6 +117,20 @@ PRICES: dict[str, Price] = {
     # so leaving this row out would blank the whole trial's cost rather than
     # merely one role's share. Same numbers on both routes, per the catalog.
     "glm-4.5-air": Price(input=0.13, output=0.85, cache_read=0.025),
+    # Moonshot's Kimi K3, as OpenRouter serves it: `moonshotai/kimi-k3` quotes
+    # 0.000003 / 0.000015 per token with an `input_cache_read` of 0.0000003
+    # and no separate cache-write line (`/api/v1/models`, read 2026-08-07) —
+    # the usual "a write is an ordinary input token" shape, which is what
+    # `cache_write=None` means here. The same three numbers are carried by the
+    # Stella seed catalog (`crates/stella-model/src/catalog.rs`, the
+    # `moonshotai/kimi-k3` row), so the two tables agree by construction.
+    #
+    # No first-party row: Moonshot is not a provider any seat can be routed
+    # to (`moonshotai` appears in the catalog only as this OpenRouter entry's
+    # family), so a direct tier would be an unreachable guess. A route with no
+    # row of its own prices at the gateway tier, which errs against the seat
+    # rather than for it (#1498).
+    "kimi-k3": Price(input=3.0, output=15.0, cache_read=0.30),
     "claude-fable-5": Price(
         input=10.0, output=50.0, cache_read=1.0, cache_write=12.50
     ),
@@ -145,7 +159,21 @@ PRICES: dict[str, Price] = {
 }
 
 #: Routing prefixes that are ArenaBench's or Harbor's, never the provider's.
-_ROUTE_PREFIXES = ("openrouter/", "anthropic/", "zai/", "z-ai/", "openai/", "google/")
+#:
+#: Every vendor namespace a gateway slug can carry belongs here, or the bare id
+#: underneath it is unreachable: with ``moonshotai/`` missing, a ``kimi-k3``
+#: row existed for nothing, because no spelling any seat records
+#: (``moonshotai/kimi-k3``, ``openrouter/moonshotai/kimi-k3``) ever collapsed
+#: onto it (#2108).
+_ROUTE_PREFIXES = (
+    "openrouter/",
+    "anthropic/",
+    "zai/",
+    "z-ai/",
+    "openai/",
+    "google/",
+    "moonshotai/",
+)
 
 
 def _normalise(model: str) -> str:

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -90,6 +90,7 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
     reasons: dict[str, int] = {}
     clock_time = 0.0
     priced: float | None = 0.0
+    unpriced: set[str] = set()
     for m in metrics.values():
         if m.status != "done":
             continue
@@ -97,6 +98,7 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
         clock_time += m.clock_time or 0.0
         if priced is not None:
             priced = None if m.priced_cost is None else priced + m.priced_cost
+        unpriced.update(m.unpriced_models)
         reason = m.outcome_reason() or "unlabelled"
         reasons[reason] = reasons.get(reason, 0) + 1
         if m.resolved is None:
@@ -132,6 +134,10 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
         "priced_cost_per_solve": (
             round(priced / solved, 6) if priced is not None and solved else None
         ),
+        # The reason both figures above can be null, carried with them so a
+        # trends row that plots nothing can say which model it has no rate
+        # for rather than silently dropping out of the chart (#2108).
+        "unpriced_models": sorted(unpriced),
     }
 
 

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -279,6 +279,13 @@ class TrialMetrics:
     #: List-price cost recomputed from this trial's own token counts using one
     #: shared table. ``None`` when the model is unpriced — missing beats wrong.
     priced_cost: float | None = None
+    #: The model ids this trial ran that :mod:`.pricing` has no row for — the
+    #: *reason* :attr:`priced_cost` is ``None``, carried beside it. Missing
+    #: beats wrong, but missing and unexplained is how an entire arm's cost
+    #: column read blank across every kimi match without anyone noticing
+    #: (#2108). Empty whenever the cost is known, so a non-empty tuple is
+    #: always something an operator can act on: add the row, re-read.
+    unpriced_models: tuple[str, ...] = ()
     clock_time: float = 0.0
     #: Seconds since the trial last wrote any :data:`LIVENESS_NAMES`
     #: artifact — its liveness, whichever files this arm happens to write.
@@ -390,6 +397,7 @@ class TrialMetrics:
             "priced_cost": (
                 round(self.priced_cost, 6) if self.priced_cost is not None else None
             ),
+            "unpriced_models": list(self.unpriced_models),
             "cache_hit_rate": self.cache_hit_rate,
             "clock_time": round(self.clock_time, 2),
             "age_s": self.age_s,
@@ -681,6 +689,23 @@ class MetricsReader:
                         break
             return price
 
+        def seat_label() -> str:
+            """What to call this trial's model when nothing could price it.
+
+            The same candidates :func:`single_rate` tries, in the same order,
+            so the name a reader is told to go add a row for is the one the
+            lookup actually failed on.
+            """
+            for name in (qualified, configured, *metrics.models):
+                if name:
+                    return str(name)
+            return ""
+
+        # Every id the shared table had no row for. Collected rather than
+        # counted: the operator's next move is to add those rows, and a bare
+        # "unpriced" tells them nothing about which (#2108).
+        unpriced: list[str] = []
+
         # A pipeline seat runs several models at several rates — worker,
         # verifier, triage — so where the stream says which model each step
         # used, each model's subtotal is priced at its own rate and the trial
@@ -692,7 +717,7 @@ class MetricsReader:
         # beats wrong here.
         by_model = (events or {}).get("by_model") or {}
         if any(model for model in by_model):
-            total = 0.0
+            subtotal = 0.0
             for model, bucket in by_model.items():
                 if not model:
                     price = single_rate()  # steps that named no model
@@ -701,10 +726,14 @@ class MetricsReader:
                 else:
                     price = price_for(model)  # no route fact: gateway tier
                 if price is None:
-                    total = None
-                    break
-                total += trial_cost(price, **bucket)
-            metrics.priced_cost = total
+                    # Scanning continues past the first miss on purpose: the
+                    # cost is blanked either way, and naming every missing row
+                    # makes one edit to `pricing.PRICES` enough to price the
+                    # trial rather than uncovering the next gap on a re-read.
+                    unpriced.append(model or seat_label())
+                    continue
+                subtotal += trial_cost(price, **bucket)
+            metrics.priced_cost = None if unpriced else subtotal
         else:
             # ATIF-only trials publish grand totals and a single model; a
             # stream that never named one is priced the same way.
@@ -717,6 +746,14 @@ class MetricsReader:
                     cache_read=metrics.cache_read,
                     cache_write=metrics.cache_write,
                 )
+            else:
+                unpriced.append(seat_label())
+        # Deduplicated, order preserved, and empty names dropped — a queued
+        # trial that has not named a model yet is unstarted, not unpriced, and
+        # must not raise a warning an operator cannot act on.
+        metrics.unpriced_models = tuple(
+            dict.fromkeys(name for name in unpriced if name)
+        )
 
         # A running trial has no finish timestamp, so wall clock has to come
         # from its artifacts' own span rather than from Harbor. The earliest
@@ -800,6 +837,13 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
             if any(t.priced_cost is not None for t in trials)
             else None
         ),
+        # Why the figure above is missing, when it is. A blank cost cell is
+        # the symptom and this is the cause, carried in the same payload so
+        # every reader of the totals — CLI, UI, a saved `results.json` — can
+        # say "no pricing entry for X" instead of showing an empty column and
+        # letting a whole arm's spend go unnoticed (#2108). Sorted so the
+        # payload is deterministic.
+        "unpriced_models": sorted({name for t in trials for name in t.unpriced_models}),
         "cache_hit_rate": (
             sum(t.cache_read for t in trials) / sum(t.tokens_in for t in trials) * 100.0
             if sum(t.tokens_in for t in trials) > 0

--- a/arenabench/tests/test_pricing.py
+++ b/arenabench/tests/test_pricing.py
@@ -132,6 +132,60 @@ class TestRoutePricing:
 
 
 
+class TestKimiPricing:
+    """The Moonshot arm of the 2026-08-07 head-to-heads (#2108).
+
+    Witness: on the old table no ``kimi`` id had a row at all, so a seat
+    running ``moonshotai/kimi-k3`` aggregated ``priced_cost = None`` and the
+    arena's cost column was blank for that whole arm — beside a GLM arm that
+    showed $0.56, in a match billed as a cost comparison.
+
+    Rates: OpenRouter's ``/api/v1/models``, read 2026-08-07 — ``prompt``
+    0.000003 and ``completion`` 0.000015 per token, ``input_cache_read``
+    0.0000003, no ``input_cache_write`` line. The Stella catalog
+    (``crates/stella-model/src/catalog.rs``) carries the same three numbers.
+    """
+
+    def test_the_gateway_rate_is_the_pinned_one(self):
+        price = price_for("kimi-k3")
+        assert price is not None
+        assert (price.input, price.output, price.cache_read) == (3.0, 15.0, 0.30)
+        # No separate write line: a cache write is an ordinary input token.
+        assert price.cache_write is None
+
+    def test_every_spelling_a_seat_records_resolves_to_that_rate(self):
+        """The bare row alone fixes nothing: `moonshotai/` was not a known
+        routing prefix, so no id any seat actually records — the OpenRouter
+        slug, or Harbor's fully qualified form — collapsed onto it. Each
+        spelling is asserted against the *rate*, never merely against the
+        others: three `None`s are equal too, which is the shape this whole
+        class exists to catch."""
+        for spelling in ("kimi-k3", "moonshotai/kimi-k3", "openrouter/moonshotai/kimi-k3"):
+            price = price_for(spelling)
+            assert price is not None, spelling
+            assert (price.input, price.output) == (3.0, 15.0), spelling
+
+    def test_a_recorded_moonshot_route_prices_at_the_gateway_tier(self):
+        """No first-party row exists, because no seat can be routed direct to
+        Moonshot — the catalog knows `moonshotai` only as this OpenRouter
+        entry's family. A route with no row of its own takes the gateway rate,
+        which errs against the seat rather than for it (#1498)."""
+        assert price_for_route("moonshotai/kimi-k3") is not None
+        assert price_for_route("moonshotai/kimi-k3") == price_for("kimi-k3")
+        assert price_on_route("openrouter", "moonshotai/kimi-k3") == price_for("kimi-k3")
+
+    def test_a_kimi_trials_tokens_cost_a_real_number(self):
+        """The end of the bug as it was observed: token counts in, a figure
+        out, where the whole arm used to render nothing."""
+        cost = trial_cost(
+            price_for("moonshotai/kimi-k3"),
+            tokens_in=1_000_000,
+            tokens_out=100_000,
+            cache_read=600_000,
+        )
+        assert cost == pytest.approx(0.4 * 3.0 + 0.6 * 0.30 + 0.1 * 15.0)
+
+
 class TestSonnet5Pricing:
     """The model both seats of the kvk matches actually ran (2026-08-06).
 

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -401,6 +401,97 @@ class TestMetrics:
         assert metrics.priced_cost == pytest.approx(0.60 + 0.966)
 
 
+class TestUnpricedModelsAreNamed:
+    """A blank cost column has to say whose cost is blank (#2108).
+
+    Witness: on the old code a seat on an unpriced model produced
+    ``priced_cost = None`` and nothing else — no field, no line, no name — so
+    an entire kimi arm rendered no cost at all in a match billed as a cost
+    comparison, and stayed that way across every kimi match run to date. The
+    price rows are half the fix; being loud when the next model is missing is
+    the other half.
+    """
+
+    def test_a_kimi_seat_now_costs_a_real_number(self, tmp_path: Path):
+        """The bug exactly as observed on match `14d0127b8ca7`: a seat running
+        the OpenRouter Moonshot slug, whose comparable cost was blank."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(
+                    model="moonshotai/kimi-k3",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                    cached_input_tokens=0,
+                )
+            ],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost == pytest.approx(3.0)
+        assert metrics.unpriced_models == ()
+
+    def test_an_unpriced_model_names_itself_beside_the_missing_cost(
+        self, tmp_path: Path
+    ):
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [usage(model="acme/mystery-1", cost_usd=3.0)],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost is None, "missing still beats a guessed number"
+        assert metrics.unpriced_models == ("acme/mystery-1",)
+        assert metrics.to_json()["unpriced_models"] == ["acme/mystery-1"]
+
+    def test_every_missing_role_is_named_not_only_the_first(self, tmp_path: Path):
+        """One re-read, one edit: pricing stops at the first miss for the
+        *cost* (it is blank either way) but not for the diagnosis, or fixing a
+        pipeline seat would mean discovering its gaps one match at a time."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(model="zai/glm-5.2", input_tokens=1_000_000, output_tokens=0),
+                usage(role="verifier", model="acme/mystery-1", output_tokens=0),
+                usage(role="triage", model="acme/mystery-2", output_tokens=0),
+            ],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost is None
+        assert set(metrics.unpriced_models) == {"acme/mystery-1", "acme/mystery-2"}
+
+    def test_a_trial_that_named_no_model_raises_no_warning(self, tmp_path: Path):
+        """A queued trial is unstarted, not unpriced. A warning naming nothing
+        is noise, and noise is what makes the real one easy to skip past."""
+        trial_dir = tmp_path / "job" / "t__1"
+        (trial_dir / "agent").mkdir(parents=True)
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.priced_cost is None
+        assert metrics.unpriced_models == ()
+
+    def test_the_totals_carry_the_names_so_a_reader_sees_the_cause(self):
+        """`aggregate` is what the CLI scoreboard, the arena UI and a saved
+        `results.json` all read. The name has to reach them, or the fix stops
+        at a field nothing displays."""
+        totals = aggregate(
+            [
+                TrialMetrics("a", "a__1", resolved=True, priced_cost=1.5),
+                TrialMetrics(
+                    "b", "b__1", resolved=True, unpriced_models=("moonshotai/kimi-k3",)
+                ),
+                TrialMetrics(
+                    "c", "c__1", resolved=True, unpriced_models=("moonshotai/kimi-k3",)
+                ),
+            ]
+        )
+        assert totals["unpriced_models"] == ["moonshotai/kimi-k3"]
+
+    def test_a_fully_priced_contestant_reports_no_names_at_all(self):
+        totals = aggregate([TrialMetrics("a", "a__1", resolved=True, priced_cost=1.5)])
+        assert totals["unpriced_models"] == []
+
+
 class TestAggregate:
     def test_solve_rate_divides_by_judged_not_attempted(self):
         """Dividing by attempted makes every contestant start near 0% and

--- a/arenabench/ui/components/arena/stat-strip.tsx
+++ b/arenabench/ui/components/arena/stat-strip.tsx
@@ -25,6 +25,12 @@ import { Tip } from "@/components/ui/tooltip";
  * - **An unmeasured quantity renders as `—`, never as zero.** Zero is a
  *   score; absence is not. `priced_cost` is null for an unpriced model, and
  *   wasted time is null until some trial has actually been replayed.
+ *
+ * A `—` still has to say *why*, though, or the honesty rule turns into
+ * invisibility: an entire kimi arm rendered no cost for weeks because the
+ * dash looked like every other dash (#2108). When the cost is unknown the
+ * tile's sub-line names the model with no price row, which is the one fact
+ * that turns a blank cell into a one-line fix.
  */
 function Stat({
   label,
@@ -73,8 +79,10 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
     let tokensOut = 0;
     let selfReported = 0;
     let priced: number | null = 0;
+    const unpriced = new Set<string>();
     for (const seat of seats) {
       const t = seat.totals;
+      for (const slug of t.unpriced_models || []) unpriced.add(slug);
       trials += t.trials || 0;
       judged += t.judged || 0;
       passed += t.passed || 0;
@@ -86,7 +94,17 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
         priced = t.priced_cost == null ? null : priced + t.priced_cost;
       }
     }
-    return { trials, judged, passed, running, tokensIn, tokensOut, selfReported, priced };
+    return {
+      trials,
+      judged,
+      passed,
+      running,
+      tokensIn,
+      tokensOut,
+      selfReported,
+      priced,
+      unpriced: [...unpriced].sort(),
+    };
   }, [seats]);
 
   // Solve rate over *judged* trials, not over every trial that exists: a
@@ -170,8 +188,20 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
       <Stat
         label="cost"
         value={fmtMoney(totals.priced)}
-        sub="one price table, all seats"
-        blurb="Every seat's tokens priced through a single table, which is the only cost figure comparable across contestants. '—' means some model in this match is unpriced, so the total is unknown rather than lower."
+        sub={
+          totals.unpriced.length > 0
+            ? `no price for ${totals.unpriced.join(", ")}`
+            : "one price table, all seats"
+        }
+        tone={totals.unpriced.length > 0 ? "warn" : undefined}
+        blurb={
+          "Every seat's tokens priced through a single table, which is the only cost figure " +
+          "comparable across contestants. '—' means some model in this match is unpriced, so " +
+          "the total is unknown rather than lower" +
+          (totals.unpriced.length > 0
+            ? ` — no row in the shared price table for ${totals.unpriced.join(", ")}.`
+            : ".")
+        }
       />
       <Stat
         label="self-reported"

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -95,6 +95,11 @@ export interface Totals {
   total_cost: number;
   /** Every seat's tokens through one price table. `null` = model unpriced. */
   priced_cost: number | null;
+  /** Model ids this seat ran that the shared price table has no row for — the
+   *  reason `priced_cost` is null, so a blank cost cell can name its cause
+   *  instead of reading as "free" (#2108). Empty whenever the cost is known;
+   *  absent only in payloads recorded before the field existed. */
+  unpriced_models?: string[];
   tokens_in: number;
   tokens_out: number;
   cache_read: number;
@@ -105,7 +110,10 @@ export interface Totals {
   wasted_time?: number | null;
   /** How many trials the wasted-time sum covers (`arenabench flip` runs). */
   flip_trials?: number;
-  [key: string]: number | null | undefined;
+  // `string[]` rides in the index signature for `unpriced_models` alone. Every
+  // *dimension* key is still numeric — `race.tsx` indexes by `dim.key` and
+  // coerces with `Number` — and no dimension is or will be a list.
+  [key: string]: number | string[] | null | undefined;
 }
 
 export interface ContestantSnap {
@@ -178,6 +186,8 @@ export interface SeriesOutcomes {
   clock_time: number;
   priced_cost: number | null;
   priced_cost_per_solve: number | null;
+  /** Which models the two figures above have no rate for (#2108). */
+  unpriced_models?: string[];
 }
 
 export interface SeriesTaskVerdict {


### PR DESCRIPTION
Closes #2108

## The defect

`arenabench/arenabench/pricing.py`'s `PRICES` had **zero** rows for any
Moonshot model, so a seat running `moonshotai/kimi-k3` aggregated
`priced_cost = None` and the arena's cost column was blank for that whole arm.
Observed live on match `14d0127b8ca7` (2026-08-07): the GLM 5.2 arm showed
`$0.56`, the Kimi K3 arm showed nothing, in a head-to-head billed as a cost
comparison.

Confirmed before touching anything, on `origin/main`:

```
$ python3 -c "from arenabench.pricing import price_for; print(price_for('moonshotai/kimi-k3'))"
None
```

## The fix, in two halves

**The rows would not have been enough on their own.** `moonshotai/` was not in
`_ROUTE_PREFIXES`, so `_normalise()` never stripped it — a bare `kimi-k3` row
would have sat there unreachable by every spelling a seat actually records
(`moonshotai/kimi-k3` from the stream, `openrouter/moonshotai/kimi-k3` from
Harbor). Both are needed:

- `"kimi-k3": Price(input=3.0, output=15.0, cache_read=0.30)` — the gateway
  tier, per the module's dual-tier convention.
- `moonshotai/` joins `_ROUTE_PREFIXES`, so all three spellings collapse onto
  it.

**No first-party row**, deliberately: Moonshot is not a provider any seat can
be routed to (`moonshotai` appears in `crates/stella-model/src/catalog.rs`
only as this OpenRouter entry's *family*), so a direct tier would be an
unreachable guess. A route with no row of its own prices at the gateway tier,
which errs against the seat rather than for it — the #1498 rule.

### Pricing source

OpenRouter's `/api/v1/models`, fetched 2026-08-07 (the endpoint the module
docstring already names as the source of truth for the bare tier):

```
moonshotai/kimi-k3 | prompt 0.000003  completion 0.000015
                   | input_cache_read 0.0000003  input_cache_write (absent)
```

→ $3.00 in / $15.00 out / $0.30 cached read per Mtok. `cache_write=None`
because there is no separate write line — a cache write bills as an ordinary
input token. The Stella seed catalog carries the identical three numbers
(`crates/stella-model/src/catalog.rs`, the `moonshotai/kimi-k3` row:
`3.0 / 15.0 / 0.3`), so the two tables agree by construction rather than by
coincidence.

## The failure mode — the other half of the bug

A missing rate produced a silent `None` and *nothing else*. That is why this
survived every kimi match to date: the blank cell looked like every other
blank cell. So:

- `TrialMetrics.unpriced_models` — the ids the table had no row for, in
  `to_json()` and therefore in every trial cell payload. **Collected, not
  counted**: the per-model loop no longer breaks at the first miss (the cost
  is blanked either way), so one edit to `PRICES` closes every gap instead of
  uncovering the next one on a re-read.
- `aggregate()` totals carry `unpriced_models`, so the CLI scoreboard, the
  arena UI and a saved `results.json` all read the cause beside the symptom.
  `series.py`'s trends rows carry it too.
- `arenabench run` prints `!! no pricing entry for <slug> — priced cost
  unavailable` per seat.
- The arena's cost tile names the model (`no price for moonshotai/kimi-k3`, in
  the `warn` tone) instead of an unexplained `—`.

A trial that has named no model raises nothing: queued is unstarted, not
unpriced, and a warning naming nothing is the noise that makes the real one
easy to skip.

`priced_cost` semantics are unchanged — still `None`, never a guess, never
`total_cost`. Missing still beats wrong; this removes *missing and
unexplained*.

## Witness

`arenabench/tests/test_pricing.py::TestKimiPricing` (4 tests) and
`arenabench/tests/test_telemetry.py::TestUnpricedModelsAreNamed` (6 tests).

Flip verified by reverting only the four implementation files to `HEAD`
(`git checkout --`, working tree preserved for the tests) and re-running:

```
FAILED test_pricing.py::TestKimiPricing::test_the_gateway_rate_is_the_pinned_one - assert None is not None
FAILED test_pricing.py::TestKimiPricing::test_a_kimi_trials_tokens_cost_a_real_number - assert None == 2.88 ± 2.9e-06
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_a_kimi_seat_now_costs_a_real_number - assert None == 3.0 ± 3.0e-06
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_an_unpriced_model_names_itself_beside_the_missing_cost - AttributeError: 'TrialMetrics' object has no attribute 'unpriced_models'
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_every_missing_role_is_named_not_only_the_first - AttributeError: ...
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_a_trial_that_named_no_model_raises_no_warning - AttributeError: ...
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_the_totals_carry_the_names_so_a_reader_sees_the_cause - TypeError: TrialMetrics.__init__() got an unexpected keyword argument 'unpriced_models'
FAILED test_telemetry.py::TestUnpricedModelsAreNamed::test_a_fully_priced_contestant_reports_no_names_at_all - KeyError: 'unpriced_models'
```

Two of the ten passed vacuously on the old code (three `None`s compare equal),
which is the exact shape this class exists to catch — they were rewritten to
assert against the *rate* rather than against each other before this landed.

All ten pass on this branch, with `tests/test_pricing.py`,
`tests/test_telemetry.py`, `tests/test_series.py`, `tests/test_leaderboard.py`
and `tests/test_arena.py` green (185 passed). No test was deleted or renamed.

## Not covered here (filed, not left)

- **#2171** — nothing gates `PRICES` against the models a match can actually
  seat. This fix makes the gap loud *after* a match has spent money; a parity
  test against `catalog.rs` (the `test_posture.py::TestOutputCeilingParity`
  precedent) or a `sut_problem_for`-style preflight would refuse before it.
  Third recurrence of this shape after #1566 and #1498.
- **#2172** — `lane.tsx` (the per-seat cell) still renders a bare `—`; the
  server already sends `unpriced_models` in the cell payload and the `Cell` TS
  type does not declare it. `arenabench/ui` has no typecheck or test in CI, so
  it cannot carry a witness.
- `ruff check` is red on `arenabench/` at `HEAD` — 7 pre-existing findings in
  `agents.py`, `credentials.py`, `sut.py` and two test files, none in files
  this PR touches. Already tracked as **#2146**; not widened here.

`ruff format` disagrees with essentially the whole package, so it is clearly
not the codebase's formatter and was not applied.

## Summary by Sourcery

Add pricing for Moonshot Kimi K3 and surface unpriced models throughout telemetry and UI so missing cost is explicitly attributed instead of silently blank.

New Features:
- Introduce explicit tracking of unpriced models in trial metrics, aggregates, series outcomes, CLI output and arena UI cost tile so readers see which model lacks a price row.

Bug Fixes:
- Add a price entry and routing support for Moonshot Kimi K3 so seats using this model produce a real priced cost instead of a blank cost column.
- Ensure cost aggregation continues past the first missing rate while collecting all unpriced models, preventing silent failures when multiple models lack pricing.

Enhancements:
- Extend routing prefix normalization to cover Moonshot provider slugs so bare model ids in the shared price table are reachable from all recorded spellings.
- Expose unpriced model identifiers in JSON telemetry and series outcomes to make downstream consumers and trend visualizations explain missing cost figures.

Tests:
- Add dedicated tests for Kimi pricing and for naming unpriced models across telemetry, aggregation and UI to capture the previous silent failure mode and prevent regressions.