### PR TITLE
fix(arenabench): find or install a Harbor that can grade, instead of only refusing one that cannot

### DIFF
--- a/arenabench/arenabench/harbor.py
+++ b/arenabench/arenabench/harbor.py
@@ -39,30 +39,75 @@ the Harbor that runs that dataset's matches, falling back to the global
 probe here takes the *resolved binary*, not a fresh global lookup, so the
 Harbor that is asked "do you still have ``--agent-import-path``?" is the one
 that will actually be launched.
+
+**A floor is a thing to satisfy, not only a thing to check.** Refusing to run
+is the right answer when the only Harbor on the machine would mis-grade. It
+was also, for a while, the answer when a perfectly good one sat one directory
+away — the Frontier lane's own virtualenv — because resolution had exactly one
+implicit source, ``PATH``, and PATH held an unrelated 0.6.1. A dataset that
+declares a floor therefore goes through :func:`resolve_for_dataset`, which
+looks for a Harbor that satisfies it and, finding none, installs one. The
+refusal survives underneath as the last resort it was always meant to be.
+
+Two rules keep that convenience from becoming its own hazard:
+
+* **An explicit pin is never second-guessed.** A binary named by
+  ``ARENABENCH_HARBOR`` or a per-dataset override is used, or refused with the
+  variable's name — never quietly replaced. Pinning is how a lane declares its
+  audited constant, and a search that overrode it would make that declaration
+  a lie.
+* **A dataset with no floor resolves exactly as it always did**: PATH, and
+  nothing else. Without a floor every Harbor grades identically as far as this
+  module can tell, so there is nothing to search *for* — and searching anyway
+  is how Terminal-Bench's pinned 0.6.1 lane would silently start running some
+  newer binary that happened to be lying around.
 """
 
 from __future__ import annotations
 
 import functools
+import itertools
 import os
 import re
 import shutil
 import subprocess
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
 
 __all__ = [
     "HARBOR_ENV",
+    "MANAGED_HOME_ENV",
+    "NO_PROVISION_ENV",
     "HarborTooOldError",
     "HarborUnavailableError",
+    "Resolution",
     "dataset_harbor_env",
     "harbor_bin",
     "harbor_version",
+    "managed_root",
     "parse_version",
+    "provision",
     "require_for_dataset",
+    "resolve_for_dataset",
     "supports_agent_import_path",
 ]
 
 #: Points ArenaBench at one specific Harbor, rather than whatever is on PATH.
 HARBOR_ENV = "ARENABENCH_HARBOR"
+
+#: Moves the directory :func:`provision` installs Harbors into.
+MANAGED_HOME_ENV = "ARENABENCH_HARBOR_HOME"
+
+#: Set truthy to make a missing Harbor a refusal instead of an installation.
+#: A hermetic CI runner wants this; a laptop about to start a match does not.
+NO_PROVISION_ENV = "ARENABENCH_HARBOR_NO_PROVISION"
+
+#: How long one ``uv`` invocation gets. Generous because this is a cold
+#: package download on a machine that may be running a benchmark at the same
+#: time, and the cost of being wrong is a spurious failure at the start of a
+#: paid run.
+PROVISION_TIMEOUT = 900.0
 
 
 def dataset_harbor_env(dataset_key: str) -> str:
@@ -87,6 +132,37 @@ class HarborTooOldError(RuntimeError):
     """The installed Harbor predates what this dataset needs to grade correctly."""
 
 
+def _executable(path: str | Path) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _pinned(dataset_key: str | None) -> tuple[str, str] | None:
+    """The Harbor an environment variable names, and which variable named it.
+
+    ``None`` when no pin is set, which is the signal that resolution is free
+    to look around. A pin that points at nothing is an error rather than a
+    fallback: it means someone stated an intent that cannot be honoured, and
+    quietly running a different Harbor is precisely what a pin exists to
+    prevent.
+    """
+    names = []
+    if dataset_key:
+        names.append(dataset_harbor_env(dataset_key))
+    names.append(HARBOR_ENV)
+    for name in names:
+        value = os.environ.get(name)
+        if not value:
+            continue
+        if not _executable(value):
+            raise HarborUnavailableError(
+                f"{name}={value} is not an executable file. Point it at a "
+                "harbor binary (e.g. .venv/bin/harbor), or unset it to fall "
+                "back to the resolution this module documents."
+            )
+        return value, name
+    return None
+
+
 def harbor_bin(dataset_key: str | None = None) -> str:
     """The Harbor to run, honouring the per-dataset override first.
 
@@ -94,26 +170,14 @@ def harbor_bin(dataset_key: str | None = None) -> str:
     given), then the global :data:`HARBOR_ENV`, then PATH. Raises
     :class:`HarborUnavailableError` with the ways to fix it, rather than
     letting a missing binary surface as a subprocess error deep in a launch.
+
+    This answers "which Harbor, all else being equal". A caller that knows the
+    dataset's floor wants :func:`resolve_for_dataset` instead, which can find
+    or build one that clears it.
     """
-    if dataset_key:
-        name = dataset_harbor_env(dataset_key)
-        override = os.environ.get(name)
-        if override:
-            if not os.path.isfile(override) or not os.access(override, os.X_OK):
-                raise HarborUnavailableError(
-                    f"{name}={override} is not an executable file. Point it at "
-                    "a harbor binary (e.g. .venv/bin/harbor), or unset it to "
-                    "fall back to the global resolution."
-                )
-            return override
-    override = os.environ.get(HARBOR_ENV)
-    if override:
-        if not os.path.isfile(override) or not os.access(override, os.X_OK):
-            raise HarborUnavailableError(
-                f"{HARBOR_ENV}={override} is not an executable file. Point it at a "
-                "harbor binary (e.g. .venv/bin/harbor), or unset it to use PATH."
-            )
-        return override
+    pin = _pinned(dataset_key)
+    if pin is not None:
+        return pin[0]
     found = shutil.which("harbor")
     if found is None:
         raise HarborUnavailableError(
@@ -217,11 +281,315 @@ def require_for_dataset(
     if parse_version(installed) >= parse_version(minimum):
         return
     raise HarborTooOldError(
-        f"{dataset_title} needs harbor >= {minimum}, but {resolved} is "
-        f"{installed}. An older Harbor does not merely fail here — it drops "
-        f"task settings it does not recognise and grades against the wrong "
-        f"container topology, so the run would finish and report a wrong "
-        f"score. Install a newer Harbor, or set {HARBOR_ENV} (or the "
-        f"per-dataset override this module documents) to a virtualenv that "
-        f"has one (e.g. `uv pip install 'harbor[modal]=={minimum}'`)."
+        _too_old(dataset_title, minimum, f"{resolved} is {installed}")
+        + f" Install a newer Harbor, or set {HARBOR_ENV} (or the per-dataset "
+        f"override this module documents) to a virtualenv that has one "
+        f"(e.g. `uv pip install 'harbor[modal]=={minimum}'`)."
     )
+
+
+def _too_old(dataset_title: str, minimum: str, found: str) -> str:
+    """The single statement of why an old Harbor is refused, not warned about.
+
+    ``found`` is the only part that differs between a pin that came up short
+    and a whole search that did, so the explanation itself — the reason this
+    is a refusal — has one copy and cannot drift into two tempers.
+    """
+    return (
+        f"{dataset_title} needs harbor >= {minimum}, but {found}. An older "
+        "Harbor does not merely fail here — it drops task settings it does "
+        "not recognise and grades against the wrong container topology, so "
+        "the run would finish and report a wrong score."
+    )
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """The Harbor a match is about to launch, and how it came to be chosen.
+
+    ``origin`` exists so the choice reaches the run's notes. Resolution can
+    now end at a binary nobody named — one found in a lane's virtualenv, or
+    one installed on the spot — and a measurement apparatus that reconfigures
+    itself has to say so where the numbers are read, not only in a log.
+    """
+
+    binary: str
+    version: str
+    origin: str
+
+    @property
+    def note(self) -> str:
+        """The one line a run records about which Harbor graded it."""
+        return f"harbor {self.version} ({self.binary}) — {self.origin}"
+
+
+def managed_root() -> Path:
+    """Where ArenaBench keeps the Harbors it installed itself.
+
+    One directory per exact version, because a machine running two datasets
+    with two floors needs both at once and a single shared directory is how
+    one of them would silently become the other. Overridable with
+    :data:`MANAGED_HOME_ENV`, matching what
+    :func:`~arenabench.registry.export_root` already offers for datasets.
+    """
+    override = os.environ.get(MANAGED_HOME_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".arenabench" / "harbor"
+
+
+def _version_or_none(binary: str) -> str | None:
+    """This binary's version, or ``None`` when it cannot be asked for one.
+
+    Discovery walks speculative paths, and a stale or half-built virtualenv on
+    one of them has to drop out of the running rather than abort a search that
+    would have found a good Harbor two entries later.
+
+    Through :func:`harbor_version` rather than the cache behind it, so every
+    version this module believes comes from the one public accessor.
+    """
+    try:
+        return harbor_version(binary)
+    except HarborUnavailableError:
+        return None
+
+
+def _meets(version: str | None, minimum: str | None) -> bool:
+    if version is None:
+        return False
+    return not minimum or parse_version(version) >= parse_version(minimum)
+
+
+def _repo_root() -> Path | None:
+    """This checkout's root, or ``None`` when ArenaBench runs from elsewhere.
+
+    Both starting points earn their place. ArenaBench is normally run straight
+    out of a checkout with no install at all (``python -m arenabench`` with the
+    project directory as the working directory), which only the working
+    directory finds; an installed copy would not be found that way, and
+    ``__file__`` is what still points into a tree then.
+    """
+    for start in (Path(__file__).resolve().parent, Path.cwd()):
+        try:
+            resolved = start.resolve()
+        except OSError:  # a deleted working directory is not fatal here
+            continue
+        for candidate in (resolved, *resolved.parents):
+            if (candidate / "bench").is_dir() and (candidate / "arenabench").is_dir():
+                return candidate
+    return None
+
+
+def _discovered() -> Iterator[tuple[str, str]]:
+    """Harbors worth trying once PATH's cannot grade the dataset.
+
+    Ordered by how much ArenaBench knows about each: the ones it installed
+    itself, newest first, then the per-lane virtualenvs of this checkout —
+    ``bench/evidence/frontier/.venv`` being exactly where a correct Harbor was
+    already sitting on the machine that motivated this search.
+    """
+    root = managed_root()
+    if root.is_dir():
+        versions = sorted(root.iterdir(), key=lambda p: parse_version(p.name), reverse=True)
+        for child in versions:
+            binary = child / "bin" / "harbor"
+            if _executable(binary):
+                yield str(binary), f"installed by arenabench in {root}"
+    repo = _repo_root()
+    if repo is None:
+        return
+    for pattern in ("bench/*/.venv/bin/harbor", "bench/evidence/*/.venv/bin/harbor"):
+        for binary in sorted(repo.glob(pattern)):
+            if _executable(binary):
+                lane = binary.relative_to(repo).parents[2]
+                yield str(binary), f"found in this checkout's {lane} virtualenv"
+
+
+def _install(uv: str, venv: Path, version: str, timeout: float) -> None:
+    """Build `venv` and put exactly ``harbor==version`` in it.
+
+    ``--relocatable`` is load-bearing rather than tidy: :func:`provision`
+    renames this directory into place when it is finished, and uv's ordinary
+    console scripts hard-code the interpreter path they were created at, so a
+    moved virtualenv's ``harbor`` would be a file that exists and cannot run.
+
+    Plain ``harbor``, not ``harbor[modal]``: every match this resolves for
+    launches with ``--env docker``, and the Modal extra is a large dependency
+    tree for a scheduler that would not be used. A lane that wants Modal
+    builds its own virtualenv and pins it, which is the path that already
+    exists for saying so.
+    """
+    steps = (
+        [uv, "venv", "--relocatable", str(venv)],
+        [uv, "pip", "install", "--python", str(venv / "bin" / "python"), f"harbor=={version}"],
+    )
+    for argv in steps:
+        try:
+            out = subprocess.run(
+                argv, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise HarborUnavailableError(f"`{' '.join(argv)}` did not finish: {exc}") from exc
+        if out.returncode != 0:
+            noise = _ANSI.sub("", (out.stderr or out.stdout or "")).strip().splitlines()
+            tail = " / ".join(noise[-3:]) if noise else f"exit {out.returncode}"
+            raise HarborUnavailableError(f"`{' '.join(argv)}` failed: {tail}")
+
+
+def provision(minimum: str, *, timeout: float = PROVISION_TIMEOUT) -> str:
+    """Install exactly Harbor `minimum` under :func:`managed_root`, and return it.
+
+    The install lands in a staging directory named for this process and is
+    renamed into place only once it is complete, so a crash or a cancelled run
+    can never leave a half-populated version directory for the next match to
+    find, believe, and launch.
+
+    That rename is also what serialises concurrent callers, which is the
+    ordinary case here rather than a contrived one — this machine routinely
+    has three arena servers up at once. Two processes may both build; exactly
+    one rename can win, and the loser takes the winner's copy. It is
+    identical by construction, since the version is pinned exactly, and
+    replacing a directory another process may already be executing out of
+    would be the more dangerous move.
+    """
+    target = managed_root() / minimum
+    binary = target / "bin" / "harbor"
+
+    def ready() -> bool:
+        return _executable(binary) and _meets(_version_or_none(str(binary)), minimum)
+
+    if ready():
+        return str(binary)
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise HarborUnavailableError(
+            f"no harbor >= {minimum} was found, and `uv` is not installed so "
+            "one cannot be built. Install uv (https://docs.astral.sh/uv/), or "
+            f"set {HARBOR_ENV} to a virtualenv that has a new enough harbor."
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = target.with_name(f"{target.name}.staging.{os.getpid()}")
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        _install(uv, staging, minimum, timeout)
+        try:
+            os.rename(staging, target)
+        except OSError:
+            # Either a peer finished first, or an older build left a directory
+            # here that is not usable. Take a good one; replace a bad one.
+            _version_of.cache_clear()
+            if not ready():
+                shutil.rmtree(target, ignore_errors=True)
+                os.rename(staging, target)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    _version_of.cache_clear()
+    if not ready():
+        raise HarborUnavailableError(
+            f"installed harbor into {target}, but it does not report a "
+            f"version of at least {minimum}"
+        )
+    return str(binary)
+
+
+def _provision_allowed() -> bool:
+    return os.environ.get(NO_PROVISION_ENV, "").strip().lower() not in ("1", "true", "yes", "on")
+
+
+def resolve_for_dataset(
+    dataset_key: str | None,
+    minimum: str | None,
+    dataset_title: str,
+    *,
+    allow_provision: bool | None = None,
+) -> Resolution:
+    """The Harbor that will grade this dataset — found, or installed if need be.
+
+    The order is a policy, not a preference:
+
+    1. **A pin wins outright.** Used if it clears the floor, refused by name if
+       it does not. Never replaced — see this module's header.
+    2. **PATH keeps its job whenever it can do it.** A machine whose ``harbor``
+       already grades this dataset resolves exactly as it did before any of
+       this existed.
+    3. **Otherwise look**, through :func:`_discovered`, for one that clears the
+       floor. This is the step that would have turned the failure this function
+       was written for into a run: the right Harbor was already installed, one
+       directory away, and nothing was looking.
+    4. **Otherwise build one**, unless :data:`NO_PROVISION_ENV` says not to.
+    5. **Otherwise refuse**, naming every Harbor that was tried and its
+       version, because "too old" without "and here is what I looked at" is
+       the message that sent someone hunting for a binary they already had.
+
+    Steps 3 and 4 only ever happen when `minimum` is set. Without a floor
+    there is nothing to search for, and the search would silently swap the
+    binary under a lane whose claim rests on one audited version.
+    """
+    pin = _pinned(dataset_key)
+    if pin is not None:
+        binary, name = pin
+        version = harbor_version(binary)
+        if minimum and not _meets(version, minimum):
+            raise HarborTooOldError(
+                _too_old(dataset_title, minimum, f"{binary} is {version}")
+                + f" That Harbor is pinned by {name}, and a pin is honoured "
+                "rather than second-guessed, so this is for you to change: "
+                f"point {name} at a newer virtualenv, or unset it to let "
+                "arenabench find or install one."
+            )
+        return Resolution(binary, version, f"pinned by {name}")
+
+    # Deliberately through `harbor_bin` and not a bare `shutil.which`: that is
+    # the seam the rest of the codebase and its tests already treat as "the
+    # ordinary lookup", and a second copy here would be a second thing to keep
+    # true. Without a floor its answer is also the final answer.
+    if not minimum:
+        binary = harbor_bin(dataset_key)
+        return Resolution(binary, harbor_version(binary), "found on PATH")
+    try:
+        on_path: str | None = harbor_bin(dataset_key)
+    except HarborUnavailableError:
+        on_path = None
+
+    tried: list[str] = []
+    candidates = itertools.chain(
+        [(on_path, "found on PATH")] if on_path else [],
+        _discovered(),
+    )
+    for binary, origin in candidates:
+        version = _version_or_none(binary)
+        if version is None:
+            continue
+        if _meets(version, minimum):
+            return Resolution(binary, version, origin)
+        tried.append(f"{binary} is {version}")
+
+    if allow_provision is None:
+        allow_provision = _provision_allowed()
+    if not allow_provision:
+        raise HarborTooOldError(
+            _too_old(dataset_title, minimum, _summarise(tried))
+            + f" Installing one automatically is off ({NO_PROVISION_ENV}), so "
+            f"either unset that or set {HARBOR_ENV} to a virtualenv that has "
+            f"harbor {minimum} or newer."
+        )
+    try:
+        binary = provision(minimum)
+    except HarborUnavailableError as exc:
+        raise HarborTooOldError(
+            _too_old(dataset_title, minimum, _summarise(tried))
+            + f" Installing one automatically also failed: {exc}"
+        ) from exc
+    return Resolution(binary, harbor_version(binary), f"installed by arenabench for {dataset_title}")
+
+
+def _summarise(tried: list[str]) -> str:
+    """What the search actually saw, for a refusal that has to be actionable."""
+    if not tried:
+        return "no harbor was found at all"
+    if len(tried) == 1:
+        return tried[0]
+    return "the only ones found were " + ", ".join(tried)

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -109,12 +109,14 @@ def _base_environment() -> dict[str, str]:
     return env
 
 
-def _provenance_for(match: Match) -> provenance.Provenance:
+def _provenance_for(
+    match: Match, resolved: harbor.Resolution | None
+) -> provenance.Provenance:
     """The apparatus this match is about to run on.
 
-    Harbor is asked for its version here rather than trusted from config: the
-    binary on PATH can change between one match and the next, and the record
-    has to say what actually graded *these* trials.
+    Harbor is recorded from the resolution rather than trusted from config:
+    the binary on PATH can change between one match and the next, and the
+    record has to say what actually graded *these* trials.
 
     The SUT half reads the **same pin observation the launch reads**
     (:meth:`Match.sut_pin_for`), not a second resolution of the same ref:
@@ -126,14 +128,20 @@ def _provenance_for(match: Match) -> provenance.Provenance:
     """
     from . import __version__
 
-    try:
-        binary = harbor.harbor_bin(match.spec.dataset)
-        version: str | None = harbor.harbor_version(binary)
-    except harbor.HarborUnavailableError:
-        # The launch below will fail and say so properly. The record still
-        # gets written, unknown rather than absent, so a half-started match
-        # is not mistaken later for one that ran on the current Harbor.
+    # The Harbor half takes the *same resolution the launch will use*, for the
+    # reason the SUT half does: resolving twice records an apparatus that was
+    # never the one that ran. Harbor resolution can now end at a binary nobody
+    # named — one discovered in a lane virtualenv, or one installed on the
+    # spot — so a second independent lookup here would have written down the
+    # PATH Harbor while a different one did the grading.
+    if resolved is None:
+        # Resolution failed; the launch below fails too and says so properly.
+        # The record is still written, unknown rather than absent, so a
+        # half-started match is not mistaken later for one that ran on the
+        # current Harbor.
         version, binary = None, ""
+    else:
+        version, binary = resolved.version, resolved.binary
 
     sut_seats: dict[str, dict[str, str]] = {}
     for contestant in match.spec.contestants:
@@ -630,16 +638,37 @@ class MatchRunner:
         match.status = "running"
         match.started_at = time.time()
 
+        # Resolve Harbor once, for the whole match, before anything else needs
+        # an answer. Three things follow from doing it here rather than inside
+        # each seat's launch: provenance records the binary that actually
+        # grades (below), a Harbor that has to be installed is installed once
+        # instead of once per seat, and a machine-wide problem is reported as
+        # one fact about the match instead of N identical seat errors.
+        #
+        # The failure is carried rather than raised, so a Harbor that cannot
+        # be resolved still surfaces exactly where it did before — against
+        # each seat, next to that seat's other launch errors.
+        resolved: harbor.Resolution | None = None
+        harbor_error: Exception | None = None
+        try:
+            resolved = self.resolve_harbor(match)
+        except (harbor.HarborUnavailableError, harbor.HarborTooOldError) as exc:
+            harbor_error = exc
+
         # Record the apparatus before the first trial, not after the last one:
         # a match that is killed mid-run still produced trials, and a trial
         # whose grading stack is unrecorded cannot be compared to anything
         # later (see `arenabench.provenance`).
-        match.provenance = _provenance_for(match)
+        match.provenance = _provenance_for(match, resolved)
         provenance.write_match(match.workspace, match.provenance)
 
         for contestant in match.spec.contestants:
             try:
-                run = self._launch(match, contestant)
+                if resolved is None:
+                    raise harbor_error or harbor.HarborUnavailableError(
+                        "harbor was not resolved for this match"
+                    )
+                run = self._launch(match, contestant, resolved)
             except Exception as exc:  # a bad seat must not abort the match
                 log.exception("failed to launch %s", contestant.name)
                 run = ContestantRun(
@@ -675,7 +704,21 @@ class MatchRunner:
             target=self._await_completion, args=(match,), daemon=True
         ).start()
 
-    def _launch(self, match: Match, contestant: Contestant) -> ContestantRun:
+    def resolve_harbor(self, match: Match) -> harbor.Resolution:
+        """The one Harbor this match's seats will all be graded by.
+
+        Deliberately not a default argument on :meth:`_launch`: a parameter
+        that quietly resolves again when omitted is how provenance came to
+        record an apparatus that never ran (#2098). Every caller says which
+        resolution it means, and there is exactly one per match.
+        """
+        return harbor.resolve_for_dataset(
+            match.spec.dataset, match.dataset.min_harbor, match.dataset.title
+        )
+
+    def _launch(
+        self, match: Match, contestant: Contestant, resolved: harbor.Resolution
+    ) -> ContestantRun:
         spec = resolve_agent(contestant.agent)
         job_name = f"{match.spec.id}-{contestant.slug}"
         job_dir = match.jobs_root / job_name
@@ -698,17 +741,14 @@ class MatchRunner:
         for knob in spec.unhonoured(contestant.engine):
             run.warnings.append(f"{spec.title} ignores {knob}")
 
-        # Resolve Harbor — per dataset, so one server can pin the audited
-        # 0.6.1 for Terminal-Bench while Frontier-Bench runs its 0.20.0 venv —
-        # and check it is new enough to grade THIS dataset before anything is
-        # launched. A Harbor that predates a task setting discards it and
-        # produces a complete run with a wrong score, so this is a refusal,
-        # not a warning (see `arenabench.harbor`).
-        harbor_exe = harbor.harbor_bin(match.spec.dataset)
-        harbor.require_for_dataset(
-            match.dataset.min_harbor, match.dataset.title, binary=harbor_exe
-        )
-        run.notes.append(f"harbor {harbor.harbor_version(harbor_exe)} ({harbor_exe})")
+        # Harbor was resolved once for the whole match, per dataset — so one
+        # server can pin the audited 0.6.1 for Terminal-Bench while
+        # Frontier-Bench runs a 0.20.0 it found or installed — and already
+        # checked against this dataset's floor. The note records which binary
+        # and how it was chosen, because resolution can legitimately land
+        # somewhere nobody named (see `arenabench.harbor`).
+        harbor_exe = resolved.binary
+        run.notes.append(resolved.note)
 
         # Prefer an offline export. Given a registry ref, Harbor resolves
         # every task against its backend at run time, and one failed lookup

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -893,7 +893,7 @@ class TestOfflineTaskSource:
         })
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(spec)
-        runner._launch(match, spec.contestants[0])
+        runner._launch(match, spec.contestants[0], runner.resolve_harbor(match))
         return seen["command"]
 
     def test_an_export_is_filtered_by_bare_task_name(self, tmp_path: Path, monkeypatch):
@@ -952,7 +952,7 @@ class TestSeatLaunchRecord:
         )
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(spec)
-        run = runner._launch(match, spec.contestants[0])
+        run = runner._launch(match, spec.contestants[0], runner.resolve_harbor(match))
 
         record = json.loads(seat_manifest_path(run.job_dir).read_text(encoding="utf-8"))
         # The two spellings genuinely diverge for this seat — that divergence

--- a/arenabench/tests/test_presets.py
+++ b/arenabench/tests/test_presets.py
@@ -322,6 +322,141 @@ class TestPerDatasetHarbor:
         assert dataset.min_harbor == "0.20.0"
 
 
+def _fake_harbor(path: Path, version: str) -> Path:
+    """A binary that answers ``--version`` and nothing else.
+
+    Enough for resolution, which only ever asks that question of a candidate.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'#!/bin/sh\necho "{version}"\n')
+    path.chmod(0o755)
+    return path
+
+
+class TestResolutionSatisfiesTheFloorRatherThanOnlyCheckingIt:
+    """A floor the machine can already meet must not stop a run.
+
+    The failure this class pins down happened on a laptop that had a correct
+    Harbor installed the whole time: PATH held an unrelated 0.6.1, resolution
+    looked nowhere else, and every seat of a one-task Frontier-Bench match
+    failed before a single trial ran. Refusing was right in general and wrong
+    here, and the difference is whether anything went looking.
+    """
+
+    def test_an_old_harbor_on_path_is_no_longer_the_end_of_the_search(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """The witness: PATH cannot grade, something else can, so the run lives."""
+        on_path = _fake_harbor(tmp_path / "path" / "harbor", "0.6.1")
+        good = _fake_harbor(tmp_path / "managed" / "0.20.0" / "bin" / "harbor", "0.20.0")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+
+        resolved = harbor.resolve_for_dataset(
+            "frontier-bench", "0.20.0", "Frontier Bench"
+        )
+
+        assert resolved.binary == str(good)
+        assert resolved.version == "0.20.0"
+
+    def test_a_dataset_with_no_floor_still_resolves_to_path_alone(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Terminal-Bench's 0.6.1 lane must not be quietly upgraded.
+
+        Its whole claim rests on one audited binary. With no floor to satisfy
+        there is nothing to search *for*, so the newer Harbor sitting right
+        there is not a better answer — it is a different experiment.
+        """
+        on_path = _fake_harbor(tmp_path / "path" / "harbor", "0.6.1")
+        _fake_harbor(tmp_path / "managed" / "0.20.0" / "bin" / "harbor", "0.20.0")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+
+        resolved = harbor.resolve_for_dataset(
+            "terminal-bench-2.1", None, "Terminal-Bench 2.1"
+        )
+
+        assert resolved.binary == str(on_path)
+
+    def test_path_keeps_the_job_when_it_can_do_the_job(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Satisfying the floor is the test, not being the newest thing around."""
+        on_path = _fake_harbor(tmp_path / "path" / "harbor", "0.20.0")
+        _fake_harbor(tmp_path / "managed" / "0.30.0" / "bin" / "harbor", "0.30.0")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+
+        resolved = harbor.resolve_for_dataset(
+            "frontier-bench", "0.20.0", "Frontier Bench"
+        )
+
+        assert resolved.binary == str(on_path)
+
+    def test_a_pin_that_is_too_old_is_refused_by_name_never_replaced(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """A pin states an intent; searching past it would make that a lie.
+
+        This is the one case that still refuses even though a good Harbor is
+        sitting in plain sight, and it refuses *because* one is: silently
+        running a binary other than the pinned one is how a lane stops being
+        the thing it says it is.
+        """
+        pinned = _fake_harbor(tmp_path / "pinned" / "harbor", "0.6.1")
+        _fake_harbor(tmp_path / "managed" / "0.20.0" / "bin" / "harbor", "0.20.0")
+        monkeypatch.setenv("ARENABENCH_HARBOR_FRONTIER_BENCH", str(pinned))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+
+        with pytest.raises(harbor.HarborTooOldError) as refusal:
+            harbor.resolve_for_dataset("frontier-bench", "0.20.0", "Frontier Bench")
+
+        assert "ARENABENCH_HARBOR_FRONTIER_BENCH" in str(refusal.value)
+
+    def test_a_refusal_names_every_harbor_it_actually_looked_at(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """"Too old" without "and here is what I saw" is what sent someone hunting."""
+        on_path = _fake_harbor(tmp_path / "path" / "harbor", "0.6.1")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+        monkeypatch.setenv(harbor.NO_PROVISION_ENV, "1")
+        monkeypatch.setattr(harbor, "_repo_root", lambda: None)
+
+        with pytest.raises(harbor.HarborTooOldError) as refusal:
+            harbor.resolve_for_dataset("frontier-bench", "0.20.0", "Frontier Bench")
+
+        message = str(refusal.value)
+        assert str(on_path) in message and "0.6.1" in message
+
+    def test_nothing_usable_anywhere_installs_one_rather_than_giving_up(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """The last resort before the refusal, and the reason a fresh box works.
+
+        Stubbed at :func:`arenabench.harbor.provision` rather than run for
+        real: that a ``uv`` install produces a working 0.20.0 is uv's contract,
+        not this module's, and paying a package download per test run would buy
+        no confidence about the thing under test — which is that resolution
+        *reaches* for it before it refuses.
+        """
+        on_path = _fake_harbor(tmp_path / "path" / "harbor", "0.6.1")
+        built = _fake_harbor(tmp_path / "built" / "bin" / "harbor", "0.20.0")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        monkeypatch.setenv(harbor.MANAGED_HOME_ENV, str(tmp_path / "managed"))
+        monkeypatch.delenv(harbor.NO_PROVISION_ENV, raising=False)
+        monkeypatch.setattr(harbor, "_repo_root", lambda: None)
+        monkeypatch.setattr(harbor, "provision", lambda minimum, **_: str(built))
+
+        resolved = harbor.resolve_for_dataset(
+            "frontier-bench", "0.20.0", "Frontier Bench"
+        )
+
+        assert resolved.binary == str(built)
+        assert resolved.version == "0.20.0"
+
+
 class TestBothLaunchPathsAgree:
     """`arenabench run` and the UI must resolve a seat the same way.
 

--- a/arenabench/tests/test_security.py
+++ b/arenabench/tests/test_security.py
@@ -137,7 +137,7 @@ class TestSeatEnvironmentIsScreened:
         )
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(replace(spec, contestants=(seat,)))
-        run = runner._launch(match, seat)
+        run = runner._launch(match, seat, runner.resolve_harbor(match))
 
         assert seen["env"]["ZAI_API_KEY"] == "zk"
         assert seen["env"].get("PATH") != "/evil/bin"

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -357,7 +357,7 @@ class TestCheckoutDiscovery:
 
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._spec(head))
-        runner._launch(match, match.spec.contestants[0])
+        runner._launch(match, match.spec.contestants[0], runner.resolve_harbor(match))
 
         roots = captured[0]["env"]["PYTHONPATH"].split(os.pathsep)
         assert str(repo / "bench" / "harbor_adapter") in roots
@@ -781,8 +781,9 @@ class TestTwoSeatsRaceTwoBuilds:
 
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._two_seat_spec(head, other))
+        resolution = runner.resolve_harbor(match)
         runs = {
-            contestant.id: runner._launch(match, contestant)
+            contestant.id: runner._launch(match, contestant, resolution)
             for contestant in match.spec.contestants
         }
 
@@ -810,7 +811,7 @@ class TestTwoSeatsRaceTwoBuilds:
 
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._two_seat_spec(head, other))
-        record = runner_module._provenance_for(match)
+        record = runner_module._provenance_for(match, runner.resolve_harbor(match))
 
         assert record.sut_seats["champ"]["commit"] == head
         assert record.sut_seats["chall"]["commit"] == other
@@ -877,7 +878,7 @@ class TestAPinIsObservedOnce:
 
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._stella_spec(built))
-        run = runner._launch(match, match.spec.contestants[0])
+        run = runner._launch(match, match.spec.contestants[0], runner.resolve_harbor(match))
 
         assert run.error == ""
         assert captured[0]["env"]["STELLA_BINARY"] == str(binary)
@@ -905,7 +906,7 @@ class TestAPinIsObservedOnce:
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._stella_spec("main"))
         with pytest.raises(sut.SutUnavailableError) as refusal:
-            runner._launch(match, match.spec.contestants[0])
+            runner._launch(match, match.spec.contestants[0], runner.resolve_harbor(match))
         assert "moved since the build" in str(refusal.value)
         assert built[:8] in str(refusal.value)
         assert captured == [], "a refused trial must launch nothing at all"
@@ -933,8 +934,10 @@ class TestAPinIsObservedOnce:
         monkeypatch.setattr(sut, "resolve_ref", moving)
         runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
         match = runner.create(self._stella_spec("main"))
-        match.provenance = runner_module._provenance_for(match)
-        run = runner._launch(match, match.spec.contestants[0])
+        match.provenance = runner_module._provenance_for(
+            match, runner.resolve_harbor(match)
+        )
+        run = runner._launch(match, match.spec.contestants[0], runner.resolve_harbor(match))
 
         assert run.error == ""
         recorded = match.provenance.sut_seats["st"]["commit"]


### PR DESCRIPTION
## What broke

Kicking off a **one-task Frontier-Bench match** failed before a single trial ran. Every seat died with the same message:

> Frontier Bench needs harbor >= 0.20.0, but `/opt/homebrew/bin/harbor` is 0.6.1. An older Harbor does not merely fail here — it drops task settings it does not recognise and grades against the wrong container topology…

The refusal itself is correct and stays. Harbor 0.6.1 does not know Frontier-Bench's `[verifier] environment_mode = "separate"`, pydantic's default `extra="ignore"` discards it, and the run completes with rewards from the wrong container topology — plausible numbers answering a different question, which is the worst failure a benchmark can have.

What was wrong is that **a correct Harbor was installed on that machine the whole time**, one directory away in `bench/evidence/frontier/.venv`. Nothing looked for it, because resolution had exactly one implicit source: `PATH`.

## What changed

A floor is now something to **satisfy** before it is something to fail on. `resolve_for_dataset` walks, in order:

1. an explicit pin (`ARENABENCH_HARBOR`, or the per-dataset override),
2. `PATH`, kept whenever it can grade the dataset,
3. Harbors arenabench installed itself, then this checkout's lane virtualenvs,
4. a fresh `uv` install of the exact pinned version,
5. and only then the refusal — which now names every binary it looked at and what version each was.

Two rules keep that convenience from becoming its own hazard:

- **A pin is never second-guessed.** A pinned Harbor is used, or refused *by variable name* — never quietly replaced. Pinning is how a lane declares its audited constant; a search that overrode it would make that declaration a lie.
- **A dataset with no floor resolves exactly as before**: `PATH`, and nothing else. Terminal-Bench 2.1 keeps running the 0.6.1 its claim rests on, rather than some newer binary that happens to be lying around. This is the property that lets the change land while a Terminal-Bench match is running.

### Resolution moved up to the match

It had been happening once per seat, and separately again when building the provenance record. That second lookup is the shape that once wrote down an apparatus which never ran (#2098) — and with discovery in play, the two could now legitimately disagree, recording 0.6.1 while 0.20.0 did the grading. One resolution per match feeds both, so:

- provenance cannot name a Harbor that did not grade,
- a Harbor that must be installed is installed **once**, not per seat,
- and a machine-wide problem is one fact about the match instead of *N* identical seat errors.

`resolve_harbor` is a named method rather than a defaulted `_launch` parameter on purpose: a parameter that silently re-resolves when omitted is precisely how #2098 happened.

## Witness

Six tests in `arenabench/tests/test_presets.py::TestResolutionSatisfiesTheFloorRatherThanOnlyCheckingIt`. Checked the artisanal way, in a detached worktree at `origin/main` with only the test file copied in: **6/6 fail there, 6/6 pass here.**

Because an `AttributeError` witness only proves a name is new, the behaviour was also verified end to end on the machine that hit the bug, against its real `PATH` and real virtualenvs:

| tree | frontier-bench |
|---|---|
| `origin/main` | `REFUSES: HarborTooOldError … /opt/homebrew/bin/harbor is 0.6.1` — the reported error, exactly |
| this branch | `LAUNCHES: harbor 0.20.0 (~/.arenabench/harbor/0.20.0/bin/harbor)` |

And the lane that must not move:

```
terminal-bench-2.1   -> 0.6.1    /opt/homebrew/bin/harbor  [found on PATH]
frontier-bench       -> 0.20.0   ~/.arenabench/harbor/0.20.0/bin/harbor
```

The provisioned binary was checked for real, not just for a version string: `harbor run --help` advertises `--include-task-name`, and `uv venv --relocatable` was confirmed to produce a `#!/bin/sh` wrapper that still runs after the staging directory is renamed into place — which is what makes the build-then-rename safe.

Full suite: 489 passed.

## Notes

- **No lock file.** Concurrent provisions are serialised by the rename itself: both may build, exactly one rename wins, and the loser takes the winner's copy — identical by construction, since the version is pinned exactly. Replacing a directory another process may be executing out of would be the more dangerous move. This machine routinely has three arena servers up, so this is the ordinary case, not a contrived one.
- **Plain `harbor`, not `harbor[modal]`.** Every match this resolves for launches `--env docker`; the Modal extra is a large dependency tree for a scheduler that would not be used. A lane wanting Modal builds and pins its own virtualenv, which is the path that already exists for saying so.
- **`ARENABENCH_HARBOR_NO_PROVISION=1`** turns installation back off for a hermetic runner.
- No new dependencies. `uv` is invoked if present and its absence is a named, actionable error.

## Left behind, filed

- **#2270** — `bench/evidence/frontier/env.sh` still hard-fails on a missing lane virtualenv, which is the same "a floor is only checked, never satisfied" shape on the shell surface. Not fixed here: that lane asserts an *exact* version for an audited evidence claim and needs `harbor[modal]`, so it is a different resolver with different constraints, not a call into this one.
- **Refs #1773** — that issue asks for the same move for Docker (preflight at match start instead of letting both seats crash into it). This lands the match-level preflight seam for Harbor; Docker is still unchecked, so the issue stays open.
