### PR TITLE
fix(stella-pipeline): bound what the untracked diff pass reads — the post-execute probe rode big-tree trials into the harness kill

### DIFF
--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -21,6 +21,13 @@ mod flip_halt_arming;
 /// there, beside the only test that scripts it.
 mod witness_repair_bound;
 
+/// The untracked-diff read bound (#2110) — a child module for the same two
+/// reasons `flip_halt_arming` is: it reaches the shared fakes through this
+/// file's own `use super::*`, and the already-oversized `tests.rs` does not
+/// grow another module declaration. The counting diagnostic runner it needs
+/// lives there, beside the only test that scripts it.
+mod untracked_render_bound;
+
 /// The #1291 diff-coverage scenarios — a child module for the same two
 /// reasons `flip_halt_arming` is: it reaches the shared fakes through this
 /// file's own `use super::*`, and the already-oversized `tests.rs` does not

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/untracked_render_bound.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/untracked_render_bound.rs
@@ -1,0 +1,177 @@
+//! The untracked-diff read bound (#2110) — the witness and the counting
+//! diagnostic runner only it scripts.
+//!
+//! The defect this pins: `gather_diff`'s untracked pass read every fresh
+//! untracked path, two `git diff --no-index` subprocesses apiece, with no
+//! bound of its own. On a task that unpacks and builds a source tree that is
+//! thousands of paths — Terminal-Bench's `sqlite-with-gcov` extracts SQLite
+//! into the workspace and builds it with `--coverage`, and the harness
+//! commits a git baseline first, so every extracted and generated file is
+//! untracked and fresh. The pass then spent the trial's whole remaining wall
+//! clock reading a build tree, and the journal ended after the worker's final
+//! text with no warrant, no verify, no verdict and no `complete` event.
+//!
+//! The fix bounds what is READ without loosening what is KNOWN: the tail past
+//! [`super::super::super::verify_probes`]'s budget is still named (the
+//! warrant parses those markers into its path rules) and still counted (the
+//! diff-size budget must stay tripped), so the only thing given up is content
+//! nothing could have used.
+
+use super::*;
+
+/// A [`DiagnosticRunner`] that answers any untracked path and COUNTS the
+/// subprocesses it was asked for.
+///
+/// The count is the whole point: the bound under test is a cost bound, and a
+/// test that only inspected the resulting text would pass just as happily on
+/// a probe that read all ten thousand files and then rendered a few.
+struct CountingDiagnostics {
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl CountingDiagnostics {
+    fn new() -> Self {
+        Self {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl DiagnosticRunner for CountingDiagnostics {
+    async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
+        let stdout = match invocation {
+            // A clean tracked tree: the whole change is the untracked files.
+            DiagnosticInvocation::GitDiff => String::new(),
+            DiagnosticInvocation::UntrackedNumstat { path } => {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                format!("7\t0\t{path}")
+            }
+            DiagnosticInvocation::UntrackedPatch { path } => {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                format!("diff --git a/{path} b/{path}\n+++ b/{path}\n@@ -0,0 +1 @@\n+content\n")
+            }
+        };
+        CmdOutcome {
+            exit_code: 0,
+            stdout_tail: stdout,
+            stderr_tail: String::new(),
+            kind: CmdKind::Completed,
+        }
+    }
+}
+
+/// How many fresh untracked paths the scripted tree grows — comfortably past
+/// the budget, and the same order of magnitude as a built SQLite tree.
+const FRESH_PATHS: usize = 3000;
+
+/// #2110's witness: a turn that leaves thousands of fresh untracked files
+/// must cost a BOUNDED number of diff subprocesses, while still naming and
+/// counting every one of those paths.
+///
+/// On `main` the pass reads all of them — `2 * FRESH_PATHS` subprocesses —
+/// which is the unbounded cost that rode Terminal-Bench trials into the
+/// harness kill before the warrant could be emitted.
+#[tokio::test]
+async fn a_tree_sized_untracked_change_is_read_within_a_bounded_number_of_probes() {
+    let provider = ScriptedProvider::new(vec![]);
+    let resolver = OneProvider(&provider);
+    let diagnostics = CountingDiagnostics::new();
+    // An unpacked, built source tree: every path fresh this turn.
+    let paths: Vec<String> = (0..FRESH_PATHS)
+        .map(|i| format!("sqlite/src/file{i:05}.c"))
+        .collect();
+    let repo_status = FakeRepoStatus::new(paths.iter().map(|p| (p.as_str(), "v1")).collect());
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &diagnostics,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+
+    let surface = CandidateSurface {
+        diagnostics: &diagnostics,
+        tests: &runner,
+        lint: None,
+        mutation: None,
+        coverage: None,
+        repo_status: &repo_status,
+        cwd: None,
+        hook_runner: None,
+        workspace: None,
+    };
+
+    let probe = pipeline.gather_diff(surface, &HashMap::new()).await;
+
+    // THE BOUND. Two subprocesses per path read; unbounded, this is 6000.
+    let calls = diagnostics.calls();
+    assert!(
+        calls < 2 * FRESH_PATHS,
+        "the untracked pass must not read every path of an unpacked tree — \
+         it read {calls} of a possible {} (#2110)",
+        2 * FRESH_PATHS
+    );
+
+    // ...and the bound costs nothing the warrant or the budget depended on.
+    assert!(
+        probe.available,
+        "a readable tree still reports itself readable"
+    );
+    // Counted through the shared prefix the warrant's own parser keys on, so
+    // this asserts the property that parser depends on rather than a shape
+    // this test invented.
+    let named = probe
+        .text
+        .lines()
+        .filter(|line| line.starts_with(crate::witness::warrant::UNTRACKED_CHANGE_PREFIX))
+        .count();
+    assert_eq!(
+        named, FRESH_PATHS,
+        "every fresh path is still NAMED: the warrant parses these markers \
+         into the path set it holds to its 'every path must agree' rules, so \
+         an unnamed tail could relax exactly when a witness is owed"
+    );
+    assert!(
+        probe.lines as usize >= FRESH_PATHS,
+        "every fresh path still contributes at least its floor of 1 line, so \
+         a tree-sized change stays OVER the diff-size budget rather than \
+         slipping under it: {} lines for {FRESH_PATHS} paths",
+        probe.lines
+    );
+    assert!(
+        probe.text.contains("were not read"),
+        "the truncation is declared, not silent — the tail's counts are \
+         floors and a reader must be told so: {}",
+        &probe.text[probe.text.len().saturating_sub(400)..]
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/verify_probes.rs
+++ b/crates/stella-pipeline/src/pipeline/verify_probes.rs
@@ -335,6 +335,19 @@ impl<'a> Pipeline<'a> {
                 .map(|(path, _)| path.as_str())
                 .collect();
             fresh.sort(); // deterministic order for the appended evidence
+            // Only the HEAD of that list is read. Every path read costs two
+            // `git diff --no-index` subprocesses, so the pass is linear in
+            // the number of files the turn created — and a task that unpacks
+            // and builds a source tree creates thousands at once. See
+            // [`UNTRACKED_RENDER_BUDGET`] for the trials that spent their
+            // whole remaining clock here and never reached the warrant.
+            //
+            // A count, never a clock: the tail this splits off decides what
+            // the verifier reads, and a wall-clock cut would make that text —
+            // and every prompt built from it — depend on how fast the machine
+            // happened to be. Replay and prompt-cache stability both need this
+            // to be a function of the tree alone.
+            let unmeasured = fresh.split_off(fresh.len().min(UNTRACKED_RENDER_BUDGET));
             // Each of these is a `git diff --no-index --numstat` subprocess.
             // Run sequentially, a turn that creates many untracked files paid
             // one full process round-trip per file — on every verification
@@ -381,6 +394,30 @@ impl<'a> Pipeline<'a> {
                         untracked_rendered.push(path.to_string());
                     }
                 }
+            }
+            // The tail past the budget is NAMED and COUNTED, just not read.
+            //
+            // Naming is not optional. `witness::warrant::untracked_marker_paths`
+            // parses these markers back into the path set the warrant holds to
+            // its "every path must agree" rules, so a tail that went unnamed
+            // could turn a mixed change into a homogeneous one — a `.md`-only
+            // prefix standing in for a tree that also grew source — and relax
+            // exactly when a witness is owed.
+            //
+            // Counting is not optional either, and `1` is this module's
+            // standing floor for "changed, but not measurable in lines" (the
+            // value [`Self::untracked_added_lines`] already falls back to for
+            // a binary file). It is what keeps a large unpack OVER the
+            // diff-size budget rather than slipping under it — the property
+            // the concurrency note above refuses to let a truncating cap cost.
+            for path in &unmeasured {
+                lines = lines.saturating_add(1);
+                text.push('\n');
+                text.push_str(&crate::witness::warrant::untracked_change_line(path, 1));
+            }
+            if !unmeasured.is_empty() {
+                text.push('\n');
+                text.push_str(&untracked_budget_note(unmeasured.len()));
             }
         }
         DiffProbe {
@@ -548,6 +585,47 @@ pub(super) struct DiffProbe {
 /// costs roughly one round-trip instead of N, low enough that a turn which
 /// creates hundreds cannot fork an unbounded burst of git processes.
 const UNTRACKED_NUMSTAT_CONCURRENCY: usize = 16;
+
+/// How many freshly untracked paths [`Pipeline::gather_diff`] will READ.
+///
+/// Reading one path costs two `git diff --no-index` subprocesses — a numstat
+/// and a patch — so the pass is linear in the number of files the turn
+/// created, with no bound of its own. A task that unpacks and builds a source
+/// tree creates thousands at once, and the harness that runs Terminal-Bench
+/// commits a git baseline before the agent starts, so every extracted and
+/// generated file is untracked *and* fresh.
+///
+/// Measured on `sqlite-with-gcov`, whose agent extracts SQLite into the
+/// workspace and builds it with `--coverage`: the pass fanned out roughly nine
+/// thousand subprocesses over a tree it had no use for. Across five models and
+/// six matches, every timed-out trial of that task died inside this
+/// post-execute observation with its journal ending before the warrant — the
+/// verify stage, the verdict and the whole witness record lost because the
+/// probe was reading a build tree when the harness killed it (#2110).
+///
+/// The budget bounds only what is READ. Every fresh path is still named in
+/// the diff text and still contributes to the line count, so neither the
+/// warrant's path rules nor the diff-size budget can be relaxed by a tail
+/// going unmeasured — which is precisely what the concurrency note above
+/// refuses to let a truncating cap cost. Set far above any plausible authored
+/// change, so an ordinary turn never reaches it at all.
+const UNTRACKED_RENDER_BUDGET: usize = 256;
+
+/// The sentence [`Pipeline::gather_diff`] appends when a turn created more
+/// untracked paths than [`UNTRACKED_RENDER_BUDGET`] lets it read, so a reader
+/// is told the tail's counts are floors rather than measurements.
+///
+/// Deliberately NOT built through
+/// [`crate::witness::warrant::untracked_change_line`]: that marker's shape is
+/// parsed back into a path set, and this sentence names a count, not a file.
+fn untracked_budget_note(unmeasured: usize) -> String {
+    format!(
+        "[{unmeasured} further untracked path(s) are named above but were not read: this turn \
+         created more new files than the diff probe reads ({UNTRACKED_RENDER_BUDGET}). Their \
+         line counts are floors of 1, not measurements. This is NOT evidence that those files \
+         are empty, unchanged, or unimportant.]"
+    )
+}
 
 /// Reduce one `git diff --no-index -- /dev/null <path>` patch to the part a
 /// reviewer can read: the hunks, or git's binary sentence.

--- a/crates/stella-pipeline/src/pipeline/verify_probes.rs
+++ b/crates/stella-pipeline/src/pipeline/verify_probes.rs
@@ -2,7 +2,8 @@
 //! touched-tests observation that feeds the flip oracle (#860 typed
 //! outcomes), the lint delta behind the regression veto (#861), and the
 //! working-tree diff observation (`gather_diff`/`absorb_probe`) with the
-//! honest-empty-diff discipline around it.
+//! honest-empty-diff discipline around it, bounded in what it READS by
+//! [`UNTRACKED_RENDER_BUDGET`] (#2110) without loosening what it counts.
 //! A child module of `pipeline` so the private candidate types stay
 //! reachable, split out to keep the orchestrator under the size gate.
 

--- a/crates/stella-pipeline/src/pipeline/verify_probes.rs
+++ b/crates/stella-pipeline/src/pipeline/verify_probes.rs
@@ -596,13 +596,17 @@ const UNTRACKED_NUMSTAT_CONCURRENCY: usize = 16;
 /// commits a git baseline before the agent starts, so every extracted and
 /// generated file is untracked *and* fresh.
 ///
-/// Measured on `sqlite-with-gcov`, whose agent extracts SQLite into the
-/// workspace and builds it with `--coverage`: the pass fanned out roughly nine
-/// thousand subprocesses over a tree it had no use for. Across five models and
-/// six matches, every timed-out trial of that task died inside this
-/// post-execute observation with its journal ending before the warrant — the
-/// verify stage, the verdict and the whole witness record lost because the
-/// probe was reading a build tree when the harness killed it (#2110).
+/// Observed on `sqlite-with-gcov`, whose agent extracts SQLite into the
+/// workspace and builds it with `--coverage`. Across five models and six
+/// matches, every timed-out trial of that task died inside this post-execute
+/// observation with its journal ending before the warrant — the verify stage,
+/// the verdict and the whole witness record lost because the probe was
+/// reading a build tree when the harness killed it (#2110). The trials'
+/// artifacts do not record how many paths that tree held, so the cost is
+/// stated from a reproduction rather than claimed from the run: a synthetic
+/// tree of 4,502 fresh paths cost 9,004 subprocesses and ~30s in a single
+/// pass on fast local storage, which is a floor for a tree of that shape and
+/// well under the real one.
 ///
 /// The budget bounds only what is READ. Every fresh path is still named in
 /// the diff text and still contributes to the line count, so neither the


### PR DESCRIPTION
Closes #2110

## Diagnosis

**#2110 still reproduces. It is not covered by #2122 or #2131** — I checked that first, from the ground-truth journals rather than from the dashboard.

The trial named in the issue is on disk: `~/.arenabench/matches/14d0127b8ca7/jobs/14d0127b8ca7-stella-kimi-k3/sqlite-with-gcov__2PdctrU/`.

- **#2122 cannot fire here.** Its fix races the adapter's stream wait against a probe of the durable journal and releases on a proven `complete` event. This trial's `_stella_stream` reports `complete_event_count: 0`, `stream_complete: false`, `process_returned: false`. There is no `complete` event to race on, because Stella never got that far — #2122's symptom is a *finished* trial held open by the pipe, this one is a trial that never finished.
- **#2131 does not shorten the idle.** It reaps the container agent *after* Harbor's deadline cancels the run. It makes the orphan stop; it does not stop the 9 minutes of silence that precede it.

**Where the idle is.** `proof_step_counts: {'assurance': 1}` — the `Warrant` proof never fired. The warrant is emitted at `crates/stella-pipeline/src/pipeline.rs:1981`, immediately after `gather_diff` at `:1962` and `absorb_probe` at `:1963`. So the hang is inside that two-line post-execute observation seam, exactly where the issue predicted.

**The mechanism.** The harbor adapter commits a git baseline in the task workspace before the agent starts (`trial.log`: `git init` → `git add -A` → commit). `sqlite-with-gcov`'s agent then extracts SQLite into `/app/sqlite` and builds it with `--coverage`. Every extracted and generated file is therefore **untracked and fresh**. `gather_diff` read all of them, two `git diff --no-index` subprocesses apiece (`untracked_added_lines` + `untracked_patch_body`), with no bound of its own, plus a full read of each file including the 8.5MB amalgamation and every `.gcno`.

**On the cost number, stated honestly.** The trial artifacts do not record how many paths `/app/sqlite` held, so I did not claim a subprocess count from the run. I reproduced the shape instead: a synthetic tree of **4,502 fresh paths** cost **9,004 subprocesses and 29.4s** in a single pass on native APFS. That is a *floor* — fast local storage, a tree smaller than a built SQLite, and one pass. It establishes the cost is unbounded and grows with the tree; it does not by itself account for the full 9-minute idle, and I am not claiming it does.

**Not one bad trial.** Across all 7 `AgentTimeoutError` trials of `sqlite-with-gcov` on this machine — 5 models (kimi-k3, glm-5-2, sonnet-5, fable-5, openrouter), 6 matches — **every single one** ends with `{'assurance': 1}` and no warrant. It is a property of the task's tree, not of a model. Splitting by last event written:

| last event | trials | died in |
|---|---|---|
| `text` | 2 | `gather_diff` — **this PR** |
| `file_change` | 4 | probe settle — **#2229**, filed |
| `tool_start` | 1 | genuinely still working (→ #2109) |

The four `file_change` trials have **zero** `file_change` events before the last `tool_result` and 490–1714 after it, cut off mid-stream. That is the second half of the same seam (`absorb_probe` → `settle_workspace_probe`, a *sync* whole-tree walk plus one emission per path); `gather_diff` had already returned for them. It needs a different fix in a different crate, so it is filed as **#2229** with the full table rather than bolted on here.

**On #2111.** The journal has no wall-clock anchor today, so I did not try to localize the gap from timestamps. The argument above rests on *which events exist* (`complete_event_count`, `proof_step_counts`, the position of `file_change` relative to the last `tool_result`) — ordinal facts that survive the missing timestamps. The one external anchor I used is file mtimes on the trial artifacts: `stella-events.jsonl` last written 16:29, harness timeout at 16:38, trial start 16:23 → a ~9 minute idle after the last journal write.

## The fix

Bound what the untracked pass **reads** (`UNTRACKED_RENDER_BUDGET = 256`), not what it **knows**.

The existing comment in `gather_diff` rightly refuses a truncating cap, because the count feeds the zero-diff guard and the diff-size budget and a dropped tail would let a large untracked change slip under a budget it should have tripped. This keeps that property intact:

- **Every fresh path is still named.** `witness::warrant::untracked_marker_paths` parses those markers into the path set the warrant holds to its "every path must agree" rules. A tail that went unnamed could turn a mixed change into a homogeneous one — a `.md`-only prefix standing in for a tree that also grew source — and relax exactly when a witness is owed. This was the trap in my first sketch; keeping the cheap marker for every path is what avoids it.
- **Every fresh path is still counted**, at the module's existing floor of `1` (the value `untracked_added_lines` already falls back to for a binary file). With `diff_budget_lines: 400`, a tree-sized change reports thousands of lines and stays *over* the budget rather than slipping under it.
- **The truncation is declared**, in the shape `DIFF_PROBE_FAILED` and `verification_honest_diff` already use — the tail's counts are floors, not measurements, and a reader is told so.
- Only the per-file patch body and numstat are given up, for paths past the budget.

**A count, not a clock.** A wall-clock cut would make the verifier's diff text — and every prompt built from it — depend on how fast the machine happened to be. Replay determinism and prompt-cache stability (invariant 7) both need this to be a function of the tree alone. That also makes the witness deterministic, with no sleeps.

`UNTRACKED_RENDER_BUDGET = 256` sits far above any plausible authored change, so an ordinary turn never reaches it and behaviour is unchanged everywhere else.

Exemplar followed: `witness_repair_bound` (#2141), the sibling bound in the same subsystem — same "derive a bound, degrade honestly, stay on the rail" shape, same child-module test layout.

## Witness test

`crates/stella-pipeline/src/pipeline/tests/verification_hardening/untracked_render_bound.rs::a_tree_sized_untracked_change_is_read_within_a_bounded_number_of_probes`

A counting `DiagnosticRunner` double over a 3,000-path fresh tree. It asserts the **cost** (a text-only assertion would pass just as happily on a probe that read everything and rendered a little), and then that the bound cost nothing the warrant or the budget depended on: all 3,000 paths still named, `lines >= 3000`, truncation declared.

**Flip verified** by reverting only the impl (`git checkout origin/main -- crates/stella-pipeline/src/pipeline/verify_probes.rs`) and re-running:

```
without the fix: FAILED — "the untracked pass must not read every path of an
                 unpacked tree — it read 6000 of a possible 6000 (#2110)"
with the fix:    ok
```

No test was deleted or renamed.

## Verification

- `cargo test -p stella-pipeline` — 623 passed, 0 failed (+ all 5 integration targets green).
- `cargo clippy -p stella-pipeline --all-targets` — clean.
- `cargo fmt -p stella-pipeline --check` — clean.
- `check-file-size` / `check-left-behind` / `check-god-files` — all OK. No god file grew; `verify_probes.rs` is 713 lines and not grandfathered; the baseline is untouched.


## On #2135 — does it share this root?

**Different root, and they are complements, not duplicates.** #2110 is "one stage does unbounded work"; #2135 is "nothing above the stages enforces the declared deadline". Both are true, and my forensics are direct evidence for #2135's claim: all 7 timeouts are harness SIGKILLs, none is an engine-side stop with partial work — the journals simply stop mid-write, which is what a `SIGKILL` looks like and what a `BudgetGuard::set_task_deadline` stop would not.

What the next agent on #2135 should know:

1. **A deadline would not have saved these trials even if it had acted.** Invariant 6 puts aborts at safe boundaries only, and `gather_diff`/`absorb_probe` are one straight-line seam between the last model call and the warrant — there is no safe boundary inside it to abort at. So #2135 needs #2110 and #2229 fixed underneath it, or its deadline will keep arriving during work it is not allowed to interrupt.
2. **`absorb_probe` is synchronous**, so it blocks the runtime thread outright. No `tokio::time::timeout` wrapper above it can preempt it — worth knowing before designing the enforcement point.
3. The per-trial artifacts under `~/.arenabench/matches/*/jobs/*/*/agent/stella-run.json` carry `_stella_stream` (`complete_event_count`, `proof_step_counts`, `process_returned`), which is the cheapest way to classify a timeout's shape without replaying anything.

I have added this to #2135 as a comment rather than restating it there.

## Follow-ups filed

- **#2229** — the other half of the seam: `settle_workspace_probe` + `file_change` emission, unbounded, with the 4-trial evidence table and the "measure the walk against the emission before choosing a fix" instruction.
- **#2230** — the untracked marker list reaching the verifier prompt is still unbounded (a residual this PR shrinks but does not close; the warrant needs the path set, the verifier needs readable evidence, and one string currently serves both).

No `TODO`/`FIXME` was added.
