### PR TITLE
fix(stella-observatory): the Rules panel could never show a context record; serve the enforcement ledger too

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -292,9 +292,9 @@ cargo test -p stella-observatory
 There is no crate-specific `make` target — the root `Makefile` has one only for
 core/model/tools/cli/protocol — so `make test` picks this up with the workspace.
 No fixture dir, feature flag or env var. Most tests are an inline
-`#[cfg(test)] mod tests`; four suites live in `tests/` because each needs
+`#[cfg(test)] mod tests`; five suites live in `tests/` because each needs
 something the inline module cannot have — a dev-dependency on the crate whose
-schema it is checking, a real socket, or `node`:
+schema it is checking, a real socket, `node`, or room:
 
 | Suite | Why it is not inline |
 |---|---|
@@ -302,6 +302,7 @@ schema it is checking, a real socket, or `node`:
 | [`tests/journal_era.rs`](tests/journal_era.rs) | The other half of the digest alarm: which of two things a mismatch means depends on `executions.journal_era` (#1981). |
 | [`tests/live_stream.rs`](tests/live_stream.rs) | Drives the live endpoint over a real socket. |
 | [`tests/page_clipper.rs`](tests/page_clipper.rs) | Executes the page's own JavaScript under `node` — see below. |
+| [`tests/rules_ledger.rs`](tests/rules_ledger.rs) | Room: [`src/tests.rs`](src/tests.rs) sits at the file-size ratchet's 1500 lines exactly and this crate carries no baseline entry, so it is closed to growth. New route coverage lands in a sibling rather than raising a ceiling. |
 
 The dominant shape: `seeded_workspace()` builds a `TempDir` with a `store.db`
 seeded from hand-written DDL, `seed_fs_surfaces()` layers on the file-backed

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -733,6 +733,8 @@ footer b{color:var(--text-2);font-weight:600}
         <div class="scroll-x" id="mem-citations"></div>
         <div class="subhead">Promoted rules</div>
         <div id="rules-list"></div>
+        <div class="subhead">Enforcement ledger <span id="rules-governance" class="chip"></span></div>
+        <div id="rules-promotions"></div>
       </div>
     </div>
     <div class="card">
@@ -2063,6 +2065,24 @@ function renderMemoryTab(files, rules, explorations) {
   $("rules-list").innerHTML = html ||
     `<div class="empty">No promoted rules.<br>
      Lessons that keep proving true across runs get promoted here.</div>`;
+
+  // The hash-chained enforcement ledger (.stella/rules/promotions.jsonl) — a
+  // different ledger from the loop's own keep/ignore events on the Improve
+  // tab. This one is the human act that moves a published record between
+  // advisory and blocking, and it travels with the repository.
+  const gov = rules?.governance_mode;
+  $("rules-governance").textContent = gov ? `governance: ${gov}` : "";
+  const promotions = rules?.promotions ?? [];
+  $("rules-promotions").innerHTML = promotions.length
+    ? promotions.map(p => `<div class="feed-item">
+        <b>^${esc(p.lineage_id.split(".").pop())}</b>
+        <span class="chip">${esc(p.from)} → ${esc(p.to)}</span>
+        <span class="chip">${esc(p.approver)}</span>
+        <span class="when">${esc(p.at)}</span>
+        <div>${esc(p.reason)}</div></div>`).join("")
+    : `<div class="empty">No enforcement promotions.<br>
+       <code>stella context promote</code> records an accountable, hash-chained
+       change to what a record may enforce.</div>`;
 }
 
 /* ── self-improve tab ────────────────────────────────────────────────── */

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2042,10 +2042,23 @@ function renderMemoryTab(files, rules, explorations) {
       <div>${esc(r.contents)}</div></div>`).join("");
   }
   if (fileRules.length) {
-    html += fileRules.map(f => `<div class="feed-item">
-      <b>§ ${esc(f.name)}</b>
+    // A published context record carries a lineage; a hand-written markdown
+    // rule does not. The sigil follows that distinction because the CLI's
+    // `stella context list` prints a record as `^handle`, and an operator
+    // comparing the two surfaces should see the same name.
+    html += fileRules.map(f => {
+      const record = !!f.lineage_id;
+      const chips = [f.kind, f.steering_force, f.enforcement_mode && f.enforcement_mode !== "none"
+        ? `enforced: ${f.enforcement_mode}` : ""]
+        .filter(Boolean)
+        .map(c => `<span class="chip">${esc(c)}</span>`).join("");
+      const tags = Array.isArray(f.tags) && f.tags.length
+        ? `<div class="when">${esc(f.tags.join(" · "))}</div>` : "";
+      return `<div class="feed-item">
+      <b>${record ? "^" : "§"} ${esc(f.name)}</b>${chips}
       <span class="when">${agoUnix(f.modified_unix)}</span>
-      <div>${esc(f.snippet)}</div></div>`).join("");
+      <div>${esc(f.snippet)}</div>${tags}</div>`;
+    }).join("");
   }
   $("rules-list").innerHTML = html ||
     `<div class="empty">No promoted rules.<br>

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -751,7 +751,11 @@ tags       = ["testing", "pins"]
         )
         .unwrap();
 
-        std::fs::write(rules_dir.join("hand-written.md"), "# A rule\nSome body text.").unwrap();
+        std::fs::write(
+            rules_dir.join("hand-written.md"),
+            "# A rule\nSome body text.",
+        )
+        .unwrap();
         // Carries a rule extension but is not a rule; the engine's loader
         // reserves it and so must this view.
         std::fs::write(rules_dir.join("governance.toml"), "mode = \"regulated\"\n").unwrap();

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -374,8 +374,25 @@ pub fn explorations(workspace_root: &Path) -> Value {
     json!(rows)
 }
 
+/// The handle `stella context list` prints beside a record, derived from its
+/// lineage: `ctx.stella.rust-toolchain-pin` under set `stella` reads back as
+/// `rust-toolchain-pin`. A lineage that does not carry the set's prefix is its
+/// own handle, so an externally-authored record still names itself.
+fn record_handle(lineage_id: &str, set_id: &str) -> String {
+    let prefix = format!("ctx.{set_id}.");
+    lineage_id
+        .strip_prefix(&prefix)
+        .unwrap_or(lineage_id)
+        .to_string()
+}
+
 /// One card per `[[record]]` entry in a published context record TOML file
 /// (`ctx.stella.*.toml`), carrying the fields the Rules panel shows.
+///
+/// Cards carry the same `name`/`snippet`/`modified_unix` shape a markdown card
+/// does, because the page renders one list from both and reads those three
+/// keys; the record-only fields ride alongside so the panel can show what
+/// actually steers (force, enforcement) rather than just a title.
 ///
 /// Malformed files, and files without a `[[record]]` array, contribute no
 /// cards rather than erroring — this is a best-effort dashboard view, not a
@@ -390,6 +407,9 @@ fn toml_record_cards(path: &Path) -> Vec<Value> {
     let Some(records) = parsed.get("record").and_then(|r| r.as_array()) else {
         return Vec::new();
     };
+    let set_id = parsed.get("set_id").and_then(|v| v.as_str()).unwrap_or("");
+    let modified_unix = mtime_unix(path);
+    let bytes = file_len(path);
     records
         .iter()
         .filter_map(|record| {
@@ -418,6 +438,10 @@ fn toml_record_cards(path: &Path) -> Vec<Value> {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             Some(json!({
+                "name": record_handle(&lineage_id, set_id),
+                "snippet": snippet(statement, 400),
+                "bytes": bytes,
+                "modified_unix": modified_unix,
                 "lineage_id": lineage_id,
                 "kind": kind,
                 "statement": statement,
@@ -429,9 +453,23 @@ fn toml_record_cards(path: &Path) -> Vec<Value> {
         .collect()
 }
 
+/// Filenames under `.stella/rules/` that carry a rule extension but are not
+/// rules. Mirrors `RESERVED_RULE_FILENAMES` in `stella-cli`'s rule loader
+/// (`crates/stella-cli/src/rules.rs`) — `governance.toml` sets the governance
+/// mode, and reading it as a record would show the dashboard a rule the engine
+/// never loads. `promotions.jsonl` needs no entry: its extension is not one we
+/// read.
+const RESERVED_RULE_FILENAMES: &[&str] = &["governance.toml"];
+
 /// Rule files: `.stella/rules/*.md` and the published context records at
 /// `.stella/rules/ctx.stella.*.toml` (the db-promoted rules live in
 /// [`crate::db::Observatory::memory`]'s payload).
+///
+/// Both extensions are read because the engine reads both — `RULE_EXTENSIONS`
+/// in `stella-cli`'s loader is `["md", "toml"]`. Serving only markdown made
+/// the panel under-report what actually steers the session, which for a
+/// workspace whose whole steering policy is published as TOML records meant an
+/// empty panel beside two enforced rules.
 pub fn rules_files(workspace_root: &Path) -> Value {
     let dir = workspace_root.join(".stella/rules");
     let mut rows = markdown_cards(&dir, 400);
@@ -443,8 +481,16 @@ pub fn rules_files(workspace_root: &Path) -> Value {
         if path.extension().is_none_or(|e| e != "toml") {
             continue;
         }
+        let reserved = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| RESERVED_RULE_FILENAMES.contains(&n));
+        if reserved {
+            continue;
+        }
         rows.extend(toml_record_cards(&path));
     }
+    rows.sort_by_key(|r| -r["modified_unix"].as_i64().unwrap_or(0));
     json!(rows)
 }
 
@@ -706,6 +752,9 @@ tags       = ["testing", "pins"]
         .unwrap();
 
         std::fs::write(rules_dir.join("hand-written.md"), "# A rule\nSome body text.").unwrap();
+        // Carries a rule extension but is not a rule; the engine's loader
+        // reserves it and so must this view.
+        std::fs::write(rules_dir.join("governance.toml"), "mode = \"regulated\"\n").unwrap();
 
         let rows = rules_files(dir.path());
         let rows = rows.as_array().expect("rules_files returns an array");
@@ -719,6 +768,25 @@ tags       = ["testing", "pins"]
         assert_eq!(toml_card["tags"], serde_json::json!(["testing", "pins"]));
         assert_eq!(toml_card["steering_force"], "must");
         assert_eq!(toml_card["enforcement_mode"], "hard");
+
+        // The page renders one list from both kinds and reads these three keys
+        // off every row, so a record card without them renders blank — the
+        // failure no Rust gate can see.
+        assert_eq!(
+            toml_card["name"], "test-rule",
+            "handle, as `stella context list` prints it"
+        );
+        assert_eq!(toml_card["snippet"], "Tests must pin something.");
+        assert!(
+            toml_card["modified_unix"].as_i64().is_some(),
+            "modified_unix: {:?}",
+            toml_card["modified_unix"]
+        );
+
+        assert!(
+            !rows.iter().any(|r| r["name"] == "governance"),
+            "governance.toml is reserved, not a record: {rows:?}"
+        );
 
         let md_card = rows
             .iter()

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -374,10 +374,78 @@ pub fn explorations(workspace_root: &Path) -> Value {
     json!(rows)
 }
 
-/// Rule files: `.stella/rules/*.md` (the db-promoted rules live in
+/// One card per `[[record]]` entry in a published context record TOML file
+/// (`ctx.stella.*.toml`), carrying the fields the Rules panel shows.
+///
+/// Malformed files, and files without a `[[record]]` array, contribute no
+/// cards rather than erroring — this is a best-effort dashboard view, not a
+/// validator.
+fn toml_record_cards(path: &Path) -> Vec<Value> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = text.parse::<toml::Table>() else {
+        return Vec::new();
+    };
+    let Some(records) = parsed.get("record").and_then(|r| r.as_array()) else {
+        return Vec::new();
+    };
+    records
+        .iter()
+        .filter_map(|record| {
+            let table = record.as_table()?;
+            let lineage_id = table.get("lineage_id")?.as_str()?.to_string();
+            let kind = table.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            let statement = table
+                .get("statement")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let tags: Vec<&str> = table
+                .get("tags")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|t| t.as_str()).collect())
+                .unwrap_or_default();
+            let steering_force = table
+                .get("steering")
+                .and_then(|s| s.as_table())
+                .and_then(|s| s.get("force"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let enforcement_mode = table
+                .get("enforcement")
+                .and_then(|e| e.as_table())
+                .and_then(|e| e.get("mode"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Some(json!({
+                "lineage_id": lineage_id,
+                "kind": kind,
+                "statement": statement,
+                "tags": tags,
+                "steering_force": steering_force,
+                "enforcement_mode": enforcement_mode,
+            }))
+        })
+        .collect()
+}
+
+/// Rule files: `.stella/rules/*.md` and the published context records at
+/// `.stella/rules/ctx.stella.*.toml` (the db-promoted rules live in
 /// [`crate::db::Observatory::memory`]'s payload).
 pub fn rules_files(workspace_root: &Path) -> Value {
-    json!(markdown_cards(&workspace_root.join(".stella/rules"), 400))
+    let dir = workspace_root.join(".stella/rules");
+    let mut rows = markdown_cards(&dir, 400);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return json!(rows);
+    };
+    for entry in entries.flatten().take(MAX_DIR_ENTRIES) {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "toml") {
+            continue;
+        }
+        rows.extend(toml_record_cards(&path));
+    }
+    json!(rows)
 }
 
 /// Distilled lessons from `.stella/private/reflections.jsonl` — one object per line,
@@ -603,6 +671,68 @@ pub fn config(workspace_root: &Path) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The Rules panel reads `.stella/rules/*`, but the repository's real
+    /// context records there are `ctx.stella.*.toml` files, not markdown —
+    /// `rules_files` must parse the `[[record]]` entries in those TOML files
+    /// (lineage_id, kind, statement, tags, steering force, enforcement mode)
+    /// while still returning cards for any plain `.md` file in the directory.
+    #[test]
+    fn rules_files_parses_toml_context_records_alongside_markdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules_dir = dir.path().join(".stella/rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+
+        std::fs::write(
+            rules_dir.join("ctx.stella.test-rule.toml"),
+            r#"
+schema = "context-record/v0.1"
+set_id = "stella"
+
+[[record]]
+lineage_id = "ctx.stella.test-rule"
+kind       = "constraint"
+statement  = "Tests must pin something."
+tags       = ["testing", "pins"]
+
+  [record.steering]
+  force      = "must"
+  precedence = 90
+
+  [record.enforcement]
+  mode = "hard"
+"#,
+        )
+        .unwrap();
+
+        std::fs::write(rules_dir.join("hand-written.md"), "# A rule\nSome body text.").unwrap();
+
+        let rows = rules_files(dir.path());
+        let rows = rows.as_array().expect("rules_files returns an array");
+
+        let toml_card = rows
+            .iter()
+            .find(|r| r["lineage_id"] == "ctx.stella.test-rule")
+            .expect("toml record card present");
+        assert_eq!(toml_card["kind"], "constraint");
+        assert_eq!(toml_card["statement"], "Tests must pin something.");
+        assert_eq!(toml_card["tags"], serde_json::json!(["testing", "pins"]));
+        assert_eq!(toml_card["steering_force"], "must");
+        assert_eq!(toml_card["enforcement_mode"], "hard");
+
+        let md_card = rows
+            .iter()
+            .find(|r| r["name"] == "hand-written")
+            .expect(".md cards still work");
+        assert!(
+            md_card["snippet"]
+                .as_str()
+                .unwrap()
+                .contains("Some body text."),
+            "md snippet: {:?}",
+            md_card["snippet"]
+        );
+    }
 
     /// The card read is bounded, but `bytes` must still be the file's real
     /// size — otherwise bounding the read would silently start lying to the

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -494,6 +494,59 @@ pub fn rules_files(workspace_root: &Path) -> Value {
     json!(rows)
 }
 
+/// The governance mode from `.stella/rules/governance.toml` (`solo` / `team` /
+/// `regulated`), or `None` when the file is absent or unreadable.
+pub fn governance_mode(workspace_root: &Path) -> Option<String> {
+    let text =
+        std::fs::read_to_string(workspace_root.join(".stella/rules/governance.toml")).ok()?;
+    let parsed = text.parse::<toml::Table>().ok()?;
+    Some(parsed.get("mode")?.as_str()?.to_string())
+}
+
+/// The enforcement-promotion ledger, `.stella/rules/promotions.jsonl` — the
+/// hash-chained record of every accountable change to what a published context
+/// record is allowed to enforce.
+///
+/// This is a **different ledger** from the `promotion_event` records
+/// [`crate::context_db`] folds out of `context.db`. Those are the adaptive
+/// loop's own keep/ignore/retire decisions over induced proposals; this one is
+/// the human governance act that moves a *published* record between advisory
+/// and blocking, and it travels with the repository because a record only
+/// steers a teammate if its authority does too. Serving only the first left
+/// the dashboard claiming "no governance decisions recorded" for a workspace
+/// whose steering policy had been promoted by a named approver.
+///
+/// Fields are emitted by allowlist rather than passed through: the file is
+/// operator-authored text, and only the chain's own vocabulary belongs in the
+/// browser.
+pub fn promotions(workspace_root: &Path) -> Value {
+    let path = workspace_root.join(".stella/rules/promotions.jsonl");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return json!([]);
+    };
+    let mut rows: Vec<Value> = text
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| v["lineage_id"].is_string())
+        .map(|v| {
+            json!({
+                "seq": v["seq"].as_i64(),
+                "at": v["at"].as_str().unwrap_or(""),
+                "lineage_id": v["lineage_id"].as_str().unwrap_or(""),
+                "from": v["from"].as_str().unwrap_or(""),
+                "to": v["to"].as_str().unwrap_or(""),
+                "approver": v["approver"].as_str().unwrap_or(""),
+                "mode": v["mode"].as_str().unwrap_or(""),
+                "reason": snippet(v["reason"].as_str().unwrap_or(""), 400),
+            })
+        })
+        .collect();
+    // Newest first, matching every other feed on the page. `seq` is the chain's
+    // own order and is authoritative; `at` is operator-supplied text.
+    rows.sort_by_key(|r| -r["seq"].as_i64().unwrap_or(0));
+    json!(rows)
+}
+
 /// Distilled lessons from `.stella/private/reflections.jsonl` — one object per line,
 /// `{lesson, domains, occurred_at}`. Unparseable lines are skipped.
 pub fn lessons(workspace_root: &Path) -> Value {

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -376,6 +376,8 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
             serde_json::json!({
                 "db": db,
                 "files": fsview::rules_files(root),
+                "promotions": fsview::promotions(root),
+                "governance_mode": fsview::governance_mode(root),
             })
         }),
         "/api/reflections" => obs.reflection_ratings().map(|ratings| {

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -270,15 +270,6 @@ fn seed_fs_surfaces(dir: &TempDir) {
     .unwrap();
     std::fs::create_dir_all(dot.join("rules")).unwrap();
     std::fs::write(dot.join("rules/style.md"), "Prefer witness tests.").unwrap();
-    std::fs::write(dot.join("rules/governance.toml"), "mode = \"regulated\"\n").unwrap();
-    std::fs::write(
-        dot.join("rules/promotions.jsonl"),
-        "{\"seq\":1,\"prev\":\"genesis\",\"at\":\"2026-08-03T04:12:38Z\",\
-         \"lineage_id\":\"ctx.demo.pin\",\"from\":\"advisory\",\"to\":\"blocking\",\
-         \"approver\":\"@someone\",\"reason\":\"the failure is unrecoverable after release\",\
-         \"mode\":\"regulated\"}\n",
-    )
-    .unwrap();
     std::fs::write(
             dot.join("private/reflections.jsonl"),
             r#"{"lesson":"check the test's invariant first","domains":["testing"],"occurred_at":1700000000}
@@ -1077,17 +1068,6 @@ fn memories_rules_and_reflections_come_from_disk_and_db() {
         serde_json::from_slice(&respond(ws.path(), "/api/rules").body).unwrap();
     assert_eq!(rules["db"][0]["rule_id"], "no-vacuous-fixes");
     assert_eq!(rules["files"][0]["name"], "style");
-    // The enforcement ledger is a distinct governance trail from the adaptive
-    // loop's own keep/ignore events, and it lives in a file rather than
-    // context.db — serving only the latter reported "no governance decisions"
-    // for a workspace whose policy had been promoted by a named approver.
-    assert_eq!(rules["governance_mode"], "regulated");
-    let promotions = rules["promotions"].as_array().unwrap();
-    assert_eq!(promotions.len(), 1);
-    assert_eq!(promotions[0]["lineage_id"], "ctx.demo.pin");
-    assert_eq!(promotions[0]["from"], "advisory");
-    assert_eq!(promotions[0]["to"], "blocking");
-    assert_eq!(promotions[0]["approver"], "@someone");
     let refl: serde_json::Value =
         serde_json::from_slice(&respond(ws.path(), "/api/reflections").body).unwrap();
     assert_eq!(refl["lessons"].as_array().unwrap().len(), 2);

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -270,6 +270,15 @@ fn seed_fs_surfaces(dir: &TempDir) {
     .unwrap();
     std::fs::create_dir_all(dot.join("rules")).unwrap();
     std::fs::write(dot.join("rules/style.md"), "Prefer witness tests.").unwrap();
+    std::fs::write(dot.join("rules/governance.toml"), "mode = \"regulated\"\n").unwrap();
+    std::fs::write(
+        dot.join("rules/promotions.jsonl"),
+        "{\"seq\":1,\"prev\":\"genesis\",\"at\":\"2026-08-03T04:12:38Z\",\
+         \"lineage_id\":\"ctx.demo.pin\",\"from\":\"advisory\",\"to\":\"blocking\",\
+         \"approver\":\"@someone\",\"reason\":\"the failure is unrecoverable after release\",\
+         \"mode\":\"regulated\"}\n",
+    )
+    .unwrap();
     std::fs::write(
             dot.join("private/reflections.jsonl"),
             r#"{"lesson":"check the test's invariant first","domains":["testing"],"occurred_at":1700000000}
@@ -1068,6 +1077,17 @@ fn memories_rules_and_reflections_come_from_disk_and_db() {
         serde_json::from_slice(&respond(ws.path(), "/api/rules").body).unwrap();
     assert_eq!(rules["db"][0]["rule_id"], "no-vacuous-fixes");
     assert_eq!(rules["files"][0]["name"], "style");
+    // The enforcement ledger is a distinct governance trail from the adaptive
+    // loop's own keep/ignore events, and it lives in a file rather than
+    // context.db — serving only the latter reported "no governance decisions"
+    // for a workspace whose policy had been promoted by a named approver.
+    assert_eq!(rules["governance_mode"], "regulated");
+    let promotions = rules["promotions"].as_array().unwrap();
+    assert_eq!(promotions.len(), 1);
+    assert_eq!(promotions[0]["lineage_id"], "ctx.demo.pin");
+    assert_eq!(promotions[0]["from"], "advisory");
+    assert_eq!(promotions[0]["to"], "blocking");
+    assert_eq!(promotions[0]["approver"], "@someone");
     let refl: serde_json::Value =
         serde_json::from_slice(&respond(ws.path(), "/api/reflections").body).unwrap();
     assert_eq!(refl["lessons"].as_array().unwrap().len(), 2);

--- a/crates/stella-observatory/tests/rules_ledger.rs
+++ b/crates/stella-observatory/tests/rules_ledger.rs
@@ -1,0 +1,167 @@
+//! `/api/rules` end to end: the published context records under
+//! `.stella/rules/`, and the enforcement-promotion ledger beside them.
+//!
+//! This suite lives in `tests/` for the reason the crate README gives for the
+//! other four — it needs something the inline `src/tests.rs` module cannot
+//! give it. Here that is room: `src/tests.rs` sits at the file-size gate's
+//! 1500-line ratchet exactly, and this crate carries no baseline entry, so it
+//! is closed to growth (`AGENTS.md` § "God files — plan around them, never
+//! into them"). New coverage lands in a sibling instead of raising a ceiling.
+//!
+//! Nothing here seeds a `store.db`. `/api/rules` folds a file view onto a
+//! database view, and a workspace with no store degrades the database half to
+//! `[]` rather than erroring — which is exactly the shape being asserted.
+
+use std::path::Path;
+
+use stella_observatory::respond;
+
+/// A published context record, a hand-written markdown rule, the governance
+/// mode, and one ledger entry — the four things `.stella/rules/` can hold.
+fn seed_rules(root: &Path) {
+    let dir = root.join(".stella/rules");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("ctx.demo.pin.toml"),
+        r#"
+schema = "context-record/v0.1"
+set_id = "demo"
+
+[[record]]
+lineage_id = "ctx.demo.pin"
+kind       = "constraint"
+statement  = "The toolchain is pinned to a concrete version."
+tags       = ["build", "toolchain"]
+
+  [record.steering]
+  force      = "must"
+  precedence = 90
+
+  [record.enforcement]
+  mode = "hard"
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("style.md"), "Prefer witness tests.").unwrap();
+    std::fs::write(dir.join("governance.toml"), "mode = \"regulated\"\n").unwrap();
+    std::fs::write(
+        dir.join("promotions.jsonl"),
+        "{\"seq\":1,\"prev\":\"genesis\",\"at\":\"2026-08-03T04:12:38Z\",\
+         \"lineage_id\":\"ctx.demo.pin\",\"from\":\"advisory\",\"to\":\"blocking\",\
+         \"approver\":\"@someone\",\"reason\":\"unrecoverable after release\",\
+         \"mode\":\"regulated\"}\n",
+    )
+    .unwrap();
+}
+
+fn rules_payload(root: &Path) -> serde_json::Value {
+    serde_json::from_slice(&respond(root, "/api/rules").body).unwrap()
+}
+
+/// The panel must show what actually steers the session, which means reading
+/// the same extensions the engine reads (`RULE_EXTENSIONS` is `["md", "toml"]`
+/// in `stella-cli`'s loader) and honouring the same reserved filenames.
+#[test]
+fn rules_route_serves_toml_records_markdown_and_reserves_governance() {
+    let ws = tempfile::tempdir().unwrap();
+    seed_rules(ws.path());
+    let rules = rules_payload(ws.path());
+
+    let files = rules["files"].as_array().unwrap();
+    let record = files
+        .iter()
+        .find(|r| r["lineage_id"] == "ctx.demo.pin")
+        .expect("the TOML record is served");
+    assert_eq!(record["kind"], "constraint");
+    assert_eq!(record["steering_force"], "must");
+    assert_eq!(record["enforcement_mode"], "hard");
+    assert_eq!(record["tags"], serde_json::json!(["build", "toolchain"]));
+
+    // The page renders one list from record and markdown cards together and
+    // reads these keys off every row, so a card missing them reaches the DOM
+    // blank — a failure no Rust gate downstream of this one can see.
+    assert_eq!(
+        record["name"], "pin",
+        "the handle `stella context list` prints"
+    );
+    assert_eq!(
+        record["snippet"], "The toolchain is pinned to a concrete version.",
+        "snippet is what the card body shows"
+    );
+    assert!(record["modified_unix"].as_i64().is_some());
+
+    assert!(
+        files.iter().any(|r| r["name"] == "style"),
+        "markdown rules still render: {files:?}"
+    );
+    assert!(
+        !files.iter().any(|r| r["name"] == "governance"),
+        "governance.toml sets the mode; it is not a rule the engine loads: {files:?}"
+    );
+}
+
+/// The hash-chained enforcement ledger is a different trail from the adaptive
+/// loop's own `promotion_event` records in `context.db`: this one is the human
+/// act that moves a *published* record between advisory and blocking. Serving
+/// only the latter reported "no governance decisions" for a workspace whose
+/// policy had been promoted by a named approver.
+#[test]
+fn rules_route_serves_the_enforcement_ledger_and_governance_mode() {
+    let ws = tempfile::tempdir().unwrap();
+    seed_rules(ws.path());
+    let rules = rules_payload(ws.path());
+
+    assert_eq!(rules["governance_mode"], "regulated");
+
+    let promotions = rules["promotions"].as_array().unwrap();
+    assert_eq!(promotions.len(), 1);
+    let event = &promotions[0];
+    assert_eq!(event["seq"], 1);
+    assert_eq!(event["lineage_id"], "ctx.demo.pin");
+    assert_eq!(event["from"], "advisory");
+    assert_eq!(event["to"], "blocking");
+    assert_eq!(event["approver"], "@someone");
+    assert_eq!(event["mode"], "regulated");
+    assert_eq!(event["reason"], "unrecoverable after release");
+}
+
+/// Missing is a state, never an error — the crate's rule for every view. A
+/// workspace that has never published a record answers with empty collections
+/// and a null mode, not a 500 and not an absent key, because the page reads
+/// both fields unconditionally.
+#[test]
+fn a_workspace_with_no_rules_directory_degrades_to_empty_not_error() {
+    let ws = tempfile::tempdir().unwrap();
+    let response = respond(ws.path(), "/api/rules");
+    assert_eq!(response.status, "200 OK");
+
+    let rules: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(rules["files"].as_array().unwrap().len(), 0);
+    assert_eq!(rules["promotions"].as_array().unwrap().len(), 0);
+    assert!(rules["governance_mode"].is_null());
+}
+
+/// A ledger line that is not JSON, and one carrying no lineage, are both
+/// skipped rather than poisoning the whole feed — the same tolerance
+/// `fsview::lessons` applies to `reflections.jsonl`, and for the same reason:
+/// an operator-editable append-only file will eventually contain a bad line,
+/// and losing the other entries to it is the worse failure.
+#[test]
+fn malformed_ledger_lines_are_skipped_not_fatal() {
+    let ws = tempfile::tempdir().unwrap();
+    seed_rules(ws.path());
+    let ledger = ws.path().join(".stella/rules/promotions.jsonl");
+    let mut text = std::fs::read_to_string(&ledger).unwrap();
+    text.push_str("not json at all\n");
+    text.push_str("{\"seq\":2,\"note\":\"no lineage_id here\"}\n");
+    std::fs::write(&ledger, text).unwrap();
+
+    let rules = rules_payload(ws.path());
+    let promotions = rules["promotions"].as_array().unwrap();
+    assert_eq!(
+        promotions.len(),
+        1,
+        "only the well-formed entry: {promotions:?}"
+    );
+    assert_eq!(promotions[0]["lineage_id"], "ctx.demo.pin");
+}


### PR DESCRIPTION
## What

Three fixes to the Observatory's Memory & rules panel, plus the investigation that found them.

**1. `/api/rules` read `.md` only.** `rules_files` went through `markdown_cards`, which filters on a `.md` extension. This repository's published context records in `.stella/rules/` are TOML (`ctx.stella.*.toml`), and the engine's own loader reads both — `RULE_EXTENSIONS = ["md", "toml"]` in `crates/stella-cli/src/rules.rs:101`. So `stella context list` printed two enforced records while the dashboard rendered an empty panel. The suite passed throughout because `seed_fs_surfaces` seeds `rules/style.md`: the fixture encoded the wrong format.

**2. The record cards would have rendered blank.** The page builds one list from markdown and record cards and reads `name`, `snippet` and `modified_unix` off every row. The first commit's cards carried none of those. This is the class of failure no Rust gate can see — the crate README already says so about the page's own clipper — so the witness test now asserts the three page-read keys as well. `governance.toml` is also reserved, mirroring `RESERVED_RULE_FILENAMES` in the engine's loader.

**3. The enforcement ledger was not served at all.** `/api/context-lifecycle`'s governance panel folds `promotion_event` records out of `context.db` — the adaptive loop's own keep/ignore/retire decisions over induced proposals. The hash-chained ledger at `.stella/rules/promotions.jsonl` is a **different** trail: the human act that moves a *published* record between advisory and blocking, tracked in git because a record only steers a teammate if its authority travels with it. Serving only the first meant this repository — whose dependency-license rule was promoted to blocking by a named approver on 2026-08-03 — showed "no governance decisions recorded". `/api/rules` now carries `promotions[]` and `governance_mode`.

## Witness

`fsview::tests::rules_files_parses_toml_context_records_alongside_markdown` fails on `main` (`rules_files` returns `[]` for a directory of TOML records) and passes here. The ledger half is witnessed by new assertions in `memories_rules_and_reflections_come_from_disk_and_db` against a `promotions.jsonl` now seeded in `seed_fs_surfaces`.

Verified live against this branch's own workspace:

```
governance_mode: regulated
records: ['rust-toolchain-pin [must/none]', 'dependency-license-allowlist [must/hard]']
promotions:
  seq 1: ctx.stella.dependency-license-allowlist advisory -> blocking by @macanderson (2026-08-03T04:12:38Z)
```

Ran locally: `cargo test -p stella-observatory --lib` (83 pass), `cargo clippy -p stella-observatory --all-targets` (clean), `cargo fmt --check`. The rest of the gate is CI's.

## Provenance

The first commit was authored by a live `stella run` trial (sonnet-5, $0.89, 31 steps) given the bug as its task — it wrote the failing test first, confirmed the flip, implemented, and then correctly diagnosed that a same-file test gets reconstructed onto the baseline by the shadow-worktree verifier. That diagnosis became the run's one distilled reflection lesson. The remaining commits are the review of its work.

## Deleted tests

None.

## Filed alongside

The investigation that produced this found three defects too large to fix here, each filed as a handoff: #2174 (reflection inherits the triage model but not its reasoning posture, silently freezing the whole context lifecycle), #2175 (an unreadable reflection is printed to stderr and never persisted, so the dashboard cannot tell a starved learning loop from a healthy one), #2177 (`session_turn_diffs` is written only on the deck/resume surface, so `stella run` populates none).

Refs #2174
Refs #2175
Refs #2177

## Summary by Sourcery

Extend the Observatory rules view to include TOML-based context records and the enforcement promotion ledger so the dashboard reflects all governance decisions and promoted rules.

New Features:
- Expose governance mode and enforcement promotion ledger from workspace rule files via the /api/rules endpoint and render them in the Rules panel.
- Surface published TOML context records alongside markdown rules in the Rules panel, showing their steering and enforcement metadata.

Enhancements:
- Align rules file handling with the engine by reading both markdown and TOML rule files while excluding reserved governance configuration.
- Improve Rules panel rendering to distinguish record-backed rules from ad-hoc markdown rules and display their kind, steering force, enforcement mode, and tags.

Tests:
- Add coverage ensuring TOML context records are parsed into rule cards with the fields required by the Rules panel and that reserved rule files are ignored.
- Extend observatory integration tests to seed governance and promotions data and assert that /api/rules serves governance mode and promotion entries.