### PR TITLE
fix(arenabench): a trial the agent never ran is not a loss — and it cost us today's tie

### DIFF
--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -377,6 +377,42 @@ class TrialMetrics:
             return None
         return min(100.0, self.cache_read / self.tokens_in * 100.0)
 
+    def never_ran(self) -> bool:
+        """Whether this trial has POSITIVE evidence the agent never got a turn.
+
+        Deliberately conservative, in the direction that costs us. Absence of
+        telemetry is not proof of absence of work — #2132 is exactly that
+        hazard, four trials in one match published no usage at all — so voiding
+        on missing numbers alone would let a genuine loss disappear and flatter
+        the arm. Every condition here has to hold:
+
+        * the trial **did not pass** — a solved task ran, whatever its
+          telemetry says, so a pass is never voided;
+        * the verifier **produced a score** — this rule says "a verdict is not
+          evidence of an attempt", which presupposes a verdict. An UNJUDGED
+          trial is already handled, and handled better, by the `void_setup` /
+          `void_credentials` / `void_cancelled` family below: those name *why*
+          it never got a verdict, and a generic "no fair attempt" here would
+          throw that cause away;
+        * **no steps**, and
+        * **no tokens in either direction** — steps alone would void a trial
+          whose usage failed to attach mid-run;
+        * and a **recorded failure**, which is the positive half: something
+          went wrong at startup and said so. A silent zero stays a loss.
+
+        Not classified on the exception name, because that name is ambiguous:
+        `NonZeroAgentExitCodeError` covers both "Stella crashed at step 40" and
+        "Stella never started", which are opposite facts about the agent.
+        """
+        if self.resolved or self.reward is None:
+            return False
+        return (
+            bool(self.failure)
+            and self.steps <= 0
+            and self.tokens_in <= 0
+            and self.tokens_out <= 0
+        )
+
     def outcome_reason(self) -> str | None:
         """One closed label for *how* this judged trial ended (#2076).
 
@@ -391,6 +427,16 @@ class TrialMetrics:
         """
         if self.status != "done":
             return None
+        if self.never_ran():
+            # Before the verdict is consulted at all. A verifier run against an
+            # untouched workspace returns 0 as surely as one run against a
+            # botched attempt, so `resolved is False` is not evidence that
+            # anything was attempted — and the guard below only reaches
+            # `void_no_fair_attempt` when the trial went UNJUDGED. Six trials
+            # on this rig had zero steps, zero observed spend, a provider that
+            # rejected the very first call, and a scored 0 recorded against the
+            # agent's name (#1480's rule, applied to the shape that slipped it).
+            return "void_no_fair_attempt"
         if self.resolved is None:
             # Group A: judged, no verdict — not agent performance.
             if not self.failure:
@@ -889,7 +935,16 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
     the one nobody can defend afterwards.
     """
     trials = list(trials)
-    judged = [t for t in trials if t.resolved is not None]
+    # A verdict is not evidence of an attempt. The verifier scores an untouched
+    # workspace 0 exactly as it scores a botched one, so a trial the agent
+    # never got a turn in arrives here as `resolved is False` and would divide
+    # into the solve rate as a loss. Six trials on this rig did: zero steps,
+    # zero tokens, a provider that refused the first call, a 0 recorded against
+    # the agent's name. Held out for the same reason `infrastructure` is, and
+    # counted below for the same reason too — the exclusion is disclosed, never
+    # silent.
+    never_ran = [t for t in trials if t.status == "done" and t.never_ran()]
+    judged = [t for t in trials if t.resolved is not None and not t.never_ran()]
     passed = [t for t in judged if t.resolved]
     # Trials that published a proof rail at all. Its own subset, because the
     # rail's denominator is not the match's: a seat with no pipeline
@@ -899,6 +954,11 @@ def aggregate(trials: Iterable[TrialMetrics]) -> dict[str, Any]:
     return {
         "trials": len(trials),
         "infrastructure": sum(1 for t in trials if t.infrastructure),
+        # Trials held out of `judged` because the agent never ran. Distinct
+        # from `infrastructure`, which counts trials that never reached a
+        # verdict at all: these DID get scored, and the score is what had to
+        # be discarded.
+        "never_ran": len(never_ran),
         "running": sum(1 for t in trials if t.status == "running"),
         "done": sum(1 for t in trials if t.status == "done"),
         "judged": len(judged),

--- a/arenabench/tests/test_outcome_reason.py
+++ b/arenabench/tests/test_outcome_reason.py
@@ -130,12 +130,22 @@ class TestAgainstTheLocalCorpus:
                     judged += 1
                     reason = m.outcome_reason()
                     assert reason, f"{match.spec.id}/{m.trial}: judged, no reason"
-                    # Group A == the trials the void machinery already
-                    # excludes (resolved is None on a judged trial); the
-                    # taxonomy must add names, never reclassify.
-                    assert reason.startswith("void_") == (m.resolved is None), (
+                    # A `void_` label must mean exactly "outside the solve
+                    # rate" — the prefix is only useful if it tracks the
+                    # denominator mechanically.
+                    #
+                    # This used to assert `void_ == (resolved is None)`, on the
+                    # premise that only an unjudged trial can be a void. That
+                    # premise was false, and the corpus is what disproved it:
+                    # six trials here have a scored 0 with zero steps, zero
+                    # tokens and a provider that refused the first call. The
+                    # verifier grades an untouched workspace 0 as readily as a
+                    # botched one, so `resolved is False` never meant "the
+                    # agent attempted this". Those six were counted as losses.
+                    excluded = m.resolved is None or m.never_ran()
+                    assert reason.startswith("void_") == excluded, (
                         f"{match.spec.id}/{m.trial}: {reason} vs "
-                        f"resolved={m.resolved}"
+                        f"resolved={m.resolved} never_ran={m.never_ran()}"
                     )
         assert judged, "corpus present but nothing judged — the walk is inert"
 

--- a/arenabench/tests/test_telemetry.py
+++ b/arenabench/tests/test_telemetry.py
@@ -492,6 +492,95 @@ class TestUnpricedModelsAreNamed:
         assert totals["unpriced_models"] == []
 
 
+class TestATrialTheAgentNeverRanIsNotALoss:
+    """A verdict is not evidence of an attempt.
+
+    The verifier scores an untouched workspace 0 exactly as it scores a botched
+    one, so a trial whose agent never got a turn arrives as `resolved=False`
+    and divides into the solve rate as a loss. Six trials on this rig were that
+    shape: zero steps, zero tokens, a provider that refused the very first call
+    (Anthropic HTTP 400), and a 0 recorded against the agent's name. The
+    existing `void_no_fair_attempt` guard could not catch them because it only
+    runs when a trial goes UNJUDGED (#1480).
+
+    Witness for both halves: the label, and — the half that actually moves a
+    number — the denominator.
+    """
+
+    def _never_ran(self) -> TrialMetrics:
+        return TrialMetrics(
+            "a", "a__1", status="done", resolved=False, reward=0.0,
+            failure="NonZeroAgentExitCodeError",
+            steps=0, tokens_in=0, tokens_out=0,
+        )
+
+    def test_zero_work_with_a_scored_verdict_is_labelled_a_void(self):
+        assert self._never_ran().outcome_reason() == "void_no_fair_attempt"
+
+    def test_and_it_leaves_the_solve_rate_denominator(self):
+        """The label alone changes nothing a scoreboard prints."""
+        totals = aggregate(
+            [
+                TrialMetrics("a", "a__1", status="done", resolved=True,
+                             steps=10, tokens_in=100),
+                self._never_ran(),
+            ]
+        )
+        assert totals["judged"] == 1, "the trial that never ran is not judged"
+        assert totals["solve_rate"] == 100.0, "1 of 1 that started, not 1 of 2"
+        assert totals["never_ran"] == 1, "and the exclusion is disclosed, not silent"
+
+    def test_a_real_loss_still_counts_against_the_agent(self):
+        """The guard must not become a way for genuine failures to vanish."""
+        worked_and_lost = TrialMetrics(
+            "a", "a__1", status="done", resolved=False, reward=0.0,
+            failure="AgentTimeoutError", steps=40, tokens_in=5000, tokens_out=900,
+        )
+        assert worked_and_lost.outcome_reason() == "timeout_before_solve"
+        totals = aggregate([worked_and_lost])
+        assert totals["judged"] == 1 and totals["solve_rate"] == 0.0
+        assert totals["never_ran"] == 0
+
+    def test_telemetry_that_failed_to_attach_is_not_mistaken_for_no_attempt(self):
+        """Steps alone would void a trial whose usage never got reported.
+
+        Both zeros are required precisely so a telemetry gap — a real hazard
+        here, see #2132 — cannot be read as "the agent did nothing".
+        """
+        no_usage_but_stepped = TrialMetrics(
+            "a", "a__1", status="done", resolved=False, reward=0.0,
+            failure="AgentTimeoutError", steps=12, tokens_in=0, tokens_out=0,
+        )
+        assert not no_usage_but_stepped.never_ran()
+        assert aggregate([no_usage_but_stepped])["judged"] == 1
+
+    def test_a_pass_is_never_voided_however_thin_its_telemetry(self):
+        """A solved task ran, whatever its usage rows say.
+
+        The first cut of this rule keyed on zeros alone and voided *passing*
+        trials whose telemetry was absent — turning a win into a non-event.
+        The bias has to run the other way: when the evidence is ambiguous the
+        trial stays in the denominator, because a rule that quietly deletes
+        losses flatters the arm it is measuring.
+        """
+        thin_pass = TrialMetrics("a", "a__1", status="done", resolved=True)
+        assert not thin_pass.never_ran()
+        assert aggregate([thin_pass])["solve_rate"] == 100.0
+
+    def test_a_silent_zero_with_no_failure_named_stays_a_loss(self):
+        """No numbers AND no stated reason is ambiguous, so it is not voided.
+
+        Voiding needs the positive half — something went wrong at startup and
+        said so. Absence of evidence is not evidence of absence, and the
+        unflattering reading is the honest default.
+        """
+        silent = TrialMetrics(
+            "a", "a__1", status="done", resolved=False, reward=0.0, failure=""
+        )
+        assert not silent.never_ran()
+        assert aggregate([silent])["judged"] == 1
+
+
 class TestUnmeasuredUsageIsNotZeroUsage:
     """Absence of telemetry is not a measurement of zero (#2132).
 


### PR DESCRIPTION
The verifier grades an untouched workspace 0 exactly as it grades a botched
attempt, so a trial whose agent never got a turn arrives as `resolved=False`
and divides into the solve rate as a failure. Six trials on this rig are that
shape: zero steps, zero tokens, a provider that refused the very first call
(Anthropic HTTP 400), and a scored 0 recorded against the agent's name.

The existing `void_no_fair_attempt` guard (#1480) could not catch them,
because it only runs when a trial goes UNJUDGED. Having a verdict was treated
as proof of having attempted. It is not.

`never_ran()` is deliberately conservative, in the direction that costs us.
Every condition must hold: the trial did not pass (a solved task ran,
whatever its telemetry says); the verifier produced a score (an unjudged
trial keeps its more specific `void_setup`/`void_credentials`/`void_cancelled`
label, which names *why*); no steps; no tokens either way; and a recorded
failure. That last one is the positive half — absence of telemetry is not
evidence of absence of work (#2132 is exactly that hazard), so a silent zero
with no stated reason stays a loss. A rule that quietly deletes losses
flatters the arm it measures.

Not classified on the exception name, because the name is ambiguous:
`NonZeroAgentExitCodeError` covers both "crashed at step 40" and "never
started", which are opposite facts about the agent.

The corpus invariant in `test_outcome_reason` asserted `void_ == (resolved is
None)` under the banner "the taxonomy must add names, never reclassify". That
equivalence WAS the bug — it hard-codes the false premise — so it is updated
to `void_ == (resolved is None or never_ran())`, keeping the property that
actually matters: a `void_` prefix means exactly "outside the solve rate".

What it does to the real boards, and the direction is the point — it mostly
corrects CLAUDE CODE upward, not Stella:

  bbc9ea944037  claude-code   0/15 =  0.0%  ->  0/0            (15 never ran)
  dd52a57a6f49  claude-code    2/6 = 33.3%  ->  2/2 = 100.0%    (4 never ran)
  ba6464fca798  claude-code    1/3 = 33.3%  ->  1/1 = 100.0%    (2 never ran)
  7f3be09b9843  claude-code    5/6 = 83.3%  ->  5/5 = 100.0%    (1 never ran)
  929a79f955d9  stella         0/4 =  0.0%  ->  0/0             (4 never ran)

dd52a57a6f49's four are the 429'd Claude Code trials that were noted by hand
at the time as "scored as losses"; nothing enforced it.

It also revises a result reported earlier today. The Opus-5 bare-loop
head-to-head on `sqlite-with-gcov` (7f3be09b9843) read Stella 5/6 vs Claude
Code 5/6 — a tie. With the corrected denominator it is Stella 5/6 (83.3%) vs
Claude Code 5/5 (100%). Claude Code wins it. That is the first thing the
clean denominator bought, and it cost us the tie.

Witness: six tests, all failing on main — the label
(`assert 'agent_error' == 'void_no_fair_attempt'`), the denominator
(`judged == 1`, `never_ran == 1`), and three guards that a real loss, a
thin-telemetry pass, and a silent zero all stay counted.

## Summary by Sourcery

Exclude trials where the agent never actually ran from solve-rate denominators and mark them with a void outcome reason, while preserving genuine failures as losses.

Bug Fixes:
- Treat zero-work, scored trials with explicit startup failures as `void_no_fair_attempt` instead of counting them as losses in the solve rate.
- Ensure `void_` outcome labels consistently mean "outside the solve rate", including for trials that never ran despite having a verdict.
- Prevent trials with missing telemetry, thin telemetry passes, or silent zeros without a named failure from being incorrectly voided or excluded from the denominator.

Enhancements:
- Introduce a `never_ran` classification on trial telemetry to detect trials where the agent never got a turn and track them separately in aggregate metrics.
- Extend aggregate telemetry metrics to report a `never_ran` count alongside judged and infrastructure trials.
- Tighten outcome-reason invariants and corpus tests to reflect the new `never_ran` semantics and keep the solve-rate denominator mechanically aligned with `void_` labels.

Tests:
- Add a focused test suite covering `never_ran` trials, ensuring correct labeling, denominator handling, and protection against misclassifying real losses or telemetry gaps.