### PR TITLE
fix(bench): reap the container agent when Harbor's deadline cancels the run

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -119,8 +119,9 @@ from .stream_envelope import (
     _stream_to_envelope,
     _sum_step_usage,  # noqa: F401 — re-exported for tests/test_adapter.py
 )
-from .stream_release import communicate_with_release, journal_reports_completion
+from .stream_release import journal_reports_completion
 from .telemetry_export import PRIVATE_TELEMETRY_DIR, export_private_telemetry
+from .timeout_reap import exec_with_agent_reap
 from .turn_budget import (
     TURN_BUDGET_ENV as _TURN_BUDGET_ENV,
 )
@@ -692,8 +693,8 @@ async def _secure_exec_with_credential_fd(
         if callable(test_hook):
             return await test_hook(command=command, env=env, stdin=bytes(wire))
 
-        compose = _compose_base_argv(environment)
-        compose.extend(["exec", "-T"])
+        compose_base = _compose_base_argv(environment)
+        compose = [*compose_base, "exec", "-T"]
 
         cwd = getattr(environment.task_env_config, "workdir", None)
         if cwd:
@@ -725,14 +726,9 @@ async def _secure_exec_with_credential_fd(
                 "selected provider credential remains in Docker's host environment"
             )
 
-        process = await asyncio.create_subprocess_exec(
-            *compose,
-            env=host_env,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+        return await exec_with_agent_reap(
+            compose, compose_base, host_env, wire, completion_probe, _INSTALL_PATH
         )
-        return await communicate_with_release(process, wire, completion_probe)
     finally:
         for index in range(len(wire)):
             wire[index] = 0

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -87,6 +87,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/stream_envelope.py",
     "bench/harbor_adapter/stella_harbor/stream_release.py",
     "bench/harbor_adapter/stella_harbor/telemetry_export.py",
+    "bench/harbor_adapter/stella_harbor/timeout_reap.py",
     "bench/harbor_adapter/stella_harbor/turn_budget.py",
 )
 _FIXED_READINESS_SOURCE_PATHS = (

--- a/bench/harbor_adapter/stella_harbor/stream_release.py
+++ b/bench/harbor_adapter/stella_harbor/stream_release.py
@@ -13,13 +13,18 @@ is deliberately NOT released — a hung pipeline must stay visible as a timeout
 rather than be dressed up as a finished trial (#2110 stays loud).
 
 Nothing inside the container is ever signalled: only the **client** process is
-terminated, so daemons the verifier will probe stay up.
+terminated, so daemons the verifier will probe stay up. That is the contract
+of the *completion* branch specifically — a run that never proved completion
+is reaped in the container by :mod:`stella_harbor.timeout_reap` (#2131), which
+shares this module's client teardown and adds the half a proxy cannot do.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import signal
 from collections.abc import Callable
 
 from harbor.environments.base import ExecResult
@@ -42,6 +47,60 @@ STREAM_RELEASED_NOTE = (
     "a process the agent left running held the stream open past Stella's "
     "exit (#2122)"
 )
+
+#: Seconds the client is given to honour each signal of the teardown
+#: escalation. Docker's exec client exits promptly once it stops proxying, so
+#: this is a ceiling on a pathological client, not a routine cost.
+_CLIENT_SIGNAL_GRACE_SECONDS = 5.0
+
+
+def _signal_client(
+    process: asyncio.subprocess.Process, signal_number: int
+) -> None:
+    """Signal the client's process group when it leads one, else the client.
+
+    ``docker compose`` can leave helper children of its own behind, and
+    signalling only the leader reaps the leader while orphaning the rest — so
+    the group is the correct unit whenever the client owns one, which it does
+    when it was spawned with ``start_new_session=True``.
+
+    The leadership check is a safety interlock, not an optimization: a client
+    that leads no session of its own sits in the *harness's* process group, and
+    a group signal there would kill the benchmark run itself. Signalling the
+    single process is always correct; signalling the group is only sometimes
+    correct, so it has to be proven first.
+    """
+    with contextlib.suppress(OSError):
+        if os.getpgid(process.pid) == process.pid:
+            os.killpg(process.pid, signal_number)
+            return
+    with contextlib.suppress(ProcessLookupError):
+        process.send_signal(signal_number)
+
+
+async def terminate_client(
+    process: asyncio.subprocess.Process,
+    *,
+    grace_seconds: float = _CLIENT_SIGNAL_GRACE_SECONDS,
+) -> None:
+    """Escalate ``SIGTERM`` → ``SIGKILL`` against the client, and reap it.
+
+    Reaping is the point of the final ``wait()``: an exited child that nothing
+    waits on stays a zombie for as long as the harness lives, and a benchmark
+    run performs one of these per timed-out trial.
+
+    Nothing inside the container is signalled from here — the client is a
+    proxy, and killing a proxy does not stop what it was proxying for. The
+    container side belongs to :mod:`stella_harbor.timeout_reap`.
+    """
+    if process.returncode is not None:
+        return
+    for signal_number in (signal.SIGTERM, signal.SIGKILL):
+        _signal_client(process, signal_number)
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(process.wait(), timeout=grace_seconds)
+            return
+    await process.wait()
 
 
 def journal_reports_completion(stream: str | None) -> bool:
@@ -132,13 +191,7 @@ async def communicate_with_release(
             process, wire, completion_probe
         )
     except BaseException:
-        if process.returncode is None:
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                process.kill()
-                await process.wait()
+        await terminate_client(process)
         raise
     stdout = stdout_bytes.decode(errors="replace") if stdout_bytes else None
     if released:

--- a/bench/harbor_adapter/stella_harbor/timeout_reap.py
+++ b/bench/harbor_adapter/stella_harbor/timeout_reap.py
@@ -232,16 +232,23 @@ async def exec_with_agent_reap(
     exception continues, so the container is quiet before Harbor moves on to
     the verifier, and the durable journal has stopped growing before the
     adapter re-reads it for the trial's usage.
+
+    The spawn is inside the ``try`` because a deadline can land on it: Docker's
+    exec has already started the agent in the container by the time the client
+    is up, so a cancellation delivered while awaiting the handle leaves exactly
+    the orphan this exists to prevent — and the reap needs the Compose prefix,
+    not the handle, so it can still run when there is no client to tear down.
     """
-    process = await asyncio.create_subprocess_exec(
-        *argv,
-        env=dict(host_env),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-        start_new_session=True,
-    )
+    process: asyncio.subprocess.Process | None = None
     try:
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            env=dict(host_env),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=True,
+        )
         return await communicate_with_release(process, wire, completion_probe)
     except BaseException:
         # Nothing in here may replace the exception being reported: a trial

--- a/bench/harbor_adapter/stella_harbor/timeout_reap.py
+++ b/bench/harbor_adapter/stella_harbor/timeout_reap.py
@@ -81,10 +81,32 @@ def container_reap_program(agent_path: str) -> str:
     mentions the path in an argument. The trailing-space case catches the
     ``"<path> (deleted)"`` form the kernel reports when the binary was replaced
     while running.
+
+    Liveness is read from the state field of ``/proc/<pid>/stat``, not from the
+    existence of ``/proc/<pid>``: a reaped-but-unwaited process keeps its
+    directory for as long as its parent ignores it, so a presence check would
+    report a zombie as a survivor and spend the whole grace waiting for a
+    process that is already dead.
+
+    No ``cut``, ``ps`` or ``awk``: the fields come out of ``set --``, so the
+    program depends on nothing but the shell itself.
     """
     quoted = shlex.quote(agent_path)
     return f"""set -u
 agent={quoted}
+# Echoes the subset of $pids that is still running — zombies excluded.
+running() {{
+    result=''
+    for pid in $pids; do
+        stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
+        # A process that vanished mid-read yields an empty line, and `set -u`
+        # would abort the whole reap on the "$1" below rather than skip it.
+        [ -n "$stat" ] || continue
+        set -- ${{stat##*') '}}
+        [ "$1" = Z ] || result="$result $pid"
+    done
+    echo "$result"
+}}
 pids=''
 for entry in /proc/[0-9]*; do
     exe=$(readlink "$entry/exe" 2>/dev/null) || continue
@@ -99,8 +121,10 @@ fi
 groups=''
 for pid in $pids; do
     stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
-    rest=${{stat##*') '}}
-    pgid=$(echo "$rest" | cut -d' ' -f3)
+    [ -n "$stat" ] || continue
+    set -- ${{stat##*') '}}
+    [ $# -ge 3 ] || continue
+    pgid=$3
     case " $groups " in
         *" $pgid "*) ;;
         *) groups="$groups $pgid" ;;
@@ -112,21 +136,22 @@ for pgid in $groups; do
 done
 waited=0
 while [ "$waited" -lt {_TERM_GRACE_SECONDS} ]; do
-    alive=''
-    for pid in $pids; do
-        [ -d "/proc/$pid" ] && alive="$alive $pid"
-    done
-    [ -n "$alive" ] || break
+    [ -n "$(running)" ] || break
     sleep 1
     waited=$((waited + 1))
 done
 for pgid in $groups; do
     kill -KILL "-$pgid" 2>/dev/null || true
 done
-survivors=''
-for pid in $pids; do
-    [ -d "/proc/$pid" ] && survivors="$survivors $pid"
+# SIGKILL is delivered, not completed: give the kernel a moment before
+# reporting, so the report is the outcome and not the race.
+settled=0
+while [ "$settled" -lt 2 ]; do
+    [ -n "$(running)" ] || break
+    sleep 1
+    settled=$((settled + 1))
 done
+survivors=$(running)
 echo '{REAP_LOG_PREFIX} survivors:'"${{survivors:- none}}"
 exit 0
 """

--- a/bench/harbor_adapter/stella_harbor/timeout_reap.py
+++ b/bench/harbor_adapter/stella_harbor/timeout_reap.py
@@ -1,0 +1,231 @@
+"""Reaping the agent when Harbor's per-trial deadline cancels the run (#2131).
+
+Harbor enforces the agent deadline by cancelling the coroutine that awaits the
+exec client. Cancellation reaches the ``await`` and nothing else: the
+``docker compose exec`` client is a *proxy*, and a Docker exec process is not
+signalled when its client goes away. So on every timeout trial the Stella
+process kept running inside the container, unsupervised, while Harbor started
+the verifier — 414 seconds of it in match ``cc00894779ff``, including two
+further billed model calls and a 103.8s container command, all of it
+concurrent with the scoring of the same filesystem it was still writing to.
+
+Two things follow from that, and this module owns both:
+
+* **The agent is reaped in the container**, not merely disconnected from. The
+  reap is a second, short-lived Compose exec that finds the agent by its
+  installed binary and escalates ``SIGTERM`` → ``SIGKILL`` against its process
+  group with a bounded wait in between.
+* **The journal becomes final.** The adapter reconstructs a timed-out trial's
+  usage by re-reading ``stella-events.jsonl`` after ``run()`` unwinds
+  (``populate_context_post_run``); it under-reported by 16–35% only because the
+  orphan kept appending after the snapshot. Killing the writer first is what
+  makes that re-read the truth rather than a moving target.
+
+This is the **timeout** branch. :mod:`stella_harbor.stream_release` owns the
+**completion** branch, and the two are deliberately opposite: a run that
+proved it finished releases the stream without signalling anything inside the
+container, because the daemons a finished agent left behind are what the
+verifier is about to probe (#2122). A run that never finished has no such
+claim on them, so its process group goes.
+
+The group, not the process tree: ``docker exec`` starts the agent as its own
+process-group leader, so the group holds Stella plus the shells it spawned for
+its tools — the work that must stop — while a service the agent properly
+daemonized (``setsid``, and every real ``sshd``/``nginx`` daemon mode does)
+has left that group and survives the signal. That is the line this module
+draws, and it is drawn where the kernel already drew one.
+
+Every step here is best-effort by contract: a reap that fails must never
+displace the timeout Harbor is in the middle of reporting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import shlex
+import sys
+from collections.abc import Callable, Mapping, Sequence
+
+from harbor.environments.base import ExecResult
+
+from .stream_release import communicate_with_release, terminate_client
+
+#: Compose service the benchmark task runs in. Matches the run's own argv.
+_SERVICE = "main"
+#: Wall clock the whole container-side reap may take, including Docker's own
+#: exec setup. Comfortably above the in-container escalation below, and small
+#: enough that a Docker daemon that has itself wedged cannot hold the trial's
+#: timeout open.
+_REAP_BUDGET_SECONDS = 40.0
+#: Seconds the in-container escalation waits between ``SIGTERM`` and
+#: ``SIGKILL``. Polled once a second, so a Stella that exits on the term signal
+#: costs about a second, not the whole grace.
+_TERM_GRACE_SECONDS = 8
+
+#: Greppable prefix on every line the reap prints, so the fact that a trial was
+#: reaped (and which pids it took) is recoverable from the trial's stderr log.
+REAP_LOG_PREFIX = "stella-harbor-reap:"
+
+
+def container_reap_program(agent_path: str) -> str:
+    """The POSIX ``sh`` program that reaps the agent inside the container.
+
+    Deliberately free of ``pkill``/``pgrep``/``ps``: Terminal-Bench images are
+    minimal and several ship none of them, and a reap that silently no-ops on
+    the images most likely to time out would be worse than no reap at all.
+    ``/proc`` is the one interface every Linux container has.
+
+    Identification is by ``/proc/<pid>/exe``, which the kernel resolves — a
+    ``cmdline`` match would also accept a task's own process that merely
+    mentions the path in an argument. The trailing-space case catches the
+    ``"<path> (deleted)"`` form the kernel reports when the binary was replaced
+    while running.
+    """
+    quoted = shlex.quote(agent_path)
+    return f"""set -u
+agent={quoted}
+pids=''
+for entry in /proc/[0-9]*; do
+    exe=$(readlink "$entry/exe" 2>/dev/null) || continue
+    case $exe in
+        "$agent"|"$agent "*) pids="$pids ${{entry#/proc/}}" ;;
+    esac
+done
+if [ -z "$pids" ]; then
+    echo '{REAP_LOG_PREFIX} no agent process is running'
+    exit 0
+fi
+groups=''
+for pid in $pids; do
+    stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
+    rest=${{stat##*') '}}
+    pgid=$(echo "$rest" | cut -d' ' -f3)
+    case " $groups " in
+        *" $pgid "*) ;;
+        *) groups="$groups $pgid" ;;
+    esac
+done
+echo '{REAP_LOG_PREFIX} signalling agent pids'"$pids"' in groups'"$groups"
+for pgid in $groups; do
+    kill -TERM "-$pgid" 2>/dev/null || true
+done
+waited=0
+while [ "$waited" -lt {_TERM_GRACE_SECONDS} ]; do
+    alive=''
+    for pid in $pids; do
+        [ -d "/proc/$pid" ] && alive="$alive $pid"
+    done
+    [ -n "$alive" ] || break
+    sleep 1
+    waited=$((waited + 1))
+done
+for pgid in $groups; do
+    kill -KILL "-$pgid" 2>/dev/null || true
+done
+survivors=''
+for pid in $pids; do
+    [ -d "/proc/$pid" ] && survivors="$survivors $pid"
+done
+echo '{REAP_LOG_PREFIX} survivors:'"${{survivors:- none}}"
+exit 0
+"""
+
+
+def container_reap_argv(compose_base: Sequence[str], agent_path: str) -> list[str]:
+    """The Compose argv that runs :func:`container_reap_program`.
+
+    Runs as uid 0 so the escalation can reach an agent started as another user;
+    carries no credential, so unlike the run itself it needs no stdin handoff.
+    """
+    return [
+        *compose_base,
+        "exec",
+        "-T",
+        "-u",
+        "0",
+        _SERVICE,
+        "sh",
+        "-c",
+        container_reap_program(agent_path),
+    ]
+
+
+async def reap_container_agent(
+    compose_base: Sequence[str],
+    host_env: Mapping[str, str],
+    agent_path: str,
+    *,
+    budget_seconds: float = _REAP_BUDGET_SECONDS,
+) -> str | None:
+    """Kill and reap the agent inside the container; report what it took.
+
+    Returns the reap's own output, or ``None`` when it could not be run. The
+    output is a diagnosis, never a control signal: the caller re-raises the
+    timeout either way.
+    """
+    process = await asyncio.create_subprocess_exec(
+        *container_reap_argv(compose_base, agent_path),
+        env=dict(host_env),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        # Its own session, so the escalation below signals this client's group
+        # and never the harness's.
+        start_new_session=True,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(
+            process.communicate(), timeout=budget_seconds
+        )
+    except (TimeoutError, asyncio.CancelledError):
+        await terminate_client(process)
+        return None
+    return stdout.decode(errors="replace") if stdout else ""
+
+
+async def exec_with_agent_reap(
+    argv: Sequence[str],
+    compose_base: Sequence[str],
+    host_env: Mapping[str, str],
+    wire: bytes | bytearray,
+    completion_probe: Callable[[], bool] | None,
+    agent_path: str,
+) -> ExecResult:
+    """Run the agent's exec client, reaping the agent if the wait is cut short.
+
+    ``argv`` is the full Compose invocation for the run; ``compose_base`` is
+    the project-scoped prefix the reap's own exec is built from.
+
+    The client is spawned into its own session so that a teardown can signal
+    the client's process group without reaching the harness — see
+    :func:`stella_harbor.stream_release.terminate_client`, which performs that
+    teardown for both branches.
+
+    ``BaseException`` and not ``Exception``: the case this exists for is
+    ``CancelledError``, which is neither. The reap is awaited before the
+    exception continues, so the container is quiet before Harbor moves on to
+    the verifier, and the durable journal has stopped growing before the
+    adapter re-reads it for the trial's usage.
+    """
+    process = await asyncio.create_subprocess_exec(
+        *argv,
+        env=dict(host_env),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        return await communicate_with_release(process, wire, completion_probe)
+    except BaseException:
+        # Nothing in here may replace the exception being reported: a trial
+        # that timed out must still be recorded as a trial that timed out, and
+        # a Docker daemon wedged enough to refuse the reap is precisely when
+        # that matters most.
+        report: str | None = None
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            report = await reap_container_agent(compose_base, host_env, agent_path)
+        detail = (report or "").strip() or "the reap could not be run"
+        print(f"{REAP_LOG_PREFIX} the run was cut short; {detail}", file=sys.stderr)
+        raise

--- a/bench/harbor_adapter/tests/test_timeout_reap.py
+++ b/bench/harbor_adapter/tests/test_timeout_reap.py
@@ -56,6 +56,8 @@ from stella_harbor.timeout_reap import (  # noqa: E402
 )
 
 _CREDENTIAL = "timeout-reap-witness-secret"
+#: Written by the fake driver's run branch; the cancellation waits for it.
+RUN_STARTED = "run-started"
 
 
 def _pid_alive(pid: int) -> bool:
@@ -134,6 +136,11 @@ def _fake_compose_driver(tmp_path: Path, journal_writer: _JournalWriter) -> Path
     reap invocation is recognised by the marker the real reap program carries,
     and stops the in-container stand-in — which is precisely the authority the
     adapter must exercise and previously never did.
+
+    The run branch announces itself first. Timing the cancellation off the
+    journal instead would time it off a process the run never started, and the
+    test would race the run's own spawn on a loaded machine — passing or
+    failing for a reason that has nothing to do with its subject.
     """
     driver = tmp_path / "compose-driver"
     driver.write_text(
@@ -145,6 +152,7 @@ def _fake_compose_driver(tmp_path: Path, journal_writer: _JournalWriter) -> Path
         "        exit 0\n"
         "        ;;\n"
         "esac\n"
+        f": > {shlex.quote(str(tmp_path / RUN_STARTED))}\n"
         "exec sleep 60\n",
         encoding="utf-8",
     )
@@ -220,8 +228,11 @@ class TestContainerAgentReap:
                         credentials=(_CREDENTIAL,),
                     )
                 )
-                # Let the run get going, then time it out the way Harbor does.
-                while agent.events() < 3:
+                # Let the run get going, then time it out the way Harbor does:
+                # the client must be up and the agent must be producing.
+                started = tmp_path / RUN_STARTED
+                while not (started.exists() and agent.events() >= 3):
+                    assert not task.done(), "the run ended before it could time out"
                     await asyncio.sleep(0.05)
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/bench/harbor_adapter/tests/test_timeout_reap.py
+++ b/bench/harbor_adapter/tests/test_timeout_reap.py
@@ -1,0 +1,437 @@
+"""Reaping the agent when Harbor's deadline cancels the run (#2131).
+
+Harbor enforces the per-trial agent deadline by cancelling the coroutine that
+awaits the exec client. Before this module's subject existed, that was the
+whole of the timeout: the ``docker compose exec`` *client* went away and the
+Stella process it was proxying for kept running in the container — 414 seconds
+of it in match ``cc00894779ff``, billing model calls and mutating the very
+filesystem the verifier had already started scoring, and appending to the
+journal the adapter re-reads for the trial's usage (which is why every timeout
+trial under-reported by 16–35%).
+
+These tests use real local processes, in the shapes that matter:
+
+* an in-container agent, modelled as a process in its own session that the
+  host-side client cannot reach by signal — only an explicit reap can;
+* a client with a child of its own, which a signal to the leader alone leaves
+  orphaned;
+* the reap program itself, run against a real process through ``/proc``.
+
+The completion branch (#2122) is pinned here too, from the other side: a run
+that ends on its own must issue no reap at all, because the daemons a finished
+agent left behind are what the verifier is about to probe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+import stella_harbor  # noqa: E402
+from stella_harbor import (  # noqa: E402
+    _INSTALL_PATH,
+    _secure_exec_with_credential_fd,
+)
+from stella_harbor.stream_release import (  # noqa: E402
+    communicate_with_release,
+    terminate_client,
+)
+from stella_harbor.timeout_reap import (  # noqa: E402
+    REAP_LOG_PREFIX,
+    container_reap_argv,
+    container_reap_program,
+    exec_with_agent_reap,
+)
+
+_CREDENTIAL = "timeout-reap-witness-secret"
+
+
+def _pid_alive(pid: int) -> bool:
+    """Whether ``pid`` still exists, without waiting on it."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover - not reachable for own children
+        return True
+    return True
+
+
+def _await_condition(predicate, *, timeout: float = 10.0) -> bool:
+    """Poll ``predicate`` from synchronous test code until it holds."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+class _JournalWriter:
+    """A stand-in for Stella running inside the container.
+
+    In its own session on purpose: the container is a different namespace, so
+    no signal aimed at the host-side exec client can reach the real thing
+    either. Only an explicit reap can, which is exactly what is under test.
+    """
+
+    def __init__(self, journal: Path) -> None:
+        self.journal = journal
+        self.process = subprocess.Popen(  # noqa: S603 - fixture, fixed argv
+            [
+                "sh",
+                "-c",
+                f'i=0; while [ "$i" -lt 600 ]; do echo "event $i" '
+                f">> {shlex.quote(str(journal))}; sleep 0.05; i=$((i + 1)); done",
+            ],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    @property
+    def pid(self) -> int:
+        return self.process.pid
+
+    def running(self) -> bool:
+        """Whether the stand-in is still alive — reaping it as we ask.
+
+        ``os.kill(pid, 0)`` cannot answer this: a killed child of the test
+        process is a zombie until something waits on it, and a zombie answers
+        signal 0 exactly as a live process does.
+        """
+        return self.process.poll() is None
+
+    def events(self) -> int:
+        try:
+            return len(self.journal.read_text().splitlines())
+        except OSError:
+            return 0
+
+    def close(self) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(self.process.pid, signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            self.process.wait(timeout=5)
+
+
+def _fake_compose_driver(tmp_path: Path, journal_writer: _JournalWriter) -> Path:
+    """A stand-in for ``docker compose`` that answers both invocations.
+
+    The run invocation holds the exec stream open, as a live agent's does. The
+    reap invocation is recognised by the marker the real reap program carries,
+    and stops the in-container stand-in — which is precisely the authority the
+    adapter must exercise and previously never did.
+    """
+    driver = tmp_path / "compose-driver"
+    driver.write_text(
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        f"    *{REAP_LOG_PREFIX}*)\n"
+        f"        kill -TERM {journal_writer.pid} 2>/dev/null || true\n"
+        f"        echo '{REAP_LOG_PREFIX} the stand-in agent was reaped'\n"
+        "        exit 0\n"
+        "        ;;\n"
+        "esac\n"
+        "exec sleep 60\n",
+        encoding="utf-8",
+    )
+    driver.chmod(0o755)
+    return driver
+
+
+def _fake_environment(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id="trial/timeout-reap",
+        environment_dir=tmp_path,
+        _docker_compose_paths=[],
+        _env_vars=SimpleNamespace(
+            to_env_dict=lambda *, include_os_env: {"PATH": os.environ.get("PATH", "")}
+        ),
+        _compose_task_env={},
+        _persistent_env={},
+        task_env_config=SimpleNamespace(workdir="/workspace"),
+        _resolve_user=lambda _user: "agent",
+    )
+
+
+async def _spawn(script: str) -> asyncio.subprocess.Process:
+    """A client shaped like the compose exec client: its own session."""
+    return await asyncio.create_subprocess_exec(
+        "sh",
+        "-c",
+        script,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+
+class TestContainerAgentReap:
+    def test_a_cancelled_run_reaps_the_container_agent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The witness for #2131, end to end through the secure runner.
+
+        Harbor's deadline arrives as a cancellation of the awaited exec. Before
+        the fix the cancellation stopped at the client, the agent kept writing,
+        and the journal the adapter re-reads for the trial's usage was still
+        growing while the verifier ran. After it, the agent is reaped and the
+        journal is final — which is what makes that re-read honest.
+        """
+        journal = tmp_path / "stella-events.jsonl"
+        agent = _JournalWriter(journal)
+        try:
+            driver = _fake_compose_driver(tmp_path, agent)
+            monkeypatch.setattr(
+                stella_harbor, "_compose_base_argv", lambda _environment: [str(driver)]
+            )
+            monkeypatch.setattr(
+                stella_harbor,
+                "_compose_host_environment",
+                lambda _environment: {"PATH": os.environ.get("PATH", "")},
+            )
+
+            async def scenario() -> None:
+                task = asyncio.ensure_future(
+                    _secure_exec_with_credential_fd(
+                        _fake_environment(tmp_path),
+                        command=[
+                            _INSTALL_PATH,
+                            "--model",
+                            "openrouter/model",
+                            "run",
+                            "task",
+                        ],
+                        env={"STELLA_CREDENTIAL_HANDOFF_FD": "0"},
+                        credentials=(_CREDENTIAL,),
+                    )
+                )
+                # Let the run get going, then time it out the way Harbor does.
+                while agent.events() < 3:
+                    await asyncio.sleep(0.05)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+            asyncio.run(scenario())
+
+            assert _await_condition(lambda: not agent.running()), (
+                "the agent outlived the cancelled await: it is still running "
+                "alongside the verifier, still billing, still writing"
+            )
+            settled = agent.events()
+            time.sleep(0.5)
+            assert agent.events() == settled, (
+                "the journal kept growing after the timeout, so the usage the "
+                "adapter reconstructs from it is a moving target"
+            )
+        finally:
+            agent.close()
+
+    def test_a_completed_run_issues_no_reap(self, tmp_path: Path) -> None:
+        """Composition with #2122: the completion branch signals nothing.
+
+        A run that ended on its own leaves daemons the verifier is about to
+        probe. Reaping there would break the trials the exec-stream release was
+        built for, so the reap must be reachable only from the failure path.
+        """
+        marker = tmp_path / "reap-was-issued"
+        driver = tmp_path / "compose-driver"
+        driver.write_text(
+            "#!/bin/sh\n"
+            'case "$*" in\n'
+            f"    *{REAP_LOG_PREFIX}*) : > {shlex.quote(str(marker))} ;;\n"
+            "esac\n"
+            "echo done\n",
+            encoding="utf-8",
+        )
+        driver.chmod(0o755)
+
+        result = asyncio.run(
+            exec_with_agent_reap(
+                [str(driver), "run"],
+                [str(driver)],
+                {"PATH": os.environ.get("PATH", "")},
+                b"",
+                None,
+                _INSTALL_PATH,
+            )
+        )
+
+        assert result.stdout == "done\n"
+        assert result.return_code == 0
+        assert not marker.exists(), "a finished run must not be reaped"
+
+
+class TestClientTeardown:
+    def test_a_cancelled_wait_reaps_the_clients_children(self) -> None:
+        """A signal to the leader alone orphans everything it spawned.
+
+        The compose client is one process among the several a teardown has to
+        account for; terminating only the leader left its children running and
+        reaped nothing. The client is spawned into its own session so the group
+        signal is provably scoped to it and can never reach the harness.
+        """
+        holder: dict[str, int] = {}
+
+        async def scenario() -> None:
+            process = await _spawn("sleep 60 & echo $!; exec sleep 60")
+            assert process.stdout is not None
+            holder["child"] = int((await process.stdout.readline()).strip())
+            holder["client"] = process.pid
+            task = asyncio.ensure_future(communicate_with_release(process, b"", None))
+            await asyncio.sleep(0.2)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        try:
+            asyncio.run(scenario())
+            assert not _pid_alive(holder["client"]), "the client was not reaped"
+            assert _await_condition(lambda: not _pid_alive(holder["child"])), (
+                "the client's child outlived the teardown"
+            )
+        finally:
+            for pid in holder.values():
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
+
+    def test_a_client_that_leads_no_session_is_signalled_alone(self) -> None:
+        """The safety interlock: never group-signal the harness's own group.
+
+        A client spawned without its own session shares the group pytest runs
+        in. The teardown must fall back to signalling that one process — a
+        group signal there would take the whole benchmark run with it.
+        """
+
+        async def scenario() -> int:
+            process = await asyncio.create_subprocess_exec(
+                "sleep",
+                "60",
+                stdout=asyncio.subprocess.PIPE,
+            )
+            assert os.getpgid(process.pid) != process.pid
+            await terminate_client(process, grace_seconds=2.0)
+            return process.returncode
+
+        assert asyncio.run(scenario()) is not None
+
+
+class TestReapProgram:
+    def test_the_reap_argv_runs_as_root_in_the_task_service(self) -> None:
+        argv = container_reap_argv(["docker", "compose", "-p", "trial"], _INSTALL_PATH)
+        assert argv[:4] == ["docker", "compose", "-p", "trial"]
+        assert argv[4:9] == ["exec", "-T", "-u", "0", "main"]
+        assert argv[9:11] == ["sh", "-c"]
+        assert _INSTALL_PATH in argv[11]
+
+    def test_the_reap_program_is_valid_posix_shell(self, tmp_path: Path) -> None:
+        program = tmp_path / "reap.sh"
+        program.write_text(container_reap_program(_INSTALL_PATH), encoding="utf-8")
+        assert subprocess.run(  # noqa: S603 - fixed argv
+            ["sh", "-n", str(program)], capture_output=True
+        ).returncode == 0
+
+    @pytest.mark.skipif(
+        not Path("/proc/self/exe").exists(),
+        reason="the reap identifies the agent through /proc (Linux containers)",
+    )
+    def test_the_reap_program_kills_the_agent_process_group(
+        self, tmp_path: Path
+    ) -> None:
+        """Run the real program against a real process group.
+
+        The agent is identified by ``/proc/<pid>/exe``, so the stand-in has to
+        be a copied binary at its own path rather than an interpreter running a
+        script — that is the identification the program actually performs.
+        """
+        agent_binary = tmp_path / "stella"
+        shutil.copy(shutil.which("sleep") or "/bin/sleep", agent_binary)
+        agent_binary.chmod(0o755)
+        agent = subprocess.Popen(  # noqa: S603 - fixture, fixed argv
+            [str(agent_binary), "60"], start_new_session=True
+        )
+        try:
+            completed = subprocess.run(  # noqa: S603 - fixed argv
+                ["sh", "-c", container_reap_program(str(agent_binary))],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert completed.returncode == 0, completed.stderr
+            assert str(agent.pid) in completed.stdout
+            assert "survivors: none" in completed.stdout
+            assert agent.wait(timeout=5) != 0
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(agent.pid, signal.SIGKILL)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                agent.wait(timeout=5)
+
+    def test_the_reap_program_is_quiet_when_no_agent_is_running(
+        self, tmp_path: Path
+    ) -> None:
+        """An agent that already exited is the ordinary case on a slow client.
+
+        The program must report that and exit clean rather than signalling a
+        pid it guessed, and never with the shell's ``set -u`` tripping over an
+        empty match.
+        """
+        completed = subprocess.run(  # noqa: S603 - fixed argv
+            ["sh", "-c", container_reap_program(str(tmp_path / "absent-stella"))],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert f"{REAP_LOG_PREFIX} no agent process is running" in completed.stdout
+
+
+def test_the_reap_never_displaces_the_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reap that cannot run must not turn a timeout into something else.
+
+    Harbor scores the trial by the exception it receives. A Docker daemon that
+    has itself wedged is exactly when the reap fails, and exactly when the
+    trial most needs to still read as a timeout.
+    """
+    driver = tmp_path / "compose-driver"
+    driver.write_text("#!/bin/sh\nexec sleep 60\n", encoding="utf-8")
+    driver.chmod(0o755)
+
+    async def _refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("docker is unavailable")
+
+    async def scenario() -> None:
+        task = asyncio.ensure_future(
+            exec_with_agent_reap(
+                [str(driver), "run"],
+                [str(driver)],
+                {"PATH": os.environ.get("PATH", "")},
+                b"",
+                None,
+                _INSTALL_PATH,
+            )
+        )
+        await asyncio.sleep(0.2)
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _refuse)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,7 +8,7 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 1834 bench/harbor_adapter/stella_harbor/__init__.py
-4298 bench/harbor_adapter/stella_harbor/secure_launcher.py
+4299 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2335 bench/harbor_adapter/tests/test_adapter.py
 3360 bench/harbor_adapter/tests/test_secure_launcher.py
 8272 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
## Problem

Harbor enforces the per-trial agent deadline by cancelling the coroutine that awaits the exec client. Cancellation reached the `await` and nothing else: `docker compose exec`'s client is a **proxy**, and a Docker exec process is not signalled when its client goes away.

So on every timeout trial the Stella process kept running inside the container, unsupervised, while Harbor started the verifier — **414 seconds of it** in match `cc00894779ff`, including two further billed model calls and a 103.8s container command, all concurrent with the scoring of the same filesystem it was still writing to.

The same orphan is why **usage was under-reported 16–35%** on every timeout trial. The adapter already reconstructs a timed-out trial's totals by re-reading `stella-events.jsonl` (`populate_context_post_run`); the numbers were wrong only because the orphan kept appending after the snapshot. Killing the writer first is what makes that re-read the truth rather than a moving target — so no separate reconciliation path is needed, and none is added.

## How it composes with #2136 / #2122

`stream_release.py` owns the **completion** branch and keeps it: a run that proved it finished releases the stream and signals nothing inside the container, because the daemons a finished agent left behind are what the verifier is about to probe. The new `timeout_reap.py` owns the **timeout** branch, which is deliberately the opposite — a run that never finished has no such claim on them.

The two share one seam: `stream_release.terminate_client`, the host-side client teardown. It now escalates `SIGTERM` → `SIGKILL` against the client's process **group** and reaps it, instead of signalling the leader alone and orphaning its children. The group is used only when the client provably leads its own session (`os.getpgid(pid) == pid`); a client that does not sits in the *harness's* group, where a group signal would kill the benchmark run itself. That interlock has its own test.

The reap identifies the agent by `/proc/<pid>/exe` and signals its process group — the group `docker exec` created for it, holding Stella and the shells it spawned for its tools. No `ps`/`pgrep`/`pkill`/`cut`: Terminal-Bench images are minimal and the fields come out of `set --`, so the program needs nothing but the shell.

Best-effort by contract throughout: a reap that cannot run prints why and lets the timeout continue unchanged, because Harbor scores the trial by the exception it receives. That is pinned by `test_the_reap_never_displaces_the_timeout`.

## Witness tests

`bench/harbor_adapter/tests/test_timeout_reap.py`, verified by reverting each impl file and re-running:

| Witness | Reverting | Failure on the old code |
|---|---|---|
| `TestContainerAgentReap::test_a_cancelled_run_reaps_the_container_agent` | `stella_harbor/__init__.py` to its base version | `AssertionError: the agent outlived the cancelled await: it is still running alongside the verifier, still billing, still writing` |
| `TestClientTeardown::test_a_cancelled_wait_reaps_the_clients_children` | `communicate_with_release`'s teardown body to main's | `AssertionError: the client's child outlived the teardown` |

Both run against real local processes: the first drives the whole secure runner with a fake Compose driver and an in-container stand-in in its own session (unreachable by any host-side signal — only an explicit reap can stop it), and asserts both that the agent dies **and** that its journal stops growing.

## Container-level verification

The reap program is not only unit-tested; it was run in a real `debian:bookworm-slim` container against an agent shaped like a `docker exec` one — session leader, a tool child in its group, a `setsid` daemon beside it:

```
stella-harbor-reap: signalling agent pids 11 in groups 9
stella-harbor-reap: survivors: none
agent  (11): gone
tool   (12): gone
daemon (13): ALIVE
```

That run is also what caught a bug in the first draft: a killed process keeps its `/proc/<pid>` directory until its parent waits on it, so a presence check reported a zombie as a survivor. Liveness now reads the state field of `/proc/<pid>/stat`, `Z` excluded. A `TestReapProgram` test runs the real program against a real process group, skipped off Linux and live in CI.

## Notes for review

- **`_FIXED_ADAPTER_SOURCE_PATHS`** — the new module is registered in `secure_launcher.py`'s fail-closed source set. The 31 `test_secure_launcher` failures without it are that guard working as designed. That one irreducible line costs a **+1 file-size ceiling** for `secure_launcher.py`, hand-edited to that single entry rather than regenerated: `--update` would also retighten `crates/stella-core/src/driver/tests.rs` and `stella_harbor/__init__.py` from other people's merged work, and a retightened ceiling is the fastest way to break `main` for an in-flight PR sized against the old one.
- **`__init__.py` shrinks by 4 lines** (1834 → 1830) and its ceiling is deliberately *not* tightened, so the headroom goes to the next change there rather than being banked here (context: #2153, now closed by #2163).
- **A flake caught and fixed inside the PR**, not shipped: the witness failed once in a full-suite run because it timed the cancellation off a signal unrelated to the run's progress. Fixing it exposed a real hole — the client spawn sat *outside* the `try`, so a deadline landing on it reaped nothing even though Docker had already started the agent. The spawn is now inside. Stable across three targeted runs and two full-suite runs (504 passed, 2 skipped).
- No test was deleted.

## Left behind — filed, not buried

- **#2188** — #2131's third bullet (the reasoning-delta splice in the `cc00894779ff` traces) was a stream-capture question, not this process-lifetime bug. Split out with the evidence paths and a method, as #2131's own definition of done required.
- **#2189** — the reap's group boundary: a service the agent backgrounded *without* `setsid` shares the agent's group and is now killed on the timeout path. A deliberate, documented line with a real cost either way; filed so it is measured rather than assumed.
- **#2190** — the half of #2131's definition of done that needs the rig: confirm on a real forced-timeout trial that no agent survives when the verifier starts and that reported usage equals the journal's totals.

Related: #2110 (idle to `AgentTimeoutError`), #2135 (per-task deadline never acted).

Closes #2131

## Summary by Sourcery

Ensure container agents are explicitly reaped when Harbor cancels a trial, so timed‑out runs stop work in the container and usage reconstruction sees a stable journal.

Bug Fixes:
- Stop container agents and their subprocesses from continuing to run and bill usage after Harbor cancels the exec client on timeout trials.
- Fix client teardown so child processes spawned by the exec client are also terminated, avoiding orphaned helpers that survive timeouts.

Enhancements:
- Introduce a shared client termination helper that escalates signals and reaps the exec client’s process group when safe, reusing it across completion and timeout paths.
- Add a container-side reap mechanism that locates the agent binary via /proc, kills its process group, and logs the outcome without changing timeout semantics.
- Wire the secure exec path to use the new agent-reaping exec wrapper instead of calling the stream release code directly.
- Register the new timeout reap module in the secure launcher’s fixed source set to keep the adapter fail-closed.

Documentation:
- Document the separation between completion and timeout branches and the best-effort, non-displacing nature of the container-agent reap in the new timeout module and updated stream release docs.

Tests:
- Add end-to-end tests that drive the secure runner with a fake compose driver to assert that cancelled runs reap the in-container agent and freeze the journal.
- Add tests that verify completed runs never trigger a reap, preserving container daemons for verifier probing.
- Add tests covering client teardown behaviour, including group signalling safety when the client does or does not lead its own session.
- Add tests for the in-container reap program’s argv, shell validity, behaviour against real process groups, and handling of absent agents.
- Add a test ensuring that failures to run the reap never alter the timeout exception reported back to Harbor.