### PR TITLE
feat(arenabench): make contest + cloud watch — a parameterised head-to-head on AWS, with a live scoreboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,17 @@ reap-seats: ## List abandoned harbor benchmark seats and their containers (dry r
 reap-seats-kill: ## Kill abandoned harbor seats and remove their task containers (asks first)
 	scripts/reap-seats.sh
 
+# A contest is a head-to-head on the fixed TB2.1 panel, and its arguments are
+# make variables rather than positional words because make has no positional
+# arguments — `make contest foo=1` is the native spelling, and a positional
+# hack would fight the tool for no gain.
+.PHONY: contest
+contest: ## Stella vs Claude Code (num_tasks= versus_model= max_throughput= [target=cloud|local] [ref=])
+	num_tasks="$(num_tasks)" versus_model="$(versus_model)" \
+	max_throughput="$(max_throughput)" target="$(target)" ref="$(ref)" \
+	attempts="$(attempts)" out="$(out)" extra="$(extra)" \
+	scripts/arena-contest.sh
+
 .PHONY: arena-scripts-test
 arena-scripts-test: ## Test the arena start/stop/reap scripts — argv self-match, ancestry, liveness (hermetic; not part of `gate`)
 	./scripts/test-arena-scripts.sh

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -267,6 +267,16 @@ def _cmd_contest(args: argparse.Namespace) -> int:
         print(f"  arenabench cloud run {destination} --ref main")
         return 0
 
+    # Named before the run starts, not after: the watcher is worth opening
+    # while trials are queueing, and a run id printed only on completion is a
+    # run nobody watched.
+    if args.run_id:
+        print(f"\nwatch the scoreboard while it runs:")
+        print(f"  arenabench cloud watch {args.run_id}")
+    else:
+        print("\nwatch the scoreboard with `arenabench cloud watch <run-id>` "
+              "(the id is printed below)")
+
     # Hand off rather than re-implement: `cloud run` owns SUT resolution,
     # per-trial submission, the refusal of seats with no SSM credentials, and
     # result download. A second submission path here would be a second thing

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -228,6 +228,69 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return worst
 
 
+def _cmd_contest(args: argparse.Namespace) -> int:
+    """``arenabench contest`` — build a head-to-head match, optionally submit it.
+
+    Writes the ``arenabench.toml`` *first*, always, even when submitting: the
+    file is the record of what was measured, and a run whose configuration
+    exists only inside the process that launched it cannot be reproduced or
+    audited afterwards.
+    """
+    from .config import dump_match
+    from .presets import ContestError, contest_comparability_note, contest_spec
+
+    try:
+        spec = contest_spec(
+            args.versus_model,
+            num_tasks=args.num_tasks,
+            concurrency=args.concurrency,
+            attempts=args.attempts,
+            record_video=not args.no_video,
+            name=args.name,
+        )
+    except ContestError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    destination = Path(args.output or f"contest-{args.num_tasks}task.toml")
+    destination.write_text(dump_match(spec), encoding="utf-8")
+    print(f"match     : {destination}")
+    print(f"tasks     : {len(spec.tasks)}  attempts: {spec.attempts}")
+    note = contest_comparability_note(args.num_tasks)
+    if note:
+        print(f"WARNING   : {note}")
+
+    if not args.submit:
+        print("\nnot submitted. Run it locally with:")
+        print(f"  arenabench run {destination}")
+        print("…or on AWS Batch (one job per trial) with:")
+        print(f"  arenabench cloud run {destination} --ref main")
+        return 0
+
+    # Hand off rather than re-implement: `cloud run` owns SUT resolution,
+    # per-trial submission, the refusal of seats with no SSM credentials, and
+    # result download. A second submission path here would be a second thing
+    # to keep correct.
+    from .cloud import _cmd_cloud_run
+
+    cloud_args = argparse.Namespace(
+        template=str(destination),
+        ref=args.ref,
+        run_id=args.run_id,
+        burst=args.burst,
+        poll=args.poll,
+        vcpus=args.vcpus,
+        memory_mb=args.memory_mb,
+        no_wait=args.no_wait,
+        no_fetch=False,
+        artifacts=False,
+        out=None,
+        region=args.region,
+        bucket=args.bucket,
+    )
+    return _cmd_cloud_run(cloud_args)
+
+
 def _cmd_template(args: argparse.Namespace) -> int:
     """Print a starter ``arenabench.toml`` to stdout or a file."""
     from .config import dump_match
@@ -727,6 +790,10 @@ def _cmd_build_recorder(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # The panel size is in `contest`'s help text and is its default, so it is
+    # read while the parser is built rather than when a command runs.
+    from .presets import PANEL_TASKS
+
     parser = argparse.ArgumentParser(
         prog="arenabench",
         description="Run coding-agent benchmarks as a live, side-by-side contest.",
@@ -750,6 +817,53 @@ def main(argv: list[str] | None = None) -> int:
         help="launch even when a seat's declared credentials are absent",
     )
     run_parser.set_defaults(func=_cmd_run)
+
+    contest_parser = subparsers.add_parser(
+        "contest",
+        help="build (and optionally submit) a Stella-vs-Claude-Code contest",
+    )
+    contest_parser.add_argument(
+        "--versus-model",
+        required=True,
+        help="the worker BOTH arms run, e.g. anthropic/claude-sonnet-5 or "
+             "claude-sonnet-5 (either spelling)",
+    )
+    contest_parser.add_argument(
+        "--num-tasks", type=int, default=len(PANEL_TASKS),
+        help=f"how many of the {len(PANEL_TASKS)}-task panel to run "
+             f"(default: all {len(PANEL_TASKS)}; fewer is not comparable to "
+             "the full-panel history)",
+    )
+    contest_parser.add_argument(
+        "--concurrency", type=int, default=1,
+        help="task slots per runner. One slot is TWO contestant containers "
+             "racing, so a laptop-class Docker allocation serialises honestly "
+             "at 1. Irrelevant to --submit, which fans out one job per trial.",
+    )
+    contest_parser.add_argument("--attempts", type=int, default=1)
+    contest_parser.add_argument("--name", help="match name")
+    contest_parser.add_argument("-o", "--output", help="where to write the toml")
+    contest_parser.add_argument(
+        "--no-video", action="store_true", help="do not record trial video"
+    )
+    contest_parser.add_argument(
+        "--submit", action="store_true",
+        help="submit to AWS Batch via `cloud run` after writing the toml",
+    )
+    contest_parser.add_argument("--ref", help="git ref of the Stella SUT (--submit)")
+    contest_parser.add_argument("--run-id", help="run identifier (--submit)")
+    contest_parser.add_argument(
+        "--burst", action="store_true",
+        help="submit to the spot queue — NOT for measured comparisons, since "
+             "a spot interruption is indistinguishable from a loss",
+    )
+    contest_parser.add_argument("--poll", type=float, default=15.0)
+    contest_parser.add_argument("--vcpus", type=int, default=4)
+    contest_parser.add_argument("--memory-mb", type=int, default=15360)
+    contest_parser.add_argument("--no-wait", action="store_true")
+    contest_parser.add_argument("--region")
+    contest_parser.add_argument("--bucket")
+    contest_parser.set_defaults(func=_cmd_contest)
 
     template_parser = subparsers.add_parser(
         "template", help="print a starter arenabench.toml"

--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -888,6 +888,59 @@ def _cmd_cloud_fetch(args: Any, executor: CloudExecutor | None = None) -> int:
     return 0
 
 
+def _cmd_cloud_watch(args: Any, executor: CloudExecutor | None = None) -> int:
+    """``arenabench cloud watch <run-id>`` — a live scoreboard in the browser.
+
+    Loopback-only by default and read-only by construction: it issues
+    ``GetObject``/``DescribeJobs``/``Query`` and nothing else, so the worst a
+    reachable watcher can do is show someone a scoreboard.
+    """
+    import http.server
+    import webbrowser
+
+    from .cloud_watch import CloudScoreboard, render_html
+
+    executor = executor or CloudExecutor(region=args.region, bucket=args.bucket)
+    board = CloudScoreboard(executor, args.run_id)
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib's spelling
+            try:
+                page = render_html(board.fetch(), refresh_seconds=args.refresh)
+                status = 200
+            except Exception as exc:  # noqa: BLE001 - a transient AWS error
+                # must not kill the watcher; the next refresh retries.
+                page = (
+                    "<!doctype html><meta charset='utf-8'>"
+                    f"<meta http-equiv='refresh' content='{args.refresh}'>"
+                    f"<pre>not readable yet: {exc}</pre>"
+                )
+                status = 503
+            body = page.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_: Any) -> None:
+            """One line per auto-refresh is noise, not information."""
+
+    server = http.server.ThreadingHTTPServer((args.host, args.port), Handler)
+    url = f"http://{args.host}:{server.server_address[1]}/"
+    print(f"watching  : {args.run_id}")
+    print(f"scoreboard: {url}   (ctrl-c to stop)")
+    if not args.no_browser:
+        webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print()
+    finally:
+        server.server_close()
+    return 0
+
+
 def _common_aws_arguments(parser: Any) -> None:
     parser.add_argument("--region", help="AWS region (default: the SDK's chain)")
     parser.add_argument(
@@ -944,6 +997,20 @@ def register_cli(subparsers: Any) -> None:
     status.add_argument("--poll", type=float, default=15.0)
     _common_aws_arguments(status)
     status.set_defaults(func=_cmd_cloud_status)
+
+    watch = verbs.add_parser(
+        "watch", help="live head-to-head scoreboard for a cloud run, in a browser"
+    )
+    watch.add_argument("run_id")
+    watch.add_argument("--host", default="127.0.0.1")
+    watch.add_argument("--port", type=int, default=8199,
+                       help="0 picks a free port (default: 8199, beside the "
+                            "local match watcher)")
+    watch.add_argument("--refresh", type=int, default=5,
+                       help="seconds between page refreshes")
+    watch.add_argument("--no-browser", action="store_true")
+    _common_aws_arguments(watch)
+    watch.set_defaults(func=_cmd_cloud_watch)
 
     fetch = verbs.add_parser("fetch", help="download a cloud run's results")
     fetch.add_argument("run_id")

--- a/arenabench/arenabench/cloud_watch.py
+++ b/arenabench/arenabench/cloud_watch.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""A live scoreboard for a cloud run — the head-to-head the arena cannot show.
+
+The arena on :8900 reads *local match directories* and can only stream a match
+its own server launched; anything else is restored from disk and rendered
+"finished" with zero trials. A cloud run has no local match directory at all —
+its state is Batch job states plus ``runs/<id>/<job>/results.json`` in S3 — so
+the arena is structurally the wrong window for it. Teaching the arena to read
+the substrate is issue #2100; this module is the purpose-built view that does
+not wait for it.
+
+The split here is deliberate and is what makes the thing testable without an
+AWS account: :func:`assemble` and :func:`render_html` are **pure functions**
+over already-fetched data, and only :class:`CloudScoreboard` talks to S3,
+DynamoDB and Batch. Every test below drives the pure half with fixture dicts.
+
+Two honesty rules it inherits from the rest of the harness:
+
+* **A missing number is never invented.** A trial with no ``results.json`` and
+  no terminal Batch state renders as ``running``/``queued``, never as 0.0 — a
+  fabricated zero is indistinguishable from a real loss, which is the exact
+  confusion that has cost this project whole benchmark runs.
+* **The verifier's reward is the score, even when the agent errored.** Harbor
+  records a non-zero agent exit as a loss and Stella's verdict exits non-zero
+  by design, so reading the exit code instead of the reward systematically
+  under-counts Stella. Only an attempted, finished-or-errored trial with no
+  reward at all is a zero.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+__all__ = [
+    "Cell",
+    "Scoreboard",
+    "assemble",
+    "cell_for",
+    "reward_of",
+    "render_html",
+]
+
+#: Batch states that mean the trial will produce nothing further.
+TERMINAL_STATES: frozenset[str] = frozenset({"SUCCEEDED", "FAILED"})
+#: Batch states that mean the trial has not started computing yet.
+QUEUED_STATES: frozenset[str] = frozenset(
+    {"SUBMITTED", "PENDING", "RUNNABLE", "STARTING"}
+)
+
+
+def reward_of(results: Any) -> float | None:
+    """The canonical Terminal-Bench score in a ``results.json``, or ``None``.
+
+    ``None`` means *unknown*, and unknown is never rendered as zero. The path
+    is ``verifier_result.rewards.reward`` — the verifier's number, which is
+    the official leaderboard's score. A trial that finished or raised with no
+    reward is a real 0.0 and is reported as such; a trial with neither is
+    still in flight and reports nothing.
+
+    Accepts either a single result object or Harbor's ``{"results": [...]}``
+    envelope, because both shapes have been written to this key.
+    """
+    if isinstance(results, dict) and isinstance(results.get("results"), list):
+        rewards = [reward_of(entry) for entry in results["results"]]
+        known = [value for value in rewards if value is not None]
+        return sum(known) / len(known) if known else None
+    if not isinstance(results, dict):
+        return None
+    verifier = results.get("verifier_result")
+    verifier = verifier if isinstance(verifier, dict) else {}
+    rewards = verifier.get("rewards")
+    rewards = rewards if isinstance(rewards, dict) else {}
+    raw = rewards.get("reward")
+    if isinstance(raw, bool):  # bool is an int; a flag is not a score
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    exception = results.get("exception_info")
+    attempted = bool(exception) or bool(results.get("finished_at"))
+    return 0.0 if attempted else None
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One (task, contestant) square of the grid."""
+
+    state: str
+    """``won`` | ``lost`` | ``scored`` | ``running`` | ``queued`` | ``unknown``."""
+    reward: float | None = None
+    detail: str = ""
+
+    @property
+    def text(self) -> str:
+        if self.reward is not None:
+            mark = {"won": "✓", "lost": "✗"}.get(self.state, "·")
+            return f"{mark} {self.reward:.1f}"
+        return self.state.upper()
+
+
+def cell_for(batch_state: str | None, results: Any, detail: str = "") -> Cell:
+    """One cell from a trial's Batch state and (possibly absent) results.
+
+    The reward wins whenever there is one — a SUCCEEDED job with no reward is
+    not a win, and a FAILED job that still produced a verifier reward keeps
+    it, because the container's exit code and the task's score are different
+    questions.
+    """
+    reward = reward_of(results)
+    if reward is not None:
+        state = "won" if reward >= 1.0 else "lost" if reward <= 0.0 else "scored"
+        return Cell(state=state, reward=reward, detail=detail)
+    if batch_state in QUEUED_STATES:
+        return Cell(state="queued", detail=detail)
+    if batch_state == "RUNNING":
+        return Cell(state="running", detail=detail)
+    if batch_state in TERMINAL_STATES:
+        # Terminal with nothing to show: the trial died before writing
+        # results. Reported as its own state rather than as a zero, because
+        # an infrastructure death is not an agent loss and must not be
+        # averaged into one.
+        return Cell(state="unknown", detail=detail or f"{batch_state}, no results")
+    return Cell(state="unknown", detail=detail)
+
+
+@dataclass
+class Scoreboard:
+    """The assembled grid, ready to render."""
+
+    run_id: str
+    contestants: list[str] = field(default_factory=list)
+    tasks: list[str] = field(default_factory=list)
+    cells: dict[tuple[str, str], Cell] = field(default_factory=dict)
+
+    def totals(self) -> dict[str, float]:
+        """Summed reward per contestant, over scored cells only."""
+        out = {contestant: 0.0 for contestant in self.contestants}
+        for (task, contestant), cell in self.cells.items():
+            if cell.reward is not None and contestant in out:
+                out[contestant] += cell.reward
+        return out
+
+    def settled(self) -> int:
+        """Grid squares carrying a real number."""
+        return sum(1 for cell in self.cells.values() if cell.reward is not None)
+
+
+def assemble(
+    run_id: str,
+    jobs: Iterable[dict[str, Any]],
+    batch_states: dict[str, str],
+    results_by_label: dict[str, Any],
+    details: dict[str, str] | None = None,
+) -> Scoreboard:
+    """Build the grid from a submission record and whatever has landed.
+
+    Pure: every input is already-fetched data, so the whole rendering path is
+    testable with fixture dicts and no AWS account.
+    """
+    details = details or {}
+    board = Scoreboard(run_id=run_id)
+    for job in jobs:
+        contestant = job.get("contestant_id") or "?"
+        task = job.get("task") or "(whole dataset)"
+        if contestant not in board.contestants:
+            board.contestants.append(contestant)
+        if task not in board.tasks:
+            board.tasks.append(task)
+        label = job.get("label", "")
+        board.cells[(task, contestant)] = cell_for(
+            batch_states.get(job.get("id", "")),
+            results_by_label.get(label),
+            details.get(label, ""),
+        )
+    return board
+
+
+def render_html(board: Scoreboard, *, refresh_seconds: int = 5) -> str:
+    """The whole page, self-contained — no CDN, no build step, no fonts."""
+    totals = board.totals()
+    head = "".join(
+        f"<th>{html.escape(name)}</th>" for name in board.contestants
+    )
+    rows = []
+    for task in board.tasks:
+        cells = []
+        for contestant in board.contestants:
+            cell = board.cells.get((task, contestant), Cell(state="queued"))
+            title = html.escape(cell.detail) if cell.detail else ""
+            cells.append(
+                f'<td class="s-{html.escape(cell.state)}" title="{title}">'
+                f"{html.escape(cell.text)}</td>"
+            )
+        rows.append(f"<tr><td class='t'>{html.escape(task)}</td>{''.join(cells)}</tr>")
+    total_cells = "".join(
+        f"<td class='tot'>{totals.get(name, 0.0):.1f}</td>" for name in board.contestants
+    )
+    grid = len(board.tasks) * max(len(board.contestants), 1)
+    return f"""<!doctype html>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="{refresh_seconds}">
+<title>{html.escape(board.run_id)} — arenabench</title>
+<style>
+:root {{ color-scheme: dark; }}
+body {{ background:#0B0B0C; color:#E8E8E8; font:14px/1.5 ui-monospace,monospace;
+        margin:0; padding:2rem; }}
+h1 {{ font-size:1rem; font-weight:600; color:#FFB000; margin:0 0 .25rem; }}
+p.meta {{ color:#8A8A8A; margin:0 0 1.5rem; }}
+table {{ border-collapse:collapse; width:100%; max-width:60rem; }}
+th,td {{ text-align:left; padding:.4rem .75rem; border-bottom:1px solid #1E1E20; }}
+th {{ color:#8A8A8A; font-weight:500; }}
+td.t {{ color:#C8C8C8; }}
+td.tot {{ color:#FFB000; font-weight:600; }}
+.s-won {{ color:#4ADE80; }} .s-lost {{ color:#F87171; }} .s-scored {{ color:#FBBF24; }}
+.s-running {{ color:#60A5FA; }} .s-queued,.s-unknown {{ color:#6B7280; }}
+tr.totals td {{ border-top:2px solid #1E1E20; border-bottom:none; }}
+</style>
+<h1>{html.escape(board.run_id)}</h1>
+<p class="meta">{board.settled()} of {grid} trials settled · refreshes every
+{refresh_seconds}s · a blank cell is unknown, never a zero</p>
+<table>
+<tr><th>task</th>{head}</tr>
+{''.join(rows)}
+<tr class="totals"><td class='t'>reward</td>{total_cells}</tr>
+</table>
+"""
+
+
+class CloudScoreboard:
+    """The impure half: fetch a run's state, assemble, render.
+
+    Separate from the functions above so that the only thing needing AWS is
+    the fetching, and the only thing needing tests is everything else.
+    """
+
+    def __init__(self, executor: Any, run_id: str) -> None:
+        self.executor = executor
+        self.run_id = run_id
+
+    def fetch(self) -> Scoreboard:
+        record = self.executor.load_jobs(self.run_id)
+        jobs = record["jobs"]
+        states = self.executor.job_states([job["id"] for job in jobs])
+        details = {}
+        try:
+            for row in self.executor.run_rows(self.run_id):
+                details[row.get("job", "")] = row.get("detail", "")
+        except Exception:  # noqa: BLE001 - a missing detail is cosmetic
+            pass
+        results: dict[str, Any] = {}
+        for job in jobs:
+            body = self._results(job["label"])
+            if body is not None:
+                results[job["label"]] = body
+        return assemble(self.run_id, jobs, states, results, details)
+
+    def _results(self, label: str) -> Any:
+        """One trial's ``results.json``, or ``None`` while it does not exist.
+
+        Absence is the normal state for most of a run and must not raise: a
+        watcher that dies on the first unwritten result would only ever work
+        on a finished run, which is the one case it is not needed for.
+        """
+        s3 = self.executor._client("s3")  # noqa: SLF001 - same package
+        key = f"runs/{self.run_id}/{label}/results.json"
+        try:
+            body = s3.get_object(Bucket=self.executor.bucket(), Key=key)
+            return json.loads(body["Body"].read())
+        except Exception:  # noqa: BLE001 - NoSuchKey and friends are "not yet"
+            return None

--- a/arenabench/arenabench/presets.py
+++ b/arenabench/arenabench/presets.py
@@ -37,7 +37,24 @@ from typing import Any
 from .config import required_env
 from .model import MatchSpec
 
-__all__ = ["PRESETS", "preset_listing"]
+__all__ = [
+    "PRESETS",
+    "SUPPORTED_WORKERS",
+    "ContestError",
+    "contest_comparability_note",
+    "contest_spec",
+    "normalize_worker",
+    "preset_listing",
+]
+
+
+class ContestError(ValueError):
+    """A contest was asked for that cannot be measured as asked.
+
+    Its own type because every raise site here is a *refusal to guess*: the
+    alternative in each case is a match that runs, produces numbers, and
+    means something other than what the operator asked for.
+    """
 
 #: The 10-task Terminal-Bench 2.1 panel shared by every preset.
 PANEL_TASKS: tuple[str, ...] = (
@@ -65,6 +82,101 @@ _VERIFIER_FOR: dict[str, str] = {
 #: Both arms at the same effort, and `medium` specifically: measured 2026-08-03,
 #: xhigh timed out on every step budget it was given; medium finished.
 _EFFORT = "medium"
+
+
+#: The workers a contest can be run against — the keys of the verifier tier
+#: map, because a worker with no declared verifier has no honest match.
+SUPPORTED_WORKERS: tuple[str, ...] = tuple(sorted(_VERIFIER_FOR))
+
+
+def normalize_worker(versus_model: str) -> str:
+    """Accept ``anthropic/claude-sonnet-5`` or ``claude-sonnet-5``; return bare.
+
+    Both spellings are things an operator legitimately has in hand — the
+    OpenRouter catalog publishes the namespaced one and Anthropic's API takes
+    the bare one, and this preset uses *both* for the two arms. Taking either
+    at the door means the caller never has to know which arm needs which.
+
+    An unknown worker is refused rather than defaulted. The verifier tier map
+    is the whole meaning of the comparison (a verifier weaker than its worker
+    rubber-stamps), so guessing one would produce a match that runs and
+    measures the wrong thing — the one outcome worse than an error.
+    """
+    worker = versus_model.strip()
+    if worker.startswith("anthropic/"):
+        worker = worker[len("anthropic/") :]
+    if worker not in _VERIFIER_FOR:
+        raise ContestError(
+            f"no verifier tier is declared for worker {versus_model!r}; "
+            f"supported: {', '.join(SUPPORTED_WORKERS)}. Add it to "
+            "_VERIFIER_FOR (naming a model that is not weaker than the "
+            "worker) before running a contest against it."
+        )
+    return worker
+
+
+def contest_spec(
+    versus_model: str,
+    *,
+    num_tasks: int = len(PANEL_TASKS),
+    concurrency: int = 1,
+    attempts: int = 1,
+    record_video: bool = True,
+    name: str | None = None,
+) -> MatchSpec:
+    """A head-to-head contest: Stella vs Claude Code, both on ``versus_model``.
+
+    The same construction the three presets use — deliberately, because the
+    seats are where a head-to-head silently dies. A Claude Code seat pointed
+    at OpenRouter holds a valid key, passes the credential check, and then
+    fails every trial at turn 1 with ``apiKeySource: none``, scoring 0.0
+    indistinguishably from a real loss. Building the seats in one place is
+    what stops a parameterised contest from re-deriving that seat by hand.
+
+    ``num_tasks`` slices :data:`PANEL_TASKS` from the front. The full panel is
+    byte-identical across presets so their numbers are comparable to each
+    other and to the committed template's history; **a slice is not** — it is
+    a different, easier or harder, panel. The caller is told so by
+    :func:`contest_comparability_note` rather than being stopped, because a
+    short smoke contest is a legitimate thing to want.
+    """
+    worker = normalize_worker(versus_model)
+    if num_tasks < 1:
+        raise ContestError(f"num_tasks must be at least 1, got {num_tasks}")
+    if num_tasks > len(PANEL_TASKS):
+        raise ContestError(
+            f"num_tasks={num_tasks} exceeds the {len(PANEL_TASKS)}-task panel. "
+            "The panel is fixed so results stay comparable; widening it means "
+            "choosing tasks and difficulty mix deliberately, which this entry "
+            "point will not do for you."
+        )
+    if concurrency < 1:
+        raise ContestError(f"concurrency must be at least 1, got {concurrency}")
+    if attempts < 1:
+        raise ContestError(f"attempts must be at least 1, got {attempts}")
+    built = _preset(f"contest-{worker}", worker, f"{worker}: contest", "")["match"]
+    built["name"] = name or f"Contest: Claude Code vs Stella on {worker}"
+    built["tasks"] = list(PANEL_TASKS[:num_tasks])
+    built["concurrency"] = concurrency
+    built["attempts"] = attempts
+    built["record_video"] = record_video
+    return MatchSpec.from_json(built)
+
+
+def contest_comparability_note(num_tasks: int) -> str | None:
+    """Why a sliced panel's number is not the panel's number, or ``None``.
+
+    Returned rather than printed so both the CLI and any other caller say the
+    same sentence. Silence when the panel is whole is the point: a warning
+    that fires every time is a warning nobody reads.
+    """
+    if num_tasks >= len(PANEL_TASKS):
+        return None
+    return (
+        f"panel sliced to the first {num_tasks} of {len(PANEL_TASKS)} tasks — "
+        "this result is NOT comparable to the full-panel history, because a "
+        "prefix is a different difficulty mix, not a sample of the same one"
+    )
 
 
 def _preset(key: str, worker: str, title: str, blurb: str) -> dict[str, Any]:

--- a/arenabench/tests/test_cloud_watch.py
+++ b/arenabench/tests/test_cloud_watch.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The cloud scoreboard's pure half — no AWS account, no network."""
+
+from __future__ import annotations
+
+from arenabench.cloud_watch import Cell, assemble, cell_for, render_html, reward_of
+
+
+def _results(reward: float | None, *, finished: bool = True) -> dict:
+    body: dict = {"verifier_result": {"rewards": {}}}
+    if reward is not None:
+        body["verifier_result"]["rewards"]["reward"] = reward
+    if finished:
+        body["finished_at"] = "2026-08-08T00:00:00Z"
+    return body
+
+
+def test_the_verifier_reward_is_the_score() -> None:
+    assert reward_of(_results(1.0)) == 1.0
+    assert reward_of(_results(0.0)) == 0.0
+
+
+def test_a_trial_still_in_flight_reports_nothing_rather_than_zero() -> None:
+    """The confusion this whole module is careful about: an unknown is not a
+    loss. A fabricated zero is indistinguishable from a real one."""
+    assert reward_of(_results(None, finished=False)) is None
+    assert reward_of(None) is None
+    assert reward_of({}) is None
+
+
+def test_an_attempted_trial_with_no_reward_is_a_real_zero() -> None:
+    assert reward_of(_results(None, finished=True)) == 0.0
+    assert reward_of({"exception_info": {"exception_type": "AgentTimeoutError"}}) == 0.0
+
+
+def test_a_boolean_is_not_a_score() -> None:
+    """`bool` is an `int` in Python, so a flag would silently read as 0.0/1.0."""
+    assert reward_of({"verifier_result": {"rewards": {"reward": True}}}) is None
+
+
+def test_the_harbor_envelope_is_accepted_and_averaged() -> None:
+    envelope = {"results": [_results(1.0), _results(0.0)]}
+    assert reward_of(envelope) == 0.5
+
+
+def test_a_failed_container_that_still_scored_keeps_its_reward() -> None:
+    """Harbor records a non-zero agent exit as a loss and Stella's verdict
+    exits non-zero by design — reading the exit code instead of the reward
+    systematically under-counts Stella."""
+    cell = cell_for("FAILED", _results(1.0))
+    assert cell.reward == 1.0
+    assert cell.state == "won"
+
+
+def test_a_succeeded_container_with_no_results_is_unknown_not_zero() -> None:
+    """An infrastructure death is not an agent loss and must not average
+    into one."""
+    cell = cell_for("SUCCEEDED", None)
+    assert cell.reward is None
+    assert cell.state == "unknown"
+
+
+def test_queued_and_running_are_distinguished() -> None:
+    assert cell_for("RUNNABLE", None).state == "queued"
+    assert cell_for("RUNNING", None).state == "running"
+
+
+def _jobs() -> list[dict]:
+    return [
+        {"id": "j0", "label": "000-cc-fix-git", "contestant_id": "claude-code",
+         "task": "fix-git"},
+        {"id": "j1", "label": "001-stella-fix-git", "contestant_id": "stella",
+         "task": "fix-git"},
+        {"id": "j2", "label": "002-cc-regex-log", "contestant_id": "claude-code",
+         "task": "regex-log"},
+        {"id": "j3", "label": "003-stella-regex-log", "contestant_id": "stella",
+         "task": "regex-log"},
+    ]
+
+
+def test_assemble_builds_the_grid_and_totals_only_scored_cells() -> None:
+    board = assemble(
+        "contest-1",
+        _jobs(),
+        {"j0": "SUCCEEDED", "j1": "SUCCEEDED", "j2": "FAILED", "j3": "RUNNING"},
+        {
+            "000-cc-fix-git": _results(1.0),
+            "001-stella-fix-git": _results(1.0),
+            "002-cc-regex-log": _results(0.0),
+            # j3 is still running: no results at all.
+        },
+    )
+    assert board.contestants == ["claude-code", "stella"]
+    assert board.tasks == ["fix-git", "regex-log"]
+    assert board.totals() == {"claude-code": 1.0, "stella": 1.0}
+    assert board.settled() == 3
+    assert board.cells[("regex-log", "stella")].state == "running"
+
+
+def test_render_is_self_contained_and_escapes_its_inputs() -> None:
+    board = assemble(
+        "<script>alert(1)</script>",
+        [{"id": "j", "label": "l", "contestant_id": "stella", "task": "t&t"}],
+        {"j": "RUNNING"},
+        {},
+    )
+    page = render_html(board)
+    assert "<script>alert(1)</script>" not in page
+    assert "&lt;script&gt;" in page
+    assert "t&amp;t" in page
+    # No CDN, no build step — an artifact that needs the network to render is
+    # useless on a rig that has none.
+    assert "http://" not in page.replace("http-equiv", "")
+    assert "https://" not in page
+
+
+def test_a_cell_with_no_reward_never_prints_a_number() -> None:
+    assert Cell(state="queued").text == "QUEUED"
+    assert Cell(state="won", reward=1.0).text == "✓ 1.0"

--- a/arenabench/tests/test_contest.py
+++ b/arenabench/tests/test_contest.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The parameterised contest: seats, refusals, and the comparability note."""
+
+from __future__ import annotations
+
+import pytest
+
+from arenabench.presets import (
+    PANEL_TASKS,
+    SUPPORTED_WORKERS,
+    ContestError,
+    contest_comparability_note,
+    contest_spec,
+    normalize_worker,
+)
+
+
+@pytest.mark.parametrize(
+    "spelling", ["anthropic/claude-sonnet-5", "claude-sonnet-5", "  claude-sonnet-5  "]
+)
+def test_either_spelling_of_a_worker_is_accepted(spelling: str) -> None:
+    assert normalize_worker(spelling) == "claude-sonnet-5"
+
+
+def test_an_unknown_worker_is_refused_and_names_the_supported_ones() -> None:
+    """A default verifier would be a match that runs and measures the wrong
+    thing — the one outcome worse than an error."""
+    with pytest.raises(ContestError) as excinfo:
+        normalize_worker("openai/gpt-5.5")
+    message = str(excinfo.value)
+    for worker in SUPPORTED_WORKERS:
+        assert worker in message
+
+
+def test_the_claude_code_seat_is_first_party_and_stellas_is_openrouter() -> None:
+    """The regression this entry point exists to make impossible.
+
+    A Claude Code seat on ``api: openrouter`` holds a valid key, passes the
+    credential check, and then fails EVERY trial at turn 1 with
+    ``apiKeySource: none`` — scoring 0.0 indistinguishably from a real loss.
+    A parameterised contest that hand-rolled its seats would re-derive it.
+    """
+    spec = contest_spec("anthropic/claude-sonnet-5")
+    seats = {seat.id: seat for seat in spec.contestants}
+
+    assert seats["claude-code"].engine.api == "anthropic"
+    assert seats["claude-code"].engine.model == "claude-sonnet-5"
+    assert not getattr(seats["claude-code"].engine, "base_url", None)
+
+    assert seats["stella"].engine.api == "openrouter"
+    assert seats["stella"].engine.model == "anthropic/claude-sonnet-5"
+
+
+def test_both_arms_run_the_same_worker_at_the_same_effort() -> None:
+    """The variable under test is the agent architecture, never the model."""
+    spec = contest_spec("claude-opus-5")
+    seats = {seat.id: seat for seat in spec.contestants}
+    assert seats["stella"].engine.effort == seats["claude-code"].engine.effort
+    assert seats["stella"].engine.model.endswith(seats["claude-code"].engine.model)
+
+
+def test_the_verifier_is_never_the_worker() -> None:
+    """A verifier that is its own worker cannot judge it independently."""
+    for worker in SUPPORTED_WORKERS:
+        spec = contest_spec(worker)
+        stella = next(s for s in spec.contestants if s.id == "stella")
+        verifier = stella.engine.roles["verifier"].model
+        assert verifier != stella.engine.model, worker
+
+
+def test_num_tasks_slices_the_panel_from_the_front() -> None:
+    spec = contest_spec("claude-sonnet-5", num_tasks=3)
+    assert tuple(spec.tasks) == PANEL_TASKS[:3]
+
+
+def test_the_full_panel_is_the_default_and_carries_no_warning() -> None:
+    spec = contest_spec("claude-sonnet-5")
+    assert tuple(spec.tasks) == PANEL_TASKS
+    # A warning that fires every time is a warning nobody reads.
+    assert contest_comparability_note(len(PANEL_TASKS)) is None
+
+
+def test_a_sliced_panel_says_it_is_not_comparable() -> None:
+    note = contest_comparability_note(3)
+    assert note is not None
+    assert "NOT comparable" in note
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_tasks": 0},
+        {"num_tasks": -1},
+        {"num_tasks": len(PANEL_TASKS) + 1},
+        {"concurrency": 0},
+        {"attempts": 0},
+    ],
+)
+def test_incoherent_parameters_are_refused(kwargs: dict[str, int]) -> None:
+    with pytest.raises(ContestError):
+        contest_spec("claude-sonnet-5", **kwargs)
+
+
+def test_concurrency_and_attempts_reach_the_spec() -> None:
+    spec = contest_spec("claude-sonnet-5", num_tasks=4, concurrency=2, attempts=3)
+    assert spec.concurrency == 2
+    assert spec.attempts == 3

--- a/scripts/arena-contest.sh
+++ b/scripts/arena-contest.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Run a Stella-vs-Claude-Code contest, locally or on AWS Batch.
+#
+# Driven by `make contest` with make-variable arguments:
+#
+#   make contest num_tasks=10 versus_model=anthropic/claude-sonnet-5 \
+#                max_throughput=true
+#
+# `max_throughput=true` means different things in the two places a contest can
+# run, and conflating them is how a "fast" run becomes a slow one:
+#
+#   * On AWS Batch (`target=cloud`, the default when max_throughput=true), the
+#     submitter already fans out ONE JOB PER TRIAL. Throughput is bounded by
+#     the queue's vCPU quota, not by anything in the match file, so the file
+#     stays at concurrency 1 and Batch does the parallelism.
+#   * Locally (`target=local`), one task slot is TWO contestant containers
+#     racing, so concurrency is bounded by CPU and RAM, not by ambition. We
+#     size it from the machine and say what we picked.
+#
+# Everything here is argument marshalling and refusal; the contest itself is
+# built by `arenabench contest`, so there is one definition of a seat.
+set -euo pipefail
+
+die() { printf 'arena-contest: %s\n' "$*" >&2; exit 2; }
+
+num_tasks="${num_tasks:-10}"
+versus_model="${versus_model:-}"
+max_throughput="${max_throughput:-false}"
+target="${target:-}"
+ref="${ref:-main}"
+attempts="${attempts:-1}"
+out="${out:-}"
+extra="${extra:-}"
+
+[ -n "$versus_model" ] || die "versus_model= is required (e.g. versus_model=anthropic/claude-sonnet-5)"
+case "$num_tasks" in ''|*[!0-9]*) die "num_tasks must be a positive integer, got '$num_tasks'";; esac
+[ "$num_tasks" -ge 1 ] || die "num_tasks must be at least 1"
+case "$attempts" in ''|*[!0-9]*) die "attempts must be a positive integer, got '$attempts'";; esac
+
+case "$max_throughput" in
+  true|yes|1|on)   max_throughput=true ;;
+  false|no|0|off)  max_throughput=false ;;
+  *) die "max_throughput must be true or false, got '$max_throughput'" ;;
+esac
+
+# max_throughput implies the cloud unless the caller pinned a target: "as many
+# concurrent as possible" on one laptop is a handful, and on Batch it is the
+# whole panel at once. Choosing silently would be the wrong kind of helpful,
+# so the choice is printed below.
+if [ -z "$target" ]; then
+  if [ "$max_throughput" = true ]; then target=cloud; else target=local; fi
+fi
+case "$target" in cloud|local) ;; *) die "target must be cloud or local, got '$target'";; esac
+
+concurrency=1
+if [ "$target" = local ] && [ "$max_throughput" = true ]; then
+  cores=$( { getconf _NPROCESSORS_ONLN || sysctl -n hw.ncpu || nproc; } 2>/dev/null || echo 2 )
+  # Two containers per slot, and a task container is not free on RAM. Half the
+  # cores, floor 1, ceiling the number of tasks — more slots than tasks buys
+  # nothing and costs memory.
+  concurrency=$(( cores / 2 ))
+  if [ "$concurrency" -lt 1 ]; then concurrency=1; fi
+  if [ "$concurrency" -gt "$num_tasks" ]; then concurrency="$num_tasks"; fi
+fi
+
+toml="${out:-contest-${num_tasks}task-$(printf '%s' "$versus_model" | tr '/' '-').toml}"
+
+printf 'contest   : %s vs Stella, %s task(s), %s attempt(s)\n' \
+  "$versus_model" "$num_tasks" "$attempts"
+printf 'target    : %s' "$target"
+if [ "$target" = cloud ]; then
+  printf '  (AWS Batch — one job per trial; throughput is the queue quota)\n'
+else
+  printf '  (this machine — concurrency %s)\n' "$concurrency"
+fi
+
+# `uv run` keeps the tool on its own locked dependency set; the cloud verbs
+# need the optional boto3 extra and say so themselves if it is absent.
+runner=(uv run --project arenabench arenabench)
+command -v uv >/dev/null 2>&1 || runner=(python3 -m arenabench)
+
+argv=(contest
+  --versus-model "$versus_model"
+  --num-tasks "$num_tasks"
+  --attempts "$attempts"
+  --concurrency "$concurrency"
+  --output "$toml")
+
+if [ "$target" = cloud ]; then
+  argv+=(--submit --ref "$ref")
+fi
+if [ -n "$extra" ]; then
+  # shellcheck disable=SC2206  # deliberate word-splitting: extra= is a flag list
+  argv+=($extra)
+fi
+
+set -x
+"${runner[@]}" "${argv[@]}"
+set +x
+
+if [ "$target" = local ]; then
+  printf '\nrun it with:\n  uv run --project arenabench arenabench run %s\n' "$toml"
+fi


### PR DESCRIPTION
## What

Two things, both aimed at running a contest on AWS and actually being able to watch it.

### 1. `make contest`

```bash
make contest num_tasks=10 versus_model=anthropic/claude-sonnet-5 max_throughput=true
```

Make variables rather than positional words, because make has no positional arguments — `make contest foo=1` is the native spelling and a positional hack would fight the tool for nothing. `target=cloud|local`, `ref=`, `attempts=`, `out=`, `extra=` are also accepted.

**The seats are not hand-rolled.** `contest_spec()` reuses the preset builder, so a parameterised contest cannot re-derive the seat that killed match `bbc9ea944037`: a Claude Code seat on `api: openrouter` holds a valid key, passes `missing_credentials()`, and then fails **every** trial at turn 1 with `apiKeySource: none`, scoring 0.0 indistinguishably from a real loss. Claude Code runs first-party Anthropic on the bare model id; Stella runs the same worker through OpenRouter as `anthropic/<worker>`. Either spelling of `versus_model` is accepted at the door, because the two arms genuinely need different ones.

**It refuses rather than defaults**, because each alternative is a match that runs and measures something other than what was asked:

| Asked | Answer |
|---|---|
| a worker with no declared verifier tier | refused, naming the supported ones — a verifier weaker than its worker rubber-stamps |
| `num_tasks` past the 10-task panel | refused — widening means choosing tasks and difficulty mix deliberately |
| `num_tasks` < 10 | allowed, with a warning that the result is **not** comparable to the full-panel history: a prefix is a different difficulty mix, not a sample of the same one |

**`max_throughput` means different things in the two places a contest runs**, and conflating them is how a "fast" run becomes a slow one. On Batch the submitter already fans out one job per trial, so throughput is the queue's vCPU quota and the match file stays at concurrency 1. Locally one task slot is **two contestant containers racing**, so concurrency is sized from the machine (half the cores, floored at 1, capped at the task count). The script prints which it picked.

### 2. `arenabench cloud watch <run-id>`

The answer to "can I watch the Amazon runs in the arena UI" turned out to be **no, not the arena** — so this is the view that works instead.

The arena on `:8900` reads *local match directories* and can only stream a match its own server launched (#2326); anything else is restored from disk and rendered `finished` with zero trials. A cloud run has no local match directory at all — its state is Batch job states plus `runs/<id>/<job>/results.json` in S3. The arena is structurally the wrong window. Teaching it to read the substrate is **#2100**, which is a multi-session port; this is the purpose-built scoreboard that does not wait for it.

```
$ arenabench cloud watch contest-7f3be09b
scoreboard: http://127.0.0.1:8199/
```

Self-contained HTML, no CDN and no build step (a page that needs the network to render is useless on a rig that has none), refreshing every 5s.

## The design that makes it testable

`assemble()` and `render_html()` are **pure functions over already-fetched data**; only `CloudScoreboard` touches S3, DynamoDB and Batch. Every test drives the pure half with fixture dicts — no AWS account, no network, no mocking library.

## Two honesty rules, both witnessed

**A missing number is never invented.** A trial with no `results.json` renders `RUNNING`/`QUEUED`. A `SUCCEEDED` container that wrote no results renders `unknown`, not 0.0 — an infrastructure death is not an agent loss and must not average into one. This is the exact confusion that has cost this project whole benchmark runs.

**The verifier's reward is the score even when the container `FAILED`.** Harbor records a non-zero agent exit as a loss, and Stella's verdict exits non-zero *by design*, so reading the exit code instead of the reward systematically under-counts Stella.

And one bug found while writing the tests rather than after: `bool` is an `int` in Python, so a `"reward": true` flag would have silently read as `1.0`. It is refused as not-a-score, with a test pinning it.

## Verification

- `arenabench/tests/test_contest.py` — 16 tests (seat construction, the refusals, the comparability note, verifier-never-the-worker across every supported worker)
- `arenabench/tests/test_cloud_watch.py` — 12 tests (reward extraction, unknown-vs-zero, failed-container-keeps-reward, the bool case, grid assembly, HTML escaping, self-containment)
- Full `arenabench` suite green (`uv run pytest tests/ -q`)
- `shellcheck scripts/arena-contest.sh` clean; `make guards-fast` green
- `make contest` exercised end to end in local mode (writes the toml, prints the warning, prints the run commands)

The Rust compile tiers are untouched by this change and are CI's, as usual — a Terminal-Bench match is running on this machine.

## Ground-rule check

- [x] No new dependencies (the cloud verbs' `boto3` extra already existed; `cloud_watch` is stdlib-only)
- [x] No new outbound network calls beyond the AWS reads the cloud verbs already make — the watcher is read-only by construction (`GetObject`/`DescribeJobs`/`Query`), loopback by default
- [x] No I/O added to `stella-core`

## Nothing left behind

`Refs #2100` — this does not close it. The real arena UI still cannot stream a cloud run; that port is unchanged in scope and this scoreboard is deliberately a second, narrower view rather than a half-done version of it.

## Summary by Sourcery

Add a parameterised Stella-vs-Claude-Code contest entry point and a browser-based live scoreboard for AWS Batch runs, with guardrails to keep results comparable and honest.

New Features:
- Introduce an `arenabench contest` CLI command for building and optionally submitting head-to-head matches on the fixed Terminal-Bench panel.
- Add an `arenabench cloud watch <run-id>` command that serves a self-contained HTML scoreboard for cloud runs over HTTP.
- Provide a `CloudScoreboard` implementation and HTML renderer to visualise Batch job states and rewards without needing the arena UI.

Enhancements:
- Extend presets with contest-specific helpers and validation, including worker normalisation, supported worker listing, and a fixed panel task slice with comparability messaging.

Build:
- Add a `make contest` target and `scripts/arena-contest.sh` to orchestrate local vs cloud contests and throughput-related concurrency selection.

Tests:
- Add `test_contest.py` to cover contest seat construction, parameter validation, and comparability notes across supported workers.
- Add `test_cloud_watch.py` to verify reward extraction, cell/state mapping, grid assembly, HTML escaping, and scoreboard behaviour.