### PR TITLE
fix(stella-cli): stop every deck lane wedging at forwarder.await after its turn

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -125,7 +125,7 @@ use crate::memory::{SessionMemory, inject_recall_block};
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::{agents_list_creating, agents_list_inbound, handle_agent_create};
-pub(crate) use forwarder::spawn_forwarder;
+pub(crate) use forwarder::{close_turn_stream, spawn_forwarder};
 use scope_gate::DeckApprovalGate;
 use sessions_view::sessions_inbound;
 use settings_io::{apply_pending_reload, handle_engine_config_input, handle_tools_input};
@@ -4242,8 +4242,7 @@ async fn run_lead_turn(
     // is still reading user input — so latch the flag that tells its prompt
     // arm to treat what arrives as the next turn, not a sidecar request.
     steering.mark_settling();
-    drop(tx);
-    let persistence_complete = forwarder.await.unwrap_or(false);
+    let persistence_complete = close_turn_stream(registry, tx, forwarder).await;
     claims.release_all();
 
     if let Some((store, id)) = &execution {
@@ -4450,8 +4449,7 @@ async fn run_lead_pipeline_turn(
     };
     // Same settle window as `run_lead_turn` — see `SteeringTap::mark_settling`.
     steering.mark_settling();
-    drop(tx);
-    let persistence_complete = forwarder.await.unwrap_or(false);
+    let persistence_complete = close_turn_stream(registry, tx, forwarder).await;
     claims.release_all();
 
     if let Some((store, id)) = &execution {

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -146,3 +146,87 @@ pub(crate) fn spawn_forwarder(
         persistence_complete
     })
 }
+
+/// End a lane's turn stream and wait out its forwarder — the deck-lane twin
+/// of [`agent::close_event_stream`], owing the same debt in the same order.
+///
+/// `drop(tx)` on its own never closes the channel: the turn handed the
+/// registry an `EventSender` clone (`ToolRegistry::attach_events`) so
+/// `record_touch` could announce `FileChange`s, and the registry outlives the
+/// turn — the deck's session registry by design, a worker lane's because the
+/// closing future itself still holds the `Arc`. With that clone alive, the
+/// forwarder's `recv()` loop stayed pending forever and awaiting it wedged
+/// the turn future *after* the deck had painted the turn done: the driver
+/// never left its mid-turn `select!`, every prompt queued as the "next turn"
+/// of a turn that could not end, and only `/clear` — the one input that
+/// breaks that `select!` — could free the session (#2290). One-shot
+/// `stella run` hit the same shape as #960; the deck lanes reintroduced it
+/// when #903 pointed the recorder at the turn channel without paying the
+/// detach the fix demands.
+///
+/// Detaching unconditionally is safe against concurrent lanes because turns
+/// do not overlap on one registry (the invariant
+/// [`stella_tools::subagent::TurnControlsGuard`] documents): the lead's turns
+/// run sequentially on the session registry, and every worker lane builds a
+/// registry of its own.
+pub(crate) async fn close_turn_stream(
+    registry: &stella_tools::ToolRegistry,
+    tx: UnboundedSender<AgentEvent>,
+    forwarder: tokio::task::JoinHandle<bool>,
+) -> bool {
+    registry.detach_event_stream();
+    drop(tx);
+    forwarder.await.unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frozen-deck witness (#2290): a turn's tail must complete even
+    /// though the registry still holds the `EventSender` the turn attached.
+    /// Before [`close_turn_stream`], every lane's tail was `drop(tx)` +
+    /// `forwarder.await` — with the registry's clone alive the forwarder
+    /// never saw the channel close, the turn future never returned, and the
+    /// deck queued prompts forever under a lane it had painted done.
+    #[tokio::test]
+    async fn the_turn_tail_completes_with_the_registry_still_attached() {
+        let root = tempfile::tempdir().expect("root");
+        let registry =
+            stella_tools::ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+        let (in_tx, mut in_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let forwarder = spawn_forwarder(
+            rx,
+            None,
+            InsightScope {
+                provider_id: "anthropic".into(),
+                cache_ttl: stella_model::CacheTtl::default(),
+            },
+            in_tx,
+            "lead".to_string(),
+            None,
+        );
+        registry.attach_events(stella_core::EventSender::new(tx.clone()));
+        tx.send(AgentEvent::Complete {
+            model: "m".into(),
+            cost_usd: 0.0,
+        })
+        .unwrap();
+
+        let settled = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            close_turn_stream(&registry, tx, forwarder),
+        )
+        .await;
+
+        let persistence_complete =
+            settled.expect("the registry-held sender must not wedge the turn tail");
+        assert!(
+            persistence_complete,
+            "an event-only stream persists cleanly"
+        );
+        // The forwarded event reached the deck lane before the stream closed.
+        assert!(matches!(in_rx.try_recv(), Ok(Inbound::Event { .. })));
+    }
+}

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -36,7 +36,7 @@ use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::sync::{oneshot, watch};
 
 use crate::agent;
-use crate::command_deck::{LEAD, now_ms, prompt_line, spawn_forwarder};
+use crate::command_deck::{LEAD, close_turn_stream, now_ms, prompt_line, spawn_forwarder};
 use crate::config::Config;
 use crate::runtime::TokioSleeper;
 
@@ -763,8 +763,7 @@ async fn run_worker(
             _ = stop_wait => RacedTurn::Stopped,
         }
     };
-    drop(tx);
-    let persistence_complete = forwarder.await.unwrap_or(false);
+    let persistence_complete = close_turn_stream(&registry, tx, forwarder).await;
     // Release the worker's whole claim set — the stop path included (the
     // dropped turn future cannot release for itself).
     claims.release_all();

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -100,10 +100,13 @@ pub type TurnControlsSlot = Arc<RwLock<TurnControls>>;
 ///
 /// A guard rather than a bare setter, and the asymmetry with
 /// [`crate::ToolRegistry::attach_events`] is deliberate: a stale event sender
-/// is inert (it writes to a channel nobody reads), but a stale
-/// [`stella_core::ports::TurnSteering`] is *armed*. `soft_stop_requested`
-/// latches by contract, so a tap left published past a stopped turn would
-/// stop every child of the next turn at its first boundary.
+/// misbehaves passively, but a stale [`stella_core::ports::TurnSteering`] is
+/// *armed*. `soft_stop_requested` latches by contract, so a tap left
+/// published past a stopped turn would stop every child of the next turn at
+/// its first boundary. ("Passively" is not "inertly": the sender holds its
+/// turn channel open, so a turn tail that awaits that channel's reader must
+/// call [`crate::ToolRegistry::detach_event_stream`] first or deadlock — the
+/// frozen-deck bug, and #960 before it.)
 ///
 /// Clearing on drop — rather than on an explicit detach call — is the same
 /// argument as `stella_core::subagent::AgentAttribution`: the turn future can


### PR DESCRIPTION
## What & why

A finished deck turn never actually returned. Every lane's turn tail was `drop(tx); forwarder.await` — but the turn had handed the session-lived registry a strong `EventSender` clone (`attach_events`, #903), so the channel never closed, `spawn_forwarder`'s `recv()` loop stayed pending, and the turn future parked forever *after* the deck had painted `✓ done · 100%`. The driver never left its mid-turn `select!`: every prompt queued as the "next turn" of a turn that could not end, and only `/clear` (the one input that breaks that select) could free the session. Worker lanes shared the tail, so their executions never closed out either. Store evidence: since Aug 1 nearly every deck session has exactly one execution, and the frozen session's row has NULL `finished_at`.

One-shot `stella run` hit this exact deadlock as #960; its fix, `close_event_stream`, documents the detach as "the counterpart every turn owes `attach_events`". The deck lanes never paid it.

This PR adds `close_turn_stream` — the deck-lane twin of `close_event_stream`, same order (detach → drop → await) — and routes all three lane tails through it (`run_lead_turn`, `run_lead_pipeline_turn`, `run_worker`). The unconditional detach is safe because turns do not overlap on one registry (the invariant `TurnControlsGuard` documents: lead turns are sequential on the session registry; each worker lane builds its own). The "a stale event sender is inert" claim in `stella-tools/src/subagent.rs` — the assumption this bug hid behind — is corrected in place.

**Exemplar:** the repo's own `close_event_stream` (#960) — this is the same seam given the same shape, shared instead of re-derived per lane.

Closes #2290

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`command_deck::forwarder::tests::the_turn_tail_completes_with_the_registry_still_attached` runs a lane tail with the registry still holding the turn's sender under a 5s timeout. On `main` the seam does not exist; the deadlock it closes was demonstrated directly by a temporary inverse test (old tail shape + registry attach → `forwarder` still pending after a full 2s timeout, run locally, not committed).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo test -p stella-cli --bin stella` — 1489 passed (full workspace suite + clippy left to CI; this machine is kept clear of workspace builds per operator instruction)
- [x] Docs updated where behavior changed (`close_turn_stream` docs; the stale "inert sender" doc in `stella-tools/src/subagent.rs`)
- [x] `Closes #2290` appears both above and as a commit trailer

## Nothing left behind

- No tests deleted.
- Filed #2292: `ends_with_a_question` misses imperative asks with no `?` — the frozen turn in the report also ended with an unmarked ask and painted `done`.