### PR TITLE
fix(arenabench): reuse the arena already serving a workspace, and let it see matches written after it booted

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -66,7 +66,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     from .credentials import apply_saved_credentials, credentials_path, load_credentials
     from .monitor import MatchWatcher
     from .runner import MatchRunner
-    from .server import ArenaServer
+    from .server import ArenaServer, find_running_arena
 
     try:
         spec = load_match(Path(args.template).expanduser())
@@ -154,6 +154,16 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
     match = runner.create(spec)
     runner.start(match)
+
+    # Name the arena already serving this workspace, if there is one. `run` is
+    # headless by contract and must not start a server, but it knows the match
+    # id and the operator's next question is always "where do I watch it" —
+    # answered previously by starting another arena and forgetting the port.
+    watch_port = find_running_arena(workspace, "127.0.0.1")
+    if watch_port is not None:
+        print(f"watch     : http://127.0.0.1:{watch_port}/matches/{match.id}")
+    else:
+        print(f"watch     : arenabench serve   (then open match {match.id})")
     # The built-in supervisor: the same rules `arenabench watch` runs from
     # another process, reported inline so a CI log shows a dead arm at the
     # minute it died rather than in the postmortem (#1480).
@@ -278,6 +288,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             port=args.port,
             open_browser=not args.no_browser,
             allow_remote=args.allow_remote,
+            reuse=not args.no_reuse,
         )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -760,6 +771,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="permit a non-loopback --host; anyone who can reach it can spend "
              "your provider credits",
+    )
+    serve_parser.add_argument(
+        "--no-reuse",
+        action="store_true",
+        help="start a new arena even if one already serves this workspace "
+             "(default: reuse it and print its URL)",
     )
     serve_parser.set_defaults(func=_cmd_serve)
 

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -115,6 +115,57 @@ def is_loopback(host: str) -> bool:
     return host.strip().lower() in LOOPBACK_HOSTS
 
 
+#: Ports `serve` sweeps looking for an arena that is already up. The default
+#: plus a small window, because that is where previous arenas actually land:
+#: an operator who hits "address in use" tries the next number, and on this
+#: machine that produced six arenas on 8181/8900/8901/8902/8917/8933, all
+#: serving one workspace, none of them aware of the others. Bounded and
+#: deterministic on purpose — discovery must cost a handful of loopback
+#: connects, never a port scan.
+ARENA_DISCOVERY_PORTS: tuple[int, ...] = (8900, 8901, 8902, 8903, 8904, 8905)
+
+
+def probe_arena(host: str, port: int, *, timeout: float = 0.6) -> str | None:
+    """The workspace an arena on ``host:port`` is serving, or ``None``.
+
+    ``None`` covers every not-an-arena case identically — nothing listening, a
+    foreign service, a half-open socket, an arena too wedged to answer — because
+    the caller's next move is the same for all of them and a taxonomy of
+    failures here would only be a taxonomy of guesses.
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(
+            f"http://{host}:{port}/api/health", timeout=timeout
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, ValueError):
+        return None
+    if not isinstance(payload, dict) or not payload.get("ok"):
+        return None
+    workspace = payload.get("workspace")
+    return str(workspace) if workspace else None
+
+
+def find_running_arena(
+    workspace: Path, host: str, *, ports: tuple[int, ...] = ARENA_DISCOVERY_PORTS
+) -> int | None:
+    """The port of a live arena already serving ``workspace``, if there is one.
+
+    Matched on the resolved workspace, not merely on "something answered": two
+    arenas over different workspaces are two different experiments and must not
+    be silently conflated.
+    """
+    target = str(workspace.expanduser().resolve())
+    for port in ports:
+        served = probe_arena(host, port)
+        if served and str(Path(served).expanduser().resolve()) == target:
+            return port
+    return None
+
+
 def allowed_hosts(host: str, port: int) -> frozenset[str]:
     """Every ``Host`` header value that names the loopback arena.
 
@@ -904,14 +955,22 @@ def serve(
     registry: Registry | None = None,
     open_browser: bool = False,
     allow_remote: bool = False,
+    reuse: bool = True,
 ) -> None:
-    """Run the arena until interrupted.
+    """Run the arena until interrupted, or attach to one already serving it.
 
     Raises :class:`ValueError` on a non-loopback ``host`` unless ``allow_remote``
     says the operator meant it. Refusing rather than warning is the point: the
     warning was printed after the socket was already open, to a terminal nobody
     reads twice, on the one decision that hands strangers a shell's worth of
     credentials.
+
+    With ``reuse`` (the default) an arena already serving this workspace is
+    reported and reused rather than duplicated. Every arena reads the same
+    on-disk match store, so a second one shows the same runs while adding a
+    port to remember, a process to kill, and a real hazard: two arenas over one
+    workspace can both drive a run. Pass ``reuse=False`` to insist on a fresh
+    bind, which then fails honestly if the port is taken.
     """
     local = is_loopback(host)
     if not local and not allow_remote:
@@ -920,6 +979,28 @@ def serve(
             "launch runs with your provider credentials. Pass --allow-remote if "
             "that is genuinely what you want."
         )
+    if reuse:
+        # The requested port first: asking for one that already serves this
+        # workspace is the common case, and it should attach rather than raise
+        # "address already in use" at a caller who wanted exactly that arena.
+        existing = find_running_arena(
+            workspace, host, ports=(port, *ARENA_DISCOVERY_PORTS)
+        )
+        if existing is not None:
+            url = f"http://{host}:{existing}/"
+            print(f"\n  arenabench  ->  {url}  (already serving this workspace)")
+            print(f"  workspace   ->  {workspace}")
+            print("  reusing it instead of starting a second arena over the same")
+            print("  match store; pass --no-reuse to force a new one.\n")
+            if open_browser:
+                __import__("webbrowser").open(url)
+            return
+        occupant = probe_arena(host, port)
+        if occupant is not None:
+            raise ValueError(
+                f"port {port} already serves a different arena "
+                f"(workspace {occupant}); choose another --port"
+            )
     arena = ArenaServer(workspace, registry)
     handler = _handler_factory(arena, allowed_hosts(host, port) if local else None)
     httpd = ThreadingHTTPServer((host, port), handler)

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -212,6 +212,13 @@ class ArenaServer:
         # History first: finished matches on disk are listed before any new
         # one starts, so a restart never erases what the workspace remembers.
         self.runner.restore_from_disk()
+        #: When the disk sweep above last ran. `restore_from_disk` used to run
+        #: only here, so an arena never saw a match another process created
+        #: after it booted — and `arenabench run` is a separate process. The
+        #: only way to watch a new run was therefore to start another arena,
+        #: which is how one machine ended up with six of them over one
+        #: workspace. See `_refresh_from_disk`.
+        self._last_disk_sweep: float = time.monotonic()
         self.recorder_status: tuple[bool, str] = (False, "not checked")
         #: Owns SUT builds. One per server so a build survives the request
         #: that started it and can be polled from any later one.
@@ -393,7 +400,31 @@ class ArenaServer:
         """
         return series_payload(list(self.runner.matches.values()))
 
+    #: Shortest gap between disk sweeps driven by a request. The listing is
+    #: polled by every open browser tab, and the sweep stats every match
+    #: directory, so it is throttled rather than run per request. Two seconds
+    #: is below the UI's own refresh cadence, so a match still appears in the
+    #: list about as fast as it appears on disk.
+    DISK_SWEEP_INTERVAL_SECONDS = 2.0
+
+    def _refresh_from_disk(self) -> None:
+        """Pick up matches other processes created since the last sweep.
+
+        `arenabench run` writes its match into the same workspace from its own
+        process. Without this, only matches present when the arena booted were
+        ever listed, and the fix people reached for was another arena.
+        """
+        now = time.monotonic()
+        if now - self._last_disk_sweep < self.DISK_SWEEP_INTERVAL_SECONDS:
+            return
+        self._last_disk_sweep = now
+        try:
+            self.runner.restore_from_disk()
+        except Exception:  # a listing must survive one unreadable match dir
+            log.exception("disk sweep failed while listing matches")
+
     def list_matches(self) -> Any:
+        self._refresh_from_disk()
         return {
             "matches": [
                 {
@@ -415,6 +446,13 @@ class ArenaServer:
 
     def match(self, match_id: str) -> Any:
         match = self.runner.matches.get(match_id)
+        if match is None:
+            # Only on a miss, and only then: someone opening a link to a match
+            # this arena has not swept yet should get the match, not a 404 that
+            # sends them off to start another arena.
+            self._last_disk_sweep = 0.0
+            self._refresh_from_disk()
+            match = self.runner.matches.get(match_id)
         if match is None:
             raise KeyError(match_id)
         return match.snapshot()

--- a/arenabench/tests/test_security.py
+++ b/arenabench/tests/test_security.py
@@ -186,6 +186,92 @@ class TestLoopbackOnly:
             server_module.ThreadingHTTPServer = original  # type: ignore[misc]
         assert stop.is_set()
 
+    def test_an_arena_already_serving_this_workspace_is_reused_not_duplicated(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """A second arena over one workspace is a hazard, not a convenience.
+
+        Every arena reads the same on-disk match store, so duplicates show the
+        same runs while adding a port to remember, a process to kill, and two
+        servers able to drive one run. Left unchecked this produced six arenas
+        on one machine over one workspace. Witness: without the reuse probe,
+        `serve` binds a second socket and never prints the running arena's URL.
+        """
+        from arenabench import server as server_module
+
+        bound: list[int] = []
+
+        class _ShouldNotBind:
+            def __init__(self, addr, _handler):
+                bound.append(addr[1])
+                self.daemon_threads = False
+
+        monkeypatch.setattr(
+            server_module, "ThreadingHTTPServer", _ShouldNotBind, raising=True
+        )
+        # An arena is already up on 8902 over this very workspace.
+        monkeypatch.setattr(
+            server_module,
+            "probe_arena",
+            lambda host, port, **kw: str(tmp_path) if port == 8902 else None,
+            raising=True,
+        )
+
+        serve(tmp_path, host="127.0.0.1", port=8902)
+
+        assert bound == [], "reuse must not open a second socket"
+        out = capsys.readouterr().out
+        assert "http://127.0.0.1:8902/" in out
+        assert "--no-reuse" in out, "the escape hatch has to be discoverable"
+
+    def test_no_reuse_still_starts_a_fresh_arena(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The escape hatch stays honest: asked for a new one, bind a new one."""
+        from arenabench import server as server_module
+
+        bound: list[int] = []
+
+        class _Server:
+            def __init__(self, addr, _handler):
+                bound.append(addr[1])
+                self.daemon_threads = False
+
+            def serve_forever(self):
+                raise KeyboardInterrupt
+
+            def shutdown(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        monkeypatch.setattr(
+            server_module, "ThreadingHTTPServer", _Server, raising=True
+        )
+        monkeypatch.setattr(
+            server_module, "probe_arena", lambda *a, **k: str(tmp_path), raising=True
+        )
+
+        serve(tmp_path, host="127.0.0.1", port=8902, reuse=False)
+
+        assert bound == [8902]
+
+    def test_a_port_held_by_a_different_workspaces_arena_is_refused(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Two workspaces are two experiments; sharing a port would conflate them."""
+        from arenabench import server as server_module
+
+        monkeypatch.setattr(
+            server_module,
+            "probe_arena",
+            lambda host, port, **kw: "/somewhere/else",
+            raising=True,
+        )
+        with pytest.raises(ValueError, match="different arena"):
+            serve(tmp_path, host="127.0.0.1", port=8902)
+
     def test_only_the_bound_address_is_an_acceptable_host_header(self):
         hosts = allowed_hosts("127.0.0.1", 8900)
         assert "127.0.0.1:8900" in hosts and "localhost:8900" in hosts

--- a/arenabench/tests/test_security.py
+++ b/arenabench/tests/test_security.py
@@ -272,6 +272,48 @@ class TestLoopbackOnly:
         with pytest.raises(ValueError, match="different arena"):
             serve(tmp_path, host="127.0.0.1", port=8902)
 
+    def test_a_running_arena_lists_a_match_another_process_wrote(
+        self, tmp_path: Path
+    ):
+        """The reason six arenas existed: only startup ever read the store.
+
+        `arenabench run` writes its match from its own process, so an arena
+        that swept the store only at boot could never list it — and the fix
+        people reached for was another arena. Reusing one is only correct if
+        the one you reuse can see the run. Witness: without the sweep the
+        listing stays empty and the direct lookup 404s.
+        """
+        import json as _json
+
+        from arenabench.server import ArenaServer
+
+        arena = ArenaServer(tmp_path)
+        assert arena.list_matches()["matches"] == []
+
+        # Another process lands a match in the same workspace.
+        match_dir = tmp_path / "matches" / "abc123"
+        (match_dir / "jobs").mkdir(parents=True)
+        (match_dir / "spec.json").write_text(
+            _json.dumps(
+                {
+                    "id": "abc123",
+                    "name": "written by another process",
+                    "dataset": "terminal-bench-2.1",
+                    "tasks": ["fix-git"],
+                    "contestants": [
+                        {"name": "s", "agent": "stella", "engine": {"model": "m"}}
+                    ],
+                }
+            )
+        )
+
+        arena._last_disk_sweep = 0.0  # skip the poll throttle, not the sweep
+        listed = [m["id"] for m in arena.list_matches()["matches"]]
+        assert "abc123" in listed
+        # And the direct lookup resolves rather than 404ing someone off to
+        # start yet another arena.
+        assert isinstance(arena.match("abc123"), dict)
+
     def test_only_the_bound_address_is_an_acceptable_host_header(self):
         hosts = allowed_hosts("127.0.0.1", 8900)
         assert "127.0.0.1:8900" in hosts and "localhost:8900" in hosts


### PR DESCRIPTION
## What

Two fixes to how `arenabench serve` finds an arena, split out of #2308 where they had ridden along undeclared. They are one change in two halves — the second is what makes the first correct — and they touch nothing the bare-loop arm touches.

**Reuse instead of duplicate.** `serve` bound a socket without ever asking whether an arena was already up, so every session that hit "address in use" and tried the next number left another one running. On this machine that reached **six** arenas — 8181, 8900, 8901, 8902, 8917, 8933 — all serving the identical workspace, none aware of the others.

That is a hazard, not clutter. Every arena reads the same on-disk match store, so a duplicate shows the same runs while adding a port to remember, a process to kill, and two servers both able to drive one run.

`serve` now probes `/api/health` — which already reported `{ok, workspace}` and needed no new endpoint — before binding:

- an arena serving **this** workspace, on the requested port or anywhere in a small bounded window: print its URL and reuse it;
- an arena serving a **different** workspace on the requested port: refuse, since two workspaces are two experiments and sharing a port would conflate them;
- nothing listening: bind as before.

**A running arena must see matches other processes wrote.** `restore_from_disk` ran exactly once, in `ArenaServer.__init__`, so an arena listed only what existed when it booted. `arenabench run` writes its match from its own process, so a run started *after* the arena was invisible to it — and the fix everyone reached for was to start another arena, which swept the store on its way up and could see the new match. Six times.

That is also why reuse alone is not enough: attaching to an arena that cannot see your run is worse than starting a new one. Both halves are needed for either to be right.

## Shape, and the parts worth arguing about

- **The discovery window.** `ARENA_DISCOVERY_PORTS` is a small bounded set of loopback ports, probed with a short timeout. It opens outbound connections to `127.0.0.1` only, and only to ports this tool itself binds. The probe collapses every not-an-arena case to `None` — nothing listening, a foreign service, a wedged arena — because the caller's next move is identical for all of them and a taxonomy there would only be a taxonomy of guesses.
- **`serve`'s default changes from bind to attach.** This is the deliberate behaviour change and the reason the split was asked for. `--no-reuse` forces a fresh arena, and then a taken port fails honestly rather than silently walking to the next number.
- **The sweep is throttled, not per-request.** The listing is polled by every open tab and the sweep stats each match directory, so it runs at most once every two seconds — below the UI's own refresh cadence, so a match appears in the list about as fast as it appears on disk. A single-match lookup sweeps too, but only on a miss: opening a link to a match this arena has not swept yet should return the match, not a 404 that sends the reader off to start another server.
- **A failed sweep is logged and swallowed.** One unreadable match directory must not take down the listing, which is the only view of every *other* match.
- `run` gains a `watch:` line naming the arena already serving the workspace, or telling you to start one. It stays headless and starts nothing: it just knows the match id, and "where do I watch this" was the question previously answered by starting another arena and forgetting the port.

## Witness tests

- `test_a_running_arena_lists_a_match_another_process_wrote` — an arena boots over an empty workspace, another process lands a match in it, and without the sweep the listing stays empty and the direct lookup raises.
- The reuse tests cover all three probe outcomes, including the refusal when the port is held by an arena serving a *different* workspace.

## Verification

`arenabench`: full suite green on this branch against current `main` (541 passed). The six reuse/discovery tests pass by name. No tests deleted.

## Provenance

Cherry-picked unchanged from #2308 (`a81a674a`, `5fafd62d`) onto current `main`, where they belong under their own title — roughly half that PR's diff was this feature, named nowhere in its description.

Refs #2308

## Summary by Sourcery

Reuse existing arenas already serving a workspace instead of starting duplicates, and ensure a running arena sees matches written after it started.

New Features:
- Add discovery of running arenas via /api/health to allow arenabench serve to attach to an existing arena for the same workspace by default.
- Expose a --no-reuse flag so operators can force creation of a fresh arena even when one is already serving the workspace.
- Print a watch URL or guidance from arenabench run pointing to an existing arena for the match being started.

Bug Fixes:
- Ensure ArenaServer periodically reloads matches from disk so matches created by other processes are listed and can be fetched by id instead of returning 404.
- Prevent arenabench serve from silently creating multiple arenas for the same workspace when the requested port is already in use, and refuse ports occupied by arenas for different workspaces.

Enhancements:
- Throttle disk sweeps to a short interval to avoid per-request filesystem scans while keeping the UI listing responsive.
- Add logic for on-demand disk refresh when looking up a single match id that is not yet in memory.

Tests:
- Add tests covering arena reuse behavior, the --no-reuse escape hatch, refusal when a port serves a different workspace, and visibility of matches written by another process.