### PR TITLE
fix(stella-cli): unbreak main — the cinematic's palette law still demanded gold

### DIFF
--- a/crates/stella-cli/src/init_fx.rs
+++ b/crates/stella-cli/src/init_fx.rs
@@ -1,5 +1,5 @@
 //! The `stella init` cinematic — a tiny terminal animation that plays while
-//! the workspace is being indexed: a sky-blue starfield drifting by, crossed by
+//! the workspace is being indexed: a nebula starfield drifting by, crossed by
 //! stella's mascot-grade absurdity, a turtle on a jetpack skateboard.
 //!
 //! Rendering discipline mirrors the deck's fx rules:
@@ -16,8 +16,11 @@
 //!   exactly as before.
 //!
 //! Colors come from the brand palette (crates/stella-tui/src/palette.rs) and are
-//! enforced by this module's tests: the two star/flame inks are the `SKY_DEEP`
-//! and `SKY` brand tokens, and the shell takes the deck's categorical violet.
+//! enforced by this module's tests: the two star/flame inks are the `ACCENT_DEEP`
+//! and `ACCENT` brand tokens, and the shell takes the deck's categorical violet.
+//! (This sentence named `SKY_DEEP`/`SKY` until the Nebula recolour — tokens that
+//! are now retired hues the theme tests forbid, which is precisely the drift the
+//! next paragraph describes.)
 //! This module used to carry a private palette of its own that tracked nothing;
 //! it now takes the brand tokens directly, so the cinematic and the deck agree
 //! by construction instead of merely coinciding.
@@ -163,11 +166,11 @@ fn truncate_width(row: &mut String, width: usize) {
 /// palette-law test must check the *choice*, not the escape bytes.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Ink {
-    /// Deep sky — jetpack flames and the skateboard deck.
+    /// Deep nebula — jetpack flames and the skateboard deck.
     Flame,
     /// Muted — the dimmer twinkle of a star.
     Star,
-    /// Brand sky — the brighter twinkle of a star.
+    /// Brand nebula — the brighter twinkle of a star.
     StarBright,
     /// Violet — the turtle's shell linework. Categorical, not brand.
     Shell,

--- a/crates/stella-cli/src/init_fx.rs
+++ b/crates/stella-cli/src/init_fx.rs
@@ -452,13 +452,20 @@ mod tests {
             Some(crate::tui::token_rgb(theme::TEXT_TERTIARY))
         );
         assert_eq!(Ink::Shell.rgb(), Some(crate::tui::token_rgb(theme::ORCHID)));
-        // And the star/flame pair stays warm — the comet's Phosphor Gold is
-        // r > g > b — so the cinematic can never drift back to the retired
-        // electric blue while still passing. (This clause read "cool, not
-        // warm" under the blue identity; the comet inverts it.)
+        // And the star/flame pair stays cool — the Nebula's violet stops are
+        // blue-dominant — so the cinematic can never drift back to the retired
+        // Phosphor Gold while still passing. The clause has now read all three
+        // ways: cool under the blue identity, warm under the comet, and cool
+        // again under the Nebula, which demoted gold from *the brand* to a
+        // rationed north point. It is the direction that keeps changing, not
+        // the rule: the pair must match whatever the brand currently is, and
+        // must never silently be the palette it just retired.
         for ink in [Ink::Flame, Ink::StarBright] {
             let (r, g, b) = ink.rgb().expect("colored inks carry rgb");
-            assert!(r > g && g > b, "{ink:?} must read warm gold, not cool");
+            assert!(
+                b > r && b > g,
+                "{ink:?} must read cool nebula, not warm gold"
+            );
         }
     }
 

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -451,7 +451,10 @@ fn palette_law_the_nebula_is_the_brand() {
     let Color::Rgb(gr, gg, gb) = GOLD else {
         panic!("GOLD must be a truecolor token");
     };
-    assert!(gr > gg && gg > gb, "GOLD must stay warm-dominant (r > g > b)");
+    assert!(
+        gr > gg && gg > gb,
+        "GOLD must stay warm-dominant (r > g > b)"
+    );
 
     // 2. The retired hues are gone from every token and alias.
     let mut all: Vec<Color> = ALL_RGB_TOKENS.to_vec();


### PR DESCRIPTION
## What & why

**`main` is red on the required `fmt + clippy + test` job and this unbreaks it.**
Two failures, one cause:

```
cargo fmt --check   crates/stella-tui/src/theme/tests.rs:451
cargo test          init_fx::tests::palette_law_only_brand_inks
                    panicked at crates/stella-cli/src/init_fx.rs:461:13:
                    Flame must read warm gold, not cool
```

#2226 (`feat(brand): recolor the full kit to the Nebula palette`) moved the brand
from Phosphor Gold to a violet→cyan Nebula and — in its own words — demoted gold
*"from **the brand** to a rare north point"*. It updated `stella-tui`'s theme but
not `stella-cli`'s cinematic, which asserts a **directional law** over the very
same tokens:

| Ink | reads | now resolves to | |
|---|---|---|---|
| `Ink::Flame` | `theme::ACCENT_DEEP` | `palette::BRAND_DEEP` `#6544E6` | (101, 68, **230**) |
| `Ink::StarBright` | `theme::ACCENT` | `palette::BRAND` `#8F72FF` | (143, 114, **255**) |

Both are blue-dominant, so `r > g > b` could not pass. That clause encoded the
**retired** comet identity.

## The fix

Inverted to `b > r && b > g`. **The guard's purpose survives intact**: `GOLD`
(`#FFC857` = 255, 200, 87) fails it, so the cinematic still cannot silently drift
back to the palette the brand just retired.

The comment now states the rule rather than one identity — *match whatever the
brand currently is, never be the one it just retired* — because this clause has
been flipped **three times** (cool under the blue identity, warm under the comet,
cool again under the Nebula) and each flip was discovered by a red `main`.

Second commit fixes prose in the same file with the same drift: the module doc
claimed the inks are the `SKY_DEEP` and `SKY` tokens. Both are **retired** —
they survive only in `crates/stella-tui/src/theme/tests.rs` as
`RETIRED_SKY_DEEP`, on the list the theme tests forbid from reappearing. Also
retitles the two `Ink` variants ("Deep sky", "Brand sky") and the opening line's
"sky-blue starfield", which has not been sky blue for two recolours.

The `fmt` hunk in `theme/tests.rs` is `cargo fmt` output, untouched by hand.

## The witness

This one has a real fail→pass flip, and CI already ran the failing half:

- **Fails on `main`** — run
  [31244652065](https://github.com/macanderson/stella/actions/runs/31244652065)
  on `7edec3b2`: `test result: FAILED. 1487 passed; 1 failed`, with
  `Flame must read warm gold, not cool`.
- **Passes here** — `cargo test -p stella-cli --bin stella
  palette_law_only_brand_inks` → `test result: ok. 1 passed; 0 failed`.

No new test is added on purpose: the existing law **is** the witness, and it was
already asserting the right thing about the wrong palette.

## The gate

- [x] `cargo fmt --all --check` → exit **0** (the failing step on `main`)
- [x] `cargo test -p stella-cli --bin stella palette_law_only_brand_inks` → ok.
      Scoped to `--bin stella` deliberately: a full `-p stella-cli` links the
      integration binaries and OOMs on a 16 GB machine.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — **left to CI**
- [ ] `cargo test --workspace` — **left to CI**
- [x] Comment/doc changes only outside the one-line assertion; no behaviour
      change to rendering. `paint_preserves_visible_content` and the token
      *binding* assertions are untouched and still guard the rest.

## Nothing left behind

- [x] Filed: **#2260** — a recolour must hand-update every palette law and
      nothing lists them. The directional assertions live in two crates
      (`init_fx.rs` and `theme/tests.rs`) with no index, so a recolour finds them
      by going red — three times now. Proposes co-locating the laws, or better,
      deriving the law as "must not be a retired hue" so it survives the next
      recolour with no edit at all.

Already tracked, not fixed here: **#2152** — only 3 of the gate's checks are
required on `main`, which is how #2226 merged with `cargo fmt --check` and
`cargo test` red in the first place. That is the reason this reached `main`
rather than being caught on the PR, and it is the more valuable fix.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No cross-boundary types added

## Anything reviewers should know?

I inverted the law rather than rebinding `Ink::Flame` to `theme::GOLD`, and that
was a deliberate reading of #2226's stated design: *"the body runs the Nebula
gradient; the north point is the only gold"*, gold *"rationed"* to roughly one
moment per view. The cinematic's starfield and flames are body, not north point,
so they follow the Nebula. If the intent was actually that the flame stays the
gold north point, the fix is a one-line rebind instead and I am happy to swap it.

## Summary by Sourcery

Align the init cinematic with the updated Nebula brand palette and restore passing palette-law tests on main.

Enhancements:
- Update init cinematic documentation and ink variant descriptions to reflect the Nebula palette and current brand tokens instead of retired sky hues.
- Adjust the palette-law assertion for the cinematic inks to enforce a cool, Nebula-matching color relationship and prevent regression to the retired Phosphor Gold palette.

Tests:
- Re-enable the failing palette-law test for cinematic inks by updating its color dominance assertion to match the Nebula brand palette.