### PR TITLE
fix(bench): the task deadline was built, wired and shipped — nothing ever gave it a value

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -444,7 +444,7 @@ than clearing it — 16384 → 32000 changed which trials truncated, and 64000
 |---|---|---|---|
 | `params.max_tokens` | 32,000 | **64,000** (the model's ceiling) | this posture |
 | `EngineConfig::model_timeout` | 600s | **816s** | 60s above the longest rewarded Arm B step (756s) |
-| `--turn-budget` | unwired; 840s by hand on the box | **per-trial, from Harbor's own agent timeout −60s** | the adapter, which previously had no way to learn the deadline |
+| `--turn-budget` | unwired; 840s by hand on the box | **per-trial, from Harbor's own agent timeout −60s** | the adapter, which now discovers that timeout from the trial itself (#2135) |
 
 The rule setting all three is the same, and it is the only one that makes a
 head-to-head mean anything: **never be the side that stops first.** A ceiling

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -174,6 +174,8 @@ _DEFAULT_BUDGET = "5.0"
 # recorded one" the same way. Deliberately not numeric: nothing downstream
 # should be able to read it as a ceiling that was in force.
 _NO_BUDGET_CAP = "unbounded"
+# The same discipline on the wall-clock axis (#2135; `turn_budget` says why).
+_NO_TASK_DEADLINE = "unarmed"
 _DEFAULT_DISABLE_REFLECTION = "1"
 _DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _ADAPTER_VERSION = "0.6.0"
@@ -817,6 +819,7 @@ class StellaAgent(BaseInstalledAgent):
     # `None` is "no per-trial cap", which is a real posture and not a missing
     # value — see `_configured_budget`.
     _budget_usd: str | None
+    _turn_budget_sec: str | None
     _credential_handoff_mode: str
     _host_credential_source: str
     _host_credential_name: str | None
@@ -1026,6 +1029,7 @@ class StellaAgent(BaseInstalledAgent):
         env = self._forwarded_env()
         self._disable_reflection = env["STELLA_DISABLE_REFLECTION"]
         self._budget_usd = self._configured_budget()
+        self._turn_budget_sec = self._configured_turn_budget()
         verifier = self._verifier_model()
         (
             self._engine_posture,
@@ -1405,18 +1409,13 @@ class StellaAgent(BaseInstalledAgent):
     def _configured_turn_budget(self) -> str | None:
         """Resolve the turn deadline in seconds, or ``None`` for no deadline.
 
-        Policy and parsing live in :mod:`stella_harbor.turn_budget`; this
-        supplies the two inputs and nothing else.
-
-        ``getattr`` rather than attribute access: Harbor constructs this class,
-        but the suite builds instances without running ``__init__`` — the same
-        reason ``_configured_value`` reaches for ``_resolved_env_vars`` this
-        way — and an adapter that only works when fully constructed is an
-        adapter whose deadline handling is untested.
+        Policy, parsing, precedence and the reason ``logs_dir`` is an input at
+        all (#2135) live in :mod:`stella_harbor.turn_budget`.
         """
         return _resolve_turn_budget(
             getattr(self, "_agent_timeout_sec", None),
             self._configured_value(_TURN_BUDGET_ENV),
+            getattr(self, "logs_dir", None),
         )
 
     def _forwarded_env(self) -> dict[str, str]:
@@ -1557,6 +1556,8 @@ class StellaAgent(BaseInstalledAgent):
             budget_usd = self._configured_budget()
         if budget_usd is None:
             budget_usd = _NO_BUDGET_CAP
+        turn_budget_sec = getattr(self, "_turn_budget_sec", None)
+        turn_budget_sec = turn_budget_sec or self._configured_turn_budget()
         credential_handoff_mode = getattr(
             self, "_credential_handoff_mode", _HANDOFF_MODE
         )
@@ -1641,6 +1642,8 @@ class StellaAgent(BaseInstalledAgent):
             "stella_base_url": base_url,
             "stella_provider_route_policy": provider_route_policy,
             "stella_budget_usd": budget_usd,
+            # The wall-clock half of the same disclosure (#2135).
+            "stella_turn_budget_sec": turn_budget_sec or _NO_TASK_DEADLINE,
             "stella_output_format": "stream-json",
             "stella_disable_reflection": reflection,
             "stella_reflection_policy": (

--- a/bench/harbor_adapter/stella_harbor/turn_budget.py
+++ b/bench/harbor_adapter/stella_harbor/turn_budget.py
@@ -33,11 +33,48 @@ deadline has to come from the trial.
 comparator whose winning `regex-chess` run took 2,746s of wall clock on this
 same dataset. Stella was declining continuations roughly 3x too early, which
 turns a policy meant to save turns into one that ends them.
+
+## Why the agent kwarg alone was not enough (#2135)
+
+The two inputs above are both things a *caller* has to remember to supply, and
+in match `cc00894779ff` neither was: every trial's `config.json` records
+`agent.kwargs: {}`, and ArenaBench's `harbor run` command line
+(`arenabench/arenabench/runner.py`) passes no `--agent-kwarg` at all. So
+`resolve_turn_budget(None, None)` returned `None`, `--turn-budget` was omitted
+from argv, `Config::turn_budget` stayed `None`, and
+`stella_cli::runtime::one_shot_budget_guard` never called
+`BudgetGuard::set_task_deadline`. The whole #1481/#1503/#1507 mechanism was
+built, wired and armed-capable, and simply never armed — every timeout in that
+match was Harbor's own `AgentTimeoutError` SIGKILL at 900.0s.
+
+A supplied kwarg is therefore treated as the operator's explicit statement, not
+as the only channel. Harbor already writes the resolved trial configuration to
+`config.json` at the trial root — one level above the agent's `logs_dir`, as
+the first statement of `Trial.run()`, before the agent is started — and that
+document plus the task's own `task.toml` carry every input Harbor's own
+deadline arithmetic uses. [`discover_trial_deadline`] recomputes it from those
+two files, so the deadline is per-trial (the shape requirement above) and no
+runner has to remember anything.
+
+That recomputation mirrors `harbor/trial/trial.py` and is therefore coupled to
+a version of Harbor. It **fails open**, always: any missing, unreadable, or
+mis-shaped input reads as "no deadline known" and leaves the flag off, which is
+exactly the behaviour that shipped before this module existed. Guessing a
+deadline is the one outcome that is worse than not having one.
 """
 
 from __future__ import annotations
 
+import json
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
+
+# Harbor's own filenames. `config.json` is the resolved trial configuration
+# (`TrialPaths.config_path`); `task.toml` is the task definition it points at.
+TRIAL_CONFIG_FILENAME = "config.json"
+TASK_CONFIG_FILENAME = "task.toml"
 
 # Host-side name for the deadline, forwarded to the CLI as `--turn-budget`.
 # Registered host-only in the adapter: it is read on the host and expressed as
@@ -85,16 +122,134 @@ def coerce_timeout_seconds(raw: Any) -> float | None:
     return seconds
 
 
+def coerce_timeout_multiplier(raw: Any) -> float | None:
+    """Parse a stated timeout multiplier, or ``None`` when none is stated.
+
+    Deliberately not [`coerce_timeout_seconds`]: Harbor selects a multiplier
+    with ``is not None``, so a stated ``0`` genuinely means "no time at all",
+    while a deadline of ``0`` means "no deadline known". Collapsing the two
+    would arm a full-length deadline against a trial Harbor kills on the
+    instant. Non-finite and unparseable still read as unstated — there is no
+    sane deadline to derive from a NaN.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if value != value or value in (float("inf"), float("-inf")):
+        return None
+    return value
+
+
+def trial_agent_deadline(
+    trial_config: Mapping[str, Any],
+    task_agent_timeout_sec: Any,
+) -> float | None:
+    """Recompute the wall clock Harbor will kill this trial's agent at. Pure.
+
+    A transcription of `harbor/trial/trial.py`'s own arithmetic::
+
+        base       = agent.override_timeout_sec or task.agent.timeout_sec
+        cap        = agent.max_timeout_sec or inf
+        multiplier = agent_timeout_multiplier ?? timeout_multiplier
+        deadline   = min(base, cap) * multiplier
+
+    Stated as one pure function over two already-loaded documents so the
+    arithmetic is testable without a trial directory, a task on disk, or
+    Harbor installed at all — and so the I/O half ([`discover_trial_deadline`])
+    holds nothing but reading and fail-open.
+
+    ``None`` whenever no base timeout is stated. An absent multiplier is
+    ``1.0`` because that is Harbor's own default for both fields; an absent
+    *deadline* is never defaulted.
+    """
+    agent = trial_config.get("agent")
+    agent = agent if isinstance(agent, Mapping) else {}
+    base = coerce_timeout_seconds(agent.get("override_timeout_sec"))
+    if base is None:
+        base = coerce_timeout_seconds(task_agent_timeout_sec)
+    if base is None:
+        return None
+    cap = coerce_timeout_seconds(agent.get("max_timeout_sec"))
+    if cap is not None:
+        base = min(base, cap)
+    multiplier = coerce_timeout_multiplier(trial_config.get("agent_timeout_multiplier"))
+    if multiplier is None:
+        multiplier = coerce_timeout_multiplier(trial_config.get("timeout_multiplier"))
+    if multiplier is None:
+        multiplier = 1.0
+    return base * multiplier
+
+
+def discover_trial_deadline(logs_dir: Any) -> float | None:
+    """Read the deadline Harbor resolved for THIS trial off the trial tree.
+
+    ``logs_dir`` is what Harbor hands the agent — ``TrialPaths.agent_dir`` —
+    and the trial's ``config.json`` is its immediate parent. Only that one
+    location is consulted: walking further up would eventually find *some*
+    other trial's or job's configuration and silently arm a deadline belonging
+    to a different run. A multi-step trial relocates the agent directory
+    afterwards, so its later layout is simply not discoverable here, and reads
+    as no deadline rather than as a wrong one.
+
+    Fail-open by construction. Every failure mode — no ``logs_dir``, no
+    ``config.json``, malformed JSON or TOML, a task path that no longer exists,
+    a Harbor whose schema has moved — returns ``None``, which omits the flag
+    and restores exactly the pre-#1161 behaviour.
+    """
+    if not logs_dir:
+        return None
+    try:
+        raw = (Path(logs_dir).parent / TRIAL_CONFIG_FILENAME).read_text(
+            encoding="utf-8"
+        )
+        trial_config = json.loads(raw)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(trial_config, Mapping):
+        return None
+    return trial_agent_deadline(trial_config, _task_agent_timeout(trial_config))
+
+
+def _task_agent_timeout(trial_config: Mapping[str, Any]) -> Any:
+    """The per-task ``[agent] timeout_sec`` the trial config points at.
+
+    ``None`` when the trial names no local task path — a dataset resolved from
+    a registry ref rather than an offline export has ``task.path: null``, and
+    the task definition is then not on this host at all.
+    """
+    task = trial_config.get("task")
+    path = task.get("path") if isinstance(task, Mapping) else None
+    if not path:
+        return None
+    try:
+        with open(Path(path) / TASK_CONFIG_FILENAME, "rb") as handle:
+            task_config = tomllib.load(handle)
+    except (OSError, ValueError):
+        return None
+    agent = task_config.get("agent")
+    return agent.get("timeout_sec") if isinstance(agent, Mapping) else None
+
+
 def resolve_turn_budget(
     agent_timeout_sec: Any = None,
     env_value: Any = None,
+    trial_logs_dir: Any = None,
 ) -> str | None:
     """Return the ``--turn-budget`` argv value, or ``None`` to omit the flag.
 
-    Precedence is deadline-first: Harbor's own per-trial ``agent_timeout_sec``
-    wins because it *is* the constraint being modelled, and an operator-set
-    ``STELLA_TURN_BUDGET`` is the fallback for a runner that cannot pass an
-    agent kwarg.
+    Precedence is deadline-first, most-specific-source-first:
+
+    1. ``agent_timeout_sec`` — the operator said it outright, via
+       ``--agent-kwarg agent_timeout_sec=<seconds>``.
+    2. The deadline discovered from this trial's own Harbor configuration
+       (``trial_logs_dir``). Same authority as (1) — it *is* Harbor's number —
+       but derived rather than stated, so an explicit kwarg still wins.
+    3. ``STELLA_TURN_BUDGET`` — a static operator fallback, last because one
+       value cannot be right for a dataset whose tasks carry different
+       timeouts.
 
     ``None`` leaves the continuation allowance a pure count — exactly the
     behaviour before #1161 — so a caller with no deadline is unaffected.
@@ -105,6 +260,8 @@ def resolve_turn_budget(
     than the misconfiguration it is.
     """
     deadline = coerce_timeout_seconds(agent_timeout_sec)
+    if deadline is None:
+        deadline = discover_trial_deadline(trial_logs_dir)
     if deadline is None:
         deadline = coerce_timeout_seconds(env_value)
     if deadline is None:

--- a/bench/harbor_adapter/tests/test_turn_budget.py
+++ b/bench/harbor_adapter/tests/test_turn_budget.py
@@ -15,13 +15,17 @@ import pytest
 
 pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
 
+# The #2135 helpers are reached as `turn_budget.<name>` at each call site
+# rather than imported by name, deliberately: a `from … import` of a symbol a
+# tree does not have is a COLLECTION error, which fails the whole file at once
+# and proves only that a name is missing. Reached this way, each test fails on
+# its own — the behavioural witness on its assertion about the argv the adapter
+# builds, which is the fact #2135 is about.
+from stella_harbor import turn_budget  # noqa: E402 - after importorskip by design
 from stella_harbor.turn_budget import (  # noqa: E402 - after importorskip by design
     TEARDOWN_SEC,
-    coerce_timeout_multiplier,
     coerce_timeout_seconds,
-    discover_trial_deadline,
     resolve_turn_budget,
-    trial_agent_deadline,
 )
 
 from .test_adapter import _bare_agent  # noqa: E402 - after importorskip by design
@@ -327,33 +331,33 @@ class TestDiscoveryFailsOpenNeverGuesses:
     """
 
     def test_no_logs_dir_at_all(self) -> None:
-        assert discover_trial_deadline(None) is None
-        assert discover_trial_deadline("") is None
+        assert turn_budget.discover_trial_deadline(None) is None
+        assert turn_budget.discover_trial_deadline("") is None
 
     def test_a_trial_directory_with_no_config(self, tmp_path: Path) -> None:
         logs_dir = tmp_path / "trial" / "agent"
         logs_dir.mkdir(parents=True)
-        assert discover_trial_deadline(logs_dir) is None
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_config_that_is_not_json(self, tmp_path: Path) -> None:
         logs_dir = _trial_tree(tmp_path)
         (logs_dir.parent / "config.json").write_text("{not json", encoding="utf-8")
-        assert discover_trial_deadline(logs_dir) is None
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_task_that_is_not_on_this_host(self, tmp_path: Path) -> None:
         """A registry-resolved dataset records ``task.path: null``."""
         logs_dir = _trial_tree(
             tmp_path, trial_config={"task": {"path": None, "source": "registry"}}
         )
-        assert discover_trial_deadline(logs_dir) is None
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_task_directory_with_no_task_toml(self, tmp_path: Path) -> None:
-        assert discover_trial_deadline(_trial_tree(tmp_path, task_timeout_sec=None)) is None
+        assert turn_budget.discover_trial_deadline(_trial_tree(tmp_path, task_timeout_sec=None)) is None
 
     def test_a_task_toml_that_is_not_toml(self, tmp_path: Path) -> None:
         logs_dir = _trial_tree(tmp_path)
         (tmp_path / "task" / "task.toml").write_text("[[[", encoding="utf-8")
-        assert discover_trial_deadline(logs_dir) is None
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_multi_step_layout_reads_as_unknown_not_as_a_sibling_trial(
         self, tmp_path: Path
@@ -366,30 +370,30 @@ class TestDiscoveryFailsOpenNeverGuesses:
         logs_dir = _trial_tree(tmp_path)
         deeper = logs_dir.parent / "steps" / "step-1" / "agent"
         deeper.mkdir(parents=True)
-        assert discover_trial_deadline(deeper) is None
+        assert turn_budget.discover_trial_deadline(deeper) is None
 
 
 class TestTrialDeadlineArithmeticMirrorsHarbor:
     """`harbor/trial/trial.py`'s own formula, pure and without a trial tree."""
 
     def test_the_task_timeout_is_the_base(self) -> None:
-        assert trial_agent_deadline({}, 900.0) == 900.0
+        assert turn_budget.trial_agent_deadline({}, 900.0) == 900.0
 
     def test_an_override_replaces_the_task_timeout(self) -> None:
         config = {"agent": {"override_timeout_sec": 1200.0}}
-        assert trial_agent_deadline(config, 900.0) == 1200.0
+        assert turn_budget.trial_agent_deadline(config, 900.0) == 1200.0
 
     def test_a_cap_lowers_but_never_raises(self) -> None:
-        assert trial_agent_deadline({"agent": {"max_timeout_sec": 600.0}}, 900.0) == 600.0
-        assert trial_agent_deadline({"agent": {"max_timeout_sec": 3600.0}}, 900.0) == 900.0
+        assert turn_budget.trial_agent_deadline({"agent": {"max_timeout_sec": 600.0}}, 900.0) == 600.0
+        assert turn_budget.trial_agent_deadline({"agent": {"max_timeout_sec": 3600.0}}, 900.0) == 900.0
 
     def test_the_agent_multiplier_wins_over_the_global_one(self) -> None:
         config = {"timeout_multiplier": 3.0, "agent_timeout_multiplier": 2.0}
-        assert trial_agent_deadline(config, 900.0) == 1800.0
-        assert trial_agent_deadline({"timeout_multiplier": 3.0}, 900.0) == 2700.0
+        assert turn_budget.trial_agent_deadline(config, 900.0) == 1800.0
+        assert turn_budget.trial_agent_deadline({"timeout_multiplier": 3.0}, 900.0) == 2700.0
 
     def test_no_stated_base_is_no_deadline(self) -> None:
-        assert trial_agent_deadline({"timeout_multiplier": 2.0}, None) is None
+        assert turn_budget.trial_agent_deadline({"timeout_multiplier": 2.0}, None) is None
 
     def test_a_stated_zero_multiplier_is_no_time_not_a_missing_multiplier(
         self,
@@ -400,14 +404,14 @@ class TestTrialDeadlineArithmeticMirrorsHarbor:
         "unstated" would arm a full-length deadline against a run that has
         none, so the two parsers are deliberately different.
         """
-        assert trial_agent_deadline({"agent_timeout_multiplier": 0}, 900.0) == 0.0
+        assert turn_budget.trial_agent_deadline({"agent_timeout_multiplier": 0}, 900.0) == 0.0
         assert resolve_turn_budget(None, None, None) is None
-        assert coerce_timeout_multiplier(0) == 0.0
+        assert turn_budget.coerce_timeout_multiplier(0) == 0.0
         assert coerce_timeout_seconds(0) is None
 
     @pytest.mark.parametrize("raw", [None, True, False, "", "abc", "nan", "inf"])
     def test_a_multiplier_that_is_not_a_number_is_unstated(self, raw: object) -> None:
-        assert coerce_timeout_multiplier(raw) is None
+        assert turn_budget.coerce_timeout_multiplier(raw) is None
 
 
 class TestResolveTurnBudgetIsPure:

--- a/bench/harbor_adapter/tests/test_turn_budget.py
+++ b/bench/harbor_adapter/tests/test_turn_budget.py
@@ -8,17 +8,57 @@ code becomes its own module. The subject is one seam —
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
 
 from stella_harbor.turn_budget import (  # noqa: E402 - after importorskip by design
     TEARDOWN_SEC,
+    coerce_timeout_multiplier,
     coerce_timeout_seconds,
+    discover_trial_deadline,
     resolve_turn_budget,
+    trial_agent_deadline,
 )
 
 from .test_adapter import _bare_agent  # noqa: E402 - after importorskip by design
+
+
+def _trial_tree(
+    tmp_path: Path,
+    *,
+    task_timeout_sec: object = 900.0,
+    trial_config: dict[str, object] | None = None,
+) -> Path:
+    """Lay out a Harbor single-step trial and return its agent ``logs_dir``.
+
+    The shape Harbor itself writes (``harbor/models/trial/paths.py``): the
+    resolved ``config.json`` at the trial root, the agent's log directory
+    immediately beneath it, and the task definition wherever ``task.path``
+    says. Built on disk rather than mocked because the thing under test is a
+    file layout, and a mock of it would agree with whatever the code does.
+    """
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    if task_timeout_sec is not None:
+        (task_dir / "task.toml").write_text(
+            f'schema_version = "1.1"\n\n[agent]\ntimeout_sec = {task_timeout_sec}\n',
+            encoding="utf-8",
+        )
+    config: dict[str, object] = {
+        "task": {"path": str(task_dir)},
+        "timeout_multiplier": 1.0,
+        "agent": {"override_timeout_sec": None, "max_timeout_sec": None},
+    }
+    config.update(trial_config or {})
+    trial_dir = tmp_path / "trial"
+    logs_dir = trial_dir / "agent"
+    logs_dir.mkdir(parents=True)
+    (trial_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return logs_dir
 
 
 class TestTurnBudgetReachesTheEngine:
@@ -143,6 +183,231 @@ class TestTurnBudgetReachesTheEngine:
             cmd = agent._build_command("Fix the bug")
 
             assert "--turn-budget" not in cmd, junk
+
+
+class TestTheDeadlineArmsWithoutAnybodyPassingIt:
+    """#2135's witness: no runner ever passed the kwarg, so nothing armed.
+
+    ``BudgetGuard::set_task_deadline`` (#1481), its safe-boundary consumer in
+    ``stella-core::driver::settlement`` (#1503) and the CLI's
+    ``one_shot_budget_guard`` (#1507) were all built, wired and shipped. They
+    were also completely inert on the bench path, because arming them needs a
+    ``--turn-budget`` on argv, that flag needs a deadline, and the only two
+    channels for one were things a *caller* had to remember:
+
+    * ``--agent-kwarg agent_timeout_sec=…`` — every trial in match
+      ``cc00894779ff`` records ``agent.kwargs: {}``, and ArenaBench's
+      ``harbor run`` command line passes no ``--agent-kwarg`` at all.
+    * ``STELLA_TURN_BUDGET`` — a static value, and wrong by construction for a
+      dataset whose tasks carry 900s and 1800s deadlines.
+
+    So ``resolve_turn_budget(None, None)`` returned ``None``, the flag was
+    omitted, ``Config::turn_budget`` stayed ``None``, and every timeout in that
+    match was Harbor's own SIGKILL rather than an engine-side stop.
+
+    Harbor has always known the number, and writes it — with the inputs that
+    produce it — to ``config.json`` at the trial root before the agent starts.
+    These tests fail on a tree where the adapter does not read it.
+    """
+
+    def test_a_trial_arms_its_deadline_with_no_kwarg_and_no_variable(
+        self, tmp_path: Path
+    ) -> None:
+        """The witness. Exactly the inputs `cobol-modernization__kt3nQsB` had."""
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent.logs_dir = _trial_tree(tmp_path, task_timeout_sec=900.0)
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--turn-budget" in cmd
+        assert cmd[cmd.index("--turn-budget") + 1] == "840"
+
+    def test_the_deadline_stays_per_task_across_a_mixed_dataset(
+        self, tmp_path: Path
+    ) -> None:
+        """The reason a static variable could never be the answer.
+
+        Terminal-Bench 2.1 runs 900s and 1800s tasks in one job. Discovery is
+        per trial, so each gets its own deadline rather than the tightest one.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent.logs_dir = _trial_tree(tmp_path, task_timeout_sec=1800.0)
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "1740"
+
+    def test_an_explicit_kwarg_still_outranks_what_was_discovered(
+        self, tmp_path: Path
+    ) -> None:
+        """Stated beats derived: an operator who says it means it."""
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent.logs_dir = _trial_tree(tmp_path, task_timeout_sec=1800.0)
+        agent._agent_timeout_sec = 900.0
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "840"
+
+    def test_the_discovered_deadline_outranks_the_static_variable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The variable is the fallback for a host that has no trial to read."""
+        monkeypatch.setenv("STELLA_TURN_BUDGET", "900")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent.logs_dir = _trial_tree(tmp_path, task_timeout_sec=1800.0)
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--turn-budget") + 1] == "1740"
+
+    def test_the_armed_value_is_disclosed_in_the_trials_own_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        """A trace field, so triage never has to reconstruct argv again.
+
+        Reading a timed-out trial's artifacts could not distinguish "the
+        deadline was armed and the run blew through it" from "no deadline was
+        ever armed" — the exact ambiguity that made #2135 a forensics job.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent.logs_dir = _trial_tree(tmp_path, task_timeout_sec=900.0)
+        agent._metrics = {"status": "completed", "steps": 1}
+        agent._return_code = 0
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+
+        assert ctx.metadata["stella_turn_budget_sec"] == "840"
+
+    def test_an_unarmed_trial_says_so_rather_than_saying_nothing(self) -> None:
+        """A word, not an omission — the ``stella_budget_usd`` discipline.
+
+        Harbor's metadata dict drops ``None``, so an absent key would spell
+        "no deadline was armed" and "this adapter predates the field" the same
+        way, which is how the original question became unanswerable.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-sonnet-5"
+        agent._metrics = {"status": "completed", "steps": 1}
+        agent._return_code = 0
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+
+        assert ctx.metadata["stella_turn_budget_sec"] == "unarmed"
+
+
+class TestDiscoveryFailsOpenNeverGuesses:
+    """A recomputation coupled to Harbor's version must degrade, not invent.
+
+    Every one of these returns "no deadline known", which omits the flag and
+    restores the pre-#1161 behaviour exactly. The alternative — a fallback
+    constant — is the failure this module's header already names: a guessed
+    deadline makes the engine decline continuations it could afford.
+    """
+
+    def test_no_logs_dir_at_all(self) -> None:
+        assert discover_trial_deadline(None) is None
+        assert discover_trial_deadline("") is None
+
+    def test_a_trial_directory_with_no_config(self, tmp_path: Path) -> None:
+        logs_dir = tmp_path / "trial" / "agent"
+        logs_dir.mkdir(parents=True)
+        assert discover_trial_deadline(logs_dir) is None
+
+    def test_a_config_that_is_not_json(self, tmp_path: Path) -> None:
+        logs_dir = _trial_tree(tmp_path)
+        (logs_dir.parent / "config.json").write_text("{not json", encoding="utf-8")
+        assert discover_trial_deadline(logs_dir) is None
+
+    def test_a_task_that_is_not_on_this_host(self, tmp_path: Path) -> None:
+        """A registry-resolved dataset records ``task.path: null``."""
+        logs_dir = _trial_tree(
+            tmp_path, trial_config={"task": {"path": None, "source": "registry"}}
+        )
+        assert discover_trial_deadline(logs_dir) is None
+
+    def test_a_task_directory_with_no_task_toml(self, tmp_path: Path) -> None:
+        assert discover_trial_deadline(_trial_tree(tmp_path, task_timeout_sec=None)) is None
+
+    def test_a_task_toml_that_is_not_toml(self, tmp_path: Path) -> None:
+        logs_dir = _trial_tree(tmp_path)
+        (tmp_path / "task" / "task.toml").write_text("[[[", encoding="utf-8")
+        assert discover_trial_deadline(logs_dir) is None
+
+    def test_a_multi_step_layout_reads_as_unknown_not_as_a_sibling_trial(
+        self, tmp_path: Path
+    ) -> None:
+        """Only the immediate parent is consulted, on purpose.
+
+        Walking further up eventually finds *some* configuration, and arming a
+        deadline that belongs to a different run is worse than arming none.
+        """
+        logs_dir = _trial_tree(tmp_path)
+        deeper = logs_dir.parent / "steps" / "step-1" / "agent"
+        deeper.mkdir(parents=True)
+        assert discover_trial_deadline(deeper) is None
+
+
+class TestTrialDeadlineArithmeticMirrorsHarbor:
+    """`harbor/trial/trial.py`'s own formula, pure and without a trial tree."""
+
+    def test_the_task_timeout_is_the_base(self) -> None:
+        assert trial_agent_deadline({}, 900.0) == 900.0
+
+    def test_an_override_replaces_the_task_timeout(self) -> None:
+        config = {"agent": {"override_timeout_sec": 1200.0}}
+        assert trial_agent_deadline(config, 900.0) == 1200.0
+
+    def test_a_cap_lowers_but_never_raises(self) -> None:
+        assert trial_agent_deadline({"agent": {"max_timeout_sec": 600.0}}, 900.0) == 600.0
+        assert trial_agent_deadline({"agent": {"max_timeout_sec": 3600.0}}, 900.0) == 900.0
+
+    def test_the_agent_multiplier_wins_over_the_global_one(self) -> None:
+        config = {"timeout_multiplier": 3.0, "agent_timeout_multiplier": 2.0}
+        assert trial_agent_deadline(config, 900.0) == 1800.0
+        assert trial_agent_deadline({"timeout_multiplier": 3.0}, 900.0) == 2700.0
+
+    def test_no_stated_base_is_no_deadline(self) -> None:
+        assert trial_agent_deadline({"timeout_multiplier": 2.0}, None) is None
+
+    def test_a_stated_zero_multiplier_is_no_time_not_a_missing_multiplier(
+        self,
+    ) -> None:
+        """Harbor selects the multiplier with ``is not None``.
+
+        A stated ``0`` means the trial is killed on the instant. Reading it as
+        "unstated" would arm a full-length deadline against a run that has
+        none, so the two parsers are deliberately different.
+        """
+        assert trial_agent_deadline({"agent_timeout_multiplier": 0}, 900.0) == 0.0
+        assert resolve_turn_budget(None, None, None) is None
+        assert coerce_timeout_multiplier(0) == 0.0
+        assert coerce_timeout_seconds(0) is None
+
+    @pytest.mark.parametrize("raw", [None, True, False, "", "abc", "nan", "inf"])
+    def test_a_multiplier_that_is_not_a_number_is_unstated(self, raw: object) -> None:
+        assert coerce_timeout_multiplier(raw) is None
 
 
 class TestResolveTurnBudgetIsPure:

--- a/bench/harbor_adapter/tests/test_turn_budget.py
+++ b/bench/harbor_adapter/tests/test_turn_budget.py
@@ -352,7 +352,8 @@ class TestDiscoveryFailsOpenNeverGuesses:
         assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_task_directory_with_no_task_toml(self, tmp_path: Path) -> None:
-        assert turn_budget.discover_trial_deadline(_trial_tree(tmp_path, task_timeout_sec=None)) is None
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=None)
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_task_toml_that_is_not_toml(self, tmp_path: Path) -> None:
         logs_dir = _trial_tree(tmp_path)
@@ -384,16 +385,20 @@ class TestTrialDeadlineArithmeticMirrorsHarbor:
         assert turn_budget.trial_agent_deadline(config, 900.0) == 1200.0
 
     def test_a_cap_lowers_but_never_raises(self) -> None:
-        assert turn_budget.trial_agent_deadline({"agent": {"max_timeout_sec": 600.0}}, 900.0) == 600.0
-        assert turn_budget.trial_agent_deadline({"agent": {"max_timeout_sec": 3600.0}}, 900.0) == 900.0
+        lowered = {"agent": {"max_timeout_sec": 600.0}}
+        raised = {"agent": {"max_timeout_sec": 3600.0}}
+        assert turn_budget.trial_agent_deadline(lowered, 900.0) == 600.0
+        assert turn_budget.trial_agent_deadline(raised, 900.0) == 900.0
 
     def test_the_agent_multiplier_wins_over_the_global_one(self) -> None:
         config = {"timeout_multiplier": 3.0, "agent_timeout_multiplier": 2.0}
         assert turn_budget.trial_agent_deadline(config, 900.0) == 1800.0
-        assert turn_budget.trial_agent_deadline({"timeout_multiplier": 3.0}, 900.0) == 2700.0
+        global_only = {"timeout_multiplier": 3.0}
+        assert turn_budget.trial_agent_deadline(global_only, 900.0) == 2700.0
 
     def test_no_stated_base_is_no_deadline(self) -> None:
-        assert turn_budget.trial_agent_deadline({"timeout_multiplier": 2.0}, None) is None
+        stated = {"timeout_multiplier": 2.0}
+        assert turn_budget.trial_agent_deadline(stated, None) is None
 
     def test_a_stated_zero_multiplier_is_no_time_not_a_missing_multiplier(
         self,
@@ -404,7 +409,8 @@ class TestTrialDeadlineArithmeticMirrorsHarbor:
         "unstated" would arm a full-length deadline against a run that has
         none, so the two parsers are deliberately different.
         """
-        assert turn_budget.trial_agent_deadline({"agent_timeout_multiplier": 0}, 900.0) == 0.0
+        instant = {"agent_timeout_multiplier": 0}
+        assert turn_budget.trial_agent_deadline(instant, 900.0) == 0.0
         assert resolve_turn_budget(None, None, None) is None
         assert turn_budget.coerce_timeout_multiplier(0) == 0.0
         assert coerce_timeout_seconds(0) is None


### PR DESCRIPTION
Closes #2135

## Verification first: #1481 / #1503 / #1507 all shipped. Nothing ever armed them.

The issue asked for a re-verification rather than an assumption, so here it is,
established on `main` before any code was written.

| Question | Answer | Evidence |
|---|---|---|
| Does `BudgetGuard::set_task_deadline` exist? | **Yes** | `crates/stella-core/src/budget.rs:287`, with the pure `check_deadline(now)` beside it at `:301` (#1481) |
| Is it wired to a consumer? | **Yes** | `crates/stella-core/src/driver/settlement.rs:161` — checked at the engine's safe boundaries, returns `TurnOutcome::Aborted { kind: DeliberateStop }` with the reason `"task deadline exceeded by …s — stopping with partial work"` (#1503) |
| Does the shipping binary arm it? | **Yes, when it has a value** | `crates/stella-cli/src/runtime.rs:86` `one_shot_budget_guard`, called from `crates/stella-cli/src/agent.rs:359` with `cfg.turn_budget` (#1507) |
| Does the harbor adapter pass `--turn-budget`? | **Yes, when it has a value** | `bench/harbor_adapter/stella_harbor/__init__.py:1326`, policy in `turn_budget.py` |
| **Was it ever given a value on the harbor path?** | **No. Not once.** | see below |

So: **the mechanism was built, wired, and shipped — and was inert because
nothing supplied the one input it needs.** Both channels for that input were
things a *caller* had to remember, and no caller did:

1. **The agent kwarg.** Harbor 0.6.1 hands `agent_timeout_sec` to the **oracle**
   agent only (`harbor/trial/trial.py:181-187`: `if config.agent.name ==
   AgentName.ORACLE.value`). Every installed agent takes it via
   `--agent-kwarg`. ArenaBench's `harbor run` command line
   (`arenabench/arenabench/runner.py:731-761`) passes no `--agent-kwarg` at all,
   and every trial in match `cc00894779ff` records `"kwargs": {}` in its
   `config.json`.
2. **`STELLA_TURN_BUDGET`.** A static value, and wrong by construction for a
   dataset whose tasks carry different deadlines — 900s and 1800s are both live
   in Terminal-Bench 2.1.

Therefore `resolve_turn_budget(None, None)` → `None` → the flag is omitted →
`Config::turn_budget` stays `None` → `set_task_deadline` is never called →
`check_deadline` returns `Continue` forever. `cobol-modernization__kt3nQsB`'s 44
`budget_tick` events against a $15 budget it spent $0.87 of are exactly what
that looks like from the journal: the only guard that could speak was the one
that had nothing to say.

**Honest scoping of the evidence.** The wiring gap above is established from
source and from the trials' own `config.json` — it is not an inference. The
*counterfactual* ("an armed deadline would have stopped this trial at ~840s") is
**not** measured: journal events carry no timestamps yet (#2111), so I cannot
place the last safe boundary on the clock, and a single model call spanning
840→900s would have been SIGKILLed with the deadline armed. What the trace
shows is a stream cut mid-reasoning at 900.0s with `stream_complete: false`,
which is consistent with an unarmed deadline and is what PR #2233's forensics
independently found across all 7 `AgentTimeoutError` trials.

## The fix

Harbor has always known the number and writes it to `config.json` at the trial
root — one level above the agent's `logs_dir`, as the first statement of
`Trial.run()`, before the agent starts. `turn_budget.discover_trial_deadline()`
reads it there and recomputes Harbor's own arithmetic from that document plus
the task's `task.toml`:

```
base       = agent.override_timeout_sec or task.agent.timeout_sec
cap        = agent.max_timeout_sec or inf
multiplier = agent_timeout_multiplier ?? timeout_multiplier
deadline   = min(base, cap) * multiplier
```

Precedence becomes stated → discovered → static: an explicit `--agent-kwarg`
still wins, discovery is the per-trial default, `STELLA_TURN_BUDGET` remains the
fallback for a host with no trial to read.

Split so the arithmetic is a pure function over two already-loaded documents
(`trial_agent_deadline`) and the I/O half holds nothing but reading and
fail-open (`discover_trial_deadline`). Since the recomputation mirrors a
specific Harbor version, **every failure mode returns `None`** — no `logs_dir`,
no `config.json`, malformed JSON or TOML, a registry-resolved task with
`path: null`, a schema that moved. That omits the flag and restores exactly the
pre-#1161 behaviour. A guessed deadline is the one outcome worse than none, and
this module's own header already says so.

Two parsers, not one, deliberately: Harbor selects a multiplier with
`is not None`, so a stated `0` genuinely means "killed on the instant", while a
*deadline* of `0` means "no deadline known". Collapsing them would arm a
full-length deadline against a trial with no time at all.

**The trace field.** The armed value is disclosed as `stella_turn_budget_sec` in
the trial's own metadata, next to `stella_budget_usd` — a word (`"unarmed"`)
rather than an omission, because Harbor's metadata dict drops `None` and an
absent key would spell "no deadline was armed" and "this adapter predates the
field" identically. That ambiguity is precisely what made this issue a forensics
job.

## Invariant 6

Untouched, and deliberately so: **this PR adds no new abort point.** The only
consumer of the deadline remains `driver/settlement.rs::check_budget`, which
`run_step_inner` calls between model calls and never mid-tool — the boundary
#1503 chose. All this change does is give that existing check a non-`None`
deadline to compare against. Nothing here wraps a `tokio::time::timeout` around
anything, which matters given PR #2233's finding that `absorb_probe` is
synchronous and cannot be preempted by an outer timeout.

## Relationship to #2110 / #2229 — this does not subsume them

Per the handoff on #2135 from #2110's investigation: all 7 `AgentTimeoutError`
trials examined there died in the post-execute observation seam (`gather_diff`,
`settle_workspace_probe`), which is straight-line work with **no safe boundary
inside it**. A deadline landing there has nothing invariant 6 permits it to do.
**A deadline sits above those bugs; it does not fix them, and they must be fixed
underneath it** — #2110 in PR #2233, #2229 still open.

Nor does an armed deadline make the pipeline deadline-aware. It is honoured by
the engine's step loop only; every raw stage call (`raw_usage.rs` →
`run_accounted_call`) meters dollars and never the clock, so triage / research /
plan / witness / verify / verdict / revise still start with zero wall clock left.
That is a second, independent defect, filed as **#2238** with a full handoff
rather than smuggled into an adapter change.

## Witness test

`bench/harbor_adapter/tests/test_turn_budget.py::TestTheDeadlineArmsWithoutAnybodyPassingIt::test_a_trial_arms_its_deadline_with_no_kwarg_and_no_variable`
— exactly the inputs `cobol-modernization__kt3nQsB` had: a real Harbor
single-step trial tree on disk, a 900s `task.toml`, no kwarg, no environment
variable.

**Flip verified** by reverting only the two implementation files
(`git checkout origin/main -- stella_harbor/turn_budget.py stella_harbor/__init__.py`)
and re-running:

```
E   AssertionError: assert '--turn-budget' in ['/usr/local/bin/stella',
    '--model', 'openrouter/anthropic/claude-sonnet-5', '--budget', '5.0',
    '--base-url', ...]
```

25 failed / 27 passed on the old implementation; **52 passed** with it restored;
**547 passed, 2 skipped** for the whole adapter suite. The new helpers are
reached as `turn_budget.<name>` at each call site rather than imported by name
on purpose — a `from … import` of a missing symbol is a *collection* error,
which reds the file at once and proves only that a name is absent, not that the
behaviour is.

## Testing

- `uv run --frozen pytest tests/` in `bench/harbor_adapter` — 547 passed, 2 skipped
- `uv run --frozen ruff check` clean on every touched file
- `scripts/check-file-size.sh` — `__init__.py` is a god file with 4 lines of
  headroom, so its prose was moved into `turn_budget.py` (that module's
  documented home) to pay for the 5 lines added; 1833 ≤ its 1834 ceiling, **no
  baseline entry raised**
- `scripts/check-left-behind.sh`, `scripts/check-no-scratch.sh` — clean
- No new dependencies: `json`, `tomllib` and `pathlib` are stdlib on the
  adapter's `requires-python = ">=3.12"`
- No Rust changed, so no crate needed rebuilding
- **No tests deleted.**

## Follow-ups filed

- **#2238** — the armed deadline is honoured only by the engine's step loop;
  every raw pipeline stage call meters dollars and never the clock. Includes the
  before-execute-abort vs. after-execute-pivot design question, the invariant 6
  constraint, and #2233's synchronous-callee warning.
- **#2240** — `budget_tick` carries no wall-clock axis, so the ground-truth
  journal still cannot say whether a deadline was armed. This PR answers that
  for a bench trial's metadata; the journal is the artifact every other surface
  projects from.

Linked, not duplicated: #2021 (single-call wall clock), #2149 / #2204 (bounding
individual witness stages), #1703 (no `CancelToken` seam), #2229, #2111.

## Summary by Sourcery

Arm per-trial turn deadlines in the Harbor adapter by discovering task-specific timeouts from trial configuration and exposing the armed value in benchmark metadata, while keeping behaviour fail-open when no reliable deadline can be derived.

New Features:
- Support discovery of per-trial turn deadlines from Harbor trial configuration and task definitions so the engine receives a concrete `--turn-budget` without explicit kwargs or environment variables.
- Expose the configured turn deadline in trial metadata via a `stella_turn_budget_sec` field, distinguishing armed from unarmed runs.

Enhancements:
- Refine turn-budget resolution precedence so explicit agent kwargs override discovered deadlines, which in turn override static environment configuration.
- Add pure helpers and parsing utilities for timeout seconds and multipliers, mirroring Harbor’s own deadline arithmetic for trials.
- Document the adapter’s deadline discovery behaviour and its fail-open strategy in code comments and readiness documentation.

Tests:
- Extend Harbor adapter tests with fixtures that build realistic trial directory layouts and validate deadline discovery, precedence rules, failure modes, and metadata disclosure for turn budgets.