### PR TITLE
fix(arenabench): an unmeasured trial is not a $0.00 trial, and a partial sum is not a seat total

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -192,6 +192,16 @@ def _cmd_run(args: argparse.Namespace) -> int:
         # one-line edit to `pricing.PRICES`.
         for slug in totals.get("unpriced_models") or ():
             print(f"    !! no pricing entry for {slug} — priced cost unavailable")
+        # The other way a total goes short: trials nothing measured. Their
+        # tokens and cost read 0 in every figure on the line above, which is
+        # the absence of a measurement and not a measurement of zero (#2132).
+        # Printed with the denominator so the line says what it is a total of.
+        unmeasured = totals.get("unmeasured_trials") or 0
+        if unmeasured:
+            print(
+                f"    !! {unmeasured}/{totals['trials']} trials published no usage "
+                "— the token and cost totals above are over the rest"
+            )
         if totals["judged"] == 0:
             worst = 1
     if args.results:

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -96,7 +96,13 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
             continue
         judged += 1
         clock_time += m.clock_time or 0.0
-        if priced is not None:
+        # A trial nothing measured is skipped rather than poisoning the seat:
+        # it has no tokens to be short by, and since #2132 gave it
+        # `priced_cost = None` (it used to be a fabricated `0.0`), poisoning
+        # here would blank the trends cost for every match containing one
+        # crashed setup. A trial that *did* spend tokens and could not be
+        # priced still poisons — that spend is unknown, never smaller.
+        if priced is not None and m.usage_measured:
             priced = None if m.priced_cost is None else priced + m.priced_cost
         unpriced.update(m.unpriced_models)
         reason = m.outcome_reason() or "unlabelled"

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -96,14 +96,17 @@ def _seat_outcomes(metrics: dict[str, Any]) -> dict[str, Any]:
             continue
         judged += 1
         clock_time += m.clock_time or 0.0
-        # A trial nothing measured is skipped rather than poisoning the seat:
-        # it has no tokens to be short by, and since #2132 gave it
-        # `priced_cost = None` (it used to be a fabricated `0.0`), poisoning
-        # here would blank the trends cost for every match containing one
-        # crashed setup. A trial that *did* spend tokens and could not be
-        # priced still poisons — that spend is unknown, never smaller.
-        if priced is not None and m.usage_measured:
-            priced = None if m.priced_cost is None else priced + m.priced_cost
+        if priced is not None:
+            if m.priced_cost is not None:
+                priced += m.priced_cost
+            elif m.usage_measured:
+                # Spent tokens nobody could price: unknown, never smaller.
+                priced = None
+            # else: a trial nothing measured, skipped rather than poisoning the
+            # seat. It has no tokens to be short by, and since #2132 gave it
+            # `priced_cost = None` (it used to be a fabricated `0.0`),
+            # poisoning here would blank the trends cost for every match that
+            # contains one crashed setup.
         unpriced.update(m.unpriced_models)
         reason = m.outcome_reason() or "unlabelled"
         reasons[reason] = reasons.get(reason, 0) + 1

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -319,6 +319,33 @@ class TrialMetrics:
     wasted_elapsed: float | None = None
 
     @property
+    def usage_measured(self) -> bool:
+        """Whether any source published usage for this trial at all (#2132).
+
+        ``False`` means **nothing measured this trial** — which is a different
+        fact from "it spent nothing", and pricing it as one is how a real
+        $0.79 became a confident ``$0.00`` in a cost comparison. The artifacts
+        cannot tell a trial that never launched from one whose stream was lost,
+        and the second kind is not hypothetical: usage can be dropped mid-run
+        (#1467) and a timed-out trial's writer can be reaped while it is still
+        appending (#2131).
+
+        Read off observed spend rather than off the presence of a file or a
+        row, for the same reason the zero-spend guard in :meth:`MetricsReader.read`
+        is: a ``step_usage`` whose token fields never arrived is exactly as
+        unmeasured as no ``step_usage`` at all, and only the numbers say so.
+        No real model call reports zero of everything, so "all counters zero"
+        is "unknown", never "free".
+        """
+        return bool(
+            self.tokens_in
+            or self.tokens_out
+            or self.cache_read
+            or self.cache_write
+            or self.total_cost
+        )
+
+    @property
     def cache_hit_rate(self) -> float | None:
         """Share of prompt tokens served from cache, 0-100.
 
@@ -398,6 +425,7 @@ class TrialMetrics:
                 round(self.priced_cost, 6) if self.priced_cost is not None else None
             ),
             "unpriced_models": list(self.unpriced_models),
+            "usage_measured": self.usage_measured,
             "cache_hit_rate": self.cache_hit_rate,
             "clock_time": round(self.clock_time, 2),
             "age_s": self.age_s,
@@ -716,7 +744,21 @@ class MetricsReader:
         # share would publish a cost that is confidently short, and missing
         # beats wrong here.
         by_model = (events or {}).get("by_model") or {}
-        if any(model for model in by_model):
+        if not metrics.usage_measured:
+            # Nothing measured this trial, so there is nothing to price and no
+            # rate is missing. The branches below would have run its zeroed
+            # counters through `trial_cost` and published `$0.00` — a confident
+            # measurement of "spent nothing" produced by the absence of any
+            # measurement at all, and the one number a cost comparison must
+            # never invent (#2132). `None` is the honest answer, and
+            # `usage_measured` beside it in `to_json` is the reason.
+            #
+            # No `unpriced_models` entry: the table is not missing a row, so
+            # naming a model here would send an operator to edit
+            # `pricing.PRICES` for a trial that produced no tokens — the same
+            # discipline as the queued-trial rule below.
+            metrics.priced_cost = None
+        elif any(model for model in by_model):
             subtotal = 0.0
             for model, bucket in by_model.items():
                 if not model:
@@ -831,12 +873,39 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
         "total_cost": sum(t.total_cost for t in trials),
         # Comparable spend: every seat priced from the same table. `None` when
         # no trial had a priced model, so the column stays empty rather than
-        # reading as a free run.
+        # reading as a free run — and `None`, too, when any trial *did* spend
+        # tokens nobody could price.
+        #
+        # That second rule is the #2132 fix. This used to sum the priced share
+        # and publish it as the seat's cost, which silently dropped every
+        # unpriced trial: on match `cc00894779ff` the seat read `$1.94` against
+        # a true `$5.25` — 63% short, with nothing on the number saying it was
+        # a subset. It also contradicted the two rules either side of it. The
+        # per-trial reduction above already blanks a whole trial on one
+        # unpriced subtotal ("missing beats wrong"), `series.py`'s
+        # `_seat_outcomes` already null-poisons a seat, and the arena's cost
+        # tile already null-poisons across seats; `aggregate` was the single
+        # link in that chain that quietly filled the gap with nothing.
+        #
+        # A trial that measured *no* usage does not poison: it has no tokens to
+        # be short by, its whole row already reads empty, and blanking the
+        # column for every match with one crashed setup would trade a wrong
+        # number for no number at all. It is counted in `unmeasured_trials`
+        # instead, so the denominator of every total here stays visible.
         "priced_cost": (
-            sum(t.priced_cost for t in trials if t.priced_cost is not None)
-            if any(t.priced_cost is not None for t in trials)
-            else None
+            None
+            if any(t.priced_cost is None and t.usage_measured for t in trials)
+            else (
+                sum(t.priced_cost for t in trials if t.priced_cost is not None)
+                if any(t.priced_cost is not None for t in trials)
+                else None
+            )
         ),
+        # How many trials contributed no usage measurement at all — the
+        # denominator behind every token and cost total above. Absence of
+        # telemetry is not a measurement of zero (#2132), so a reader has to be
+        # able to see that "4736446 tokens" was summed over six of ten trials.
+        "unmeasured_trials": sum(1 for t in trials if not t.usage_measured),
         # Why the figure above is missing, when it is. A blank cost cell is
         # the symptom and this is the cause, carried in the same payload so
         # every reader of the totals — CLI, UI, a saved `results.json` — can

--- a/arenabench/tests/test_series.py
+++ b/arenabench/tests/test_series.py
@@ -176,6 +176,22 @@ class TestOutcomeCounting:
         assert outcomes["priced_cost"] is None
         assert outcomes["priced_cost_per_solve"] is None
 
+    def test_a_trial_that_measured_nothing_does_not_poison_the_cost(self) -> None:
+        """The other half of the rule above (#2132). An unpriced trial makes
+        the seat's cost unknown only when it *measured* usage; one that
+        published no telemetry at all has no tokens to be short by, and since
+        #2132 gave it `priced_cost = None` (it used to be a fabricated `0.0`)
+        it would otherwise poison every match containing one crashed setup."""
+        seat = _seat(
+            {
+                "a": _trial("a", resolved=True, priced=2.0),
+                "b": _trial("b", resolved=False, priced=None, tokens=0),
+            }
+        )
+        outcomes = match_row(_match([seat]))["seats"][0]["outcomes"]
+        assert outcomes["priced_cost"] == 2.0
+        assert outcomes["priced_cost_per_solve"] == 2.0
+
     def test_unjudged_trials_do_not_count(self) -> None:
         seat = _seat(
             {

--- a/arenabench/tests/test_series.py
+++ b/arenabench/tests/test_series.py
@@ -25,6 +25,7 @@ def _trial(
     priced: float | None = 1.0,
     clock: float = 100.0,
     status: str = "done",
+    tokens: int = 1000,
 ) -> TrialMetrics:
     m = TrialMetrics(task=task, trial=f"{task}__x")
     m.status = status
@@ -32,6 +33,12 @@ def _trial(
     m.failure = failure or ""
     m.priced_cost = priced
     m.clock_time = clock
+    # A trial that ran spent tokens, and since #2132 that is what tells the
+    # cost rules apart: an unpriced trial that *measured* usage poisons the
+    # seat's cost, while one that measured nothing is skipped. Default nonzero
+    # so every fixture here is the ordinary case; pass `tokens=0` for the
+    # trial that published no telemetry at all.
+    m.tokens_in = tokens
     return m
 
 

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -560,8 +560,12 @@ class TestUnmeasuredUsageIsNotZeroUsage:
         column from a trial that genuinely ran for free."""
         metrics = MetricsReader().read(self._never_ran(tmp_path), "fix-git")
         assert metrics.tokens_in == 0, "the fixture is a trial with no telemetry"
-        assert metrics.usage_measured is False
+        # The behavioural assertion first, deliberately: on the old code this
+        # line reads `assert 0.0 is None` — a real flip — where leading with
+        # `usage_measured` would only ever report a missing attribute and
+        # prove nothing about what the number used to be (#2173's lesson).
         assert metrics.priced_cost is None, "unknown spend, not zero spend"
+        assert metrics.usage_measured is False
         assert metrics.unpriced_models == (), (
             "the price table is not missing a row here — sending an operator "
             "to edit PRICES for a trial that produced no tokens is noise"
@@ -575,8 +579,8 @@ class TestUnmeasuredUsageIsNotZeroUsage:
         why is the failure mode #2108 fixed for unpriced models, one reason
         over."""
         payload = MetricsReader().read(self._never_ran(tmp_path), "fix-git").to_json()
-        assert payload["usage_measured"] is False
         assert payload["priced_cost"] is None
+        assert payload["usage_measured"] is False
 
     def test_a_measured_trial_still_reports_its_cost(self, tmp_path: Path):
         """The guard must not blank a trial that really did spend: `None` is
@@ -622,8 +626,8 @@ class TestUnmeasuredUsageIsNotZeroUsage:
         )
         metrics = MetricsReader().read(trial_dir, "t")
         assert metrics.steps == 1, "the row itself ingested fine"
-        assert metrics.usage_measured is False
         assert metrics.priced_cost is None
+        assert metrics.usage_measured is False
 
     def test_the_seat_total_refuses_a_partial_priced_sum(self):
         """The second witness, and the match-total half of #2132.

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -492,6 +492,189 @@ class TestUnpricedModelsAreNamed:
         assert totals["unpriced_models"] == []
 
 
+class TestUnmeasuredUsageIsNotZeroUsage:
+    """Absence of telemetry is not a measurement of zero (#2132).
+
+    Two witnesses for two halves of one habit. Per trial, a trial that
+    published no usage at all was priced at a confident ``$0.00`` — four of
+    the ten trials in match ``cc00894779ff`` are that shape, artifacts under
+    ``~/.arenabench/matches/cc00894779ff/``: an ``agent/`` directory holding
+    nothing but ``setup``, ``agent_result: null``, and a ``RuntimeError``.
+    Per seat, ``aggregate`` summed the priced share of the trials and
+    published it as the seat's comparable cost; on that same match it read
+    ``$1.94`` against a true ``$5.25``, 63% short and unmarked.
+
+    The discriminating condition for the seat half is that the match is
+    *mixed*: an all-priced seat totalled correctly and a wholly unpriced one
+    reported ``None``, so only a seat holding both kinds of trial was ever
+    wrong — which is exactly what a pipeline seat produces the moment one
+    role runs a model the shared table has no row for.
+    """
+
+    @staticmethod
+    def _never_ran(tmp_path: Path) -> Path:
+        """A trial Harbor tore down before the agent wrote anything.
+
+        Modelled on `fix-git__yPKRSwX` in match `cc00894779ff`: `result.json`
+        with an exception and no `agent_result`, an `agent/` directory holding
+        only Harbor's own `setup`, and a seat manifest naming a model the
+        price table *does* have a row for — which is what turned "nothing to
+        price" into "priced at zero".
+        """
+        trial_dir = tmp_path / "job" / "fix-git__1"
+        (trial_dir / "agent" / "setup").mkdir(parents=True)
+        (trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "config": {"agent": {"model_name": "openrouter/z-ai/glm-5.2"}},
+                    "agent_result": None,
+                    "exception_info": {
+                        "exception_type": "RuntimeError",
+                        "exception_message": "container teardown",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        seat_manifest_path(trial_dir.parent).write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "contestant": "seat",
+                    "agent": "stella",
+                    "api": "openrouter",
+                    "model": "z-ai/glm-5.2",
+                    "qualified_model": "openrouter/z-ai/glm-5.2",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return trial_dir
+
+    def test_a_trial_that_measured_nothing_is_not_priced_at_zero(
+        self, tmp_path: Path
+    ):
+        """The witness. On the old code this trial reported `priced_cost` of
+        exactly `0.0` — a measurement of "spent nothing" manufactured out of
+        the absence of any measurement, and indistinguishable in the cost
+        column from a trial that genuinely ran for free."""
+        metrics = MetricsReader().read(self._never_ran(tmp_path), "fix-git")
+        assert metrics.tokens_in == 0, "the fixture is a trial with no telemetry"
+        assert metrics.usage_measured is False
+        assert metrics.priced_cost is None, "unknown spend, not zero spend"
+        assert metrics.unpriced_models == (), (
+            "the price table is not missing a row here — sending an operator "
+            "to edit PRICES for a trial that produced no tokens is noise"
+        )
+
+    def test_the_cell_payload_says_the_zeroes_were_never_measured(
+        self, tmp_path: Path
+    ):
+        """`to_json` is the whole API surface: the arena cell, the SSE stream
+        and a saved `results.json` all read it. A null cost that cannot say
+        why is the failure mode #2108 fixed for unpriced models, one reason
+        over."""
+        payload = MetricsReader().read(self._never_ran(tmp_path), "fix-git").to_json()
+        assert payload["usage_measured"] is False
+        assert payload["priced_cost"] is None
+
+    def test_a_measured_trial_still_reports_its_cost(self, tmp_path: Path):
+        """The guard must not blank a trial that really did spend: `None` is
+        only ever the answer for a trial nothing measured."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(
+                    model="z-ai/glm-5.2",
+                    input_tokens=1_000_000,
+                    output_tokens=0,
+                    cached_input_tokens=0,
+                    cache_write_tokens=0,
+                )
+            ],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.usage_measured is True
+        assert metrics.priced_cost is not None and metrics.priced_cost > 0
+
+    def test_a_step_that_reported_no_tokens_counts_as_unmeasured(
+        self, tmp_path: Path
+    ):
+        """Read off observed spend, not off the presence of a row.
+
+        A `step_usage` whose token fields never arrived (#1467's dropped
+        usage; #2131's reaped writer) is exactly as unmeasured as no
+        `step_usage` at all — and a stream full of them is how a trial with
+        real steps and tools shows an all-zero usage row."""
+        trial_dir = tmp_path / "job" / "t__1"
+        write_events(
+            trial_dir / "agent" / "stella-events.jsonl",
+            [
+                usage(
+                    input_tokens=0,
+                    output_tokens=0,
+                    cached_input_tokens=0,
+                    cache_write_tokens=0,
+                    cost_usd=0.0,
+                )
+            ],
+        )
+        metrics = MetricsReader().read(trial_dir, "t")
+        assert metrics.steps == 1, "the row itself ingested fine"
+        assert metrics.usage_measured is False
+        assert metrics.priced_cost is None
+
+    def test_the_seat_total_refuses_a_partial_priced_sum(self):
+        """The second witness, and the match-total half of #2132.
+
+        On the old code this returned `1.5` — the priced share published as
+        the seat's comparable cost, with the unpriced trial's real tokens
+        contributing nothing and no marker saying so. That is how match
+        `cc00894779ff` reported `$1.94` for an arm that spent `$5.25`."""
+        totals = aggregate(
+            [
+                TrialMetrics("a", "a__1", resolved=True, tokens_in=10, priced_cost=1.5),
+                TrialMetrics(
+                    "b",
+                    "b__1",
+                    resolved=True,
+                    tokens_in=1_000_000,
+                    priced_cost=None,
+                    unpriced_models=("acme/mystery-1",),
+                ),
+            ]
+        )
+        assert totals["priced_cost"] is None, "a subset is not a total"
+        assert totals["unpriced_models"] == ["acme/mystery-1"]
+
+    def test_an_unmeasured_trial_does_not_blank_the_seats_cost(self):
+        """The line the poison stops at. A trial with no tokens has no spend
+        to be short by, and blanking the column for every match containing one
+        crashed setup would trade a wrong number for no number at all — so it
+        is counted, not poisoned."""
+        totals = aggregate(
+            [
+                TrialMetrics("a", "a__1", resolved=True, tokens_in=10, priced_cost=1.5),
+                TrialMetrics("b", "b__1", resolved=False, priced_cost=None),
+            ]
+        )
+        assert totals["priced_cost"] == pytest.approx(1.5)
+        assert totals["unmeasured_trials"] == 1
+
+    def test_the_totals_name_how_many_trials_measured_nothing(self):
+        """The denominator behind every token and cost figure in the totals."""
+        totals = aggregate(
+            [
+                TrialMetrics("a", "a__1", resolved=True, tokens_in=10, priced_cost=1.5),
+                TrialMetrics("b", "b__1", resolved=False),
+                TrialMetrics("c", "c__1", resolved=False),
+            ]
+        )
+        assert totals["trials"] == 3
+        assert totals["unmeasured_trials"] == 2
+
+
 class TestAggregate:
     def test_solve_rate_divides_by_judged_not_attempted(self):
         """Dividing by attempted makes every contestant start near 0% and
@@ -510,13 +693,18 @@ class TestAggregate:
     def test_no_judged_trials_is_zero_not_a_crash(self):
         assert aggregate([])["solve_rate"] == 0.0
 
-    def test_priced_cost_sums_only_the_trials_that_have_one(self):
+    def test_priced_cost_refuses_a_partial_sum_but_still_totals_the_rest(self):
+        """Renamed from `test_priced_cost_sums_only_the_trials_that_have_one`,
+        which asserted the #2132 defect: trial `b` really spent (its
+        `total_cost` says 9.0) and could not be priced, so summing only `a`
+        published a comparable cost that was confidently short. `total_cost`
+        is unaffected — it is each agent's own number and never compared."""
         trials = [
             TrialMetrics("a", "a__1", resolved=True, total_cost=9.0, priced_cost=1.5),
             TrialMetrics("b", "b__1", resolved=True, total_cost=9.0, priced_cost=None),
         ]
         totals = aggregate(trials)
-        assert totals["priced_cost"] == pytest.approx(1.5)
+        assert totals["priced_cost"] is None
         assert totals["total_cost"] == pytest.approx(18.0)
 
     def test_a_wholly_unpriced_contestant_reports_no_cost_at_all(self):

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -100,6 +100,11 @@ export interface Totals {
    *  instead of reading as "free" (#2108). Empty whenever the cost is known;
    *  absent only in payloads recorded before the field existed. */
   unpriced_models?: string[];
+  /** Trials that published no usage at all. Their tokens and cost read 0 in
+   *  every total here, which is the absence of a measurement rather than a
+   *  measurement of zero (#2132) — so this is the denominator those totals
+   *  were summed over. Absent only in payloads recorded before the field. */
+  unmeasured_trials?: number;
   tokens_in: number;
   tokens_out: number;
   cache_read: number;
@@ -152,6 +157,11 @@ export interface Cell {
   cache_write: number;
   total_cost: number;
   priced_cost: number | null;
+  /** `false` when no source published usage for this trial: its zeroed token
+   *  and cost fields are unknown, not measured, and `priced_cost` is null for
+   *  that reason rather than because a price row is missing (#2132). Absent
+   *  only in payloads recorded before the field existed. */
+  usage_measured?: boolean;
   clock_time: number;
   cap_hits?: number;
   has_video?: boolean;


### PR DESCRIPTION
Closes #2132

## The discriminating condition

The drop is conditional, and the condition is **whether the trial produced a
usage measurement at all** — not whether it timed out, not `witness_author`,
not `stella_accounting.state: "incomplete"`.

I could not reproduce the issue's specific reading (`openssl-selfsigned-cert`
at `tokens_in: 0`), and I think that half is a misattribution — evidence
below. What *does* reproduce, on current `main` against the artifacts the
issue names, is the failure the issue's title and third paragraph describe:
**zero standing in for "unknown", and a match total that silently
under-counts.** Two places, one habit.

### 1. Per trial — a trial nothing measured was priced at exactly `$0.00`

`MetricsReader.read` fell through to the ATIF branch for a trial with no
event stream and no trajectory, ran its zeroed counters through
`trial_cost()`, and published `priced_cost = 0.0` — a confident measurement
of "spent nothing" manufactured out of the absence of any measurement.

Four of the ten trials in `cc00894779ff` are exactly that shape
(`fix-git`, `git-leak-recovery`, `prove-plus-comm`, `sanitize-git-repo`):
an `agent/` directory holding nothing but `setup`, `agent_result: null`,
`exception_info.exception_type: "RuntimeError"`. Confirmed on `origin/main`
before touching anything:

```
task                       API in  API cost  API priced   (live server, main)
fix-git                         0       0.0         0.0
git-leak-recovery               0       0.0         0.0
prove-plus-comm                 0       0.0         0.0
sanitize-git-repo               0       0.0         0.0
```

`priced_cost: 0.0` — **not** `null`. That is precisely the shape the issue
quotes. The ingest cannot tell a trial that never launched from one whose
stream was lost, and the second kind is not hypothetical (#1467 drops usage
mid-run; #2131 reaps a timed-out trial's writer while it is still appending).
Either way `$0.00` is a claim the artifacts do not support.

### 2. Per seat — `aggregate()` published the priced *share* as the total

```python
"priced_cost": (
    sum(t.priced_cost for t in trials if t.priced_cost is not None)
    if any(t.priced_cost is not None for t in trials)
    else None
),
```

Every trial whose cost was unknown contributed nothing, and the partial sum
went out as the seat's comparable spend with no marker. On `cc00894779ff`:

| | seat `priced_cost` |
|---|---|
| `main` (live server, `curl 127.0.0.1:8900/api/matches/cc00894779ff`) | **$1.94** |
| true sum of the trials that priced | **$5.25** |

**63% short**, in the one number the bench conventions use for cost
comparisons. The discriminating condition here is that the match is *mixed*:
an all-priced seat totalled correctly and a wholly unpriced one already
reported `None`, so only a seat holding both kinds was ever wrong — which is
what a pipeline seat produces the moment one role runs a model the shared
table has no row for.

It was also the odd one out among three aggregations of the same field. The
per-trial reduction directly above it already blanks a whole trial on one
unpriced subtotal ("missing beats wrong"), `series.py::_seat_outcomes`
already null-poisons a seat, and `stat-strip.tsx` already null-poisons across
seats. `aggregate` was the single link that quietly filled the gap with
nothing.

## Why the `openssl` reading does not reproduce

Ground truth first, per the repo rule. `openssl-selfsigned-cert__5VMc6i2`'s
`stella-events.jsonl` census — 49 `step_usage`, roles
`{triage 1, plan 1, worker 43, witness_author 3, distress_guidance 1}`,
models `{claude-sonnet-5 44, kimi-k3 4, glm-5.2 1}`, `in=973,962 out=45,596
cost=$0.90645` — matches the issue's own numbers exactly. The file's mtime is
`16:36:33`, **36 minutes before the issue was filed**, and it has not been
touched since, so the artifacts I read are byte-identical to the reporter's.
Against them:

- a fresh `MetricsReader` on current `main` returns `tokens_in: 973962`;
- **both** long-lived servers (`:8900`, started 4:18PM from a since-deleted
  worktree, i.e. running older code; `:8901`) return `tokens_in: 973962`.

What openssl *did* have at the time is `priced_cost: null` — `kimi-k3` was
unpriced until #2173 landed at 19:08, two hours after the issue. And
`fmtMoney(null)` renders `—`. So the openssl cell's *cost* column was blank
(that is #2108, already fixed), while the `tokens_in: 0 … priced_cost: 0`
shape the issue quotes belongs to the four never-ran trials in the same grid.
`priced_cost: 0` is the tell: openssl's was `null`, never `0`.

I am stating this rather than quietly fixing something else. If the reporter
has a saved payload showing openssl at `tokens_in: 0`, that is a different
bug and worth reopening on.

## The fix

- **`TrialMetrics.usage_measured`** — a property (like `cache_hit_rate`
  beside it, so it cannot go stale) that is `False` when no counter and no
  cost was observed. Read off observed spend rather than off the presence of
  a file or a row, for the same reason #1480's guard is: a `step_usage` whose
  token fields never arrived is exactly as unmeasured as no `step_usage` at
  all. No real model call reports zero of everything, so "all counters zero"
  is *unknown*, never *free*.
- **`priced_cost = None`** for such a trial, never `0.0`. No `unpriced_models`
  entry — the price table is not missing a row, and sending an operator to
  edit `PRICES` for a trial that produced no tokens is the noise that makes
  the real warning easy to skip (#2173's own queued-trial rule).
- **`aggregate()["priced_cost"]` refuses a partial sum**: `None` when any
  trial *spent tokens* nobody could price. A trial that measured *nothing*
  does not poison — it has no tokens to be short by, and blanking the column
  for every match with one crashed setup would trade a wrong number for no
  number. It is counted in the new **`unmeasured_trials`** instead, so the
  denominator behind every token and cost total stays visible.
- `series.py::_seat_outcomes` learns the same distinction, so the trends
  panel does not go blank now that never-ran trials price as `None`.
- `arenabench run` prints `!! N/M trials published no usage — the token and
  cost totals above are over the rest`, beside #2173's existing unpriced line.
- `ui/lib/types.ts` declares both fields. Rendering is #2221 (below).

Result on `cc00894779ff`: `priced_cost: 5.24646278`, `unmeasured_trials: 4`,
`unpriced_models: []` — against `$1.94` and no marker on `main`.

## Witness

`arenabench/tests/test_telemetry.py::TestUnmeasuredUsageIsNotZeroUsage`
(7 tests), plus the renamed `TestAggregate` case.

Flip verified by reverting **only** the four implementation files to
`origin/main` (`git checkout origin/main -- …`, working tree and tests
preserved — no `git stash`, parallel agents are live) and re-running:

```
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_a_trial_that_measured_nothing_is_not_priced_at_zero - AssertionError: unknown spend, not zero spend
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_the_cell_payload_says_the_zeroes_were_never_measured - assert 0.0 is None
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_a_step_that_reported_no_tokens_counts_as_unmeasured - assert 0.0 is None
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_the_seat_total_refuses_a_partial_priced_sum - AssertionError: a subset is not a total
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_an_unmeasured_trial_does_not_blank_the_seats_cost - KeyError: 'unmeasured_trials'
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_the_totals_name_how_many_trials_measured_nothing - KeyError: 'unmeasured_trials'
FAILED TestUnmeasuredUsageIsNotZeroUsage::test_a_measured_trial_still_reports_its_cost - AttributeError: 'TrialMetrics' object has no attribute 'usage_measured'
FAILED TestAggregate::test_priced_cost_refuses_a_partial_sum_but_still_totals_the_rest - assert 1.5 is None
```

Five of the eight fail on a **value**, not a missing attribute — the
assertions were deliberately reordered to put `priced_cost is None` first
after a first pass showed three of them failing with `AttributeError`, which
proves the field is new and nothing about what the number used to be
(#2173's "passed vacuously" lesson, applied in the other direction).

All 8 pass on this branch; the whole `arenabench/tests/` suite is green
(461 passed).

**Tests changed, named as the deleted-test guard asks:**

- `TestAggregate::test_priced_cost_sums_only_the_trials_that_have_one` →
  `test_priced_cost_refuses_a_partial_sum_but_still_totals_the_rest`. It
  asserted the defect: trial `b` really spent (`total_cost = 9.0`) and could
  not be priced, so summing only `a` was the under-count. No test deleted.
- `test_series.py::_trial` gains `tokens: int = 1000`, so its fixtures stay
  the ordinary "this trial ran" case now that measured and unmeasured trials
  follow different cost rules. `test_unpriced_models_poison_the_cost_never_shrink_it`
  caught my first cut of the `series.py` change, which had dropped priced
  trials out of the sum — its assertion is unchanged.

## Relationship to #2131 / PR #2198

**Different bug, adjacent evidence — no overlap, nothing to close.** #2198
fixes the *writer* side: Harbor's deadline cancels the run, the orphaned
agent keeps appending to `stella-events.jsonl`, and the usage snapshot taken
before that under-reports. This PR fixes the *reader* side and touches no
adapter code.

They do meet on one fact, which is why `usage_measured` is read off observed
spend rather than off "is there a `step_usage` row": #2131 is a live
demonstration that a stream can stop carrying usage while the trial is still
producing rows. openssl shows the shape directly — `trajectory.json`
(16:35:32) accounts for 42 records while the event stream (16:36:33) holds
49, and `stella_accounting.state` is `"incomplete"` for that reason. A row
whose token fields never arrived is now treated as unmeasured, not as zero.

## Filed, not left

- **#2220** (P1) — the zero-spend guard is gated on `steps > 0`, so a trial
  that produced *no* telemetry is still scored as an agent loss. Those same
  four trials are why `cc00894779ff` reads 40% (4/10) where the six trials
  that actually started give 67% (4/6). `usage_measured` makes the predicate
  a one-liner; the root cause of these particular RuntimeErrors is **#2127**.
- **#2221** (P3) — `usage_measured` / `unmeasured_trials` reach the payload
  and `types.ts` but nothing renders them, so a cell whose usage was never
  observed still draws `0 tok`. Pairs naturally with #2172; `arenabench/ui`
  has no test harness (#1751), so neither can carry a witness.
- **#2219** (P3) — `_reduce_events` computes `verifier_passed` and nothing
  reads it, while `live_feed.py` computes the same value and does surface it.

Not widened: `ruff check` on the five files this PR touches is clean; the 7
pre-existing `arenabench/` findings (#2193/#2146) are untouched and
`ruff format` was not run. **#2171** (nothing gates `PRICES` against seatable
models) is the standing preventative for the unpriced half and is unaffected.
