### PR TITLE
feat(stella-cli): the trace-replay learning harness — the whole learning loop, driven from recorded traces, with zero model calls (#2304)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,16 @@ test-cli: ## Test stella-cli only (the shipping binary)
 test-protocol: ## Test stella-protocol only (shared types)
 	cargo test -p stella-protocol
 
+# The trace-replay learning harness (#2304, `doc:trace-replay-learning-harness`
+# §8). Deliberately NOT a `make gate` step: the assertions are ordinary in-crate
+# tests already covered by the gate's existing `test` step, and a target whose
+# job is to PRINT a report adds nothing as pass/fail — while every added step is
+# one more shared cell the Makefile, AGENTS.md and CONTRIBUTING.md must agree on.
+.PHONY: replay-learning
+replay-learning: ## Replay the synthetic months corpus and print what the learners built (#2304)
+	cargo test -p stella-cli --bin stella \
+	  memory::replay::tests::replay_learning_report -- --exact --nocapture
+
 .PHONY: record-golden
 record-golden: ## Re-record the golden replay trajectories (review the fixture diff!)
 	STELLA_REFRESH_GOLDEN=1 cargo test -p stella-pipeline --lib golden

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -67,6 +67,12 @@ mod private_state;
 mod projection;
 pub(crate) mod proposals;
 mod recall;
+// #2304: the trace-replay learning harness — the learning machinery driven from
+// recorded traces with zero model calls. Test-only by construction: the crate is
+// bin-only, so an in-crate module is the only place this can reach
+// `SessionMemory` at all (`doc:trace-replay-learning-harness` §4).
+#[cfg(test)]
+pub(crate) mod replay;
 // Phase 4 (#715): reversible retirement of context that stops helping.
 pub(crate) mod retirement;
 pub(crate) mod rules_mining;
@@ -419,20 +425,38 @@ impl SessionMemory {
     /// logs, which is what makes the learning loop replayable and what lets a
     /// test place itself on either side of a TTL.
     ///
+    /// `include_workspace_skills` decides whether this session may write into
+    /// the workspace's own skills and rules directories — a *trusted project*,
+    /// in `open_for_session`'s terms. The replayer needs it true, and that is
+    /// not a convenience: with it false, `write_candidates` and `induce_rules`
+    /// both record their proposals and then decline to write a FILE (#737). A
+    /// replay of a whole corpus would behave perfectly correctly and build
+    /// nothing, which reads as a broken learner rather than as a session that
+    /// was never trusted to publish. Measured, not theorised — it is the
+    /// difference between the committed corpus producing two skills and a rule,
+    /// and producing zero.
+    ///
     /// **Test-gated until the trace-replay harness lands** (epic #2304,
     /// `doc:trace-replay-learning-harness` §4). `stella-cli` is a bin-only
     /// crate, so no external consumer could call this even in principle, and
-    /// leaving it on the production build would be dead code. Drop the gate in
-    /// the same commit that adds the replayer — the same discipline
-    /// [`SessionMemory::set_task_id`] is held to.
+    /// leaving it on the production build would be dead code. The harness is
+    /// itself `#[cfg(test)]` for exactly that reason, so the gate stays —
+    /// the same discipline [`SessionMemory::set_task_id`] is held to.
     #[cfg(test)]
     pub(crate) fn open_with_clock(
         workspace_root: &Path,
         warn: bool,
+        include_workspace_skills: bool,
         clock: std::sync::Arc<dyn Clock>,
     ) -> Option<Self> {
         let task_id = deterministic_task_id(clock.as_ref());
-        Self::open_inner(workspace_root, warn, false, clock, task_id)
+        Self::open_inner(
+            workspace_root,
+            warn,
+            include_workspace_skills,
+            clock,
+            task_id,
+        )
     }
 
     fn open_inner(

--- a/crates/stella-cli/src/memory/replay.rs
+++ b/crates/stella-cli/src/memory/replay.rs
@@ -1,0 +1,332 @@
+//! The trace-replay learning harness — drive the learning machinery from
+//! recorded traces, with zero model calls.
+//!
+//! Spec: `doc:trace-replay-learning-harness`. Epic #2304.
+//!
+//! Instead of sessions producing traces that feed learning, recorded traces
+//! drive learning directly, and the harness watches what the agent builds —
+//! memories, skills, rules, tools — across a simulated engagement.
+//!
+//! ## Why this needs no new architecture
+//!
+//! Every learner already sits below the model boundary or behind a port —
+//! invariant 1 ("ports, not concretions") and invariant 2 ("no I/O in the
+//! engine") paying out. Of the five learners, four make **no** model call at all
+//! and the fifth makes exactly one, through the `Provider` port. So the whole
+//! harness is one test double and a clock:
+//!
+//! | Learner | Model calls |
+//! |---|---|
+//! | Memory formation (`reflect_and_record`) | exactly one, via `Provider` |
+//! | Skill learning (`mine_skill_candidates` → `decide_auto_creation`) | none |
+//! | Rules mining (`extract_reflection_observations` → `induce_rule_proposals`) | none |
+//! | Tool foundry (`detect_tool_gaps`) | none, **by design** |
+//! | Selection / lifecycle | none |
+//!
+//! ## The loop is shorter than the spec's, and that is a finding
+//!
+//! §4.1 lists eight steps, of which it gives the replayer observation
+//! extraction (5) and rule induction (6) as its own calls. They are **already
+//! inside** `reflect_and_record`: `auto_create_skills_typed` runs uses
+//! extraction, the retirement sweep, observation extraction, skill proposals and
+//! rule induction in that order, from one pool of observations. Calling them
+//! again from here would not corrupt anything — extraction is replay-idempotent
+//! through content-derived record ids — but it would be a second mechanism
+//! shadowing the shipped one, and the harness would then be certifying its own
+//! wiring rather than the loop's. The replayer drives the seam the drivers drive
+//! and lets the loop do the rest.
+//!
+//! ## Determinism contract (§4.2)
+//!
+//! - **No wall clock, no `Instant`, no pid.** #2320 put the learning plane on an
+//!   injected clock; this harness sets it per turn and asserts the consequence
+//!   rather than assuming it.
+//! - **A per-replay temp workspace**, never the developer's `$HOME`.
+//! - **Two replays of one trace produce byte-identical summaries** — an
+//!   assertion, not a comment. Note what a summary may therefore *not* contain:
+//!   an `edge.public_id` is minted from a process-global counter, so it differs
+//!   between two replays inside one process. Compare edge content, never edge
+//!   identity (see `stella_context`'s `process_nonce` audit note).
+
+pub(crate) mod summary;
+pub(crate) mod trace;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use stella_context::{Clock, FixedClock};
+use stella_core::tool_foundry::{GapDetectionConfig, ShellInvocation, detect_tool_gaps};
+use stella_protocol::{
+    CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, Provider,
+    ProviderError,
+};
+
+use self::summary::ReplaySummary;
+use self::trace::{ScriptedReflection, Trace, TraceError, TraceTurn};
+use crate::memory::SessionMemory;
+
+/// The single model boundary in the learning loop, stubbed.
+///
+/// One scripted answer per construction, because a `SessionMemory` reflection
+/// turn makes exactly one call. A `ModelError` arm returns
+/// `ProviderError::Terminal`, which is what a real terminal provider failure
+/// looks like to `complete_standalone` — the path that produces
+/// `ReflectionReport::model_error` and records nothing.
+struct ScriptedProvider {
+    /// `None` scripts a failed call.
+    response: Option<String>,
+    error: String,
+    calls: Mutex<u32>,
+}
+
+impl ScriptedProvider {
+    fn for_turn(reflection: &ScriptedReflection) -> Self {
+        Self {
+            response: reflection.as_response(),
+            error: match reflection {
+                ScriptedReflection::ModelError { message } => message.clone(),
+                _ => String::new(),
+            },
+            calls: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn id(&self) -> &str {
+        "replay"
+    }
+
+    async fn complete_ref(
+        &self,
+        _request: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        *self.calls.lock().expect("call count") += 1;
+        let Some(text) = self.response.clone() else {
+            return Err(ProviderError::Terminal(self.error.clone()));
+        };
+        Ok(CompletionResult {
+            text,
+            tool_calls: Vec::new(),
+            // `reported: true` is load-bearing. The standalone call's accounting
+            // closeout refuses to settle a call whose usage never arrived, and
+            // reflection surfaces that as a model error — indistinguishable,
+            // from outside, from a model that said nothing. A harness whose
+            // whole subject is "did anything get learned" cannot afford to
+            // confuse those two.
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 1,
+                ..CompletionUsage::default()
+            },
+            model: "replay".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Whether a trace-supplied relative path could reach outside the workspace.
+///
+/// Rejects anything absolute, rooted, or containing a `..` component. A
+/// component walk rather than a `starts_with` check, because `starts_with` is
+/// lexical and `root/../escaped.txt` satisfies it.
+fn escapes_root(relative: &str) -> bool {
+    use std::path::Component;
+    let path = Path::new(relative);
+    path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+}
+
+/// Drives one trace against one temp workspace.
+pub(crate) struct Replayer<'a> {
+    root: &'a Path,
+    clock: std::sync::Arc<FixedClock>,
+    /// Every shell invocation seen so far, in trace order. The foundry mines the
+    /// whole history each turn (it is pure over the slice), which is what the
+    /// live CLI adapter does when it reads the durable `tool_calls` receipt log.
+    shell_history: Vec<ShellInvocation>,
+    foundry: GapDetectionConfig,
+}
+
+impl<'a> Replayer<'a> {
+    /// Replay `trace` against `root`, returning what the learners built.
+    ///
+    /// `root` must be a fresh directory the caller owns — a temp dir in
+    /// practice. The harness seeds `.stella/` itself.
+    pub(crate) async fn run(trace: &Trace, root: &'a Path) -> Result<ReplaySummary, TraceError> {
+        let mut replayer = Replayer {
+            root,
+            // The first turn sets it anyway; starting at the trace's own first
+            // instant keeps the store's own open-time writes on the timeline
+            // rather than at the epoch.
+            clock: std::sync::Arc::new(FixedClock::new(
+                trace.turns().next().map(|(_, t)| t.at).unwrap_or(0),
+            )),
+            shell_history: Vec::new(),
+            foundry: GapDetectionConfig::default(),
+        };
+        replayer.seed(trace)?;
+
+        let mut summary = ReplaySummary::new(trace);
+        for session in &trace.sessions {
+            // One `SessionMemory` per trace session, because several pieces of
+            // state are per-session by contract — the skill auto-creation cap
+            // most visibly. Reusing one instance across sessions would model a
+            // single endless session and silently relax that cap.
+            //
+            // `include_workspace_skills: true` models a trusted project. It is
+            // not a convenience: with it false, `write_candidates` and
+            // `induce_rules` both decline to write a FILE (#737), so a harness
+            // that left it false would replay a whole corpus and correctly build
+            // nothing — and read as a broken learner.
+            let mut memory = SessionMemory::open_with_clock(
+                root,
+                false,
+                true,
+                replayer.clock.clone() as std::sync::Arc<dyn Clock>,
+            )
+            .ok_or_else(|| {
+                TraceError::Unreplayable(format!(
+                    "session memory would not open at {}",
+                    root.display()
+                ))
+            })?;
+            memory.set_task_id(&session.task_id);
+
+            for turn in &session.turns {
+                replayer.turn(&mut memory, turn, &mut summary).await;
+            }
+        }
+
+        summary.observe_final_state(root, &replayer.shell_history, replayer.foundry);
+        Ok(summary)
+    }
+
+    /// Write the trace's workspace seed to disk.
+    fn seed(&self, trace: &Trace) -> Result<(), TraceError> {
+        let unwritable =
+            |what: &str, e: std::io::Error| TraceError::Unreplayable(format!("{what}: {e}"));
+        std::fs::create_dir_all(self.root.join(".stella"))
+            .map_err(|e| unwritable("cannot create .stella", e))?;
+
+        if !trace.workspace.domains.is_empty() {
+            let domains = crate::domains::Domains {
+                version: 1,
+                inferred_by: "replay".to_string(),
+                domains: trace
+                    .workspace
+                    .domains
+                    .iter()
+                    .map(|name| crate::domains::Domain {
+                        name: name.clone(),
+                        description: String::new(),
+                        paths: Vec::new(),
+                    })
+                    .collect(),
+            };
+            domains.save(self.root).map_err(TraceError::Unreplayable)?;
+        }
+
+        for (relative, contents) in &trace.workspace.files {
+            // A seed path is fixture data, not model output, but it still must
+            // not escape the temp root — a `..` in a committed fixture would
+            // write into the developer's tree.
+            //
+            // Checked on components rather than with `Path::starts_with`, which
+            // is *lexical*: `root/../escaped.txt` starts with `root` by that
+            // test and sails straight through. Measured, not assumed — the
+            // obvious version of this guard passed the fixture that escapes.
+            if escapes_root(relative) {
+                return Err(TraceError::Unreplayable(format!(
+                    "seed path {relative:?} escapes the workspace root"
+                )));
+            }
+            let path = self.root.join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| unwritable("cannot seed tree", e))?;
+            }
+            std::fs::write(&path, contents).map_err(|e| unwritable("cannot seed file", e))?;
+        }
+        Ok(())
+    }
+
+    /// Apply this turn's forgetting and tree deletions.
+    ///
+    /// Best-effort in the same direction the loop is: a tombstone that will not
+    /// write means the lesson is not suppressed, which the assertion will catch
+    /// loudly. Silently swallowing it here would be worse than a panic, because
+    /// the suite would then report a *passing* suppression it never applied.
+    fn apply_world_changes(&self, turn: &TraceTurn) {
+        if !turn.forget.is_empty()
+            && let Ok(store) = stella_store::Store::open(self.root)
+        {
+            for (index, statement) in turn.forget.iter().enumerate() {
+                let _ = store.forget(
+                    stella_store::ContextSurface::Memory,
+                    &format!("replay-forget-{}-{index}", turn.at),
+                    statement,
+                    "forgotten by the trace",
+                );
+            }
+        }
+        for relative in &turn.removed_files {
+            if !escapes_root(relative) {
+                let _ = std::fs::remove_file(self.root.join(relative));
+            }
+        }
+    }
+
+    /// One turn, in the order §4.1 fixes.
+    async fn turn(
+        &mut self,
+        memory: &mut SessionMemory,
+        turn: &TraceTurn,
+        summary: &mut ReplaySummary,
+    ) {
+        // 1. The clock is the only time source in the system.
+        self.clock.set(turn.at);
+
+        // 1a. The world as it is at the top of this turn: what the user forgot,
+        //     and what left the tree. Both happen *before* the reflection,
+        //     which is where they land in a real engagement — you forget a
+        //     lesson, then the next turn must not re-learn it.
+        self.apply_world_changes(turn);
+
+        // 2-3. Script the single model boundary.
+        let provider = ScriptedProvider::for_turn(&turn.reflection);
+        let transcript: Vec<CompletionMessage> = turn
+            .transcript
+            .iter()
+            .map(CompletionMessage::from)
+            .collect();
+
+        // 4. The one call. Everything downstream of it — the forgetting filter,
+        //    the store write, the mining log, observation extraction, both
+        //    miners, the retirement sweep — is already deterministic and runs
+        //    inside it.
+        let report = memory
+            .reflect_and_record(&provider, "replay", &transcript, true, turn.succeeded, None)
+            .await;
+
+        // 5. The foundry, over the history accumulated so far. Pure over the
+        //    slice and documented to be byte-identical for identical input, so
+        //    it needs no adaptation at all.
+        self.shell_history
+            .extend(turn.shell.iter().map(ShellInvocation::from));
+        let tools = detect_tool_gaps(&self.shell_history, self.foundry);
+
+        // 6. Snapshot.
+        summary.observe_turn(turn, &report, tools.len());
+    }
+}

--- a/crates/stella-cli/src/memory/replay/summary.rs
+++ b/crates/stella-cli/src/memory/replay/summary.rs
@@ -1,0 +1,312 @@
+//! What a replay built, and the honest way to report it.
+//!
+//! `doc:trace-replay-learning-harness` §6. The summary is the harness's whole
+//! output, so two properties matter more than completeness:
+//!
+//! 1. **It must be reproducible.** Assertion 8 compares two replays of one trace
+//!    byte for byte, so nothing minted from a process-global source may appear
+//!    here. That rules out `edge.public_id` specifically — `EDGE_SEQ` is a
+//!    process-global counter, so the same logical edge gets different ids in two
+//!    replays *inside one process*. Content, never identity.
+//! 2. **It must not flatter.** An artifact count that rises because the fixture
+//!    repeated one lesson forty times measures the **fixture**. So the corpus's
+//!    own recurrence profile is printed *beside* the artifact counts, never
+//!    instead of them, and [`ReplaySummary::render`] cannot emit one without the
+//!    other. Reporting a learner's yield without the shape of what it was fed is
+//!    the kind of small dishonesty that costs more than it buys.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use stella_core::tool_foundry::{GapDetectionConfig, ShellInvocation, detect_tool_gaps};
+
+use super::trace::{ScriptedReflection, Trace, TraceTurn};
+use crate::memory::ReflectionReport;
+
+/// What one replay built, plus the corpus shape it was built from.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ReplaySummary {
+    /// The fixture's own one-line description. A number that cannot name its
+    /// corpus is not reportable (§11's "the corpus proves the corpus").
+    pub description: String,
+    // ---- what the corpus supplied -----------------------------------------
+    pub sessions: usize,
+    pub turns: usize,
+    pub distinct_tasks: usize,
+    /// Turns whose scripted reflection was a well-formed lessons array.
+    pub turns_with_lessons: usize,
+    /// Turns scripted as an unreadable response.
+    pub turns_unreadable: usize,
+    /// Turns scripted as a failed model call.
+    pub turns_model_error: usize,
+    /// Lessons the corpus offered, before any filtering.
+    pub lessons_offered: usize,
+    // ---- what the learners built ------------------------------------------
+    /// Lessons that actually reached the context store.
+    pub lessons_recorded: usize,
+    /// Distinct memory texts in the store at the end.
+    pub memories: usize,
+    /// `SKILL.md` files on disk at the end.
+    pub skills: Vec<String>,
+    /// Published rule records on disk at the end.
+    pub rules: Vec<String>,
+    /// Tool proposals the foundry would mint from the whole shell history.
+    pub tools: Vec<String>,
+    // ---- when ---------------------------------------------------------------
+    /// Turn ordinal (1-based) at which each artifact class first appeared.
+    pub first_memory_turn: Option<usize>,
+    pub first_skill_turn: Option<usize>,
+    pub first_tool_turn: Option<usize>,
+    /// Every turn's reported model error, in order — the starvation record.
+    ///
+    /// A turn that recorded nothing *and* said why is a different event from a
+    /// turn that recorded nothing quietly, and assertion 7 is the difference.
+    pub model_errors: Vec<String>,
+}
+
+impl ReplaySummary {
+    pub(crate) fn new(trace: &Trace) -> Self {
+        let mut summary = ReplaySummary {
+            description: trace.description.clone(),
+            sessions: trace.sessions.len(),
+            distinct_tasks: trace.distinct_tasks(),
+            ..Default::default()
+        };
+        for (_, turn) in trace.turns() {
+            match &turn.reflection {
+                ScriptedReflection::Lessons { lessons, .. } => {
+                    summary.turns_with_lessons += 1;
+                    summary.lessons_offered += lessons.len();
+                }
+                ScriptedReflection::Unreadable { .. } => summary.turns_unreadable += 1,
+                ScriptedReflection::ModelError { .. } => summary.turns_model_error += 1,
+            }
+        }
+        summary
+    }
+
+    /// Fold one replayed turn into the summary.
+    pub(crate) fn observe_turn(
+        &mut self,
+        _turn: &TraceTurn,
+        report: &ReflectionReport,
+        tool_proposals: usize,
+    ) {
+        self.turns += 1;
+        self.lessons_recorded += report.recorded;
+        if report.recorded > 0 && self.first_memory_turn.is_none() {
+            self.first_memory_turn = Some(self.turns);
+        }
+        if tool_proposals > 0 && self.first_tool_turn.is_none() {
+            self.first_tool_turn = Some(self.turns);
+        }
+        if let Some(error) = &report.model_error {
+            self.model_errors.push(error.clone());
+        }
+    }
+
+    /// Read the workspace and the foundry once the last turn has run.
+    ///
+    /// Deliberately a filesystem read rather than an accumulated tally: what is
+    /// *on disk* is what a later session would actually load, and a counter
+    /// incremented at the write site would keep claiming a file that a
+    /// no-clobber refusal never created.
+    pub(crate) fn observe_final_state(
+        &mut self,
+        root: &Path,
+        shell_history: &[ShellInvocation],
+        foundry: GapDetectionConfig,
+    ) {
+        self.skills = relative_names(
+            root,
+            &crate::memory::skill_paths_on_disk(&crate::memory::workspace_skills_dir(root)),
+        );
+        self.rules = published_rules(root);
+        self.tools = detect_tool_gaps(shell_history, foundry)
+            .into_iter()
+            .map(|proposal| proposal.name)
+            .collect();
+        if !self.skills.is_empty() && self.first_skill_turn.is_none() {
+            // Skills are only observable on disk, so the best we can honestly
+            // say is "by the end". A per-turn probe would cost a directory walk
+            // per turn to sharpen a number nothing asserts on.
+            self.first_skill_turn = Some(self.turns);
+        }
+        self.memories = memory_texts(root).len();
+    }
+
+    /// The §6 report, as `make replay-learning` prints it.
+    ///
+    /// Deterministic by construction: every list is sorted, and no field here is
+    /// minted from a process-global source.
+    pub(crate) fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str("── trace-replay learning harness ──────────────────────\n");
+        if !self.description.is_empty() {
+            out.push_str(&format!("corpus: {}\n", self.description));
+        }
+        out.push_str("\nwhat the corpus supplied\n");
+        out.push_str(&format!(
+            "  {} session(s), {} turn(s), {} distinct task(s)\n",
+            self.sessions, self.turns, self.distinct_tasks
+        ));
+        out.push_str(&format!(
+            "  reflections: {} with lessons, {} unreadable, {} model error(s)\n",
+            self.turns_with_lessons, self.turns_unreadable, self.turns_model_error
+        ));
+        out.push_str(&format!(
+            "  {} lesson(s) offered across {} turn(s) — recurrence {:.2} lesson/turn\n",
+            self.lessons_offered,
+            self.turns,
+            recurrence(self.lessons_offered, self.turns),
+        ));
+
+        out.push_str("\nwhat the learners built\n");
+        out.push_str(&format!(
+            "  memories: {} distinct in store ({} lesson(s) recorded of {} offered)\n",
+            self.memories, self.lessons_recorded, self.lessons_offered
+        ));
+        out.push_str(&format!("  skills:   {}\n", render_list(&self.skills)));
+        out.push_str(&format!("  rules:    {}\n", render_list(&self.rules)));
+        out.push_str(&format!("  tools:    {}\n", render_list(&self.tools)));
+        out.push_str(&format!(
+            "  turns-to-first: memory {}, skill {}, tool {}\n",
+            render_turn(self.first_memory_turn),
+            render_turn(self.first_skill_turn),
+            render_turn(self.first_tool_turn),
+        ));
+
+        // The honesty guard, and the reason this is one function rather than
+        // two: a caller cannot print the yield above without printing the shape
+        // it came from.
+        out.push_str("\nread the two together\n");
+        out.push_str(&format!(
+            "  {} artifact(s) from {} lesson(s) over {} distinct task(s). A count that rises\n  \
+             because one lesson repeats is a fact about this fixture, not about the learner.\n",
+            self.skills.len() + self.rules.len() + self.tools.len(),
+            self.lessons_offered,
+            self.distinct_tasks,
+        ));
+        if !self.model_errors.is_empty() {
+            out.push_str(&format!(
+                "\n{} turn(s) taught the lifecycle nothing and said so:\n",
+                self.model_errors.len()
+            ));
+            for error in &self.model_errors {
+                out.push_str(&format!("  · {}\n", first_line(error)));
+            }
+        }
+        out
+    }
+}
+
+fn recurrence(lessons: usize, turns: usize) -> f64 {
+    if turns == 0 {
+        0.0
+    } else {
+        lessons as f64 / turns as f64
+    }
+}
+
+fn render_turn(turn: Option<usize>) -> String {
+    turn.map(|t| t.to_string()).unwrap_or_else(|| "—".into())
+}
+
+fn render_list(items: &[String]) -> String {
+    if items.is_empty() {
+        "none".to_string()
+    } else {
+        format!("{} — {}", items.len(), items.join(", "))
+    }
+}
+
+/// The first line of a message, so a multi-line model error does not derail the
+/// report's shape.
+fn first_line(text: &str) -> &str {
+    text.lines().next().unwrap_or(text)
+}
+
+/// Paths as workspace-relative strings, sorted.
+///
+/// The temp root differs on every run, so an absolute path would defeat
+/// assertion 8 on its own — the summary must name what was built, never where
+/// this particular replay put it.
+fn relative_names(root: &Path, paths: &[String]) -> Vec<String> {
+    let root = root.to_string_lossy();
+    let mut names: Vec<String> = paths
+        .iter()
+        .map(|path| {
+            path.strip_prefix(root.as_ref())
+                .unwrap_or(path)
+                .trim_start_matches('/')
+                .replace('\\', "/")
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+/// Every published rule record's file stem, sorted.
+pub(crate) fn published_rules(root: &Path) -> Vec<String> {
+    let dir = crate::memory::rules_mining::workspace_rules_dir(root);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "toml" || extension == "md")
+        })
+        // `governance.toml` and `promotions.jsonl` are the plane's own
+        // bookkeeping, not mined records.
+        .filter(|path| {
+            path.file_stem()
+                .is_some_and(|stem| stem != "governance" && stem != "promotions")
+        })
+        .filter_map(|path| Some(path.file_stem()?.to_string_lossy().into_owned()))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Every memory text in the workspace's context store, sorted and deduplicated.
+///
+/// Opened read-only through a fresh `ContextStore` rather than borrowed from a
+/// live `SessionMemory`, because the summary is taken after the last session has
+/// been dropped — which is also when a real later session would see it.
+pub(crate) fn memory_texts(root: &Path) -> Vec<String> {
+    with_store(root, |store| store.memory_nodes().ok())
+}
+
+/// Open the workspace's context store read-only and project its nodes to
+/// deduplicated, sorted text.
+///
+/// Opened fresh rather than borrowed from a live `SessionMemory`, because the
+/// summary is taken after the last session has been dropped — which is also when
+/// a real later session would see it.
+fn with_store<F>(root: &Path, read: F) -> Vec<String>
+where
+    F: FnOnce(&stella_context::ContextStore) -> Option<Vec<stella_context::NodeRow>>,
+{
+    let Ok(path) = crate::memory::context_db_path(root) else {
+        return Vec::new();
+    };
+    let Ok(store) = stella_context::ContextStore::open_with(
+        &path,
+        std::sync::Arc::new(stella_context::HashEmbedder::default()),
+        std::sync::Arc::new(stella_context::SystemClock),
+    ) else {
+        return Vec::new();
+    };
+    let Some(nodes) = read(&store) else {
+        return Vec::new();
+    };
+    nodes
+        .into_iter()
+        .map(|node| node.content)
+        .collect::<BTreeSet<String>>()
+        .into_iter()
+        .collect()
+}

--- a/crates/stella-cli/src/memory/replay/tests.rs
+++ b/crates/stella-cli/src/memory/replay/tests.rs
@@ -1,0 +1,803 @@
+//! The assertions — the point of the harness (`doc:trace-replay-learning-harness` §5).
+//!
+//! Each pins a mechanism with no other end-to-end proof. Every one is paired
+//! with its negative control, because "the loop built a skill" is not evidence
+//! that the *gate* works — only "and it did not build one when the gate should
+//! have stopped it" is.
+//!
+//! ## What replaying the real loop taught us, and had to be designed around
+//!
+//! A fixture cannot be written for this suite without knowing three things that
+//! are not obvious from any single module, and that were measured here first.
+//!
+//! **1. The dedup filter and the miner use the same metric at the same
+//! threshold.** `retain_unknown` drops a lesson whose Jaccard overlap with an
+//! existing memory is `>= 0.5` (`stella_store::SIMILARITY_THRESHOLD`), and it
+//! runs *before* the mining log is appended — so a dropped lesson never becomes
+//! an observation and can never contribute an occurrence. The skill miner then
+//! clusters at `min_similarity: 0.5` (`SkillMineConfig`). Same number, same
+//! metric. For a cluster of three to form at all, three lessons must be similar
+//! enough to cluster while staying dissimilar enough to survive dedup.
+//!
+//! **That band exists only because the two tokenizers differ**, and the
+//! difference is load-bearing:
+//!
+//! | | `stella_store::forget::tokens` | `stella_core::mining::terms` |
+//! |---|---|---|
+//! | `crates/stella-tools/src/registry.rs` | **one** token | **five** terms |
+//! | stopwords and words of ≤2 chars | kept | dropped |
+//!
+//! So a shared *path* contributes one token to the dedup comparison and five
+//! terms to the clustering one, while differing filler inflates the dedup union
+//! invisibly to the miner. That is exactly the shape a real engagement produces
+//! — the same file re-encountered in different words — which is why the corpus
+//! below is written that way rather than as obvious near-duplicates. A fixture
+//! of literal repetitions builds **nothing**, and would read as a broken learner
+//! rather than as a fixture that cannot clear the filter.
+//!
+//! **2. The foundry only holes a *value-like* argument.** `classify_argument`
+//! makes a positional argument a parameter only if it is a path or a number (or
+//! quoted, or after `=`); a bareword stays in the skeleton. So
+//! `cargo test -p <crate>` yields a *different signature per crate* and can
+//! never cluster, while `rg -n "<pattern>" <path>` clusters immediately. Right
+//! behaviour — a bareword is usually a subcommand — but a fixture that varies a
+//! bareword measures nothing.
+//!
+//! **3. A file only lands under a trusted project.** With
+//! `include_workspace_skills` false, `write_candidates` and `induce_rules` both
+//! decline to write to disk (#737) while still recording proposals. A harness
+//! that left it false would replay a whole corpus, behave perfectly correctly,
+//! and build nothing.
+
+use std::path::Path;
+
+use super::summary::ReplaySummary;
+use super::trace::*;
+use super::*;
+
+// ---- fixture construction -------------------------------------------------
+
+const T0: i64 = 1_700_000_000;
+const DAY: i64 = 86_400;
+
+/// The file every recurring lesson in the corpus names. One shared path is what
+/// gives the miner five common terms while costing the dedup filter one token.
+const REGISTRY: &str = "crates/stella-tools/src/registry.rs";
+
+fn lesson(text: &str) -> TraceLesson {
+    TraceLesson {
+        lesson: text.to_string(),
+        domains: Vec::new(),
+        kind: crate::memory::LessonKind::Domain,
+    }
+}
+
+/// A turn with one scripted lesson and no shell history.
+fn turn(at: i64, text: &str) -> TraceTurn {
+    TraceTurn {
+        at,
+        prompt: "work".to_string(),
+        transcript: vec![TraceMessage {
+            role: TraceRole::User,
+            content: "work".to_string(),
+        }],
+        reflection: ScriptedReflection::Lessons {
+            lessons: vec![lesson(text)],
+            provenance: Provenance::Recorded,
+        },
+        shell: Vec::new(),
+        succeeded: true,
+        forget: Vec::new(),
+        removed_files: Vec::new(),
+    }
+}
+
+/// A turn whose reflection the parser cannot read.
+fn unreadable_turn(at: i64, text: &str) -> TraceTurn {
+    TraceTurn {
+        reflection: ScriptedReflection::Unreadable {
+            text: text.to_string(),
+        },
+        ..turn(at, "")
+    }
+}
+
+/// A turn whose model call fails outright.
+fn model_error_turn(at: i64, message: &str) -> TraceTurn {
+    TraceTurn {
+        reflection: ScriptedReflection::ModelError {
+            message: message.to_string(),
+        },
+        ..turn(at, "")
+    }
+}
+
+fn shell(commands: &[&str]) -> Vec<TraceShell> {
+    commands
+        .iter()
+        .map(|command| TraceShell {
+            command: (*command).to_string(),
+            succeeded: true,
+        })
+        .collect()
+}
+
+/// One session per turn — each turn its own task, the shape that satisfies the
+/// distinct-task gate.
+fn one_task_each(turns: Vec<TraceTurn>) -> Vec<TraceSession> {
+    turns
+        .into_iter()
+        .enumerate()
+        .map(|(index, turn)| TraceSession {
+            id: format!("session-{index}"),
+            task_id: format!("task-{index}"),
+            turns: vec![turn],
+        })
+        .collect()
+}
+
+/// Every turn inside ONE session and ONE task — the negative control for the
+/// distinct-task gate. Same lessons, same instants, same everything else.
+fn all_one_task(turns: Vec<TraceTurn>) -> Vec<TraceSession> {
+    vec![TraceSession {
+        id: "session-single".to_string(),
+        task_id: "task-single".to_string(),
+        turns,
+    }]
+}
+
+fn trace(description: &str, sessions: Vec<TraceSession>) -> Trace {
+    Trace {
+        version: TRACE_VERSION,
+        description: description.to_string(),
+        workspace: WorkspaceSeed {
+            domains: vec!["tools".to_string(), "engine".to_string()],
+            files: [(REGISTRY.to_string(), String::new())]
+                .into_iter()
+                .collect(),
+        },
+        sessions,
+    }
+}
+
+/// Four re-encounters of one convention, phrased as an engineer would phrase
+/// them on four different days. See the module docs for why they are worded
+/// this way and not as literal repeats.
+fn recurring_registry_lessons() -> Vec<TraceTurn> {
+    [
+        "Register the tool in crates/stella-tools/src/registry.rs",
+        "Tool registration lives at crates/stella-tools/src/registry.rs",
+        "Tools register through crates/stella-tools/src/registry.rs",
+        "Registered tools come from crates/stella-tools/src/registry.rs",
+    ]
+    .iter()
+    .enumerate()
+    .map(|(index, text)| turn(T0 + index as i64 * DAY, text))
+    .collect()
+}
+
+/// Replay into a temp dir, under a **fixed** directory name.
+///
+/// The fixed name is load-bearing for assertion 8, and finding out why is one of
+/// the things replaying the real loop taught us. A published record's lineage is
+/// `ctx.<set-id>.<mined-suffix>`, and `derive_set_id` falls back to the
+/// *workspace directory name* when there is no git remote — so replaying into
+/// `/tmp/.tmpQ7x1a9` and `/tmp/.tmpB3k0zz` produced `ctx.tmpq7x1a9.…` and
+/// `ctx.tmpb3k0zz.…` for the same learned rule.
+///
+/// That is correct behaviour, not a bug: a record's lineage is scoped to the
+/// workspace it belongs to, and two workspaces genuinely differ. The wrong fix
+/// would have been to strip the set id out of the summary, which hides real
+/// nondeterminism behind a narrower report. Naming the workspace instead makes
+/// the harness deterministic, and keeps the full lineage id — the thing a
+/// teammate would actually see — inside what assertion 8 compares.
+fn replay_root(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    dir.path().join("stella-replay-workspace")
+}
+
+async fn replay(corpus: &Trace) -> (ReplaySummary, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let summary = Replayer::run(corpus, &replay_root(&dir))
+        .await
+        .expect("the trace replays");
+    (summary, dir)
+}
+
+// ---- PR 2's own witnesses -------------------------------------------------
+
+/// Invariant 4: every type crossing the fixture boundary round-trips through
+/// `serde_json` byte for byte.
+#[test]
+fn the_trace_format_round_trips_byte_for_byte() {
+    let original = trace("round trip", one_task_each(recurring_registry_lessons()));
+    let json = serde_json::to_string_pretty(&original).expect("serialize");
+    let parsed = Trace::parse(&json).expect("parse");
+    assert_eq!(original, parsed, "a trace must survive a round trip");
+    assert_eq!(
+        json,
+        serde_json::to_string_pretty(&parsed).expect("re-serialize"),
+        "and re-serializing must produce identical bytes"
+    );
+}
+
+/// An unknown version is a refusal, never a best-effort parse.
+///
+/// A newer fixture read by an older loader would be missing whatever the new
+/// version added, and the harness would then report a confident summary of a
+/// corpus it only partly understood — the worst failure available to a tool
+/// whose entire output is a claim about what was learned.
+#[test]
+fn an_unknown_trace_version_is_refused_rather_than_partly_parsed() {
+    let mut future = trace("from the future", one_task_each(vec![turn(T0, "a lesson")]));
+    future.version = TRACE_VERSION + 1;
+    let json = serde_json::to_string(&future).expect("serialize");
+    assert_eq!(
+        Trace::parse(&json),
+        Err(TraceError::UnsupportedVersion {
+            found: TRACE_VERSION + 1,
+            supported: TRACE_VERSION,
+        })
+    );
+}
+
+/// The replayer sets the clock per turn rather than advancing it, so a trace
+/// that steps backwards would replay happily and produce a log whose recency
+/// order contradicts its own line order. Refused at load.
+#[test]
+fn a_trace_that_steps_time_backwards_is_refused() {
+    let backwards = trace(
+        "backwards",
+        one_task_each(vec![turn(T0 + DAY, "later"), turn(T0, "earlier")]),
+    );
+    let json = serde_json::to_string(&backwards).expect("serialize");
+    assert!(
+        matches!(Trace::parse(&json), Err(TraceError::Unreplayable(_))),
+        "non-decreasing time is a load-time contract"
+    );
+}
+
+/// The trivial case, end to end: two turns, one durable lesson, one memory.
+#[tokio::test]
+async fn a_two_turn_trace_replays_and_builds_exactly_one_memory() {
+    let corpus = trace(
+        "two turns, one durable lesson",
+        one_task_each(vec![
+            turn(
+                T0,
+                "Register the tool in crates/stella-tools/src/registry.rs",
+            ),
+            // A restatement close enough to be dropped by `retain_unknown`, so
+            // two turns yield one memory — the dedup path, asserted rather than
+            // assumed.
+            turn(
+                T0 + DAY,
+                "Register the tool in crates/stella-tools/src/registry.rs please",
+            ),
+        ]),
+    );
+    let (summary, _dir) = replay(&corpus).await;
+    assert_eq!(summary.turns, 2);
+    assert_eq!(
+        summary.memories, 1,
+        "the second turn restates the first, so only one memory should exist"
+    );
+    assert!(
+        summary.model_errors.is_empty(),
+        "neither turn should report an error: {:?}",
+        summary.model_errors
+    );
+}
+
+// ---- §5 assertion 1: distinct-task counting -------------------------------
+
+/// A lesson recurring across **distinct tasks** yields artifacts; the same
+/// lessons inside **one** task yield none.
+///
+/// This is the exact confusion `SessionMemory::set_task_id` exists to fix, and
+/// the two halves differ in nothing but the task boundary — same texts, same
+/// instants, same workspace.
+#[tokio::test]
+async fn recurrence_across_distinct_tasks_builds_what_recurrence_within_one_task_does_not() {
+    let across = trace(
+        "one convention, four tasks",
+        one_task_each(recurring_registry_lessons()),
+    );
+    let (spread, _a) = replay(&across).await;
+
+    let within = trace(
+        "one convention, one task",
+        all_one_task(recurring_registry_lessons()),
+    );
+    let (single, _b) = replay(&within).await;
+
+    assert_eq!(spread.distinct_tasks, 4);
+    assert_eq!(single.distinct_tasks, 1);
+    assert_eq!(
+        spread.memories, single.memories,
+        "both corpora record the same lessons — only the task boundary differs"
+    );
+
+    assert!(
+        !spread.skills.is_empty(),
+        "four distinct tasks should clear the eligibility gate: {spread:?}"
+    );
+    assert!(
+        single.skills.is_empty(),
+        "four turns of ONE task must not mint a skill — that is the \
+         anti-poisoning rule, and it is the whole reason task identity is \
+         carried at all. Built: {:?}",
+        single.skills
+    );
+    assert!(single.rules.is_empty(), "nor a rule: {:?}", single.rules);
+}
+
+// ---- §5 assertion 2: promotion is advisory, and never clobbers ------------
+
+/// An auto-activated rule is **advisory** — `force = should`, no enforcement
+/// block — so an inferred directive can never deny a tool call.
+///
+/// The published TOML is read back off disk rather than inspected in memory:
+/// the file is what a teammate's session actually loads, and an assertion
+/// against the in-memory record would pass even if the writer dropped a field.
+#[tokio::test]
+async fn an_auto_activated_rule_is_advisory_and_never_blocking() {
+    let corpus = trace(
+        "one convention, four tasks",
+        one_task_each(recurring_registry_lessons()),
+    );
+    let (summary, dir) = replay(&corpus).await;
+    assert!(
+        !summary.rules.is_empty(),
+        "expected an auto-activated rule: {summary:?}"
+    );
+
+    for name in &summary.rules {
+        let path = crate::memory::rules_mining::workspace_rules_dir(&replay_root(&dir))
+            .join(format!("{name}.toml"));
+        let toml = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("published rule {} unreadable: {e}", path.display()));
+        assert!(
+            toml.contains("force = \"should\"") || toml.contains("force = 'should'"),
+            "a mined rule must be advisory, not `must`: {toml}"
+        );
+        assert!(
+            !toml.contains("[enforcement]"),
+            "an inferred directive must never carry an enforcement block — that \
+             is the line between suggesting a convention and denying a tool \
+             call: {toml}"
+        );
+        assert!(
+            toml.contains("inferred"),
+            "and it must be labelled as inferred: {toml}"
+        );
+    }
+}
+
+/// Auto-activation never clobbers a file already on disk (#737).
+///
+/// A hand-written record at the path the miner would publish to must survive
+/// the replay byte for byte.
+#[tokio::test]
+async fn auto_activation_never_clobbers_an_existing_record() {
+    // First, learn where the miner publishes.
+    let corpus = trace(
+        "one convention, four tasks",
+        one_task_each(recurring_registry_lessons()),
+    );
+    let (first, dir) = replay(&corpus).await;
+    let name = first
+        .rules
+        .first()
+        .cloned()
+        .expect("the corpus should auto-activate a rule");
+    drop(dir);
+
+    // Now replay the same corpus into a workspace where that file already
+    // exists, hand-written.
+    let second = tempfile::tempdir().expect("tempdir");
+    let root = replay_root(&second);
+    let rules = crate::memory::rules_mining::workspace_rules_dir(&root);
+    std::fs::create_dir_all(&rules).expect("rules dir");
+    let occupied = rules.join(format!("{name}.toml"));
+    let hand_written = "# hand-written; the miner must not touch this\n";
+    std::fs::write(&occupied, hand_written).expect("seed the record");
+
+    Replayer::run(&corpus, &root)
+        .await
+        .expect("the trace replays");
+
+    assert_eq!(
+        std::fs::read_to_string(&occupied).expect("still readable"),
+        hand_written,
+        "auto-activation overwrote a file it did not create"
+    );
+}
+
+// ---- §5 assertion 3: skills need recurrence -------------------------------
+
+/// A one-off lesson never becomes a skill, however good it is.
+#[tokio::test]
+async fn a_one_off_lesson_does_not_become_a_skill() {
+    let corpus = trace(
+        "four unrelated one-off lessons",
+        one_task_each(vec![
+            turn(
+                T0,
+                "Register the tool in crates/stella-tools/src/registry.rs",
+            ),
+            turn(
+                T0 + DAY,
+                "Budget aborts happen between model calls in crates/stella-core/src/driver.rs",
+            ),
+            turn(
+                T0 + 2 * DAY,
+                "SSE parsing for Anthropic sits in crates/stella-model/src/anthropic.rs",
+            ),
+            turn(
+                T0 + 3 * DAY,
+                "Golden deck frames are regenerated with BLESS=1 under stella-tui",
+            ),
+        ]),
+    );
+    let (summary, _dir) = replay(&corpus).await;
+    assert_eq!(
+        summary.memories, 4,
+        "four distinct lessons should all be recorded"
+    );
+    assert!(
+        summary.skills.is_empty(),
+        "four unrelated lessons are four facts, not a recurring pattern: {:?}",
+        summary.skills
+    );
+}
+
+// ---- §5 assertion 4: the foundry needs variation --------------------------
+
+/// A shape recurring with **≥2 distinct argument sets** yields a tool proposal;
+/// the identical command repeated yields none.
+///
+/// The negative half is the interesting one: an exact repeat is loop detection's
+/// business, not the foundry's, and `min_distinct_arguments: 2` draws that line.
+#[tokio::test]
+async fn a_shape_with_varying_arguments_mints_a_tool_and_an_exact_repeat_does_not() {
+    let varied = trace(
+        "one shape, three argument sets",
+        one_task_each(vec![
+            TraceTurn {
+                shell: shell(&["rg -n \"unwrap\" crates/stella-core/src/driver.rs"]),
+                ..turn(T0, "Grepping for unwrap is how the panic audit starts")
+            },
+            TraceTurn {
+                shell: shell(&["rg -n \"expect\" crates/stella-cli/src/agent.rs"]),
+                ..turn(
+                    T0 + DAY,
+                    "The agent loop lives in crates/stella-cli/src/agent.rs",
+                )
+            },
+            TraceTurn {
+                shell: shell(&["rg -n \"panic\" crates/stella-model/src/openai.rs"]),
+                ..turn(
+                    T0 + 2 * DAY,
+                    "OpenAI's adapter is crates/stella-model/src/openai.rs",
+                )
+            },
+        ]),
+    );
+    let (with_variation, _a) = replay(&varied).await;
+    assert!(
+        !with_variation.tools.is_empty(),
+        "three invocations of one shape with three argument sets should propose \
+         a tool: {with_variation:?}"
+    );
+
+    let repeated = trace(
+        "one shape, one argument set, three times",
+        one_task_each(vec![
+            TraceTurn {
+                shell: shell(&["rg -n \"unwrap\" crates/stella-core/src/driver.rs"]),
+                ..turn(T0, "Grepping for unwrap is how the panic audit starts")
+            },
+            TraceTurn {
+                shell: shell(&["rg -n \"unwrap\" crates/stella-core/src/driver.rs"]),
+                ..turn(
+                    T0 + DAY,
+                    "The agent loop lives in crates/stella-cli/src/agent.rs",
+                )
+            },
+            TraceTurn {
+                shell: shell(&["rg -n \"unwrap\" crates/stella-core/src/driver.rs"]),
+                ..turn(
+                    T0 + 2 * DAY,
+                    "OpenAI's adapter is crates/stella-model/src/openai.rs",
+                )
+            },
+        ]),
+    );
+    let (without_variation, _b) = replay(&repeated).await;
+    assert!(
+        without_variation.tools.is_empty(),
+        "an exact repeat is a loop, not a parameterized tool: {:?}",
+        without_variation.tools
+    );
+}
+
+// ---- §5 assertion 5: forgetting is durable --------------------------------
+
+/// A tombstoned lesson is never re-learned — **including when a later turn
+/// restates it in different words.**
+///
+/// The paraphrase is the entire assertion. A corpus that tombstones a lesson and
+/// then re-emits it *verbatim* proves almost nothing: byte-identical content
+/// already collapses on its own through content-hash lineage. What needs proving
+/// is `retain_unforgotten`'s restatement matching, so the corpus must paraphrase.
+#[tokio::test]
+async fn a_forgotten_lesson_is_not_re_learned_from_a_paraphrase() {
+    let forgotten = "Register the tool in crates/stella-tools/src/registry.rs";
+    let paraphrase = "Register the tool inside crates/stella-tools/src/registry.rs";
+
+    let corpus = trace(
+        "a lesson, forgotten, then restated",
+        one_task_each(vec![
+            turn(T0, forgotten),
+            TraceTurn {
+                forget: vec![forgotten.to_string()],
+                ..turn(T0 + DAY, paraphrase)
+            },
+        ]),
+    );
+    let (summary, dir) = replay(&corpus).await;
+
+    let texts = super::summary::memory_texts(&replay_root(&dir));
+    assert!(
+        !texts.iter().any(|text| text == paraphrase),
+        "a paraphrase of a forgotten lesson was re-learned: {texts:?}"
+    );
+    assert_eq!(
+        summary.lessons_recorded, 1,
+        "only the pre-tombstone turn should have recorded anything"
+    );
+}
+
+// ---- §5 assertion 6: retirement --------------------------------------------
+
+/// A memory whose every path anchor has left the tree is retired by the
+/// deterministic sweep, and lands in the set recall suppresses.
+///
+/// **Only testable since #2320.** The sweep's `now` used to come from the wall
+/// clock, so no test could position a trace's timeline relative to it.
+///
+/// The assertion is against `retirement::retired_ids` — the exact set
+/// `suppression::suppression_reader` unions into every recall — and *not*
+/// against the store's live nodes. That distinction is the mechanism, not a
+/// detail: retirement deliberately does **not** write `node.superseded_at`,
+/// because that column is filtered by `node_by_public_id`, and projecting
+/// retirement onto it would make a retired record impossible to fetch by id —
+/// when staying explicitly retrievable is exactly what separates retirement
+/// from forgetting. So a test asserting "the memory is gone from the store"
+/// would fail against a perfectly working sweep, and one asserting "the count
+/// went down" would quietly re-specify retirement as deletion.
+#[tokio::test]
+async fn a_memory_whose_files_all_vanished_is_retired() {
+    let anchored = "Register the tool in crates/stella-tools/src/registry.rs";
+    let corpus = trace(
+        "a lesson about a file that is later deleted",
+        one_task_each(vec![
+            turn(T0, anchored),
+            // Six simulated months later, the file is gone.
+            TraceTurn {
+                removed_files: vec![REGISTRY.to_string()],
+                ..turn(
+                    T0 + 180 * DAY,
+                    "Budget aborts happen between model calls in crates/stella-core/src/driver.rs",
+                )
+            },
+        ]),
+    );
+    let (_summary, dir) = replay(&corpus).await;
+    let root = replay_root(&dir);
+
+    let path = crate::memory::context_db_path(&root).expect("context db path");
+    let store = stella_context::ContextStore::open_with(
+        &path,
+        std::sync::Arc::new(stella_context::HashEmbedder::default()),
+        std::sync::Arc::new(stella_context::SystemClock),
+    )
+    .expect("context store");
+
+    let vanished_node = store
+        .memory_nodes()
+        .expect("memory nodes")
+        .into_iter()
+        .find(|node| node.content == anchored)
+        .expect("the anchored lesson should still be STORED — retirement is reversible");
+    let retired = crate::memory::retirement::retired_ids(&store);
+
+    assert!(
+        retired.contains(&vanished_node.public_id),
+        "a memory whose only anchor left the tree should be in the retired set \
+         that recall suppresses. Retired: {retired:?}"
+    );
+}
+
+// ---- §5 assertion 7: the starvation guard ---------------------------------
+
+/// A corpus of unreadable reflections builds **nothing**, and the harness
+/// **says so loudly**.
+///
+/// This is the most valuable assertion in the suite. `reflect_and_record`
+/// returns `recorded: 0` both for "nothing worth learning" and for "I could not
+/// read the response", and a clean zero on every turn looks exactly like an
+/// agent that keeps getting things right. What separates them is that the
+/// unreadable path *reports a reason*, so the summary must carry one per turn.
+#[tokio::test]
+async fn an_unreadable_corpus_builds_nothing_and_says_why() {
+    let corpus = trace(
+        "a model that narrates instead of answering",
+        one_task_each(vec![
+            unreadable_turn(T0, "Sure! Here is what I learned this turn: ..."),
+            unreadable_turn(T0 + DAY, "Let me think about that step by step."),
+            unreadable_turn(T0 + 2 * DAY, "I have reflected on the turn."),
+            model_error_turn(T0 + 3 * DAY, "provider refused the reflection call"),
+        ]),
+    );
+    let (summary, _dir) = replay(&corpus).await;
+
+    assert_eq!(summary.memories, 0, "nothing should have been learned");
+    assert!(summary.skills.is_empty());
+    assert!(summary.rules.is_empty());
+    assert_eq!(
+        summary.model_errors.len(),
+        4,
+        "every starved turn must report why — a silent zero is \
+         indistinguishable from a turn with nothing to teach: {summary:?}"
+    );
+    let report = summary.render();
+    assert!(
+        report.contains("taught the lifecycle nothing and said so"),
+        "the rendered summary must surface starvation rather than printing a \
+         tidy row of zeroes:\n{report}"
+    );
+}
+
+/// The distinction the guard rests on: a turn with genuinely nothing to say is
+/// **not** an error, and must not be reported as one.
+#[tokio::test]
+async fn an_empty_reflection_is_not_reported_as_starvation() {
+    let empty = || TraceTurn {
+        reflection: ScriptedReflection::Lessons {
+            lessons: Vec::new(),
+            provenance: Provenance::Recorded,
+        },
+        ..turn(T0, "")
+    };
+    let corpus = trace(
+        "turns with nothing worth learning",
+        one_task_each(vec![
+            empty(),
+            TraceTurn {
+                at: T0 + DAY,
+                ..empty()
+            },
+        ]),
+    );
+    let (summary, _dir) = replay(&corpus).await;
+    assert_eq!(summary.memories, 0);
+    assert!(
+        summary.model_errors.is_empty(),
+        "an empty lessons array is a legitimate 'nothing to record', not a \
+         failure to read the model: {:?}",
+        summary.model_errors
+    );
+}
+
+// ---- §5 assertion 8: determinism -------------------------------------------
+
+/// Two replays of one trace produce byte-identical summaries.
+///
+/// The determinism contract itself, and the reason the summary may carry no
+/// `edge.public_id`: `EDGE_SEQ` is a process-global counter, so the same logical
+/// edge is minted with different ids by two replays *inside one process*.
+#[tokio::test]
+async fn two_replays_of_one_trace_are_byte_identical() {
+    let corpus = committed_corpus();
+    let (first, _a) = replay(&corpus).await;
+    let (second, _b) = replay(&corpus).await;
+    assert_eq!(
+        first, second,
+        "two replays of one trace must build the same things"
+    );
+    assert_eq!(
+        first.render(),
+        second.render(),
+        "and must render byte-identical reports"
+    );
+}
+
+// ---- the committed corpus ---------------------------------------------------
+
+fn committed_corpus() -> Trace {
+    Trace::fixture("simulated-months").expect("the committed corpus loads")
+}
+
+/// The committed corpus replays and builds one of everything.
+///
+/// This is the epic's "done when": a synthetic simulated-months trace that
+/// replays deterministically in CI, with the §6 metrics printed per run.
+#[tokio::test]
+async fn the_committed_corpus_builds_a_memory_a_skill_a_rule_and_a_tool() {
+    let corpus = committed_corpus();
+    let (summary, _dir) = replay(&corpus).await;
+    println!("{}", summary.render());
+
+    assert!(summary.turns >= 8, "a months corpus needs turns to span");
+    assert!(
+        summary.distinct_tasks >= 3,
+        "and distinct tasks to count: {summary:?}"
+    );
+    assert!(summary.memories > 0, "memories: {summary:?}");
+    assert!(!summary.skills.is_empty(), "skills: {summary:?}");
+    assert!(!summary.rules.is_empty(), "rules: {summary:?}");
+    assert!(!summary.tools.is_empty(), "tools: {summary:?}");
+}
+
+/// `make replay-learning`'s entry point — prints the §6 summary for the
+/// committed corpus.
+///
+/// A test rather than a binary because `stella-cli` is bin-only, and a report is
+/// not a pass/fail gate: it is deliberately **not** a `make gate` step, so it
+/// adds no shared cell for the three gate documents to disagree about.
+#[tokio::test]
+async fn replay_learning_report() {
+    let corpus = committed_corpus();
+    let (summary, _dir) = replay(&corpus).await;
+    println!("\n{}", summary.render());
+}
+
+/// The harness reads no ambient state — its workspace is all it sees.
+///
+/// The pattern `crates/stella-runtime/tests/no_ambient_reads.rs` already
+/// enforces for the runtime, applied here because a replay that quietly picked
+/// up the developer's `~/.stella` would produce a summary nobody else can
+/// reproduce — passing locally and failing in CI, or worse, the other way round.
+#[test]
+fn the_harness_workspace_is_the_only_state_it_reads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(
+        !dir.path().join(".stella").exists(),
+        "a fresh replay workspace starts empty"
+    );
+    assert_eq!(
+        super::summary::memory_texts(dir.path()),
+        Vec::<String>::new(),
+        "and holds no memories before a trace has run"
+    );
+    assert_eq!(
+        super::summary::published_rules(dir.path()),
+        Vec::<String>::new(),
+        "and no rules"
+    );
+}
+
+/// A seed path may not escape the workspace root.
+#[tokio::test]
+async fn a_seed_path_cannot_escape_the_workspace() {
+    let mut escaping = trace("escaping seed", one_task_each(vec![turn(T0, "a lesson")]));
+    escaping
+        .workspace
+        .files
+        .insert("../escaped.txt".to_string(), "no".to_string());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = replay_root(&dir);
+    assert!(
+        matches!(
+            Replayer::run(&escaping, &root).await,
+            Err(TraceError::Unreplayable(_))
+        ),
+        "a committed fixture must not be able to write outside the temp root"
+    );
+    assert!(!escaped_path(&root).exists());
+}
+
+fn escaped_path(root: &Path) -> std::path::PathBuf {
+    root.parent().unwrap_or(root).join("escaped.txt")
+}

--- a/crates/stella-cli/src/memory/replay/trace.rs
+++ b/crates/stella-cli/src/memory/replay/trace.rs
@@ -1,0 +1,364 @@
+//! The trace format — a recorded engagement, replayable with no model calls.
+//!
+//! Versioned and serde-first (invariant 4): every type here round-trips through
+//! `serde_json` byte-for-byte, and [`Trace::parse`] refuses an unknown version
+//! rather than best-effort parsing it. A fixture that a newer loader wrote is a
+//! fixture this loader cannot honestly replay, and quietly dropping the fields
+//! it does not understand would produce a *plausible* summary — the worst
+//! possible failure for a harness whose whole output is a claim about what the
+//! learner built.
+//!
+//! ## Two departures from `doc:trace-replay-learning-harness` §3
+//!
+//! The spec sketches `shell: Vec<ShellInvocation>` and
+//! `ScriptedReflection::Lessons(Vec<ReflectionLesson>)` directly. Neither
+//! survives contact with the types:
+//!
+//! - `stella_core::tool_foundry::ShellInvocation` derives no serde impls, and
+//!   giving it one would put a fixture-format concern in the engine. [`TraceShell`]
+//!   is the two-field mirror, converted at the boundary.
+//! - A `ReflectionLesson` carries `occurred_at` and `task_id`, which the
+//!   *replayer* owns — a trace that could set them would be able to contradict
+//!   its own clock. [`TraceLesson`] carries only what the model would have said.
+//!
+//! Both are cases of the fixture format deliberately not being the runtime
+//! type, so a trace cannot express a state the live loop could never reach.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use stella_core::tool_foundry::ShellInvocation;
+use stella_protocol::CompletionMessage;
+
+use crate::memory::LessonKind;
+
+/// The only trace version this loader accepts.
+///
+/// Bump it in the same change that alters the format, and teach [`Trace::parse`]
+/// the migration or the refusal. It is `u32` and not a semver string because
+/// there is exactly one consumer and a total order is all it needs.
+pub(crate) const TRACE_VERSION: u32 = 1;
+
+/// One recorded engagement: an ordered sequence of sessions, each a sequence of
+/// turns.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Trace {
+    pub version: u32,
+    /// A one-line description of what this corpus is *for*, printed beside the
+    /// metrics. §6's honesty guard begins here: a number that cannot name its
+    /// fixture is not reportable.
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub workspace: WorkspaceSeed,
+    pub sessions: Vec<TraceSession>,
+}
+
+/// The tree a trace replays against, before any turn runs.
+///
+/// Anchor resolution reads the real filesystem (`memory::anchors`), so a lesson
+/// naming `crates/stella-model/src/mistral.rs` anchors only if that path exists.
+/// Seeding files is therefore not decoration — it is what puts the anchoring
+/// path under test instead of silently skipping it.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub(crate) struct WorkspaceSeed {
+    /// Domain names written to `.stella/domains.toml`. A lesson's `domains` are
+    /// filtered against these, so an undeclared domain is dropped exactly as it
+    /// would be live.
+    #[serde(default)]
+    pub domains: Vec<String>,
+    /// Path → contents, relative to the workspace root. Contents may be empty;
+    /// only existence matters to anchoring.
+    #[serde(default)]
+    pub files: BTreeMap<String, String>,
+}
+
+/// One session. `task_id` is the boundary governance counts distinct tasks by,
+/// and supplying it is the entire reason `SessionMemory::set_task_id` exists.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct TraceSession {
+    pub id: String,
+    pub task_id: String,
+    pub turns: Vec<TraceTurn>,
+}
+
+/// One turn: an instant, what the model would have said, and what the shell did.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct TraceTurn {
+    /// Unix seconds. The replayer *sets* the clock to this before the turn;
+    /// nothing in the harness ever reads the wall clock (#2320).
+    pub at: i64,
+    pub prompt: String,
+    /// The transcript stub the reflection prompt digests. Only the tail matters
+    /// — `reflect_on_turn` reverses and takes twelve — so a stub need not be a
+    /// whole transcript.
+    #[serde(default)]
+    pub transcript: Vec<TraceMessage>,
+    /// What the model would have said, replayed through the scripted provider.
+    pub reflection: ScriptedReflection,
+    /// The turn's shell history, accumulated and fed to `detect_tool_gaps`.
+    #[serde(default)]
+    pub shell: Vec<TraceShell>,
+    /// Drives the reflection prompt template and the recorded outcome.
+    #[serde(default = "yes")]
+    pub succeeded: bool,
+    /// Statements the user forgot *before* this turn ran.
+    ///
+    /// A real engagement contains forgetting, and it is the one input that can
+    /// prove suppression is durable: a tombstone written here must stop the
+    /// lesson being re-learned for the rest of the trace, including when a
+    /// later turn restates it in different words. Applied ahead of the turn's
+    /// reflection, which is where a user's "forget that" lands relative to the
+    /// next thing the agent learns.
+    #[serde(default)]
+    pub forget: Vec<String>,
+    /// Paths that left the tree *before* this turn ran.
+    ///
+    /// The deterministic half of retirement: a memory whose path anchors have
+    /// all vanished is stale by a reproducible check, needing no model and no
+    /// human. Without a way to delete a seeded file mid-trace there is no way
+    /// to reach that sweep at all, so a corpus could never certify that a
+    /// retired memory stops being rendered.
+    #[serde(default)]
+    pub removed_files: Vec<String>,
+}
+
+fn yes() -> bool {
+    true
+}
+
+/// A transcript line. Deliberately not `CompletionMessage`: a trace needs a
+/// role and some text, and nothing downstream of the reflection digest reads
+/// tool calls or ids off it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct TraceMessage {
+    pub role: TraceRole,
+    pub content: String,
+}
+
+/// Who spoke. Only the roles a reflection digest distinguishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum TraceRole {
+    User,
+    Assistant,
+}
+
+impl From<&TraceMessage> for CompletionMessage {
+    fn from(message: &TraceMessage) -> Self {
+        match message.role {
+            TraceRole::User => CompletionMessage::user(&message.content),
+            TraceRole::Assistant => CompletionMessage::assistant(&message.content),
+        }
+    }
+}
+
+/// One shell invocation, mirroring [`ShellInvocation`] with serde attached.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TraceShell {
+    pub command: String,
+    #[serde(default = "yes")]
+    pub succeeded: bool,
+}
+
+impl From<&TraceShell> for ShellInvocation {
+    fn from(shell: &TraceShell) -> Self {
+        ShellInvocation {
+            command: shell.command.clone(),
+            succeeded: shell.succeeded,
+        }
+    }
+}
+
+/// What the reflection model would have returned this turn.
+///
+/// **Three arms, deliberately.** The two failure arms are not padding: they are
+/// what the live loop actually hits, and they are the ones that starve learning
+/// *silently*. `reflect_and_record` returns `recorded: 0` both for "nothing
+/// worth learning" and for "I could not read the response", and telling those
+/// apart is the entire purpose of the `Unreadable` branch. A corpus that only
+/// ever scripts happy-path lessons cannot certify the starvation guard, which is
+/// the most valuable assertion the harness has.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum ScriptedReflection {
+    /// A well-formed lessons array.
+    Lessons {
+        lessons: Vec<TraceLesson>,
+        /// Where these lessons came from. Defaults to [`Provenance::Recorded`]
+        /// so a hand-written fixture needs no ceremony; an adapter that
+        /// *derives* lessons from a foreign transcript must say so, or a
+        /// downstream number could silently mix invented lessons with recorded
+        /// ones (`doc:trace-replay-learning-harness` §7.2).
+        #[serde(default)]
+        provenance: Provenance,
+    },
+    /// A response the parser cannot read — drives `ReflectionParse::Unreadable`.
+    Unreadable { text: String },
+    /// The model call itself failed — drives `StandaloneCallError`.
+    ModelError { message: String },
+}
+
+/// One lesson as the model would have emitted it.
+///
+/// No `occurred_at` and no `task_id`: both are the replayer's to stamp, from the
+/// turn's clock and the session's boundary. A trace that could set them would be
+/// able to contradict its own timeline, and every assertion about recency or
+/// distinct-task counting would then be asserting the fixture rather than the
+/// learner.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct TraceLesson {
+    pub lesson: String,
+    #[serde(default)]
+    pub domains: Vec<String>,
+    #[serde(default)]
+    pub kind: LessonKind,
+}
+
+/// Whether a scripted reflection was recorded or derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Provenance {
+    /// Written by hand, or captured from a real Stella reflection. The claim a
+    /// metric may be reported against.
+    #[default]
+    Recorded,
+    /// Synthesized by an adapter from a source that carried no reflection JSON.
+    /// Present so option (a) in §7.2 is *labelled* if it is ever built — a
+    /// number derived from these measures the synthesizer, not the learner.
+    Derived,
+}
+
+/// Why a trace could not be loaded. Typed, not a `String` (invariant 5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TraceError {
+    /// The bytes are not the trace format at all.
+    Malformed(String),
+    /// A version this loader does not implement. Never best-effort parsed.
+    UnsupportedVersion { found: u32, supported: u32 },
+    /// A structurally valid trace that could not be replayed as written.
+    Unreplayable(String),
+}
+
+impl std::fmt::Display for TraceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TraceError::Malformed(why) => write!(f, "trace is malformed: {why}"),
+            TraceError::UnsupportedVersion { found, supported } => write!(
+                f,
+                "trace version {found} is not supported (this loader implements {supported}); \
+                 refusing rather than parsing it partially"
+            ),
+            TraceError::Unreplayable(why) => write!(f, "trace cannot be replayed: {why}"),
+        }
+    }
+}
+
+impl Trace {
+    /// Parse a trace, refusing an unknown version.
+    pub(crate) fn parse(json: &str) -> Result<Self, TraceError> {
+        let trace: Trace =
+            serde_json::from_str(json).map_err(|e| TraceError::Malformed(e.to_string()))?;
+        if trace.version != TRACE_VERSION {
+            return Err(TraceError::UnsupportedVersion {
+                found: trace.version,
+                supported: TRACE_VERSION,
+            });
+        }
+        trace.check()?;
+        Ok(trace)
+    }
+
+    /// Load a committed fixture by name from `tests/fixtures/traces/`.
+    ///
+    /// Resolved through `CARGO_MANIFEST_DIR`, the in-crate convention already
+    /// used by `crate::paths` and four other places — never a path relative to
+    /// the process's cwd, which differs between `cargo test` and a debugger.
+    pub(crate) fn fixture(name: &str) -> Result<Self, TraceError> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("traces")
+            .join(format!("{name}.json"));
+        let json = std::fs::read_to_string(&path)
+            .map_err(|e| TraceError::Malformed(format!("cannot read {}: {e}", path.display())))?;
+        Self::parse(&json)
+    }
+
+    /// Structural checks a replay depends on but serde cannot express.
+    ///
+    /// Non-decreasing time is the one that matters. The clock is *set* per turn
+    /// rather than advanced, so a trace that went backwards would replay
+    /// happily and produce a log whose recency ordering contradicts its own
+    /// line order — an assertion about retirement or ranking would then be
+    /// asserting nonsense. Refuse at load, where the fixture author can see it.
+    fn check(&self) -> Result<(), TraceError> {
+        let mut previous: Option<i64> = None;
+        let mut seen_sessions: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for session in &self.sessions {
+            if !seen_sessions.insert(session.id.as_str()) {
+                return Err(TraceError::Unreplayable(format!(
+                    "session id {:?} appears twice; ids identify a session's own \
+                     `SessionMemory`, so a repeat would silently merge two sessions",
+                    session.id
+                )));
+            }
+            if session.turns.is_empty() {
+                return Err(TraceError::Unreplayable(format!(
+                    "session {:?} has no turns",
+                    session.id
+                )));
+            }
+            for turn in &session.turns {
+                if let Some(previous) = previous
+                    && turn.at < previous
+                {
+                    return Err(TraceError::Unreplayable(format!(
+                        "session {:?} steps time backwards ({previous} → {}); the replayer \
+                         sets the clock per turn, so a trace must be non-decreasing",
+                        session.id, turn.at
+                    )));
+                }
+                previous = Some(turn.at);
+            }
+        }
+        if self.sessions.is_empty() {
+            return Err(TraceError::Unreplayable("trace has no sessions".into()));
+        }
+        Ok(())
+    }
+
+    /// Every turn in the trace, in replay order, tagged with its session.
+    pub(crate) fn turns(&self) -> impl Iterator<Item = (&TraceSession, &TraceTurn)> {
+        self.sessions
+            .iter()
+            .flat_map(|session| session.turns.iter().map(move |turn| (session, turn)))
+    }
+
+    /// How many distinct tasks the corpus spans — the denominator §6's
+    /// recurrence profile is read against.
+    pub(crate) fn distinct_tasks(&self) -> usize {
+        self.sessions
+            .iter()
+            .map(|s| s.task_id.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+    }
+}
+
+impl ScriptedReflection {
+    /// The wire text a provider would have returned for this arm.
+    ///
+    /// `Lessons` renders as the bare JSON array the reflection prompt asks for,
+    /// which is what puts the fixture on the same parsing path a live response
+    /// takes — including the domain filter and the three-lesson truncation.
+    pub(crate) fn as_response(&self) -> Option<String> {
+        match self {
+            ScriptedReflection::Lessons { lessons, .. } => {
+                Some(serde_json::to_string(lessons).unwrap_or_else(|_| "[]".to_string()))
+            }
+            ScriptedReflection::Unreadable { text } => Some(text.clone()),
+            ScriptedReflection::ModelError { .. } => None,
+        }
+    }
+}

--- a/crates/stella-cli/src/memory/tests/determinism.rs
+++ b/crates/stella-cli/src/memory/tests/determinism.rs
@@ -73,7 +73,7 @@ async fn reflection_log_at(at: i64) -> (tempfile::TempDir, String) {
     std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
 
     let clock: Arc<dyn Clock> = Arc::new(FixedClock::new(at));
-    let mut memory = SessionMemory::open_with_clock(dir.path(), false, clock)
+    let mut memory = SessionMemory::open_with_clock(dir.path(), false, false, clock)
         .expect("session memory opens in a temp workspace");
 
     let transcript = vec![
@@ -185,7 +185,7 @@ async fn the_context_store_shares_the_session_clock() {
     std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
 
     let clock: Arc<dyn Clock> = Arc::new(FixedClock::new(T));
-    let mut memory = SessionMemory::open_with_clock(dir.path(), false, clock)
+    let mut memory = SessionMemory::open_with_clock(dir.path(), false, false, clock)
         .expect("session memory opens in a temp workspace");
 
     let transcript = vec![

--- a/crates/stella-cli/tests/fixtures/traces/simulated-months.json
+++ b/crates/stella-cli/tests/fixtures/traces/simulated-months.json
@@ -1,0 +1,375 @@
+{
+  "version": 1,
+  "description": "one engineer, one repository, six simulated months - a tool-registration convention re-encountered across four distinct tasks in four different wordings, a recurring `rg -n <pattern> <path>` shape, one unreadable reflection, and several unrelated one-off facts so the corpus stays multi-topic",
+  "workspace": {
+    "domains": [
+      "tools",
+      "model",
+      "engine",
+      "tui",
+      "process"
+    ],
+    "files": {
+      "crates/stella-tools/src/registry.rs": "// tool registry\n",
+      "crates/stella-core/src/driver.rs": "// the step loop\n",
+      "crates/stella-model/src/anthropic.rs": "// anthropic adapter\n",
+      "crates/stella-cli/src/agent.rs": "// agent wiring\n",
+      "crates/stella-tui/src/deck_render.rs": "// deck render\n",
+      "crates/stella-tui/src/views/engine.rs": "// engine view\n"
+    }
+  },
+  "sessions": [
+    {
+      "id": "s01",
+      "task_id": "add-the-mistral-adapter",
+      "turns": [
+        {
+          "at": 1700000000,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Register the tool in crates/stella-tools/src/registry.rs",
+                "domains": [
+                  "tools"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"impl Tool\" crates/stella-tools/src/registry.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        },
+        {
+          "at": 1700003600,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Provider adapters are one file per vendor under crates/stella-model/src",
+                "domains": [
+                  "model"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"complete_ref\" crates/stella-model/src/anthropic.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        }
+      ]
+    },
+    {
+      "id": "s02",
+      "task_id": "fix-the-budget-abort",
+      "turns": [
+        {
+          "at": 1701209600,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Budget aborts happen only between model calls in crates/stella-core/src/driver.rs",
+                "domains": [
+                  "engine"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"budget\" crates/stella-core/src/driver.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        },
+        {
+          "at": 1701216800,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Tool registration lives at crates/stella-tools/src/registry.rs",
+                "domains": [
+                  "tools"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"BudgetGuard\" crates/stella-cli/src/agent.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        }
+      ]
+    },
+    {
+      "id": "s03",
+      "task_id": "teach-the-deck-a-new-tab",
+      "turns": [
+        {
+          "at": 1704060800,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Golden deck frames are regenerated with BLESS=1 under stella-tui",
+                "domains": [
+                  "tui"
+                ],
+                "kind": "process"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"TestBackend\" crates/stella-tui/src/deck_render.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        },
+        {
+          "at": 1704062600,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            }
+          ],
+          "reflection": {
+            "kind": "unreadable",
+            "text": "Let me think about what I learned. Actually, nothing much!"
+          },
+          "shell": [],
+          "succeeded": true
+        },
+        {
+          "at": 1704066200,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Tools register through crates/stella-tools/src/registry.rs",
+                "domains": [
+                  "tools"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"Widget\" crates/stella-tui/src/views/engine.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        }
+      ]
+    },
+    {
+      "id": "s04",
+      "task_id": "audit-the-unwrap-census",
+      "turns": [
+        {
+          "at": 1708294400,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Registered tools come from crates/stella-tools/src/registry.rs",
+                "domains": [
+                  "tools"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"unwrap\" crates/stella-core/src/driver.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        },
+        {
+          "at": 1708298000,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "A red gate is an automatic not-yet; run make gate before pushing",
+                "domains": [
+                  "process"
+                ],
+                "kind": "process"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"expect\" crates/stella-cli/src/agent.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        }
+      ]
+    },
+    {
+      "id": "s05",
+      "task_id": "trim-the-stale-memories",
+      "turns": [
+        {
+          "at": 1715379200,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "SSE parsing for Anthropic sits in crates/stella-model/src/anthropic.rs",
+                "domains": [
+                  "model"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"data:\" crates/stella-model/src/anthropic.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        }
+      ]
+    }
+  ]
+}

--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -114,6 +114,22 @@ static EDGE_SEQ: AtomicU64 = AtomicU64::new(0);
 /// nanos plus the static's ASLR-randomized address — not cryptographic, just
 /// distinct per process, which is all the v10 `UNIQUE` constraint needs
 /// backing for.
+///
+/// **Audited for the clock port (#2320): this is an identity nonce, not a time
+/// reading, and it deliberately stays off [`crate::Clock`].** The `SystemTime`
+/// read below never reaches a comparable field — nothing orders, ranges over or
+/// compares `edge.public_id`; the row's *time* is the separate `recorded_at`
+/// column, which callers already pass in as `now` and which the clock port does
+/// govern. Putting a fixed clock behind the nonce would only make two processes
+/// in one second mint from the same keyspace, which is the collision it exists
+/// to prevent.
+///
+/// Determinism note for replay harnesses: `public_id` is unreproducible anyway,
+/// and not because of this nonce. [`EDGE_SEQ`] is a process-global counter, so
+/// two replays of one trace *inside a single process* mint different ids for
+/// the same logical edge. An edge `public_id` is therefore never admissible in
+/// a replay summary compared for byte-identity — compare edge content, not edge
+/// identity (`doc:trace-replay-learning-harness` §4.2).
 fn process_nonce() -> u64 {
     static NONCE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
     *NONCE.get_or_init(|| {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -551,7 +551,8 @@
         9,
         10,
         11,
-        12
+        12,
+        13
       ],
       "status": "proposed",
       "title": "The trace-replay learning harness \u2014 drive the learning machinery from recorded traces, with zero model calls"

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -427,3 +427,89 @@ parallel once 2 lands.
 - `doc:replay-golden-trajectories` — a different replay concern: event-stream
   drift for the pipeline, not learning formation. The two share the word
   "replay" and nothing else.
+
+---
+
+## 13. As built
+
+The plan above survived contact with the code; the sequencing did not. PR 1 (the
+clock seam) landed on its own as #2340 closing #2320, and PRs 2–4 land together
+here — the format, the assertions and the metrics are one module, and splitting
+an assertion suite from the replayer that exists only to run it produces a PR
+that tests nothing.
+
+This section records where the implementation departs from the plan, so the
+document stays true to the tree. **Everything here was measured by replaying the
+real loop; none of it is visible from reading any single module**, which is the
+harness earning its keep before it shipped.
+
+### 13.1 Four measurements that changed the fixtures
+
+1. **The dedup filter and the skill miner use the same metric at the same
+   threshold, so a corpus of natural repetitions builds nothing.**
+   `retain_unknown` drops a lesson at Jaccard `>= 0.5` against existing
+   memories, *before* the mining log is appended — so a dropped lesson never
+   becomes an observation and can never contribute an occurrence. The miner then
+   clusters at `min_similarity: 0.5`. For a cluster of three to form, three
+   lessons must be similar enough to cluster while staying dissimilar enough to
+   survive dedup. The band exists **only because the tokenizers differ**:
+   `stella_store::forget::tokens` keeps a path as one token and keeps stopwords,
+   while `stella_core::mining::terms` shatters the path into five terms and
+   drops them. Four naturally-varied phrasings of one convention mined **zero**
+   candidates; four written into the band mined a skill and a rule. Filed as
+   **#2358** — the committed corpus is worded around this defect, and that
+   workaround should not outlive it.
+2. **The foundry holes only a value-like argument.** `classify_argument` makes a
+   positional argument a parameter only if it is a path or a number, so
+   `cargo test -p <crate>` yields a different signature per crate and never
+   clusters, while `rg -n "<pattern>" <path>` clusters immediately. Correct — a
+   bareword is usually a subcommand — but a fixture varying a bareword measures
+   nothing.
+3. **A record's lineage embeds the workspace directory name.** `derive_set_id`
+   falls back to it with no git remote, so two replays into different temp dirs
+   produced different lineage ids for the same learned rule and assertion 8
+   failed. The harness names its workspace rather than narrowing the summary to
+   hide it: stripping the set id would have buried real nondeterminism behind a
+   shorter report.
+4. **`Path::starts_with` is lexical**, so `root/../escaped.txt` satisfies it and
+   the obvious seed-path guard passed a fixture that escapes. It walks
+   components now.
+
+### 13.2 Where the implementation diverges from §3, §4 and §5
+
+- **The replayer's loop is shorter than §4.1's.** Steps 5 and 6 (observation
+  extraction, rule induction) are already inside `reflect_and_record` —
+  `auto_create_skills_typed` runs uses extraction, the retirement sweep,
+  observation extraction, skill proposals and rule induction from one
+  observation pool. Driving them again would shadow the shipped path with a
+  second mechanism, and the harness would certify its own wiring.
+- **`open_with_clock` takes `include_workspace_skills`.** With it false,
+  `write_candidates` and `induce_rules` record their proposals and decline to
+  write a FILE (#737), so a replay builds nothing while behaving correctly.
+- **`TraceShell` and `TraceLesson` mirror the runtime types rather than reusing
+  them.** `ShellInvocation` has no serde impls, and a `ReflectionLesson` carries
+  `occurred_at`/`task_id`, which the replayer owns — a trace able to set them
+  could contradict its own clock, and every assertion about recency or
+  distinct-task counting would then be asserting the fixture.
+- **`TraceTurn` gained `forget` and `removed_files`.** Assertions 5 and 6 are
+  unreachable without them, and both model real events in an engagement.
+- **Assertion 6 asserts against `retirement::retired_ids`, not the store's live
+  nodes.** Retirement deliberately does not write `node.superseded_at`, because
+  staying retrievable by id is what separates retirement from forgetting. A test
+  asserting "the memory is gone" fails against a working sweep, and one
+  asserting "the count went down" re-specifies retirement as deletion.
+- **`turns-to-first` is exact for memories and tools, approximate for skills,
+  absent for rules.** Filed as **#2359**: a placeholder must not render like a
+  measurement.
+
+### 13.3 Still open
+
+- **#2358** — the dedup/mining threshold collision. The most consequential thing
+  the harness has found.
+- **#2359** — the placeholder metric.
+- **The corpus can prove the corpus.** §6's recurrence profile mitigates it and
+  does not remove it.
+- **Recall-ranking assertions remain scoped out**, inheriting #2288.
+- **#2321** — extracting the learning loop into a library crate would let the
+  harness be an ordinary integration test rather than a `#[cfg(test)]` module.
+- **The §7 adapter** is a separate change; §13 gains its half when it lands.


### PR DESCRIPTION
Refs #2304. Implements PRs **2, 3 and 4** of `doc:trace-replay-learning-harness` §9 — the trace format and loader, the replayer, the eight assertions, the committed simulated-months corpus, the metrics, and `make replay-learning`.

**Rebased onto `main`.** The clock seam this depends on landed as **#2340** (closing #2320) from a parallel session while this was in flight; my duplicate #2335 is closed, with the two things it carried that #2340 did not recorded [there](https://github.com/macanderson/stella/pull/2335#issuecomment-5228386228) and folded in here. Base is `main`; no stack.

> **Note on `main` being red.** `make shellcheck` fails on `scripts/test-arena-scripts.sh`, which arrived with #2351 and is tracked as **#2355**. Not touched here — per AGENTS.md, a red ratchet you did not cause does not get folded into an unrelated PR.

## The spec's central claim holds, and cost nothing to collect

Of the five learners, four already make **no** model call and the fifth crosses exactly one port. So the harness is one scripted `Provider` and a clock — invariant 1 ("ports, not concretions") paying out. There is no new architecture here and no parallel implementation of anything.

**The replayer's loop is shorter than §4.1's, and that is a finding.** The spec gives the replayer observation extraction (step 5) and rule induction (step 6) as its own calls. They are already *inside* `reflect_and_record` — `auto_create_skills_typed` runs uses extraction, the retirement sweep, observation extraction, skill proposals and rule induction from one observation pool. Calling them again would not corrupt anything (extraction is replay-idempotent via content-derived ids) but it would be a second mechanism shadowing the shipped one, and the harness would then certify its own wiring instead of the loop's. The replayer drives the seam the drivers drive and lets the loop do the rest.

## Four things replaying the real loop measured, each of which changed the fixtures

These are the payoff. None is stated by any single module, and every one of them would have produced a *confidently wrong* fixture.

**1. The dedup filter and the skill miner use the same metric at the same threshold, so a corpus of literal repetitions builds nothing.** `retain_unknown` drops a lesson at Jaccard `>= 0.5` against existing memories, and it runs *before* the mining log is appended — so a dropped lesson never becomes an observation and can never contribute an occurrence. The miner then clusters at `min_similarity: 0.5`. For a cluster of three to form, three lessons must be similar enough to cluster while staying dissimilar enough to survive dedup.

That band exists **only because the tokenizers differ**, and the difference is load-bearing:

| | `stella_store::forget::tokens` | `stella_core::mining::terms` |
|---|---|---|
| `crates/stella-tools/src/registry.rs` | **one** token | **five** terms |
| stopwords, words ≤2 chars | kept | dropped |

A shared *path* costs the dedup comparison one token and gives the miner five, while differing filler inflates the dedup union invisibly to the miner. That is also the shape a real engagement produces — the same file re-encountered in different words — so the corpus is written that way. My first probe used four naturally-varied phrasings and mined **zero** candidates; it reads as a broken learner until you know this.

**2. The foundry holes only a *value-like* argument.** `classify_argument` makes a positional argument a parameter only if it is a path or a number (or quoted, or after `=`); a bareword stays in the skeleton. So `cargo test -p <crate>` yields a different signature per crate and never clusters, while `rg -n "<pattern>" <path>` clusters immediately. Correct behaviour — a bareword is usually a subcommand — but a fixture varying a bareword measures nothing.

**3. A record's lineage embeds the workspace directory name.** `derive_set_id` falls back to it with no git remote, so two replays into `/tmp/.tmpQ7x1a9` and `/tmp/.tmpB3k0zz` produced `ctx.tmpq7x1a9.…` and `ctx.tmpb3k0zz.…` for the same learned rule, and assertion 8 failed. Correct behaviour again — a record's lineage is scoped to its workspace. The tempting fix was to strip the set id out of the summary; that hides real nondeterminism behind a narrower report. Naming the replay workspace instead makes the harness deterministic *and* keeps the full lineage id — what a teammate actually sees — inside what assertion 8 compares.

**4. `Path::starts_with` is lexical, so the obvious escape guard passes a fixture that escapes.** `root/../escaped.txt` starts with `root` by that test. The guard now walks components. Caught by its own test, which is the argument for writing the negative control first.

## The eight assertions (§5), each with its negative control

| # | Assertion | Negative control |
|---|---|---|
| 1 | Recurrence across ≥3 distinct tasks builds a skill and a rule | The **same lessons at the same instants** inside one task build neither |
| 2 | An auto-activated rule is advisory — `force = "should"`, no `[enforcement]` | — |
| 2b | Auto-activation never clobbers a hand-written record (#737) | — |
| 3 | A repeated skill-shaped lesson yields `SKILL.md` | Four unrelated one-offs yield none |
| 4 | A shape with ≥2 distinct argument sets mints a tool | The identical command three times mints none |
| 5 | A tombstoned lesson is not re-learned **from a paraphrase** | — |
| 6 | A memory whose anchors all vanished lands in the retired set | — |
| 7 | An unreadable corpus builds nothing **and says why** | An *empty* lessons array is not reported as starvation |
| 8 | Two replays of one trace are byte-identical | — |

Two are worth calling out.

**Assertion 5 paraphrases, deliberately.** A corpus that tombstones a lesson and re-emits it *verbatim* proves almost nothing: byte-identical content already collapses through content-hash lineage. What needs proving is `retain_unforgotten`'s restatement matching, so the fixture restates.

**Assertion 6 asserts against `retirement::retired_ids`, not against the store's live nodes** — and getting this wrong first is what taught it. Retirement deliberately does **not** write `node.superseded_at`, because that column is filtered by `node_by_public_id` and projecting retirement onto it would make a retired record impossible to fetch by id, when staying retrievable is exactly what separates retirement from forgetting. A test asserting "the memory is gone" fails against a perfectly working sweep; "the count went down" quietly re-specifies retirement as deletion. The test asserts the memory is **still stored** *and* **in the set recall suppresses**.

## Two departures from the spec's §3 sketch

Both are the fixture format deliberately not being the runtime type, so a trace cannot express a state the live loop could never reach.

- `ShellInvocation` derives no serde impls, and adding them would put a fixture concern in the engine. `TraceShell` is the two-field mirror.
- `ReflectionLesson` carries `occurred_at` and `task_id`, which the **replayer** owns. A trace able to set them could contradict its own clock, and every assertion about recency or distinct-task counting would then be asserting the fixture. `TraceLesson` carries only what the model would have said.

`ScriptedReflection` also carries the §7.2 `provenance` field from the start (defaulting to `Recorded`), so PR 5's adapter can label derived lessons without a format version bump.

## Two fields the spec did not have

`TraceTurn::forget` and `TraceTurn::removed_files`, both applied before the turn's reflection. Assertions 5 and 6 are unreachable without them — there is no way to tombstone a lesson or delete a seeded file mid-trace otherwise — and both model real events in a real engagement rather than being test backdoors.

## Metrics, and the honesty guard

`make replay-learning` prints the §6 report. The recurrence profile is emitted by the **same function** as the artifact counts, so a caller cannot print the yield without the shape it came from:

```
what the learners built
  memories: 9 distinct in store (9 lesson(s) recorded of 9 offered)
  skills:   2 — .stella/skills/registered-tools-come-from-crates-stella-b54d480a.md, …
  rules:    1 — ctx.stella-replay-workspace.registered-tools-come-from-crates-stella-b54d480a
  tools:    1 — rg_n
  turns-to-first: memory 1, skill 10, tool 3

read the two together
  4 artifact(s) from 9 lesson(s) over 5 distinct task(s). A count that rises
  because one lesson repeats is a fact about this fixture, not about the learner.

1 turn(s) taught the lifecycle nothing and said so:
  · reflection response was not a readable JSON array of lessons, so this turn taught
    the context lifecycle nothing; …
```

An artifact count that rises because a fixture repeats one lesson measures the fixture, and reporting it alone is the kind of small dishonesty that costs more than it buys.

## CI wiring

**No new `GATE_STEPS` entry**, per §8. The assertions are ordinary in-crate tests, already covered by `make gate`'s existing `test` step, so there is no `gate-parity` churn across the Makefile, AGENTS.md and CONTRIBUTING.md. `make replay-learning` is a convenience target only: a target whose job is to *print a report* adds nothing as pass/fail, and every added step is one more shared cell three documents must agree on.

## Verification

- `cargo test -p stella-cli` — **1524 passed, 0 failed** (18 new), on top of `main`
- `cargo clippy -p stella-cli -p stella-context --all-targets -- -D warnings` — clean
- `make guards-fast` — clean apart from the pre-existing `shellcheck` failure tracked as #2355
- `make replay-learning` — output above

**No tests deleted.**

## Scope notes

- Everything is `#[cfg(test)]`. `stella-cli` is bin-only, so an in-crate module is the only place this can reach `SessionMemory` at all (§4), and gating it means zero production surface and no `#[allow(dead_code)]` describing an API nothing can reach.
- `SessionMemory::set_task_id` **stays `#[cfg(test)]`-gated**. Its doc comment says to drop the gate for the first real caller; a test-only replayer is not one, and the comment's intent — don't ship unreachable API — is satisfied as written. Extracting the learning loop to a library crate so the harness could be an ordinary integration test is #2321.
- **PR 5 (the Claude Code transcript adapter) is not in this PR** and is independent of 3–4 now that the format exists.
- Recall-*ranking* assertions are scoped out per §11: they would inherit #2288.

## What this PR adds to `main`'s clock seam

One line, and it is load-bearing: **`open_with_clock` gains `include_workspace_skills`.** #2340 hardcoded it `false`. With it false, `write_candidates` and `induce_rules` record their proposals and then decline to write a FILE (#737) — so a replay of the whole corpus behaves perfectly correctly and builds **nothing**. It is the difference between the committed corpus producing two skills and a rule, and producing zero.

`main`'s doc comment says to drop the `#[cfg(test)]` gate "in the same commit that adds the replayer". **The gate stays**, because the replayer is itself `#[cfg(test)]` — `stella-cli` is bin-only, so an in-crate module is the only way to reach `SessionMemory` at all (§4), and an ungated constructor nothing production can call would be exactly the dead code the gate exists to prevent. The comment's intent is satisfied; its literal instruction is not, and that is deliberate. #2321 (extracting the learning loop to a library crate) is what would change the answer.
