### PR TITLE
protocol: stamp every stream-json line with the sink's wall clock

### DIFF
--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -923,6 +923,12 @@ class TranscriptState:
     offset: int = 0
     seq: int = 0
     started: float | None = None
+    #: The first line's own ``ts`` (epoch millis), when the stream carries one.
+    #: Every later entry's ``t`` is measured from this, so a finished trial read
+    #: in one pass reports the offsets the run actually had rather than the
+    #: offsets of the *read* (#2111). ``None`` for a stream recorded before the
+    #: field existed, which falls back to ``started``.
+    origin_ms: float | None = None
     #: Open text/reasoning entries being accumulated from deltas, by kind.
     open_entries: dict[str, int] = field(default_factory=dict)
     #: ``call_id`` -> entry sequence, so a tool result can find its call.
@@ -1014,13 +1020,40 @@ class TranscriptReader:
         state.seq += 1
         return state.seq
 
+    @staticmethod
+    def _elapsed_for(event: dict[str, Any], state: TranscriptState) -> float:
+        """Seconds from the trial's first event to this one.
+
+        Read from the line's own ``ts`` (epoch millis, stamped by Stella's sink
+        — see ``stella_protocol::journal``). Measuring from ``time.time()``
+        instead was the #2111 bug: a finished trial is read in a single pass, so
+        every event in the file was parsed within the same few milliseconds and
+        every row rendered ``0:00``. Anchoring to the *stream's* first stamp
+        makes an archived transcript report the offsets the run actually had —
+        and makes the paced replay in ``ui/components/arena/transcript-page.tsx``
+        pace on them instead of flushing at its 16 ms floor.
+
+        Two hedges the wire contract requires. A system clock is not monotonic,
+        so an NTP step can put a later line before the origin; that is clamped
+        to ``0.0`` rather than rendered as a negative offset. And a stream with
+        no ``ts`` at all — anything recorded before the field existed — keeps
+        the old read-time behaviour, which is wrong in the same way it always
+        was but is the only thing such a file supports.
+        """
+        stamp = event.get("ts")
+        if isinstance(stamp, (int, float)) and not isinstance(stamp, bool):
+            if state.origin_ms is None:
+                state.origin_ms = float(stamp)
+            return round(max(0.0, (float(stamp) - state.origin_ms) / 1000.0), 2)
+        if state.started is None:
+            state.started = time.time()
+        return round(time.time() - state.started, 2)
+
     def _entries_for(
         self, event: dict[str, Any], state: TranscriptState, path_key: str
     ) -> list[dict[str, Any]]:
         kind = str(event.get("type", ""))
-        if state.started is None:
-            state.started = time.time()
-        now = round(time.time() - state.started, 2)
+        now = self._elapsed_for(event, state)
 
         def entry(
             seq: int, etype: str, title: str, body: str = "", **meta: Any

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -632,6 +632,83 @@ class TestFlip:
         assert leaders(totals, DIMENSIONS)["wasted_time"] == ["tight"]
 
 
+class TestTranscriptElapsed:
+    """The transcript's elapsed column, which read `0:00` on every row (#2111).
+
+    `t` was measured from `time.time()` at parse. A finished trial is read in
+    one pass, so every event in the file was parsed within the same few
+    milliseconds, every `t` rounded to `0.0`, and `fmtClock(0)` rendered `0:00`
+    down the whole gutter — indistinguishable, to anyone watching a live match,
+    from a broken feed. It also flattened the paced replay in
+    `ui/components/arena/transcript-page.tsx`, which paces on the gap between
+    consecutive `t` values and therefore had no gaps to pace on.
+
+    The fix is to read the `ts` Stella now stamps on each line and measure from
+    the stream's own first stamp.
+    """
+
+    def test_elapsed_comes_from_the_events_own_stamps(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            {"ts": 1_754_582_400_000, "type": "stage", "name": "execute"},
+            {"ts": 1_754_582_412_500, "type": "stage", "name": "witness"},
+            {"ts": 1_754_582_490_000, "type": "stage", "name": "verify"},
+        ])
+        entries = TranscriptReader().read(path)
+        assert [e["t"] for e in entries] == [0.0, 12.5, 90.0]
+
+    def test_an_idle_gap_before_a_timeout_is_visible(self, tmp_path: Path):
+        """The forensic half of #2111: the wall clock between the last real
+        event and the timeout is the whole question, and it is unanswerable
+        unless both ends carry a stamp."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            {"ts": 1_754_582_400_000, "type": "text", "text": "done"},
+            {"ts": 1_754_582_900_000, "type": "error", "message": "AgentTimeoutError"},
+        ])
+        entries = TranscriptReader().read(path)
+        assert entries[-1]["t"] - entries[0]["t"] == 500.0
+
+    def test_a_clock_step_backwards_never_renders_a_negative_offset(
+        self, tmp_path: Path
+    ):
+        """A system clock is not monotonic; the wire contract says so and asks
+        consumers to clamp. Rendering `-0:03` would look like corruption."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            {"ts": 1_754_582_400_000, "type": "stage", "name": "execute"},
+            {"ts": 1_754_582_397_000, "type": "stage", "name": "verify"},
+        ])
+        entries = TranscriptReader().read(path)
+        assert [e["t"] for e in entries] == [0.0, 0.0]
+
+    def test_a_stream_recorded_before_the_stamp_existed_still_reads(
+        self, tmp_path: Path
+    ):
+        """Every `stella-events.jsonl` under `bench/evidence/` has no `ts`.
+        Those archives must keep rendering — flat offsets and all — rather than
+        failing on a missing key."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            {"type": "stage", "name": "execute"},
+            {"type": "stage", "name": "verify"},
+        ])
+        entries = TranscriptReader().read(path)
+        assert [e["title"] for e in entries] == ["execute", "verify"]
+        assert all(isinstance(e["t"], float) for e in entries)
+
+    def test_incremental_reads_share_one_origin(self, tmp_path: Path):
+        """A live tail sees the file in several passes. The offsets must be
+        measured from the trial's first event, not from whatever line happened
+        to open the current batch."""
+        path = tmp_path / "e.jsonl"
+        reader = TranscriptReader()
+        write_events(path, [{"ts": 1_754_582_400_000, "type": "stage", "name": "a"}])
+        assert [e["t"] for e in reader.read(path)] == [0.0]
+        write_events(path, [{"ts": 1_754_582_460_000, "type": "stage", "name": "b"}])
+        assert [e["t"] for e in reader.read(path)] == [60.0]
+
+
 class TestTranscript:
     def test_streaming_fragments_coalesce_under_one_seq(self, tmp_path: Path):
         path = tmp_path / "e.jsonl"

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -3,11 +3,13 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use stella_core::ports::Clock;
 use stella_core::{EventSendError, EventSender};
 use stella_protocol::AgentEvent;
 use tokio::sync::mpsc;
 
 use crate::OutputFormat;
+use crate::runtime::WallClock;
 
 /// Trusted launcher-only sink for timeout-survivable stream-json telemetry.
 ///
@@ -147,7 +149,7 @@ pub(super) fn event_sender_for_run(
         match configured_durable_stream_path() {
             Ok(Some(path)) => {
                 return (
-                    ordered_durable_event_sender(sender, path.to_path_buf()),
+                    ordered_durable_event_sender(sender, path.to_path_buf(), Arc::new(WallClock)),
                     true,
                 );
             }
@@ -189,13 +191,25 @@ pub(super) fn pipeline_event_sender(events: &EventSender, format: OutputFormat) 
     })
 }
 
+/// The durable sink, and the point at which an event becomes a *line*.
+///
+/// The line carries this sink's own `ts` (#2111). The renderer publishes the
+/// same event to stdout a moment later and stamps its own, so the two copies
+/// differ by the persist — which is the truth, and is why the stamp is
+/// documented as "when this sink admitted the line" rather than "when the event
+/// happened". Nothing downstream may diff the two streams byte-for-byte; they
+/// are two recordings of one event, not two copies of one recording.
 fn ordered_durable_event_sender(
     sender: mpsc::UnboundedSender<AgentEvent>,
     path: std::path::PathBuf,
+    clock: Arc<dyn Clock>,
 ) -> EventSender {
     let ordering = Arc::new(std::sync::Mutex::new(()));
     EventSender::from_fn(move |event| {
-        let line = match serde_json::to_string(&event) {
+        // Read the clock before taking the ordering lock, not after: a stamp is
+        // the instant the sink *admitted* the event, and blocking behind another
+        // producer's write would attribute that wait to this event.
+        let line = match stella_protocol::stamped_line(&event, clock.now_ms()) {
             Ok(line) => line,
             Err(error) => {
                 terminate_stream_json(&format!("stream-json serialization failed: {error}"))
@@ -313,6 +327,16 @@ mod pipeline_sender_tests {
 mod durable_stream_tests {
     use super::*;
 
+    /// A [`Clock`] that never advances, so a durable line's bytes are a
+    /// function of the event alone and an assertion can pin them.
+    struct FixedClock(u64);
+
+    impl Clock for FixedClock {
+        fn now_ms(&self) -> u64 {
+            self.0
+        }
+    }
+
     struct SinkCheckingWriter {
         path: std::path::PathBuf,
         written: Vec<u8>,
@@ -374,6 +398,34 @@ mod durable_stream_tests {
     }
 
     #[test]
+    fn every_durable_line_is_anchored_to_wall_clock() {
+        // The evidence file is the only record a finished trial leaves. Without
+        // this key nothing in it can be placed on a clock, so an idle gap before
+        // a timeout is unmeasurable and the arena transcript has no offsets to
+        // render (#2111).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let (raw_tx, _renderer) = mpsc::unbounded_channel();
+        let sender = ordered_durable_event_sender(
+            raw_tx,
+            path.clone(),
+            Arc::new(FixedClock(1_754_582_400_123)),
+        );
+
+        sender
+            .send(AgentEvent::Stage {
+                name: stella_protocol::StageKind::Execute,
+            })
+            .unwrap();
+
+        let recorded = std::fs::read_to_string(&path).unwrap();
+        let line: serde_json::Value = serde_json::from_str(recorded.trim_end()).unwrap();
+        assert_eq!(line["ts"], serde_json::json!(1_754_582_400_123u64));
+        // Flattened, not nested: every existing reader still finds the tag.
+        assert_eq!(line["type"], serde_json::json!("stage"));
+    }
+
+    #[test]
     fn preflight_rejects_non_regular_sink() {
         let dir = tempfile::tempdir().unwrap();
         assert!(preflight_durable_stream_path(dir.path()).is_err());
@@ -384,7 +436,7 @@ mod durable_stream_tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("events.jsonl");
         let (raw_tx, mut paused_renderer) = mpsc::unbounded_channel();
-        let sender = ordered_durable_event_sender(raw_tx, path.clone());
+        let sender = ordered_durable_event_sender(raw_tx, path.clone(), Arc::new(FixedClock(7)));
         let stage = AgentEvent::Stage {
             name: stella_protocol::StageKind::Execute,
         };
@@ -416,8 +468,8 @@ mod durable_stream_tests {
         // simulates timeout/cancellation after provider completion.
         let expected = format!(
             "{}\n{}\n",
-            serde_json::to_string(&stage).unwrap(),
-            serde_json::to_string(&usage).unwrap()
+            stella_protocol::stamped_line(&stage, 7).unwrap(),
+            stella_protocol::stamped_line(&usage, 7).unwrap()
         );
         assert_eq!(std::fs::read_to_string(&path).unwrap(), expected);
         assert_eq!(

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -1,6 +1,9 @@
 //! Event/telemetry persistence and execution closeout.
 
 use super::*;
+use stella_core::ports::Clock;
+
+use crate::runtime::WallClock;
 
 #[derive(Default)]
 pub(crate) struct RendererOutcome {
@@ -61,6 +64,10 @@ pub(crate) fn spawn_renderer(
             crate::diag_boot::dx(),
             Some(crate::diag_boot::workspace_root()),
         );
+        // The stream-json sink's clock. Wall-anchored, not `SystemClock`: a
+        // journal stamp has to stay comparable across processes and runs, and a
+        // per-construction origin is exactly the wrong shape for that (#2111).
+        let clock = WallClock;
         while let Some(event) = rx.recv().await {
             bridge.observe(&event);
             let event = if format == OutputFormat::StreamJson {
@@ -99,7 +106,7 @@ pub(crate) fn spawn_renderer(
                 // Serialization of a protocol enum never fails; if it somehow
                 // does, terminate before the provider loop can spend on a
                 // later unmetered call.
-                OutputFormat::StreamJson => emit_stream_json(&event, durable_pre_persisted),
+                OutputFormat::StreamJson => emit_stream_json(&event, durable_pre_persisted, &clock),
                 OutputFormat::Json => outcome.events.push(event),
                 OutputFormat::Text => match &event {
                     AgentEvent::ToolStart { call } => {
@@ -140,7 +147,7 @@ pub(crate) fn spawn_renderer(
             {
                 outcome.persistence_complete = false;
             }
-            emit_stream_json(&event, durable_pre_persisted);
+            emit_stream_json(&event, durable_pre_persisted, &clock);
         }
         // The stream is closed, so the bounded tally is final: one record
         // carrying the per-token counts that deliberately produced none of
@@ -153,8 +160,12 @@ pub(crate) fn spawn_renderer(
 /// Publish one stream-json line, honoring Harbor's durable sink. Failures are
 /// terminal rather than a warning: a benchmark run whose evidence file is
 /// incomplete must not keep spending on later calls.
-fn emit_stream_json(event: &AgentEvent, durable_pre_persisted: bool) {
-    match serde_json::to_string(event) {
+///
+/// The line is stamped with `clock`'s wall clock (#2111) — the instant *this*
+/// sink admitted it. When the durable sender already persisted the event it
+/// stamped its own instant a moment earlier; see `output::ordered_durable_event_sender`.
+fn emit_stream_json(event: &AgentEvent, durable_pre_persisted: bool, clock: &dyn Clock) {
+    match stella_protocol::stamped_line(event, clock.now_ms()) {
         Ok(line) if durable_pre_persisted => {
             emit_pre_persisted_stream_json_line_or_terminate(&line)
         }

--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -101,6 +101,7 @@ tests with them.
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The crate's flat re-export surface, and the statement of the one-directional wire-compatibility rule. Read it first. |
 | [`src/event.rs`](src/event.rs) | `AgentEvent` and its supporting types — the stream-json vocabulary, 34 wire variants plus the tagless `Unknown` fallback. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
+| [`src/journal.rs`](src/journal.rs) | `StampedEvent` / `stamped_line` — one *line* of the event stream: an `AgentEvent` plus the optional wall-clock `ts` its sink stamps at the write boundary (#2111). Deliberately not a field of the enum: a stamp is a fact about a write, the same event reaches more than one sink, and this crate owns no clock. |
 | [`src/context_event.rs`](src/context_event.rs) | `LifecycleEventEnvelope` / `LifecycleEvent` — the *other* event channel, the one an older binary can still read. Open it when a new event must survive replay by an older reader. |
 | [`src/completion.rs`](src/completion.rs) | `CompletionRequest` / `CompletionResult` / `CompletionUsage`, `GenerationParams`, `FinishReason`. The one envelope every provider adapter translates to and from. |
 | [`src/provider.rs`](src/provider.rs) | The `Provider` port and `ToolCallObserver`, the seam speculative tool execution hangs on. |

--- a/crates/stella-protocol/src/journal.rs
+++ b/crates/stella-protocol/src/journal.rs
@@ -53,16 +53,16 @@ use crate::event::AgentEvent;
 /// `docs/wire/agentevent.schema.json` and `docs/wire/agentevent.d.ts`, so the
 /// contract a consumer reads and the contract this module documents cannot
 /// drift apart.
+///
+/// Deliberately terse — it is repeated on all 39 variants of a generated
+/// artifact, and the reasoning behind each clause belongs in this module's docs
+/// and in the `.d.ts` banner, which a reader meets exactly once.
 pub const TS_DESCRIPTION: &str = "\
-Wall-clock instant at which the sink that wrote this line admitted it, in \
-milliseconds since the Unix epoch (UTC). Added by the sink, not by the event: \
-the same event written to two sinks carries each sink's own instant, and the \
-durable JSONL file is stamped at the moment it was persisted (which is before \
-the stdout copy, by construction). Read from the system clock, so it is NOT \
-monotonic — it can repeat or move backwards across an NTP step, and consumers \
-computing an elapsed offset must clamp a negative delta rather than trust it. \
-Absent on any line recorded before this field existed, and on any sink with no \
-clock to offer; a consumer must treat it as optional forever.";
+Wall-clock instant at which the sink wrote this line, in milliseconds since the \
+Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it \
+is optional forever — a line recorded before the field existed has none — and \
+it is not monotonic, so a consumer computing an elapsed offset must clamp a \
+negative delta rather than trust it.";
 
 /// One line of a stream-json journal: an [`AgentEvent`] and the `ts` its sink
 /// stamped on it.

--- a/crates/stella-protocol/src/journal.rs
+++ b/crates/stella-protocol/src/journal.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The journal *line*: one [`AgentEvent`] plus the wall-clock stamp the sink
+//! that wrote it adds.
+//!
+//! Until #2111 nothing on the stream anchored an event to wall clock.
+//! `step_usage` and `tool_result` carry a `duration_ms`, which measures a span
+//! but names no instant, so two questions could not be answered from a recorded
+//! `stella-events.jsonl` at all: *when* did this happen, and *where did the wall
+//! clock go* between two events. The second is the one that mattered — an idle
+//! gap before a timeout is invisible when there is nothing to subtract — and the
+//! visible symptom was an arena transcript rendering `0:00` for every row of a
+//! finished trial.
+//!
+//! ## Why the stamp is not a field of [`AgentEvent`]
+//!
+//! The stamp is a fact about a *write*, not about the thing that happened.
+//! The same event is written to more than one sink (the durable JSONL file and
+//! stdout), the engine that produced it is a pure, replayable, clock-free fold,
+//! and `stella-protocol` carries no time source by charter. Putting `ts` inside
+//! the enum would have meant a field on all 39 variants, a clock reachable from
+//! `stella-core`, and a stamp baked into every replay fixture.
+//!
+//! So the event vocabulary is untouched and the stamp rides in an envelope
+//! applied at the sink. The envelope **flattens**, so the bytes on the wire are
+//! the event's own object with one extra key:
+//!
+//! ```text
+//! {"ts":1754582400123,"type":"tool_result","call_id":"c1",…}
+//! ```
+//!
+//! Every existing consumer keeps reading `event["type"]` exactly as before —
+//! this is an added key, not a new nesting level.
+//!
+//! ## Direction of compatibility
+//!
+//! Writers always stamp ([`stamped_line`] takes a `u64`, not an option).
+//! Readers must not require it: every journal recorded before #2111, and every
+//! line produced by a sink that has no clock to offer, has no `ts` at all. On
+//! [`StampedEvent`] the field is therefore `Option<u64>` with `serde(default)`,
+//! and a `None` serializes to *exactly* the bytes a bare `AgentEvent` produces —
+//! which is what makes the change additive rather than a new format.
+
+use serde::{Deserialize, Serialize};
+
+use crate::event::AgentEvent;
+
+/// The wire meaning of the `ts` key, in the words the generated schema and the
+/// `.d.ts` publish to downstream implementers.
+///
+/// One copy on purpose: `schema_export` prints this string into
+/// `docs/wire/agentevent.schema.json` and `docs/wire/agentevent.d.ts`, so the
+/// contract a consumer reads and the contract this module documents cannot
+/// drift apart.
+pub const TS_DESCRIPTION: &str = "\
+Wall-clock instant at which the sink that wrote this line admitted it, in \
+milliseconds since the Unix epoch (UTC). Added by the sink, not by the event: \
+the same event written to two sinks carries each sink's own instant, and the \
+durable JSONL file is stamped at the moment it was persisted (which is before \
+the stdout copy, by construction). Read from the system clock, so it is NOT \
+monotonic — it can repeat or move backwards across an NTP step, and consumers \
+computing an elapsed offset must clamp a negative delta rather than trust it. \
+Absent on any line recorded before this field existed, and on any sink with no \
+clock to offer; a consumer must treat it as optional forever.";
+
+/// One line of a stream-json journal: an [`AgentEvent`] and the `ts` its sink
+/// stamped on it.
+///
+/// This is the **read** side of the contract — the shape a consumer parses a
+/// `stella-events.jsonl` line into. Writers use [`stamped_line`], which cannot
+/// express an unstamped line.
+///
+/// `ts` is [`Option`] because absence is a real and permanent case (see the
+/// module docs), and it is skipped when `None` so that a `StampedEvent` with no
+/// stamp serializes byte-for-byte identically to the bare [`AgentEvent`] it
+/// wraps. That identity is the reason this type can be introduced without a
+/// format version: it is the same wire, with one optional key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StampedEvent {
+    /// Milliseconds since the Unix epoch (UTC) — see [`TS_DESCRIPTION`] for the
+    /// full contract, which is the text downstream implementers read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts: Option<u64>,
+    /// The event itself, flattened: its keys sit beside `ts` on one object
+    /// rather than under a nested member.
+    #[serde(flatten)]
+    pub event: AgentEvent,
+}
+
+/// The write side. Borrowed so that stamping a line never clones an event —
+/// a `Text` event carries a whole model answer, and the sinks stamp every one.
+#[derive(Serialize)]
+struct StampedEventRef<'a> {
+    ts: u64,
+    #[serde(flatten)]
+    event: &'a AgentEvent,
+}
+
+/// Serialize one journal line: `event`, stamped with `ts_ms`.
+///
+/// `ts_ms` is milliseconds since the Unix epoch, read from the caller's clock —
+/// this crate has no time source of its own (invariant #2), so the sink that
+/// owns a clock supplies the instant and this function only renders it.
+///
+/// # Errors
+///
+/// Propagates the `serde_json` failure. Serializing a protocol enum does not
+/// fail in practice; the sinks treat it as terminal rather than dropping a line
+/// from evidence someone is paying to collect.
+pub fn stamped_line(event: &AgentEvent, ts_ms: u64) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&StampedEventRef { ts: ts_ms, event })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_event() -> AgentEvent {
+        AgentEvent::Text {
+            text: "the full answer".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_stamped_line_is_the_event_object_plus_one_key() {
+        let line = stamped_line(&text_event(), 1_754_582_400_123).unwrap();
+        assert_eq!(
+            line,
+            r#"{"ts":1754582400123,"type":"text","text":"the full answer"}"#
+        );
+    }
+
+    #[test]
+    fn an_unstamped_value_serializes_exactly_as_the_bare_event() {
+        let stamped = StampedEvent {
+            ts: None,
+            event: text_event(),
+        };
+        assert_eq!(
+            serde_json::to_string(&stamped).unwrap(),
+            serde_json::to_string(&text_event()).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_line_recorded_before_the_field_existed_still_parses() {
+        let legacy = serde_json::to_string(&text_event()).unwrap();
+        let parsed: StampedEvent = serde_json::from_str(&legacy).unwrap();
+        assert!(parsed.ts.is_none());
+        assert!(matches!(parsed.event, AgentEvent::Text { text } if text == "the full answer"));
+    }
+
+    #[test]
+    fn a_stamped_line_round_trips_byte_for_byte() {
+        let line = stamped_line(&text_event(), 1_754_582_400_123).unwrap();
+        let parsed: StampedEvent = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed.ts, Some(1_754_582_400_123));
+        assert_eq!(serde_json::to_string(&parsed).unwrap(), line);
+    }
+
+    #[test]
+    fn an_event_from_a_newer_stella_keeps_its_body_and_its_stamp() {
+        // `AgentEvent::Unknown` re-emits the object it parsed. The envelope must
+        // not lose the stamp on the way past it, or forward-compat and forensics
+        // would be mutually exclusive on exactly the lines that need both.
+        let line = r#"{"ts":7,"type":"from_the_future","detail":{"a":1}}"#;
+        let parsed: StampedEvent = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed.ts, Some(7));
+        assert!(parsed.event.is_unknown());
+        assert_eq!(parsed.event.type_tag(), "from_the_future");
+
+        let round_tripped: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&parsed).unwrap()).unwrap();
+        assert_eq!(
+            round_tripped,
+            serde_json::from_str::<serde_json::Value>(line).unwrap()
+        );
+    }
+}

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -56,6 +56,7 @@ pub mod completion;
 pub mod context_event;
 pub mod error;
 pub mod event;
+pub mod journal;
 pub mod ladder;
 pub mod proof;
 pub mod provider;
@@ -87,6 +88,10 @@ pub use event::{
     PolicyKind, PrStatus, ProofStep, ProposedHunk, ProviderShare, ScopeProposal, StageKind,
     TaskItem, TaskStatus, UsageIncompleteReason, VerdictEvidence,
 };
+// The journal line is the event plus the wall-clock stamp its sink adds
+// (#2111). Deliberately a separate type from `AgentEvent`: a stamp is a fact
+// about a write, and the engine that produces events owns no clock.
+pub use journal::{StampedEvent, stamped_line};
 // The ladder vocabulary moved out of `event` when the rung joined it (#1043);
 // re-exported here so `stella_protocol::LadderSnapshot` never moved.
 pub use ladder::{LadderRung, LadderSnapshot, OracleObservation, ProofTree};

--- a/crates/stella-protocol/src/schema_export.rs
+++ b/crates/stella-protocol/src/schema_export.rs
@@ -80,10 +80,60 @@ pub struct UnsupportedSchema {
     pub detail: String,
 }
 
-/// The JSON Schema (2020-12) for [`AgentEvent`] and its whole payload graph.
+/// The JSON Schema (2020-12) for one line of the event stream: [`AgentEvent`]
+/// and its whole payload graph, plus the optional `ts` its sink stamps on.
+///
+/// `ts` is not a member of any variant — it is added at the write boundary by
+/// [`crate::journal::stamped_line`], because a stamp is a fact about a write and
+/// the engine that produces events owns no clock (#2111). But this artifact
+/// exists to describe *the bytes a consumer reads*, and those bytes carry the
+/// key. Omitting it would leave the one generated document a downstream
+/// implementer trusts silently short of the wire, which is the failure this
+/// module was built to prevent.
+///
+/// So it is attached here rather than derived, in one uniform pass over every
+/// variant, with its prose taken from [`crate::journal::TS_DESCRIPTION`] so the
+/// published contract and the Rust doc cannot drift. Attaching, not deriving,
+/// is the honest shape: `schemars` would only reproduce it by flattening an
+/// envelope into the root, which would cost the discriminated union — and with
+/// it `KnownTypeTag`, the one thing a forward-compatible consumer most needs.
 #[must_use]
 pub fn agent_event_schema() -> Value {
-    schemars::schema_for!(AgentEvent).to_value()
+    let mut schema = schemars::schema_for!(AgentEvent).to_value();
+    attach_journal_stamp(&mut schema);
+    schema
+}
+
+/// Declare `ts` as an optional property of every root variant.
+///
+/// Optional on purpose, and on every surface: a line recorded before the field
+/// existed has none, and `stella-serve` frames the event in an envelope that
+/// stamps its own. "May be present" is the only claim true of all three
+/// surfaces this schema covers.
+///
+/// Silent about a root that is not a `oneOf` of objects. Such a root cannot
+/// come from `AgentEvent` — the sole caller — and the exporter's own
+/// [`tag_literals`] already fails loudly on that shape, so a second bespoke
+/// error here would only duplicate a check that is better placed.
+fn attach_journal_stamp(schema: &mut Value) {
+    let property = serde_json::json!({
+        "description": crate::journal::TS_DESCRIPTION,
+        "format": "uint64",
+        "minimum": 0,
+        "type": "integer",
+    });
+    let Some(variants) = schema.get_mut("oneOf").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for variant in variants {
+        if let Some(properties) = variant
+            .get_mut("properties")
+            .and_then(Value::as_object_mut)
+            .filter(|properties| properties.contains_key("type"))
+        {
+            properties.insert("ts".to_string(), property.clone());
+        }
+    }
 }
 
 /// The schema, pretty-printed with a trailing newline.
@@ -126,6 +176,12 @@ const HEADER: &str = "\
 // A `\"type\"` value not listed here is NOT an error: it is an event from a
 // newer stella. Forward-compatible consumers keep such a line intact and move
 // on, exactly as `AgentEvent::Unknown` does on the Rust side.
+//
+// Every variant carries an optional `ts`: the wall-clock instant its sink wrote
+// the line, in milliseconds since the Unix epoch. It is stamped by the sink, not
+// by the event, so it is absent on any line recorded before the field existed —
+// treat it as optional forever, and clamp a negative delta, because a system
+// clock is not monotonic.
 ";
 
 /// Print TypeScript declarations for a schema produced by

--- a/crates/stella-protocol/tests/journal_stamp_wire.rs
+++ b/crates/stella-protocol/tests/journal_stamp_wire.rs
@@ -1,0 +1,128 @@
+//! The `ts` stamp on a journal line, from a consumer's side of the wire.
+//!
+//! Witness for #2111. Before it, `stella-events.jsonl` anchored nothing to wall
+//! clock: `step_usage` and `tool_result` name a span (`duration_ms`) but no
+//! instant, so a recorded trial could answer neither "when did this happen" nor
+//! "where did the wall clock go between these two events" — and the arena
+//! transcript, having nothing to subtract, rendered `0:00` for every row.
+//!
+//! These tests read the line the way every consumer does — as JSON, not as a
+//! Rust value — because that is the surface the contract is made of. The three
+//! properties that matter downstream:
+//!
+//!  1. the stamp is *there*, and it is the instant the sink supplied;
+//!  2. it is a sibling key of `type`, not a new nesting level, so every reader
+//!     written before #2111 keeps working unchanged;
+//!  3. a line without it still parses, forever — archived benchmark evidence
+//!     has none, and neither does a sink with no clock to offer.
+
+use serde_json::Value;
+use stella_protocol::{AgentEvent, StampedEvent, stamped_line};
+
+/// The instant every assertion below is written against: 2026-08-07T16:00:00Z,
+/// well past the point where a plausible-but-wrong `0` would pass unnoticed.
+const TS: u64 = 1_754_582_400_123;
+
+fn tool_result() -> AgentEvent {
+    AgentEvent::ToolResult {
+        call_id: "call-1".to_string(),
+        output: stella_protocol::ToolOutput::Ok {
+            content: "ok".to_string(),
+        },
+        duration_ms: 4_200,
+        speculated: false,
+    }
+}
+
+#[test]
+fn a_journal_line_carries_the_instant_its_sink_supplied() {
+    let line: Value = serde_json::from_str(&stamped_line(&tool_result(), TS).unwrap()).unwrap();
+
+    assert_eq!(
+        line.get("ts").and_then(Value::as_u64),
+        Some(TS),
+        "a journal line with no `ts` anchors nothing to wall clock: {line}"
+    );
+}
+
+#[test]
+fn the_stamp_is_a_sibling_of_the_tag_not_a_new_nesting_level() {
+    // Every existing reader — arenabench's transcript reader, the harbor
+    // adapter's live feed and exit-cause classifier — keys off `event["type"]`
+    // at the top level. Nesting the event under an envelope member would have
+    // broken all three at once; flattening costs them nothing.
+    let line: Value = serde_json::from_str(&stamped_line(&tool_result(), TS).unwrap()).unwrap();
+
+    assert_eq!(
+        line.get("type").and_then(Value::as_str),
+        Some("tool_result")
+    );
+    assert_eq!(line.get("duration_ms").and_then(Value::as_u64), Some(4_200));
+    assert_eq!(line.get("call_id").and_then(Value::as_str), Some("call-1"));
+}
+
+#[test]
+fn elapsed_is_computable_from_two_lines() {
+    // The arena transcript's whole job, reduced to arithmetic: the offset of an
+    // event from the first line of the trial. This is what could not be done at
+    // all before the field existed.
+    let first: StampedEvent =
+        serde_json::from_str(&stamped_line(&tool_result(), TS).unwrap()).unwrap();
+    let later: StampedEvent =
+        serde_json::from_str(&stamped_line(&tool_result(), TS + 90_000).unwrap()).unwrap();
+
+    let elapsed_ms = later.ts.zip(first.ts).map(|(later, first)| later - first);
+    assert_eq!(elapsed_ms, Some(90_000));
+}
+
+#[test]
+fn a_line_recorded_before_the_stamp_existed_still_parses() {
+    // Every `stella-events.jsonl` under bench/evidence/ is this shape. A reader
+    // that required `ts` would refuse to replay the archive.
+    let archived = serde_json::to_string(&tool_result()).unwrap();
+    let parsed: StampedEvent = serde_json::from_str(&archived).unwrap();
+
+    assert_eq!(parsed.ts, None);
+    assert!(matches!(parsed.event, AgentEvent::ToolResult { .. }));
+}
+
+#[test]
+fn an_unstamped_line_is_byte_identical_to_the_bare_event() {
+    // The reason this is an added key rather than a new format: with no stamp,
+    // the envelope disappears from the wire entirely.
+    let unstamped = StampedEvent {
+        ts: None,
+        event: tool_result(),
+    };
+
+    assert_eq!(
+        serde_json::to_string(&unstamped).unwrap(),
+        serde_json::to_string(&tool_result()).unwrap()
+    );
+}
+
+#[test]
+fn a_stamped_line_round_trips_byte_for_byte() {
+    // Invariant #4, on the type that now crosses the CLI → arena boundary.
+    let line = stamped_line(&tool_result(), TS).unwrap();
+    let parsed: StampedEvent = serde_json::from_str(&line).unwrap();
+
+    assert_eq!(serde_json::to_string(&parsed).unwrap(), line);
+}
+
+#[test]
+fn an_event_from_a_newer_stella_keeps_both_its_body_and_its_stamp() {
+    // Forward-compat and forensics must not be mutually exclusive: an
+    // `AgentEvent::Unknown` re-emits the object it wrapped, and the stamp has to
+    // survive that passthrough or the very lines an older reader cannot explain
+    // would also be the ones it cannot place in time.
+    let line = r#"{"ts":1754582400123,"type":"from_the_future","detail":{"a":1}}"#;
+    let parsed: StampedEvent = serde_json::from_str(line).unwrap();
+
+    assert_eq!(parsed.ts, Some(TS));
+    assert!(parsed.event.is_unknown());
+    assert_eq!(
+        serde_json::from_str::<Value>(&serde_json::to_string(&parsed).unwrap()).unwrap(),
+        serde_json::from_str::<Value>(line).unwrap()
+    );
+}

--- a/docs/wire/README.md
+++ b/docs/wire/README.md
@@ -22,6 +22,24 @@ format. They share one TypeScript printer
 (`stella_protocol::schema_export`), so there is one subset of JSON Schema to
 keep in step rather than two.
 
+## The one attached property, and why it is not derived
+
+Every `AgentEvent` variant in `agentevent.schema.json` carries an optional
+`ts`: the wall-clock instant, in Unix-epoch milliseconds, at which the sink
+wrote that line (#2111). It is not a member of any variant — it is applied at
+the write boundary by `stella_protocol::journal::stamped_line`, because a stamp
+is a fact about a *write*, the same event reaches more than one sink, and the
+engine that produces events owns no clock.
+
+`schemars` therefore cannot derive it, and `schema_export::attach_journal_stamp`
+adds it in one uniform pass instead, with its prose taken from
+`journal::TS_DESCRIPTION` so the published text and the Rust doc are one string.
+The alternative — flattening an envelope struct into the schema root — would
+have cost the discriminated union, and with it `KnownTypeTag`, which is the one
+thing a forward-compatible consumer most needs. Optional on every surface is the
+only claim true of all three: a line recorded before the field existed has none,
+and `stella-serve` frames the event in an envelope that stamps its own.
+
 ## The one hand-written line, and why it is safe
 
 `seq` is added by the transport at delivery time, not by the engine, so no

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -10,6 +10,12 @@
 // A `"type"` value not listed here is NOT an error: it is an event from a
 // newer stella. Forward-compatible consumers keep such a line intact and move
 // on, exactly as `AgentEvent::Unknown` does on the Rust side.
+//
+// Every variant carries an optional `ts`: the wall-clock instant its sink wrote
+// the line, in milliseconds since the Unix epoch. It is stamped by the sink, not
+// by the event, so it is absent on any line recorded before the field existed —
+// treat it as optional forever, and clamp a negative delta, because a system
+// clock is not monotonic.
 
 /**
  * The semantic kind of one context block — one durable, individually
@@ -1091,18 +1097,38 @@ export interface VerdictEvidence {
  */
 export type AgentEvent = {
   name: StageKind;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "stage";
 } | {
   text: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "text";
 } | {
   delta: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "text_delta";
 } | {
   delta: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "reasoning";
 } | {
   call: ToolCall;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "tool_start";
 } | {
   call_id: string;
@@ -1116,11 +1142,19 @@ export type AgentEvent = {
    * it. `serde(default)` so streams recorded before this field parse.
    */
   speculated?: boolean;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "tool_result";
 } | {
   call_id: string;
   name: string;
   reason: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "speculation_discarded";
 } | {
   /**
@@ -1130,9 +1164,17 @@ export type AgentEvent = {
    */
   attempt: number;
   reason: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "retry";
 } | {
   text: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "steered";
 } | {
   /**
@@ -1148,6 +1190,10 @@ export type AgentEvent = {
    * Seconds between engine-side probes of the watched state.
    */
   poll_interval_secs: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "turn_parked";
 } | {
   /**
@@ -1161,6 +1207,10 @@ export type AgentEvent = {
    * `stella-protocol` never depends on `stella-core`).
    */
   reason: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "turn_woken";
 } | {
   /**
@@ -1189,6 +1239,10 @@ export type AgentEvent = {
    * cycle), or consecutive no-progress calls (stagnation) observed.
    */
   repeats: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   turn_instance: number;
   type: "loop_detected";
 } | {
@@ -1199,6 +1253,10 @@ export type AgentEvent = {
    */
   scope: BudgetScope;
   spent_usd: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "budget_denied";
 } | {
   /**
@@ -1227,6 +1285,10 @@ export type AgentEvent = {
    * reclassified as terminal.
    */
   retryable?: boolean;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   turn_instance: number;
   type: "retries_exhausted";
 } | {
@@ -1241,6 +1303,10 @@ export type AgentEvent = {
    * decision was about.
    */
   subject: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "policy_decision";
 } | {
   after_tokens: number;
@@ -1312,6 +1378,10 @@ export type AgentEvent = {
    */
   superseded?: number;
   superseded_blocks?: string[];
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "compaction";
 } | {
   limit_usd?: number | null;
@@ -1331,6 +1401,10 @@ export type AgentEvent = {
    */
   session_spent_usd?: number | null;
   spent_usd: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "budget_tick";
 } | {
   /**
@@ -1422,6 +1496,10 @@ export type AgentEvent = {
   role?: ModelCallRole;
   step: number;
   tool_calls: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "step_usage";
 } | {
   duration_ms: number;
@@ -1447,17 +1525,29 @@ export type AgentEvent = {
    */
   retries?: number | null;
   role: ModelCallRole;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "usage_incomplete";
 } | {
   cost_usd: number;
   met: boolean;
   reasoning: string;
   round: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "goal_verdict";
 } | {
   from: string;
   reason: string;
   to: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "provider_fallback";
 } | {
   /**
@@ -1469,6 +1559,10 @@ export type AgentEvent = {
   kind: FileChangeKind;
   path: string;
   removed?: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "file_change";
 } | {
   frames: ContextFrameRef[];
@@ -1485,6 +1579,10 @@ export type AgentEvent = {
   latency_ms?: number;
   provider_mix: ProviderShare[];
   tokens: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "context_recall";
   /**
    * The CGP usage report for this recall (`docs/spec/adaptive-context/context-reuse.md` §2):
@@ -1513,6 +1611,10 @@ export type AgentEvent = {
 } | {
   provider: string;
   superseded: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "context_write";
   upserts: number;
 } | {
@@ -1546,6 +1648,10 @@ export type AgentEvent = {
    * Estimated tokens at birth (the engine's estimator).
    */
   token_cost: number;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "block_registered";
 } | {
   /**
@@ -1598,22 +1704,42 @@ export type AgentEvent = {
   role: ModelCallRole;
   step: number;
   /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
+  /**
    * Monotonic per session — groups the steps of one `run_turn`.
    */
   turn_instance: number;
   type: "step_manifest";
 } | {
   step: ProofStep;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "proof";
 } | {
   evidence: VerdictEvidence;
   passed: boolean;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "verdict";
 } | {
   proposal: ScopeProposal;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "scope_review";
 } | {
   proposal: HunkProposal;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "hunk_review";
 } | {
   /**
@@ -1623,18 +1749,34 @@ export type AgentEvent = {
   id: string;
   options: string[];
   question: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "ask_user";
 } | {
   artifact_id: string;
   kind: MediaKind;
   state: MediaJobState;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "media_progress";
 } | {
   artifact: MediaArtifactRef;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "media_complete";
 } | {
   message: string;
   sha: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "commit";
 } | {
   /**
@@ -1649,21 +1791,41 @@ export type AgentEvent = {
    */
   number?: number | null;
   status: PrStatus;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "pr";
   url: string;
 } | {
   tasks: TaskItem[];
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "task_update";
 } | {
   phase: SubAgentPhase;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "sub_agent";
 } | {
   message: string;
   retryable: boolean;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "error";
 } | {
   cost_usd: number;
   model: string;
+  /**
+   * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
+   */
+  ts?: number;
   type: "complete";
 };
 

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1708,6 +1708,12 @@
         "name": {
           "$ref": "#/$defs/StageKind"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "stage",
           "type": "string"
@@ -1724,6 +1730,12 @@
       "properties": {
         "text": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "text",
@@ -1742,6 +1754,12 @@
         "delta": {
           "type": "string"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "text_delta",
           "type": "string"
@@ -1759,6 +1777,12 @@
         "delta": {
           "type": "string"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "reasoning",
           "type": "string"
@@ -1775,6 +1799,12 @@
       "properties": {
         "call": {
           "$ref": "#/$defs/ToolCall"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "tool_start",
@@ -1806,6 +1836,12 @@
           "description": "True when this result was produced by speculative execution: the\ncall was read-only and began executing while the model was still\nstreaming the rest of its response, so `duration_ms` (the real\nexecution time) overlapped the model call instead of following\nit. `serde(default)` so streams recorded before this field parse.",
           "type": "boolean"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "tool_result",
           "type": "string"
@@ -1830,6 +1866,12 @@
         },
         "reason": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "speculation_discarded",
@@ -1856,6 +1898,12 @@
         "reason": {
           "type": "string"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "retry",
           "type": "string"
@@ -1873,6 +1921,12 @@
       "properties": {
         "text": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "steered",
@@ -1904,6 +1958,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "turn_parked",
           "type": "string"
@@ -1929,6 +1989,12 @@
         "reason": {
           "description": "`\"changed\"` | `\"deadline_expired\"` — mirrors\n`stella-core::waiting::WakeReason` (kept as a string here so\n`stella-protocol` never depends on `stella-core`).",
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "turn_woken",
@@ -1967,6 +2033,12 @@
         "repeats": {
           "description": "Consecutive identical calls (exact repeat), full cycles (short\ncycle), or consecutive no-progress calls (stagnation) observed.",
           "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
@@ -2009,6 +2081,12 @@
           "format": "double",
           "type": "number"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "budget_denied",
           "type": "string"
@@ -2044,6 +2122,12 @@
           "description": "Whether the LAST attempt's error was of a retryable class —\nmirrors the paired [`AgentEvent::Error`]'s `retryable` field,\ncomputed from the same `ProviderError::is_retryable()` call.\n`false` means retrying again could never have helped: the\nclearest case is `ProviderError::Auth` failing on attempt 1,\nwhere `attempts` is 1 and no retry was ever attempted despite\nthis event's name (#926) — a receipts/telemetry consumer that\nonly sees `RetriesExhausted` would otherwise record a\nreliability incident for what is really a bad credential.\n`#[serde(default = \"retries_exhausted_retryable_default\")]`:\nevent logs recorded before this field existed predate the\ndistinction, so on replay they read as \"genuinely retryable\"\n— the pre-#926 behavior — rather than being silently\nreclassified as terminal.",
           "type": "boolean"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "turn_instance": {
           "format": "uint32",
           "minimum": 0,
@@ -2075,6 +2159,12 @@
         "subject": {
           "description": "The tool name, capability, or workspace-relative path the\ndecision was about.",
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "policy_decision",
@@ -2185,6 +2275,12 @@
           },
           "type": "array"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "compaction",
           "type": "string"
@@ -2233,6 +2329,12 @@
         "spent_usd": {
           "format": "double",
           "type": "number"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "budget_tick",
@@ -2347,6 +2449,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "step_usage",
           "type": "string"
@@ -2406,6 +2514,12 @@
         "role": {
           "$ref": "#/$defs/ModelCallRole"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "usage_incomplete",
           "type": "string"
@@ -2439,6 +2553,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "goal_verdict",
           "type": "string"
@@ -2464,6 +2584,12 @@
         },
         "to": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "provider_fallback",
@@ -2506,6 +2632,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "file_change",
           "type": "string"
@@ -2542,6 +2674,12 @@
         },
         "tokens": {
           "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
@@ -2584,6 +2722,12 @@
         },
         "superseded": {
           "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
@@ -2639,6 +2783,12 @@
         "token_cost": {
           "description": "Estimated tokens at birth (the engine's estimator).",
           "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
@@ -2716,6 +2866,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "turn_instance": {
           "description": "Monotonic per session — groups the steps of one `run_turn`.",
           "format": "uint32",
@@ -2747,6 +2903,12 @@
         "step": {
           "$ref": "#/$defs/ProofStep"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "proof",
           "type": "string"
@@ -2767,6 +2929,12 @@
         "passed": {
           "type": "boolean"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "verdict",
           "type": "string"
@@ -2785,6 +2953,12 @@
         "proposal": {
           "$ref": "#/$defs/ScopeProposal"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "scope_review",
           "type": "string"
@@ -2801,6 +2975,12 @@
       "properties": {
         "proposal": {
           "$ref": "#/$defs/HunkProposal"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "hunk_review",
@@ -2829,6 +3009,12 @@
         "question": {
           "type": "string"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "ask_user",
           "type": "string"
@@ -2854,6 +3040,12 @@
         "state": {
           "$ref": "#/$defs/MediaJobState"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "media_progress",
           "type": "string"
@@ -2872,6 +3064,12 @@
       "properties": {
         "artifact": {
           "$ref": "#/$defs/MediaArtifactRef"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "media_complete",
@@ -2892,6 +3090,12 @@
         },
         "sha": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "commit",
@@ -2931,6 +3135,12 @@
         "status": {
           "$ref": "#/$defs/PrStatus"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "pr",
           "type": "string"
@@ -2955,6 +3165,12 @@
           },
           "type": "array"
         },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "type": {
           "const": "task_update",
           "type": "string"
@@ -2971,6 +3187,12 @@
       "properties": {
         "phase": {
           "$ref": "#/$defs/SubAgentPhase"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "sub_agent",
@@ -2991,6 +3213,12 @@
         },
         "retryable": {
           "type": "boolean"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "error",
@@ -3013,6 +3241,12 @@
         },
         "model": {
           "type": "string"
+        },
+        "ts": {
+          "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
         },
         "type": {
           "const": "complete",

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -153,10 +153,38 @@ it next, which may be a newer client that would have understood them.
   are unordered by definition. Compare parsed values, never raw lines.
 </Callout>
 
+## The `ts` stamp
+
+Every line carries an optional `ts`: the wall-clock instant the sink wrote it, in
+milliseconds since the Unix epoch (UTC).
+
+```json
+{"ts":1754582400123,"type":"tool_result","call_id":"c1","duration_ms":4200}
+```
+
+It is stamped by the *sink*, not carried by the event, and three consequences
+follow that a client has to hold:
+
+- **It is optional forever.** A line recorded before the field existed has none —
+  which is every archived `stella-events.jsonl` — so read it as
+  `ts ?? null`, never as a required key.
+- **It is not monotonic.** It comes from the system clock, so an NTP step can put
+  a later line before an earlier one. Clamp a negative delta to zero rather than
+  rendering it.
+- **It measures the write, not the event.** The same event published to two sinks
+  carries each sink's own instant. Use it for offsets within one stream; do not
+  align two streams to the millisecond with it.
+
+Durations remain the right tool for spans: `tool_result` and `step_usage` carry a
+`duration_ms` measured by the engine, which is exact where `ts` is only an
+anchor.
+
 ## What is *not* guaranteed
 
 - **Ordering between event types** beyond what the pipeline documents. `text_delta`
   lines interleave with other events.
+- **A monotonic `ts`.** See above: it is a wall clock, and it can repeat or move
+  backwards.
 - **That every event has a stable meaning to you.** `text_delta` is an explicit
   best-effort preview: the `text` event that follows carries the authoritative
   step text, and you must *replace* accumulated deltas with it rather than append


### PR DESCRIPTION
## What & why

`stella-events.jsonl` anchored nothing to wall clock. `step_usage` and `tool_result`
carry a `duration_ms` — which names a *span* but no *instant* — so two questions
could not be answered from a recorded trial at all: when did this happen, and where
did the wall clock go between these two events. The visible symptom was the arena
transcript rendering `0:00` in the elapsed gutter for every row of a finished trial,
which reads as a broken feed to anyone watching a live match. The forensic symptom
was worse: the idle-to-`AgentTimeoutError` gap in #2110 is invisible because there
is nothing to subtract.

Closes #2111

### The field

`ts` — `u64`, milliseconds since the Unix epoch (UTC), the instant **the sink that
wrote the line admitted it**. Not a member of any `AgentEvent` variant: a stamp is a
fact about a *write*, the same event is written to more than one sink, and neither
`stella-core` (a pure, replayable fold) nor `stella-protocol` (zero I/O by charter)
owns a clock. Putting it in the enum would have meant a field on all 39 variants, a
clock reachable from the engine, and a timestamp baked into every replay fixture.

So it rides an envelope applied at the sink — `stella_protocol::journal` — that
**flattens**, so the bytes gain one key rather than a nesting level:

```json
{"ts":1754582400123,"type":"tool_result","call_id":"c1","duration_ms":4200}
```

Every existing reader (`arenabench/arenabench/telemetry.py`,
`bench/harbor_adapter/stella_harbor/live_feed.py`, `exit_cause.py`) keys off
`event["type"]` at the top level and is untouched by the addition. The clock is the
`stella_core::ports::Clock` port, and specifically `crates/stella-cli/src/runtime.rs::WallClock`
— which already existed for exactly this ("stamps that must stay comparable across
processes and runs"), and whose doc already says `SystemClock`'s per-construction
origin is "exactly the wrong one for a durable timestamp". Tests inject a fixed
clock, so no golden becomes time-dependent.

Both stream-json sinks stamp: the durable JSONL file
(`agent/output.rs::ordered_durable_event_sender`) and the stdout copy
(`agent/persistence.rs::emit_stream_json`). They read the clock independently, so the
two copies of one event differ by the persist. That is the truth and is why the field
is documented as "when this sink admitted the line" rather than "when the event
happened"; the alternative — one stamp shared by both — would mean changing the
`mpsc::UnboundedSender<AgentEvent>` channel type, i.e. changing `stella-core`'s
`EventSender` API and touching `bus.rs`, which is a god file at its exact ceiling.
`ordered_durable_event_sender`'s doc comment states the consequence: nothing may diff
the two streams byte-for-byte.

**Deliberately not stamped:** `stella_pipeline::replay::to_jsonl`. That journal is a
golden fixture format and must stay a pure function of the run.

### Backward compatibility

`StampedEvent.ts` is `Option<u64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.

- **Read side, optional forever.** Every `stella-events.jsonl` under `bench/evidence/`
  has no `ts`, and a reader that required it would refuse to replay the archive.
  Witnessed by `a_line_recorded_before_the_stamp_existed_still_parses`.
- **Write side, always stamped.** `stamped_line` takes a `u64`, not an option, so a
  sink cannot silently forget.
- **A `None` serializes to exactly the bytes a bare `AgentEvent` produces**
  (`an_unstamped_line_is_byte_identical_to_the_bare_event`). That identity is why
  this is an added key rather than a new format — no version negotiation exists or
  is needed.
- **`AgentEvent::Unknown` keeps both halves.** An event from a newer stella
  re-serializes with its body *and* its stamp intact
  (`an_event_from_a_newer_stella_keeps_both_its_body_and_its_stamp`) — forward-compat
  and forensics must not be mutually exclusive on exactly the lines that need both.
- No committed fixture or golden changed. `crates/stella-protocol/tests/text_event_wire.rs`,
  which pins exact bytes for `text`/`text_delta`, is untouched and green — `AgentEvent`'s
  own serialization is unchanged.

### Prompt-bound content: unaffected (invariant #7)

**The stamp never enters the system prompt or any cached prefix.** It is applied at
the *output* sink — `agent/output.rs` and `agent/persistence.rs`, both on the write
path to a file or to stdout — and nothing on the prompt-assembly path
(`agent.rs::build_system_prompt`, `memory.rs`) reads a clock or sees a `StampedEvent`.
`stella-protocol` still carries no time dependency; the only clock is `WallClock` in
`stella-cli`. Prompt-cache hit rates are untouched.

### Regenerated wire artifacts

Yes — `docs/wire/agentevent.schema.json` and `docs/wire/agentevent.d.ts`, via
`bash scripts/export-agentevent-schema.sh`, never by hand.
`bash scripts/check-wire-schema.sh` is green.

`schemars` cannot derive the key, because it is not on the type. `schema_export::attach_journal_stamp`
adds it in one uniform pass over the 39 root variants, with its prose taken from
`journal::TS_DESCRIPTION` so the published contract and the Rust doc are one string.
The rejected alternative was flattening an envelope struct into the schema root: that
turns the root from a discriminated union into an object, and takes `KnownTypeTag`
with it — the one thing a forward-compatible consumer most needs. Optional on every
variant is also the only claim true of all three surfaces the artifact covers: an
archived line has none, and `stella-serve` frames the event in an envelope that stamps
its own (follow-up #2234). The reasoning is recorded in `docs/wire/README.md` beside
the existing "one hand-written line" note, which is the precedent for a
transport-added key.

Read the diff: it is `ts?: number` added to each variant's `properties`, never to
`required`, and nothing else moved.

### The consumer half — the `0:00` the issue leads with

`arenabench/arenabench/telemetry.py::TranscriptReader` fabricated `t` from
`time.time()` at parse. A finished trial is read in one pass, so every event in the
file was parsed within the same few milliseconds, every `t` rounded to `0.0`, and
`fmtClock(0)` rendered `0:00` down the whole gutter. It reads the line's own `ts` now
and measures from the stream's first stamp. The UI needed no change:
`transcript-page.tsx` and `lane.tsx` already render `entry.t`, and the paced replay
already clamps its gap to `[16 ms, 1200 ms]`, so a real 500-second idle gap paces
correctly instead of stalling.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

**Primary — `arenabench/tests/test_telemetry.py::TestTranscriptElapsed`.** Pure
Python, compiles on `main`, fails there at runtime on exactly the reported symptom.
Flip verified by `git checkout origin/main -- arenabench/arenabench/telemetry.py` and
re-running:

```
FAILED TestTranscriptElapsed::test_elapsed_comes_from_the_events_own_stamps
  assert [0.0, 0.0, 0.0] == [0.0, 12.5, 90.0]
FAILED TestTranscriptElapsed::test_an_idle_gap_before_a_timeout_is_visible
  assert (0.0 - 0.0) == 500.0
FAILED TestTranscriptElapsed::test_incremental_reads_share_one_origin
  assert [0.0] == [60.0]
```

`assert [0.0, 0.0, 0.0] == [0.0, 12.5, 90.0]` **is** the `0:00` column, reproduced.
With the fix restored: 56 passed in `test_telemetry.py`, 521 passed + 2 skipped in
`bench/harbor_adapter/tests/`. The other two cases in the class
(negative-delta clamp, unstamped archive) pass on `main` trivially and are regression
guards, not witnesses — named here so the distinction is not overclaimed.

**Protocol — `crates/stella-protocol/tests/journal_stamp_wire.rs`** (7 tests, reading
the line as JSON, the way a consumer does). Flip verified by removing
`src/journal.rs` and `git checkout origin/main -- src/lib.rs`:

```
error[E0432]: unresolved imports `stella_protocol::StampedEvent`, `stella_protocol::stamped_line`
  --> crates/stella-protocol/tests/journal_stamp_wire.rs:20:35
```

**Emitter — `agent::output::durable_stream_tests::every_durable_line_is_anchored_to_wall_clock`**,
asserting the durable sink's own bytes carry `ts` under a `FixedClock`.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`)
- [x] `cargo clippy -p stella-protocol --all-targets --features schema -- -D warnings`; `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol -p stella-cli --no-deps`
- [x] `cargo test -p stella-protocol --features schema` (146), `-p stella-cli --bin stella` (1479), `-p stella-pipeline replay` (55)
- [x] `make guards-fast` — every toolchain-free guard, including `file-size`, `god-files`, `left-behind`, `module-reachability`, `doc-links`
- [x] `bash scripts/check-wire-schema.sh`
- [x] Docs updated: `website/content/docs/event-stream-compatibility.mdx`, `docs/wire/README.md`, `crates/stella-protocol/README.md`
- [x] `Closes #2111` appears above **and** as a commit trailer

Scoped deliberately, not `--workspace`: CI is the gate and the dev machine is shared.
No test was deleted or renamed.

## Nothing left behind

- [x] Filed: **#2234** — `stella-serve`'s SSE frames carry no stamp, so a host driving
      the engine still has the gap this PR closed for the CLI. Written as a handoff:
      files, the `ServerFrame`-vs-line design question, `envelope_pin` as the tripwire,
      and the wire-schema obligation.
- Commented on **#2110** with the `jq` one-liner the new field makes possible, and the
  honest caveat that it does not retro-explain `cc00894779ff` — archives have no `ts`.
- **#2135** (per-task deadline) is related and untouched; linked, not duplicated.

## Ground-rule check

- [x] No I/O added to `stella-core`; the clock is the existing `ports::Clock` port,
      implemented in `stella-cli` where concrete time sources belong. No new deps.
- [x] No new outbound network calls.
- [x] New cross-boundary type round-trips through serde — `a_stamped_line_round_trips_byte_for_byte`,
      plus the byte-identity and legacy-parse cases above (invariant #4).

## Anything reviewers should know?

**The one thing worth arguing about** is the two independent stamps on the durable
file and its stdout copy. It is documented at the sink and in the wire contract, and
unifying them is a `stella-core` API change reaching into a god file at its exact
ceiling. Say the word and I will file it rather than leave the judgement in a PR
comment.

## Summary by Sourcery

Stamp each stream-json journal line with a wall-clock timestamp at the sink and expose it in the protocol, then consume it in the arena transcript to compute realistic elapsed offsets while keeping older archives and consumers compatible.

New Features:
- Introduce a `StampedEvent` envelope and `stamped_line` helper that add an optional wall-clock `ts` to serialized `AgentEvent` lines.
- Extend the wire schema and TypeScript declarations so every `AgentEvent` variant may carry an optional `ts` field for sink-stamped timestamps.

Bug Fixes:
- Fix arena transcript elapsed times always rendering as `0:00` by reading per-line `ts` stamps instead of parse-time wall clock.
- Ensure transcript elapsed offsets remain non-negative and that streams recorded before `ts` existed still render using the old parse-time behavior.

Enhancements:
- Stamp both durable JSONL evidence and stdout stream-json with sink-local wall-clock instants using the CLI `WallClock`, and document that the two streams may differ.
- Clarify event-stream compatibility docs with the semantics and caveats of the `ts` stamp, including non-monotonic clocks and stream-local offsets.
- Add protocol-side tests and CLI durable-stream tests that validate presence, shape, and round-trip behavior of the `ts` stamp across legacy and future events.

Documentation:
- Document the `ts` journal stamp and its compatibility guarantees in the wire README, schema banner, and event-stream compatibility docs.
- Update the stella-protocol README to describe the new `journal` module and its stamped event line type.

Tests:
- Add arena telemetry tests that exercise elapsed computation from `ts`, visibility of idle gaps, clock step handling, legacy unstamped streams, and incremental reads.
- Add protocol tests verifying that stamped lines include `ts`, remain flat, parse without `ts`, round-trip byte-for-byte, and preserve stamps on unknown events.
- Add CLI durable stream tests ensuring every persisted line is stamped with wall clock and remains flat for existing readers.