### PR TITLE
fix(arenabench): one trial per instance — Batch host networking made concurrent dockerds collide

### DIFF
--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -391,9 +391,12 @@ Resources:
         MinvCpus: 0
         DesiredvCpus: 0
         MaxvCpus: !Ref OnDemandMaxvCpus
+        # Exactly one size, and it is the trial's size on purpose: a trial
+        # requests 4 vCPU, an m6i.xlarge *has* 4 vCPU, so Batch can never
+        # place two trials on one instance. That is a correctness
+        # requirement, not a tuning choice — see TrialTopology below.
         InstanceTypes:
-          - m6i
-          - c6i
+          - m6i.xlarge
         Subnets: !Ref SubnetIds
         SecurityGroupIds:
           - !Ref BatchSecurityGroup
@@ -418,9 +421,10 @@ Resources:
         MinvCpus: 0
         DesiredvCpus: 0
         MaxvCpus: !Ref SpotMaxvCpus
+        # One trial per instance here too: the netns collision is a property
+        # of the runner, not of the purchase model.
         InstanceTypes:
-          - m6i
-          - c6i
+          - m6i.xlarge
         Subnets: !Ref SubnetIds
         SecurityGroupIds:
           - !Ref BatchSecurityGroup
@@ -554,7 +558,8 @@ Resources:
         # The inner dockerd cannot stack overlayfs on the container's own
         # overlay root (EINVAL); it needs a data root on a real filesystem.
         # The entrypoint carves a per-job subdirectory under this host
-        # volume so concurrent trials on one instance never share storage.
+        # volume, which also keeps a crashed job from stranding storage that
+        # the next job on a reused instance would inherit.
         Volumes:
           - Name: dind-scratch
             Host:
@@ -562,11 +567,32 @@ Resources:
         MountPoints:
           - SourceVolume: dind-scratch
             ContainerPath: /scratch
+        # TrialTopology: one trial per EC2 instance, enforced from both ends.
+        #
+        # Batch runs EC2 jobs with ECS `networkMode: host`, so every trial
+        # container on an instance shares the *host* network namespace. A
+        # trial boots its own dockerd, and Docker's filter chains
+        # (DOCKER-BRIDGE, DOCKER-FORWARD, ...) are globally-named per
+        # namespace: the first dockerd creates them and every later one dies
+        # with `iptables: Chain already exists`. Storage isolation (above)
+        # does not help, because the namespace is what is shared.
+        #
+        # So the request below is deliberately the *whole* m6i.xlarge —
+        # 4 of its 4 vCPUs — which is what makes double-placement
+        # unrepresentable rather than merely unlikely. The compute
+        # environments pin that one instance size for the same reason.
+        # Lowering either number without giving each dockerd its own network
+        # namespace reintroduces the collision.
+        #
+        # This costs nothing: m6i pricing is linear in size, so 4 xlarge
+        # instances and 1 m6i.4xlarge bill the same per vCPU-hour, and one
+        # trial per box additionally removes the CPU contention that skews
+        # timeout-bound tasks when two agents race on one instance.
         ResourceRequirements:
           - Type: VCPU
-            Value: "2"
+            Value: "4"
           - Type: MEMORY
-            Value: "7168"
+            Value: "15360"
         Command:
           - smoke
         Environment:

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -31,12 +31,37 @@ cleanup_dockerd() {
     [ -n "${JOB_SLUG:-}" ] && rm -rf "/scratch/$JOB_SLUG" 2>/dev/null || true
 }
 
+assert_sole_dockerd() {
+    # Batch runs EC2 jobs with ECS `networkMode: host`, so a second trial
+    # placed on this instance would share our network namespace — and
+    # Docker's filter chains are named globally within a namespace. The
+    # second dockerd then dies on `DOCKER-BRIDGE: Chain already exists`
+    # after a 60-second wait, reported as fifty lines of daemon log that
+    # name neither the neighbour nor the placement that created it.
+    #
+    # The job definition and both compute environments size a trial to the
+    # whole instance so this cannot happen; this is the backstop for the
+    # ways that guarantee can be bypassed anyway — a submit-time
+    # `--vcpus` override, a hand-written job definition, a compute
+    # environment edited to allow a larger instance type. Refusing here
+    # costs one iptables read and turns a mystifying crash into its cause.
+    if iptables -w -t filter -n -L DOCKER-BRIDGE >/dev/null 2>&1; then
+        log "FATAL: another dockerd already owns this network namespace."
+        log "  Batch uses host networking, so two trials on one instance"
+        log "  share it and only the first dockerd can start. Give this"
+        log "  trial the whole instance (4 vCPU on m6i.xlarge) or give each"
+        log "  dockerd its own netns. See TrialTopology in infra/core.yaml."
+        return 1
+    fi
+}
+
 start_dockerd() {
+    assert_sole_dockerd || return 1
     # Overlayfs cannot nest: with /var/lib/docker on the container's own
     # overlay root, the inner dockerd's mounts fail with EINVAL. The job
     # definition mounts a host-path volume at /scratch; a per-job
-    # subdirectory there gives each concurrent trial its own storage on a
-    # real filesystem, cleaned up on exit to free the shared instance disk.
+    # subdirectory there gives this trial storage on a real filesystem,
+    # cleaned up on exit so a reused instance starts clean.
     local data_root=/var/lib/docker
     if [ -d /scratch ]; then
         JOB_SLUG=$(printf '%s' "$JOB_ID" | tr -c 'A-Za-z0-9_-' '_')


### PR DESCRIPTION
## What broke

Match `s5h2h-0807` (Sonnet 5 head-to-head, 20 tasks x 2 seats) lost **40 of 40
trials** in under six minutes, every one before its first model call:

```
failed to start daemon: Error initializing network controller: ...
failed to create FILTER chain DOCKER-BRIDGE: iptables: Chain already exists
```

AWS Batch runs EC2 container jobs with ECS `networkMode: host` (verified on the
generated task definition `arenabench-trial:2`). Every trial container packed
onto an instance therefore shares the **host network namespace**, and Docker's
filter chains are named globally within a namespace: the first dockerd creates
`DOCKER-BRIDGE`, and every later one refuses to start after a 60-second wait.

The runner already gave each trial its own storage under `/scratch`, which is
exactly why this looked isolated and was not — the namespace, not the disk, is
what was shared.

## Why the provisioning smoke passed

It was a single job. I re-ran that control while diagnosing: one job alone on
the same queue with the same image and job definition **succeeds, exit 0**. A
control of one cannot detect this bug; concurrency is the witness.

## The fix

One trial per EC2 instance, enforced from both ends so double placement is
unrepresentable rather than merely unlikely:

- both compute environments pin `m6i.xlarge` instead of the `m6i`/`c6i`
  families, so `BEST_FIT_PROGRESSIVE` cannot select a box large enough to pack;
- `arenabench-trial` requests that instance whole — 4 vCPU / 15360 MiB, up from
  2 / 7168. The job definition had drifted below the 4 vCPU `cloud.py` overrides
  at submit time, so a hand-submitted job would have packed two per box even on
  an `xlarge`.

`assert_sole_dockerd` in the runner entrypoint is the backstop for the paths
that can bypass sizing anyway (a submit-time `--vcpus` override, a hand-written
job definition, a compute environment edited to allow a larger type). It reads
the `DOCKER-BRIDGE` chain and refuses with the cause named, instead of fifty
lines of daemon log that name neither the neighbour nor the placement.

## Cost and throughput are unchanged

A trial needs 4 vCPU whether or not instances are shared, so the account's 64
vCPU quota still allows **16 concurrent trials** — the same number that was
running before. m6i pricing is linear in size, so four `xlarge` bill as one
`4xlarge`. One trial per box additionally removes CPU contention between
co-placed agents, which is a measurement improvement on timeout-bound tasks
(this repo's dominant failure mode), not only a workaround.

## Verification

- `shellcheck arenabench/infra/runner/entrypoint.sh` — clean.
- `aws cloudformation validate-template` — accepted.
- Single-job control on the unmodified stack: `SUCCEEDED`, exit 0 (this is the
  control that does *not* discriminate — recorded so the next reader does not
  mistake it for proof).
- **Witness is concurrency:** a >= 4-trial match must reach `RUNNING` on every
  job with no `Chain already exists` in `/arenabench/batch`. That is the real
  proof and it runs when the deployed stack carries this change — it cannot be
  produced from a checkout, which is why this is a draft until the relaunched
  match reports.

No Rust crate is touched, so no witness test in the workspace sense applies.

## Note for whoever squashes this

The commit body reads `Refs #2166`; the correct reference is **#2179**. `#2166`
is an unrelated merged PR. The typo was already pushed and both force-push and
branch deletion are blocked in this environment, so please correct the line in
the squash message at merge time.

Refs #2179

## Summary by Sourcery

Ensure each arenabench trial runs on its own EC2 instance to avoid Docker network namespace collisions when using AWS Batch host networking.

Enhancements:
- Constrain on-demand and spot Batch compute environments to m6i.xlarge so trial jobs cannot be co-located on a single instance.
- Increase arenabench-trial job vCPU and memory requests to match the full m6i.xlarge capacity, aligning sizing with the one-trial-per-instance topology.
- Add a runtime guard in the runner entrypoint that detects an existing DOCKER-BRIDGE chain and aborts with a clear explanation when another dockerd already owns the host network namespace.

Deployment:
- Update core CloudFormation configuration for Batch compute environments and trial job definition to enforce one trial per EC2 instance and document the TrialTopology rationale.