### PR TITLE
feat(loop-bench): per-feature attribution counters in the A/B report (#2382)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stella-core",
+ "stella-protocol",
  "tempfile",
 ]
 

--- a/bench/loop-bench/Cargo.toml
+++ b/bench/loop-bench/Cargo.toml
@@ -28,6 +28,13 @@ path = "src/main.rs"
 # reading the same aggregates, the same guard set, and the same significance
 # test the offline harness applied, and two report types is two standards.
 stella-core = { path = "../../crates/stella-core" }
+# The wire vocabulary the distiller reads (#2382). Only `StageKind` is used,
+# and only to canonicalize a stage name off the stream: the verdict stage is
+# aliased `judge`/`verifier` on the wire, so a hardcoded name list here would
+# split one stage's counter in two AND duplicate the stage vocabulary the
+# protocol crate exists to hold exactly once (L-E1). Already in the build
+# graph beneath `stella-core`, so it costs no compile time.
+stella-protocol = { path = "../../crates/stella-protocol" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -53,9 +53,13 @@ promotion decided by them is a decision about the machine.
 For each trial dir `<jobs-dir>/<job-name>/<task>__<id>/`, `distill_events` reads
 `agent/stella-events.jsonl`: `step_usage` counts model calls, `tool_start` tool
 calls (`write_file` / `edit_file` / `apply_edits` are writes — never
-`delete_file`, or a destructive loop would look productive; `project_overview` /
-`graph_query` are context queries), and a terminal event is `complete` or an
-`error` with `retryable: false`. The reward comes from `verifier/reward.txt`.
+`delete_file`, or a destructive loop would look productive; `project_overview`
+and `graph_query` each get their own column, `ov` and `gq`), and a terminal
+event is `complete` or an `error` with `retryable: false`. The reward comes from
+`verifier/reward.txt`.
+
+Beside those loop-health counters, every trial also carries a **per-feature
+attribution** map — see [§ Feature attribution](#feature-attribution-2382).
 
 Four more files in the same directory are read, each closing a hole where
 harbor knew something the harness did not (#1299) — see
@@ -202,6 +206,81 @@ promote however cleanly the arms separate — it reports
 into a gate (exit `6`); it is off by default because a comparison is a
 measurement and "no winner" is a legitimate answer to it.
 
+## Feature attribution (#2382)
+
+The aggregates above answer *which arm won*. They cannot answer **which feature
+moved**, and that is the question a paired ablation is run to settle. Until
+#2382 the harness attributed exactly two features — `project_overview` and
+`graph_query` — so every other feature in the tree needed a bespoke `jq` pass
+per experiment, written beside the report rather than inside it. A figure
+computed over a *different* trial set than the report's pass rate is not
+comparable with it, and nothing on the page says so; that is precisely where a
+measurement artifact creeps in.
+
+So every trial now also carries a counter map, distilled by
+[`src/features.rs`](src/features.rs) from the same stream, and folded by
+`stella-core` over the same **paired** trials as every other figure. Each key is
+`<namespace>.<what>`, and the value counts exactly what the key names:
+
+| Key | One per | Card |
+|---|---|---|
+| `tool.<name>` | `tool_start`, keyed by the tool's own name | F2, F3, F5, F11 |
+| `stage.<kind>` | `stage`, keyed by the canonical `StageKind` tag | F6, F7, F10 |
+| `recall.calls` / `.frames` / `.tokens` / `.frames_rejected` | `context_recall` — the event, its admitted frames, its injected tokens, and the frames the host rejected whole | F8 |
+| `context_write.calls` / `.upserts` / `.superseded` | `context_write` and its two counts | F9, F14 |
+| `subagent.spawned` / `.refused` | `sub_agent` `started`, and a `finished` whose status is `refused` | F11 |
+
+`--compare` prints them per arm with the baseline-relative delta, above the
+verdict and never folded into it — a feature delta is evidence about *what
+changed*, not a bar a candidate may be promoted on:
+
+```
+FEATURE ATTRIBUTION — per-trial mean (total), over the paired trials only
+feature                        recall-off      recall-on    Δ recall-on
+──────────────────────────────────────────────────────────────────────────
+recall.frames                     0.00 (0)      3.00 (18)        +3.000
+tool.grep                         2.00 (12)      0.00 (0)        -2.000
+```
+
+Four decisions there are load-bearing:
+
+- **Tools are keyed by name, never by a class.** A foundry-authored tool is
+  indistinguishable from a built-in on the wire — `ToolCall` carries a name and
+  arguments and nothing about where the tool came from — so a `tool.foundry`
+  bucket would be the harness *guessing* from a name it does not own. Keying by
+  name reports what the stream says, and an operator ablating their adopted tool
+  knows its name.
+- **Stages are canonicalized through `StageKind`.** The verdict stage shipped on
+  the wire as `judge` and is still aliased that way, so a raw-string key would
+  file one stage under two names and report each as having half-fired.
+- **The key set is the union of both arms.** A counter only one arm emitted is
+  the single most interesting row an ablation produces; an intersection would
+  delete exactly that finding. An arm that never counted a key reads as zero
+  occurrences, which is what it is — the counters are folded over trials that
+  *ran*.
+- **The delta is derived, never stored.** It is `candidate.mean − baseline.mean`
+  computed at read time, so it cannot disagree with the two figures printed
+  beside it.
+
+`no_evidence_cut` — recall's evidence-gate refusal count — is **deliberately
+absent**, though #2382 asks for it. It is real (`stella-context`'s
+`RetrievalResult`) but never reaches the wire: `AgentEvent::ContextRecall`
+carries the admitted frames and, via `usage`, the ones the *host* rejected, and
+neither is the evidence gate's refusal. Counting `recall.frames_rejected` and
+labelling it the evidence cut would be a different number wearing the name of
+the one the experiment asked for. Tracked as #2398.
+
+The counters are **additive**: no existing counter changed meaning, the report's
+`COMPARISON_SCHEMA_VERSION` does not move, and an arm that counts nothing
+serializes exactly as it did before. `stella tune effort` reads a deliberately
+narrow view of a trial row and ignores the new key — checked in
+`crates/stella-cli/src/memory/self_tuning.rs`, not assumed.
+
+The offline warehouse ([`../telemetry_store/`](../telemetry_store/)) needs no
+change to stay consistent: `ingest.py` stores every event's whole payload in
+`events` (plus a `tool_calls` row per call), so the same counters are derivable
+there in SQL from the same file.
+
 ## The nightly CI gate (#873)
 
 [`.github/workflows/nightly-bench.yml`](../../.github/workflows/nightly-bench.yml)
@@ -268,8 +347,12 @@ verdict — no Docker, no harbor, no key. Each pins a real defect: batched
 `apply_edits` reporting zero writes, an ellipsis past the column budget that
 shifted a whole row, a retryable warning read as terminal, a *solved* run with
 no `complete` event called silent, a stream of non-JSON stella output passing
-for an unexplained silent death. A new signal means a `TrialReport` field, an
-arm in `distill_events`, a `print_table` column (`TABLE_WIDTH`), and a test.
+for an unexplained silent death. A new **loop-health** signal means a
+`TrialReport` field, an arm in `distill_events`, a `print_table` column
+(`TABLE_WIDTH`), and a test. A new **feature-attribution** counter is smaller:
+a key in [`src/features.rs`](src/features.rs), a row in the table above, and a
+test — it needs no column, because `--compare` renders whatever keys the stream
+produced.
 
 The #1299 tests build real trial directories under a `tempfile::tempdir` and run
 `analyze` over them, because the defects they pin are about *files harbor wrote

--- a/bench/loop-bench/src/compare.rs
+++ b/bench/loop-bench/src/compare.rs
@@ -69,6 +69,7 @@ pub fn arm_trials(id: &str, value: &str, reports: &[TrialReport]) -> ArmTrials {
                     retries: r.retries,
                 },
                 turns: r.model_calls,
+                features: r.features.clone(),
             })
             .collect(),
     }
@@ -123,7 +124,92 @@ pub fn print_comparison(report: &ComparisonReport) {
             report.unpaired_tasks.join(", ")
         );
     }
+    print_features(report);
     print_verdict(report);
+}
+
+/// Width of one feature cell: `12.34 (1234)` and a space.
+const FEATURE_CELL: usize = 14;
+/// Width of one delta cell: `-1234.567` and a `Δ <arm>` header over it.
+const DELTA_CELL: usize = 12;
+/// Width of the feature key column. Long enough for `context_write.superseded`,
+/// the longest key the distiller mints from a fixed name; a `tool.<name>` key
+/// past it truncates rather than shifting the row.
+const FEATURE_KEY: usize = 26;
+
+/// The per-feature attribution block (#2382): what each arm's trials actually
+/// did, and the baseline-relative delta a paired ablation is run to read.
+///
+/// Printed **before** the verdict and never folded into it. These counters are
+/// evidence about *which feature moved*, and the verdict is decided on the
+/// primary metric and the guards alone — a feature delta is not a bar a
+/// candidate can pass or fail, and rendering it above the verdict is how the
+/// page says which of the two the operator is allowed to promote on.
+///
+/// Silent when nothing counted: a stream with no attributable events (or one
+/// from a stella old enough not to emit them) should not print an empty table
+/// implying the features were measured and found absent.
+fn print_features(report: &ComparisonReport) {
+    let keys = report.feature_keys();
+    if keys.is_empty() {
+        return;
+    }
+    let baseline = report.config.baseline_id.as_str();
+    let candidates: Vec<&str> = report
+        .arms
+        .iter()
+        .map(|arm| arm.id.as_str())
+        .filter(|id| *id != baseline)
+        .collect();
+    // (arm, key) -> delta. Empty when the baseline arm is missing, which is
+    // the same condition that leaves the verdict a `MissingBaseline` refusal.
+    let deltas = report.feature_deltas();
+
+    println!("\nFEATURE ATTRIBUTION — per-trial mean (total), over the paired trials only");
+    print!("{:<FEATURE_KEY$}", "feature");
+    for arm in &report.arms {
+        print!(" {:>FEATURE_CELL$}", truncate(&arm.id, FEATURE_CELL));
+    }
+    for arm in &candidates {
+        print!(
+            " {:>DELTA_CELL$}",
+            truncate(&format!("Δ {arm}"), DELTA_CELL)
+        );
+    }
+    println!();
+    let width =
+        FEATURE_KEY + (FEATURE_CELL + 1) * report.arms.len() + (DELTA_CELL + 1) * candidates.len();
+    println!("{}", "─".repeat(width));
+
+    for key in &keys {
+        print!("{:<FEATURE_KEY$}", truncate(key, FEATURE_KEY));
+        for arm in &report.arms {
+            // A key this arm never counted is zero occurrences, not a gap:
+            // the counters are folded over trials that ran, so "no such
+            // event" is an observation about the arm.
+            let (mean, total) = arm
+                .features
+                .get(*key)
+                .map_or((0.0, 0), |stat| (stat.mean, stat.total));
+            print!(" {:>FEATURE_CELL$}", format!("{mean:.2} ({total})"));
+        }
+        for arm in &candidates {
+            let delta = deltas
+                .iter()
+                .find(|d| d.arm == *arm && d.key == *key)
+                .map(|d| d.delta_mean);
+            print!(
+                " {:>DELTA_CELL$}",
+                delta.map_or_else(|| "—".to_string(), |d| format!("{d:+.3}"))
+            );
+        }
+        println!();
+    }
+    if candidates.len() == report.arms.len() {
+        println!(
+            "  ⚠ no arm is named `{baseline}` — the Δ column has no baseline to measure against."
+        );
+    }
 }
 
 fn leader_label(leader: &Leader) -> String {

--- a/bench/loop-bench/src/compare/tests.rs
+++ b/bench/loop-bench/src/compare/tests.rs
@@ -152,3 +152,114 @@ fn a_stream_without_usage_fields_reports_zero_tokens() {
     assert_eq!(distilled.retries, 0);
     assert_eq!(distilled.model_calls, 1);
 }
+
+/// #2382 (3): a paired ablation yields a per-feature number directly — each
+/// counter reaches both arms, and the delta is the candidate's per-trial mean
+/// less the baseline's.
+#[test]
+fn a_paired_ablation_reports_each_feature_counter_with_its_delta() {
+    let with_recall = |frames: u64| {
+        let mut r = report("ctx", 1.0, 0.1, 1_000, 4);
+        r.features = [
+            ("recall.calls".to_string(), 1),
+            ("recall.frames".to_string(), frames),
+        ]
+        .into_iter()
+        .collect();
+        r
+    };
+    // The off arm emits no recall event at all — the shape an ablation
+    // actually produces, and the one an intersection of keys would delete.
+    let without_recall = || {
+        let mut r = report("ctx", 0.0, 0.1, 1_000, 4);
+        r.features = [("tool.grep".to_string(), 2)].into_iter().collect();
+        r
+    };
+
+    let off: Vec<TrialReport> = (0..6).map(|_| without_recall()).collect();
+    let on: Vec<TrialReport> = (0..6).map(|_| with_recall(3)).collect();
+    let arms = vec![
+        arm_trials("recall-off", "off", &off),
+        arm_trials("recall-on", "on", &on),
+    ];
+    let report = compare(&arms, &config("recall-off"));
+
+    // The union of keys, so the counter only the candidate emitted survives.
+    assert_eq!(
+        report.feature_keys(),
+        vec!["recall.calls", "recall.frames", "tool.grep"]
+    );
+
+    let on_arm = report.arm("recall-on").expect("candidate arm");
+    let frames = on_arm.features["recall.frames"];
+    assert_eq!(frames.total, 18, "3 frames × 6 paired trials");
+    assert!((frames.mean - 3.0).abs() < 1e-9);
+
+    let deltas = report.feature_deltas();
+    let frames_delta = deltas
+        .iter()
+        .find(|d| d.key == "recall.frames")
+        .expect("a delta for every key");
+    assert_eq!(frames_delta.arm, "recall-on");
+    assert_eq!(frames_delta.baseline.total, 0);
+    assert!((frames_delta.delta_mean - 3.0).abs() < 1e-9);
+
+    // And it differences in the other direction too: the tool the off arm
+    // reached for instead.
+    let grep = deltas
+        .iter()
+        .find(|d| d.key == "tool.grep")
+        .expect("a delta for every key");
+    assert!((grep.delta_mean + 2.0).abs() < 1e-9);
+}
+
+/// A trial the comparison excludes contributes no counters either. A feature
+/// delta computed over a wider trial set than the pass rate beside it is not
+/// comparable with it, which is the whole reason the counters ride the trial
+/// rather than being folded beside the report.
+#[test]
+fn an_unpaired_trials_counters_are_excluded_with_the_rest_of_it() {
+    let counted = |task: &str, frames: u64| {
+        let mut r = report(task, 1.0, 0.1, 1_000, 4);
+        r.features = [("recall.frames".to_string(), frames)]
+            .into_iter()
+            .collect();
+        r
+    };
+    let base: Vec<TrialReport> = (0..6).map(|_| counted("shared", 1)).collect();
+    let mut candidate: Vec<TrialReport> = (0..6).map(|_| counted("shared", 1)).collect();
+    // A task only this arm ran, carrying a large counter.
+    candidate.push(counted("solo", 500));
+
+    let arms = vec![
+        arm_trials("a", "a", &base),
+        arm_trials("b", "b", &candidate),
+    ];
+    let report = compare(&arms, &config("a"));
+    assert_eq!(report.unpaired_tasks, vec!["solo".to_string()]);
+    let b = report.arm("b").expect("candidate arm");
+    assert_eq!(
+        b.features["recall.frames"].total, 6,
+        "the unpaired trial's 500 frames are excluded with the trial itself"
+    );
+    let delta = report
+        .feature_deltas()
+        .into_iter()
+        .find(|d| d.key == "recall.frames")
+        .expect("a delta");
+    assert!(
+        delta.delta_mean.abs() < 1e-9,
+        "the arms are identical on the paired set"
+    );
+}
+
+/// A comparison of arms that counted nothing has no attribution block to
+/// print. An empty table implies the features were measured and found absent.
+#[test]
+fn arms_that_counted_nothing_have_no_feature_keys() {
+    let base: Vec<TrialReport> = (0..6).map(|_| report("t", 0.0, 0.1, 100, 2)).collect();
+    let arms = vec![arm_trials("a", "a", &base), arm_trials("b", "b", &base)];
+    let report = compare(&arms, &config("a"));
+    assert!(report.feature_keys().is_empty());
+    assert!(report.feature_deltas().is_empty());
+}

--- a/bench/loop-bench/src/features.rs
+++ b/bench/loop-bench/src/features.rs
@@ -1,0 +1,216 @@
+//! Per-feature attribution: turning one event into counters the A/B can
+//! difference (#2382).
+//!
+//! The distiller's original counters answer "was the loop healthy?" — tool
+//! calls, model calls, spend, a verdict. Two features got a column of their
+//! own (`project_overview`, `graph_query`) and every other feature in the tree
+//! got none, so a paired ablation of recall, of the witness stage, of
+//! subagents, of an adopted foundry tool produced **no number**: the events
+//! were all there in `stella-events.jsonl`, and answering the question meant a
+//! fresh `jq` pass written per experiment, run beside the report rather than
+//! inside it. That is where a measurement artifact creeps in — a figure
+//! computed over a different trial set than the one the report's pass rate
+//! came from is not comparable with it, and nothing on the page says so.
+//!
+//! So attribution rides the trial and is folded by
+//! [`stella_core::comparison`] over the same **paired** trials as every other
+//! figure. See [`stella_core::comparison::feature`] for that contract; this
+//! module owns only the vocabulary.
+//!
+//! # The vocabulary
+//!
+//! Every key is `<namespace>.<what>`, and the value counts exactly what the
+//! key names — events, frames, tokens, entries. Units differ across keys on
+//! purpose: a key is only ever compared against itself in the other arm.
+//!
+//! | Key | One per |
+//! |---|---|
+//! | `tool.<name>` | `tool_start`, keyed by the tool's own name |
+//! | `stage.<kind>` | `stage`, keyed by the canonical [`StageKind`] tag |
+//! | `recall.calls` / `.frames` / `.tokens` / `.frames_rejected` | `context_recall` — the event, its admitted frames, its injected tokens, and the frames the host rejected whole |
+//! | `context_write.calls` / `.upserts` / `.superseded` | `context_write` and its two counts |
+//! | `subagent.spawned` / `.refused` | `sub_agent` `started`, and a `finished` whose status is `refused` |
+//!
+//! Three choices in there are load-bearing:
+//!
+//! * **Tools are keyed by name, never by a class.** A foundry-authored tool is
+//!   indistinguishable from a built-in on the wire — `ToolCall` carries a
+//!   name and arguments and nothing about where the tool came from — so any
+//!   `tool.foundry` counter would be this module *guessing* from a name it
+//!   does not own, and a guess presented as an observation is the failure mode
+//!   the whole harness exists to avoid. Keying by name reports what the stream
+//!   actually says, and an operator ablating their adopted tool knows its
+//!   name. It also gets `project_overview` and `graph_query` their own keys
+//!   for free, which #2382 asks for on its own account: F3 and F5 are separate
+//!   cards with separate kill criteria and cannot share a bucket.
+//! * **Stages are canonicalized through [`StageKind`], not read as strings.**
+//!   The verdict stage shipped on the wire as `judge` and is still aliased
+//!   that way, so a raw-string key would split one stage across `stage.judge`
+//!   and `stage.verdict` depending on when the stream was recorded — two half
+//!   counters, each reading as a stage that half-fired.
+//! * **A sub-agent phase is read off its tag, not deserialized whole.** The
+//!   `Started` payload carries five fields today; parsing the variant would
+//!   make the spawn counter fail closed the day a sixth is added, and a
+//!   counter that silently loses spawns is worse than one keyed off the
+//!   discriminator that has to stay stable anyway.
+//!
+//! # What is deliberately absent
+//!
+//! `no_evidence_cut` — recall's evidence-gate refusal count, which #2382 asks
+//! for. It is real (`stella-context`'s `RetrievalResult`) but it **never
+//! reaches the wire**: `AgentEvent::ContextRecall` carries the frames that
+//! were admitted and, via `usage`, the ones the *host* rejected, and neither
+//! is the evidence gate's refusal. Counting `recall.frames_rejected` and
+//! calling it the evidence cut would be a different number wearing the name of
+//! the one the experiment asked for. Tracked as #2398.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use stella_protocol::StageKind;
+
+/// Counter keys, as [`stella_core::comparison::TrialRecord::features`] holds
+/// them.
+pub type FeatureCounts = BTreeMap<String, u64>;
+
+/// Prefix for the per-tool-name counters.
+const TOOL: &str = "tool.";
+/// Prefix for the per-[`StageKind`] counters.
+const STAGE: &str = "stage.";
+
+/// Longest tool name that becomes a key verbatim.
+///
+/// Tool names are model-supplied runtime data and reach `tool_start` before
+/// anything has vouched for them, so an absurd one must not become an absurd
+/// map key in a published report. Truncation rather than a cap on distinct
+/// keys: dropping a counter silently is how a report claims coverage it does
+/// not have, and every real name in the catalog is far under this.
+const MAX_TOOL_NAME: usize = 48;
+
+/// Add one event's contribution to `counts`.
+///
+/// Unrecognized events contribute nothing — a stream from a newer stella is
+/// read for what this build understands, never rejected. Missing fields
+/// contribute zero for the same reason: a counter is an observation about what
+/// the stream said, and a stream that said nothing about recall tokens has a
+/// recall token count of zero, not an error.
+pub fn record(event: &Value, counts: &mut FeatureCounts) {
+    match event.get("type").and_then(Value::as_str) {
+        Some("tool_start") => {
+            if let Some(name) = event
+                .get("call")
+                .and_then(|call| call.get("name"))
+                .and_then(Value::as_str)
+                .filter(|name| !name.is_empty())
+            {
+                bump(counts, &format!("{TOOL}{}", clamp(name)), 1);
+            }
+        }
+        Some("stage") => {
+            if let Some(name) = event.get("name").and_then(Value::as_str) {
+                bump(counts, &format!("{STAGE}{}", canonical_stage(name)), 1);
+            }
+        }
+        Some("context_recall") => {
+            bump(counts, "recall.calls", 1);
+            let frames = event
+                .get("frames")
+                .and_then(Value::as_array)
+                .map_or(0, |frames| frames.len() as u64);
+            bump(counts, "recall.frames", frames);
+            bump(counts, "recall.tokens", u64_at(event, "tokens"));
+            bump(counts, "recall.frames_rejected", frames_rejected(event));
+        }
+        Some("context_write") => {
+            bump(counts, "context_write.calls", 1);
+            bump(counts, "context_write.upserts", u64_at(event, "upserts"));
+            bump(
+                counts,
+                "context_write.superseded",
+                u64_at(event, "superseded"),
+            );
+        }
+        Some("sub_agent") => record_subagent(event.get("phase"), counts),
+        _ => {}
+    }
+}
+
+/// A spawn, and separately a spawn that never ran.
+///
+/// A refusal (no budget headroom, the nesting cap) still brackets, so it is
+/// counted in `subagent.spawned` too — the parent *asked*. Reporting the two
+/// side by side is the difference between "subagents did nothing for this arm"
+/// and "subagents were never allowed to run", which are opposite findings with
+/// opposite fixes.
+fn record_subagent(phase: Option<&Value>, counts: &mut FeatureCounts) {
+    let Some(phase) = phase else { return };
+    match phase.get("phase").and_then(Value::as_str) {
+        Some("started") => bump(counts, "subagent.spawned", 1),
+        Some("finished") if phase.get("status").and_then(Value::as_str) == Some("refused") => {
+            bump(counts, "subagent.refused", 1);
+        }
+        _ => {}
+    }
+}
+
+/// The frames the CGP host rejected whole, summed over the recall's providers.
+///
+/// Distinct from the evidence gate's `no_evidence_cut` (see the module docs):
+/// this is the host refusing a provider's frame — a misdeclared cost, a
+/// consent gate, a failed leg — which is a fact about the plumbing rather than
+/// about relevance.
+fn frames_rejected(event: &Value) -> u64 {
+    event
+        .get("usage")
+        .and_then(|usage| usage.get("providers"))
+        .and_then(Value::as_array)
+        .map_or(0, |providers| {
+            providers
+                .iter()
+                .map(|provider| u64_at(provider, "frames_rejected"))
+                .fold(0u64, u64::saturating_add)
+        })
+}
+
+/// The stage's canonical wire tag, resolving the `judge`/`verifier` aliases
+/// onto `verdict`.
+///
+/// A tag this build does not know is kept verbatim rather than bucketed into
+/// an "other": a newer stella's stage should appear under its own name, and
+/// the operator reading a key they do not recognize has learned exactly the
+/// true thing.
+fn canonical_stage(name: &str) -> String {
+    let Ok(kind) = serde_json::from_value::<StageKind>(Value::String(name.to_string())) else {
+        return clamp(name);
+    };
+    match serde_json::to_value(kind) {
+        Ok(Value::String(tag)) => tag,
+        _ => clamp(name),
+    }
+}
+
+fn clamp(name: &str) -> String {
+    crate::truncate(name, MAX_TOOL_NAME)
+}
+
+fn u64_at(value: &Value, field: &str) -> u64 {
+    value.get(field).and_then(Value::as_u64).unwrap_or(0)
+}
+
+/// Saturating, because these are counts folded over an unbounded stream and a
+/// bench harness must not be the thing that overflows on a pathological trial.
+fn bump(counts: &mut FeatureCounts, key: &str, by: u64) {
+    if let Some(slot) = counts.get_mut(key) {
+        *slot = slot.saturating_add(by);
+    } else {
+        counts.insert(key.to_string(), by);
+    }
+}
+
+/// Fold `from` into `into` — how a multi-step trial's per-step counters become
+/// the trial's.
+pub fn merge(into: &mut FeatureCounts, from: &FeatureCounts) {
+    for (key, count) in from {
+        bump(into, key, *count);
+    }
+}

--- a/bench/loop-bench/src/lib.rs
+++ b/bench/loop-bench/src/lib.rs
@@ -67,6 +67,7 @@
 
 pub mod artifacts;
 pub mod compare;
+pub mod features;
 pub mod reconcile;
 
 use std::collections::BTreeMap;
@@ -75,6 +76,7 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::artifacts::{StepStream, TrialArtifacts};
+use crate::features::FeatureCounts;
 use crate::reconcile::{Reconciliation, Requested, reported_task_name};
 
 /// The per-task loop + context signals, distilled from one trial's event
@@ -170,6 +172,21 @@ pub struct TrialReport {
     /// warnings land here too — it is the most recent explanation, not a
     /// verdict.
     pub last_error: Option<String>,
+    /// Per-feature counters distilled from the same stream (#2382) — recall,
+    /// context write-back, subagents, per-stage entries, and one key per tool
+    /// name. See [`features`] for the vocabulary and why it is keyed the way
+    /// it is.
+    ///
+    /// These are the *attribution* channel, distinct from the loop-health
+    /// counters above: they carry into [`compare`] and are differenced per
+    /// arm, which is what turns a paired ablation into a per-feature number
+    /// instead of a bespoke `jq` pass per experiment. Additive — every
+    /// existing counter keeps its meaning, or every comparison recorded before
+    /// today silently becomes incomparable.
+    ///
+    /// Skipped when empty so a `NOT-RUN` row's JSON is unchanged.
+    #[serde(skip_serializing_if = "FeatureCounts::is_empty")]
+    pub features: FeatureCounts,
 }
 
 impl TrialReport {
@@ -449,6 +466,7 @@ pub fn fold_steps(steps: &[TrialReport]) -> TrialReport {
         folded.spend_usd += step.spend_usd;
         folded.budget_capped |= step.budget_capped;
         folded.terminal_event = step.terminal_event;
+        features::merge(&mut folded.features, &step.features);
         for stage in &step.stages {
             if seen_stage.insert(stage.clone()) {
                 folded.stages.push(stage.clone());
@@ -488,6 +506,11 @@ pub fn distill_events(task: &str, raw: &str) -> TrialReport {
             continue;
         };
         r.parsed_lines += 1;
+        // Attribution runs over every parsed event, beside — never instead of
+        // — the loop-health fold below. The two answer different questions and
+        // an event can feed both (a `tool_start` is one tool call *and* one
+        // `tool.<name>`).
+        features::record(&ev, &mut r.features);
         match ev.get("type").and_then(Value::as_str) {
             Some("step_usage") => {
                 r.model_calls += 1;

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -822,3 +822,201 @@ fn passed_is_reward_one_and_nothing_else() {
     assert!(!with(None).passed(), "never verified is not a pass");
     assert_eq!(tally(&[with(Some(0.5)), with(None)]).solved, 0);
 }
+
+// ── Per-feature attribution (#2382) ──────────────────────────────────────────
+//
+// The witness set for the counters `--compare` differences per arm. Each
+// asserts a known value off a stream that is a faithful sample of the wire
+// shape, because the whole point of the channel is that a number in a report
+// came from the events and not from a hand-written `jq` pass beside it.
+
+/// A stream exercising every event the attribution channel reads, once.
+///
+/// Deliberately spelled as the wire spells it — `sub_agent`'s nested `phase`
+/// discriminator, `context_recall`'s `usage.providers[]` — rather than a
+/// convenient flattening. A fixture that agrees with the distiller but not
+/// with the engine proves nothing.
+fn attributable_stream() -> String {
+    ev(&[
+        r#"{"type":"stage","name":"triage"}"#,
+        r#"{"type":"stage","name":"context_recall"}"#,
+        r#"{"type":"context_recall","frames":[{"citation_label":"a","source":"s","token_cost":10},{"citation_label":"b","source":"s","token_cost":20}],"provider_mix":[{"provider":"stella-context","frames":2}],"tokens":30,"latency_ms":12,"usage":{"budget_requested":100,"budget_consumed":30,"as_of":"2026-08-08T00:00:00Z","providers":[{"provider_id":"stella-context","frames_served":3,"frames_rejected":1,"token_cost":30}]}}"#,
+        r#"{"type":"stage","name":"execute"}"#,
+        r#"{"type":"tool_start","call":{"name":"graph_query"}}"#,
+        r#"{"type":"tool_start","call":{"name":"project_overview"}}"#,
+        r#"{"type":"tool_start","call":{"name":"task"}}"#,
+        r#"{"type":"sub_agent","phase":{"phase":"started","agent_id":"c1","instruction_preview":"look","budget_usd":0.05,"write_access":false,"depth":1}}"#,
+        r#"{"type":"sub_agent","phase":{"phase":"finished","agent_id":"c1","status":"completed","summary":"done"}}"#,
+        r#"{"type":"sub_agent","phase":{"phase":"started","agent_id":"c2","instruction_preview":"look","budget_usd":null,"write_access":false,"depth":1}}"#,
+        r#"{"type":"sub_agent","phase":{"phase":"finished","agent_id":"c2","status":"refused","summary":""}}"#,
+        r#"{"type":"tool_start","call":{"name":"repo_stats"}}"#,
+        r#"{"type":"stage","name":"witness"}"#,
+        r#"{"type":"stage","name":"verify"}"#,
+        r#"{"type":"stage","name":"context_write"}"#,
+        r#"{"type":"context_write","provider":"stella-context","upserts":4,"superseded":1}"#,
+        r#"{"type":"complete","model":"m","cost_usd":0.01}"#,
+    ])
+}
+
+fn count(r: &TrialReport, key: &str) -> u64 {
+    *r.features.get(key).unwrap_or_else(|| {
+        panic!(
+            "no `{key}` counter; the stream distilled {:?}",
+            r.features.keys().collect::<Vec<_>>()
+        )
+    })
+}
+
+/// #2382: recall, context write-back, subagents, stages and every tool name
+/// each land their own counter with the value the stream states.
+#[test]
+fn every_attributable_event_reaches_its_own_counter() {
+    let r = distill_events("attributed", &attributable_stream());
+
+    // Recall: one event, two admitted frames, thirty tokens, and the one
+    // frame the host rejected whole.
+    assert_eq!(count(&r, "recall.calls"), 1);
+    assert_eq!(count(&r, "recall.frames"), 2);
+    assert_eq!(count(&r, "recall.tokens"), 30);
+    assert_eq!(count(&r, "recall.frames_rejected"), 1);
+
+    // Write-back.
+    assert_eq!(count(&r, "context_write.calls"), 1);
+    assert_eq!(count(&r, "context_write.upserts"), 4);
+    assert_eq!(count(&r, "context_write.superseded"), 1);
+
+    // Two children asked for, one of them never allowed to run.
+    assert_eq!(count(&r, "subagent.spawned"), 2);
+    assert_eq!(count(&r, "subagent.refused"), 1);
+
+    // Stages, one key each.
+    for stage in ["triage", "context_recall", "execute", "witness", "verify"] {
+        assert_eq!(count(&r, &format!("stage.{stage}")), 1, "stage.{stage}");
+    }
+
+    // Tools by name — including one the harness has no dedicated column for,
+    // which is the whole reason the channel is keyed by name.
+    assert_eq!(count(&r, "tool.graph_query"), 1);
+    assert_eq!(count(&r, "tool.project_overview"), 1);
+    assert_eq!(count(&r, "tool.task"), 1);
+    assert_eq!(count(&r, "tool.repo_stats"), 1);
+}
+
+/// #2382 (1): `project_overview` and `graph_query` are counted separately, and
+/// the counters agree with the dedicated columns that predate them. F3 and F5
+/// are separate cards with separate kill criteria; one shared bucket cannot
+/// grade either.
+#[test]
+fn the_two_context_tools_are_counted_separately_and_agree_with_their_columns() {
+    let r = distill_events(
+        "split",
+        &ev(&[
+            r#"{"type":"tool_start","call":{"name":"project_overview"}}"#,
+            r#"{"type":"tool_start","call":{"name":"graph_query"}}"#,
+            r#"{"type":"tool_start","call":{"name":"graph_query"}}"#,
+        ]),
+    );
+    assert_eq!(count(&r, "tool.project_overview"), 1);
+    assert_eq!(count(&r, "tool.graph_query"), 2);
+    assert_eq!(u64::from(r.project_overview_calls), 1);
+    assert_eq!(u64::from(r.graph_query_calls), 2);
+}
+
+/// The verdict stage shipped on the wire as `judge` and is still aliased that
+/// way, so a raw-string key would file the same stage under two names and
+/// report each as having half-fired.
+#[test]
+fn a_stage_recorded_under_its_wire_alias_lands_in_the_canonical_bucket() {
+    let r = distill_events(
+        "aliased",
+        &ev(&[
+            r#"{"type":"stage","name":"judge"}"#,
+            r#"{"type":"stage","name":"verifier"}"#,
+            r#"{"type":"stage","name":"verdict"}"#,
+        ]),
+    );
+    assert_eq!(count(&r, "stage.verdict"), 3);
+    assert!(!r.features.contains_key("stage.judge"));
+    assert!(!r.features.contains_key("stage.verifier"));
+}
+
+/// A stage this build does not know keeps its own name. A newer stella's
+/// stage bucketed into an `other` would report as a stage that never fired.
+#[test]
+fn an_unknown_stage_is_counted_under_its_own_name() {
+    let r = distill_events("future", &ev(&[r#"{"type":"stage","name":"negotiate"}"#]));
+    assert_eq!(count(&r, "stage.negotiate"), 1);
+}
+
+/// A stage that fires twice — the revise back-edge re-entering `execute` —
+/// counts twice. The pre-existing `stages` list de-duplicates by design (it
+/// answers "where did it vanish?"), so the counter is the only place a repair
+/// loop is visible.
+#[test]
+fn a_stage_entered_twice_counts_twice_where_the_stage_list_dedupes() {
+    let r = distill_events(
+        "revised",
+        &ev(&[
+            r#"{"type":"stage","name":"execute"}"#,
+            r#"{"type":"stage","name":"verify"}"#,
+            r#"{"type":"stage","name":"execute"}"#,
+        ]),
+    );
+    assert_eq!(count(&r, "stage.execute"), 2);
+    assert_eq!(r.stages, vec!["execute", "verify"]);
+}
+
+/// A multi-step trial's counters sum, exactly as its tool and model call
+/// counts do — the trial did all of it.
+#[test]
+fn a_multi_step_trials_counters_sum_across_its_steps() {
+    let job = tempfile::tempdir().expect("job dir");
+    let trial = job.path().join("multi__t1");
+    for (step, tool) in [("one", "graph_query"), ("two", "graph_query")] {
+        let agent = trial.join("steps").join(step).join("agent");
+        std::fs::create_dir_all(&agent).expect("mkdir");
+        std::fs::write(
+            agent.join("stella-events.jsonl"),
+            format!(r#"{{"type":"tool_start","call":{{"name":"{tool}"}}}}"#),
+        )
+        .expect("write");
+    }
+    write_result(
+        &trial,
+        serde_json::json!({
+            "task_name": "multi",
+            "step_results": [{"step_name": "one"}, {"step_name": "two"}],
+        }),
+    );
+    let requested = vec!["multi".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    assert_eq!(count(only(&analysis), "tool.graph_query"), 2);
+}
+
+/// The counters reach the JSON a CI consumer trends, under `features`.
+#[test]
+fn the_json_report_carries_the_feature_counters() {
+    let job = tempfile::tempdir().expect("job dir");
+    trial_dir(
+        job.path(),
+        "ran__t1",
+        &[r#"{"type":"tool_start","call":{"name":"edit_file"}}"#],
+    );
+    let requested = vec!["ran".to_string(), "never".to_string()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let json = serde_json::to_value(json_report(&analysis)).expect("serialize");
+    let rows = json["trials"].as_array().expect("rows");
+    let ran = rows
+        .iter()
+        .find(|row| row["task"] == "ran")
+        .expect("the trial that ran");
+    assert_eq!(ran["features"]["tool.edit_file"], 1);
+    let never = rows
+        .iter()
+        .find(|row| row["task"] == "never")
+        .expect("the NOT-RUN row");
+    assert!(
+        never.get("features").is_none(),
+        "an empty counter set is skipped, so a NOT-RUN row's JSON is unchanged"
+    );
+}

--- a/crates/stella-cli/src/memory/self_tuning.rs
+++ b/crates/stella-cli/src/memory/self_tuning.rs
@@ -514,6 +514,33 @@ mod tests {
         assert_eq!(from_array.rewards, from_object.rewards);
     }
 
+    /// #2382: loop-bench rows now carry a `features` map of per-feature
+    /// counters. This command reads a deliberately narrow view of a row, so a
+    /// key it has no opinion about must be ignored — and that is checked here
+    /// rather than assumed, because the failure mode is `stella tune effort`
+    /// refusing every artifact produced after the counters landed.
+    #[test]
+    fn a_bench_report_carrying_feature_counters_still_reads() {
+        let with_features = r#"{"trials":[
+            {"task":"a","reward":1.0,"spend_usd":0.50,"loop_detected":0,
+             "features":{"tool.graph_query":2,"recall.frames":7}}
+        ],"tally":{"total":1,"solved":1,"loop_broken":0,"crashed":0}}"#;
+        let report = parse_bench_report(with_features).expect("an unknown key is ignored");
+        assert_eq!(report.trials.len(), 1);
+        assert_eq!(report.trials[0].reward, Some(1.0));
+
+        // And the arithmetic is unchanged by the extra key's presence.
+        let without = r#"{"trials":[
+            {"task":"a","reward":1.0,"spend_usd":0.50,"loop_detected":0}
+        ],"tally":{"total":1,"solved":1,"loop_broken":0,"crashed":0}}"#;
+        let plain = parse_bench_report(without).expect("the plain shape reads");
+        let weights = RewardWeights::default();
+        assert_eq!(
+            arm_from_trials("a", "high", &report.trials, &weights).rewards,
+            arm_from_trials("a", "high", &plain.trials, &weights).rewards,
+        );
+    }
+
     /// A file that is neither shape stays an error. In particular a JSON object
     /// that is not a report must not read as a report of zero trials, which
     /// would reach the A/B as "insufficient samples" — a statement about the

--- a/crates/stella-core/src/comparison.rs
+++ b/crates/stella-core/src/comparison.rs
@@ -46,6 +46,15 @@
 //!    resolves to [`ComparisonVerdict::GuardBlocked`] — a named refusal
 //!    carrying its evidence, never a silent non-promotion.
 //!
+//! # Which feature moved
+//!
+//! The aggregates say which arm won; they cannot say which *feature* did it.
+//! [`TrialRecord::features`] is the opaque per-feature counter channel that
+//! can — folded over the same paired trials as everything else, so a feature
+//! delta and a pass-rate delta in one report describe one population. See
+//! [`feature`] for the contract, and [`ComparisonReport::feature_deltas`] for
+//! the baseline-relative view a paired ablation reads.
+//!
 //! # Reading the report
 //!
 //! ```
@@ -57,6 +66,7 @@
 //!         task: task.to_string(),
 //!         outcome: TaskOutcome { succeeded, cost_usd: 0.1, tokens: 1_000, retries: 0 },
 //!         turns: 4,
+//!         features: Default::default(),
 //!     }
 //! }
 //!
@@ -77,6 +87,7 @@
 //! ```
 
 mod arm;
+pub mod feature;
 mod guard;
 mod metric;
 mod report;
@@ -84,6 +95,7 @@ mod task;
 mod trial;
 
 pub use arm::ArmSummary;
+pub use feature::{FeatureCounts, FeatureDelta, FeatureStat};
 pub use guard::{Guard, GuardFinding};
 pub use metric::Metric;
 pub use report::{

--- a/crates/stella-core/src/comparison/arm.rs
+++ b/crates/stella-core/src/comparison/arm.rs
@@ -1,8 +1,11 @@
 //! One arm's trials folded into the aggregates a report shows and a guard
 //! compares.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
+use super::feature::{self, FeatureStat};
 use super::metric::{mean, median};
 use super::trial::TrialRecord;
 use crate::self_tuning::{RewardWeights, reward};
@@ -46,6 +49,12 @@ pub struct ArmSummary {
     pub median_turns: f64,
     /// Retries per paired trial.
     pub mean_retries: f64,
+    /// Every per-feature counter this arm's paired trials carried, summed and
+    /// averaged over the same trials as the figures above (see
+    /// [`super::feature`]). Empty for a caller that counts nothing, and
+    /// skipped when empty so such a report's JSON is unchanged.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub features: BTreeMap<String, FeatureStat>,
 }
 
 impl ArmSummary {
@@ -107,6 +116,7 @@ impl ArmSummary {
             mean_tokens: mean(&tokens),
             median_turns: median(&turns),
             mean_retries: mean(&retries),
+            features: feature::fold(paired),
         }
     }
 }

--- a/crates/stella-core/src/comparison/feature.rs
+++ b/crates/stella-core/src/comparison/feature.rs
@@ -1,0 +1,114 @@
+//! Per-feature counters — the comparison's **opaque attribution channel**.
+//!
+//! The aggregates beside these (pass rate, cost, tokens, turns) answer "which
+//! arm won". They cannot answer "*which feature* moved", and that is the
+//! question a paired ablation exists to settle: recall on vs off, the witness
+//! stage on vs off, a foundry tool adopted vs not. Before this channel existed,
+//! every such experiment needed a bespoke `jq` pass over the event stream, run
+//! beside the report rather than inside it — and a number computed over a
+//! *different* trial set than the report's is the exact measurement artifact
+//! pairing exists to prevent.
+//!
+//! So a counter rides the trial. It is folded over the same **paired** trials
+//! as every other figure, excluded by the same rule, and divided by the same
+//! denominator. A feature delta and a pass-rate delta in one report are
+//! therefore statements about one population.
+//!
+//! # The keys are the caller's, and this module does not know them
+//!
+//! [`FeatureCounts`] is a plain string-keyed tally. Nothing here knows what
+//! `tool.graph_query` or `stage.witness` means, exactly as nothing here knows
+//! whether an arm's `value` names a model or a prompt template — the arm stays
+//! opaque (see [`super::ArmTrials`]), and so does the counter. A harness owns
+//! its vocabulary and documents it; the engine folds numbers.
+//!
+//! Two rules the caller carries, because this module cannot enforce them:
+//!
+//! * **A key means the same thing in both arms.** Re-keying a counter between
+//!   runs produces a delta against zero, which reads as a total regression.
+//! * **Keys are bounded.** They become map entries in a report; a key minted
+//!   per trial (a timestamp, a call id) turns a comparison into a log.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::trial::TrialRecord;
+
+/// One trial's feature counters, keyed by a stable caller-owned name.
+///
+/// The value counts whatever the key names — recall events, frames admitted,
+/// tokens injected, stage entries. Mixed units across keys are fine and
+/// expected: each key is compared only against itself in the other arm.
+pub type FeatureCounts = BTreeMap<String, u64>;
+
+/// One feature counter folded over one arm's paired trials.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FeatureStat {
+    /// Summed across every paired trial of the arm.
+    pub total: u64,
+    /// `total / trials` — the comparable figure.
+    ///
+    /// The total alone is not comparable: pairing excludes at *trial*
+    /// granularity, so two arms over the same tasks can still fold different
+    /// trial counts, and the arm that ran more trials wins every total by
+    /// construction. `0.0` when the arm folded no paired trials.
+    pub mean: f64,
+}
+
+impl FeatureStat {
+    /// `total` spread over `trials`, with `trials == 0` yielding a zero mean
+    /// rather than a `NaN` — a report over an arm that never ran stays
+    /// readable, and the sample floor in
+    /// [`crate::self_tuning::select_winner`] is what refuses to promote on it.
+    fn new(total: u64, trials: usize) -> Self {
+        Self {
+            total,
+            mean: if trials == 0 {
+                0.0
+            } else {
+                total as f64 / trials as f64
+            },
+        }
+    }
+}
+
+/// One arm's counter for one key, next to the baseline's.
+///
+/// Deliberately carries both arms' figures rather than the difference alone: a
+/// `+2.0` delta is a different finding at `0 → 2` than at `40 → 42`, and a
+/// reader who has to go back to the arm summaries to tell them apart will not.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeatureDelta {
+    /// The counter key, verbatim as the caller wrote it.
+    pub key: String,
+    /// The non-baseline arm this delta describes.
+    pub arm: String,
+    /// The baseline arm's figures for `key`, zeroed when it never counted it.
+    pub baseline: FeatureStat,
+    /// `arm`'s figures for `key`, zeroed when it never counted it.
+    pub candidate: FeatureStat,
+    /// `candidate.mean - baseline.mean`. The only derived number here, and it
+    /// is derived rather than stored on the arms so it can never disagree with
+    /// its operands.
+    pub delta_mean: f64,
+}
+
+/// Fold one arm's paired trials into a per-key [`FeatureStat`].
+///
+/// Saturating, because a counter is a count and a comparison must not be the
+/// thing that overflows on an absurd input — the same posture
+/// [`super::ArmSummary`] takes on tokens.
+pub(super) fn fold(paired: &[&TrialRecord]) -> BTreeMap<String, FeatureStat> {
+    let mut totals: BTreeMap<&str, u64> = BTreeMap::new();
+    for trial in paired {
+        for (key, count) in &trial.features {
+            let slot = totals.entry(key.as_str()).or_default();
+            *slot = slot.saturating_add(*count);
+        }
+    }
+    totals
+        .into_iter()
+        .map(|(key, total)| (key.to_string(), FeatureStat::new(total, paired.len())))
+        .collect()
+}

--- a/crates/stella-core/src/comparison/props.rs
+++ b/crates/stella-core/src/comparison/props.rs
@@ -17,9 +17,10 @@ fn arb_trial() -> impl Strategy<Value = TrialRecord> {
         0u64..100_000,
         0u32..8,
         0u32..40,
+        arb_features(),
     )
         .prop_map(
-            |(task, succeeded, cost_usd, tokens, retries, turns)| TrialRecord {
+            |(task, succeeded, cost_usd, tokens, retries, turns, features)| TrialRecord {
                 task: task.to_string(),
                 outcome: TaskOutcome {
                     succeeded,
@@ -28,8 +29,21 @@ fn arb_trial() -> impl Strategy<Value = TrialRecord> {
                     retries,
                 },
                 turns,
+                features,
             },
         )
+}
+
+/// A small key alphabet, so generated arms genuinely share counters — with
+/// unique keys every delta would be against an absent baseline and the
+/// interesting case would never be generated. The empty map is reachable,
+/// which is the ordinary shape for a caller that counts nothing.
+fn arb_features() -> impl Strategy<Value = FeatureCounts> {
+    proptest::collection::btree_map(
+        prop::sample::select(vec!["tool.grep".to_string(), "recall.frames".to_string()]),
+        0u64..500,
+        0..3,
+    )
 }
 
 fn arb_arm(id: &'static str) -> impl Strategy<Value = ArmTrials> {
@@ -168,5 +182,28 @@ proptest! {
             None | Some(std::cmp::Ordering::Less)
         );
         prop_assert_eq!(finding.regressed, expected_regressed);
+    }
+
+    /// Every feature delta re-derives from the two stats printed beside it.
+    /// A delta a reader cannot check against its operands is a number they
+    /// have to take on faith, which is the opposite of what the channel is
+    /// for — so it is derived, never stored, and this is that guarantee.
+    #[test]
+    fn a_feature_delta_always_re_derives_from_its_operands(
+        base in arb_arm("base"),
+        candidate in arb_arm("candidate"),
+    ) {
+        let report = compare(&[base, candidate], &ComparisonConfig::new("base", Metric::PassRate));
+        for summary in &report.arms {
+            for stat in summary.features.values() {
+                prop_assert!(stat.mean.is_finite());
+                // `total` is a sum of counts over `trials` trials, so the mean
+                // can never exceed it for a non-empty arm.
+                prop_assert!(stat.mean <= stat.total as f64 + 1e-9);
+            }
+        }
+        for delta in report.feature_deltas() {
+            prop_assert!((delta.delta_mean - (delta.candidate.mean - delta.baseline.mean)).abs() < 1e-9);
+        }
     }
 }

--- a/crates/stella-core/src/comparison/report.rs
+++ b/crates/stella-core/src/comparison/report.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 use super::arm::ArmSummary;
+use super::feature::{FeatureDelta, FeatureStat};
 use super::guard::{Guard, GuardFinding};
 use super::metric::Metric;
 use super::task::TaskRow;
@@ -141,7 +142,66 @@ impl ComparisonReport {
     pub fn arm(&self, id: &str) -> Option<&ArmSummary> {
         self.arms.iter().find(|a| a.id == id)
     }
+
+    /// Every per-feature counter key any arm carried, sorted and deduplicated.
+    ///
+    /// The **union**, not the baseline's set: a counter only the candidate
+    /// emitted is the single most interesting row a feature ablation can
+    /// produce ("the arm with recall on admitted 34 frames; the other emitted
+    /// no such event at all"), and an intersection would delete exactly that
+    /// finding.
+    pub fn feature_keys(&self) -> Vec<&str> {
+        let mut keys: BTreeSet<&str> = BTreeSet::new();
+        for arm in &self.arms {
+            keys.extend(arm.features.keys().map(String::as_str));
+        }
+        keys.into_iter().collect()
+    }
+
+    /// Each non-baseline arm's counters against the baseline's, one entry per
+    /// (arm, key) over [`Self::feature_keys`] — arms in report order, keys
+    /// sorted.
+    ///
+    /// A key an arm never counted contributes a zeroed [`FeatureStat`] rather
+    /// than being skipped. That is the honest reading here and only here: the
+    /// counters are folded over trials that *ran*, so "this arm emitted no
+    /// such event" is an observation about the arm, not a gap in the record.
+    ///
+    /// Empty when the report has no arm named by
+    /// [`ComparisonConfig::baseline_id`] — with nothing to measure against
+    /// there is no delta to state, and inventing one against the first arm
+    /// would silently rebase the comparison.
+    pub fn feature_deltas(&self) -> Vec<FeatureDelta> {
+        let Some(baseline) = self.arm(&self.config.baseline_id) else {
+            return Vec::new();
+        };
+        let keys = self.feature_keys();
+        let mut deltas = Vec::new();
+        for arm in &self.arms {
+            if arm.id == baseline.id {
+                continue;
+            }
+            for key in &keys {
+                let base = baseline.features.get(*key).copied().unwrap_or(ZERO_STAT);
+                let candidate = arm.features.get(*key).copied().unwrap_or(ZERO_STAT);
+                deltas.push(FeatureDelta {
+                    key: (*key).to_string(),
+                    arm: arm.id.clone(),
+                    baseline: base,
+                    candidate,
+                    delta_mean: candidate.mean - base.mean,
+                });
+            }
+        }
+        deltas
+    }
 }
+
+/// What an arm that never counted a key contributes to a delta.
+const ZERO_STAT: FeatureStat = FeatureStat {
+    total: 0,
+    mean: 0.0,
+};
 
 /// Fold trials from two or more arms into one comparison.
 ///

--- a/crates/stella-core/src/comparison/tests.rs
+++ b/crates/stella-core/src/comparison/tests.rs
@@ -14,6 +14,7 @@ fn trial(task: &str, succeeded: bool) -> TrialRecord {
             retries: 0,
         },
         turns: 4,
+        features: FeatureCounts::new(),
     }
 }
 
@@ -27,6 +28,7 @@ fn priced(task: &str, succeeded: bool, cost_usd: f64, tokens: u64, turns: u32) -
             retries: 0,
         },
         turns,
+        features: FeatureCounts::new(),
     }
 }
 
@@ -452,4 +454,166 @@ fn a_stricter_selection_config_is_honored() {
     let report = compare(&arms, &config);
     assert!(!report.verdict.is_winner());
     assert_eq!(report.config.selection.min_samples_per_arm, 20);
+}
+
+// ── The per-feature attribution channel (#2382) ─────────────────────────────
+
+/// A trial carrying feature counters.
+fn counted(task: &str, succeeded: bool, counts: &[(&str, u64)]) -> TrialRecord {
+    TrialRecord {
+        features: counts
+            .iter()
+            .map(|(key, count)| ((*key).to_string(), *count))
+            .collect(),
+        ..trial(task, succeeded)
+    }
+}
+
+/// Counters fold over the arm's paired trials, and the mean is per trial —
+/// the only comparable figure, since pairing excludes at trial granularity and
+/// two arms over the same tasks can still fold different trial counts.
+#[test]
+fn feature_counters_fold_into_a_total_and_a_per_trial_mean() {
+    let arms = vec![
+        arm(
+            "base",
+            "off",
+            (0..4).map(|_| counted("t", false, &[])).collect(),
+        ),
+        arm(
+            "candidate",
+            "on",
+            (0..4)
+                .map(|_| counted("t", true, &[("recall.frames", 3)]))
+                .collect(),
+        ),
+    ];
+    let report = compare(&arms, &ComparisonConfig::new("base", Metric::PassRate));
+    let stat = report.arm("candidate").expect("arm").features["recall.frames"];
+    assert_eq!(stat.total, 12);
+    assert!((stat.mean - 3.0).abs() < 1e-9);
+    assert!(
+        report.arm("base").expect("arm").features.is_empty(),
+        "an arm that counted nothing carries no keys"
+    );
+}
+
+/// The key set is the **union**. A counter only the candidate emitted is the
+/// most interesting row a feature ablation produces, and an intersection would
+/// delete exactly that finding.
+#[test]
+fn the_feature_key_set_is_the_union_of_both_arms() {
+    let arms = vec![
+        arm(
+            "base",
+            "off",
+            (0..3)
+                .map(|_| counted("t", false, &[("tool.grep", 2)]))
+                .collect(),
+        ),
+        arm(
+            "candidate",
+            "on",
+            (0..3)
+                .map(|_| counted("t", true, &[("recall.frames", 1)]))
+                .collect(),
+        ),
+    ];
+    let report = compare(&arms, &ComparisonConfig::new("base", Metric::PassRate));
+    assert_eq!(report.feature_keys(), vec!["recall.frames", "tool.grep"]);
+
+    let deltas = report.feature_deltas();
+    assert_eq!(deltas.len(), 2, "one per (non-baseline arm, key)");
+    let frames = deltas
+        .iter()
+        .find(|d| d.key == "recall.frames")
+        .expect("key");
+    assert_eq!(frames.baseline.total, 0, "absent is zero occurrences");
+    assert!((frames.delta_mean - 1.0).abs() < 1e-9);
+    let grep = deltas.iter().find(|d| d.key == "tool.grep").expect("key");
+    assert!((grep.delta_mean + 2.0).abs() < 1e-9);
+}
+
+/// Counters obey pairing like every other figure: a trial excluded from the
+/// aggregates is excluded from the counters too. A feature delta computed over
+/// a wider trial set than the pass rate beside it is not comparable with it.
+#[test]
+fn an_excluded_trials_counters_are_excluded_too() {
+    let mut candidate: Vec<TrialRecord> = (0..3)
+        .map(|_| counted("shared", true, &[("recall.frames", 1)]))
+        .collect();
+    candidate.push(counted("solo", true, &[("recall.frames", 999)]));
+    let arms = vec![
+        arm(
+            "base",
+            "off",
+            (0..3)
+                .map(|_| counted("shared", false, &[("recall.frames", 1)]))
+                .collect(),
+        ),
+        arm("candidate", "on", candidate),
+    ];
+    let report = compare(&arms, &ComparisonConfig::new("base", Metric::PassRate));
+    assert_eq!(report.unpaired_tasks, vec!["solo".to_string()]);
+    assert_eq!(
+        report.arm("candidate").expect("arm").features["recall.frames"].total,
+        3
+    );
+}
+
+/// With no arm named by the config there is nothing to measure against, so no
+/// delta is stated. Rebasing onto the first arm would silently answer a
+/// different question than the one that was asked.
+#[test]
+fn a_missing_baseline_yields_no_feature_deltas() {
+    let arms = vec![arm(
+        "only",
+        "only",
+        (0..3)
+            .map(|_| counted("t", true, &[("tool.grep", 1)]))
+            .collect(),
+    )];
+    let report = compare(&arms, &ComparisonConfig::new("absent", Metric::PassRate));
+    assert_eq!(
+        report.feature_keys(),
+        vec!["tool.grep"],
+        "the keys are still visible"
+    );
+    assert!(report.feature_deltas().is_empty());
+}
+
+/// Additive, and checked rather than asserted: a report from a producer that
+/// counts nothing serializes exactly as it did before the channel existed, and
+/// a report recorded before it existed still deserializes.
+#[test]
+fn the_feature_channel_is_additive_on_the_wire() {
+    let arms = vec![
+        arm("base", "off", repeat("t", false, 6)),
+        arm("candidate", "on", repeat("t", true, 6)),
+    ];
+    let report = compare(&arms, &ComparisonConfig::new("base", Metric::PassRate));
+    let json = serde_json::to_value(&report).expect("serialize");
+    assert!(
+        json["arms"][0].get("features").is_none(),
+        "an arm that counted nothing adds no key: {}",
+        json["arms"][0]
+    );
+    assert_eq!(
+        COMPARISON_SCHEMA_VERSION, 1,
+        "the channel is additive, so the schema version does not move"
+    );
+
+    // A trial recorded before the field existed round-trips to an empty map.
+    let older = serde_json::json!({
+        "task": "t",
+        "outcome": {"succeeded": true, "cost_usd": 0.1, "tokens": 10, "retries": 0},
+        "turns": 3,
+    });
+    let record: TrialRecord = serde_json::from_value(older).expect("older shape still parses");
+    assert!(record.features.is_empty());
+
+    // And the whole report round-trips byte-for-byte (invariant #4).
+    let text = serde_json::to_string(&report).expect("serialize");
+    let back: ComparisonReport = serde_json::from_str(&text).expect("deserialize");
+    assert_eq!(serde_json::to_string(&back).expect("re-serialize"), text);
 }

--- a/crates/stella-core/src/comparison/trial.rs
+++ b/crates/stella-core/src/comparison/trial.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::feature::FeatureCounts;
 use crate::self_tuning::TaskOutcome;
 
 /// One task run once under one arm.
@@ -26,6 +27,15 @@ pub struct TrialRecord {
     /// Model calls the trial spent. `0` is legitimate for a trial that never
     /// launched, so it is not a sentinel for "unknown".
     pub turns: u32,
+    /// Per-feature counters this trial observed — the opaque attribution
+    /// channel described in [`super::feature`]. Empty is the ordinary case
+    /// for a caller that measures nothing beyond the aggregates.
+    ///
+    /// `serde(default)` and skipped when empty, so a report recorded before
+    /// counters existed still deserializes and a producer that counts nothing
+    /// emits byte-identical JSON to the one it emitted before.
+    #[serde(default, skip_serializing_if = "FeatureCounts::is_empty")]
+    pub features: FeatureCounts,
 }
 
 /// One arm of the comparison: a named configuration and every trial run under

--- a/crates/stella-core/src/skills/appraisal.rs
+++ b/crates/stella-core/src/skills/appraisal.rs
@@ -56,8 +56,8 @@ use serde::{Deserialize, Serialize};
 
 use super::SkillOrigin;
 use crate::comparison::{
-    ArmTrials, ComparisonConfig, ComparisonReport, ComparisonVerdict, Guard, LiftEvidence, Metric,
-    TrialRecord, compare,
+    ArmTrials, ComparisonConfig, ComparisonReport, ComparisonVerdict, FeatureCounts, Guard,
+    LiftEvidence, Metric, TrialRecord, compare,
 };
 use crate::self_tuning::{KeepReason, RewardWeights, SelectionConfig, TaskOutcome};
 
@@ -293,6 +293,10 @@ fn arms_from(trials: &[SkillTrial]) -> Vec<ArmTrials> {
         task: t.task.clone(),
         outcome: t.outcome,
         turns: t.turns,
+        // A skill appraisal counts no per-feature attribution: the arms here
+        // are "the skill was selected" vs "it was not", which the split
+        // itself already states.
+        features: FeatureCounts::new(),
     };
     vec![
         ArmTrials {


### PR DESCRIPTION
## What & why

`loop-bench --compare` attributed exactly two features — `project_overview` and `graph_query` — so every other feature in the #2374 plan had rich events in `stella-events.jsonl` and **no counter in the comparison report**. A paired ablation of recall, of the witness stage, of subagents, of an adopted foundry tool produced no per-feature number without a bespoke `jq`/Python pass written per experiment, run *beside* the report rather than inside it. A figure computed over a different trial set than the report's pass rate is not comparable with it, and nothing on the page says so — which is exactly where a measurement artifact creeps in.

Every trial now carries a counter map distilled from the same stream, and `stella-core::comparison` folds it over the same **paired** trials as every other figure. A feature delta and a pass-rate delta in one report are therefore statements about one population.

```
FEATURE ATTRIBUTION — per-trial mean (total), over the paired trials only
feature                        recall-off      recall-on   Δ recall-on
──────────────────────────────────────────────────────────────────────
recall.calls                     0.00 (0)       1.00 (6)        +1.000
recall.frames                    0.00 (0)      3.50 (21)        +3.500
recall.frames_rejected           0.00 (0)       0.00 (0)        +0.000
stage.execute                   2.00 (12)       1.00 (6)        -1.000
subagent.spawned                 0.00 (0)       1.00 (6)        +1.000
tool.graph_query                 0.00 (0)      2.00 (12)        +2.000
tool.grep                       4.00 (24)       0.00 (0)        -4.000
```

**The vocabulary** (`bench/loop-bench/src/features.rs`), keyed `<namespace>.<what>`:

| Key | One per | Card |
|---|---|---|
| `tool.<name>` | `tool_start`, keyed by the tool's own name | F2, F3, F5, F11 |
| `stage.<kind>` | `stage`, keyed by the canonical `StageKind` tag | F6, F7, F10 |
| `recall.calls` / `.frames` / `.tokens` / `.frames_rejected` | `context_recall` | F8 |
| `context_write.calls` / `.upserts` / `.superseded` | `context_write` | F9, F14 |
| `subagent.spawned` / `.refused` | `sub_agent` `started`; a `finished` with status `refused` | F11 |

**Four decisions are load-bearing, and each is a defect if reversed:**

- **Tools are keyed by name, never by a class.** A foundry-authored tool is indistinguishable from a built-in on the wire — `ToolCall` carries a name and arguments and nothing about provenance — so a `tool.foundry` bucket would be the harness *guessing* from a name it does not own. Keying by name reports what the stream says. It also gives `project_overview` and `graph_query` separate keys, which #2382 item 1 asks for on its own account: F3 and F5 have separate kill criteria and cannot share a bucket.
- **Stages are canonicalized through `StageKind`.** The verdict stage shipped as `judge` and is still aliased that way, so a raw-string key would file one stage under two names and report each as having half-fired. This is also why the crate takes a `stella-protocol` dependency (below) rather than hardcoding a stage list, which would duplicate the vocabulary L-E1 exists to hold exactly once.
- **The key set is the union of both arms.** A counter only one arm emitted is the single most interesting row an ablation produces; an intersection deletes exactly that finding.
- **The delta is derived, never stored** — `candidate.mean − baseline.mean` at read time, so it cannot disagree with the two figures printed beside it. And it is a **per-trial mean**, because pairing excludes at trial granularity and the arm that folded more trials wins every raw total by construction.

The block prints **above the verdict and is never folded into it**: a feature delta is evidence about what changed, not a bar a candidate may be promoted on.

**Exemplar.** The opaque-counters-on-an-opaque-arm shape mirrors this crate's own `self_tuning::ArmSamples` — an id, a display value, and a bag of per-trial observations the engine folds without knowing what they mean. `stella-core::comparison::feature` knows nothing about `tool.graph_query`, exactly as it knows nothing about whether an arm's `value` names a model or a prompt template.

Closes #2382
Refs #2374

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Checked the artisanal way — a detached worktree at `HEAD` with **only** the three test files copied in:

```
error[E0609]: no field `features` on type `TrialReport`
error[E0599]: no method named `feature_keys` found for struct `ComparisonReport`
error[E0609]: no field `features` on type `&ArmSummary`
error[E0599]: no method named `feature_deltas` found for struct `ComparisonReport`
```

The set (10 new tests + 1 new property):

- `every_attributable_event_reaches_its_own_counter` — one stream carrying every attributable event, spelled as the wire spells it (`sub_agent`'s nested `phase` discriminator, `context_recall`'s `usage.providers[]`), asserting each counter's known value.
- `the_two_context_tools_are_counted_separately_and_agree_with_their_columns` — #2382 item 1.
- `a_stage_recorded_under_its_wire_alias_lands_in_the_canonical_bucket` — `judge`/`verifier`/`verdict` all fold to `stage.verdict`.
- `an_unknown_stage_is_counted_under_its_own_name`, `a_stage_entered_twice_counts_twice_where_the_stage_list_dedupes` (the revise back-edge), `a_multi_step_trials_counters_sum_across_its_steps`, `the_json_report_carries_the_feature_counters`.
- `a_paired_ablation_reports_each_feature_counter_with_its_delta`, `an_unpaired_trials_counters_are_excluded_with_the_rest_of_it`, `arms_that_counted_nothing_have_no_feature_keys` (loop-bench compare).
- `feature_counters_fold_into_a_total_and_a_per_trial_mean`, `the_feature_key_set_is_the_union_of_both_arms`, `an_excluded_trials_counters_are_excluded_too`, `a_missing_baseline_yields_no_feature_deltas`, `the_feature_channel_is_additive_on_the_wire` (stella-core).
- Property `a_feature_delta_always_re_derives_from_its_operands`, and `arb_trial` now generates counters so the existing determinism/totality properties cover them.
- `a_bench_report_carrying_feature_counters_still_reads` (stella-cli) — the second-reader check below.

No test was deleted or renamed in this PR.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1535 pass; **one pre-existing failure**, `daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`, already tracked as #2393. Confirmed with the cheap control: it fails identically on a stashed tree at the merge base, so it is not this change.
- [x] Every guard: `make invariants doc-links command-docs brand-case file-size god-files gate-parity left-behind role-names stat-portability module-reachability wire-schema` and `make doc-warnings`, all green. `shellcheck` is not installed in this environment and was the only step not run; this PR touches no shell.
- [x] Docs updated — `bench/loop-bench/README.md` gains § Feature attribution (the documented contract for what the harness measures, per #2382 item 5) and its § Key concepts paragraph no longer calls the two context tools one bucket.
- [x] `Closes #2382` appears both here and as a commit trailer.

## Nothing left behind

- [x] Filed: **#2398** — `AgentEvent::ContextRecall` carries no `no_evidence_cut`, so the evidence gate's refusal count is unmeasurable from the trace.

#2382 item 2 asks for the `no_evidence_cut` refusal count. **It is deliberately not implemented, and this is the one part of the issue's scope this PR does not deliver.** The count is real (`stella-context`'s `RetrievalResult`) but never reaches the wire: `AgentEvent::ContextRecall` carries the admitted frames and, via `usage`, the frames the CGP *host* rejected — a misdeclared cost, a consent gate, a failed leg — which is a fact about plumbing, not relevance. Counting `recall.frames_rejected` and labelling it the evidence cut would be a different number wearing the name of the one the experiment asked for. The gap is documented in the module docs and the README rather than papered over, and #2398 is written as a handoff (it also names a second finding: `telemetry_event` suppresses the event entirely when `frames.is_empty()`, so a recall where the gate refused *everything* is invisible in the stream — the single most interesting case for grading the gate).

Also linked, not duplicated: #2393 (the flaky daemon test above).

## Ground-rule check

- [x] No I/O added to `stella-core` — `comparison::feature` is pure folds over owned data.
- [x] No new outbound network calls.
- [x] New cross-boundary types round-trip through serde — `the_feature_channel_is_additive_on_the_wire` asserts the whole `ComparisonReport` re-serializes byte-identically (invariant #4).

**One new dependency**, `loop-bench` → `stella-protocol` (path). Justification: the distiller reads the wire contract and was doing so with magic strings; `StageKind` is the only import, and only to canonicalize a stage name off the stream. The alternative — a hardcoded stage-name list in the bench crate — both splits the aliased `verdict` bucket and duplicates the stage vocabulary that `stella-protocol` exists to hold exactly once (L-E1). It is already in the build graph beneath `stella-core`, which `loop-bench` depends on, so it costs no compile time.

## Anything reviewers should know?

**On the freeze.** #2374 names 0.7 as an explicit freeze exception, scoped to "extends an existing counter table in the bench harness". This PR adds no user-facing surface: no new CLI flag, no new command, no new output file. `--compare`'s existing rendering gains a block; the single-run `--json` gains a `features` key per row.

**On additivity — checked, not assumed** (#2382 item 4). `COMPARISON_SCHEMA_VERSION` does **not** move: the change is compatible, and bumping it would make every existing consumer refuse reports it can read fine. `TrialRecord.features` and `ArmSummary.features` are `#[serde(default, skip_serializing_if = …)]`, so a producer that counts nothing emits byte-identical JSON and a report recorded before today still deserializes. The second reader, `stella tune effort`, reads a deliberately narrow view of a trial row (`BenchTrial`) and ignores unknown keys — `a_bench_report_carrying_feature_counters_still_reads` proves it, and proves the resulting arm arithmetic is identical with and without the key, because the failure mode would be `stella tune effort` refusing every artifact produced after this lands.

**Where I chose not to widen.** Per-task feature rows (the `TaskRow` level) would be a dashboard, and #2382 explicitly rules that out. Likewise the deltas are computed, not stored — a stored delta is one more cell that can drift from its operands, and this repo has lost a `main` to that shape before.

**Cardinality.** `tool.<name>` keys come from model-supplied names, so they are truncated to 48 characters before becoming a map key. Truncation rather than a cap on distinct keys: dropping a counter silently is how a report claims coverage it does not have.

**The offline warehouse** (`bench/telemetry_store/`) needs no change to stay consistent — `ingest.py` already stores every event's whole payload in `events` plus a `tool_calls` row per call, so the same counters are derivable there in SQL from the same file. Noted in the README rather than left implicit.

---

## Summary by Sourcery

Add per-feature attribution counters to loop-bench trial reports and stella-core comparisons so A/B runs can report feature-level deltas from the same paired trials as the primary metrics.

New Features:
- Introduce a per-feature attribution channel that records per-trial counters (e.g., tools, stages, recall, context write, subagents) and exposes them through TrialReport and ComparisonReport.
- Render a FEATURE ATTRIBUTION table in loop-bench --compare output, showing per-arm per-feature means, totals, and baseline-relative deltas.
- Add support in stella-core for aggregating feature counters per arm and computing baseline-relative feature deltas for paired comparisons.

Enhancements:
- Ensure multi-step trials merge per-step feature counters into a single trial-level view and that attribution respects trial pairing logic.
- Constrain and canonicalize feature keys (e.g., tool names with length limits, stages via StageKind) to keep reports stable and forward-compatible.
- Extend property-based tests to cover feature counters and deltas, guaranteeing derived deltas stay consistent with their operands.

Documentation:
- Document the new feature attribution channel in the loop-bench README, including key vocabulary, semantics, and compatibility guarantees.

Tests:
- Add focused tests across loop-bench, stella-core comparison, and stella-cli to validate feature counting from event streams, aggregation behavior, JSON wire compatibility, and consumer resilience to the new keys.

Chores:
- Wire a new stella-protocol dependency into loop-bench to reuse the canonical stage vocabulary for attribution.
