### PR TITLE
feat(arenabench): Sonnet 5 head-to-head with Stella's pipeline off, and a guard on the committed match files

### DIFF
--- a/arenabench/matches/sonnet5-cc-vs-stella-bare-loop.toml
+++ b/arenabench/matches/sonnet5-cc-vs-stella-bare-loop.toml
@@ -1,0 +1,135 @@
+# arenabench match — Sonnet 5, Claude Code vs Stella's BARE LOOP
+#
+#   local:  arenabench run matches/sonnet5-cc-vs-stella-bare-loop.toml --progress
+#   cloud:  arenabench cloud run matches/sonnet5-cc-vs-stella-bare-loop.toml
+#
+# One worker model on both arms and NO staged pipeline on the Stella arm, so
+# the variable under test is the bare agent loop against Claude Code's — not
+# the model, and not Stella's multi-role orchestration.
+#
+# `bare_loop = true` becomes `STELLA_NO_PIPELINE=1` in the seat's environment
+# and `stella run --no-pipeline` in the container. It settles triage, witness
+# and verify in one word because all three ARE the pipeline, which is why this
+# file carries no `[contestant.engine.roles.*]` table at all: a role override
+# under a bare loop is a pin nothing reads, and a match must not describe a
+# configuration it did not run. The companion arm — same panel, same model,
+# pipeline ON — is the `sonnet5-h2h` preset (`arenabench/presets.py`), so the
+# two files together are the A/B of the pipeline itself.
+#
+# The seats authenticate differently on purpose, exactly as the Fable 5 cycle
+# did:
+#
+#   Claude Code  Anthropic first-party, on a Claude subscription
+#                (CLAUDE_CODE_OAUTH_TOKEN — no metered spend)
+#   Stella       OpenRouter, metered (OPENROUTER_API_KEY)
+#
+# OpenRouter serves Anthropic models from Anthropic, and the arms are not
+# meant to share a provider here — one is deliberately on the subscription, so
+# the routing confound documented in openrouter-headhead-routing-confound does
+# not apply. Claude Code cannot take the OpenRouter route in any case: 2.1.222
+# refuses every model against it, including a plain `claude-sonnet-5`, before
+# issuing a request (measured 2026-08-04, see
+# matches/glm52-claude-code-vs-stella.toml).
+#
+# This file carries no secrets. Export CLAUDE_CODE_OAUTH_TOKEN and
+# OPENROUTER_API_KEY before running; in the cloud both are read from SSM
+# parameters under /arenabench/ and a seat whose credential is absent is
+# refused at submit time rather than scored as a loss.
+
+[match]
+name = "sonnet 5: claude code vs stella (bare loop)"
+dataset = "terminal-bench-2.1"
+
+# The tip of `main` at authoring time, pinned as a full SHA rather than the
+# branch name. `arenabench cloud run` resolves a ref through
+# `binaries/<ref>/latest.json` and only builds on a MISS, so `sut_ref = "main"`
+# silently reuses whatever main-built artifact is already in the bucket —
+# which is "some earlier main", not the latest one. A commit SHA has no cached
+# artifact, so it builds exactly this tree. Override per-run with `--ref`.
+sut_ref = "4f718d9ab7ff0b3edcb4a16c7d698c789f33dbaf"
+
+# The house 10-task Terminal-Bench 2.1 panel (`PANEL_TASKS` in
+# arenabench/presets.py): 1 easy / 6 medium / 3 hard, mirroring the dataset's
+# own 4/54/30 spread rather than over-weighting the tasks both agents already
+# pass, which would compress the delta under test. Same list as the Fable 5
+# cycle and the `sonnet5-h2h` preset, so this run is comparable against them
+# instead of only against itself. No task here is tagged [heavy] — a heavy
+# task forces concurrency to 1 and would serialise the whole panel.
+tasks = [
+  "fix-git",
+  "regex-log",
+  "sqlite-with-gcov",
+  "large-scale-text-editing",
+  "openssl-selfsigned-cert",
+  "nginx-request-logging",
+  "query-optimize",
+  "cancel-async-tasks",
+  "dna-assembly",
+  "write-compressor",
+]
+attempts = 1
+
+# Local-run setting only, and honest at 1 for a laptop-class Docker
+# allocation: one task slot is two contestant containers racing. In the cloud
+# it is not read at all — `arenabench cloud run` slices the match into one
+# (task, seat) trial per Batch container and pins each slice to concurrency 1,
+# because there the container is the unit of isolation.
+concurrency = 1
+
+# Off, deliberately, because this file is written to be launched in the cloud:
+# the Batch runner image ships no recorder build context, so the supervisor
+# would start, find no image, and record nothing. Flip it to `true` for a
+# local run where `arenabench build-recorder` has been run once.
+record_video = false
+
+# Claude Code installs itself per trial: apt-get plus the claude.ai installer,
+# measured at 229s against a 360s default.
+setup_timeout_multiplier = 4.0
+
+[[contestant]]
+id = "claude-code"
+name = "Claude Code (Sonnet 5)"
+agent = "claude-code"
+color = "#FF6B9D"
+
+  [contestant.engine]
+  api = "anthropic"
+  model = "claude-sonnet-5"
+  reasoning = true
+  # `medium` on both arms so effort is not a confound. Measured 2026-08-03:
+  # xhigh timed out on every step budget it was given; medium finished.
+  effort = "medium"
+  # No base_url: this seat runs at Anthropic, authenticated by the
+  # subscription token. No budget_usd either — Claude Code honours no spend
+  # cap, and on the plan the marginal spend is zero; the plan's quota is the
+  # ceiling.
+
+  [contestant.env]
+  # Names only — never values.
+  required = ["CLAUDE_CODE_OAUTH_TOKEN"]
+
+[[contestant]]
+id = "stella"
+name = "Stella (Sonnet 5, bare loop)"
+agent = "stella"
+color = "#FFB000"
+
+  [contestant.engine]
+  api = "openrouter"
+  model = "anthropic/claude-sonnet-5"
+  reasoning = true
+  effort = "medium"
+  # Sonnet 5's real output ceiling, the same number on both routes — asserted
+  # as an equality in stella-model's catalog tests, not transcribed here.
+  max_tokens = 128000
+  # The whole point of this file: raw step loop, no triage, no witness, no
+  # verify, no second model anywhere in the run.
+  bare_loop = true
+  # Per-trial cap (becomes STELLA_BUDGET), with per-trial isolation so one
+  # runaway trial cannot eat the other nine tasks' budget. Held at the
+  # pipeline arm's $12 rather than cut: a bare loop spends less per trial
+  # (one role, not three), and a cap that binds would measure the cap.
+  budget_usd = 12.0
+
+  [contestant.env]
+  required = ["OPENROUTER_API_KEY"]

--- a/arenabench/tests/test_matches.py
+++ b/arenabench/tests/test_matches.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The committed match files under ``matches/``, checked as configuration.
+
+These files are launched — locally by an operator and, through
+``arenabench cloud run``, onto paid AWS Batch capacity. Until now nothing read
+them outside a run, so every mistake in one was discovered by spending money
+on it: a template that does not parse fails at launch, and the more expensive
+shape fails *nowhere at all* — a knob the seat's agent quietly ignores, or a
+pipeline role pinned on an arm that runs no pipeline. Both produce a complete
+run with plausible numbers, described by a file that says it measured
+something else.
+
+The suite deliberately reads the directory rather than a list: a match file
+nobody added here would otherwise be the one that ships unchecked.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from arenabench.agents import resolve_agent
+from arenabench.config import match_from_toml
+from arenabench.model import MatchSpec
+
+MATCHES = Path(__file__).resolve().parent.parent / "matches"
+
+
+def _match_files() -> list[Path]:
+    files = sorted(MATCHES.glob("*.toml"))
+    assert files, f"no match templates under {MATCHES}"
+    return files
+
+
+def _spec(path: Path) -> MatchSpec:
+    return match_from_toml(tomllib.loads(path.read_text(encoding="utf-8")))
+
+
+@pytest.mark.parametrize("path", _match_files(), ids=lambda p: p.name)
+class TestCommittedMatches:
+    def test_parses(self, path: Path) -> None:
+        """`match_from_toml` refuses a bad template; that refusal belongs here,
+        not at the moment a submission has already reserved capacity."""
+        spec = _spec(path)
+        assert spec.contestants, f"{path.name} seats nobody"
+        assert spec.dataset
+
+    def test_every_declared_knob_is_one_its_agent_honours(self, path: Path) -> None:
+        """A setting the agent ignores is a claim the run cannot support.
+
+        `unhonoured` reports only knobs the operator actually set, so this
+        fails exactly when a file describes a configuration its seat never
+        received — a `base_url` on an agent with nowhere to put one, a
+        `budget_usd` on an agent that honours no spend cap.
+        """
+        for seat in _spec(path).contestants:
+            missed = resolve_agent(seat.agent).unhonoured(seat.engine)
+            assert not missed, f"{path.name}: seat {seat.id!r} sets {missed}"
+
+    def test_a_bare_loop_seat_pins_no_pipeline_roles(self, path: Path) -> None:
+        """`bare_loop` settles triage, witness and verify at once, because all
+        three ARE the pipeline. A role override beside it is read by nothing:
+        the run is a single model, while the file — and the scoreboard's
+        published identity — names three.
+
+        Parse cannot catch this. `Engine` carries both fields independently
+        and the runner simply never looks at `roles` once `STELLA_NO_PIPELINE`
+        is set, so the mismatch survives all the way into the results.
+        """
+        for seat in _spec(path).contestants:
+            if seat.engine.bare_loop:
+                assert not seat.engine.roles, (
+                    f"{path.name}: seat {seat.id!r} runs the bare loop but pins "
+                    f"roles {sorted(seat.engine.roles)}"
+                )


### PR DESCRIPTION
## What & why

Two things, one logical change: the match this repo was asked to run, and the
check that makes a committed match file mean what it says.

**`arenabench/matches/sonnet5-cc-vs-stella-bare-loop.toml`** — Claude Code vs
Stella, both arms on `claude-sonnet-5` at `medium` effort, with Stella's staged
pipeline **off**. `bare_loop = true` becomes `STELLA_NO_PIPELINE=1` in the seat
environment (`runner.py`) and `stella run --no-pipeline` in the container
(`stella_harbor/loop_mode.py`), which settles triage, witness and verify at once
because all three *are* the pipeline. The file therefore pins no
`[contestant.engine.roles.*]` table at all — under a bare loop a role override
is a pin nothing reads, and the published identity would name three models the
run never called. The panel is the house 10-task Terminal-Bench 2.1 mix
(`PANEL_TASKS`), identical to the `sonnet5-h2h` preset, so preset and file are
the A/B of the pipeline itself rather than two unrelated runs.

`sut_ref` is a full commit SHA rather than `"main"` deliberately:
`CloudExecutor.resolve_sut` builds only on a `binaries/<ref>/latest.json` miss,
so a branch name silently reuses whatever main-built artifact is already in the
bucket. That is #2388; the SHA is the workaround and the comment says so.

**`arenabench/tests/test_matches.py`** — nothing read these files outside a run
before, so every mistake in one was discovered by spending money on it. The
suite reads the directory rather than a list (a file nobody remembered to add
would be the one that ships unchecked) and holds three properties: every
committed template parses; no seat declares a knob its agent does not honour
(`AgentSpec.unhonoured`); and a `bare_loop` seat pins no pipeline roles.

Exemplar for the parametrized-over-a-directory shape: `ripgrep`'s
`tests/data`-driven suites — the subject is derived from the tree, not
transcribed beside it, which is the same reason `bench.yml` names `bench/` whole
rather than its four subdirectories.

Refs #2387, #2388

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`test_a_bare_loop_seat_pins_no_pipeline_roles` is the load-bearing one, and it
is a genuine fail→pass: parse cannot catch this mismatch, because `Engine`
carries `bare_loop` and `roles` independently and the runner simply stops
reading `roles` once `STELLA_NO_PIPELINE` is set — so the contradiction survives
into the results. Checked the artisanal way: appending a
`[contestant.engine.roles.verifier]` table to the new match file fails the test
with `seat 'stella' runs the bare loop but pins roles ['verifier']`; removing it
passes. `test_parses` and `test_every_declared_knob_is_one_its_agent_honours`
likewise had no coverage before — `matches/*.toml` was read by nothing outside a
launch.

No test deleted or renamed in this PR.

## The gate

- [x] `cargo fmt --check` — no Rust changed; ran the toolchain-free guards
      instead: `no-scratch`, `no-secrets`, `file-size`, `god-files`,
      `left-behind`, `doc-links`, `brand-case`, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust
- [x] `cargo test --workspace` — n/a; the suite this change lives in is the
      ArenaBench one that `bench.yml` runs: **542 passed, 2 skipped**
      (`pytest -q`, Docker-only suites excluded), and `ruff check` clean on the
      new file
- [x] Docs updated where behavior/flags changed — no behavior or flag changed;
      the match file documents its own posture inline, as its siblings do
- [x] CLA signed
- [ ] `Closes #N` — nothing to close; this PR opens work rather than finishing
      an issue

## Nothing left behind

- [x] Filed: #2387, #2388

**#2387 is a blocker for actually launching this match, and it is not fixed
here.** The Batch runner image (`arenabench/infra/runner/Dockerfile`) installs
no `harbor`, no `uv` to provision one, and no `stella_harbor` adapter, so
`arenabench cloud run` would burn one container per trial and measure nothing —
and the Stella seat specifically would raise `AdapterUnavailableError`. It is
filed rather than fixed because the obvious fix (`COPY bench/harbor_adapter`)
collides head-on with the ejection design in `infra/README.md`, where `PkgPath`
becomes `.` and that directory leaves the build context entirely. Publishing
`stella-harbor` to an index, fetching it by git URL + ref the way the SUT
already is, or accepting a transition-guarded monorepo `COPY` are three
different answers with different consequences after the split — a maintainer's
call, not a session's.

#2388 (`--ref main` reuses a stale artifact) is worked around in this file by
pinning a SHA; the fix belongs in `cloud.py`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below —
      no Rust touched, no new dependency in any manifest
- [x] No new outbound network calls

## Anything reviewers should know?

**This match has not been run.** The session that authored it had no AWS
credentials (`sts:GetCallerIdentity` returns `InvalidClientTokenId`), so nothing
was submitted, nothing was spent, and no number here is claimed. What is
verified is the configuration: it parses, both seats resolve, the Stella seat
carries `bare_loop=True` with no roles, both models resolve on their declared
routes in `stella-model`'s seed catalog, and the fan-out is 20 Batch trials
(10 tasks x 2 seats x 1 attempt).

Two deliberate asymmetries, both inherited from the Fable 5 cycle rather than
invented here. The seats authenticate differently — Claude Code first-party on
`CLAUDE_CODE_OAUTH_TOKEN`, Stella metered on `OPENROUTER_API_KEY` — because
Claude Code 2.1.222 refuses every model against OpenRouter before issuing a
request (measured 2026-08-04, documented in
`matches/glm52-claude-code-vs-stella.toml`), and OpenRouter serves Anthropic
models from Anthropic. And `record_video = false`, unlike its siblings: the
Batch runner image ships no recorder build context, so the supervisor would
start, find no image, and record nothing. Flip it for a local run.

`budget_usd` is held at the pipeline arm's $12 rather than cut for the cheaper
bare loop, so the cap cannot bind and become the thing being measured.

---

## Summary by Sourcery

Add a new Sonnet 5 Claude Code vs Stella bare-loop match configuration and introduce tests that validate all committed match templates as configuration rather than discovering issues at run time.

New Features:
- Define a new ArenaBench match file for Claude Code vs Stella running Sonnet 5 with Stella's pipeline disabled and consistent authentication and budgeting settings.

Tests:
- Add a test suite that loads all committed match templates, ensuring they parse, only use knobs honoured by their agents, and that any bare-loop seat does not declare pipeline roles.
