### PR TITLE
fix(arenabench): let an arena running inside a checkout find it

### DIFF
--- a/arenabench/arenabench/catalog.py
+++ b/arenabench/arenabench/catalog.py
@@ -31,7 +31,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from .sut import STELLA_REPO_ENV, stella_repo
+from .sut import repo_problem, stella_repo
 
 __all__ = ["models_payload", "parse_catalog"]
 
@@ -121,8 +121,7 @@ def models_payload() -> dict[str, Any]:
     repo = stella_repo()
     if repo is None:
         raise RuntimeError(
-            f"no Stella checkout found — set {STELLA_REPO_ENV} to the "
-            "repository root so the model catalog can be read"
+            f"the model catalog cannot be read: {repo_problem()}"
         )
     entries = parse_catalog(_read(repo, _CATALOG_REL, "the model catalog"))
     if not entries:

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -909,9 +909,20 @@ class MatchRunner:
         env.setdefault("STELLA_DISABLE_REFLECTION", "1")
 
         # Both packages must be importable by the Harbor subprocess: the
-        # ArenaBench adapter and the stella_harbor base it subclasses.
+        # ArenaBench adapter and the stella_harbor base it subclasses. Missing
+        # the second one does not fail loudly — `harbor_agent.py` falls back to
+        # `_Base = object`, Harbor dies with "ArenaStellaAgent() takes no
+        # arguments", and *exits 0*, so the seat reports done having run
+        # nothing. The adapter ships in the same checkout `sut.stella_repo()`
+        # already found, so an arena running out of a clone can wire itself
+        # rather than depend on an operator remembering one variable whose
+        # omission is invisible.
         roots = [str(Path(__file__).resolve().parent.parent)]
         adapter = os.environ.get("ARENABENCH_STELLA_ADAPTER")
+        if not adapter:
+            repo = sut.stella_repo()
+            if repo is not None and (repo / "bench" / "harbor_adapter").is_dir():
+                adapter = str(repo / "bench" / "harbor_adapter")
         if adapter:
             roots.append(str(Path(adapter).expanduser().resolve()))
         existing = os.environ.get("PYTHONPATH", "")

--- a/arenabench/arenabench/sut.py
+++ b/arenabench/arenabench/sut.py
@@ -66,6 +66,7 @@ __all__ = [
     "drift_between",
     "embedded_commit",
     "list_branches",
+    "repo_problem",
     "resolve_pin",
     "resolve_ref",
     "staged_commits",
@@ -111,6 +112,21 @@ _FULL_SHA = re.compile(r"\A[0-9a-f]{40}\Z")
 #: whitespace, no `..`, and nothing outside a conservative character set.
 _SAFE_REF = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._/-]{0,200}\Z")
 
+#: Where this package sits on disk — the anchor :func:`_discovered_repo` walks
+#: up from. Bound once at import, and read through the module attribute so a
+#: test can point the walk somewhere that is deliberately not a checkout.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+
+#: Files that identify a tree as *this* repository rather than whatever git
+#: checkout the arena happens to be installed inside. Both are sources
+#: :mod:`arenabench.catalog` reads at runtime, so matching them means the
+#: discovery is self-validating: a tree that has them is one the arena can
+#: actually do its job against.
+_STELLA_MARKERS = (
+    Path("crates") / "stella-model" / "src" / "catalog.rs",
+    Path("bench") / "harbor_adapter" / "stella_harbor" / "posture.py",
+)
+
 
 class SutUnavailableError(RuntimeError):
     """No Stella checkout, or git could not answer."""
@@ -123,6 +139,70 @@ def sut_root() -> Path:
     return base / "sut"
 
 
+def _discovered_repo(start: Path | None = None) -> Path | None:
+    """The Stella checkout this very module is running out of, if any.
+
+    The arena lives *inside* the repository it measures (``<repo>/arenabench``),
+    so ``python -m arenabench serve`` from a clone is the ordinary development
+    launch — and it was the one launch that could not answer "which Stella?",
+    because neither environment variable is set on that path. Walking up from
+    the package's own location closes that with no new configuration, and ties
+    the answer to the code that is executing rather than to an ambient
+    directory: two arenas on one machine then resolve refs against the
+    checkouts they were each installed from, which is the honest answer for a
+    tool whose whole job is saying which commit ran.
+
+    Both markers are files :mod:`arenabench.catalog` itself reads, so a tree
+    carrying them is by construction one this arena can work against — an
+    unrelated git repository (the arena pip-installed into some other project's
+    virtualenv) matches neither and is correctly declined rather than claimed.
+    """
+    anchor = start if start is not None else _PACKAGE_DIR
+    for candidate in [anchor, *anchor.parents]:
+        if (candidate / ".git").exists() and all(
+            (candidate / marker).exists() for marker in _STELLA_MARKERS
+        ):
+            return candidate
+    return None
+
+
+def _repo_search() -> tuple[Path | None, str | None]:
+    """The checkout and, when there is none, why — for callers that report.
+
+    Kept as one function because the two answers must never disagree: a
+    message that says "not configured" to someone who *did* configure it is
+    how a five-second fix becomes an afternoon.
+    """
+    explicit = os.environ.get(STELLA_REPO_ENV)
+    if explicit:
+        candidate = Path(explicit).expanduser()
+        if (candidate / ".git").exists():
+            return candidate, None
+        return None, (
+            f"{STELLA_REPO_ENV} is set to {candidate}, but that is not a git "
+            "checkout — point it at the repository root."
+        )
+    adapter = os.environ.get("ARENABENCH_STELLA_ADAPTER")
+    above_adapter: Path | None = None
+    if adapter:
+        above_adapter = Path(adapter).expanduser().resolve().parent.parent
+        if (above_adapter / ".git").exists():
+            return above_adapter, None
+    discovered = _discovered_repo()
+    if discovered is not None:
+        return discovered, None
+    if above_adapter is not None:
+        return None, (
+            f"ARENABENCH_STELLA_ADAPTER names {adapter}, but the repository "
+            f"root above it ({above_adapter}) is not a git checkout — set "
+            f"{STELLA_REPO_ENV} to the repository root."
+        )
+    return None, (
+        "no Stella checkout is configured, and the arena is not running from "
+        f"inside one. Set {STELLA_REPO_ENV} to the repository root."
+    )
+
+
 def stella_repo() -> Path | None:
     """The Stella checkout to resolve refs against, or ``None``.
 
@@ -130,18 +210,18 @@ def stella_repo() -> Path | None:
     to run a Stella seat (``ARENABENCH_STELLA_ADAPTER`` points at
     ``<repo>/bench/harbor_adapter``) names the repository two levels up, so a
     rig that can run Stella at all can usually answer this without new
-    configuration.
+    configuration. Failing both, :func:`_discovered_repo` asks whether this
+    arena is itself running out of a checkout.
     """
-    explicit = os.environ.get(STELLA_REPO_ENV)
-    if explicit:
-        candidate = Path(explicit).expanduser()
-        return candidate if (candidate / ".git").exists() else None
-    adapter = os.environ.get("ARENABENCH_STELLA_ADAPTER")
-    if adapter:
-        candidate = Path(adapter).expanduser().resolve().parent.parent
-        if (candidate / ".git").exists():
-            return candidate
-    return None
+    return _repo_search()[0]
+
+
+def repo_problem() -> str | None:
+    """Why :func:`stella_repo` found nothing, phrased for whoever must fix it.
+
+    ``None`` when a checkout was found.
+    """
+    return _repo_search()[1]
 
 
 def _git(repo: Path, *args: str, timeout: float = 30.0) -> str:
@@ -293,10 +373,7 @@ def resolve_ref(ref: str, repo: Path | None = None) -> str:
     """
     repo = repo or stella_repo()
     if repo is None:
-        raise SutUnavailableError(
-            "no Stella checkout found — set "
-            f"{STELLA_REPO_ENV} to the repository root"
-        )
+        raise SutUnavailableError(f"cannot resolve {ref!r}: {repo_problem()}")
     safe = _safe_ref(ref)
     candidates = [safe] if (_FULL_SHA.match(safe) or "/" in safe) else [
         f"origin/{safe}",
@@ -772,13 +849,9 @@ def sut_status(ref: str = "main") -> dict[str, Any]:
         "ready": False,
         "problem": None,
     }
-    repo = stella_repo()
+    repo, why = _repo_search()
     if repo is None:
-        out["problem"] = (
-            "no Stella checkout is configured, so the arena cannot say which "
-            f"commit a Stella seat would run. Set {STELLA_REPO_ENV} to the "
-            "repository root."
-        )
+        out["problem"] = f"the arena cannot say which commit it would run: {why}"
         legacy = legacy_staged()
         out["legacy"] = legacy.to_json() if legacy else None
         return out

--- a/arenabench/arenabench/sut_build.py
+++ b/arenabench/arenabench/sut_build.py
@@ -42,6 +42,7 @@ from .sut import (
     SutUnavailableError,
     binary_for,
     file_sha256,
+    repo_problem,
     resolve_ref,
     stella_repo,
     sut_root,
@@ -268,9 +269,7 @@ class SutBuilder:
     def _build(self, record: BuildRecord) -> tuple[Path, str]:
         repo = stella_repo()
         if repo is None:
-            raise SutUnavailableError(
-                "no Stella checkout configured; set ARENABENCH_STELLA_REPO"
-            )
+            raise SutUnavailableError(f"nothing to build from: {repo_problem()}")
         if shutil.which("cargo") is None:
             raise SutUnavailableError("cargo is not on PATH")
 

--- a/arenabench/tests/test_catalog.py
+++ b/arenabench/tests/test_catalog.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from arenabench import catalog as cat
+from arenabench import sut
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -115,11 +116,24 @@ class TestLiveSources:
         for provider, listing in providers.items():
             assert listing == sorted(listing, key=lambda e: e["slug"]), provider
 
-    def test_no_checkout_degrades_with_the_env_name(
+    def test_an_unconfigured_arena_reads_the_catalog_it_ships_beside(
         self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare `python -m arenabench serve` used to fall back to a free-text
+        model field, because the catalog lives in the checkout the arena is
+        itself running out of and nothing looked there."""
+        monkeypatch.delenv("ARENABENCH_STELLA_REPO", raising=False)
+        monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+        assert cat.models_payload()["providers"]
+
+    def test_no_checkout_degrades_with_the_env_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("ARENABENCH_STELLA_REPO", raising=False)
         monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+        # ...and out of a checkout entirely, which is the only remaining way to
+        # have none: an arena installed into some other project's virtualenv.
+        monkeypatch.setattr(sut, "_PACKAGE_DIR", tmp_path)
         with pytest.raises(RuntimeError) as caught:
             cat.models_payload()
         assert "ARENABENCH_STELLA_REPO" in str(caught.value)

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -13,6 +13,7 @@ which Stella it measured.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -235,6 +236,131 @@ class TestLaunchRefusal:
         visible.
         """
         assert MatchSpec.from_json({"name": "m", "dataset": "d"}).sut_ref == "main"
+
+
+class TestCheckoutDiscovery:
+    """An arena running out of a checkout must not report that it has none.
+
+    The arena ships *inside* the repository it measures (``<repo>/arenabench``),
+    so ``python -m arenabench serve`` from a clone is the ordinary development
+    launch — and it was the one launch that could not resolve a ref. Neither
+    ``ARENABENCH_STELLA_REPO`` nor ``ARENABENCH_STELLA_ADAPTER`` is set on that
+    path, so every Stella seat was refused with "no Stella checkout is
+    configured" by a process whose own source file sat two directories below
+    the repository root, and the model select fell back to free text for the
+    same reason.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _unconfigured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exactly the environment of a bare `python -m arenabench serve`."""
+        monkeypatch.delenv(sut.STELLA_REPO_ENV, raising=False)
+        monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+
+    def test_the_checkout_this_arena_runs_from_needs_no_configuration(self) -> None:
+        found = sut.stella_repo()
+        assert found is not None, (
+            "the arena refused to name the checkout it is executing out of"
+        )
+        for marker in sut._STELLA_MARKERS:
+            assert (found / marker).exists(), marker
+        assert sut.repo_problem() is None
+
+    def test_an_unrelated_git_checkout_is_declined(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Discovery must not claim whatever repository the arena happens to be
+        installed inside: resolving `main` against someone else's history
+        answers with a commit that means nothing here, which is worse than
+        answering with nothing at all."""
+        package = tmp_path / "elsewhere" / "arenabench"
+        package.mkdir(parents=True)
+        (tmp_path / "elsewhere" / ".git").mkdir()
+        monkeypatch.setattr(sut, "_PACKAGE_DIR", package)
+
+        assert sut.stella_repo() is None
+        assert sut.STELLA_REPO_ENV in (sut.repo_problem() or "")
+
+    def test_a_misconfigured_repo_env_is_not_reported_as_unconfigured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit setting that is wrong is reported, never quietly
+        replaced by discovery — and telling an operator who set the variable to
+        set the variable is how a five-second fix becomes an afternoon."""
+        wrong = tmp_path / "not-a-checkout"
+        monkeypatch.setenv(sut.STELLA_REPO_ENV, str(wrong))
+
+        assert sut.stella_repo() is None
+        problem = sut.repo_problem() or ""
+        assert "not a git checkout" in problem
+        assert str(wrong) in problem
+
+    def _stage_head(self, monkeypatch: pytest.MonkeyPatch, home: Path) -> tuple[Path, str]:
+        """A staged binary for a commit this checkout really has.
+
+        Pins the resolved commit rather than `main`: a branch name is a moving
+        target and these tests assert about discovery, not about the tip.
+        """
+        monkeypatch.setenv("ARENABENCH_HOME", str(home))
+        monkeypatch.delenv(sut.STELLA_BINARY_ENV, raising=False)
+        repo = sut.stella_repo()
+        assert repo is not None
+        head = _git(repo, "rev-parse", "HEAD")
+        staged = sut.sut_root() / head
+        staged.mkdir(parents=True)
+        binary = staged / "stella"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        (staged / "sut_commit.txt").write_text(head)
+        return repo, head
+
+    def _spec(self, ref: str) -> MatchSpec:
+        return MatchSpec.from_json(
+            {
+                "name": "m",
+                "dataset": "terminal-bench-2.1",
+                "tasks": ["fix-git"],
+                "sut_ref": ref,
+                "contestants": [
+                    {
+                        "name": "seat",
+                        "agent": "stella",
+                        "engine": {"api": "openrouter", "model": "m"},
+                    }
+                ],
+            }
+        )
+
+    def test_a_pinned_seat_launches_with_nothing_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point, end to end: a staged binary for the pinned commit
+        is enough to launch, with no arena-specific environment at all."""
+        _, head = self._stage_head(monkeypatch, tmp_path / "home")
+        assert sut.sut_problem_for(self._spec(head)) is None
+
+    def test_the_launch_wires_the_adapter_from_that_same_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Launching is not enough if the seat then runs nothing.
+
+        Without ``stella_harbor`` on the subprocess's ``PYTHONPATH``,
+        ``harbor_agent.py`` falls back to ``_Base = object``, Harbor dies with
+        "ArenaStellaAgent() takes no arguments" — and **exits 0**, so the seat
+        reports done having made no model call at all. The adapter ships in the
+        checkout discovery just found, so the arena can wire it rather than
+        depend on an operator remembering a variable whose omission is silent.
+        """
+        repo, head = self._stage_head(monkeypatch, tmp_path / "home")
+        _stub_harbor(monkeypatch)
+        captured = _capture_popen(monkeypatch)
+
+        runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+        match = runner.create(self._spec(head))
+        runner._launch(match, match.spec.contestants[0])
+
+        roots = captured[0]["env"]["PYTHONPATH"].split(os.pathsep)
+        assert str(repo / "bench" / "harbor_adapter") in roots
 
 
 def _stamped(path: Path, commit: str | None) -> Path:


### PR DESCRIPTION
## The bug

`python -m arenabench serve` from a clone — the ordinary development launch —
could not launch a Stella seat. Reproduced live on a running server before the
fix:

```console
$ curl -s 'http://127.0.0.1:8181/api/sut?ref=main'
{"ref": "main", "repo": null, ..., "ready": false,
 "problem": "no Stella checkout is configured, so the arena cannot say which
             commit a Stella seat would run. Set ARENABENCH_STELLA_REPO ..."}
```

`sut.stella_repo()` answered only from `ARENABENCH_STELLA_REPO` or
`ARENABENCH_STELLA_ADAPTER`. That bare launch sets neither, so the arena refused
every Stella seat for want of a checkout **it was executing out of** — the
refusing source file sits two directories below the repository root. The model
select degraded to free text on the same path, for the same reason.

## The fix

Three changes, one cause.

**`_discovered_repo()`** walks up from the package's own location and accepts a
tree carrying both sources `arenabench.catalog` already reads at runtime
(`crates/stella-model/src/catalog.rs`,
`bench/harbor_adapter/stella_harbor/posture.py`). The check is self-validating:
a tree with those markers is by construction one this arena can work against,
and an arena pip-installed inside some unrelated repository matches neither and
is declined rather than claimed. Anchoring on the package rather than the
working directory is deliberate — it keeps the answer tied to the code that is
executing, so two arenas on one machine resolve refs against the checkouts they
were each installed from rather than against whatever directory someone
happened to `cd` into. Precedence is unchanged: an explicit environment variable
still wins, and discovery only answers when nothing was configured.

**`repo_problem()`** gives the reporting callers the real cause. A wrong
`ARENABENCH_STELLA_REPO` used to render as "no Stella checkout is configured",
which tells an operator who set the variable to set the variable.

**`_agent_environment`** derives the Harbor adapter root from that same checkout
when `ARENABENCH_STELLA_ADAPTER` is unset. Without this the fix would be a
downgrade: the launch would now succeed into a seat that runs nothing, because
`harbor_agent.py` falls back to `_Base = object`, Harbor dies with
`ArenaStellaAgent() takes no arguments` — and **exits 0**, so the seat reports
done having made no model call.

## Witness

`TestCheckoutDiscovery` (six cases in `arenabench/tests/test_sut.py`) and
`test_an_unconfigured_arena_reads_the_catalog_it_ships_beside` all fail on
`main` and pass here. Checked in a detached shadow worktree at `origin/main`
with only the test files copied in:

```
FAILED TestCheckoutDiscovery::test_the_checkout_this_arena_runs_from_needs_no_configuration
  - AssertionError: the arena refused to name the checkout it is executing out of
FAILED TestCheckoutDiscovery::test_a_pinned_seat_launches_with_nothing_configured
  - assert None is not None
FAILED TestCheckoutDiscovery::test_an_unrelated_git_checkout_is_declined
FAILED TestCheckoutDiscovery::test_a_misconfigured_repo_env_is_not_reported_as_unconfigured
FAILED TestLiveSources::test_an_unconfigured_arena_reads_the_catalog_it_ships_beside
FAILED TestLiveSources::test_no_checkout_degrades_with_the_env_name
```

The first two are behavioral failures, not missing-symbol errors — the second is
the reported symptom exactly.

Full suite: `uv run python -m pytest` in `arenabench/` — all green (1 skipped).
`make guards-fast` green. No new `ruff` findings on the touched files (the three
it reports there are all present on `main`).

## Deleted tests

None. `test_no_checkout_degrades_with_the_env_name` is **kept** and its
assertion is unchanged; it gains a `sut._PACKAGE_DIR` patch, because deleting
both environment variables is no longer sufficient to have no checkout. The
"unconfigured degrades honestly" contract it exists to hold is still held.

## Exemplar

`stella_repo()`'s tiering follows `cargo`'s own workspace-root discovery: an
explicit setting wins, then an implicit walk upward from a known anchor, then an
honest refusal that names what to set.

## Not fixed here

Filed as follow-ups rather than widened into this PR — see the issues linked in
the thread.

## Summary by Sourcery

Automatically discover the Stella checkout an arena is running from, improve error reporting around missing or misconfigured checkouts, and ensure Harbor adapter wiring so seats launched from a checkout actually run models.

New Features:
- Add automatic discovery of the Stella repo by walking up from the installed arenabench package and recognizing repository-specific marker files.
- Infer the Harbor adapter location from the discovered checkout when no explicit adapter path is configured.

Bug Fixes:
- Fix arenas launched from a local checkout that previously could not resolve Stella refs or read the model catalog without explicit environment configuration.
- Prevent seats from appearing to complete successfully while running no model when the Harbor adapter base package was missing from PYTHONPATH.

Enhancements:
- Provide repo_problem() to report precise, user-facing explanations for why no usable Stella checkout was found instead of generic "not configured" messages.
- Unify repo lookup and error messaging via a shared _repo_search helper used by sut status, ref resolution, catalog reading, and build logic.

Tests:
- Add end-to-end and unit tests covering checkout discovery behavior, misconfiguration reporting, adapter wiring, and catalog reading both with and without a checkout.