### PR TITLE
fix(gate): unbreak main — shellcheck fails every PR on the arena stub's echo run

### DIFF
--- a/scripts/test-arena-scripts.sh
+++ b/scripts/test-arena-scripts.sh
@@ -218,28 +218,33 @@ check "reap-seats rejects a non-numeric --min-idle-secs" "$?" "1"
 # STUB_LINGER, one that dies mid-wait) — so classification has nothing to
 # consult but the log, which is the invariant under test.
 LAUNCH_STUB="$STUB_DIR/launcher"
-{
-  echo '#!/bin/sh'
-  echo 'case "$1" in'
-  echo '  -c) exit 0 ;;'
-  echo '  -)'
-  echo '    cat >/dev/null'
-  echo '    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"'
-  # The linger child's stdout is redirected for the same reason the reap
-  # test's orphan is: inherited, it would hold arena-run's $(...) pipe open
-  # for its whole lifetime.
-  echo '    if [ -n "${STUB_LINGER:-}" ]; then'
-  echo '      sleep "$STUB_LINGER" >/dev/null 2>&1 &'
-  echo '      pid=$!'
-  echo '    else'
-  echo '      sh -c ":" & pid=$!'
-  echo '      wait "$pid" 2>/dev/null'
-  echo '    fi'
-  echo '    echo "$pid 8964 ${STUB_LOG_OFFSET:-0} $STUB_LOG"'
-  echo '    ;;'
-  echo '  *) exit 0 ;;'
-  echo 'esac'
-} > "$LAUNCH_STUB"
+# A quoted heredoc, not a run of `echo '…'`: every line below is literal text
+# for the generated stub, and the quoted delimiter says so once instead of
+# per line. shellcheck read the echo form as sixteen accidental single-quote
+# mistakes (SC2016/SC2028) and failed the gate for the whole repository.
+#
+# The linger child's stdout is redirected inside the stub for the same reason
+# the reap test's orphan is: inherited, it would hold arena-run's $(...) pipe
+# open for its whole lifetime.
+cat <<'LAUNCH_STUB_BODY' > "$LAUNCH_STUB"
+#!/bin/sh
+case "$1" in
+  -c) exit 0 ;;
+  -)
+    cat >/dev/null
+    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"
+    if [ -n "${STUB_LINGER:-}" ]; then
+      sleep "$STUB_LINGER" >/dev/null 2>&1 &
+      pid=$!
+    else
+      sh -c ":" & pid=$!
+      wait "$pid" 2>/dev/null
+    fi
+    echo "$pid 8964 ${STUB_LOG_OFFSET:-0} $STUB_LOG"
+    ;;
+  *) exit 0 ;;
+esac
+LAUNCH_STUB_BODY
 chmod +x "$LAUNCH_STUB"
 
 RUN_HOME="$(mktemp -d)"


### PR DESCRIPTION
## main is red, and this is why

`shellcheck` exits non-zero on `scripts/test-arena-scripts.sh`, which fails the `fmt + clippy + test` job for **every PR in flight**, whatever that PR touches. Confirmed against `origin/main` itself (`c78c7c9a`) rather than inferred from a PR: 9 findings, SC2016 and SC2028.

```
In scripts/test-arena-scripts.sh line 223:
  echo 'case "$1" in'
       ^------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

In scripts/test-arena-scripts.sh line 227:
  echo '    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"'
       ^-- SC2016 (info)
       ^-- SC2028 (info): echo may not expand escape sequences. Use printf.
```

Arrived with #2328. The `info` severity is misleading — shellcheck's exit code is non-zero for any finding at or above its default threshold, so an "info" here is a hard gate failure.

## Fix

The single quotes were **correct**: the block is generating a stub interpreter, and every line is literal text that must not expand. Sixteen `echo '…'` lines say that sixteen times and shellcheck can only read each one as a possible mistake. A quoted heredoc says it once, structurally:

```sh
cat <<'LAUNCH_STUB_BODY' > "$LAUNCH_STUB"
#!/bin/sh
case "$1" in
...
LAUNCH_STUB_BODY
```

Deliberately **not** a `# shellcheck disable=SC2016,SC2028`, because SC2028 was pointing at something real — see below.

## Byte-identical, checked rather than claimed

Generated the stub both ways and diffed:

```
IDENTICAL:  17 lines, 361 bytes
```

`bash scripts/test-arena-scripts.sh` → **20 passed, 0 failed**. `shellcheck scripts/test-arena-scripts.sh` → clean, exit 0.

## The check earned its keep

Run under `sh`, the two forms **differ**. dash's `echo` expands `\n`, so the old form emits a literal newline *inside* the stub's `printf` format string:

```diff
-    printf "%s
-" "$STUB_LOG_BODY" >> "$STUB_LOG"
+    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"
```

Under `bash` — this script's actual shebang — `echo` leaves the escape alone and the two agree, which is why the suite passes today.

So SC2028 was not noise. It was flagging a latent portability defect: harmless under the current shebang, a broken generated stub the day someone changes it to `#!/bin/sh` or copies the idiom into a POSIX script. The heredoc removes the hazard instead of silencing the warning about it.

(I found this because my first verification harness ran under `sh` and reported a diff. The script was fine; my harness was wrong. Worth stating plainly — the failing diff is what surfaced the real portability point.)

## Scope

One file, one block. No behaviour change, no test deleted, nothing else touched — this exists to get `main` green so the queued PRs can be judged on their own contents.

## Summary by Sourcery

Replace the echo-based stub generator in test-arena-scripts with a quoted heredoc to keep the generated launcher script literal while satisfying shellcheck and restoring the main branch’s CI gate.

Enhancements:
- Ensure the arena launcher stub is generated in a shell-agnostic, portability-safe way that matches the previous behavior byte-for-byte while removing reliance on echo escape handling.

Tests:
- Keep the arena scripts test harness behavior unchanged while making it pass shellcheck cleanly so the fmt+clippy+test CI job no longer fails for unrelated pull requests.