### PR TITLE
docs(stella-context): record the #2320 edge-nonce audit — identity, not time, and public_id is never replay-comparable

### DIFF
--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -114,6 +114,22 @@ static EDGE_SEQ: AtomicU64 = AtomicU64::new(0);
 /// nanos plus the static's ASLR-randomized address — not cryptographic, just
 /// distinct per process, which is all the v10 `UNIQUE` constraint needs
 /// backing for.
+///
+/// **Audited for the clock port (#2320): this is an identity nonce, not a time
+/// reading, and it deliberately stays off [`crate::Clock`].** The `SystemTime`
+/// read below never reaches a comparable field — nothing orders, ranges over or
+/// compares `edge.public_id`; the row's *time* is the separate `recorded_at`
+/// column, which callers already pass in as `now` and which the clock port does
+/// govern. Putting a fixed clock behind the nonce would only make two processes
+/// in one second mint from the same keyspace, which is the collision it exists
+/// to prevent.
+///
+/// Determinism note for replay harnesses: `public_id` is unreproducible anyway,
+/// and not because of this nonce. [`EDGE_SEQ`] is a process-global counter, so
+/// two replays of one trace *inside a single process* mint different ids for
+/// the same logical edge. An edge `public_id` is therefore never admissible in
+/// a replay summary compared for byte-identity — compare edge content, not edge
+/// identity (`doc:trace-replay-learning-harness` §4.2).
 fn process_nonce() -> u64 {
     static NONCE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
     *NONCE.get_or_init(|| {


### PR DESCRIPTION
The trace-replay spec assigns PR 1 of five an audit of the `SystemTime` read at `edge.rs:121` (`doc:trace-replay-learning-harness` §9 row 1, §11 "may defeat determinism"). Two parallel implementations of that PR existed: #2340, which landed and closed #2320 but never touched `edge.rs`, and #2335, which did the audit but was superseded and closed. This PR carries the audit's outcome over from #2335's `bb7f4772`, verbatim, as the doc comment on `process_nonce` — the one place the next reader will actually hit it.

## The audit outcome

**Identity nonce, not a time source — deliberately left off the `Clock` port.** `process_nonce()` hashes into `edge.public_id`, so it is serialized, but never into a *comparable* field: nothing orders, ranges over, or compares `public_id`. The row's time is the separate `recorded_at` column, which callers already pass in as `now` (`insert_edge`'s signature) and which the clock port already governs. Putting a fixed clock behind the nonce would only make two processes in one second mint from the same keyspace — the exact collision it exists to prevent.

**The finding §11 did not anticipate:** `public_id` is unreproducible *anyway*, and not because of the nonce. `EDGE_SEQ` is a process-global counter, so two replays of one trace inside a single process mint different ids for the same logical edge. An edge `public_id` is therefore never admissible in a replay summary compared for byte-identity — the harness must compare edge content, not edge identity. This constrains PR 4's metrics and is now stated where PR 4's author will read it.

Per §11's contingency ("if it reaches a comparable field, PR 1 grows to cover it"): it does not reach a comparable field, so no code change is needed — the deliverable is the recorded verdict.

## Verification

- Comment-only: 16 added doc-comment lines, zero code changes.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-context --no-deps` — green (the gate's form).
- Claims re-checked against today's main, not just inherited: `insert_edge` takes `now: &str` (edge.rs:159), `Clock` is re-exported at the crate root (lib.rs:73) so the intra-doc link resolves, and the `public_id` hash folds in `{nonce}:{seq}` (edge.rs:167).

## Noticed while verifying, not fixed here

`cargo doc -p stella-context --no-deps --document-private-items -D warnings` surfaces 9 pre-existing broken intra-doc links on private items (`candidates.rs`, `retrieval.rs`, `ranking.rs`, `domain.rs`, `schema.rs`, `ann.rs`) that the gate's public-items-only form masks. None are introduced by this PR; the gate gap and these exact sites are already tracked as #2336.
