### PR TITLE
fix(stella-tools): never leave the worker blind or falsely warned about its own workspace

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -287,10 +287,14 @@ fn append_project_scripts(prompt: &mut String, workspace_root: &std::path::Path)
 /// useful on monorepos far past a few hundred files (issue #328). Read-only
 /// (`stella_tools::overview::render_orientation_block`
 /// opens an existing index and never builds one), so it adds nothing to
-/// first-response latency; it appears once the session's background index
-/// build has completed (or immediately when the workspace was pre-indexed,
-/// as the benchmark adapter does). Byte-stable for a given index state, so it
-/// keeps the cache-stable system prefix stable. The point is fewer
+/// first-response latency. It renders the graph-backed map once the session's
+/// background index build has completed (or immediately when the workspace was
+/// pre-indexed, as the benchmark adapter does), and falls back to a bounded
+/// top-level listing whenever the index is absent or empty — a worker is never
+/// left blind on an unindexable tree. Byte-stable for a given index and
+/// top-level tree state, so it keeps the cache-stable system prefix stable
+/// (the prompt is assembled once per session, so mid-session churn cannot
+/// reach the prefix). The point is fewer
 /// grep/glob/read_file discovery turns: the model starts knowing the shape of
 /// the code.
 fn append_project_orientation(prompt: &mut String, workspace_root: &std::path::Path) {

--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -86,9 +86,10 @@ impl RepoStructurePort for GitRepoStructure {
             _ => String::new(),
         };
         // Read-only like the system-prompt seam: renders only from an
-        // EXISTING index (never builds one inline), is bounded and
-        // byte-stable for a given index state, and simply appears once the
-        // session's background graph build has landed.
+        // EXISTING index (never builds one inline), is bounded, and is
+        // byte-stable for a given index and top-level tree state. The
+        // graph-backed map appears once the session's background graph build
+        // has landed; until then it falls back to a bounded top-level listing.
         compose_structure_summary(
             tree,
             stella_tools::overview::render_orientation_block(&self.root),

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -72,8 +72,11 @@ const GREP_CMDS: &[&str] = &["grep", "egrep", "fgrep", "rg", "ripgrep", "ag"];
 /// pattern out of the common command shapes, returning each word already
 /// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
 /// path with spaces stays one word) and preserves backslash escapes like
-/// `\|` (so an alternation survives into [`is_symbol_shaped`]); bare
-/// operators (`&&`, `|`, `;`) come back as their own words to bound a scan.
+/// `\|` (so an alternation survives into [`is_symbol_shaped`]); unquoted
+/// operators (`&&`, `||`, `|`, `;`, `&`) come back as their own words to
+/// bound a scan — including when attached to a word, so `cd /app; ls` yields
+/// the target `/app`, not the unresolvable `/app;` a paid bench trial saw
+/// warned about as an escape from its own session root.
 fn shell_words(command: &str) -> Vec<String> {
     let mut words: Vec<String> = Vec::new();
     let mut cur = String::new();
@@ -90,7 +93,21 @@ fn shell_words(command: &str) -> Vec<String> {
                 in_double = !in_double;
                 has_word = true;
             }
-            '\\' if in_double => {
+            c @ (';' | '&' | '|') if !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                let mut op = String::from(c);
+                // `&&` / `||` are one operator; `;;` never appears in the
+                // shapes this scans, so `;` stays single.
+                if c != ';' && chars.peek() == Some(&c) {
+                    chars.next();
+                    op.push(c);
+                }
+                words.push(op);
+            }
+            '\\' if !in_single => {
                 // Keep the escape literal (covers `\|`, `\"`, …); we don't
                 // interpret it, just preserve it for the symbol test.
                 cur.push('\\');
@@ -130,11 +147,14 @@ fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
             continue;
         }
         let target = pair[1].as_str();
-        // `-` (cd to previous dir) is caught by the `-` prefix below.
+        // `-` (cd to previous dir) is caught by the `-` prefix below. An
+        // operator word means the `cd` had no target at all (`cd && make`):
+        // that goes to `$HOME`, which we skip for the same reason as `~`.
         if target.is_empty()
             || target.starts_with('$')
             || target.starts_with('~')
             || target.starts_with('-')
+            || matches!(target, ";" | "&" | "&&" | "|" | "||")
         {
             continue;
         }
@@ -647,6 +667,41 @@ mod tests {
         assert_eq!(cd_escape_target("cd $HOME && ls", dir.path()), None);
         assert_eq!(cd_escape_target("cd ~/foo && ls", dir.path()), None);
         assert_eq!(cd_escape_target("grep -rn x .", dir.path()), None);
+    }
+
+    #[test]
+    fn shell_words_splits_operators_attached_to_a_word() {
+        assert_eq!(shell_words("cd /app; ls"), ["cd", "/app", ";", "ls"]);
+        assert_eq!(shell_words("a&&b"), ["a", "&&", "b"]);
+        assert_eq!(
+            shell_words("a || b|c & d"),
+            ["a", "||", "b", "|", "c", "&", "d"]
+        );
+        // Quoted and escaped operators stay inside the word.
+        assert_eq!(shell_words("echo 'a;b'"), ["echo", "a;b"]);
+        assert_eq!(shell_words(r"grep x\|y ."), ["grep", r"x\|y", "."]);
+    }
+
+    /// The false positive a paid bench trial hit: `cd /app; …` with session
+    /// root `/app` drew the "work here is invisible to the diff and to
+    /// verification" warning, because the target parsed as the unresolvable
+    /// `/app;`.
+    #[test]
+    fn an_attached_separator_does_not_fake_a_cd_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        // In-root cd with the separator attached — no drift, no warning.
+        assert_eq!(cd_escape_target("cd sub; ls", &root), None);
+        assert_eq!(
+            cd_escape_target(&format!("cd {}; ls", root.display()), &root),
+            None
+        );
+        // A real escape still warns, and names the clean target.
+        assert_eq!(cd_escape_target("cd /; ls", &root).as_deref(), Some("/"));
+        // A bare `cd` before an operator goes to `$HOME` — unresolvable
+        // here, so it is skipped rather than misnamed.
+        assert_eq!(cd_escape_target("cd && ls", &root), None);
     }
 
     #[test]

--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -92,14 +92,18 @@ impl Tool for ProjectOverview {
 }
 
 /// A compact, deterministic orientation block for the system prompt, or
-/// `None` when there is no usable index.
+/// `None` only when the workspace is empty — the worker starts oriented, it
+/// never has to *choose* to look.
 ///
 /// Read-only on purpose: it opens an **existing** index and never builds one,
 /// so it can be called during system-prompt assembly without ever blocking
 /// the first response on an index build (which would defeat the point of a
-/// fast first turn). When the index is absent — a fresh session before the
-/// background build finishes — it returns `None` and the model can still call
-/// `project_overview` explicitly.
+/// fast first turn). When the index is absent or has indexed nothing — a
+/// fresh session before the background build finishes, or a tree with no
+/// files the indexer has a grammar for (an eight-trial bench run rendered
+/// this block in zero worker prompts for exactly that reason) — it degrades
+/// to [`listing_orientation_block`], one bounded `read_dir` of the root,
+/// instead of silently vanishing.
 ///
 /// Deliberately the complement of the script index (which the prompt already
 /// injects separately): languages, top-level layout, entry points, and
@@ -113,6 +117,11 @@ impl Tool for ProjectOverview {
 /// `MAX_TOP_LEVEL_DIRS`, so a monorepo far beyond a few hundred files
 /// renders the same useful map a small tree does.
 pub fn render_orientation_block(root: &Path) -> Option<String> {
+    graph_orientation_block(root).or_else(|| listing_orientation_block(root))
+}
+
+/// The graph-backed map — `None` when the index is absent or empty.
+fn graph_orientation_block(root: &Path) -> Option<String> {
     let path = stella_store::existing_workspace_private_sqlite_path(root, "codegraph.db")
         .ok()
         .flatten()?;
@@ -168,6 +177,43 @@ pub fn render_orientation_block(root: &Path) -> Option<String> {
         return None;
     }
     Some(lines.join("\n"))
+}
+
+/// The graphless fallback: one sorted, bounded `read_dir` of the workspace
+/// root. A tree the indexer has no grammar for (COBOL, nginx configs, a
+/// tarball) still orients the worker from the first token — what it can see
+/// at the top level — instead of leaving the prompt silently blank. Hidden
+/// entries stay out (which also covers `.stella`), directories carry a
+/// trailing `/`, and an empty workspace renders nothing: there is nothing to
+/// orient toward, and the task text already says so.
+fn listing_orientation_block(root: &Path) -> Option<String> {
+    let mut entries: Vec<String> = std::fs::read_dir(root)
+        .ok()?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let name = entry.file_name().into_string().ok()?;
+            if name.starts_with('.') {
+                return None;
+            }
+            let is_dir = entry.file_type().ok()?.is_dir();
+            Some(if is_dir { format!("{name}/") } else { name })
+        })
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+    entries.sort();
+    let omitted = entries.len().saturating_sub(MAX_TOP_LEVEL_DIRS);
+    entries.truncate(MAX_TOP_LEVEL_DIRS);
+    let mut listing = format!("Top level: {}", entries.join(", "));
+    if omitted > 0 {
+        listing.push_str(&format!(", +{omitted} more"));
+    }
+    Some(format!(
+        "## Project map (top-level listing — no code index yet)\n{listing}\n\
+         No indexed symbols here yet; once code exists, project_overview \
+         returns the graph-backed map."
+    ))
 }
 
 /// Assemble the overview. Total by construction: every source degrades to
@@ -503,16 +549,50 @@ mod tests {
     }
 
     #[test]
-    fn orientation_block_is_none_without_an_index_and_never_builds_one() {
+    fn orientation_block_without_an_index_lists_the_top_level_and_never_builds_one() {
         // Read-only: it must not create an index during system-prompt
-        // assembly, or it would block the first response on a build.
+        // assembly, or it would block the first response on a build. It still
+        // orients — the pre-index degradation is a listing, not a blank.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").unwrap();
-        assert!(render_orientation_block(dir.path()).is_none());
+        let block = render_orientation_block(dir.path()).expect("a non-empty tree orients");
+        assert!(block.contains("no code index yet"), "{block}");
+        assert!(block.contains("lib.rs"), "{block}");
         assert!(
             !crate::graph::graph_db_path(dir.path()).exists(),
             "the read-only block must not build an index"
         );
+        // An empty workspace is the one case with nothing to say.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(render_orientation_block(empty.path()).is_none());
+    }
+
+    /// The eight-trial bench shape: `stella init` built the index, but the
+    /// workspace holds nothing the indexer has a grammar for (a tarball under
+    /// deny-listed `vendor/`, COBOL sources). The empty graph must degrade to
+    /// the top-level listing, never to a silently blank prompt — every worker
+    /// prompt in that run went blank exactly here.
+    #[test]
+    fn an_empty_index_falls_back_to_the_top_level_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("vendor")).unwrap();
+        std::fs::write(dir.path().join("vendor").join("src.tar.gz"), b"x").unwrap();
+        std::fs::write(dir.path().join("main.cob"), "IDENTIFICATION DIVISION.\n").unwrap();
+        let _ = build_overview(dir.path());
+        let block = render_orientation_block(dir.path()).expect("the fallback renders");
+        assert!(block.contains("no code index yet"), "{block}");
+        assert!(block.contains("main.cob"), "{block}");
+        assert!(block.contains("vendor/"), "{block}");
+    }
+
+    #[test]
+    fn the_top_level_listing_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..MAX_TOP_LEVEL_DIRS + 3 {
+            std::fs::write(dir.path().join(format!("f{i:02}")), b"").unwrap();
+        }
+        let block = render_orientation_block(dir.path()).expect("renders");
+        assert!(block.contains("+3 more"), "{block}");
     }
 
     #[test]

--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -102,7 +102,7 @@ impl Tool for ProjectOverview {
 /// fresh session before the background build finishes, or a tree with no
 /// files the indexer has a grammar for (an eight-trial bench run rendered
 /// this block in zero worker prompts for exactly that reason) — it degrades
-/// to [`listing_orientation_block`], one bounded `read_dir` of the root,
+/// to `listing_orientation_block`, one bounded `read_dir` of the root,
 /// instead of silently vanishing.
 ///
 /// Deliberately the complement of the script index (which the prompt already


### PR DESCRIPTION
## What

Two defects in what the worker is told about its own workspace, both found by tracing every trial of bench match 958b92296de1 (2026-08-08, opus-5 xhigh full pipeline):

1. **`shell_words` never split unquoted operators off a word, contradicting its own doc.** `cd /app; ls` parsed its cd target as `/app;`, which cannot resolve inside session root `/app`, so the agent was told — twice, in a paid trial, while standing in its own session root — that its work was "invisible to the file tools, to this turn's diff, and to verification". The word splitter now emits unquoted `;`, `&`, `|`, `&&`, `||` as their own words (including when attached), backslash-escapes are preserved outside single quotes, and `cd_escape_target` skips operator words (a bare `cd && make` goes to `$HOME`, unresolvable here — skipped like `~`, "better a missed note than a wrong one"). This also repairs the grep-boundary scan, which shares the splitter.

2. **The system-prompt orientation block silently vanished whenever the code graph was empty** — the steady state on bench workspaces (empty dirs, tarballs under deny-listed `vendor/`, grammars we don't carry). All eight trial worker prompts carried no project map, and the worker called `graph_query` zero times all night. `render_orientation_block` now degrades to one sorted, bounded `read_dir` top-level listing instead of `None`, so the worker starts oriented on any non-empty workspace. The read-only contract is unchanged: it still never builds an index at prompt-assembly time, and the block stays byte-stable for a given tree state (sorted, bounded by `MAX_TOP_LEVEL_DIRS`), preserving the prompt-cache invariant (AGENTS.md invariant #7).

## Witness

- `an_attached_separator_does_not_fake_a_cd_escape` — the exact false-positive shape from the paid trial.
- `an_empty_index_falls_back_to_the_top_level_listing` — the exact bench shape: `stella init` built the index, nothing was indexable, the prompt must not go blank.
- Plus `shell_words_splits_operators_attached_to_a_word` and `the_top_level_listing_is_bounded`.

Verified the flip the artisanal way: with only the implementation hunks reverted, all five fail; with them restored, `cargo test -p stella-tools` is fully green. Clippy `--all-targets -D warnings` and rustdoc `-D warnings` clean.

## Reshaped test (deleted-test guard)

`orientation_block_is_none_without_an_index_and_never_builds_one` is renamed and reshaped to `orientation_block_without_an_index_lists_the_top_level_and_never_builds_one`: its "returns None" half asserted exactly the behavior this PR removes; its "never builds an index" half is kept and still asserted, and the None case now lives where it belongs (an empty workspace).

## Residue

Filed from the same trace audit: #2277 (triage reasoning=off burned its whole token cap), #2278 (reactive-only task deadline lost a trial by 1.6s), #2279 (watcher liveness in containers unproven; no graph-state journal event), #2280 (unattributable SIGTERM killed the match), #2281 (premature-complete monitor conflates 402 aborts with giving up).

## Summary by Sourcery

Ensure the worker always has an accurate, non-blank view of its workspace in prompts and shell-command analysis.

Bug Fixes:
- Fix shell command word splitting so unquoted operators are separated from adjacent words, preventing mis-detection of cd targets and workspace escapes.
- Treat operator-only cd invocations as non-escaping, avoiding false workspace-escape warnings.

Enhancements:
- Make the orientation block fall back to a bounded, sorted top-level directory listing when the code graph index is absent or empty, instead of omitting the project map.
- Exclude hidden entries from the fallback listing and bound its size to maintain deterministic, cache-friendly prompts.

Tests:
- Add tests covering operator splitting in shell_words and cd escape detection for attached separators and bare cd before operators.
- Add tests ensuring the orientation block falls back to a top-level listing when the index is empty and that the listing respects bounding.