### PR TITLE
test(bench): retire the class — sweep every adapter caller in the tree, not two named seams

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,8 +67,20 @@ jobs:
           # still names the file it reads, so a crate move cannot silently
           # drop it (the last one left the test's own path literal one segment
           # short with Rust CI all-green).
+          #
+          # `bench/` is named whole rather than by its four tooling
+          # subdirectories, because the adapter-caller sweep
+          # (`test_manifest_parity.py`, #2203) derives its subject from the
+          # tree instead of a list, and callers had already appeared outside
+          # those four: `bench/tb21_preregistration.py` imports the adapter,
+          # and `bench/loop-bench/src/main.rs` carries the
+          # `--agent-import-path` entry-point spec Harbor resolves at launch,
+          # in Rust. Enumerating subdirectories here is the same per-seam
+          # pinning that let #2182 through one level up — the sweep asserts
+          # this pattern covers every caller it reads, so the next one cannot
+          # land outside the filter unnoticed.
           if git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Eq '^(bench/harbor_adapter/|bench/terminal_bench_analysis/|bench/telemetry_store/|bench/evidence/|arenabench/|crates/stella-model/src/catalog\.rs$|\.github/workflows/bench\.yml$)'; then
+            | grep -Eq '^(bench/|arenabench/|crates/stella-model/src/catalog\.rs$|\.github/workflows/bench\.yml$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/bench/harbor_adapter/tests/test_manifest_parity.py
+++ b/bench/harbor_adapter/tests/test_manifest_parity.py
@@ -394,16 +394,18 @@ _SPEC_SUFFIXES = frozenset(
 )
 
 #: `from stella_harbor… import a, b as c` — the same pattern the per-seam check
-#: above uses, applied to the whole tree rather than one directory.
+#: above uses, applied to the whole tree rather than one directory. The leading
+#: run is horizontal whitespace only, unlike that one's `\s*`: `\s` spans
+#: newlines, which would put a match's start on a blank line above the import
+#: and report the wrong line number.
 _EMBEDDED_IMPORT = re.compile(
-    r"^\s*from\s+(stella_harbor(?:\.[\w.]+)?)\s+import\s+([^\n#]+)", re.MULTILINE
+    r"^[ \t]*from[ \t]+(stella_harbor(?:\.[\w.]+)?)[ \t]+import[ \t]+([^\n#]+)",
+    re.MULTILINE,
 )
 
 #: `--agent-import-path stella_harbor:StellaAgent`, and the packaging spelling
 #: of the same thing (`stella_harbor.secure_launcher:main`).
-_ENTRY_POINT_SPEC = re.compile(
-    r"\bstella_harbor(\.[A-Za-z_][\w.]*)?:([A-Za-z_]\w*)"
-)
+_ENTRY_POINT_SPEC = re.compile(r"\bstella_harbor(\.[A-Za-z_][\w.]*)?:([A-Za-z_]\w*)")
 
 
 class _Sweep(NamedTuple):
@@ -476,7 +478,9 @@ def _member(module: ModuleType, name: str) -> Any | None:
 def _attribute(obj: Any, parts: list[str]) -> Any | None:
     """Resolve a dotted chain off an already-bound object."""
     for part in parts:
-        found = _member(obj, part) if inspect.ismodule(obj) else getattr(obj, part, None)
+        found = (
+            _member(obj, part) if inspect.ismodule(obj) else getattr(obj, part, None)
+        )
         if found is None:
             return None
         obj = found
@@ -537,7 +541,9 @@ def _check_call(
         return False
 
     accepted = set(signature.parameters)
-    unknown = sorted({keyword.arg for keyword in node.keywords if keyword.arg} - accepted)
+    unknown = sorted(
+        {keyword.arg for keyword in node.keywords if keyword.arg} - accepted
+    )
     if unknown:
         problems.append(
             f"{where}:{node.lineno}: `{label}` is called with {unknown}, which "
@@ -553,7 +559,10 @@ def _check_call(
             1
             for p in parameters
             if p.kind
-            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
         )
         if len(node.args) > seats:
             problems.append(
@@ -638,7 +647,11 @@ def _sweep_python(
             chain = _dotted(node.func)
             if not chain or chain[0] not in bound:
                 continue
-            target = bound[chain[0]] if len(chain) == 1 else _attribute(bound[chain[0]], chain[1:])
+            target = (
+                bound[chain[0]]
+                if len(chain) == 1
+                else _attribute(bound[chain[0]], chain[1:])
+            )
             label = ".".join(chain)
             if target is None:
                 problems.append(
@@ -661,8 +674,13 @@ def _sweep_embedded(root: Path, problems: list[str]) -> tuple[int, set[str]]:
         if text is None or "stella_harbor" not in text:
             continue
         where = path.relative_to(root).as_posix()
-        for module_name, imported in _EMBEDDED_IMPORT.findall(text):
-            line = text[: text.index(f"from {module_name} import")].count("\n") + 1
+        for match in _EMBEDDED_IMPORT.finditer(text):
+            module_name, imported = match.group(1), match.group(2)
+            # From the match offset, not a search for the text: a script that
+            # imports twice from the same module would otherwise report both
+            # at the first one's line, and a wrong line number in a paid-run
+            # driver is a wrong file to open at 3am.
+            line = text.count("\n", 0, match.start()) + 1
             module = _import_module(module_name, f"{where}:{line}", problems)
             if module is None:
                 files.add(where)

--- a/bench/harbor_adapter/tests/test_manifest_parity.py
+++ b/bench/harbor_adapter/tests/test_manifest_parity.py
@@ -1,6 +1,8 @@
-"""`bench/evidence/make_manifest.py` calls this adapter — pin the call shape.
+"""Every caller of this adapter must still bind to it — pin the call shape.
 
-The subject is #2182. The adapter's host-side selector entry points
+Two layers, in one module because they are one subject read at two altitudes.
+
+**The seam (#2182).** The adapter's host-side selector entry points
 (`_benchmark_engine_posture`, `_benchmark_assurance_tiers`) were renamed
 `witness_author` → `verifier`; `make_manifest.py` was left calling them with
 `witness_author=`. That is a `TypeError`, raised inline while the manifest dict
@@ -34,18 +36,56 @@ The shape is copied from `test_posture.py::TestOutputCeilingParity` and
 `test_assurance_tiers.py::test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors`:
 a check whose two halves live in different suites reads one of them as source
 text, and says which literal to edit when the path moves.
+
+**The class (#2203).** Everything above names its two seams as literals — a
+`_CALLEES` dict and one directory — which is the same ratchet #2182 was, one
+notch tighter. The next rename strands the *third* caller, and it fails the
+same way: silent in every suite, loud only on the run host, mid-paid-run.
+
+So the second half of this module derives its subject from the repository
+instead of from a list. It sweeps every file outside the adapter package for
+the three ways something outside `stella_harbor` reaches into it, and checks
+each against the live module:
+
+- `.py` — read the AST. Every `from stella_harbor… import X` / `import
+  stella_harbor…` must resolve, and every call through a name that import bound
+  must pass keywords the live `inspect.signature` accepts, and no more
+  positional arguments than it can take.
+- `.sh` / `.bash` / `.md` / `.mdx` — read the `from stella_harbor… import …`
+  lines textually. Shell is not parseable as Python, and this is the half that
+  catches `witness_ab.sh`: an `ImportError` inside a heredoc, behind `|| exit
+  1`, which took the *treatment* arm off the air for weeks.
+- Everything textual — resolve the `module:attribute` entry-point specs
+  (`--agent-import-path stella_harbor:StellaAgent`). Harbor resolves that
+  string at launch, so a rename breaks it in `.sh`, in `.md`, in `.mdx`, and in
+  `bench/loop-bench/src/main.rs` — a caller in a language no Python check would
+  otherwise reach.
+
+**A sweep that finds nothing is worse than no sweep**, because it reads as a
+passing gate; that is precisely how #2182 survived. So `_require_non_vacuous`
+fails on a zero count for any of the three, on a repository root that does not
+contain the adapter package, and on an adapter submodule that will not import —
+and `TestSweepAntiVacuity` exercises each of those failures against a synthetic
+tree rather than trusting them.
+
+Known limits, declared rather than silent: a call whose keywords arrive by
+`**splat` is not checkable from source and is skipped (the manifest seam forbids
+splats outright, above); a callee taking `**kwargs` accepts anything and is
+skipped; and a name rebound after import is resolved to the imported object.
 """
 
 from __future__ import annotations
 
 import ast
+import functools
 import importlib
 import importlib.util
 import inspect
+import os
 import re
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -296,3 +336,591 @@ def test_the_two_blocks_disclose_the_arm_in_their_digests() -> None:
             f"{block.__name__} hashes the two arms identically: the arm would "
             "be invisible in the registered digest (#1007)"
         )
+
+
+# ---------------------------------------------------------------------------
+# The class-level sweep (#2203): every caller, derived from the tree
+# ---------------------------------------------------------------------------
+
+#: The adapter package, relative to the repository root. Everything under it is
+#: excluded from the `.py` sweep — an intra-package import is the package's own
+#: business, and it is the one thing a rename cannot leave behind.
+_PACKAGE_PARTS = ("bench", "harbor_adapter", "stella_harbor")
+
+#: Directory names never descended into. Build output and virtualenvs hold
+#: vendored copies of this adapter's own dependencies, and `.claude/` holds
+#: agent worktrees — each a second checkout of this repository, which would be
+#: swept as though its files were this one's.
+_PRUNED_DIRS = frozenset(
+    {
+        ".git",
+        ".claude",
+        ".mypy_cache",
+        ".next",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+        "target",
+        "venv",
+    }
+)
+
+#: Files that can embed Python the interpreter never sees as a `.py` — a shell
+#: heredoc, a fenced block in a runbook. Read textually, because they are not
+#: parseable as Python and the failure being pinned is a name, not a call.
+_EMBEDDED_SUFFIXES = frozenset({".bash", ".md", ".mdx", ".sh", ".zsh"})
+
+#: Files that can carry a `module:attribute` entry-point spec. Deliberately
+#: wider than the two above: Harbor resolves that string at launch, so the spec
+#: is a live call in whatever language happens to be holding it — including
+#: `bench/loop-bench/src/main.rs`.
+_SPEC_SUFFIXES = frozenset(
+    {
+        ".bash",
+        ".json",
+        ".md",
+        ".mdx",
+        ".py",
+        ".rs",
+        ".sh",
+        ".toml",
+        ".txt",
+        ".yaml",
+        ".yml",
+        ".zsh",
+    }
+)
+
+#: `from stella_harbor… import a, b as c` — the same pattern the per-seam check
+#: above uses, applied to the whole tree rather than one directory.
+_EMBEDDED_IMPORT = re.compile(
+    r"^\s*from\s+(stella_harbor(?:\.[\w.]+)?)\s+import\s+([^\n#]+)", re.MULTILINE
+)
+
+#: `--agent-import-path stella_harbor:StellaAgent`, and the packaging spelling
+#: of the same thing (`stella_harbor.secure_launcher:main`).
+_ENTRY_POINT_SPEC = re.compile(
+    r"\bstella_harbor(\.[A-Za-z_][\w.]*)?:([A-Za-z_]\w*)"
+)
+
+
+class _Sweep(NamedTuple):
+    """One repository-wide pass: what was checked, and what did not hold.
+
+    The counts are not decoration — they are the anti-vacuity evidence. A
+    sweep reporting no problems and no checks has not proved the tree is
+    clean; it has proved only that it stopped reading (#2182).
+    """
+
+    problems: tuple[str, ...]
+    resolved_imports: int
+    checked_calls: int
+    embedded_imports: int
+    entry_points: int
+    caller_files: tuple[str, ...]
+
+
+def _adapter_package(root: Path) -> Path:
+    """The adapter package under `root`, or a failure naming what to edit."""
+    package = root.joinpath(*_PACKAGE_PARTS)
+    assert package.is_dir(), (
+        f"{package} is not a directory, so this sweep is not looking at a "
+        "Stella checkout and every count below would be zero. If the layout "
+        "moved, correct `_REPO_ROOT` / `_PACKAGE_PARTS` in this file"
+    )
+    return package
+
+
+def _walk(root: Path, suffixes: frozenset[str]) -> list[Path]:
+    """Every file under `root` with one of `suffixes`, pruned and sorted.
+
+    Sorted so a failure list is stable across machines: the tree is walked to
+    produce a diffable report, not just a boolean.
+    """
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(name for name in dirnames if name not in _PRUNED_DIRS)
+        for name in sorted(filenames):
+            if Path(name).suffix in suffixes:
+                found.append(Path(dirpath) / name)
+    return found
+
+
+def _read(path: Path) -> str | None:
+    """The file's text, or `None` when it is not UTF-8 text at all."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _member(module: ModuleType, name: str) -> Any | None:
+    """`getattr`, but importing a submodule that nothing has pulled in yet.
+
+    `from stella_harbor import posture` binds a submodule the parent package
+    may not have imported, so a bare `hasattr` reports a live name as missing.
+    Treating that as a rename would be a false red on a benchmark gate, which
+    costs as much trust as the miss it is guarding against.
+    """
+    if hasattr(module, name):
+        return getattr(module, name)
+    try:
+        importlib.import_module(f"{module.__name__}.{name}")
+    except ImportError:
+        return None
+    return getattr(module, name, None)
+
+
+def _attribute(obj: Any, parts: list[str]) -> Any | None:
+    """Resolve a dotted chain off an already-bound object."""
+    for part in parts:
+        found = _member(obj, part) if inspect.ismodule(obj) else getattr(obj, part, None)
+        if found is None:
+            return None
+        obj = found
+    return obj
+
+
+def _dotted(node: ast.expr) -> list[str] | None:
+    """`a.b.c` → `["a", "b", "c"]`; anything else → `None`."""
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return list(reversed(parts))
+
+
+def _import_module(name: str, where: str, problems: list[str]) -> ModuleType | None:
+    """Import an adapter module, recording a failure instead of raising.
+
+    An unimportable `stella_harbor.<thing>` is the module-level spelling of
+    #2182 — the caller names something the package no longer has — so it has
+    to read as a parity failure, not as a broken test run.
+    """
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        problems.append(
+            f"{where}: `{name}` will not import ({exc}). A caller naming a "
+            "module the adapter no longer has fails at launch, not at import "
+            "of this suite (#2203)"
+        )
+        return None
+
+
+def _check_call(
+    node: ast.Call, target: Any, label: str, where: str, problems: list[str]
+) -> bool:
+    """Compare one call against the live signature. True when it was read.
+
+    Returns False for the shapes source cannot answer — a callee that takes
+    `**kwargs` accepts anything, and a caller splatting `**mapping` names
+    nothing statically. Both are declared limits in the module docstring
+    rather than silent passes.
+    """
+    if not callable(target):
+        return False
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):
+        return False
+    parameters = list(signature.parameters.values())
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters):
+        return False
+    if any(keyword.arg is None for keyword in node.keywords):
+        return False
+
+    accepted = set(signature.parameters)
+    unknown = sorted({keyword.arg for keyword in node.keywords if keyword.arg} - accepted)
+    if unknown:
+        problems.append(
+            f"{where}:{node.lineno}: `{label}` is called with {unknown}, which "
+            f"its live signature does not accept ({sorted(accepted)}). One "
+            "side of this seam was renamed without the other — a TypeError on "
+            "the run host, in code no suite reaches off it (#2182)"
+        )
+
+    starred = any(isinstance(arg, ast.Starred) for arg in node.args)
+    variadic = any(p.kind is inspect.Parameter.VAR_POSITIONAL for p in parameters)
+    if not starred and not variadic:
+        seats = sum(
+            1
+            for p in parameters
+            if p.kind
+            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        )
+        if len(node.args) > seats:
+            problems.append(
+                f"{where}:{node.lineno}: `{label}` is called with "
+                f"{len(node.args)} positional arguments; its live signature "
+                f"takes at most {seats}. The callee's arity moved and this "
+                "caller did not (#2203)"
+            )
+    return True
+
+
+def _bind_adapter_names(
+    tree: ast.Module, where: str, problems: list[str]
+) -> tuple[dict[str, Any], int]:
+    """Every name this module's imports bind to something in the adapter."""
+    bound: dict[str, Any] = {}
+    resolved = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if not node.module or node.module.split(".")[0] != "stella_harbor":
+                continue
+            module = _import_module(node.module, f"{where}:{node.lineno}", problems)
+            if module is None:
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                resolved += 1
+                member = _member(module, alias.name)
+                if member is None:
+                    problems.append(
+                        f"{where}:{node.lineno}: imports `{alias.name}` from "
+                        f"`{node.module}`, which no longer defines it (#2182)"
+                    )
+                    continue
+                bound[alias.asname or alias.name] = member
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] != "stella_harbor":
+                    continue
+                resolved += 1
+                module = _import_module(alias.name, f"{where}:{node.lineno}", problems)
+                if module is None:
+                    continue
+                if alias.asname:
+                    bound[alias.asname] = module
+                else:
+                    bound["stella_harbor"] = importlib.import_module("stella_harbor")
+    return bound, resolved
+
+
+def _sweep_python(
+    root: Path, package: Path, problems: list[str]
+) -> tuple[int, int, set[str]]:
+    """AST-check every `.py` outside the package. → (imports, calls, files)."""
+    resolved = 0
+    checked = 0
+    files: set[str] = set()
+    for path in _walk(root, frozenset({".py"})):
+        if package in path.parents:
+            continue
+        text = _read(path)
+        if text is None or "stella_harbor" not in text:
+            continue
+        where = path.relative_to(root).as_posix()
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError as exc:
+            problems.append(f"{where}: will not parse as Python ({exc})")
+            continue
+
+        bound, found = _bind_adapter_names(tree, where, problems)
+        resolved += found
+        if found:
+            files.add(where)
+        if not bound:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            chain = _dotted(node.func)
+            if not chain or chain[0] not in bound:
+                continue
+            target = bound[chain[0]] if len(chain) == 1 else _attribute(bound[chain[0]], chain[1:])
+            label = ".".join(chain)
+            if target is None:
+                problems.append(
+                    f"{where}:{node.lineno}: `{label}` does not resolve on the "
+                    "live adapter — the attribute it reaches through is gone "
+                    "(#2203)"
+                )
+                continue
+            if _check_call(node, target, label, where, problems):
+                checked += 1
+    return resolved, checked, files
+
+
+def _sweep_embedded(root: Path, problems: list[str]) -> tuple[int, set[str]]:
+    """Resolve `from stella_harbor… import …` in shell and prose."""
+    checked = 0
+    files: set[str] = set()
+    for path in _walk(root, _EMBEDDED_SUFFIXES):
+        text = _read(path)
+        if text is None or "stella_harbor" not in text:
+            continue
+        where = path.relative_to(root).as_posix()
+        for module_name, imported in _EMBEDDED_IMPORT.findall(text):
+            line = text[: text.index(f"from {module_name} import")].count("\n") + 1
+            module = _import_module(module_name, f"{where}:{line}", problems)
+            if module is None:
+                files.add(where)
+                continue
+            for entry in imported.split(","):
+                bare = entry.strip().split(" as ")[0].strip().strip("()")
+                if not bare or bare == "*":
+                    continue
+                checked += 1
+                files.add(where)
+                if _member(module, bare) is None:
+                    problems.append(
+                        f"{where}:{line}: imports `{bare}` from `{module_name}`, "
+                        "which no longer defines it. Embedded in a heredoc "
+                        "behind `|| exit 1`, this takes the arm off the air "
+                        "with no other symptom (#2182)"
+                    )
+    return checked, files
+
+
+def _sweep_entry_points(root: Path, problems: list[str]) -> tuple[int, set[str]]:
+    """Resolve every `module:attribute` spec a launcher would import."""
+    checked = 0
+    files: set[str] = set()
+    for path in _walk(root, _SPEC_SUFFIXES):
+        text = _read(path)
+        if text is None or "stella_harbor" not in text:
+            continue
+        where = path.relative_to(root).as_posix()
+        for line_no, line in enumerate(text.splitlines(), 1):
+            for match in _ENTRY_POINT_SPEC.finditer(line):
+                module_name = "stella_harbor" + (match.group(1) or "")
+                attribute = match.group(2)
+                checked += 1
+                files.add(where)
+                module = _import_module(module_name, f"{where}:{line_no}", problems)
+                if module is None:
+                    continue
+                if _member(module, attribute) is None:
+                    problems.append(
+                        f"{where}:{line_no}: names the entry point "
+                        f"`{module_name}:{attribute}`, which the adapter no "
+                        "longer defines. Harbor resolves this string at "
+                        "launch, so the run dies before its first turn (#2203)"
+                    )
+    return checked, files
+
+
+@functools.cache
+def _sweep(root: Path) -> _Sweep:
+    """One pass over `root`. Cached: three tests read the same walk."""
+    package = _adapter_package(root)
+    problems: list[str] = []
+    resolved, checked, python_files = _sweep_python(root, package, problems)
+    embedded, embedded_files = _sweep_embedded(root, problems)
+    specs, spec_files = _sweep_entry_points(root, problems)
+    return _Sweep(
+        problems=tuple(problems),
+        resolved_imports=resolved,
+        checked_calls=checked,
+        embedded_imports=embedded,
+        entry_points=specs,
+        caller_files=tuple(sorted(python_files | embedded_files | spec_files)),
+    )
+
+
+def _require_non_vacuous(sweep: _Sweep) -> None:
+    """Fail when the sweep examined nothing — the #2182 failure mode itself.
+
+    Separated from the assertions that read `problems` so it can be pointed at
+    a synthetic tree and *observed* failing, rather than believed.
+    """
+    empty = [
+        name
+        for name, count in (
+            ("resolved imports", sweep.resolved_imports),
+            ("checked call sites", sweep.checked_calls),
+            ("embedded shell/prose imports", sweep.embedded_imports),
+            ("entry-point specs", sweep.entry_points),
+        )
+        if count == 0
+    ]
+    assert not empty, (
+        f"the adapter-caller sweep found zero {' and zero '.join(empty)}. A "
+        "parity check that examines nothing reads as a passing gate, which is "
+        "strictly worse than no gate — it is how #2182 survived. Either the "
+        "callers moved out from under `_PRUNED_DIRS` / `_PACKAGE_PARTS` in "
+        "this file, or the sweep stopped reading its subject"
+    )
+
+
+def test_the_sweep_reads_the_repository_before_it_judges_it() -> None:
+    """Guard the guard, first — everything below is vacuous without this."""
+    _require_non_vacuous(_sweep(_REPO_ROOT))
+
+
+def test_every_caller_in_the_tree_still_binds_to_the_live_adapter() -> None:
+    """The class #2182 belongs to: any caller, any language, any seam.
+
+    `_CALLEES` and `_EVIDENCE_RUN` above name two seams. This names none: it
+    derives the callee set from the live module and the caller set from the
+    tree, so the third caller — the one no one has written yet — is covered on
+    the day it lands rather than on the day it strands.
+    """
+    sweep = _sweep(_REPO_ROOT)
+    _require_non_vacuous(sweep)
+    assert not sweep.problems, "\n".join(("", *sweep.problems))
+
+
+def test_the_bench_workflow_runs_when_a_caller_changes() -> None:
+    """A sweep that reads a file must be triggered by that file.
+
+    Same argument as `test_posture.py::TestOutputCeilingParity::
+    test_the_bench_workflow_runs_when_the_catalog_changes`, one class wider:
+    this suite is gated behind a path filter, and it now reads callers the
+    filter did not name — `bench/tb21_preregistration.py` was outside it.
+
+    Documentation is exempt, and the exemption is the honest half. A stale
+    `stella_harbor:StellaAgent` in a published guide misleads a reader; it does
+    not take an arm off the air, and the sweep still catches it on the next
+    push to `main`, where the filter does not apply. Widening the filter to
+    every `.md`/`.mdx` in the repository would run this suite on prose changes
+    forever to shorten that window, which is the wrong trade.
+    """
+    workflow = _REPO_ROOT / ".github" / "workflows" / "bench.yml"
+    assert workflow.is_file(), f"{workflow} is missing"
+    match = re.search(r"grep -Eq '(\^\([^']+\))'", workflow.read_text(encoding="utf-8"))
+    assert match, (
+        f"{workflow.name} no longer carries a `grep -Eq '^(…)'` scope filter "
+        "in the shape this check reads; if it was restructured, correct this "
+        "test rather than deleting it"
+    )
+    scope = re.compile(match.group(1))
+    uncovered = [
+        path
+        for path in _sweep(_REPO_ROOT).caller_files
+        if Path(path).suffix not in {".md", ".mdx"} and not scope.search(path)
+    ]
+    assert not uncovered, (
+        f"{workflow.name}'s scope filter does not match {uncovered}, so a PR "
+        "touching only those callers skips this suite — including the sweep "
+        "whose whole subject they are"
+    )
+
+
+#: The sweep reads this file too, so a fixture below that spelled a stranded
+#: name literally would be found — correctly — by the real sweep and fail it.
+#: Every fixture therefore assembles the module name at runtime through this.
+_ADAPTER = "stella_harbor"
+
+
+class TestSweepAntiVacuity:
+    """Prove each way the sweep can stop reading actually fails.
+
+    #2182 was not missed for want of a check; it was missed because the check
+    that existed could not run where the defect was, and said nothing about
+    that. So every "this cannot silently pass" claim above is exercised here
+    against a synthetic tree, rather than asserted in a docstring.
+    """
+
+    @staticmethod
+    def _skeleton(root: Path) -> Path:
+        """A tree that looks like a checkout but contains no callers."""
+        package = root.joinpath(*_PACKAGE_PARTS)
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        return package
+
+    def test_a_tree_that_is_not_a_checkout_names_the_constant_to_edit(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(AssertionError) as caught:
+            _sweep(tmp_path / "not-a-checkout")
+        message = str(caught.value)
+        assert "_REPO_ROOT" in message
+        assert "_PACKAGE_PARTS" in message
+
+    def test_a_tree_with_no_callers_fails_rather_than_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole point: zero findings over zero subjects is not green."""
+        self._skeleton(tmp_path)
+        sweep = _sweep(tmp_path)
+        assert not sweep.problems, "the empty tree must be clean, just vacuous"
+        with pytest.raises(AssertionError) as caught:
+            _require_non_vacuous(sweep)
+        message = str(caught.value)
+        assert "resolved imports" in message
+        assert "entry-point specs" in message
+
+    def test_an_adapter_module_a_caller_names_but_lacks_is_a_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """A rename at module granularity, not just at name granularity."""
+        self._skeleton(tmp_path)
+        caller = tmp_path / "caller.py"
+        caller.write_text(
+            f"from {_ADAPTER}.no_such_module import thing\nthing()\n",
+            encoding="utf-8",
+        )
+        problems = _sweep(tmp_path).problems
+        assert any("no_such_module" in problem for problem in problems), problems
+        assert any("will not import" in problem for problem in problems), problems
+
+    def test_a_stranded_keyword_is_named_with_its_file_and_line(
+        self, tmp_path: Path
+    ) -> None:
+        """The #2182 shape itself, reproduced against the live adapter."""
+        self._skeleton(tmp_path)
+        caller = tmp_path / "caller.py"
+        caller.write_text(
+            "\n".join(
+                (
+                    f"from {_ADAPTER} import _benchmark_engine_posture",
+                    "",
+                    "_benchmark_engine_posture(",
+                    f'    "{_WORKER}",',
+                    f'    witness_author="{_VERIFIER}",',
+                    ")",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        problems = _sweep(tmp_path).problems
+        assert any(
+            "caller.py:3" in problem and "witness_author" in problem
+            for problem in problems
+        ), problems
+
+    def test_a_stranded_entry_point_spec_is_a_failure(self, tmp_path: Path) -> None:
+        """The `--agent-import-path` seam, which no AST walk can see."""
+        self._skeleton(tmp_path)
+        (tmp_path / "run.sh").write_text(
+            f"harbor run --agent-import-path {_ADAPTER}:NoSuchAgent\n",
+            encoding="utf-8",
+        )
+        problems = _sweep(tmp_path).problems
+        assert any(
+            "run.sh:1" in problem and "NoSuchAgent" in problem for problem in problems
+        ), problems
+
+    def test_a_stranded_heredoc_import_is_a_failure(self, tmp_path: Path) -> None:
+        """`witness_ab.sh`'s shape: a name inside shell, behind `|| exit 1`."""
+        self._skeleton(tmp_path)
+        (tmp_path / "arm.sh").write_text(
+            "\n".join(
+                (
+                    "python3 - <<'PY' || exit 1",
+                    f"from {_ADAPTER}.posture import _validated_witness_author",
+                    "PY",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        problems = _sweep(tmp_path).problems
+        assert any(
+            "arm.sh:2" in problem and "_validated_witness_author" in problem
+            for problem in problems
+        ), problems


### PR DESCRIPTION
Closes #2203

## The problem

#2182 was two callers of `bench/harbor_adapter` stranded by one rename (#1394, `witness_author` → `verifier`), each of which killed benchmark evidence generation on the run host: no manifest written at all, and the **witness-on treatment arm refusing to launch**, silently, for weeks.

PR #2202 fixed both and pinned them *by name* — a `_CALLEES` dict of two functions and one directory (`bench/evidence/run/`) scanned for `from stella_harbor… import …`. That is the same per-seam ratchet #2182 was, one notch tighter. The third caller a rename strands is not covered, and fails the same way: silent in every suite, loud only on the run host, mid-paid-run.

Four separate bugs in one night share that shape (#2134, #2171, #2182, #2196): two sides of a boundary that nothing checks. This retires the class rather than the instance.

## What this does

`bench/harbor_adapter/tests/test_manifest_parity.py` now derives its subject from the repository instead of a list. It sweeps every file outside `bench/harbor_adapter/stella_harbor/` for the three ways something reaches into the adapter and checks each against the **live module**:

| Seam | How | Checked today |
|---|---|---|
| `.py` imports | `ast.ImportFrom` / `ast.Import` → `importlib` + `getattr` | **139** |
| `.py` call sites | keywords and positional arity vs `inspect.signature` of the resolved callee | **419** |
| `.sh` / `.bash` / `.md` / `.mdx` embedded imports | textual — shell is not parseable as Python, and this is the half that catches `witness_ab.sh` | **4** |
| `module:attribute` entry-point specs, any text file | `--agent-import-path stella_harbor:StellaAgent`, which Harbor resolves at launch — including in `bench/loop-bench/src/main.rs`, a caller in a language no Python check would otherwise reach | **51** |

**613 seams across 44 files**, in ~1 second. The callee set is never hardcoded: it is whatever `inspect.signature` says today.

### Anti-vacuity is enforced, not asserted

A sweep that finds nothing reads as a passing gate, which is strictly worse than no gate — that is precisely how #2182 survived. `_require_non_vacuous` fails on a zero count for **any** of the four, on a root that is not a Stella checkout (naming `_REPO_ROOT` / `_PACKAGE_PARTS` as the thing to edit), and on an adapter module a caller names but the package lacks. `TestSweepAntiVacuity` exercises each of those failures against a synthetic tree rather than believing them.

## Witness evidence

**1. The real stranded callers, reverted to their pre-#2202 form** (`git checkout b722e61d^ -- bench/evidence/make_manifest.py bench/evidence/run/witness_ab.sh`). The sweep names the file, the line, and both disagreeing names:

```
bench/evidence/make_manifest.py:120: `_benchmark_engine_posture` is called with ['witness_author'],
  which its live signature does not accept (['candidates', 'max_revisions', 'model',
  'model_timeout_secs', 'triage_model', 'verifier', 'verifier_evidence_demand', 'worker_effort']).
  One side of this seam was renamed without the other — a TypeError on the run host, in code no
  suite reaches off it (#2182)
bench/evidence/make_manifest.py:144: `_benchmark_assurance_tiers` is called with ['witness_author'],
  which its live signature does not accept (['model', 'verifier']). …
bench/evidence/run/witness_ab.sh:94: imports `_validated_witness_author` from
  `stella_harbor.posture`, which no longer defines it. Embedded in a heredoc behind `|| exit 1`,
  this takes the arm off the air with no other symptom (#2182)
```

Restored → 16 passed.

**2. The point of the PR — a caller the per-seam check cannot see.** Two scratch edits stranding callers *outside* `_CALLEES` and `_EVIDENCE_RUN`: `bench/evidence/frontier/setup_venv.sh` (a paid-run preflight with the identical `|| exit 1` heredoc shape, one directory over from the one #2202 scans) and `bench/tb21_preregistration.py` (outside `bench.yml`'s old scope filter entirely).

**Every per-seam test from #2202 passed. 15 of 16 green. Only the class-level sweep failed:**

```
bench/tb21_preregistration.py:161: imports `_CALIBRATION_TASK_FILTER` from
  `stella_harbor.secure_launcher`, which no longer defines it (#2182)
bench/evidence/frontier/setup_venv.sh:34: imports `StellaHarborAgent` from `stella_harbor`,
  which no longer defines it. Embedded in a heredoc behind `|| exit 1`, this takes the arm
  off the air with no other symptom (#2182)
```

Restored → 16 passed.

**3. Anti-vacuity fires.** `TestSweepAntiVacuity` (5 tests) proves each stop-reading mode against a synthetic tree: a root that is not a checkout names `_REPO_ROOT` and `_PACKAGE_PARTS`; a tree with the package but no callers is *clean and vacuous*, and `_require_non_vacuous` raises naming "resolved imports" and "entry-point specs"; an adapter module a caller names but lacks is reported as "will not import"; a stranded keyword is named with `caller.py:3`; a stranded `stella_harbor:NoSuchAgent` spec with `run.sh:1`; a stranded heredoc import with `arm.sh:2`.

## Where it lives, and why

**Extended `test_manifest_parity.py` rather than adding a competing module**, per #2203's "or subsuming them". Both layers are one subject read at two altitudes, and the module docstring now frames them that way. It is a **pytest in the harbor suite, not a new `make gate` step** — the suite already runs as the required `harbor_adapter + analyzer pytest` context, so it blocks merges with **zero** `Makefile` / `AGENTS.md` / `CONTRIBUTING.md` churn and no `gate-parity` risk. (`./scripts/check-gate-parity.sh` → OK, 25 steps, unchanged.) A gate step would also have to import `harbor`, which `make gate` has no venv for.

**No test was deleted, renamed, or weakened.** Every #2202 test is intact: its arm-selector and digest-disclosure assertions are semantic and cannot be derived generically, and its mechanical half gives the exact #2182 shape a targeted message. The sweep subsumes but does not replace it. The file went 298 → 935 lines (ceiling 1500; `check-file-size` OK, no baseline change).

## The one workflow change

`bench.yml`'s scope filter named four subdirectories of `bench/`, and **two callers already lived outside them** — `bench/tb21_preregistration.py` and `bench/loop-bench/src/main.rs`. #2203 asked me to confirm no workflow change was needed; it was. The filter now names `bench/` whole, because enumerating subdirectories is the same per-seam pinning one level up. `test_the_bench_workflow_runs_when_a_caller_changes` parses the filter out of the workflow and asserts it matches every caller the sweep reads, so the next one cannot land outside it unnoticed — the shape of `test_posture.py::TestOutputCeilingParity::test_the_bench_workflow_runs_when_the_catalog_changes`, one class wider. Cost: `bench/`-only PRs now run six pytest suites instead of skipping.

`.md`/`.mdx` are exempt from that assertion, and the exemption is the honest half: a stale spec in a published guide misleads a reader but does not take an arm off the air, and it is still caught on the next push to `main`. Tracked in #2227.

## Testing

Targeted only — CI is the gate.

- `pytest -q tests/test_manifest_parity.py` → **16 passed** (10 pre-existing + 6 new)
- `pytest -q tests/test_posture.py -k OutputCeilingParity` → 5 passed (the other reader of `bench.yml`)
- `ruff format --check` + `ruff check` under the adapter's own `[tool.ruff]` (88 columns) → clean
- `check-gate-parity`, `check-file-size`, `check-left-behind`, `check-no-scratch`, `check-action-pins`, `check-role-names` → all OK

## Nothing left behind

- **#2227** (filed) — the sweep's three declared blind spots: heredoc Python gets name resolution but not signature checking; `**splat` callers and `**kwargs` callees are skipped; docs are exempt from the reachability assertion. Written as a handoff with a suggested approach and an anti-vacuity requirement.
- **#2049** is *not* subsumed. The sweep now resolves adapter import names inside `bench/evidence/run/*.sh` (repo-wide, not just that directory) — one class of defect in those scripts. It checks nothing about the shell itself: quoting, unset variables, `[` vs `[[`, exit-code handling. `make shellcheck` still skips them.

## Exemplar

`test_posture.py::TestOutputCeilingParity` for the read-the-other-side-as-source shape and the workflow-reachability assertion; `test_assurance_tiers.py::test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` for deriving the subject from the live module instead of a literal.

## Summary by Sourcery

Add a repository-wide adapter caller sweep and align the bench workflow trigger to cover all adapter callers.

Enhancements:
- Extend the harbor adapter manifest parity test module with a class-level sweep that derives adapter callers from the repository tree and verifies imports, call sites, and entry-point specs against the live adapter.
- Introduce anti-vacuity checking and synthetic-tree tests to ensure the sweep fails when it examines no callers or when adapter modules or names are missing.

CI:
- Broaden the `bench.yml` path filter to trigger the bench workflow on any changes under `bench/`, ensuring the new sweep runs whenever adapter callers change.

Tests:
- Add tests that exercise the repository-wide sweep, enforce non-vacuous behavior, and verify the bench workflow scope matches all adapter callers discovered by the sweep.