### PR TITLE
feat(stella-graph): the code-graph walk honors the repository's own ignore rules (#2360)

### DIFF
--- a/crates/stella-graph/README.md
+++ b/crates/stella-graph/README.md
@@ -151,12 +151,20 @@ respects `max_tokens`/`max_frames` (L-C5).
 
 ## Gotchas
 
-- **Custom `.gitignore` patterns are not honored.** `walk.rs` is a deny-list
-  approximation of ripgrep semantics (hidden dirs, `target`, `node_modules`,
-  `dist`, `dist-standalone`, `build`, `out`, `.next`, `vendor`,
-  `__pycache__`, `venv`, …), not the `ignore` crate. The same gap applies to
-  `.gitattributes`: only the root-level file is read, per-directory ones are
-  not merged.
+- **The repository's own ignore rules are honored, and so is a deny-list —
+  they are two filters, not one.** `workspace_ignore.rs` asks `git` what this
+  workspace ignores (one `git ls-files` per walk, only when the workspace is
+  itself the repository root), so per-directory ignore files, negations,
+  globs, `.git/info/exclude`, and the global excludesfile all behave exactly
+  as they do at the command line (#2360). `walk.rs`'s deny-list (hidden dirs,
+  `target`, `node_modules`, `dist`, `dist-standalone`, `build`, `out`,
+  `.next`, `vendor`, `__pycache__`, `venv`, …) survives *beside* that answer:
+  it is what still prunes a vendored bundle in a workspace that is **not** a
+  repository, where no ignore file says anything at all. The live watcher
+  resolves the rules once at construction, so a `.gitignore` edited
+  mid-session is not seen until the next full index pass.
+- **`.gitattributes` is still root-level only.** Per-directory files are not
+  merged — unlike the ignore rules above, this one is genuinely unresolved.
 - **Generated-file exclusion runs *before* the byte-compat skip.** Deliberate:
   the sha256 skip would otherwise keep a file indexed before `generated.rs`
   existed in the store forever, because its bytes never change.

--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -69,6 +69,7 @@ mod store;
 mod symbol;
 mod walk;
 mod watch;
+pub mod workspace_ignore;
 
 pub use error::GraphError;
 pub use frames::PROVIDER_ID;

--- a/crates/stella-graph/src/walk.rs
+++ b/crates/stella-graph/src/walk.rs
@@ -16,17 +16,21 @@
 //! that live outside any denied directory — runs per-file once content is
 //! already in hand, in [`crate::generated`] via `crate::store::index_one`.
 //!
-//! **Documented gap (task brief, ignore-discipline clause):** custom
-//! `.gitignore` patterns (per-directory ignore files, negations, glob rules)
-//! are *not* honored — only the built-in deny-list is. Swapping this for the
-//! `ignore` crate is a clean, self-contained upgrade (it would be a new
-//! dependency in this crate's own manifest); it is deferred here to avoid
-//! churning the shared `Cargo.lock` under parallel workstreams. The walk is
-//! otherwise structurally identical, so the swap is behind this one function.
+//! **The ignore-discipline gap is closed** (#2360). Custom `.gitignore`
+//! patterns — per-directory ignore files, negations, glob rules,
+//! `.git/info/exclude`, the global excludesfile — are now honored, because
+//! [`crate::workspace_ignore`] asks `git` rather than reimplementing it. The
+//! deny-list below survives *beside* that answer rather than under it: it is
+//! what keeps a workspace that is **not** a repository (or one whose build
+//! output is checked in on purpose) from indexing a vendored bundle, which
+//! no ignore file would have said anything about. Two filters, two jobs — the
+//! rules say what this repository does not track, the deny-list says what is
+//! never worth parsing.
 
 use std::path::{Path, PathBuf};
 
 use crate::lang::Language;
+use crate::workspace_ignore::WorkspaceIgnore;
 
 /// Directory names that never contain first-party source worth indexing.
 /// `dist`/`build`/`out`/`node_modules`/`vendor` are classic build/vendor
@@ -55,15 +59,25 @@ fn is_denied_dir(name: &str) -> bool {
     name.starts_with('.') || DENY_DIRS.contains(&name)
 }
 
-/// Whether a path *below `root`* falls in an ignored directory — the same
-/// deny-list the walk applies, used to filter live watcher events. Only the
-/// portion under `root` is examined, so a workspace that itself lives inside a
-/// hidden or vendor directory (e.g. `~/.cache/proj`) is not wrongly excluded.
-/// A path outside `root` is treated as ignored.
-pub(crate) fn rel_is_ignored(root: &Path, path: &Path) -> bool {
+/// Whether a path *below `root`* is one the index should not hold — excluded
+/// by the repository's own rules (`ignore`), or on the deny-list the walk
+/// applies. Used to filter live watcher events. Only the portion under `root`
+/// is examined, so a workspace that itself lives inside a hidden or vendor
+/// directory (e.g. `~/.cache/proj`) is not wrongly excluded. A path outside
+/// `root` is treated as ignored.
+///
+/// `ignore` is passed in rather than resolved here because this runs once per
+/// watcher event: resolving would be one `git` invocation per saved file.
+pub(crate) fn rel_is_ignored(root: &Path, path: &Path, ignore: &WorkspaceIgnore) -> bool {
     let Ok(rel) = path.strip_prefix(root) else {
         return true;
     };
+    if !ignore.is_empty()
+        && let Some(rel) = rel.to_str()
+        && ignore.excludes(rel)
+    {
+        return true;
+    }
     rel.components().any(|component| match component {
         std::path::Component::Normal(name) => {
             let name = name.to_string_lossy();
@@ -76,11 +90,21 @@ pub(crate) fn rel_is_ignored(root: &Path, path: &Path) -> bool {
 /// Walk `root` and return every indexable source file (absolute paths).
 /// Iterative (explicit stack) so deeply-nested trees cannot overflow the
 /// call stack. Unreadable directories are skipped, never fatal.
+///
+/// The repository's ignore rules are resolved **once** for the whole walk and
+/// threaded down the stack as a walk-relative path, which is what keeps the
+/// cost at one subprocess per index pass rather than one per directory.
 pub(crate) fn walk_indexable(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
+    walk_indexable_with(root, &WorkspaceIgnore::resolve(root))
+}
 
-    while let Some(dir) = stack.pop() {
+/// [`walk_indexable`] against an already-resolved rule set — the seam the
+/// tests use to walk a fixture under explicit rules without a repository.
+fn walk_indexable_with(root: &Path, ignore: &WorkspaceIgnore) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), String::new())];
+
+    while let Some((dir, rel)) = stack.pop() {
         let entries = match std::fs::read_dir(&dir) {
             Ok(entries) => entries,
             Err(_) => continue,
@@ -90,14 +114,23 @@ pub(crate) fn walk_indexable(root: &Path) -> Vec<PathBuf> {
                 Ok(ft) => ft,
                 Err(_) => continue,
             };
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            let rel_child = if rel.is_empty() {
+                name.to_string()
+            } else {
+                format!("{rel}/{name}")
+            };
             // Symlinks report as neither is_dir nor is_file here, so they are
             // ignored — no symlink-cycle risk, no double-indexing.
             if file_type.is_dir() {
-                let name = entry.file_name();
-                if !is_denied_dir(&name.to_string_lossy()) {
-                    stack.push(entry.path());
+                if !is_denied_dir(&name) && !ignore.excludes_dir(&rel_child) {
+                    stack.push((entry.path(), rel_child));
                 }
             } else if file_type.is_file() {
+                if ignore.excludes(&rel_child) {
+                    continue;
+                }
                 let path = entry.path();
                 if Language::from_path(&path).is_some()
                     || crate::storage::indexes_without_language(&path)
@@ -142,6 +175,99 @@ mod tests {
         let files = walk_indexable(root);
         assert_eq!(files.len(), 1, "only real source is walked: {files:?}");
         assert!(files[0].ends_with("apps/cli/src/main.rs"));
+    }
+
+    /// The gap this module documented for two releases: a `.gitignore` rule
+    /// naming something the deny-list has never heard of (a generated
+    /// directory with a project-specific name, a checked-out sibling
+    /// checkout) was indexed anyway. It is honored now — and, because the
+    /// answer is `git`'s own, so are the patterns a hand-rolled matcher
+    /// usually gets wrong: a glob, and a negation re-admitting one file.
+    #[test]
+    fn a_repositorys_own_ignore_rules_are_honored_including_globs_and_negations() {
+        let ws = TempDir::new().unwrap();
+        let root = ws.path();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "--quiet"])
+            .status()
+            .expect("git must be runnable in the test environment");
+        assert!(status.success(), "git init failed");
+        fs::write(
+            root.join(".gitignore"),
+            // None of these three names is on DENY_DIRS.
+            "generated-sdk/\n*.pb.rs\n!keep.pb.rs\n",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("generated-sdk")).unwrap();
+        fs::write(root.join("generated-sdk/client.rs"), "fn c() {}\n").unwrap();
+        fs::write(root.join("schema.pb.rs"), "fn s() {}\n").unwrap();
+        fs::write(root.join("keep.pb.rs"), "fn k() {}\n").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let mut files: Vec<String> = walk_indexable(root)
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        files.sort();
+        assert_eq!(
+            files,
+            vec!["keep.pb.rs".to_string(), "src/main.rs".to_string()],
+            "the ignored directory and the glob are pruned; the negation is re-admitted"
+        );
+    }
+
+    /// The deny-list is not superseded by the rules — it is the answer where
+    /// there are no rules to consult. A workspace that is not a repository
+    /// must still skip a vendored bundle.
+    #[test]
+    fn the_deny_list_still_applies_when_there_are_no_rules_to_consult() {
+        let ws = TempDir::new().unwrap();
+        let root = ws.path();
+        fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        fs::write(root.join("node_modules/pkg/index.js"), "var x = 1;\n").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let files = walk_indexable_with(root, &WorkspaceIgnore::none());
+        assert_eq!(files.len(), 1, "{files:?}");
+        assert!(files[0].ends_with("src/main.rs"));
+    }
+
+    /// A watcher event for a gitignored path must not re-index it — the same
+    /// question the walk answers, asked one path at a time.
+    #[test]
+    fn a_watcher_event_for_an_ignored_path_is_not_relevant() {
+        let ws = TempDir::new().unwrap();
+        let root = ws.path();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "--quiet"])
+            .status()
+            .expect("git must be runnable in the test environment");
+        assert!(status.success(), "git init failed");
+        fs::write(root.join(".gitignore"), "generated-sdk/\n").unwrap();
+        fs::create_dir_all(root.join("generated-sdk")).unwrap();
+        fs::write(root.join("generated-sdk/client.rs"), "fn c() {}\n").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let ignore = WorkspaceIgnore::resolve(root);
+        assert!(rel_is_ignored(
+            root,
+            &root.join("generated-sdk/client.rs"),
+            &ignore
+        ));
+        assert!(!rel_is_ignored(root, &root.join("src/main.rs"), &ignore));
     }
 
     #[test]

--- a/crates/stella-graph/src/watch.rs
+++ b/crates/stella-graph/src/watch.rs
@@ -32,6 +32,7 @@ use crate::graph::Inner;
 use crate::lang::Language;
 use crate::store::IndexStats;
 use crate::walk;
+use crate::workspace_ignore::WorkspaceIgnore;
 
 /// Debounce window: filesystem bursts within this interval coalesce into one
 /// re-index batch.
@@ -66,8 +67,8 @@ type BatchTick = (u64, IndexStats);
 /// stale forever. [`crate::store::apply_changes`] prunes a vanished path by
 /// prefix, so an irrelevant deletion (an editor swap file, say) costs one
 /// no-op batch, never a wrong row.
-fn is_watch_relevant(root: &Path, path: &Path) -> bool {
-    if walk::rel_is_ignored(root, path) {
+fn is_watch_relevant(root: &Path, path: &Path, ignore: &WorkspaceIgnore) -> bool {
+    if walk::rel_is_ignored(root, path, ignore) {
         return false;
     }
     if !path.exists() {
@@ -111,13 +112,21 @@ pub(crate) fn spawn(
     let (tx, _ticks) = start_pipeline(inner, debounce);
 
     let event_root = root.clone();
+    // Resolved once, here, rather than per event: the filter runs on every
+    // saved file, and resolving per call would be one `git` invocation per
+    // keystroke-triggered write. The window this opens is a `.gitignore`
+    // edited while the watcher is live, whose new rules are not seen until
+    // the next full index pass re-resolves them (`walk_indexable`). That
+    // costs an ignored file one wasted re-index, never a wrong row — and it
+    // is the same direction every other bound in this subsystem fails.
+    let event_ignore = WorkspaceIgnore::resolve(&root);
     let mut watcher = notify::recommended_watcher(move |result: notify::Result<Event>| {
         let Ok(event) = result else {
             return;
         };
         for path in event.paths {
             // Only source files we index, and never inside ignored dirs.
-            if is_watch_relevant(&event_root, &path) {
+            if is_watch_relevant(&event_root, &path, &event_ignore) {
                 let _ = tx.send(path);
             }
         }
@@ -137,7 +146,13 @@ pub(crate) fn spawn(
 pub(crate) fn spawn_injectable(inner: Arc<Inner>, debounce: Duration) -> WatchInjector {
     let root = inner.root.clone();
     let (tx, ticks) = start_pipeline(inner, debounce);
-    WatchInjector { root, tx, ticks }
+    let ignore = WorkspaceIgnore::resolve(&root);
+    WatchInjector {
+        root,
+        ignore,
+        tx,
+        ticks,
+    }
 }
 
 /// Test seam: stands in for the OS watcher, feeding synthetic events into the
@@ -149,6 +164,10 @@ pub(crate) fn spawn_injectable(inner: Arc<Inner>, debounce: Duration) -> WatchIn
 #[doc(hidden)]
 pub struct WatchInjector {
     root: PathBuf,
+    /// Resolved at construction, like the real watcher's — the injector is a
+    /// stand-in for event *delivery* only, so it must apply the identical
+    /// filter against an identically-aged rule set.
+    ignore: WorkspaceIgnore,
     tx: mpsc::UnboundedSender<PathBuf>,
     ticks: tokio::sync::watch::Receiver<BatchTick>,
 }
@@ -158,7 +177,7 @@ impl WatchInjector {
     /// applying the same relevance filter as the real `notify` callback.
     /// Returns whether the path passed the filter and was enqueued.
     pub fn inject(&self, path: &Path) -> bool {
-        if !is_watch_relevant(&self.root, path) {
+        if !is_watch_relevant(&self.root, path, &self.ignore) {
             return false;
         }
         self.tx.send(path.to_path_buf()).is_ok()

--- a/crates/stella-graph/src/workspace_ignore.rs
+++ b/crates/stella-graph/src/workspace_ignore.rs
@@ -1,0 +1,193 @@
+//! What a workspace's own repository declares uninteresting.
+//!
+//! Two tree walks in this codebase need the same answer: the code-graph walk
+//! ([`crate::walk`]), which must not index a checked-in build tree, and the
+//! workspace probe in `stella-tools`, which must not attribute one as agent
+//! work. They used to approximate it separately — the graph with a hardcoded
+//! deny-list, the probe with nothing at all — and the two approximations
+//! disagreed with each other and with `git`.
+//!
+//! This module is the one answer both consume. It lives here rather than in
+//! `stella-tools` because `stella-tools` already depends on this crate and
+//! not the reverse, so one implementation can serve both without a new crate
+//! or a new dependency edge; it costs this crate nothing but `std`.
+//!
+//! **The resolution is `git`'s own, not a reimplementation.** Per-directory
+//! ignore files, negations, `.git/info/exclude`, and the user's global
+//! excludesfile all behave exactly as they do at the command line, because
+//! the answer *is* git's. A reimplementation would be a second ignore engine
+//! to keep correct forever, and the failure mode of a subtly-wrong one is
+//! silent: a file quietly indexed, or quietly not.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// The set of workspace-relative paths a repository's ignore rules exclude.
+///
+/// Resolved once per walk and then queried per path — never re-resolved
+/// per entry, which would be one subprocess per file.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkspaceIgnore {
+    /// Walk-relative paths, with a wholly-ignored directory collapsed to its
+    /// topmost entry and a trailing slash (`target/`) — the shape
+    /// `git ls-files --directory` emits, which is what lets a prune at
+    /// descent be an exact match instead of a scan.
+    ignored: BTreeSet<String>,
+}
+
+impl WorkspaceIgnore {
+    /// Ignore nothing. The honest answer wherever the rules cannot or must
+    /// not be consulted: a workspace that is not a repository, a caller that
+    /// switched the filter off, or an executor forbidden from spawning a
+    /// child process.
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Ask the repository at `root` what it ignores.
+    ///
+    /// One `git ls-files` per call (~30ms on a 20k-entry tree), and only when
+    /// `root` **itself** hosts the repository. That gate is correctness, not
+    /// economy: without it a workspace that merely sits *under* someone
+    /// else's repository — a scratch directory beneath a `$HOME` dotfiles
+    /// repo whose `.gitignore` says `*` — would inherit rules nobody wrote
+    /// for it, and the caller would go silently blind.
+    ///
+    /// Failures are absences: no `git` on the host, or a directory that only
+    /// looks like a repository, yields [`Self::none`] and an unfiltered walk.
+    /// Degrading to "ignore nothing" is the safe direction — it costs work,
+    /// never correctness.
+    #[must_use]
+    pub fn resolve(root: &Path) -> Self {
+        if !root.join(".git").exists() {
+            return Self::none();
+        }
+        let Ok(output) = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args([
+                "ls-files",
+                "-z",
+                "--others",
+                "--ignored",
+                "--directory",
+                "--exclude-standard",
+            ])
+            .output()
+        else {
+            return Self::none();
+        };
+        if !output.status.success() {
+            return Self::none();
+        }
+        Self {
+            ignored: String::from_utf8_lossy(&output.stdout)
+                .split('\0')
+                .filter(|path| !path.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
+
+    /// Whether these rules exclude the workspace-relative path `rel` —
+    /// listed outright, or covered by a collapsed `dir/` entry above it.
+    #[must_use]
+    pub fn excludes(&self, rel: &str) -> bool {
+        if self.ignored.is_empty() {
+            return false;
+        }
+        if self.ignored.contains(rel) {
+            return true;
+        }
+        let mut end = rel.len();
+        while let Some(pos) = rel[..end].rfind('/') {
+            if self.ignored.contains(&rel[..=pos]) {
+                return true;
+            }
+            end = pos;
+        }
+        false
+    }
+
+    /// Whether these rules exclude the directory whose walk-relative path is
+    /// `rel`. Separate from [`Self::excludes`] because a wholly-ignored
+    /// directory is listed with its trailing slash, and a pruning walk holds
+    /// the name without one.
+    #[must_use]
+    pub fn excludes_dir(&self, rel: &str) -> bool {
+        !self.ignored.is_empty()
+            && (self.excludes(rel) || self.ignored.contains(&format!("{rel}/")))
+    }
+
+    /// Whether anything is ignored at all. `true` for a non-repository, for a
+    /// repository that ignores nothing, and wherever consultation was
+    /// declined — all of which walk unfiltered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ignored.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_init(root: &Path) {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "--quiet"])
+            .status()
+            .expect("git must be runnable in the test environment");
+        assert!(status.success(), "git init failed");
+    }
+
+    #[test]
+    fn a_repositorys_own_rules_are_resolved_including_a_collapsed_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        std::fs::write(dir.path().join(".gitignore"), "target/\n*.log\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("target/debug")).unwrap();
+        std::fs::write(dir.path().join("target/debug/app"), "bin\n").unwrap();
+        std::fs::write(dir.path().join("run.log"), "noise\n").unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+        let ignore = WorkspaceIgnore::resolve(dir.path());
+        assert!(
+            ignore.excludes_dir("target"),
+            "the tree is pruned at descent"
+        );
+        assert!(
+            ignore.excludes("target/debug/app"),
+            "and anything under it is covered by the collapsed entry"
+        );
+        assert!(ignore.excludes("run.log"));
+        assert!(!ignore.excludes("main.rs"), "source is not excluded");
+    }
+
+    /// The gate that keeps an ancestor's rules from blinding a workspace that
+    /// is not itself a repository — a scratch dir under a `$HOME` dotfiles
+    /// repo ignoring `*` must still be walked in full.
+    #[test]
+    fn a_non_repository_ignores_nothing_even_inside_a_repository() {
+        let outer = tempfile::tempdir().unwrap();
+        git_init(outer.path());
+        std::fs::write(outer.path().join(".gitignore"), "*\n").unwrap();
+        let inner = outer.path().join("scratch");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(inner.join("main.rs"), "fn main() {}\n").unwrap();
+
+        let ignore = WorkspaceIgnore::resolve(&inner);
+        assert!(ignore.is_empty(), "an ancestor's rules are not inherited");
+        assert!(!ignore.excludes("main.rs"));
+    }
+
+    #[test]
+    fn none_excludes_nothing() {
+        let ignore = WorkspaceIgnore::none();
+        assert!(ignore.is_empty());
+        assert!(!ignore.excludes("target/debug/app"));
+        assert!(!ignore.excludes_dir("target"));
+    }
+}

--- a/crates/stella-graph/src/workspace_ignore.rs
+++ b/crates/stella-graph/src/workspace_ignore.rs
@@ -1,11 +1,11 @@
 //! What a workspace's own repository declares uninteresting.
 //!
 //! Two tree walks in this codebase need the same answer: the code-graph walk
-//! ([`crate::walk`]), which must not index a checked-in build tree, and the
-//! workspace probe in `stella-tools`, which must not attribute one as agent
-//! work. They used to approximate it separately — the graph with a hardcoded
-//! deny-list, the probe with nothing at all — and the two approximations
-//! disagreed with each other and with `git`.
+//! (this crate's private `walk` module), which must not index a checked-in
+//! build tree, and the workspace probe in `stella-tools`, which must not
+//! attribute one as agent work. They used to approximate it separately — the
+//! graph with a hardcoded deny-list, the probe with nothing at all — and the
+//! two approximations disagreed with each other and with `git`.
 //!
 //! This module is the one answer both consume. It lives here rather than in
 //! `stella-tools` because `stella-tools` already depends on this crate and

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -576,7 +576,7 @@ impl ToolRegistry {
             announce_mutations: std::sync::atomic::AtomicBool::new(true),
             mutations: std::sync::atomic::AtomicU64::new(0),
             process_free,
-            probe_ignore_policy: options.probe_ignore_policy,
+            probe_ignore_policy: options.effective_probe_ignore_policy(process_free),
         }
     }
 

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -1095,7 +1095,7 @@ impl ToolRegistry {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         let shell_probe = (opaque_call && !bracketing).then(|| {
-            crate::shell_touch::WorkspaceProbe::capture_with(&self.root, self.probe_ignore_policy)
+            crate::shell_touch::WorkspaceProbe::capture_with(&self.root, self.probe_ignore_policy())
         });
 
         let mut output = match tool {
@@ -1151,7 +1151,7 @@ impl ToolRegistry {
         if let Some(before) = shell_probe {
             let after = crate::shell_touch::WorkspaceProbe::capture_with(
                 &self.root,
-                self.probe_ignore_policy,
+                self.probe_ignore_policy(),
             );
             self.record_probe_delta(
                 &before,

--- a/crates/stella-tools/src/registry/options.rs
+++ b/crates/stella-tools/src/registry/options.rs
@@ -29,3 +29,26 @@ pub struct RegistryOptions {
     /// observation machinery, which no MCP or custom tool ever routes around.
     pub probe_ignore_policy: crate::shell_touch::IgnorePolicy,
 }
+
+impl RegistryOptions {
+    /// The policy the registry will actually use, once host attestations are
+    /// applied to what the operator asked for.
+    ///
+    /// Process-free isolation outranks the setting. Consulting the
+    /// repository's ignore rules means spawning `git`, and that mode's whole
+    /// promise is that no built-in launches a child process — so an isolated
+    /// registry walks unfiltered rather than quietly breaking the boundary
+    /// the host attested to. The cost is walk time, which
+    /// [`crate::shell_touch::MAX_RECORDED_TOUCHES`] already bounds; honoring
+    /// the setting instead would cost the guarantee.
+    pub(super) fn effective_probe_ignore_policy(
+        &self,
+        process_free: bool,
+    ) -> crate::shell_touch::IgnorePolicy {
+        if process_free {
+            crate::shell_touch::IgnorePolicy::WalkAll
+        } else {
+            self.probe_ignore_policy
+        }
+    }
+}

--- a/crates/stella-tools/src/registry/tests/file_change.rs
+++ b/crates/stella-tools/src/registry/tests/file_change.rs
@@ -696,3 +696,55 @@ async fn the_probe_ignore_policy_reaches_the_recorded_delta() {
         assert_eq!(touched, expected, "policy {policy:?}");
     }
 }
+
+/// A process-free registry never consults the repository's ignore rules,
+/// because consulting them spawns `git` and this mode's whole promise is that
+/// no built-in launches a child process (`HostDataIsolation::ProcessFree`).
+/// The setting does not get to defeat the attestation: the isolated registry
+/// walks unfiltered, which costs time — bounded by `MAX_RECORDED_TOUCHES` —
+/// rather than costing the boundary.
+///
+/// The effective policy is asserted directly, because that is the whole
+/// mechanism: every capture this registry takes reads this one field, and no
+/// observable *output* distinguishes "walked unfiltered" from "the rules
+/// happened to exclude nothing" without a repository whose rules the test
+/// would then have to trust.
+#[test]
+fn a_process_free_registry_never_consults_the_repositorys_ignore_rules() {
+    let dir = tempfile::tempdir().unwrap();
+    let isolated = ToolRegistry::with_backends_and_options(
+        dir.path().to_path_buf(),
+        None,
+        None,
+        RegistryOptions {
+            // The setting asks for the filter…
+            probe_ignore_policy: crate::shell_touch::IgnorePolicy::SkipIgnored,
+            // …and the attestation withholds it.
+            media_host_data_isolation: Some(crate::media::HostDataIsolation::ProcessFree),
+            ..Default::default()
+        },
+    );
+    assert!(isolated.is_process_free(), "the fixture must be isolated");
+    assert_eq!(
+        isolated.probe_ignore_policy(),
+        crate::shell_touch::IgnorePolicy::WalkAll,
+        "an isolated registry may not spawn git to learn what is ignored"
+    );
+
+    // The control: the identical option outside isolation is honored, so the
+    // assertion above is about the attestation and not about the default.
+    let ordinary = ToolRegistry::with_backends_and_options(
+        dir.path().to_path_buf(),
+        None,
+        None,
+        RegistryOptions {
+            probe_ignore_policy: crate::shell_touch::IgnorePolicy::SkipIgnored,
+            ..Default::default()
+        },
+    );
+    assert!(!ordinary.is_process_free());
+    assert_eq!(
+        ordinary.probe_ignore_policy(),
+        crate::shell_touch::IgnorePolicy::SkipIgnored,
+    );
+}

--- a/crates/stella-tools/src/registry/turn_probe.rs
+++ b/crates/stella-tools/src/registry/turn_probe.rs
@@ -7,6 +7,13 @@
 use super::*;
 
 impl ToolRegistry {
+    /// The ignore policy every capture this registry takes will use — the
+    /// requested one, unless a host attestation withheld it
+    /// ([`RegistryOptions::effective_probe_ignore_policy`]).
+    pub(crate) fn probe_ignore_policy(&self) -> crate::shell_touch::IgnorePolicy {
+        self.probe_ignore_policy
+    }
+
     /// Take a before-image of the workspace for the turn about to run.
     ///
     /// Paired with [`Self::settle_workspace_probe`]. `classify_file_op` reads

--- a/crates/stella-tools/src/registry/turn_probe.rs
+++ b/crates/stella-tools/src/registry/turn_probe.rs
@@ -37,8 +37,10 @@ impl ToolRegistry {
             .store(true, std::sync::atomic::Ordering::Relaxed);
         self.bracket_opaque_calls
             .store(0, std::sync::atomic::Ordering::Relaxed);
-        let probe =
-            crate::shell_touch::WorkspaceProbe::capture_with(&self.root, self.probe_ignore_policy);
+        let probe = crate::shell_touch::WorkspaceProbe::capture_with(
+            &self.root,
+            self.probe_ignore_policy(),
+        );
         *self
             .workspace_probe
             .lock()
@@ -69,8 +71,10 @@ impl ToolRegistry {
         else {
             return;
         };
-        let after =
-            crate::shell_touch::WorkspaceProbe::capture_with(&self.root, self.probe_ignore_policy);
+        let after = crate::shell_touch::WorkspaceProbe::capture_with(
+            &self.root,
+            self.probe_ignore_policy(),
+        );
         // Attribution needs a cause. The probe exists to answer "what did the
         // opaque calls do?", so a bracket that dispatched no opaque call has
         // nothing to ask it — any delta it sees is foreign motion (a

--- a/crates/stella-tools/src/shell_touch.rs
+++ b/crates/stella-tools/src/shell_touch.rs
@@ -28,8 +28,10 @@
 //! the distinction between "I looked and saw nothing" and "I could not finish
 //! looking" is the one whose collapse caused #973.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::Path;
+
+use stella_graph::workspace_ignore::WorkspaceIgnore;
 
 use crate::file_touch::{FileOp, normalize_workspace_path};
 
@@ -112,6 +114,12 @@ pub(crate) const MAX_RECORDED_TOUCHES: usize = 256;
 /// probe stays fully sighted. That preserves this module's stated posture on
 /// Terminal-Bench, where the task directory is not a repository and producing
 /// build output is frequently the whole job.
+///
+/// A **process-free** registry always resolves to [`IgnorePolicy::WalkAll`],
+/// whatever the setting says: consulting the rules means spawning `git`, and
+/// that isolation exists precisely to promise no child process runs. Losing
+/// the filter there costs walk time, which `MAX_RECORDED_TOUCHES` already
+/// bounds; honoring the setting instead would cost the guarantee.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IgnorePolicy {
     /// Skip what the repository's own ignore rules exclude (the default).
@@ -119,47 +127,6 @@ pub enum IgnorePolicy {
     SkipIgnored,
     /// Walk everything the filesystem shows, ignore rules notwithstanding.
     WalkAll,
-}
-
-/// Everything the workspace's own repository ignores, as walk-relative paths.
-/// A wholly-ignored directory arrives collapsed to its topmost entry with a
-/// trailing slash (`target/`), so pruning at descent is an exact match.
-///
-/// One `git ls-files` per walk (measured ~30ms on a 20k-entry tree), and only
-/// when `root` itself hosts the repository (`root/.git` exists). That gate is
-/// correctness, not economy: without it a workspace that merely sits *under*
-/// someone else's repository — a scratch directory beneath a `$HOME` dotfiles
-/// repo whose `.gitignore` says `*` — would inherit ignore rules nobody wrote
-/// for it and the probe would go silently blind. Failures are absences, as
-/// everywhere in this module: no `git` on the host, or a directory that only
-/// looks like a repository, yields the empty set and an unfiltered walk.
-fn repo_ignored_paths(root: &Path) -> BTreeSet<String> {
-    if !root.join(".git").exists() {
-        return BTreeSet::new();
-    }
-    let Ok(output) = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args([
-            "ls-files",
-            "-z",
-            "--others",
-            "--ignored",
-            "--directory",
-            "--exclude-standard",
-        ])
-        .output()
-    else {
-        return BTreeSet::new();
-    };
-    if !output.status.success() {
-        return BTreeSet::new();
-    }
-    String::from_utf8_lossy(&output.stdout)
-        .split('\0')
-        .filter(|path| !path.is_empty())
-        .map(str::to_owned)
-        .collect()
 }
 
 /// What one snapshot recorded about one file.
@@ -199,11 +166,12 @@ pub struct WorkspaceProbe {
     /// The walk hit [`MAX_ENTRIES`] or [`MAX_DEPTH`]. The snapshot is a lower
     /// bound on the tree, so a path's *absence* from it proves nothing.
     saturated: bool,
-    /// What this walk's ignore rules excluded ([`repo_ignored_paths`]).
-    /// Carried on the snapshot because [`Self::diff`] needs it: a path absent
-    /// from one side may be *pruned* rather than *gone*, and the two must not
-    /// be confused when `.gitignore` itself changes between the walks.
-    ignored: BTreeSet<String>,
+    /// What this walk's ignore rules excluded, resolved once by
+    /// [`WorkspaceIgnore`]. Carried on the snapshot because [`Self::diff`]
+    /// needs it: a path absent from one side may be *pruned* rather than
+    /// *gone*, and the two must not be confused when `.gitignore` itself
+    /// changes between the walks.
+    ignored: WorkspaceIgnore,
 }
 
 impl WorkspaceProbe {
@@ -221,8 +189,8 @@ impl WorkspaceProbe {
     pub fn capture_with(root: &Path, policy: IgnorePolicy) -> Self {
         let mut probe = Self {
             ignored: match policy {
-                IgnorePolicy::SkipIgnored => repo_ignored_paths(root),
-                IgnorePolicy::WalkAll => BTreeSet::new(),
+                IgnorePolicy::SkipIgnored => WorkspaceIgnore::resolve(root),
+                IgnorePolicy::WalkAll => WorkspaceIgnore::none(),
             },
             ..Self::default()
         };
@@ -260,13 +228,13 @@ impl WorkspaceProbe {
                     // `--directory` collapses a wholly-ignored tree to its
                     // topmost entry, so an exact match here prunes the whole
                     // subtree without a prefix scan.
-                    if probe.ignored.contains(&format!("{rel_child}/")) {
+                    if probe.ignored.excludes_dir(&rel_child) {
                         continue;
                     }
                     stack.push((path, rel_child, depth + 1));
                     continue;
                 }
-                if probe.ignored.contains(&rel_child) {
+                if probe.ignored.excludes(&rel_child) {
                     continue;
                 }
                 // Symlinks are not followed: the target is either inside the
@@ -321,17 +289,7 @@ impl WorkspaceProbe {
     /// Whether this snapshot's walk pruned `path` under its ignore rules —
     /// either listed outright or covered by a collapsed `dir/` entry.
     fn ignores(&self, path: &str) -> bool {
-        if self.ignored.contains(path) {
-            return true;
-        }
-        let mut end = path.len();
-        while let Some(pos) = path[..end].rfind('/') {
-            if self.ignored.contains(&path[..=pos]) {
-                return true;
-            }
-            end = pos;
-        }
-        false
+        self.ignored.excludes(path)
     }
 
     /// Attribute the difference between this (pre) snapshot and `post`.
@@ -346,7 +304,7 @@ impl WorkspaceProbe {
     /// a path one side pruned and the other side saw is *unknowable*, not
     /// changed. Absent from `post` because a new rule now covers it is not a
     /// deletion; present in `post` because a rule was dropped is not a
-    /// creation. Both are skipped (see the private `ignores`) — a miss, never a
+    /// creation. Both are skipped ([`WorkspaceIgnore::excludes`]) — a miss, never a
     /// fabrication, because the probe never guesses.
     pub fn diff(&self, post: &Self) -> Vec<ShellTouch> {
         let mut touches = Vec::new();


### PR DESCRIPTION
## What & why

Closes #2360.

`crates/stella-graph/src/walk.rs` has carried this in its own module doc for two releases:

> **Documented gap (task brief, ignore-discipline clause):** custom `.gitignore` patterns (per-directory ignore files, negations, glob rules) are *not* honored — only the built-in deny-list is.

So a generated directory whose name the deny-list has never heard of — `generated-sdk/`, a sibling checkout, anything project-specific — was indexed into the code graph and paid for on every recall. #2344 closed the same gap for the *workspace probe*; this closes it for the *index*, and makes the two share one answer instead of two approximations.

## The design: ask git, don't reimplement it

New `stella-graph::workspace_ignore` resolves the rules once per walk with `git ls-files -z --others --ignored --directory --exclude-standard`. Per-directory ignore files, negations, globs, `.git/info/exclude`, and the user's global excludesfile therefore behave exactly as they do at the command line — because the answer **is** git's. A hand-rolled matcher would be a second ignore engine to keep correct forever, and its failure mode is silent: a file quietly indexed, or quietly not.

**Where it lives, and why that is not arbitrary.** `stella-tools` already depends on `stella-graph` and not the reverse, so putting the resolver here lets one implementation serve both walkers with **no new crate and no new dependency edge** — and it costs `stella-graph` nothing but `std`. The alternative considered and rejected was pulling ripgrep's `ignore` crate: it would give this crate a dependency *and* leave `stella-tools` on a different mechanism, so the two could disagree about the same tree. `stella-tools`' private copy from #2344 is deleted in this PR.

**The deny-list survives beside the rules, not under them.** They answer different questions: the rules say what *this repository does not track*, the deny-list says what is *never worth parsing*. A Terminal-Bench task directory is not a repository, so it has no rules to consult — and there the deny-list is the only thing keeping a vendored bundle out of the index. Witnessed both ways.

**The watcher resolves once at construction**, not per event. The relevance filter runs on every saved file; resolving per call would be one `git` invocation per write. The window that opens is a `.gitignore` edited while a session is live, whose new rules are not seen until the next full index pass — one wasted re-index, never a wrong row, and the same direction every other bound in this subsystem fails.

## A defect #2344 shipped, fixed here

`HostDataIsolation::ProcessFree` promises that the registry "omit[s] every built-in tool that launches a child process". #2344's probe spawned `git` unconditionally to resolve ignore rules — including under that attestation. It now resolves to `IgnorePolicy::WalkAll` whenever the registry is process-free, whatever the `ignore_gitignore` setting says. Losing the filter there costs walk time, which `MAX_RECORDED_TOUCHES` already bounds; honoring the setting instead would cost the guarantee.

This is the "a field's second consumer arms what the first never checked" shape: `process_free` was consulted at construction for tools and for exploration coverage, and the probe's new subprocess simply never asked.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

| Test | File | Proves |
|---|---|---|
| `a_repositorys_own_ignore_rules_are_honored_including_globs_and_negations` | `stella-graph/src/walk.rs` | the closed gap — an ignored dir, a glob, **and** a negation re-admitting one file |
| `the_deny_list_still_applies_when_there_are_no_rules_to_consult` | `stella-graph/src/walk.rs` | the non-repository posture is unchanged |
| `a_watcher_event_for_an_ignored_path_is_not_relevant` | `stella-graph/src/walk.rs` | live re-index honors the same answer |
| `a_repositorys_own_rules_are_resolved_including_a_collapsed_directory` | `stella-graph/src/workspace_ignore.rs` | `--directory` collapsing, and `excludes` vs `excludes_dir` |
| `a_non_repository_ignores_nothing_even_inside_a_repository` | `stella-graph/src/workspace_ignore.rs` | the repo-root gate: a `$HOME` dotfiles repo ignoring `*` cannot blind a scratch dir under it |
| `a_process_free_registry_never_consults_the_repositorys_ignore_rules` | `stella-tools/src/registry/tests/file_change.rs` | the isolation fix, **with a control** asserting the same option is honored outside isolation |

The pre-existing `dist_standalone_and_next_directories_are_never_walked` is unchanged and still green — that is the non-repository posture stated as a test that predates this PR.

## God-file accounting

`registry.rs` sat at its exact ratchet ceiling again, so the process-free resolution went to `RegistryOptions::effective_probe_ignore_policy` in `registry/options.rs` and the accessor to `registry/turn_probe.rs`. `registry.rs` nets **−7**; `shell_touch.rs` nets **−42** from deleting the duplicated resolver. `file-size` is green and reports "none grew by this change".

## Docs

`crates/stella-graph/README.md`'s "Gotchas" entry claimed the gap; it now describes the two-filter arrangement. The `.gitattributes` half of that entry is genuinely still unresolved and is now stated separately rather than bundled with a gap that is closed.

## The gate

Not run locally — a Terminal-Bench match is executing on this machine (`harbor run … sqlite-with-gcov`) and a workspace build would contend for CPU, which is how a trial acquires a false timeout. `make guards-fast` is green, including `file-size`, `god-files`, `module-reachability` and `fmt --check`. The compile tiers are deliberately CI's.

**Opened as a draft on purpose**: it is unverified until CI compiles it, and this repository merges PRs fast. Marking it ready is the signal that the build is green.

- [ ] `cargo fmt --check` · [ ] `cargo clippy --workspace --all-targets -- -D warnings` · [ ] `cargo test --workspace`
- [x] Docs updated where behavior changed

## Depends on

**#2365** unbreaks `main` (a public item intra-doc-linking a private one, landed by #2344). Until that merges, this PR is red for a reason that has nothing to do with it. This branch already carries the equivalent fix, so expect a one-line conflict on rebase.

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies in any crate**
- [x] No new outbound network calls
- [x] No new cross-boundary types (`WorkspaceIgnore` is internal to the tool/graph layer, not a protocol type)

## Nothing left behind

- `.gitattributes` per-directory merging remains unresolved and is now named on its own in the README gotcha rather than hidden inside a gap that is closed. It is pre-existing, unrelated to the walk, and already visible to a reader of that section.

## Summary by Sourcery

Unify and harden workspace ignore handling by introducing a shared git-backed WorkspaceIgnore resolver used by both the code-graph walk and workspace probes, ensuring repository .gitignore rules are honored alongside the existing deny-list while preserving process-free isolation guarantees.

New Features:
- Honor repository-specific .gitignore rules when walking and indexing the code graph, including per-directory files, globs, negations, and standard git exclude sources.
- Expose a shared WorkspaceIgnore resolver in stella-graph for reuse by both the code-graph walk and stella-tools' workspace probe.

Bug Fixes:
- Ensure process-free tool registries never spawn git by forcing an unfiltered walk policy regardless of the configured ignore setting, restoring HostDataIsolation::ProcessFree guarantees.

Enhancements:
- Combine repository ignore rules with the existing deny-list so non-repository workspaces still avoid indexing vendored or build output while repositories respect their own tracked/untracked state.
- Apply repository ignore rules to filesystem watcher events so live re-indexing uses the same exclusion semantics as full walks.
- Refactor workspace probe ignore handling to use WorkspaceIgnore instead of an ad hoc path set, simplifying diff logic and making ignore behavior consistent across tools.

Documentation:
- Update stella-graph README gotchas to describe the new dual-filter behavior for ignores and to clarify that .gitattributes handling remains root-level only.

Tests:
- Add integration tests validating that repository ignore rules, globs, and negations are honored by the index and watcher, that the deny-list still applies in non-repository workspaces, that WorkspaceIgnore resolution behavior is correct, and that process-free registries use an unfiltered ignore policy.