### PR TITLE
fix(stella-pipeline): stop role calls starving on reasoning tokens, and stop a degraded verdict re-opening finished work (#2128, #2129)

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2091,24 +2091,8 @@ impl<'a> Pipeline<'a> {
                     }
                 }
             }
-            let mut inputs = LadderInputs {
-                flip_achieved: state.oracle.is_flipped(),
-                touched_tests_passed,
-                diff_lines: state.diff_lines,
-                diff_budget: self.config.diff_budget_lines,
-                diff_available: state.diff_available,
-                file_change_events: state.signals.file_changes,
-                mutating_actions: state.signals.mutating_actions,
-                // Filled by the pre-submit audit below (#861, #870, #1291) —
-                // the lint, coverage and mutation probes only run when a
-                // fast-submit is imminent.
-                new_diag_errors: 0,
-                new_diag_warnings: 0,
-                veto_warnings: self.config.diagnostics_veto_warnings,
-                witness_tautological: false,
-                diff_coverage: DiffCoverage::Unmeasured,
-                require_diff_coverage: self.config.require_diff_coverage,
-            };
+            let mut inputs =
+                self.ladder_inputs(&state, touched_tests_passed, effective_cmd.is_some());
 
             // Pre-submit audit (#859, #861): a deterministic pass is about
             // to be credited, so spend the two cheap checks that can refute
@@ -2536,7 +2520,7 @@ impl<'a> Pipeline<'a> {
                                 },
                             );
                             match self
-                                .verifier(&mut state.degradation, prompt, &inputs, spend)
+                                .verifier(&state.degradation, prompt, &inputs, spend)
                                 .await
                             {
                                 Ok(verdict) => {

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2092,7 +2092,7 @@ impl<'a> Pipeline<'a> {
                 }
             }
             let mut inputs =
-                self.ladder_inputs(&state, touched_tests_passed, effective_cmd.is_some());
+                self.ladder_inputs(&state, touched_tests_passed, effective_cmd.is_none());
 
             // Pre-submit audit (#859, #861): a deterministic pass is about
             // to be credited, so spend the two cheap checks that can refute

--- a/crates/stella-pipeline/src/pipeline/evidence.rs
+++ b/crates/stella-pipeline/src/pipeline/evidence.rs
@@ -66,7 +66,7 @@ impl<'a> Pipeline<'a> {
         &self,
         state: &CandidateState,
         touched_tests_passed: Option<bool>,
-        flip_evidence_obtainable: bool,
+        no_test_surface: bool,
     ) -> LadderInputs {
         LadderInputs {
             flip_achieved: state.oracle.is_flipped(),
@@ -83,7 +83,7 @@ impl<'a> Pipeline<'a> {
             diff_coverage: DiffCoverage::Unmeasured,
             require_diff_coverage: self.config.require_diff_coverage,
             verify_done_flip: state.signals.verify_done_confirmations > 0,
-            flip_evidence_obtainable,
+            no_test_surface,
         }
     }
 

--- a/crates/stella-pipeline/src/pipeline/evidence.rs
+++ b/crates/stella-pipeline/src/pipeline/evidence.rs
@@ -52,6 +52,41 @@ fn bounded_oracle_trace(trace: &[OracleObservation]) -> String {
 }
 
 impl<'a> Pipeline<'a> {
+    /// Assemble one verification round's [`LadderInputs`] from the candidate's
+    /// accumulated state — the evidence record `ladder_decision` and the
+    /// fallback verdict reason over. Lives here rather than in
+    /// `verify_candidate` for the same reason the summary below does:
+    /// `pipeline.rs` is closed to growth, and this literal is the seam that
+    /// grows whenever the ladder learns a channel (#2129 added two).
+    ///
+    /// The diagnostics, tautology, and coverage fields start at their
+    /// "nothing observed" values on purpose: the pre-submit audit
+    /// (#861, #870, #1291) fills them only when a fast-submit is imminent.
+    pub(super) fn ladder_inputs(
+        &self,
+        state: &CandidateState,
+        touched_tests_passed: Option<bool>,
+        flip_evidence_obtainable: bool,
+    ) -> LadderInputs {
+        LadderInputs {
+            flip_achieved: state.oracle.is_flipped(),
+            touched_tests_passed,
+            diff_lines: state.diff_lines,
+            diff_budget: self.config.diff_budget_lines,
+            diff_available: state.diff_available,
+            file_change_events: state.signals.file_changes,
+            mutating_actions: state.signals.mutating_actions,
+            new_diag_errors: 0,
+            new_diag_warnings: 0,
+            veto_warnings: self.config.diagnostics_veto_warnings,
+            witness_tautological: false,
+            diff_coverage: DiffCoverage::Unmeasured,
+            require_diff_coverage: self.config.require_diff_coverage,
+            verify_done_flip: state.signals.verify_done_confirmations > 0,
+            flip_evidence_obtainable,
+        }
+    }
+
     /// Assemble the deterministic evidence summary and the witness-stripped
     /// diff for one model-verdict round.
     ///

--- a/crates/stella-pipeline/src/pipeline/execute_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/execute_stage.rs
@@ -20,6 +20,7 @@ pub(super) struct TurnTallies {
     file_changes: Arc<AtomicU32>,
     mutating: Arc<AtomicU32>,
     opaque: Arc<AtomicU32>,
+    verify_confirmations: Arc<AtomicU32>,
 }
 
 impl TurnTallies {
@@ -28,8 +29,18 @@ impl TurnTallies {
         signals.file_changes += self.file_changes.load(Ordering::Relaxed);
         signals.mutating_actions += self.mutating.load(Ordering::Relaxed);
         signals.opaque_actions += self.opaque.load(Ordering::Relaxed);
+        signals.verify_done_confirmations += self.verify_confirmations.load(Ordering::Relaxed);
     }
 }
+
+/// The built-in verification tool's registered name
+/// (`stella-tools/src/verify.rs`) and the leading marker of its success
+/// output. Name-based like [`crate::witness::warrant::diff_accountable_mutator`],
+/// and both halves must match before a confirmation is tallied: the name
+/// alone could be shadowed by an attached MCP tool, and the marker alone
+/// could be echoed by a shell call's stdout.
+const VERIFY_DONE_TOOL: &str = "verify_done";
+const WITNESS_CONFIRMED_MARKER: &str = "WITNESS CONFIRMED";
 
 impl<'a> Pipeline<'a> {
     /// Execute stage: one turn for simple/single-task; one turn per plan step
@@ -229,6 +240,13 @@ impl<'a> Pipeline<'a> {
         let mutating = seen_mutating.clone();
         let seen_opaque = Arc::new(AtomicU32::new(0));
         let opaque = seen_opaque.clone();
+        let seen_verify = Arc::new(AtomicU32::new(0));
+        let verify = seen_verify.clone();
+        // The `verify_done` calls in flight, so their results can be scored
+        // (#2129). Correlated by `call_id` for the same reason the command
+        // map below is — a step dispatches calls concurrently.
+        let pending_verify: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let verify_calls = pending_verify.clone();
         let read_only = self.read_only_tool_names();
         let consumer = self.events.clone();
         // Correlate a shell call's command line (carried on `ToolStart`) with
@@ -292,6 +310,15 @@ impl<'a> Pipeline<'a> {
                     {
                         pending.insert(call.call_id.clone(), command.to_string());
                     }
+                    // Track `verify_done` dispatches unconditionally (#2129):
+                    // its confirmation is flip evidence the fallback verdict
+                    // must be able to read, and the calls are rare enough
+                    // that the set costs nothing on ordinary turns.
+                    if call.name == VERIFY_DONE_TOOL
+                        && let Ok(mut pending) = verify_calls.lock()
+                    {
+                        pending.insert(call.call_id.clone());
+                    }
                     consumer.send(event)
                 }
                 AgentEvent::ToolResult {
@@ -320,6 +347,19 @@ impl<'a> Pipeline<'a> {
                             halt.observe(&command, content);
                         }
                     }
+                    // A `verify_done` success that opens with the confirmed
+                    // marker is a deterministic flip observation (#2129). The
+                    // marker is the tool's first output byte, so `starts_with`
+                    // cannot be satisfied by a quoted echo in a longer reply.
+                    if verify_calls
+                        .lock()
+                        .ok()
+                        .is_some_and(|mut pending| pending.remove(call_id))
+                        && let ToolOutput::Ok { content } = output
+                        && content.starts_with(WITNESS_CONFIRMED_MARKER)
+                    {
+                        verify.fetch_add(1, Ordering::Relaxed);
+                    }
                     consumer.send(event)
                 }
                 _ => consumer.send(event),
@@ -331,6 +371,7 @@ impl<'a> Pipeline<'a> {
                 file_changes: seen_file_changes,
                 mutating: seen_mutating,
                 opaque: seen_opaque,
+                verify_confirmations: seen_verify,
             },
         )
     }

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -447,31 +447,25 @@ mod tests {
     /// for any other reason is a model declining, which more room cannot fix.
     #[test]
     fn only_an_empty_length_stop_counts_as_starvation() {
-        let base = CompletionResult {
-            text: String::new(),
-            finish_reason: Some(FinishReason::Length),
-            ..CompletionResult::default()
-        };
-        assert!(starved_of_output(&base));
+        fn result(text: &str, finish_reason: Option<FinishReason>) -> CompletionResult {
+            CompletionResult {
+                text: text.to_string(),
+                tool_calls: Vec::new(),
+                usage: stella_protocol::CompletionUsage::default(),
+                model: "scripted".into(),
+                cost_usd: 0.0,
+                finish_reason,
+            }
+        }
+        let length = Some(FinishReason::Length);
+        assert!(starved_of_output(&result("", length)));
         assert!(
-            starved_of_output(&CompletionResult {
-                text: "   \n ".into(),
-                ..base.clone()
-            }),
+            starved_of_output(&result("   \n ", length)),
             "whitespace is not an answer"
         );
-        assert!(!starved_of_output(&CompletionResult {
-            text: "PASS — looks right".into(),
-            ..base.clone()
-        }));
-        assert!(!starved_of_output(&CompletionResult {
-            finish_reason: Some(FinishReason::Stop),
-            ..base.clone()
-        }));
-        assert!(!starved_of_output(&CompletionResult {
-            finish_reason: None,
-            ..base
-        }));
+        assert!(!starved_of_output(&result("PASS — looks right", length)));
+        assert!(!starved_of_output(&result("", Some(FinishReason::Stop))));
+        assert!(!starved_of_output(&result("", None)));
     }
 
     /// A retry is bought only when more room could change the answer.

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -380,3 +380,106 @@ fn call_meta<'r>(role: ModelCallRole, resolved: &'r ResolvedRole<'_>) -> RawCall
         model_id: &resolved.model_ref.model_id,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #2128 witness for the prevention half: every capped role reaches the
+    /// wire with reasoning headroom above its written output contract, so a
+    /// reasoning model has room to think before its first answer token. The
+    /// old caps (512 triage, 1024 verdict) are exactly the numbers that came
+    /// back empty across a whole benchmark match.
+    #[test]
+    fn every_capped_role_carries_reasoning_headroom() {
+        let none = RoleCallOverrides::default();
+        for (role, contract) in [
+            (ModelCallRole::Triage, 512),
+            (ModelCallRole::Verdict, 1024),
+            (ModelCallRole::DistressGuidance, 1024),
+            (ModelCallRole::Plan, 4096),
+            (ModelCallRole::PlanRepair, 4096),
+            (ModelCallRole::Worker, 2048),
+        ] {
+            let cap = role_output_cap(role, &none, Some(64_000))
+                .unwrap_or_else(|| panic!("{role:?} is a capped role"));
+            assert_eq!(
+                cap,
+                contract + REASONING_HEADROOM_TOKENS,
+                "{role:?} must budget its output contract PLUS thinking room"
+            );
+            assert!(
+                cap < 64_000,
+                "{role:?} must still be far under the engine base — the cap is \
+                 what keeps a runaway role call bounded"
+            );
+        }
+    }
+
+    /// An operator's explicit cap is honored exactly, headroom included or
+    /// not: it is the most specific statement about the call, and quietly
+    /// serving a larger number would make the setting a suggestion. The
+    /// starvation retry is what keeps honoring it from being a silent loss.
+    #[test]
+    fn an_explicit_override_is_never_widened() {
+        let pinned = RoleCallOverrides {
+            max_output_tokens: Some(512),
+            ..RoleCallOverrides::default()
+        };
+        assert_eq!(
+            role_output_cap(ModelCallRole::Triage, &pinned, Some(64_000)),
+            Some(512)
+        );
+    }
+
+    /// An uncapped role inherits the engine base, exactly as before.
+    #[test]
+    fn an_uncapped_role_still_inherits_the_engine_base() {
+        let none = RoleCallOverrides::default();
+        assert_eq!(
+            role_output_cap(ModelCallRole::Reflection, &none, Some(64_000)),
+            Some(64_000)
+        );
+    }
+
+    /// The starvation signature requires BOTH halves: a truncated reply with
+    /// text is ordinary (the parsers cope), and an empty reply that stopped
+    /// for any other reason is a model declining, which more room cannot fix.
+    #[test]
+    fn only_an_empty_length_stop_counts_as_starvation() {
+        let base = CompletionResult {
+            text: String::new(),
+            finish_reason: Some(FinishReason::Length),
+            ..CompletionResult::default()
+        };
+        assert!(starved_of_output(&base));
+        assert!(
+            starved_of_output(&CompletionResult {
+                text: "   \n ".into(),
+                ..base.clone()
+            }),
+            "whitespace is not an answer"
+        );
+        assert!(!starved_of_output(&CompletionResult {
+            text: "PASS — looks right".into(),
+            ..base.clone()
+        }));
+        assert!(!starved_of_output(&CompletionResult {
+            finish_reason: Some(FinishReason::Stop),
+            ..base.clone()
+        }));
+        assert!(!starved_of_output(&CompletionResult {
+            finish_reason: None,
+            ..base
+        }));
+    }
+
+    /// A retry is bought only when more room could change the answer.
+    #[test]
+    fn a_retry_is_declined_when_room_was_never_the_constraint() {
+        assert_eq!(starved_retry_cap(Some(1024)), Some(STARVED_RETRY_CAP));
+        assert_eq!(starved_retry_cap(Some(STARVED_RETRY_CAP)), None);
+        assert_eq!(starved_retry_cap(Some(64_000)), None);
+        assert_eq!(starved_retry_cap(None), None);
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -8,7 +8,8 @@ use stella_core::{
     AccountedCall, AccountedCallError, BudgetGuard, ReceiptContext, run_accounted_call,
 };
 use stella_protocol::{
-    CompletionMessage, CompletionRequest, CompletionResult, ModelCallRole, ReasoningEffort,
+    CompletionMessage, CompletionRequest, CompletionResult, FinishReason, ModelCallRole,
+    ReasoningEffort,
 };
 
 use super::stage_budget::{PipelineBudgetAbort, budget_abort};
@@ -45,6 +46,36 @@ pub(super) enum RawCallError {
     Budget(PipelineBudgetAbort),
 }
 
+/// Headroom added to every management role's *visible-output* budget so a
+/// reasoning model can think before it answers (#2128).
+///
+/// `max_output_tokens` is one number on the wire and reasoning models bill
+/// their reasoning stream against it, so a cap sized for the role's written
+/// output contract is a cap the model spends entirely on thinking: in match
+/// `cc00894779ff` every triage call (512) and every verdict call (1024)
+/// returned `finish_reason: length` with `output_text: ""` — the reasoning
+/// token count matched or exceeded the cap in each one. Empty triage
+/// collapsed research/plan/scope/witness to defaults that looked like
+/// decisions; empty verdict degraded to the heuristic and re-opened finished
+/// work (#2129).
+///
+/// The number is a heuristic bound, and this comment is the honest place to
+/// say so: no posture axis reports a model's reasoning budget, and the value
+/// varies by model and prompt. It is deliberately generous relative to the
+/// contracts below (which are two to six lines) and still an order of
+/// magnitude under the 64k engine base, so a runaway role call is still
+/// bounded. [`starved_retry_cap`] is the actual guarantee — headroom only
+/// makes it rare.
+const REASONING_HEADROOM_TOKENS: u32 = 4_096;
+
+/// The cap a call that provably starved is retried at (#2128).
+///
+/// Reached only after a response came back empty with `finish_reason:
+/// length`, which is the provider stating that the budget ran out before the
+/// first visible token. Sized so one retry is enough for any reasoning
+/// budget observed in the wild rather than sized to a model.
+const STARVED_RETRY_CAP: u32 = 32_768;
+
 /// Role-shaped request bounds `(max_output_tokens, effort)` for the
 /// management chokepoint, applied between the caller's explicit overrides
 /// (which always win) and the engine config's worker-tier base.
@@ -56,6 +87,11 @@ pub(super) enum RawCallError {
 /// two to six lines with a 64k allowance and unbounded thinking. The bounded
 /// shape is the one the engine's own overflow summarizer already pins
 /// (`stella-core`'s `run_compaction_pass`: 1,200 tokens, `effort: Low`).
+///
+/// Each arm names the role's **visible-output** contract;
+/// [`REASONING_HEADROOM_TOKENS`] is added on top by [`role_output_cap`], so
+/// the numbers here stay readable against the prompts that justify them
+/// instead of silently encoding someone's guess at a thinking budget.
 ///
 /// Exhaustive over [`ModelCallRole`] on purpose: a new role dispatched
 /// through this chokepoint must decide its bounds here, not inherit the
@@ -89,6 +125,55 @@ fn management_bounds(role: ModelCallRole) -> (Option<u32>, Option<ReasoningEffor
         | ModelCallRole::Reflection
         | ModelCallRole::Summarization => (None, None),
     }
+}
+
+/// The wire cap for one management call: the caller's explicit override
+/// (which always wins, unchanged), else the role's visible-output contract
+/// plus [`REASONING_HEADROOM_TOKENS`], else the engine base.
+///
+/// The override is deliberately NOT given headroom. It is the most specific
+/// statement anyone made about this call — an operator who pinned 512 asked
+/// for 512, and quietly serving 4,608 would make the setting a suggestion.
+/// A starved override still gets the retry below, which is the difference
+/// between honoring a number and silently discarding its result.
+fn role_output_cap(
+    role: ModelCallRole,
+    overrides: &RoleCallOverrides,
+    base: Option<u32>,
+) -> Option<u32> {
+    if let Some(explicit) = overrides.max_output_tokens {
+        return Some(explicit);
+    }
+    match management_bounds(role).0 {
+        Some(contract) => Some(contract.saturating_add(REASONING_HEADROOM_TOKENS)),
+        None => base,
+    }
+}
+
+/// The cap to retry a provably starved call at, or `None` when a retry could
+/// not change the outcome (#2128).
+///
+/// `None` when the call already had at least [`STARVED_RETRY_CAP`] of room:
+/// the response was then empty for some reason more room cannot fix, and
+/// buying a second identical call to discover that again is waste.
+fn starved_retry_cap(previous: Option<u32>) -> Option<u32> {
+    match previous {
+        Some(cap) if cap < STARVED_RETRY_CAP => Some(STARVED_RETRY_CAP),
+        Some(_) => None,
+        // No cap was set at all, so the budget was never the binding
+        // constraint — nothing to raise.
+        None => None,
+    }
+}
+
+/// Whether a completion is the cap-starvation signature (#2128): the provider
+/// stopped at the token limit and no visible text was produced.
+///
+/// Both halves are required. `Length` with text is an ordinary truncation
+/// (the parsers handle a clipped reply), and empty text with any other finish
+/// reason is a model declining to answer — neither is fixed by more room.
+fn starved_of_output(result: &CompletionResult) -> bool {
+    result.text.trim().is_empty() && result.finish_reason == Some(FinishReason::Length)
 }
 
 impl<'a> Pipeline<'a> {
@@ -138,26 +223,109 @@ impl<'a> Pipeline<'a> {
         // verifier prompt from anything reading the estimate.
         let estimated_input_tokens =
             stella_core::estimator::estimate_conversation_tokens(&messages);
-        let (role_cap, role_effort) = management_bounds(role);
-        let req = CompletionRequest {
+        let cap = role_output_cap(role, overrides, engine.max_output_tokens);
+        // Kept for the starvation retry (#2128), and ONLY when one could
+        // change the outcome. An earlier revision moved the list into the
+        // request precisely to avoid this copy, on the grounds that nothing
+        // read it afterwards — true then, and no longer: a call that comes
+        // back empty because the cap was spent on reasoning is recoverable,
+        // and recovering it means re-sending what it sent. One `Vec` copy of
+        // a management prompt against a provider round trip is the cheaper
+        // half of that trade.
+        let retry_messages = starved_retry_cap(cap).map(|_| messages.clone());
+        let request = |messages, max_output_tokens| CompletionRequest {
             messages,
-            max_output_tokens: overrides
-                .max_output_tokens
-                .or(role_cap)
-                .or(engine.max_output_tokens),
+            max_output_tokens,
             temperature: overrides.temperature.or(engine.temperature),
-            effort: overrides.effort.or(role_effort).or(engine.effort),
+            effort: overrides
+                .effort
+                .or(management_bounds(role).1)
+                .or(engine.effort),
             reasoning: overrides.reasoning.or(engine.reasoning),
             params: overrides.params.or(engine.params),
             tools: Vec::new(),
         };
+        let result = self
+            .dispatch_raw(
+                &call_meta(role, resolved),
+                request(messages, cap),
+                policy,
+                timeout,
+                estimated_input_tokens,
+                budget,
+                total,
+            )
+            .await?;
+        // A provider that stopped at the token limit with nothing visible to
+        // show for it has stated that the budget ran out before the first
+        // answer token — the #2128 signature. Every other outcome returns
+        // here unchanged.
+        let Some(raised) = starved_of_output(&result)
+            .then(|| starved_retry_cap(cap))
+            .flatten()
+        else {
+            return Ok(result);
+        };
+        let Some(messages) = retry_messages else {
+            return Ok(result);
+        };
+        // Loud, never silent: before this, an empty triage collapsed the
+        // research/plan/scope/witness stages to defaults that read like
+        // decisions, and an empty verdict degraded to the heuristic — both
+        // with nothing in the transcript naming the cause.
+        self.warn(format!(
+            "the {role:?} call returned no output: it stopped at its {} token limit with an \
+             empty response, which on a reasoning model means the whole budget went to \
+             reasoning. Retrying once at {raised}.",
+            cap.map_or_else(|| "(unset)".to_string(), |c| c.to_string()),
+        ));
+        let retried = self
+            .dispatch_raw(
+                &call_meta(role, resolved),
+                request(messages, Some(raised)),
+                RetryPolicy::deterministic(),
+                timeout,
+                estimated_input_tokens,
+                budget,
+                total,
+            )
+            .await?;
+        // The retry's own emptiness is not worth a third call, but it IS
+        // worth saying: the caller is about to take a degraded path, and this
+        // is the only place that knows why.
+        if starved_of_output(&retried) {
+            self.warn(format!(
+                "the {role:?} retry at {raised} tokens returned no output either; this call's \
+                 result is unusable and the stage will take its degraded path"
+            ));
+        }
+        Ok(retried)
+    }
+
+    /// One metered dispatch: everything [`Pipeline::metered_raw_call`] does
+    /// per attempt, so its starvation retry (#2128) re-sends through exactly
+    /// the same accounting seam the first attempt used. Both attempts are
+    /// real paid calls and each emits its own `StepUsage`, which is the
+    /// honest record — the retry is not free and the telemetry must not
+    /// imply it was.
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_raw(
+        &self,
+        meta: &RawCallMeta<'_>,
+        request: CompletionRequest,
+        retry_policy: RetryPolicy,
+        timeout: Option<Duration>,
+        estimated_input_tokens: u64,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Result<CompletionResult, RawCallError> {
         match run_accounted_call(
             AccountedCall {
-                provider: resolved.provider,
-                role,
-                model_hint: resolved.model_ref.model_id.clone(),
-                request: req,
-                retry_policy: policy,
+                provider: meta.provider,
+                role: meta.role,
+                model_hint: meta.model_id.to_string(),
+                request,
+                retry_policy,
                 timeout,
                 estimated_input_tokens,
                 // Management roles assemble their own prompts — the role's task
@@ -170,7 +338,7 @@ impl<'a> Pipeline<'a> {
                     call_seq: self.raw_call_seq.fetch_add(1, Ordering::Relaxed),
                     // Phase 2 (#713): a management role rides the session's
                     // engine config, so it inherits the same lifecycle switch.
-                    lifecycle_enabled: engine.lifecycle_enabled,
+                    lifecycle_enabled: self.config.engine.lifecycle_enabled,
                 }),
             },
             budget,
@@ -192,5 +360,23 @@ impl<'a> Pipeline<'a> {
                 ))
             }
         }
+    }
+}
+
+/// The routing facts both attempts of a [`Pipeline::metered_raw_call`] share.
+/// Borrowed rather than cloned per attempt: the retry sends to the same
+/// resolved provider and model, and re-resolving could silently retry
+/// somewhere else.
+struct RawCallMeta<'r> {
+    role: ModelCallRole,
+    provider: &'r dyn stella_protocol::Provider,
+    model_id: &'r str,
+}
+
+fn call_meta<'r>(role: ModelCallRole, resolved: &'r ResolvedRole<'_>) -> RawCallMeta<'r> {
+    RawCallMeta {
+        role,
+        provider: resolved.provider,
+        model_id: &resolved.model_ref.model_id,
     }
 }

--- a/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
@@ -306,6 +306,59 @@ async fn gate_a_no_op_turn_fails_closed_without_spend() {
     .await;
 }
 
+/// #2128 witness: a reasoning model that spends its whole output cap on
+/// reasoning returns `finish_reason: length` with empty text. That response
+/// carries no verdict token, so before this the verdict silently degraded to
+/// the heuristic and — with no flip to rescue it — failed a candidate no
+/// model had actually judged. Now the starvation signature buys ONE retry at
+/// a raised cap, and the retried verdict is the one that decides.
+///
+/// The extra `Verdict` in `roles` is the point of pinning it here: the retry
+/// is a real paid call and this gate is where spend changes get argued.
+#[tokio::test]
+async fn gate_a_starved_verdict_call_is_retried_rather_than_degraded() {
+    run_scenario(Scenario {
+        name: "starved_verdict",
+        goal: "Fix the failing test",
+        provider: vec![
+            text_result("single"),
+            text_result("done"),
+            starved_result(),
+            text_result("PASS — change is consistent with the goal"),
+        ],
+        // A timed-out baseline: no flip is ever armed, so the ladder is
+        // inconclusive and escalates — the exact shape that made an empty
+        // verdict decide the run.
+        tests: vec![TestScript::TimeOut, TestScript::Pass],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: None,
+        test_command: Some("cargo test -p x"),
+        // Zero, so the failing heuristic this test refutes cannot be masked
+        // by a revision loop: on the old code the run ends `passed: false`
+        // on three calls.
+        max_revisions: 0,
+        expect: Expect {
+            passed: true,
+            deterministic: false,
+            verifier_stage: true,
+            roles: &[Triage, Worker, Verdict, Verdict],
+            test_runs: 2,
+        },
+    })
+    .await;
+}
+
+/// The cap-starvation signature (#2128): the provider stopped at the token
+/// limit having emitted nothing. On a reasoning model this is what a role cap
+/// sized for the visible output contract produces — the reasoning stream
+/// bills against the same budget.
+fn starved_result() -> CompletionResult {
+    CompletionResult {
+        finish_reason: Some(FinishReason::Length),
+        ..text_result("")
+    }
+}
+
 /// Fix-by-disappearance (#867): the baseline names its failing test, the
 /// candidate's suite passes with a complete listing that no longer contains
 /// it (deleted/renamed). The exit code says flip; the same-failure rule says
@@ -344,4 +397,149 @@ async fn gate_a_vanished_failing_test_earns_no_flip() {
         },
     })
     .await;
+}
+
+/// A tool registry advertising only `verify_done`, whose result carries the
+/// confirmed-witness marker the real tool prints
+/// (`stella-tools/src/verify.rs`). Mutating like the real one, so a turn that
+/// calls it is never written off as a no-op.
+struct ConfirmingVerifyDone;
+
+#[async_trait]
+impl ToolExecutor for ConfirmingVerifyDone {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "verify_done".into(),
+            description: "prove the change with a witness test".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: "WITNESS CONFIRMED — deterministic definition of done met:\n\
+                      - new code:      `pytest -q` exit 0 (PASS)\n\
+                      - previous code: baseline abc1234 (pinned) → exit 1 (FAIL)"
+                .into(),
+        }
+    }
+}
+
+/// One completion that calls `verify_done` and nothing else.
+fn verify_done_call() -> CompletionResult {
+    CompletionResult {
+        tool_calls: vec![ToolCall {
+            call_id: "verify-1".into(),
+            name: "verify_done".into(),
+            input: serde_json::json!({}),
+        }],
+        ..text_result("")
+    }
+}
+
+/// #2129 witness: the worker's own `verify_done` run confirmed a genuine
+/// baseline-pinned fail→pass flip, and the verdict model then answered
+/// without a verdict token — degrading to the heuristic. The heuristic used
+/// to read only the pipeline's own flip oracle, which tracks a different
+/// command, so it asserted "no flip" over a trace that literally contained
+/// `WITNESS CONFIRMED` and re-opened finished work: in match
+/// `cc00894779ff`'s `extract-elf` trial that cost 780s of 1022s reworking a
+/// task already proven done.
+///
+/// A `verify_done` confirmation is a deterministic tool observation, not
+/// another model's opinion, so it must survive a verifier outage exactly the
+/// way the oracle's own flip does (#1788).
+#[tokio::test]
+async fn a_confirmed_verify_done_flip_survives_a_degraded_verdict() {
+    // triage; worker calls verify_done; worker finishes; a verdict reply
+    // carrying no PASS/FAIL token, which is what degrades to the heuristic.
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        verify_done_call(),
+        text_result("done — the witness proves it"),
+        text_result("Here is my assessment of the change."),
+    ]);
+    let resolver = OneProvider(&provider);
+    // Both observations time out: no flip is armed and no touched test is
+    // ever confirmed green, so the heuristic has nothing BUT the
+    // `verify_done` confirmation to stand on.
+    let runner = ScriptedRunner::scripted(
+        vec![TestScript::TimeOut, TestScript::TimeOut],
+        "@@ -1 +1 @@\n-old\n+new",
+    );
+    let tools = ConfirmingVerifyDone;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        max_revisions: 0,
+        distress_guidance: false,
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Extract the ELF payload", &mut messages, &mut budget)
+        .await
+        .expect("the run reaches a verdict");
+
+    assert!(
+        matches!(outcome.status, PipelineStatus::Completed { .. }),
+        "a confirmed verify_done flip must survive the verifier outage that \
+         re-opened this exact shape; got {:?}",
+        outcome.status
+    );
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(verdict.passed, "the heuristic must credit the confirmation");
+    assert!(
+        verdict.summary.contains("verify_done"),
+        "the evidence must name what it credited, so a reader can audit it: {}",
+        verdict.summary
+    );
+
+    // The degradation really happened — without this, a run that somehow
+    // never escalated would satisfy the assertions above for the wrong
+    // reason.
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Proof {
+                step: ProofStep::VerdictDegraded { .. }
+            }
+        )),
+        "the verdict degraded to the heuristic; that is the state under test"
+    );
 }

--- a/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
@@ -517,7 +517,7 @@ async fn a_confirmed_verify_done_flip_survives_a_degraded_verdict() {
         .expect("the run reaches a verdict");
 
     assert!(
-        matches!(outcome.status, PipelineStatus::Completed { .. }),
+        matches!(outcome.status, PipelineStatus::Completed),
         "a confirmed verify_done flip must survive the verifier outage that \
          re-opened this exact shape; got {:?}",
         outcome.status

--- a/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs
@@ -19,6 +19,7 @@
 
 use super::verification_hardening::{ScriptedLint, lint_error};
 use super::*;
+use stella_protocol::FinishReason;
 
 /// What one scenario pins. `roles` is the full ordered model-call sequence
 /// (from `StepManifest` events) — order matters, because "verifier before

--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -529,6 +529,13 @@ impl Provider for BoundsProvider {
 /// full ceiling once the CLI seeds it) and an unset effort, which leaves the
 /// provider's default (high) reasoning allowance burning thinking tokens on a
 /// classification. The chokepoint must pin the bounded shape instead.
+///
+/// The wire number is that three-line output contract (512) PLUS the
+/// reasoning headroom every capped role now carries (#2128). The bare
+/// contract was what shipped, and on a reasoning model it is a cap spent
+/// entirely on thinking: across match `cc00894779ff` every triage call
+/// returned `finish_reason: length` with empty text, silently collapsing the
+/// research/plan/scope/witness stages onto their defaults.
 #[tokio::test]
 async fn triage_dispatches_with_pinned_management_bounds() {
     let provider = BoundsProvider::new(vec![text_result("single")]);
@@ -576,9 +583,10 @@ async fn triage_dispatches_with_pinned_management_bounds() {
 
     assert_eq!(
         provider.bounds(),
-        vec![(Some(512), Some(stella_protocol::ReasoningEffort::Low))],
-        "the triage dispatch must carry the pinned management bounds, not \
-         fall through to the worker-tier allowance"
+        vec![(Some(4608), Some(stella_protocol::ReasoningEffort::Low))],
+        "the triage dispatch must carry the pinned management bounds — its \
+         512-token output contract plus reasoning headroom — and neither fall \
+         through to the worker-tier allowance nor starve a reasoning model"
     );
 }
 

--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -267,7 +267,7 @@ async fn late_verdict_is_abandoned_and_falls_back_to_the_heuristic() {
 
     let verdict = pipeline
         .verifier(
-            &mut super::super::verifier_stage::VerdictDegradation::new(1),
+            &super::super::verifier_stage::VerdictDegradation::new(1),
             prompt,
             &inputs,
             &mut Spend {

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/verdict_degraded_facts.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/verdict_degraded_facts.rs
@@ -73,12 +73,21 @@ async fn a_two_candidate_fanout_records_which_candidates_degraded() {
     );
 }
 
-/// #1787 witness, dedup half: ONE candidate whose escalation hits the same
-/// non-compliant verifier on the first round AND on the revision records its
-/// degradation fact exactly once — per candidate, not per round (the ladder
-/// rung already counts rounds).
+/// #2129 witness, replacing #1787's dedup half: ONE candidate whose
+/// escalation hits the same non-compliant verifier on the first round AND on
+/// the revision records a degradation fact for EACH — the proof stream is a
+/// record of what happened, not a notice to a reader, and aggregate
+/// telemetry counts its rows.
+///
+/// #1787 deduplicated this per candidate on the reasoning that the fact does
+/// not change between rounds. It does not, but its *incidence* does, and
+/// that turned out to be the number that mattered: in match `cc00894779ff`
+/// the `extract-elf` trial degraded twice and emitted one proof event, so
+/// round 2 was invisible to everything reading the stream. The once-per-run
+/// prose warning is what keeps the transcript from repeating itself — that
+/// half of #1787 is unchanged, and asserted below.
 #[tokio::test]
-async fn a_candidate_degrading_on_every_round_records_one_fact() {
+async fn a_candidate_degrading_on_every_round_records_a_fact_per_occurrence() {
     // triage; worker; tokenless verdict; revision turn; tokenless verdict.
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
@@ -147,8 +156,8 @@ async fn a_candidate_degrading_on_every_round_records_one_fact() {
     );
 
     // Both scripted verdict calls were really made — without this, a run that
-    // never reached the second escalation would pass the one-fact assertion
-    // below for the wrong reason.
+    // never reached the second escalation would pass the per-occurrence
+    // assertion below for the wrong reason.
     assert_eq!(
         provider.prompts().len(),
         5,
@@ -167,7 +176,19 @@ async fn a_candidate_degrading_on_every_round_records_one_fact() {
         .collect();
     assert_eq!(
         facts,
-        vec![1],
-        "two degraded rounds, one candidate, one fact"
+        vec![1, 1],
+        "two degraded rounds, one candidate, one fact EACH — both keyed to \
+         that candidate's ordinal"
+    );
+    let warnings = events
+        .iter()
+        .filter(|event| {
+            matches!(event, AgentEvent::Error { message, .. }
+                if message.contains("falls back to a deterministic heuristic"))
+        })
+        .count();
+    assert_eq!(
+        warnings, 1,
+        "the prose warning still fires once per run — #1787's other half"
     );
 }

--- a/crates/stella-pipeline/src/pipeline/verifier_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/verifier_stage.rs
@@ -26,27 +26,24 @@ pub(super) struct VerifierNotices {
 }
 
 /// One candidate's verdict-degradation record: its ordinal (1-based,
-/// [`ProofStep::Oracle`]'s `run` convention) and whether the degradation fact
-/// has been emitted yet.
+/// [`ProofStep::Oracle`]'s `run` convention).
 ///
-/// Per candidate rather than per run, because a best-of-N fan-out degrading N
-/// times used to leave one prose caveat and no record of *which* candidates
-/// the heuristic judged (#1787) — and per candidate rather than per round,
-/// because the escalation loop can hit the same dead verifier on every
-/// revision and the fact does not change. Plain candidate-local state, never
-/// a shared flag: candidates run concurrently, and resetting a run-wide flag
-/// at candidate boundaries would race.
+/// Per candidate, because a best-of-N fan-out degrading N times used to
+/// leave one prose caveat and no record of *which* candidates the heuristic
+/// judged (#1787). The proof fact itself is emitted per OCCURRENCE, not once
+/// per candidate (#2129): deduplicating it made a round-2 degradation
+/// invisible in aggregate telemetry — an `extract-elf` trace held two
+/// degraded verdicts and one proof event — and unlike the prose warning
+/// below, a proof stream is a record of what happened, not a notice to a
+/// reader. Plain candidate-local state, never a shared flag: candidates run
+/// concurrently.
 pub(super) struct VerdictDegradation {
     candidate: u32,
-    recorded: bool,
 }
 
 impl VerdictDegradation {
     pub(super) fn new(candidate: u32) -> Self {
-        Self {
-            candidate,
-            recorded: false,
-        }
+        Self { candidate }
     }
 }
 
@@ -115,7 +112,7 @@ impl<'a> Pipeline<'a> {
     /// call can fail.
     pub(super) async fn verifier(
         &self,
-        degradation: &mut VerdictDegradation,
+        degradation: &VerdictDegradation,
         prompt: ManagementPrompt,
         inputs: &LadderInputs,
         spend: &mut Spend<'_>,
@@ -214,11 +211,12 @@ impl<'a> Pipeline<'a> {
     /// prose warning once per run, like the caveat above, because the
     /// escalation loop can hit the same dead verifier several times and the
     /// transcript needs the fact, not an echo; and the structured
-    /// [`ProofStep::VerdictDegraded`] fact once per candidate, because the
-    /// run-wide warning cannot say *which* of a fan-out's candidates the
-    /// heuristic judged (#1787). The ladder rung (`HeuristicFallback`)
-    /// records *that* it happened on every round either way.
-    fn warn_verifier_fallback(&self, degradation: &mut VerdictDegradation, why: &str) {
+    /// [`ProofStep::VerdictDegraded`] fact on EVERY occurrence, carrying the
+    /// candidate ordinal the run-wide warning cannot (#1787). Per occurrence
+    /// rather than per candidate (#2129): the proof stream is the record
+    /// aggregate telemetry reads, and deduplicating it hid every degradation
+    /// after a candidate's first.
+    fn warn_verifier_fallback(&self, degradation: &VerdictDegradation, why: &str) {
         if !self
             .verifier_notices
             .fallback_warned
@@ -229,12 +227,9 @@ impl<'a> Pipeline<'a> {
                  falls back to a deterministic heuristic"
             ));
         }
-        if !degradation.recorded {
-            degradation.recorded = true;
-            self.emit_proof(ProofStep::VerdictDegraded {
-                candidate: degradation.candidate,
-                reason: why.to_string(),
-            });
-        }
+        self.emit_proof(ProofStep::VerdictDegraded {
+            candidate: degradation.candidate,
+            reason: why.to_string(),
+        });
     }
 }

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -443,13 +443,17 @@ pub struct LadderInputs {
     /// own command; before this field, a confirmed `verify_done` flip and a
     /// failing "no flip" fallback verdict coexisted in one trace.
     pub verify_done_flip: bool,
-    /// Whether a tracked test command even existed this round (configured
-    /// `--test-command` or an authored witness). Configuration, not evidence,
-    /// like [`Self::veto_warnings`]: when `false`, "no flip" is a demand the
-    /// task structurally cannot meet (#2129 — a one-line `answer.txt`
-    /// deliverable has no tests to flip), and the fallback must not read the
-    /// absence as failure.
-    pub flip_evidence_obtainable: bool,
+    /// Positive claim that this round had NO tracked test command at all —
+    /// neither a configured `--test-command` nor an authored witness — so
+    /// "no flip" is a demand the task structurally cannot meet (#2129: a
+    /// one-line `answer.txt` deliverable has no tests to flip).
+    ///
+    /// Configuration, not evidence, like [`Self::veto_warnings`]. Phrased as
+    /// the *dispensation* rather than the capability so `Default` denies it:
+    /// this is the one field that can turn a fallback FAIL into an
+    /// abstention, and a caller that forgets to set it must get the
+    /// conservative answer, never the permissive one.
+    pub no_test_surface: bool,
 }
 
 impl LadderInputs {
@@ -1030,7 +1034,7 @@ pub fn heuristic_fallback(inputs: &LadderInputs) -> Verdict {
     // The abstention requires positive work signals: reaching this fallback
     // already means the ladder found the turn observable, but the guard keeps
     // this function honest as a pure value — all-dark inputs still FAIL.
-    let unmeetable_demand = !inputs.flip_evidence_obtainable
+    let unmeetable_demand = inputs.no_test_surface
         && (inputs.diff_lines > 0 || inputs.file_change_events > 0 || inputs.mutating_actions > 0);
     let passed = inputs.flip_achieved
         || inputs.verify_done_flip

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -436,6 +436,20 @@ pub struct LadderInputs {
     /// Carried here so the ladder stays a pure function of one input value,
     /// exactly like [`Self::veto_warnings`].
     pub require_diff_coverage: bool,
+    /// The worker's own `verify_done` tool run printed `WITNESS CONFIRMED`
+    /// this candidate (#2129): a deterministic fail-on-baseline / pass-on-new
+    /// shadow run, observed off the turn's `ToolResult` stream. Distinct from
+    /// [`Self::flip_achieved`] because the pipeline's oracle tracks only its
+    /// own command; before this field, a confirmed `verify_done` flip and a
+    /// failing "no flip" fallback verdict coexisted in one trace.
+    pub verify_done_flip: bool,
+    /// Whether a tracked test command even existed this round (configured
+    /// `--test-command` or an authored witness). Configuration, not evidence,
+    /// like [`Self::veto_warnings`]: when `false`, "no flip" is a demand the
+    /// task structurally cannot meet (#2129 — a one-line `answer.txt`
+    /// deliverable has no tests to flip), and the fallback must not read the
+    /// absence as failure.
+    pub flip_evidence_obtainable: bool,
 }
 
 impl LadderInputs {
@@ -483,8 +497,14 @@ impl LadderInputs {
     /// is scored **unverified**, never failed: a run is not broken by the
     /// absence of a way to check it, and a Terminal-Bench trial that scored
     /// 1.0 against its own verifier has taken exactly this path.
+    ///
+    /// A worker-run `verify_done` confirmation counts as corroboration
+    /// (#2129): it is a deterministic tool observation — the witness failed
+    /// on the pinned baseline and passed on the change — not another model's
+    /// opinion, which is exactly the class of evidence this predicate exists
+    /// to demand.
     pub fn verifier_pass_stands_alone(&self) -> bool {
-        !self.flip_achieved && self.touched_tests_passed != Some(true)
+        !self.flip_achieved && self.touched_tests_passed != Some(true) && !self.verify_done_flip
     }
 
     /// Whether this turn provably did nothing: it dispatched no call that
@@ -994,16 +1014,41 @@ pub fn bound_forwarded_reasoning(text: &str) -> String {
 /// refutation, and it must not outrank the strongest deterministic evidence
 /// this crate has. Before this, a candidate whose flip was confirmed but
 /// whose diff ran over budget (routing it to the model verifier) was driven
-/// to `VerificationFailed` by a provider being down. With neither flip nor
-/// green tests the fallback still fails closed: the escalation existed
-/// because something was genuinely inconclusive, and a revision is the
-/// honest next move.
+/// to `VerificationFailed` by a provider being down. A worker-run
+/// `verify_done` confirmation is the same class of evidence and counts the
+/// same way (#2129): the oracle tracks only its own command, so before this
+/// a trace held `WITNESS CONFIRMED` and a failing "no flip" fallback verdict
+/// at once. With neither flip nor green tests the fallback still fails
+/// closed — **unless no tracked test command exists at all** (#2129): "no
+/// flip" is then a demand the task structurally cannot meet, and over a turn
+/// that produced observable work the fallback abstains upward instead
+/// (`passed: true` with nothing deterministic behind it, which
+/// [`LadderInputs::verifier_pass_stands_alone`] downgrades to an
+/// **unverified** score downstream — never a full pass). Failing that shape
+/// re-opened cleanly finished non-code tasks into loop-kills and timeouts.
 pub fn heuristic_fallback(inputs: &LadderInputs) -> Verdict {
-    let passed = inputs.flip_achieved || inputs.touched_tests_passed == Some(true);
+    // The abstention requires positive work signals: reaching this fallback
+    // already means the ladder found the turn observable, but the guard keeps
+    // this function honest as a pure value — all-dark inputs still FAIL.
+    let unmeetable_demand = !inputs.flip_evidence_obtainable
+        && (inputs.diff_lines > 0 || inputs.file_change_events > 0 || inputs.mutating_actions > 0);
+    let passed = inputs.flip_achieved
+        || inputs.verify_done_flip
+        || inputs.touched_tests_passed == Some(true)
+        || unmeetable_demand;
     let reasoning = if inputs.flip_achieved {
         "verifier unavailable; heuristic fallback passed on the observed fail→pass flip".to_string()
-    } else if passed {
+    } else if inputs.verify_done_flip {
+        "verifier unavailable; heuristic fallback passed on the worker's verify_done \
+         confirmation (witness failed on the pinned baseline, passed on the change)"
+            .to_string()
+    } else if inputs.touched_tests_passed == Some(true) {
         "verifier unavailable; heuristic fallback passed on green touched tests".to_string()
+    } else if passed {
+        "verifier unavailable; no tracked test command exists, so flip evidence is \
+         structurally unobtainable for this task — abstaining on the turn's observed \
+         work rather than failing it (scored unverified downstream)"
+            .to_string()
     } else {
         "verifier unavailable; heuristic fallback failed (no flip, touched tests not \
          confirmed green)"

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -741,6 +741,111 @@ fn heuristic_fallback_passes_only_on_confirmed_green_tests() {
     );
 }
 
+/// #2129 witness, first half: a `verify_done` confirmation is deterministic
+/// tool evidence and must rescue the fallback exactly as the oracle's own
+/// flip does (#1788). The oracle tracks only its own command, so a run whose
+/// witness was proven by the worker's `verify_done` call had
+/// `flip_achieved: false` and a `WITNESS CONFIRMED` tool result in the same
+/// trace — and the fallback failed it.
+#[test]
+fn a_verify_done_confirmation_rescues_the_fallback_like_a_flip() {
+    let confirmed = heuristic_fallback(&LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        verify_done_flip: true,
+        flip_evidence_obtainable: true,
+        diff_lines: 5,
+        diff_budget: 100,
+        diff_available: true,
+        mutating_actions: 1,
+        ..Default::default()
+    });
+    assert!(
+        confirmed.passed,
+        "a proven baseline-pinned flip must survive a verifier outage"
+    );
+    assert!(
+        confirmed.reasoning.contains("verify_done"),
+        "the reason must name the evidence it credited: {}",
+        confirmed.reasoning
+    );
+    // The same inputs without the confirmation are the pre-existing FAIL —
+    // this is what makes the assertion above about the new channel and not
+    // about some other relaxation.
+    assert!(
+        !heuristic_fallback(&LadderInputs {
+            verify_done_flip: false,
+            flip_evidence_obtainable: true,
+            diff_lines: 5,
+            diff_budget: 100,
+            diff_available: true,
+            mutating_actions: 1,
+            ..Default::default()
+        })
+        .passed
+    );
+}
+
+/// #2129 witness, second half: when no tracked test command exists at all,
+/// "no flip" is a demand the task structurally cannot meet, and failing on it
+/// is a verdict about the pipeline's own instrumentation rather than about
+/// the work.
+///
+/// The shape is `count-dataset-tokens`: the deliverable is a one-line
+/// `answer.txt`, there is nothing to flip, the worker solved it and stopped
+/// cleanly — and a degraded verdict re-opened execution and burned 45% of the
+/// trial re-deriving an answer that never changed.
+///
+/// The abstention is upward but NOT a full pass:
+/// [`LadderInputs::verifier_pass_stands_alone`] still holds over these
+/// inputs, so the caller scores the candidate `Unverified`.
+#[test]
+fn an_unobtainable_flip_demand_abstains_instead_of_failing() {
+    let no_test_surface = LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        flip_evidence_obtainable: false,
+        diff_lines: 3,
+        diff_budget: 100,
+        diff_available: true,
+        mutating_actions: 2,
+        ..Default::default()
+    };
+    let verdict = heuristic_fallback(&no_test_surface);
+    assert!(
+        verdict.passed,
+        "a demand the task cannot meet must not read as the task failing"
+    );
+    assert!(
+        verdict.reasoning.contains("structurally unobtainable"),
+        "the reason must say WHY it abstained, not just that it passed: {}",
+        verdict.reasoning
+    );
+    assert!(
+        no_test_surface.verifier_pass_stands_alone(),
+        "nothing deterministic backs this, so it scores unverified downstream"
+    );
+
+    // With a tracked command available, the same all-dark evidence is a
+    // genuine failure to produce what the task COULD have produced.
+    assert!(
+        !heuristic_fallback(&LadderInputs {
+            flip_evidence_obtainable: true,
+            ..no_test_surface
+        })
+        .passed
+    );
+    // And the abstention needs observed work: an all-quiet turn with no
+    // command still fails closed rather than passing on emptiness.
+    assert!(
+        !heuristic_fallback(&LadderInputs {
+            flip_evidence_obtainable: false,
+            ..LadderInputs::default()
+        })
+        .passed
+    );
+}
+
 #[test]
 fn evidence_builders_tag_determinism_correctly() {
     assert!(

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -753,7 +753,6 @@ fn a_verify_done_confirmation_rescues_the_fallback_like_a_flip() {
         flip_achieved: false,
         touched_tests_passed: None,
         verify_done_flip: true,
-        flip_evidence_obtainable: true,
         diff_lines: 5,
         diff_budget: 100,
         diff_available: true,
@@ -775,7 +774,6 @@ fn a_verify_done_confirmation_rescues_the_fallback_like_a_flip() {
     assert!(
         !heuristic_fallback(&LadderInputs {
             verify_done_flip: false,
-            flip_evidence_obtainable: true,
             diff_lines: 5,
             diff_budget: 100,
             diff_available: true,
@@ -801,17 +799,17 @@ fn a_verify_done_confirmation_rescues_the_fallback_like_a_flip() {
 /// inputs, so the caller scores the candidate `Unverified`.
 #[test]
 fn an_unobtainable_flip_demand_abstains_instead_of_failing() {
-    let no_test_surface = LadderInputs {
+    let untestable = LadderInputs {
         flip_achieved: false,
         touched_tests_passed: None,
-        flip_evidence_obtainable: false,
+        no_test_surface: true,
         diff_lines: 3,
         diff_budget: 100,
         diff_available: true,
         mutating_actions: 2,
         ..Default::default()
     };
-    let verdict = heuristic_fallback(&no_test_surface);
+    let verdict = heuristic_fallback(&untestable);
     assert!(
         verdict.passed,
         "a demand the task cannot meet must not read as the task failing"
@@ -822,7 +820,7 @@ fn an_unobtainable_flip_demand_abstains_instead_of_failing() {
         verdict.reasoning
     );
     assert!(
-        no_test_surface.verifier_pass_stands_alone(),
+        untestable.verifier_pass_stands_alone(),
         "nothing deterministic backs this, so it scores unverified downstream"
     );
 
@@ -830,8 +828,8 @@ fn an_unobtainable_flip_demand_abstains_instead_of_failing() {
     // genuine failure to produce what the task COULD have produced.
     assert!(
         !heuristic_fallback(&LadderInputs {
-            flip_evidence_obtainable: true,
-            ..no_test_surface
+            no_test_surface: false,
+            ..untestable
         })
         .passed
     );
@@ -839,11 +837,15 @@ fn an_unobtainable_flip_demand_abstains_instead_of_failing() {
     // command still fails closed rather than passing on emptiness.
     assert!(
         !heuristic_fallback(&LadderInputs {
-            flip_evidence_obtainable: false,
+            no_test_surface: true,
             ..LadderInputs::default()
         })
         .passed
     );
+    // The dispensation is opt-in by construction: the all-dark default must
+    // never be the permissive input, because a caller that forgets this
+    // field would then silently buy an abstention.
+    assert!(!LadderInputs::default().no_test_surface);
 }
 
 #[test]

--- a/crates/stella-pipeline/src/witness/warrant.rs
+++ b/crates/stella-pipeline/src/witness/warrant.rs
@@ -200,6 +200,13 @@ pub struct ChangeSignals {
     /// the diff fully explains, and an opaque call is by definition something
     /// it does not.
     pub opaque_actions: u32,
+    /// `verify_done` tool runs this turn whose result printed
+    /// `WITNESS CONFIRMED` — a deterministic fail-on-baseline / pass-on-new
+    /// shadow observation made by the worker's own tool call (#2129). Counted
+    /// off the `ToolResult` stream, so like every field here it records what
+    /// the turn *did*; the ladder reads it as flip evidence the pipeline's
+    /// own oracle (which tracks only its own command) cannot see.
+    pub verify_done_confirmations: u32,
 }
 
 /// Whether a *mutating* tool call's effects are fully accountable to the


### PR DESCRIPTION
Two coupled defects from match `cc00894779ff` (the pipeline self-sabotage cluster, #2127–#2135). The first starves every management role call of visible output; the second turns the resulting silence into a failing verdict against work that was already finished. Together they, not the worker model, produced that match's timeouts.

## #2128 — role calls enable reasoning but cap output below the reasoning budget

`max_output_tokens` is one number on the wire, and reasoning models bill their reasoning stream against it. The role caps were sized for each role's *written output contract* (triage 512, verdict 1024), so on a reasoning model the whole budget went to thinking: across that match **every** triage and verdict call returned `finish_reason: length` with `output_text: ""`, reasoning tokens at or above the cap in each one.

Two changes, prevention and guarantee:

- **Headroom.** `management_bounds` still names each role's visible-output contract; `role_output_cap` adds `REASONING_HEADROOM_TOKENS` (4,096) on top. Triage now reaches the wire at 4,608 rather than 512 — still an order of magnitude under the 64k engine base, so a runaway role call stays bounded. An operator's explicit `max_output_tokens` override is **not** widened: it is the most specific statement about the call, and quietly serving a bigger number would make the setting a suggestion.
- **The retry, which is the actual guarantee.** The headroom is a heuristic — no posture axis reports a model's reasoning budget, and the comment says so. So `metered_raw_call` now detects the starvation signature on the wire (empty text **and** `finish_reason: length` — both halves required) and retries once at 32,768, emitting a warning naming the cap. If the retry is also empty, that gets its own warning: the caller is about to take a degraded path and this is the only place that knows why. Previously an empty triage silently collapsed research/plan/scope/witness onto defaults that read like decisions.

Both attempts are real paid calls and each emits its own `StepUsage`; the shared dispatch was factored into `Pipeline::dispatch_raw` so the retry rides exactly the accounting seam the first attempt used.

## #2129 — a degraded verdict re-opens cleanly finished work

Three defects, all fixed:

1. **The fallback ignored `verify_done`.** The flip oracle tracks only its own command, so a run whose witness the worker proved with `verify_done` had `flip_achieved: false` and a `WITNESS CONFIRMED` tool result in the same trace — and the heuristic failed it. The execute-stage event filter now tallies `verify_done` calls whose result *starts with* the confirmed marker (name and marker both required: the name alone could be shadowed by an MCP tool, the marker alone echoed by a shell call), and that reaches the ladder as `LadderInputs::verify_done_flip`. It rescues the fallback exactly as the oracle's own flip does (#1788) and counts as corroboration in `verifier_pass_stands_alone` — it is a deterministic tool observation, not another model's opinion.
2. **The heuristic demanded evidence non-code tasks cannot produce.** With no tracked test command at all, "no flip" is unmeetable — the `count-dataset-tokens` shape, where the deliverable is a one-line `answer.txt`. The fallback now abstains upward over a turn with observed work instead of failing. It is **not** a full pass: `verifier_pass_stands_alone` still holds, so the caller scores it `Unverified`. The field is spelled `no_test_surface` (the dispensation) rather than `flip_evidence_obtainable` (the capability) specifically so `Default` denies it — this is the one input that can turn a FAIL into an abstention, and a caller that forgets it must get the conservative answer. A test pins that default.
3. **Degradation was under-reported.** `ProofStep::VerdictDegraded` now fires per occurrence rather than once per candidate. #1787 deduplicated it on the reasoning that the fact does not change between rounds — true, but its *incidence* does, and that was the number that mattered: `extract-elf` degraded twice and emitted one event, so round 2 was invisible to aggregate telemetry. The once-per-run **prose warning** is unchanged; that half of #1787 still holds and is now asserted alongside.

## Witness tests

Two behavioral witnesses in `pipeline/tests/degradation_gate.rs`, both verified to fail on the base commit by restoring every source file to `68e9f25f` and keeping only the tests:

- `gate_a_starved_verdict_call_is_retried_rather_than_degraded` — old code: `roles == [Triage, Worker, Verdict]`, no retry, `passed: false`. New: `[Triage, Worker, Verdict, Verdict]`, `passed: true`. Pinned in the degradation gate because the retry is real spend.
- `a_confirmed_verify_done_flip_survives_a_degraded_verdict` — old code returns `VerificationFailed` carrying the issue's verbatim string, `"verifier unavailable; heuristic fallback failed (no flip, touched tests not confirmed green)"`. New code completes and the evidence names `verify_done`.

Plus pure-function witnesses in `verify/tests.rs` (both fallback changes, each with the negative control showing the pre-existing FAIL still fails) and unit tests in `raw_usage.rs` for the cap arithmetic, the override, the starvation signature's two required halves, and the retry's decline condition.

## Test expectations updated (intended behavior changes)

- `triage_dispatches_with_pinned_management_bounds`: `Some(512)` → `Some(4608)`. This is #2128's prevention half stated as a reviewable line.
- `a_candidate_degrading_on_every_round_records_one_fact` → **renamed** to `a_candidate_degrading_on_every_round_records_a_fact_per_occurrence`, and its assertion inverted from `vec![1]` to `vec![1, 1]`. Naming the rename explicitly for the deleted-test guard: no test was removed, one was renamed and re-aimed, and it now also asserts the prose warning stays at one.

## Verification

`cargo test -p stella-pipeline` (622 lib + 22 integration, all green), `cargo clippy -p stella-pipeline --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, `check-file-size` and `check-left-behind` pass. Rebased onto `ba728985`; took main's `verification_hardening` split (#2170) and re-applied the per-occurrence pin in its new home, `verification_hardening/verdict_degraded_facts.rs`.

## Left behind

`LadderSnapshot` does not yet carry `verify_done_flip` / `no_test_surface`, so the two new channels steer the verdict without appearing in the replay projection. Filed as a follow-up — it is a `stella-protocol` wire change needing schema regeneration, which does not belong in this PR.

Closes #2128
Closes #2129

## Summary by Sourcery

Adjust management role output caps and add a starvation-aware retry for reasoning model calls, and ensure heuristic verdict fallback correctly credits verify_done confirmations, abstains when flip evidence is unobtainable, and reports verdict degradation accurately.

New Features:
- Introduce a starvation detection and single-retry mechanism for management role completions that return no visible output due to token limits.
- Track verify_done tool confirmations and surface them to the verification ladder as deterministic flip evidence.
- Add configuration to mark tasks with no test surface so the verifier can abstain rather than fail when flip evidence cannot exist.

Bug Fixes:
- Prevent triage and verdict management calls from starving on reasoning tokens by adding headroom above their visible-output budgets.
- Ensure a degraded verdict does not fail work that was already confirmed done by a verify_done tool run.
- Avoid failing non-testable tasks purely for lack of flip evidence by treating the situation as an abstention instead.
- Emit verdict degradation proof events on every occurrence rather than once per candidate to reflect actual incidence in telemetry.

Enhancements:
- Refactor metered_raw_call dispatching into a shared helper so starvation retries reuse the same accounting path and usage reporting.
- Extend execution-stage tallies and candidate change signals to include verify_done confirmations for downstream verification logic.
- Centralize construction of LadderInputs, including new verification-related channels, in a dedicated pipeline helper.
- Maintain a single prose warning per run for verifier fallback while increasing structured proof granularity for degraded verdicts.

Tests:
- Add degradation gate scenarios to witness starvation-induced verdict retries and verify_done-confirmed flips surviving degraded verdicts.
- Extend verification tests to cover verify_done-based fallback rescue and abstention behavior for tasks without a test surface.
- Add raw usage unit tests for role caps with reasoning headroom, explicit max_output_tokens overrides, starvation signature detection, and retry cap decisions.
- Update verdict degradation telemetry tests to assert per-occurrence proof emission alongside a single per-run warning.