### PR TITLE
fix(arenabench): let a Batch trial decrypt the credentials it may fetch

### DIFF
--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -539,6 +539,25 @@ Resources:
                   - ssm:GetParameters
                   - ssm:GetParametersByPath
                 Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/arenabench/*
+              # Every credential under /arenabench is a SecureString, and
+              # reading one is two authorizations, not one: SSM returns the
+              # ciphertext and KMS decrypts it. Without this the job is
+              # allowed to fetch a parameter it can never read, and the
+              # failure surfaces nowhere near its cause — the run's eight
+              # trials each staged the SUT, then died exit 2 on "required
+              # environment variables are not set: any of OPENROUTER_API_KEY",
+              # which reads as a match-file mistake rather than an IAM one.
+              # `kms:ViaService` keeps the grant to decryption performed on
+              # this role's behalf BY Parameter Store: the job can read the
+              # secrets it is entitled to and cannot use the key for anything
+              # else. The alias is the account's AWS-managed SSM key, whose
+              # own key policy already requires the caller be in this account.
+              - Effect: Allow
+                Action: kms:Decrypt
+                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub ssm.${AWS::Region}.amazonaws.com
 
   TrialJobDefinition:
     Type: AWS::Batch::JobDefinition


### PR DESCRIPTION
## The bug

Every parameter under `/arenabench` is a **SecureString**, so reading one is two
authorizations, not one: Parameter Store returns the ciphertext and KMS decrypts
it. `TrialJobRole` held `ssm:GetParameter*` and no `kms:Decrypt` — a trial was
allowed to fetch a credential it could never read.

Reproduced on a real run, `r20260807-195329-b104e1`, 8 trials on
Terminal-Bench 2.1. Every job started dockerd, staged the SUT, verified its
sha256 against the build manifest — and then exited 2:

```
error: required environment variables are not set:
  Stella (Fable 5 full pipeline, xhigh): any of OPENROUTER_API_KEY
  (use --allow-missing-env to run anyway)
```

That message points at the match file. The match file is correct. The only
trace of the real cause sat 40 lines earlier in the container log:

```
[runner] no SSM credentials readable; continuing
```

`simulate-principal-policy` names it exactly:

```
ssm:GetParametersByPath  allowed
ssm:GetParameter         allowed
kms:Decrypt              implicitDeny     <-- here
```

The credential preflight did its job — the run refused before a single model
call, so this cost nothing but wall clock. The defect is that it refused for a
reason no one could act on.

## The fix

One statement on `TrialJobRole`, scoped with `kms:ViaService` so the grant
covers decryption performed on this role's behalf **by Parameter Store** and
nothing else. The resource is the account's AWS-managed SSM key, whose own key
policy already requires the caller be in this account — so this is the IAM half
of a two-sided check, not a broad key grant.

## Verification

`aws cloudformation validate-template` passes against the edited file. The
authorization decision above is reproducible with `simulate-principal-policy`
before and after the stack update:

```bash
aws iam simulate-principal-policy \
  --policy-source-arn arn:aws:iam::578673726240:role/arenabench-trial-job \
  --action-names ssm:GetParameter kms:Decrypt \
  --resource-arns arn:aws:ssm:us-east-1:578673726240:parameter/arenabench/openrouter_api_key \
  --region us-east-1
```

No witness test: this is a CloudFormation IAM statement with no executable
surface in the workspace. The `simulate-principal-policy` flip from
`implicitDeny` to `allowed` is the evidence.

## Applying it

The template is the source of truth, so this needs a stack update to take
effect — it is not applied by merging:

```bash
aws cloudformation update-stack --stack-name arenabench-core --region us-east-1 \
  --template-body file://arenabench/infra/core.yaml \
  --parameters $(aws cloudformation describe-stacks --stack-name arenabench-core \
      --region us-east-1 --query 'Stacks[0].Parameters[].ParameterKey' --output text \
      | tr '\t' '\n' | sed 's/.*/ParameterKey=&,UsePreviousValue=true/' | tr '\n' ' ') \
  --capabilities CAPABILITY_NAMED_IAM
```

## Not fixed here

- **#XXXX** — `VercelWebRole` carries the identical
  `ssm:GetParameter*`-without-`kms:Decrypt` shape and would fail the same silent
  way. Granting a public web app's OIDC role the ability to decrypt benchmark
  credentials is a security decision rather than a bug fix, so it deliberately
  does not ride along here.
- **#XXXX** — `export_ssm_credentials` in `arenabench/infra/runner/entrypoint.sh`
  sends the AWS error to `/dev/null` and logs a bland "no SSM credentials
  readable". "There are no parameters" and "I am not allowed to read them" are
  different conditions and only the first is served by staying quiet. That
  discarded string named the missing permission outright.
