### PR TITLE
fix(stella-cli): the raw step loop probes the workspace once per turn, not twice per shell call (#2337)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -73,7 +73,7 @@ use outcome::{
 pub(crate) use outcome::{pipeline_execution_closeout, settled_cost_since};
 use output::*;
 pub(crate) use persistence::{
-    PersistOutcome, close_event_stream, persist_event, persist_event_detailed,
+    PersistOutcome, TurnBracket, close_event_stream, persist_event, persist_event_detailed,
     record_execution_end, spawn_renderer, warn_store_write_failed,
 };
 pub(crate) use presence::SessionPresence;
@@ -567,7 +567,7 @@ async fn run_pipeline_one_shot(
             cost_usd: outcome.total_cost_usd + reflection_report.cost_usd,
         });
     }
-    let rendered = close_event_stream(&registry, tx, renderer).await;
+    let rendered = close_event_stream(&registry, tx, renderer, TurnBracket::Leave).await;
     let persistence_complete = rendered.persistence_complete;
     let collected = rendered.events;
 
@@ -2143,7 +2143,7 @@ async fn run_turn(
     // channel, ending the renderer's `recv()` loop; awaiting it ensures every
     // already-queued event has actually printed before this function returns
     // (no events lost to a detached task racing process exit).
-    let rendered = close_event_stream(registry, tx, renderer).await;
+    let rendered = close_event_stream(registry, tx, renderer, TurnBracket::Settle).await;
     let persistence_complete = rendered.persistence_complete;
     let collected = rendered.events;
 

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -110,6 +110,21 @@ pub(crate) async fn run_raw_one_shot(
     // Machine-wide presence: findable in the deck's SESSIONS overlay and
     // replayable from its journal after this process exits.
     let mut presence = SessionPresence::announce(cfg, prompt, &registry);
+    // Probe the workspace once for this turn instead of twice per shell call.
+    //
+    // This is the bracket the staged pipeline has always armed and the raw
+    // step loop never did (#2337), which left `ToolRegistry::execute` on its
+    // per-call branch — the granularity `turn_probe`'s own doc comment says
+    // "would have spent the entire trial budget watching itself work". It
+    // measurably did: on Terminal-Bench's `sqlite-with-gcov`, one `tar xzf`
+    // of the vendored SQLite tarball cost ~500s of a 900s budget with nothing
+    // but tree walks to show for it.
+    //
+    // Settled in `close_event_stream` rather than after `run_turn` returns,
+    // because the turn's event sender dies inside it: the ledger would still
+    // be written, but every `FileChange` would be born into a closed channel
+    // and the journal would show a turn that touched nothing.
+    registry.begin_workspace_probe();
     let outcome = run_turn(
         &*provider,
         base_tools,

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -27,10 +27,118 @@ pub(crate) async fn close_event_stream(
     registry: &ToolRegistry,
     tx: stella_core::EventSender,
     renderer: tokio::task::JoinHandle<RendererOutcome>,
+    bracket: TurnBracket,
 ) -> RendererOutcome {
+    // Ahead of `detach_event_stream`, because the settle's `FileChange`s are
+    // born on this sender: settling after the detach would still write the
+    // durable ledger while the journal and the live deck saw nothing change.
+    if matches!(bracket, TurnBracket::Settle) {
+        registry.settle_workspace_probe();
+    }
     registry.detach_event_stream();
     drop(tx);
     renderer.await.unwrap_or_default()
+}
+
+#[cfg(test)]
+mod turn_bracket_tests {
+    use super::*;
+
+    /// Witness for #2337.
+    ///
+    /// The raw step loop arms one workspace-probe bracket per turn and has no
+    /// later stage to close it, so `close_event_stream` is where it settles —
+    /// and it has to settle while the sender is still live, because that is
+    /// where a `FileChange` is born. Fails on `main`, where the function took
+    /// no bracket and settled nothing: a file that only `bash` knew about
+    /// reached the durable ledger and never the journal.
+    #[tokio::test]
+    async fn a_settled_bracket_journals_what_only_the_shell_knew_it_wrote() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let registry = ToolRegistry::new(root, stella_tools::RegistryOptions::default());
+
+        let (raw_tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
+        let tx = stella_core::EventSender::new(raw_tx);
+        registry.attach_events(tx.clone());
+        let renderer = spawn_renderer(rx, OutputFormat::Json, None, "test".to_string(), true);
+
+        registry.begin_workspace_probe();
+        // Opaque by construction: `classify_file_op` reads a tool's input, and
+        // no input describes what a shell command will touch. The tree is the
+        // only witness, which is the whole reason the probe exists.
+        registry
+            .execute(
+                "bash",
+                &serde_json::json!({ "command": "printf hi > witnessed.txt" }),
+            )
+            .await;
+
+        let rendered = close_event_stream(&registry, tx, renderer, TurnBracket::Settle).await;
+        let journalled: Vec<&str> = rendered
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::FileChange { path, .. } => Some(path.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            journalled
+                .iter()
+                .any(|path| path.ends_with("witnessed.txt")),
+            "a settled bracket must journal the shell's write; saw {journalled:?}"
+        );
+    }
+
+    /// The other half of the pair, and the reason the choice is a parameter
+    /// rather than an unconditional settle: the staged pipeline settles in its
+    /// own verify stage and re-arms from that walk, so a settle here would buy
+    /// nothing but a second walk over a tree nothing has touched since.
+    #[tokio::test]
+    async fn leaving_the_bracket_settles_nothing_here() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let registry = ToolRegistry::new(root, stella_tools::RegistryOptions::default());
+
+        let (raw_tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
+        let tx = stella_core::EventSender::new(raw_tx);
+        registry.attach_events(tx.clone());
+        let renderer = spawn_renderer(rx, OutputFormat::Json, None, "test".to_string(), true);
+
+        registry.begin_workspace_probe();
+        registry
+            .execute(
+                "bash",
+                &serde_json::json!({ "command": "printf hi > unwitnessed.txt" }),
+            )
+            .await;
+
+        let rendered = close_event_stream(&registry, tx, renderer, TurnBracket::Leave).await;
+        assert!(
+            !rendered.events.iter().any(|event| matches!(
+                event,
+                AgentEvent::FileChange { path, .. } if path.ends_with("unwitnessed.txt")
+            )),
+            "an unsettled bracket must leave the delta for its own owner to settle"
+        );
+    }
+}
+
+/// Whether closing this stream also closes the turn's workspace-probe bracket.
+///
+/// The raw step loop arms one bracket per turn ([`super::goal::run_raw_one_shot`])
+/// and has no later stage to settle it, so the settle belongs here — the last
+/// instant at which the sender is still live. The staged pipeline settles in
+/// its own verify stage and re-arms from that same walk, so asking for a
+/// settle here would only buy a second walk to re-measure a tree that nothing
+/// has touched since the first one.
+pub(crate) enum TurnBracket {
+    /// Settle the armed probe before releasing the senders.
+    Settle,
+    /// Leave it armed — this path settles its bracket elsewhere, or never
+    /// armed one, in which case `settle_workspace_probe` is a no-op anyway.
+    Leave,
 }
 
 /// `durable_pre_persisted` is set when [`super::output::event_sender_for_run`]

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -400,9 +400,11 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
     // drop ours, and only then await the renderer — otherwise the channel
     // never closes and a completed resume hangs.
     drop(tx);
-    let persistence_complete = close_event_stream(&tools_registry, events, renderer)
-        .await
-        .persistence_complete;
+    // Resume arms no bracket of its own, so there is nothing here to settle.
+    let persistence_complete =
+        close_event_stream(&tools_registry, events, renderer, TurnBracket::Leave)
+            .await
+            .persistence_complete;
     let files = tools_registry.files_touched();
     if let Some((store, id)) = &execution
         && !record_execution_end(


### PR DESCRIPTION
## What & why

The raw step loop probed the workspace **twice per shell call**. It now probes **once per turn**, which is what `turn_probe`'s own doc comment says the design requires:

> one walk of a 20,000-entry tree costs ~1s, a turn issues hundreds of shell calls, and the harness kills a trial at 900s. **Per-call probing would have spent the entire trial budget watching itself work.**

The staged pipeline arms that bracket. `run_raw_one_shot` never did, so `ToolRegistry::execute` fell to the per-call branch — the exact granularity the comment rejects.

Closes #2337

## The evidence

Measured on Terminal-Bench 2.1 `sqlite-with-gcov`, Opus 5 xhigh, bare step loop. Per-tool-call breakdown of one trial from `stella-events.jsonl`, **after** the touch bound (#2344) was already in the binary:

```
#11  60.5s  bash  ->  499.3s   257 file_change   <- tar xzf sqlite-fossil-release.tar.gz
#16 588.1s  bash  ->  165.0s     0               <- apt-get install
#17 753.1s  bash  ->  135.4s     5               <- ./configure --enable-gcov
model 82s of 893s -> 811s (91%) OUTSIDE the model
```

A `tar xzf` takes seconds. The other ~495s was tree walking. The touch bound capped what those walks **record**; this caps how often they **happen** — the two are complementary halves, which is why capping recording alone left most of the cost standing (touches fell 9×, the call time fell ~1.4×).

For scale, on the same task and model tier: the arm scored **0/6** before the touch bound and **5/6** after it, tying Claude Code's 5/6. Both of that arm's remaining timeouts are clock-bound, which is what this PR targets.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_settled_bracket_journals_what_only_the_shell_knew_it_wrote` — a `bash` call writes a file no tool schema describes, and the settled bracket puts it on the journal.

Its control, `leaving_the_bracket_settles_nothing_here`, is **main's behavior**: same setup, no settle, no `FileChange`. The pair demonstrates the same event's absence and presence rather than asserting only the happy path.

## Design notes for reviewers

**Why the settle is in `close_event_stream` and not after `run_turn` returns.** The turn's event sender dies inside `run_turn`. Settling afterwards would still write the durable ledger, but every `FileChange` would be born into a closed channel — the journal and the live deck would show a turn that touched nothing, while the ledger disagreed. Settling before `detach_event_stream` is the last instant at which both are true.

**Why `TurnBracket` is a parameter rather than an unconditional settle.** The pipeline settles in its own verify stage and *re-arms from that same walk*; a second settle at close would buy one more walk over a tree nothing had touched since. `Leave` is also right for `resume`, which arms no bracket at all — there the settle is already a no-op, and saying so is cheaper than making a reader prove it.

**Why `agent.rs` gained no lines.** It sits at exactly its 2270-line ceiling. The two call sites were *modified* in place and `TurnBracket` joined an existing re-export list, so the ratchet sees no growth. Verified: still 2270.

## The gate

- [x] `cargo fmt --all`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli --bin stella` — 1521 passed, 0 failed
- [x] File-size ratchet: `agent.rs` unchanged at 2270

## Nothing left behind

- [x] Filed: #2339 (`arenabench run` crashes on `match.id`, orphaning runs)

One gap named rather than fixed, and called out in the commit message: **the interactive multi-turn loop** (`agent.rs`'s other `run_turn` caller) still arms no bracket, so it remains on per-call probing. `run_turn` now settles unconditionally, which is a harmless no-op there until something arms it. Filing a follow-up for that arming; it needs a line in `agent.rs`, which is at its ceiling, so it wants a relief valve rather than a one-liner.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types (`TurnBracket` is `pub(crate)`, never serialized)

## Anything reviewers should know?

Stacked on the touch bound in #2344, which is still unmerged at time of writing — the two fix different halves of the same cost and the numbers above were taken with #2344's commit in the binary. Landing this one alone would help less than the figures suggest.

## Summary by Sourcery

Align workspace probe behavior in the raw step loop with turn-level probing and ensure probes are settled while the event stream is still live.

Bug Fixes:
- Prevent the raw step loop from probing the workspace on every tool call by introducing a turn-scoped probe bracket that settles once per turn.

Enhancements:
- Add a TurnBracket parameter to event stream closure to control whether a workspace probe is settled or left for another stage.
- Update turn, pipeline, and resume flows to pass the appropriate TurnBracket choice when closing the event stream, avoiding redundant tree walks.

Tests:
- Add witness tests that verify settled brackets journal shell-created file changes while unset brackets leave the delta to be settled elsewhere.