### PR TITLE
test(stella-cli): derive the shared prompt contracts and check both prompts embed them

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -28,6 +28,13 @@ use super::*;
 // byte-stable-prefix property (L-E8) a runtime `format!` would give up. One
 // shared literal, embedded verbatim by both prompts, is also what keeps the two
 // copies from drifting the way the catalogue's did (#450).
+//
+// ADDING A CONTRACT: embed it in BOTH prompts below, and add its row to
+// `SHARED_CONTRACTS` in `prompt/parity.rs`. That module derives the set of
+// contracts from this file's own source, so it fails by name on either
+// omission — the coupling used to hold by convention alone, and a contract
+// reaching `SYSTEM_PROMPT` only is invisible to `stella run` and to every
+// bench measurement, which read `PIPELINE_SYSTEM_PROMPT` (#2231).
 
 /// The cross-tool steering shared by both static prompts — what the generated
 /// schemas cannot say. No trailing newline: each prompt continues with its own

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -451,15 +451,22 @@ pub(crate) fn render_file_tree(files: &str, max_lines: usize) -> String {
     out
 }
 
+/// The structural half of the shared-contract discipline: the tests above are
+/// written one per contract, so they cover the contracts that exist and say
+/// nothing about the next one. This module derives the set from this file's own
+/// source and asserts the coupling over it (#2231). Declared last because
+/// `macro_rules!` scope is textual — the contracts above have to be in scope.
+#[cfg(test)]
+mod parity;
+
 #[cfg(test)]
 mod tests {
-    use super::{PIPELINE_SYSTEM_PROMPT, SYSTEM_PROMPT, append_workspace_memories};
+    use super::append_workspace_memories;
 
-    /// Every static prompt, labelled.
-    const PROMPTS: &[(&str, &str)] = &[
-        ("SYSTEM_PROMPT", SYSTEM_PROMPT),
-        ("PIPELINE_SYSTEM_PROMPT", PIPELINE_SYSTEM_PROMPT),
-    ];
+    // Every static prompt, labelled. Lives in `parity`, where it is
+    // cross-checked against this file's own source, so a third prompt cannot
+    // join the set without joining the list every test here iterates (#2231).
+    use super::parity::STATIC_PROMPTS as PROMPTS;
 
     /// The catalogue-shaped lines of `prompt`: `- <tool_name>: …`, where the
     /// lead-in is a bare canonical tool name or a `/`-joined run of them.

--- a/crates/stella-cli/src/agent/prompt/parity.rs
+++ b/crates/stella-cli/src/agent/prompt/parity.rs
@@ -92,6 +92,10 @@ const SHARED_CONTRACTS: &[(&str, &str)] = &[
     ("tool_steering", tool_steering!()),
     ("scope_discipline", scope_discipline!()),
     ("measurement_discipline", measurement_discipline!()),
+    (
+        "verification_proportionality",
+        verification_proportionality!(),
+    ),
 ];
 
 /// Every static prompt, paired with its assembled bytes. Same derivation

--- a/crates/stella-cli/src/agent/prompt/parity.rs
+++ b/crates/stella-cli/src/agent/prompt/parity.rs
@@ -1,0 +1,434 @@
+//! Structural parity for the shared prompt contracts (#2231).
+//!
+//! `prompt.rs` declares its cross-cutting contracts — tool steering, scope,
+//! measurement — as `macro_rules!` string literals so that **both** static
+//! prompts can embed the same bytes: one literal, two `concat!` sites, no
+//! second copy to drift from. The catalogue this pattern replaced had drifted
+//! in exactly that way (`verify_done` and `ask_user` took comma splices in the
+//! pipeline copy where the base copy took an em dash, #450).
+//!
+//! Each contract was then pinned by its own hand-written test. That covers the
+//! contracts that exist and says nothing about the next one: a fifth contract
+//! embedded in `SYSTEM_PROMPT` alone, with no test written for it, failed
+//! nothing. Confirmed on `main` before this module existed — a throwaway
+//! contract added to `SYSTEM_PROMPT` only left `cargo test -p stella-cli --bin
+//! stella prompt` at "45 passed; 0 failed". The coupling held by convention.
+//!
+//! `PIPELINE_SYSTEM_PROMPT` is the half that would go missing quietly: it is
+//! what `stella run` sends and what the bench harness exercises, so a contract
+//! landing in `SYSTEM_PROMPT` alone is invisible to every measurement the
+//! project makes decisions from.
+//!
+//! # The set is derived, never listed
+//!
+//! A hardcoded roster of contracts would reproduce the defect one level up —
+//! the fifth contract simply joins the set without joining the list. So the
+//! authority here is `prompt.rs`'s own source text: [`scan`] reads the
+//! `macro_rules!` declarations and the `const … = concat!(` prompt
+//! declarations out of it, and the two runtime registries below exist only
+//! because a macro cannot be invoked by a name computed at runtime. Both are
+//! cross-checked against the scan in both directions, so a registry that falls
+//! behind the source is a named failure rather than a check that quietly
+//! covers less.
+//!
+//! # Byte stability is untouched
+//!
+//! Every value here is a `&'static str` fixed at compile time: the contracts
+//! stay `macro_rules!` literals, the prompts stay `concat!` compositions, and
+//! this module only reads them. Nothing becomes runtime-computed, so the
+//! byte-stable prefix the prompt cache keys on (invariant 7 / L-E8) is exactly
+//! what it was. The scan in fact *enforces* one half of that: a prompt
+//! rewritten as a runtime `format!` stops parsing as a static prompt and the
+//! registry cross-check fails naming it.
+//!
+//! # Anti-vacuity
+//!
+//! A check that silently examines nothing reads as a passing gate, which is
+//! strictly worse than no check — the same shape as #2182, where a parity
+//! check could not run where it mattered. So every way this scan could come up
+//! empty is an error with a name: [`ScanError::NoContractsDeclared`],
+//! [`ScanError::NoStaticPromptsParsed`], a registry that no longer matches the
+//! source, and a contract literal too short for `contains` to prove anything.
+//! `the_scan_fails_loudly_rather_than_finding_nothing` drives each one.
+
+use super::{PIPELINE_SYSTEM_PROMPT, SYSTEM_PROMPT};
+
+/// `prompt.rs` read as text, at compile time.
+///
+/// `include_str!` resolves relative to this file, so renaming or moving either
+/// file is a compile error rather than a scan that quietly reads nothing — the
+/// strongest available form of the anti-vacuity guard.
+const PROMPT_SOURCE: &str = include_str!("../prompt.rs");
+
+/// A line every reader of `prompt.rs` will recognise, asserted before anything
+/// else so "the scan parsed nothing" can never be confused with "the scan is
+/// pointed at the wrong text".
+const SOURCE_ANCHOR: &str = "//! System-prompt assembly and file-tree rendering.";
+
+/// A shared contract shorter than this is empty or a placeholder, and
+/// `prompt.contains(it)` proves nothing. Not a style rule — the floor exists
+/// only so the verbatim assertion cannot pass vacuously against a hollowed-out
+/// literal. The shortest real contract today is several hundred characters.
+const MIN_CONTRACT_CHARS: usize = 80;
+
+/// Every shared contract, paired with the bytes its macro expands to.
+///
+/// The authority on *which* contracts exist is `prompt.rs` itself;
+/// `the_registries_match_the_source` fails when this list and the scan differ
+/// in either direction. This list exists only because a `macro_rules!` cannot
+/// be invoked by a name computed at runtime, and expanding each one here is
+/// what lets the check compare bytes rather than source text.
+const SHARED_CONTRACTS: &[(&str, &str)] = &[
+    ("tool_steering", tool_steering!()),
+    ("scope_discipline", scope_discipline!()),
+    ("measurement_discipline", measurement_discipline!()),
+];
+
+/// Every static prompt, paired with its assembled bytes. Same derivation
+/// discipline as [`SHARED_CONTRACTS`], and shared with `prompt.rs`'s own test
+/// module so there is one list of prompts to keep current rather than two.
+pub(super) const STATIC_PROMPTS: &[(&str, &str)] = &[
+    ("SYSTEM_PROMPT", SYSTEM_PROMPT),
+    ("PIPELINE_SYSTEM_PROMPT", PIPELINE_SYSTEM_PROMPT),
+];
+
+/// Why a parity scan of `prompt.rs` could not be completed.
+///
+/// Each variant is a way the check would otherwise examine *less* than it
+/// must. They are errors rather than "nothing to check" precisely because an
+/// empty scan reads exactly like a passing gate.
+#[derive(Debug, PartialEq, Eq)]
+enum ScanError {
+    /// `prompt.rs` declares no `macro_rules!` at all: either the shared-literal
+    /// pattern was abandoned, or this scan is reading the wrong text.
+    NoContractsDeclared,
+    /// No static prompt parsed. A prompt is recognised by its declaration being
+    /// a compile-time `concat!` — the shape invariant 7 (L-E8) rests on — so
+    /// this also fires when one is rewritten as a runtime composition.
+    NoStaticPromptsParsed,
+}
+
+/// What `prompt.rs`'s source says about its own shared contracts.
+#[derive(Debug)]
+struct Scan<'a> {
+    /// Contract macro names, in declaration order.
+    contracts: Vec<&'a str>,
+    /// For every static prompt: its constant name, and the body of the
+    /// `concat!` that assembles it.
+    prompts: Vec<(&'a str, &'a str)>,
+}
+
+/// Read the shared-contract structure out of `source`, or say why not.
+fn scan(source: &str) -> Result<Scan<'_>, ScanError> {
+    let contracts = declared_contracts(source);
+    if contracts.is_empty() {
+        return Err(ScanError::NoContractsDeclared);
+    }
+    let prompts = static_prompt_bodies(source);
+    if prompts.is_empty() {
+        return Err(ScanError::NoStaticPromptsParsed);
+    }
+    Ok(Scan { contracts, prompts })
+}
+
+/// Every `(contract, prompt)` pair the source leaves uncoupled — the defect
+/// this module exists to name. Empty is the healthy answer.
+fn unembedded<'a>(scan: &Scan<'a>) -> Vec<(&'a str, &'a str)> {
+    let mut missing = Vec::new();
+    for contract in &scan.contracts {
+        let invocation = format!("{contract}!()");
+        for (prompt, body) in &scan.prompts {
+            if !body.contains(&invocation) {
+                missing.push((*contract, *prompt));
+            }
+        }
+    }
+    missing
+}
+
+/// The names of every top-level `macro_rules!` declared in `source`.
+///
+/// Every macro in `prompt.rs` is a shared prompt contract, and this treats them
+/// as such: a helper macro added there fails the coupling check until it is
+/// either embedded in both prompts or moved somewhere it is not mistaken for a
+/// contract. That is the fail-closed direction — the alternative is an opt-in
+/// marker, which is the convention this module replaces.
+fn declared_contracts(source: &str) -> Vec<&str> {
+    source.lines().filter_map(contract_name).collect()
+}
+
+/// The name declared by a top-level `macro_rules!` line, if this is one.
+///
+/// Column 0 only. Every contract is declared at the top level, and requiring it
+/// keeps prose that merely mentions the keyword out of the scan.
+fn contract_name(line: &str) -> Option<&str> {
+    let name = line
+        .strip_prefix("macro_rules!")?
+        .trim()
+        .trim_end_matches('{')
+        .trim();
+    is_ident(name).then_some(name)
+}
+
+/// `(name, body)` for every static prompt in `source`, where `body` is the text
+/// between the `concat!(` line and the `);` that closes it.
+///
+/// A body that ends early — were a prompt ever to contain a line opening with
+/// `);` — can only *remove* text, so it can turn a coupled contract into a
+/// reported failure and never the reverse. This scan is allowed to be wrong
+/// only in the direction that shouts.
+fn static_prompt_bodies(source: &str) -> Vec<(&str, &str)> {
+    let mut prompts = Vec::new();
+    let mut offset = 0usize;
+    for raw in source.split_inclusive('\n') {
+        offset += raw.len();
+        let Some(name) = static_prompt_name(raw.trim_end()) else {
+            continue;
+        };
+        let rest = &source[offset..];
+        // rustfmt closes a multi-line `concat!` on its own line.
+        let Some(end) = rest.find("\n);") else {
+            continue;
+        };
+        prompts.push((name, &rest[..end]));
+    }
+    prompts
+}
+
+/// The constant name declared by a top-level static-prompt line, if this is
+/// one: `[pub(crate) ]const NAME: &str = concat!(`.
+///
+/// The `concat!` is load-bearing rather than incidental syntax. Both prompts
+/// are compile-time concatenations precisely so the cached prefix stays
+/// byte-stable (invariant 7 / L-E8); a prompt rewritten as a runtime `format!`
+/// stops matching here, and the registry cross-check turns that into a named
+/// failure rather than a prompt this scan quietly stops covering.
+fn static_prompt_name(line: &str) -> Option<&str> {
+    let declaration = line
+        .strip_prefix("pub(crate) const ")
+        .or_else(|| line.strip_prefix("pub const "))
+        .or_else(|| line.strip_prefix("const "))?;
+    let (name, rest) = declaration.split_once(':')?;
+    let name = name.trim();
+    (is_ident(name) && rest.trim() == "&str = concat!(").then_some(name)
+}
+
+/// Whether `name` is a plain Rust identifier — the shape both a macro name and
+/// a constant name take here.
+fn is_ident(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// The scan of `prompt.rs` itself, or a panic naming what stopped it.
+fn source_scan() -> Scan<'static> {
+    scan(PROMPT_SOURCE).unwrap_or_else(|error| {
+        panic!(
+            "the shared-contract scan could not read crates/stella-cli/src/agent/prompt.rs \
+             ({error:?}). It examines nothing in this state, which reads as a passing gate — \
+             correct the parser in agent/prompt/parity.rs rather than leaving it silent (#2231)"
+        )
+    })
+}
+
+/// Guard the guard: everything below iterates a set this scan produced, so an
+/// empty or misdirected scan would pass every one of them vacuously.
+///
+/// #2182 was exactly a parity check that could not run where it mattered, so
+/// these assertions come before the ones that matter.
+#[test]
+fn the_scan_reads_its_subject() {
+    assert!(
+        PROMPT_SOURCE.contains(SOURCE_ANCHOR),
+        "the text this module scans is not agent/prompt.rs — it does not open with \
+         {SOURCE_ANCHOR:?}. Correct the `include_str!` in agent/prompt/parity.rs"
+    );
+    let scan = source_scan();
+    assert!(
+        !scan.contracts.is_empty(),
+        "no `macro_rules!` contract was found in prompt.rs: either the shared-literal \
+         pattern was abandoned (#450) or `contract_name` no longer matches how they are \
+         declared"
+    );
+    assert!(
+        scan.prompts.len() >= 2,
+        "prompt.rs declares fewer than two static `concat!` prompts ({:?}) — the whole \
+         subject of this check is that a contract reaches BOTH, so a scan finding one \
+         has stopped being able to see the defect",
+        scan.prompts
+            .iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The two runtime registries are the only hardcoded lists in this module, and
+/// this is what stops them being hardcoded in the way that matters: the source
+/// is the authority and a registry that falls behind it fails by name.
+///
+/// Checked in both directions. A missing row is the #2231 hole itself — a new
+/// contract joining the set without joining the list. A stale row is the
+/// mirror: a list that claims to cover something the source no longer has.
+#[test]
+fn the_registries_match_the_source() {
+    let scan = source_scan();
+    assert_registry(
+        "contract",
+        &scan.contracts,
+        SHARED_CONTRACTS,
+        "prompt/parity.rs SHARED_CONTRACTS",
+    );
+    let prompts: Vec<&str> = scan.prompts.iter().map(|(name, _)| *name).collect();
+    assert_registry(
+        "static prompt",
+        &prompts,
+        STATIC_PROMPTS,
+        "prompt/parity.rs STATIC_PROMPTS",
+    );
+}
+
+/// Both halves of one registry check, so the two calls above read the same.
+fn assert_registry(subject: &str, declared: &[&str], registry: &[(&str, &str)], home: &str) {
+    let registered: Vec<&str> = registry.iter().map(|(name, _)| *name).collect();
+    for name in declared {
+        assert!(
+            registered.contains(name),
+            "prompt.rs declares the {subject} `{name}`, which {home} does not list. \
+             Add its row — the list is what lets the check compare bytes, and a {subject} \
+             missing from it is checked by nothing (#2231)"
+        );
+    }
+    for name in &registered {
+        assert!(
+            declared.contains(name),
+            "{home} lists the {subject} `{name}`, which prompt.rs no longer declares. \
+             Drop the stale row so the registry cannot claim coverage it does not have"
+        );
+    }
+}
+
+/// The coupling itself, at the source level: every shared contract is invoked
+/// by every static prompt's `concat!`.
+///
+/// This is the assertion the four hand-written `both_prompts_*` tests each made
+/// for one contract. Read off the source, it holds for the fifth contract too,
+/// which is the whole point (#2231).
+#[test]
+fn every_shared_contract_is_invoked_by_every_static_prompt() {
+    let scan = source_scan();
+    let missing = unembedded(&scan);
+    assert!(
+        missing.is_empty(),
+        "a shared prompt contract is embedded by only some of the static prompts, so the \
+         two prompts have already diverged (#450, #2231). Missing: {}",
+        missing
+            .iter()
+            .map(|(contract, prompt)| format!("`{contract}!()` is not in {prompt}"))
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
+}
+
+/// The coupling at the byte level: the contract's expanded text is in the
+/// assembled prompt, not merely its invocation in the source.
+///
+/// Source and bytes are genuinely different questions. A contract could be
+/// invoked inside a comment, or the macro could expand to something other than
+/// the literal it appears to hold; only the assembled `&'static str` settles
+/// what the model is actually sent.
+#[test]
+fn every_shared_contract_reaches_every_static_prompt_verbatim() {
+    for (contract, text) in SHARED_CONTRACTS {
+        assert!(
+            text.chars().count() >= MIN_CONTRACT_CHARS,
+            "the `{contract}` literal is {} characters — too short for `contains` to prove \
+             anything, so the assertions below would pass against a hollowed-out contract",
+            text.chars().count()
+        );
+        for (label, prompt) in STATIC_PROMPTS {
+            assert!(
+                prompt.contains(text),
+                "{label} does not embed the shared `{contract}` block verbatim"
+            );
+        }
+    }
+}
+
+/// Every way this check could come up empty, driven on hand-built sources.
+///
+/// The tests above all iterate sets the scan produced; if the scan silently
+/// returned nothing they would pass while examining nothing, which is the
+/// failure mode the whole module is aimed at. These pin that each of those
+/// ways is an error with a name instead.
+#[test]
+fn the_scan_fails_loudly_rather_than_finding_nothing() {
+    assert_eq!(
+        scan("").unwrap_err(),
+        ScanError::NoContractsDeclared,
+        "an empty source must be an error, never an empty set of contracts to check"
+    );
+    assert_eq!(
+        scan("// nothing here declares a contract\nfn main() {}\n").unwrap_err(),
+        ScanError::NoContractsDeclared,
+        "a source with no `macro_rules!` must be an error"
+    );
+    assert_eq!(
+        scan("macro_rules! only_contract {\n    () => { \"x\" };\n}\n").unwrap_err(),
+        ScanError::NoStaticPromptsParsed,
+        "contracts with nowhere to be embedded must be an error"
+    );
+    // The byte-stability half: a prompt rewritten as a runtime composition
+    // stops being a static prompt, and that is loud rather than invisible.
+    assert_eq!(
+        scan(concat!(
+            "macro_rules! only_contract {\n    () => { \"x\" };\n}\n",
+            "pub(crate) fn system_prompt() -> String {\n    format!(\"{}\", only_contract!())\n}\n"
+        ))
+        .unwrap_err(),
+        ScanError::NoStaticPromptsParsed,
+        "a prompt assembled at runtime must not silently drop out of the scan (invariant 7)"
+    );
+}
+
+/// The catch, demonstrated on a source built to hold the defect.
+///
+/// The witness the artisanal way — stripping a real embedding from `prompt.rs`
+/// and watching the test above fail — proves it once, in a checkout nobody else
+/// sees. This proves the same thing every time the suite runs, and pins the
+/// half that matters: the omission is reported *naming which contract and which
+/// prompt*, because "something is wrong in prompt.rs" is not a handoff.
+#[test]
+fn an_omission_from_one_prompt_only_is_caught_and_named() {
+    let source = concat!(
+        "macro_rules! shared_everywhere {\n    () => { \"a\" };\n}\n",
+        "macro_rules! shared_by_convention {\n    () => { \"b\" };\n}\n",
+        "pub(crate) const SYSTEM_PROMPT: &str = concat!(\n",
+        "    shared_everywhere!(),\n",
+        "    shared_by_convention!(),\n",
+        ");\n",
+        "pub(crate) const PIPELINE_SYSTEM_PROMPT: &str = concat!(\n",
+        "    shared_everywhere!(),\n",
+        ");\n",
+    );
+    let scan = scan(source).expect("the fixture declares contracts and static prompts");
+    assert_eq!(
+        scan.contracts,
+        ["shared_everywhere", "shared_by_convention"]
+    );
+    assert_eq!(
+        scan.prompts
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>(),
+        ["SYSTEM_PROMPT", "PIPELINE_SYSTEM_PROMPT"]
+    );
+    assert_eq!(
+        unembedded(&scan),
+        vec![("shared_by_convention", "PIPELINE_SYSTEM_PROMPT")],
+        "the exact #2231 shape — a contract in one prompt only — must be reported, and \
+         reported with both names"
+    );
+}

--- a/crates/stella-cli/src/agent/prompt/parity.rs
+++ b/crates/stella-cli/src/agent/prompt/parity.rs
@@ -41,6 +41,16 @@
 //! rewritten as a runtime `format!` stops parsing as a static prompt and the
 //! registry cross-check fails naming it.
 //!
+//! # What deliberately stayed
+//!
+//! The per-contract `both_prompts_*` tests in `prompt.rs` are not deleted here.
+//! Their embedding assertion is now redundant with this module, but each one's
+//! doc comment is the provenance record for its contract and their *claim*
+//! assertions guard the literal's content rather than its presence — a
+//! different property. Consolidating them is #2237, deliberately sequenced
+//! after #2232 lands rather than merged into a `mod tests` block another PR is
+//! adding a test to.
+//!
 //! # Anti-vacuity
 //!
 //! A check that silently examines nothing reads as a passing gate, which is


### PR DESCRIPTION
## What

A check that derives the set of shared prompt contracts from `crates/stella-cli/src/agent/prompt.rs`'s own source and asserts each one is embedded in **both** static prompts — so the coupling is enforced rather than remembered.

New file: `crates/stella-cli/src/agent/prompt/parity.rs` (444 lines, `#[cfg(test)]`). `prompt.rs` grows by 14 lines net (+20/-6): the `mod parity;` declaration, an ADDING A CONTRACT note in the paragraph that already explains the shared-literal pattern, and `mod tests` now reading its `PROMPTS` list out of `parity::STATIC_PROMPTS` instead of keeping a second copy.

Closes #2231

## The gap, confirmed on main first

`prompt.rs` declares its cross-cutting contracts as `macro_rules!` literals so both prompts embed the same bytes, and each was pinned by its own hand-written test. That covers the contracts that exist and says nothing about the next one. Measured before writing anything, on `origin/main` at 6b9c135a — a fifth contract embedded in `SYSTEM_PROMPT` only, no test written for it:

```
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 1433 filtered out
```

Nothing fails. `PIPELINE_SYSTEM_PROMPT` is the half that goes missing quietly: it is what `stella run` sends and what the bench harness exercises, so a contract landing in `SYSTEM_PROMPT` alone is invisible to every measurement the project makes decisions from.

## How the set is derived, and why that is the point

The issue offered two shapes and preferred a `SHARED_CONTRACTS` slice; this ships the slice **and** the structural guard it called option 2, because a hardcoded roster reproduces the defect one level up — the fifth contract joins the set without joining the list, which is exactly how per-seam pinning failed in #2182/#2203.

`scan()` reads `prompt.rs`'s text (`include_str!`, compile-time) for two things:

- **contracts** — every top-level `macro_rules!` declaration.
- **static prompts** — every top-level `const NAME: &str = concat!(` declaration, and the body of that `concat!`.

Neither list is written down anywhere. The two runtime registries (`SHARED_CONTRACTS`, `STATIC_PROMPTS`) exist only because a macro cannot be invoked by a name computed at runtime, and `the_registries_match_the_source` fails **in both directions** when either falls behind the scan. Proof that they are not hardcoded in the way that matters: adding a `throwaway_contract!` macro to `prompt.rs` and nothing else fails immediately with

```
prompt.rs declares the contract `throwaway_contract`, which prompt/parity.rs
SHARED_CONTRACTS does not list — add its row. The list is what lets the check
compare bytes, and a contract missing from it is checked by nothing (#2231)
```

Six tests: the guard-the-guard scan check, the registry cross-check, the source-level coupling (`name!()` in every `concat!` body), the byte-level coupling (the expanded literal in the assembled `&'static str`), the anti-vacuity detectors, and a synthetic fixture holding the defect. **Three contracts** are validated today against **two prompts** — six pairs. #2232's `verification_proportionality!` is picked up automatically as a *failure* until its row is added; see "Merge interaction" below.

Exemplar: `bench/harbor_adapter/tests/test_manifest_parity.py` (#2202/#2228), which retired this failure class for bench adapter callers. This closes the prompt half — the fifth instance of "two sides of a boundary that nothing checks", after #2134, #2171, #2182, #2196.

## Witness

Three flips, all run the artisanal way against a committed tree.

**1. A real omission from one prompt only** — `measurement_discipline!()` stripped from `PIPELINE_SYSTEM_PROMPT`, left in `SYSTEM_PROMPT`:

```
test agent::prompt::parity::every_shared_contract_is_invoked_by_every_static_prompt ... FAILED
  a shared prompt contract is embedded by only some of the static prompts, so the two
  prompts have already diverged (#450, #2231).
  Missing: `measurement_discipline!()` is not in PIPELINE_SYSTEM_PROMPT

test agent::prompt::parity::every_shared_contract_reaches_every_static_prompt_verbatim ... FAILED
  PIPELINE_SYSTEM_PROMPT does not embed the shared `measurement_discipline` block verbatim

test result: FAILED. 4 passed; 2 failed
```

Both the contract and the prompt are named, at both the source and the byte level.

**2. The exact #2231 shape** — a *new* contract embedded in `SYSTEM_PROMPT` only, with no hand-written test of its own. This is the state that was green on main:

```
test agent::prompt::parity::the_registries_match_the_source ... FAILED
  prompt.rs declares the contract `throwaway_contract`, which prompt/parity.rs
  SHARED_CONTRACTS does not list ...
test agent::prompt::parity::every_shared_contract_is_invoked_by_every_static_prompt ... FAILED
  Missing: `throwaway_contract!()` is not in PIPELINE_SYSTEM_PROMPT

test result: FAILED. 49 passed; 2 failed
```

The decisive detail: **every pre-existing test passed**, including all three `both_prompts_*` tests, the #639 catalogue guard, and `both_static_prompts_carry_a_read_symbol_steering_line`. Only the two derived checks fire. That is the hole, closed.

**3. Anti-vacuity** — the parser deliberately made stale (`strip_prefix("macro_rules!")` changed to `"macro_rules !"`), simulating a scan that has stopped matching how contracts are declared:

```
test result: FAILED. 1 passed; 5 failed

the shared-contract scan could not read crates/stella-cli/src/agent/prompt.rs
(NoContractsDeclared). It examines nothing in this state, which reads as a passing
gate — correct the parser in agent/prompt/parity.rs rather than leaving it silent (#2231)
```

A scan that finds nothing is an error with a name, never an empty set quietly iterated. `the_scan_fails_loudly_rather_than_finding_nothing` drives each way in as well — empty source, no `macro_rules!`, no static prompt, and a prompt rewritten as a runtime `format!` — on hand-built sources, so the detectors are witnessed on every run rather than assumed. Note the one test that stayed green in flip 3 (`...reaches_every_static_prompt_verbatim`): it reads the runtime registry, not the scan, so the byte-level assertion is independent of the parser by construction.

Restored and green after each flip: `cargo test -p stella-cli --bin stella prompt` gives **51 passed, 0 failed** (45 before + 6 new).

## Byte stability is unaffected — invariant 7 / L-E8

No prompt literal becomes runtime-computed. The contracts stay `macro_rules!` returning string literals, both prompts stay `concat!` compositions, every value in this module is a `&'static str` fixed at compile time, and the module only *reads* them — `git diff` touches no byte inside any prompt constant. The prompt-cache prefix is exactly what it was.

The check in fact **enforces** one half of that invariant: a prompt is recognised only by `const NAME: &str = concat!(`, so rewriting one as a runtime composition stops it parsing as a static prompt, and the registry cross-check turns that into a named failure rather than a prompt the scan quietly stops covering. Pinned by `the_scan_fails_loudly_rather_than_finding_nothing`'s fourth case.

## Merge interaction with #2232 — please read before merging either

#2232 adds a fourth contract (`verification_proportionality!`) to `prompt.rs`. These two branches merge textually clean and produce a **red** `main`: the new contract has no `SHARED_CONTRACTS` row, so `the_registries_match_the_source` fails. Whichever lands second needs one line:

```rust
("verification_proportionality", verification_proportionality!()),
```

The failure message names the file and the list, so it is a one-line fix with a handoff attached rather than a puzzle. This is why the ADDING A CONTRACT note went into `prompt.rs` beside the macros — the next author works there, not in the check. Flagged on #2232 as well.

## God files

None touched. `prompt.rs` is 712 lines (was 698, ceiling 1500, not grandfathered); `prompt/parity.rs` is 444. `agent/tests.rs` is untouched. `scripts/check-file-size.sh` reports "none grew". No baseline entry added, no ceiling raised.

## Checks

`cargo test -p stella-cli --bin stella prompt` gives 51 passed. `cargo clippy -p stella-cli --all-targets -- -D warnings` clean. `cargo fmt --check -p stella-cli` clean. `check-file-size`, `check-left-behind`, `check-brand-case`, `check-god-files`, `check-module-reachability` all pass. Not run locally: `--workspace` tests and the rest of `make gate` — CI is the gate, and the diff reaches one crate.

## Tests deleted

**None.** Issue #2231's definition of done asked for the per-contract `both_prompts_*` tests to be consolidated; that is deliberately deferred, and the reasoning is recorded in `parity.rs`'s module doc rather than left in a session:

1. #2232 is open against the same `mod tests` block. Deleting three tests from a file another PR is adding a test to is the same-seam shape that produced #1976 and #1860 — both branches green, the merge clean, one side simply not containing the other's lines.
2. The structural guard (the issue's option 2) closes the hole *entirely*, which makes consolidation an orthogonal cleanup rather than the mechanism. Each test's doc comment is the provenance record for its contract, and its claim assertions guard the literal's **content** — a different property, which the issue explicitly said to keep.

Filed as #2237 so it is tracked, not dropped.

## Nothing left behind

- **#2237** — consolidate the per-contract embedding assertions once #2232 lands; also gives `scope_discipline!` and `tool_steering!` the content guard they lack (a trim that hollows out `scope_discipline!` while leaving it embedded passes everything in the tree today).
- **#2239** — `agent/tests.rs` keeps a third hardcoded copy of the static-prompt pair, outside the derived registry. Fixing it removes lines from a god file, so it is safe, but it is a separate seam.

No TODOs added. Related: #2228 (the class-level sweep this mirrors), #2227, #2203, #450, #639, #1955, #1957, #1958.
