### PR TITLE
fix(stella-cli): mine the recurrence the store deduplicates, and measure the clustering threshold in its own token space (#2358)

### DIFF
--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -28,9 +28,10 @@ use super::{
 #[cfg(test)]
 mod guarantees;
 
-/// What [`SessionMemory::retain_unknown`] drops and keeps. A child module for
-/// the same reason as [`guarantees`]: the filter is private, and it is the
-/// filter itself that needs pinning, not the turn that happens to call it.
+/// What [`SessionMemory::partition_known`] stores, diverts to the mining log,
+/// and drops. A child module for the same reason as [`guarantees`]: the split
+/// is private, and it is the split itself that needs pinning, not the turn
+/// that happens to call it.
 #[cfg(test)]
 mod dedupe;
 
@@ -159,20 +160,17 @@ impl SessionMemory {
         // at recall is what makes forgetting durable — an unsuppressed lesson
         // would land in the log and stay re-mineable forever.
         let lessons = self.retain_unforgotten(turn_store.as_ref(), lessons);
-        // Then drop what we already know. The loop re-learns the same facts in
-        // slightly different words every turn, and only byte-identical content
-        // collapses on its own (a memory's lineage is seeded from its content
-        // hash), so paraphrases accumulate unchecked.
-        //
-        // Measured on a live treatment store: 23 stored memories encoding
-        // **six** distinct facts, with "commands are registered in registry.py"
-        // held seven separate times — 61% of the store was restatement. That is
-        // not merely untidy. Recall has a budget, so three slots spent on three
-        // phrasings of one fact are three slots not spent on the other five,
-        // and the store gets worse at covering the codebase the longer it runs.
-        let lessons = self.retain_unknown(lessons);
+        // Then split what survives into lessons the store should learn and
+        // restatements of what it already holds. The split — rather than the
+        // filter this used to be — is the #2358 fix: a restatement must skip
+        // the store (see `partition_known` for the measured cost of storing
+        // paraphrases) but still reach the mining log below, because a lesson
+        // the loop keeps re-learning is exactly the recurrence the skill and
+        // rule miners count. Dropping it here starved both miners of the
+        // most common recurrence shape there is.
+        let (novel, restatements) = self.partition_known(lessons);
 
-        if lessons.is_empty() {
+        if novel.is_empty() && restatements.is_empty() {
             return ReflectionReport {
                 cost_usd: reflection_cost_usd,
                 events: reflection_events,
@@ -196,36 +194,50 @@ impl SessionMemory {
         // guessed (see `anchors::resolve_anchors`). A lesson that names no file
         // simply gets no anchors, which is the common case for process notes
         // and is exactly right — they are not about a file.
-        let delta = ContextDelta {
-            memories: lessons
-                .iter()
-                .map(|l| {
-                    MemoryInput::reflection(&l.lesson, l.domains.iter().cloned())
-                        .with_recall_tier(l.kind.recall_tier())
-                        .with_anchors(crate::memory::anchors::resolve_anchors(
-                            &self.workspace_root,
-                            &l.lesson,
-                        ))
-                })
-                .collect(),
-            ..Default::default()
+        let stored = if novel.is_empty() {
+            // Nothing needed storing, so nothing failed to store: a
+            // restatement-only turn feeds the miners below and claims no
+            // memory.
+            true
+        } else {
+            let delta = ContextDelta {
+                memories: novel
+                    .iter()
+                    .map(|l| {
+                        MemoryInput::reflection(&l.lesson, l.domains.iter().cloned())
+                            .with_recall_tier(l.kind.recall_tier())
+                            .with_anchors(crate::memory::anchors::resolve_anchors(
+                                &self.workspace_root,
+                                &l.lesson,
+                            ))
+                    })
+                    .collect(),
+                ..Default::default()
+            };
+            self.store.upsert(delta).await.is_ok()
         };
-        let stored = self.store.upsert(delta).await.is_ok();
 
         // 2. Append to the mining log and mine for auto-creatable skills.
-        // Count how many lessons actually reached the log so the message below
-        // reports partial persistence accurately (some serialize/append writes
-        // may fail while others succeed). Each lesson is also mirrored into
-        // `store.db`'s durable `reflections` table — the surface the
-        // observatory's reflections panel, the JSON export, and the prune
-        // carve-out read; without the mirror those readers only ever saw an
-        // empty table. Best-effort like every store write here: a failed
-        // mirror never touches the jsonl path or the turn.
+        // BOTH halves of the split reach the log — the log is the mining
+        // substrate, and the restatements *are* the recurrence it exists to
+        // record (#2358). Count how many novel lessons actually reached the
+        // log so the message below reports partial persistence accurately
+        // (some serialize/append writes may fail while others succeed). Each
+        // lesson is also mirrored into `store.db`'s durable `reflections`
+        // table — the surface the observatory's reflections panel, the JSON
+        // export, and the prune carve-out read; without the mirror those
+        // readers only ever saw an empty table. Best-effort like every store
+        // write here: a failed mirror never touches the jsonl path or the
+        // turn.
         let log_path =
             stella_store::workspace_private_state_path(&self.workspace_root, "reflections.jsonl")
                 .ok();
-        let mut logged_count = 0usize;
-        for lesson in &lessons {
+        let mut novel_logged = 0usize;
+        for (is_novel, lesson) in novel
+            .iter()
+            .map(|l| (true, l))
+            .chain(restatements.iter().map(|l| (false, l)))
+        {
             if let Ok(line) = serde_json::to_string(lesson)
                 && stella_store::append_workspace_private_line(
                     &self.workspace_root,
@@ -233,8 +245,9 @@ impl SessionMemory {
                     &line,
                 )
                 .is_ok()
+                && is_novel
             {
-                logged_count += 1;
+                novel_logged += 1;
             }
             if let Some(store) = &turn_store {
                 let _ = store.record_reflection(&stella_store::ReflectionRow {
@@ -259,23 +272,27 @@ impl SessionMemory {
             self.auto_create_skills(log_path, quiet);
         }
 
-        if !quiet {
-            let n = lessons.len();
+        // A restatement-only turn stays quiet, exactly as it did when the
+        // whole turn was dropped: "we already knew that" repeated every turn
+        // is noise. The messages describe only the novel half, which is the
+        // half the user could lose.
+        if !quiet && !novel.is_empty() {
+            let n = novel.len();
             if stored {
                 println!(
                     "  {} remembered {n} lesson(s) from this turn",
                     "✦".magenta()
                 );
-            } else if logged_count == n {
+            } else if novel_logged == n {
                 println!(
                     "  {} could not persist {n} lesson(s) to the context store \
                      (logged to reflections.jsonl only)",
                     "!".yellow()
                 );
-            } else if logged_count > 0 {
+            } else if novel_logged > 0 {
                 println!(
                     "  {} could not persist {n} lesson(s) to the context store; \
-                     {logged_count} of {n} reached reflections.jsonl",
+                     {novel_logged} of {n} reached reflections.jsonl",
                     "!".yellow()
                 );
             } else {
@@ -287,7 +304,7 @@ impl SessionMemory {
             }
         }
         ReflectionReport {
-            recorded: if stored { lessons.len() } else { 0 },
+            recorded: if stored { novel.len() } else { 0 },
             model_error: None,
             cost_usd: reflection_cost_usd,
             events: reflection_events,
@@ -321,7 +338,8 @@ impl SessionMemory {
             .collect()
     }
 
-    /// Drop lessons that restate something the store already holds.
+    /// Split lessons into ones the store should learn and restatements of
+    /// something it already holds — `(novel, restatements)`.
     ///
     /// The same predicate [`Self::retain_unforgotten`] uses, pointed at live
     /// memories instead of tombstones. The machinery for "is this the same
@@ -329,20 +347,34 @@ impl SessionMemory {
     /// asked the question *do we know this already*, only *did the user delete
     /// this*.
     ///
-    /// Deliberately silent about *re-*learning: a fact mined twice is weak
-    /// evidence it matters, and a future change could raise salience on the
-    /// existing memory instead of discarding the restatement. Discarding is the
-    /// conservative half — it cannot make the store worse, and it is what stops
-    /// one fact crowding out five at recall time.
+    /// The novel half is the only half that may be stored. Measured on a live
+    /// treatment store: 23 stored memories encoding **six** distinct facts,
+    /// with "commands are registered in registry.py" held seven separate
+    /// times — 61% of the store was restatement. That is not merely untidy.
+    /// Recall has a budget, so three slots spent on three phrasings of one
+    /// fact are three slots not spent on the other five, and the store gets
+    /// worse at covering the codebase the longer it runs.
+    ///
+    /// The restatements are returned rather than dropped because *re*-learning
+    /// is the strongest recurrence evidence the loop ever sees, and discarding
+    /// it here was what starved the skill and rule miners (#2358): a lesson
+    /// that never reaches `reflections.jsonl` never becomes an observation and
+    /// can never contribute an occurrence. A within-batch repeat is different —
+    /// one reflection call returns up to three lessons and routinely says the
+    /// same thing twice, which is the model stuttering, not the codebase
+    /// recurring — so it lands in neither half.
     ///
     /// Restatement matching is fuzzy by construction (`SIMILARITY_THRESHOLD`
     /// over token sets, the same predicate [`stella_store::is_suppressed`]
-    /// applies), so this can drop a genuinely new lesson that happens to share
-    /// most of its vocabulary with an old one. That trade is the same one
-    /// forgetting already makes,
-    /// and it errs the right way here: a missed new memory costs one fact,
-    /// while an unchecked duplicate costs a recall slot on every future turn.
-    fn retain_unknown(&self, lessons: Vec<ReflectionLesson>) -> Vec<ReflectionLesson> {
+    /// applies), so this can divert a genuinely new lesson that happens to
+    /// share most of its vocabulary with an old one. That trade is the same
+    /// one forgetting already makes, and it errs the right way here: the
+    /// diverted lesson still counts toward mining, while an unchecked
+    /// duplicate costs a recall slot on every future turn.
+    fn partition_known(
+        &self,
+        lessons: Vec<ReflectionLesson>,
+    ) -> (Vec<ReflectionLesson>, Vec<ReflectionLesson>) {
         let known: Vec<String> = match self.store.memory_nodes() {
             // Compare against the memory's own text, which is what a later
             // recall would inject — the display label is truncated.
@@ -350,23 +382,24 @@ impl SessionMemory {
             // A store we cannot read is not evidence that nothing is stored, so
             // keep the lessons rather than risk dropping the first ones a fresh
             // workspace ever learns.
-            Err(_) => return lessons,
+            Err(_) => return (lessons, Vec::new()),
         };
-        let mut kept: Vec<ReflectionLesson> = Vec::with_capacity(lessons.len());
+        let mut novel: Vec<ReflectionLesson> = Vec::with_capacity(lessons.len());
+        let mut restatements: Vec<ReflectionLesson> = Vec::new();
         for lesson in lessons {
-            // Check against this batch too: one reflection call returns up to
-            // three lessons and routinely says the same thing twice.
-            let already =
-                stella_store::is_suppressed(&lesson.lesson, known.iter().map(String::as_str))
-                    || stella_store::is_suppressed(
-                        &lesson.lesson,
-                        kept.iter().map(|l: &ReflectionLesson| l.lesson.as_str()),
-                    );
-            if !already {
-                kept.push(lesson);
+            let repeats_batch = |batch: &[ReflectionLesson]| {
+                stella_store::is_suppressed(&lesson.lesson, batch.iter().map(|l| l.lesson.as_str()))
+            };
+            if repeats_batch(&novel) || repeats_batch(&restatements) {
+                continue;
+            }
+            if stella_store::is_suppressed(&lesson.lesson, known.iter().map(String::as_str)) {
+                restatements.push(lesson);
+            } else {
+                novel.push(lesson);
             }
         }
-        kept
+        (novel, restatements)
     }
 
     /// Mine the whole reflection log for recurring lessons and auto-create

--- a/crates/stella-cli/src/memory/learning/dedupe.rs
+++ b/crates/stella-cli/src/memory/learning/dedupe.rs
@@ -1,18 +1,25 @@
-//! What `retain_unknown` must and must not drop.
+//! What `partition_known` must store, divert, and drop.
 //!
 //! The commit that added the filter deferred these ("tests follow"), so the
-//! behavior shipped unpinned. It is a *lossy* filter on the path that persists
-//! learning — the failure mode is silent, and the thing it silently discards is
-//! the only record of what a turn taught. That is worth pinning precisely.
+//! behavior shipped unpinned. It sits on the path that persists learning — the
+//! failure mode is silent, and what it misroutes is the only record of what a
+//! turn taught. That is worth pinning precisely.
 //!
-//! Three properties, in the order they matter:
+//! Four properties, in the order they matter:
 //!
-//! * a restatement of something already stored is dropped (the point);
-//! * a novel lesson survives (the thing a too-eager filter would break);
+//! * a restatement of something already stored is **diverted, not dropped** —
+//!   it must stay out of the context store (recall has a budget) while still
+//!   reaching the caller, who appends it to the mining log where it counts as
+//!   a recurrence (#2358: dropping it here starved the skill and rule miners
+//!   of the most common recurrence shape there is);
+//! * a novel lesson lands in the novel half (the thing a too-eager filter
+//!   would break);
 //! * a batch that says one thing twice keeps one copy, **including on an empty
 //!   store** — one reflection call returns up to three lessons and routinely
 //!   repeats itself, and the store being empty is exactly when a fresh
-//!   workspace is learning its first facts.
+//!   workspace is learning its first facts;
+//! * a within-batch repeat of a *diverted* lesson is also dropped — the model
+//!   stuttering must not manufacture extra mining occurrences.
 //!
 //! The strings are chosen against the real predicate rather than by feel:
 //! matching is Jaccard over token sets at `SIMILARITY_THRESHOLD` (0.5), so each
@@ -23,7 +30,7 @@ use stella_context::{ContextDelta, MemoryInput};
 
 use crate::memory::{LessonKind, ReflectionLesson, SessionMemory};
 
-/// A lesson carrying `text`; every other field is irrelevant to the filter,
+/// A lesson carrying `text`; every other field is irrelevant to the split,
 /// which reads `lesson` and nothing else.
 fn lesson(text: &str) -> ReflectionLesson {
     ReflectionLesson {
@@ -44,7 +51,7 @@ fn session() -> (tempfile::TempDir, SessionMemory) {
 }
 
 /// Store `text` as a reflection memory — the same shape the loop writes, so
-/// the filter reads it back the same way a real second turn would.
+/// the split reads it back the same way a real second turn would.
 async fn remember(memory: &SessionMemory, text: &str) {
     memory
         .store
@@ -61,7 +68,7 @@ fn texts(lessons: &[ReflectionLesson]) -> Vec<&str> {
 }
 
 #[tokio::test]
-async fn a_paraphrase_of_a_stored_memory_is_dropped_and_a_new_fact_survives() {
+async fn a_paraphrase_of_a_stored_memory_is_diverted_and_a_new_fact_is_stored() {
     let (_dir, memory) = session();
     remember(&memory, "commands are registered in registry.py").await;
 
@@ -70,14 +77,21 @@ async fn a_paraphrase_of_a_stored_memory_is_dropped_and_a_new_fact_survives() {
     // Shares no token with the stored memory → 0.0.
     let novel = "the witness stage rejects a blind diff probe";
 
-    let kept = memory.retain_unknown(vec![lesson(restatement), lesson(novel)]);
+    let (kept, diverted) = memory.partition_known(vec![lesson(restatement), lesson(novel)]);
 
     assert_eq!(
         texts(&kept),
         vec![novel],
-        "a paraphrase of a stored memory must be dropped and an unrelated \
-         lesson must survive; dropping the novel one would make the filter \
-         cost more than the duplicates it removes"
+        "a paraphrase of a stored memory must stay out of the store and an \
+         unrelated lesson must land in it; storing the paraphrase would spend \
+         a recall slot restating what the store already holds"
+    );
+    assert_eq!(
+        texts(&diverted),
+        vec![restatement],
+        "and the paraphrase must come back as a restatement rather than \
+         vanish — it is the recurrence signal the skill and rule miners \
+         count, and dropping it is how the learning loop starved (#2358)"
     );
 }
 
@@ -93,13 +107,21 @@ async fn one_batch_saying_the_same_thing_twice_keeps_the_first_on_an_empty_store
     let second = "auth tokens expire after fifteen minutes";
     let other = "the migration runner reorders columns on rollback";
 
-    let kept = memory.retain_unknown(vec![lesson(first), lesson(second), lesson(other)]);
+    let (kept, diverted) =
+        memory.partition_known(vec![lesson(first), lesson(second), lesson(other)]);
 
     assert_eq!(
         texts(&kept),
         vec![first, other],
         "one reflection call routinely says the same thing twice; the batch \
          must collapse to the first phrasing even when the store is empty"
+    );
+    assert!(
+        diverted.is_empty(),
+        "a within-batch stutter is one turn repeating itself, not the \
+         codebase recurring — counting it as a mining occurrence would let a \
+         single verbose reflection impersonate three turns of evidence: {:?}",
+        texts(&diverted)
     );
 }
 
@@ -110,7 +132,7 @@ async fn an_empty_store_keeps_every_distinct_lesson() {
     let a = "the pre-push gate exports GIT_DIR to every hook it runs";
     let b = "best-of-n candidates share one tool registry";
 
-    let kept = memory.retain_unknown(vec![lesson(a), lesson(b)]);
+    let (kept, diverted) = memory.partition_known(vec![lesson(a), lesson(b)]);
 
     assert_eq!(
         texts(&kept),
@@ -118,5 +140,29 @@ async fn an_empty_store_keeps_every_distinct_lesson() {
         "nothing is known yet, so nothing is a restatement — a filter that \
          swallowed a fresh workspace's first lessons would be worse than the \
          duplication it exists to prevent"
+    );
+    assert!(diverted.is_empty());
+}
+
+#[tokio::test]
+async fn a_batch_repeat_of_a_diverted_restatement_is_dropped_not_double_counted() {
+    let (_dir, memory) = session();
+    remember(&memory, "commands are registered in registry.py").await;
+
+    // Both are restatements of the stored memory (each shares its 5 tokens;
+    // 5/8 = 0.625 and 5/7 = 0.714), and the second restates the first
+    // (7 shared of 8 → 0.875).
+    let restated = "commands are registered in registry.py for the cli";
+    let restated_again = "commands are registered in registry.py for cli";
+
+    let (kept, diverted) = memory.partition_known(vec![lesson(restated), lesson(restated_again)]);
+
+    assert!(kept.is_empty(), "nothing here is new knowledge");
+    assert_eq!(
+        texts(&diverted),
+        vec![restated],
+        "one turn's stutter must contribute ONE mining occurrence, not two — \
+         occurrences are the miners' evidence, and a batch echo is not \
+         evidence of anything but verbosity"
     );
 }

--- a/crates/stella-cli/src/memory/replay/tests.rs
+++ b/crates/stella-cli/src/memory/replay/tests.rs
@@ -10,30 +10,14 @@
 //! A fixture cannot be written for this suite without knowing three things that
 //! are not obvious from any single module, and that were measured here first.
 //!
-//! **1. The dedup filter and the miner use the same metric at the same
-//! threshold.** `retain_unknown` drops a lesson whose Jaccard overlap with an
-//! existing memory is `>= 0.5` (`stella_store::SIMILARITY_THRESHOLD`), and it
-//! runs *before* the mining log is appended — so a dropped lesson never becomes
-//! an observation and can never contribute an occurrence. The skill miner then
-//! clusters at `min_similarity: 0.5` (`SkillMineConfig`). Same number, same
-//! metric. For a cluster of three to form at all, three lessons must be similar
-//! enough to cluster while staying dissimilar enough to survive dedup.
-//!
-//! **That band exists only because the two tokenizers differ**, and the
-//! difference is load-bearing:
-//!
-//! | | `stella_store::forget::tokens` | `stella_core::mining::terms` |
-//! |---|---|---|
-//! | `crates/stella-tools/src/registry.rs` | **one** token | **five** terms |
-//! | stopwords and words of ≤2 chars | kept | dropped |
-//!
-//! So a shared *path* contributes one token to the dedup comparison and five
-//! terms to the clustering one, while differing filler inflates the dedup union
-//! invisibly to the miner. That is exactly the shape a real engagement produces
-//! — the same file re-encountered in different words — which is why the corpus
-//! below is written that way rather than as obvious near-duplicates. A fixture
-//! of literal repetitions builds **nothing**, and would read as a broken learner
-//! rather than as a fixture that cannot clear the filter.
+//! **1. Dedup and clustering are different predicates in different token
+//! spaces, and the corpus may be worded naturally because #2358 is fixed.**
+//! `partition_known` diverts a store-restatement to the mining log instead of
+//! dropping it, so recurrence survives dedup by construction, and the miners'
+//! `min_similarity` (0.4) is measured in `stella_core::mining::terms` space
+//! rather than inherited from the store's dedup constant — see
+//! [`the_dedup_and_clustering_predicates_hold_the_declared_relationship`] for
+//! the relationship, asserted with this corpus's own strings.
 //!
 //! **2. The foundry only holes a *value-like* argument.** `classify_argument`
 //! makes a positional argument a parameter only if it is a path or a number (or
@@ -50,6 +34,8 @@
 //! and build nothing.
 
 use std::path::Path;
+
+use stella_core::skills::{self, SkillMineConfig, SkillObservation};
 
 use super::summary::ReplaySummary;
 use super::trace::*;
@@ -160,15 +146,22 @@ fn trace(description: &str, sessions: Vec<TraceSession>) -> Trace {
     }
 }
 
-/// Four re-encounters of one convention, phrased as an engineer would phrase
-/// them on four different days. See the module docs for why they are worded
-/// this way and not as literal repeats.
+/// Five re-encounters of one convention, phrased as an engineer would phrase
+/// them on five different days — naturally varied, plus one near-restatement
+/// of the first. Both recurrence shapes a real engagement produces, and both
+/// were once invisible to the miners (#2358): the varied wordings sat below
+/// the inherited 0.5 clustering threshold, and the restatement was dropped by
+/// dedup before it could reach the mining log.
 fn recurring_registry_lessons() -> Vec<TraceTurn> {
     [
-        "Register the tool in crates/stella-tools/src/registry.rs",
-        "Tool registration lives at crates/stella-tools/src/registry.rs",
-        "Tools register through crates/stella-tools/src/registry.rs",
-        "Registered tools come from crates/stella-tools/src/registry.rs",
+        "Tool registration happens in crates/stella-tools/src/registry.rs — add the entry there.",
+        "Register a new tool by editing the ToolRegistry in crates/stella-tools/src/registry.rs.",
+        "A tool nobody registered in crates/stella-tools/src/registry.rs is invisible to the agent.",
+        "Every builtin is wired through crates/stella-tools/src/registry.rs before it can be called.",
+        // Close enough to the first wording that `partition_known` keeps it out
+        // of the context store — and it still counts as a mining occurrence,
+        // which is the #2358 fix in one line.
+        "Tool registration happens in crates/stella-tools/src/registry.rs, so add the new entry there.",
     ]
     .iter()
     .enumerate()
@@ -266,9 +259,9 @@ async fn a_two_turn_trace_replays_and_builds_exactly_one_memory() {
                 T0,
                 "Register the tool in crates/stella-tools/src/registry.rs",
             ),
-            // A restatement close enough to be dropped by `retain_unknown`, so
-            // two turns yield one memory — the dedup path, asserted rather than
-            // assumed.
+            // A restatement close enough for `partition_known` to divert it to
+            // the mining log, so two turns yield one memory — the dedup path,
+            // asserted rather than assumed.
             turn(
                 T0 + DAY,
                 "Register the tool in crates/stella-tools/src/registry.rs please",
@@ -299,7 +292,7 @@ async fn a_two_turn_trace_replays_and_builds_exactly_one_memory() {
 #[tokio::test]
 async fn recurrence_across_distinct_tasks_builds_what_recurrence_within_one_task_does_not() {
     let across = trace(
-        "one convention, four tasks",
+        "one convention, five tasks",
         one_task_each(recurring_registry_lessons()),
     );
     let (spread, _a) = replay(&across).await;
@@ -310,25 +303,133 @@ async fn recurrence_across_distinct_tasks_builds_what_recurrence_within_one_task
     );
     let (single, _b) = replay(&within).await;
 
-    assert_eq!(spread.distinct_tasks, 4);
+    assert_eq!(spread.distinct_tasks, 5);
     assert_eq!(single.distinct_tasks, 1);
     assert_eq!(
         spread.memories, single.memories,
         "both corpora record the same lessons — only the task boundary differs"
     );
+    assert_eq!(
+        spread.memories, 4,
+        "the fifth turn restates the first, so the store holds four distinct \
+         memories while the mining log holds five occurrences — the #2358 \
+         split, visible from the outside"
+    );
 
     assert!(
         !spread.skills.is_empty(),
-        "four distinct tasks should clear the eligibility gate: {spread:?}"
+        "a naturally-worded convention recurring across distinct tasks should \
+         clear the eligibility gate: {spread:?}"
+    );
+    assert!(
+        !spread.rules.is_empty(),
+        "and with four occurrences over four distinct tasks its confidence \
+         clears the auto-activation bar: {spread:?}"
     );
     assert!(
         single.skills.is_empty(),
-        "four turns of ONE task must not mint a skill — that is the \
+        "five turns of ONE task must not mint a skill — that is the \
          anti-poisoning rule, and it is the whole reason task identity is \
          carried at all. Built: {:?}",
         single.skills
     );
     assert!(single.rules.is_empty(), "nor a rule: {:?}", single.rules);
+}
+
+/// The lesson texts of [`recurring_registry_lessons`], for asserting on the
+/// corpus's own strings rather than a copy that could drift from it.
+fn registry_lesson_texts() -> Vec<String> {
+    recurring_registry_lessons()
+        .into_iter()
+        .filter_map(|turn| match turn.reflection {
+            ScriptedReflection::Lessons { mut lessons, .. } => lessons.pop().map(|l| l.lesson),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The #2358 contract, declared: store dedup and miner clustering are
+/// **different predicates in different token spaces**, and each must hold its
+/// own half of the band on the corpus above.
+///
+/// `stella_store::SIMILARITY_THRESHOLD` (0.5) is measured over
+/// `forget::tokens`, which keeps a file path as one token; the miners'
+/// `min_similarity` (0.4) is measured over `stella_core::mining::terms`, which
+/// shatters the same path into five terms. The same pair of lessons scores
+/// differently under each, so neither number may be "aligned" with the other
+/// or moved without re-measuring in its own space — the measurements live on
+/// [`SkillMineConfig::min_similarity`]'s doc comment. When one of them (or a
+/// tokenizer) moved before, the mining band silently closed and the loop kept
+/// mining lessons every turn while producing nothing durable, with no error
+/// anywhere. This test is the tripwire: it fails if either side moves in a way
+/// the other half was not re-measured against.
+#[test]
+fn the_dedup_and_clustering_predicates_hold_the_declared_relationship() {
+    let mining = SkillMineConfig::default();
+    assert_eq!(
+        mining.min_similarity,
+        stella_core::rules::MineConfig::default().min_similarity,
+        "the skills and rules miners cluster one observation pool; a rule \
+         threshold drifting from the skill threshold would make one artifact \
+         class see recurrence the other cannot"
+    );
+    assert!(
+        mining.min_similarity < stella_store::forget::SIMILARITY_THRESHOLD,
+        "clustering must see recurrence in lessons the store keeps as \
+         distinct: natural variation scores lower under `mining::terms` than \
+         restatement scores under `forget::tokens`, so the clustering bar \
+         sits below the dedup bar"
+    );
+
+    let texts = registry_lesson_texts();
+    let (varied, restated) = (&texts[..4], texts[4].as_str());
+
+    // The store half: the four natural wordings are distinct knowledge (each
+    // gets stored), while the fifth restates the first (diverted to the log).
+    for (index, wording) in varied.iter().enumerate() {
+        for other in &varied[index + 1..] {
+            assert!(
+                !stella_store::is_restatement(wording, other),
+                "the corpus's natural wordings must each survive dedup, or \
+                 the store never learns them: {wording:?} vs {other:?}"
+            );
+        }
+    }
+    assert!(
+        stella_store::is_restatement(&varied[0], restated),
+        "the fifth wording must trip dedup — it exists to prove a deduped \
+         restatement still reaches the miners"
+    );
+
+    // The miner half: clustering sees one convention in those same strings —
+    // including the restatement dedup kept out of the store.
+    let observations = texts
+        .iter()
+        .enumerate()
+        .map(|(index, text)| SkillObservation {
+            text: text.clone(),
+            occurred_at: index as u64,
+            domains: Vec::new(),
+            salient: false,
+            reference: format!("trace:{index}"),
+        })
+        .collect();
+    let candidates = skills::mine_skill_candidates(observations, &[], &mining);
+    let candidate = candidates
+        .first()
+        .expect("the naturally-worded convention must mine a candidate");
+    assert!(
+        candidate.occurrences >= mining.min_occurrences,
+        "the cluster must clear the recurrence bar on its own: {candidate:?}"
+    );
+    assert!(
+        candidate
+            .evidence
+            .iter()
+            .any(|evidence| evidence.reference == "trace:4"),
+        "the store-deduped restatement must count as a mining occurrence — \
+         that ordering is the other half of the #2358 fix: {candidate:?}"
+    );
 }
 
 // ---- §5 assertion 2: promotion is advisory, and never clobbers ------------
@@ -342,7 +443,7 @@ async fn recurrence_across_distinct_tasks_builds_what_recurrence_within_one_task
 #[tokio::test]
 async fn an_auto_activated_rule_is_advisory_and_never_blocking() {
     let corpus = trace(
-        "one convention, four tasks",
+        "one convention, five tasks",
         one_task_each(recurring_registry_lessons()),
     );
     let (summary, dir) = replay(&corpus).await;
@@ -381,7 +482,7 @@ async fn an_auto_activated_rule_is_advisory_and_never_blocking() {
 async fn auto_activation_never_clobbers_an_existing_record() {
     // First, learn where the miner publishes.
     let corpus = trace(
-        "one convention, four tasks",
+        "one convention, five tasks",
         one_task_each(recurring_registry_lessons()),
     );
     let (first, dir) = replay(&corpus).await;

--- a/crates/stella-cli/tests/fixtures/traces/simulated-months.json
+++ b/crates/stella-cli/tests/fixtures/traces/simulated-months.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "description": "one engineer, one repository, six simulated months - a tool-registration convention re-encountered across four distinct tasks in four different wordings, a recurring `rg -n <pattern> <path>` shape, one unreadable reflection, and several unrelated one-off facts so the corpus stays multi-topic",
+  "description": "one engineer, one repository, six simulated months - a tool-registration convention re-encountered across five distinct tasks in four naturally-varied wordings plus one near-restatement, a recurring `rg -n <pattern> <path>` shape, one unreadable reflection, and several unrelated one-off facts so the corpus stays multi-topic",
   "workspace": {
     "domains": [
       "tools",
@@ -40,7 +40,7 @@
             "kind": "lessons",
             "lessons": [
               {
-                "lesson": "Register the tool in crates/stella-tools/src/registry.rs",
+                "lesson": "Tool registration happens in crates/stella-tools/src/registry.rs — add the entry there.",
                 "domains": [
                   "tools"
                 ],
@@ -148,7 +148,7 @@
             "kind": "lessons",
             "lessons": [
               {
-                "lesson": "Tool registration lives at crates/stella-tools/src/registry.rs",
+                "lesson": "Register a new tool by editing the ToolRegistry in crates/stella-tools/src/registry.rs.",
                 "domains": [
                   "tools"
                 ],
@@ -238,7 +238,7 @@
             "kind": "lessons",
             "lessons": [
               {
-                "lesson": "Tools register through crates/stella-tools/src/registry.rs",
+                "lesson": "A tool nobody registered in crates/stella-tools/src/registry.rs is invisible to the agent.",
                 "domains": [
                   "tools"
                 ],
@@ -278,7 +278,7 @@
             "kind": "lessons",
             "lessons": [
               {
-                "lesson": "Registered tools come from crates/stella-tools/src/registry.rs",
+                "lesson": "Every builtin is wired through crates/stella-tools/src/registry.rs before it can be called.",
                 "domains": [
                   "tools"
                 ],
@@ -364,6 +364,40 @@
           "shell": [
             {
               "command": "rg -n \"data:\" crates/stella-model/src/anthropic.rs",
+              "succeeded": true
+            }
+          ],
+          "succeeded": true
+        },
+        {
+          "at": 1715382800,
+          "prompt": "work",
+          "transcript": [
+            {
+              "role": "user",
+              "content": "work"
+            },
+            {
+              "role": "assistant",
+              "content": "done"
+            }
+          ],
+          "reflection": {
+            "kind": "lessons",
+            "lessons": [
+              {
+                "lesson": "Tool registration happens in crates/stella-tools/src/registry.rs, so add the new entry there.",
+                "domains": [
+                  "tools"
+                ],
+                "kind": "domain"
+              }
+            ],
+            "provenance": "recorded"
+          },
+          "shell": [
+            {
+              "command": "rg -n \"register\" crates/stella-tools/src/registry.rs",
               "succeeded": true
             }
           ],

--- a/crates/stella-core/src/rules.rs
+++ b/crates/stella-core/src/rules.rs
@@ -693,7 +693,12 @@ pub struct MineConfig {
     /// candidate.
     pub min_occurrences: usize,
     /// Jaccard term-overlap threshold to cluster two lessons as "the
-    /// same".
+    /// same". Must match [`crate::skills::SkillMineConfig::min_similarity`],
+    /// whose doc comment carries the measurements behind the number — both
+    /// miners cluster the same observation pool through
+    /// `crate::mining::cluster_observations`, and a rule threshold that
+    /// drifted from the skill threshold would make one artifact class see
+    /// recurrence the other cannot (#2358).
     pub min_similarity: f64,
     /// Max candidates returned, ranked by score.
     pub limit: usize,
@@ -703,7 +708,7 @@ impl Default for MineConfig {
     fn default() -> Self {
         Self {
             min_occurrences: 3,
-            min_similarity: 0.5,
+            min_similarity: 0.4,
             limit: 10,
         }
     }

--- a/crates/stella-core/src/rules/tests.rs
+++ b/crates/stella-core/src/rules/tests.rs
@@ -701,8 +701,8 @@ fn mine_candidates_respects_the_limit() {
     // Five lessons with deliberately disjoint vocabulary (a shared
     // boilerplate template — e.g. "lesson about {word} handling" —
     // would keep 3 of 4 terms identical across "different" lessons,
-    // pushing Jaccard similarity above the default 0.5 threshold and
-    // collapsing them into one cluster instead of five), each
+    // pushing Jaccard similarity above the default clustering threshold
+    // and collapsing them into one cluster instead of five), each
     // recurring three times so all five clear the occurrence
     // threshold and become candidates before truncation.
     let lessons = [

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -596,6 +596,25 @@ pub struct SkillMineConfig {
     pub min_occurrences: usize,
     /// Jaccard term-overlap threshold to cluster two observations as "the
     /// same".
+    ///
+    /// This number lives in `crate::mining::terms`'s token space and only
+    /// there. It is deliberately **not** `stella-store`'s dedup threshold
+    /// (`SIMILARITY_THRESHOLD`, 0.5): that constant was measured over
+    /// `forget::tokens`, which keeps a file path as ONE token and keeps
+    /// stopwords, while `terms` shatters the same path into five terms and
+    /// drops stopwords — so the same pair of lessons scores differently under
+    /// each. The two numbers describe different spaces and must be tuned
+    /// against measurements in their own space (#2358).
+    ///
+    /// Measured in *this* space, over lessons phrased the way a real
+    /// engagement phrases them: four naturally-varied restatements of one
+    /// convention score 0.40 pairwise; short path-dominated phrasings score
+    /// 0.67; the worst adversarial cross-fact pair (two short lessons naming
+    /// different files in one crate) scores 0.36; typical cross-fact pairs
+    /// sit at or below 0.29. The default sits at 0.4 — on the natural-variation
+    /// signal, above the cross-fact ceiling. At the inherited 0.5 the miner
+    /// could only see recurrence worded into the 0.5–0.67 band, which is why
+    /// naturally-phrased conventions never became skills.
     pub min_similarity: f64,
     /// Max candidates returned, ranked by score.
     pub limit: usize,
@@ -605,7 +624,7 @@ impl Default for SkillMineConfig {
     fn default() -> Self {
         Self {
             min_occurrences: 3,
-            min_similarity: 0.5,
+            min_similarity: 0.4,
             limit: 10,
         }
     }

--- a/crates/stella-core/src/skills/migration_contract.rs
+++ b/crates/stella-core/src/skills/migration_contract.rs
@@ -276,11 +276,18 @@ fn lexical_miner_counts_events_not_distinct_tasks() {
 /// observation. Both halves are gate-relevant: the typed path reuses this
 /// miner, so a threshold change would move the promotion bar for every user
 /// without touching a settings file.
+///
+/// `min_similarity` moved 0.5 → 0.4 as the #2358 fix: 0.5 was inherited from
+/// the store's dedup constant, which is measured in a different token space,
+/// and it put naturally-varied restatements of one convention (0.40 pairwise
+/// in `mining::terms` space) permanently out of clustering reach. The field's
+/// doc comment on [`SkillMineConfig`] carries the measurements; moving the
+/// number again means re-measuring, not editing this assertion to match.
 #[test]
 fn the_shipped_thresholds_are_three_occurrences_or_one_salient() {
     let config = SkillMineConfig::default();
     assert_eq!(config.min_occurrences, 3);
-    assert_eq!(config.min_similarity, 0.5);
+    assert_eq!(config.min_similarity, 0.4);
     assert_eq!(config.limit, 10);
 
     let two = (0..2)

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -445,20 +445,23 @@ harness earning its keep before it shipped.
 
 ### 13.1 Four measurements that changed the fixtures
 
-1. **The dedup filter and the skill miner use the same metric at the same
-   threshold, so a corpus of natural repetitions builds nothing.**
-   `retain_unknown` drops a lesson at Jaccard `>= 0.5` against existing
-   memories, *before* the mining log is appended — so a dropped lesson never
-   becomes an observation and can never contribute an occurrence. The miner then
-   clusters at `min_similarity: 0.5`. For a cluster of three to form, three
-   lessons must be similar enough to cluster while staying dissimilar enough to
-   survive dedup. The band exists **only because the tokenizers differ**:
-   `stella_store::forget::tokens` keeps a path as one token and keeps stopwords,
-   while `stella_core::mining::terms` shatters the path into five terms and
-   drops them. Four naturally-varied phrasings of one convention mined **zero**
-   candidates; four written into the band mined a skill and a rule. Filed as
-   **#2358** — the committed corpus is worded around this defect, and that
-   workaround should not outlive it.
+1. **The dedup filter and the skill miner used the same metric at the same
+   threshold, so a corpus of natural repetitions built nothing.** Filed as
+   **#2358** and fixed in two halves. Ordering: `partition_known` (né
+   `retain_unknown`) now *diverts* a store-restatement to the mining log
+   instead of dropping it before the log was appended, so re-learning — the
+   most common recurrence shape — finally counts as an occurrence while the
+   store still keeps one copy. Threshold: the miners' `min_similarity` moved
+   from the inherited 0.5 to 0.4, a value measured in
+   `stella_core::mining::terms`'s own token space (naturally-varied same-fact
+   pairs score 0.40; the worst cross-fact pair 0.36) rather than borrowed from
+   `stella_store::SIMILARITY_THRESHOLD`, which is measured over a tokenizer
+   that keeps a path as one token where `terms` shatters it into five. The
+   relationship is declared and tripwired by
+   `the_dedup_and_clustering_predicates_hold_the_declared_relationship`, and
+   the committed corpus is now worded the way a real engagement words itself —
+   four natural phrasings plus one near-restatement — instead of being
+   engineered into the accidental band the old thresholds left open.
 2. **The foundry holes only a value-like argument.** `classify_argument` makes a
    positional argument a parameter only if it is a path or a number, so
    `cargo test -p <crate>` yields a different signature per crate and never
@@ -504,8 +507,6 @@ harness earning its keep before it shipped.
 
 ### 13.3 Still open
 
-- **#2358** — the dedup/mining threshold collision. The most consequential thing
-  the harness has found.
 - **#2359** — the placeholder metric.
 - **The corpus can prove the corpus.** §6's recurrence profile mitigates it and
   does not remove it.


### PR DESCRIPTION
## What & why

Skill and rule auto-creation from reflection was reachable only inside a narrow, accidental band, found by replaying the real loop under the trace-replay harness (#2304). Two defects composed into it, and this PR fixes both halves:

**Ordering.** `retain_unknown` dropped a store-restatement *before* the mining log was appended, so re-learning — the most common recurrence shape the loop sees (measured: 61% of a live store was restatement) — never became an observation and could never contribute an occurrence to either miner. It is now `partition_known`, which **diverts** a restatement to `reflections.jsonl` instead of dropping it: the store still keeps one copy per fact (recall has a budget, and that dedup is right), while the log records every recurrence. Within-batch stutter still lands nowhere, so one verbose reflection cannot impersonate three turns of evidence.

**Threshold.** The miners clustered at Jaccard ≥ 0.5 — a number inherited from `stella_store::forget`'s dedup constant, which is measured over a tokenizer that keeps a file path as ONE token, where `mining::terms` shatters the same path into five. Measured in the miners' own space, naturally-varied same-fact pairs score **0.40** and the worst adversarial cross-fact pair **0.36** — so at 0.5, natural phrasing could never cluster and only wording engineered into the 0.5–0.67 band ever mined anything. `min_similarity` moves to **0.4** in both miners, with the measurements recorded on the field's doc comment.

The relationship between the two thresholds is now **declared in code and tripwired**: `the_dedup_and_clustering_predicates_hold_the_declared_relationship` asserts both halves of the band on the committed corpus's own strings (the four natural wordings each survive dedup; the fifth trips it; the miner clusters them anyway, *including* the deduped restatement). The committed corpus and `recurring_registry_lessons()` are reworded to natural phrasing plus one near-restatement, the replay tests' long "how to word a fixture around this bug" explanation shrinks to a sentence, and spec `doc:trace-replay-learning-harness` §13.1 item 1 now describes the fix.

Exemplar note: the split keeps decision logic pure and in `stella-core`/`stella-store` (Invariant 2) — only the sequencing lives in `stella-cli`, matching the existing `retain_unforgotten`/`is_suppressed` structure rather than inventing a new mechanism.

Closes #2358

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Both halves verified independently by reverting each in place and re-running:

- **Threshold flip** (0.4 → 0.5): `the_dedup_and_clustering_predicates_hold_the_declared_relationship`, `recurrence_across_distinct_tasks_builds_what_recurrence_within_one_task_does_not`, `the_committed_corpus_builds_a_memory_a_skill_a_rule_and_a_tool`, `an_auto_activated_rule_is_advisory_and_never_blocking`, and `auto_activation_never_clobbers_an_existing_record` all FAIL.
- **Ordering flip** (restatements dropped before the log): four end-to-end replay tests FAIL — the fourth occurrence never lands, so the rule's confidence stays at 70 < 85 and nothing auto-activates.

The negative controls still hold: five turns of ONE task mint nothing (anti-poisoning), unrelated one-off lessons stay singletons, forgotten lessons stay forgotten (`retain_unforgotten` still runs before the log — forgetting remains durable).

## The gate

- [x] `cargo fmt --check`
- [x] clippy clean on the three touched crates (`stella-core`, `stella-store` — untouched in the end, `stella-cli`), `--all-targets`/`--tests`; CI runs the workspace
- [x] `cargo test -p stella-core --lib` (1039), `-p stella-store --lib` (317), `-p stella-cli --bin stella` (1521) all green; CI runs the workspace suite
- [x] Docs updated where behavior changed (doc comments on both `min_similarity` fields, `partition_known`, spec §13.1/§13.3)
- [x] CLA signed
- [x] `Closes #2358` appears both above and as a commit trailer

Renamed test, named per the deleted-test guard's contract:
`memory::learning::dedupe::a_paraphrase_of_a_stored_memory_is_dropped_and_a_new_fact_survives` → `a_paraphrase_of_a_stored_memory_is_diverted_and_a_new_fact_is_stored` (same file, assertion sharpened for the new split; nothing else deleted).

## Nothing left behind

- [x] Filed: #2369 — the far tail of natural variation (same-fact pairs at 0.28) still sits below the cross-fact noise ceiling (0.36) in lexical-Jaccard space; no threshold can catch it, so it needs anchor-aware clustering / IDF-weighting / stemming, written up as a handoff with the measurements.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The observatory's lessons panel and `stella proposals` read `reflections.jsonl` directly; they now see restatements too. That is faithful — the log is the mining journal, and restatements are real events in it. The store-backed `reflections` table mirror stays in lockstep with the jsonl by design.
- `0.4` catches the corpus's natural pairs at exactly 0.40 (6/15, deterministic in f64). The tripwire test asserts through the real miner on the real strings, so a fixture rewording that drops below the threshold fails loudly with the measurements in the failure message trail, not silently.
- Alternative rejected: raising the *dedup* threshold instead (issue direction 2) — it neither lets natural phrasings cluster (their blocker is the miner's space, where they score 0.40) nor preserves the recall-budget measurement behind 0.5 in `forget::tokens` space.

## Summary by Sourcery

Ensure naturally phrased recurring lessons contribute to skill and rule mining while keeping the context store deduplicated.

Bug Fixes:
- Fix loss of recurrence signal by diverting store restatements to the mining log instead of dropping them before mining.
- Fix clustering blind spot by lowering miners’ similarity threshold to a value measured in their own token space and aligning skills and rules thresholds.

Enhancements:
- Refine session memory handling to split novel lessons from restatements, logging both while only storing novel lessons.
- Add a tripwire test that asserts the relationship between store dedup and miner clustering predicates against the committed corpus.
- Tighten replay and dedupe tests to cover restatement diversion, within-batch stutter handling, and recurrence across tasks with natural wording.
- Clarify documentation and spec around dedup vs clustering behavior and the measurements behind the mining thresholds.

Documentation:
- Update trace-replay harness spec and mining configuration docs to describe the new dedup/clustering behavior and measured thresholds.

Tests:
- Expand replay, dedupe, and mining configuration tests to cover the new partitioning of lessons, threshold changes, and the declared dedup/clustering relationship.