### PR TITLE
fix(gate): the file-size ratchet judges a first-time crossing against the base too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,17 +424,20 @@ inputs, not review afterthoughts:
   an escape hatch for a genuinely irreducible line (a module declaration in
   an already-oversized `lib.rs`), never something a plan may assume.
 
-**The ratchet judges your change, not the tree** (#2004). A file over its
-ceiling fails only when `current > max(ceiling, size in the base tree)` — so a
-violation that was already there before your branch existed is reported as
-drift and does not fail you, while anything your change grows past what it
-inherited fails exactly as it always did. The base is the merge commit's first
-parent on a pull request, the merge base locally, and nothing at all in a
-shallow clone or a fresh repository — where the guard falls back to the strict
-whole-tree check, because an unresolvable base must make it stricter, never
-weaker. This exists because the baseline is one shared cell every growing PR
-must write, and three times running two PRs that each wrote it correctly
-composed into a red `main` that then failed everyone downstream. Two
+**The ratchet judges your change, not the tree** (#2004). A file over the line
+fails only when `current > max(its own limit, size in the base tree)` — where
+that limit is the baseline entry for a grandfathered file and the 1500 lines
+above for every other (#2397). So a violation that was already there before
+your branch existed is reported as drift and does not fail you, while anything
+your change grows past what it inherited fails exactly as it always did.
+Inherited drift is survived, never absorbed: a first-time crossing you walked
+past still wants splitting, and still gets no baseline entry. The base is the
+merge commit's first parent on a pull request, the merge base locally, and
+nothing at all in a shallow clone or a fresh repository — where the guard falls
+back to the strict whole-tree check, because an unresolvable base must make it
+stricter, never weaker. This exists because the baseline is one shared cell
+every growing PR must write, and three times running two PRs that each wrote it
+correctly composed into a red `main` that then failed everyone downstream. Two
 consequences for planning: **do not "fix" a red ratchet you did not cause** by
 folding a baseline regeneration into an unrelated PR — land it on its own from
 a fresh `main`; and note that splitting a god file buys structure, not slack,

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -82,6 +82,17 @@
 # ceiling raised deliberately via `--update` still passes exactly as before:
 # the regenerated ceiling equals the current size.
 #
+# `ceiling` here means the file's own limit, whichever kind it has: the baseline
+# entry for a grandfathered file, and LIMIT for every other. The rule was first
+# written for grandfathered files alone, and a file with no baseline entry went
+# on failing on sight — so the very first crossing of the 1500-line limit on
+# `main` turned every open PR red, byte-identical trees included, which is the
+# exact failure #2004 exists to prevent (#2397). What differs between the two
+# kinds is only the remedy the report names, not the arithmetic: a drifted
+# ceiling is cleared by regenerating the baseline, while a first-time crossing
+# is cleared by splitting the file. A first-time crossing is never grandfathered
+# on the way past — inherited drift is reported and survived, not absorbed.
+#
 # The base is the same pair `scripts/check-deleted-tests.sh` uses, for the same
 # reason: on a `pull_request` event the checkout is `refs/pull/N/merge`, so HEAD
 # is the merge commit and HEAD^1 is the base branch tip. That asks "does this
@@ -222,10 +233,10 @@ size_at_base() {
 # Single awk pass: read the baseline into a map, then judge each current file.
 # Baseline lines are tagged B, current sizes C, so one awk sees both streams.
 #
-# A file over its ceiling is emitted as a CANDIDATE, not a verdict: awk sees one
+# A file over its limit is emitted as a CANDIDATE, not a verdict: awk sees one
 # tree and so cannot tell growth from inherited drift. The classification needs
-# the base tree and happens below. Candidates are emitted in GREW's position so
-# the assembled report keeps its original section order.
+# the base tree and happens below. Candidates are emitted in their section's
+# position so the assembled report keeps its original section order.
 raw_report="$(
   {
     grep -v '^#' "$baseline" | sed 's/^/B /'
@@ -240,14 +251,14 @@ raw_report="$(
         else if (n > ceiling[path])
           grew = grew sprintf("GREWCAND %s %d %d\n", path, n, ceiling[path])
       } else if (n > limit) {
-        newover = newover sprintf("  %s is %d lines, over the %d-line limit\n", path, n, limit)
+        newover = newover sprintf("NEWCAND %s %d\n", path, n)
       }
     }
     END {
       for (p in ceiling)
         if (!(p in seen))
           stale = stale sprintf("  %s (baseline entry, file no longer tracked)\n", p)
-      if (newover) printf "NEWOVER\n%s", newover
+      if (newover) printf "%s", newover
       if (grew) printf "%s", grew
       if (obsolete) printf "OBSOLETE\n%s", obsolete
       if (stale) printf "STALE\n%s", stale
@@ -255,16 +266,52 @@ raw_report="$(
   '
 )"
 
+# max($2, size of $1 at the base): the largest this change may leave the file
+# at, given the limit $2 it is held to. With no base commit the second term is
+# absent and this is that limit alone — the original whole-tree check.
+#
+# Shared by both candidate kinds because the arithmetic is the same rule; only
+# the limit passed in and the remedy reported differ (#2397).
+effective_limit() {
+  local own="$2" at_base
+  if [ -n "$base_commit" ]; then
+    at_base="$(size_at_base "$1")"
+    if [ "$at_base" -gt "$own" ]; then
+      own="$at_base"
+    fi
+  fi
+  printf '%s\n' "$own"
+}
+
 # Classify each candidate against the base tree, preserving the stream order so
 # the GREW section still lands between NEWOVER and OBSOLETE.
-#
-# `current > max(ceiling, size at base)` — see the header. With no base commit
-# the second term is absent and this is the original whole-tree check.
 report=""
 drift=""
+newover_header_emitted=0
 grew_header_emitted=0
 while IFS= read -r line; do
   case "$line" in
+  "NEWCAND "*)
+    # Deliberate word split, as for GREWCAND below.
+    # shellcheck disable=SC2086
+    set -- $line
+    cand_path="$2"
+    cand_now="$3"
+    if [ "$cand_now" -gt "$(effective_limit "$cand_path" "$LIMIT")" ]; then
+      if [ "$newover_header_emitted" -eq 0 ]; then
+        report="${report}NEWOVER
+"
+        newover_header_emitted=1
+      fi
+      report="$report$(printf '  %s is %d lines, over the %d-line limit' \
+        "$cand_path" "$cand_now" "$LIMIT")
+"
+    else
+      drift="$drift$(printf '  %s is %d lines, over the %d-line limit — already so at the base; split it' \
+        "$cand_path" "$cand_now" "$LIMIT")
+"
+    fi
+    ;;
   "GREWCAND "*)
     # Deliberate word split: these are this script's own awk-formatted records,
     # and the baseline format has never admitted a path containing a space.
@@ -273,14 +320,7 @@ while IFS= read -r line; do
     cand_path="$2"
     cand_now="$3"
     cand_ceiling="$4"
-    cand_effective="$cand_ceiling"
-    if [ -n "$base_commit" ]; then
-      cand_base="$(size_at_base "$cand_path")"
-      if [ "$cand_base" -gt "$cand_effective" ]; then
-        cand_effective="$cand_base"
-      fi
-    fi
-    if [ "$cand_now" -gt "$cand_effective" ]; then
+    if [ "$cand_now" -gt "$(effective_limit "$cand_path" "$cand_ceiling")" ]; then
       if [ "$grew_header_emitted" -eq 0 ]; then
         report="${report}GREW
 "
@@ -290,7 +330,7 @@ while IFS= read -r line; do
         "$cand_path" "$cand_now" "$cand_ceiling" "$((cand_now - cand_ceiling))")
 "
     else
-      drift="$drift$(printf '  %s is %d lines against a ceiling of %d — already so at the base' \
+      drift="$drift$(printf '  %s is %d lines against a ceiling of %d — already so at the base; regenerate' \
         "$cand_path" "$cand_now" "$cand_ceiling")
 "
     fi
@@ -312,10 +352,13 @@ if [ -n "$drift" ]; then
     echo "check-file-size: baseline drift (not caused by this change, not fatal)"
     printf '%s' "$drift"
     echo ""
-    echo "These files were already over their recorded ceiling in the base tree,"
-    echo "so another change put them there and this one only inherited it. Run"
-    echo "\"make file-size-update\" on a fresh main and land the baseline diff on"
-    echo "its own to clear it."
+    echo "These files were already over the line in the base tree, so another change"
+    echo "put them there and this one only inherited it. Each line above names its"
+    echo "own remedy, and they differ: \"regenerate\" is a grandfathered file whose"
+    echo "ceiling drifted below it, cleared by \"make file-size-update\"; \"split it\" is"
+    echo "a file that crossed the ${LIMIT}-line limit for the first time, which is never"
+    echo "given a baseline entry. Either way it is that file's own change, landed on"
+    echo "its own from a fresh main — not folded into this one."
   } >&2
 fi
 
@@ -361,4 +404,4 @@ else
   mode_note=" No base resolved — strict whole-tree check."
 fi
 trap '' PIPE
-echo "check-file-size: OK — $tracked Rust/Python/shell files, none over $LIMIT lines except $grandfathered grandfathered (none grew by this change).${mode_note}${drift_note}" || true
+echo "check-file-size: OK — $tracked Rust/Python/shell files, $grandfathered grandfathered over $LIMIT lines, and nothing went over by this change.${mode_note}${drift_note}" || true

--- a/scripts/test-file-size.sh
+++ b/scripts/test-file-size.sh
@@ -87,16 +87,24 @@ commit() {
 }
 
 # want <name> <expect-pass|expect-fail> <repo> [substring]
+#
+# The substring is checked on BOTH verdicts. On expect-fail it pins which file
+# was flagged; on expect-pass it pins what a passing run still reported — a
+# drift note is a real finding that happens not to be fatal, and a guard that
+# passed by forgetting the file would satisfy a bare expect-pass.
 want() {
   local name="$1" expect="$2" dir="$3" sub="${4:-}" out rc
   out="$("$dir/scripts/check-file-size.sh" 2>&1)"
   rc=$?
   if [ "$expect" = "expect-pass" ]; then
-    if [ "$rc" -eq 0 ]; then
-      pass=$((pass + 1)); echo "ok   $name"
-    else
+    if [ "$rc" -ne 0 ]; then
       fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+      return
     fi
+    case "$out" in
+      *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+      *) fail=$((fail + 1)); echo "FAIL $name — passed, but did not report '$sub':"; echo "$out" ;;
+    esac
     return
   fi
   if [ "$rc" -eq 0 ]; then
@@ -254,6 +262,55 @@ commit "$r" "the base branch drifts while the PR is open"
 git -C "$r" merge -q --no-ff -m "Merge feature" feature
 want "B6 a refs/pull/N/merge checkout finds its base branch tip unaided" \
   expect-pass "$r"
+
+# ── The same rule for a file with NO baseline entry (#2397) ──────────────────
+#
+# B1-B4 all concern grandfathered files, and so did the fix: the allowance ran
+# in the branch that reads a baseline ceiling, and a file with no entry went on
+# failing on sight. So the first time any file crossed 1500 lines on `main`,
+# every open PR went red — including PRs whose tree was byte-identical to the
+# base, which is precisely the shape #2004 was written to end. B7-B9 pin the
+# rule to both kinds of file, and B8/B9 are what stop that from becoming a
+# licence: a first-time crossing is survived only while the branch does not
+# make it worse, and it is never absorbed into the baseline.
+
+# The blocking case: over the limit at the base, with no baseline entry, and
+# this change touches something else entirely. It must pass — and it must still
+# SAY so, because the debt is real and only the ownership of it is in question.
+# A guard that passed by forgetting the file would satisfy the verdict alone.
+r="$(new_repo "newover_at_base")"
+plant "$r" "src/big.rs" 1600
+commit "$r" "base: a first-time crossing lands on main"
+plant "$r" "src/unrelated.rs" 10
+commit "$r" "head: an unrelated change walks past it"
+export FILE_SIZE_BASE_REF="HEAD^1"
+want "B7 a first-time crossing inherited from the base is drift, not this change's failure" \
+  expect-pass "$r" "src/big.rs is 1600 lines, over the 1500-line limit — already so at the base; split it"
+unset FILE_SIZE_BASE_REF
+
+# The bloat the ratchet exists to block, in its commonest form: the branch
+# itself pushes a file over the limit for the first time.
+r="$(new_repo "newover_grown_here")"
+plant "$r" "src/big.rs" 1400
+commit "$r" "base: under the limit"
+plant "$r" "src/big.rs" 1600
+commit "$r" "head: this change crosses the limit"
+export FILE_SIZE_BASE_REF="HEAD^1"
+want "B8 a file this change pushes over the limit still fails" \
+  expect-fail "$r" "src/big.rs is 1600 lines, over the 1500-line limit"
+unset FILE_SIZE_BASE_REF
+
+# Drift must not become a licence here either — the B4 asymmetry, for a file
+# with no baseline entry to grow against.
+r="$(new_repo "newover_growth_on_drift")"
+plant "$r" "src/big.rs" 1600
+commit "$r" "base: already over, and not grandfathered"
+plant "$r" "src/big.rs" 1650
+commit "$r" "head: grow it further still"
+export FILE_SIZE_BASE_REF="HEAD^1"
+want "B9 growth on top of an inherited first-time crossing still fails" \
+  expect-fail "$r" "src/big.rs is 1650 lines, over the 1500-line limit"
+unset FILE_SIZE_BASE_REF
 
 echo
 echo "passed ${pass}, failed ${fail}"


### PR DESCRIPTION
## What & why

`main` is red on the `file size ratchet` check, and so is every open PR —
including PRs whose tree is byte-identical to the base. #2394 (typed errors,
touching no file under `arenabench/`) is blocked on this alone.

#2004 made the ratchet judge *the change*, not the tree —
`current > max(ceiling, size at base)`. But that arithmetic ran in only **one**
branch of the classifier in `scripts/check-file-size.sh`. A file with a baseline
entry was emitted as a `GREWCAND` candidate and got the allowance; a file with
**no** entry was emitted as a finished `NEWOVER` verdict and fell into the
catch-all, where the base tree is never consulted.

So `arenabench/arenabench/telemetry.py` going 1474 → 1534 in 76c7aae (#2391)
failed every branch that walked past it. `max(1500, 1534) = 1534` and
`current = 1534`, so `1534 > 1534` is false and this must pass — it failed
because that comparison never ran for this record type.

Both candidate kinds now run through one `effective_limit` helper, differing
only in the limit passed in: the baseline entry for a grandfathered file, the
1500-line limit for every other. **The asymmetry is preserved** — a file this
change pushes over still fails, growth on top of inherited drift still fails,
and an inherited crossing is reported as drift rather than absorbed into the
baseline.

The drift lines now name their own remedy — `regenerate` for a grandfathered
file whose ceiling drifted, `split it` for a first-time crossing. The old
footer prescribed `make file-size-update` for every case, which is the one
action a first-time crossing must never take.

Closes #2397

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`B7 a first-time crossing inherited from the base is drift, not this change's
failure` in `scripts/test-file-size.sh`. Checked the artisanal way — the new
tests run against the old guard:

```
--- old guard, new tests ---
FAIL B7 ... — expected OK, got:
check-file-size: FAILED
  src/big.rs is 1600 lines, over the 1500-line limit
ok   B8 a file this change pushes over the limit still fails
ok   B9 growth on top of an inherited first-time crossing still fails
passed 15, failed 1
```

B8 and B9 passing on **both** guards is the point of them: they are the
anti-hole cases, and a fix that broke them would show up as a green they cannot
give. The three cases are the three #2397 asks for.

`want` in the harness now checks its substring on the passing path as well.
Without that, B7 would have been satisfied by a guard that passed *by forgetting
the file existed* — the drift note is a real finding that happens not to be
fatal, and asserting only the exit code would not have distinguished the fix
from that regression.

Verified on the real tree, which is byte-identical to its base for this file:

```console
$ ./scripts/check-file-size.sh
check-file-size: baseline drift (not caused by this change, not fatal)
  arenabench/arenabench/telemetry.py is 1534 lines, over the 1500-line limit — already so at the base; split it
...
check-file-size: OK — 1214 Rust/Python/shell files, 30 grandfathered over 1500 lines, and nothing went over by this change. Judged against cd12845. 1 file(s) carry inherited drift (see above).
exit=0
```

## The gate

- [x] `cargo fmt --check`
- [x] `make guards-fast` — every toolchain-free guard green, `shellcheck`
      included (it is installed in this container and was run)
- [x] `./scripts/test-file-size.sh` — 16/16
- [x] `cargo clippy` / `cargo test --workspace` — not run: this change touches
      no Rust. `scripts/impacted-crates.sh` puts a shell+markdown diff on the
      `guards-fast` rung, which is what ran.
- [x] Docs updated — AGENTS.md § "God files" stated the rule as
      `max(ceiling, …)`, which was only ever true for grandfathered files
- [x] `Closes #2397` appears both here and as a commit trailer

## Nothing left behind

- [x] Filed: #2403, #2404

- **#2403** — `arenabench/arenabench/telemetry.py` is still 1534 lines. This PR
  makes the tree *survive* that, not clear it; the split is the other half of
  #2397 and belongs with arenabench, per AGENTS.md § "God files" on not folding
  a ratchet fix you did not cause into an unrelated PR.
- **#2404** — `make file-size-update` will happily write a baseline entry for a
  first-time crossing, which the header it writes into explicitly forbids. Found
  while verifying `--update` still worked here (it added telemetry.py as a 31st
  entry). One command away from any author staring at a red gate, and this PR
  makes it sharper by telling that author to "split it" while the tool next to
  them offers to make the message disappear.

## Ground-rule check

- [x] No I/O added to `stella-core` — no Rust changed at all
- [x] No new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**Why this is not a weakening of the ratchet.** The worry with any "already
broken at the base" rule is that drift becomes a licence to bloat, which is
worse than the red `main` it fixes. That is exactly what B4 pins for
grandfathered files, and B9 now pins the same asymmetry for non-grandfathered
ones: a file at 1600 in the base that this change grows to 1650 still fails,
against the base size and not the limit. What the change permits is strictly
"leave it exactly as you found it".

**The one behavior that is genuinely new and permanent.** An inherited
first-time crossing is now reported on every run rather than failing, so the
`telemetry.py` line will print until #2403 lands. That is the intended end
state per #2397 — drift is loud and non-fatal — but it does mean the report is
the only pressure on the file, which is why #2403 exists rather than a comment.

**Rejected alternative:** raising the ceiling for `telemetry.py` by adding a
baseline entry, or splitting the Python file here. The first is forbidden
outright (the baseline takes no new entries) and would have hidden the guard
bug rather than fixed it — the guard would then have been wrong in the same way
for the *next* first-time crossing. The second is a real fix but a different
PR's: it is arenabench's change, it must land from a fresh `main`, and folding
it in here would be the exact move AGENTS.md names.

**Green summary line reworded.** It claimed "none over 1500 lines except N
grandfathered", which inherited drift makes false. It now says what it can
stand behind: N grandfathered, and nothing went over *by this change*.

---

## Summary by Sourcery

Adjust file size ratchet to judge both grandfathered and non-grandfathered files against the base tree, treating inherited first-time crossings as non-fatal drift while still failing growth introduced by the current change.

Bug Fixes:
- Fix file-size ratchet so PRs whose trees are identical to the base no longer fail when a file first crossed the limit on main.
- Ensure files without baseline entries use the same base-aware limit calculation as grandfathered files, preventing incorrect NEWOVER failures.

Enhancements:
- Introduce a shared effective_limit helper to centralize base-aware limit calculation for both candidate types in the file-size check.
- Refine drift reporting to distinguish between grandfathered ceiling drift (regenerate baseline) and first-time crossings (split the file), and update the OK summary line to reflect inherited drift accurately.

Documentation:
- Update AGENTS.md to describe the ratchet rule in terms of each file’s own limit (baseline or global limit) and clarify how inherited drift for first-time crossings is reported and handled.

Tests:
- Extend the file-size guard test suite with cases for non-grandfathered files (B7–B9), covering inherited first-time crossings, new crossings introduced by the branch, and growth on top of inherited drift, plus stricter output substring checks in the test harness.
