### PR TITLE
fix(records): the budget drops the least important record — force, then precedence (#2299)

### DIFF
--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -637,12 +637,18 @@ fn default_basis(kind: RecordKind) -> TruthBasis {
 }
 
 /// The precedence a force implies, so conflicting records order deterministically.
+///
+/// Monotonic with [`Force::strength`], and a test pins that: `may` used to be
+/// stamped *below* `info` here, which read as "an informational note outranks a
+/// relevant one" everywhere precedence is consulted — silently, because the only
+/// consumer at the time was conflict detection, which asks whether two
+/// precedences are equal and never which is larger.
 fn precedence_for(force: Force) -> u32 {
     match force {
         Force::Must => 100,
         Force::Should => 40,
-        Force::Info => 20,
-        Force::May => 15,
+        Force::May => 20,
+        Force::Info => 15,
     }
 }
 

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -456,3 +456,32 @@ fn a_built_proposal_serializes_to_the_toml_surface() {
     assert_eq!(parsed.schema, stella_core::ingest::SCHEMA_TAG);
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn the_stamped_precedence_agrees_with_the_force_it_came_from() {
+    // Derived from the force ordering rather than pinned as a table, because a
+    // table is how this inverted in the first place: `may` was stamped 15 and
+    // `info` 20, and any test asserting those literals would have agreed with
+    // the bug. Stated as a property, the next edit that disagrees with
+    // `Force::strength` fails here instead of quietly re-ranking what the
+    // volatile channel's budget drops.
+    let strongest_first = [Force::Must, Force::Should, Force::May, Force::Info];
+    let mut sorted = strongest_first;
+    sorted.sort_by_key(|force| std::cmp::Reverse(force.strength()));
+    assert_eq!(
+        sorted, strongest_first,
+        "this fixture must list every force, strongest first"
+    );
+    for pair in strongest_first.windows(2) {
+        let (stronger, weaker) = (pair[0], pair[1]);
+        assert!(
+            precedence_for(stronger) > precedence_for(weaker),
+            "`{}` implies precedence {} but the weaker `{}` implies {} — a stronger \
+             force must never imply a lower precedence",
+            stronger.as_str(),
+            precedence_for(stronger),
+            weaker.as_str(),
+            precedence_for(weaker),
+        );
+    }
+}

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -653,6 +653,31 @@ impl Force {
     pub fn is_always_injected(self) -> bool {
         matches!(self, Self::Must | Self::Should)
     }
+
+    /// How strongly this force steers, as a rank: higher outranks lower.
+    ///
+    /// Spelled out rather than derived from the declaration order, even though
+    /// the variants happen to be declared strongest-first. A `derive(Ord)` here
+    /// would read *backwards* — `Must < Info` — and the one consumer that needs
+    /// this is a budget deciding which record to drop, where an inverted
+    /// comparison silently keeps the wrong one. The numbers are gaps, not
+    /// addresses: nothing may depend on their absolute values.
+    ///
+    /// Used by [`records::render`][r] to rank scarcity. The cached channel gets
+    /// the same ordering for free by grouping `must` before `should`, so this
+    /// exists to give the **volatile** channel the guarantee its sibling had
+    /// structurally — `may` outranks `info` there whatever precedence either one
+    /// declared.
+    ///
+    /// [r]: super::super::records::render
+    pub fn strength(self) -> u8 {
+        match self {
+            Self::Must => 3,
+            Self::Should => 2,
+            Self::May => 1,
+            Self::Info => 0,
+        }
+    }
 }
 
 /// How a violation is enforced.

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -323,6 +323,27 @@ impl Record {
     pub fn on_expiry(&self) -> Option<&str> {
         self.truth.as_ref()?.on_expiry.as_deref()
     }
+
+    /// This record's declared [`Steering::precedence`], or `0` when it declared
+    /// none.
+    ///
+    /// The default is the floor rather than a midpoint on purpose: an
+    /// undeclared precedence is an author who did not make a claim, and the
+    /// two consumers — conflict detection ([`records::validate`][v]) and the
+    /// budget's drop order ([`records::render`][r]) — must read that silence
+    /// the same way. It lives here because it did not: the accessor existed
+    /// privately in `validate`, so the second consumer would otherwise have
+    /// spelled the default a second time, and a default in two places is one
+    /// edit away from two different answers to "which record wins".
+    ///
+    /// [v]: super::super::records::validate
+    /// [r]: super::super::records::render
+    pub fn precedence(&self) -> u32 {
+        self.steering
+            .as_ref()
+            .and_then(|steering| steering.precedence)
+            .unwrap_or(0)
+    }
 }
 
 /// Normalize a lineage id into the id-body slug (`ctx.acme.web.pkg-manager` →
@@ -349,7 +370,26 @@ fn slug(lineage_id: &str) -> String {
 pub struct Steering {
     /// The steering force / injection channel.
     pub force: Force,
-    /// Tie-break precedence when two records conflict (higher wins).
+    /// Which record wins when two of them cannot both have their way (higher
+    /// wins). Absent means `0` — see [`Record::precedence`][p].
+    ///
+    /// Two situations ask that question, and both read this field:
+    ///
+    /// - **A conflict.** Two records matching the same paths with different
+    ///   enforcement. A difference here is the designed resolution, so
+    ///   [`records::validate`][v] reports the overlap only at *equal*
+    ///   precedence.
+    /// - **Scarcity.** More applicable records than the channel budget fits.
+    ///   [`records::render`][r] drops ascending-precedence first, so the least
+    ///   important record is the one that loses its place.
+    ///
+    /// It ranks nothing outside those two: with budget to spare every selected
+    /// record renders, in the order it was given, exactly as if this field were
+    /// absent.
+    ///
+    /// [p]: Record::precedence
+    /// [v]: super::super::records::validate
+    /// [r]: super::super::records::render
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub precedence: Option<u32>,
     /// When the record applies. Drives per-turn selection on the volatile

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -38,6 +38,16 @@
 //! [`MissingContextKind::NotRendered`][nr], and it can only be recorded by whoever
 //! did the dropping.
 //!
+//! # Order and scarcity are two questions
+//!
+//! Records render in the order the caller gave them, which for the cached channel
+//! must not vary across turns. *Which* records render is asked only when a budget
+//! binds, and answered by declared precedence rather than by position — a record
+//! is not worth less for having loaded later. [`survivors`] resolves that ahead of
+//! rendering, so the two answers cannot drift into each other; with budget to
+//! spare it admits everything and the block is byte-for-byte what load order alone
+//! would have produced.
+//!
 //! [cited]: super::super::context_record::context_use::ContextUseKind::Cited
 //! [nr]: super::super::context_record::context_use::MissingContextKind
 
@@ -98,6 +108,8 @@ pub struct RenderedChannel {
     pub rendered: Vec<String>,
     /// Handles the budget dropped after selection. These are `selected` but **not**
     /// `rendered` — the silent gap `MissingContextKind::NotRendered` names.
+    ///
+    /// Chosen by ascending precedence, not by position: see [`survivors`].
     pub dropped: Vec<String>,
 }
 
@@ -143,6 +155,12 @@ fn effective_force(record: &LoadedRecord, disposition: &Disposition) -> Force {
 /// Records are emitted in the order given. The caller controls that order, and for
 /// the cached channel it must be stable across turns (see [`super::assign_handles`]
 /// on why handles do not depend on load order).
+///
+/// **Which records are emitted is a separate question from their order**, and the
+/// budget is the only thing that ever asks it — see [`survivors`]. With budget to
+/// spare the two questions collapse and every record renders where it was given;
+/// under pressure the least important record loses its place rather than the
+/// last-loaded one.
 pub fn render_channel(
     inputs: &[RenderInput<'_>],
     channel: Channel,
@@ -168,28 +186,38 @@ pub fn render_channel(
 }
 
 /// `## Workspace rules`, grouped `### Must` then `### Should`.
+///
+/// Force outranks precedence here, and the grouping is what makes that true: the
+/// `must` section is laid out first and so meets the budget first, leaving
+/// `should` to compete for the remainder. Precedence then ranks within a group,
+/// which is the only place it has anything left to decide.
 fn render_cached(inputs: &[&RenderInput<'_>], budget_chars: Option<usize>) -> RenderedChannel {
     let mut out = RenderedChannel {
         text: CACHED_HEADING.to_string(),
         ..RenderedChannel::default()
     };
     for (force, heading) in [(Force::Must, "### Must"), (Force::Should, "### Should")] {
-        let group: Vec<&&RenderInput<'_>> = inputs
+        let group: Vec<&RenderInput<'_>> = inputs
             .iter()
+            .copied()
             .filter(|input| effective_force(input.record, input.disposition) == force)
             .collect();
         if group.is_empty() {
             continue;
         }
         let mut section = format!("\n\n{heading}");
+        let lines = bullet_lines(&group);
+        // The heading counts against the budget whether or not the section is
+        // ultimately written — a group that fits nothing has already been
+        // charged for it, which is the conservative direction.
+        let keep = survivors(&group, &lines, out.text.len() + section.len(), budget_chars);
         let mut wrote_any = false;
-        for input in group {
-            let line = format!("\n{}", bullet(input));
-            if over_budget(&out.text, &section, &line, budget_chars) {
+        for ((input, line), keep) in group.iter().zip(&lines).zip(keep) {
+            if !keep {
                 out.dropped.push(input.record.handle.clone());
                 continue;
             }
-            section.push_str(&line);
+            section.push_str(line);
             out.rendered.push(input.record.handle.clone());
             wrote_any = true;
         }
@@ -214,13 +242,14 @@ fn render_volatile(inputs: &[&RenderInput<'_>], budget_chars: Option<usize>) -> 
         ..RenderedChannel::default()
     };
     let header_len = out.text.len();
-    for input in inputs {
-        let line = format!("\n{}", bullet(input));
-        if over_budget(&out.text, "", &line, budget_chars) {
+    let lines = bullet_lines(inputs);
+    let keep = survivors(inputs, &lines, header_len, budget_chars);
+    for ((input, line), keep) in inputs.iter().zip(&lines).zip(keep) {
+        if !keep {
             out.dropped.push(input.record.handle.clone());
             continue;
         }
-        out.text.push_str(&line);
+        out.text.push_str(line);
         out.rendered.push(input.record.handle.clone());
     }
     if out.text.len() == header_len {
@@ -242,9 +271,69 @@ fn bullet(input: &RenderInput<'_>) -> String {
     format!("- {statement} ^{}{suffix}", input.record.handle)
 }
 
-/// Whether appending `line` would exceed the channel budget.
-fn over_budget(text: &str, pending: &str, line: &str, budget_chars: Option<usize>) -> bool {
-    budget_chars.is_some_and(|budget| text.len() + pending.len() + line.len() > budget)
+/// The rendered line for each input, in the order given.
+///
+/// Materialized up front because [`survivors`] has to weigh the lines in one
+/// order and the caller emits them in another; formatting twice would be the
+/// kind of duplication that lets the two orders disagree about a record's size.
+fn bullet_lines(inputs: &[&RenderInput<'_>]) -> Vec<String> {
+    inputs
+        .iter()
+        .map(|input| format!("\n{}", bullet(input)))
+        .collect()
+}
+
+/// Which records fit, decided by precedence — the answer parallel to `inputs`.
+///
+/// # Why this is not just the emit loop with a length check
+///
+/// It used to be, and that made the budget's victim a function of **load
+/// order**: the first-loaded records took the space and whatever came last was
+/// ledgered as `dropped`, so a `precedence = 80` record could lose its place to
+/// a `precedence = 40` one from an earlier file (#2299). The drop was honest —
+/// [`RenderedChannel::dropped`] recorded it — and still wrong, because nothing
+/// about arriving later makes a record worth less.
+///
+/// So scarcity is resolved here, ahead of and apart from rendering, in
+/// descending precedence. The sort is **stable**, so records that made no
+/// competing claim (equal precedence — including the `0` that
+/// [`Record::precedence`][p] gives the ones that declared none) keep load order
+/// and the block stays deterministic. The caller then emits the survivors in the
+/// order it was given: precedence settles *who*, never *where*, which is the
+/// same split `pack_to_budget` draws in `stella-context` — a band decides
+/// nothing until something has to be dropped.
+///
+/// A record too long for the space left is skipped rather than terminal: the
+/// walk continues, so a lower-precedence record still renders when the only
+/// thing outranking it could never have fit. That keeps the budget from being
+/// spent on nothing, and the skipped record is ledgered like any other drop.
+///
+/// [p]: super::super::ingest::record::Record::precedence
+fn survivors(
+    inputs: &[&RenderInput<'_>],
+    lines: &[String],
+    spent: usize,
+    budget_chars: Option<usize>,
+) -> Vec<bool> {
+    let Some(budget) = budget_chars else {
+        return vec![true; inputs.len()];
+    };
+    let mut by_precedence: Vec<usize> = (0..inputs.len()).collect();
+    by_precedence.sort_by_key(|&i| std::cmp::Reverse(inputs[i].record.record.precedence()));
+
+    let mut keep = vec![false; inputs.len()];
+    let mut used = spent;
+    for i in by_precedence {
+        let Some(after) = used
+            .checked_add(lines[i].len())
+            .filter(|len| *len <= budget)
+        else {
+            continue;
+        };
+        used = after;
+        keep[i] = true;
+    }
+    keep
 }
 
 #[cfg(test)]
@@ -277,6 +366,43 @@ mod tests {
         let mut loaded = loaded_from(record);
         loaded.handle = lineage.rsplit('.').next().unwrap_or(lineage).to_string();
         loaded
+    }
+
+    /// [`at`] with a declared precedence — the claim that decides who survives a
+    /// budget. `at` leaves every record at the builder's default, so the tests
+    /// above exercise the equal-precedence path and must be unaffected by any of
+    /// this.
+    fn ranked(force: Force, lineage: &str, statement: &str, precedence: u32) -> LoadedRecord {
+        let mut loaded = at(force, lineage, statement);
+        loaded
+            .record
+            .steering
+            .as_mut()
+            .expect("`at` builds every record with a steering block")
+            .precedence = Some(precedence);
+        loaded
+    }
+
+    /// Three same-length bullets, so a budget expressed in characters admits a
+    /// count rather than a particular record, and the tests never hardcode a
+    /// byte total.
+    fn three_equal_length() -> (LoadedRecord, LoadedRecord, LoadedRecord) {
+        (
+            ranked(Force::Info, "ctx.a.b.aa", "Alpha statement.", 10),
+            ranked(Force::Info, "ctx.a.b.bb", "Bravo statement.", 50),
+            ranked(Force::Info, "ctx.a.b.cc", "Cocoa statement.", 90),
+        )
+    }
+
+    /// The budget that fits exactly `n` of the same-length bullets.
+    fn budget_for(n: usize, records: &[&LoadedRecord]) -> usize {
+        let select = Disposition::Select;
+        let inputs: Vec<RenderInput<'_>> = records
+            .iter()
+            .take(n)
+            .map(|record| input(record, &select))
+            .collect();
+        render_channel(&inputs, Channel::Volatile, None).text.len()
     }
 
     #[test]
@@ -485,6 +611,180 @@ mod tests {
             "a record the budget dropped is `selected` but not `rendered` — the ledger \
              cannot tell those apart unless the renderer says so"
         );
+    }
+
+    // Who the budget drops (#2299). Precedence answers that and nothing else —
+    // the order records render in is still the order they were given.
+
+    #[test]
+    fn the_budget_drops_the_least_important_record_not_the_last_one() {
+        // The shape from the field: the weaker claim loads first and used to
+        // take the space on that alone.
+        let weak = ranked(Force::Info, "ctx.a.b.weak", "Weaker claim.", 40);
+        let strong = ranked(Force::Info, "ctx.a.b.strong", "Stronger claim.", 80);
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[input(&weak, &select), input(&strong, &select)],
+            Channel::Volatile,
+            Some(budget_for(1, &[&strong])),
+        );
+        assert_eq!(out.rendered, vec!["strong"]);
+        assert_eq!(
+            out.dropped,
+            vec!["weak"],
+            "arriving earlier is not a reason to outrank a record that declared \
+             itself more important"
+        );
+    }
+
+    #[test]
+    fn survivors_render_in_load_order_not_in_precedence_order() {
+        // Load order and precedence order disagree about the two survivors, so
+        // this fails if selection is allowed to leak into layout.
+        let (low, mid, high) = three_equal_length();
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[
+                input(&low, &select),
+                input(&mid, &select),
+                input(&high, &select),
+            ],
+            Channel::Volatile,
+            Some(budget_for(2, &[&low, &mid])),
+        );
+        assert_eq!(
+            out.rendered,
+            vec!["bb", "cc"],
+            "precedence chose the survivors; the caller's order places them"
+        );
+        assert_eq!(out.dropped, vec!["aa"]);
+    }
+
+    #[test]
+    fn an_unbudgeted_block_is_byte_identical_whatever_the_precedences() {
+        // The claim that makes this change safe to ship: precedence decides
+        // nothing until something has to be dropped, so a block under no
+        // pressure is what load order alone would have produced.
+        let (low, mid, high) = three_equal_length();
+        let flat = [
+            at(Force::Info, "ctx.a.b.aa", "Alpha statement."),
+            at(Force::Info, "ctx.a.b.bb", "Bravo statement."),
+            at(Force::Info, "ctx.a.b.cc", "Cocoa statement."),
+        ];
+        let select = Disposition::Select;
+        let ranked_block = render_channel(
+            &[
+                input(&low, &select),
+                input(&mid, &select),
+                input(&high, &select),
+            ],
+            Channel::Volatile,
+            None,
+        );
+        let flat_block = render_channel(
+            &[
+                input(&flat[0], &select),
+                input(&flat[1], &select),
+                input(&flat[2], &select),
+            ],
+            Channel::Volatile,
+            None,
+        );
+        assert_eq!(ranked_block, flat_block);
+    }
+
+    #[test]
+    fn equal_precedence_still_loses_in_load_order() {
+        // Records that made no competing claim must break their tie the way
+        // they always did, or the block stops being deterministic.
+        let first = at(Force::Info, "ctx.a.b.aa", "Alpha statement.");
+        let second = at(Force::Info, "ctx.a.b.bb", "Bravo statement.");
+        let third = at(Force::Info, "ctx.a.b.cc", "Cocoa statement.");
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[
+                input(&first, &select),
+                input(&second, &select),
+                input(&third, &select),
+            ],
+            Channel::Volatile,
+            Some(budget_for(2, &[&first, &second])),
+        );
+        assert_eq!(out.rendered, vec!["aa", "bb"]);
+        assert_eq!(out.dropped, vec!["cc"]);
+    }
+
+    #[test]
+    fn a_record_too_long_to_fit_does_not_starve_the_ones_that_do() {
+        // Outranking everything is not the same as fitting. The walk skips the
+        // record it cannot place and keeps going, so the budget buys context
+        // instead of being held open for something that was never going to fit.
+        let huge = ranked(
+            Force::Info,
+            "ctx.a.b.huge",
+            "A statement far too long to fit in the space this budget leaves.",
+            99,
+        );
+        let small = ranked(Force::Info, "ctx.a.b.small", "Short.", 1);
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[input(&huge, &select), input(&small, &select)],
+            Channel::Volatile,
+            Some(budget_for(1, &[&small])),
+        );
+        assert_eq!(out.rendered, vec!["small"]);
+        assert_eq!(
+            out.dropped,
+            vec!["huge"],
+            "the record that could not fit is ledgered, not silently skipped"
+        );
+    }
+
+    #[test]
+    fn the_cached_budget_drops_by_precedence_too() {
+        // The same defect lived in both renderers; fixing one would have left a
+        // must-record losing its place in the prefix for having loaded first.
+        let weak = ranked(Force::Must, "ctx.a.b.weak", "Weaker claim.", 40);
+        let strong = ranked(Force::Must, "ctx.a.b.strong", "Stronger claim.", 80);
+        let select = Disposition::Select;
+        let full = render_channel(
+            &[input(&weak, &select), input(&strong, &select)],
+            Channel::Cached,
+            None,
+        );
+        let out = render_channel(
+            &[input(&weak, &select), input(&strong, &select)],
+            Channel::Cached,
+            Some(full.text.len() - 1),
+        );
+        assert_eq!(out.rendered, vec!["strong"]);
+        assert_eq!(out.dropped, vec!["weak"]);
+    }
+
+    #[test]
+    fn force_outranks_precedence_in_the_cached_block() {
+        // Precedence ranks within a force group, never across one: `must` is
+        // the coarser statement of importance and the grouping already spends
+        // the budget on it first.
+        let should = ranked(Force::Should, "ctx.a.b.should", "Advisory claim.", 90);
+        let must = ranked(Force::Must, "ctx.a.b.must", "Binding claim.", 10);
+        let select = Disposition::Select;
+        let full = render_channel(
+            &[input(&should, &select), input(&must, &select)],
+            Channel::Cached,
+            None,
+        );
+        let out = render_channel(
+            &[input(&should, &select), input(&must, &select)],
+            Channel::Cached,
+            Some(full.text.len() - 1),
+        );
+        assert_eq!(
+            out.rendered,
+            vec!["must"],
+            "a precedence-90 advisory must not displace a binding rule"
+        );
+        assert_eq!(out.dropped, vec!["should"]);
     }
 
     #[test]

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -43,7 +43,7 @@
 //! Records render in the order the caller gave them, which for the cached channel
 //! must not vary across turns. *Which* records render is asked only when a budget
 //! binds, and answered by declared precedence rather than by position — a record
-//! is not worth less for having loaded later. [`survivors`] resolves that ahead of
+//! is not worth less for having loaded later. `survivors` resolves that ahead of
 //! rendering, so the two answers cannot drift into each other; with budget to
 //! spare it admits everything and the block is byte-for-byte what load order alone
 //! would have produced.
@@ -109,7 +109,8 @@ pub struct RenderedChannel {
     /// Handles the budget dropped after selection. These are `selected` but **not**
     /// `rendered` — the silent gap `MissingContextKind::NotRendered` names.
     ///
-    /// Chosen by ascending precedence, not by position: see [`survivors`].
+    /// Chosen by ascending precedence, not by position — the least important
+    /// record loses its place, not the last-loaded one.
     pub dropped: Vec<String>,
 }
 
@@ -157,10 +158,10 @@ fn effective_force(record: &LoadedRecord, disposition: &Disposition) -> Force {
 /// on why handles do not depend on load order).
 ///
 /// **Which records are emitted is a separate question from their order**, and the
-/// budget is the only thing that ever asks it — see [`survivors`]. With budget to
-/// spare the two questions collapse and every record renders where it was given;
-/// under pressure the least important record loses its place rather than the
-/// last-loaded one.
+/// budget is the only thing that ever asks it. With budget to spare the two
+/// questions collapse and every record renders where it was given; under pressure
+/// the record with the lowest declared `precedence` loses its place rather than
+/// the last-loaded one.
 pub fn render_channel(
     inputs: &[RenderInput<'_>],
     channel: Channel,

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -284,7 +284,7 @@ fn bullet_lines(inputs: &[&RenderInput<'_>]) -> Vec<String> {
         .collect()
 }
 
-/// Which records fit, decided by precedence — the answer parallel to `inputs`.
+/// Which records fit, ranked by importance — the answer parallel to `inputs`.
 ///
 /// # Why this is not just the emit loop with a length check
 ///
@@ -295,21 +295,40 @@ fn bullet_lines(inputs: &[&RenderInput<'_>]) -> Vec<String> {
 /// [`RenderedChannel::dropped`] recorded it — and still wrong, because nothing
 /// about arriving later makes a record worth less.
 ///
-/// So scarcity is resolved here, ahead of and apart from rendering, in
-/// descending precedence. The sort is **stable**, so records that made no
-/// competing claim (equal precedence — including the `0` that
-/// [`Record::precedence`][p] gives the ones that declared none) keep load order
-/// and the block stays deterministic. The caller then emits the survivors in the
-/// order it was given: precedence settles *who*, never *where*, which is the
-/// same split `pack_to_budget` draws in `stella-context` — a band decides
-/// nothing until something has to be dropped.
+/// So scarcity is resolved here, ahead of and apart from rendering. The caller
+/// then emits the survivors in the order it was given: importance settles *who*,
+/// never *where*, which is the same split `pack_to_budget` draws in
+/// `stella-context` — a band decides nothing until something has to be dropped.
 ///
-/// A record too long for the space left is skipped rather than terminal: the
-/// walk continues, so a lower-precedence record still renders when the only
-/// thing outranking it could never have fit. That keeps the budget from being
-/// spent on nothing, and the skipped record is ledgered like any other drop.
+/// # Importance is force, then precedence
+///
+/// **Force first** ([`Force::strength`][s]), because force is the coarser claim
+/// and a `may` record outranks an `info` one whatever numbers they declared.
+/// This is free for the cached channel, whose grouping already spends the budget
+/// on `must` before `should` — it exists for the volatile channel, which had no
+/// such guarantee and where the sole production budget actually binds. Leaving
+/// that asymmetry in place would have made the drop order hostage to every
+/// authoring path agreeing with the force ordering, and one already did not:
+/// `precedence_for` in `stella-cli`'s ingest stamped `may = 15` below
+/// `info = 20`, which was inert while precedence only fed conflict detection and
+/// would have started evicting the stronger record the moment it also ranked
+/// scarcity.
+///
+/// **Precedence within a force**, which is where an author's own ranking
+/// applies. The sort is **stable**, so records that made no competing claim
+/// (equal on both — including the `0` that [`Record::precedence`][p] gives the
+/// ones that declared none) keep load order and the block stays deterministic.
+///
+/// # A record that cannot fit is skipped, not terminal
+///
+/// The walk continues past it, so a less important record still renders in space
+/// the more important one could not have used anyway. That keeps the budget from
+/// being held open for nothing; the skipped record is ledgered like any other
+/// drop. Note this is the one case where a lower-ranked record outlives a higher-
+/// ranked one, and it is a statement about size, not about worth.
 ///
 /// [p]: super::super::ingest::record::Record::precedence
+/// [s]: super::super::ingest::record::Force::strength
 fn survivors(
     inputs: &[&RenderInput<'_>],
     lines: &[String],
@@ -319,12 +338,18 @@ fn survivors(
     let Some(budget) = budget_chars else {
         return vec![true; inputs.len()];
     };
-    let mut by_precedence: Vec<usize> = (0..inputs.len()).collect();
-    by_precedence.sort_by_key(|&i| std::cmp::Reverse(inputs[i].record.record.precedence()));
+    let mut by_importance: Vec<usize> = (0..inputs.len()).collect();
+    by_importance.sort_by_key(|&i| {
+        let input = inputs[i];
+        std::cmp::Reverse((
+            effective_force(input.record, input.disposition).strength(),
+            input.record.record.precedence(),
+        ))
+    });
 
     let mut keep = vec![false; inputs.len()];
     let mut used = spent;
-    for i in by_precedence {
+    for i in by_importance {
         let Some(after) = used
             .checked_add(lines[i].len())
             .filter(|len| *len <= budget)
@@ -760,6 +785,73 @@ mod tests {
         );
         assert_eq!(out.rendered, vec!["strong"]);
         assert_eq!(out.dropped, vec!["weak"]);
+    }
+
+    #[test]
+    fn force_outranks_precedence_in_the_volatile_block_too() {
+        // The cached channel gets this from its grouping; the volatile channel
+        // has no grouping, so it has to be ranked in. These are the exact
+        // numbers `precedence_for` stamped on extracted records — `may` below
+        // `info` — which is what makes force-first a guarantee rather than a
+        // hope that every authoring path agrees with the force ordering.
+        let trivia = ranked(Force::Info, "ctx.a.b.trivia", "Informational.", 20);
+        let actionable = ranked(Force::May, "ctx.a.b.actionable", "Do the thing.", 15);
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[input(&trivia, &select), input(&actionable, &select)],
+            Channel::Volatile,
+            Some(budget_for(1, &[&actionable])),
+        );
+        assert_eq!(
+            out.rendered,
+            vec!["actionable"],
+            "a `may` record must outrank an `info` one whatever precedence each declared"
+        );
+        assert_eq!(out.dropped, vec!["trivia"]);
+    }
+
+    #[test]
+    fn a_demoted_record_competes_at_the_force_it_renders_under() {
+        // A demoted `must` renders as `may`, so it must rank as `may` — reading
+        // the declared force here would let it outrank the volatile channel's
+        // own records on a claim the sweep already took away from it.
+        let demoted = ranked(Force::Must, "ctx.a.b.demoted", "Was binding.", 10);
+        let native = ranked(Force::May, "ctx.a.b.native", "Still relevant.", 90);
+        let stale = Disposition::SelectStale {
+            reason: "its truth probe no longer holds".to_string(),
+        };
+        let select = Disposition::Select;
+        let out = render_channel(
+            &[input(&demoted, &stale), input(&native, &select)],
+            Channel::Volatile,
+            Some(budget_for(1, &[&native])),
+        );
+        assert_eq!(
+            out.rendered,
+            vec!["native"],
+            "a demoted record ranks at its effective force, not its declared one"
+        );
+        assert_eq!(out.dropped, vec!["demoted"]);
+    }
+
+    #[test]
+    fn a_budget_nothing_reaches_changes_nothing() {
+        // The unbudgeted test proves `None` is inert; this proves a `Some` large
+        // enough to bind on nothing is inert too. Those are different code paths
+        // — `None` short-circuits, a generous `Some` walks the whole ranking —
+        // and only the second one is what production actually passes.
+        let (low, mid, high) = three_equal_length();
+        let select = Disposition::Select;
+        let inputs = [
+            input(&low, &select),
+            input(&mid, &select),
+            input(&high, &select),
+        ];
+        let unbudgeted = render_channel(&inputs, Channel::Volatile, None);
+        let generous = render_channel(&inputs, Channel::Volatile, Some(usize::MAX));
+        assert_eq!(generous, unbudgeted);
+        assert_eq!(generous.rendered, vec!["aa", "bb", "cc"]);
+        assert!(generous.dropped.is_empty());
     }
 
     #[test]

--- a/crates/stella-core/src/records/tests.rs
+++ b/crates/stella-core/src/records/tests.rs
@@ -580,8 +580,9 @@ applies_to = { paths = [".git/*"], keywords = ["fsck", "reflog"] }
 
         // Render order is load order by contract ("records are emitted in the
         // order given" — render.rs), so this asserts the exact set in that
-        // order; precedence is a conflict tiebreaker, not a ranking. That the
-        // budget also drops in load order rather than by precedence is #2299.
+        // order. Precedence ranks nothing here: it decides which records
+        // survive a budget, and this render is unbudgeted, so the
+        // precedence-40 record still precedes the precedence-80 one.
         assert_eq!(
             rendered.rendered,
             vec!["mtime-not-recency", "reflog-first"],
@@ -681,6 +682,23 @@ applies_to = { paths = [".git/*"], keywords = ["fsck", "reflog"] }
         assert!(
             !squeezed.dropped.is_empty(),
             "the budget dropped a record and the ledger must say so"
+        );
+
+        // Honesty is not enough: the ledger can be truthful about a victim the
+        // budget had no business choosing. The two records are within a byte of
+        // each other in length, so a budget one byte short of the block fits
+        // exactly one — and precedence, not load order, must say which. The
+        // precedence-40 record loads first and used to win on that alone (#2299).
+        assert_eq!(
+            squeezed.rendered,
+            vec!["reflog-first".to_string()],
+            "the surviving record must be the higher-precedence one"
+        );
+        assert_eq!(
+            squeezed.dropped,
+            vec!["mtime-not-recency".to_string()],
+            "a precedence-80 record lost its place to a precedence-40 one that \
+             merely loaded earlier"
         );
     }
 

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -269,7 +269,7 @@ fn find_conflicts(records: &[LoadedRecord]) -> Vec<Conflict> {
 }
 
 fn conflict_between(left: &LoadedRecord, right: &LoadedRecord) -> Option<Conflict> {
-    if precedence_of(&left.record) != precedence_of(&right.record) {
+    if left.record.precedence() != right.record.precedence() {
         // Different precedence is the *designed* way to express which record wins;
         // there is nothing to resolve.
         return None;
@@ -296,7 +296,7 @@ fn conflict_between(left: &LoadedRecord, right: &LoadedRecord) -> Option<Conflic
              exclusion, a different precedence, or a supersession link",
             left_mode.as_str(),
             right_mode.as_str(),
-            precedence_of(&left.record),
+            left.record.precedence(),
         ),
         suspended: suspended.clone(),
     })
@@ -307,14 +307,6 @@ fn applies_to(record: &Record) -> Option<&AppliesTo> {
         .steering
         .as_ref()
         .and_then(|steering| steering.applies_to.as_ref())
-}
-
-fn precedence_of(record: &Record) -> u32 {
-    record
-        .steering
-        .as_ref()
-        .and_then(|steering| steering.precedence)
-        .unwrap_or(0)
 }
 
 fn mode_of(record: &Record) -> EnforcementMode {


### PR DESCRIPTION
## What & why

`render_channel` resolved budget pressure inside the emit loop, so the records
that fit were simply the ones that came first. A `precedence = 80` record could
be ledgered as `dropped` while a `precedence = 40` one from an earlier file took
its place. The drop was *honest* (`RenderedChannel::dropped` recorded it, which
is how the four-class certification in #2306 found this) and still wrong:
arriving later is not a reason to be worth less.

**Scarcity now resolves in `survivors`, ahead of and apart from rendering.**
Order and membership become two questions with two answers:

| Question | Answered by |
|---|---|
| *Which* records render, when a budget binds | force, then precedence |
| *Where* they render | the caller's order, exactly as before |

That split is the one `pack_to_budget` already draws in `stella-context`, and
the exemplar this follows:

- `crates/stella-cli/src/contextgraph.rs:797` — *"Selection is finished; how the
  survivors **render** must now be free of score and cost."*
- `crates/stella-context/src/retrieval/ranking.rs:293` — *"a band is not a
  score… the tier decides nothing until something has to be dropped."*

The sort is **stable**, so records that made no competing claim keep load order.
With budget to spare the block is byte-for-byte what load order alone produced,
pinned by two tests (`None` short-circuits; a generous `Some` walks the whole
ranking — different paths, and only the second is what production passes).

Closes #2299

## Importance is force, then precedence — and why that is not scope creep

The first version of this PR ranked by precedence alone. **Adversarial review
found that it armed a latent inversion rather than closing it**, and the second
commit fixes that. The finding is worth stating plainly because it changes what
this PR is:

The **cached** channel gets "force outranks precedence" *structurally* — it
groups `must` before `should`, so the stronger force meets the budget first. The
**volatile** channel has no grouping, so under precedence-only ranking a `may`
and an `info` record competed on their declared numbers alone. And one authoring
path had those numbers backwards: `precedence_for`
(`crates/stella-cli/src/ingest_cmd/extract.rs:640`) stamped `may = 15` beneath
`info = 20`.

That inversion was **inert before this PR** — precedence only fed conflict
detection, which asks whether two values are *equal* and never which is larger.
Ranking scarcity by precedence would have made it live, on the one production
path where a budget actually binds (`RECORD_CHANNEL_BUDGET = 2_000`,
`crates/stella-cli/src/memory/recall.rs:84`): an extracted corpus over budget
would have dropped the actionable `may` record and kept the `info` trivia.

This is the repo's boundary-parity shape — two sides of one renderer and nothing
checking they agreed — so it is fixed as a class rather than as an instance:

- **`survivors` ranks `(Force::strength, precedence)`.** A no-op for the cached
  channel (force is constant within a group); for the volatile channel it makes
  the sibling's structural guarantee explicit. It ranks the **effective** force,
  so a demoted `must` competes as the `may` it renders as, not the `must` the
  sweep already took away from it.
- **`Force::strength` spells the order out** rather than deriving it from
  declaration order. `derive(Ord)` would read `Must < Info` — backwards — and
  the consumer is a budget where an inverted comparison silently keeps the wrong
  record.
- **`precedence_for` swaps the inverted pair**, and its test derives
  monotonicity from `Force::strength` rather than pinning a table. A table is
  how this inverted in the first place: any test asserting the literals would
  have agreed with the bug.

Fixing only the constant would have left the guarantee resting on every future
authoring path picking numbers that agree with the force ordering.

### The other decisions

1. **The unbudgeted render order stays load order.** The issue offered
   precedence-ranking it instead. I did not, so the display contract ("records
   are emitted in the order given") stays literally true and the change cannot
   perturb a block under no pressure.
2. **Both renderers, not just the volatile one.** The same loop shape carried
   the same defect into `render_cached`. Worth flagging honestly: **that half is
   production-dead today** — both production cached renders pass no budget
   (`agent/prompt.rs:236`, `rules.rs:1080`), so its witness can only ever be a
   unit test. Fixed anyway, because the parameter exists and the next caller to
   pass a budget should not inherit the bug.
3. **A record too long to fit is skipped, not terminal**, so a less important
   record still renders in space the more important one could not have used. The
   one case where a lower-ranked record outlives a higher-ranked one, and it is
   a statement about size, not worth.
4. **Absent `precedence` still reads as `0`.** `records::validate` has always
   read silence that way for conflict detection; two consumers of one field
   disagreeing about what silence means would be worse than the bug being fixed.
   `Record::precedence()` now gives that default one home instead of two.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Every witness was verified against **its own distinct negation**, not assumed:

| Test | Negation it fails under |
|---|---|
| `a_budget_drop_is_ledgered_never_silent` (extended per the issue) | precedence sort disabled |
| `the_budget_drops_the_least_important_record_not_the_last_one` | precedence sort disabled |
| `survivors_render_in_load_order_not_in_precedence_order` | precedence sort disabled |
| `the_cached_budget_drops_by_precedence_too` | precedence sort disabled |
| `force_outranks_precedence_in_the_volatile_block_too` | force component removed from the key |
| `a_demoted_record_competes_at_the_force_it_renders_under` | declared force substituted for effective |
| `the_stamped_precedence_agrees_with_the_force_it_came_from` | the old `may=15 / info=20` pair |

On `main`, the issue's own witness fails with:

```
assertion `left == right` failed: the surviving record must be the higher-precedence one
  left: ["mtime-not-recency"]     # precedence 40, loaded first
 right: ["reflog-first"]          # precedence 80, loaded second
```

Four further tests are **guards, not witnesses** — they pass both ways by design
and pin what must *not* change: byte-identity when unbudgeted, byte-identity
under a generous `Some`, load order among equals, and a too-long record not
starving the ones that fit.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-core` — 1039 + 8 passed, 0 failed
- [x] `cargo test -p stella-cli --bins` — 1490 passed, 0 failed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps`
- [x] `make guards-fast` — all guards green (`file-size`: none grew;
      `left-behind`: 0)
- [x] Docs updated where behavior changed — `Steering::precedence` (the field
      had two consumers and claimed one), `Force::strength`,
      `RenderedChannel::dropped`, `render_channel`, `render_cached`,
      `precedence_for`, and the `render` module header
- [x] `Closes #2299` in the description **and** as a commit trailer

**Not run locally, deliberately:** `cargo clippy --workspace` and `cargo test
--workspace`. An ArenaBench match was running on this machine throughout, and a
full-workspace build would have stolen CPU from a live measurement. Both changed
crates were built and tested in full; CI carries the workspace tiers. Flagging
it rather than ticking boxes I did not earn — CI was green on the first two
commits.

## Nothing left behind

- [x] Filed: **#2323**, **#2338**

- **#2323** — `MissingContextKind::NotRendered` is **never constructed anywhere
  in production code**. The renderer computes `dropped`, four doc comments
  promise it closes the silent gap, and the only production caller
  (`memory/recall.rs:83-86`) takes `.text` and discards it. So this PR makes the
  budget pick the right victim; nobody can yet see that it picked one. Extended
  with a design constraint from review: `dropped` needs a typed reason
  (crowded-out vs never-could-fit), matching `stella_context::DropReason`.
- **#2338** — `inferred_rule_record` (`context_records.rs:692`) is the only
  authoring path that stamps **no** precedence, so a human-promoted rule sits at
  the floor. Dormant only because it stamps `Should` and cached renders pass no
  budget; it goes live the day the sweep demotes one. Force-first ranking does
  not cover it — same force falls through to precedence.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `Record::precedence()` and `Force::strength()`
      are accessors over existing serde fields; no wire or schema change

## Anything reviewers should know?

**`precedence` now serves two masters** — conflict resolution and scarcity. An
author bumping it to silence a conflict warning also changes what survives a
budget. `Steering::precedence`'s doc is rewritten to unify them honestly as "who
wins when both cannot have their way", but #2338 is the empirical evidence that
existing writers set the field under the old single meaning, and it should be
read alongside this PR rather than after it.

**Blast radius.** The volatile channel is per-turn, so nothing here touches
prompt-cache stability. The cached channel's bytes cannot change at all today
(both callers pass `None`).
