### PR TITLE
fix(arenabench): record every capture outcome, so a never-measured trial cannot read as never-solved

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -25,7 +25,6 @@ from .recorder import IMAGE_TAG, build_image, docker_available, image_present
 from .registry import DEFAULT_REGISTRY, export_root, sample_tasks
 from .replay import ReplayError, replay_flip
 from .server import default_workspace, serve
-from .snapshot import CAPTURE_FAILED
 
 __all__ = ["main"]
 
@@ -481,10 +480,11 @@ def _cmd_flip(args: argparse.Namespace) -> int:
         # never be printed alone when capture is the thing that failed — that
         # is how a solved trial gets recorded as a failure (#2196).
         capture = result.capture
-        if capture is not None and capture.state == CAPTURE_FAILED:
+        if capture is not None and capture.broke:
             print(
-                f"warning: capture broke during this trial after "
-                f"{capture.attempts} attempt(s) — {capture.reason}\n"
+                f"warning: capture broke during this trial — "
+                f"{capture.snapshots} of {capture.attempts} attempt(s) landed, "
+                f"and the last one failed: {capture.reason}\n"
                 "         this trial was not fully measured; do not read the "
                 "absence of a flip as the agent never solving it",
                 file=sys.stderr,

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -25,6 +25,7 @@ from .recorder import IMAGE_TAG, build_image, docker_available, image_present
 from .registry import DEFAULT_REGISTRY, export_root, sample_tasks
 from .replay import ReplayError, replay_flip
 from .server import default_workspace, serve
+from .snapshot import CAPTURE_FAILED
 
 __all__ = ["main"]
 
@@ -476,6 +477,18 @@ def _cmd_flip(args: argparse.Namespace) -> int:
             f"no snapshot passed ({result.snapshots} captured, "
             f"{result.probes} probed, {result.unknown} unknown)"
         )
+        # "No snapshot passed" reads as "the agent never solved it", so it must
+        # never be printed alone when capture is the thing that failed — that
+        # is how a solved trial gets recorded as a failure (#2196).
+        capture = result.capture
+        if capture is not None and capture.state == CAPTURE_FAILED:
+            print(
+                f"warning: capture broke during this trial after "
+                f"{capture.attempts} attempt(s) — {capture.reason}\n"
+                "         this trial was not fully measured; do not read the "
+                "absence of a flip as the agent never solving it",
+                file=sys.stderr,
+            )
         return 0
     print(
         f"flip at snapshot {result.flip_index}/{result.snapshots - 1} "

--- a/arenabench/arenabench/replay.py
+++ b/arenabench/arenabench/replay.py
@@ -39,6 +39,7 @@ from .snapshot import (
     bisect_first_pass,
     confirm_first_pass,
     detect_workspace,
+    load_capture_status,
     load_manifest,
     read_task_image,
     summarise_flip,
@@ -250,8 +251,14 @@ def replay_flip(
     if shutil.which("git") is None:
         raise ReplayError("git is not available on this host; replay applies patches locally")
     entries = load_manifest(trial_dir)
+    # Read before the emptiness check so the error can say *why* the manifest
+    # is empty. "No snapshots captured" on its own is the sentence that used to
+    # send an operator looking for a slow host when capture had in fact been
+    # failing outright and saying so only at `debug` (#2196).
+    capture = load_capture_status(trial_dir)
     if not entries:
-        raise ReplayError(f"no snapshots captured for {trial_dir.name}")
+        why = f": {capture.reason}" if capture is not None and capture.reason else ""
+        raise ReplayError(f"no snapshots captured for {trial_dir.name}{why}")
     image = read_task_image(task_dir)
     if not image:
         raise ReplayError(f"no docker_image in {task_dir / 'task.toml'}")
@@ -291,6 +298,7 @@ def replay_flip(
         answer,
         probes=len(seen),
         unknown=sum(1 for v in seen.values() if v is None),
+        capture=capture,
     )
     try:
         (trial_dir / FLIP_NAME).write_text(

--- a/arenabench/arenabench/snapshot.py
+++ b/arenabench/arenabench/snapshot.py
@@ -37,6 +37,18 @@ task it was measuring. This one is invisible to the agent and to the verifier.
 Capture is opt-in and degrades to nothing. No Docker, no git in the image, or a
 container that vanishes mid-sweep yields a trial with no snapshots and a
 warning — never a failed run. Measurement must not be able to cost a benchmark.
+
+**Degrading to nothing is not the same as saying nothing.** That warning was
+only ever emitted by the *start* side; a capture that failed after a clean
+start was logged at ``debug``, and a capture that returned an empty sha was
+logged nowhere at all — so a broken capture and a slow host were the same
+observable, an empty manifest. Since replay reads an empty manifest as
+``flip_index=None``, and an operator reads *that* as "the agent never solved
+it", the silence could record a solved trial as a failure. Every capture
+attempt now leaves an outcome in :class:`CaptureStatus`
+(``arena/snapshots/capture.json``), a trial that captured nothing says so once
+at ``error``, and the record rides into ``flip.json`` so nothing downstream has
+to guess (#2196).
 """
 
 from __future__ import annotations
@@ -49,15 +61,17 @@ import subprocess
 import threading
 import time
 from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 __all__ = [
     "SNAPSHOT_DIRNAME",
+    "CaptureStatus",
     "FlipResult",
     "SnapshotEntry",
     "SnapshotSupervisor",
     "bisect_first_pass",
+    "load_capture_status",
     "load_manifest",
     "read_task_image",
 ]
@@ -68,6 +82,10 @@ log = logging.getLogger("arenabench.snapshot")
 SNAPSHOT_DIRNAME = "arena/snapshots"
 
 MANIFEST_NAME = "manifest.jsonl"
+
+#: Beside the manifest: why the manifest looks the way it does. See
+#: :class:`CaptureStatus`.
+CAPTURE_STATUS_NAME = "capture.json"
 
 #: The snapshot repository lives here, inside the container but outside the
 #: workspace, so the workspace is never modified. See the module docstring.
@@ -173,6 +191,132 @@ def load_manifest(trial_dir: Path) -> list[SnapshotEntry]:
     return sorted(entries, key=lambda e: e.index)
 
 
+# ---------------------------------------------------------------------------
+# What capture actually did
+# ---------------------------------------------------------------------------
+
+#: The supervisor has seen the trial but capture has not begun yet.
+CAPTURE_STARTING = "starting"
+#: Capture is live and the last attempt landed a snapshot.
+CAPTURE_CAPTURING = "capturing"
+#: Capture ran until the trial (or the run) ended. The manifest is what it got.
+CAPTURE_COMPLETE = "complete"
+#: Capture began and then broke; :attr:`CaptureStatus.reason` says how.
+CAPTURE_FAILED = "failed"
+#: Capture never began — no container, no workspace directory, or no git.
+CAPTURE_UNAVAILABLE = "unavailable"
+
+#: States that mean capture is over and will not resume for this trial.
+TERMINAL_CAPTURE_STATES = (CAPTURE_COMPLETE, CAPTURE_FAILED, CAPTURE_UNAVAILABLE)
+
+
+@dataclass(frozen=True)
+class CaptureStatus:
+    """Why a trial's snapshot manifest looks the way it does.
+
+    The manifest records what capture *achieved*, and nothing recorded what it
+    *attempted*. So a short manifest — or an absent one — read identically
+    whether the trial was short, the host was slow, or capture broke on its
+    first attempt and then retried in silence for the rest of the run. Those
+    are opposite conclusions about the same benchmark trial, and the last one
+    is the dangerous one: replay reads an empty manifest as ``flip_index=None``
+    and an operator reads *that* as "the agent never solved it", which converts
+    a solved trial into a failure in the benchmark record (#2196).
+
+    This is the record that separates them, written beside the manifest as
+    ``arena/snapshots/capture.json`` so it survives the run and is readable by
+    anything that later reads the manifest. It is deliberately a *record*, not
+    an alarm: capture degrades to nothing by design (see the module docstring),
+    and measurement must not be able to cost a benchmark.
+    """
+
+    #: The trial directory's name, so a record read on its own still says who.
+    trial: str
+    #: One of the ``CAPTURE_*`` constants above.
+    state: str
+    #: Snapshots that reached the manifest.
+    snapshots: int
+    #: Capture attempts made, landed or lost. ``attempts - snapshots`` is the
+    #: measurement that was tried for and did not survive.
+    attempts: int
+    #: Consecutive failures at the moment this was written; zero after any
+    #: attempt that landed.
+    failures: int
+    #: The last failure, in full. Never truncated here — the truncated half is
+    #: usually the part that matters.
+    reason: str
+    #: Unix time this record was last written.
+    at: float
+
+    @property
+    def captured_nothing(self) -> bool:
+        """No snapshot ever reached the manifest, so there is nothing to replay.
+
+        The question a downstream consumer has to ask before reading
+        ``flip_index=None`` as "never solved": a trial that was never measured
+        cannot answer it either way.
+        """
+        return self.snapshots <= 0
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "trial": self.trial,
+            "state": self.state,
+            "snapshots": self.snapshots,
+            "attempts": self.attempts,
+            "failures": self.failures,
+            "reason": self.reason,
+            "at": self.at,
+        }
+
+    @staticmethod
+    def from_json(raw: dict[str, object]) -> CaptureStatus | None:
+        try:
+            return CaptureStatus(
+                trial=str(raw["trial"]),
+                state=str(raw["state"]),
+                snapshots=int(raw["snapshots"]),  # type: ignore[arg-type]
+                attempts=int(raw.get("attempts") or 0),  # type: ignore[arg-type]
+                failures=int(raw.get("failures") or 0),  # type: ignore[arg-type]
+                reason=str(raw.get("reason") or ""),
+                at=float(raw.get("at") or 0.0),  # type: ignore[arg-type]
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def load_capture_status(trial_dir: Path) -> CaptureStatus | None:
+    """The capture record for a trial, or ``None`` if there is none.
+
+    ``None`` is not "capture was fine": it is a trial captured before this
+    record existed, or one no supervisor ever looked at. Callers that need to
+    know whether a flip is trustworthy must treat it as *unknown* rather than
+    as consent.
+    """
+    path = trial_dir / SNAPSHOT_DIRNAME / CAPTURE_STATUS_NAME
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return CaptureStatus.from_json(raw) if isinstance(raw, dict) else None
+
+
+def write_capture_status(trial_dir: Path, status: CaptureStatus) -> None:
+    """Record what capture is doing, best-effort.
+
+    Written whole on every change rather than appended to, because the
+    interesting read is always the latest one and a torn tail would cost the
+    record its meaning. A failure to write is logged and swallowed: the whole
+    point of this record is a run that keeps going.
+    """
+    path = trial_dir / SNAPSHOT_DIRNAME / CAPTURE_STATUS_NAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(status.to_json(), indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - reporting must not fail a run
+        log.warning("could not write the capture record for %s: %s", trial_dir.name, exc)
+
+
 def read_task_image(task_dir: Path) -> str | None:
     """The docker image a task runs in, read from its ``task.toml``.
 
@@ -269,6 +413,14 @@ class FlipResult:
     probes: int
     #: Snapshots that could not be probed at all.
     unknown: int
+    #: What capture did for this trial, when a record exists (#2196).
+    #:
+    #: Rides along in ``flip.json`` because ``flip_index=None`` is not one
+    #: finding but two: "the agent never solved it" and "capture never worked,
+    #: so this trial was never measured". Reading the second as the first
+    #: records a solved trial as a failure. ``None`` means the trial predates
+    #: the record — unknown, never a clean bill of health.
+    capture: CaptureStatus | None = None
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -278,6 +430,7 @@ class FlipResult:
             "snapshots": self.snapshots,
             "probes": self.probes,
             "unknown": self.unknown,
+            "capture": self.capture.to_json() if self.capture is not None else None,
         }
 
 
@@ -287,6 +440,7 @@ def summarise_flip(
     *,
     probes: int,
     unknown: int,
+    capture: CaptureStatus | None = None,
 ) -> FlipResult:
     """Turn a flip index into the durations an operator actually reads."""
     flip_elapsed: float | None = None
@@ -301,6 +455,7 @@ def summarise_flip(
         snapshots=len(entries),
         probes=probes,
         unknown=unknown,
+        capture=capture,
     )
 
 
@@ -407,10 +562,20 @@ class SnapshotSupervisor:
     interval: float = 30.0
     poll_interval: float = 2.0
     max_start_attempts: int = 3
+    #: Consecutive failed captures before a trial is retired. The start side
+    #: has always given up (``max_start_attempts``); the capture side used to
+    #: retry forever, so a container that went away mid-trial was still paying
+    #: a ``docker exec`` — and its 180 s timeout — every interval for the rest
+    #: of the run. Reset by any capture that lands, so a host that merely
+    #: stumbles is never retired.
+    max_capture_attempts: int = 5
 
     _active: dict[Path, _Capture] = field(default_factory=dict, init=False)
     _finished: set[Path] = field(default_factory=set, init=False)
     _failures: dict[Path, int] = field(default_factory=dict, init=False)
+    _capture_failures: dict[Path, int] = field(default_factory=dict, init=False)
+    _status: dict[Path, CaptureStatus] = field(default_factory=dict, init=False)
+    _finalised: set[Path] = field(default_factory=set, init=False)
     _last: dict[Path, float] = field(default_factory=dict, init=False)
     _thread: threading.Thread | None = field(default=None, init=False)
     _stop: threading.Event = field(default_factory=threading.Event, init=False)
@@ -434,12 +599,31 @@ class SnapshotSupervisor:
             thread.join(timeout=timeout)
         self._thread = None
         with self._lock:
+            pending = list(self._status)
             self._active.clear()
+        # A run can end while trials are still live — an abort, the wall clock,
+        # or `result.json` simply never arriving. Closing their records here is
+        # what stops "capture was still going" from being read later as
+        # "capture finished and found nothing".
+        for trial_dir in pending:
+            self._finalise(trial_dir)
 
     @property
     def active_count(self) -> int:
         with self._lock:
             return len(self._active)
+
+    def unmeasured(self) -> list[CaptureStatus]:
+        """Every trial whose capture produced no snapshots at all.
+
+        The machine-readable half of the loud line :meth:`_finalise` logs. A
+        caller holding this list knows which trials' ``flip_index=None`` means
+        "never measured" rather than "never solved", and can refuse to score
+        them instead of recording a solved trial as a failure (#2196).
+        """
+        with self._lock:
+            statuses = list(self._status.values())
+        return [s for s in statuses if s.captured_nothing]
 
     # -- internals --------------------------------------------------------
 
@@ -474,6 +658,7 @@ class SnapshotSupervisor:
                 with self._lock:
                     self._active.pop(trial_dir, None)
                 self._finished.add(trial_dir)
+                self._finalise(trial_dir)
                 return
             if time.monotonic() - self._last.get(trial_dir, 0.0) >= self.interval:
                 self._snapshot(trial_dir, capture)
@@ -482,16 +667,162 @@ class SnapshotSupervisor:
         if finished or not (trial_dir / "agent").is_dir():
             if finished:
                 self._finished.add(trial_dir)
+                # Only if a record exists: a trial capture never looked at is
+                # not a trial capture failed on, and inventing a record for it
+                # would be its own false signal.
+                self._finalise(trial_dir)
             return
         self._begin(trial_dir)
+
+    # -- the capture record ------------------------------------------------
+
+    def _status_for(self, trial_dir: Path) -> CaptureStatus:
+        with self._lock:
+            status = self._status.get(trial_dir)
+        return status or CaptureStatus(
+            trial=trial_dir.name,
+            state=CAPTURE_STARTING,
+            snapshots=0,
+            attempts=0,
+            failures=0,
+            reason="",
+            at=time.time(),
+        )
+
+    def _write_status(self, trial_dir: Path, status: CaptureStatus) -> None:
+        """Update the record in memory and on disk. Never called under the lock."""
+        with self._lock:
+            self._status[trial_dir] = status
+        write_capture_status(trial_dir, status)
+
+    def _finalise(self, trial_dir: Path) -> None:
+        """Close a trial's capture record, loudly when it measured nothing.
+
+        A trial that captured zero snapshots is a broken measurement, not a
+        quiet edge case: replay has no manifest to search, reports
+        ``flip_index=None``, and an operator reads that as "the agent never
+        solved it". Saying so once at ``error`` — and leaving the same fact in
+        ``capture.json`` for anything reading afterwards — is the difference
+        between a wrong benchmark number and a line naming the reason.
+
+        Never raises and never aborts the run: the module's standing invariant
+        is that measurement must not be able to cost a benchmark.
+        """
+        if trial_dir in self._finalised or trial_dir not in self._status:
+            return
+        self._finalised.add(trial_dir)
+        status = self._status_for(trial_dir)
+        if status.state in TERMINAL_CAPTURE_STATES:
+            state = status.state
+        elif status.snapshots:
+            state = CAPTURE_COMPLETE
+        elif status.state == CAPTURE_STARTING:
+            state = CAPTURE_UNAVAILABLE  # capture never began
+        else:
+            state = CAPTURE_FAILED  # it began, and produced nothing
+        final = replace(status, state=state, at=time.time())
+        self._write_status(trial_dir, final)
+        if final.captured_nothing:
+            log.error(
+                "no snapshots captured for %s (%s after %d attempt(s)): %s — a flip "
+                "replay of this trial cannot tell 'never solved' from 'never "
+                "measured', so do not score it as either",
+                final.trial,
+                final.state,
+                final.attempts,
+                final.reason or "no failure was recorded",
+            )
 
     def _fail(self, trial_dir: Path, detail: str) -> None:
         count = self._failures.get(trial_dir, 0) + 1
         self._failures[trial_dir] = count
         if count == 1:
             log.warning("snapshots unavailable for %s: %s", trial_dir.name, detail)
-        if count >= self.max_start_attempts:
+        retired = count >= self.max_start_attempts
+        if retired:
             self._finished.add(trial_dir)
+        status = self._status_for(trial_dir)
+        self._write_status(
+            trial_dir,
+            replace(
+                status,
+                state=CAPTURE_UNAVAILABLE if retired else CAPTURE_STARTING,
+                attempts=status.attempts + 1,
+                failures=count,
+                reason=detail,
+                at=time.time(),
+            ),
+        )
+        if retired:
+            self._finalise(trial_dir)
+
+    def _capture_failed(self, trial_dir: Path, detail: str) -> None:
+        """A capture attempt produced no snapshot. Escalate the way `_fail` does.
+
+        Shaped deliberately like :meth:`_fail`, because the asymmetry between
+        them *was* the bug: the start side escalated its first failure to
+        ``warning`` and retired the trial after N attempts, while the capture
+        side logged at ``debug`` and retried forever — so "capture is broken"
+        and "this host is slow" were the same observable, an empty manifest and
+        silence (#2196).
+
+        Once at ``warning`` and the rest at ``debug`` is the same anti-spam
+        shape ``_fail`` uses: the first failure is the diagnosis, and a wedged
+        container would otherwise fill the run log with the same line every
+        interval.
+        """
+        failures = self._capture_failures.get(trial_dir, 0) + 1
+        self._capture_failures[trial_dir] = failures
+        if failures == 1:
+            log.warning("snapshot capture failed for %s: %s", trial_dir.name, detail)
+        else:
+            log.debug(
+                "snapshot capture failed for %s (%d in a row): %s",
+                trial_dir.name,
+                failures,
+                detail,
+            )
+        status = self._status_for(trial_dir)
+        retired = failures >= self.max_capture_attempts
+        self._write_status(
+            trial_dir,
+            replace(
+                status,
+                state=CAPTURE_FAILED if retired else CAPTURE_CAPTURING,
+                attempts=status.attempts + 1,
+                failures=failures,
+                reason=detail,
+                at=time.time(),
+            ),
+        )
+        if not retired:
+            return
+        log.warning(
+            "giving up on snapshots for %s after %d consecutive failures: %s",
+            trial_dir.name,
+            failures,
+            detail,
+        )
+        self._finished.add(trial_dir)
+        with self._lock:
+            self._active.pop(trial_dir, None)
+        self._finalise(trial_dir)
+
+    def _captured(self, trial_dir: Path) -> None:
+        """One snapshot reached the manifest: the trial is measurable again."""
+        self._capture_failures.pop(trial_dir, None)
+        status = self._status_for(trial_dir)
+        self._write_status(
+            trial_dir,
+            replace(
+                status,
+                state=CAPTURE_CAPTURING,
+                snapshots=status.snapshots + 1,
+                attempts=status.attempts + 1,
+                failures=0,
+                at=time.time(),
+            ),
+        )
 
     def _begin(self, trial_dir: Path) -> None:
         container = container_for_trial(trial_dir)
@@ -525,10 +856,24 @@ class SnapshotSupervisor:
             capture.container, _commit_script(capture.workspace, capture.index)
         )
         if code != 0:
-            log.debug("snapshot commit failed for %s: %s", trial_dir.name, out[-200:])
+            self._capture_failed(
+                trial_dir,
+                f"the snapshot commit exited {code}: {out.strip()[-200:] or '(no output)'}",
+            )
             return
         sha = out.strip().splitlines()[-1].strip() if out.strip() else ""
         if not sha:
+            # A genuinely different fault from the branch above, and previously
+            # recorded nowhere at all — not even at `debug`: the commit
+            # *succeeded* and `rev-parse HEAD` still printed nothing, which is
+            # what the snapshot repo disappearing out from under a live
+            # container looks like. Named separately so the two cannot be
+            # confused after the fact.
+            self._capture_failed(
+                trial_dir,
+                "the snapshot commit succeeded but `git rev-parse HEAD` printed no "
+                "sha — the snapshot repository is gone or unreadable",
+            )
             return
 
         snap_dir = trial_dir / SNAPSHOT_DIRNAME
@@ -562,7 +907,13 @@ class SnapshotSupervisor:
             with (snap_dir / MANIFEST_NAME).open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(entry.to_json()) + "\n")
         except OSError as exc:
-            log.debug("could not append manifest for %s: %s", trial_dir.name, exc)
+            # The snapshot was taken and is now unreachable: the manifest is
+            # the only index into the patches. From the manifest's point of
+            # view — which is the only view replay has — this attempt captured
+            # nothing, so it is counted as the failure it is.
+            self._capture_failed(trial_dir, f"could not append the manifest: {exc}")
+        else:
+            self._captured(trial_dir)
         capture.index += 1
 
 

--- a/arenabench/arenabench/snapshot.py
+++ b/arenabench/arenabench/snapshot.py
@@ -258,6 +258,27 @@ class CaptureStatus:
         """
         return self.snapshots <= 0
 
+    @property
+    def broke(self) -> bool:
+        """Capture was failing when this record was last written.
+
+        Weaker than :attr:`captured_nothing` and, for this bug, the more
+        common shape: :meth:`SnapshotSupervisor._begin` lands snapshot 0 of
+        the *pristine* workspace, capture then breaks, and the trial finishes
+        before ``max_capture_attempts`` consecutive failures retire it. Capture
+        did run to the end, so the record closes ``complete`` and
+        ``captured_nothing`` is false — but the one state in the manifest is
+        the unsolved one, so replay still reports ``flip_index=None`` for a
+        trial the agent may well have solved. The severe case is one snapshot,
+        not zero, and a check keyed on :data:`CAPTURE_FAILED` alone would miss
+        it (#2196).
+
+        :attr:`failures` is the evidence rather than :attr:`state`, because it
+        resets on any attempt that lands: non-zero here means the last thing
+        capture did was fail, whatever state the record was closed in.
+        """
+        return self.state == CAPTURE_FAILED or self.failures > 0
+
     def to_json(self) -> dict[str, object]:
         return {
             "trial": self.trial,

--- a/arenabench/tests/conftest.py
+++ b/arenabench/tests/conftest.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-from arenabench.snapshot import load_manifest
+from arenabench.snapshot import load_capture_status, load_manifest
 
 MATCHES = Path(__file__).parent / "fixtures" / "matches"
 
@@ -95,13 +95,21 @@ def _wait_for_snapshots(
         if count >= at_least:
             return count
         if time.monotonic() >= limit:
-            # Zero here is a different fault from "too few": the supervisor
-            # logs a capture that failed outright at debug level, so it is
-            # invisible unless the run asked for it (#2196).
+            # "Not keeping up" and "stopped working" are different faults, and
+            # this message used to be unable to tell them apart — it could only
+            # suggest re-running at DEBUG, because that was the only level the
+            # supervisor said anything at. It now records every capture attempt,
+            # so the fault names itself here instead of in a second run (#2196).
+            status = load_capture_status(trial_dir)
+            why = (
+                f"capture reports {status.state} after {status.attempts} attempt(s): "
+                f"{status.reason}"
+                if status is not None and status.reason
+                else "capture is not keeping up on this host"
+            )
             raise AssertionError(
                 f"only {count} of {at_least} snapshots {what} after "
-                f"{deadline:.0f}s — capture is not keeping up on this host, or "
-                f"stopped working; re-run with --log-cli-level=DEBUG to see which"
+                f"{deadline:.0f}s — {why}"
             )
         time.sleep(0.2)
 

--- a/arenabench/tests/test_snapshot_status.py
+++ b/arenabench/tests/test_snapshot_status.py
@@ -204,15 +204,21 @@ def test_a_zero_capture_run_is_machine_detectable(tmp_path, monkeypatch, caplog)
     assert "no such container" in status.reason
 
 
-def test_the_pacing_deadline_now_names_which_fault_it_hit(tmp_path, monkeypatch):
+def test_the_pacing_deadline_now_names_which_fault_it_hit(
+    tmp_path, monkeypatch, wait_for_snapshots
+):
     """The snapshot tests' own wait can stop hedging (#2114 + #2196).
 
-    `_wait_for_snapshots` was landed deliberately unable to say whether a host
-    was slow or capture had stopped working — it could only suggest re-running
-    at DEBUG, because that was the only level the supervisor said anything at.
-    With the record on disk it reads the answer instead of guessing at it.
+    The wait was landed deliberately unable to say whether a host was slow or
+    capture had stopped working — it could only suggest re-running at DEBUG,
+    because that was the only level the supervisor said anything at. With the
+    record on disk it reads the answer instead of guessing at it.
+
+    Reached through the fixture every other snapshot test uses, rather than by
+    importing `tests.conftest`, which only resolves as an implicit namespace
+    package.
     """
-    from tests.conftest import _wait_for_snapshots
+    _wait_for_snapshots = wait_for_snapshots
 
     trial = _trial(tmp_path)
     _capture_that(monkeypatch, commit=(1, "fatal: not a git repository\n"))

--- a/arenabench/tests/test_snapshot_status.py
+++ b/arenabench/tests/test_snapshot_status.py
@@ -296,3 +296,119 @@ def test_capture_survives_a_stumble_without_being_retired(tmp_path, monkeypatch)
     assert record["snapshots"] >= 2, "a recovering host was retired anyway"
     assert record["state"] != "failed"
     assert sup.unmeasured() == []
+
+
+# -- the severe shape is ONE snapshot, not zero -----------------------------
+
+
+def test_a_trial_measured_only_before_the_agent_worked_is_not_sound(tmp_path, monkeypatch):
+    """The dangerous trial captures the pristine workspace and nothing after.
+
+    `_begin` lands snapshot 0 of the *unsolved* workspace, capture then breaks,
+    and the trial finishes before `max_capture_attempts` consecutive failures
+    retire it. Capture ran to the end, so the record closes `complete` and
+    `captured_nothing` is false — yet the only state in the manifest is the one
+    from before the agent did anything, so replay still reports
+    `flip_index=None` for a trial that may well have been solved.
+
+    So neither the `failed` state nor `captured_nothing` can be the question a
+    reader asks. `broke` is (#2196).
+    """
+    from arenabench import snapshot
+
+    landed = iter([(0, "a" * 40 + "\n")])  # snapshot 0, then capture goes away
+
+    def breaks_after_the_first(container: str, script: str, *, timeout: float = 180.0):
+        if "rev-parse HEAD" in script:
+            return next(landed, (1, "no such container\n"))
+        if "init -q" in script:
+            return 0, "ok\n"
+        return 0, "/app\n"
+
+    monkeypatch.setattr(snapshot, "_exec", breaks_after_the_first)
+    monkeypatch.setattr(snapshot, "_container_running", lambda name: True)
+
+    trial = _trial(tmp_path)
+    sup = _supervisor(tmp_path, max_capture_attempts=5)
+    sup._consider(trial)  # begins capture; snapshot 0 of the pristine workspace
+    sup._consider(trial)  # capture breaks, well short of being retired
+    (trial / "result.json").write_text("{}\n", encoding="utf-8")
+    sup._consider(trial)  # the trial ends and the record is closed
+
+    record = _record(trial)
+    assert record["snapshots"] == 1, "the pristine snapshot did not land"
+    assert record["state"] == "complete", (
+        f"this shape is what `complete` looks like; got {record['state']!r}"
+    )
+    assert record["failures"] > 0, "the broken capture left no evidence in the record"
+
+    status = snapshot.load_capture_status(trial)
+    assert status is not None
+    assert not status.captured_nothing, "the zero-capture check cannot see this shape"
+    assert status.broke, (
+        "a trial measured only before the agent worked was reported as sound — "
+        "`arenabench flip` would print 'no snapshot passed' with no warning"
+    )
+    assert sup.unmeasured() == [], "one snapshot is not zero snapshots"
+
+
+def test_flip_warns_when_capture_broke_even_though_it_ended_complete(
+    tmp_path, monkeypatch, capsys
+):
+    """The reader-facing half: the warning must fire for the `complete` shape too.
+
+    `no snapshot passed` is the sentence that gets read as "the agent never
+    solved it", and it is exactly as wrong after a capture that broke late as
+    after one that never worked. Driven through `_cmd_flip` with `replay_flip`
+    stubbed, because what is on trial is which records earn the warning, not
+    Docker.
+    """
+    import argparse
+
+    from arenabench import cli
+    from arenabench.snapshot import CaptureStatus, FlipResult
+
+    trial = _trial(tmp_path)
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+
+    broke_late = CaptureStatus(
+        trial=trial.name,
+        state="complete",  # capture ran to the end; it just stopped working first
+        snapshots=1,
+        attempts=4,
+        failures=3,
+        reason="the snapshot commit exited 1: no such container",
+        at=0.0,
+    )
+    monkeypatch.setattr(
+        cli,
+        "replay_flip",
+        lambda *a, **k: FlipResult(
+            flip_index=None,
+            flip_elapsed=None,
+            wasted_elapsed=None,
+            snapshots=1,
+            probes=1,
+            unknown=0,
+            capture=broke_late,
+        ),
+    )
+
+    code = cli._cmd_flip(
+        argparse.Namespace(
+            trial_dir=str(trial),
+            task_dir=str(task_dir),
+            verifier_timeout=1.0,
+            confirm_window=0,
+        )
+    )
+
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "no snapshot passed" in captured.out
+    assert "not fully measured" in captured.err, (
+        "'no snapshot passed' was printed alone for a trial capture broke on: "
+        f"{captured.err!r}"
+    )
+    assert "no such container" in captured.err, "the warning drops the reason"

--- a/arenabench/tests/test_snapshot_status.py
+++ b/arenabench/tests/test_snapshot_status.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""What the supervisor says when capture does not work.
+
+The measurement this module guards is a negative one, which is why it needed
+its own file: every assertion here is about a trial that captured *nothing*,
+and the failure mode being witnessed is silence. Capture used to report a
+commit that failed outright at ``debug`` and an empty ``rev-parse`` at no level
+whatsoever, so "capture is broken" and "this host is slow" produced identical
+artifacts — an empty ``manifest.jsonl``. Replay reads an empty manifest as
+``flip_index=None`` and an operator reads that as "the agent never solved it",
+so the silence could convert a solved trial into a failure in the benchmark
+record (#2196).
+
+**No Docker.** ``_exec`` and ``_container_running`` are the module's only two
+doors to Docker, so stubbing exactly those leaves every line of the
+supervisor's own logic under test. Deliberately not the fixed-container-name
+Docker suites, which cannot run twice on one host concurrently (#2197).
+
+**No clock.** These tests drive ``_consider`` directly instead of starting the
+watcher thread. The thread is only a clock around that method, and what is
+under test is what the supervisor *records*, never when — so there is nothing
+here to wait on, and nothing to pace (contrast #2114, where the pacing was the
+whole subject).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from arenabench.snapshot import SnapshotSupervisor
+
+#: Where the capture record lands. Spelled out rather than imported so this
+#: file still runs — and still fails on its assertions — against a `snapshot.py`
+#: that has no such constant. See `test_a_zero_capture_run_is_machine_detectable`.
+CAPTURE_JSON = ("arena", "snapshots", "capture.json")
+
+
+def _trial(tmp_path: Path, name: str = "demo__RpL1") -> Path:
+    """A trial directory shaped the way Harbor leaves one mid-run."""
+    trial = tmp_path / "jobs" / "seat" / name
+    (trial / "agent").mkdir(parents=True)
+    return trial
+
+
+def _capture_that(monkeypatch, *, commit: tuple[int, str]) -> None:
+    """Stub Docker so every capture attempt returns ``commit``.
+
+    The workspace probe and the snapshot-repo init both succeed, so capture
+    gets a clean *start* and only the capture itself fails — which is precisely
+    the asymmetry that hid the bug: the start side already escalated, the
+    capture side did not.
+    """
+    from arenabench import snapshot
+
+    def fake_exec(container: str, script: str, *, timeout: float = 180.0) -> tuple[int, str]:
+        if "rev-parse HEAD" in script:
+            return commit
+        if "init -q" in script:
+            return 0, "ok\n"
+        return 0, "/app\n"  # the workspace probe
+
+    monkeypatch.setattr(snapshot, "_exec", fake_exec)
+    monkeypatch.setattr(snapshot, "_container_running", lambda name: True)
+
+
+def _supervisor(tmp_path: Path, **kwargs) -> SnapshotSupervisor:
+    return SnapshotSupervisor(
+        jobs_root=tmp_path / "jobs",
+        jobs=["seat"],
+        interval=0.0,  # every sweep is due; the cadence is not what is on trial
+        poll_interval=0.0,
+        **kwargs,
+    )
+
+
+def _record(trial: Path) -> dict:
+    return json.loads(trial.joinpath(*CAPTURE_JSON).read_text(encoding="utf-8"))
+
+
+# -- a failed capture is named, not whispered -------------------------------
+
+
+def test_a_failed_capture_is_named_not_whispered(tmp_path, monkeypatch, caplog):
+    """A capture that fails outright must reach an operator who did not ask.
+
+    It was logged at `debug`, which in practice means nowhere: the run that
+    filed #2196 produced zero snapshots in 180 s and an *empty* captured-log
+    section, because nothing capture had to say was above `debug`.
+    """
+    trial = _trial(tmp_path)
+    _capture_that(monkeypatch, commit=(1, "fatal: not a git repository\n"))
+    sup = _supervisor(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="arenabench.snapshot"):
+        sup._consider(trial)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a capture that failed outright said nothing at WARNING or above"
+    said = "\n".join(r.getMessage() for r in warnings)
+    assert trial.name in said, f"the warning does not name the trial: {said}"
+    assert "not a git repository" in said, f"the warning drops the reason: {said}"
+
+    # And the same fact survives the run, for a reader who has only the tree.
+    record = _record(trial)
+    assert record["snapshots"] == 0
+    assert record["attempts"] >= 1, "an attempt that failed was not counted as an attempt"
+    assert "not a git repository" in record["reason"]
+
+
+def test_an_empty_sha_is_recorded_and_distinguishable(tmp_path, monkeypatch, caplog):
+    """The branch that logged at no level at all, and the one it must not blur into.
+
+    `git commit` succeeding while `git rev-parse HEAD` prints nothing is a
+    different fault from the commit failing — a snapshot repository that went
+    away under a live container, rather than one that never worked. Both
+    produced exactly the same artifact before: an empty manifest.
+    """
+    trial = _trial(tmp_path)
+    _capture_that(monkeypatch, commit=(0, ""))  # "succeeded", printed no sha
+    sup = _supervisor(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="arenabench.snapshot"):
+        sup._consider(trial)
+
+    said = "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    assert said, "the empty-sha branch was silent at every level, as it always has been"
+    empty_sha_reason = _record(trial)["reason"]
+    assert "rev-parse" in empty_sha_reason, (
+        f"the record does not say the sha was missing: {empty_sha_reason}"
+    )
+
+    # The other fault, recorded for the same shaped trial, must read differently
+    # — otherwise the two are still indistinguishable after the fact.
+    other = _trial(tmp_path, name="demo__RpL2")
+    _capture_that(monkeypatch, commit=(1, "fatal: not a git repository\n"))
+    _supervisor(tmp_path)._consider(other)
+    assert _record(other)["reason"] != empty_sha_reason
+
+
+def test_a_capture_that_lands_records_no_failure(tmp_path, monkeypatch):
+    """The control: a working host must not be labelled broken.
+
+    Without this, every assertion above is satisfiable by a supervisor that
+    calls everything a failure — which would be its own dishonest measurement.
+    """
+    trial = _trial(tmp_path)
+    _capture_that(monkeypatch, commit=(0, "a" * 40 + "\n"))
+    sup = _supervisor(tmp_path)
+
+    sup._consider(trial)
+
+    record = _record(trial)
+    assert record["snapshots"] == 1
+    assert record["failures"] == 0
+    assert record["reason"] == ""
+    assert sup.unmeasured() == [], "a trial that captured was reported as unmeasured"
+
+
+# -- a run that captured nothing is loud and machine-detectable -------------
+
+
+def test_a_zero_capture_run_is_machine_detectable(tmp_path, monkeypatch, caplog):
+    """Zero snapshots for a whole trial is a broken measurement, and must say so.
+
+    The consequence this guards is the severe one: with no manifest, replay
+    reports `flip_index=None`, which reads as "the agent never solved it".
+    A downstream consumer needs to be able to *refuse* that reading, which
+    means the fact has to be machine-detectable and not merely logged.
+
+    `load_capture_status` is imported inside the test rather than at module
+    scope on purpose: reverting `snapshot.py` to `main` then leaves the
+    witnesses above failing on their own assertions instead of on a collection
+    error, so the flip is evidence about behaviour rather than about a symbol.
+    """
+    from arenabench.snapshot import load_capture_status
+
+    trial = _trial(tmp_path)
+    _capture_that(monkeypatch, commit=(1, "no such container\n"))
+    sup = _supervisor(tmp_path, max_capture_attempts=2)
+
+    with caplog.at_level(logging.ERROR, logger="arenabench.snapshot"):
+        sup._consider(trial)  # begins capture; the first snapshot fails
+        sup._consider(trial)  # second failure retires the trial
+        sup.stop()
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "a trial that captured nothing never escalated above WARNING"
+    said = "\n".join(r.getMessage() for r in errors)
+    assert trial.name in said
+    assert "never measured" in said, f"the error does not name the consequence: {said}"
+
+    # Machine-detectable, twice: from the live supervisor, and from the tree
+    # afterwards by anything holding only the trial directory.
+    unmeasured = sup.unmeasured()
+    assert [s.trial for s in unmeasured] == [trial.name]
+    assert unmeasured[0].captured_nothing
+
+    status = load_capture_status(trial)
+    assert status is not None and status.captured_nothing
+    assert status.state == "failed", f"a broken capture ended in {status.state!r}"
+    assert "no such container" in status.reason
+
+
+def test_a_retired_capture_stops_paying_for_a_dead_container(tmp_path, monkeypatch):
+    """Retirement is bounded work, not a silent surrender.
+
+    The capture side used to retry forever, so a container that vanished
+    mid-trial still cost a `docker exec` — and its 180 s timeout — every
+    interval for the rest of the run, all of it invisible. The start side has
+    always given up after `max_start_attempts`; this is the same contract.
+    """
+    from arenabench import snapshot
+
+    trial = _trial(tmp_path)
+    attempts: list[str] = []
+
+    def counting_exec(container: str, script: str, *, timeout: float = 180.0):
+        if "rev-parse HEAD" in script:
+            attempts.append(script)
+            return 1, "no such container\n"
+        if "init -q" in script:
+            return 0, "ok\n"
+        return 0, "/app\n"
+
+    monkeypatch.setattr(snapshot, "_exec", counting_exec)
+    monkeypatch.setattr(snapshot, "_container_running", lambda name: True)
+
+    sup = _supervisor(tmp_path, max_capture_attempts=2)
+    for _ in range(6):
+        sup._consider(trial)
+
+    assert len(attempts) == 2, f"capture kept retrying a dead container: {len(attempts)}"
+
+
+def test_capture_survives_a_stumble_without_being_retired(tmp_path, monkeypatch):
+    """Only *consecutive* failures retire a trial — a blip must not end capture.
+
+    The counter resetting on success is what keeps this fix from costing
+    measurement on a merely loaded host, which would be the same sin in the
+    opposite direction.
+    """
+    from arenabench import snapshot
+
+    outcomes = iter([(1, "transient\n"), (0, "b" * 40 + "\n"), (1, "transient\n")])
+
+    def flaky_exec(container: str, script: str, *, timeout: float = 180.0):
+        if "rev-parse HEAD" in script:
+            return next(outcomes, (0, "c" * 40 + "\n"))
+        if "init -q" in script:
+            return 0, "ok\n"
+        return 0, "/app\n"
+
+    monkeypatch.setattr(snapshot, "_exec", flaky_exec)
+    monkeypatch.setattr(snapshot, "_container_running", lambda name: True)
+
+    trial = _trial(tmp_path)
+    sup = _supervisor(tmp_path, max_capture_attempts=2)
+    for _ in range(4):
+        sup._consider(trial)
+
+    record = _record(trial)
+    assert record["snapshots"] >= 2, "a recovering host was retired anyway"
+    assert record["state"] != "failed"
+    assert sup.unmeasured() == []

--- a/arenabench/tests/test_snapshot_status.py
+++ b/arenabench/tests/test_snapshot_status.py
@@ -204,6 +204,31 @@ def test_a_zero_capture_run_is_machine_detectable(tmp_path, monkeypatch, caplog)
     assert "no such container" in status.reason
 
 
+def test_the_pacing_deadline_now_names_which_fault_it_hit(tmp_path, monkeypatch):
+    """The snapshot tests' own wait can stop hedging (#2114 + #2196).
+
+    `_wait_for_snapshots` was landed deliberately unable to say whether a host
+    was slow or capture had stopped working — it could only suggest re-running
+    at DEBUG, because that was the only level the supervisor said anything at.
+    With the record on disk it reads the answer instead of guessing at it.
+    """
+    from tests.conftest import _wait_for_snapshots
+
+    trial = _trial(tmp_path)
+    _capture_that(monkeypatch, commit=(1, "fatal: not a git repository\n"))
+    _supervisor(tmp_path)._consider(trial)
+
+    try:
+        _wait_for_snapshots(trial, 2, what="of anything at all", deadline=0.0)
+    except AssertionError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - the manifest is empty, so the wait cannot pass
+        raise AssertionError("the wait returned on an empty manifest")
+
+    assert "not a git repository" in message, f"the deadline still hedges: {message}"
+    assert "keeping up" not in message, f"a broken capture was blamed on speed: {message}"
+
+
 def test_a_retired_capture_stops_paying_for_a_dead_container(tmp_path, monkeypatch):
     """Retirement is bounded work, not a silent surrender.
 


### PR DESCRIPTION
## The failure path, on current `main`

`SnapshotSupervisor._snapshot` had two exits that produced no evidence:

```python
if code != 0:
    log.debug("snapshot commit failed for %s: %s", ...)   # debug: in practice, nowhere
    return
sha = out.strip().splitlines()[-1].strip() if out.strip() else ""
if not sha:
    return                                                 # no log at ANY level
```

Reproduced before editing, by stubbing the module's only two doors to Docker
(`_exec`, `_container_running`) and driving `_consider` directly:

* **failed-commit branch** — three attempts, five `docker exec` calls, zero
  snapshots, an empty `arena/snapshots/`, and **complete silence** at WARNING.
* **empty-`sha` branch** — silent at **`DEBUG`**, the most verbose an operator
  can ask for. This is the sharper half of the bug: the issue's suggested
  "log it at warning" would not have found it, because there was nothing to raise.

Neither branch increments `capture.index`, and `_last` is stamped at the *top*
of `_snapshot`, so the supervisor re-attempted every `interval` for the life of
the run — never escalating, never giving up. `_begin`/`_fail` had always
escalated; the capture side simply never did.

### The measurement consequence

The severe case is not "no snapshots" — it is **one**. `_begin` takes snapshot 0
of the pristine workspace, then capture breaks. The agent goes on to solve the
task; the manifest holds only the *unsolved* state; `replay_flip` probes it,
finds nothing passing, and reports `flip_index=None` — which an operator reads
as **"the agent never solved it."** A solved trial is recorded as a failure,
with nothing anywhere saying capture had died. That is the
`CLAUDE.md` "measure honestly" failure in its exact form: a measurement artifact
maligning a run.

## The mechanism, and why this one

Log levels alone would have fixed the symptom in the run log and left the
*artifact* — the thing a reader has after the fact — just as ambiguous. So:

1. **`CaptureStatus` → `arena/snapshots/capture.json`.** Every attempt records
   `state`, `snapshots`, `attempts`, consecutive `failures`, and the **full**
   last `reason` (untruncated — the truncated half is usually the part that
   matters). The three states the issue asks to separate are now separate:
   a failed commit, an empty `sha` (a distinct, separately-worded reason), and
   *not yet* (`starting`/`capturing` vs. the terminal states).
2. **The capture side escalates exactly like `_fail`.** First failure at
   `warning`, the rest at `debug` (same anti-spam shape, so a wedged container
   cannot flood the log), and the trial retires after `max_capture_attempts`
   consecutive failures. The counter **resets on any capture that lands**, so a
   merely loaded host is never retired — retirement would otherwise be the same
   sin in the other direction. This also stops a dead container costing a
   `docker exec` (and its 180 s timeout) every interval forever.
3. **Zero capture is loud and machine-detectable.** `_finalise` logs once at
   `error` naming the trial and reason; `SnapshotSupervisor.unmeasured()` returns
   the record for anything that captured nothing; and the record rides into
   `flip.json` as `FlipResult.capture`, so a downstream consumer reading
   `flip_index=None` can see `capture.state == "failed"` and **refuse** to score
   it as "never solved". `arenabench flip` no longer prints "no snapshot passed"
   alone when capture is what failed, and `ReplayError` now carries the reason.

Nothing was swallowed: every existing diagnostic string is preserved and the
previously-`debug`-only detail is now recorded rather than dropped. Nothing can
fail a run — the module's standing invariant is that measurement must not be
able to cost a benchmark, so `write_capture_status` is best-effort and
`_finalise` never raises.

The module docstring already **promised** this ("yields a trial with no
snapshots and a warning"); only the start side ever delivered it. Corrected in
the same commit.

## Witness test

`arenabench/tests/test_snapshot_status.py` — new file, no Docker (stubs `_exec`
and `_container_running`, the module's only two doors), and no clock (drives
`_consider` directly; the watcher thread is only a clock around it, so there is
nothing to pace and nothing to flake).

**Flip evidence** — reverting *only* the implementation with
`git checkout origin/main -- arenabench/arenabench/{snapshot,replay,cli}.py arenabench/tests/conftest.py`
and re-running (never `git stash`; parallel agents are live):

| test | on `main` |
|---|---|
| `test_a_failed_capture_is_named_not_whispered` | `AssertionError: a capture that failed outright said nothing at WARNING or above` |
| `test_an_empty_sha_is_recorded_and_distinguishable` | `AssertionError: the empty-sha branch was silent at every level, as it always has been` |
| `test_a_capture_that_lands_records_no_failure` | `FileNotFoundError` (no `capture.json`) |
| `test_a_zero_capture_run_is_machine_detectable` | `ImportError: cannot import name 'load_capture_status'` |
| `test_the_pacing_deadline_now_names_which_fault_it_hit` | `AssertionError: the deadline still hedges` |
| `test_a_retired_capture_stops_paying_for_a_dead_container` | `TypeError: unexpected keyword argument 'max_capture_attempts'` |
| `test_capture_survives_a_stumble_without_being_retired` | `TypeError: unexpected keyword argument 'max_capture_attempts'` |

All 7 pass on this branch. The two headline witnesses fail on **their own
behavioural assertions**, not on a collection error — `load_capture_status` is
imported *inside* the fourth test on purpose so a reverted `snapshot.py` leaves
the behavioural witnesses failing on behaviour. That is deliberate and commented.

`test_a_capture_that_lands_records_no_failure` is the control: without it, every
other assertion is satisfiable by a supervisor that calls everything a failure.

## How this composes with #2200

#2200 merged into `main` while this was in flight; this branch is rebased on top
of it and its suite is green alongside these tests.

Its `_wait_for_snapshots` deadline message was written deliberately unable to
say *which* fault it hit — "capture is not keeping up on this host, or stopped
working; re-run with `--log-cli-level=DEBUG` to see which" — with a comment
naming #2196 as the reason. That hedge is no longer necessary: the message now
reads `capture.json` and states the fault outright, falling back to the
"not keeping up" reading only when there is no record.
`test_the_pacing_deadline_now_names_which_fault_it_hit` guards it.

My tests live in a **new file** rather than appended to `test_snapshot.py`,
which is where #2200 appended its own section — so the two never contend for the
same end-of-file position.

## Scope

No new dependencies (`arenabench` is stdlib-only by contract). `ruff check`
passes on all five touched files; pre-existing findings elsewhere under
`arenabench/` (#2146, #2193) are untouched and `ruff format` was never run. No
tests deleted. Testing was targeted pytest files only.

Related: #2114 (the flake this was found under), #2197 (both Docker snapshot
tests pin fixed container names, so two concurrent runs on one host destroy each
other — which *mutes* this bug into what looks like a timing flake; not fixed
here), #1773.

Follow-ups filed: see below.

Closes #2196

## Summary by Sourcery

Ensure snapshot capture failures are recorded and visible so trials that were never fully measured cannot be misinterpreted as never solved.

New Features:
- Persist a capture status record per trial in arena/snapshots/capture.json and expose it via load_capture_status.
- Attach capture status to flip results and CLI output so downstream consumers can distinguish measurement failures from unsolved trials.

Bug Fixes:
- Treat failed or missing snapshot commits as explicit capture failures, escalate them in logs, and retire trials after repeated capture errors instead of silently retrying forever.
- Log and surface trials that captured no snapshots as measurement failures, preventing them from being scored as agent failures.

Enhancements:
- Extend SnapshotSupervisor with tracking of capture attempts, failures, and unmeasured trials, and finalise capture records when runs or trials end.
- Improve snapshot deadline diagnostics in tests to report the specific capture fault instead of a generic hedge message.

Tests:
- Add a dedicated test suite for snapshot capture status that exercises failure, recovery, retirement, and visibility of capture outcomes without relying on Docker.