### PR TITLE
fix(arenabench): a seat that never loaded its adapter is not an agent loss (#2127, #2192)

### DIFF
--- a/arenabench/arenabench/adapter.py
+++ b/arenabench/arenabench/adapter.py
@@ -1,0 +1,141 @@
+"""Staged harbor-adapter sources, so a match outlives its launch checkout.
+
+The arena resolved the ``stella_harbor`` package out of the checkout the
+server was launched from, and resolved it again at *every* trial's install.
+In match ``cc00894779ff`` that checkout — a git worktree — was deleted while
+the match was running. The four trials that installed afterwards each died in
+agent setup naming a path that no longer existed, 0 steps and 0 tokens
+apiece, and the dashboard scored all four as agent losses: ``solve_rate``
+read 40% against a true agent record of 4/6 (#2127).
+
+Staging removes the dependency rather than accounting for it. The sources are
+copied once, on first use, into ``<arenabench home>/adapter/<digest>/``, and
+every later trial in the process reads that copy. Two consequences worth
+naming:
+
+* A running server is immune to its own launch tree disappearing.
+* A match measures exactly one adapter revision — which is what the
+  provenance record already claims, and was not previously guaranteed, since
+  an operator editing the adapter mid-match changed what later trials ran.
+
+The digest is content-addressed, so an edited adapter stages a fresh
+directory on the next match rather than being shadowed by a stale copy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+from .sut import arenabench_home
+
+__all__ = [
+    "PACKAGE_NAME",
+    "AdapterUnavailableError",
+    "adapter_root",
+    "stage_adapter",
+]
+
+#: The package a Stella seat must be able to import. The adapter directory on
+#: ``PYTHONPATH`` is the one that *contains* it.
+PACKAGE_NAME = "stella_harbor"
+
+
+class AdapterUnavailableError(RuntimeError):
+    """The harbor adapter's sources cannot be found or staged.
+
+    Named rather than a bare :class:`RuntimeError` so
+    :data:`arenabench.telemetry.INFRASTRUCTURE_FAILURES` can recognise it: a
+    trial that never reached a state where the agent could act is an
+    operational abort, and must stay out of ``solve_rate``'s denominator.
+    """
+
+
+def adapter_root() -> Path:
+    """Where staged adapter sources live, honouring ``ARENABENCH_HOME``."""
+    return arenabench_home() / "adapter"
+
+
+#: Staged roots already materialised by this process, keyed by resolved
+#: source path **and** the arena home it was staged under. Process-scoped on
+#: purpose: the point is that trial *n* does not re-read a source tree trial 1
+#: already copied, so the copy has to outlive the source within one server run.
+#:
+#: The home is part of the key because it is read from the environment, and a
+#: cache keyed on the source alone hands back a path under whichever home
+#: happened to be set first — which in the test suite meant staging into the
+#: developer's real ``~/.arenabench`` and then reusing it from a tmp-home test.
+_staged: dict[tuple[Path, Path], Path] = {}
+
+
+def _digest(source: Path) -> str:
+    """A content digest over the adapter package.
+
+    Every file under the package is folded in — not just ``*.py`` — because
+    the adapter ships data beside its code, and a digest that ignored those
+    would reuse a stale staging directory after they changed.
+    """
+    package = source / PACKAGE_NAME
+    files = sorted(p for p in package.rglob("*") if p.is_file())
+    if not files:
+        raise AdapterUnavailableError(
+            f"no {PACKAGE_NAME} sources under {package}. Point "
+            "ARENABENCH_STELLA_ADAPTER at <stella>/bench/harbor_adapter."
+        )
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(str(path.relative_to(package)).encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def stage_adapter(source: Path) -> Path:
+    """Stage ``source``'s adapter package and return the root to import from.
+
+    Idempotent per process and per content digest. The returned path is a
+    directory containing :data:`PACKAGE_NAME`, suitable for ``PYTHONPATH``.
+
+    Raises :class:`AdapterUnavailableError` when the sources are absent and
+    nothing has been staged for this source yet — the honest failure, because
+    there is no adapter to run and every later step would misreport why.
+    """
+    source = source.expanduser().resolve()
+    root = adapter_root()
+    key = (source, root)
+    cached = _staged.get(key)
+    if cached is not None and (cached / PACKAGE_NAME).is_dir():
+        return cached
+
+    if not (source / PACKAGE_NAME).is_dir():
+        raise AdapterUnavailableError(
+            f"the harbor adapter is not at {source}: no {PACKAGE_NAME} "
+            "directory. If the arena's checkout moved or was deleted mid-run, "
+            "restart the server from a live checkout, or point "
+            "ARENABENCH_STELLA_ADAPTER at <stella>/bench/harbor_adapter."
+        )
+
+    destination = root / _digest(source)
+    marker = destination / PACKAGE_NAME
+    if not marker.is_dir():
+        destination.mkdir(parents=True, exist_ok=True)
+        # Copy to a sibling first, then rename: a half-copied tree that a
+        # concurrent match started importing would fail in a way that reads
+        # like a corrupt adapter rather than a racing one.
+        pending = destination.with_name(f"{destination.name}.pending")
+        shutil.rmtree(pending, ignore_errors=True)
+        shutil.copytree(source / PACKAGE_NAME, pending / PACKAGE_NAME)
+        try:
+            (pending / PACKAGE_NAME).rename(marker)
+        except OSError:
+            # Another match staged the identical digest first. Its copy is
+            # byte-identical by construction, so losing the race is fine.
+            if not marker.is_dir():
+                raise
+        finally:
+            shutil.rmtree(pending, ignore_errors=True)
+
+    _staged[key] = destination
+    return destination

--- a/arenabench/arenabench/adapter.py
+++ b/arenabench/arenabench/adapter.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+import tempfile
 from pathlib import Path
 
 from .sut import arenabench_home
@@ -124,16 +125,28 @@ def stage_adapter(source: Path) -> Path:
         # Copy to a sibling first, then rename: a half-copied tree that a
         # concurrent match started importing would fail in a way that reads
         # like a corrupt adapter rather than a racing one.
-        pending = destination.with_name(f"{destination.name}.pending")
-        shutil.rmtree(pending, ignore_errors=True)
-        shutil.copytree(source / PACKAGE_NAME, pending / PACKAGE_NAME)
+        #
+        # The sibling name must be unique per attempt, not per digest. The
+        # server is a ThreadingHTTPServer, so two matches staging the same
+        # digest run this concurrently in one process: with a shared name,
+        # the second thread's rmtree deletes the first thread's finished copy
+        # and the first thread's rename then publishes the second's
+        # *in-flight* partial tree — permanently, since the cache check above
+        # never revisits a digest that exists.
+        pending = Path(
+            tempfile.mkdtemp(dir=destination.parent, prefix=f"{destination.name}.pending-")
+        )
         try:
-            (pending / PACKAGE_NAME).rename(marker)
-        except OSError:
-            # Another match staged the identical digest first. Its copy is
-            # byte-identical by construction, so losing the race is fine.
-            if not marker.is_dir():
-                raise
+            shutil.copytree(source / PACKAGE_NAME, pending / PACKAGE_NAME)
+            try:
+                (pending / PACKAGE_NAME).rename(marker)
+            except OSError:
+                # Another match staged the identical digest first. Its copy is
+                # byte-identical by construction *and complete* — a unique
+                # staging dir is what makes that second half true — so losing
+                # the race is fine.
+                if not marker.is_dir():
+                    raise
         finally:
             shutil.rmtree(pending, ignore_errors=True)
 

--- a/arenabench/arenabench/harbor_agent.py
+++ b/arenabench/arenabench/harbor_agent.py
@@ -185,6 +185,17 @@ def _engine_from_env() -> Engine | None:
     return Engine.from_json(parsed) if isinstance(parsed, dict) else None
 
 
+class StellaAdapterMissingError(ImportError):
+    """``stella_harbor`` is not importable in this process.
+
+    An :class:`ImportError` subclass so existing ``except ImportError`` paths
+    still catch it, and *named* so it can be recognised downstream:
+    :data:`arenabench.telemetry.INFRASTRUCTURE_FAILURES` treats it as an
+    operational abort, because a seat whose adapter never loaded did not lose
+    a contest — it never entered one.
+    """
+
+
 def _load_base_agent() -> type:
     """Import ``stella_harbor.StellaAgent`` with a legible failure.
 
@@ -195,7 +206,7 @@ def _load_base_agent() -> type:
     try:
         from stella_harbor import StellaAgent
     except ImportError as exc:  # pragma: no cover - environment-dependent
-        raise ImportError(
+        raise StellaAdapterMissingError(
             "arenabench's Stella contestant needs the `stella_harbor` adapter "
             "on PYTHONPATH. Point ARENABENCH_STELLA_ADAPTER at "
             "<stella>/bench/harbor_adapter, or install it with "
@@ -204,10 +215,34 @@ def _load_base_agent() -> type:
     return StellaAgent
 
 
+def _unavailable_base(exc: ImportError) -> type:
+    """A stand-in base that keeps this module importable and refuses to run.
+
+    ``object`` was the previous stand-in, and it discarded the error built
+    three lines above it. ``ArenaStellaAgent(...)`` then raised
+    ``TypeError: ArenaStellaAgent() takes no arguments`` inside the Harbor
+    subprocess — a message naming neither the cause nor the fix — on a path
+    where Harbor **exits 0**, so the arena recorded a seat that was *done*
+    with zero steps and no model call, indistinguishable in the match UI from
+    an agent that ran and failed the task (#2192, observed on matches
+    ``44c124e06ef7`` and ``3ca70da630ed``).
+
+    Refusing at construction keeps the importability this fallback exists for
+    — constants, type checking, test collection — while making the failure
+    loud exactly where it matters.
+    """
+
+    class _StellaAdapterUnavailable:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            raise exc
+
+    return _StellaAdapterUnavailable
+
+
 try:  # pragma: no cover - exercised by whichever environment imports this
     _Base = _load_base_agent()
-except ImportError:  # pragma: no cover
-    _Base = object
+except ImportError as _exc:  # pragma: no cover
+    _Base = _unavailable_base(_exc)
 
 
 class ArenaStellaAgent(_Base):  # type: ignore[misc,valid-type]

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from . import harbor, provenance, sut
+from .adapter import AdapterUnavailableError, stage_adapter
 from .agents import (
     credential_env_for,
     launch_flags,
@@ -910,21 +911,32 @@ class MatchRunner:
 
         # Both packages must be importable by the Harbor subprocess: the
         # ArenaBench adapter and the stella_harbor base it subclasses. Missing
-        # the second one does not fail loudly — `harbor_agent.py` falls back to
-        # `_Base = object`, Harbor dies with "ArenaStellaAgent() takes no
-        # arguments", and *exits 0*, so the seat reports done having run
-        # nothing. The adapter ships in the same checkout `sut.stella_repo()`
-        # already found, so an arena running out of a clone can wire itself
-        # rather than depend on an operator remembering one variable whose
-        # omission is invisible.
+        # the second one used not to fail loudly — `harbor_agent.py` fell back
+        # to `_Base = object`, Harbor died with "ArenaStellaAgent() takes no
+        # arguments", and *exited 0*, so the seat reported done having run
+        # nothing (#2192, now a named refusal at construction). The adapter
+        # ships in the same checkout `sut.stella_repo()` already found, so an
+        # arena running out of a clone can wire itself rather than depend on
+        # an operator remembering one variable whose omission is invisible.
+        #
+        # The adapter is then *staged* rather than read from that checkout at
+        # every trial: the launch worktree was deleted mid-match once and took
+        # four trials with it, each scored as an agent loss (#2127). Staging
+        # is content-addressed and process-cached, so trial 2 never touches
+        # the source tree trial 1 copied.
         roots = [str(Path(__file__).resolve().parent.parent)]
         adapter = os.environ.get("ARENABENCH_STELLA_ADAPTER")
         if not adapter:
             repo = sut.stella_repo()
             if repo is not None and (repo / "bench" / "harbor_adapter").is_dir():
                 adapter = str(repo / "bench" / "harbor_adapter")
-        if adapter:
-            roots.append(str(Path(adapter).expanduser().resolve()))
+        if not adapter:
+            raise AdapterUnavailableError(
+                "a Stella seat needs the harbor adapter, and neither "
+                "ARENABENCH_STELLA_ADAPTER nor a Stella checkout names one. "
+                "Point ARENABENCH_STELLA_ADAPTER at <stella>/bench/harbor_adapter."
+            )
+        roots.append(str(stage_adapter(Path(adapter))))
         existing = os.environ.get("PYTHONPATH", "")
         if existing:
             roots.append(existing)

--- a/arenabench/arenabench/sut.py
+++ b/arenabench/arenabench/sut.py
@@ -132,11 +132,19 @@ class SutUnavailableError(RuntimeError):
     """No Stella checkout, or git could not answer."""
 
 
+def arenabench_home() -> Path:
+    """The arena's own state directory, honouring ``ARENABENCH_HOME``.
+
+    One definition, because every staged artifact hangs off it — SUT binaries
+    here, harbor-adapter sources in :mod:`arenabench.adapter`.
+    """
+    home = os.environ.get("ARENABENCH_HOME")
+    return Path(home).expanduser() if home else Path.home() / ".arenabench"
+
+
 def sut_root() -> Path:
     """Where staged SUT binaries live, honouring ``ARENABENCH_HOME``."""
-    home = os.environ.get("ARENABENCH_HOME")
-    base = Path(home).expanduser() if home else Path.home() / ".arenabench"
-    return base / "sut"
+    return arenabench_home() / "sut"
 
 
 def _discovered_repo(start: Path | None = None) -> Path | None:

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -193,6 +193,14 @@ INFRASTRUCTURE_FAILURES: frozenset[str] = frozenset(
         "AddTestsDirError",
         "DownloadVerifierDirError",
         "MissingExtraError",
+        # The harness could not assemble the seat at all: the harbor adapter
+        # was absent from PYTHONPATH, or its sources vanished mid-match when
+        # the server's launch worktree was deleted. Four trials of
+        # `cc00894779ff` died this way with 0 steps and 0 tokens and were
+        # scored as agent losses, reading `solve_rate` 40% against a true
+        # agent record of 4/6 (#2127, #2192).
+        "AdapterUnavailableError",
+        "StellaAdapterMissingError",
         # Credentials are an operator setting, not a capability.
         "AuthenticationError",
         "OAuthCallbackError",
@@ -227,6 +235,8 @@ VOID_SETUP: frozenset[str] = frozenset(
         "AddTestsDirError",
         "DownloadVerifierDirError",
         "MissingExtraError",
+        "AdapterUnavailableError",
+        "StellaAdapterMissingError",
     }
 )
 VOID_CREDENTIALS: frozenset[str] = frozenset(

--- a/arenabench/tests/test_adapter.py
+++ b/arenabench/tests/test_adapter.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""A seat that never loaded its adapter did not lose a contest.
+
+Two defects with one consequence, both observed on real paid matches:
+
+* The arena resolved the ``stella_harbor`` sources out of its launch checkout
+  at **every** trial's install. Deleting that worktree mid-match killed the
+  four trials of ``cc00894779ff`` that installed afterwards — 0 steps, 0
+  tokens each — and the dashboard scored all four as agent losses, publishing
+  ``solve_rate`` 40% against a true agent record of 4/6 (#2127).
+* When the adapter was simply absent, ``harbor_agent`` fell back to
+  ``_Base = object``, discarding the actionable ``ImportError`` it had just
+  built. ``ArenaStellaAgent(...)`` then raised ``TypeError: takes no
+  arguments`` and Harbor **exited 0**, so the seat reported *done* having run
+  nothing (#2192).
+
+Both now fail by name, and both names are classified as infrastructure, so
+neither can re-enter ``solve_rate``'s denominator.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from arenabench import adapter
+from arenabench.adapter import (
+    PACKAGE_NAME,
+    AdapterUnavailableError,
+    adapter_root,
+    stage_adapter,
+)
+from arenabench.harbor_agent import StellaAdapterMissingError, _unavailable_base
+from arenabench.telemetry import INFRASTRUCTURE_FAILURES, VOID_SETUP
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A private arena home, and an empty process cache, per test."""
+    monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(adapter, "_staged", {})
+    yield
+
+
+def _source_tree(root: Path) -> Path:
+    """A minimal adapter checkout: the package, some code, and a data file."""
+    package = root / PACKAGE_NAME
+    (package / "sub").mkdir(parents=True)
+    (package / "__init__.py").write_text("VERSION = '1'\n", encoding="utf-8")
+    (package / "sub" / "posture.py").write_text("X = 1\n", encoding="utf-8")
+    (package / "prices.json").write_text('{"a": 1}\n', encoding="utf-8")
+    return root
+
+
+def test_a_staged_adapter_outlives_the_checkout_it_was_copied_from(tmp_path: Path):
+    """The #2127 witness: trial 1 stages, the worktree dies, trial 2 runs."""
+    source = _source_tree(tmp_path / "worktree" / "bench" / "harbor_adapter")
+
+    first = stage_adapter(source)
+    assert (first / PACKAGE_NAME / "__init__.py").is_file()
+    assert adapter_root() in first.parents
+
+    # The launch worktree is deleted mid-match, exactly as in cc00894779ff.
+    shutil.rmtree(tmp_path / "worktree")
+    assert not source.exists()
+
+    second = stage_adapter(source)
+    assert second == first
+    assert (second / PACKAGE_NAME / "sub" / "posture.py").read_text() == "X = 1\n"
+    assert (second / PACKAGE_NAME / "prices.json").is_file()
+
+
+def test_staging_is_content_addressed_so_an_edited_adapter_is_not_shadowed(
+    tmp_path: Path,
+):
+    source = _source_tree(tmp_path / "adapter")
+    before = stage_adapter(source)
+
+    (source / PACKAGE_NAME / "sub" / "posture.py").write_text("X = 2\n", encoding="utf-8")
+    adapter._staged.clear()  # a later match, same process
+    after = stage_adapter(source)
+
+    assert after != before, "an edited adapter must stage a fresh directory"
+    assert (after / PACKAGE_NAME / "sub" / "posture.py").read_text() == "X = 2\n"
+
+
+def test_a_data_file_change_alone_restages(tmp_path: Path):
+    """The digest folds in every file, not just ``*.py``."""
+    source = _source_tree(tmp_path / "adapter")
+    before = stage_adapter(source)
+
+    (source / PACKAGE_NAME / "prices.json").write_text('{"a": 2}\n', encoding="utf-8")
+    adapter._staged.clear()
+
+    assert stage_adapter(source) != before
+
+
+def test_absent_sources_with_nothing_staged_refuse_by_name(tmp_path: Path):
+    """The honest failure — and a name telemetry can classify."""
+    with pytest.raises(AdapterUnavailableError) as caught:
+        stage_adapter(tmp_path / "gone")
+    assert "ARENABENCH_STELLA_ADAPTER" in str(caught.value)
+
+
+def test_an_empty_package_directory_is_refused_rather_than_staged(tmp_path: Path):
+    (tmp_path / "adapter" / PACKAGE_NAME).mkdir(parents=True)
+    with pytest.raises(AdapterUnavailableError):
+        stage_adapter(tmp_path / "adapter")
+
+
+def test_a_missing_adapter_refuses_at_construction_naming_the_fix():
+    """The #2192 witness.
+
+    The old stand-in was ``object``; constructing against it raised
+    ``TypeError: takes no arguments`` and Harbor exited 0.
+    """
+    base = _unavailable_base(
+        StellaAdapterMissingError(
+            "arenabench's Stella contestant needs the `stella_harbor` adapter "
+            "on PYTHONPATH. Point ARENABENCH_STELLA_ADAPTER at "
+            "<stella>/bench/harbor_adapter."
+        )
+    )
+
+    class Seat(base):  # type: ignore[misc,valid-type]
+        pass
+
+    with pytest.raises(StellaAdapterMissingError) as caught:
+        Seat("task-id", model="x")
+    assert "ARENABENCH_STELLA_ADAPTER" in str(caught.value)
+    assert not isinstance(caught.value, TypeError)
+
+
+def test_both_failures_are_infrastructure_not_agent_losses():
+    """The half that actually moves the published number."""
+    for name in ("AdapterUnavailableError", "StellaAdapterMissingError"):
+        assert name in INFRASTRUCTURE_FAILURES, f"{name} would score as a loss"
+        assert name in VOID_SETUP, f"{name} needs an outcome-taxonomy bucket"
+
+
+def test_the_named_error_is_still_an_import_error():
+    """Existing ``except ImportError`` paths must keep catching it."""
+    assert issubclass(StellaAdapterMissingError, ImportError)

--- a/arenabench/tests/test_adapter.py
+++ b/arenabench/tests/test_adapter.py
@@ -21,7 +21,9 @@ neither can re-enter ``solve_rate``'s denominator.
 
 from __future__ import annotations
 
+import itertools
 import shutil
+import threading
 from pathlib import Path
 
 import pytest
@@ -109,6 +111,80 @@ def test_an_empty_package_directory_is_refused_rather_than_staged(tmp_path: Path
     (tmp_path / "adapter" / PACKAGE_NAME).mkdir(parents=True)
     with pytest.raises(AdapterUnavailableError):
         stage_adapter(tmp_path / "adapter")
+
+
+def test_concurrent_staging_never_publishes_a_half_copied_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The server is threaded, so two matches stage one digest at once.
+
+    A staging directory named after the digest alone is shared, and the
+    damage is permanent: thread B's ``rmtree`` deletes A's finished copy, A
+    then renames B's *in-flight* tree into place, and the cache check never
+    revisits a digest that already exists — every later trial in the process
+    imports the partial adapter.
+
+    The interleaving is forced rather than raced, so this fails
+    deterministically against a shared staging name.
+    """
+    source = _source_tree(tmp_path / "adapter")
+    real_copytree = shutil.copytree
+    a_copied = threading.Event()
+    b_mid_copy = threading.Event()
+    a_done = threading.Event()
+    calls = itertools.count()
+
+    def sequenced(src, dst, *args, **kwargs):
+        # ``copytree`` recurses through this same module attribute for every
+        # subdirectory; only the top-level package copy is a staging attempt.
+        if Path(dst).name != PACKAGE_NAME:
+            return real_copytree(src, dst, *args, **kwargs)
+        if next(calls) == 0:
+            # A: copy in full, then hold before the rename while B runs.
+            result = real_copytree(src, dst, *args, **kwargs)
+            a_copied.set()
+            assert b_mid_copy.wait(timeout=10), "B never reached its copy"
+            return result
+        # B: land one file, let A rename whatever is at the staging path,
+        # then finish. Mid-copy is the state A must not be able to publish.
+        src, dst = Path(src), Path(dst)
+        dst.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src / "__init__.py", dst / "__init__.py")
+        b_mid_copy.set()
+        assert a_done.wait(timeout=10), "A never finished"
+        for path in sorted(p for p in src.rglob("*") if p.is_file()):
+            target = dst / path.relative_to(src)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+        return str(dst)
+
+    monkeypatch.setattr(adapter.shutil, "copytree", sequenced)
+    failures: list[BaseException] = []
+
+    def stage(record_done: bool):
+        try:
+            stage_adapter(source)
+        except BaseException as error:  # a thread's failure is asserted below
+            failures.append(error)
+        finally:
+            if record_done:
+                a_done.set()
+
+    first = threading.Thread(target=stage, args=(True,))
+    first.start()
+    assert a_copied.wait(timeout=10), f"A never copied: {failures}"
+    adapter._staged.clear()  # a second match, same process, same digest
+    second = threading.Thread(target=stage, args=(False,))
+    second.start()
+    first.join(timeout=15)
+    second.join(timeout=15)
+    assert not first.is_alive() and not second.is_alive(), "staging wedged"
+    assert not failures, f"staging raised: {failures}"
+
+    published = adapter_root() / adapter._digest(source) / PACKAGE_NAME
+    assert (published / "__init__.py").is_file()
+    assert (published / "prices.json").is_file(), "published a half-copied tree"
+    assert (published / "sub" / "posture.py").read_text() == "X = 1\n"
 
 
 def test_a_missing_adapter_refuses_at_construction_naming_the_fix():

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -21,6 +21,7 @@ import pytest
 
 from arenabench import runner as runner_module
 from arenabench import sut
+from arenabench.adapter import stage_adapter
 from arenabench.model import MatchSpec
 from arenabench.provenance import Provenance
 from arenabench.registry import DEFAULT_REGISTRY
@@ -62,6 +63,13 @@ def repo(tmp_path: Path, monkeypatch) -> Path:
     (origin / "a.txt").write_text("three")
     _git(origin, "commit", "-qam", "third")
     _git(work, "fetch", "-q", "origin")
+
+    # A Stella checkout carries the harbor adapter, and a launch now refuses a
+    # Stella seat without one rather than producing a seat that imports nothing
+    # and reports done (#2127, #2192). The fixture models that, minimally.
+    adapter = work / "bench" / "harbor_adapter" / "stella_harbor"
+    adapter.mkdir(parents=True)
+    (adapter / "__init__.py").write_text("VERSION = 'fixture'\n")
 
     monkeypatch.setenv(sut.STELLA_REPO_ENV, str(work))
     monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
@@ -344,12 +352,19 @@ class TestCheckoutDiscovery:
     ) -> None:
         """Launching is not enough if the seat then runs nothing.
 
-        Without ``stella_harbor`` on the subprocess's ``PYTHONPATH``,
-        ``harbor_agent.py`` falls back to ``_Base = object``, Harbor dies with
-        "ArenaStellaAgent() takes no arguments" — and **exits 0**, so the seat
-        reports done having made no model call at all. The adapter ships in the
-        checkout discovery just found, so the arena can wire it rather than
-        depend on an operator remembering a variable whose omission is silent.
+        Without ``stella_harbor`` on the subprocess's ``PYTHONPATH``, the seat
+        makes no model call at all — historically in silence, since
+        ``harbor_agent.py`` fell back to ``_Base = object`` and Harbor exited 0
+        (#2192, now a named refusal). The adapter ships in the checkout
+        discovery just found, so the arena can wire it rather than depend on an
+        operator remembering a variable whose omission is invisible.
+
+        What reaches ``PYTHONPATH`` is a **staged copy** of that checkout's
+        adapter rather than the checkout path itself (#2127): the launch
+        worktree was deleted mid-match once and took four trials with it. The
+        assertion below therefore pins the property that matters — the seat can
+        import ``stella_harbor``, and what it imports came from this checkout —
+        rather than the literal source path, which is no longer what is wired.
         """
         repo, head = self._stage_head(monkeypatch, tmp_path / "home")
         _stub_harbor(monkeypatch)
@@ -360,7 +375,9 @@ class TestCheckoutDiscovery:
         runner._launch(match, match.spec.contestants[0])
 
         roots = captured[0]["env"]["PYTHONPATH"].split(os.pathsep)
-        assert str(repo / "bench" / "harbor_adapter") in roots
+        staged = stage_adapter(repo / "bench" / "harbor_adapter")
+        assert str(staged) in roots
+        assert (Path(staged) / "stella_harbor").is_dir()
 
 
 def _stamped(path: Path, commit: str | None) -> Path:


### PR DESCRIPTION
## The bug, twice

Two defects with one consequence: a trial that never made a model call was counted in `solve_rate`'s denominator as though the agent had tried and failed.

**#2127 — the adapter was read from the launch checkout, at every trial.** In match `cc00894779ff` the server was launched from a git worktree, and that worktree was deleted while the match ran. The four trials that installed afterwards — `fix-git`, `git-leak-recovery`, `sanitize-git-repo`, `prove-plus-comm` — each died in agent setup naming a path that no longer existed: 0 steps, 0 tokens, dead in 30–60s. The server process, its cwd literally inside the deleted worktree, kept accepting and burning trials. The dashboard reported `infrastructure: 0`, `judged: 10`, **`solve_rate` 40%** — against a true agent record of 4/6.

**#2192 — an absent adapter failed silently.** `harbor_agent` built a precise, actionable `ImportError` and then discarded it three lines later with `_Base = object`. `ArenaStellaAgent(...)` then raised `TypeError: takes no arguments` inside the Harbor subprocess, and **Harbor exits 0** — so the arena recorded the seat as *done*, with zero steps and no model call, indistinguishable in the match UI from an agent that ran and failed. Observed on `44c124e06ef7` and `3ca70da630ed`, diagnosable only by opening the seat log.

Both are the class #2098 named: *a fallback that turns a configuration error into a wrong measurement instead of a refusal.*

## The fix

**Stage the adapter instead of re-reading it** (`arenabench/adapter.py`, new). Sources are copied once, on first use, into `<arenabench home>/adapter/<digest>/`; every later trial in the process imports the copy. A running server is now immune to its own launch tree disappearing. Two details that are load-bearing:

- The digest is **content-addressed over every file** in the package, not just `*.py` — the adapter ships data beside its code, and a digest that ignored those would reuse a stale staging directory after they changed. An edited adapter stages fresh rather than being shadowed.
- The process cache is keyed by **(source, arena home)**, not source alone. Keyed on source alone it hands back a path under whichever home was set first — which in the test suite meant staging into the developer's real `~/.arenabench` and then reusing it from a tmp-home test. That is a bug I introduced and caught mid-review; the key is why it cannot recur.

Copy-then-rename, so a concurrent match cannot import a half-copied tree.

**Refuse loudly instead of silently** (`harbor_agent.py`). The module stays importable — that fallback exists so the web UI can list Stella on a machine that never built it — but the stand-in base now raises the saved error **at construction** rather than being `object`. The error is a named `StellaAdapterMissingError(ImportError)`, so existing `except ImportError` paths still catch it.

**Keep both out of the denominator** (`telemetry.py`). `AdapterUnavailableError` and `StellaAdapterMissingError` join `INFRASTRUCTURE_FAILURES` and `VOID_SETUP`. This is the half that actually moves the published number: a seat whose adapter never loaded did not lose a contest, it never entered one.

## A test-fixture change worth reviewing

A Stella seat with no adapter now refuses at launch by name. That made four tests in `test_sut.py` fail — they build a fake checkout with no `bench/harbor_adapter`, so they were previously exercising a launch that *would have produced a zero-work seat*. The `repo` fixture now creates a minimal `bench/harbor_adapter/stella_harbor/`, because a real Stella checkout has one.

**No test was deleted.** `test_the_launch_wires_the_adapter_from_that_same_checkout` keeps its name and its intent; its assertion moves from the literal source path to the staged root, because the staged copy is now what gets wired. Its docstring says why.

## Witness

`arenabench/tests/test_adapter.py`:

- `test_a_staged_adapter_outlives_the_checkout_it_was_copied_from` — stages, deletes the worktree, stages again. The `cc00894779ff` sequence.
- `test_a_missing_adapter_refuses_at_construction_naming_the_fix` — pins that the error names `ARENABENCH_STELLA_ADAPTER` and is **not** a `TypeError`.
- `test_both_failures_are_infrastructure_not_agent_losses` — fails without the telemetry change with `AdapterUnavailableError would score as a loss`. Verified by removing the names and re-running.
- Plus content-addressing (`*.py` and data-file), and the `ImportError` subclass contract.

```
pytest -q (arenabench, non-docker)    all pass
ruff check / ruff format              clean on every file touched
```

## Not fixed here

`arenabench`'s **own** package root is still resolved from `__file__`, so a deleted launch tree can still strand `import arenabench` in the Harbor subprocess by the same mechanism. Staging only covers `stella_harbor`, which is what the observed traceback named. Worth its own issue — I'll file it against this PR.

Closes #2127
Closes #2192

## Summary by Sourcery

Ensure Harbor-based Stella seats only count as contests when their adapter successfully loads, staging adapter sources for robustness and classifying adapter load failures as infrastructure rather than agent losses.

New Features:
- Introduce adapter staging infrastructure that copies the harbor adapter into an ArenaBench home directory and reuses a content-addressed, process-cached copy across trials.

Bug Fixes:
- Prevent seats whose harbor adapter is missing or whose sources disappear mid-match from being treated as agent losses or counted in solve rate.
- Fix silent adapter import failures by raising a named StellaAdapterMissingError at agent construction instead of falling back to an unusable base class.

Enhancements:
- Unify ArenaBench home resolution for staged artifacts and update agent environment wiring to use staged adapter paths rather than direct checkout paths.
- Improve error signalling around missing harbor adapters so operators receive actionable guidance and downstream code can classify the failures correctly.

Documentation:
- Document the new adapter staging behavior, error types, and their impact on solve rate classification in module and test docstrings.

Tests:
- Add a dedicated adapter test suite covering staging behavior, content-addressing, missing-source handling, and infrastructure classification of adapter failures.
- Update system-under-test fixtures and adapter wiring tests to expect staged adapter paths and explicit failures when the harbor adapter is absent.