### PR TITLE
fix(stella-cli): the learning plane reads an injected clock — replayable sessions, and a testable truth sweep (#2320)

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use stella_context::{
-    ContextDelta, ContextStore, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion,
+    Clock, ContextDelta, ContextStore, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion,
     HashEmbedder, NodeInput, NodeKind, RecallTier, SystemClock, format_rfc3339,
 };
 use stella_core::skills::{self, SelectionConfig, Skill};
@@ -183,17 +183,32 @@ impl LessonKind {
     }
 }
 
-/// A session-scoped task identity, distinct per process.
+/// A session-scoped task identity, distinct per concurrent session.
 ///
 /// One `stella run` is one task, so for the headless path this is exactly the
 /// right boundary. For a long REPL session it is an approximation, but a
 /// strictly better one than per-turn.
-fn default_task_id() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    format!("session:{secs}-{}", std::process::id())
+///
+/// Both halves are now injected rather than read from the ambient process
+/// (#2320). The time comes from the session's [`Clock`], so a fixed clock
+/// yields a fixed id; `nonce` is whatever distinguishes this session from
+/// another running concurrently against the same workspace — see
+/// [`SessionMemory::session_nonce`].
+fn default_task_id(clock: &dyn Clock, nonce: &str) -> String {
+    format!("session:{}-{nonce}", clock.now_unix_secs())
+}
+
+/// What a production session uses for the [`default_task_id`] nonce.
+///
+/// The pid is kept here — and *only* here — because the nonce's whole job is
+/// to keep two stella processes started in the same second from filing their
+/// lessons under one task id, and governance counts distinct tasks. Dropping it
+/// outright would silently merge two concurrent sessions into one task, which
+/// is a governance undercount rather than a determinism win. Injecting it
+/// instead gets both properties: production is byte-identical to before, and a
+/// replay supplies its own nonce from the trace.
+fn process_session_nonce() -> String {
+    std::process::id().to_string()
 }
 
 mod reflection;
@@ -270,6 +285,20 @@ pub struct SessionMemory {
     /// re-deriving it here would re-walk the rule directories and re-run the
     /// truth sweep on every turn.
     record_registry: Option<stella_core::records::Registry>,
+    /// This session's time source — the only one the learning plane reads
+    /// (#2320).
+    ///
+    /// `stella-context` has shipped this port since the store was bi-temporal,
+    /// and `ContextStore::open_with` has always taken one; the CLI's learning
+    /// path was simply routing around it, reading `SystemTime::now()` at six
+    /// sites. That asymmetry had a cost beyond replay: `retire_failing_context`
+    /// stamps its truth sweep from here, so with a hardcoded system clock no
+    /// test could ever place a record past its TTL and watch it retire.
+    ///
+    /// Production hands this a [`SystemClock`] from every existing constructor,
+    /// so prompts stay byte-stable (invariant 7). A test or a trace replay hands
+    /// it a `FixedClock` through [`Self::open_with_clock`].
+    clock: std::sync::Arc<dyn Clock>,
 }
 
 impl SessionMemory {
@@ -277,6 +306,34 @@ impl SessionMemory {
     /// the store can't open — a session without memory beats no session.
     pub fn open(workspace_root: &Path, warn: bool) -> Option<Self> {
         Self::open_with_workspace_skills(workspace_root, warn, false)
+    }
+
+    /// Open the workspace's memory against a caller-supplied time source and
+    /// session nonce — the door a deterministic replay comes through (#2320).
+    ///
+    /// Every other constructor defaults to [`SystemClock`] and the pid, so
+    /// production behaviour is unchanged; this one exists so a harness can put
+    /// the whole learning plane on a clock it advances itself.
+    ///
+    /// Test-gated because `stella-cli` is a bin-only crate: there is no
+    /// external consumer that could call it, and shipping it unreachable would
+    /// be an `#[allow(dead_code)]` describing an API nothing can reach — the
+    /// same reasoning that gates [`Self::set_task_id`] below.
+    #[cfg(test)]
+    pub(crate) fn open_with_clock(
+        workspace_root: &Path,
+        warn: bool,
+        include_workspace_skills: bool,
+        clock: std::sync::Arc<dyn Clock>,
+        session_nonce: impl Into<String>,
+    ) -> Option<Self> {
+        Self::open_inner(
+            workspace_root,
+            warn,
+            include_workspace_skills,
+            clock,
+            session_nonce.into(),
+        )
     }
 
     /// Override the task boundary lessons are stamped with.
@@ -296,6 +353,13 @@ impl SessionMemory {
     #[cfg(test)]
     pub(crate) fn set_task_id(&mut self, task_id: impl Into<String>) {
         self.task_id = task_id.into();
+    }
+
+    /// This session's current instant, as the truth sweep and every lifecycle
+    /// predicate see it.
+    #[cfg(test)]
+    pub(crate) fn clock_now_rfc3339(&self) -> String {
+        self.clock.now_rfc3339()
     }
 
     #[cfg(test)]
@@ -364,6 +428,22 @@ impl SessionMemory {
         warn: bool,
         include_workspace_skills: bool,
     ) -> Option<Self> {
+        Self::open_inner(
+            workspace_root,
+            warn,
+            include_workspace_skills,
+            std::sync::Arc::new(SystemClock),
+            process_session_nonce(),
+        )
+    }
+
+    fn open_inner(
+        workspace_root: &Path,
+        warn: bool,
+        include_workspace_skills: bool,
+        clock: std::sync::Arc<dyn Clock>,
+        session_nonce: String,
+    ) -> Option<Self> {
         // Ephemeral benchmark trials must neither recall task/user-planted
         // learning state nor create or migrate a context database that can
         // perturb the task under test. Reflection is separately pinned off
@@ -379,7 +459,7 @@ impl SessionMemory {
         match ContextStore::open_and_warm(
             &db_path,
             std::sync::Arc::new(HashEmbedder::default()),
-            std::sync::Arc::new(SystemClock),
+            clock.clone(),
         )
         .map(|store| store.with_tuning(retrieval.tuning()))
         {
@@ -408,8 +488,9 @@ impl SessionMemory {
                     ab_turn: 0,
                     // Phase 3 (#714)
                     lifecycle_enabled: tuning::session_lifecycle_enabled(workspace_root),
-                    task_id: default_task_id(),
+                    task_id: default_task_id(clock.as_ref(), &session_nonce),
                     execution_id: None,
+                    clock,
                 })
             }
             Err(e) => {
@@ -564,10 +645,7 @@ impl SessionMemory {
             }
         }
 
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(started_unix_secs);
+        let now_secs = self.clock.now_unix_secs();
         let mut episode = EpisodeInput::new(
             summary,
             format_rfc3339(started_unix_secs),
@@ -658,12 +736,18 @@ pub(crate) fn context_db_path(workspace_root: &Path) -> Result<PathBuf, String> 
         .map_err(|e| format!("cannot resolve private context state: {e}"))
 }
 
-/// Seconds since the Unix epoch — the episode timestamps' primitive.
+/// Seconds since the Unix epoch — the episode timestamps' primitive, read
+/// through the [`Clock`] port rather than `SystemTime` directly.
+///
+/// This is the *production* clock by construction, and deliberately so: its
+/// callers are the turn drivers (`agent.rs`, `agent/goal.rs`, `command_deck.rs`)
+/// that stamp when a real turn started, not the learning plane. A session's own
+/// timestamps come from its injected [`SessionMemory::clock`]; a replay supplies
+/// `started_unix_secs` from the trace and never calls this. Reading through the
+/// port anyway leaves exactly one spelling of "seconds since the epoch" in the
+/// crate, which is what stops the next wall-clock read growing back here.
 pub(crate) fn unix_now_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+    SystemClock.now_unix_secs()
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -71,6 +71,11 @@ impl SessionMemory {
             &self.domains.names(),
             succeeded,
             budget_limit,
+            // The session's clock, so a replayed turn stamps its lessons with
+            // the trace's instant rather than today's (#2320). Negative (i.e.
+            // pre-epoch) readings clamp to 0, matching the `unwrap_or(0)` the
+            // wall-clock read this replaced already did.
+            u64::try_from(self.clock.now_unix_secs()).unwrap_or(0),
         )
         .await
         {
@@ -440,12 +445,11 @@ impl SessionMemory {
     /// remove. Refusals are printed too — a sweep that silently declines to act
     /// on protected records reads as "nothing was failing", a different claim.
     fn retire_failing_context(&self, quiet: bool) {
-        let now = stella_context::format_rfc3339(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0) as i64,
-        );
+        // Through the session's clock, not the wall clock (#2320). This one
+        // line is why the seam is a defect fix and not only a harness
+        // prerequisite: the sweep used to always see today, so no test could
+        // place a record past its TTL and assert it retires.
+        let now = self.clock.now_rfc3339();
 
         // Deterministic validation first (#753): a memory whose path anchors
         // have ALL left the tree is stale by a reproducible check, needing no

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -101,6 +101,10 @@ pub(crate) async fn reflect_routed(
         .await
 }
 
+/// `recorded_at_unix_secs` is the instant every mined lesson's `occurred_at` is
+/// stamped with. It is a parameter rather than a wall-clock read so a session
+/// on a fixed clock produces a fixed log (#2320); callers pass their
+/// [`stella_context::Clock`]'s reading.
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,
@@ -109,6 +113,7 @@ pub async fn reflect_on_turn(
     domain_names: &[String],
     succeeded: bool,
     budget_limit: Option<f64>,
+    recorded_at_unix_secs: u64,
 ) -> Result<
     (ReflectionParse, Option<SelfReviewRow>, f64, Vec<AgentEvent>),
     crate::accounted_call::StandaloneCallError,
@@ -306,7 +311,7 @@ pub async fn reflect_on_turn(
     )
     .await?;
     Ok((
-        parse_lessons_checked(&accounted.result.text, domain_names),
+        parse_lessons_checked(&accounted.result.text, domain_names, recorded_at_unix_secs),
         parse_self_review(&accounted.result.text),
         accounted.cost_usd,
         accounted.events,
@@ -461,7 +466,13 @@ fn extract_lesson_array(text: &str) -> Option<Vec<ReflectionLesson>> {
     None
 }
 
-pub fn parse_lessons_checked(text: &str, allowed_domains: &[String]) -> ReflectionParse {
+/// Parse the model's lessons array, stamping each lesson's `occurred_at` with
+/// `now_unix_secs` — supplied by the caller's clock, never read here (#2320).
+pub fn parse_lessons_checked(
+    text: &str,
+    allowed_domains: &[String],
+    now_unix_secs: u64,
+) -> ReflectionParse {
     let Some(mut lessons) = extract_lesson_array(text) else {
         // An empty response is a legitimate "nothing to record". Anything else
         // is a response we failed to read, and the caller should say so.
@@ -471,13 +482,9 @@ pub fn parse_lessons_checked(text: &str, allowed_domains: &[String]) -> Reflecti
             ReflectionParse::Unreadable(text.chars().take(180).collect())
         };
     };
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0);
     lessons.truncate(3);
     for lesson in &mut lessons {
-        lesson.occurred_at = now;
+        lesson.occurred_at = now_unix_secs;
         lesson.domains.retain(|domain| {
             allowed_domains
                 .iter()

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -24,6 +24,12 @@ use stella_protocol::{
     Provider, ProviderError, ReasoningEffort,
 };
 
+/// The instant these tests stamp lessons with. Fixed rather than read from the
+/// wall clock: `reflect_on_turn` takes its recording time as a parameter
+/// (#2320), and a test that passed `SystemClock` would be re-introducing the
+/// nondeterminism the parameter exists to remove.
+const REFLECTED_AT: u64 = 1_700_000_000;
+
 /// Records the prompt it is asked to complete — and the request's dispatch
 /// shape (effort, output cap) — then answers with a well-formed empty result
 /// so the caller's parsing path stays on its happy road: the request is what
@@ -84,6 +90,7 @@ async fn prompt_for(succeeded: bool) -> String {
         &["testing".to_string()],
         succeeded,
         None,
+        REFLECTED_AT,
     )
     .await
     .expect("the stub provider cannot fail");
@@ -178,6 +185,7 @@ async fn reflection_dispatches_low_effort_with_its_bounded_output_cap() {
         &["testing".to_string()],
         true,
         None,
+        REFLECTED_AT,
     )
     .await
     .expect("the stub provider cannot fail");

--- a/crates/stella-cli/src/memory/self_tuning.rs
+++ b/crates/stella-cli/src/memory/self_tuning.rs
@@ -23,6 +23,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use stella_context::Clock;
 use stella_core::self_tuning::{
     ArmSamples, ArmStats, Decision, RewardWeights, RollbackRecord, SelectionConfig, TaskOutcome,
     reward, select_winner,
@@ -270,13 +271,17 @@ fn load_scope_engine_config(path: &Path) -> AgentEngineConfig {
         .unwrap_or_default()
 }
 
-/// Milliseconds since the Unix epoch (best-effort; `0` if the clock is before
-/// the epoch). Only used to timestamp ledger lines.
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+/// Milliseconds since the Unix epoch, read through the caller's clock
+/// (best-effort; `0` if that clock is before the epoch). Only used to timestamp
+/// ledger lines.
+///
+/// A parameter rather than a `SystemTime` read so this module holds no wall
+/// clock of its own (#2320). `stella tune` passes [`SystemClock`], keeping the
+/// sub-second precision the ledger always had — see
+/// [`stella_context::Clock::now_unix_millis`], whose default deliberately does
+/// not invent one for a fixed clock.
+fn now_ms(clock: &dyn Clock) -> u64 {
+    u64::try_from(clock.now_unix_millis()).unwrap_or(0)
 }
 
 /// Append one entry to the self-tuning ledger.
@@ -331,12 +336,13 @@ fn active_promotion(
 pub(crate) fn publish_experiment(
     workspace_root: &Path,
     report: &ExperimentReport,
+    clock: &dyn Clock,
 ) -> Result<(), String> {
     append_entry(
         workspace_root,
         &LedgerEntry::Experiment {
             report: Box::new(report.clone()),
-            at_ms: now_ms(),
+            at_ms: now_ms(clock),
         },
     )
 }
@@ -356,6 +362,7 @@ pub(crate) fn promote(
     scope: SettingsScope,
     chosen: ReasoningEffort,
     promotion: &stella_core::self_tuning::Promotion,
+    clock: &dyn Clock,
 ) -> Result<PriorState, String> {
     let path = scope.path(workspace_root)?;
     let mut cfg = load_scope_engine_config(&path);
@@ -384,7 +391,7 @@ pub(crate) fn promote(
             rollback: record,
             previous_effort_auto: prior_auto,
             scope,
-            at_ms: now_ms(),
+            at_ms: now_ms(clock),
         },
     )?;
 
@@ -409,7 +416,10 @@ pub(crate) enum RollbackOutcome {
 
 /// Revert the last effort promotion: restore the worker effort and the
 /// `effort_auto` value that were in place before it, in the scope it wrote.
-pub(crate) fn rollback(workspace_root: &Path) -> Result<RollbackOutcome, String> {
+pub(crate) fn rollback(
+    workspace_root: &Path,
+    clock: &dyn Clock,
+) -> Result<RollbackOutcome, String> {
     let Some((record, prior_auto, scope)) = active_promotion(workspace_root) else {
         return Ok(RollbackOutcome::Nothing);
     };
@@ -439,7 +449,7 @@ pub(crate) fn rollback(workspace_root: &Path) -> Result<RollbackOutcome, String>
             restored_value: record.previous_value.clone(),
             restored_effort_auto: prior_auto,
             scope,
-            at_ms: now_ms(),
+            at_ms: now_ms(clock),
         },
     )?;
 
@@ -457,6 +467,11 @@ mod tests {
     // than going through `project_config_path` (which prefers a stella.toml
     // when one exists).
     use crate::settings::project_settings_path;
+
+    /// The ledger clock these tests stamp `at_ms` from. A fixed clock rather
+    /// than [`stella_context::SystemClock`] so a ledger assertion can never
+    /// depend on when the suite ran (#2320).
+    const TEST_CLOCK: stella_context::FixedClock = stella_context::FixedClock::new(1_700_000_000);
 
     fn trial(reward: Option<f64>) -> BenchTrial {
         BenchTrial {
@@ -564,13 +579,13 @@ mod tests {
             &SelectionConfig::default(),
         );
         assert!(report.decision.is_promotion(), "clean win should promote");
-        publish_experiment(root, &report).unwrap();
+        publish_experiment(root, &report, &TEST_CLOCK).unwrap();
 
         let Decision::Promote(p) = &report.decision else {
             unreachable!()
         };
         let chosen = parse_effort(&p.winner.value).unwrap();
-        let prior = promote(root, SettingsScope::Project, chosen, p).unwrap();
+        let prior = promote(root, SettingsScope::Project, chosen, p, &TEST_CLOCK).unwrap();
         assert_eq!(prior.effort, None, "worker effort was unset before");
 
         let settings = project_settings_path(root);
@@ -588,7 +603,7 @@ mod tests {
         );
 
         // Rollback restores the prior (unset) worker effort.
-        match rollback(root).unwrap() {
+        match rollback(root, &TEST_CLOCK).unwrap() {
             RollbackOutcome::Restored { restored, .. } => assert_eq!(restored, None),
             RollbackOutcome::Nothing => panic!("expected a rollback"),
         }
@@ -599,7 +614,10 @@ mod tests {
         );
 
         // A second rollback is a no-op (the promotion is already reverted).
-        assert!(matches!(rollback(root).unwrap(), RollbackOutcome::Nothing));
+        assert!(matches!(
+            rollback(root, &TEST_CLOCK).unwrap(),
+            RollbackOutcome::Nothing
+        ));
     }
 
     #[test]
@@ -633,12 +651,13 @@ mod tests {
             SettingsScope::Project,
             parse_effort(&p.winner.value).unwrap(),
             p,
+            &TEST_CLOCK,
         )
         .unwrap();
         assert_eq!(prior.effort.as_deref(), Some("low"));
         assert_eq!(worker_effort_in(&settings).as_deref(), Some("high"));
 
-        rollback(root).unwrap();
+        rollback(root, &TEST_CLOCK).unwrap();
         assert_eq!(
             worker_effort_in(&settings).as_deref(),
             Some("low"),

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -5,6 +5,9 @@
 // #1221: the A/B recall control — its durable schedule, what a control turn
 // suppresses, and the attribution that separates the arms afterwards.
 mod ab_control;
+// #2320: the learning plane's time comes from an injected clock, which is what
+// makes a replayed session reproducible and the truth sweep testable at all.
+mod clock_seam;
 mod path_token;
 mod quarantine;
 // Which sessions actually receive the volatile record channel — a separate
@@ -15,6 +18,10 @@ mod record_channel;
 mod skill_creation;
 
 use super::*;
+
+/// The instant lesson-parsing tests stamp `occurred_at` with. Fixed, because
+/// the parser now takes its clock reading as a parameter (#2320).
+const PARSED_AT: u64 = 1_700_000_000;
 
 fn msg(role: MessageRole, content: &str) -> CompletionMessage {
     CompletionMessage {
@@ -672,14 +679,14 @@ fn unreadable_reflection_is_distinguished_from_having_nothing_to_say() {
 
     assert!(
         matches!(
-            parse_lessons_checked("", &[]),
+            parse_lessons_checked("", &[], PARSED_AT),
             ReflectionParse::Lessons(lessons) if lessons.is_empty()
         ),
         "an empty response is a legitimate 'nothing to record'"
     );
     assert!(
         matches!(
-            parse_lessons_checked("no json here", &[]),
+            parse_lessons_checked("no json here", &[], PARSED_AT),
             ReflectionParse::Unreadable(_)
         ),
         "prose with no array is a response we failed to read, not an empty one"
@@ -965,7 +972,7 @@ fn lessons_of(text: &str) -> Vec<crate::memory::ReflectionLesson> {
 }
 
 fn lessons_with(text: &str, allowed: &[String]) -> Vec<crate::memory::ReflectionLesson> {
-    match crate::memory::reflection::parse_lessons_checked(text, allowed) {
+    match crate::memory::reflection::parse_lessons_checked(text, allowed, PARSED_AT) {
         crate::memory::reflection::ReflectionParse::Lessons(lessons) => lessons,
         crate::memory::reflection::ReflectionParse::Unreadable(excerpt) => {
             panic!("expected a readable lesson array, got unreadable: {excerpt}")

--- a/crates/stella-cli/src/memory/tests/clock_seam.rs
+++ b/crates/stella-cli/src/memory/tests/clock_seam.rs
@@ -1,0 +1,215 @@
+//! The learning plane reads its time from an injected clock, not the wall
+//! clock (#2320).
+//!
+//! `stella-context` has shipped a `Clock` port since the store went
+//! bi-temporal, and `ContextStore::open_with` has always accepted one. The
+//! CLI's learning path routed around it: `SystemTime::now()` at six sites, plus
+//! a pid folded into the task id. Two consequences, and only the second is
+//! about replay:
+//!
+//! - a session's mined log could not be reproduced, which blocks every
+//!   assertion in `doc:trace-replay-learning-harness`; and
+//! - `retire_failing_context` always handed the truth sweep *today*, so no test
+//!   could place a record past its TTL and watch it retire. That one is a
+//!   defect on its own terms.
+//!
+//! What makes the first assertion below a witness rather than a tautology is
+//! worth stating, because the obvious version is not one. "Two sessions on a
+//! fixed clock write byte-identical logs" **passes on `main` by luck**: two
+//! opens milliseconds apart almost always land in the same wall-clock second
+//! and share a pid, so the ids match and nothing is proven. The assertion that
+//! actually fails on `main` is the second one — the log's timestamps equal the
+//! *fixed instant we chose*, which is years away from today. Byte-identity is
+//! kept beside it because it is the property the harness depends on; the
+//! pinned instant is what proves the seam exists.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use stella_context::{Clock, FixedClock};
+use stella_protocol::{
+    CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, Provider,
+    ProviderError,
+};
+
+use crate::memory::*;
+
+/// The instant both sessions run at: 2023-11-14T22:13:20Z. Deliberately far in
+/// the past, so a wall-clock read cannot coincide with it.
+const REPLAY_INSTANT: i64 = 1_700_000_000;
+
+/// A provider that answers every call with one fixed completion — the reflection
+/// the model "would have said". The single model boundary in the learning loop,
+/// stubbed; everything downstream of it is already deterministic.
+struct ScriptedProvider {
+    text: String,
+    calls: Mutex<u32>,
+}
+
+impl ScriptedProvider {
+    fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            calls: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+
+    async fn complete_ref(
+        &self,
+        _request: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        *self.calls.lock().expect("call count") += 1;
+        Ok(CompletionResult {
+            text: self.text.clone(),
+            tool_calls: Vec::new(),
+            // `reported: true` is load-bearing, not decoration: the standalone
+            // call's accounting closeout refuses to settle a call whose usage
+            // never arrived, and the reflection surfaces that as
+            // "accounting closeout failed" — indistinguishable, from the
+            // outside, from a model that said nothing.
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 1,
+                ..CompletionUsage::default()
+            },
+            model: "scripted".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// One well-formed lessons array, with a domain the workspace does not declare
+/// so the domain filter has something to strip — keeping the fixture on the
+/// same path a real reflection takes.
+const SCRIPTED_LESSONS: &str = r#"[
+  {"lesson": "Provider adapters live one file per vendor under stella-model/src.", "domains": [], "kind": "domain"},
+  {"lesson": "Run make gate before pushing; a red gate is an automatic not-yet.", "domains": [], "kind": "process"}
+]"#;
+
+/// Run one scripted reflection turn against a fresh workspace on a clock frozen
+/// at `REPLAY_INSTANT`, and hand back the mining log it wrote.
+async fn one_scripted_turn(root: &Path) -> String {
+    let clock: std::sync::Arc<dyn Clock> = std::sync::Arc::new(FixedClock::new(REPLAY_INSTANT));
+    let mut memory = SessionMemory::open_with_clock(root, false, false, clock, "witness")
+        .expect("session memory");
+    let provider = ScriptedProvider::new(SCRIPTED_LESSONS);
+    let transcript = vec![
+        CompletionMessage::user("add the mistral adapter"),
+        CompletionMessage::assistant("added crates/stella-model/src/mistral.rs"),
+    ];
+    let report = memory
+        .reflect_and_record(&provider, "scripted", &transcript, true, true, None)
+        .await;
+    // A silent `recorded: 0` is exactly the starvation the loop is prone to, so
+    // the fixture refuses to be satisfied by one: if the scripted reflection
+    // did not land, say why rather than failing later on an empty file.
+    assert!(
+        report.model_error.is_none(),
+        "the scripted reflection failed: {:?}",
+        report.model_error
+    );
+    std::fs::read_to_string(
+        root.join(".stella")
+            .join("private")
+            .join("reflections.jsonl"),
+    )
+    .unwrap_or_default()
+}
+
+/// A fresh workspace with the `.stella` skeleton the memory paths expect.
+fn workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+    dir
+}
+
+/// THE witness. Every timestamp a reflection turn records comes from the
+/// session's clock, so a session pinned to a past instant records that instant.
+///
+/// Fails on `main`, deterministically and for two independent reasons: the
+/// lesson's `occurred_at` is stamped from `SystemTime::now()` inside
+/// `parse_lessons_checked`, and the `task_id` embeds both `SystemTime::now()`
+/// and the pid. Both read *today*, which is not `REPLAY_INSTANT`.
+#[tokio::test]
+async fn a_session_records_its_clocks_instant_not_todays() {
+    let dir = workspace();
+    let log = one_scripted_turn(dir.path()).await;
+    assert!(
+        !log.trim().is_empty(),
+        "the scripted reflection should have recorded at least one lesson"
+    );
+
+    for line in log.lines().filter(|l| !l.trim().is_empty()) {
+        let lesson: ReflectionLesson =
+            serde_json::from_str(line).expect("each log line is a ReflectionLesson");
+        assert_eq!(
+            lesson.occurred_at, REPLAY_INSTANT as u64,
+            "occurred_at must come from the session clock, not the wall clock"
+        );
+        assert_eq!(
+            lesson.task_id,
+            format!("session:{REPLAY_INSTANT}-witness"),
+            "the task id must be built from the session clock and the supplied \
+             nonce — no wall-clock read, no pid"
+        );
+    }
+}
+
+/// The property the replay harness actually depends on: one trace, run twice,
+/// writes the same bytes. Distinct temp workspaces, same clock, same script.
+///
+/// Kept beside the assertion above rather than instead of it — on its own this
+/// can pass on `main` whenever both sessions land in one wall-clock second, so
+/// it certifies the harness's contract without witnessing the fix.
+#[tokio::test]
+async fn two_runs_of_one_scripted_turn_are_byte_identical() {
+    let first = workspace();
+    let second = workspace();
+    let a = one_scripted_turn(first.path()).await;
+    let b = one_scripted_turn(second.path()).await;
+    assert!(!a.trim().is_empty(), "the first run recorded nothing");
+    assert_eq!(a, b, "two replays of one turn must write identical logs");
+}
+
+/// The seam's other half, and the reason it is a defect fix rather than only a
+/// harness prerequisite: the truth sweep's `now` is the session's, so a test can
+/// finally place time past a record's TTL.
+///
+/// Impossible to write before this change — `retire_failing_context` built its
+/// `now` from `SystemTime::now()`, so every sweep saw today no matter what the
+/// test did.
+#[tokio::test]
+async fn the_truth_sweep_sees_the_session_clock() {
+    let dir = workspace();
+    let clock = std::sync::Arc::new(FixedClock::new(REPLAY_INSTANT));
+    let memory = SessionMemory::open_with_clock(
+        dir.path(),
+        false,
+        false,
+        clock.clone() as std::sync::Arc<dyn Clock>,
+        "sweep",
+    )
+    .expect("session memory");
+
+    assert_eq!(
+        memory.clock_now_rfc3339(),
+        stella_context::format_rfc3339(REPLAY_INSTANT),
+        "the session's now is its clock's now"
+    );
+
+    // A year later, on demand rather than on the calendar.
+    clock.advance(365 * 24 * 60 * 60);
+    assert_eq!(
+        memory.clock_now_rfc3339(),
+        stella_context::format_rfc3339(REPLAY_INSTANT + 365 * 24 * 60 * 60),
+        "advancing the session clock moves the instant the sweep will see"
+    );
+}

--- a/crates/stella-cli/src/tune_cmd.rs
+++ b/crates/stella-cli/src/tune_cmd.rs
@@ -141,13 +141,22 @@ fn run_effort(
 
     print_report(&report);
     // Always publish the receipt — a kept baseline is evidence too.
-    engine::publish_experiment(workspace_root, &report)?;
+    // `stella tune` is a human-driven command, so it stamps its ledger from
+    // the production clock. The parameter exists so the module holds no wall
+    // clock of its own (#2320).
+    engine::publish_experiment(workspace_root, &report, &stella_context::SystemClock)?;
 
     match &report.decision {
         Decision::Promote(p) => {
             if promote {
                 let chosen = engine::parse_effort(&p.winner.value)?;
-                let prior = engine::promote(workspace_root, scope, chosen, p)?;
+                let prior = engine::promote(
+                    workspace_root,
+                    scope,
+                    chosen,
+                    p,
+                    &stella_context::SystemClock,
+                )?;
                 println!(
                     "\n{} worker effort → {} (was {}) in {} settings.",
                     "promoted".green().bold(),
@@ -184,7 +193,7 @@ fn run_effort(
 }
 
 fn run_rollback(workspace_root: &Path) -> Result<(), String> {
-    match engine::rollback(workspace_root)? {
+    match engine::rollback(workspace_root, &stella_context::SystemClock)? {
         RollbackOutcome::Nothing => {
             println!("nothing to roll back — no effort promotion is in effect.");
         }

--- a/crates/stella-context/src/clock.rs
+++ b/crates/stella-context/src/clock.rs
@@ -24,6 +24,19 @@ pub trait Clock: Send + Sync {
     fn now_rfc3339(&self) -> String {
         format_rfc3339(self.now_unix_secs())
     }
+
+    /// Milliseconds since the Unix epoch, for the callers that stamp a ledger
+    /// line finer than a second.
+    ///
+    /// The default derives from [`Self::now_unix_secs`], which is exactly right
+    /// for a deterministic clock: [`FixedClock`] is set in whole seconds, so a
+    /// sub-second component it never received would have to be invented, and an
+    /// invented digit is the one thing a replay cannot have. [`SystemClock`]
+    /// overrides it to keep the real sub-second precision its callers had
+    /// before the port existed.
+    fn now_unix_millis(&self) -> i64 {
+        self.now_unix_secs().saturating_mul(1_000)
+    }
 }
 
 /// The production clock, reading the system wall clock.
@@ -41,6 +54,13 @@ impl Clock for SystemClock {
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0)
     }
+
+    fn now_unix_millis(&self) -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0)
+    }
 }
 
 /// A deterministic clock for tests and for callers that want to pin
@@ -53,7 +73,12 @@ pub struct FixedClock {
 
 impl FixedClock {
     /// Construct a clock frozen at `unix_secs`.
-    pub fn new(unix_secs: i64) -> Self {
+    ///
+    /// `const` so a test or a replay fixture can declare its instant as a
+    /// `const` item rather than build one per call — the instant is a property
+    /// of the fixture, and spelling it once is what keeps two assertions in the
+    /// same suite from silently disagreeing about "now".
+    pub const fn new(unix_secs: i64) -> Self {
         Self {
             secs: AtomicI64::new(unix_secs),
         }
@@ -165,6 +190,25 @@ mod tests {
         assert_eq!(clock.now_unix_secs(), 1_060);
         clock.set(42);
         assert_eq!(clock.now_rfc3339(), format_rfc3339(42));
+    }
+
+    #[test]
+    fn fixed_clock_millis_derive_from_its_seconds() {
+        // A deterministic clock must not invent a sub-second digit it was
+        // never given — that digit is precisely what a replay cannot reproduce.
+        let clock = FixedClock::new(1_600_000_000);
+        assert_eq!(clock.now_unix_millis(), 1_600_000_000_000);
+        clock.advance(1);
+        assert_eq!(clock.now_unix_millis(), 1_600_000_001_000);
+    }
+
+    #[test]
+    fn system_clock_millis_keep_subsecond_precision() {
+        // The override exists so ledger callers keep the precision they had
+        // before the port; the default would floor every stamp to `*000`.
+        let millis = SystemClock.now_unix_millis();
+        assert!(millis >= SystemClock.now_unix_secs().saturating_mul(1_000));
+        assert!(millis < (SystemClock.now_unix_secs() + 2).saturating_mul(1_000));
     }
 
     #[test]

--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -114,6 +114,22 @@ static EDGE_SEQ: AtomicU64 = AtomicU64::new(0);
 /// nanos plus the static's ASLR-randomized address — not cryptographic, just
 /// distinct per process, which is all the v10 `UNIQUE` constraint needs
 /// backing for.
+///
+/// **Audited for the clock port (#2320): this is an identity nonce, not a time
+/// reading, and it deliberately stays off [`crate::Clock`].** The `SystemTime`
+/// read below never reaches a comparable field — nothing orders, ranges over or
+/// compares `edge.public_id`; the row's *time* is the separate `recorded_at`
+/// column, which callers already pass in as `now` and which the clock port does
+/// govern. Putting a fixed clock behind the nonce would only make two processes
+/// in one second mint from the same keyspace, which is the collision it exists
+/// to prevent.
+///
+/// Determinism note for replay harnesses: `public_id` is unreproducible anyway,
+/// and not because of this nonce. [`EDGE_SEQ`] is a process-global counter, so
+/// two replays of one trace *inside a single process* mint different ids for
+/// the same logical edge. An edge `public_id` is therefore never admissible in
+/// a replay summary compared for byte-identity — compare edge content, not edge
+/// identity (`doc:trace-replay-learning-harness` §4.2).
 fn process_nonce() -> u64 {
     static NONCE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
     *NONCE.get_or_init(|| {


### PR DESCRIPTION
Closes #2320. First of the five PRs in `doc:trace-replay-learning-harness` §9 — the strict prerequisite for the rest of epic #2304.

## The gap

`stella-context` has shipped a `Clock` port since the store went bi-temporal (`trait Clock`, `SystemClock`, `FixedClock` with `advance`/`set`), and `ContextStore::open_with` has always accepted one. The context store's own tests inject `FixedClock` in eight places.

**The CLI's learning path routed around it** — six direct `SystemTime::now()` reads, plus a pid folded into the task id. Contrast `stella-core::records`, where every lifecycle predicate already takes `now: &str` as a parameter. The records plane was replayable; the CLI memory plane was not.

Two consequences, and only the second is about the harness:

- `retire_failing_context` built its `now` from the wall clock, so **the truth sweep always saw today** and no test could place a record past its TTL and assert it retires. A defect on its own terms.
- A session's mined log could not be reproduced, which blocks every Phase-2 assertion in the spec.

## What changed

`SessionMemory` holds an `Arc<dyn Clock>`, hands it to `ContextStore::open_and_warm`, and reads it at all six sites. Every existing constructor defaults to `SystemClock`, so **production is byte-identical** — invariant 7 (byte-stable prompts) is unaffected by construction, not by inspection.

| Site | Now reads |
|---|---|
| `memory.rs` `default_task_id` | the session clock + an injected nonce |
| `memory.rs` `record_episode` | `self.clock` |
| `memory.rs` `unix_now_secs` | `SystemClock` **through the port** |
| `memory/reflection.rs` `parse_lessons_checked` | a `now_unix_secs` parameter |
| `memory/learning.rs` `retire_failing_context` | `self.clock` |
| `memory/self_tuning.rs` `now_ms` | a `&dyn Clock` parameter |

No `SystemTime::now()` remains anywhere under `crates/stella-cli/src/memory/` or in `memory.rs`.

### Three judgement calls worth reviewing

**1. The pid stays in production, injected rather than removed.** The issue asks for `std::process::id()` to be dropped for "an explicit session ordinal". Dropping it outright loses the property it was there for: two stella processes starting in the same second against one workspace would file their lessons under *one* task id, and governance counts distinct tasks — a silent undercount. Injecting it gets both: `process_session_nonce()` for production (byte-identical to today), a trace-supplied nonce for replay. Flagging it explicitly since it departs from the issue text.

**2. `Clock` gains `now_unix_millis()`.** `self_tuning`'s ledger stamps `at_ms`, and flooring it to `secs * 1000` would have been a real behaviour change. The trait default derives from seconds — correct for `FixedClock`, which is *set* in whole seconds and must not invent a sub-second digit — and `SystemClock` overrides it to keep the precision its callers already had.

**3. `unix_now_secs()` reads `SystemClock` rather than taking a clock.** Its callers are the turn drivers (`agent.rs`, `agent/goal.rs`, `command_deck.rs`) stamping when a real turn started, not the learning plane; a replay supplies `started_unix_secs` from the trace and never calls it. Routing it through the port anyway leaves exactly one spelling of "seconds since the epoch" in the crate, so the next wall-clock read cannot quietly grow back there.

## The `edge.rs:121` audit the issue asks for

**Outcome: identity nonce, not a time source. Annotated in place, left off the clock.** `process_nonce()` hashes into `edge.public_id`, so it *is* serialized — but never into a **comparable** field: nothing orders, ranges over, or compares `public_id`. The row's time is the separate `recorded_at` column, which callers already pass in and the port already governs. Putting a fixed clock behind the nonce would only make two processes in one second mint from the same keyspace, which is the collision it exists to prevent.

**A finding the issue did not anticipate, recorded in the same comment:** `public_id` is unreproducible anyway, and not because of the nonce. `EDGE_SEQ` is a *process-global* counter, so two replays of one trace **inside a single process** mint different ids for the same logical edge. An edge `public_id` is therefore never admissible in a replay summary compared for byte-identity — the harness must compare edge content, not edge identity. That constrains PR 4's metrics and is noted where the next reader will hit it.

## Witness

`crates/stella-cli/src/memory/tests/clock_seam.rs`, three tests.

**`a_session_records_its_clocks_instant_not_todays` is the witness.** A scripted-provider reflection turn on `FixedClock(1_700_000_000)` must write a log whose `occurred_at` and `task_id` carry *that* instant.

Verified the artisanal way — the two behaviour lines were reverted behind the new seam and the suite re-run:

```
test a_session_records_its_clocks_instant_not_todays ... FAILED
  assertion `left == right` failed: occurred_at must come from the session clock, not the wall clock
    left: 1786222713
   right: 1700000000
```

**Why the issue's proposed witness is not one, and is kept anyway.** "Two `FixedClock(T)` sessions write byte-identical `reflections.jsonl`" **passes on `main`** — two opens milliseconds apart share a wall-clock second and a pid, so the ids match and nothing is proven. It did exactly that in the run above (`two_runs_of_one_scripted_turn_are_byte_identical ... ok` with the old behaviour restored). It stays in the suite because byte-identity is the property the harness depends on; the pinned instant is what proves the seam exists. Both are needed, and the module doc says so.

The third test, `the_truth_sweep_sees_the_session_clock`, advances the session clock a year and asserts the sweep's `now` moves with it — the assertion that was impossible to write before this change.

## Verification

- `cargo test -p stella-cli` — 1492 passed, 0 failed (plus 12 integration binaries green)
- `cargo test -p stella-context` — 158 passed
- `cargo clippy -p stella-cli -p stella-context --all-targets -- -D warnings` — clean
- `make guards-fast` — all green, including `file-size` (nothing grew past its ceiling) and `check-invariants`

**No tests deleted.** Three test call sites gained an explicit instant argument (`PARSED_AT`, `REFLECTED_AT`, `TEST_CLOCK`) instead of an implicit wall-clock read; every one is the same test asserting the same thing.

## Not in this PR

- `set_task_id` **stays `#[cfg(test)]`-gated.** Its doc comment says "drop the gate in the same commit that adds the first real caller", and that caller is the replayer in PR 2. #2320 anticipated this ordering and says to leave the gate.
- `open_with_clock` is `#[cfg(test)]` for the same reason `set_task_id` is: `stella-cli` is bin-only, so an ungated constructor nothing can reach would be dead code with an `#[allow]` on it.

## Summary by Sourcery

Route stella-cli’s learning and tuning paths through the shared clock abstraction to make session behavior deterministic, replayable, and testable while preserving production behavior.

Bug Fixes:
- Ensure the truth sweep in `retire_failing_context` uses the session clock so tests can correctly retire records that have passed their TTL.

Enhancements:
- Make `SessionMemory` hold an injected `Clock` and session nonce, using them for task IDs, episode timestamps, and reflection lesson timestamps instead of direct wall-clock reads.
- Extend the `Clock` trait with millisecond-resolution timestamps and implement precise millisecond reading for `SystemClock` while keeping `FixedClock` deterministic.
- Refine the self-tuning ledger to take a `Clock` parameter for all timestamping, and adjust CLI commands to pass the production clock explicitly.
- Document and audit edge `public_id` nonce behavior to clarify its non-temporal nature and replay implications.

Tests:
- Add a dedicated test module that verifies the learning plane and truth sweep respect the injected clock and that scripted sessions produce byte-identical logs under a fixed clock.
- Update existing reflection and self-tuning tests to supply explicit instants or fixed clocks, removing dependence on the ambient wall clock.