### PR TITLE
feat(bench): a bare-loop arm ArenaBench can actually run — declared on the engine, not exported

### DIFF
--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -41,6 +41,7 @@ from .model import (
     Engine,
     MatchSpec,
     RoleConfig,
+    declared_flag,
     is_credential_name,
 )
 
@@ -120,6 +121,18 @@ def _declared_env(
 
 
 def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> Engine:
+    # Refused rather than coerced: a human wrote `bare_loop = "no"` and meant
+    # something by it, and the one outcome a selector must never have is to
+    # silently run the arm it was spelled to decline. `declared_flag` returns
+    # None for exactly the values `bool()` would have read backwards.
+    bare_loop = declared_flag(raw.get("bare_loop", False))
+    if bare_loop is None:
+        problems.append(
+            f"{where}: engine.bare_loop must be a boolean — "
+            f"{raw.get('bare_loop')!r} declares neither arm"
+        )
+        bare_loop = False
+
     roles_raw = raw.get("roles")
     roles: dict[str, RoleConfig] = {}
     if isinstance(roles_raw, dict):
@@ -143,7 +156,7 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
         max_tokens=(
             int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
         ),
-        bare_loop=bool(raw.get("bare_loop", False)),
+        bare_loop=bare_loop,
         roles=roles,
     )
 
@@ -190,6 +203,15 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
         engine = _engine_from_toml(engine_raw, problems, where)
         if not engine.model:
             problems.append(f"{where}: engine.model is required")
+        if engine.bare_loop and agent and agent != "stella":
+            # Refused at parse for the same reason `sut_ref` is below (#2082):
+            # a selector nothing reads is a template claiming to measure an arm
+            # it never ran, and the whole point of declaring the loop on the
+            # engine was that a match cannot lie about which one it used.
+            problems.append(
+                f"{where}: bare_loop applies only to a stella seat — "
+                f"{agent!r} has no staged pipeline to switch off"
+            )
 
         env_raw = entry.get("env")
         declared: tuple[str, ...] = ()

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -133,6 +133,17 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
         )
         bare_loop = False
 
+    # The sibling field, same reader, same refusal (#2334). Its fallback is
+    # True where `bare_loop`'s is False: `reasoning` defaults ON, so the
+    # shipping configuration is the one an unreadable value must not leave.
+    reasoning = declared_flag(raw.get("reasoning", True))
+    if reasoning is None:
+        problems.append(
+            f"{where}: engine.reasoning must be a boolean — "
+            f"{raw.get('reasoning')!r} declares neither"
+        )
+        reasoning = True
+
     roles_raw = raw.get("roles")
     roles: dict[str, RoleConfig] = {}
     if isinstance(roles_raw, dict):
@@ -147,7 +158,7 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
     return Engine(
         api=str(raw.get("api") or "openrouter"),
         model=str(raw.get("model") or ""),
-        reasoning=bool(raw.get("reasoning", True)),
+        reasoning=reasoning,
         effort=str(raw.get("effort") or "high"),
         base_url=(str(raw["base_url"]).strip() or None) if raw.get("base_url") else None,
         budget_usd=(

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -143,6 +143,7 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
         max_tokens=(
             int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
         ),
+        bare_loop=bool(raw.get("bare_loop", False)),
         roles=roles,
     )
 
@@ -454,6 +455,10 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
             out.append("  " + _line("max_tokens", engine.max_tokens))
         if engine.budget_usd is not None:
             out.append("  " + _line("budget_usd", engine.budget_usd))
+        if engine.bare_loop:
+            # Emitted only when true, so every existing template renders back
+            # byte-identical and a saved match cannot gain an arm it never had.
+            out.append("  " + _line("bare_loop", engine.bare_loop))
 
         if engine.roles:
             out.append("")

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -284,10 +284,23 @@ class Engine:
     base_url: str | None = None
     #: Per-trial USD target handed to the agent, if it supports one.
     budget_usd: float | None = None
-    #: Output-token ceiling per step. Left ``None`` to take the agent's own
-    #: default — but see the Stella adapter's note on why a low cap plus high
-    #: effort is the classic way to buy reasoning that cannot fit an answer.
+    #: Output-token ceiling per step. Leave ``None`` to take the model's own
+    #: maximum, which is nearly always right. A model spends up to whatever
+    #: ceiling it is handed, so a cap pinned BELOW its real one cuts the step
+    #: off mid-reasoning and the call comes back ``length`` with no answer and
+    #: no tool call. That is what #2128 actually was: not effort overrunning a
+    #: budget the model was told about — it is not supposed to do that — but a
+    #: cap we chose without knowing the model's real ceiling. See the Stella
+    #: adapter's note in ``posture.py`` for the measurement.
     max_tokens: int | None = None
+    #: Run the agent's raw step loop instead of its staged pipeline. For Stella
+    #: that is ``--no-pipeline``, which settles triage, witness and verify at
+    #: once because all three ARE the pipeline. Declared on the engine rather
+    #: than exported at launch: the runner scrubs every ambient ``STELLA_*`` so
+    #: a host setting can never quietly reconfigure a seat, and which loop an
+    #: arm ran belongs in the match's published identity either way. Agents
+    #: with no pipeline ignore it, like the role overrides below.
+    bare_loop: bool = False
     #: Per-role overrides, keyed by a member of :data:`ROLES`.
     roles: dict[str, RoleConfig] = field(default_factory=dict)
 
@@ -347,6 +360,7 @@ class Engine:
             "base_url": self.base_url,
             "budget_usd": self.budget_usd,
             "max_tokens": self.max_tokens,
+            "bare_loop": self.bare_loop,
             "roles": {name: role.to_json() for name, role in self.roles.items()},
         }
 
@@ -372,6 +386,7 @@ class Engine:
             max_tokens=(
                 int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
             ),
+            bare_loop=bool(raw.get("bare_loop", False)),
             roles=roles,
         )
 
@@ -380,8 +395,12 @@ class Engine:
         """A one-line human description, e.g. ``glm-5.2 · xhigh · +2 roles``."""
         short = self.model.rsplit("/", 1)[-1] or "unset"
         think = self.effort if self.reasoning else "no-reasoning"
+        # Named before the roles: on a bare-loop arm the roles are inert, and a
+        # label reading "+2 roles" with no mention of the loop would advertise
+        # management stages that never ran.
+        loop = " · bare loop" if self.bare_loop else ""
         extra = f" · +{len(self.roles)} roles" if self.roles else ""
-        return f"{short} · {think}{extra}"
+        return f"{short} · {think}{loop}{extra}"
 
 
 @dataclass(frozen=True)

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -258,6 +258,44 @@ class RoleConfig:
         )
 
 
+#: Stella's own truthy vocabulary (``crates/stella-cli/src/settings.rs``),
+#: plus its negations, so a match file and the agent it configures agree on
+#: what "true" means.
+_FLAG_TRUE = frozenset({"1", "true", "yes", "on"})
+_FLAG_FALSE = frozenset({"", "0", "false", "no", "off"})
+
+
+def declared_flag(value: Any) -> bool | None:
+    """A declared boolean, or ``None`` when the value does not declare one.
+
+    ``bool(value)`` is the wrong reader for a config flag: it answers ``True``
+    for the string ``"false"``, for the sole reason that it is not empty. A
+    seat spelled to run the staged pipeline would then run the bare loop — a
+    selector spelled to close must never open, which is the discipline
+    ``STELLA_TRUST_PROJECT`` paid for.
+
+    Returning ``None`` for anything unrecognised is what lets each caller
+    answer differently, and they do: the TOML loader refuses the template
+    outright, because a human wrote that word and meant something by it; the
+    JSON loader falls back to the closed default, because it is fed by
+    round-tripped machine output where a stray value is corruption rather than
+    intent.
+    """
+    if isinstance(value, bool):
+        return value
+    # JSON's spelling of a boolean when a client serialises one as a number.
+    # Any other int is a value that meant something else, and is not a flag.
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        word = value.strip().lower()
+        if word in _FLAG_TRUE:
+            return True
+        if word in _FLAG_FALSE:
+            return False
+    return None
+
+
 @dataclass(frozen=True)
 class Engine:
     """How one contestant's model calls are pinned — the full engine config.
@@ -386,7 +424,10 @@ class Engine:
             max_tokens=(
                 int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
             ),
-            bare_loop=bool(raw.get("bare_loop", False)),
+            # Closed on anything that does not declare a boolean: this side is
+            # fed by round-tripped machine output, so a value neither `true`
+            # nor `false` is corruption, and corruption must not select an arm.
+            bare_loop=declared_flag(raw.get("bare_loop")) is True,
             roles=roles,
         )
 

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -415,7 +415,11 @@ class Engine:
         return cls(
             api=str(raw.get("api") or "openrouter"),
             model=str(raw.get("model") or ""),
-            reasoning=bool(raw.get("reasoning", True)),
+            # Same reader as `bare_loop`, and the same misreading avoided
+            # (#2334): `bool("false")` is True. The fallback is True, because
+            # `reasoning` defaults ON — "closed" for this field means the
+            # shipping configuration, not the off state.
+            reasoning=declared_flag(raw.get("reasoning", True)) is not False,
             effort=str(raw.get("effort") or "high"),
             base_url=(str(raw["base_url"]) or None) if raw.get("base_url") else None,
             budget_usd=(

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -947,6 +947,12 @@ class MatchRunner:
             env["STELLA_BUDGET"] = str(engine.budget_usd)
         if engine.base_url:
             env["STELLA_BASE_URL"] = engine.base_url
+        if engine.bare_loop:
+            # Set here rather than inherited: `_base_environment` scrubs every
+            # ambient STELLA_* so a host export can never stand in for a seat's
+            # declared configuration. The adapter turns this into
+            # `stella run --no-pipeline`.
+            env["STELLA_NO_PIPELINE"] = "1"
         env.setdefault("STELLA_DISABLE_REFLECTION", "1")
 
         # Both packages must be importable by the Harbor subprocess: the

--- a/arenabench/arenabench/series.py
+++ b/arenabench/arenabench/series.py
@@ -64,6 +64,13 @@ def _seat_signature(contestant: Any) -> dict[str, Any]:
         # #2023's vocabulary: an arm with any independently pinned role is a
         # materially different agent from one model wearing every hat.
         "arm": "treatment" if pinned_roles else "control",
+        # Strictly more material than a pinned role, and for the same reason:
+        # a bare-loop arm has no triage, witness or verify stage at all, so a
+        # line drawn from it to a staged-pipeline match charts two different
+        # agents as one. ``getattr`` like ``color`` below — records written
+        # before this field, and the duck-typed stand-ins in the tests, carry
+        # no ``bare_loop``.
+        "bare_loop": bool(getattr(engine, "bare_loop", False)),
     }
 
 
@@ -204,6 +211,9 @@ def match_row(match: Any) -> dict[str, Any]:
     seat_sig_token = "&".join(
         sorted(
             f"{s['agent']}={s['model']}({','.join(f'{r}:{m}' for r, m in s['roles'].items())})"
+            # Present only on a bare-loop seat, so every group key written
+            # before this arm existed still spells itself the same way.
+            f"{'+bare-loop' if s['bare_loop'] else ''}"
             for s in seat_signatures
         )
     )

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -143,54 +143,6 @@ class TestMatchSpec:
         assert any("dataset" in p for p in problems)
         assert any("model" in p for p in problems)
 
-    def test_bare_loop_survives_json_and_toml_and_reaches_the_seat_env(self):
-        """A bare-loop arm must survive every launch path and reach the seat.
-
-        The runner scrubs every ambient ``STELLA_*`` so a host export cannot
-        stand in for a seat's declared configuration, which means an exported
-        ``STELLA_NO_PIPELINE`` silently ran the pipeline instead — the arm
-        looked configured and was not. Declaring it on the engine is what makes
-        it travel with the match. Witness: field absent → each hop drops it and
-        the seat env carries no selector.
-        """
-        import tomllib
-
-        from arenabench.config import dump_match, match_from_toml
-
-        spec = MatchSpec.from_json(
-            {
-                "dataset": "terminal-bench-2.1",
-                "contestants": [
-                    {
-                        "name": "s",
-                        "agent": "stella",
-                        "engine": {"model": "m", "bare_loop": True},
-                    },
-                ],
-            }
-        )
-        assert spec.contestants[0].engine.bare_loop is True
-        rehydrated = MatchSpec.from_json(spec.to_json())
-        assert rehydrated.contestants[0].engine.bare_loop is True
-        parsed = match_from_toml(tomllib.loads(dump_match(spec)))
-        assert parsed.contestants[0].engine.bare_loop is True
-        # The label has to say so: the roles are inert on a bare-loop arm, and
-        # a label naming only them advertises stages that never ran.
-        assert "bare loop" in parsed.contestants[0].engine.label
-
-        # Default stays off, and stays absent from a rendered template, so
-        # every existing match renders back unchanged.
-        plain = MatchSpec.from_json(
-            {
-                "dataset": "terminal-bench-2.1",
-                "contestants": [
-                    {"name": "s", "agent": "stella", "engine": {"model": "m"}},
-                ],
-            }
-        )
-        assert plain.contestants[0].engine.bare_loop is False
-        assert "bare_loop" not in dump_match(plain)
-
     def test_agent_timeout_multiplier_survives_json_and_toml(self):
         """The agent-execution budget knob must survive every launch path.
 

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -143,6 +143,54 @@ class TestMatchSpec:
         assert any("dataset" in p for p in problems)
         assert any("model" in p for p in problems)
 
+    def test_bare_loop_survives_json_and_toml_and_reaches_the_seat_env(self):
+        """A bare-loop arm must survive every launch path and reach the seat.
+
+        The runner scrubs every ambient ``STELLA_*`` so a host export cannot
+        stand in for a seat's declared configuration, which means an exported
+        ``STELLA_NO_PIPELINE`` silently ran the pipeline instead — the arm
+        looked configured and was not. Declaring it on the engine is what makes
+        it travel with the match. Witness: field absent → each hop drops it and
+        the seat env carries no selector.
+        """
+        import tomllib
+
+        from arenabench.config import dump_match, match_from_toml
+
+        spec = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {
+                        "name": "s",
+                        "agent": "stella",
+                        "engine": {"model": "m", "bare_loop": True},
+                    },
+                ],
+            }
+        )
+        assert spec.contestants[0].engine.bare_loop is True
+        rehydrated = MatchSpec.from_json(spec.to_json())
+        assert rehydrated.contestants[0].engine.bare_loop is True
+        parsed = match_from_toml(tomllib.loads(dump_match(spec)))
+        assert parsed.contestants[0].engine.bare_loop is True
+        # The label has to say so: the roles are inert on a bare-loop arm, and
+        # a label naming only them advertises stages that never ran.
+        assert "bare loop" in parsed.contestants[0].engine.label
+
+        # Default stays off, and stays absent from a rendered template, so
+        # every existing match renders back unchanged.
+        plain = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {"name": "s", "agent": "stella", "engine": {"model": "m"}},
+                ],
+            }
+        )
+        assert plain.contestants[0].engine.bare_loop is False
+        assert "bare_loop" not in dump_match(plain)
+
     def test_agent_timeout_multiplier_survives_json_and_toml(self):
         """The agent-execution budget knob must survive every launch path.
 

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -119,6 +119,52 @@ class TestEngine:
         )
         assert Engine.from_json(engine.to_json()) == engine
 
+    def test_reasoning_spelled_off_as_a_string_actually_turns_it_off(self):
+        """`bool("false")` is True, and that answer ran the opposite arm (#2334).
+
+        `reasoning` is a negative selector with a True default: the only
+        reason to write it at all is to turn reasoning off, so the one value
+        anyone ever types was precisely the one read backwards. This repo's
+        own match files prove operators write the string forms — see the
+        `reasoning = "off"` role overrides in
+        `arenabench/matches/glm52-claude-code-vs-stella.toml` — they simply
+        happened to sit under `[contestant.engine.roles.*]`, which `RoleConfig`
+        parses correctly, rather than two spaces out under the engine, which
+        did not.
+        """
+        for spelled_off in ("false", "False", "no", "off", "0", ""):
+            engine = Engine.from_json({"model": "m", "reasoning": spelled_off})
+            assert engine.reasoning is False, spelled_off
+
+        for spelled_on in (True, 1, "true", "TRUE", " yes ", "on"):
+            engine = Engine.from_json({"model": "m", "reasoning": spelled_on})
+            assert engine.reasoning is True, spelled_on
+
+        # Absent keeps the documented default, and an undeclarable value keeps
+        # it too: for this field the shipping configuration is reasoning ON, so
+        # falling back to False would be the closed answer to the wrong question.
+        assert Engine.from_json({"model": "m"}).reasoning is True
+        assert Engine.from_json({"model": "m", "reasoning": "maybe"}).reasoning is True
+
+    def test_a_toml_template_refuses_a_reasoning_it_cannot_read(self):
+        """The human-authored side refuses rather than defaulting (#2334)."""
+        from arenabench.config import MatchTemplateError, match_from_toml
+
+        with pytest.raises(MatchTemplateError) as caught:
+            match_from_toml(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestant": [
+                        {
+                            "name": "s",
+                            "agent": "stella",
+                            "engine": {"model": "m", "reasoning": "sometimes"},
+                        },
+                    ],
+                }
+            )
+        assert "reasoning" in str(caught.value)
+
 
 class TestMatchSpec:
     def test_duplicate_seat_names_are_disambiguated(self):

--- a/arenabench/tests/test_bare_loop.py
+++ b/arenabench/tests/test_bare_loop.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The bare-loop arm: declared on the engine, and never quietly assumed.
+
+Every test here guards one hop of the same chain — match file → ``Engine``
+→ seat environment → adapter argv → published manifest — because the defect
+this arm was born from was not a crash. An exported ``STELLA_NO_PIPELINE``
+was scrubbed by ``runner._base_environment`` before Harbor started, so the
+run took the staged pipeline while the match file, the launcher, the runner
+log and the seat label all said bare loop. Nothing reported it.
+
+So the bias is toward the values that produce a *plausible* arm rather than
+an error: a word spelled to decline that reads as consent, a selector on a
+seat that has no pipeline to switch off, a default that drifts. A benchmark
+that crashes gets fixed; one that silently measured the other arm gets
+published.
+
+Its own module rather than more length on ``test_arena.py``: that file sits
+one edit from the repository's 1500-line limit, and the rule is that
+separable new code becomes its own module. Its adapter-side counterpart is
+``bench/harbor_adapter/tests/test_loop_mode.py``.
+
+No Docker, no network, no model key: every fixture is synthetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arenabench.model import MatchSpec
+
+
+class TestBareLoopArm:
+    def test_bare_loop_survives_json_and_toml_and_reaches_the_seat_env(self):
+        """A bare-loop arm must survive every launch path and reach the seat.
+
+        The runner scrubs every ambient ``STELLA_*`` so a host export cannot
+        stand in for a seat's declared configuration, which means an exported
+        ``STELLA_NO_PIPELINE`` silently ran the pipeline instead — the arm
+        looked configured and was not. Declaring it on the engine is what makes
+        it travel with the match. Witness: field absent → each hop drops it and
+        the seat env carries no selector.
+        """
+        import tomllib
+
+        from arenabench.config import dump_match, match_from_toml
+
+        spec = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {
+                        "name": "s",
+                        "agent": "stella",
+                        "engine": {"model": "m", "bare_loop": True},
+                    },
+                ],
+            }
+        )
+        assert spec.contestants[0].engine.bare_loop is True
+        rehydrated = MatchSpec.from_json(spec.to_json())
+        assert rehydrated.contestants[0].engine.bare_loop is True
+        parsed = match_from_toml(tomllib.loads(dump_match(spec)))
+        assert parsed.contestants[0].engine.bare_loop is True
+        # The label has to say so: the roles are inert on a bare-loop arm, and
+        # a label naming only them advertises stages that never ran.
+        assert "bare loop" in parsed.contestants[0].engine.label
+
+        # Default stays off, and stays absent from a rendered template, so
+        # every existing match renders back unchanged.
+        plain = MatchSpec.from_json(
+            {
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {"name": "s", "agent": "stella", "engine": {"model": "m"}},
+                ],
+            }
+        )
+        assert plain.contestants[0].engine.bare_loop is False
+        assert "bare_loop" not in dump_match(plain)
+
+    def test_a_word_spelled_to_decline_never_selects_the_bare_loop(self):
+        """`bool("false")` is True, and that answer would run the wrong arm.
+
+        The JSON side is fed by round-tripped machine output, so an
+        undeclarable value is corruption and falls back to the closed default
+        rather than selecting an arm nobody asked for.
+        """
+        for spelled_off in ("false", "False", "no", "off", "0", "", "  "):
+            spec = MatchSpec.from_json(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestants": [
+                        {
+                            "name": "s",
+                            "agent": "stella",
+                            "engine": {"model": "m", "bare_loop": spelled_off},
+                        },
+                    ],
+                }
+            )
+            assert spec.contestants[0].engine.bare_loop is False, spelled_off
+
+        # Neither arm, and nothing to guess from: closed.
+        for undeclarable in ("maybe", 2, [], {}, "1.0"):
+            spec = MatchSpec.from_json(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestants": [
+                        {
+                            "name": "s",
+                            "agent": "stella",
+                            "engine": {"model": "m", "bare_loop": undeclarable},
+                        },
+                    ],
+                }
+            )
+            assert spec.contestants[0].engine.bare_loop is False, undeclarable
+
+        # Every spelling of yes still opens it, so strictness costs nothing a
+        # match author would notice.
+        for spelled_on in (True, 1, "true", "TRUE", " yes ", "on"):
+            spec = MatchSpec.from_json(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestants": [
+                        {
+                            "name": "s",
+                            "agent": "stella",
+                            "engine": {"model": "m", "bare_loop": spelled_on},
+                        },
+                    ],
+                }
+            )
+            assert spec.contestants[0].engine.bare_loop is True, spelled_on
+
+    def test_a_toml_template_refuses_a_bare_loop_it_cannot_read(self):
+        """The human-authored side refuses instead of defaulting.
+
+        Someone wrote that word and meant something by it; running the other
+        arm silently is the exact failure this whole selector exists to avoid.
+        """
+        from arenabench.config import MatchTemplateError, match_from_toml
+
+        with pytest.raises(MatchTemplateError) as caught:
+            match_from_toml(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestant": [
+                        {
+                            "name": "s",
+                            "agent": "stella",
+                            "engine": {"model": "m", "bare_loop": "sometimes"},
+                        },
+                    ],
+                }
+            )
+        assert "bare_loop" in str(caught.value)
+
+    def test_a_non_stella_seat_may_not_declare_a_bare_loop(self):
+        """A key that reads as effective and is not, refused at parse.
+
+        Same refusal as `sut_ref` on a non-stella seat and for the same reason
+        (#2082): the CLI flag never reaches an agent that has no pipeline, so
+        a template declaring it would advertise an arm it never ran.
+        """
+        from arenabench.config import MatchTemplateError, match_from_toml
+
+        with pytest.raises(MatchTemplateError) as caught:
+            match_from_toml(
+                {
+                    "dataset": "terminal-bench-2.1",
+                    "contestant": [
+                        {
+                            "name": "cc",
+                            "agent": "claude-code",
+                            "engine": {"model": "m", "bare_loop": True},
+                        },
+                    ],
+                }
+            )
+        assert "bare_loop applies only to a stella seat" in str(caught.value)
+

--- a/arenabench/tests/test_series.py
+++ b/arenabench/tests/test_series.py
@@ -48,15 +48,23 @@ def _seat(
     name: str = "stella",
     model: str = "anthropic/claude-sonnet-5",
     roles: dict[str, str] | None = None,
+    bare_loop: bool | None = None,
 ) -> SimpleNamespace:
     role_objs = {
         role: SimpleNamespace(model=pinned) for role, pinned in (roles or {}).items()
     }
+    # ``None`` omits the attribute entirely rather than setting it False, so the
+    # default seat keeps exercising the legacy path — a record written before
+    # the bare-loop arm existed has no such field, and must still key as a
+    # staged-pipeline run rather than raising.
+    engine = SimpleNamespace(model=model, roles=role_objs)
+    if bare_loop is not None:
+        engine.bare_loop = bare_loop
     return SimpleNamespace(
         id=f"seat-{name}",
         name=name,
         agent="stella",
-        engine=SimpleNamespace(model=model, roles=role_objs),
+        engine=engine,
         _metrics=metrics,
     )
 
@@ -235,6 +243,40 @@ class TestComparability:
         assert (
             control_row["comparability"]["group_key"]
             != treatment_row["comparability"]["group_key"]
+        )
+
+    def test_a_bare_loop_arm_never_joins_the_staged_pipeline_series(self) -> None:
+        """A bare-loop arm has no triage, witness or verify stage at all.
+
+        Strictly more material than the pinned role above, which is why it
+        keys apart for the same reason. Without this the two matches share a
+        ``group_key``, and the trends client draws a connected line between an
+        agent measured with its management stages and one measured without —
+        this module's docstring calls that the most misleading thing the
+        feature could do.
+        """
+        metrics = {"a": _trial("a", resolved=True)}
+        pipeline = _match([_seat(metrics)], match_id="m1")
+        bare = _match([_seat(metrics, bare_loop=True)], match_id="m2")
+        assert match_row(pipeline)["comparability"]["seats"][0]["bare_loop"] is False
+        assert match_row(bare)["comparability"]["seats"][0]["bare_loop"] is True
+        assert (
+            match_row(pipeline)["comparability"]["group_key"]
+            != match_row(bare)["comparability"]["group_key"]
+        )
+
+    def test_declaring_the_pipeline_keys_the_same_as_never_mentioning_it(self) -> None:
+        """Every group key written before this arm existed must be unchanged.
+
+        ``bare_loop = false`` and a record with no such field are the same
+        measurement, so the token is emitted only when true — otherwise this
+        change would silently re-group the entire existing corpus."""
+        metrics = {"a": _trial("a", resolved=True)}
+        legacy = _match([_seat(metrics)], match_id="m1")
+        declared = _match([_seat(metrics, bare_loop=False)], match_id="m2")
+        assert (
+            match_row(legacy)["comparability"]["group_key"]
+            == match_row(declared)["comparability"]["group_key"]
         )
 
     def test_seat_order_does_not_split_a_group(self) -> None:

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -186,6 +186,22 @@ _DURABLE_STREAM_ENV = "STELLA_DURABLE_STREAM_JSON_PATH"
 _ENGINE_CONFIG_ENV = "STELLA_ENGINE_CONFIG_JSON"
 _HANDOFF_MODE = "anonymous-fd"
 
+# Selects the raw step loop (`stella run --no-pipeline`) instead of the staged
+# pipeline. One flag settles all three management stages at once, because
+# triage, witness and verify ARE the pipeline — the bare loop has no stage to
+# turn off individually. This is the arm that measures the agent loop itself:
+# with the pipeline in, a board number folds worker capability together with
+# triage/witness/verdict behaviour, and #2128/#2129 showed those can dominate
+# it. Host-only, expressed purely as argv; nothing about it is forwarded into
+# the task container.
+_NO_PIPELINE_ENV = "STELLA_NO_PIPELINE"
+
+# Stella's own truthy vocabulary (`crates/stella-cli/src/settings.rs::truthy_flag`).
+# Matched exactly, and deliberately not "any non-empty value": a posture spelled
+# `STELLA_NO_PIPELINE=false` must leave the pipeline ON, the same way
+# `STELLA_TRUST_PROJECT=false` must not open the trust boundary.
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
 # Apply these *after* every ambient/Harbor-provided extra. A benchmark task is
 # untrusted input: it must not load a repository .env, opt itself into trusted
 # project settings/hooks, or route paid provider traffic through a task-chosen
@@ -258,6 +274,11 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         # The third coupled ceiling (#1211 §6.2). Same bucket again: read on the
         # host, reaching Stella only inside the hashed posture.
         _MODEL_TIMEOUT_ENV,
+        # The bare-loop selector. Host-only for the same reason as the turn
+        # deadline above: read here, expressed as argv, never forwarded — and
+        # registered because the ambient check fails closed, so an unlisted
+        # selector refuses the run rather than quietly running the other arm.
+        _NO_PIPELINE_ENV,
         # The portability target triple and glibc floor (#1018). `env.sh` exports
         # both so `build_sut.sh` builds to the same floor `preflight` asserts
         # against — keeping them apart is what let a glibc-2.35 binary reach five
@@ -1333,7 +1354,13 @@ class StellaAgent(BaseInstalledAgent):
         # instead of parsing as a flag. Without it, `stella run '- foo'`
         # exits 2 before the agent starts — one 2026-07-31 trial
         # (pytorch-model-recovery) died exactly this way and scored 0.
-        parts += ["run", "--output-format", "stream-json", "--", instruction]
+        parts += ["run"]
+        # A flag OF `run`, like `--output-format` and for the same reason
+        # (stella#1493): it is a promise about this one invocation, not a
+        # session-wide setting.
+        if self._bare_loop_requested():
+            parts += ["--no-pipeline"]
+        parts += ["--output-format", "stream-json", "--", instruction]
         return parts
 
     def _selected_provider_credentials(self) -> SelectedProviderCredentials:
@@ -1405,6 +1432,16 @@ class StellaAgent(BaseInstalledAgent):
         if budget is None or not str(budget).strip():
             return None
         return budget
+
+    def _bare_loop_requested(self) -> bool:
+        """Whether this arm runs the raw step loop instead of the pipeline.
+
+        Absent means the pipeline, which is what ``stella run`` does by default
+        — an arm has to ask for the bare loop, so a match that says nothing
+        measures the shipping configuration.
+        """
+        value = self._configured_value(_NO_PIPELINE_ENV)
+        return value is not None and value.strip().lower() in _TRUTHY_ENV_VALUES
 
     def _configured_turn_budget(self) -> str | None:
         """Resolve the turn deadline in seconds, or ``None`` for no deadline.
@@ -1558,6 +1595,9 @@ class StellaAgent(BaseInstalledAgent):
             budget_usd = _NO_BUDGET_CAP
         turn_budget_sec = getattr(self, "_turn_budget_sec", None)
         turn_budget_sec = turn_budget_sec or self._configured_turn_budget()
+        # Resolved the same way `_build_command` resolves it, so the manifest
+        # cannot disagree with the argv that ran.
+        bare_loop = self._bare_loop_requested()
         credential_handoff_mode = getattr(
             self, "_credential_handoff_mode", _HANDOFF_MODE
         )
@@ -1645,6 +1685,13 @@ class StellaAgent(BaseInstalledAgent):
             # The wall-clock half of the same disclosure (#2135).
             "stella_turn_budget_sec": turn_budget_sec or _NO_TASK_DEADLINE,
             "stella_output_format": "stream-json",
+            # Which loop actually ran. First-class rather than inferable,
+            # because the posture below still names a verifier and a triage
+            # author on a bare-loop arm — they are inputs the CLI ignores once
+            # `--no-pipeline` selects the raw step loop, and a manifest that
+            # only showed the posture would read as a pipeline run that simply
+            # never authored a witness (#2134's shape exactly).
+            "stella_loop_mode": "bare_step_loop" if bare_loop else "staged_pipeline",
             "stella_disable_reflection": reflection,
             "stella_reflection_policy": (
                 "disabled_for_ephemeral_benchmark"

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -92,6 +92,8 @@ from .exit_cause import (
 )
 from .git_baseline import ensure_git, run_git_baseline
 from .locate import locate_binary as _locate_binary
+from .loop_mode import NO_PIPELINE_ENV, loop_argv, loop_mode_name
+from .loop_mode import is_truthy as _is_truthy
 from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
@@ -186,22 +188,6 @@ _DURABLE_STREAM_ENV = "STELLA_DURABLE_STREAM_JSON_PATH"
 _ENGINE_CONFIG_ENV = "STELLA_ENGINE_CONFIG_JSON"
 _HANDOFF_MODE = "anonymous-fd"
 
-# Selects the raw step loop (`stella run --no-pipeline`) instead of the staged
-# pipeline. One flag settles all three management stages at once, because
-# triage, witness and verify ARE the pipeline — the bare loop has no stage to
-# turn off individually. This is the arm that measures the agent loop itself:
-# with the pipeline in, a board number folds worker capability together with
-# triage/witness/verdict behaviour, and #2128/#2129 showed those can dominate
-# it. Host-only, expressed purely as argv; nothing about it is forwarded into
-# the task container.
-_NO_PIPELINE_ENV = "STELLA_NO_PIPELINE"
-
-# Stella's own truthy vocabulary (`crates/stella-cli/src/settings.rs::truthy_flag`).
-# Matched exactly, and deliberately not "any non-empty value": a posture spelled
-# `STELLA_NO_PIPELINE=false` must leave the pipeline ON, the same way
-# `STELLA_TRUST_PROJECT=false` must not open the trust boundary.
-_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
-
 # Apply these *after* every ambient/Harbor-provided extra. A benchmark task is
 # untrusted input: it must not load a repository .env, opt itself into trusted
 # project settings/hooks, or route paid provider traffic through a task-chosen
@@ -274,11 +260,8 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         # The third coupled ceiling (#1211 §6.2). Same bucket again: read on the
         # host, reaching Stella only inside the hashed posture.
         _MODEL_TIMEOUT_ENV,
-        # The bare-loop selector. Host-only for the same reason as the turn
-        # deadline above: read here, expressed as argv, never forwarded — and
-        # registered because the ambient check fails closed, so an unlisted
-        # selector refuses the run rather than quietly running the other arm.
-        _NO_PIPELINE_ENV,
+        # The bare-loop selector; :mod:`loop_mode` says why it is host-only.
+        NO_PIPELINE_ENV,
         # The portability target triple and glibc floor (#1018). `env.sh` exports
         # both so `build_sut.sh` builds to the same floor `preflight` asserts
         # against — keeping them apart is what let a glibc-2.35 binary reach five
@@ -371,13 +354,6 @@ _PROVIDER_ROUTE_CONFIG_ENV = frozenset(_PROVIDER_ADDRESS_ENV_VARS) | frozenset(
     }
 )
 _COMPOSE_SERVICE_LABEL = "com.docker.compose.service"
-
-
-def _is_truthy(value: str | None) -> bool:
-    """Return whether a string environment variable represents truth."""
-    if not value:
-        return False
-    return value.strip().lower() in ("1", "true", "yes", "on")
 
 
 def _validated_public_base_url(value: str) -> str:
@@ -1354,12 +1330,7 @@ class StellaAgent(BaseInstalledAgent):
         # instead of parsing as a flag. Without it, `stella run '- foo'`
         # exits 2 before the agent starts — one 2026-07-31 trial
         # (pytorch-model-recovery) died exactly this way and scored 0.
-        parts += ["run"]
-        # A flag OF `run`, like `--output-format` and for the same reason
-        # (stella#1493): it is a promise about this one invocation, not a
-        # session-wide setting.
-        if self._bare_loop_requested():
-            parts += ["--no-pipeline"]
+        parts += ["run", *loop_argv(self._configured_value)]
         parts += ["--output-format", "stream-json", "--", instruction]
         return parts
 
@@ -1432,16 +1403,6 @@ class StellaAgent(BaseInstalledAgent):
         if budget is None or not str(budget).strip():
             return None
         return budget
-
-    def _bare_loop_requested(self) -> bool:
-        """Whether this arm runs the raw step loop instead of the pipeline.
-
-        Absent means the pipeline, which is what ``stella run`` does by default
-        — an arm has to ask for the bare loop, so a match that says nothing
-        measures the shipping configuration.
-        """
-        value = self._configured_value(_NO_PIPELINE_ENV)
-        return value is not None and value.strip().lower() in _TRUTHY_ENV_VALUES
 
     def _configured_turn_budget(self) -> str | None:
         """Resolve the turn deadline in seconds, or ``None`` for no deadline.
@@ -1595,9 +1556,6 @@ class StellaAgent(BaseInstalledAgent):
             budget_usd = _NO_BUDGET_CAP
         turn_budget_sec = getattr(self, "_turn_budget_sec", None)
         turn_budget_sec = turn_budget_sec or self._configured_turn_budget()
-        # Resolved the same way `_build_command` resolves it, so the manifest
-        # cannot disagree with the argv that ran.
-        bare_loop = self._bare_loop_requested()
         credential_handoff_mode = getattr(
             self, "_credential_handoff_mode", _HANDOFF_MODE
         )
@@ -1685,13 +1643,8 @@ class StellaAgent(BaseInstalledAgent):
             # The wall-clock half of the same disclosure (#2135).
             "stella_turn_budget_sec": turn_budget_sec or _NO_TASK_DEADLINE,
             "stella_output_format": "stream-json",
-            # Which loop actually ran. First-class rather than inferable,
-            # because the posture below still names a verifier and a triage
-            # author on a bare-loop arm — they are inputs the CLI ignores once
-            # `--no-pipeline` selects the raw step loop, and a manifest that
-            # only showed the posture would read as a pipeline run that simply
-            # never authored a witness (#2134's shape exactly).
-            "stella_loop_mode": "bare_step_loop" if bare_loop else "staged_pipeline",
+            # Which loop ran — not inferable from the posture below (#2134).
+            "stella_loop_mode": loop_mode_name(self._configured_value),
             "stella_disable_reflection": reflection,
             "stella_reflection_policy": (
                 "disabled_for_ephemeral_benchmark"

--- a/bench/harbor_adapter/stella_harbor/loop_mode.py
+++ b/bench/harbor_adapter/stella_harbor/loop_mode.py
@@ -1,0 +1,114 @@
+"""Which loop a Stella arm ran: the selector, its argv, and its manifest name.
+
+Split out of the adapter package root for the reason :mod:`posture` was, and
+recorded in that module's own docstring: the repository's file-size ratchet
+holds that separable new code becomes its own module rather than more length
+on an already-oversized file.
+
+The seam is genuine. Nothing here knows what a Harbor agent is: every function
+takes a *reader* — one callable resolving an environment key to its configured
+value — so :meth:`StellaAgent._configured_value` supplies the real one and a
+test supplies ``{...}.get``. That is also what makes the invariant below
+mechanical rather than aspirational: the argv and the manifest are two
+projections of :func:`bare_loop_selected`, so they cannot disagree about which
+loop ran.
+
+**What the selector selects.** ``stella run`` runs the staged pipeline by
+default; ``--no-pipeline`` runs the agent's raw step loop instead. One flag
+settles all three management stages at once, because triage, witness and
+verify *are* the pipeline — the bare loop has no stage to turn off
+individually. This is the arm that measures the agent loop itself: with the
+pipeline in, a board number folds worker capability together with
+triage/witness/verdict behaviour, and #2128/#2129 showed those stages can
+dominate it outright.
+
+**Why it is host-only.** :data:`NO_PIPELINE_ENV` is read on the host and
+expressed purely as argv; nothing about it is forwarded into the task
+container, so it is registered in the adapter's ``_HOST_ONLY_STELLA_ENV``.
+That registration is not bookkeeping: the ambient check fails closed, so an
+unregistered selector would have refused the run rather than quietly running
+the other arm.
+
+**Why a selector spelled to close must not open.** :func:`is_truthy` matches
+Stella's own vocabulary (``crates/stella-cli/src/settings.rs::truthy_flag``)
+exactly, and deliberately not "any non-empty value". ``STELLA_NO_PIPELINE=false``
+has to leave the pipeline **on**, the same way ``STELLA_TRUST_PROJECT=false``
+must not open the trust boundary. It is the adapter root's historical
+``_is_truthy``, moved here rather than copied: this module briefly shipped a
+second frozenset spelling the same four words, which is the drift the move
+prevents.
+
+**Why the mode is first-class in the manifest.** It is not inferable from the
+posture: the posture still names a verifier and a triage author on a bare-loop
+arm — inputs the CLI ignores once ``--no-pipeline`` is set — so a manifest
+showing only the posture would read as a pipeline run that merely never
+authored a witness, which is #2134's shape exactly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = [
+    "BARE_STEP_LOOP",
+    "NO_PIPELINE_ENV",
+    "STAGED_PIPELINE",
+    "bare_loop_selected",
+    "is_truthy",
+    "loop_argv",
+    "loop_mode_name",
+]
+
+#: Resolves one environment key to its configured value, or ``None``.
+Reader = Callable[[str], "str | None"]
+
+#: Selects the raw step loop instead of the staged pipeline. Host-only.
+NO_PIPELINE_ENV = "STELLA_NO_PIPELINE"
+
+#: The two values ``stella_loop_mode`` may take in a trial manifest. Named
+#: rather than inline literals, so a reader of a published result and a reader
+#: of this adapter are looking at the same two strings.
+BARE_STEP_LOOP = "bare_step_loop"
+STAGED_PIPELINE = "staged_pipeline"
+
+#: Stella's truthy vocabulary. One tuple, because two copies is two chances for
+#: one of them to drift into accepting ``"false"``.
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def is_truthy(value: str | None) -> bool:
+    """Whether a string environment variable represents truth.
+
+    Absent, empty, and every word outside :data:`_TRUTHY` are all false, so a
+    selector that is merely *present* does not switch anything on.
+    """
+    if not value:
+        return False
+    return value.strip().lower() in _TRUTHY
+
+
+def bare_loop_selected(configured: Reader) -> bool:
+    """Whether this arm runs the raw step loop instead of the pipeline.
+
+    The single resolution point both projections below read. Absent means the
+    pipeline, which is what ``stella run`` does by default — an arm has to ask
+    for the bare loop, so a match that says nothing measures the shipping
+    configuration.
+    """
+    return is_truthy(configured(NO_PIPELINE_ENV))
+
+
+def loop_argv(configured: Reader) -> tuple[str, ...]:
+    """The tokens ``run`` takes for this loop mode — empty for the pipeline.
+
+    ``--no-pipeline`` is a flag *of* ``run``, like ``--output-format`` and for
+    the same reason (stella#1493): it is a promise about this one invocation,
+    not a session-wide setting. Returning nothing for the default is what keeps
+    the pipeline's argv byte-identical to what it was before this arm existed.
+    """
+    return ("--no-pipeline",) if bare_loop_selected(configured) else ()
+
+
+def loop_mode_name(configured: Reader) -> str:
+    """The manifest's name for this loop mode."""
+    return BARE_STEP_LOOP if bare_loop_selected(configured) else STAGED_PIPELINE

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -605,9 +605,11 @@ def _benchmark_engine_posture(
         #
         # The engine default carries a comment saying 16k was itself a raise
         # from 8k for exactly this failure on glm-5.2, and names per-model caps
-        # as the real fix. Effort and the output cap are coupled: raising the
-        # tier without raising the cap buys reasoning that cannot fit an answer
-        # beside it, and the step ends with no tool call at all.
+        # as the real fix — which is the accurate reading. The model is not
+        # overrunning a budget it was told about; it is being cut off at a
+        # number we picked without knowing its real ceiling, so the step ends
+        # mid-reasoning with no tool call at all. Effort raises how much of the
+        # ceiling gets spent, but the ceiling is the thing that has to be right.
         #
         # 64000, which is the model's own ceiling and therefore the
         # comparator's. The previous value was 32000, held there because

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -65,11 +65,10 @@ _FIXED_ANALYZER_PATH = "bench/terminal_bench_analysis/tb21_analysis.py"
 _FIXED_PUBLIC_TIMING_PATH = "bench/terminal_bench_analysis/github_public_timing.py"
 _FIXED_PROTOCOL_PATH = "bench/terminal-bench-2.1-protocol.md"
 # Every Python source in the adapter package, enumerated rather than globbed:
-# the public-tree check compares this exact set against what the published
-# commit contains, so an adapter file that exists locally but is missing here
-# would be executed without ever being byte-compared to the published source.
-# A new module must therefore be added here, and the fail-closed set mismatch
-# ("public adapter tree hash differs from runtime identity") is what enforces it.
+# the public-tree check compares this exact set against the published commit,
+# so a file present locally but missing here would be executed without ever
+# being byte-compared to its published source. A new module must therefore be
+# added here; "public adapter tree hash differs from runtime identity" enforces it.
 _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/__init__.py",
     "bench/harbor_adapter/stella_harbor/atif.py",
@@ -81,6 +80,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/host_attestation.py",
     "bench/harbor_adapter/stella_harbor/live_feed.py",
     "bench/harbor_adapter/stella_harbor/locate.py",
+    "bench/harbor_adapter/stella_harbor/loop_mode.py",
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -297,6 +297,51 @@ class TestBuildCommand:
         assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", "Fix the bug"]
         assert "--base-url" not in cmd  # not set
 
+    def test_bare_loop_arm_passes_no_pipeline_after_the_run_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bare-loop arm exists at all: `--no-pipeline` reaches argv.
+
+        Without it there is no way to measure the raw step loop, so a match
+        comparing agent architectures silently measured the pipeline instead.
+        """
+        monkeypatch.setenv("STELLA_NO_PIPELINE", "1")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-opus-5"
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--no-pipeline" in cmd
+        # A flag OF `run`, never a global — clap rejects it before the subcommand.
+        assert cmd.index("--no-pipeline") > cmd.index("run")
+        assert cmd[-5:] == [
+            "--no-pipeline",
+            "--output-format",
+            "stream-json",
+            "--",
+            "Fix the bug",
+        ]
+
+    def test_pipeline_is_the_default_and_a_falsey_value_does_not_disable_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent or explicitly-off leaves the shipping configuration running.
+
+        `STELLA_NO_PIPELINE=false` must keep the pipeline ON: a selector spelled
+        to close must not open, the same discipline `STELLA_TRUST_PROJECT`
+        learned the hard way.
+        """
+        agent = _bare_agent()
+        agent.model_name = "openrouter/anthropic/claude-opus-5"
+
+        monkeypatch.delenv("STELLA_NO_PIPELINE", raising=False)
+        assert "--no-pipeline" not in agent._build_command("Fix the bug")
+
+        for spelled_off in ("false", "0", "no", "off", ""):
+            monkeypatch.setenv("STELLA_NO_PIPELINE", spelled_off)
+            cmd = agent._build_command("Fix the bug")
+            assert "--no-pipeline" not in cmd, spelled_off
+
     def test_env_overrides_and_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("STELLA_MODEL", "zai/glm-5.2")
         monkeypatch.setenv("STELLA_BUDGET", "10.0")

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -297,51 +297,6 @@ class TestBuildCommand:
         assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", "Fix the bug"]
         assert "--base-url" not in cmd  # not set
 
-    def test_bare_loop_arm_passes_no_pipeline_after_the_run_token(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The bare-loop arm exists at all: `--no-pipeline` reaches argv.
-
-        Without it there is no way to measure the raw step loop, so a match
-        comparing agent architectures silently measured the pipeline instead.
-        """
-        monkeypatch.setenv("STELLA_NO_PIPELINE", "1")
-        agent = _bare_agent()
-        agent.model_name = "openrouter/anthropic/claude-opus-5"
-
-        cmd = agent._build_command("Fix the bug")
-
-        assert "--no-pipeline" in cmd
-        # A flag OF `run`, never a global — clap rejects it before the subcommand.
-        assert cmd.index("--no-pipeline") > cmd.index("run")
-        assert cmd[-5:] == [
-            "--no-pipeline",
-            "--output-format",
-            "stream-json",
-            "--",
-            "Fix the bug",
-        ]
-
-    def test_pipeline_is_the_default_and_a_falsey_value_does_not_disable_it(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Absent or explicitly-off leaves the shipping configuration running.
-
-        `STELLA_NO_PIPELINE=false` must keep the pipeline ON: a selector spelled
-        to close must not open, the same discipline `STELLA_TRUST_PROJECT`
-        learned the hard way.
-        """
-        agent = _bare_agent()
-        agent.model_name = "openrouter/anthropic/claude-opus-5"
-
-        monkeypatch.delenv("STELLA_NO_PIPELINE", raising=False)
-        assert "--no-pipeline" not in agent._build_command("Fix the bug")
-
-        for spelled_off in ("false", "0", "no", "off", ""):
-            monkeypatch.setenv("STELLA_NO_PIPELINE", spelled_off)
-            cmd = agent._build_command("Fix the bug")
-            assert "--no-pipeline" not in cmd, spelled_off
-
     def test_env_overrides_and_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("STELLA_MODEL", "zai/glm-5.2")
         monkeypatch.setenv("STELLA_BUDGET", "10.0")

--- a/bench/harbor_adapter/tests/test_loop_mode.py
+++ b/bench/harbor_adapter/tests/test_loop_mode.py
@@ -1,0 +1,178 @@
+"""Which loop an arm ran: the selector, the argv it produces, and the manifest.
+
+Three levels, because the bug this guards against can enter at any of them:
+the selector could accept a word spelled to close, the argv could drop a flag
+the match declared, or the manifest could publish a mode the command never
+ran. The last is the one nothing would have caught — a manifest is read long
+after the process that wrote it is gone.
+
+Lives beside ``test_adapter.py`` rather than inside it for the reason
+:mod:`stella_harbor.loop_mode` lives beside the package root: both files sit
+on the repository's file-size ratchet, and separable new code becomes its own
+module rather than more length on an already-oversized one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from stella_harbor import StellaAgent  # noqa: E402
+from stella_harbor.loop_mode import (  # noqa: E402
+    BARE_STEP_LOOP,
+    NO_PIPELINE_ENV,
+    STAGED_PIPELINE,
+    bare_loop_selected,
+    is_truthy,
+    loop_argv,
+    loop_mode_name,
+)
+
+#: Every spelling Stella itself treats as true (`settings.rs::truthy_flag`).
+SPELLED_ON = ("1", "true", "TRUE", "  True  ", "yes", "on")
+
+#: Absent, empty, and every way of saying no. ``"false"`` is the one that
+#: matters: a plain truthiness test would read it as ``True`` because it is a
+#: non-empty string, and the arm would silently run the loop it declined.
+SPELLED_OFF = (None, "", "  ", "0", "false", "False", "no", "off", "nope")
+
+
+def _reader(value: str | None):
+    """A stand-in for ``StellaAgent._configured_value`` over one key."""
+    return lambda key: value if key == NO_PIPELINE_ENV else None
+
+
+def _agent(monkeypatch: pytest.MonkeyPatch, value: str | None) -> StellaAgent:
+    """An agent whose only configured input is the loop selector."""
+    if value is None:
+        monkeypatch.delenv(NO_PIPELINE_ENV, raising=False)
+    else:
+        monkeypatch.setenv(NO_PIPELINE_ENV, value)
+    agent = StellaAgent.__new__(StellaAgent)
+    agent.model_name = "openrouter/anthropic/claude-opus-5"
+    return agent
+
+
+class TestSelector:
+    """The pure half: one string in, a loop mode out."""
+
+    @pytest.mark.parametrize("value", SPELLED_ON)
+    def test_stellas_truthy_vocabulary_selects_the_bare_loop(self, value: str) -> None:
+        assert is_truthy(value)
+        assert bare_loop_selected(_reader(value))
+
+    @pytest.mark.parametrize("value", SPELLED_OFF)
+    def test_a_selector_spelled_to_close_does_not_open(self, value: str | None) -> None:
+        """`STELLA_NO_PIPELINE=false` must leave the pipeline ON.
+
+        The same discipline `STELLA_TRUST_PROJECT` learned the hard way: a flag
+        whose value says no must not be read as yes merely for being present.
+        """
+        assert not is_truthy(value)
+        assert not bare_loop_selected(_reader(value))
+
+    @pytest.mark.parametrize("value", SPELLED_ON + SPELLED_OFF)
+    def test_both_projections_derive_from_the_one_selection(
+        self, value: str | None
+    ) -> None:
+        """argv and manifest name are two views of one boolean, never two reads."""
+        selected = bare_loop_selected(_reader(value))
+        assert loop_argv(_reader(value)) == (("--no-pipeline",) if selected else ())
+        assert loop_mode_name(_reader(value)) == (
+            BARE_STEP_LOOP if selected else STAGED_PIPELINE
+        )
+
+
+class TestArgv:
+    """The flag has to reach the command line, in the right position."""
+
+    def test_bare_loop_arm_passes_no_pipeline_after_the_run_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bare-loop arm exists at all: `--no-pipeline` reaches argv.
+
+        Without it there is no way to measure the raw step loop, so a match
+        comparing agent architectures silently measured the pipeline instead.
+        """
+        cmd = _agent(monkeypatch, "1")._build_command("Fix the bug")
+
+        assert "--no-pipeline" in cmd
+        # A flag OF `run`, never a global — clap rejects it before the subcommand.
+        assert cmd.index("--no-pipeline") > cmd.index("run")
+        assert cmd[-5:] == [
+            "--no-pipeline",
+            "--output-format",
+            "stream-json",
+            "--",
+            "Fix the bug",
+        ]
+
+    @pytest.mark.parametrize("value", SPELLED_OFF)
+    def test_the_pipeline_is_the_default_and_stays_byte_identical(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ) -> None:
+        """Absent or explicitly-off leaves the shipping configuration running.
+
+        Asserting the exact tail, not just the flag's absence: the default
+        arm's argv must be what it was before this arm existed, or every
+        already-published pipeline result is measuring something new.
+        """
+        cmd = _agent(monkeypatch, value)._build_command("Fix the bug")
+
+        assert "--no-pipeline" not in cmd
+        tail = ["run", "--output-format", "stream-json", "--", "Fix the bug"]
+        assert cmd[-5:] == tail
+
+
+class TestManifest:
+    """The published record must name the loop the command actually ran."""
+
+    @staticmethod
+    def _loop_mode(agent: StellaAgent) -> str:
+        agent._metrics = {
+            "cost_usd": None,
+            "n_input_tokens": None,
+            "n_output_tokens": None,
+            "n_cache_tokens": None,
+            "status": "completed",
+            "model": None,
+            "steps": None,
+        }
+        agent._return_code = 0
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+        return ctx.metadata["stella_loop_mode"]
+
+    @pytest.mark.parametrize("value", SPELLED_ON + SPELLED_OFF)
+    def test_the_manifest_cannot_disagree_with_the_argv_that_ran(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ) -> None:
+        """The invariant, stated over the whole vocabulary in both directions.
+
+        A manifest is read long after the process that wrote it exits, so a
+        mode that disagrees with the command is not a stale label — it is a
+        published result claiming to have measured an arm it never ran. #2134
+        was that shape: a record read as a pipeline run that merely never
+        authored a witness.
+        """
+        agent = _agent(monkeypatch, value)
+        flagged = "--no-pipeline" in agent._build_command("Fix the bug")
+
+        mode = self._loop_mode(agent)
+
+        assert mode == (BARE_STEP_LOOP if flagged else STAGED_PIPELINE)
+        # And pinned absolutely, so a rename of both sides at once still fails.
+        assert mode == (BARE_STEP_LOOP if is_truthy(value) else STAGED_PIPELINE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Adds the arm ArenaBench could not express: **Stella's raw step loop**, with the staged pipeline — and therefore triage, witness and verify — switched off. Declared per-seat as `bare_loop = true` in a match's `[contestant.engine]`.

```toml
[contestant.engine]
api = "openrouter"
model = "anthropic/claude-opus-5"
effort = "xhigh"
bare_loop = true      # -> stella run --no-pipeline
```

> **Scope note (review round 2).** The arena reuse/discovery work that previously rode along in this branch — `ARENA_DISCOVERY_PORTS`, `probe_arena`, `find_running_arena`, `serve(reuse=…)`, `--no-reuse`, the `watch:` line — was roughly half the diff and named nowhere in the description. It is now **#2322**, under its own title. This branch is the bare-loop arm alone.

## Why

With the pipeline in, a board number folds worker capability together with triage/witness/verdict behaviour, and match `cc00894779ff` showed those stages can dominate it outright (#2128, #2129). There was no way to run the other side of that comparison: every adapter env knob *configures* the pipeline, none turns it off. One flag settles all three management stages because triage, witness and verify **are** the pipeline — the bare loop has no stage to switch off individually.

## The bug this found on the way

The first commit put the selector in the environment. It did nothing, in silence. `runner._base_environment` scrubs every ambient `STELLA_*` (`_SCRUBBED_PREFIXES`) precisely so a host export cannot stand in for a seat's declared configuration — correct design — so `STELLA_NO_PIPELINE=1` was dropped before Harbor started. The arm ran the **full pipeline** while the match file, the launcher, the runner's log line and the seat label all said bare loop.

Nothing reported it. It was caught by reading the trial's own stage events (`triage → context_recall → research → plan → execute`, where a bare loop emits only `execute`). Hence: the selector belongs on the engine, travelling with the match, which is also the honest home for it — which loop an arm ran is part of a published result's identity.

## Shape

- `Engine.bare_loop` sits beside `budget_usd`/`base_url`; survives JSON and TOML round-trips.
- The runner derives the seat's `STELLA_NO_PIPELINE` exactly where it already derives `STELLA_BUDGET`.
- The adapter appends `--no-pipeline` as a flag **of** `run` (like `--output-format` since #1493).
- Registered in `_HOST_ONLY_STELLA_ENV`: read on the host, expressed as argv, never forwarded into the task container. The ambient check fails closed, so an unregistered selector would have refused the run rather than quietly enabling it.
- `Engine.label` renders "bare loop"; the role overrides are inert on such an arm and a label naming only them advertises stages that never ran.
- The TOML renderer emits the key only when true, so every existing template renders back byte-identical.

### `stella_harbor/loop_mode.py` — the new module

All of the above now lives in one sibling module rather than as more length on the adapter root. It takes a **reader** — one callable resolving an environment key — instead of knowing what a Harbor agent is, so `StellaAgent._configured_value` supplies the real one and a test supplies `{...}.get`. That is what makes the central invariant mechanical rather than aspirational: the argv and the manifest are two projections of one `bare_loop_selected` call, and cannot disagree about which loop ran.

## Honesty in the manifest

New first-class `stella_loop_mode` (`bare_step_loop` / `staged_pipeline`). It is not inferable from the posture: the posture still names a verifier and a triage author on a bare-loop arm — inputs the CLI ignores once `--no-pipeline` is set — so a manifest showing only the posture would read as a pipeline run that merely never authored a witness, which is #2134's shape exactly. The posture JSON itself is untouched, because the CLI validates it strictly and fails closed on an unknown key.

## What review round 2 changed

**A bare-loop arm shared a comparability group with a staged-pipeline one.** `_seat_signature` returned `{name, agent, model, roles, arm}`, and neither it nor `seat_sig_token` mentioned the loop — so two matches differing by whether triage, witness and verify ran *at all* produced a byte-identical `group_key`, and the trends client drew a connected series between them. Verified, not assumed: with only the token half disabled, both matches key to `bbbbbbbb|ca978112|stella=anthropic/claude-sonnet-5()`. The precedent was already in `series.py` — `arm: "treatment"` exists because one independently pinned role makes a materially different agent, and removing three whole stages is strictly more than that. The token is emitted **only when true**, so every group key written before this arm existed still spells itself the same way (pinned by its own test).

**`bool()` is the wrong reader for a config flag.** It answers `True` for the string `"false"`, for the sole reason that it is not empty — so a seat spelled to run the pipeline would have run the bare loop. `declared_flag` accepts real booleans, JSON's `0`/`1`, and Stella's own vocabulary with its negations, and returns `None` for anything else. That lets each caller answer differently, and they do:

| loader | undeclarable value | why |
| --- | --- | --- |
| `_engine_from_toml` | **refuses the template** | a human wrote that word and meant something by it |
| `Engine.from_json` | **closed default** | fed by round-tripped machine output, where a stray value is corruption, not intent |

**A non-stella seat may no longer declare one.** Refused at parse for the same reason `sut_ref` already is (#2082): the flag never reaches an agent with no pipeline, so a template declaring it advertises an arm it never ran.

## The file-size gate — no ceiling was raised

Both offenders are back to **their exact sizes on `main`**, with no baseline edit:

| file | before | now | ceiling |
| --- | --- | --- | --- |
| `stella_harbor/__init__.py` | 1880 | **1833** | 1834 |
| `tests/test_adapter.py` | 2380 | **2335** | 2335 |

The gate also caught two things worth naming on their own:

- The adapter root **already had `_is_truthy`** with the identical four-word vocabulary, and this branch had added a second copy 180 lines above it. One implementation now, re-exported under the historical private name so every existing caller and its test are untouched.
- `arenabench/tests/test_arena.py` would have crossed 1500 and become a **new** god file, which the baseline accepts no entry for. Its bare-loop tests move to `tests/test_bare_loop.py`, the arenabench-side counterpart of `tests/test_loop_mode.py`.

One judgement call worth flagging: a new adapter module must also be listed in `_FIXED_ADAPTER_SOURCE_PATHS`, or it executes without ever being byte-compared to its published source — the fail-closed set mismatch caught exactly that, as its comment promises. That one line would have put `secure_launcher.py` at 4300 against a 4299 ceiling. Rather than write to the baseline (the shared cell AGENTS.md names as the top cause of red `main`), the comment directly above that tuple is reflowed from six lines to five with every fact intact, including the grep-able error string. Say the word if you would rather have the honest one-line baseline bump instead.

## Witness tests

All fail on `main` and pass here:

- `test_bare_loop_arm_passes_no_pipeline_after_the_run_token` — on main, `--no-pipeline` is absent from argv.
- `test_bare_loop_survives_json_and_toml_and_reaches_the_seat_env` — on main, `AttributeError: 'Engine' object has no attribute 'bare_loop'`.
- `test_a_bare_loop_arm_never_joins_the_staged_pipeline_series` — both matches key to one string.
- `test_declaring_the_pipeline_keys_the_same_as_never_mentioning_it` — the existing corpus must not silently re-group.
- `test_a_word_spelled_to_decline_never_selects_the_bare_loop`.
- `test_a_toml_template_refuses_a_bare_loop_it_cannot_read`.
- `test_a_non_stella_seat_may_not_declare_a_bare_loop`.
- `test_the_manifest_cannot_disagree_with_the_argv_that_ran` — over the whole vocabulary, in both directions.

Guard tests included for the default: absent or falsey leaves the shipping pipeline configuration running, the default arm's argv stays byte-identical, and a plain match still renders with no `bare_loop` key.

## Verification

- `bench/harbor_adapter`: 611 passed, 2 skipped.
- `arenabench`: full suite green.
- `scripts/check-file-size.sh`: green, no baseline edit.
- `ruff check` clean on every file touched.
- End-to-end chain proven before spending any provider credit — match file → `Engine.bare_loop` → runner seat env → adapter argv — under the same interpreter Harbor runs, producing `... run --no-pipeline --output-format stream-json -- <task>`.

## Retiring the class, not just the instance — `Closes #2334`

`Engine.reasoning` had the identical defect, at `model.py:418` and `config.py:150`. It is worse there than it was for `bare_loop`: `reasoning` is a **negative selector with a `True` default**, so the only reason to write it at all is to turn reasoning off — and `reasoning = "false"` turned it *on*. The one value anyone ever types was precisely the one read backwards, and nothing downstream contradicted the file.

I filed this as #2334 first and deferred it, on the assumption that correcting it would change what an already-saved template measures. **That assumption was wrong, and checking is what showed it.** The three templates under `arenabench/matches/` do use the string spellings — `reasoning = "on"` / `"off"` — but only inside `[contestant.engine.roles.*]` tables, which `RoleConfig._opt_bool` has always parsed correctly. Every *engine-level* value in the tree is a real TOML boolean. So:

- no saved match changes meaning, and no published result is re-measured;
- the repo's own match files nevertheless prove operators write the string forms, so this was live ammunition waiting for someone to write `reasoning = "off"` two spaces out instead of four.

With the deferral's premise gone, and the parser already introduced by this PR, fixing it here retires the class rather than leaving a second instance of it in the same two functions. Both sites keep the same TOML-refuses / JSON-defaults asymmetry — except that the fallback is `True`, because for this field the shipping configuration *is* reasoning on. `RoleConfig._opt_bool` is already correct and is deliberately untouched.

Witness: `test_reasoning_spelled_off_as_a_string_actually_turns_it_off` fails on the old expression with `AssertionError: false`, paired with `test_a_toml_template_refuses_a_reasoning_it_cannot_read`.

**Tests deleted: none.** Five tests moved between files and are named above (`test_bare_loop_*` and the two argv tests, from `test_arena.py` and `test_adapter.py` into `test_bare_loop.py` and `test_loop_mode.py`).
