### PR TITLE
fix(arenabench): pace the docker snapshot tests on the manifest, not the clock

### DIFF
--- a/arenabench/tests/conftest.py
+++ b/arenabench/tests/conftest.py
@@ -15,16 +15,29 @@ Each extraction is stamped with the archive's digest, so an unchanged
 archive costs one hash per session and an updated one re-extracts from
 scratch. The first-ever extraction is not concurrency-safe across processes
 (the suite runs single-process; revisit the stamp if pytest-xdist arrives).
+
+Also home to the pacing every snapshot test shares — see
+:func:`_wait_for_snapshots`.
 """
 
 from __future__ import annotations
 
 import hashlib
 import shutil
+import time
 import zipfile
 from pathlib import Path
 
+import pytest
+
+from arenabench.snapshot import load_manifest
+
 MATCHES = Path(__file__).parent / "fixtures" / "matches"
+
+#: How long a snapshot wait tolerates before calling the host broken. Generous
+#: on purpose: the whole point of waiting on the manifest is that capture cost
+#: is not knowable in advance, so the only wrong deadline is a tight one.
+SNAPSHOT_DEADLINE = 180.0
 
 
 def _unpack(archive: Path) -> None:
@@ -45,3 +58,50 @@ def _unpack(archive: Path) -> None:
 def pytest_configure(config) -> None:
     for archive in sorted(MATCHES.glob("*.zip")):
         _unpack(archive)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot pacing
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_snapshots(
+    trial_dir: Path,
+    at_least: int,
+    *,
+    what: str,
+    deadline: float = SNAPSHOT_DEADLINE,
+) -> int:
+    """Block until ``trial_dir`` holds ``at_least`` snapshots; return the count.
+
+    ``SnapshotSupervisor.interval`` is a floor on the cadence, never a period:
+    ``_snapshot`` stamps its clock *before* running the container's ``git
+    add``/``commit``/``diff``, so a capture dearer than the interval stretches
+    the real cadence to whatever the host allows. One was measured at 5.6 s
+    against a 2.0 s interval.
+
+    So a ``time.sleep`` sized from the interval is a bet on capture speed, and
+    losing it is what made the docker snapshot tests flaky under load — three
+    snapshots where the arithmetic assumed seven, failing as "too few
+    snapshots to bisect meaningfully" (#2114). Waiting on the manifest is the
+    same test with the bet removed: it costs a fast host nothing extra and
+    lets a slow one take as long as it needs, while still failing loudly —
+    never skipping — on a host that has genuinely stopped capturing.
+    """
+    limit = time.monotonic() + deadline
+    while True:
+        count = len(load_manifest(trial_dir))
+        if count >= at_least:
+            return count
+        if time.monotonic() >= limit:
+            raise AssertionError(
+                f"only {count} of {at_least} snapshots {what} after "
+                f"{deadline:.0f}s — capture is not keeping up on this host"
+            )
+        time.sleep(0.2)
+
+
+@pytest.fixture
+def wait_for_snapshots():
+    """The condition-driven pacing every snapshot test uses instead of sleeping."""
+    return _wait_for_snapshots

--- a/arenabench/tests/conftest.py
+++ b/arenabench/tests/conftest.py
@@ -34,10 +34,11 @@ from arenabench.snapshot import load_manifest
 
 MATCHES = Path(__file__).parent / "fixtures" / "matches"
 
-#: How long a snapshot wait tolerates before calling the host broken. Generous
-#: on purpose: the whole point of waiting on the manifest is that capture cost
-#: is not knowable in advance, so the only wrong deadline is a tight one.
-SNAPSHOT_DEADLINE = 180.0
+#: How long a snapshot wait tolerates before calling the host broken. Sized as
+#: roughly twenty times the dearest capture ever measured (5.6 s, against a
+#: 2.0 s interval, on the run that filed #2114), so it cannot lose a race a
+#: working host would eventually win — while still bounding a wedged one.
+SNAPSHOT_DEADLINE = 120.0
 
 
 def _unpack(archive: Path) -> None:
@@ -94,9 +95,13 @@ def _wait_for_snapshots(
         if count >= at_least:
             return count
         if time.monotonic() >= limit:
+            # Zero here is a different fault from "too few": the supervisor
+            # logs a capture that failed outright at debug level, so it is
+            # invisible unless the run asked for it (#2196).
             raise AssertionError(
                 f"only {count} of {at_least} snapshots {what} after "
-                f"{deadline:.0f}s — capture is not keeping up on this host"
+                f"{deadline:.0f}s — capture is not keeping up on this host, or "
+                f"stopped working; re-run with --log-cli-level=DEBUG to see which"
             )
         time.sleep(0.2)
 

--- a/arenabench/tests/test_replay_docker.py
+++ b/arenabench/tests/test_replay_docker.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import time
 from pathlib import Path
 
 import pytest
@@ -92,7 +91,9 @@ def bindable_root():
         shutil.rmtree(root, ignore_errors=True)
 
 
-def test_flip_lands_where_the_solution_actually_appeared(bindable_root: Path):
+def test_flip_lands_where_the_solution_actually_appeared(
+    bindable_root: Path, wait_for_snapshots
+):
     jobs = bindable_root / "jobs"
     trial = jobs / "seat" / "demo__RpL1"
     (trial / "agent").mkdir(parents=True)
@@ -117,12 +118,28 @@ def test_flip_lands_where_the_solution_actually_appeared(bindable_root: Path):
         )
         sup.start()
         try:
-            time.sleep(5)  # snapshots taken while unsolved
+            # Every wait below is on the manifest, never on the clock: a
+            # capture costs whatever the host charges for `docker commit`, and
+            # a fixed sleep sized from `interval` is a bet on that price that
+            # a loaded host wins (#2114). See `_wait_for_snapshots`.
+            wait_for_snapshots(trial, 2, what="of the unsolved workspace")
             _sh("docker", "exec", name, "sh", "-c", "echo done > /app/solution.txt")
             solved_at = len(load_manifest(trial))
-            time.sleep(5)  # snapshots taken after solving
+            # One capture may already have been in flight when the solution
+            # landed, so entry `solved_at` might predate it — but the
+            # supervisor captures on a single thread, so `solved_at + 1`
+            # started afterwards and definitely contains it. Two entries is
+            # therefore the smallest wait that puts a passing snapshot in the
+            # manifest.
+            wait_for_snapshots(trial, solved_at + 2, what="of the solved workspace")
+            finished_at = len(load_manifest(trial))
             (trial / "result.json").write_text('{"reward": 1}', encoding="utf-8")
-            time.sleep(3)
+            # `result.json` is how the supervisor learns a trial ended: it
+            # takes one last snapshot — the graded state, which the interval
+            # will rarely have landed on — and retires the trial. That entry
+            # is also what keeps the flip off the end of the manifest, so
+            # `wasted_elapsed` has something to measure.
+            wait_for_snapshots(trial, finished_at + 1, what="of the graded state")
         finally:
             sup.stop(timeout=20)
     finally:

--- a/arenabench/tests/test_snapshot.py
+++ b/arenabench/tests/test_snapshot.py
@@ -305,13 +305,17 @@ def test_snapshot_waiting_outlasts_the_fixed_sleep_it_replaces(
     sup.start()
     try:
         wait_for_snapshots(trial, 2, what="of a deliberately slow capture", deadline=60.0)
+        # Read here, not after `stop()`: joining the watcher finishes a capture
+        # already in flight, which would hand the manifest an entry the pacing
+        # never waited for. The docker tests read the manifest mid-run for the
+        # same reason — that reading is what their assertions are sized from.
+        entries = load_manifest(trial)
     finally:
         sup.stop(timeout=20)
 
-    entries = load_manifest(trial)
     # What waiting on the condition collects.
     assert len(entries) >= 2
-    # What waiting on the clock collected: the "too few snapshots to bisect
-    # meaningfully" failure this test exists to keep fixed.
+    # What waiting on the clock would have collected from the very same run:
+    # the "too few snapshots to bisect meaningfully" failure of #2114.
     on_the_clock = [e for e in entries if e.at - started <= OLD_FIXED_SLEEP]
     assert len(on_the_clock) < 2, "the stubbed capture was not slow enough to starve a sleep"

--- a/arenabench/tests/test_snapshot.py
+++ b/arenabench/tests/test_snapshot.py
@@ -11,12 +11,16 @@ the number an operator reads.
 
 from __future__ import annotations
 
+import itertools
 import json
+import time
 
+from arenabench import snapshot
 from arenabench.model import MatchSpec
 from arenabench.snapshot import (
     SNAPSHOT_DIRNAME,
     SnapshotEntry,
+    SnapshotSupervisor,
     bisect_first_pass,
     confirm_first_pass,
     container_for_trial,
@@ -243,3 +247,71 @@ def test_snapshot_interval_never_spins_the_watcher():
 def test_capture_is_off_by_default():
     spec = MatchSpec.from_json({"dataset": "d", "contestants": []})
     assert spec.capture_snapshots is False
+
+
+# -- pacing -----------------------------------------------------------------
+
+#: The fixed sleep the docker snapshot tests used to pace themselves with,
+#: before they waited on the manifest instead (#2114).
+OLD_FIXED_SLEEP = 5.0
+
+
+def _slow_capture(monkeypatch, *, cost: float) -> None:
+    """Run a real supervisor without Docker, at a capture cost we choose.
+
+    ``_exec`` and ``_container_running`` are the module's only two doors to
+    Docker, so stubbing exactly those leaves every line of the supervisor's own
+    timing under test — which is the part that decides the cadence.
+    """
+    commits = itertools.count()
+
+    def fake_exec(container: str, script: str, *, timeout: float = 180.0) -> tuple[int, str]:
+        if "rev-parse HEAD" in script:
+            # What a loaded host pays for `git add`/`commit` over a workspace.
+            time.sleep(cost)
+            return 0, f"{next(commits):040x}\n"
+        if "diff --binary" in script:
+            return 0, ""
+        if "init -q" in script:
+            return 0, "ok\n"
+        return 0, "/app\n"  # the workspace probe
+
+    monkeypatch.setattr(snapshot, "_exec", fake_exec)
+    monkeypatch.setattr(snapshot, "_container_running", lambda name: True)
+
+
+def test_snapshot_waiting_outlasts_the_fixed_sleep_it_replaces(
+    tmp_path, monkeypatch, wait_for_snapshots
+):
+    """Capture cost, not ``interval``, sets the cadence — so pace on the manifest.
+
+    ``SnapshotSupervisor._snapshot`` stamps its clock *before* it runs the
+    container's ``git add``/``commit``, so a capture dearer than ``interval``
+    stretches the real cadence to whatever the host allows; 5.6 s against a
+    2.0 s interval was measured on the run that filed #2114. The docker
+    snapshot tests used to sleep a fixed five seconds and then assert a
+    snapshot count, which is a bet on capture speed. Here the bet is rigged to
+    lose, and only a wait on the manifest still collects what those assertions
+    need.
+    """
+    trial = tmp_path / "jobs" / "seat" / "demo__Slow1"
+    (trial / "agent").mkdir(parents=True)
+    _slow_capture(monkeypatch, cost=3.0)
+
+    sup = SnapshotSupervisor(
+        jobs_root=tmp_path / "jobs", jobs=["seat"], interval=2.0, poll_interval=0.1
+    )
+    started = time.time()
+    sup.start()
+    try:
+        wait_for_snapshots(trial, 2, what="of a deliberately slow capture", deadline=60.0)
+    finally:
+        sup.stop(timeout=20)
+
+    entries = load_manifest(trial)
+    # What waiting on the condition collects.
+    assert len(entries) >= 2
+    # What waiting on the clock collected: the "too few snapshots to bisect
+    # meaningfully" failure this test exists to keep fixed.
+    on_the_clock = [e for e in entries if e.at - started <= OLD_FIXED_SLEEP]
+    assert len(on_the_clock) < 2, "the stubbed capture was not slow enough to starve a sleep"

--- a/arenabench/tests/test_snapshot_docker.py
+++ b/arenabench/tests/test_snapshot_docker.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import time
 from pathlib import Path
 
 import pytest
@@ -87,19 +86,28 @@ def test_the_workspace_is_found_inside_the_image(container):
     assert detect_workspace(name) == "/app"
 
 
-def test_capture_produces_patches_and_leaves_the_workspace_untouched(container):
+def test_capture_produces_patches_and_leaves_the_workspace_untouched(
+    container, wait_for_snapshots
+):
     name, trial, jobs_root = container
     sup = SnapshotSupervisor(
         jobs_root=jobs_root, jobs=["seat"], interval=2.0, poll_interval=0.5
     )
     sup.start()
     try:
-        time.sleep(4)
+        # Waiting on the manifest rather than the clock: capture costs whatever
+        # the host charges for `docker commit`, which is not bounded by
+        # `interval` (#2114). See `_wait_for_snapshots`.
+        wait_for_snapshots(trial, 1, what="of the pristine workspace")
         _sh("docker", "exec", name, "sh", "-c", "echo two >> /app/a.txt; echo new > /app/b.txt")
-        time.sleep(4)
+        edited_at = len(load_manifest(trial))
+        # A capture may have been in flight when the edit landed, so entry
+        # `edited_at` might predate it; the supervisor captures on a single
+        # thread, so `edited_at + 1` started afterwards and must carry a patch.
+        wait_for_snapshots(trial, edited_at + 2, what="of the edited workspace")
         # `result.json` appearing is how the supervisor learns a trial ended.
         (trial / "result.json").write_text('{"reward": 1}', encoding="utf-8")
-        time.sleep(3)
+        wait_for_snapshots(trial, edited_at + 3, what="of the graded state")
     finally:
         sup.stop(timeout=20)
 


### PR DESCRIPTION
## What & why

`test_flip_lands_where_the_solution_actually_appeared` flakes on `main` under
load, and it is currently on every PR monitor's "known flakes, rerun once"
list across the parallel fleet — so it burns real CI cycles and, worse, gives
every genuine failure in that file a ready-made excuse. This removes it.

**The mechanism.** `SnapshotSupervisor.interval` is a *floor* on the capture
cadence, never a period: `_snapshot` stamps `self._last` **before** running the
container's `git add`/`commit`/`diff`, so a capture dearer than `interval`
stretches the real cadence to whatever the host charges. One was measured at
5.6 s against a 2.0 s interval. The test then sized `time.sleep(5)` / `sleep(5)`
/ `sleep(3)` from that interval and asserted `len(entries) >= 4` — a bet on
capture speed. Under load it collected three and failed as *"too few snapshots
to bisect meaningfully"* on an unmodified `main` at 8b266fc6.

**The fix is not a bigger sleep** — that trades a flake for a slower test and
loses again on a slower host. Every wait is now on the *condition*:
`_wait_for_snapshots` (a shared `conftest` helper) polls the manifest until the
required entries exist, and raises a named `AssertionError` on a generous
deadline. It never skips. **No assertion changed** — `>= 4`, `flip_index >=
solved_at`, `unknown == 0`, `probes < snapshots` are all untouched, and the
test still fails if the flip lands before the solution.

One subtlety the waits now encode explicitly: they ask for **two** entries
either side of the event, not one. A capture can already be in flight when the
workspace changes, so the first new entry may predate it; the supervisor
captures on a single thread, so the *second* is the one guaranteed to have
started afterwards. That also keeps the flip off the end of the manifest, which
is what `wasted_elapsed > 0` needs.

`test_snapshot_docker.py::test_capture_produces_patches_and_leaves_the_workspace_untouched`
shares the identical `sleep(4)/sleep(4)/sleep(3)` hazard and is fixed the same
way.

Exemplar for the shape: pytest's own `pytest.WaitFor`-style polling in
`_pytest.pytester` — wait on the observable state, cap it with a deadline,
never on a sleep sized from an unrelated constant.

Closes #2114

## The witness

`arenabench/tests/test_snapshot.py::test_snapshot_waiting_outlasts_the_fixed_sleep_it_replaces`

A flaky test cannot be flipped on demand, so the witness rigs the bet to lose
deterministically instead. `_slow_capture` stubs `snapshot._exec` and
`snapshot._container_running` — the module's only two doors to Docker, so the
supervisor's own timing stays entirely under test — and charges 3.0 s per
capture against a 2.0 s interval. Entries then land at t+3 s and t+6 s: fewer
than two inside the five-second budget the old pacing allowed. **It needs no
Docker**, so unlike the test it protects it runs everywhere.

The test asserts both halves of the flip on one run: `len(entries) >= 2` (what
waiting on the condition collects) and `len(on_the_clock) < 2` (what the clock
would have collected from the very same run).

**Verified by reverting only the line under change** — swapping
`wait_for_snapshots(...)` back to `time.sleep(OLD_FIXED_SLEEP)` and re-running:

```
E       AssertionError: assert 1 >= 2
E        +  where 1 = len([SnapshotEntry(index=0, ... elapsed=3.007, workspace='/app')])
```

the same shape as the reported `assert len(entries) >= 4  # got 3`. Restored,
it passes in 6.3 s. (No `git stash` was used anywhere — parallel agents share
one stash stack.)

The second commit exists because the first attempt at this witness **passed
under the old pacing**, which would have made it worthless: `sup.stop()` joins
the watcher and finishes a capture already in flight, so a manifest read *after*
`stop()` holds an entry the pacing never waited for. The witness now reads the
manifest at the decision point, mid-run — exactly where the docker tests read
`solved_at`.

## The gate

Rust is untouched (`arenabench/` is the standalone stdlib-only Python package),
so this ran the targeted suites rather than `make gate`:

- `python -m pytest tests/test_snapshot.py` — 23 passed
- `python -m pytest tests/test_snapshot_docker.py` — 3 passed (Docker present)
- `python -m pytest tests/test_replay_docker.py` — passed, twice, ~141 s
- `ruff check` on all four touched files — clean. The 3 remaining findings under
  `arenabench/tests/` are pre-existing in `test_presets.py` / `test_sut.py`,
  tracked in #2146 / #2193 and deliberately left alone. `ruff format` was not
  run (it disagrees with the whole package).
- No tests deleted; no dependencies added.

## Nothing left behind

Two pre-existing hazards found while verifying this, both filed as handoffs and
both out of scope here:

- **#2196** — `SnapshotSupervisor` logs a capture that failed *outright* at
  `log.debug`, and the empty-`sha` branch logs nothing at all, so "never
  captured" and "slow" are the same observable. Hit live during this work: one
  run produced **zero** snapshots in 180 s with Docker healthy, git installed
  and `detect_workspace` returning `/app`, and pytest's captured-log section was
  empty. In a real match that surfaces as `flip_index=None` — *"the agent never
  solved it"* — which is the silent-wrong-answer class `test_replay_docker.py`
  exists to prevent. The timeout message added here deliberately does **not**
  claim "slow" for that reason.
- **#2197** — both Docker snapshot tests pin fixed container names
  (`demo__rpl1-main-1`, `demo__abc123-main-1`) and one a fixed
  `~/.arenabench/test-replay`, each force-removed on fixture entry. Two
  concurrent runs on one host destroy each other, muted by #2196 into what looks
  like a timing flake.

The witness adds ~6.3 s to the Docker-free suite. That is the minimum cost of
genuinely outlasting a five-second bet, and it is paid on every host rather
than only where Docker exists.

## Summary by Sourcery

Replace fixed sleep-based pacing in snapshot-related tests with condition-based waits on snapshot manifests to eliminate timing flakes under load.

New Features:
- Introduce a shared wait_for_snapshots pytest fixture that polls snapshot manifests until a required number of entries is present, with a bounded deadline.

Bug Fixes:
- Fix flakiness in docker snapshot tests by waiting on manifest state rather than assuming a minimum snapshot count after fixed sleep intervals.

Enhancements:
- Add a dedicated test that demonstrates the new manifest-based pacing outlasts the old fixed sleep approach using a controlled slow capture without Docker.
- Improve documentation comments around snapshot pacing and failure modes to clarify timing behavior and logging expectations.

Tests:
- Add a new non-Docker test verifying that condition-based waiting collects more snapshots than the previous clock-based pacing under slow capture conditions.
- Update docker-based snapshot and replay tests to use the wait_for_snapshots fixture for robust pacing around solution events and workspace edits.