### PR TITLE
fix(stella-cli): route the learning loop's wall-clock reads through the Clock port that already existed

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -194,7 +194,9 @@ impl LessonKind {
 /// second from minting one id, which governance would then count as a single
 /// task. Dropping it would buy reproducibility on a path that is never
 /// replayed, at the price of under-counting concurrent work. The deterministic
-/// half lives in [`deterministic_task_id`] instead, so the nondeterminism is
+/// half lives in `deterministic_task_id` instead (not a doc link: it is
+/// test-gated, so it does not exist in the documented build), so the
+/// nondeterminism is
 /// confined to the constructor that wants it rather than shared by both.
 fn default_task_id(clock: &dyn Clock) -> String {
     format!("session:{}-{}", clock.now_unix_secs(), std::process::id())

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use stella_context::{
-    ContextDelta, ContextStore, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion,
+    Clock, ContextDelta, ContextStore, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion,
     HashEmbedder, NodeInput, NodeKind, RecallTier, SystemClock, format_rfc3339,
 };
 use stella_core::skills::{self, SelectionConfig, Skill};
@@ -188,12 +188,31 @@ impl LessonKind {
 /// One `stella run` is one task, so for the headless path this is exactly the
 /// right boundary. For a long REPL session it is an approximation, but a
 /// strictly better one than per-turn.
-fn default_task_id() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    format!("session:{secs}-{}", std::process::id())
+///
+/// The pid stays (#2320). It is not a time source and it is not a task
+/// boundary — its only job is to keep two processes that start in the same
+/// second from minting one id, which governance would then count as a single
+/// task. Dropping it would buy reproducibility on a path that is never
+/// replayed, at the price of under-counting concurrent work. The deterministic
+/// half lives in [`deterministic_task_id`] instead, so the nondeterminism is
+/// confined to the constructor that wants it rather than shared by both.
+fn default_task_id(clock: &dyn Clock) -> String {
+    format!("session:{}-{}", clock.now_unix_secs(), std::process::id())
+}
+
+/// The task identity [`SessionMemory::open_with_clock`] mints: derived from the
+/// injected clock alone, so two sessions opened at the same instant agree.
+///
+/// Deliberately carries no pid. A caller reaching for the deterministic
+/// constructor is replaying a recorded engagement, where "which process am I"
+/// is not a question with an answer — and where two sessions minting the same
+/// id at the same instant is the property under test, not a collision.
+///
+/// Gated alongside its only caller, [`SessionMemory::open_with_clock`] — drop
+/// both gates together when the trace-replay harness lands (#2304).
+#[cfg(test)]
+fn deterministic_task_id(clock: &dyn Clock) -> String {
+    format!("session:{}", clock.now_unix_secs())
 }
 
 mod reflection;
@@ -270,6 +289,21 @@ pub struct SessionMemory {
     /// re-deriving it here would re-walk the rule directories and re-run the
     /// truth sweep on every turn.
     record_registry: Option<stella_core::records::Registry>,
+    /// The session's time source (#2320) — the only one the learning loop is
+    /// allowed to read.
+    ///
+    /// `stella-context` has shipped this port since the bi-temporal store
+    /// landed, and [`ContextStore::open_and_warm`] has always taken one; the
+    /// learning loop simply routed around it and called `SystemTime::now()` in
+    /// five places. That made every write here non-replayable, and one of the
+    /// five was [`SessionMemory::retire_failing_context`], whose `now` is the
+    /// instant the truth sweep judges TTLs against — so retirement could not be
+    /// tested at all, because the sweep always saw today.
+    ///
+    /// Production passes [`SystemClock`] through every existing constructor, so
+    /// this changes no shipped behaviour; it is the seam that lets a test
+    /// advance time on purpose.
+    clock: std::sync::Arc<dyn Clock>,
 }
 
 impl SessionMemory {
@@ -364,6 +398,48 @@ impl SessionMemory {
         warn: bool,
         include_workspace_skills: bool,
     ) -> Option<Self> {
+        let clock: std::sync::Arc<dyn Clock> = std::sync::Arc::new(SystemClock);
+        let task_id = default_task_id(clock.as_ref());
+        Self::open_inner(
+            workspace_root,
+            warn,
+            include_workspace_skills,
+            clock,
+            task_id,
+        )
+    }
+
+    /// Open a session whose every timestamp — the stamps on mined lessons, the
+    /// episode clock, the instant the truth sweep judges TTLs against, and the
+    /// default task id — comes from `clock` rather than the wall clock (#2320).
+    ///
+    /// Two sessions opened this way at the same instant write byte-identical
+    /// logs, which is what makes the learning loop replayable and what lets a
+    /// test place itself on either side of a TTL.
+    ///
+    /// **Test-gated until the trace-replay harness lands** (epic #2304,
+    /// `doc:trace-replay-learning-harness` §4). `stella-cli` is a bin-only
+    /// crate, so no external consumer could call this even in principle, and
+    /// leaving it on the production build would be dead code. Drop the gate in
+    /// the same commit that adds the replayer — the same discipline
+    /// [`SessionMemory::set_task_id`] is held to.
+    #[cfg(test)]
+    pub(crate) fn open_with_clock(
+        workspace_root: &Path,
+        warn: bool,
+        clock: std::sync::Arc<dyn Clock>,
+    ) -> Option<Self> {
+        let task_id = deterministic_task_id(clock.as_ref());
+        Self::open_inner(workspace_root, warn, false, clock, task_id)
+    }
+
+    fn open_inner(
+        workspace_root: &Path,
+        warn: bool,
+        include_workspace_skills: bool,
+        clock: std::sync::Arc<dyn Clock>,
+        task_id: String,
+    ) -> Option<Self> {
         // Ephemeral benchmark trials must neither recall task/user-planted
         // learning state nor create or migrate a context database that can
         // perturb the task under test. Reflection is separately pinned off
@@ -379,7 +455,7 @@ impl SessionMemory {
         match ContextStore::open_and_warm(
             &db_path,
             std::sync::Arc::new(HashEmbedder::default()),
-            std::sync::Arc::new(SystemClock),
+            clock.clone(),
         )
         .map(|store| store.with_tuning(retrieval.tuning()))
         {
@@ -408,8 +484,9 @@ impl SessionMemory {
                     ab_turn: 0,
                     // Phase 3 (#714)
                     lifecycle_enabled: tuning::session_lifecycle_enabled(workspace_root),
-                    task_id: default_task_id(),
+                    task_id,
                     execution_id: None,
+                    clock,
                 })
             }
             Err(e) => {
@@ -564,10 +641,10 @@ impl SessionMemory {
             }
         }
 
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(started_unix_secs);
+        // The episode's end instant, from the session clock (#2320). `started`
+        // arrives as a parameter and always did, so a caller that knows when
+        // the turn began — a replayer, a test — now controls both ends.
+        let now_secs = self.clock.now_unix_secs();
         let mut episode = EpisodeInput::new(
             summary,
             format_rfc3339(started_unix_secs),
@@ -659,6 +736,15 @@ pub(crate) fn context_db_path(workspace_root: &Path) -> Result<PathBuf, String> 
 }
 
 /// Seconds since the Unix epoch — the episode timestamps' primitive.
+///
+/// This is the **ambient** wall clock, for callers outside a session that need
+/// a start instant to hand to [`SessionMemory::record_episode`] — the drivers
+/// in `agent.rs`, `agent/goal.rs` and `command_deck.rs`, which own no clock.
+/// [`SessionMemory`] itself no longer calls it (#2320): every timestamp the
+/// learning loop writes comes from [`SessionMemory::clock`], and the one value
+/// that still arrives from out here rides in as `started_unix_secs`, a
+/// parameter a replayer supplies. Reaching for this from inside a session would
+/// re-open the seam #2320 closed.
 pub(crate) fn unix_now_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -71,6 +71,7 @@ impl SessionMemory {
             &self.domains.names(),
             succeeded,
             budget_limit,
+            self.clock.now_unix_secs().max(0) as u64,
         )
         .await
         {
@@ -440,12 +441,12 @@ impl SessionMemory {
     /// remove. Refusals are printed too — a sweep that silently declines to act
     /// on protected records reads as "nothing was failing", a different claim.
     fn retire_failing_context(&self, quiet: bool) {
-        let now = stella_context::format_rfc3339(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0) as i64,
-        );
+        // The instant every TTL and staleness predicate below is judged
+        // against, from the session clock (#2320). While this read was
+        // `SystemTime::now()` the sweep always saw today, so no test could
+        // place a record past its TTL — retirement was unobservable rather
+        // than merely untested.
+        let now = self.clock.now_rfc3339();
 
         // Deterministic validation first (#753): a memory whose path anchors
         // have ALL left the tree is stale by a reproducible check, needing no

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -71,7 +71,6 @@ impl SessionMemory {
             &self.domains.names(),
             succeeded,
             budget_limit,
-            self.clock.now_unix_secs().max(0) as u64,
         )
         .await
         {
@@ -138,9 +137,18 @@ impl SessionMemory {
         // from one reflection call read as one task and three turns on one task
         // read as three. Both directions are wrong; the session id is at least
         // a real boundary for the one-shot path, where one process is one task.
+        //
+        // `occurred_at` is stamped in the same pass, from the session clock
+        // (#2320). Both fields answer "which session, and when" — one loop
+        // owning both is why neither the reflection dispatch nor the parser
+        // needs to know the time. It also overwrites anything a model put in
+        // the field: a lesson's instant is ours to assign, never the
+        // response's to claim.
         let mut lessons = lessons;
+        let occurred_at = self.clock.now_unix_secs().max(0) as u64;
         for lesson in &mut lessons {
             lesson.task_id = self.task_id.clone();
+            lesson.occurred_at = occurred_at;
         }
 
         // Drop anything the user has already forgotten, BEFORE it reaches any

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -101,12 +101,10 @@ pub(crate) async fn reflect_routed(
         .await
 }
 
-/// `now` is the instant every lesson this call mines is stamped with, in Unix
-/// seconds. It is a parameter rather than a `SystemTime::now()` read because
-/// `occurred_at` is written verbatim into `reflections.jsonl`, which the skill
-/// and rule miners re-read — so a wall-clock read here made the whole mining
-/// log unreproducible (#2320). Callers inside a session pass
-/// `SessionMemory::clock`.
+/// Stamps no timestamp of its own (#2320). `occurred_at` is assigned by
+/// `SessionMemory::reflect_and_record`, in the same pass that stamps
+/// `task_id`, from the session clock — so neither this dispatch nor the parser
+/// below ever reads a clock, and the mining log they feed is reproducible.
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,
@@ -115,7 +113,6 @@ pub async fn reflect_on_turn(
     domain_names: &[String],
     succeeded: bool,
     budget_limit: Option<f64>,
-    now: u64,
 ) -> Result<
     (ReflectionParse, Option<SelfReviewRow>, f64, Vec<AgentEvent>),
     crate::accounted_call::StandaloneCallError,
@@ -313,7 +310,7 @@ pub async fn reflect_on_turn(
     )
     .await?;
     Ok((
-        parse_lessons_checked(&accounted.result.text, domain_names, now),
+        parse_lessons_checked(&accounted.result.text, domain_names),
         parse_self_review(&accounted.result.text),
         accounted.cost_usd,
         accounted.events,
@@ -468,9 +465,9 @@ fn extract_lesson_array(text: &str) -> Option<Vec<ReflectionLesson>> {
     None
 }
 
-/// `now` (Unix seconds) is stamped onto every lesson as `occurred_at`. See
-/// [`reflect_on_turn`] for why it is a parameter and not a clock read.
-pub fn parse_lessons_checked(text: &str, allowed_domains: &[String], now: u64) -> ReflectionParse {
+/// Purely a parser: it reads no clock and assigns no instant. `occurred_at`
+/// is the session's to stamp — see [`reflect_on_turn`] (#2320).
+pub fn parse_lessons_checked(text: &str, allowed_domains: &[String]) -> ReflectionParse {
     let Some(mut lessons) = extract_lesson_array(text) else {
         // An empty response is a legitimate "nothing to record". Anything else
         // is a response we failed to read, and the caller should say so.
@@ -482,7 +479,6 @@ pub fn parse_lessons_checked(text: &str, allowed_domains: &[String], now: u64) -
     };
     lessons.truncate(3);
     for lesson in &mut lessons {
-        lesson.occurred_at = now;
         lesson.domains.retain(|domain| {
             allowed_domains
                 .iter()

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -101,6 +101,12 @@ pub(crate) async fn reflect_routed(
         .await
 }
 
+/// `now` is the instant every lesson this call mines is stamped with, in Unix
+/// seconds. It is a parameter rather than a `SystemTime::now()` read because
+/// `occurred_at` is written verbatim into `reflections.jsonl`, which the skill
+/// and rule miners re-read — so a wall-clock read here made the whole mining
+/// log unreproducible (#2320). Callers inside a session pass
+/// `SessionMemory::clock`.
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,
@@ -109,6 +115,7 @@ pub async fn reflect_on_turn(
     domain_names: &[String],
     succeeded: bool,
     budget_limit: Option<f64>,
+    now: u64,
 ) -> Result<
     (ReflectionParse, Option<SelfReviewRow>, f64, Vec<AgentEvent>),
     crate::accounted_call::StandaloneCallError,
@@ -306,7 +313,7 @@ pub async fn reflect_on_turn(
     )
     .await?;
     Ok((
-        parse_lessons_checked(&accounted.result.text, domain_names),
+        parse_lessons_checked(&accounted.result.text, domain_names, now),
         parse_self_review(&accounted.result.text),
         accounted.cost_usd,
         accounted.events,
@@ -461,7 +468,9 @@ fn extract_lesson_array(text: &str) -> Option<Vec<ReflectionLesson>> {
     None
 }
 
-pub fn parse_lessons_checked(text: &str, allowed_domains: &[String]) -> ReflectionParse {
+/// `now` (Unix seconds) is stamped onto every lesson as `occurred_at`. See
+/// [`reflect_on_turn`] for why it is a parameter and not a clock read.
+pub fn parse_lessons_checked(text: &str, allowed_domains: &[String], now: u64) -> ReflectionParse {
     let Some(mut lessons) = extract_lesson_array(text) else {
         // An empty response is a legitimate "nothing to record". Anything else
         // is a response we failed to read, and the caller should say so.
@@ -471,10 +480,6 @@ pub fn parse_lessons_checked(text: &str, allowed_domains: &[String]) -> Reflecti
             ReflectionParse::Unreadable(text.chars().take(180).collect())
         };
     };
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0);
     lessons.truncate(3);
     for lesson in &mut lessons {
         lesson.occurred_at = now;

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -24,12 +24,6 @@ use stella_protocol::{
     Provider, ProviderError, ReasoningEffort,
 };
 
-/// The instant handed to `reflect_on_turn` (#2320). These tests assert on the
-/// *request* the reflection builds, never on a timestamp, so the value only has
-/// to be fixed. `1_600_000_000` is 2020-09-13T12:26:40Z — the same reference
-/// instant `stella-context`'s clock tests use.
-const FIXED_NOW: u64 = 1_600_000_000;
-
 /// Records the prompt it is asked to complete — and the request's dispatch
 /// shape (effort, output cap) — then answers with a well-formed empty result
 /// so the caller's parsing path stays on its happy road: the request is what
@@ -90,7 +84,6 @@ async fn prompt_for(succeeded: bool) -> String {
         &["testing".to_string()],
         succeeded,
         None,
-        FIXED_NOW,
     )
     .await
     .expect("the stub provider cannot fail");
@@ -185,7 +178,6 @@ async fn reflection_dispatches_low_effort_with_its_bounded_output_cap() {
         &["testing".to_string()],
         true,
         None,
-        FIXED_NOW,
     )
     .await
     .expect("the stub provider cannot fail");

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -24,6 +24,12 @@ use stella_protocol::{
     Provider, ProviderError, ReasoningEffort,
 };
 
+/// The instant handed to `reflect_on_turn` (#2320). These tests assert on the
+/// *request* the reflection builds, never on a timestamp, so the value only has
+/// to be fixed. `1_600_000_000` is 2020-09-13T12:26:40Z — the same reference
+/// instant `stella-context`'s clock tests use.
+const FIXED_NOW: u64 = 1_600_000_000;
+
 /// Records the prompt it is asked to complete — and the request's dispatch
 /// shape (effort, output cap) — then answers with a well-formed empty result
 /// so the caller's parsing path stays on its happy road: the request is what
@@ -84,6 +90,7 @@ async fn prompt_for(succeeded: bool) -> String {
         &["testing".to_string()],
         succeeded,
         None,
+        FIXED_NOW,
     )
     .await
     .expect("the stub provider cannot fail");
@@ -178,6 +185,7 @@ async fn reflection_dispatches_low_effort_with_its_bounded_output_cap() {
         &["testing".to_string()],
         true,
         None,
+        FIXED_NOW,
     )
     .await
     .expect("the stub provider cannot fail");

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -5,6 +5,10 @@
 // #1221: the A/B recall control — its durable schedule, what a control turn
 // suppresses, and the attribution that separates the arms afterwards.
 mod ab_control;
+// #2320: the session clock. That the learning loop reads one injected time
+// source rather than the wall clock is the property replay rests on, and it is
+// what makes the truth sweep's TTL branch reachable from a test at all.
+mod determinism;
 mod path_token;
 mod quarantine;
 // Which sessions actually receive the volatile record channel — a separate
@@ -15,6 +19,11 @@ mod record_channel;
 mod skill_creation;
 
 use super::*;
+
+/// The instant these parsing tests stamp lessons with (#2320). They assert on
+/// what was parsed, never on when — the value only has to be fixed, so the
+/// suite cannot start depending on the day it runs.
+const PARSE_FIXED_NOW: u64 = 1_600_000_000;
 
 fn msg(role: MessageRole, content: &str) -> CompletionMessage {
     CompletionMessage {
@@ -672,14 +681,14 @@ fn unreadable_reflection_is_distinguished_from_having_nothing_to_say() {
 
     assert!(
         matches!(
-            parse_lessons_checked("", &[]),
+            parse_lessons_checked("", &[], PARSE_FIXED_NOW),
             ReflectionParse::Lessons(lessons) if lessons.is_empty()
         ),
         "an empty response is a legitimate 'nothing to record'"
     );
     assert!(
         matches!(
-            parse_lessons_checked("no json here", &[]),
+            parse_lessons_checked("no json here", &[], PARSE_FIXED_NOW),
             ReflectionParse::Unreadable(_)
         ),
         "prose with no array is a response we failed to read, not an empty one"
@@ -965,7 +974,7 @@ fn lessons_of(text: &str) -> Vec<crate::memory::ReflectionLesson> {
 }
 
 fn lessons_with(text: &str, allowed: &[String]) -> Vec<crate::memory::ReflectionLesson> {
-    match crate::memory::reflection::parse_lessons_checked(text, allowed) {
+    match crate::memory::reflection::parse_lessons_checked(text, allowed, PARSE_FIXED_NOW) {
         crate::memory::reflection::ReflectionParse::Lessons(lessons) => lessons,
         crate::memory::reflection::ReflectionParse::Unreadable(excerpt) => {
             panic!("expected a readable lesson array, got unreadable: {excerpt}")

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -20,11 +20,6 @@ mod skill_creation;
 
 use super::*;
 
-/// The instant these parsing tests stamp lessons with (#2320). They assert on
-/// what was parsed, never on when — the value only has to be fixed, so the
-/// suite cannot start depending on the day it runs.
-const PARSE_FIXED_NOW: u64 = 1_600_000_000;
-
 fn msg(role: MessageRole, content: &str) -> CompletionMessage {
     CompletionMessage {
         role,
@@ -659,7 +654,17 @@ fn parse_lessons_drops_invented_domains_and_caps_at_three() {
         vec!["API"],
         "case-insensitive match kept"
     );
-    assert!(lessons[0].occurred_at > 0);
+    // The parser deliberately stamps NO instant (#2320). It used to assert
+    // `occurred_at > 0` here, back when `parse_lessons_checked` read the wall
+    // clock — the read that made the mining log unreproducible. Stamping is now
+    // the session's, in `reflect_and_record`'s existing task-id pass, and is
+    // pinned end to end in `memory::tests::determinism`. Asserting the zero
+    // keeps that boundary honest: a clock creeping back into the parser would
+    // fail here rather than pass quietly.
+    assert_eq!(
+        lessons[0].occurred_at, 0,
+        "parsing assigns no instant — the session does"
+    );
 }
 
 #[test]
@@ -681,14 +686,14 @@ fn unreadable_reflection_is_distinguished_from_having_nothing_to_say() {
 
     assert!(
         matches!(
-            parse_lessons_checked("", &[], PARSE_FIXED_NOW),
+            parse_lessons_checked("", &[]),
             ReflectionParse::Lessons(lessons) if lessons.is_empty()
         ),
         "an empty response is a legitimate 'nothing to record'"
     );
     assert!(
         matches!(
-            parse_lessons_checked("no json here", &[], PARSE_FIXED_NOW),
+            parse_lessons_checked("no json here", &[]),
             ReflectionParse::Unreadable(_)
         ),
         "prose with no array is a response we failed to read, not an empty one"
@@ -974,7 +979,7 @@ fn lessons_of(text: &str) -> Vec<crate::memory::ReflectionLesson> {
 }
 
 fn lessons_with(text: &str, allowed: &[String]) -> Vec<crate::memory::ReflectionLesson> {
-    match crate::memory::reflection::parse_lessons_checked(text, allowed, PARSE_FIXED_NOW) {
+    match crate::memory::reflection::parse_lessons_checked(text, allowed) {
         crate::memory::reflection::ReflectionParse::Lessons(lessons) => lessons,
         crate::memory::reflection::ReflectionParse::Unreadable(excerpt) => {
             panic!("expected a readable lesson array, got unreadable: {excerpt}")

--- a/crates/stella-cli/src/memory/tests/determinism.rs
+++ b/crates/stella-cli/src/memory/tests/determinism.rs
@@ -99,18 +99,22 @@ async fn reflection_log_at(at: i64) -> (tempfile::TempDir, String) {
 }
 
 /// **The witness.** Two sessions frozen at the same instant write the same
-/// bytes.
+/// bytes, *and those bytes carry that instant*.
 ///
-/// On `main` this fails on the task id alone: `default_task_id` was
-/// `session:{SystemTime::now()}-{process::id()}`, so two sessions in one
-/// process shared a pid but raced the second boundary, and two sessions in
-/// different processes never agreed at all. `occurred_at` was a second,
-/// independent wall-clock read in `parse_lessons_checked`.
-///
-/// Byte equality rather than a field-by-field comparison is deliberate: the
-/// log is re-read verbatim by `mine_skill_candidates` and the observation
+/// Byte equality rather than a field-by-field comparison is deliberate: the log
+/// is re-read verbatim by `mine_skill_candidates` and the observation
 /// extractor, so *the bytes* are the interface, and a new field that quietly
-/// reintroduces a clock read would slip past a narrower assertion.
+/// reintroduced a clock read would slip past a narrower assertion.
+///
+/// The second half is not decoration, and measuring it changed this test.
+/// Equality **alone passes on the unfixed code**: both sessions run in one
+/// process, so a wall-clock `occurred_at` and a pid-bearing task id agree with
+/// each other whenever the two runs land in the same second — which is almost
+/// always. Verified by reverting the three internals behind their new
+/// signatures: the equality-only form passed while the three value-pinning
+/// tests below failed. An assertion that holds on the broken code except when
+/// it straddles a second boundary is a flake, not a witness, so this one pins
+/// the value too.
 #[tokio::test]
 async fn two_sessions_at_one_fixed_clock_write_byte_identical_mining_logs() {
     let (_a_dir, a) = reflection_log_at(T).await;
@@ -119,6 +123,12 @@ async fn two_sessions_at_one_fixed_clock_write_byte_identical_mining_logs() {
         a, b,
         "two sessions frozen at the same instant must produce an identical \
          mining log — this is the property trace replay rests on"
+    );
+    assert!(
+        a.contains(&format!("\"occurred_at\":{T}"))
+            && a.contains(&format!("\"task_id\":\"session:{T}\"")),
+        "…and they must agree on the *injected* instant, not merely on \
+         whatever the wall clock read twice in one second: {a}"
     );
 }
 

--- a/crates/stella-cli/src/memory/tests/determinism.rs
+++ b/crates/stella-cli/src/memory/tests/determinism.rs
@@ -1,0 +1,208 @@
+//! The session clock (#2320): every timestamp the learning loop writes comes
+//! from one injected time source, never the wall clock.
+//!
+//! `stella-context` has shipped [`Clock`]/[`FixedClock`] since the bi-temporal
+//! store landed, and `ContextStore::open_and_warm` has always taken one — the
+//! learning loop simply routed around the port and called `SystemTime::now()`
+//! in five places. Two consequences, and this module pins both:
+//!
+//! 1. **Nothing the loop wrote was reproducible.** `occurred_at` on every mined
+//!    lesson, and the session's task id, came from the wall clock, so the
+//!    mining log the skill and rule miners re-read differed on every run.
+//! 2. **Retirement was unobservable.** `retire_failing_context` judged TTLs
+//!    against `SystemTime::now()`, so a test could never place a record past
+//!    its expiry — the sweep always saw today.
+//!
+//! Its own file rather than more of `memory/tests.rs`, which sits close under
+//! the 1500-line ratchet `scripts/check-file-size.sh` enforces.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use stella_context::{Clock, FixedClock, format_rfc3339};
+use stella_protocol::{
+    CompletionRequestRef, CompletionResult, CompletionUsage, Provider, ProviderError,
+};
+
+use super::msg;
+use crate::memory::*;
+
+/// A fixed instant well clear of "now", so a test that accidentally read the
+/// wall clock could not pass by coincidence. 2020-09-13T12:26:40Z — the
+/// reference instant `stella-context`'s own clock tests use.
+const T: i64 = 1_600_000_000;
+
+/// Answers every reflection with one byte-identical lesson.
+///
+/// The response carries no timestamp of its own: `occurred_at` is stamped by
+/// `parse_lessons_checked` from the instant the caller supplies, which is
+/// exactly the value under test.
+struct ScriptedReflection;
+
+#[async_trait]
+impl Provider for ScriptedReflection {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Ok(CompletionResult {
+            text: r#"{"lessons": [{"lesson": "prefer withTenantDb over raw db()",
+                 "kind": "domain", "domains": []}]}"#
+                .into(),
+            tool_calls: vec![],
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 1,
+                ..CompletionUsage::default()
+            },
+            model: "scripted".into(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Run one scripted turn against a fresh workspace whose session clock is
+/// frozen at `at`, and return the bytes of the mining log it produced.
+async fn reflection_log_at(at: i64) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock::new(at));
+    let mut memory = SessionMemory::open_with_clock(dir.path(), false, clock)
+        .expect("session memory opens in a temp workspace");
+
+    let transcript = vec![
+        msg(MessageRole::User, "fix the tenancy leak"),
+        msg(MessageRole::Assistant, "swapped db() for withTenantDb"),
+    ];
+    let report = memory
+        .reflect_and_record(
+            &ScriptedReflection,
+            "scripted",
+            &transcript,
+            true,
+            true,
+            None,
+        )
+        .await;
+    assert_eq!(report.recorded, 1, "the scripted lesson was mined");
+
+    let path = stella_store::workspace_private_state_path(dir.path(), "reflections.jsonl")
+        .expect("private state path resolves");
+    let bytes = std::fs::read_to_string(&path).expect("the mining log was written");
+    (dir, bytes)
+}
+
+/// **The witness.** Two sessions frozen at the same instant write the same
+/// bytes.
+///
+/// On `main` this fails on the task id alone: `default_task_id` was
+/// `session:{SystemTime::now()}-{process::id()}`, so two sessions in one
+/// process shared a pid but raced the second boundary, and two sessions in
+/// different processes never agreed at all. `occurred_at` was a second,
+/// independent wall-clock read in `parse_lessons_checked`.
+///
+/// Byte equality rather than a field-by-field comparison is deliberate: the
+/// log is re-read verbatim by `mine_skill_candidates` and the observation
+/// extractor, so *the bytes* are the interface, and a new field that quietly
+/// reintroduces a clock read would slip past a narrower assertion.
+#[tokio::test]
+async fn two_sessions_at_one_fixed_clock_write_byte_identical_mining_logs() {
+    let (_a_dir, a) = reflection_log_at(T).await;
+    let (_b_dir, b) = reflection_log_at(T).await;
+    assert_eq!(
+        a, b,
+        "two sessions frozen at the same instant must produce an identical \
+         mining log — this is the property trace replay rests on"
+    );
+}
+
+/// The companion the byte-equality test needs to be sound.
+///
+/// Equality alone can pass for the wrong reason: two sessions that both read
+/// the wall clock inside one second agree with each other while agreeing with
+/// nothing. This pins the actual value, so the log can only match if the
+/// injected clock — and not the machine's — is what reached the record.
+#[tokio::test]
+async fn the_mined_lesson_is_stamped_with_the_injected_instant() {
+    let (_dir, log) = reflection_log_at(T).await;
+    let line = log.lines().next().expect("one lesson was logged");
+    let lesson: ReflectionLesson = serde_json::from_str(line).expect("the log line is a lesson");
+
+    assert_eq!(
+        lesson.occurred_at, T as u64,
+        "occurred_at comes from the session clock, not the wall clock"
+    );
+    assert_eq!(
+        lesson.task_id,
+        format!("session:{T}"),
+        "the deterministic constructor derives its task id from the same clock"
+    );
+}
+
+/// Different instants must still produce different records — the fix must not
+/// have frozen time into a constant, which would make every replay agree for
+/// the uninteresting reason.
+#[tokio::test]
+async fn a_later_clock_stamps_a_later_lesson() {
+    let (_early_dir, early) = reflection_log_at(T).await;
+    let (_late_dir, late) = reflection_log_at(T + 86_400).await;
+    assert_ne!(
+        early, late,
+        "a session a day later records a different instant"
+    );
+
+    let later: ReflectionLesson =
+        serde_json::from_str(late.lines().next().expect("one lesson")).expect("a lesson");
+    assert_eq!(later.occurred_at, (T + 86_400) as u64);
+}
+
+/// The clock the session hands the context store is the same one it stamps its
+/// own records with.
+///
+/// Before #2320 `open_*` built the store with `SystemClock` unconditionally, so
+/// even a caller that wanted a fixed clock got a store that disagreed with it —
+/// the bi-temporal `recorded_at` on every memory came from the wall clock while
+/// the mining log came from somewhere else. Nothing could line the two up.
+#[tokio::test]
+async fn the_context_store_shares_the_session_clock() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock::new(T));
+    let mut memory = SessionMemory::open_with_clock(dir.path(), false, clock)
+        .expect("session memory opens in a temp workspace");
+
+    let transcript = vec![
+        msg(MessageRole::User, "fix the tenancy leak"),
+        msg(MessageRole::Assistant, "swapped db() for withTenantDb"),
+    ];
+    let report = memory
+        .reflect_and_record(
+            &ScriptedReflection,
+            "scripted",
+            &transcript,
+            true,
+            true,
+            None,
+        )
+        .await;
+    assert_eq!(report.recorded, 1, "the scripted lesson was mined");
+
+    // `recorded_at` is the store's own transaction time, written by the clock
+    // handed to `ContextStore::open_and_warm` — a different write path from the
+    // mining log above, and the one that proves both halves read one source.
+    let nodes = memory.store.memory_nodes().expect("memory nodes readable");
+    let node = nodes.first().expect("the lesson landed in context.db");
+    assert_eq!(
+        node.recorded_at,
+        format_rfc3339(T),
+        "the store stamps its transaction time from the session clock; before \
+         #2320 `open_*` built it with SystemClock no matter what the caller asked for"
+    );
+}

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -214,8 +214,17 @@ Per turn, in order:
   isolated, so the harness asserts no ambient read — the pattern
   `crates/stella-runtime/tests/no_ambient_reads.rs` already enforces for the
   runtime.
-- **Two replays of one trace produce byte-identical summaries.** This is
-  assertion 8, not a comment.
+- **Two replays of one trace produce byte-identical summaries, and those
+  summaries carry the trace's own instants.** This is assertion 8, not a
+  comment — and the second clause is load-bearing, not emphasis.
+
+  Agreement alone is not evidence of determinism: two replays sharing one
+  ambient clock agree with each other while agreeing with nothing. Measured, not
+  reasoned — #2320's originally-specified witness was exactly the weak form, and
+  it **passed against the unfixed code**, because two sessions in one process
+  read the same wall-clock second. It only failed on a run that happened to
+  straddle a second boundary. Every determinism assertion in this harness must
+  pin the injected value, not merely the agreement.
 
 ---
 
@@ -232,7 +241,7 @@ Each pins a mechanism that today has no end-to-end proof.
 | 5 | A tombstoned lesson is **never re-learned**, including when the corpus later restates it in different words | `retain_unforgotten` matches by restatement, not equality — so the corpus must paraphrase, or the assertion is vacuous |
 | 6 | A retired record stops rendering into the prompt | truth sweep + the volatile channel |
 | 7 | A corpus of `Unreadable` reflections builds **nothing** and the harness **says so loudly** | the starvation guard — a clean `recorded: 0` on every turn must not read as "the agent keeps getting things right" |
-| 8 | Two replays of one trace produce byte-identical summaries | the determinism contract itself |
+| 8 | Two replays of one trace produce byte-identical summaries **and those summaries carry the trace's own instants** | the determinism contract itself |
 
 Assertion 5 deserves a note: because suppression matches restatements, a corpus
 that tombstones lesson *L* and then re-emits *L verbatim* proves almost nothing —


### PR DESCRIPTION
## What & why

`stella-context` has shipped a `Clock` port — `SystemClock`, `FixedClock` with `advance`/`set` — since the bi-temporal store landed, and `ContextStore::open_and_warm` has always taken one. The CLI's learning loop routed around it and called `SystemTime::now()` directly. This threads the port through `SessionMemory` so every timestamp the loop writes comes from one injected source.

Closes #2320.

### The five reads, and what each cost

| Site | Now reads |
|---|---|
| `memory.rs::default_task_id` | `clock.now_unix_secs()` |
| `memory.rs::record_episode` | `self.clock.now_unix_secs()` |
| `memory/learning.rs::retire_failing_context` | `self.clock.now_rfc3339()` |
| `memory/reflection.rs::parse_lessons_checked` | nothing — stamping moved (below) |
| `open_with_workspace_skills` → `ContextStore` | the caller's clock, not a hardcoded `SystemClock` |

`retire_failing_context` is the one that was a defect on its own terms: its `now` is the instant the truth sweep judges TTLs against, so while it read the wall clock **no test could place a record past its expiry**. Retirement was unobservable, not merely untested.

### Three judgment calls worth reviewing

**1. The pid stays in `default_task_id`.** The issue said to drop it. I disagree and kept it, because it is not a time source and removing it trades a rare governance under-count (two processes starting in the same second mint one id, and governance counts *distinct tasks*) for reproducibility on a path that is never replayed. The determinism lives in a separate `deterministic_task_id` used only by the new constructor, so the nondeterminism is confined to the constructor that wants it. Happy to drop it if you'd rather.

**2. `occurred_at` is stamped in `reflect_and_record`, not the parser.** My first pass threaded a `now: u64` through `reflect_on_turn` → `parse_lessons_checked`, which pushed `reflect_on_turn` to 8 arguments and tripped `clippy::too_many_arguments`. The repo would have accepted a justified `#[allow]` (`subsession.rs:531` is the precedent) — but `reflect_and_record` **already** loops over the lessons to stamp `task_id`, and `occurred_at` answers the same question. Stamping both there removes the parameter entirely: no `#[allow]`, both signatures unchanged from `main`, a smaller diff, and `parse_lessons_checked` becomes a pure parser that reads no clock at all. Better than the lint suppression I set out to write.

**3. `unix_now_secs()` stays as-is.** It is `pub(crate)` and called from twelve places in `agent.rs`, `agent/goal.rs` and `command_deck.rs` — drivers that own no clock and use it to compute the `started_unix_secs` they pass *into* `record_episode`. `SessionMemory` itself no longer calls it, so it is not part of the loop's determinism problem: the one value still arriving from outside rides in as a parameter a replayer controls. Documented at the definition rather than churned through two god files. Flagged below.

### The `edge.rs:121` audit the issue asked for

Resolved, no change needed. It is `process_nonce()` — pid ⊕ first-use subsec nanos ⊕ the static's ASLR address, folded into edge id minting so the process-local `EDGE_SEQ` cannot collide across processes, backing schema v10's `UNIQUE` index on `edge.public_id`. It is a nonce, never a comparable or ordered field, and it already says so in its own doc comment. Consequence worth knowing for #2304: edge `public_id`s are not reproducible across processes, so a replay harness must not assert on them.

## The witness

- [x] Includes a witness test (fails on `main`, passes here) — `crates/stella-cli/src/memory/tests/determinism.rs`, four tests.

**Verified the artisanal way, and the result changed the tests.** Rather than only checking that they fail on `main` (where they would fail merely because `open_with_clock` is absent — proving the API is new, not that the behaviour is fixed), I reverted the three internals *behind their unchanged signatures* and re-ran.

The first round found a real problem with **the witness the issue specified**:

```
two_sessions_at_one_fixed_clock_write_byte_identical_mining_logs ... ok      ← on the BROKEN code
the_mined_lesson_is_stamped_with_the_injected_instant ...        FAILED
a_later_clock_stamps_a_later_lesson ...                          FAILED
the_context_store_shares_the_session_clock ...                   FAILED
```

Byte-equality between two sessions **passes on the unfixed code**. Both run in one process, so a wall-clock `occurred_at` and a pid-bearing task id agree with each other whenever the two runs land in the same second — which is nearly always. It would only have failed on a run that straddled a second boundary. That is a flake, not a witness, and #2320 specified it as the witness. I have said so on the issue.

So the equality test now also pins the *value*, and all four fail without the fix:

```
two_sessions_at_one_fixed_clock_write_byte_identical_mining_logs ... FAILED
the_mined_lesson_is_stamped_with_the_injected_instant ...            FAILED
a_later_clock_stamps_a_later_lesson ...                              FAILED
the_context_store_shares_the_session_clock ...                       FAILED
test result: FAILED. 0 passed; 4 failed
```

and all four pass on this branch. The probe was re-run against the *final* code shape after the argument refactor, not the first draft. `a_later_clock_stamps_a_later_lesson` exists so the fix cannot pass by freezing time into a constant.

## The gate

- [x] `make gate CARGO_SCOPE="-p stella-cli"` — **exit 0**, all 25 steps, including `clippy -D warnings`, rustdoc `-D warnings`, `test --workspace` (1493 passed), and the self-driving shell harness (60 checks).
- [x] `cargo fmt --check`
- [x] Docs updated — doc comments at every changed seam; no flags or behaviour changed for users.
- [x] `Closes #2320` in this description **and** as a commit trailer.

Two things the gate caught that are worth naming rather than burying:

- **rustdoc**: I linked `[`deterministic_task_id`]` from a public doc comment while the item is `#[cfg(test)]`, so it does not exist in the documented build. Now plain text with a note saying why.
- **One existing assertion changed, deliberately.** `memory::tests::parse_lessons_drops_invented_domains_and_caps_at_three` asserted `lessons[0].occurred_at > 0` — true only because the parser read the wall clock, which is the bug. It now asserts `occurred_at == 0`, pinning the new boundary: parsing assigns no instant, the session does. No test was deleted or renamed; the assertion was inverted on purpose and the reason is in a comment beside it.

## Nothing left behind

- **`self_tuning.rs::now_ms` is still a wall-clock read** and lives under `crates/stella-cli/src/memory/`, so #2320's literal definition of done ("no `SystemTime::now()` remains in `crates/stella-cli/src/memory/`") is **not** fully met by this PR. Deliberate: it is reached only from `tune_cmd.rs`, never from `SessionMemory`, so it is a separate surface with its own witness. It is tracked as site 2 of **#2330** (the seven hand-rolled `now_ms` copies). Calling this out rather than quietly claiming the DoD.
- **`unix_now_secs`'s twelve driver call sites** stay on the ambient clock — see judgment call 3. Threading a clock into `agent.rs`/`command_deck.rs` (both god files, closed to growth) is its own change.
- **#2330** covers the same shape elsewhere: `ports::Clock::now_ms` re-implemented by hand in seven places, including inside `stella-core`.
- Unblocks epic **#2304** / `doc:trace-replay-learning-harness` PR 1 of 5. `open_with_clock` and `deterministic_task_id` are `#[cfg(test)]`-gated with a comment to drop both gates in the commit that lands the replayer.

## Summary by Sourcery

Route all learning loop timestamps through a session-level Clock, making stella-cli’s SessionMemory time behavior reproducible and testable while preserving existing CLI behavior.

New Features:
- Introduce a test-only SessionMemory::open_with_clock constructor that accepts an injected Clock for deterministic sessions.
- Add a deterministic_task_id helper to derive reproducible task IDs from the injected clock.

Bug Fixes:
- Fix retire_failing_context to use the session clock rather than the wall clock so TTL-based retirement can be observed and tested.
- Ensure mined lessons’ occurred_at timestamps are sourced from the session clock, eliminating nondeterministic wall-clock reads in the learning loop.

Enhancements:
- Thread a Clock through SessionMemory and ContextStore so both the mining log and bi-temporal store share a single time source.
- Refine task ID generation to separate nondeterministic default_task_id from deterministic_task_id used in replay scenarios.
- Make reflection and lesson parsing pure with respect to time by moving timestamp stamping into reflect_and_record.
- Document the intended use of unix_now_secs as an ambient clock helper and the role of the session clock for determinism.

Tests:
- Add determinism tests that validate replayable mining logs, correct stamping of injected instants, differing timestamps for differing clocks, and shared clock usage between SessionMemory and ContextStore.
- Adjust an existing parser test to assert that lessons parsed from reflections start with occurred_at = 0, confirming that timestamp assignment is now a session concern.