### PR TITLE
feat(arenabench): surface the proof rail — witness, oracle flip, pipeline models, and the reasons

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -25,6 +25,7 @@ from .recorder import IMAGE_TAG, build_image, docker_available, image_present
 from .registry import DEFAULT_REGISTRY, export_root, sample_tasks
 from .replay import ReplayError, replay_flip
 from .server import default_workspace, serve
+from .telemetry import EVENTS_NAME, MetricsReader, TrialMetrics, aggregate
 
 __all__ = ["main"]
 
@@ -457,6 +458,98 @@ def _task_dir_for(trial_dir: Path) -> Path | None:
     return Path(str(path)) if path else None
 
 
+#: Grade -> the one-word reading, for the terminal's narrow column.
+_GRADE_GLYPH: dict[str, str] = {
+    "flip": "flip",
+    "oracle": "oracle",
+    "refuted": "refuted",
+    "unproven": "unproven",
+    "waived": "waived",
+    "unwarranted": "not due",
+    "model": "model",
+    "heuristic": "heuristic",
+    "none": "-",
+}
+
+
+def _cmd_proof(args: argparse.Namespace) -> int:
+    """Print the proof rail of every trial under a path.
+
+    The terminal twin of the web UI's proof column, and the surface that
+    actually gets used on the benchmark rig, which has no browser. Accepts a
+    match directory, a job directory or a single trial: everything containing
+    a Stella event stream underneath it is read.
+    """
+    root = Path(args.path).expanduser().resolve()
+    if not root.is_dir():
+        print(f"no such directory: {root}", file=sys.stderr)
+        return 1
+
+    reader = MetricsReader()
+    trials: list[tuple[str, TrialMetrics]] = []
+    for events in sorted(root.rglob(EVENTS_NAME)):
+        trial_dir = events.parent.parent
+        metrics = reader.read(trial_dir, trial_dir.name)
+        if metrics.proof is not None:
+            trials.append((trial_dir.name, metrics))
+
+    if not trials:
+        print(f"no Stella event stream under {root}", file=sys.stderr)
+        return 1
+
+    width = min(46, max(len(name) for name, _ in trials))
+    print(f"{'trial':<{width}}  {'grade':<10} {'witness':<8} {'oracle':<10} wrong  rung")
+    for name, metrics in trials:
+        proof = metrics.proof
+        assert proof is not None  # filtered above
+        # `+` passed, `-` failed, in the order observed. "never ran" gets its
+        # own token: a lone `-` would otherwise read as one failing run, and
+        # an oracle that never ran is the absence of the measurement rather
+        # than a failing one.
+        strip = "".join("+" if run.passed else "-" for run in proof.oracle_runs)
+        strip = strip or "(none)"
+        print(
+            f"{name[:width]:<{width}}  {_GRADE_GLYPH.get(proof.grade, proof.grade):<10} "
+            f"{'yes' if proof.witness_authored else 'no':<8} {strip[:10]:<10} "
+            f"{proof.failed_attempts:<5}  {proof.rung or '-'}"
+        )
+
+    totals = aggregate([m for _, m in trials])
+    print(
+        f"\n{totals['rail_trials']} trial(s) with a rail · "
+        f"{totals['proven']} proven · {totals['witnessed']} witnessed · "
+        f"{totals['wrong_guesses']} wrong guess(es) · "
+        f"{totals['refuted']} refuted · "
+        f"{totals['claimed_without_proof']} claimed without proof"
+    )
+
+    for name, metrics in trials:
+        proof = metrics.proof
+        assert proof is not None
+        reasons = [
+            *(("no witness", text) for text in proof.witness_unavailable),
+            *(("unverifiable", text) for text in proof.verification_unavailable),
+            *(("degraded", text) for text in proof.verdict_degraded),
+        ]
+        # The roster is only worth printing where the rail did something: a
+        # model-verdict trial's roster is the same two rows on every task.
+        pivotal = proof.witness_authored or bool(reasons) or proof.oracle_runs
+        if not (args.full or pivotal):
+            continue
+        print(f"\n── {name} ── {proof.grade}")
+        if proof.witness_authored:
+            print(f"   witness   {proof.witness_path}  ({proof.witness_command})")
+        if proof.tracked_command:
+            print(f"   command   {proof.tracked_command}")
+        for role in proof.roles:
+            print(f"   {role.role:<16} {role.model}  ×{role.calls}")
+        for label, text in reasons:
+            print(f"   {label}: {text}")
+        if args.full and proof.verdict_summary:
+            print(f"   verdict: {proof.verdict_summary}")
+    return 0
+
+
 def _cmd_flip(args: argparse.Namespace) -> int:
     trial_dir = Path(args.trial_dir).expanduser().resolve()
     if not trial_dir.is_dir():
@@ -725,6 +818,21 @@ def main(argv: list[str] | None = None) -> int:
         "flip",
         help="find when a trial started passing, and what it did afterwards",
     )
+    proof_parser = subparsers.add_parser(
+        "proof",
+        help="what proved each trial: the witness, the oracle flip, and who ran",
+    )
+    proof_parser.add_argument(
+        "path",
+        help="a match, job or trial directory — every event stream underneath is read",
+    )
+    proof_parser.add_argument(
+        "--full",
+        action="store_true",
+        help="print the roster and verdict summary for every trial, not only "
+             "the ones where the rail did something",
+    )
+    proof_parser.set_defaults(func=_cmd_proof)
     flip_parser.add_argument("trial_dir", help="a trial directory containing arena/snapshots")
     flip_parser.add_argument(
         "--task-dir",

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -486,20 +486,32 @@ def _cmd_proof(args: argparse.Namespace) -> int:
         return 1
 
     reader = MetricsReader()
-    trials: list[tuple[str, TrialMetrics]] = []
+    trials: list[tuple[str, str, TrialMetrics]] = []
     for events in sorted(root.rglob(EVENTS_NAME)):
         trial_dir = events.parent.parent
         metrics = reader.read(trial_dir, trial_dir.name)
         if metrics.proof is not None:
-            trials.append((trial_dir.name, metrics))
+            # A match directory holds one job per seat, and a seat is what a
+            # reader is comparing. Without it the trials of two seats
+            # interleave under task names that look like duplicates.
+            trials.append((trial_dir.parent.name, trial_dir.name, metrics))
 
     if not trials:
         print(f"no Stella event stream under {root}", file=sys.stderr)
         return 1
 
-    width = min(46, max(len(name) for name, _ in trials))
-    print(f"{'trial':<{width}}  {'grade':<10} {'witness':<8} {'oracle':<10} wrong  rung")
-    for name, metrics in trials:
+    # Only shown when the path spans more than one seat: for a single job it
+    # is the same string on every row.
+    seats = {job for job, _, _ in trials}
+    trials.sort(key=lambda row: (row[0], row[1]))
+    width = min(46, max(len(name) for _, name, _ in trials))
+    seat_width = min(28, max(len(job) for job in seats)) if len(seats) > 1 else 0
+    seat_head = f"{'seat':<{seat_width}}  " if seat_width else ""
+    print(
+        f"{seat_head}{'trial':<{width}}  {'grade':<10} {'witness':<8} "
+        f"{'oracle':<10} wrong  rung"
+    )
+    for job, name, metrics in trials:
         proof = metrics.proof
         assert proof is not None  # filtered above
         # `+` passed, `-` failed, in the order observed. "never ran" gets its
@@ -508,13 +520,15 @@ def _cmd_proof(args: argparse.Namespace) -> int:
         # than a failing one.
         strip = "".join("+" if run.passed else "-" for run in proof.oracle_runs)
         strip = strip or "(none)"
+        seat_cell = f"{job[:seat_width]:<{seat_width}}  " if seat_width else ""
         print(
-            f"{name[:width]:<{width}}  {_GRADE_GLYPH.get(proof.grade, proof.grade):<10} "
+            f"{seat_cell}{name[:width]:<{width}}  "
+            f"{_GRADE_GLYPH.get(proof.grade, proof.grade):<10} "
             f"{'yes' if proof.witness_authored else 'no':<8} {strip[:10]:<10} "
             f"{proof.failed_attempts:<5}  {proof.rung or '-'}"
         )
 
-    totals = aggregate([m for _, m in trials])
+    totals = aggregate([m for _, _, m in trials])
     print(
         f"\n{totals['rail_trials']} trial(s) with a rail · "
         f"{totals['proven']} proven · {totals['witnessed']} witnessed · "
@@ -523,7 +537,7 @@ def _cmd_proof(args: argparse.Namespace) -> int:
         f"{totals['claimed_without_proof']} claimed without proof"
     )
 
-    for name, metrics in trials:
+    for job, name, metrics in trials:
         proof = metrics.proof
         assert proof is not None
         reasons = [
@@ -536,7 +550,7 @@ def _cmd_proof(args: argparse.Namespace) -> int:
         pivotal = proof.witness_authored or bool(reasons) or proof.oracle_runs
         if not (args.full or pivotal):
             continue
-        print(f"\n── {name} ── {proof.grade}")
+        print(f"\n── {job + ' · ' if seat_width else ''}{name} ── {proof.grade}")
         if proof.witness_authored:
             print(f"   witness   {proof.witness_path}  ({proof.witness_command})")
         if proof.tracked_command:

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -95,6 +95,14 @@ class Dimension:
 #: reported because an operator reconciling an invoice needs it, and it is
 #: labelled so nobody reads it as a comparison.
 #:
+#: ``proven`` and ``claimed_without_proof`` come from the proof rail
+#: (:mod:`.proof`) and are ``None`` for a seat that publishes none — every
+#: non-Stella arm. That is the same discipline ``wasted_time`` follows below
+#: and it matters more here, because the natural zero flatters: a seat with no
+#: rail has not "never claimed a pass without proof", it produced no evidence
+#: either way, and crowning it for that would be the scoreboard rewarding the
+#: absence of the very machinery it is trying to measure.
+#:
 #: ``wasted_time`` only exists for trials an operator replayed with
 #: ``arenabench flip`` — for everything else the aggregate is ``None``, which
 #: the leaderboard already reads as "no number, no crown". That is load-bearing:
@@ -107,6 +115,20 @@ DIMENSIONS: tuple[Dimension, ...] = (
         "higher",
         "%",
         "verifier rewards / trials completed",
+    ),
+    Dimension(
+        "proven",
+        "Proven",
+        "higher",
+        "",
+        "trials an authored witness or tracked command carried fail→pass",
+    ),
+    Dimension(
+        "claimed_without_proof",
+        "Unproven Claims",
+        "lower",
+        "",
+        "passing verdicts with nothing deterministic behind them",
     ),
     Dimension("clock_time", "Clock Time", "lower", "s", "wall-clock across all trials"),
     Dimension(

--- a/arenabench/arenabench/proof.py
+++ b/arenabench/arenabench/proof.py
@@ -1,0 +1,492 @@
+"""What actually proved a trial — the witness, the oracle flip, and who ran.
+
+Stella's pipeline publishes a *proof rail* alongside its ordinary telemetry:
+a running account of whether the change it made was demanded to prove itself,
+whether an independent model authored a failing test, whether that test then
+flipped fail→pass, and — when none of that happened — the sentence saying why.
+The rail is the whole point of the agent. It is the machinery that stops a
+model from announcing "done" on work that is not done.
+
+Every one of those events was already in ``stella-events.jsonl`` and none of
+them reached a scoreboard. :mod:`arenabench.telemetry` folded the stream for
+tokens, cost and a pass/fail bit and dropped the rest on the floor; the web
+UI shipped a filter chip for ``proof`` entries that nothing has ever produced.
+This module is the missing reduction.
+
+**Why it is a separate module.** The distillation is a pure fold over parsed
+events with no I/O of its own, which makes it directly testable against
+recorded fixtures — and :mod:`arenabench.telemetry` is already close enough to
+the 1500-line ratchet that growing it is the wrong move regardless.
+
+**The one thing to understand before reading a grade.** The pipeline emits
+``passed: true`` for three different situations: a real deterministic flip, an
+``unverifiable`` outcome where every channel was blind, and a ``waived`` one
+where triage skipped review. Only :attr:`TrialProof.rung` and the honesty
+prefix on the verdict summary tell them apart. A reader that trusts ``passed``
+alone cannot distinguish proven work from an unexamined claim, which is the
+exact confusion the proof rail exists to prevent — so
+:attr:`TrialProof.claimed_without_proof` is computed here rather than left to
+each caller to rediscover.
+
+Wire contract: ``crates/stella-protocol/src/proof.rs`` (the ``ProofStep``
+enum), ``crates/stella-protocol/src/ladder.rs`` (``LadderSnapshot``,
+``OracleObservation``, ``LadderRung``) and
+``crates/stella-protocol/src/event/call_role.rs`` (``ModelCallRole``). The
+generated schema in ``docs/wire/agentevent.schema.json`` is authoritative.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "GRADES",
+    "OracleRun",
+    "RoleCall",
+    "TrialProof",
+    "distill",
+]
+
+#: Verdict-summary prefixes the pipeline stamps when it is telling you the
+#: result is *not* backed by proof. Ordered most- to least-specific; the first
+#: match wins. Sourced from ``crates/stella-pipeline/src/verify.rs`` — the
+#: constructors that build each summary — and deliberately matched against the
+#: head of the string rather than anywhere in it, because a model's own prose
+#: quotes these words often enough to matter.
+_HONESTY_MARKERS: tuple[tuple[str, str], ...] = (
+    ("NO WORK ATTEMPTED", "nothing_attempted"),
+    ("UNVERIFIABLE", "unverifiable"),
+    ("UNVERIFIED", "uncorroborated"),
+    ("UNPROVEN", "unproven"),
+)
+
+#: How far into a summary a marker may sit and still count as a prefix. The
+#: constructors put it first, but some paths prepend a rung word, so this is a
+#: little slack rather than an exact ``startswith``.
+_MARKER_WINDOW = 90
+
+#: The rungs whose evidence is deterministic — a test was actually run and
+#: observed. ``crates/stella-protocol/src/ladder.rs::is_deterministic``.
+#: Notably ``waived`` is *not* here despite riding a ``deterministic: true``
+#: evidence flag: a waiver is an unexamined claim, not an observation.
+_DETERMINISTIC_RUNGS = frozenset({"submit_fast", "revise"})
+
+#: Grades in descending order of how much the result is actually worth,
+#: with the sentence a reader needs to interpret one. This is the single
+#: badge the scoreboard shows per trial.
+GRADES: dict[str, str] = {
+    "flip": "an independently authored witness test failed, then passed",
+    "oracle": "a tracked test command flipped fail→pass",
+    "refuted": "the oracle ran and never passed — the claim was caught",
+    "unproven": "proof was warranted and no witness could be authored",
+    "waived": "verification was waived; nothing checked the work",
+    "unwarranted": "no proof was demanded of this change",
+    "model": "a model asserted the result with no deterministic backing",
+    "heuristic": "not even a model — a fallback rule decided",
+    "none": "no proof rail ran for this trial",
+}
+
+
+@dataclass(frozen=True)
+class OracleRun:
+    """One observation of the tracked test command.
+
+    ``tree`` is ``"baseline"`` (the unmodified code, expected to fail) or
+    ``"candidate"`` (the agent's change, expected to pass). An authored
+    witness's failing baseline is folded into the oracle *after the fact* by
+    the witness stage rather than published as its own step, so a run of
+    candidate-only observations beginning with a failure is the ordinary
+    shape of a genuine flip — not a missing baseline.
+    """
+
+    tree: str
+    passed: bool
+    #: The command, when the observation came from a ``proof.oracle`` event.
+    #: Empty for observations recovered from the verdict's ``oracle_trace``,
+    #: which carries only ``tree`` and ``passed``.
+    command: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {"tree": self.tree, "passed": self.passed, "command": self.command}
+
+
+@dataclass(frozen=True)
+class RoleCall:
+    """Every model call one pipeline role made, and what it cost.
+
+    The census axis is ``step_usage.role``, which names the model that
+    *actually served* the call rather than the one configured for it. That
+    distinction is the entire point: the witness author rides the verifier's
+    resolution and is then independence-filtered against the worker, so a
+    config file cannot tell you who wrote the test and this can.
+    """
+
+    role: str
+    model: str
+    calls: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "model": self.model,
+            "calls": self.calls,
+            "tokens_in": self.tokens_in,
+            "tokens_out": self.tokens_out,
+            "cost_usd": round(self.cost_usd, 6),
+        }
+
+
+@dataclass
+class TrialProof:
+    """The proof rail of one trial, reduced to what a reader must decide on."""
+
+    # -- was proof demanded at all? ----------------------------------------
+    #: ``proof.warrant.required``. ``None`` when no warrant was published,
+    #: which is every non-pipeline seat and every run that ended before
+    #: execute.
+    warranted: bool | None = None
+    #: Why no proof was demanded, when it was not. One of six fixed sentences
+    #: from ``crates/stella-pipeline/src/witness/warrant.rs`` — "documentation
+    #: only; prose has no runtime behavior to flip" and its siblings.
+    warrant_reason: str = ""
+    #: Diff size the warrant saw. Its budget lives on the ladder.
+    diff_lines: int | None = None
+
+    # -- was a witness authored? -------------------------------------------
+    #: A ``stage: witness`` event was seen. When proof was warranted and this
+    #: is ``False``, the stage never started — a different failure from one
+    #: that started and could not finish.
+    stage_ran: bool = False
+    witness_path: str = ""
+    witness_command: str = ""
+    witness_fingerprint: str = ""
+    #: Full, untruncated reasons a witness could not be produced. Plural
+    #: because authoring gets one repair attempt, so a run can fail twice for
+    #: different reasons and only the pair explains what happened.
+    witness_unavailable: tuple[str, ...] = ()
+
+    # -- did it flip? -------------------------------------------------------
+    oracle_runs: tuple[OracleRun, ...] = ()
+    #: The pipeline's own flip verdict from the ladder. Preferred over
+    #: re-deriving one from :attr:`oracle_runs`, which sees only the
+    #: observations that reached the stream.
+    flip_achieved: bool | None = None
+    #: The command flipped, when one was tracked.
+    tracked_command: str = ""
+    #: The same command passed *and* failed across runs — a flip that proves
+    #: flakiness rather than a fix.
+    unstable_flip: bool = False
+    #: The baseline failed for a different reason than the witness asserts,
+    #: so the pipeline declined to credit the flip.
+    flip_refused: bool = False
+    #: ``Some(true)`` when every witness artifact still matched its pinned
+    #: identity at verdict time. Never ``False`` on the wire — tampering
+    #: aborts the candidate — so its presence is the stated proof the
+    #: tamper check ran.
+    witness_intact: bool | None = None
+    touched_tests_passed: bool | None = None
+
+    # -- what backed the verdict? ------------------------------------------
+    rung: str = ""
+    verdict_passed: bool | None = None
+    verdict_summary: str = ""
+    #: Which honesty marker the summary carries, or ``""`` for a plain claim.
+    honesty: str = ""
+    #: ``proof.assurance`` — what the pipeline itself said corroborated the
+    #: result, published at triage before any of it happened.
+    assurance_witness: bool | None = None
+    assurance_verifier: bool | None = None
+    #: Whether the verifier resolved to a different model than the worker.
+    #: ``False`` means the run graded its own homework.
+    verifier_independent: bool | None = None
+    #: ``covered`` / ``not_covered`` / ``unmeasured`` — whether the flipping
+    #: test actually exercises the lines that changed.
+    diff_coverage: str = ""
+    verdict_degraded: tuple[str, ...] = ()
+    verification_unavailable: tuple[str, ...] = ()
+
+    # -- who ran ------------------------------------------------------------
+    roles: tuple[RoleCall, ...] = ()
+
+    # -- computed -----------------------------------------------------------
+    grade: str = "none"
+
+    @property
+    def witness_authored(self) -> bool:
+        """Whether a witness test was accepted, grafted and pinned.
+
+        ``proof.witness_authored`` fires only past every integrity check, so
+        this is the real thing rather than an attempt.
+        """
+        return bool(self.witness_path)
+
+    @property
+    def failed_attempts(self) -> int:
+        """How many times the model thought it was done and a test disagreed.
+
+        Counts the failing oracle observations before the first passing one —
+        and *all* of them when none ever passed, so that ``failed_attempts >
+        0`` selects every trial where the agent guessed wrong, whether or not
+        it recovered. Scoping it to "before the first pass" alone would make
+        the refuted trials, which are the starkest cases of exactly this,
+        report zero. Read it beside :attr:`grade`, which says whether the
+        recovery happened.
+        """
+        failures = 0
+        for run in self.oracle_runs:
+            if run.passed:
+                break
+            failures += 1
+        return failures
+
+    @property
+    def deterministic(self) -> bool:
+        """Whether a test was actually run and observed for this verdict."""
+        return self.rung in _DETERMINISTIC_RUNGS
+
+    @property
+    def claimed_without_proof(self) -> bool:
+        """A passing verdict that nothing deterministic backs.
+
+        The honesty trap, computed once here so no caller has to rediscover
+        it: ``unverifiable`` and ``waived`` both publish ``passed: true``, and
+        a model verdict is an assertion rather than an observation. A trial
+        where this is ``True`` said it was done and produced no evidence that
+        it was.
+        """
+        return self.verdict_passed is True and not self.deterministic
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "grade": self.grade,
+            "warranted": self.warranted,
+            "warrant_reason": self.warrant_reason,
+            "diff_lines": self.diff_lines,
+            "stage_ran": self.stage_ran,
+            "witness_authored": self.witness_authored,
+            "witness_path": self.witness_path,
+            "witness_command": self.witness_command,
+            "witness_fingerprint": self.witness_fingerprint,
+            "witness_unavailable": list(self.witness_unavailable),
+            "oracle_runs": [run.to_json() for run in self.oracle_runs],
+            "failed_attempts": self.failed_attempts,
+            "flip_achieved": self.flip_achieved,
+            "tracked_command": self.tracked_command,
+            "unstable_flip": self.unstable_flip,
+            "flip_refused": self.flip_refused,
+            "witness_intact": self.witness_intact,
+            "touched_tests_passed": self.touched_tests_passed,
+            "rung": self.rung,
+            "deterministic": self.deterministic,
+            "claimed_without_proof": self.claimed_without_proof,
+            "verdict_passed": self.verdict_passed,
+            "verdict_summary": self.verdict_summary,
+            "honesty": self.honesty,
+            "assurance_witness": self.assurance_witness,
+            "assurance_verifier": self.assurance_verifier,
+            "verifier_independent": self.verifier_independent,
+            "diff_coverage": self.diff_coverage,
+            "verdict_degraded": list(self.verdict_degraded),
+            "verification_unavailable": list(self.verification_unavailable),
+            "roles": [role.to_json() for role in self.roles],
+        }
+
+
+def _honesty_of(summary: str) -> str:
+    head = summary[:_MARKER_WINDOW]
+    for marker, label in _HONESTY_MARKERS:
+        if marker in head:
+            return label
+    return ""
+
+
+def _grade_of(proof: TrialProof) -> str:
+    """The single badge, from the strongest evidence the trial produced.
+
+    Ordered by what a reader should conclude, not by which field was easiest
+    to reach. A refutation outranks every soft outcome below it because it is
+    the rail working: the agent claimed done, the oracle disagreed, and the
+    claim did not ship.
+    """
+    if proof.flip_achieved and proof.witness_authored:
+        return "flip"
+    if proof.flip_achieved:
+        return "oracle"
+    if proof.oracle_runs and not any(run.passed for run in proof.oracle_runs):
+        return "refuted"
+    if proof.witness_unavailable:
+        return "unproven"
+    if proof.rung == "waived":
+        return "waived"
+    if proof.warranted is False:
+        return "unwarranted"
+    if proof.rung == "heuristic_fallback":
+        return "heuristic"
+    if proof.rung in ("model_verdict", "model_judge") or proof.verdict_summary:
+        return "model"
+    return "none"
+
+
+def _roles_from(usage: Mapping[tuple[str, str], list[float]]) -> tuple[RoleCall, ...]:
+    """Role/model pairs, heaviest first, with ties broken by name.
+
+    Sorted by call count rather than first appearance so the roster reads as
+    "who did the work" — and deterministically, so a golden fixture of this
+    output stays stable across runs.
+    """
+    calls = [
+        RoleCall(
+            role=role,
+            model=model,
+            calls=int(totals[0]),
+            tokens_in=int(totals[1]),
+            tokens_out=int(totals[2]),
+            cost_usd=totals[3],
+        )
+        for (role, model), totals in usage.items()
+    ]
+    calls.sort(key=lambda call: (-call.calls, call.role, call.model))
+    return tuple(calls)
+
+
+def distill(events: Iterable[Mapping[str, Any]]) -> TrialProof:
+    """Fold a trial's event stream into its proof rail.
+
+    Tolerant by construction: every field is optional, unknown event types are
+    ignored, and both legacy spellings the protocol still reads back are
+    accepted — ``judge_verdict`` for the verdict event, ``judge`` for the
+    verifier flag on an assurance step and for the verdict *role*. An archive
+    recorded before a rename must not silently lose its proof.
+    """
+    proof = TrialProof()
+    oracle_runs: list[OracleRun] = []
+    witness_unavailable: list[str] = []
+    verification_unavailable: list[str] = []
+    degraded: list[str] = []
+    usage: dict[tuple[str, str], list[float]] = {}
+
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        kind = str(event.get("type") or "")
+
+        if kind == "stage":
+            if str(event.get("name") or "") == "witness":
+                proof.stage_ran = True
+
+        elif kind == "step_usage":
+            role = str(event.get("role") or "unknown")
+            if role == "judge":  # the pre-rename spelling of `verdict`
+                role = "verdict"
+            model = str(event.get("model") or "")
+            totals = usage.setdefault((role, model), [0.0, 0.0, 0.0, 0.0])
+            totals[0] += 1
+            totals[1] += float(event.get("input_tokens") or 0)
+            totals[2] += float(event.get("output_tokens") or 0)
+            totals[3] += float(event.get("cost_usd") or 0.0)
+
+        elif kind == "proof":
+            step = event.get("step")
+            if not isinstance(step, Mapping):
+                continue
+            step_kind = str(step.get("kind") or "")
+            if step_kind == "warrant":
+                proof.warranted = bool(step.get("required"))
+                reason = step.get("reason")
+                if reason:
+                    proof.warrant_reason = str(reason)
+                if step.get("diff_lines") is not None:
+                    proof.diff_lines = int(step.get("diff_lines") or 0)
+            elif step_kind == "assurance":
+                proof.assurance_witness = bool(step.get("witness"))
+                # `judge` is the pre-rename field name for `verifier`.
+                verifier = step.get("verifier")
+                if verifier is None:
+                    verifier = step.get("judge")
+                proof.assurance_verifier = None if verifier is None else bool(verifier)
+            elif step_kind == "witness_authored":
+                proof.witness_path = str(step.get("path") or "")
+                proof.witness_command = str(step.get("command") or "")
+                proof.witness_fingerprint = str(step.get("fingerprint") or "")
+            elif step_kind == "witness_unavailable":
+                witness_unavailable.append(str(step.get("reason") or ""))
+            elif step_kind == "verification_unavailable":
+                verification_unavailable.append(str(step.get("reason") or ""))
+            elif step_kind == "oracle":
+                oracle_runs.append(
+                    OracleRun(
+                        tree=str(step.get("tree") or ""),
+                        passed=bool(step.get("passed")),
+                        command=str(step.get("command") or ""),
+                    )
+                )
+            elif step_kind == "verdict_degraded":
+                degraded.append(str(step.get("reason") or ""))
+
+        elif kind in ("verdict", "judge_verdict"):
+            passed = event.get("passed")
+            proof.verdict_passed = None if passed is None else bool(passed)
+            evidence = event.get("evidence")
+            if not isinstance(evidence, Mapping):
+                continue
+            proof.verdict_summary = str(evidence.get("summary") or "")
+            proof.honesty = _honesty_of(proof.verdict_summary)
+            ladder = evidence.get("ladder")
+            if not isinstance(ladder, Mapping):
+                continue
+            rung = str(ladder.get("rung") or "")
+            # `model_judge` is the pre-rename spelling of `model_verdict`.
+            proof.rung = "model_verdict" if rung == "model_judge" else rung
+            proof.flip_achieved = bool(ladder.get("flip_achieved"))
+            proof.unstable_flip = bool(ladder.get("unstable_flip"))
+            proof.flip_refused = bool(ladder.get("flip_refused_different_failure"))
+            proof.tracked_command = str(ladder.get("tracked_command") or "")
+            proof.diff_coverage = str(ladder.get("diff_coverage") or "")
+            for source, target in (
+                ("witness_intact", "witness_intact"),
+                ("touched_tests_passed", "touched_tests_passed"),
+                ("verifier_independent", "verifier_independent"),
+            ):
+                value = ladder.get(source)
+                if value is not None:
+                    setattr(proof, target, bool(value))
+            # The ladder's count wins over the warrant's. Both are real, but
+            # they measure at different moments: the warrant sees the diff as
+            # it decides whether to demand proof, the ladder sees the final
+            # one at verdict time. A reader asking "how big was this change"
+            # means the second — and a warrant that fired before the diff
+            # settled publishes a 0 that would otherwise shadow it.
+            if ladder.get("diff_lines") is not None:
+                proof.diff_lines = int(ladder.get("diff_lines") or 0)
+            # The ladder's trace is the pipeline's own record and includes
+            # observations that never reached the stream as `proof.oracle`
+            # steps — notably an authored witness's failing baseline, which
+            # the witness stage folds in after the fact. Prefer it, and keep
+            # the commands the proof steps carried.
+            trace = ladder.get("oracle_trace")
+            if isinstance(trace, list) and trace:
+                command = proof.tracked_command or next(
+                    (run.command for run in oracle_runs if run.command), ""
+                )
+                oracle_runs = [
+                    OracleRun(
+                        tree=str(item.get("tree") or ""),
+                        passed=bool(item.get("passed")),
+                        command=command,
+                    )
+                    for item in trace
+                    if isinstance(item, Mapping)
+                ]
+
+    proof.oracle_runs = tuple(oracle_runs)
+    proof.witness_unavailable = tuple(witness_unavailable)
+    proof.verification_unavailable = tuple(verification_unavailable)
+    proof.verdict_degraded = tuple(degraded)
+    proof.roles = _roles_from(usage)
+    proof.grade = _grade_of(proof)
+    return proof

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -55,6 +55,7 @@ from typing import Any
 
 from .artifacts import mp4_is_finalized
 from .pricing import Price, price_for, price_for_route, price_on_route, trial_cost
+from .proof import TrialProof, distill
 
 __all__ = [
     "EVENTS_NAME",
@@ -317,6 +318,13 @@ class TrialMetrics:
     #: destroy its own solution. ``None`` whenever :attr:`flip_elapsed` is:
     #: without a located flip there is no "after".
     wasted_elapsed: float | None = None
+    #: What actually proved this trial: the witness, the oracle flip, the
+    #: reasons, and which model ran which pipeline role
+    #: (:mod:`arenabench.proof`). ``None`` for a trial with no Stella event
+    #: stream at all — a Claude Code arm publishes no proof rail, and an
+    #: empty rail there is the absence of the machinery rather than a
+    #: failure of it.
+    proof: TrialProof | None = None
 
     @property
     def usage_measured(self) -> bool:
@@ -437,6 +445,7 @@ class TrialMetrics:
             "late_error": self.late_error,
             "flip_elapsed": self.flip_elapsed,
             "wasted_elapsed": self.wasted_elapsed,
+            "proof": self.proof.to_json() if self.proof is not None else None,
         }
 
 
@@ -468,6 +477,12 @@ def _reduce_events(path: Path) -> dict[str, Any] | None:
         "late_error": "",
     }
     seen_models: set[str] = set()
+    # The proof rail's raw events, kept for one pass through
+    # :func:`arenabench.proof.distill`. Collected rather than folded inline
+    # because the distillation is a pure function worth testing on its own,
+    # and cheap to buffer: these four types are a fraction of a percent of a
+    # stream that is overwhelmingly `reasoning` deltas.
+    rail: list[dict[str, Any]] = []
     try:
         with path.open(encoding="utf-8", errors="replace") as handle:
             for line in handle:
@@ -478,6 +493,8 @@ def _reduce_events(path: Path) -> dict[str, Any] | None:
                 if not isinstance(event, dict):
                     continue
                 kind = str(event.get("type", ""))
+                if kind in ("proof", "stage", "step_usage", "verdict", "judge_verdict"):
+                    rail.append(event)
                 if kind == "tool_start":
                     totals["tools"] += 1
                 elif kind == "step_usage":
@@ -515,13 +532,17 @@ def _reduce_events(path: Path) -> dict[str, Any] | None:
                     totals["late_error"] = str(event.get("message") or "")[:400]
                 elif kind == "usage_incomplete":
                     totals["usage_incomplete"] += 1
-                elif kind == "verdict":
+                elif kind in ("verdict", "judge_verdict"):
+                    # `judge_verdict` is the pre-rename tag the protocol still
+                    # reads back; an archive recorded under it must not lose
+                    # its verdict here (`AgentEvent::Verdict`'s serde alias).
                     passed = event.get("passed")
                     totals["verifier_passed"] = None if passed is None else bool(passed)
                 elif kind == "complete":
                     totals["complete"] = True
     except OSError:
         return None
+    totals["proof"] = distill(rail)
     return totals
 
 
@@ -615,6 +636,9 @@ class MetricsReader:
             metrics.declared_complete = events["complete"]
             metrics.usage_incomplete = events["usage_incomplete"]
             metrics.late_error = events["late_error"]
+            # `.get` rather than `[…]`: a cached reduction from a reader that
+            # predates the proof rail has no such key.
+            metrics.proof = events.get("proof")
         elif metrics.age_s is not None:
             # Liveness artifacts and no verdict yet mean the trial is in
             # flight even though nothing streams — every trajectory-only arm
@@ -933,6 +957,54 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
             else None
         ),
         "flip_trials": sum(1 for t in trials if t.wasted_elapsed is not None),
+        # -- the proof rail, rolled up ------------------------------------
+        # `proven` is the only one of these that is a *rate* worth reading on
+        # its own; the rest are counts, because their denominators differ.
+        # A seat that publishes no proof rail at all (every non-Stella arm)
+        # scores 0 on each, which is correct: it proved nothing, and the
+        # reason is that it has no machinery for it rather than that it
+        # tried and failed. `rail_trials` is that denominator.
+        "rail_trials": sum(1 for t in trials if t.proof is not None),
+        #: Trials where an authored witness or a tracked command went
+        #: fail→pass. The only outcome that earns the word "done".
+        "proven": sum(
+            1 for t in trials if t.proof is not None and t.proof.grade in ("flip", "oracle")
+        ),
+        #: Trials where a witness test was authored, accepted and pinned.
+        "witnessed": sum(
+            1 for t in trials if t.proof is not None and t.proof.witness_authored
+        ),
+        #: Summed :attr:`~arenabench.proof.TrialProof.failed_attempts` — every
+        #: time a model believed it was finished and a test said otherwise,
+        #: whether or not it went on to recover. The whole reason the rail
+        #: exists, as one number.
+        "wrong_guesses": sum(
+            t.proof.failed_attempts for t in trials if t.proof is not None
+        ),
+        #: Trials the oracle ran on and never passed. The rail catching a
+        #: premature "done" is a *success* of the machinery, so this is
+        #: deliberately not folded into a failure count.
+        "refuted": sum(
+            1 for t in trials if t.proof is not None and t.proof.grade == "refuted"
+        ),
+        #: Passing verdicts with nothing deterministic behind them. The
+        #: honesty trap: `unverifiable` and `waived` both publish
+        #: `passed: true`, and a model verdict is an assertion.
+        "claimed_without_proof": sum(
+            1 for t in trials if t.proof is not None and t.proof.claimed_without_proof
+        ),
+        #: Trials where proof was warranted and no witness could be authored.
+        #: Each carries its own sentence saying why.
+        "unproven": sum(
+            1 for t in trials if t.proof is not None and t.proof.grade == "unproven"
+        ),
+        #: Trials whose verifier resolved to the same model as the worker —
+        #: the run graded its own homework.
+        "self_graded": sum(
+            1
+            for t in trials
+            if t.proof is not None and t.proof.verifier_independent is False
+        ),
     }
 
 
@@ -983,6 +1055,79 @@ def leaders(
 # --------------------------------------------------------------------------
 # Transcripts
 # --------------------------------------------------------------------------
+
+
+def _proof_line(step: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+    """One ``proof`` step as a transcript line: title, body, metadata.
+
+    The body is **never truncated**. Every other long field in this reader is
+    clipped because a transcript is a reading surface and a 60 KB tool result
+    helps nobody — but a proof reason is the pipeline's entire explanation of
+    why it could not prove something, and the half that gets cut is reliably
+    the half that says which model, which command, or which constraint. Those
+    strings are bounded by construction: the longest is a model verdict's
+    prose, and it is the thing a reader opened this page to read.
+    """
+    kind = str(step.get("kind") or "proof")
+    meta: dict[str, Any] = {"step": kind}
+    reason = str(step.get("reason") or "")
+
+    if kind == "warrant":
+        required = bool(step.get("required"))
+        lines = step.get("diff_lines")
+        meta.update(required=required, diff_lines=lines)
+        title = "warrant: proof required" if required else "warrant: no proof required"
+        detail = f"{lines} diff lines" if lines is not None else ""
+        return title, reason or detail, meta
+
+    if kind == "assurance":
+        witness = bool(step.get("witness"))
+        verifier = step.get("verifier")
+        if verifier is None:
+            verifier = step.get("judge")
+        meta.update(witness=witness, verifier=verifier)
+        return (
+            "assurance",
+            f"witness {'on' if witness else 'off'}"
+            f" · verifier {'on' if verifier else 'off'}",
+            meta,
+        )
+
+    if kind == "witness_authored":
+        meta.update(
+            path=step.get("path"),
+            command=step.get("command"),
+            fingerprint=step.get("fingerprint"),
+        )
+        return (
+            "witness authored",
+            f"{step.get('path') or ''}\n{step.get('command') or ''}",
+            meta,
+        )
+
+    if kind == "oracle":
+        passed = bool(step.get("passed"))
+        tree = str(step.get("tree") or "")
+        meta.update(passed=passed, tree=tree, command=step.get("command"))
+        return (
+            f"oracle: {tree} {'passed' if passed else 'failed'}",
+            str(step.get("command") or ""),
+            meta,
+        )
+
+    if kind == "verdict_degraded":
+        meta.update(candidate=step.get("candidate"))
+        return "verdict degraded", reason, meta
+
+    # `witness_unavailable`, `verification_unavailable`, and any step kind
+    # added to the protocol after this was written. An unknown kind renders
+    # as itself with whatever it carries rather than vanishing — the same
+    # posture `_entries_for` takes on unknown event types.
+    if reason:
+        return kind.replace("_", " "), reason, meta
+    return kind.replace("_", " "), json.dumps(
+        {k: v for k, v in step.items() if k != "kind"}
+    ), meta
 
 
 @dataclass
@@ -1260,15 +1405,38 @@ class TranscriptReader:
                 )
             ]
 
-        if kind == "verdict":
+        if kind == "proof":
+            step = event.get("step")
+            if not isinstance(step, dict):
+                return []
+            title, body, meta = _proof_line(step)
+            return [entry(self._next_seq(state), "proof", title, body, **meta)]
+
+        if kind in ("verdict", "judge_verdict"):
             passed = event.get("passed")
+            # The body is `evidence.summary`. It was read from a top-level
+            # `reasoning` key that the wire has never carried, so every
+            # verdict in every transcript rendered with an empty body — and
+            # the summary is where the pipeline says whether the pass was
+            # actually proven (`UNVERIFIABLE`/`UNVERIFIED`/`UNPROVEN`).
+            evidence = event.get("evidence")
+            evidence = evidence if isinstance(evidence, dict) else {}
+            ladder = evidence.get("ladder")
+            ladder = ladder if isinstance(ladder, dict) else {}
             return [
                 entry(
                     self._next_seq(state),
                     "verdict",
                     "verifier: pass" if passed else "verifier: fail",
-                    str(event.get("reasoning") or ""),
+                    str(evidence.get("summary") or event.get("reasoning") or ""),
                     passed=passed,
+                    rung=ladder.get("rung"),
+                    deterministic=evidence.get("deterministic"),
+                    flip_achieved=ladder.get("flip_achieved"),
+                    witness_intact=ladder.get("witness_intact"),
+                    verifier_independent=ladder.get("verifier_independent"),
+                    diff_coverage=ladder.get("diff_coverage"),
+                    oracle_trace=ladder.get("oracle_trace"),
                 )
             ]
 

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -881,6 +881,11 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
     trials = list(trials)
     judged = [t for t in trials if t.resolved is not None]
     passed = [t for t in judged if t.resolved]
+    # Trials that published a proof rail at all. Its own subset, because the
+    # rail's denominator is not the match's: a seat with no pipeline
+    # contributes trials to every total above and none to the ones below.
+    rail = [t for t in trials if t.proof is not None]
+    rail_trials = len(rail)
     return {
         "trials": len(trials),
         "infrastructure": sum(1 for t in trials if t.infrastructure),
@@ -958,53 +963,47 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
         ),
         "flip_trials": sum(1 for t in trials if t.wasted_elapsed is not None),
         # -- the proof rail, rolled up ------------------------------------
-        # `proven` is the only one of these that is a *rate* worth reading on
-        # its own; the rest are counts, because their denominators differ.
-        # A seat that publishes no proof rail at all (every non-Stella arm)
-        # scores 0 on each, which is correct: it proved nothing, and the
-        # reason is that it has no machinery for it rather than that it
-        # tried and failed. `rail_trials` is that denominator.
-        "rail_trials": sum(1 for t in trials if t.proof is not None),
+        # `rail_trials` is the denominator every count below is over, and it
+        # is zero for every seat with no pipeline (a Claude Code arm).
+        #
+        # The two *dimensions* — `proven` and `claimed_without_proof` — are
+        # `None` rather than 0 at that denominator, for the same reason
+        # `wasted_time` is: a seat that publishes no rail did not "never
+        # claim without proof", it produced no evidence either way, and a
+        # zero there would crown it on a measurement it never took. The
+        # remaining keys stay numeric because they are read as diagnostics
+        # beside `rail_trials`, never crowned on their own.
+        "rail_trials": rail_trials,
         #: Trials where an authored witness or a tracked command went
         #: fail→pass. The only outcome that earns the word "done".
-        "proven": sum(
-            1 for t in trials if t.proof is not None and t.proof.grade in ("flip", "oracle")
+        "proven": (
+            sum(1 for t in rail if t.proof.grade in ("flip", "oracle"))
+            if rail_trials
+            else None
         ),
         #: Trials where a witness test was authored, accepted and pinned.
-        "witnessed": sum(
-            1 for t in trials if t.proof is not None and t.proof.witness_authored
-        ),
+        "witnessed": sum(1 for t in rail if t.proof.witness_authored),
         #: Summed :attr:`~arenabench.proof.TrialProof.failed_attempts` — every
         #: time a model believed it was finished and a test said otherwise,
         #: whether or not it went on to recover. The whole reason the rail
         #: exists, as one number.
-        "wrong_guesses": sum(
-            t.proof.failed_attempts for t in trials if t.proof is not None
-        ),
+        "wrong_guesses": sum(t.proof.failed_attempts for t in rail),
         #: Trials the oracle ran on and never passed. The rail catching a
         #: premature "done" is a *success* of the machinery, so this is
         #: deliberately not folded into a failure count.
-        "refuted": sum(
-            1 for t in trials if t.proof is not None and t.proof.grade == "refuted"
-        ),
+        "refuted": sum(1 for t in rail if t.proof.grade == "refuted"),
         #: Passing verdicts with nothing deterministic behind them. The
         #: honesty trap: `unverifiable` and `waived` both publish
         #: `passed: true`, and a model verdict is an assertion.
-        "claimed_without_proof": sum(
-            1 for t in trials if t.proof is not None and t.proof.claimed_without_proof
+        "claimed_without_proof": (
+            sum(1 for t in rail if t.proof.claimed_without_proof) if rail_trials else None
         ),
         #: Trials where proof was warranted and no witness could be authored.
         #: Each carries its own sentence saying why.
-        "unproven": sum(
-            1 for t in trials if t.proof is not None and t.proof.grade == "unproven"
-        ),
+        "unproven": sum(1 for t in rail if t.proof.grade == "unproven"),
         #: Trials whose verifier resolved to the same model as the worker —
         #: the run graded its own homework.
-        "self_graded": sum(
-            1
-            for t in trials
-            if t.proof is not None and t.proof.verifier_independent is False
-        ),
+        "self_graded": sum(1 for t in rail if t.proof.verifier_independent is False),
     }
 
 

--- a/arenabench/tests/test_proof.py
+++ b/arenabench/tests/test_proof.py
@@ -507,6 +507,23 @@ def test_aggregate_rolls_the_rail_up(tmp_path: Path) -> None:
     assert totals["wrong_guesses"] == 2
 
 
+def test_a_seat_with_no_rail_scores_none_not_zero(tmp_path: Path) -> None:
+    """The zero would flatter, and in a benchmark that always favours somebody.
+
+    A seat with no pipeline has not "never claimed a pass without proof" — it
+    produced no evidence either way. Crowning it on a measurement it never
+    took would make the scoreboard reward the absence of the machinery it
+    exists to compare. Same discipline as `wasted_time`.
+    """
+    empty = tmp_path / "job" / "t1"
+    empty.mkdir(parents=True)
+    totals = aggregate([MetricsReader().read(empty, "a")])
+
+    assert totals["rail_trials"] == 0
+    assert totals["proven"] is None
+    assert totals["claimed_without_proof"] is None
+
+
 def test_transcript_renders_proof_entries(tmp_path: Path) -> None:
     """The regression this whole change exists to fix.
 

--- a/arenabench/tests/test_proof.py
+++ b/arenabench/tests/test_proof.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from arenabench.cli import main
 from arenabench.proof import distill
 from arenabench.telemetry import MetricsReader, TranscriptReader, aggregate
 
@@ -559,6 +560,42 @@ def test_transcript_verdict_body_is_the_evidence_summary(tmp_path: Path) -> None
     assert "flip oracle: fail→pass" in verdict["body"]
     assert verdict["meta"]["rung"] == "submit_fast"
     assert verdict["meta"]["flip_achieved"] is True
+
+
+def test_cli_prints_the_rail(tmp_path: Path, capsys) -> None:
+    """The terminal twin. It is the surface the benchmark rig actually has."""
+    _trial(tmp_path, "nginx__abc", FLIP_STREAM)
+
+    assert main(["proof", str(tmp_path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "flip" in out
+    # `-` failed, `+` passed, in the order observed.
+    assert "-++" in out
+    assert "witness_check.sh" in out
+    assert "witness_author" in out and "z-ai/glm-5.2" in out
+    assert "1 proven" in out
+
+
+def test_cli_distinguishes_an_oracle_that_never_ran(tmp_path: Path, capsys) -> None:
+    """A lone `-` would read as one failing run.
+
+    An oracle that never ran is the absence of the measurement, not a failing
+    one, and in a benchmark that difference always favours somebody.
+    """
+    _trial(
+        tmp_path,
+        "t1",
+        [_verdict(True, "looks right", rung="model_verdict", flip_achieved=False)],
+    )
+
+    main(["proof", str(tmp_path)])
+
+    assert "(none)" in capsys.readouterr().out
+
+
+def test_cli_rejects_a_path_with_no_event_stream(tmp_path: Path) -> None:
+    assert main(["proof", str(tmp_path)]) == 1
 
 
 def test_proof_reasons_are_never_truncated(tmp_path: Path) -> None:

--- a/arenabench/tests/test_proof.py
+++ b/arenabench/tests/test_proof.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The proof rail: what actually proved a trial, and what merely claimed it.
+
+The bias here is the same one the module itself is built around: a benchmark
+that reports "passed" for an unexamined claim is worse than one that reports
+nothing, because the number looks exactly like a real one. So the tests that
+matter most are the ones separating a proven pass from a claimed pass, and the
+ones asserting that a legacy spelling still parses — an archive that silently
+loses its proof reads as an agent that never produced any.
+
+Every fixture is a literal event stream in the shape
+``crates/stella-protocol/src/proof.rs`` serializes. No files, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from arenabench.proof import distill
+from arenabench.telemetry import MetricsReader, TranscriptReader, aggregate
+
+# --------------------------------------------------------------------------
+# Event-stream fixtures
+# --------------------------------------------------------------------------
+
+
+def _usage(role: str, model: str, **kw) -> dict:
+    return {
+        "type": "step_usage",
+        "role": role,
+        "model": model,
+        "input_tokens": kw.get("input_tokens", 100),
+        "output_tokens": kw.get("output_tokens", 10),
+        "cost_usd": kw.get("cost_usd", 0.01),
+    }
+
+
+def _verdict(passed: bool, summary: str, **ladder) -> dict:
+    return {
+        "type": "verdict",
+        "passed": passed,
+        "evidence": {
+            "summary": summary,
+            "deterministic": ladder.pop("deterministic", True),
+            "ladder": ladder,
+        },
+    }
+
+
+#: The gold standard: an independent model authored a failing test, the agent's
+#: first attempt failed it, the second passed. Modelled on a real recorded
+#: trial (`nginx-request-logging`, oracle trace ✗ ✓ ✓).
+FLIP_STREAM: list[dict] = [
+    {"type": "proof", "step": {"kind": "assurance", "witness": True, "verifier": True}},
+    _usage("worker", "moonshotai/kimi-k3"),
+    {"type": "stage", "name": "witness"},
+    _usage("witness_author", "z-ai/glm-5.2"),
+    {
+        "type": "proof",
+        "step": {
+            "kind": "witness_authored",
+            "path": "witness_check.sh",
+            "command": "sh witness_check.sh",
+            "fingerprint": "sha256:aa2df0d1",
+        },
+    },
+    {"type": "proof", "step": {"kind": "warrant", "required": True, "diff_lines": 0}},
+    {
+        "type": "proof",
+        "step": {
+            "kind": "oracle",
+            "command": "sh witness_check.sh",
+            "passed": False,
+            "tree": "candidate",
+        },
+    },
+    _verdict(
+        True,
+        "flip oracle: fail→pass of `sh witness_check.sh`; touched tests green",
+        rung="submit_fast",
+        flip_achieved=True,
+        tracked_command="sh witness_check.sh",
+        witness_intact=True,
+        touched_tests_passed=True,
+        diff_lines=112,
+        diff_coverage="covered",
+        oracle_trace=[
+            {"tree": "candidate", "passed": False},
+            {"tree": "candidate", "passed": True},
+            {"tree": "candidate", "passed": True},
+        ],
+    ),
+]
+
+
+# --------------------------------------------------------------------------
+# The flip — the only outcome that earns the word "done"
+# --------------------------------------------------------------------------
+
+
+def test_flip_is_graded_as_proven_and_counts_the_wrong_guess() -> None:
+    proof = distill(FLIP_STREAM)
+
+    assert proof.grade == "flip"
+    assert proof.witness_authored
+    assert proof.witness_path == "witness_check.sh"
+    assert proof.witness_command == "sh witness_check.sh"
+    assert proof.flip_achieved is True
+    assert proof.witness_intact is True
+    assert proof.deterministic
+    assert not proof.claimed_without_proof
+    # The point of the whole rail: the model thought it was done once, and a
+    # test disagreed, before it got there.
+    assert proof.failed_attempts == 1
+    assert [run.passed for run in proof.oracle_runs] == [False, True, True]
+
+
+def test_ladder_trace_supersedes_the_proof_steps() -> None:
+    """The verdict's own trace is richer than what reached the stream.
+
+    An authored witness's failing baseline is folded into the oracle after
+    the fact rather than published as a `proof.oracle` step, so counting
+    those steps undercounts every genuine flip. Here one step was emitted
+    and three observations exist.
+    """
+    proof = distill(FLIP_STREAM)
+
+    assert sum(1 for e in FLIP_STREAM if e.get("step", {}).get("kind") == "oracle") == 1
+    assert len(proof.oracle_runs) == 3
+    # The command survives the substitution — the trace itself has no room
+    # for one, and a flip strip with no command names nothing.
+    assert all(run.command == "sh witness_check.sh" for run in proof.oracle_runs)
+
+
+def test_ladder_diff_lines_beats_the_warrants_earlier_count() -> None:
+    """Both are real; they measure at different moments.
+
+    The warrant fires as it decides whether to demand proof and can publish a
+    0 that the verdict-time count contradicts. A reader asking "how big was
+    this change" means the later one.
+    """
+    proof = distill(FLIP_STREAM)
+
+    assert proof.diff_lines == 112
+
+
+# --------------------------------------------------------------------------
+# The honesty trap — three different things all publish `passed: true`
+# --------------------------------------------------------------------------
+
+
+def test_unverifiable_pass_is_not_a_proven_pass() -> None:
+    proof = distill(
+        [
+            _verdict(
+                True,
+                "UNVERIFIABLE — every verification channel was blind",
+                rung="unverifiable",
+                flip_achieved=False,
+                deterministic=False,
+            )
+        ]
+    )
+
+    assert proof.verdict_passed is True
+    assert proof.claimed_without_proof
+    assert not proof.deterministic
+    assert proof.honesty == "unverifiable"
+
+
+def test_waived_pass_is_not_a_proven_pass() -> None:
+    """A waiver rides `deterministic: true` on the evidence and is not.
+
+    `LadderRung::is_deterministic` excludes `waived` for exactly this reason,
+    and trusting the evidence flag instead would score an unexamined claim as
+    an observation.
+    """
+    proof = distill(
+        [
+            _verdict(
+                True,
+                "model review waived by triage; no independent verification",
+                rung="waived",
+                flip_achieved=False,
+                deterministic=True,
+            )
+        ]
+    )
+
+    assert proof.grade == "waived"
+    assert proof.claimed_without_proof
+
+
+def test_model_verdict_with_no_corroboration_is_a_claim() -> None:
+    proof = distill(
+        [
+            _usage("worker", "z-ai/glm-5.2"),
+            _usage("verdict", "z-ai/glm-5.2"),
+            _verdict(
+                True,
+                "The diff shows the change being applied, accomplishing the goal.",
+                rung="model_verdict",
+                flip_achieved=False,
+                verifier_independent=False,
+                deterministic=False,
+            ),
+        ]
+    )
+
+    assert proof.grade == "model"
+    assert proof.claimed_without_proof
+    assert proof.honesty == ""  # a plain claim, with no marker at all
+    # The run graded its own homework.
+    assert proof.verifier_independent is False
+
+
+def test_a_real_flip_is_never_claimed_without_proof() -> None:
+    assert not distill(FLIP_STREAM).claimed_without_proof
+
+
+# --------------------------------------------------------------------------
+# Refusal — the rail catching a premature "done"
+# --------------------------------------------------------------------------
+
+
+def test_oracle_that_never_passes_is_refuted_not_merely_failed() -> None:
+    proof = distill(
+        [
+            {
+                "type": "proof",
+                "step": {
+                    "kind": "witness_authored",
+                    "path": "witness_check.sh",
+                    "command": "sh witness_check.sh",
+                    "fingerprint": "sha256:beef",
+                },
+            },
+            _verdict(
+                False,
+                "touched tests failed after execution",
+                rung="revise",
+                flip_achieved=False,
+                tracked_command="sh witness_check.sh",
+                oracle_trace=[{"tree": "candidate", "passed": False}],
+            ),
+        ]
+    )
+
+    assert proof.grade == "refuted"
+    # A run that never recovered still guessed wrong — scoping this to
+    # "before the first pass" would report zero for the starkest case.
+    assert proof.failed_attempts == 1
+
+
+def test_witness_unavailable_carries_its_full_reason() -> None:
+    reason = (
+        "no author independent of the worker "
+        "(judge and worker both resolved to `openrouter/z-ai/glm-5.2`)"
+    )
+    proof = distill(
+        [
+            {"type": "stage", "name": "witness"},
+            {"type": "proof", "step": {"kind": "witness_unavailable", "reason": reason}},
+        ]
+    )
+
+    assert proof.grade == "unproven"
+    assert proof.stage_ran
+    assert proof.witness_unavailable == (reason,)
+
+
+def test_unwarranted_change_is_not_an_unproven_one() -> None:
+    """"No proof was demanded" and "proof was demanded and missing" differ.
+
+    Grading a docs-only change as unproven would put a correct outcome in the
+    same bucket as a failure to prove.
+    """
+    proof = distill(
+        [
+            {
+                "type": "proof",
+                "step": {
+                    "kind": "warrant",
+                    "required": False,
+                    "reason": "documentation only; prose has no runtime behavior to flip",
+                    "diff_lines": 12,
+                },
+            }
+        ]
+    )
+
+    assert proof.grade == "unwarranted"
+    assert proof.warranted is False
+    assert "documentation only" in proof.warrant_reason
+
+
+# --------------------------------------------------------------------------
+# Who ran — the pipeline model roster
+# --------------------------------------------------------------------------
+
+
+def test_roles_census_names_the_witness_author_separately_from_the_worker() -> None:
+    proof = distill(FLIP_STREAM)
+    roster = {call.role: call.model for call in proof.roles}
+
+    assert roster["worker"] == "moonshotai/kimi-k3"
+    assert roster["witness_author"] == "z-ai/glm-5.2"
+
+
+def test_roles_are_ordered_by_call_count_then_name() -> None:
+    """Deterministic, so a golden fixture of this output stays stable."""
+    proof = distill(
+        [
+            _usage("verdict", "b"),
+            _usage("worker", "a"),
+            _usage("worker", "a"),
+            _usage("triage", "c"),
+        ]
+    )
+
+    assert [(c.role, c.calls) for c in proof.roles] == [
+        ("worker", 2),
+        ("triage", 1),
+        ("verdict", 1),
+    ]
+
+
+def test_role_usage_accumulates_tokens_and_cost() -> None:
+    proof = distill(
+        [
+            _usage("worker", "a", input_tokens=100, output_tokens=10, cost_usd=0.5),
+            _usage("worker", "a", input_tokens=200, output_tokens=20, cost_usd=0.25),
+        ]
+    )
+
+    (call,) = proof.roles
+    assert (call.calls, call.tokens_in, call.tokens_out) == (2, 300, 30)
+    assert call.cost_usd == 0.75
+
+
+# --------------------------------------------------------------------------
+# Legacy spellings — an archive must not silently lose its proof
+# --------------------------------------------------------------------------
+
+
+def test_judge_verdict_tag_still_parses() -> None:
+    """`judge_verdict` is the pre-rename tag the protocol still reads back."""
+    proof = distill(
+        [
+            {
+                "type": "judge_verdict",
+                "passed": True,
+                "evidence": {
+                    "summary": "ok",
+                    "deterministic": True,
+                    "ladder": {"rung": "submit_fast", "flip_achieved": True},
+                },
+            }
+        ]
+    )
+
+    assert proof.verdict_passed is True
+    assert proof.rung == "submit_fast"
+    assert proof.flip_achieved is True
+
+
+def test_model_judge_rung_normalises_to_model_verdict() -> None:
+    proof = distill([_verdict(True, "ok", rung="model_judge", flip_achieved=False)])
+
+    assert proof.rung == "model_verdict"
+    assert proof.grade == "model"
+
+
+def test_judge_alias_on_assurance_and_role() -> None:
+    proof = distill(
+        [
+            {"type": "proof", "step": {"kind": "assurance", "witness": True, "judge": True}},
+            _usage("judge", "some/model"),
+        ]
+    )
+
+    assert proof.assurance_verifier is True
+    assert [call.role for call in proof.roles] == ["verdict"]
+
+
+# --------------------------------------------------------------------------
+# Tolerance — a stream is read while it is being written
+# --------------------------------------------------------------------------
+
+
+def test_empty_stream_grades_as_no_rail() -> None:
+    proof = distill([])
+
+    assert proof.grade == "none"
+    assert not proof.claimed_without_proof
+    assert proof.roles == ()
+
+
+def test_unknown_proof_step_kind_does_not_lose_the_rest() -> None:
+    """The protocol's `ProofStep` enum is closed and will grow."""
+    proof = distill(
+        [
+            {"type": "proof", "step": {"kind": "some_future_step", "detail": "x"}},
+            {"type": "proof", "step": {"kind": "warrant", "required": True, "diff_lines": 5}},
+        ]
+    )
+
+    assert proof.warranted is True
+
+
+def test_malformed_events_are_skipped() -> None:
+    proof = distill(
+        [
+            {"type": "proof"},  # no step
+            {"type": "proof", "step": "not-a-mapping"},
+            {"type": "verdict", "passed": True},  # no evidence
+            {"type": "proof", "step": {"kind": "warrant", "required": True, "diff_lines": 1}},
+        ]
+    )
+
+    assert proof.warranted is True
+    assert proof.verdict_passed is True
+
+
+def test_to_json_round_trips() -> None:
+    payload = json.loads(json.dumps(distill(FLIP_STREAM).to_json()))
+
+    assert payload["grade"] == "flip"
+    assert payload["failed_attempts"] == 1
+    assert payload["witness_authored"] is True
+    assert len(payload["oracle_runs"]) == 3
+    assert {row["role"] for row in payload["roles"]} == {"worker", "witness_author"}
+
+
+# --------------------------------------------------------------------------
+# Wiring — the rail has to reach a scoreboard, which is where it was lost
+# --------------------------------------------------------------------------
+
+
+def _trial(tmp_path: Path, name: str, stream: list[dict]) -> Path:
+    trial = tmp_path / "job" / name
+    (trial / "agent").mkdir(parents=True)
+    (trial / "agent" / "stella-events.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in stream) + "\n", encoding="utf-8"
+    )
+    return trial
+
+
+def test_metrics_reader_attaches_the_rail(tmp_path: Path) -> None:
+    metrics = MetricsReader().read(_trial(tmp_path, "t1", FLIP_STREAM), "nginx")
+
+    assert metrics.proof is not None
+    assert metrics.proof.grade == "flip"
+    assert metrics.to_json()["proof"]["failed_attempts"] == 1
+
+
+def test_a_trial_with_no_event_stream_has_no_rail(tmp_path: Path) -> None:
+    """A Claude Code arm publishes no proof rail.
+
+    ``None`` rather than an empty rail: it is the absence of the machinery,
+    not a failure of it, and a zero would read as "proved nothing" in a
+    column where that is an accusation.
+    """
+    empty = tmp_path / "job" / "t2"
+    empty.mkdir(parents=True)
+
+    assert MetricsReader().read(empty, "nginx").proof is None
+
+
+def test_aggregate_rolls_the_rail_up(tmp_path: Path) -> None:
+    reader = MetricsReader()
+    refuted = [
+        {
+            "type": "proof",
+            "step": {
+                "kind": "witness_authored",
+                "path": "w.sh",
+                "command": "sh w.sh",
+                "fingerprint": "sha256:1",
+            },
+        },
+        _verdict(
+            False,
+            "touched tests failed",
+            rung="revise",
+            flip_achieved=False,
+            oracle_trace=[{"tree": "candidate", "passed": False}],
+        ),
+    ]
+    claim = [_verdict(True, "looks right to me", rung="model_verdict", flip_achieved=False)]
+    trials = [
+        reader.read(_trial(tmp_path, "t1", FLIP_STREAM), "a"),
+        reader.read(_trial(tmp_path, "t2", refuted), "b"),
+        reader.read(_trial(tmp_path, "t3", claim), "c"),
+    ]
+
+    totals = aggregate(trials)
+
+    assert totals["rail_trials"] == 3
+    assert totals["proven"] == 1
+    assert totals["witnessed"] == 2
+    assert totals["refuted"] == 1
+    assert totals["claimed_without_proof"] == 1
+    # One wrong guess that recovered, one that did not.
+    assert totals["wrong_guesses"] == 2
+
+
+def test_transcript_renders_proof_entries(tmp_path: Path) -> None:
+    """The regression this whole change exists to fix.
+
+    `proof` events were parsed and then dropped: the reader had no branch for
+    them, so 394 of them across the recorded matches reached no surface at
+    all — while the web UI shipped a filter chip for a kind nothing produced.
+    """
+    trial = _trial(tmp_path, "t1", FLIP_STREAM)
+    entries = TranscriptReader().read(trial / "agent" / "stella-events.jsonl")
+
+    proofs = [e for e in entries if e["kind"] == "proof"]
+    titles = [e["title"] for e in proofs]
+
+    assert "witness authored" in titles
+    assert "warrant: proof required" in titles
+    assert "oracle: candidate failed" in titles
+    authored = next(e for e in proofs if e["title"] == "witness authored")
+    assert authored["meta"]["path"] == "witness_check.sh"
+
+
+def test_transcript_verdict_body_is_the_evidence_summary(tmp_path: Path) -> None:
+    """It was read from a top-level `reasoning` key the wire never carried.
+
+    Every verdict in every transcript therefore rendered with an empty body —
+    and the summary is precisely where the pipeline says whether a pass was
+    proven.
+    """
+    trial = _trial(tmp_path, "t1", FLIP_STREAM)
+    entries = TranscriptReader().read(trial / "agent" / "stella-events.jsonl")
+
+    verdict = next(e for e in entries if e["kind"] == "verdict")
+
+    assert "flip oracle: fail→pass" in verdict["body"]
+    assert verdict["meta"]["rung"] == "submit_fast"
+    assert verdict["meta"]["flip_achieved"] is True
+
+
+def test_proof_reasons_are_never_truncated(tmp_path: Path) -> None:
+    """Every other long field here is clipped; this one must not be.
+
+    The half a clip removes is reliably the half naming the model, the
+    command or the constraint — the part a reader opened the page for.
+    """
+    reason = "no author independent of the worker: " + "x" * 9000
+    trial = _trial(
+        tmp_path,
+        "t1",
+        [{"type": "proof", "step": {"kind": "witness_unavailable", "reason": reason}}],
+    )
+    entries = TranscriptReader().read(trial / "agent" / "stella-events.jsonl")
+
+    assert next(e for e in entries if e["kind"] == "proof")["body"] == reason

--- a/arenabench/ui/components/arena/proof-badge.tsx
+++ b/arenabench/ui/components/arena/proof-badge.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import * as React from "react";
+import type { TrialProof } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Tip } from "@/components/ui/tooltip";
+
+/**
+ * The proof rail at a glance: one grade, and the oracle's own run sequence.
+ *
+ * A benchmark's verdict column answers "did it pass". This one answers the
+ * question underneath it — *what says so*. They come apart more often than
+ * anyone expects: Stella's pipeline publishes `passed: true` for a real
+ * deterministic flip, for an `unverifiable` outcome where every channel was
+ * blind, and for a `waived` one where triage skipped review. Read the verdict
+ * alone and those three are the same cell.
+ *
+ * Two deliberate choices about colour:
+ *
+ * - **`refuted` is not red.** The oracle running and never passing means the
+ *   agent claimed done, a test disagreed, and the claim did not ship. That is
+ *   the machinery working. It is marked, not scolded.
+ * - **`none` is grey, never a zero.** A seat with no pipeline proved nothing
+ *   because it has no way to — the absence of the apparatus, not a score.
+ */
+
+/** What each grade means, and how loudly to say it. */
+const GRADE_COPY: Record<
+  string,
+  { label: string; tone: string; blurb: string }
+> = {
+  flip: {
+    label: "flip",
+    tone: "text-ok",
+    blurb:
+      "An independently authored witness test failed on the work as it stood, " +
+      "then passed. This is the only outcome that earns the word 'done'.",
+  },
+  oracle: {
+    label: "oracle",
+    tone: "text-ok",
+    blurb:
+      "A tracked test command went fail→pass. No witness was authored — the " +
+      "command was configured rather than written for this change.",
+  },
+  refuted: {
+    label: "refuted",
+    tone: "text-warn",
+    blurb:
+      "The oracle ran and never passed: the agent's claim was caught before " +
+      "it shipped. The rail working as designed, not an agent failure to " +
+      "read twice.",
+  },
+  unproven: {
+    label: "unproven",
+    tone: "text-warn",
+    blurb:
+      "Proof was warranted and no witness could be authored. The reason is on " +
+      "the transcript page, in full.",
+  },
+  waived: {
+    label: "waived",
+    tone: "text-bad",
+    blurb: "Verification was waived by triage. Nothing checked this work.",
+  },
+  unwarranted: {
+    label: "no proof due",
+    tone: "text-muted",
+    blurb:
+      "No proof was demanded of this change — documentation, config or a pure " +
+      "removal has no runtime behaviour to flip.",
+  },
+  model: {
+    label: "model said so",
+    tone: "text-bad",
+    blurb:
+      "A model asserted the result with no deterministic backing. An " +
+      "assertion, not an observation.",
+  },
+  heuristic: {
+    label: "heuristic",
+    tone: "text-bad",
+    blurb: "Not even a model — a fallback rule decided the verdict.",
+  },
+  none: {
+    label: "—",
+    tone: "text-dim",
+    blurb: "This seat publishes no proof rail. Nothing to read, and nothing missing.",
+  },
+};
+
+/** The oracle's runs as a strip of glyphs, oldest first. */
+export function FlipStrip({ proof }: { proof: TrialProof }) {
+  if (!proof.oracle_runs.length) return null;
+  return (
+    <span className="inline-flex items-center gap-[3px] font-mono text-[10px]">
+      {proof.oracle_runs.map((run, index) => (
+        <span
+          key={index}
+          className={run.passed ? "text-ok" : "text-bad"}
+          title={`${run.tree}: ${run.passed ? "passed" : "failed"}`}
+        >
+          {run.passed ? "✓" : "✗"}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+/** The sentence describing what the strip shows, for a tooltip or a caption. */
+export function flipSentence(proof: TrialProof): string {
+  const { failed_attempts: wrong, flip_achieved: flipped } = proof;
+  if (!proof.oracle_runs.length) return "The oracle never ran on this trial.";
+  if (flipped && wrong > 0) {
+    return (
+      `The model believed it was finished ${wrong} time${wrong === 1 ? "" : "s"} ` +
+      `before the test agreed.`
+    );
+  }
+  if (flipped) return "The test passed on the first observation after the change.";
+  return (
+    `The test never passed — ${wrong} failing observation${wrong === 1 ? "" : "s"}, ` +
+    `and the work went back for revision.`
+  );
+}
+
+export function ProofBadge({
+  proof,
+  showStrip = true,
+}: {
+  proof: TrialProof | null | undefined;
+  showStrip?: boolean;
+}) {
+  // Absent and null are the same to a reader: there is nothing to show. They
+  // differ only in whether the server is old, which is not the reader's
+  // problem.
+  if (!proof) {
+    return <span className="font-mono text-[11px] text-dim">—</span>;
+  }
+  const copy = GRADE_COPY[proof.grade] ?? {
+    label: proof.grade,
+    tone: "text-muted",
+    blurb: "",
+  };
+
+  const notes: string[] = [copy.blurb];
+  if (proof.oracle_runs.length) notes.push(flipSentence(proof));
+  if (proof.claimed_without_proof) {
+    notes.push("This trial reported a pass with nothing deterministic behind it.");
+  }
+  if (proof.verifier_independent === false) {
+    notes.push("The verifier was the same model as the worker — it graded its own work.");
+  }
+  if (proof.unstable_flip) {
+    notes.push("The same command both passed and failed: the flip shows flakiness, not a fix.");
+  }
+
+  return (
+    <Tip content={notes.filter(Boolean).join(" ")}>
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+        <span className={cn("font-mono text-[11px] font-semibold", copy.tone)}>
+          {copy.label}
+        </span>
+        {showStrip && <FlipStrip proof={proof} />}
+        {proof.claimed_without_proof && (
+          <span className="font-mono text-[10px] text-bad" aria-label="unproven claim">
+            ⚠
+          </span>
+        )}
+      </span>
+    </Tip>
+  );
+}
+
+export { GRADE_COPY };

--- a/arenabench/ui/components/arena/proof-panel.tsx
+++ b/arenabench/ui/components/arena/proof-panel.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import * as React from "react";
+import type { TrialProof } from "@/lib/types";
+import { fmtMoney, fmtTokens } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { FlipStrip, GRADE_COPY, flipSentence } from "@/components/arena/proof-badge";
+
+/**
+ * The proof rail of one trial, in full: what was demanded, who wrote the test,
+ * whether it flipped, and — when it did not — the untruncated sentence saying
+ * why.
+ *
+ * This is the page's answer to the only question a verdict cannot answer on
+ * its own: *is this trial done, or does it merely say it is?* Four sections,
+ * in the order a reader needs them:
+ *
+ * 1. **The flip.** The oracle's own run sequence, oldest first. A trace like
+ *    ✗ ✓ ✓ is the whole thesis in one line — the model thought it had
+ *    finished, a test disagreed, and only then did it actually finish.
+ * 2. **The witness.** Which file, which command, which fingerprint, and
+ *    whether the worker left it alone.
+ * 3. **The pipeline.** Which model served which role. The witness author is
+ *    the one that matters and the one no config file can tell you: it rides
+ *    the verifier's resolution and is then filtered for independence against
+ *    the worker.
+ * 4. **The reasons.** Verbatim, never clipped.
+ *
+ * Sections with nothing to say are omitted rather than rendered empty — but
+ * the *reason* a section is empty is itself content, so "no witness was
+ * authored" prints its sentence instead of vanishing.
+ */
+
+function Row({
+  label,
+  children,
+  tone,
+}: {
+  label: string;
+  children: React.ReactNode;
+  tone?: string;
+}) {
+  return (
+    <div className="flex gap-3 py-[3px]">
+      <span className="w-[104px] flex-none text-[10.5px] lowercase text-dim">{label}</span>
+      <span className={cn("min-w-0 flex-1 break-words text-[11.5px]", tone ?? "text-muted")}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="border-t border-line-soft py-2.5 first:border-t-0">
+      <h3 className="pb-1 text-[10.5px] font-semibold lowercase tracking-[0.08em] text-dim">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/** A yes/no/unknown fact. `null` renders as "unmeasured", never as "no". */
+function Flag({
+  value,
+  yes,
+  no,
+  unknown = "unmeasured",
+  invert = false,
+}: {
+  value: boolean | null | undefined;
+  yes: string;
+  no: string;
+  unknown?: string;
+  invert?: boolean;
+}) {
+  if (value == null) return <span className="text-dim">{unknown}</span>;
+  const good = invert ? !value : value;
+  return <span className={good ? "text-ok" : "text-bad"}>{value ? yes : no}</span>;
+}
+
+export function ProofPanel({ proof }: { proof: TrialProof | null | undefined }) {
+  if (!proof) {
+    return (
+      <div className="rounded-[10px] border border-line bg-panel px-3.5 py-3 font-mono text-[11.5px] text-dim">
+        This seat publishes no proof rail — there is no witness, no oracle and no
+        pipeline roster to read. Nothing is missing; the machinery is not there.
+      </div>
+    );
+  }
+
+  const copy = GRADE_COPY[proof.grade] ?? {
+    label: proof.grade,
+    tone: "text-muted",
+    blurb: "",
+  };
+  const reasons: Array<{ label: string; text: string }> = [
+    ...proof.witness_unavailable.map((text) => ({ label: "no witness", text })),
+    ...proof.verification_unavailable.map((text) => ({ label: "unverifiable", text })),
+    ...proof.verdict_degraded.map((text) => ({ label: "degraded", text })),
+  ];
+
+  return (
+    <div className="rounded-[10px] border border-line bg-panel px-3.5 py-1 font-mono">
+      <Section title="proof">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 pb-1">
+          <span className={cn("text-[13px] font-semibold", copy.tone)}>{copy.label}</span>
+          {proof.claimed_without_proof && (
+            <span className="rounded-[5px] bg-bad/15 px-1.5 py-[1px] text-[10.5px] text-bad">
+              ⚠ said done, proved nothing
+            </span>
+          )}
+          {proof.verifier_independent === false && (
+            <span className="rounded-[5px] bg-bad/15 px-1.5 py-[1px] text-[10.5px] text-bad">
+              graded its own work
+            </span>
+          )}
+          {proof.unstable_flip && (
+            <span className="rounded-[5px] bg-warn/15 px-1.5 py-[1px] text-[10.5px] text-warn">
+              flaky flip
+            </span>
+          )}
+        </div>
+        <p className="pb-1 text-[11.5px] leading-[1.55] text-muted">{copy.blurb}</p>
+        <Row label="rung">
+          {proof.rung || <span className="text-dim">none</span>}
+          <span className="pl-2 text-dim">
+            {proof.deterministic
+              ? "a test was run and observed"
+              : "no test was run for this verdict"}
+          </span>
+        </Row>
+        <Row label="demanded">
+          {proof.warranted === null ? (
+            <span className="text-dim">no warrant was published</span>
+          ) : proof.warranted ? (
+            "proof was required of this change"
+          ) : (
+            proof.warrant_reason || "no proof was required"
+          )}
+          {proof.diff_lines != null && (
+            <span className="pl-2 text-dim">· {proof.diff_lines} diff lines</span>
+          )}
+        </Row>
+      </Section>
+
+      <Section title="the flip">
+        {proof.oracle_runs.length ? (
+          <>
+            <Row label="oracle">
+              <span className="inline-flex items-center gap-2">
+                <FlipStrip proof={proof} />
+                <span className={proof.flip_achieved ? "text-ok" : "text-warn"}>
+                  {flipSentence(proof)}
+                </span>
+              </span>
+            </Row>
+            <Row label="command">
+              <code className="break-all text-accent">
+                {proof.tracked_command || proof.oracle_runs[0]?.command || "—"}
+              </code>
+            </Row>
+            {proof.flip_refused && (
+              <Row label="refused" tone="text-warn">
+                The baseline failed for a different reason than the test asserts, so the
+                flip was not credited.
+              </Row>
+            )}
+            <Row label="coverage">
+              {proof.diff_coverage === "covered" ? (
+                <span className="text-ok">the test exercises the changed lines</span>
+              ) : proof.diff_coverage === "not_covered" ? (
+                <span className="text-bad">the test does not touch the changed lines</span>
+              ) : (
+                <span className="text-dim">
+                  unmeasured — no coverage tooling, so whether the test ran the changed
+                  lines is unknown rather than false
+                </span>
+              )}
+            </Row>
+          </>
+        ) : (
+          <Row label="oracle" tone="text-dim">
+            The oracle never ran on this trial, so nothing observed the work
+            {proof.rung ? ` — the verdict came from the ${proof.rung} rung.` : "."}
+          </Row>
+        )}
+      </Section>
+
+      <Section title="the witness">
+        {proof.witness_authored ? (
+          <>
+            <Row label="authored">
+              <code className="break-all text-accent">{proof.witness_path}</code>
+            </Row>
+            <Row label="command">
+              <code className="break-all">{proof.witness_command}</code>
+            </Row>
+            <Row label="fingerprint">
+              <code className="break-all text-dim">{proof.witness_fingerprint}</code>
+            </Row>
+            <Row label="tamper">
+              <Flag
+                value={proof.witness_intact}
+                yes="intact — every artifact matched its pinned identity"
+                no="modified"
+                unknown="the check did not report"
+              />
+            </Row>
+          </>
+        ) : proof.witness_unavailable.length ? (
+          <Row label="authored" tone="text-warn">
+            No witness was authored. The reason is below, verbatim.
+          </Row>
+        ) : (
+          <Row label="authored" tone="text-dim">
+            {proof.stage_ran
+              ? "The witness stage started and produced nothing."
+              : "The witness stage never started."}
+          </Row>
+        )}
+        <Row label="touched tests">
+          <Flag
+            value={proof.touched_tests_passed}
+            yes="green after the change"
+            no="failed after the change"
+            unknown="unobserved"
+          />
+        </Row>
+      </Section>
+
+      {proof.roles.length > 0 && (
+        <Section title="the pipeline">
+          <table className="w-full border-collapse text-left text-[11px]">
+            <thead>
+              <tr className="text-[10px] lowercase tracking-[0.08em] text-dim">
+                <th className="py-1 pr-3 font-normal">role</th>
+                <th className="py-1 pr-3 font-normal">model</th>
+                <th className="py-1 pr-3 text-right font-normal">calls</th>
+                <th className="py-1 pr-3 text-right font-normal">in</th>
+                <th className="py-1 pr-3 text-right font-normal">out</th>
+                <th className="py-1 text-right font-normal">cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {proof.roles.map((call) => {
+                // The two roles the whole rail turns on. Everything else is
+                // context; these two decide whether the proof means anything.
+                const pivotal =
+                  call.role === "witness_author" ||
+                  call.role === "witness_repair" ||
+                  call.role === "verdict";
+                return (
+                  <tr key={`${call.role}:${call.model}`} className="border-t border-line-soft/60">
+                    <td
+                      className={cn(
+                        "py-1 pr-3 whitespace-nowrap",
+                        pivotal ? "font-semibold text-accent" : "text-muted",
+                      )}
+                    >
+                      {call.role.replace(/_/g, " ")}
+                    </td>
+                    <td className="py-1 pr-3 break-all text-foreground">{call.model || "—"}</td>
+                    <td className="py-1 pr-3 text-right text-muted">{call.calls}</td>
+                    <td className="py-1 pr-3 text-right text-muted">
+                      {fmtTokens(call.tokens_in)}
+                    </td>
+                    <td className="py-1 pr-3 text-right text-muted">
+                      {fmtTokens(call.tokens_out)}
+                    </td>
+                    <td className="py-1 text-right text-muted">{fmtMoney(call.cost_usd)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div className="pt-1.5">
+            <Row label="independence">
+              <Flag
+                value={proof.verifier_independent}
+                yes="the verifier resolved to a different model than the worker"
+                no="the verifier WAS the worker's model — it graded its own work"
+                unknown="not stamped (only the model-verdict arm records it)"
+              />
+            </Row>
+          </div>
+        </Section>
+      )}
+
+      {(reasons.length > 0 || proof.verdict_summary) && (
+        <Section title="the reasons">
+          {reasons.map((reason, index) => (
+            <div key={index} className="py-1">
+              <span className="text-[10.5px] lowercase text-warn">{reason.label}</span>
+              <p className="whitespace-pre-wrap break-words text-[11.5px] leading-[1.55] text-muted">
+                {reason.text}
+              </p>
+            </div>
+          ))}
+          {proof.verdict_summary && (
+            <div className="py-1">
+              <span className="text-[10.5px] lowercase text-dim">
+                verdict{proof.honesty ? ` · ${proof.honesty}` : ""}
+              </span>
+              <p className="whitespace-pre-wrap break-words text-[11.5px] leading-[1.55] text-muted">
+                {proof.verdict_summary}
+              </p>
+            </div>
+          )}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/arenabench/ui/components/arena/task-table.tsx
+++ b/arenabench/ui/components/arena/task-table.tsx
@@ -5,6 +5,7 @@ import type { Cell, ContestantSnap, Snapshot } from "@/lib/types";
 import { fmtClock, fmtMoney, fmtTokens } from "@/lib/format";
 import { cn, seatStyle } from "@/lib/utils";
 import { Tip } from "@/components/ui/tooltip";
+import { ProofBadge } from "@/components/arena/proof-badge";
 
 /**
  * The task table: one row per task, every contestant's numbers side by side,
@@ -163,6 +164,10 @@ export function TaskTable({ snapshot }: { snapshot: Snapshot }) {
               <th className="px-4 py-2 font-normal">task</th>
               <th className="px-2 py-2 font-normal">seat</th>
               <th className="px-2 py-2 font-normal">verdict</th>
+              {/* Beside the verdict on purpose: "did it pass" and "what says
+                  so" are two facts, and the second is the one a reader
+                  cannot reconstruct from anywhere else on this page. */}
+              <th className="px-2 py-2 font-normal">proof</th>
               {METRICS.map((m) => (
                 <th key={String(m.key)} className="px-2 py-2 text-right font-normal">
                   {m.label} <i className="not-italic text-line">{m.better === "lower" ? "↓" : "↑"}</i>
@@ -208,6 +213,9 @@ export function TaskTable({ snapshot }: { snapshot: Snapshot }) {
                           </Tip>
                         )}
                       </span>
+                    </td>
+                    <td className="whitespace-nowrap px-2 py-1.5">
+                      <ProofBadge proof={cell?.proof} />
                     </td>
                     {METRICS.map((metric) => {
                       const value = numeric(cell, metric.key);

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -7,6 +7,7 @@ import { fmtClock, fmtMoney, fmtTokens } from "@/lib/format";
 import { cn, seatStyle } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ProofPanel } from "@/components/arena/proof-panel";
 
 /**
  * A trial's transcript as its own page: `/transcript?match=…&task=…&seat=…`.
@@ -47,7 +48,11 @@ const GROUPS: Array<{ key: string; label: string; kinds: string[] }> = [
   { key: "tool", label: "tools", kinds: ["tool"] },
   { key: "tool_result", label: "results", kinds: ["tool_result"] },
   { key: "usage", label: "usage", kinds: ["usage"] },
-  { key: "flow", label: "stages", kinds: ["stage", "proof", "verdict", "complete"] },
+  { key: "flow", label: "stages", kinds: ["stage", "complete"] },
+  // Its own group, not folded into "stages": the reason to filter a
+  // transcript down to the proof rail is to read the rail, and leaving it
+  // bundled with every stage rule means turning the stages off to see it.
+  { key: "proof", label: "proof", kinds: ["proof", "verdict"] },
 ];
 
 function groupOf(kind: string): string | null {
@@ -274,10 +279,64 @@ function Entry({
     return <div className="text-[10.5px] text-dim">{usageLine(entry)}</div>;
   }
 
-  if (entry.kind === "verdict" || entry.kind === "complete") {
+  if (entry.kind === "proof") {
+    // The proof rail inline, where it happened. Colour tracks what the step
+    // means for the claim rather than the step's name: an oracle that failed
+    // and a witness that could not be authored are both the rail *working*,
+    // so they are marked, not alarmed — but a reader must be able to spot
+    // them while scrolling.
+    const meta = (entry.meta || {}) as Record<string, unknown>;
+    const step = String(meta.step ?? "");
+    const bad = step === "witness_unavailable" || step === "verification_unavailable";
+    const failed = step === "oracle" && meta.passed === false;
+    const good = step === "witness_authored" || (step === "oracle" && meta.passed === true);
     return (
-      <div className="font-semibold text-ok">
-        {(entry.title ?? entry.kind) + (body ? ` — ${body}` : "")}
+      <div>
+        <span
+          className={cn(
+            "text-[11px] font-semibold",
+            good ? "text-ok" : bad || failed ? "text-warn" : "text-accent",
+          )}
+        >
+          ⊢ <Highlight text={entry.title ?? "proof"} query={query} />
+        </span>
+        {body && (
+          <div className="whitespace-pre-wrap break-words text-muted">
+            <Highlight text={body} query={query} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (entry.kind === "verdict" || entry.kind === "complete") {
+    // A verdict is not automatically good news. `passed: true` also covers an
+    // `unverifiable` outcome and a `waived` one, so the tone follows the
+    // ladder rung — the field that actually separates a proven pass from an
+    // unexamined claim.
+    const meta = (entry.meta || {}) as Record<string, unknown>;
+    const rung = String(meta.rung ?? "");
+    const proven = rung === "submit_fast" || rung === "revise";
+    const passed = meta.passed === true;
+    return (
+      <div>
+        <span
+          className={cn(
+            "font-semibold",
+            entry.kind === "complete" || proven ? "text-ok" : passed ? "text-warn" : "text-bad",
+          )}
+        >
+          {entry.title ?? entry.kind}
+          {rung && <span className="pl-2 font-normal text-dim">rung: {rung}</span>}
+          {passed && !proven && (
+            <span className="pl-2 font-normal text-warn">nothing deterministic behind it</span>
+          )}
+        </span>
+        {body && (
+          <div className="whitespace-pre-wrap break-words text-muted">
+            <Highlight text={body} query={query} />
+          </div>
+        )}
       </div>
     );
   }
@@ -389,6 +448,10 @@ function TranscriptView({
     setThinkingOverrides({});
     setOpenResults({});
   }, [seatId, task]);
+
+  // Open by default, because it is the answer to the question that brought
+  // most readers here — the transcript below is the supporting detail.
+  const [proofOpen, setProofOpen] = React.useState(true);
 
   const visible = React.useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -599,6 +662,19 @@ function TranscriptView({
             </Button>
           ) : null}
         </div>
+      </div>
+
+      {/* The proof rail, above the transcript it summarises. A verdict says
+          whether the trial passed; only this says what claims that. */}
+      <div className="border-b border-line py-2">
+        <button
+          type="button"
+          onClick={() => setProofOpen((value) => !value)}
+          className="cursor-pointer pb-1.5 font-mono text-[11px] text-dim hover:text-muted"
+        >
+          {proofOpen ? "⏶" : "⏵"} proof
+        </button>
+        {proofOpen && <ProofPanel proof={cell?.proof} />}
       </div>
 
       <div

--- a/arenabench/ui/lib/format.ts
+++ b/arenabench/ui/lib/format.ts
@@ -36,6 +36,18 @@ export function fmtPct(value: unknown): string {
   return (Number(value) || 0).toFixed(0) + "%";
 }
 
+// A plain count of trials, drawn as absent when it was never measured — the
+// third time this discipline has had to be written down here, after fmtMoney
+// and fmtClock (#1599). It matters most for the proof dimensions: a seat with
+// no pipeline has `proven` and `claimed_without_proof` of null, and rendering
+// either as `0` would show it tied on "never claimed a pass without proof"
+// with a seat that genuinely never did. `fmtTokens` cannot be reused — it
+// abbreviates past a thousand, and 1.2k is not a number of trials.
+export function fmtCount(value: unknown): string {
+  if (value == null) return "—";
+  return String(Math.round(Number(value) || 0));
+}
+
 export function fmtDim(key: string, value: unknown): string {
   switch (key) {
     case "solve_rate":
@@ -46,6 +58,9 @@ export function fmtDim(key: string, value: unknown): string {
     case "priced_cost":
     case "total_cost":
       return fmtMoney(value);
+    case "proven":
+    case "claimed_without_proof":
+      return fmtCount(value);
     default:
       return fmtTokens(value);
   }

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -115,6 +115,25 @@ export interface Totals {
   wasted_time?: number | null;
   /** How many trials the wasted-time sum covers (`arenabench flip` runs). */
   flip_trials?: number;
+  /** Trials that published a proof rail at all — the denominator for every
+   *  count below. Zero for a seat with no pipeline (a Claude Code arm). */
+  rail_trials?: number;
+  /** Trials an authored witness or tracked command carried fail→pass. */
+  proven?: number;
+  /** Trials where a witness test was authored, accepted and pinned. */
+  witnessed?: number;
+  /** Every time a model believed it was finished and a test said otherwise,
+   *  whether or not it recovered. The reason the rail exists, as a number. */
+  wrong_guesses?: number;
+  /** Trials the oracle ran on and never passed — the rail catching a
+   *  premature "done", which is a success of the machinery, not a failure. */
+  refuted?: number;
+  /** Passing verdicts with nothing deterministic behind them. */
+  claimed_without_proof?: number;
+  /** Trials where proof was warranted and no witness could be authored. */
+  unproven?: number;
+  /** Trials whose verifier was the same model as the worker. */
+  self_graded?: number;
   // `string[]` rides in the index signature for `unpriced_models` alone. Every
   // *dimension* key is still numeric — `race.tsx` indexes by `dim.key` and
   // coerces with `Number` — and no dimension is or will be a list.
@@ -170,6 +189,92 @@ export interface Cell {
   flip_elapsed?: number | null;
   /** Seconds the trial kept running after it was already passing. */
   wasted_elapsed?: number | null;
+  /** What actually proved this trial. `null` for a seat with no Stella event
+   *  stream; absent only in payloads recorded before the rail was surfaced. */
+  proof?: TrialProof | null;
+}
+
+/** One observation of the tracked test command, in the order it happened. */
+export interface OracleRun {
+  /** `baseline` = the unmodified code, `candidate` = the agent's change. */
+  tree: string;
+  passed: boolean;
+  command: string;
+}
+
+/** Every model call one pipeline role made — the model that actually served
+ *  it, which is the only way to learn who authored a witness: the author
+ *  rides the verifier's resolution and is then filtered for independence
+ *  against the worker, so no config file can tell you. */
+export interface RoleCall {
+  role: string;
+  model: string;
+  calls: number;
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+}
+
+/**
+ * What actually proved a trial. Absent on a payload recorded before the rail
+ * was surfaced; `null` for a seat that publishes no Stella event stream at
+ * all — the absence of the machinery rather than a failure of it.
+ */
+export interface TrialProof {
+  /** The single badge. See `GRADE_COPY` in `proof-badge.tsx`. */
+  grade: string;
+
+  // was proof demanded at all?
+  warranted: boolean | null;
+  /** One of six fixed sentences when it was not — "documentation only; prose
+   *  has no runtime behavior to flip" and its siblings. */
+  warrant_reason: string;
+  diff_lines: number | null;
+
+  // was a witness authored?
+  /** A `witness` stage event was seen. Warranted-but-never-started is a
+   *  different failure from started-and-could-not-finish. */
+  stage_ran: boolean;
+  witness_authored: boolean;
+  witness_path: string;
+  witness_command: string;
+  witness_fingerprint: string;
+  /** Full, untruncated. Plural because authoring gets one repair attempt. */
+  witness_unavailable: string[];
+
+  // did it flip?
+  oracle_runs: OracleRun[];
+  /** Failing observations before the first pass — and all of them when none
+   *  passed, so `> 0` selects every trial where the model guessed wrong. */
+  failed_attempts: number;
+  flip_achieved: boolean | null;
+  tracked_command: string;
+  unstable_flip: boolean;
+  flip_refused: boolean;
+  witness_intact: boolean | null;
+  touched_tests_passed: boolean | null;
+
+  // what backed the verdict?
+  rung: string;
+  /** Whether a test was actually run and observed for this verdict. */
+  deterministic: boolean;
+  /** A passing verdict with nothing deterministic behind it. The honesty
+   *  trap: `unverifiable` and `waived` both publish `passed: true`, and a
+   *  model verdict is an assertion rather than an observation. */
+  claimed_without_proof: boolean;
+  verdict_passed: boolean | null;
+  verdict_summary: string;
+  /** Which honesty marker the summary carries, `""` for a plain claim. */
+  honesty: string;
+  assurance_witness: boolean | null;
+  assurance_verifier: boolean | null;
+  /** `false` means the run graded its own homework. */
+  verifier_independent: boolean | null;
+  diff_coverage: string;
+  verdict_degraded: string[];
+  verification_unavailable: string[];
+
+  roles: RoleCall[];
 }
 
 export interface TaskRow {


### PR DESCRIPTION
## What

ArenaBench could not tell you whether a witness test was authored, whether the oracle flipped, or which model ran which pipeline role. This adds all three, on three surfaces: a `proof` column in the task table, a proof panel above every transcript, and `arenabench proof <path>` for the rig.

## Why

Stella emits every one of these facts already. ArenaBench parsed them and dropped them: `telemetry.py`'s transcript builder had branches for `stage`, `verdict`, `usage` and the tool events, and none for `proof`. Across the 192 recorded trials on the dev machine that is **394 discarded events**. The web UI even ships a filter chip for the `proof` kind in its "stages" group — the chip has always existed with nothing behind it.

The reason this is worth a column rather than a footnote: the pipeline publishes `passed: true` for three different things — a real deterministic flip, an `unverifiable` outcome where every channel was blind, and a `waived` one where triage skipped review. Only `evidence.ladder.rung` and an `UNVERIFIABLE`/`UNVERIFIED`/`UNPROVEN` prefix on the summary tell them apart, and ArenaBench read neither. On the recorded corpus that is **52 trials claiming a pass with nothing deterministic behind them, against 6 genuine flips.**

## What it shows

```
seat                         trial                           grade      witness  oracle     wrong  rung
2229d35b916b-stella-glm-5-2  nginx-request-logging__HUx4aP2  flip       yes      --++       2      submit_fast
2229d35b916b-stella-kimi-k3  nginx-request-logging__TdHNRLC  unproven   no       (none)     0      unverifiable

── 2229d35b916b-stella-glm-5-2 · nginx-request-logging__HUx4aP2 ── flip
   witness   witness_nginx_benchmark.sh  (sh witness_nginx_benchmark.sh)
   worker           z-ai/glm-5.2  ×41
   witness_author   moonshotai/kimi-k3  ×3
   witness_repair   moonshotai/kimi-k3  ×3
```

`--++` is the whole thesis in four characters: the model believed it was finished twice, a test written by a *different* model disagreed both times, and only then did it actually finish. `TrialProof.failed_attempts` is that number, and it counts the never-recovered case too — scoping it to "before the first pass" would have made the refuted trials, the starkest examples, report zero.

## Structure

`arenabench/proof.py` is new rather than more of `telemetry.py`. The distillation is a pure fold over parsed events, which is what makes it testable against recorded fixtures; and `telemetry.py` was at 1297 lines against a 1500 ratchet, so growing it was the wrong move regardless. `telemetry.py` collects the four relevant event types during its existing single pass and calls `distill` once.

## Defects found while reading the wire contract

- **Every verdict in every transcript rendered with an empty body.** The body was read from a top-level `reasoning` key that `AgentEvent::Verdict` has never carried; the text lives at `evidence.summary`, which is exactly where the pipeline says whether a pass was proven.
- **Legacy spellings were not accepted.** Neither `judge_verdict` (the pre-rename event tag), `judge` (the pre-rename role), nor `judge` as the assurance field — all three of which the Rust protocol still reads back via serde aliases, and two of which appear in the recorded corpus. An archive recorded under the old spelling silently lost its verdict.
- **`fmtDim` fell through to `fmtTokens`, and `fmtTokens(null)` returns `"0"`.** A seat with no proof rail would have rendered `claimed_without_proof: 0` — tied, in the column, with a seat that genuinely never claimed a pass it could not prove. `fmtCount` draws it as absent. This is the third time the discipline has been written into that file, after `fmtMoney` and `fmtClock` (#1599).

`proven` and `claimed_without_proof` join `DIMENSIONS` as `None` rather than `0` for a seat with no rail, for the same reason `wasted_time` is: crowning a Claude Code arm on "never claimed a pass without proof" would make the scoreboard reward the absence of the machinery it exists to measure. `leaders()` already skips `None`, so a null crowns nobody.

## Witness test

`tests/test_proof.py::test_transcript_renders_proof_entries` fails on `main` (the reader has no `proof` branch, so `[e for e in entries if e["kind"] == "proof"]` is empty) and passes here. `test_transcript_verdict_body_is_the_evidence_summary` likewise — the body is `""` on `main`.

31 tests total, covering the honesty trap from both sides (a real flip is never `claimed_without_proof`; `waived` and `unverifiable` always are), the legacy spellings, the `None`-not-zero roll-up, and the no-truncation rule for reason strings.

## Verification

- `uv run pytest tests/` — 501 pass
- `npm run typecheck` and `npm run build` in `ui/` — clean
- `make guards-fast` — green, including `check-file-size` (`proof.py` is 489 lines; no grandfathered file grew)
- Distilled all 192 recorded trials: 6 flips, 4 refutations, 28 unproven, 52 unproven claims, 90 with no rail

## Filed, not fixed

Three findings from reading the pipeline source, each written as a handoff:

- Refs #2272 — no `proof.oracle` step or `oracle_trace` entry in the entire corpus carries `tree: "baseline"`. An authored witness's failing baseline is folded in *without* a tree label, so every recorded "fail→pass" is intra-candidate. The UI cannot distinguish the two and neither can the wire.
- Refs #2273 — `verifier_independent` is stamped only on the model-verdict arm, so five of the six real flips report `null` for the property the witness contract turns on.
- Refs #2274 — `ProofStep::Assurance` is emitted at triage and states intent, in a rail whose every other step reports something that happened. It is the most common step in the corpus (181 of 394) and a trial can publish `witness: true` and then never author one.

## Summary by Sourcery

Surface Stella’s proof rail throughout ArenaBench, exposing what actually proved each trial and distinguishing proven work from unexamined claims.

New Features:
- Add a proof rail data model and distillation in a new arenabench.proof module, capturing witnesses, oracle runs, verdict backing, and pipeline roles per trial.
- Expose per-trial proof information in telemetry, CLI (new `arenabench proof` command), task table (proof column), and transcript page (proof panel and proof-specific filtering).

Bug Fixes:
- Ensure legacy verdict and role spellings (`judge_verdict`, `judge`) are parsed correctly so older archives retain their verdict and proof information.
- Fix verdict bodies in transcripts to read from `evidence.summary` instead of a nonexistent `reasoning` field, restoring the explanation of passes and failures.
- Prevent seats without a proof rail from rendering misleading zero counts by introducing `fmtCount` and using `None` for proof-derived dimensions when unmeasured.

Enhancements:
- Augment verdict transcript entries with ladder metadata and evidence summaries, and visually distinguish deterministic proofs from bare passes in the UI.
- Extend aggregation and leaderboard dimensions with proof-based counters such as proven trials and unproven claims, treating seats with no rail as unmeasured rather than zero.
- Improve formatting utilities and type definitions to support proof counts and proof data structures without conflating absence of measurement with zero.

Tests:
- Add a comprehensive test suite for proof rail distillation, aggregation, transcript rendering, CLI output, and legacy-wire compatibility, covering flips, refutations, waived/unverifiable outcomes, and absence-of-rail behavior.