### PR TITLE
fix(stella-pipeline): the authored witness runs in a tree it was never written against — give it an explicit, enforced path frame

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -401,7 +401,11 @@ impl GitCandidateWorkspaces {
                 let witness_reads: Arc<dyn stella_core::ToolExecutor> = Arc::new(
                     crate::agent::PolicyToolSet::new_owned(registry.clone(), self.policy.clone()),
                 );
-                let witness_tools = WitnessToolExecutor::new(ws_root.clone(), witness_reads);
+                // `canon_root`, not `self.root`: the frame screen compares
+                // spellings, and the goal's paths are phrased against the
+                // real, resolved location of the workspace (#2130).
+                let witness_tools =
+                    WitnessToolExecutor::new(ws_root.clone(), &canon_root, witness_reads);
                 let native =
                     CustomToolSet::new_owned(registry, self.custom_tools.clone(), ws_root.clone());
                 // MCP: layer the candidate_safe-filtered session view on top

--- a/crates/stella-cli/src/candidate_ws/witness_tools.rs
+++ b/crates/stella-cli/src/candidate_ws/witness_tools.rs
@@ -15,14 +15,26 @@ use stella_protocol::{ToolOutput, ToolSchema};
 /// file ever exists (the repair turn's "rewrite the test" depends on this).
 pub(super) struct WitnessToolExecutor {
     root: PathBuf,
+    /// Absolute roots the authored source must not anchor itself to (#2130):
+    /// the session's own workspace root — the frame the goal's paths are
+    /// written in — and this snapshot's root, which the graft leaves behind.
+    /// Ordered session-first, because that is the spelling an author copies
+    /// out of the goal and so the one worth naming in the refusal.
+    tree_roots: Vec<String>,
     reads: Arc<dyn ToolExecutor>,
     created_path: Mutex<Option<String>>,
 }
 
 impl WitnessToolExecutor {
-    pub(super) fn new(root: PathBuf, reads: Arc<dyn ToolExecutor>) -> Self {
+    pub(super) fn new(root: PathBuf, session_root: &Path, reads: Arc<dyn ToolExecutor>) -> Self {
+        let mut tree_roots = vec![session_root.display().to_string()];
+        let snapshot = root.display().to_string();
+        if !tree_roots.contains(&snapshot) {
+            tree_roots.push(snapshot);
+        }
         Self {
             root,
+            tree_roots,
             reads,
             created_path: Mutex::new(None),
         }
@@ -67,6 +79,19 @@ impl WitnessToolExecutor {
             stella_pipeline::witness::density::screen_witness_source(&path, content)
         {
             return Self::denied("create_witness_test", vacuous);
+        }
+        // The path-frame screen (#2130), here for exactly the reasons the
+        // density screen is: the author is told the frame in its prompt, and
+        // prose is guidance — this is the enforcement, at the one boundary
+        // witness bytes take to disk. A witness that hardcodes the project's
+        // absolute paths is unsatisfiable by construction (the oracle runs it
+        // inside a copy of the tree rooted elsewhere), and refusing it here
+        // costs the author nothing: the one-create claim below is untaken, so
+        // it revises in-turn against a message that names the relative form.
+        if let Err(misframed) =
+            stella_pipeline::witness::frame::screen_witness_frame(&self.tree_roots, content)
+        {
+            return Self::denied("create_witness_test", misframed);
         }
 
         let mut claimed = self
@@ -401,10 +426,18 @@ mod tests {
     use stella_tools::{RegistryOptions, ToolRegistry};
 
     async fn witness_executor(root: &Path) -> WitnessToolExecutor {
+        witness_executor_for(root, root).await
+    }
+
+    /// The two-tree shape the production path always has (#2130): the author
+    /// stands in a snapshot while the goal's paths are phrased against the
+    /// session's own root. `witness_executor` collapses them because the tests
+    /// that use it are about file mechanics, where the distinction is noise.
+    async fn witness_executor_for(root: &Path, session_root: &Path) -> WitnessToolExecutor {
         let registry: Arc<dyn ToolExecutor> = Arc::new(
             ToolRegistry::new_detected(root.to_path_buf(), RegistryOptions::default()).await,
         );
-        WitnessToolExecutor::new(root.to_path_buf(), registry)
+        WitnessToolExecutor::new(root.to_path_buf(), session_root, registry)
     }
 
     /// A witness body that would really witness something, tagged so the tests
@@ -593,6 +626,113 @@ mod tests {
         assert!(root.path().join("tests/real_witness.rs").exists());
     }
 
+    /// #2130's witness: a witness anchored to a tree it will not run in is
+    /// refused at the boundary, and the author still has its create.
+    ///
+    /// This is the `openssl-selfsigned-cert` shape (match `cc00894779ff`): the
+    /// goal named `/app/ssl/server.crt`, so the author wrote that down, and the
+    /// oracle ran the script inside the candidate copy — where it failed
+    /// identically for every change, correct or not, and rode a finished trial
+    /// into its timeout at reward 0. On `main` this artifact is ACCEPTED and
+    /// reaches disk; here it never does, and the refusal hands back the
+    /// relative form. Both roots are refused: anchoring to the snapshot the
+    /// author is standing in is just as unsatisfiable, because the graft moves
+    /// the test into a different candidate before the oracle sees it.
+    #[tokio::test]
+    async fn a_witness_anchored_to_a_tree_it_will_not_run_in_is_refused() {
+        let root = tempfile::tempdir().unwrap();
+        let tools = witness_executor_for(root.path(), Path::new("/app")).await;
+
+        let misframed = format!(
+            "#!/bin/sh\nset -e\nSSL_DIR=/app/ssl\ntest -f \"$SSL_DIR/server.crt\"\n\
+             test -f {}/ssl/server.key\n",
+            root.path().display()
+        );
+        let output = tools
+            .execute(
+                "create_witness_test",
+                &serde_json::json!({"path": "witness_ssl_cert.sh", "content": misframed}),
+            )
+            .await;
+        match &output {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("/app/ssl"),
+                    "the refusal must quote what was written: {message}"
+                );
+                assert!(
+                    message.contains("`ssl`"),
+                    "and hand back the relative form: {message}"
+                );
+            }
+            ToolOutput::Ok { .. } => {
+                panic!("a witness pinned to the project root can never pass its oracle")
+            }
+        }
+        assert!(
+            !root.path().join("witness_ssl_cert.sh").exists(),
+            "the misframed artifact must never reach disk"
+        );
+
+        // The snapshot's own root is refused too — the artifact is grafted
+        // into a different candidate before the flip is observed.
+        let snapshot_pinned = format!(
+            "#!/bin/sh\ntest -f {}/ssl/server.crt\n",
+            root.path().display()
+        );
+        assert!(
+            tools
+                .execute(
+                    "create_witness_test",
+                    &serde_json::json!({"path": "witness_ssl_cert.sh", "content": snapshot_pinned}),
+                )
+                .await
+                .is_error(),
+            "the authoring snapshot is not the tree the oracle runs in either"
+        );
+
+        // Neither refusal consumed the one create: the correctly framed
+        // rewrite lands on the very next attempt, in the same turn.
+        let output = tools
+            .execute(
+                "create_witness_test",
+                &serde_json::json!({
+                    "path": "witness_ssl_cert.sh",
+                    "content": "#!/bin/sh\nset -e\ntest -f ssl/server.crt\ntest -f ssl/server.key\n",
+                }),
+            )
+            .await;
+        assert!(
+            matches!(output, ToolOutput::Ok { .. }),
+            "the relative rewrite must be accepted after the refusals: {output:?}"
+        );
+        assert!(root.path().join("witness_ssl_cert.sh").exists());
+    }
+
+    /// The screen refuses the tree under test and nothing else: a witness
+    /// legitimately names its interpreter and the tools it shells out to, and
+    /// an infra deliverable outside the workspace root is not the copied tree.
+    #[tokio::test]
+    async fn machine_paths_stay_available_to_the_witness_author() {
+        let root = tempfile::tempdir().unwrap();
+        let tools = witness_executor_for(root.path(), Path::new("/app")).await;
+
+        let output = tools
+            .execute(
+                "create_witness_test",
+                &serde_json::json!({
+                    "path": "witness_nginx.sh",
+                    "content": "#!/bin/sh\nset -e\ntest -x /usr/sbin/nginx\n\
+                                grep -q 'ssl_protocols TLSv1.3' /etc/nginx/nginx.conf\n",
+                }),
+            )
+            .await;
+        assert!(
+            matches!(output, ToolOutput::Ok { .. }),
+            "machine and out-of-tree paths must stay usable: {output:?}"
+        );
+    }
+
     /// #1792's witness: the blind author can discover the tree by name —
     /// `glob` is offered and executes root-confined, and its results pass
     /// the same credential exclusion as the read path, so discovery never
@@ -694,7 +834,7 @@ mod tests {
             registry,
             stella_tools::policy::ToolPolicy::from_switches([("read_file".to_string(), false)]),
         ));
-        let tools = WitnessToolExecutor::new(root.path().to_path_buf(), policied);
+        let tools = WitnessToolExecutor::new(root.path().to_path_buf(), root.path(), policied);
 
         let names: Vec<_> = tools
             .schemas()

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -391,7 +391,18 @@ impl<'a> Pipeline<'a> {
             // authors nothing), so there is never a configured command to
             // offer. The probed availability set is the toolchain fact the
             // author gets instead.
-            CompletionMessage::user(witness_prompt(goal, frames, &structure, &available)),
+            // The SESSION's root, never the authoring snapshot's: it is the
+            // frame the goal's absolute paths are written in, and the one the
+            // author must translate out of (#2130). `engine.cwd` is that root
+            // by construction — every candidate surface overrides its own copy
+            // in `engine_config_for`, and this config is the untouched base.
+            CompletionMessage::user(witness_prompt(
+                goal,
+                frames,
+                &structure,
+                &available,
+                &self.config.engine.cwd,
+            )),
         ];
         // Both tallies are local and discarded, on the same reasoning: they
         // measure the *witness author*, and the ladder's channels are about

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -39,9 +39,20 @@
 //! lexical screen the `create_witness_test` boundary applies to the authored
 //! bytes, so a vacuous artifact is refused inside the author's own turn rather
 //! than after a baseline run and a repair turn have been paid for (#863).
+//!
+//! # And could fail for a reason the work can fix
+//!
+//! The other way an artifact fails now and always is a **path frame** error:
+//! assertions written against the project's own absolute paths, while the
+//! oracle runs the test inside an isolated copy rooted somewhere else. Such a
+//! witness answers the same failure for every change, correct or not.
+//! [`frame::screen_witness_frame`] refuses it at the same boundary and for the
+//! same reason (#2130), and [`witness_prompt`] states the frame up front so
+//! the author can translate the goal's paths itself.
 
 pub mod airlock;
 pub mod density;
+pub mod frame;
 pub mod warrant;
 
 use std::collections::HashMap;
@@ -719,6 +730,13 @@ pub const WITNESS_SYSTEM_PROMPT: &str = "You are the WITNESS AUTHOR for a coding
      and .NET may use their filename conventions.\n\
      - The test must fail NOW for the RIGHT reason (it exercises the missing/broken \
      behavior), not because of a typo, a missing import, or a harness error.\n\
+     - NAME EVERY FILE IN THE PROJECT BY A PATH RELATIVE TO THE WORKING DIRECTORY. Your \
+     test runs inside an isolated COPY of the project tree, rooted at a directory that is \
+     neither the project's own root nor the one you are reading now — so an absolute path \
+     into the project reads a tree the work under test never touches, fails identically for \
+     every change, and is REFUSED at creation. If the goal names a file absolutely, strip \
+     the project root and assert on the remainder. Absolute paths to the MACHINE \
+     (`/bin/sh`, `/usr/bin/openssl`) are fine; those are not the tree under test.\n\
      - ASSERT on a value the goal decides. A test with no assertions, one comparing \
      constants (`assert_eq!(2, 2)`), one comparing a value to itself, or a bare \
      `#[should_panic]` / `raises(Exception)` is REFUSED at creation — each of those \
@@ -746,11 +764,25 @@ pub const WITNESS_SYSTEM_PROMPT: &str = "You are the WITNESS AUTHOR for a coding
 /// role cannot execute anything, so this is the one fact about the toolchain
 /// it can be GIVEN rather than left to infer — and the pipeline enforces the
 /// choice afterwards, so the section is a constraint, not a hint.
+///
+/// `workspace_root` is the project's own absolute root — the frame the GOAL
+/// is phrased in, and the one the author cannot otherwise learn (#2130). It
+/// is stated so the author can translate `"<root>/ssl/server.crt"` into the
+/// `ssl/server.crt` its test will actually be run against; the enforced half
+/// is [`frame::screen_witness_frame`] at the create boundary. Empty or
+/// relative, the section is omitted rather than guessed at — there is then
+/// nothing true to say about the mapping.
+///
+/// Deliberately the project root and NOT the authoring snapshot's path: the
+/// snapshot's directory carries a pid and a sequence number, so naming it
+/// would put per-run noise into a prompt that wants to cache (invariant 7),
+/// and it is not the root the goal's paths are written against anyway.
 pub fn witness_prompt(
     goal: &str,
     recall: &[RecalledFrame],
     repo_structure: &str,
     available_runners: &[String],
+    workspace_root: &str,
 ) -> String {
     let mut s = String::new();
     if !available_runners.is_empty() {
@@ -801,6 +833,22 @@ pub fn witness_prompt(
             s.push_str(f.content.trim());
             s.push('\n');
         }
+    }
+    // Last before the goal, because it is how the goal must be READ: the goal
+    // routinely phrases deliverables in this root's absolute paths, and the
+    // test is run somewhere else entirely (#2130).
+    if let Some(root) = frame::framing_root(workspace_root) {
+        s.push_str(&format!(
+            "\n## Where your test runs — paths are RELATIVE\nThis project's own root is \
+             `{root}`, and the goal below may name files under it absolutely. Your test is \
+             NOT run there: it is run inside an isolated copy of this tree, with the working \
+             directory at that copy's root, and the copy the flip is verified in is a \
+             different directory again. So translate every project path out of `{root}` and \
+             assert on the remainder — the goal's `{root}/ssl/server.crt` is \
+             `ssl/server.crt` to you. An absolute path into the project is refused when you \
+             create the file; absolute paths to the machine (`/bin/sh`, `/usr/bin/openssl`) \
+             are fine.\n"
+        ));
     }
     s.push_str("\n## Goal\n");
     s.push_str(goal.trim());

--- a/crates/stella-pipeline/src/witness/frame.rs
+++ b/crates/stella-pipeline/src/witness/frame.rs
@@ -1,0 +1,314 @@
+//! The witness's **path frame**: which tree its assertions are written
+//! against, versus the tree the oracle actually runs them in (#2130).
+//!
+//! Witness authoring is a two-tree operation by construction (see
+//! [`crate::pipeline`]'s `witness_stage`): the artifact is authored in a
+//! pristine snapshot, grafted into the candidate that executed, and observed
+//! there. Neither of those roots is the project's own root, and the two are
+//! not each other. The one frame that resolves in all three is a path
+//! **relative to the test's working directory** — which is the root of
+//! whichever copy is running it.
+//!
+//! An author given a goal phrased in the project's absolute paths ("create
+//! `/app/ssl/server.crt`") does not know that, and writes them down. The
+//! result is unsatisfiable by construction: on `openssl-selfsigned-cert`
+//! (match `cc00894779ff`) the authored script pinned `SSL_DIR=/app/ssl` while
+//! the oracle ran it inside `/tmp/stella_candidate_460_0/`, so both oracle
+//! runs failed with the identical hash `failure:4b33a44975e094db` — the same
+//! answer they would give for any change whatsoever, correct or not. The
+//! "missing file" verdicts that followed sent the worker through two
+//! misdiagnosis loops and rode a trial that was otherwise finished into its
+//! 900-second timeout at reward 0.
+//!
+//! [`screen_witness_frame`] is the enforced half of the answer, applied to
+//! the authored bytes at the `create_witness_test` boundary beside
+//! [`super::density::screen_witness_source`] — the same boundary, for the
+//! same reason: it is the only path witness bytes take to disk, so a check
+//! there is complete rather than advisory, and a refusal arrives as a tool
+//! error *inside the author's own turn*, where its one create is still
+//! available and it can revise for free. The advisory half is the prompt
+//! ([`super::witness_prompt`]), which states the frame and names the
+//! project root so the author can translate the goal's paths itself.
+//!
+//! # What is not screened
+//!
+//! Absolute paths to the **machine** — `/bin/sh`, `/usr/bin/openssl`,
+//! `/etc/nginx/nginx.conf` — are left alone. They are not the tree under
+//! test, they mean the same thing in every copy of it, and an infra task
+//! whose deliverable genuinely lives outside the workspace root must still be
+//! able to assert on it. Only the roots the caller declares are refused.
+
+/// Why an authored witness could never be satisfied by correct work: it
+/// anchors an assertion to a tree the oracle will not run it in.
+///
+/// One variant, and it names both the offending literal and the form the
+/// author should have written — the message is what the author revises
+/// against, exactly as in [`super::density::VacuousWitness`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MisframedWitness {
+    /// The source hardcodes an absolute path into one of the declared trees.
+    #[error(
+        "the witness hardcodes `{literal}`, an absolute path into the project tree. Your test \
+         is executed inside an isolated COPY of that tree, rooted at a different directory, so \
+         `{literal}` reads a tree the work under test never touches — no correct change can \
+         ever satisfy it. Assert on `{relative}` instead: a path relative to the test's working \
+         directory resolves in whichever copy runs it. Absolute paths to the MACHINE \
+         (`/bin/sh`, `/usr/bin/openssl`) are fine — those are not the tree under test."
+    )]
+    TreeAbsolutePath {
+        /// The offending path token, quoted exactly as the author wrote it.
+        literal: String,
+        /// The same location relative to the test's working directory — the
+        /// form that resolves in every copy. `.` when the literal named a
+        /// root itself.
+        relative: String,
+    },
+}
+
+/// Screen an authored witness's source for assertions anchored to a tree the
+/// test will not run in.
+///
+/// `tree_roots` are the absolute roots that must not appear: the project's own
+/// workspace root (the frame the goal is phrased in) and the isolated copy the
+/// author is standing in (which the graft is about to leave behind). Order is
+/// the caller's; the first offending literal found wins, so list the root an
+/// author is likeliest to have copied from the goal first.
+///
+/// `Ok(())` means no declared root is anchored to — not that the paths are
+/// right, only that they are expressed in a frame that can resolve.
+///
+/// Backslash spellings are matched too: the comparison runs over a
+/// `\`→`/` copy of both the roots and the source. That substitution is
+/// byte-for-byte length-preserving, so every offset still indexes the original
+/// bytes and the quoted literal is what the author actually typed — the same
+/// technique [`super::density`] uses to quote from unsanitized source.
+pub fn screen_witness_frame(tree_roots: &[String], source: &str) -> Result<(), MisframedWitness> {
+    let normalized = source.replace('\\', "/");
+    for root in tree_roots {
+        let root = root.replace('\\', "/");
+        let Some(root) = framing_root(&root) else {
+            continue;
+        };
+        if let Some(misframed) = first_anchored_reference(root, source, &normalized) {
+            return Err(misframed);
+        }
+    }
+    Ok(())
+}
+
+/// A root that can serve as a frame — absolute, naming at least one component
+/// — trimmed of trailing separators, or `None` when it cannot.
+///
+/// One answer, consulted by both halves of the fix, so the prompt's prose and
+/// this module's enforcement can never disagree about which roots participate:
+/// [`super::witness_prompt`] states a root only when this returns it, and
+/// [`screen_witness_frame`] matches on exactly the same set.
+///
+/// The filesystem root is excluded rather than special-cased. Every absolute
+/// path is "inside" `/`, so screening for it would refuse `/bin/sh` and leave
+/// the author no legal move, and a workspace rooted there has no relative
+/// frame to offer anyway. A drive-qualified Windows root (`C:\work`)
+/// qualifies; a bare drive (`C:\`) does not, for the same reason `/` does not.
+pub fn framing_root(root: &str) -> Option<&str> {
+    let trimmed = root.trim_end_matches(['/', '\\']);
+    let normalized = trimmed.replace('\\', "/");
+    let has_components = match normalized.split_once(":/") {
+        Some((drive, rest)) if drive.len() == 1 => !rest.is_empty(),
+        _ => normalized.starts_with('/') && normalized.len() > 1,
+    };
+    has_components.then_some(trimmed)
+}
+
+/// The first path token in `source` anchored at `root`, as the refusal the
+/// author should read.
+fn first_anchored_reference(
+    root: &str,
+    source: &str,
+    normalized: &str,
+) -> Option<MisframedWitness> {
+    let bytes = normalized.as_bytes();
+    for (start, _) in normalized.match_indices(root) {
+        // A token that merely *contains* the root's spelling is a different
+        // path: `/tmp/app/x` is not `/app`, and `$PREFIX/app` is already
+        // relative to something.
+        if start > 0
+            && bytes
+                .get(start - 1)
+                .is_some_and(|byte| continues_a_token(*byte))
+        {
+            continue;
+        }
+        let end = start + root.len();
+        // Nor is `/appliance` `/app`. Only a separator (a child of the root)
+        // or a token boundary (the root named alone) counts.
+        if bytes
+            .get(end)
+            .is_some_and(|byte| *byte != b'/' && is_path_char(*byte))
+        {
+            continue;
+        }
+        let stop = bytes
+            .get(end..)
+            .and_then(|rest| rest.iter().position(|byte| !is_path_char(*byte)))
+            .map_or(bytes.len(), |offset| end + offset);
+        // Every byte in `start..stop` is ASCII, so `stop` lands on a character
+        // boundary — but this reads model-authored bytes, so it asks rather
+        // than asserts (invariant 5).
+        let (Some(literal), Some(tail)) = (source.get(start..stop), normalized.get(end..stop))
+        else {
+            continue;
+        };
+        let relative = tail.trim_start_matches('/');
+        return Some(MisframedWitness::TreeAbsolutePath {
+            literal: literal.to_string(),
+            relative: if relative.is_empty() {
+                ".".to_string()
+            } else {
+                relative.to_string()
+            },
+        });
+    }
+    None
+}
+
+/// Bytes that continue a filesystem path token.
+fn is_path_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/')
+}
+
+/// Whether a byte *preceding* a match means the match is mid-token. Non-ASCII
+/// bytes count: the screen would rather miss a reference embedded in prose it
+/// cannot segment than refuse a legitimate witness over one.
+fn continues_a_token(byte: u8) -> bool {
+    is_path_char(byte) || !byte.is_ascii()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roots(roots: &[&str]) -> Vec<String> {
+        roots.iter().map(|root| (*root).to_string()).collect()
+    }
+
+    /// #2130's shape, verbatim in outline from the trace that motivated this:
+    /// a shell witness that pins the project's absolute paths while the oracle
+    /// runs it inside a candidate copy. It is refused, and the refusal hands
+    /// back the working-directory-relative form the author should have used.
+    #[test]
+    fn the_openssl_witness_shape_is_refused_and_names_the_relative_form() {
+        let source = "#!/bin/sh\n\
+                      # Witness: self-signed TLS certificate provisioning.\n\
+                      set -e\n\
+                      SSL_DIR=/app/ssl\n\
+                      PY=/app/check_cert.py\n\
+                      test -f \"$SSL_DIR/server.crt\" || exit 1\n";
+        match screen_witness_frame(&roots(&["/app"]), source) {
+            Err(MisframedWitness::TreeAbsolutePath { literal, relative }) => {
+                assert_eq!(literal, "/app/ssl");
+                assert_eq!(relative, "ssl");
+            }
+            other => panic!("the misframed witness must be refused, got {other:?}"),
+        }
+    }
+
+    /// The trees are two, and anchoring to either is equally unsatisfiable:
+    /// the authoring snapshot is discarded after the graft, so a witness
+    /// pinned to it reads a directory that no longer exists by verify time.
+    #[test]
+    fn the_authoring_copy_is_as_wrong_as_the_project_root() {
+        let source = "test -f /tmp/stella_candidate_460_0/ssl/server.crt\n";
+        let declared = roots(&["/app", "/tmp/stella_candidate_460_0"]);
+        match screen_witness_frame(&declared, source) {
+            Err(MisframedWitness::TreeAbsolutePath { literal, relative }) => {
+                assert_eq!(literal, "/tmp/stella_candidate_460_0/ssl/server.crt");
+                assert_eq!(relative, "ssl/server.crt");
+            }
+            other => panic!("the authoring root must be refused too, got {other:?}"),
+        }
+    }
+
+    /// Naming the root itself — `cd /app`, the commonest first line of a
+    /// misframed shell witness — is the same defect, and its relative form is
+    /// the working directory.
+    #[test]
+    fn the_root_named_alone_resolves_to_the_working_directory() {
+        match screen_witness_frame(&roots(&["/app/"]), "cd /app\nls ssl\n") {
+            Err(MisframedWitness::TreeAbsolutePath { literal, relative }) => {
+                assert_eq!(literal, "/app");
+                assert_eq!(relative, ".", "the root itself is the working directory");
+            }
+            other => panic!("a bare root reference must be refused, got {other:?}"),
+        }
+    }
+
+    /// The screen refuses the tree under test and nothing else. A witness
+    /// needs an interpreter, the tools it shells out to, and often a genuinely
+    /// external deliverable; a lookalike directory is not the root; and the
+    /// relative form the author is being pushed toward must of course pass.
+    #[test]
+    fn machine_paths_lookalikes_and_the_relative_form_are_left_alone() {
+        for source in [
+            "#!/bin/sh\nopenssl x509 -in ssl/server.crt -noout\n",
+            "test -f /usr/bin/openssl && test -x /etc/nginx/nginx.conf\n",
+            // `/appliance` and `/app.d` merely start with the root's spelling.
+            "test -d /appliance/ssl && test -d /app.d/ssl\n",
+            // Mid-token: a longer absolute path, and a prefix variable join.
+            "test -f /tmp/app/ssl/x && test -f \"$PREFIX/app/ssl/x\"\n",
+            "curl https://internal.example.com/app/ssl/server.crt\n",
+            // The frame the author is supposed to use.
+            "SSL_DIR=ssl\ntest -f \"$SSL_DIR/server.crt\"\n",
+        ] {
+            assert_eq!(
+                screen_witness_frame(&roots(&["/app"]), source),
+                Ok(()),
+                "must not refuse: {source}"
+            );
+        }
+    }
+
+    /// A root with no relative frame to offer is not screened: every absolute
+    /// path is inside `/`, so screening for it would refuse `/bin/sh` and
+    /// leave the author no legal move at all. Empty and relative roots are
+    /// likewise skipped rather than matched against everything.
+    ///
+    /// [`framing_root`] is the single answer both halves read, so the prompt
+    /// that states a root and the screen that enforces it agree by
+    /// construction — this asserts the two directions together.
+    #[test]
+    fn a_root_that_cannot_frame_anything_is_neither_stated_nor_screened() {
+        for root in ["/", "//", "", ".", "relative/root", "C:\\"] {
+            assert_eq!(framing_root(root), None, "root {root:?} frames nothing");
+            assert_eq!(
+                screen_witness_frame(&roots(&[root]), "test -f /bin/sh && test -f /app/ssl\n"),
+                Ok(()),
+                "root {root:?} must not be screened"
+            );
+        }
+        assert_eq!(framing_root("/app/"), Some("/app"));
+        assert_eq!(framing_root("C:\\work\\"), Some("C:\\work"));
+    }
+
+    /// Backslash spellings are the same reference. The comparison runs over a
+    /// length-preserving copy, so the quoted literal still comes from the
+    /// author's own bytes — and multi-byte prose neither panics nor produces a
+    /// mid-character quote.
+    #[test]
+    fn backslash_spellings_match_and_multibyte_prose_is_safe() {
+        match screen_witness_frame(&roots(&["C:\\work"]), "assert Path(r\"C:\\work\\ssl\")\n") {
+            Err(MisframedWitness::TreeAbsolutePath { literal, relative }) => {
+                assert_eq!(literal, "C:\\work\\ssl", "quotes the author's own spelling");
+                assert_eq!(relative, "ssl");
+            }
+            other => panic!("a drive-qualified root must be refused, got {other:?}"),
+        }
+        // Non-ASCII on both sides of a lookalike: no panic, no refusal.
+        assert_eq!(
+            screen_witness_frame(&roots(&["/app"]), "# 証明書は/appにある\n"),
+            Ok(())
+        );
+        // ...and a real reference introduced by non-ASCII prose is still a
+        // token start when a space separates them.
+        assert!(screen_witness_frame(&roots(&["/app"]), "# 証明書: /app/ssl\n").is_err());
+    }
+}

--- a/crates/stella-pipeline/src/witness/tests.rs
+++ b/crates/stella-pipeline/src/witness/tests.rs
@@ -536,7 +536,7 @@ fn witness_prompt_carries_goal_structure_recall_and_marker() {
         id: None,
         content_digest: None,
     }];
-    let p = witness_prompt("fix the retry bug", &recall, "src/\n  lib.rs", &[]);
+    let p = witness_prompt("fix the retry bug", &recall, "src/\n  lib.rs", &[], "");
     assert!(p.contains("fix the retry bug"));
     assert!(p.contains("src/"));
     assert!(p.contains("memory: retries"));
@@ -607,7 +607,7 @@ fn repair_prompt_names_the_passing_command() {
 #[test]
 fn probed_runner_availability_reaches_the_author_as_a_constraint() {
     let available = vec!["cargo".to_string(), "pytest".to_string()];
-    let p = witness_prompt("add a parser", &[], "Cargo.toml", &available);
+    let p = witness_prompt("add a parser", &[], "Cargo.toml", &available, "");
     assert!(
         p.contains("Test runners available in this workspace"),
         "{p}"
@@ -618,7 +618,7 @@ fn probed_runner_availability_reaches_the_author_as_a_constraint() {
         "a constraint, not a hint: {p}"
     );
 
-    let bare = witness_prompt("add a parser", &[], "Cargo.toml", &[]);
+    let bare = witness_prompt("add a parser", &[], "Cargo.toml", &[], "");
     assert!(
         !bare.contains("Test runners available in this workspace"),
         "no probes, no section: {bare}"
@@ -705,7 +705,13 @@ fn sh_witness_paths_declare_intent() {
 /// container writes a pytest file otherwise.
 #[test]
 fn a_shell_only_workspace_prompts_a_shell_witness() {
-    let sh_only = witness_prompt("secure nginx", &[], "etc/nginx.conf", &["sh".to_string()]);
+    let sh_only = witness_prompt(
+        "secure nginx",
+        &[],
+        "etc/nginx.conf",
+        &["sh".to_string()],
+        "",
+    );
     assert!(sh_only.contains("NO language test framework"), "{sh_only}");
     assert!(sh_only.contains("TEST_COMMAND: sh"), "{sh_only}");
 
@@ -714,9 +720,46 @@ fn a_shell_only_workspace_prompts_a_shell_witness() {
         &[],
         "Cargo.toml",
         &["cargo".to_string(), "sh".to_string()],
+        "",
     );
     assert!(
         !with_cargo.contains("NO language test framework"),
         "a real toolchain must keep the ordinary guidance: {with_cargo}"
     );
+}
+
+/// #2130's prompt half: the author is TOLD the frame it is authoring in.
+///
+/// The goal routinely phrases deliverables in the project's absolute paths
+/// (`/app/ssl/server.crt`), and the author has no other way to learn that its
+/// test will be run inside a copy of the tree rooted elsewhere — so it wrote
+/// them down, producing a witness that failed identically for every change.
+/// The section names the root, so the translation is mechanical; the enforced
+/// half is `frame::screen_witness_frame` at the create boundary.
+#[test]
+fn the_author_is_told_the_tree_its_test_will_run_in() {
+    let framed = witness_prompt("create /app/ssl/server.crt", &[], "", &[], "/app");
+    assert!(
+        framed.contains("Where your test runs"),
+        "the frame must be stated: {framed}"
+    );
+    assert!(
+        framed.contains("`/app`"),
+        "and must name the project root the goal is phrased in: {framed}"
+    );
+    assert!(
+        framed.contains("`ssl/server.crt`"),
+        "with the translation spelled out: {framed}"
+    );
+
+    // A root that frames nothing states nothing — `frame::framing_root` is
+    // the single answer both halves read, so prose and enforcement cannot
+    // drift apart.
+    for rootless in ["", "/", "."] {
+        let bare = witness_prompt("create ssl/server.crt", &[], "", &[], rootless);
+        assert!(
+            !bare.contains("Where your test runs"),
+            "root {rootless:?} frames nothing, so no section: {bare}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #2130

## The defect

The witness author writes its test against the paths **the goal names** — which are the project's own absolute paths — while the flip oracle runs that test **inside an isolated copy of the tree, rooted somewhere else**. Nothing connected the two frames, so the author had to guess, and it guessed the way the goal reads.

On `openssl-selfsigned-cert__5VMc6i2` (match `cc00894779ff`, SUT 447f3393) the authored script pinned `SSL_DIR=/app/ssl` and `PY=/app/check_cert.py`, and the oracle ran it inside `/tmp/stella_candidate_460_0/`. Both oracle runs returned the identical hash `failure:4b33a44975e094db` — the answer that witness gives for *any* change, correct or not. The "missing file" verdicts that followed sent the worker through two misdiagnosis loops (rewriting `check_cert.py`'s path resolution, a spec regression; then regenerating already-correct artifacts) and rode the trial into its 900 s timeout at reward 0.

## The fix — make the frame explicit, then enforce it

Two halves, matching how #1539 and #863 handled the same class ("a fact a blind role must be *given*, over a contract that is *enforced*"):

**Enforced.** `stella_pipeline::witness::frame::screen_witness_frame` (new sibling module, `crates/stella-pipeline/src/witness/frame.rs`) is a pure lexical screen over the authored bytes: it refuses any absolute path token anchored at a declared tree root and hands back the working-directory-relative form the author should have written. It is wired at the `create_witness_test` boundary in `crates/stella-cli/src/candidate_ws/witness_tools.rs`, immediately after #863's density screen and for exactly the same reasons — that boundary is the only path witness bytes take to disk, so the check is complete rather than advisory, and it runs *before* the one-create claim is taken, so a refusal costs the author nothing: the message names the fix and it revises in-turn.

Both trees are declared, not just the project's: anchoring to the authoring snapshot is equally unsatisfiable, because the graft moves the artifact into a different candidate before the oracle sees it.

**Given.** `witness_prompt` now states the project root and the translation (`the goal's <root>/ssl/server.crt is ssl/server.crt to you`), and `WITNESS_SYSTEM_PROMPT` carries the rule as a hard requirement. `frame::framing_root` is the single answer both halves read, so the prose and the enforcement cannot drift apart about which roots participate.

**What is deliberately *not* refused:** absolute paths to the *machine* — `/bin/sh`, `/usr/bin/openssl`, `/etc/nginx/nginx.conf`. They mean the same thing in every copy of the tree, and an infra task whose deliverable genuinely lives outside the workspace root must still be able to assert on it. Lookalike directories (`/appliance`, `/app.d`), longer paths that merely contain the root (`/tmp/app/x`), and variable joins (`$PREFIX/app/x`) are all left alone.

Exemplar for the shape: `witness::density` next door — a pure `Result<(), TypedError>` screen whose error message is what the author revises against, quoting the original bytes via a length-preserving normalized twin.

## Witness tests and flip evidence

Verified by neutering **only the implementation** (`screen_witness_frame` → `Ok(())`; the prompt section suppressed; the boundary call removed) with every test left in place, then restoring with `git checkout --`. No `git stash` was used.

`cargo test -p stella-cli --bin stella candidate_ws::witness_tools`

| Test | Neutered | Restored |
|---|---|---|
| `a_witness_anchored_to_a_tree_it_will_not_run_in_is_refused` | **FAILED** — panicked at `witness_tools.rs:665`, the `ToolOutput::Ok` arm: *"a witness pinned to the project root can never pass its oracle"* | ok |
| `machine_paths_stay_available_to_the_witness_author` | ok | ok |

`cargo test -p stella-pipeline --lib witness::`

| Test | Neutered | Restored |
|---|---|---|
| `witness::frame::tests::the_openssl_witness_shape_is_refused_and_names_the_relative_form` | **FAILED** | ok |
| `witness::frame::tests::the_authoring_copy_is_as_wrong_as_the_project_root` | **FAILED** | ok |
| `witness::frame::tests::the_root_named_alone_resolves_to_the_working_directory` | **FAILED** | ok |
| `witness::frame::tests::backslash_spellings_match_and_multibyte_prose_is_safe` | **FAILED** | ok |
| `witness::tests::the_author_is_told_the_tree_its_test_will_run_in` | **FAILED** | ok |
| `witness::frame::tests::machine_paths_lookalikes_and_the_relative_form_are_left_alone` | ok | ok |
| `witness::frame::tests::a_root_that_cannot_frame_anything_is_neither_stated_nor_screened` | ok | ok |

The two that pass under the neuter are the *negative* halves — they must pass in both states or the screen is over-firing.

Full suites green after restore: `cargo test -p stella-pipeline --lib` → 620 passed; `cargo test -p stella-cli --bin stella candidate_ws::witness_tools` → 11 passed. `cargo clippy -p stella-pipeline --all-targets -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-pipeline --no-deps --document-private-items` both clean.

## Both prior bounds on this seam survive

`crates/stella-pipeline/src/pipeline/witness_stage.rs` has taken two merged PRs in the last few hours. My diff to it is a **13-line addition at one call site** (`witness_prompt` gains the session root) and touches neither mechanism. Confirmed at the call sites, not only by the suite — #2165 notes the token ceiling is currently witnessed as a pure function only:

- **#2151 (wall clock)** — `WITNESS_REPAIR_CEILING` (line 125), `witness_repair_bound` (137), the live call at line 510 and `tokio::time::timeout(repair_bound, repair_turn)` at line 550, all present and unmodified.
  - `pipeline::witness_stage::tests::the_repair_bound_is_the_ceiling_tightened_by_remaining_clock` → ok
  - `pipeline::tests::verification_hardening::witness_repair_bound::a_stalled_witness_repair_is_bounded_and_degrades_honestly` → ok
- **#2162 (output tokens)** — `WITNESS_MAX_OUTPUT_TOKENS = 16_384` (line 65), `bound_witness_output_tokens` (70), and its **call site** at line 267 inside `witness_engine_config`, wrapping `apply_role_shaping` so an override can lower but never raise the bound. Present and unmodified.
  - `pipeline::witness_stage::tests::the_witness_output_ceiling_only_ever_lowers` → ok

## The blind-author half — read the trace; #1792 did **not** regress

#2130's second bullet reads the author's two empty `glob` results (`**/*` and `*` → `(no files found)`) as author-side blindness reproducing on a same-day SUT. The trace says otherwise, and the correction matters because the proposed fix would have been aimed at the wrong thing.

From `stella-events.jsonl`, `toolu_01D44A2YX6rVgFrYMSHeXGQx`: `ls -la /app` returns **only `.git` and `.stella`**. The session workspace root *is* `/app`, and for this task it is **empty** — the goal is to create everything from scratch. The authoring snapshot is a pristine copy of that root, so `glob **/*` and `glob *` returned "(no files found)" because there genuinely were no files. `glob` is offered, root-confined, and working exactly as #1792 built it.

So the residual defect was never "the author cannot see"; it is "for a from-scratch task there is nothing to see, and the only frame information available is the goal text — which is written in a frame the test will not run in". That is precisely what this PR fixes. Nothing to file against #1792.

## Not fixed here, filed instead

- **#2206 (new)** — the *worker* makes the mirror-image frame error. It pasted the goal's `/app/ssl` onto the candidate root and created `<candidate>/app/ssl/...`, i.e. `/app/app/ssl/...` after adoption; all five deliverables landed one directory too deep (`git ls-files` inside the candidate confirms). It even wrote the wrong mapping down out loud in `toolu_01TFR5bsVgdR3312Qe5ztfUZ`. **This cost the trial its reward independently of the witness**, and it is out of scope here: the worker holds the full registry with no create boundary, and refusing real work at the wrong path is a design decision, not a screen.
- **#2207 (new)** — `witness::density::screen_witness_source` is a **no-op for shell witnesses**: `Lang::from_path` has no `sh` arm, so every `.sh` artifact falls through to `Ok(())` unscreened. Since #2064 made `sh` the floor runner and `witness_prompt` now *instructs* a shell witness whenever it is the only probed runner, the corpus where a witness is hardest to author is the corpus where #863's vacuity gate is off.
- **#2149 / #2204** — the third bullet of #2130 (witness authoring consumed 478.2 s across 3 calls, 53 % of the trial's model-time budget) is the wall-clock bound on the *author* rung, already tracked. Deliberately untouched: it is a second change to the hottest file in the repo tonight, and it belongs to those issues.

## Notes

- No new dependencies. No god file grew: `crates/stella-pipeline/src/pipeline.rs` and `src/pipeline/tests.rs` are untouched; new logic and tests live in the sibling `witness/frame.rs` and in the existing `witness_tools.rs` test module.
- No tests were deleted or renamed.
- Invariants: the screen is a pure synchronous function over borrowed data with a typed error (5); no `unwrap`/`expect` on the model-authored source — the two slices go through `str::get` and skip on `None`; the prompt addition is per-call user-message content and deliberately names the *session* root rather than the snapshot's pid-bearing temp path, so nothing volatile enters the cache-markable prefix (7).

## Summary by Sourcery

Introduce an enforced path-frame check for authored witnesses and surface the workspace root in witness prompts to prevent tests from anchoring to absolute project paths that will never be exercised by the oracle.

New Features:
- Add a path-frame screening mechanism for witness artifacts that rejects absolute paths anchored to declared workspace roots while allowing machine-level paths.
- Expose the session workspace root to the witness author via an explicit section in the witness prompt explaining how to translate goal paths into working-directory-relative forms.

Bug Fixes:
- Ensure witnesses that hardcode project-root absolute paths are refused at creation instead of producing unsatisfiable tests that fail identically for every change.

Enhancements:
- Wire the new frame screen into the witness creation boundary in the CLI so misframed artifacts are rejected before being written to disk, without consuming the one-create allowance.
- Extend witness tests to cover path-frame behavior, including refusal of project and snapshot roots and acceptance of legitimate machine paths and relative paths.
- Refine the witness system prompt and authoring guidance to clearly distinguish project-tree paths from machine paths and align prompt prose with enforcement via a shared framing-root helper.

Tests:
- Add unit and integration tests validating the frame-screening logic, prompt framing behavior, and end-to-end refusal/acceptance of witness scripts under different root configurations.