### PR TITLE
fix(stella-cli): size verification to what the turn actually changed

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -643,19 +643,30 @@ mod tests {
     /// fresh chance to break verified-working state.
     ///
     /// Neither prompt drew any line between reading and mutating, so pin the
-    /// shared literal verbatim in both — plus the three claims a later trim
-    /// would take first, so the assertion cannot pass against a hollowed-out
-    /// literal. The visibility claim is the load-bearing one: proportionality
-    /// that may be taken silently is just "skip verification" with a nicer
-    /// name, and this repository's whole contract is verified done, not
-    /// claimed done.
+    /// shared literal verbatim in both — plus each clause of the rule
+    /// separately, so the assertion cannot pass against a hollowed-out literal.
+    /// Both halves of the read/mutate distinction are pinned, not just the
+    /// mutating one: a trim that kept "a check that MUTATES … can break state"
+    /// and dropped the sentence naming what to do instead would leave a
+    /// prohibition with no cheaper rung to fall to, which is how a
+    /// proportionality rule turns into a reason to verify nothing.
+    ///
+    /// The visibility claim is the load-bearing one: proportionality that may
+    /// be taken silently is just "skip verification" with a nicer name, and
+    /// this repository's whole contract is verified done, not claimed done.
     #[test]
     fn both_prompts_size_verification_to_what_the_turn_changed() {
         let shared = verification_proportionality!();
         for claim in [
-            // The distinction the issue asks to encode: reading is nearly
-            // free, mutating the system under test carries restore-risk.
+            // The distinction the issue asks to encode, both halves of it:
+            // reading is nearly free, mutating the system under test carries
+            // restore-risk.
+            "only READS",
             "MUTATES the system under test",
+            // The mapping that makes it a rule rather than an observation —
+            // a no-op turn gets the cheap probe, a real change earns the
+            // end-to-end run.
+            "A turn that changed nothing gets the read-only probe",
             // The destructive half — a speculative reset of working state.
             "Never reset working state to \"pristine\"",
             // Degradation warns, never silently disables: the cheaper rung is

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -74,6 +74,32 @@ macro_rules! measurement_discipline {
     };
 }
 
+/// The verification-proportionality contract shared by both static prompts:
+/// re-verification is not free, and a check that mutates the system under test
+/// is not the same instrument as one that only reads it. Born from the same
+/// real TB2.1 `git-multibranch` trace as the two literals above (#1958): turns
+/// whose step was already satisfied on disk still ran the maximum-strength
+/// check — install sshpass, clone, push both branches, curl both endpoints —
+/// and then a **destructive reset-to-pristine** (re-init the bare repo, wipe
+/// the deploy dirs) justified only by a guess about the grader ("it will clone
+/// fresh"). That ran four times in one task. Three of those turns had changed
+/// nothing, so `git rev-parse --is-bare-repository` / `nginx -t` /
+/// `openssl x509 -noout` would have settled the same claim for free, and each
+/// reset destroyed verified-working state for a hunch — the setup survived
+/// only because the worker happened to rebuild it correctly every time.
+///
+/// The cheap rung is a *stated* choice, never a silent omission: the last
+/// sentence is what keeps proportionality from degrading into "skip
+/// verification", the same discipline the ladder's abstain rung keeps on the
+/// verdict side (`stella_pipeline::verify`). One shared literal, embedded
+/// verbatim by both prompts, same as `tool_steering!` and for the same
+/// anti-drift reason (#450).
+macro_rules! verification_proportionality {
+    () => {
+        r#"Verification is proportional to what THIS turn changed, and re-verification is not free. A check that only READS (`git rev-parse`, `nginx -t`, `openssl x509 -noout`, reading back the config you wrote) costs almost nothing and risks nothing; a check that MUTATES the system under test — installing packages, cloning, pushing, restarting a service, re-initializing a repository — spends real time and can break state that already worked. A turn that changed nothing gets the read-only probe; a turn that did change state earns one end-to-end run of what it changed. Never reset working state to "pristine" because you guess some later consumer wants a clean slate: destroying verified-working setup needs a requirement that says so, and on a hunch it is only a fresh chance to break what already passed. Taking the cheap path is never silent — name the probe you ran and the claim it settles, so an end-to-end cycle you did not run is a stated decision rather than an omission."#
+    };
+}
+
 pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"You are Stella, a fast terminal coding agent. You help the user with software engineering tasks by reading files, writing code, running commands, and searching the codebase.
 
@@ -87,6 +113,10 @@ pub(crate) const SYSTEM_PROMPT: &str = concat!(
 
 "#,
     measurement_discipline!(),
+    r#"
+
+"#,
+    verification_proportionality!(),
     r#"
 
 Rules:
@@ -115,6 +145,10 @@ pub(crate) const PIPELINE_SYSTEM_PROMPT: &str = concat!(
 
 "#,
     measurement_discipline!(),
+    r#"
+
+"#,
+    verification_proportionality!(),
     r#"
 
 Methodology (always follow in order):
@@ -595,6 +629,49 @@ mod tests {
             assert!(
                 prompt.contains(shared),
                 "{label} does not embed the shared measurement-discipline block verbatim"
+            );
+        }
+    }
+
+    /// Witness for the verification-proportionality defect (#1958): in the same
+    /// TB2.1 `git-multibranch` trace, turns whose step was already satisfied on
+    /// disk still ran the maximum-strength check — install sshpass, clone, push
+    /// both branches, curl both endpoints — and then a destructive
+    /// reset-to-pristine justified by a guess about the grader. Four times in
+    /// one task, three of them on turns that had changed nothing, where a
+    /// read-only probe settled the same claim for free and each reset was a
+    /// fresh chance to break verified-working state.
+    ///
+    /// Neither prompt drew any line between reading and mutating, so pin the
+    /// shared literal verbatim in both — plus the three claims a later trim
+    /// would take first, so the assertion cannot pass against a hollowed-out
+    /// literal. The visibility claim is the load-bearing one: proportionality
+    /// that may be taken silently is just "skip verification" with a nicer
+    /// name, and this repository's whole contract is verified done, not
+    /// claimed done.
+    #[test]
+    fn both_prompts_size_verification_to_what_the_turn_changed() {
+        let shared = verification_proportionality!();
+        for claim in [
+            // The distinction the issue asks to encode: reading is nearly
+            // free, mutating the system under test carries restore-risk.
+            "MUTATES the system under test",
+            // The destructive half — a speculative reset of working state.
+            "Never reset working state to \"pristine\"",
+            // Degradation warns, never silently disables: the cheaper rung is
+            // announced, so a skipped end-to-end is a decision on the record.
+            "never silent",
+        ] {
+            assert!(
+                shared.contains(claim),
+                "the shared literal must keep the proportionality claim {claim:?} — \
+                 without it the rule degrades into permission to skip verification"
+            );
+        }
+        for (label, prompt) in PROMPTS {
+            assert!(
+                prompt.contains(shared),
+                "{label} does not embed the shared verification-proportionality block verbatim"
             );
         }
     }


### PR DESCRIPTION
## What

Adds a fourth shared literal to both static system prompts (`SYSTEM_PROMPT` and `PIPELINE_SYSTEM_PROMPT` in `crates/stella-cli/src/agent/prompt.rs`): **`verification_proportionality!()`** — verification is sized to what *this* turn changed, a check that only reads is not the same instrument as one that mutates the system under test, and working state is never reset to "pristine" on a guess about a later consumer.

Closes #1958

## Why

The third finding from the same TB2.1 `git-multibranch` trace (match `bbc9ea944037`) that produced #1955 (`scope_discipline!`) and #1957 (`measurement_discipline!`). Turns whose step was already satisfied on disk still ran the maximum-strength check — install sshpass, clone, push both branches, curl both endpoints — and then a **destructive reset-to-pristine** (re-init the bare repo, wipe the deploy dirs) justified only by a hunch about the grader ("it will clone fresh"). That ran four times in one task; three of those turns had changed nothing, where `git rev-parse --is-bare-repository` / `nginx -t` / `openssl x509 -noout` would have settled the same claim for free. Each reset destroyed verified-working state and was a fresh opportunity to break it — the setup survived only because the worker happened to rebuild it correctly every time.

Neither prompt drew any line at all between reading and mutating (confirmed on `main`: `rg -in "read-only|destructive|pristine|reset|proportion" crates/stella-cli/src/agent/prompt.rs` matches nothing in either constant — the single hit is an unrelated doc comment on `append_project_orientation`).

## The cheaper rung is never a silent skip

This is the point the change turns on, so it is written into the literal itself rather than left to inference. The last sentence reads:

> Taking the cheap path is never silent — name the probe you ran and the claim it settles, so an end-to-end cycle you did not run is a stated decision rather than an omission.

So proportionality produces a *narrower stated claim*, never an absent one: the worker must name the read-only probe and what it settles, which lands in the turn's own output and therefore in the evidence the verify stage reads. That is the prompt-side counterpart of the discipline the ladder already keeps on the verdict side — `LadderDecision::NothingAttempted` (`crates/stella-pipeline/src/verify.rs`) fails *closed* on a turn that dispatched zero mutating actions precisely so abstaining cannot become a hiding place for a no-op. Nothing here lets a turn verify less than it claims; it lets a turn stop paying for a mutating cycle it has no change to justify, out loud.

## Scope note — why this is prompt-side and not a new ladder rung

The issue's own "Where" section and definition of done name the static prompts, and that matches the trace: the mutating e2e cycles and the reset-to-pristine were the **worker's own shell commands**, not something the pipeline dispatched. The verdict-side proportionality the issue calls "the same idea" (#1782–#1798) already exists as the abstain / `NothingAttempted` rungs, and duplicating it as a second decision function would have been a competing authority over the same question. No new state, no new dependency, no code path changed.

## How

Follows the exemplar already in the file — `tool_steering!()` (#450), then `scope_discipline!()` (#1955) and `measurement_discipline!()` (#1957): one shared literal embedded verbatim by both prompts so the copies cannot drift, kept a compile-time `concat!` so the byte-stable-prefix property (invariant 7, L-E8) is preserved. Static text only; the prompt-cache golden fixtures assert zone structure rather than prompt bytes and are unaffected.

## Witness

**`both_prompts_size_verification_to_what_the_turn_changed`** (`crates/stella-cli/src/agent/prompt.rs`).

Flip evidence, checked the artisanal way — with only the two `verification_proportionality!()` embeddings stripped from the prompt constants (macro and test kept in place):

```
test agent::prompt::tests::both_prompts_size_verification_to_what_the_turn_changed ... FAILED
    SYSTEM_PROMPT does not embed the shared verification-proportionality block verbatim
test result: FAILED. 7 passed; 1 failed
```

and with the change:

```
running 8 tests ... test result: ok. 8 passed; 0 failed
```

Only the new test flips; the other seven in the module are unmoved. The witness also pins five clauses of the literal separately so it cannot pass against a hollowed-out block — both halves of the read/mutate distinction (`only READS`, `MUTATES the system under test`), the mapping that makes it a rule (`A turn that changed nothing gets the read-only probe`), the destructive-reset prohibition, and the visibility clause. The second commit exists because the first version of the witness pinned only the mutating half: a trim that kept the prohibition and dropped the cheaper rung would have left "do not mutate" with nowhere to fall to, and the assertion would still have passed.

Wider check: `cargo test -p stella-cli --bin stella prompt` → 46 passed, 0 failed. `cargo fmt --check -p stella-cli` and `cargo clippy -p stella-cli --all-targets -- -D warnings` clean. `scripts/check-file-size.sh` (`prompt.rs` is 786 lines, not grandfathered, ceiling 1500), `scripts/check-left-behind.sh` and `scripts/check-brand-case.sh` all pass.

## Hot seams — not touched

`git diff --name-only origin/main...HEAD` is exactly one file, `crates/stella-cli/src/agent/prompt.rs`. Neither `crates/stella-pipeline/src/pipeline/witness_stage.rs` (#2151, #2162, #2191, #2212) nor `crates/stella-pipeline/src/verify.rs` (#2216) is in the diff. Confirmed at the call sites regardless, per #2165: `witness_repair_bound` is still computed and applied through `tokio::time::timeout` around the repair turn (`witness_stage.rs:499`, `:539`), and `bound_witness_output_tokens` is still wrapped around `apply_role_shaping` inside `witness_engine_config` (`witness_stage.rs:267`).

## Tests deleted

None.

## Nothing left behind

No TODOs added. Follow-up filed: #2231 — the four shared prompt-contract literals are pinned only by same-file `contains` assertions, so nothing checks that a *new* contract added later gets embedded in both prompts rather than one.

## Summary by Sourcery

Introduce a shared verification-proportionality contract in Stella’s static system prompts to align verification effort with what each turn actually changes and ensure this discipline is explicitly encoded and tested.

Enhancements:
- Add a shared verification-proportionality prompt literal and embed it into both static system prompts to distinguish cheap read-only probes from riskier mutating checks and discourage destructive reset-to-pristine behavior.

Tests:
- Add a prompt witness test that asserts both prompts embed the full verification-proportionality block and retain its key clauses, preventing future drift or hollowing-out of the contract.