### PR TITLE
fix(arenabench): arena-run classifies a dead server from its own log, never from the box

### DIFF
--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -1026,6 +1026,11 @@ def serve(
         )
         if existing is not None:
             url = f"http://{host}:{existing}/"
+            # scripts/arena-run.sh greps its launch's slice of the server log
+            # for this exact phrase — and takes the URL off this line — to
+            # tell a deliberate handoff from a crash. The detached pid is
+            # reparented before that script can wait on it, so this line is
+            # the only per-launch channel; reword the two together.
             print(f"\n  arenabench  ->  {url}  (already serving this workspace)")
             print(f"  workspace   ->  {workspace}")
             print("  reusing it instead of starting a second arena over the same")

--- a/scripts/arena-run.sh
+++ b/scripts/arena-run.sh
@@ -272,51 +272,56 @@ read -r PID PORT LOG_OFFSET LOG <<<"$LAUNCH"
 # The authority on "did it start" is this pid, not the port. A port answering
 # proves only that SOME server is listening — which is exactly the trap when
 # another session already holds the one you asked for.
-sleep 2
-if ! kill -0 "$PID" 2>/dev/null; then
-  # An immediate exit is a crash today. It will not always be: `serve` is
-  # growing the ability to hand off to an arena already serving this workspace
-  # and exit on purpose (#2322). So ask what is actually true instead of
-  # assuming — probe /api/health, which reports the workspace each arena is
-  # serving, and report a handoff as a handoff. The holder's pid and cwd are
-  # printed with it, because "an arena is serving this workspace" and "YOUR
-  # arena is serving it" are different claims and only the second is good news.
-  HANDOFF="$(
-    "$PY" - "$ARENA_HOME" "$PORT" "$DEFAULT_PORT" <<'PY' 2>/dev/null
-import json
-import os
-import sys
-import urllib.request
-
-home = os.path.realpath(sys.argv[1])
-ports = [int(sys.argv[2])] + list(range(int(sys.argv[3]), int(sys.argv[3]) + 40))
-for port in dict.fromkeys(ports):
-    try:
-        with urllib.request.urlopen(
-            f"http://127.0.0.1:{port}/api/health", timeout=0.4
-        ) as response:
-            payload = json.load(response)
-    except Exception:
-        continue
-    if os.path.realpath(payload.get("workspace", "")) == home:
-        print(port)
-        break
-PY
+#
+# And the authority on WHY it exited is the child's own log, never the state
+# of the box. A quick exit is either a crash or `serve` finding an arena
+# already serving this workspace and exiting on purpose (#2322) — and probing
+# cannot tell those apart: the workspace defaults to ~/.arenabench for every
+# checkout on the machine, so "some arena serves this workspace" is usually
+# true here even while this launch lies dead of an unrelated crash, and a
+# probe would bury the one traceback that explains it under a green checkmark.
+# (It also fails the other way: serve's discovery sweep is bounded at 8905,
+# while arenas have really ended up on 8917 and 8933 — a probe that looks
+# further would report a handoff serve never made.) On the handoff path serve
+# prints "(already serving this workspace)" with the arena's URL, and stdout
+# is wired to the log, so the marker inside THIS launch's slice is the one
+# signal that cannot be describing some other process. An exit status was
+# never on offer: the child was start_new_session'd and its spawner has
+# already exited, so it was reparented before this shell could wait on it.
+report_dead_server() {
+  local slice handoff_line handoff_url handoff_port
+  slice="$(tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null)"
+  handoff_line="$(
+    printf '%s\n' "$slice" | awk '/already serving this workspace/ { print; exit }'
   )"
-  if [ -n "$HANDOFF" ]; then
-    printf '%s✔ an arena is already serving this workspace%s  http://127.0.0.1:%s/\n' \
-      "$green" "$reset" "$HANDOFF"
-    if command -v lsof >/dev/null 2>&1; then
-      lsof -iTCP:"$HANDOFF" -sTCP:LISTEN -Pn >&2 2>/dev/null || true
-    fi
+  if [ -n "$handoff_line" ]; then
+    handoff_url="$(
+      printf '%s\n' "$handoff_line" |
+        awk 'match($0, /http:\/\/[^ ]+/) { print substr($0, RSTART, RLENGTH); exit }'
+    )"
+    printf '%s✔ an arena is already serving this workspace%s  %s\n' \
+      "$green" "$reset" "${handoff_url:-(url not logged — see $LOG)}"
+    handoff_port="${handoff_url##*:}"
+    handoff_port="${handoff_port%%/*}"
+    case "$handoff_port" in
+      ''|*[!0-9]*) ;;
+      *)
+        if command -v lsof >/dev/null 2>&1; then
+          lsof -iTCP:"$handoff_port" -sTCP:LISTEN -Pn >&2 2>/dev/null || true
+        fi ;;
+    esac
     printf '  %sthis launch handed off to it rather than binding a second port;\n' "$dim"
     printf '  make kill-arena then make run-arena for one wired to THIS checkout%s\n' "$reset"
     exit 0
   fi
-  printf '%sserver pid %s died within 2s. Its output:%s\n' "$red" "$PID" "$reset" >&2
-  tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null | tail -n 30 >&2
+  printf '%sserver pid %s died before it was ready. Its output:%s\n' \
+    "$red" "$PID" "$reset" >&2
+  printf '%s\n' "$slice" | tail -n 30 >&2
   exit 1
-fi
+}
+
+sleep 2
+kill -0 "$PID" 2>/dev/null || report_dead_server
 
 if tail -c "+$(( LOG_OFFSET + 1 ))" "$LOG" 2>/dev/null | grep -q "Traceback"; then
   printf '%swarning: pid %s is alive but logged a traceback:%s\n' "$yellow" "$PID" "$reset" >&2
@@ -337,6 +342,11 @@ if command -v curl >/dev/null 2>&1; then
     tries=$(( tries - 1 ))
   done
 fi
+
+# A death during the wait is the same question as a death at the 2s mark, and
+# it gets the same answer from the same place. Without this, a server that
+# outlived the first check and then crashed was announced as serving.
+kill -0 "$PID" 2>/dev/null || report_dead_server
 
 printf '\n%s✔ arenabench serving%s  %s\n' "$green" "$reset" "$URL"
 printf '  pid %s   log %s\n' "$PID" "$LOG"

--- a/scripts/test-arena-scripts.sh
+++ b/scripts/test-arena-scripts.sh
@@ -204,5 +204,111 @@ esac
 "$REAP_SH" --min-idle-secs x >/dev/null 2>&1
 check "reap-seats rejects a non-numeric --min-idle-secs" "$?" "1"
 
+# --- arena-run classifies a dead child from its log, never from the box ------
+#
+# A spawned serve that exits at once either crashed or found an arena already
+# serving this workspace and handed off on purpose (#2322). The workspace
+# defaults to ~/.arenabench for every checkout on the machine, so probing "is
+# some arena serving this workspace?" answers yes on a busy box even when THIS
+# launch died of a real crash — and would bury the traceback under a green
+# checkmark. The script must read which one happened out of the child's own
+# slice of the log instead. These checks stand a stub interpreter in for the
+# adapter venv: it passes the import preflight, swallows the launch heredoc,
+# lays down a prepared log, and reports a pid that is already dead (or, with
+# STUB_LINGER, one that dies mid-wait) — so classification has nothing to
+# consult but the log, which is the invariant under test.
+LAUNCH_STUB="$STUB_DIR/launcher"
+{
+  echo '#!/bin/sh'
+  echo 'case "$1" in'
+  echo '  -c) exit 0 ;;'
+  echo '  -)'
+  echo '    cat >/dev/null'
+  echo '    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"'
+  # The linger child's stdout is redirected for the same reason the reap
+  # test's orphan is: inherited, it would hold arena-run's $(...) pipe open
+  # for its whole lifetime.
+  echo '    if [ -n "${STUB_LINGER:-}" ]; then'
+  echo '      sleep "$STUB_LINGER" >/dev/null 2>&1 &'
+  echo '      pid=$!'
+  echo '    else'
+  echo '      sh -c ":" & pid=$!'
+  echo '      wait "$pid" 2>/dev/null'
+  echo '    fi'
+  echo '    echo "$pid 8964 ${STUB_LOG_OFFSET:-0} $STUB_LOG"'
+  echo '    ;;'
+  echo '  *) exit 0 ;;'
+  echo 'esac'
+} > "$LAUNCH_STUB"
+chmod +x "$LAUNCH_STUB"
+
+RUN_HOME="$(mktemp -d)"
+trap 'cleanup_fakes; rm -rf "$STUB_DIR" "$RUN_HOME"' EXIT
+
+# The marker names port 8931 while the stub reports the launch on 8964: the
+# printed URL must come from the child's log line, not from the launch port.
+HLOG="$RUN_HOME/server-handoff.log"
+: > "$HLOG"
+RUN_OUT="$(
+  ARENA_PYTHON="$LAUNCH_STUB" ARENABENCH_HOME="$RUN_HOME" \
+  STUB_LOG="$HLOG" STUB_LOG_OFFSET=0 \
+  STUB_LOG_BODY='  arenabench  ->  http://127.0.0.1:8931/  (already serving this workspace)' \
+  "$RUN_SH" 2>&1
+)"
+check "arena-run reports a logged handoff as a handoff" "$?" "0"
+case "$RUN_OUT" in
+  *"http://127.0.0.1:8931/"*) ok "…and prints the arena url from the child's log" ;;
+  *) no "…and prints the arena url from the child's log"
+     printf '        actual:\n%s\n' "$RUN_OUT" ;;
+esac
+
+CLOG="$RUN_HOME/server-crash.log"
+: > "$CLOG"
+RUN_OUT="$(
+  ARENA_PYTHON="$LAUNCH_STUB" ARENABENCH_HOME="$RUN_HOME" \
+  STUB_LOG="$CLOG" STUB_LOG_OFFSET=0 \
+  STUB_LOG_BODY='RuntimeError: match store corrupted' \
+  "$RUN_SH" 2>&1
+)"
+check "arena-run reports a dead child with no handoff marker as a crash" "$?" "1"
+case "$RUN_OUT" in
+  *"RuntimeError: match store corrupted"*) ok "…and shows the child's own log slice" ;;
+  *) no "…and shows the child's own log slice"
+     printf '        actual:\n%s\n' "$RUN_OUT" ;;
+esac
+
+# A previous launch on this port handed off and left its marker in the shared
+# log. This launch crashed. Only the slice past the offset may be consulted.
+OLOG="$RUN_HOME/server-stale.log"
+printf '%s\n' \
+  '  arenabench  ->  http://127.0.0.1:8900/  (already serving this workspace)' \
+  > "$OLOG"
+STALE_LEN="$(wc -c < "$OLOG" | tr -d ' ')"
+RUN_OUT="$(
+  ARENA_PYTHON="$LAUNCH_STUB" ARENABENCH_HOME="$RUN_HOME" \
+  STUB_LOG="$OLOG" STUB_LOG_OFFSET="$STALE_LEN" \
+  STUB_LOG_BODY='OSError: [Errno 48] Address already in use' \
+  "$RUN_SH" 2>&1
+)"
+check "arena-run ignores a previous launch's handoff marker before the offset" "$?" "1"
+
+# A child that outlives the 2s check and dies during the ready wait was
+# previously announced as serving, banner and all.
+LLOG="$RUN_HOME/server-linger.log"
+: > "$LLOG"
+RUN_OUT="$(
+  ARENA_PYTHON="$LAUNCH_STUB" ARENABENCH_HOME="$RUN_HOME" \
+  STUB_LOG="$LLOG" STUB_LOG_OFFSET=0 STUB_LINGER=3 \
+  STUB_LOG_BODY='ValueError: port 8964 already serves a different arena' \
+  "$RUN_SH" 2>&1
+)"
+check "arena-run reports a death during the ready wait as a crash" "$?" "1"
+case "$RUN_OUT" in
+  *"✔ arenabench serving"*)
+    no "…and does not print the serving banner for a dead server"
+    printf '        actual:\n%s\n' "$RUN_OUT" ;;
+  *) ok "…and does not print the serving banner for a dead server" ;;
+esac
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

`arena-run.sh` now decides "deliberate handoff" vs "crash" for a dead server from the child's own log, never from what else is listening on the box. Follow-up to #2328, fixing the finding Vercel's reviewer raised on the handoff probe there — confirmed, with a sharper mechanism than stated.

## Why the probe was wrong

The probe answered *"is some arena serving this workspace?"* when the question was *"why did MY child exit?"* Those decouple in both directions:

- **Crash reported as handoff (the reviewer's finding).** The workspace defaults to `~/.arenabench` for every checkout on the machine, and this is a multi-tenant box by design. With any other session's arena up, a launch that crashed for a real reason — corrupted match store, bind race, anything after `serve`'s reuse check — got the green `✔` and exit 0, and the one traceback that explained the death was never printed. The case that needs the traceback most (a store corruption that kills every *new* serve while an old arena keeps answering health checks) is exactly the case the probe buried.
- **Handoff reported that serve never made.** `serve`'s discovery sweep is deliberately bounded (`ARENA_DISCOVERY_PORTS` stops at 8905) while the probe swept 40 ports — and `server.py`'s own comment records arenas really landing on 8917 and 8933. An arena there is invisible to `serve` (so no handoff happened) but visible to the probe (so one was reported).

This is the repo's bench rule applied to itself: a conclusion comes from the trace, never from a surface signal. The port state is the surface signal; the child's log is the trace.

## The fix

On the deliberate-handoff path `serve` prints `(already serving this workspace)` with the arena's URL, and the child's stdout is wired to the log. The classifier now reads exactly this launch's slice (the existing `LOG_OFFSET` discipline) for that marker: marker → handoff, exit 0, URL taken off the marker line; no marker → crash, exit 1, log slice shown. An exit status was never on offer — the child is `start_new_session`'d and reparented before the shell can `wait` on it — so the log line is the only per-launch channel. `server.py` now says so at the print site, since the phrase is a wire contract between the two files.

The same check now also runs after the ready wait: a server that outlived the 2s check and then crashed was previously announced with the full `✔ arenabench serving` banner, exit 0.

## Proof

- Four new hermetic checks in `test-arena-scripts.sh` (20 total, all passing) drive the classifier through a stub interpreter whose reported pid is already dead — or, with `STUB_LINGER`, dies mid-wait — so classification has nothing to consult but the log. The handoff test's marker names a *different* port than the launch, pinning that the URL comes from the log line; a stale-marker test pins the offset discipline.
- Differential witness on the pre-fix script (ready-wait death, `ValueError` in the log):

  ```
  OLD-SCRIPT-RC=0
  ✔ arenabench serving  http://127.0.0.1:8964/
    the pid is alive but /api/datasets has not answered yet — check the log
  ```

  The fixed script exits 1 and prints the `ValueError`.

## Summary by Sourcery

Classify arena-run server deaths using the child process’s own log slice instead of probing box ports, ensuring deliberate handoffs are distinguished from crashes and surfaced correctly.

Bug Fixes:
- Ensure arena-run reports crashed servers as failures even when another arena on the box is serving the same workspace.
- Prevent arena-run from incorrectly announcing a server as serving when it crashes after passing the initial readiness check.

Enhancements:
- Introduce a log-based dead-server classifier in arena-run.sh that extracts the handoff URL from a structured log line and limits lsof diagnostics to the logged port.
- Document in server.py that the handoff log line is a wire contract with arena-run.sh for distinguishing handoffs from crashes.

Tests:
- Add hermetic shell tests that stub the arena launcher to validate log-based classification of handoffs, crashes, stale handoff markers, and deaths during the ready wait.