### PR TITLE
fix(gate): unbreak main — a public item may not intra-doc-link a private one

### DIFF
--- a/crates/stella-tools/src/shell_touch.rs
+++ b/crates/stella-tools/src/shell_touch.rs
@@ -346,7 +346,7 @@ impl WorkspaceProbe {
     /// a path one side pruned and the other side saw is *unknowable*, not
     /// changed. Absent from `post` because a new rule now covers it is not a
     /// deletion; present in `post` because a rule was dropped is not a
-    /// creation. Both are skipped ([`Self::ignores`]) — a miss, never a
+    /// creation. Both are skipped (see the private `ignores`) — a miss, never a
     /// fabrication, because the probe never guesses.
     pub fn diff(&self, post: &Self) -> Vec<ShellTouch> {
         let mut touches = Vec::new();


### PR DESCRIPTION
## What & why

**`main` is red, and every open PR is red with it.** One line fixes it.

`WorkspaceProbe::diff` is public and its doc comment linked `[`Self::ignores`]`, which is private. `rustdoc::private_intra_doc_links` is denied under `-D warnings`, so `cargo doc` fails the required `fmt + clippy + test` job:

```
error: public documentation for `diff` links to private item `Self::ignores`
  --> crates/stella-tools/src/shell_touch.rs:349:39
error: could not document `stella-tools`
```

Reproduced on main's own runs at `ad92643b` and `298b2705`, not just on a PR head.

## How it got in

#2344 introduced the link. Its branch predated #2354, so the `cargo doc` gate that ran against it was the older command, and the failure it *did* report was read as the pre-existing shellcheck breakage that #2363 was already fixing.

## One thing worth a follow-up thought on #2336 / #2354

`--document-private-items` does **not** silence this lint for a public → private link. rustdoc's own note says "this link will resolve properly if you pass `--document-private-items`" — and both `make doc-warnings` and `ci.yml` already pass it, at the exact commits that failed. So the hint is misleading for this direction.

That does not weaken #2354; the gate caught a real defect. It just means the working rule is narrower than the hint suggests: **a public item cites a private helper in prose, never as an intra-doc link.** `pub(crate) → pub(crate)` links, which #2354 was about, are unaffected.

## The fix

The link becomes prose. No API change, no behavior change — deliberately the smallest possible diff, because an unbreak PR that also does something else is how a red `main` stays red longer.

## Witness

- [ ] This PR includes a witness test

None, and none is possible: the failing check *is* the witness. `cargo doc -D warnings` fails on `main` at this commit's parent and passes here — a witness test cannot assert about a rustdoc lint, and the gate already does.

## Gate

Not run locally — a Terminal-Bench match is executing on this machine and a workspace build would contend for CPU, which is how a trial acquires a false timeout. `make guards-fast` is green; the compile tiers are CI's.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Summary by Sourcery

Bug Fixes:
- Resolve rustdoc private_intra_doc_links failure by replacing a link to the private ignores helper with plain prose in the diff method documentation.