### PR TITLE
fix(docs): unbreak main — resync docs/manifest.json with the brand kit's v2.0 title

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -116,7 +116,7 @@
     "brand": {
       "path": "docs/brand/README.md",
       "status": "living",
-      "title": "stella\\* \u2014 brand kit v1.0"
+      "title": "stella\\* \u2014 brand kit v2.0"
     },
     "config-system": {
       "path": "docs/spec/config-system/DESIGN.md",


### PR DESCRIPTION
## What & why

**`main` is red and this unbreaks it.**

`aa288fd9` (`feat(brand): recolor the full kit to the Nebula palette`) retitled
`docs/brand/README.md` from *"brand kit v1.0"* to *"brand kit v2.0"* without
regenerating `docs/manifest.json`. The manifest records each identified
document's **title**, so a title edit invalidates it exactly as a move would:

```
check-doc-links: FAILED

  docs/manifest.json is out of date with the tree.
     Run `make doc-links-fix` -- it heals any stale path citations and
     rewrites the manifest in one pass.
```

`docs-guards` has failed on every push since. Confirmed red on `aa288fd9`
(the cause), then `f0a2cf45` and `b7a5a4da`, which merely **inherited** it —
neither touches `docs/`. `ci.yml` ignores `docs/**`, so `docs-guards` is the
only workflow that sees this, and it is failing for everyone until the manifest
is resynced.

This PR is `make doc-links-fix`'s output and nothing else — **one line**:

```diff
   "brand": {
     "path": "docs/brand/README.md",
     "status": "living",
-    "title": "stella\\* — brand kit v1.0"
+    "title": "stella\\* — brand kit v2.0"
   },
```

## The witness

- [x] No witness needed (pure CI/docs fix) — because the **guard itself is the
      witness**, and it flips exactly the right way:
      - on `main` (`7edec3b2`): `check-doc-links: FAILED — docs/manifest.json is
        out of date with the tree.`
      - with this change: `check-doc-links: OK -- 254 citation(s) resolve across
        48 identified document(s)`, **real exit code 0**.

Verified by running the script directly and reading its own exit status rather
than a pipeline's — `python3 scripts/check-doc-links.py check; echo $?` — since
`| tail` would have reported `tail`'s status and masked the result.

## The gate

All three `docs-guards` steps run locally, each judged by its real exit code:

- [x] `python3 scripts/check-doc-links.py check` → `OK -- 254 citation(s)
      resolve across 48 identified document(s)`, exit 0
- [x] `scripts/check-invariants.sh` → `OK — 8 invariants, one normative home,
      22 citation(s) resolve`, exit 0
- [x] `make command-docs` → `OK — 38 subcommands, each with a listed reference
      page`, exit 0
- [x] Diff is one line in a generated file; no Rust touched, so `ci.yml` is
      unaffected either way.

## Nothing left behind

- [x] Filed: **#2255** — nothing ties a doc's *title* to the manifest, so any
      retitle silently reds `docs-guards` on the next push, and the author's own
      PR can pass because `ci.yml` ignores `docs/**`. That is the mechanism that
      produced this break, and it will recur.

Already-tracked and deliberately not fixed here: **#2152** (only 3 of the gate's
checks are required on `main`, so a red advisory guard can auto-merge — the
reason `aa288fd9` landed red in the first place).

Also observed while verifying, and reported in #2255 rather than acted on: the
guard's advisory output lists **8 documents nothing cites**, including
`docs/wire/README.md` (2 hours old) and `docs/spec/self-driving-foundry.md`
(9 hours old). That is advisory only — exit stays 0 — but it is accumulating.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] Generated file regenerated by its own documented command, not hand-edited
