### PR TITLE
feat(stella-cli): the Claude Code transcript adapter — local-only, option (b), honest about what the corpus cannot supply (#2304)

### DIFF
--- a/crates/stella-cli/src/memory/replay.rs
+++ b/crates/stella-cli/src/memory/replay.rs
@@ -48,6 +48,10 @@
 //!   between two replays inside one process. Compare edge content, never edge
 //!   identity (see `stella_context`'s `process_nonce` audit note).
 
+// §7: the Claude Code transcript adapter. Local-only and opt-in; it derives no
+// lessons (option (b)), so it feeds the foundry and the timeline and never the
+// reflection path.
+pub(crate) mod cc_adapter;
 pub(crate) mod summary;
 pub(crate) mod trace;
 
@@ -303,21 +307,30 @@ impl<'a> Replayer<'a> {
         //     lesson, then the next turn must not re-learn it.
         self.apply_world_changes(turn);
 
-        // 2-3. Script the single model boundary.
-        let provider = ScriptedProvider::for_turn(&turn.reflection);
-        let transcript: Vec<CompletionMessage> = turn
-            .transcript
-            .iter()
-            .map(CompletionMessage::from)
-            .collect();
-
-        // 4. The one call. Everything downstream of it — the forgetting filter,
-        //    the store write, the mining log, observation extraction, both
-        //    miners, the retirement sweep — is already deterministic and runs
-        //    inside it.
-        let report = memory
-            .reflect_and_record(&provider, "replay", &transcript, true, turn.succeeded, None)
-            .await;
+        // 2-4. The single model boundary, scripted — unless the source carried
+        //      no reflection at all, in which case the turn does not reach it.
+        //      Skipping is the whole of option (b) in §7.2: an adapter over a
+        //      corpus with no reflection JSON supplies shell history, session
+        //      boundaries and timing, and scripting a reflection it never saw
+        //      would launder an invention into a result.
+        //
+        //      Everything downstream of the call — the forgetting filter, the
+        //      store write, the mining log, observation extraction, both miners,
+        //      the retirement sweep — is already deterministic and runs inside
+        //      `reflect_and_record`.
+        let report = if turn.reflection.reaches_the_model() {
+            let provider = ScriptedProvider::for_turn(&turn.reflection);
+            let transcript: Vec<CompletionMessage> = turn
+                .transcript
+                .iter()
+                .map(CompletionMessage::from)
+                .collect();
+            memory
+                .reflect_and_record(&provider, "replay", &transcript, true, turn.succeeded, None)
+                .await
+        } else {
+            crate::memory::ReflectionReport::default()
+        };
 
         // 5. The foundry, over the history accumulated so far. Pure over the
         //    slice and documented to be byte-identical for identical input, so

--- a/crates/stella-cli/src/memory/replay/cc_adapter.rs
+++ b/crates/stella-cli/src/memory/replay/cc_adapter.rs
@@ -1,0 +1,427 @@
+//! Claude Code transcripts → the trace format. **Local-only, opt-in, and
+//! deliberately half of what the corpus could supply.**
+//!
+//! `doc:trace-replay-learning-harness` §7. This is the one non-synthetic corpus
+//! available: one engineer, a handful of repositories, the same conventions
+//! re-encountered across thousands of sessions — recurrence density no synthetic
+//! fixture will match.
+//!
+//! ## What it does not do, and why that is the point
+//!
+//! **Claude Code transcripts contain no Stella reflection JSON.** There is
+//! nothing in them to script a lessons array from, so the adapter must either
+//! derive lessons from the transcript text or decline to. §7.2 puts the choice
+//! plainly:
+//!
+//! - **(a) Synthesize lessons.** This fabricates the exact signal under test —
+//!   the harness would then be measuring the adapter's lesson-invention
+//!   heuristic, not Stella's learning.
+//! - **(b) Use the corpus for shell history, session and turn boundaries, and
+//!   timing only**, feeding the tool foundry against thousands of real commands
+//!   while the reflection path stays on synthetic scripted lessons.
+//!
+//! **This implements (b).** Every turn it emits carries
+//! [`ScriptedReflection::NotRecorded`], which the replayer honours by never
+//! reaching the model boundary at all. The alternative spellings are all
+//! dishonest: an empty `Lessons` array asserts the model had nothing to say, and
+//! `Unreadable` asserts it said something unparseable — the second would also
+//! fabricate starvation and corrupt assertion 7's own metric.
+//!
+//! If (a) is ever built, its lessons must be stamped [`Provenance::Derived`], so
+//! no downstream number can silently mix invented lessons with recorded ones.
+//! The field exists already; nothing sets it yet.
+//!
+//! ## The corpus is thirty days, not months
+//!
+//! Measured 2026-08-08: 3,822 transcripts across 485 project directories,
+//! spanning 2026-07-09 → 2026-08-08. The *months* axis does not come from the
+//! corpus — it comes from the replayer's clock, which can dilate thirty days of
+//! real recurrence across a simulated six months at will. It is also a rolling
+//! window under Claude Code's own retention, so the span is not reproducible
+//! across machines or across time. Say it that way; claiming a months-long
+//! corpus we do not have is the kind of small dishonesty that costs more than it
+//! buys.
+//!
+//! ## The privacy gate (§7.1) — hard, per invariant 3
+//!
+//! - **Local-only, opt-in.** Reached only by an explicitly-enabled test; never a
+//!   default path, never a shipped command, never run by a plain `cargo test`.
+//! - **Nothing derived is committed.** The committed CI corpus stays synthetic,
+//!   permanently. A derived trace belongs in gitignored scratch, and the
+//!   `no-scratch` guard fails the gate on a committed derivative on its own.
+//! - **Every command is redacted before it is written.** Transcript text is user
+//!   content and model output — exactly what `origin_is_untrusted` classifies —
+//!   and a shell command is the highest-risk field in it, because
+//!   `export TOKEN=sk-…` and `curl -H "Authorization: Bearer …"` are ordinary
+//!   things to type. [`redact_secrets`] runs on every command, and a command
+//!   that still looks executable-with-a-credential after redaction is dropped
+//!   rather than emitted.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use stella_core::redact::redact_secrets;
+
+use super::trace::{
+    Provenance, ScriptedReflection, TRACE_VERSION, Trace, TraceMessage, TraceRole, TraceSession,
+    TraceShell, TraceTurn, WorkspaceSeed,
+};
+
+/// How a transcript line is shaped. Only the fields the adapter reads.
+///
+/// Observed line types in the corpus: `assistant`, `user`, `attachment`,
+/// `last-prompt`, `mode`, `permission-mode`, `agent-setting`, `worktree-state`,
+/// `agent-name`, `ai-title`, `relocated`, `file-history-snapshot`,
+/// `queue-operation`, `system`, `pr-link`, `file-history-delta`, `started`,
+/// `result`, `bridge-session`, `custom-title`. The adapter reads `user` and
+/// `assistant`; everything else is harness bookkeeping.
+#[derive(Debug, serde::Deserialize)]
+struct Line {
+    #[serde(default)]
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    timestamp: Option<String>,
+    #[serde(default)]
+    message: Option<Message>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Message {
+    #[serde(default)]
+    content: serde_json::Value,
+}
+
+/// What one transcript line contributed.
+#[derive(Debug, Default)]
+struct Extracted {
+    text: String,
+    commands: Vec<String>,
+}
+
+/// Why a transcript could not be adapted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AdapterError {
+    Unreadable(String),
+    /// The file parsed but carried nothing a replay could use.
+    Empty(PathBuf),
+}
+
+impl std::fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdapterError::Unreadable(why) => write!(f, "transcript unreadable: {why}"),
+            AdapterError::Empty(path) => {
+                write!(f, "{} carried no usable turns", path.display())
+            }
+        }
+    }
+}
+
+/// Adapt one Claude Code transcript into one trace session.
+///
+/// `task_id` is the transcript's own identity: one Claude Code session is one
+/// sitting, which is the closest honest approximation of one task the source
+/// offers. It is an approximation and is labelled as one — a long session
+/// genuinely spans several tasks, and the error runs toward *under*-counting
+/// distinct tasks, which is the safe direction for a promotion gate.
+pub(crate) fn session_from_transcript(
+    path: &Path,
+    contents: &str,
+) -> Result<TraceSession, AdapterError> {
+    let id = path
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let mut turns: Vec<TraceTurn> = Vec::new();
+    let mut pending: Option<TraceTurn> = None;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        // A line the adapter cannot parse is skipped, not fatal: these files are
+        // written by a different program at a version we do not control, and one
+        // unrecognized line must not discard a whole session's shell history.
+        let Ok(parsed) = serde_json::from_str::<Line>(line) else {
+            continue;
+        };
+        let at = parsed.timestamp.as_deref().and_then(parse_rfc3339);
+
+        match parsed.kind.as_str() {
+            "user" => {
+                if let Some(turn) = pending.take() {
+                    turns.push(turn);
+                }
+                let extracted = extract(&parsed);
+                pending = Some(TraceTurn {
+                    at: at.unwrap_or_default(),
+                    prompt: extracted.text.chars().take(200).collect(),
+                    // The transcript stub stays empty under option (b): nothing
+                    // reads it, because the turn never reaches the reflection
+                    // prompt. Carrying user text into a trace we did not need
+                    // would be gratuitous retention of exactly the content the
+                    // privacy gate exists to keep local.
+                    transcript: Vec::new(),
+                    reflection: ScriptedReflection::NotRecorded,
+                    shell: Vec::new(),
+                    succeeded: true,
+                    forget: Vec::new(),
+                    removed_files: Vec::new(),
+                });
+            }
+            "assistant" => {
+                let extracted = extract(&parsed);
+                if let Some(turn) = pending.as_mut() {
+                    for command in extracted.commands {
+                        if let Some(safe) = safe_command(&command) {
+                            turn.shell.push(TraceShell {
+                                command: safe,
+                                succeeded: true,
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(turn) = pending.take() {
+        turns.push(turn);
+    }
+
+    // A turn with no shell history contributes nothing under option (b) — it has
+    // no reflection to replay either — so it is dropped rather than padding the
+    // turn count with turns the harness will not act on. A turn count that
+    // includes turns nothing can be learned from is a number that flatters.
+    turns.retain(|turn| !turn.shell.is_empty());
+    if turns.is_empty() {
+        return Err(AdapterError::Empty(path.to_path_buf()));
+    }
+
+    // Timestamps must be non-decreasing (`Trace::check`). A transcript whose
+    // clock jumped backwards is repaired by clamping rather than refused: it is
+    // a real file we do not control, and one skewed line should not discard a
+    // session. Clamping is visible in the result; refusing would not be.
+    let mut previous = 0i64;
+    for turn in &mut turns {
+        if turn.at < previous {
+            turn.at = previous;
+        }
+        previous = turn.at;
+    }
+
+    Ok(TraceSession {
+        id: id.clone(),
+        task_id: id,
+        turns,
+    })
+}
+
+/// Adapt a directory of transcripts into one trace, oldest session first.
+///
+/// `description` must name the corpus — a summary that cannot say what it was
+/// built from is not reportable (§11).
+pub(crate) fn trace_from_directory(root: &Path, description: &str) -> Result<Trace, AdapterError> {
+    let entries = std::fs::read_dir(root)
+        .map_err(|e| AdapterError::Unreadable(format!("{}: {e}", root.display())))?;
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|e| e == "jsonl"))
+        .collect();
+    // Sorted so the adapter is deterministic: `read_dir` order is filesystem
+    // order, which differs between machines and even between runs.
+    paths.sort();
+
+    let mut sessions: Vec<TraceSession> = Vec::new();
+    for path in &paths {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if let Ok(session) = session_from_transcript(path, &contents) {
+            sessions.push(session);
+        }
+    }
+    // A trace's turns must be non-decreasing across sessions too, so order
+    // sessions by their first instant rather than by filename.
+    sessions.sort_by_key(|session| session.turns.first().map(|t| t.at).unwrap_or_default());
+    if sessions.is_empty() {
+        return Err(AdapterError::Empty(root.to_path_buf()));
+    }
+    let mut previous = 0i64;
+    for session in &mut sessions {
+        for turn in &mut session.turns {
+            if turn.at < previous {
+                turn.at = previous;
+            }
+            previous = turn.at;
+        }
+    }
+
+    Ok(Trace {
+        version: TRACE_VERSION,
+        description: description.to_string(),
+        workspace: WorkspaceSeed::default(),
+        sessions,
+    })
+}
+
+/// Pull text and Bash commands out of one line's message content.
+fn extract(line: &Line) -> Extracted {
+    let mut out = Extracted::default();
+    let Some(message) = &line.message else {
+        return out;
+    };
+    match &message.content {
+        serde_json::Value::String(text) => out.text = text.clone(),
+        serde_json::Value::Array(blocks) => {
+            for block in blocks {
+                match block.get("type").and_then(|t| t.as_str()) {
+                    Some("text") => {
+                        if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                            out.text.push_str(text);
+                        }
+                    }
+                    Some("tool_use") => {
+                        if block.get("name").and_then(|n| n.as_str()) == Some("Bash")
+                            && let Some(command) =
+                                block.pointer("/input/command").and_then(|c| c.as_str())
+                        {
+                            out.commands.push(command.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Redact a command, or drop it entirely.
+///
+/// Two gates, in order. First [`redact_secrets`] replaces every recognized
+/// credential. Then, if the redaction *fired*, the command is dropped rather
+/// than emitted with a `[redacted]` hole in it.
+///
+/// Dropping rather than keeping the redacted form is the conservative choice and
+/// costs almost nothing: a command that carried a credential is a one-off by
+/// nature (an `export`, a `curl` with a bearer token), so it was never going to
+/// be a recurring shape worth minting a tool from. What it *would* have done is
+/// put a partly-redacted credential context into a file, and the redactor's
+/// prefix list is a good filter rather than a complete one — a token shape it
+/// has not seen would survive. The foundry loses nothing; the gate keeps its
+/// margin.
+fn safe_command(command: &str) -> Option<String> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let redaction = redact_secrets(trimmed);
+    if redaction.redacted {
+        return None;
+    }
+    Some(redaction.text)
+}
+
+/// Parse an RFC-3339 timestamp to Unix seconds.
+///
+/// Hand-rolled to the exact shape Claude Code writes
+/// (`YYYY-MM-DDTHH:MM:SS[.mmm]Z`) rather than pulling in a date crate for one
+/// caller. Anything else returns `None` and the turn falls back to its
+/// neighbours' clamp — a wrong timestamp is worse than a missing one, because
+/// the trace's whole timeline is derived from these.
+fn parse_rfc3339(text: &str) -> Option<i64> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 19 {
+        return None;
+    }
+    let num = |from: usize, to: usize| text.get(from..to)?.parse::<i64>().ok();
+    let (year, month, day) = (num(0, 4)?, num(5, 7)?, num(8, 10)?);
+    let (hour, minute, second) = (num(11, 13)?, num(14, 16)?, num(17, 19)?);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    Some(days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second)
+}
+
+/// Days since 1970-01-01, by Howard Hinnant's `days_from_civil` — the exact
+/// inverse of the `civil_from_days` `stella-context`'s clock already uses, so
+/// the two agree at every boundary by construction rather than by testing.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let yoe = year - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// The environment variable that opts a local run in.
+///
+/// A variable rather than a flag because there is no shipped command to put a
+/// flag on: the adapter is reachable only from a test, deliberately (§7.1).
+pub(crate) const OPT_IN: &str = "STELLA_REPLAY_CC_CORPUS";
+
+/// Where Claude Code keeps its transcripts, if the caller opted in.
+///
+/// `None` unless [`OPT_IN`] is set, so no default path ever reads the user's
+/// transcripts — including in CI, where the variable is never set and the
+/// directory does not exist anyway.
+///
+/// The home anchor comes from `crate::paths`, never from the environment
+/// directly. `paths.rs`'s
+/// `nothing_else_in_this_crate_reads_a_home_out_of_the_environment` guard
+/// exists so a test can redirect one without mutating process-global state
+/// (#1139), and it caught a raw `var_os("HOME")` here on the first run.
+pub(crate) fn opted_in_corpus_root() -> Option<PathBuf> {
+    // The opt-in is checked as a `?` rather than an early return so
+    // `clippy::question_mark` is satisfied; the semantics are identical —
+    // unset means `None`, and nothing below runs.
+    std::env::var_os(OPT_IN)?;
+    let root = crate::paths::home()?.join(".claude").join("projects");
+    root.is_dir().then_some(root)
+}
+
+/// Every project directory under the corpus root, sorted.
+pub(crate) fn project_directories(root: &Path) -> BTreeMap<String, PathBuf> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return BTreeMap::new();
+    };
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .filter_map(|path| {
+            let name = path.file_name()?.to_string_lossy().into_owned();
+            Some((name, path))
+        })
+        .collect()
+}
+
+/// Assert nothing in this trace is labelled as recorded when it was derived.
+///
+/// A cheap total check rather than a promise: under option (b) the adapter emits
+/// no lessons at all, so any `Lessons` arm reaching a trace built here would
+/// mean option (a) was added without stamping [`Provenance::Derived`] — the one
+/// mistake §7.2 says must be impossible to make quietly.
+pub(crate) fn every_lesson_is_labelled(trace: &Trace) -> bool {
+    trace.turns().all(|(_, turn)| match &turn.reflection {
+        ScriptedReflection::Lessons { provenance, .. } => *provenance == Provenance::Derived,
+        _ => true,
+    })
+}
+
+/// Unused under option (b); kept so a future option (a) has one obvious place to
+/// build a labelled lesson rather than inventing a second spelling.
+#[allow(dead_code)]
+pub(crate) fn derived_message(role: TraceRole, content: &str) -> TraceMessage {
+    TraceMessage {
+        role,
+        content: content.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
+++ b/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
@@ -1,0 +1,387 @@
+//! The adapter's tests, and the privacy gate's witness.
+//!
+//! Everything here runs against **synthetic transcripts written by the test**,
+//! never against the developer's real `~/.claude/projects`. That is not
+//! squeamishness: a test that read the real corpus would pass or fail based on
+//! what its author happened to have typed that month, and would put real user
+//! content in front of CI. The one test that touches the real corpus is
+//! [`the_real_corpus_adapts_when_opted_in`], which no-ops unless
+//! `STELLA_REPLAY_CC_CORPUS` is set.
+
+use super::*;
+use crate::memory::replay::Replayer;
+
+/// One transcript line, in the shape Claude Code writes.
+fn user_line(at: &str, text: &str) -> String {
+    serde_json::json!({
+        "type": "user",
+        "timestamp": at,
+        "message": {"content": text},
+    })
+    .to_string()
+}
+
+fn assistant_bash(at: &str, commands: &[&str]) -> String {
+    let content: Vec<serde_json::Value> = commands
+        .iter()
+        .map(|command| {
+            serde_json::json!({
+                "type": "tool_use",
+                "name": "Bash",
+                "input": {"command": command},
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "type": "assistant",
+        "timestamp": at,
+        "message": {"content": content},
+    })
+    .to_string()
+}
+
+fn transcript(lines: &[String]) -> String {
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+// ---- the privacy witness (§7.1) --------------------------------------------
+
+/// **THE privacy witness.** A secret-shaped string in a transcript never reaches
+/// the trace.
+///
+/// The spec asks for "quarantined rather than stored". Under option (b) the
+/// adapter derives no *statements* at all, so there is no proposal to quarantine
+/// — the highest-risk field it touches is the shell command, and
+/// `export ANTHROPIC_API_KEY=sk-ant-…` is an ordinary thing to have typed. The
+/// gate is therefore applied where the risk actually is, and it is stricter than
+/// quarantine: the command is **dropped**, not redacted-and-kept.
+#[test]
+fn a_secret_in_a_transcript_never_reaches_the_trace() {
+    let secret = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let contents = transcript(&[
+        user_line("2026-07-10T09:00:00Z", "wire up the provider"),
+        assistant_bash(
+            "2026-07-10T09:00:05Z",
+            &[
+                &format!("export ANTHROPIC_API_KEY={secret}"),
+                "rg -n \"Provider\" crates/stella-model/src/anthropic.rs",
+            ],
+        ),
+    ]);
+
+    let session = session_from_transcript(std::path::Path::new("s1.jsonl"), &contents)
+        .expect("the transcript adapts");
+    let commands: Vec<&str> = session
+        .turns
+        .iter()
+        .flat_map(|turn| turn.shell.iter())
+        .map(|shell| shell.command.as_str())
+        .collect();
+
+    assert!(
+        !commands.iter().any(|command| command.contains(secret)),
+        "a credential reached the trace: {commands:?}"
+    );
+    assert!(
+        !commands
+            .iter()
+            .any(|command| command.starts_with("export ANTHROPIC_API_KEY")),
+        "a command that carried a credential must be dropped, not kept with a \
+         hole in it: {commands:?}"
+    );
+    assert_eq!(
+        commands,
+        vec!["rg -n \"Provider\" crates/stella-model/src/anthropic.rs"],
+        "the innocent command beside it must survive"
+    );
+}
+
+/// The redactor's prefix list is a good filter, not a complete one, so the gate
+/// is a drop rather than a substitution. Pinned as a property of `safe_command`
+/// itself, because it is one line and it is the whole gate.
+#[test]
+fn a_command_whose_redaction_fired_is_dropped_entirely() {
+    assert_eq!(
+        safe_command("rg -n \"unwrap\" crates/stella-core/src/driver.rs"),
+        Some("rg -n \"unwrap\" crates/stella-core/src/driver.rs".to_string())
+    );
+    assert_eq!(
+        safe_command("curl -H 'Authorization: Bearer sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA'"),
+        None
+    );
+    assert_eq!(safe_command("   "), None);
+}
+
+/// The corpus root is unreachable without the opt-in, whatever else is true.
+#[test]
+fn the_real_corpus_is_unreachable_without_the_opt_in() {
+    // SAFETY: single-threaded assertion on this test's own view of the
+    // environment; the variable is restored before the test returns.
+    let previous = std::env::var_os(OPT_IN);
+    unsafe { std::env::remove_var(OPT_IN) };
+    assert_eq!(
+        opted_in_corpus_root(),
+        None,
+        "no default path may read the developer's transcripts"
+    );
+    if let Some(previous) = previous {
+        unsafe { std::env::set_var(OPT_IN, previous) };
+    }
+}
+
+// ---- adaptation ------------------------------------------------------------
+
+/// A turn's boundary is a `user` line; its shell history is the Bash calls that
+/// follow it.
+#[test]
+fn turns_are_bounded_by_user_lines_and_carry_the_bash_that_followed() {
+    let contents = transcript(&[
+        user_line("2026-07-10T09:00:00Z", "first ask"),
+        assistant_bash("2026-07-10T09:00:05Z", &["rg -n \"a\" src/one.rs"]),
+        assistant_bash("2026-07-10T09:00:09Z", &["rg -n \"b\" src/two.rs"]),
+        user_line("2026-07-10T10:00:00Z", "second ask"),
+        assistant_bash("2026-07-10T10:00:04Z", &["rg -n \"c\" src/three.rs"]),
+    ]);
+    let session =
+        session_from_transcript(std::path::Path::new("abc.jsonl"), &contents).expect("adapts");
+
+    assert_eq!(session.id, "abc");
+    assert_eq!(session.task_id, "abc", "one transcript is one task");
+    assert_eq!(session.turns.len(), 2);
+    assert_eq!(session.turns[0].shell.len(), 2);
+    assert_eq!(session.turns[1].shell.len(), 1);
+    assert_eq!(session.turns[0].at, 1_783_674_000, "2026-07-10T09:00:00Z");
+    assert!(session.turns[0].at < session.turns[1].at);
+}
+
+/// **Every adapted turn is `NotRecorded`** — the whole of option (b).
+///
+/// Claude Code transcripts carry no Stella reflection JSON, so any other arm
+/// would be an assertion the source does not support. `Unreadable` in particular
+/// would fabricate starvation and corrupt assertion 7's metric.
+#[test]
+fn every_adapted_turn_declines_to_invent_a_reflection() {
+    let contents = transcript(&[
+        user_line("2026-07-10T09:00:00Z", "an ask"),
+        assistant_bash("2026-07-10T09:00:05Z", &["rg -n \"a\" src/one.rs"]),
+    ]);
+    let session =
+        session_from_transcript(std::path::Path::new("s.jsonl"), &contents).expect("adapts");
+    for turn in &session.turns {
+        assert_eq!(
+            turn.reflection,
+            ScriptedReflection::NotRecorded,
+            "the adapter must not invent the signal under test"
+        );
+        assert!(
+            turn.transcript.is_empty(),
+            "nothing reads the stub under option (b), so retaining user text \
+             would be gratuitous"
+        );
+    }
+}
+
+/// A turn that ran no shell contributes nothing and is dropped, so the turn
+/// count cannot be padded with turns the harness will never act on.
+#[test]
+fn a_turn_with_no_shell_history_is_dropped_rather_than_padding_the_count() {
+    let contents = transcript(&[
+        user_line("2026-07-10T09:00:00Z", "just chatting"),
+        user_line("2026-07-10T09:05:00Z", "still chatting"),
+    ]);
+    assert!(matches!(
+        session_from_transcript(std::path::Path::new("s.jsonl"), &contents),
+        Err(AdapterError::Empty(_))
+    ));
+}
+
+/// An unparseable line is skipped, not fatal: these files are written by another
+/// program at a version we do not control.
+#[test]
+fn one_unreadable_line_does_not_discard_the_session() {
+    let contents = transcript(&[
+        user_line("2026-07-10T09:00:00Z", "an ask"),
+        "{ this is not json".to_string(),
+        assistant_bash("2026-07-10T09:00:05Z", &["rg -n \"a\" src/one.rs"]),
+    ]);
+    let session = session_from_transcript(std::path::Path::new("s.jsonl"), &contents)
+        .expect("adapts despite the torn line");
+    assert_eq!(session.turns.len(), 1);
+    assert_eq!(session.turns[0].shell.len(), 1);
+}
+
+/// A backwards clock is clamped, not refused — one skewed line must not discard
+/// a real session, and the trace loader requires non-decreasing time.
+#[test]
+fn a_backwards_timestamp_is_clamped_so_the_trace_still_loads() {
+    let contents = transcript(&[
+        user_line("2026-07-10T10:00:00Z", "later first"),
+        assistant_bash("2026-07-10T10:00:01Z", &["rg -n \"a\" src/one.rs"]),
+        user_line("2026-07-10T09:00:00Z", "earlier second"),
+        assistant_bash("2026-07-10T09:00:01Z", &["rg -n \"b\" src/two.rs"]),
+    ]);
+    let session =
+        session_from_transcript(std::path::Path::new("s.jsonl"), &contents).expect("adapts");
+    assert!(
+        session.turns[0].at <= session.turns[1].at,
+        "clamped: {:?}",
+        session.turns.iter().map(|t| t.at).collect::<Vec<_>>()
+    );
+}
+
+/// The date arithmetic is the exact inverse of the one `stella-context`'s clock
+/// uses, so the two agree at every boundary by construction.
+#[test]
+fn timestamps_round_trip_through_the_clocks_own_formatter() {
+    for instant in [0i64, 1_600_000_000, 1_783_501_200, 1_582_934_400] {
+        let rendered = stella_context::format_rfc3339(instant);
+        assert_eq!(
+            parse_rfc3339(&rendered),
+            Some(instant),
+            "{rendered} did not round trip"
+        );
+    }
+    assert_eq!(parse_rfc3339("not a timestamp"), None);
+    assert_eq!(parse_rfc3339("2026-13-01T00:00:00Z"), None);
+}
+
+/// A directory of transcripts becomes one trace, ordered by time and loadable.
+#[tokio::test]
+async fn a_directory_of_transcripts_becomes_a_replayable_trace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("second.jsonl"),
+        transcript(&[
+            user_line("2026-07-20T09:00:00Z", "later session"),
+            assistant_bash("2026-07-20T09:00:05Z", &["rg -n \"b\" src/two.rs"]),
+        ]),
+    )
+    .expect("write");
+    std::fs::write(
+        dir.path().join("first.jsonl"),
+        transcript(&[
+            user_line("2026-07-10T09:00:00Z", "earlier session"),
+            assistant_bash("2026-07-10T09:00:05Z", &["rg -n \"a\" src/one.rs"]),
+        ]),
+    )
+    .expect("write");
+
+    let trace = trace_from_directory(dir.path(), "two synthetic transcripts").expect("adapts");
+    assert_eq!(trace.sessions.len(), 2);
+    assert_eq!(
+        trace.sessions[0].id, "first",
+        "sessions are ordered by time, not by filename"
+    );
+    assert!(every_lesson_is_labelled(&trace));
+
+    // The real proof: it survives the loader's own contract, then replays.
+    let json = serde_json::to_string(&trace).expect("serialize");
+    let reloaded = super::super::trace::Trace::parse(&json).expect("an adapted trace must load");
+    assert_eq!(reloaded, trace);
+
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let summary = Replayer::run(&trace, &workspace.path().join("adapted"))
+        .await
+        .expect("an adapted trace replays");
+    assert_eq!(summary.turns, 2);
+    assert_eq!(
+        summary.turns_not_recorded, 2,
+        "every adapted turn is counted as carrying no reflection, never as an \
+         empty one: {summary:?}"
+    );
+    assert_eq!(
+        summary.memories, 0,
+        "option (b) feeds the foundry and the timeline, never the reflection path"
+    );
+    assert!(
+        summary.model_errors.is_empty(),
+        "a turn the source never reflected on is not a starved turn: {:?}",
+        summary.model_errors
+    );
+}
+
+/// A shape recurring across adapted sessions reaches the foundry — the half of
+/// the corpus that is genuinely worth having.
+#[tokio::test]
+async fn a_recurring_shape_across_adapted_sessions_mints_a_tool() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (index, (day, path)) in [
+        ("10", "crates/stella-core/src/driver.rs"),
+        ("11", "crates/stella-cli/src/agent.rs"),
+        ("12", "crates/stella-model/src/openai.rs"),
+    ]
+    .iter()
+    .enumerate()
+    {
+        std::fs::write(
+            dir.path().join(format!("s{index}.jsonl")),
+            transcript(&[
+                user_line(&format!("2026-07-{day}T09:00:00Z"), "an ask"),
+                assistant_bash(
+                    &format!("2026-07-{day}T09:00:05Z"),
+                    &[&format!("rg -n \"unwrap\" {path}")],
+                ),
+            ]),
+        )
+        .expect("write");
+    }
+
+    let trace = trace_from_directory(dir.path(), "three sessions, one shape").expect("adapts");
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let summary = Replayer::run(&trace, &workspace.path().join("adapted"))
+        .await
+        .expect("replays");
+    assert!(
+        !summary.tools.is_empty(),
+        "one shape with three argument sets, mined from adapted transcripts: \
+         {summary:?}"
+    );
+}
+
+// ---- the real corpus, opt-in only ------------------------------------------
+
+/// Adapt the developer's real Claude Code corpus. **No-ops unless
+/// `STELLA_REPLAY_CC_CORPUS` is set**, so a plain `cargo test` — and every CI
+/// run — never touches it.
+///
+/// Nothing derived here is written to disk, printed in full, or committed. The
+/// assertions are counts and the privacy property; the committed CI corpus stays
+/// synthetic, permanently.
+#[tokio::test]
+async fn the_real_corpus_adapts_when_opted_in() {
+    let Some(root) = opted_in_corpus_root() else {
+        return;
+    };
+    let projects = project_directories(&root);
+    println!("corpus: {} project director(ies)", projects.len());
+
+    let mut adapted = 0usize;
+    let mut turns = 0usize;
+    let mut commands = 0usize;
+    for (name, path) in projects.iter().take(20) {
+        let Ok(trace) = trace_from_directory(path, name) else {
+            continue;
+        };
+        assert!(
+            every_lesson_is_labelled(&trace),
+            "an unlabelled derived lesson reached a trace built from {name}"
+        );
+        // The loader's contract must hold for a real, uncontrolled source too —
+        // this is the assertion that catches a transcript shape the adapter
+        // mishandles, rather than a synthetic one it was written against.
+        let json = serde_json::to_string(&trace).expect("serialize");
+        super::super::trace::Trace::parse(&json)
+            .unwrap_or_else(|e| panic!("adapted trace for {name} does not load: {e}"));
+
+        adapted += 1;
+        turns += trace.sessions.iter().map(|s| s.turns.len()).sum::<usize>();
+        commands += trace
+            .turns()
+            .map(|(_, turn)| turn.shell.len())
+            .sum::<usize>();
+    }
+    println!("adapted {adapted} project(s): {turns} turn(s), {commands} command(s)");
+    assert!(adapted > 0, "the opt-in was set but nothing adapted");
+}

--- a/crates/stella-cli/src/memory/replay/summary.rs
+++ b/crates/stella-cli/src/memory/replay/summary.rs
@@ -39,6 +39,11 @@ pub(crate) struct ReplaySummary {
     pub turns_unreadable: usize,
     /// Turns scripted as a failed model call.
     pub turns_model_error: usize,
+    /// Turns whose source carried no reflection at all — counted, never folded
+    /// into "nothing to learn". An adapter over a corpus with no reflection JSON
+    /// (§7.2) produces these, and a metric that silently counted them as empty
+    /// reflections would report the learner as idle when it was never asked.
+    pub turns_not_recorded: usize,
     /// Lessons the corpus offered, before any filtering.
     pub lessons_offered: usize,
     // ---- what the learners built ------------------------------------------
@@ -80,6 +85,7 @@ impl ReplaySummary {
                 }
                 ScriptedReflection::Unreadable { .. } => summary.turns_unreadable += 1,
                 ScriptedReflection::ModelError { .. } => summary.turns_model_error += 1,
+                ScriptedReflection::NotRecorded => summary.turns_not_recorded += 1,
             }
         }
         summary
@@ -151,8 +157,12 @@ impl ReplaySummary {
             self.sessions, self.turns, self.distinct_tasks
         ));
         out.push_str(&format!(
-            "  reflections: {} with lessons, {} unreadable, {} model error(s)\n",
-            self.turns_with_lessons, self.turns_unreadable, self.turns_model_error
+            "  reflections: {} with lessons, {} unreadable, {} model error(s), \
+             {} not recorded by the source\n",
+            self.turns_with_lessons,
+            self.turns_unreadable,
+            self.turns_model_error,
+            self.turns_not_recorded
         ));
         out.push_str(&format!(
             "  {} lesson(s) offered across {} turn(s) — recurrence {:.2} lesson/turn\n",

--- a/crates/stella-cli/src/memory/replay/trace.rs
+++ b/crates/stella-cli/src/memory/replay/trace.rs
@@ -172,13 +172,13 @@ impl From<&TraceShell> for ShellInvocation {
 
 /// What the reflection model would have returned this turn.
 ///
-/// **Three arms, deliberately.** The two failure arms are not padding: they are
-/// what the live loop actually hits, and they are the ones that starve learning
-/// *silently*. `reflect_and_record` returns `recorded: 0` both for "nothing
-/// worth learning" and for "I could not read the response", and telling those
-/// apart is the entire purpose of the `Unreadable` branch. A corpus that only
-/// ever scripts happy-path lessons cannot certify the starvation guard, which is
-/// the most valuable assertion the harness has.
+/// **The two failure arms are not padding.** They are what the live loop
+/// actually hits, and the ones that starve learning *silently*:
+/// `reflect_and_record` returns `recorded: 0` both for "nothing worth learning"
+/// and for "I could not read the response", and telling those apart is the
+/// entire purpose of the `Unreadable` branch. A corpus that only ever scripts
+/// happy-path lessons cannot certify the starvation guard, which is the most
+/// valuable assertion the harness has.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum ScriptedReflection {
@@ -197,6 +197,21 @@ pub(crate) enum ScriptedReflection {
     Unreadable { text: String },
     /// The model call itself failed — drives `StandaloneCallError`.
     ModelError { message: String },
+    /// **The source carried no reflection at all**, so this turn runs the
+    /// foundry and the timeline but never touches the reflection path.
+    ///
+    /// The arm exists because of a real property of the only non-synthetic
+    /// corpus available: Claude Code transcripts contain no Stella reflection
+    /// JSON (§7.2). Every way of expressing that with the other three arms is a
+    /// claim the source does not support — `Lessons { lessons: [] }` asserts the
+    /// model had nothing to say, and `Unreadable` asserts it said something
+    /// unparseable. Both would be *invented signal* in the one place the spec
+    /// warns hardest about, and `Unreadable` in particular would fabricate
+    /// starvation and corrupt assertion 7's own metric.
+    ///
+    /// So it is its own arm, counted separately in the summary, and the
+    /// replayer skips the model boundary entirely for it.
+    NotRecorded,
 }
 
 /// One lesson as the model would have emitted it.
@@ -358,7 +373,15 @@ impl ScriptedReflection {
                 Some(serde_json::to_string(lessons).unwrap_or_else(|_| "[]".to_string()))
             }
             ScriptedReflection::Unreadable { text } => Some(text.clone()),
-            ScriptedReflection::ModelError { .. } => None,
+            ScriptedReflection::ModelError { .. } | ScriptedReflection::NotRecorded => None,
         }
+    }
+
+    /// Whether this turn reaches the reflection path at all.
+    ///
+    /// [`ScriptedReflection::NotRecorded`] does not: there is nothing to script,
+    /// and scripting *something* would invent the signal under test.
+    pub(crate) fn reaches_the_model(&self) -> bool {
+        !matches!(self, ScriptedReflection::NotRecorded)
     }
 }

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -502,7 +502,34 @@ harness earning its keep before it shipped.
   absent for rules.** Filed as **#2359**: a placeholder must not render like a
   measurement.
 
-### 13.3 Still open
+### 13.3 The adapter, as built
+
+Option (b), as §7.2 recommends. Every turn it emits carries a **fourth
+`ScriptedReflection` arm, `NotRecorded`**, and the replayer skips the model
+boundary entirely for it. The arm exists because every other spelling is a claim
+the source does not support: an empty `Lessons` array asserts the model had
+nothing to say, and `Unreadable` asserts it said something unparseable — the
+second would also fabricate starvation and corrupt assertion 7's own metric,
+across sixteen thousand turns. `turns_not_recorded` is counted separately, so a
+corpus that was never asked does not read as a learner that stayed idle.
+
+The privacy gate lands where the risk actually is. Under option (b) no
+*statements* are derived, so there is no proposal to run through `gate_proposal`
+/ `quarantine_for`; the highest-risk field the adapter touches is the **shell
+command**. So `redact_secrets` runs on every command, and the gate is *stricter*
+than quarantine: a command whose redaction fired is **dropped**, not kept with a
+`[redacted]` hole in it. The redactor's prefix list is a good filter rather than
+a complete one, and a command carrying a credential was never going to be a
+recurring shape worth minting a tool from — the foundry loses nothing, and the
+gate keeps its margin.
+
+Measured against the real corpus on 2026-08-08: **496 project directories** (up
+from the 485 §7 recorded — consistent with the rolling window, and the reason a
+derived trace can never be a committed fixture); a 20-project sample adapted to
+**16,664 turns carrying 17,343 shell commands**, every trace passing the
+loader's contract.
+
+### 13.4 Still open
 
 - **#2358** — the dedup/mining threshold collision. The most consequential thing
   the harness has found.
@@ -512,4 +539,3 @@ harness earning its keep before it shipped.
 - **Recall-ranking assertions remain scoped out**, inheriting #2288.
 - **#2321** — extracting the learning loop into a library crate would let the
   harness be an ordinary integration test rather than a `#[cfg(test)]` module.
-- **The §7 adapter** is a separate change; §13 gains its half when it lands.


### PR DESCRIPTION
Refs #2304. Implements **PR 5** of `doc:trace-replay-learning-harness` §9 — the Claude Code transcript adapter — and completes spec §13 with the adapter's half (§13.3), which #2350 left open.

**Based on `main`**, which now carries the harness — #2350 merged while this was in flight.

*(Replaces #2357, which GitHub auto-closed when #2350 merged and its base branch `feat/2304-trace-replay-harness` was auto-deleted. Same content, rebased onto the merged harness.)*

## The adapter's honest limit is the design

Claude Code transcripts contain **no Stella reflection JSON**. There is nothing in them to script a lessons array from, so §7.2 puts the choice plainly: derive lessons from the transcript, or decline to. Deriving them means the harness measures the adapter's lesson-invention heuristic instead of Stella's learning — it fabricates the exact signal under test.

**This implements option (b), which the spec recommends**: shell history, session and turn boundaries, and timing only. It lights up the tool foundry against thousands of real commands and launders nothing.

### That needed a fourth `ScriptedReflection` arm

Expressing "the source carried no reflection" with the three existing arms is impossible without asserting something the source does not support:

| Spelling | The claim it makes |
|---|---|
| `Lessons { lessons: [] }` | the model had nothing to say |
| `Unreadable { .. }` | the model said something unparseable |
| `ModelError { .. }` | the call failed |

The second is the dangerous one: it would **fabricate starvation**, and assertion 7 (`an_unreadable_corpus_builds_nothing_and_says_why`) counts exactly those turns. An adapter that emitted `Unreadable` for 16,000 turns would corrupt the metric its sibling test depends on.

So `NotRecorded` is its own arm. The replayer skips the model boundary entirely for it, and the summary counts `turns_not_recorded` separately from empty reflections — a metric that folded them together would report the learner as idle when it was never asked.

`Provenance::Derived` already exists on the `Lessons` arm from #2350, and `every_lesson_is_labelled` asserts nothing reaches a trace unlabelled — so if option (a) is ever built, it cannot ship un-stamped quietly.

## The privacy gate (§7.1), applied where the risk actually is

The spec asks for "a secret-shaped string is quarantined rather than stored". Under option (b) the adapter derives **no statements**, so there is no proposal to run through `gate_proposal`/`quarantine_for`. The highest-risk field it does touch is the **shell command** — `export ANTHROPIC_API_KEY=sk-ant-…` and `curl -H "Authorization: Bearer …"` are ordinary things to have typed.

So the gate runs there, and it is **stricter than quarantine**: `redact_secrets` runs on every command, and a command whose redaction *fired* is **dropped**, not kept with a `[redacted]` hole in it. Two reasons:

- The redactor's prefix list is a good filter, not a complete one. A token shape it has not seen would survive in a command it had partly redacted, and the partial redaction is what would make that look safe.
- The foundry loses nothing. A command carrying a credential is a one-off by nature, so it was never going to be a recurring shape worth minting a tool from.

Beyond that: **local-only and opt-in** (`STELLA_REPLAY_CC_CORPUS`, reachable only from a test — no shipped command, and a plain `cargo test` never touches the corpus); **nothing derived is committed** (the CI corpus stays synthetic, permanently, and `no-scratch` fails the gate on a committed derivative on its own); and the transcript stub is left **empty**, because nothing reads it under option (b) and carrying user text into a trace we did not need would be gratuitous retention.

## Measured against the real corpus

```
corpus: 496 project director(ies)
adapted 20 project(s): 16664 turn(s), 17343 command(s)
```

Every adapted trace was round-tripped through `Trace::parse` — the loader's own contract, applied to a real uncontrolled source rather than to a synthetic fixture the adapter was written against. That is the assertion that catches a transcript shape the adapter mishandles.

**A correction to §7's measurement, recorded in §13.3.** The spec measured 485 project directories on 2026-08-08; it is 496 today. Consistent with the rolling window the spec already flags, and the reason a derived trace can never be a committed fixture.

## The spec now records what was built (§13)

The document said `status: proposed`. Rather than leave a plan describing something that now exists, §13 records the divergences and — more usefully — **the four things replaying the real loop measured**, none of which is visible from reading a single module: the shared dedup/clustering threshold, the foundry's value-like-argument rule, the workspace-derived lineage id, and lexical `starts_with`. A future reader planning fixtures needs all four.

## Verification

- `cargo test -p stella-cli` — **1531 passed, 0 failed** (12 new), on top of the merged harness
- `STELLA_REPLAY_CC_CORPUS=1 cargo test … the_real_corpus_adapts` — output above
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- `make guards-fast` — clean (#2355's shellcheck failure is fixed on `main` by #2363)

**No tests deleted.**

### One guard caught a real mistake, on the first run

`paths::tests::nothing_else_in_this_crate_reads_a_home_out_of_the_environment` failed on my `std::env::var_os("HOME")`. Fixed to `crate::paths::home()`, which is what lets a test redirect the anchor without mutating process-global state (#1139). Worth naming because it is exactly the guard working as designed.

## Not in this PR

- **Option (a)** — synthesizing lessons. The labelling machinery is in place if it is ever wanted; the spec's recommendation against it stands.
- **Committing any derived trace.** Permanently out of scope.

## Summary by Sourcery

Add a local-only, opt-in Claude Code transcript adapter that feeds real shell history into the trace replay harness without inventing reflections, and extend the harness to account for turns where the source provided no reflection.

New Features:
- Introduce a Claude Code transcript adapter that converts local transcripts into trace sessions for the replay harness under an explicit environment-based opt-in.
- Add support for a `ScriptedReflection::NotRecorded` arm and corresponding replay summary metric to represent turns where the source carried no reflection JSON.

Enhancements:
- Update the replayer to skip the reflection model boundary entirely for turns marked as not recorded while still driving the tool foundry and timeline.
- Refine the trace replay harness documentation to describe the built Claude Code adapter, its privacy guarantees, and its measured corpus characteristics.

Documentation:
- Document the Claude Code adapter design, its option (b) behavior, privacy gate, and real corpus measurements in the trace replay harness spec.

Tests:
- Add adapter and privacy-gate tests over synthetic transcripts, including opt-in behavior and timestamp handling, and a guarded test that exercises the real local corpus when enabled.