### PR TITLE
feat(stella-cli): one write surface — promotion and mined rules publish TOML context records

### DIFF
--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -34,11 +34,13 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use stella_core::ingest::record::{ContextFile, Record, SharingScope};
+use stella_core::ingest::record::SharingScope;
 use stella_core::records::{Decision, DecisionEvent, decision};
 
 use super::{FoundProposal, read_proposals, resolve_candidate, verdict_label};
-use crate::context_records::{append_decision, now_rfc3339, publication_path, read_decisions};
+use crate::context_records::{
+    append_decision, now_rfc3339, publication_path, read_decisions, write_record,
+};
 
 /// `stella context review`.
 pub fn run_review(root: &Path, show_all: bool) -> Result<(), String> {
@@ -349,24 +351,6 @@ pub fn run_ignore(
 }
 
 /// Write one record as a published context file.
-fn write_record(path: &Path, set_id: &str, record: &Record) -> Result<(), String> {
-    if let Some(dir) = path.parent() {
-        std::fs::create_dir_all(dir)
-            .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
-    }
-    let file = ContextFile {
-        schema: stella_core::ingest::record::SCHEMA_TAG.to_string(),
-        set_id: set_id.to_string(),
-        ingest_run_id: None,
-        defaults: None,
-        records: vec![record.clone()],
-        proposals: Vec::new(),
-    };
-    let body =
-        toml::to_string_pretty(&file).map_err(|e| format!("cannot serialize the record: {e}"))?;
-    std::fs::write(path, body).map_err(|e| format!("cannot write {}: {e}", path.display()))
-}
-
 /// Who is deciding. A local username is enough for solo mode; team mode carries a
 /// real identity through Git authorship instead.
 pub(crate) fn actor() -> String {

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -585,5 +585,122 @@ pub(crate) fn publication_path(
     Some(dir.join(format!("{lineage}.toml")))
 }
 
+/// Serialize `record` as a one-record context file at `path`, refusing to
+/// overwrite. `create_new` rather than a separate exists-check because every
+/// caller's pre-check is advisory and racy, and this is the write that must
+/// not destroy somebody's reviewed file (the posture #737 established for the
+/// mined-rule writer).
+pub(crate) fn write_record(
+    path: &Path,
+    set_id: &str,
+    record: &stella_core::ingest::record::Record,
+) -> Result<(), String> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    }
+    let file = stella_core::ingest::record::ContextFile {
+        schema: stella_core::ingest::record::SCHEMA_TAG.to_string(),
+        set_id: set_id.to_string(),
+        ingest_run_id: None,
+        defaults: None,
+        records: vec![record.clone()],
+        proposals: Vec::new(),
+    };
+    let body =
+        toml::to_string_pretty(&file).map_err(|e| format!("cannot serialize the record: {e}"))?;
+    let mut out = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                format!(
+                    "{} already exists — refusing to overwrite a published record",
+                    path.display()
+                )
+            } else {
+                format!("cannot write {}: {e}", path.display())
+            }
+        })?;
+    use std::io::Write as _;
+    out.write_all(body.as_bytes())
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))
+}
+
+/// Build and stamp the context record an inference-derived rule publishes —
+/// the shared shape behind `stella memory promote` and the mined-rule
+/// writers, so every code path that once minted a legacy `.md` rule emits
+/// the ratified TOML surface (ADR 0011) instead.
+///
+/// The record is advisory by construction: origin `inferred`, steering
+/// `should` (cached prefix, like the rules it replaces), no enforcement
+/// section — an inferred directive may not start blocking, and the guard a
+/// miner inferred is deliberately not carried over (#714's stripping seam).
+///
+/// The statement is refused when it would fail `stella context validate`'s
+/// one-sentence shape check: publishing a record the workspace's own CI then
+/// flags would turn a promotion into a red gate.
+pub(crate) fn inferred_rule_record(
+    set_id: &str,
+    suffix: &str,
+    statement: &str,
+    source_kind: &str,
+    source_uri: &str,
+) -> Result<stella_core::ingest::record::Record, String> {
+    use stella_core::context_record::{Origin, RecordStatus};
+    use stella_core::ingest::record as rec;
+    // A dot-prefixed workspace directory (or any set id with stray dots) would
+    // put an empty segment in the lineage (`ctx..foo.bar`); normalize rather
+    // than publish a malformed lineage.
+    let set_id = set_id.trim_matches('.');
+    let set_id = if set_id.is_empty() {
+        "workspace"
+    } else {
+        set_id
+    };
+    let statement = statement.trim();
+    if statement.is_empty() {
+        return Err("the rule statement is empty".to_string());
+    }
+    if stella_core::records::validate::statement_reads_as_pasted(statement) {
+        return Err(format!(
+            "the content spans {} characters over {} lines, but a context record's statement is \
+             a single sentence (`stella context validate` would flag it) — distill the wording \
+             first",
+            statement.chars().count(),
+            statement.lines().count()
+        ));
+    }
+    let mut record = rec::Record {
+        lineage_id: format!("ctx.{set_id}.{suffix}"),
+        record_id: None,
+        record_hash: None,
+        kind: rec::RecordKind::Rule,
+        statement: statement.to_string(),
+        tags: vec!["inferred".to_string()],
+        origin: Some(Origin::Inferred),
+        sharing_scope: Some(rec::SharingScope::Repository),
+        status: Some(RecordStatus::Active),
+        provenance: Some(rec::Provenance {
+            source_kind: Some(source_kind.to_string()),
+            source_uri: Some(source_uri.to_string()),
+            ..Default::default()
+        }),
+        steering: Some(rec::Steering {
+            force: rec::Force::Should,
+            precedence: None,
+            applies_to: None,
+        }),
+        enforcement: None,
+        truth: None,
+        links: Vec::new(),
+    };
+    record
+        .stamp(&rec::Defaults::default())
+        .map_err(|e| format!("cannot stamp the record: {e}"))?;
+    Ok(record)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/ingest_cmd.rs
+++ b/crates/stella-cli/src/ingest_cmd.rs
@@ -28,6 +28,8 @@ use stella_core::ingest::{self, Candidate, Plan, Tier};
 mod extract;
 pub(crate) mod probe;
 
+pub(crate) use extract::derive_set_id;
+
 /// Largest slice of any one file read for classification.
 ///
 /// Classification looks at the head and the bullet structure; a document that

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -668,7 +668,9 @@ fn candidate_id(suffix: &str, record_hash: Option<&str>) -> String {
 
 /// The record-set slug for this workspace: `org.repo` from the git remote when
 /// resolvable, else the workspace directory name. Deterministic per checkout.
-fn derive_set_id(root: &Path) -> String {
+/// Shared with the promotion and mined-rule publication paths, so every record
+/// a workspace emits lands in the same lineage namespace.
+pub(crate) fn derive_set_id(root: &Path) -> String {
     if let Some(remote) = git(root, &["remote", "get-url", "origin"])
         && let Some(slug) = org_repo_from_remote(&remote)
     {

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -736,16 +736,27 @@ impl SessionMemory {
             if !self.include_workspace_skills {
                 continue;
             }
-            if let Some(path) =
-                super::rules_mining::write_rule(&self.workspace_root, &rule.candidate)
-                && !quiet
-            {
-                println!(
-                    "  {} new advisory rule from recurring observations: {} ({})",
-                    "✦".magenta().bold(),
-                    rule.candidate.id.bright_magenta(),
-                    path.display()
-                );
+            match super::rules_mining::write_rule(&self.workspace_root, &rule.candidate) {
+                Ok(Some(path)) if !quiet => {
+                    println!(
+                        "  {} new advisory rule from recurring observations: {} ({})",
+                        "✦".magenta().bold(),
+                        rule.candidate.id.bright_magenta(),
+                        path.display()
+                    );
+                }
+                Ok(_) => {}
+                // A lesson the record surface refuses (an overlong or
+                // multi-line statement) stays a reviewable proposal; saying
+                // nothing here would read as "activated".
+                Err(reason) if !quiet => {
+                    println!(
+                        "  {} rule `{}` not auto-activated: {reason}",
+                        "·".dimmed(),
+                        rule.candidate.id
+                    );
+                }
+                Err(_) => {}
             }
         }
     }

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -177,35 +177,45 @@ pub(crate) fn workspace_rules_dir(workspace_root: &Path) -> std::path::PathBuf {
     workspace_root.join(".stella").join("rules")
 }
 
-/// Write a mined rule to `.stella/rules/<id>.md`, never clobbering.
+/// Publish a mined rule as a TOML context record under `.stella/rules/`,
+/// never clobbering.
 ///
-/// Returns the path when a file was actually written. Mirrors the skills
-/// path's no-clobber posture, but checks the **filesystem** rather than a
-/// loaded list: the rules loader silently skips unreadable files and
-/// directories, so a list-membership test would have the same blind spot
+/// Returns the path when a file was actually written. The no-clobber posture
+/// checks the **filesystem** rather than a loaded list: the rules loader
+/// silently skips unreadable files and directories, so a list-membership test
+/// would have the same blind spot
 /// [#737](https://github.com/macanderson/stella/issues/737) describes on the
-/// skills side. A new call site should not inherit a known defect.
+/// skills side — and the write itself is `create_new` inside
+/// [`crate::context_records::write_record`], because the exists checks here
+/// are advisory and racy. A lesson that already minted a rule under the
+/// retired markdown surface is skipped too: that file still loads, and a TOML
+/// twin would double-inject it.
 pub(crate) fn write_rule(
     workspace_root: &Path,
     candidate: &RuleCandidate,
 ) -> Option<std::path::PathBuf> {
     let candidate = without_inferred_guard(candidate.clone());
-    let dir = workspace_rules_dir(workspace_root);
-    let path = dir.join(format!("{}.md", candidate.id));
-    if path.exists() {
+    let set_id = crate::ingest_cmd::derive_set_id(workspace_root);
+    let record = crate::context_records::inferred_rule_record(
+        &set_id,
+        &candidate.id,
+        &candidate.text,
+        "observation",
+        &format!("proposal:rule:{}", candidate.id),
+    )
+    .ok()?;
+    if workspace_rules_dir(workspace_root)
+        .join(format!("{}.md", candidate.id))
+        .exists()
+    {
         return None;
     }
-    std::fs::create_dir_all(&dir).ok()?;
-    // `create_new` rather than `write`: the exists() check above is advisory
-    // and racy, and this is the write that must not destroy a user's file.
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .ok()?;
-    use std::io::Write as _;
-    file.write_all(rules::render_rule_markdown(&candidate).as_bytes())
-        .ok()?;
+    let path = crate::context_records::publication_path(
+        workspace_root,
+        stella_core::ingest::record::SharingScope::Repository,
+        &record.lineage_id,
+    )?;
+    crate::context_records::write_record(&path, &set_id, &record).ok()?;
     Some(path)
 }
 

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -180,20 +180,21 @@ pub(crate) fn workspace_rules_dir(workspace_root: &Path) -> std::path::PathBuf {
 /// Publish a mined rule as a TOML context record under `.stella/rules/`,
 /// never clobbering.
 ///
-/// Returns the path when a file was actually written. The no-clobber posture
-/// checks the **filesystem** rather than a loaded list: the rules loader
-/// silently skips unreadable files and directories, so a list-membership test
-/// would have the same blind spot
-/// [#737](https://github.com/macanderson/stella/issues/737) describes on the
-/// skills side — and the write itself is `create_new` inside
+/// `Ok(Some(path))` when a file was written; `Ok(None)` when one already
+/// exists (on either the record surface or the retired markdown one — that
+/// file still loads, and a TOML twin would double-inject it); `Err` when the
+/// record cannot be built or written, which the caller must surface rather
+/// than fold into "already exists". The no-clobber posture checks the
+/// **filesystem** rather than a loaded list: the rules loader silently skips
+/// unreadable files and directories, so a list-membership test would have the
+/// same blind spot [#737](https://github.com/macanderson/stella/issues/737)
+/// describes on the skills side — and the write itself is `create_new` inside
 /// [`crate::context_records::write_record`], because the exists checks here
-/// are advisory and racy. A lesson that already minted a rule under the
-/// retired markdown surface is skipped too: that file still loads, and a TOML
-/// twin would double-inject it.
+/// are advisory and racy.
 pub(crate) fn write_rule(
     workspace_root: &Path,
     candidate: &RuleCandidate,
-) -> Option<std::path::PathBuf> {
+) -> Result<Option<std::path::PathBuf>, String> {
     let candidate = without_inferred_guard(candidate.clone());
     let set_id = crate::ingest_cmd::derive_set_id(workspace_root);
     let record = crate::context_records::inferred_rule_record(
@@ -202,21 +203,25 @@ pub(crate) fn write_rule(
         &candidate.text,
         "observation",
         &format!("proposal:rule:{}", candidate.id),
-    )
-    .ok()?;
+    )?;
     if workspace_rules_dir(workspace_root)
         .join(format!("{}.md", candidate.id))
         .exists()
     {
-        return None;
+        return Ok(None);
     }
-    let path = crate::context_records::publication_path(
+    let Some(path) = crate::context_records::publication_path(
         workspace_root,
         stella_core::ingest::record::SharingScope::Repository,
         &record.lineage_id,
-    )?;
-    crate::context_records::write_record(&path, &set_id, &record).ok()?;
-    Some(path)
+    ) else {
+        return Err("cannot determine where to publish this record".to_string());
+    };
+    if path.exists() {
+        return Ok(None);
+    }
+    crate::context_records::write_record(&path, &set_id, &record)?;
+    Ok(Some(path))
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -114,7 +114,9 @@ fn a_written_rule_file_is_prompt_only() {
         }),
         score: 30,
     };
-    let path = write_rule(dir.path(), &candidate).expect("written");
+    let path = write_rule(dir.path(), &candidate)
+        .expect("publishable")
+        .expect("written");
     assert_eq!(
         path.extension().and_then(|e| e.to_str()),
         Some("toml"),
@@ -302,7 +304,9 @@ fn mined_rules_land_where_the_loader_reads() {
         guard: None,
         score: 30,
     };
-    write_rule(dir.path(), &candidate).expect("written");
+    write_rule(dir.path(), &candidate)
+        .expect("publishable")
+        .expect("written");
 
     // The unfiltered loader keys raw files by filename, and a record file's
     // name is its lineage — assert the lesson landed under it, which is the

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -256,7 +256,9 @@ fn writing_never_clobbers_an_existing_rule_file() {
         score: 30,
     };
     assert!(
-        write_rule(dir.path(), &candidate).is_none(),
+        write_rule(dir.path(), &candidate)
+            .expect("an existing file is a skip, not an error")
+            .is_none(),
         "the writer claimed to write over an existing file"
     );
     assert_eq!(

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -9,7 +9,7 @@
 use super::*;
 use stella_context::ContextStore;
 use stella_core::context_record::ObservationSource;
-use stella_core::rules::{RuleGuard, RuleTier};
+use stella_core::rules::RuleGuard;
 
 fn store() -> (tempfile::TempDir, ContextStore) {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -68,15 +68,21 @@ fn an_inferred_rule_is_never_blocking() {
         "an inferred guard survived — this rule would deny tool calls"
     );
 
-    // …and the rendered file has no guard frontmatter, so re-parsing it yields
-    // a Tier 1 rule. Asserting the round trip rather than just the struct:
-    // the file is what actually reaches the loader.
-    let markdown = rules::render_rule_markdown(&stripped);
-    assert!(!markdown.contains("guard-"), "{markdown}");
-    let parsed = stella_core::rules::rule_from_file("some-lesson-abcd1234.md", &markdown)
-        .expect("the rendered rule parses back");
-    assert_eq!(parsed.tier(), RuleTier::Prompt);
-    assert!(parsed.guard.is_none());
+    // …and the published record carries no enforcement section at all, so
+    // nothing downstream can arm a guard from it. Asserting the record rather
+    // than just the struct: the record is what actually reaches the loader.
+    let record = crate::context_records::inferred_rule_record(
+        "acme.web",
+        &stripped.id,
+        &stripped.text,
+        "observation",
+        "proposal:rule:some-lesson-abcd1234",
+    )
+    .expect("a publishable record");
+    assert!(
+        record.enforcement.is_none(),
+        "an inferred record must not carry enforcement"
+    );
 }
 
 /// The same, through the whole induction path.
@@ -109,14 +115,20 @@ fn a_written_rule_file_is_prompt_only() {
         score: 30,
     };
     let path = write_rule(dir.path(), &candidate).expect("written");
+    assert_eq!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("toml"),
+        "mined rules publish as TOML context records"
+    );
     let contents = std::fs::read_to_string(&path).expect("read back");
+    let loaded = stella_core::records::load_context_file(&path.display().to_string(), &contents)
+        .expect("the published record loads");
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].record.statement, LESSON);
     assert!(
-        !contents.contains("guard-"),
+        loaded[0].record.enforcement.is_none(),
         "a guard reached disk: {contents}"
     );
-    let parsed =
-        stella_core::rules::rule_from_file(&path.display().to_string(), &contents).expect("parses");
-    assert_eq!(parsed.tier(), RuleTier::Prompt);
 }
 
 // ---- GATE: distinct tasks, never raw events ----
@@ -292,17 +304,15 @@ fn mined_rules_land_where_the_loader_reads() {
     };
     write_rule(dir.path(), &candidate).expect("written");
 
+    // The unfiltered loader keys raw files by filename, and a record file's
+    // name is its lineage — assert the lesson landed under it, which is the
+    // visibility the miner's own no-clobber dedup depends on.
     let loaded = crate::rules::load_workspace_rules_unfiltered(dir.path());
-    assert!(
-        loaded.iter().any(|r| r.id == "landing-abcd1234"),
-        "a mined rule did not reach the loader: {:?}",
-        loaded.iter().map(|r| &r.id).collect::<Vec<_>>()
-    );
     assert!(
         loaded
             .iter()
-            .find(|r| r.id == "landing-abcd1234")
-            .is_some_and(|r| r.text.contains("database migration")),
-        "the rule text did not survive the round trip"
+            .any(|r| r.id.contains("landing-abcd1234") && r.text.contains("database migration")),
+        "a mined rule did not reach the loader: {:?}",
+        loaded.iter().map(|r| &r.id).collect::<Vec<_>>()
     );
 }

--- a/crates/stella-cli/src/memory_cmd.rs
+++ b/crates/stella-cli/src/memory_cmd.rs
@@ -3,10 +3,10 @@
 //! `list` ranks the project's memories most-cited first, joining the
 //! citation feedback the agent recorded (`cite_memory` → `.stella/private/store.db`)
 //! with the memories themselves (`.stella/private/context.db`), and flags the ones
-//! that have earned rule promotion. `promote <id>` turns an eligible memory
-//! into a project rule at `.stella/rules/<slug>.md` — the rules engine's own
-//! authoring format (`stella_core::rules`), so the promoted file is loaded
-//! and parsed exactly like a hand-written rule.
+//! that have earned rule promotion. `promote <id>` publishes an eligible
+//! memory as a TOML context record under `.stella/rules/` (ADR 0011) — the
+//! same surface `stella context keep` publishes to, so the promoted record is
+//! loaded, validated, and governed exactly like a reviewed one.
 //!
 //! Like `stella stats`, both subcommands read local state only and need no
 //! API key; `list` never creates a database as a side effect. Promotion is
@@ -37,10 +37,10 @@ pub enum MemoryCmd {
         #[arg(long, value_enum, default_value = "text")]
         format: QueryFormat,
     },
-    /// Promote an eligible memory to a project rule at
-    /// `.stella/rules/<slug>.md`. Eligibility is strict: cited successfully
-    /// MORE THAN 10 consecutive times since its last negative remark — one
-    /// negative citation resets the count until it is re-earned.
+    /// Promote an eligible memory to a project rule — published as a TOML
+    /// context record under `.stella/rules/`. Eligibility is strict: cited
+    /// successfully MORE THAN 10 consecutive times since its last negative
+    /// remark — one negative citation resets the count until it is re-earned.
     Promote {
         /// The memory's stable id (nod_…) as shown by `stella memory list`
         id: String,
@@ -303,22 +303,44 @@ fn promote_in(workspace_root: &std::path::Path, id: &str) -> Result<(), String> 
     }
 
     let candidate = promotion_candidate(&node, stat);
-    let rules_dir = workspace_root.join(".stella").join("rules");
-    let path = rules_dir.join(format!("{}.md", candidate.id));
+    let set_id = crate::ingest_cmd::derive_set_id(workspace_root);
+    let record = crate::context_records::inferred_rule_record(
+        &set_id,
+        &candidate.id,
+        &candidate.text,
+        "memory",
+        &format!("memory:{}", node.public_id),
+    )?;
+    // A rule this memory promoted under the retired markdown surface still
+    // steers; publishing a TOML copy beside it would double-inject the lesson.
+    let legacy = workspace_root
+        .join(".stella")
+        .join("rules")
+        .join(format!("{}.md", candidate.id));
+    if legacy.exists() {
+        return Err(format!(
+            "{} already exists from an earlier promotion — delete it first to re-promote \
+             (promotions publish TOML context records now)",
+            legacy.display()
+        ));
+    }
+    let path = crate::context_records::publication_path(
+        workspace_root,
+        stella_core::ingest::record::SharingScope::Repository,
+        &record.lineage_id,
+    )
+    .ok_or_else(|| "cannot determine where to publish this record".to_string())?;
     // The pure promotion decision is the rules engine's (`decide_promotion`);
     // this command owns only the I/O halves: the exists-check and the write.
     match rules::decide_promotion(true, path.exists()) {
         PromoteStatus::AlreadyExists => Err(format!(
-            "{} already exists — not clobbering a possibly hand-edited rule; delete it first \
+            "{} already exists — not clobbering a possibly hand-edited record; delete it first \
              to re-promote",
             path.display()
         )),
         PromoteStatus::Declined => unreachable!("promote is always approved here"),
         PromoteStatus::Written => {
-            std::fs::create_dir_all(&rules_dir)
-                .map_err(|e| format!("could not create {}: {e}", rules_dir.display()))?;
-            std::fs::write(&path, rules::render_rule_markdown(&candidate))
-                .map_err(|e| format!("could not write {}: {e}", path.display()))?;
+            crate::context_records::write_record(&path, &set_id, &record)?;
             println!(
                 "  {} promoted memory {} → {}",
                 "✦".magenta().bold(),
@@ -327,7 +349,7 @@ fn promote_in(workspace_root: &std::path::Path, id: &str) -> Result<(), String> 
             );
             println!(
                 "  {}",
-                "the rule now loads with the workspace rules (.stella/rules/)".dimmed()
+                "the record now loads with the workspace rules (.stella/rules/)".dimmed()
             );
             Ok(())
         }
@@ -858,8 +880,8 @@ fn validate_memories(workspace_root: &std::path::Path) -> Result<Vec<MemoryValid
     Ok(rows)
 }
 
-/// The promoted rule as a mining candidate, so `render_rule_markdown`
-/// produces the exact frontmatter shape `rule_from_file` parses back —
+/// The promoted rule as a mining candidate, so promotion feeds the same
+/// record-publication path as every other inferred rule —
 /// promotion never invents its own rule format. Prompt-only (no guard): the
 /// citation loop scores usefulness, it carries no file evidence to infer a
 /// safe deny-glob from.
@@ -1017,31 +1039,49 @@ mod tests {
     }
 
     #[test]
-    fn promoted_markdown_is_parsed_back_by_the_rules_engine() {
+    fn promoted_record_round_trips_through_the_record_loader() {
         let node = memory_node(
             "nod_0123456789abcdef01234567",
             "Never edit generated files",
             "Never edit generated files under gen/ — regenerate them instead.",
         );
         let candidate = promotion_candidate(&node, &stat(node.public_id.as_str(), 12, 12, true));
-        let markdown = rules::render_rule_markdown(&candidate);
+        let record = crate::context_records::inferred_rule_record(
+            "acme.web",
+            &candidate.id,
+            &candidate.text,
+            "memory",
+            &format!("memory:{}", node.public_id),
+        )
+        .expect("a publishable record");
+        assert_eq!(record.lineage_id, "ctx.acme.web.never-edit-generated-files");
 
-        // The promotion contract: the file must parse through the rules
-        // engine's own frontmatter parser and loader, exactly like a
-        // hand-authored .stella/rules/*.md file.
-        let fm = rules::parse_frontmatter(&markdown);
+        // The promotion contract: the published file must parse through the
+        // record loader exactly like a `stella context keep` publication —
+        // including the stamped hash verifying on load.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(format!("{}.toml", record.lineage_id));
+        crate::context_records::write_record(&path, "acme.web", &record).expect("written");
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let loaded =
+            stella_core::records::load_context_file(&path.display().to_string(), &contents)
+                .expect("a loadable record file");
+        assert_eq!(loaded.len(), 1);
+        let loaded = &loaded[0].record;
+        assert_eq!(loaded.statement, candidate.text);
         assert_eq!(
-            fm.data.get("description").unwrap(),
-            "Promoted from memory nod_0123456789abcdef01234567 after 12 citation(s) \
-             (12 consecutive positive)."
+            loaded.origin,
+            Some(stella_core::context_record::Origin::Inferred)
         );
-        assert_eq!(fm.body, candidate.text);
-
-        let path = format!(".stella/rules/{}.md", candidate.id);
-        let rule = rules::rule_from_file(&path, &markdown).expect("a loadable rule");
-        assert_eq!(rule.id, "never-edit-generated-files");
-        assert_eq!(rule.text, candidate.text);
-        assert!(rule.guard.is_none(), "promoted rules are prompt-only");
+        assert!(
+            loaded.enforcement.is_none(),
+            "promoted records are advisory — no guard, no blocking"
+        );
+        // And the clobber seam: the writer refuses a second publication.
+        assert!(
+            crate::context_records::write_record(&path, "acme.web", &record).is_err(),
+            "a second write must not overwrite a published record"
+        );
     }
 
     #[test]
@@ -1142,14 +1182,21 @@ mod tests {
             .expect("rules dir created")
             .filter_map(|e| e.ok().map(|e| e.path()))
             .collect();
-        assert_eq!(written.len(), 1, "exactly one rule written: {written:?}");
-        let rule_path = &written[0];
-        let raw = std::fs::read_to_string(rule_path).expect("promoted rule written");
-        let rule = rules::rule_from_file(&rule_path.display().to_string(), &raw)
-            .expect("the rules engine loads the promoted file");
-        assert_eq!(rule.text, lesson);
+        assert_eq!(written.len(), 1, "exactly one record written: {written:?}");
+        let record_path = &written[0];
+        assert_eq!(
+            record_path.extension().and_then(|e| e.to_str()),
+            Some("toml"),
+            "promotion publishes a TOML context record"
+        );
+        let raw = std::fs::read_to_string(record_path).expect("promoted record written");
+        let loaded =
+            stella_core::records::load_context_file(&record_path.display().to_string(), &raw)
+                .expect("the record loader loads the promoted file");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].record.statement, lesson);
 
-        // Idempotence: re-promotion never clobbers the written rule.
+        // Idempotence: re-promotion never clobbers the written record.
         let err = promote_in(root, &id).unwrap_err();
         assert!(err.contains("already exists"), "{err}");
     }

--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -426,10 +426,15 @@ fn materialize_directive(
         score: 0,
     };
     match crate::memory::rules_mining::write_rule(workspace_root, &candidate) {
-        Some(path) => println!("    {} wrote {}", "·".dimmed(), path.display()),
-        None => println!(
+        Ok(Some(path)) => println!("    {} wrote {}", "·".dimmed(), path.display()),
+        Ok(None) => println!(
             "    {} a rule file for `{}` already exists — left untouched",
             "·".dimmed(),
+            candidate.id
+        ),
+        Err(reason) => println!(
+            "    {} could not publish `{}`: {reason}",
+            "✗".red(),
             candidate.id
         ),
     }

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -84,7 +84,7 @@ pub use rules::{
 // which is most of why it shipped unwired. Mirrors the `skills::` exports below.
 pub use rules::{
     EvidenceSource, MineConfig, RawObservation, RuleCandidate, RuleEvidence, decide_promotion,
-    mine_candidates, render_rule_markdown,
+    mine_candidates,
 };
 pub use skills::{
     AutoCreateConfig, AutoCreateDecision, AutoCreateSkip, InstallDecision, LoadSkillsOptions,

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -45,6 +45,15 @@ const NON_WILDCARDS: &[char] = &['?', '[', ']', '{', '}', '!'];
 /// carrying something that was pasted rather than written.
 const MAX_STATEMENT_CHARS: usize = 600;
 
+/// True when `statement` violates the one-sentence shape (ADR 0012, decision 8):
+/// embedded newlines or novel-length text read as pasted prompt or tool output
+/// rather than a written claim. Exposed so every writer of a record — the CLI's
+/// promotion and mining paths included — can refuse the shape this validator
+/// would flag, instead of publishing a file that fails `stella context validate`.
+pub fn statement_reads_as_pasted(statement: &str) -> bool {
+    statement.contains('\n') || statement.chars().count() > MAX_STATEMENT_CHARS
+}
+
 /// An equal-precedence overlap between two records with different enforcement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Conflict {
@@ -152,7 +161,7 @@ fn forbidden_data(record: &Record) -> Vec<RecordFinding> {
     // A statement is one sentence. Embedded newlines or novel-length text mean raw
     // prompt or tool output was pasted into a reviewable field — which is both a
     // privacy boundary (§10) and an atomicity problem.
-    if record.statement.contains('\n') || record.statement.chars().count() > MAX_STATEMENT_CHARS {
+    if statement_reads_as_pasted(&record.statement) {
         findings.push(RecordFinding::GuardLint(format!(
             "statement is {} characters over {} lines — a record's statement is a single \
              sentence; this reads as pasted prompt or tool text",

--- a/crates/stella-core/src/rules.rs
+++ b/crates/stella-core/src/rules.rs
@@ -50,17 +50,17 @@
 //!     produce.
 //!   - The actual interactive approve/write flow (`stella rules promote`):
 //!     prompting the human, calling a filesystem port to check
-//!     `already-exists`, and writing [`render_rule_markdown`]'s output to
-//!     disk. That belongs to `stella-cli`.
+//!     `already-exists`, and publishing the candidate as a TOML context
+//!     record. That belongs to `stella-cli`.
 //!
 //! What IS ported: the full mining algorithm — lexical clustering, salience
 //! override, dedup against existing rules, guard inference from consistent
 //! file evidence, and ranking (all pure decision logic, see
-//! [`mine_candidates`]) — plus the pure half of `promoteCandidate`:
-//! rendering a candidate's exact rule-file content
-//! ([`render_rule_markdown`]) and deciding what a promotion attempt *would*
-//! do given the caller's own `approve`/`file_exists` facts
-//! ([`decide_promotion`]).
+//! [`mine_candidates`]) — plus the pure half of `promoteCandidate`: deciding
+//! what a promotion attempt *would* do given the caller's own
+//! `approve`/`file_exists` facts ([`decide_promotion`]). The markdown
+//! renderer that once sat beside it was retired when publication moved to
+//! TOML context records (ADR 0011).
 
 use std::collections::HashMap;
 
@@ -881,40 +881,12 @@ pub fn mine_candidates(
     candidates
 }
 
-/// Render the exact `.stella/rules/<id>.md` file content for `candidate` —
-/// the same frontmatter shape [`rule_from_file`] parses back (mirrors the
-/// frontmatter-building lines in `promoteCandidate`, minus the file write).
-/// Writing this to disk is the I/O half `stella-cli` owns; this half is
-/// pure and independently testable.
-pub fn render_rule_markdown(candidate: &RuleCandidate) -> String {
-    let mut lines = vec![
-        "---".to_string(),
-        format!("description: {}", candidate.description),
-    ];
-    if let Some(guard) = &candidate.guard {
-        if let Some(tool) = &guard.tool {
-            lines.push(format!("guard-tool: {tool}"));
-        }
-        if let Some(deny_path) = &guard.deny_path_glob {
-            lines.push(format!("guard-deny-path: {deny_path}"));
-        }
-        if let Some(deny_command) = &guard.deny_command_glob {
-            lines.push(format!("guard-deny-command: {deny_command}"));
-        }
-    }
-    lines.push("---".to_string());
-    lines.push(String::new());
-    lines.push(candidate.text.clone());
-    lines.push(String::new());
-    lines.join("\n")
-}
-
 /// What should happen to a candidate's rule file (TS:
 /// `PromoteResult["status"]`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromoteStatus {
-    /// The candidate should be written — the caller now writes
-    /// [`render_rule_markdown`]'s output to disk.
+    /// The candidate should be written — the caller now publishes it as a
+    /// TOML context record (the CLI's record-publication path).
     Written,
     /// `approve` was `false`; nothing should be touched (the decline
     /// path).

--- a/crates/stella-core/src/rules/tests.rs
+++ b/crates/stella-core/src/rules/tests.rs
@@ -744,69 +744,7 @@ fn mine_candidates_is_deterministic_across_reruns() {
     assert_eq!(first[0].id, second[0].id);
 }
 
-// ---- render_rule_markdown + decide_promotion ----
-
-#[test]
-fn render_rule_markdown_round_trips_through_rule_from_file() {
-    let obs = vec![
-        observation("forgot to add a test for the new route", 1),
-        observation("forgot to add a test for the new route", 2),
-        observation("forgot to add a test for the new route", 3),
-    ];
-    let candidates = mine_candidates(obs, &[], &MineConfig::default());
-    let candidate = &candidates[0];
-    let markdown = render_rule_markdown(candidate);
-    let parsed = rule_from_file(&format!("{}.md", candidate.id), &markdown).unwrap();
-    assert_eq!(parsed.id, candidate.id);
-    assert_eq!(parsed.text, candidate.text);
-    assert!(parsed.description.contains("3 recurring observations"));
-    assert!(parsed.guard.is_none());
-}
-
-#[test]
-fn render_rule_markdown_includes_an_inferred_guard() {
-    let obs = vec![
-        RawObservation {
-            text: "never edit an applied migration file directly".to_string(),
-            source: EvidenceSource::Memory,
-            reference: "memory:m1".to_string(),
-            occurred_at: 1,
-            files: vec!["packages/database/migrations/0001-applied/up.sql".to_string()],
-            salient: true,
-            memory_kind: Some("gotcha".to_string()),
-        },
-        RawObservation {
-            text: "never edit an applied migration file directly".to_string(),
-            source: EvidenceSource::Memory,
-            reference: "memory:m2".to_string(),
-            occurred_at: 2,
-            files: vec!["packages/database/migrations/0002-applied/up.sql".to_string()],
-            salient: true,
-            memory_kind: Some("gotcha".to_string()),
-        },
-    ];
-    let candidates = mine_candidates(obs, &[], &MineConfig::default());
-    let candidate = &candidates[0];
-    let markdown = render_rule_markdown(candidate);
-    let parsed = rule_from_file(&format!("{}.md", candidate.id), &markdown).unwrap();
-    assert_eq!(
-        parsed.guard,
-        Some(RuleGuard {
-            tool: None,
-            deny_path_glob: Some("packages/database/migrations/**".to_string()),
-            deny_command_glob: None,
-        })
-    );
-
-    // And the round-tripped rule feeds guards_to_deny + evaluate_guards
-    // exactly like a hand-authored one would.
-    let denies = guards_to_deny(std::slice::from_ref(&parsed));
-    assert_eq!(
-        denies.deny,
-        vec!["*(packages/database/migrations/**)".to_string()]
-    );
-    assert!(denies.reasons.values().next().unwrap().contains(&parsed.id));
-}
+// ---- decide_promotion ----
 
 #[test]
 fn decide_promotion_declines_without_approval() {

--- a/docs/spec/adaptive-context/context-pr.md
+++ b/docs/spec/adaptive-context/context-pr.md
@@ -633,8 +633,11 @@ Aligned with the adaptive-context plan (lifecycle "Phase 4: team governance"):
 
 1. **Solo promotion (shipped).** Citation-gated `stella memory promote`,
    markdown rule files, Tier 1/Tier 2 engine, store-published rules.
-2. **Canonical metadata.** Emit snake_case promotion frontmatter (§6.1) and
-   `record_hash` from the promotion path; loader accepts legacy keys.
+2. **Canonical promotion surface (shipped).** The promotion and mined-rule
+   paths publish stamped TOML context records (`record_id`/`record_hash`
+   derived by `Record::stamp`) instead of markdown frontmatter — the
+   frontmatter emission this item originally described was retired with the
+   `rules::metadata` layer; the loader still accepts legacy `.md` files.
 3. **Candidate store + Keep/Edit/Ignore.** Deduplicated candidates with
    evidence scoring, cooldowns, and the solo acceptance flow.
 4. **Context PR materialization through Git.** `stella context propose`


### PR DESCRIPTION
## What & why

Two write paths published into `.stella/rules/`, one per era: `stella context keep` wrote the ratified TOML record surface (ADR 0011), while `stella memory promote` and the mined-rule writer (`rules_mining::write_rule`, reached from the learning loop's auto-activation and `stella proposals keep`) still minted legacy markdown rules — files with no record identity, no lineage, no governance visibility, on a surface whose parser is frozen by decision.

This PR removes the duplicate write system. All three call sites now publish through one shared path (`context_records::inferred_rule_record` + `write_record`):

- **One record shape.** Origin `inferred`, steering `should` (cached prefix, the channel the legacy rules used), no enforcement section — an inferred directive may not start blocking, and the miner's inferred guard stays stripped (#714's seam, still witnessed).
- **One lineage namespace.** `derive_set_id` (previously ingest-private) is shared, so promotions, mined rules, and ingest publications land under the same `ctx.<org>.<repo>.<slug>` lineages. The helper normalizes a dot-prefixed workspace name that would otherwise mint a malformed `ctx..…` lineage.
- **One clobber discipline.** `write_record` moved from `context_cmd/review.rs` to `context_records.rs` and now opens `create_new`: every caller's exists-check was advisory and racy, and this is the write that must not destroy a reviewed file. (`stella context keep` gets this hardening for free.)
- **One quality bar.** A statement that would fail `stella context validate`'s one-sentence check is refused at publication with an actionable reason, via `statement_reads_as_pasted` now exported from the validator — instead of a copied constant, or worse, publishing a record the workspace's own CI then flags. `write_rule` returns `Result<Option<PathBuf>>` so a refused statement is reported as *why*, never folded into "already exists."
- **The dead half is gone.** `render_rule_markdown` lost its last production caller and is deleted. Legacy `.md` rules keep loading unchanged, and a lesson that already minted one is skipped rather than double-published as a TOML twin.

Design lens (maintainer's directive): what context helps the next agent that finds this record? A promoted record now carries queryable provenance (`source_kind = "memory"`, `source_uri = "memory:<id>"` / `proposal:rule:<id>`), a stamped `record_id`/`record_hash` that verifies on load, and lives under the one lifecycle (`stella context list/explain`, retirement, governance) instead of as an anonymous markdown file.

Closes #2286
Refs #2283, #714, #737

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`promoted_record_round_trips_through_the_record_loader` (memory_cmd.rs) and the `.toml`-extension + record-loader assertions in `promotion_gate_and_rule_write_work_end_to_end` and `a_written_rule_file_is_prompt_only` fail on `main`, which writes markdown; here the published file loads through `load_context_file` with the stamped hash verifying and no enforcement section. The end-to-end test also witnesses the no-clobber idempotence surviving the conversion.

**Deleted tests, named per the deleted-test guard:**
- `render_rule_markdown_round_trips_through_rule_from_file` (stella-core `rules/tests.rs`) — died with the renderer.
- `render_rule_markdown_includes_an_inferred_guard` (same) — its guard-arming half is still covered by the loader-side guard tests and the cli guard fixture.
- `promoted_markdown_is_parsed_back_by_the_rules_engine` (stella-cli `memory_cmd.rs`) — replaced by `promoted_record_round_trips_through_the_record_loader`.

Rewritten in place (not deleted): `an_inferred_rule_is_never_blocking`, `a_written_rule_file_is_prompt_only`, `mined_rules_land_where_the_loader_reads`, `promotion_gate_and_rule_write_work_end_to_end`, plus the no-clobber test asserting `Ok(None)`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (exit code checked directly)
- [x] `cargo test --workspace` — 128 suites, 0 failures
- [x] Docs updated: `stella memory` module doc + `promote` help text, `context-pr.md` rollout item 2 re-pointed from the retired frontmatter emission to the shipped TOML emission
- [x] CLA signed

## Nothing left behind

- [x] Filed previously and advanced here: #2283 (epic — this is the "one write surface" slice), #2284/#2285 unchanged. Behavior note reviewers should weigh: the learning loop no longer auto-activates a lesson whose text violates the one-sentence record shape — it stays a reviewable proposal and says so, where before it silently minted an unvalidatable `.md`. That is the intended direction (records are the quality bar), not an oversight.

## Ground-rule check

- [x] No I/O added to `stella-core` (the new export is a pure predicate); no new deps
- [x] No new outbound network calls
- [x] No cross-boundary serde shape changed: `Record` serialization is untouched; only who writes it changed

## Anything reviewers should know?

Sequencing with #2287 (the `rules::metadata` retirement): independent branches, both from `main`; the only shared file is `stella-core/src/lib.rs` where they edit different lines of adjacent re-export blocks — expected to merge cleanly in either order. `RuleCandidate`, `decide_promotion`, and the mining pipeline are unchanged; only the final write changed shape.

## Summary by Sourcery

Unify rule promotion and mining so all inferred rules publish as TOML context records instead of markdown, sharing a single record lineage and no‑clobber discipline.

New Features:
- Publish promoted memories and mined rules as stamped TOML context records on the same surface used by `stella context keep`, with advisory `inferred` origin and provenance metadata.

Bug Fixes:
- Prevent inferred rule publication from overwriting existing reviewed or hand-edited files by enforcing `create_new` semantics across all writers.
- Ensure inferred rules cannot introduce blocking behavior by omitting enforcement data from published records.
- Reject overlong or multi-line rule statements at publication using the same one-sentence validation used by `stella context validate`, avoiding creation of records CI would immediately flag.

Enhancements:
- Share the workspace record-set identifier (`derive_set_id`) across ingest, promotion, and mining so all emitted records land under a consistent lineage namespace.
- Harden auto-activation in the learning loop so lessons that fail the record-shape check remain proposals with a surfaced reason instead of silently minting legacy markdown.
- Refactor rule mining and promotion paths to use the common context record publication helper, returning richer status for callers.
- Update documentation to describe TOML context records as the canonical promotion surface and align CLI help text with the unified write path.

Tests:
- Add and update tests to assert promoted and mined rules round-trip through the context record loader, publish `.toml` files, remain prompt-only, and preserve no-clobber semantics.
- Remove tests tied to the deprecated markdown renderer while keeping guard behavior covered via record-based tests and existing fixtures.