### PR TITLE
fix(bench): derive assurance tiers from the resolved posture, by the engine's own role chain

### DIFF
--- a/bench/evidence/run/sentinel.sh
+++ b/bench/evidence/run/sentinel.sh
@@ -42,7 +42,7 @@ print(f"reward={reward} stella_status={md.get('stella_status')} "
 # (#1284), but a warrant that decided this task needed no new test is a
 # legitimate `not_reported`, and failing on it would be a false gate.
 print(f"arm={md.get('stella_assurance_arm')} "
-      f"author={md.get('stella_witness_author_model')} "
+      f"author={md.get('stella_verifier_model') or md.get('stella_witness_author_model')} "
       f"witness={md.get('stella_witness_authored_state')} "
       f"self_verdict={md.get('stella_self_verdict_state')}")
 # NOTE: while #960 stands, an AgentTimeoutError accompanies even a perfect

--- a/bench/evidence/score_dev_baseline.py
+++ b/bench/evidence/score_dev_baseline.py
@@ -141,7 +141,18 @@ def extract_trial(result_path: Path) -> dict[str, Any]:
         # fields — which arm the posture *declared*, who the independent author
         # was, whether the tier actually *fired* on this task, and what Stella
         # itself claimed about the work the external reward then graded.
-        "witness_author_model": metadata.get("stella_witness_author_model"),
+        # Both spellings, current one first. The adapter renamed this key to
+        # `stella_verifier_model` and this reader was not chased, so every
+        # dev-baseline row published since has carried `null` for the one field
+        # that says WHO the independent author was — the same
+        # producer-writes-A/reader-reads-B failure as #2134, one layer out. The
+        # old spelling stays readable because the `result.json` trees recorded
+        # before the rename still use it, and re-scoring them is the point of
+        # this script.
+        "witness_author_model": (
+            metadata.get("stella_verifier_model")
+            or metadata.get("stella_witness_author_model")
+        ),
         "witness_authored_state": metadata.get("stella_witness_authored_state"),
         "witness_authored_count": _int(stream.get("witness_authored_count")),
         "witness_warranted_count": _int(stream.get("witness_warranted_count")),

--- a/bench/evidence/tests/test_evidence_tooling.py
+++ b/bench/evidence/tests/test_evidence_tooling.py
@@ -311,6 +311,38 @@ def test_extract_carries_the_verification_ladder_a_run_actually_exercised(
     assert row["accuracy"] == 0.0
 
 
+def test_the_author_is_read_from_the_key_the_adapter_actually_writes(
+    tmp_path: Path,
+) -> None:
+    """`stella_verifier_model` is the current spelling, and this reader missed it.
+
+    The adapter renamed the key; this extractor kept asking for
+    `stella_witness_author_model`, so every dev-baseline row published since
+    said `null` for the field that names the independent author — a forensic
+    reading a channel its producer stopped writing, which is #2134's shape one
+    layer out. The test above pins the pre-rename spelling on purpose: both
+    have to resolve, or re-scoring an older `result.json` loses the field the
+    newer one just gained.
+    """
+    path = _result(
+        tmp_path,
+        {
+            "task_name": "task",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "agent_result": {
+                "metadata": {
+                    "stella_assurance_arm": "witness-on",
+                    "stella_verifier_model": "openrouter/moonshotai/kimi-k3",
+                    "stella_witness_authored_state": "authored",
+                }
+            },
+        },
+    )
+    row = scorer.extract_trial(path)
+
+    assert row["witness_author_model"] == "openrouter/moonshotai/kimi-k3"
+
+
 def test_a_trial_that_closed_no_verdict_extracts_null_not_false(tmp_path: Path) -> None:
     """Tri-state, or "not measured" starts reading as "measured and honest"."""
     path = _result(

--- a/bench/harbor_adapter/README.md
+++ b/bench/harbor_adapter/README.md
@@ -482,12 +482,23 @@ Every result exposes manifest-ready metadata keys:
   `stella_engine_posture_json`, and `stella_engine_posture_sha256`.
 - `stella_assurance_arm` (`witness-off` / `witness-on`),
   `stella_assurance_tiers` + its version, JSON and SHA-256, and
-  `stella_witness_author_model` — **which verification tiers the posture
+  `stella_verifier_model` — **which verification tiers the posture
   declares** (#1007). Paired with `stella_witness_authored_state`
   (`authored` / `unavailable` / `not_reported`) and the `stella_stream`
   witness counters, which report what this trial's proof stream actually
   observed. Declared and observed are different claims, so both are recorded:
   a run must never disable a tier discoverably only by grepping trajectories.
+
+  The declaration is derived from the **resolved engine posture**, never from
+  the host-side selector beside it, and it resolves each role the way the
+  engine does — `agents.<role>.model` > `pipeline_<role>_model` >
+  `default_model` (`AgentEngineConfig::model_for`). Both halves are #2134: a
+  harness that pins the verifier through the `_build_engine_posture` seam —
+  ArenaBench's roles config does — reaches the engine without touching
+  `STELLA_WITNESS_AUTHOR_MODEL`, and a run declared `witness-off` while
+  kimi-k3 graded its verdicts. `authored_witness_off_reason` names the two
+  models the roles resolved to and the posture keys they came from, so the
+  reason is checkable against the posture printed beside it.
 - `stella_self_verdict_state` (`passed` / `failed` / `not_reported`), plus
   `self_verdict_passed`, `self_verdict_deterministic` and `self_verdict_count`
   in `stella_stream` — **what Stella claimed about its own work** (#1284). The

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -106,6 +106,7 @@ from .posture import (
     PostureBuilder,
     _benchmark_assurance_tiers,
     _benchmark_engine_posture,
+    assurance_tiers_from_posture,
     resolve_candidates,
     resolve_verifier_evidence_demand,
     resolve_max_revisions,
@@ -1030,17 +1031,18 @@ class StellaAgent(BaseInstalledAgent):
         self._disable_reflection = env["STELLA_DISABLE_REFLECTION"]
         self._budget_usd = self._configured_budget()
         verifier = self._verifier_model()
-        self._verifier_model_value = verifier
         (
             self._engine_posture,
             self._engine_posture_json,
             self._engine_posture_sha256,
         ) = self._build_engine_posture(configured_model, verifier=verifier)
+        # From the posture, never the selector beside it (#2134).
         (
             self._assurance_tiers,
             self._assurance_tiers_json,
             self._assurance_tiers_sha256,
-        ) = _benchmark_assurance_tiers(configured_model, verifier=verifier)
+        ) = assurance_tiers_from_posture(self._engine_posture)
+        self._verifier_model_value = self._assurance_tiers.get("verifier_model")
         # Highest precedence, after ambient and all Harbor extra env. A task
         # cannot replace this with its own routing or request-effort config.
         env[_ENGINE_CONFIG_ENV] = self._engine_posture_json
@@ -1586,18 +1588,16 @@ class StellaAgent(BaseInstalledAgent):
         assurance_tiers_json = getattr(self, "_assurance_tiers_json", None)
         assurance_tiers_sha256 = getattr(self, "_assurance_tiers_sha256", None)
         # An outer timeout can reach this hook before run() built the posture.
-        # Reconstruct the declaration from the same inputs rather than leaving
-        # the arm unstated on exactly the trials most likely to be re-read.
+        # Reconstruct from the recorded posture — or, failing that, the same
+        # overridable builder — rather than leave the arm unstated (#2134).
         if assurance_tiers is None:
             try:
-                (
-                    assurance_tiers,
-                    assurance_tiers_json,
-                    assurance_tiers_sha256,
-                ) = _benchmark_assurance_tiers(
-                    self._effective_model(),
-                    verifier=self._verifier_model(),
-                )
+                declared = engine_posture or self._build_engine_posture(
+                    self._effective_model(), verifier=self._verifier_model()
+                )[0]
+                tiers = assurance_tiers_from_posture(declared)
+                assurance_tiers, assurance_tiers_json, assurance_tiers_sha256 = tiers
+                verifier_model = verifier_model or assurance_tiers["verifier_model"]
             except (ValueError, RuntimeError):
                 assurance_tiers = None
         assurance_arm = (

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -36,7 +36,15 @@ from typing import Any
 PostureBuilder = Callable[..., "tuple[dict[str, Any], str, str]"]
 
 _ENGINE_POSTURE_VERSION = "stella-tb21-engine-posture-v1"
-_ASSURANCE_TIERS_VERSION = "stella-tb21-assurance-tiers-v1"
+# v2: the declaration derives from the RESOLVED engine posture rather than from
+# the host-side witness-author selector, resolves each role through the engine's
+# own fallback chain (`agents.<role>.model` > flat key > `default_model`), and
+# states an off-reason naming the models both roles resolved to and the keys
+# they came from — instead of asserting "every role inherits default_model", a
+# sentence that was false whenever any other role carried a pin (#2134). v1
+# declarations recorded before this change keep describing what their runs
+# computed.
+_ASSURANCE_TIERS_VERSION = "stella-tb21-assurance-tiers-v2"
 
 # Host-side selector for the witness/verifier author. Unset (the default) is the
 # control arm: one inherited model, authored witness structurally off. Set to a
@@ -732,6 +740,173 @@ def _benchmark_engine_posture(
     return posture, normalized, digest
 
 
+#: The flat root key that pins each role's model, by role.
+_FLAT_ROLE_MODEL_KEY = {
+    "worker": "pipeline_worker_model",
+    "verifier": "pipeline_verifier_model",
+    "triage": "pipeline_triage_model",
+}
+
+
+def _posture_model_value(value: Any, key: str) -> str | None:
+    """Read one role-model value from a resolved posture, or refuse it.
+
+    ``None`` (the key is absent) is a real answer — the role inherits — but a
+    present value that is not a non-empty string is a malformed posture, and a
+    declaration derived from a guess about it would be exactly the
+    false-metadata failure #2134 is about. Fail closed with the reason.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"engine posture key `{key}` must be a non-empty string when "
+            f"present; got {value!r}"
+        )
+    return value.strip()
+
+
+def _posture_agent_model(posture: dict[str, Any], role: str) -> str | None:
+    """The ``agents.<role>.model`` pin, or ``None`` when the role sets none."""
+    agents = posture.get("agents")
+    if agents is None:
+        return None
+    if not isinstance(agents, dict):
+        raise ValueError(
+            f"engine posture key `agents` must be a mapping when present; got "
+            f"{agents!r}"
+        )
+    entry = agents.get(role)
+    if entry is None:
+        return None
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"engine posture key `agents.{role}` must be a mapping when "
+            f"present; got {entry!r}"
+        )
+    return _posture_model_value(entry.get("model"), f"agents.{role}.model")
+
+
+def resolve_posture_role_model(
+    posture: dict[str, Any], role: str, *, default_model: str
+) -> tuple[str, str]:
+    """Resolve one role's model from a posture, and name the key it came from.
+
+    Mirrors ``AgentEngineConfig::model_for`` (``crates/stella-cli/src/settings.rs``)
+    key for key: ``agents.<role>.model`` outranks the flat ``pipeline_<role>_model``,
+    which outranks ``default_model``. Mirroring it *exactly* is the whole point —
+    a declaration that resolves roles by a different rule than the engine does is
+    free to disagree with the run it describes, which is the shape of #2134 and of
+    #1147 before it.
+
+    Two of those rungs bit in the same match. ``cc00894779ff`` read only the
+    host-side selector and so missed the flat key an ArenaBench roles config
+    writes; a reader that took the flat key alone would still miss
+    ``agents.<role>.model`` above it, and would still call a verifier that
+    inherits ``default_model`` "the worker's model" when the *worker* is the
+    pinned one. The returned origin key is what lets the off-reason name the
+    setting an operator would actually edit, in the same vocabulary
+    ``settings_check::flat_source_label`` reports.
+    """
+    flat_key = _FLAT_ROLE_MODEL_KEY.get(role)
+    if flat_key is None:
+        raise ValueError(f"unknown engine role `{role}`")
+    agent_key = f"agents.{role}.model"
+    for key, value in (
+        (agent_key, _posture_agent_model(posture, role)),
+        (flat_key, _posture_model_value(posture.get(flat_key), flat_key)),
+    ):
+        if value is not None:
+            return value, key
+    return default_model, "default_model"
+
+
+def assurance_tiers_from_posture(
+    posture: dict[str, Any],
+) -> tuple[dict[str, Any], str, str]:
+    """Declare which verification tiers a *resolved* engine posture exercises.
+
+    The input is the exact ``agent_engine_config`` dict delivered to Stella —
+    the output of ``_benchmark_engine_posture`` or of a harness's overridden
+    builder (``StellaAgent._build_engine_posture`` is a documented seam) — so
+    the declaration can never disagree with the configuration the engine
+    actually ran. It used to be recomputed from the host-side witness-author
+    selector alone, which is a second, narrower channel: an ArenaBench roles
+    config reaches the posture without touching that selector, and match
+    ``cc00894779ff`` recorded ``verifier_model: null`` / ``arm: witness-off``
+    for a run whose posture named kimi-k3 as the verifier and whose trials
+    demonstrably authored a witness (#2134).
+
+    The witness arm's predicate is exactly one sentence, and it is the engine's
+    own: the verifier role resolves to a model different from the worker's
+    (``Pipeline::witness_author_independence``). Both sides are resolved here
+    through :func:`resolve_posture_role_model`, so "the verifier inherits" is
+    never *assumed* to mean "the verifier equals the worker" — a posture that
+    pins only the worker leaves the verifier on ``default_model``, which is an
+    independent author and used to be declared as the opposite.
+
+    When the predicate fails, the recorded off-reason states the models both
+    roles resolved to and the posture keys they came from — never a claim about
+    roles this function did not examine.
+    """
+    if not isinstance(posture, dict):
+        raise ValueError(
+            "assurance tiers need the resolved engine posture as a dict; got "
+            f"{type(posture).__name__}"
+        )
+    default_model = posture.get("default_model")
+    if not isinstance(default_model, str) or "/" not in default_model.strip():
+        raise ValueError(
+            "engine posture `default_model` must be a non-empty provider/model "
+            f"spec; got {default_model!r}"
+        )
+    baseline = default_model.strip()
+    worker, worker_origin = resolve_posture_role_model(
+        posture, "worker", default_model=baseline
+    )
+    verifier, verifier_origin = resolve_posture_role_model(
+        posture, "verifier", default_model=baseline
+    )
+    author = verifier if verifier != worker else None
+    off_reason = (
+        None
+        if author
+        else (
+            "no author independent of the worker: the engine posture resolves "
+            f"the verifier role to `{verifier}` (from `{verifier_origin}`) and "
+            f"the worker role to the same model (from `{worker_origin}`), so "
+            "the witness tier cannot be authored on any task in this run"
+        )
+    )
+    declaration: dict[str, Any] = {
+        "version": _ASSURANCE_TIERS_VERSION,
+        "arm": "witness-on" if author else "witness-off",
+        "worker_model": worker,
+        "verifier_model": author,
+        "tiers": {
+            # Flip oracle and recorded test results need no second model, so
+            # this rung is on in both arms.
+            "deterministic_verify": "on",
+            "authored_witness": "on" if author else "off",
+            # The verifier rung runs either way; in the control arm it resolves to
+            # the worker's own model, which is a materially weaker claim and is
+            # named as such rather than reported as a plain "on".
+            "model_verdict": (
+                "on-independent-of-worker" if author else "on-same-model-as-worker"
+            ),
+        },
+        "authored_witness_off_reason": off_reason,
+    }
+    normalized = json.dumps(
+        declaration,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return declaration, normalized, digest
+
+
 def _benchmark_assurance_tiers(
     model: str,
     *,
@@ -750,6 +925,13 @@ def _benchmark_assurance_tiers(
     the event stream, discoverable only by reading trajectories — which is what
     turns a stated caveat into a misread number. A scored run now either
     exercises a tier or declares it off in metadata a manifest can read (#1007).
+
+    The ``(model, verifier)`` selector shape is kept for the callers that hold
+    only the host-side inputs (``make_manifest.py``, the preregistration
+    tooling); it validates them with the same refusals as the posture builder,
+    then delegates to :func:`assurance_tiers_from_posture` so the two paths
+    cannot disagree about what a declaration says. The adapter itself derives
+    from the built posture instead — see ``StellaAgent.run`` (#2134).
     """
     selected_model = model.strip()
     if not selected_model or "/" not in selected_model:
@@ -759,41 +941,10 @@ def _benchmark_assurance_tiers(
         if verifier is not None
         else None
     )
-    declaration: dict[str, Any] = {
-        "version": _ASSURANCE_TIERS_VERSION,
-        "arm": "witness-on" if author else "witness-off",
-        "worker_model": selected_model,
-        "verifier_model": author,
-        "tiers": {
-            # Flip oracle and recorded test results need no second model, so
-            # this rung is on in both arms.
-            "deterministic_verify": "on",
-            "authored_witness": "on" if author else "off",
-            # The verifier rung runs either way; in the control arm it resolves to
-            # the worker's own model, which is a materially weaker claim and is
-            # named as such rather than reported as a plain "on".
-            "model_verdict": (
-                "on-independent-of-worker" if author else "on-same-model-as-worker"
-            ),
-        },
-        "authored_witness_off_reason": (
-            None
-            if author
-            else (
-                "no author independent of the worker: every role inherits "
-                "default_model, so the witness tier cannot be authored on any "
-                "task in this run"
-            )
-        ),
-    }
-    normalized = json.dumps(
-        declaration,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    )
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    return declaration, normalized, digest
+    posture: dict[str, Any] = {"default_model": selected_model}
+    if author is not None:
+        posture["pipeline_verifier_model"] = author
+    return assurance_tiers_from_posture(posture)
 
 
 def fold_witness_observations(events: list[dict[str, Any]]) -> dict[str, Any]:

--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -1,0 +1,356 @@
+"""What the assurance-tier declaration reads, and what it says when the arm is off.
+
+Companion to `test_posture.py`, split from it for the reason that file was split
+from `test_adapter.py`: the file-size gate treats a separable concern as its own
+module rather than as more length on an existing one.
+
+The subject is #2134. Match `cc00894779ff` recorded, in the same `result.json`,
+a posture naming `openrouter/moonshotai/kimi-k3` as the verifier and a
+declaration saying `verifier_model: null`, `arm: witness-off`, with the reason
+"every role inherits default_model" — a sentence the same file disproves. The
+declaration was recomputed from the host-side `STELLA_WITNESS_AUTHOR_MODEL`
+selector, which an ArenaBench roles config never touches: it reaches the engine
+through the `_build_engine_posture` seam instead.
+
+Two questions are covered here, and they are different:
+
+- **Which channel is read.** The declaration derives from the resolved posture,
+  so every channel into it — the host selector, a harness's overridden builder —
+  is honored by construction rather than one at a time.
+- **How a role resolves inside that posture.** The engine reads
+  `agents.<role>.model` > the flat `pipeline_<role>_model` > `default_model`
+  (`AgentEngineConfig::model_for`). A declaration that resolves roles by any
+  other rule is free to disagree with the run it describes, which is the whole
+  defect class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from harbor.models.agent.context import AgentContext  # noqa: E402
+
+from stella_harbor import (  # noqa: E402 - after importorskip by design
+    _ENGINE_CONFIG_ENV,
+    _WITNESS_AUTHOR_ENV,
+    StellaAgent,
+    assurance_tiers_from_posture,
+)
+from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    resolve_posture_role_model,
+)
+
+# The three roles of match `cc00894779ff`, kept verbatim so the regression this
+# file pins reads as the run it came from.
+_WORKER = "openrouter/anthropic/claude-sonnet-5"
+_VERIFIER = "openrouter/moonshotai/kimi-k3"
+_TRIAGE = "openrouter/z-ai/glm-5.2"
+
+# The sentence the broken declaration recorded. Asserted absent rather than
+# merely "the new text is present": the failure #2134 is about is a *false*
+# string reaching a forensic reader, so its disappearance is the fix.
+_FALSE_OFF_REASON_FRAGMENT = "every role inherits default_model"
+
+
+def _roles_posture(**overrides: Any) -> dict[str, Any]:
+    """A posture in the shape `ArenaStellaAgent._build_engine_posture` emits.
+
+    Flat role keys plus per-role posture entries that carry no `model` — which
+    is exactly the arrangement that made the old selector-only reader blind.
+    """
+    posture: dict[str, Any] = {
+        "default_model": _WORKER,
+        "pipeline_verifier_model": _VERIFIER,
+        "pipeline_triage_model": _TRIAGE,
+        "allowed_models": [_WORKER, _VERIFIER, _TRIAGE],
+        "auto_mode": "off",
+        "effort_auto": "off",
+        "reasoning_auto": "off",
+        "headless_scope_bypass": "on",
+        "agents": {
+            "default": {"effort": "xhigh", "reasoning": "on"},
+            "worker": {"effort": "xhigh", "reasoning": "on"},
+            "verifier": {"effort": "xhigh", "reasoning": "on"},
+            "triage": {"effort": "low", "reasoning": "off"},
+        },
+    }
+    posture.update(overrides)
+    return posture
+
+
+def _bare_agent() -> StellaAgent:
+    """A StellaAgent instance bypassing the Harbor base ``__init__``."""
+    return StellaAgent.__new__(StellaAgent)
+
+
+class _RolesConfigAgent(StellaAgent):
+    """The `_build_engine_posture` seam, overridden the way ArenaBench does.
+
+    A stand-in for `arenabench.harbor_agent.ArenaStellaAgent` rather than an
+    import of it: the adapter is the thing under test and must not grow a test
+    dependency on a package that lives outside this project.
+    """
+
+    posture_override: dict[str, Any] = {}
+
+    def _build_engine_posture(
+        self, model: str, *, verifier: str | None
+    ) -> tuple[dict[str, Any], str, str]:
+        posture = dict(self.posture_override)
+        normalized = json.dumps(
+            posture, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        import hashlib
+
+        return posture, normalized, hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def _run_trial(
+    agent: StellaAgent, tmp_path: Path, events: list[dict[str, Any]]
+) -> AgentContext:
+    """Drive one trial to completion and return the context it populated."""
+    (tmp_path / "stella-events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in events)
+    )
+    agent.logs_dir = tmp_path
+    agent.model_name = _WORKER
+    agent._extra_env = {}
+    agent._version = "stella 0.7.11"
+
+    class _Environment:
+        async def _stella_secure_exec_with_stdin(
+            self, *, command: list[str], env: dict[str, str], stdin: bytes
+        ):
+            # The seam's posture is the one channel into the container, and the
+            # declaration has to describe *that* dict — not a second opinion
+            # computed beside it.
+            assert json.loads(env[_ENGINE_CONFIG_ENV])["pipeline_verifier_model"] == (
+                _VERIFIER
+            )
+            return SimpleNamespace(stdout=None, stderr=None, return_code=0)
+
+    context = AgentContext()
+    asyncio.run(
+        type(agent).run.__wrapped__(agent, "Fix the task.", _Environment(), context)
+    )
+    return context
+
+
+_COMPLETED_TRIAL = [
+    {"type": "proof", "step": {"kind": "warrant", "required": True, "diff_lines": 30}},
+    {"type": "complete", "status": "completed", "cost_usd": 0.42},
+]
+
+
+class TestRolesConfigReachesTheDeclaration:
+    """#2134's headline: a verifier the host selector never saw."""
+
+    def test_a_harness_roles_config_verifier_puts_the_witness_arm_on(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The witness test for #2134.
+
+        A roles config sets `pipeline_verifier_model` through the posture seam
+        and never touches `STELLA_WITNESS_AUTHOR_MODEL`. The declaration used to
+        be recomputed from that selector, so this trial recorded `witness-off`,
+        `verifier_model: null`, and an off-reason asserting facts about roles
+        nothing had examined — for a run whose engine had an independent author
+        the whole time.
+        """
+        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
+        monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
+
+        agent = _RolesConfigAgent.__new__(_RolesConfigAgent)
+        agent.posture_override = _roles_posture()
+        context = _run_trial(agent, tmp_path, _COMPLETED_TRIAL)
+
+        assert context.metadata["stella_assurance_arm"] == "witness-on"
+        assert context.metadata["stella_verifier_model"] == _VERIFIER
+        tiers = context.metadata["stella_assurance_tiers"]
+        assert tiers["verifier_model"] == _VERIFIER
+        assert tiers["worker_model"] == _WORKER
+        assert tiers["tiers"]["authored_witness"] == "on"
+        assert tiers["tiers"]["model_verdict"] == "on-independent-of-worker"
+        assert tiers["authored_witness_off_reason"] is None
+
+    def test_the_declaration_and_the_posture_name_the_same_verifier(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One source, so the two metadata blocks cannot contradict each other.
+
+        The contradiction is the artifact a bench forensic reads first: #2134
+        was diagnosed by opening `stella_engine_posture` and
+        `stella_assurance_tiers` side by side in one `result.json`.
+        """
+        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
+        monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
+
+        agent = _RolesConfigAgent.__new__(_RolesConfigAgent)
+        agent.posture_override = _roles_posture()
+        context = _run_trial(agent, tmp_path, _COMPLETED_TRIAL)
+
+        posture = context.metadata["stella_engine_posture"]
+        tiers = context.metadata["stella_assurance_tiers"]
+        assert posture["pipeline_verifier_model"] == tiers["verifier_model"]
+        assert context.metadata["stella_verifier_model"] == tiers["verifier_model"]
+
+    def test_an_outer_timeout_reconstructs_the_declaration_from_the_seam(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A trial killed before `run()` built the posture still declares the arm.
+
+        These are the trials most likely to be re-read, and the reconstruction
+        used to call the base builder's inputs — which for a roles-config run
+        describes a posture the run would never have used.
+        """
+        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
+        monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
+        (tmp_path / "stella-events.jsonl").write_text(
+            json.dumps(_COMPLETED_TRIAL[0]) + "\n"
+        )
+
+        agent = _RolesConfigAgent.__new__(_RolesConfigAgent)
+        agent.posture_override = _roles_posture()
+        agent.logs_dir = tmp_path
+        agent.model_name = _WORKER
+        agent._extra_env = {}
+        agent._version = "stella 0.7.11"
+
+        context = AgentContext()
+        agent.populate_context_post_run(context)
+
+        assert context.metadata["stella_assurance_arm"] == "witness-on"
+        assert context.metadata["stella_verifier_model"] == _VERIFIER
+
+
+class TestRoleResolutionMirrorsTheEngine:
+    """`agents.<role>.model` > flat `pipeline_<role>_model` > `default_model`."""
+
+    def test_the_agents_entry_outranks_the_flat_key_for_the_verifier(self) -> None:
+        posture = _roles_posture()
+        posture["agents"]["verifier"] = {"effort": "xhigh", "model": _WORKER}
+
+        model, origin = resolve_posture_role_model(
+            posture, "verifier", default_model=_WORKER
+        )
+        assert (model, origin) == (_WORKER, "agents.verifier.model")
+
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
+        # The flat key still names kimi-k3; the engine would never read it,
+        # and neither may the declaration.
+        assert tiers["arm"] == "witness-off"
+        assert "agents.verifier.model" in tiers["authored_witness_off_reason"]
+
+    def test_a_pinned_worker_leaves_the_verifier_independent_on_default_model(
+        self,
+    ) -> None:
+        """"Inherits" is not the same claim as "is the worker's model".
+
+        With only the *worker* pinned, the verifier falls through to
+        `default_model` — a different model, so the engine authors a witness.
+        Reading the absence of `pipeline_verifier_model` as "same as the worker"
+        turns that run's declaration into the same false negative #2134 filed.
+        """
+        posture = _roles_posture()
+        del posture["pipeline_verifier_model"]
+        posture["pipeline_worker_model"] = _TRIAGE
+
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
+        assert tiers["worker_model"] == _TRIAGE
+        assert tiers["verifier_model"] == _WORKER
+        assert tiers["arm"] == "witness-on"
+        assert tiers["authored_witness_off_reason"] is None
+
+    def test_both_roles_inheriting_one_default_is_the_control_arm(self) -> None:
+        posture = _roles_posture()
+        del posture["pipeline_verifier_model"]
+
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
+        assert tiers["arm"] == "witness-off"
+        assert tiers["verifier_model"] is None
+        assert tiers["worker_model"] == _WORKER
+        assert tiers["tiers"]["model_verdict"] == "on-same-model-as-worker"
+
+    def test_an_unparseable_role_model_is_refused_rather_than_guessed(self) -> None:
+        """A malformed posture fails closed: a guess here IS the false metadata."""
+        malformed: tuple[dict[str, Any], ...] = (
+            {"pipeline_verifier_model": 7},
+            {"agents": ["not", "a", "map"]},
+        )
+        for override in malformed:
+            with pytest.raises(ValueError):
+                assurance_tiers_from_posture(_roles_posture(**override))
+
+        with pytest.raises(ValueError):
+            posture = _roles_posture()
+            posture["agents"]["verifier"] = {"model": "   "}
+            assurance_tiers_from_posture(posture)
+
+
+class TestTheOffReasonIsTrue:
+    """Reason strings are load-bearing for bench forensics."""
+
+    def test_the_off_reason_names_the_predicate_that_actually_failed(self) -> None:
+        posture = _roles_posture(pipeline_verifier_model=_WORKER)
+
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
+        reason = tiers["authored_witness_off_reason"]
+        assert _FALSE_OFF_REASON_FRAGMENT not in reason
+        # The two models it compared, and the key each one came from — the
+        # setting an operator would edit to restore the arm.
+        assert reason.count(f"`{_WORKER}`") == 1
+        assert "`pipeline_verifier_model`" in reason
+        assert "`default_model`" in reason
+
+    def test_the_off_reason_never_claims_a_role_it_did_not_read(self) -> None:
+        """Triage carries a pin here, which is what made the old sentence false."""
+        posture = _roles_posture(pipeline_verifier_model=_WORKER)
+        assert posture["pipeline_triage_model"] == _TRIAGE
+
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
+        reason = tiers["authored_witness_off_reason"]
+        assert _FALSE_OFF_REASON_FRAGMENT not in reason
+        assert "triage" not in reason
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SETTINGS_RS = _REPO_ROOT / "crates" / "stella-cli" / "src" / "settings.rs"
+
+
+def test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors() -> None:
+    """Pin the mirror to its original: `AgentEngineConfig::model_for`.
+
+    The declaration is only trustworthy while it resolves roles the way the
+    engine does. Reordering `model_for` without reordering
+    `resolve_posture_role_model` re-opens #2134 in a new place, and nothing
+    else in either tree would notice — the two live in different languages,
+    different test suites, and different CI jobs.
+    """
+    source = _SETTINGS_RS.read_text()
+    start = source.find("pub fn model_for(")
+    assert start != -1, (
+        f"`AgentEngineConfig::model_for` is gone from {_SETTINGS_RS} — the "
+        "posture module mirrors its fallback order and must follow the rename"
+    )
+    body = source[start : source.index("\n    }\n", start)]
+    rungs = [
+        body.index("self.agent(kind).and_then(|a| a.model"),
+        body.index("pipeline_verifier_model"),
+        body.index("self.default_model"),
+    ]
+    assert rungs == sorted(rungs), (
+        "`model_for` no longer reads `agents.<kind>.model` > the flat per-role "
+        "key > `default_model`; `resolve_posture_role_model` mirrors that order "
+        "and has to change with it (#2134)"
+    )


### PR DESCRIPTION
## What & why

The assurance-tier declaration a benchmark trial publishes said `witness-off`
for runs whose engine had an independent verifier the whole time — and gave a
reason that the same `result.json` disproves.

In match `cc00894779ff` (SUT 447f3393, 2026-08-07), five of six trials carried
simultaneously:

- `stella_engine_posture.pipeline_verifier_model: "openrouter/moonshotai/kimi-k3"`
- `stella_assurance_tiers.verifier_model: null`, `arm: "witness-off"`
- `authored_witness_off_reason: "no author independent of the worker: every role
  inherits default_model, so the witness tier cannot be authored on any task in
  this run"` — while triage demonstrably ran `z-ai/glm-5.2`.

**Two halves, because reading the right dict is only half of reading it right.**

1. **Which channel is read.** The declaration was recomputed from the host-side
   `STELLA_WITNESS_AUTHOR_MODEL` selector, while the posture is built through an
   overridable seam (`StellaAgent._build_engine_posture`) that ArenaBench's roles
   config feeds via `ARENABENCH_ENGINE_JSON` without ever touching that selector.
   It now derives from the exact posture handed to the engine
   (`assurance_tiers_from_posture`), in `run()` and in the outer-timeout
   reconstruction path alike — so every channel into the posture is honored by
   construction rather than one at a time. `stella_verifier_model` reads back off
   the declaration, so the two metadata blocks cannot contradict each other.

2. **How a role resolves inside that posture.** The engine reads
   `agents.<role>.model` > `pipeline_<role>_model` > `default_model`
   (`AgentEngineConfig::model_for`, `crates/stella-cli/src/settings.rs`).
   `resolve_posture_role_model` now mirrors that key for key, for **both** roles.
   Resolving by any other rule re-opens the same defect in a new place, and two
   rungs bit: a posture that pins only the **worker** leaves the verifier on
   `default_model` — an independent author — and reading the absent
   `pipeline_verifier_model` as "same as the worker" declared that run's arm off
   too; and `agents.verifier.model`, which outranks the flat key in the engine,
   was invisible to the declaration entirely.

The off-reason now names the models both roles resolved to **and the posture
keys they came from**, so a reader can check the sentence against the posture
printed beside it. It states the predicate the witness arm actually tests
(`Pipeline::witness_author_independence`) and nothing about roles it never
examined. Declaration version bumps to `…-v2`; v1 declarations keep describing
what their runs computed (`bench/evidence/tb21-hh10-20260731/run-manifest.json`
is untouched).

**The per-trial inconsistency the issue asks about** (`openssl-selfsigned-cert`
authored a witness while the declaration said `witness-off`, and the other five
did not) is explained by the same finding rather than by a second bug: witness
authoring is **demand-driven and runs after execution**, so whether a witness
appears is the warrant's call per task — while the declaration was a constant,
and a false one, for the whole run. The engine had its independent author
throughout; only the metadata denied it.

**Same shape, one layer out** (fixed here because it degrades the very evidence
this PR restores): `bench/evidence/score_dev_baseline.py` and
`bench/evidence/run/sentinel.sh` read `stella_witness_author_model`, a metadata
key the adapter renamed to `stella_verifier_model` — so every dev-baseline row
published since the rename carried `null` for the field naming the independent
author. Both spellings now resolve, current one first, because pre-rename
`result.json` trees are exactly what that script re-scores.
`bench/harbor_adapter/README.md` carried the stale key too.

Closes #2134

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`bench/harbor_adapter/tests/test_assurance_tiers.py::TestRolesConfigReachesTheDeclaration::test_a_harness_roles_config_verifier_puts_the_witness_arm_on`

A stand-in for `ArenaStellaAgent` overrides `_build_engine_posture` with the
match's own three roles (worker `claude-sonnet-5`, verifier `kimi-k3`, triage
`glm-5.2`) and leaves `STELLA_WITNESS_AUTHOR_MODEL` unset, exactly as the
recorded run did.

**Flip verified the artisanal way** — the two source files put back to
`origin/main` (`git checkout origin/main -- bench/harbor_adapter/stella_harbor/`)
with the test file kept, then restored:

```
FAILED …::test_a_harness_roles_config_verifier_puts_the_witness_arm_on
        - AssertionError: assert 'witness-off' == 'witness-on'
FAILED …::test_the_declaration_and_the_posture_name_the_same_verifier
        - AssertionError: assert 'openrouter/moonshotai/kimi-k3' == None
FAILED …::test_an_outer_timeout_reconstructs_the_declaration_from_the_seam
        - AssertionError: assert 'witness-off' == 'witness-on'
```

and on `main` the recorded reason is verbatim the false one:

```
MAIN off_reason: no author independent of the worker: every role inherits
default_model, so the witness tier cannot be authored on any task in this run
```

(The whole file also errors on import against `main`, since
`assurance_tiers_from_posture` / `resolve_posture_role_model` do not exist there;
the run above drops those two imports so the flip is a behavioral assertion
rather than a collection error.)

Ten tests in that file, covering both halves and the role-resolution mirror:
`test_the_agents_entry_outranks_the_flat_key_for_the_verifier`,
`test_a_pinned_worker_leaves_the_verifier_independent_on_default_model`,
`test_the_off_reason_names_the_predicate_that_actually_failed`,
`test_the_off_reason_never_claims_a_role_it_did_not_read`, and
`test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` — which
parses `AgentEngineConfig::model_for` out of `crates/stella-cli/src/settings.rs`
and fails if the Rust chain is reordered without the Python mirror following it.
The two live in different languages, test suites and CI jobs, so nothing else
would notice.

Plus `bench/evidence/tests/test_evidence_tooling.py::test_the_author_is_read_from_the_key_the_adapter_actually_writes`
for the scorer half (the pre-existing test pinning the old spelling stays — both
must resolve).

## The gate

- [x] `cargo fmt --check` — n/a, no Rust changed (the one Rust file read is read
      by a test, not edited)
- [x] `cargo clippy` / `cargo test --workspace` — n/a for the same reason; the
      suites that cover this change are the `bench.yml` pytest jobs:
      `bench/harbor_adapter` **506 passed, 1 skipped**, `bench/evidence/tests`
      **66 passed**, `arenabench` **passed** (it subclasses the adapter seam this
      PR changes)
- [x] `scripts/check-file-size.sh` — OK, none grew.
      `bench/harbor_adapter/stella_harbor/__init__.py` sits **exactly** on its
      1834-line grandfathered ceiling, so this change is net **zero lines** there
      by construction: the new logic and all of its prose live in the sibling
      `posture.py`. No baseline entry was added or raised.
- [x] `ruff check` on the touched files — clean; `__init__.py`'s two findings are
      byte-identical to `main`'s
- [x] Docs updated: `bench/harbor_adapter/README.md`

## Nothing left behind

- [x] Filed: #2182, #2183

- **#2183** — `ProofStep::Assurance { verifier: true }` asserts a plan, not a
  decision, so a run with zero verifier calls records one. This is the **third**
  defect listed in #2134; it is deliberately not fixed here because it is a
  Rust-side semantics choice (three options laid out in the issue), not the
  plumbing bug this PR is about.
- **#2182** — found while fixing this: `bench/evidence/make_manifest.py` calls
  `_benchmark_engine_posture` / `_benchmark_assurance_tiers` with
  `witness_author=` while both signatures take `verifier=`, so **every run
  manifest's posture and assurance blocks raise `TypeError` on the run host**.
  Reproduced. Not fixed here because the evidence suite runs `--no-project` and
  can never import the adapter, so the fix needs its own source-level parity
  test to be witnessable at all.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — nothing outside
      `bench/` changed, and no dependency was added anywhere
- [x] No new outbound network calls
- [x] `resolve_posture_role_model` is a pure function over an owned dict; every
      malformed input fails closed with the reason rather than guessing (a guess
      here *is* the false metadata this issue is about)

## Anything reviewers should know?

**Seam note.** This PR touches **no Rust at all** — in particular it does not
touch `crates/stella-pipeline/src/pipeline/witness_stage.rs`, which is hot right
now (#2151's wall-clock bound, merged; #2162's output-token cap, merged as
34b842a5). The only Rust file involved is
`crates/stella-cli/src/settings.rs`, and it is **read by a test**, never edited.
Nothing here should need reconciling against either.

**On the previous state of this branch.** The first commit derived the
declaration from the posture but still read only the flat `pipeline_*_model`
keys, which left both role-resolution rungs above wrong; it is squashed into this
one commit rather than shipped as-is.

## Summary by Sourcery

Derive assurance-tier declarations from the resolved engine posture to ensure witness arm metadata matches the engine’s actual verifier configuration and role resolution.

Enhancements:
- Update assurance-tier computation to resolve worker and verifier models from the engine posture using the same fallback chain as the engine and emit accurate off reasons tied to posture keys.
- Expose posture-derived assurance-tier generation through a new API and wire the adapter to use it both during normal runs and outer-timeout reconstruction, keeping posture and declaration consistent.
- Adjust dev-baseline scoring and sentinel scripts to read the current verifier metadata key while still supporting the legacy spelling, preserving author information across historical runs.

Documentation:
- Refresh Harbor adapter README to document the posture-derived assurance tiers, the role resolution order, and the updated verifier metadata key.

Tests:
- Add a dedicated assurance-tiers test module to validate posture-driven declarations, role resolution mirroring the engine, outer-timeout reconstruction, and correctness of off-reason messages.
- Extend evidence tooling tests to confirm the scorer reads the verifier model from the adapter’s current metadata key while maintaining compatibility with the previous key.