### PR TITLE
fix(gate): unbreak main — the arena script test emits its stub with a quoted heredoc

### DIFF
--- a/scripts/test-arena-scripts.sh
+++ b/scripts/test-arena-scripts.sh
@@ -218,28 +218,32 @@ check "reap-seats rejects a non-numeric --min-idle-secs" "$?" "1"
 # STUB_LINGER, one that dies mid-wait) — so classification has nothing to
 # consult but the log, which is the invariant under test.
 LAUNCH_STUB="$STUB_DIR/launcher"
-{
-  echo '#!/bin/sh'
-  echo 'case "$1" in'
-  echo '  -c) exit 0 ;;'
-  echo '  -)'
-  echo '    cat >/dev/null'
-  echo '    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"'
-  # The linger child's stdout is redirected for the same reason the reap
-  # test's orphan is: inherited, it would hold arena-run's $(...) pipe open
-  # for its whole lifetime.
-  echo '    if [ -n "${STUB_LINGER:-}" ]; then'
-  echo '      sleep "$STUB_LINGER" >/dev/null 2>&1 &'
-  echo '      pid=$!'
-  echo '    else'
-  echo '      sh -c ":" & pid=$!'
-  echo '      wait "$pid" 2>/dev/null'
-  echo '    fi'
-  echo '    echo "$pid 8964 ${STUB_LOG_OFFSET:-0} $STUB_LOG"'
-  echo '    ;;'
-  echo '  *) exit 0 ;;'
-  echo 'esac'
-} > "$LAUNCH_STUB"
+# A quoted heredoc, not a run of `echo '…'`: every line below is literal text
+# for the stub, so shellcheck reading them as *this* script's expressions was
+# nine SC2016/SC2028 findings on code that must not expand. `<<'SH'` says that
+# once, to shellcheck and to the next reader both.
+cat >"$LAUNCH_STUB" <<'SH'
+#!/bin/sh
+case "$1" in
+  -c) exit 0 ;;
+  -)
+    cat >/dev/null
+    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"
+    # The linger child's stdout is redirected for the same reason the reap
+    # test's orphan is: inherited, it would hold arena-run's $(...) pipe open
+    # for its whole lifetime.
+    if [ -n "${STUB_LINGER:-}" ]; then
+      sleep "$STUB_LINGER" >/dev/null 2>&1 &
+      pid=$!
+    else
+      sh -c ":" & pid=$!
+      wait "$pid" 2>/dev/null
+    fi
+    echo "$pid 8964 ${STUB_LOG_OFFSET:-0} $STUB_LOG"
+    ;;
+  *) exit 0 ;;
+esac
+SH
 chmod +x "$LAUNCH_STUB"
 
 RUN_HOME="$(mktemp -d)"


### PR DESCRIPTION
## What broke

`main` is red at a7077614 (#2351). The required `fmt + clippy + test` job runs

```
shellcheck install.sh scripts/*.sh .githooks/*
```

with **no severity filter**, so info-level findings fail it. #2351 built its launcher stub from a run of `echo '…'` lines:

```sh
{
  echo '#!/bin/sh'
  echo 'case "$1" in'
  ...
  echo '    printf "%s\n" "$STUB_LOG_BODY" >> "$STUB_LOG"'
} > "$LAUNCH_STUB"
```

Every one of those lines is literal text destined for the stub, but shellcheck reads them as *this* script's expressions — nine SC2016 ("expressions don't expand in single quotes") and SC2028 ("echo may not expand escape sequences") findings on code that is correct precisely because it does not expand. Exit 1, and every PR behind it inherits a failure it did not cause.

## The fix

A quoted heredoc — `cat >"$LAUNCH_STUB" <<'SH'` — which is the idiomatic way to emit literal shell text. It says "none of this expands" once, to shellcheck and to the next reader both, and removes the finding at its source rather than suppressing it. A `# shellcheck disable=SC2016,SC2028` would also have gone green, but this repo treats a suppression as a defect unless the lint is wrong in a way the code cannot express — here the code *can* express it.

The inline comment about the linger child's redirected stdout moves inside the stub, adjacent to the line it explains.

## Verification

- `shellcheck install.sh scripts/*.sh .githooks/*` — the exact CI invocation — passes clean.
- `bash scripts/test-arena-scripts.sh`: **20 passed, 0 failed**, including every stub-dependent case (logged handoff, dead child with no marker, previous launch's marker before the offset, death during the ready wait). The stub's behaviour is unchanged; only the quoting mechanism is.

No witness test: this is a lint repair with no behaviour change, and the existing suite is what proves the stub still does its job.

Refs #2351

## Summary by Sourcery

Use a quoted heredoc to generate the arena launcher stub so shellcheck passes while preserving stub behavior.

Bug Fixes:
- Resolve shellcheck lint failures in the arena launcher stub script by emitting its contents as literal text instead of single-quoted echo commands.

Enhancements:
- Move the linger-child stdout redirection comment inside the generated stub adjacent to the code it describes.