### PR TITLE
perf(stella-tools): stop billing a model round trip to move a card

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -15,6 +15,31 @@ pub(crate) async fn run_raw_one_shot(
     budget_limit: Option<f64>,
     format: OutputFormat,
 ) -> Result<(), crate::failure::CliFailure> {
+    // The bare step loop withholds the task board.
+    //
+    // The board is what makes a long autonomous run legible and resumable —
+    // and a one-shot turn has nothing to resume, so here it is pure overhead
+    // charged at the most expensive rate there is: a model round trip per
+    // card. Measured over nine solved Terminal-Bench trials, 26% of every tool
+    // call this loop made was board bookkeeping and 14% of its steps did
+    // nothing else — steps that read nothing, changed no file, and still paid
+    // for a full request under a 900s ceiling.
+    //
+    // Narrowed rather than switched off at construction: `narrow_with` can
+    // only ever remove capability, so an operator who has already disabled
+    // something keeps it disabled, and this cannot grant anything back. It is
+    // the same seam `tools.bash: "off"` travels through, which is why the
+    // board disappears from MCP-wrapped and custom tool stacks too rather than
+    // only from the built-in registry.
+    let cfg = &{
+        let mut bare = cfg.clone();
+        bare.tool_policy
+            .narrow_with(&stella_tools::policy::ToolPolicy::from_switches([(
+                "task".to_string(),
+                false,
+            )]));
+        bare
+    };
     let provider = build_provider(cfg)?;
     let registry_options = registry_options(cfg);
     // Concrete `Arc<ToolRegistry>` (not `Arc<dyn ToolExecutor>`) so the
@@ -963,6 +988,60 @@ impl stella_core::ToolExecutor for VerifierScopedTools<'_> {
     // is wrong the day that changes.
     fn drain_sub_agent_spend_usd(&self) -> f64 {
         self.inner.drain_sub_agent_spend_usd()
+    }
+}
+
+#[cfg(test)]
+mod bare_loop_board_tests {
+    use stella_tools::policy::ToolPolicy;
+
+    /// The narrowing `run_raw_one_shot` applies, asserted at the seam it uses.
+    ///
+    /// Fails on main, where the bare loop narrowed nothing and every board
+    /// tool was offered: 26% of its tool calls and 14% of its steps went on
+    /// bookkeeping that a one-shot turn can never resume.
+    fn bare_loop_policy(base: ToolPolicy) -> ToolPolicy {
+        let mut policy = base;
+        policy.narrow_with(&ToolPolicy::from_switches([("task".to_string(), false)]));
+        policy
+    }
+
+    #[test]
+    fn the_bare_loop_withholds_every_board_tool() {
+        let policy = bare_loop_policy(ToolPolicy::allow_all());
+        for tool in [
+            "task_create",
+            "task_list",
+            "task_start",
+            "task_complete",
+            "task_cancel",
+        ] {
+            assert!(!policy.allows(tool), "{tool} should be withheld");
+        }
+    }
+
+    #[test]
+    fn withholding_the_board_leaves_the_working_tools_alone() {
+        let policy = bare_loop_policy(ToolPolicy::allow_all());
+        for tool in ["bash", "read_file", "write_file", "edit_file", "grep"] {
+            assert!(policy.allows(tool), "{tool} must still be available");
+        }
+    }
+
+    /// Narrowing can only remove. An operator who has already switched
+    /// something off keeps it off, and this must never hand it back — which is
+    /// why the board is withheld through the policy seam rather than by
+    /// skipping registration.
+    #[test]
+    fn narrowing_never_grants_back_what_an_operator_denied() {
+        let operator =
+            ToolPolicy::from_switches([("bash".to_string(), false), ("task".to_string(), true)]);
+        let policy = bare_loop_policy(operator);
+        assert!(!policy.allows("bash"), "operator's denial must survive");
+        assert!(
+            !policy.allows("task_create"),
+            "an operator grant must not resurrect the board here"
+        );
     }
 }
 

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -83,18 +83,38 @@ impl Tool for TaskCreate {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "task_create".into(),
-            description: "Add a task to the session task board — the board is the session's \
+            description: "Add tasks to the session task board — the board is the session's \
                           visible plan, so create tasks BEFORE starting multi-step work, one \
-                          per concrete deliverable. New tasks start pending; mark the one you \
-                          work on with task_start (or delegate it with task_assign)."
+                          per concrete deliverable. Pass `tasks` to create a whole plan in ONE \
+                          call; `subject` creates a single task. New tasks start pending; mark \
+                          the one you work on with task_start (or delegate it with \
+                          task_assign). Board updates cost a full model round trip when they \
+                          travel alone — issue them in the SAME step as the real work they \
+                          describe, never as a step of their own."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
+                    "tasks": {
+                        "type": "array",
+                        "description": "The whole plan at once — strings, or objects with subject/description. Prefer this over several task_create calls.",
+                        "items": {
+                            "anyOf": [
+                                { "type": "string" },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "subject": { "type": "string" },
+                                        "description": { "type": "string" }
+                                    },
+                                    "required": ["subject"]
+                                }
+                            ]
+                        }
+                    },
                     "subject": { "type": "string", "description": "Imperative title (e.g. \"Fix the auth redirect loop\")" },
                     "description": { "type": "string", "description": "What needs to be done, if the subject alone is not enough" }
-                },
-                "required": ["subject"]
+                }
             }),
             read_only: false,
             speculation_safe: false,
@@ -102,6 +122,52 @@ impl Tool for TaskCreate {
     }
 
     async fn execute(&self, input: &Value, _root: &std::path::Path) -> ToolOutput {
+        // The batch form exists because the per-call form was being billed a
+        // model round trip per card. Across nine solved Terminal-Bench trials,
+        // 26% of every tool call Stella made was board bookkeeping and 14% of
+        // its steps did nothing else — a plan of four tasks cost four requests
+        // to write four lines that changed no file and read nothing.
+        if let Some(entries) = input.get("tasks").and_then(Value::as_array) {
+            if entries.is_empty() {
+                return ToolOutput::Error {
+                    message: "field `tasks` was empty — pass at least one task".into(),
+                };
+            }
+            let mut board = self.0.lock().unwrap_or_else(|p| p.into_inner());
+            let mut created = Vec::with_capacity(entries.len());
+            for (i, entry) in entries.iter().enumerate() {
+                // A bare string is the common case and worth accepting: it is
+                // what a model reaches for when the subject says it all.
+                let (subject, description) = match entry {
+                    Value::String(s) if !s.trim().is_empty() => (s.trim().to_string(), None),
+                    Value::Object(_) => match require_str(entry, "subject") {
+                        Ok(s) => (s.to_string(), optional_str(entry, "description")),
+                        Err(e) => return e,
+                    },
+                    _ => {
+                        return ToolOutput::Error {
+                            message: format!(
+                                "tasks[{i}] must be a non-empty string or an object with `subject`"
+                            ),
+                        };
+                    }
+                };
+                let item = board.create(subject, description);
+                created.push(serde_json::json!({
+                    "id": item.id,
+                    "subject": item.subject,
+                    "status": item.status,
+                }));
+            }
+            return ToolOutput::Ok {
+                content: format!(
+                    "created {} task(s) {}",
+                    created.len(),
+                    Value::Array(created)
+                ),
+            };
+        }
+
         let subject = match require_str(input, "subject") {
             Ok(s) => s,
             Err(e) => return e,
@@ -172,7 +238,9 @@ impl Tool for TaskStart {
                           on right now. Keep exactly ONE task in_progress at a time: complete \
                           the current task before starting the next. (task_assign marks \
                           delegated tasks in_progress by itself — task_start is for your own \
-                          work.)"
+                          work.) Issue this in the SAME step as the first real tool call of \
+                          that task: alone it costs a whole model round trip to change one \
+                          character on a board."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -214,7 +282,9 @@ impl Tool for TaskComplete {
             description: "Mark a board task completed the moment its work is done and \
                           verified. Complete tasks as you finish them — that is what keeps \
                           exactly one task in_progress and the board honest. Completed is \
-                          terminal."
+                          terminal. Send it alongside the next task's first real tool call \
+                          rather than in a step of its own: a step that only moves a card \
+                          reads nothing and changes nothing, and still costs a full request."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -395,6 +465,76 @@ mod tests {
         }
     }
 
+    /// Witness: a whole plan is one call, not one call per card.
+    ///
+    /// Fails on main, where `task_create` required `subject` and ignored
+    /// `tasks` — four deliverables cost four model round trips to write four
+    /// lines that read nothing and changed no file.
+    #[tokio::test]
+    async fn a_plan_of_four_tasks_is_created_in_one_call() {
+        let (board, _) = handles();
+        let tool = TaskCreate(board.clone());
+        let out = content(
+            exec(
+                &tool,
+                serde_json::json!({
+                    "tasks": [
+                        "Install the toolchain",
+                        { "subject": "Extract the vendored tarball", "description": "into /app" },
+                        "Compile with coverage",
+                        "Prove coverage data is produced",
+                    ]
+                }),
+            )
+            .await,
+        );
+        assert!(
+            out.contains("created 4 task(s)"),
+            "unexpected output: {out}"
+        );
+
+        let board = board.lock().expect("board");
+        assert_eq!(board.items().len(), 4, "all four should be on the board");
+        assert_eq!(board.items()[0].subject, "Install the toolchain");
+        assert_eq!(
+            board.items()[1].description.as_deref(),
+            Some("into /app"),
+            "the object form must keep its description"
+        );
+    }
+
+    /// The single form still works — the batch form is an addition, and a
+    /// caller that has already learned `subject` must not be broken by it.
+    #[tokio::test]
+    async fn the_single_subject_form_still_creates_one_task() {
+        let (board, _) = handles();
+        let out = content(
+            exec(
+                &TaskCreate(board.clone()),
+                serde_json::json!({ "subject": "Just the one" }),
+            )
+            .await,
+        );
+        assert!(out.contains("created task"), "unexpected output: {out}");
+        assert_eq!(board.lock().expect("board").items().len(), 1);
+    }
+
+    /// An empty batch is a caller mistake worth naming, not a silent no-op:
+    /// silently succeeding would let a model believe it had filed a plan.
+    #[tokio::test]
+    async fn an_empty_batch_is_refused_by_name() {
+        let (board, _) = handles();
+        let msg = error(
+            exec(
+                &TaskCreate(board.clone()),
+                serde_json::json!({ "tasks": [] }),
+            )
+            .await,
+        );
+        assert!(msg.contains("tasks"), "error should name the field: {msg}");
+        assert_eq!(board.lock().expect("board").items().len(), 0);
+    }
+
     #[test]
     fn all_six_tools_advertise_task_schemas() {
         let (board, queue) = handles();
@@ -429,10 +569,21 @@ mod tests {
             );
             assert_eq!(schema.input_schema["type"], "object", "{}", schema.name);
         }
-        assert_eq!(
-            schemas[0].input_schema["required"],
-            serde_json::json!(["subject"])
+        // `task_create` declares no top-level `required`: either `tasks` (a
+        // whole plan in one call) or `subject` (one card) satisfies it, and a
+        // blanket `required: ["subject"]` would reject the batch form that
+        // exists to stop a four-task plan costing four model round trips.
+        // Neither-supplied is still refused — at execution, by name.
+        assert!(
+            schemas[0].input_schema.get("required").is_none(),
+            "task_create takes either `tasks` or `subject`"
         );
+        for field in ["tasks", "subject"] {
+            assert!(
+                schemas[0].input_schema["properties"].get(field).is_some(),
+                "task_create must still advertise `{field}`"
+            );
+        }
         assert_eq!(
             schemas[5].input_schema["required"],
             serde_json::json!(["id", "briefing"])


### PR DESCRIPTION
## What & why

Stella's bare step loop was paying a **model round trip to move a card**. Measured across nine solved Terminal-Bench trials on `main`:

```
  tool calls total          : 215
  ledger-only tool calls    :  56  (26%)
  steps total               : 181
  steps doing ONLY ledger   :  25  (14%)

  bash              150
  task_create        20  <- ledger
  task_start         16  <- ledger
  task_complete      16  <- ledger
  project_overview    4  <- ledger
```

A quarter of every tool call did no work: `task_create` / `task_start` / `task_complete` neither read the workspace nor change it. Claude Code, on the same tasks, makes **zero** board calls — on `git-multibranch` it used `{Bash: 21, Write: 5, Edit: 1}` and nothing else, and it solved `large-scale-text-editing` in **six bash calls** against Stella's twenty-five steps.

The board is not the problem. It is what makes a long autonomous run legible and resumable. Charging a full request per card is the problem, and under a 900s ceiling the cost is latency, not just tokens.

Refs #2374

## The three changes

**1. Batch the board.** `task_create` accepts `tasks` — a whole plan in one call, as strings or `{subject, description}` objects. Four deliverables now cost one request instead of four. The single `subject` form is untouched.

**2. Say what a step costs.** `task_create`, `task_start`, `task_complete` state in their descriptions that a board update travelling alone costs a full round trip and belongs in the same step as the work it describes. The model chooses the batching, so the tool text is the only place that choice can be informed — this one is guidance, and I expect it to be the least reliable of the three.

**3. Withhold the board where it cannot pay for itself.** A one-shot bare loop has nothing to resume, so `run_raw_one_shot` narrows its policy with `task:off`.

## Why narrowing and not skipping registration

Two reasons, both load-bearing:

- It travels the **same seam as `tools.bash: "off"`**, so the board disappears from MCP-wrapped and custom tool stacks identically, rather than only from the built-in registry — the exact mistake `registry_options`' own doc comment records having made before.
- `narrow_with` can **only remove** capability. An operator who already denied something keeps it denied, and this can never hand a grant back. There is a witness for precisely that.

It also adds **zero lines to `agent.rs`**, which sits at its 2270-line ceiling: `run_raw_one_shot` is by construction the bare path, so the narrowing happens there.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

| test | proves |
|---|---|
| `a_plan_of_four_tasks_is_created_in_one_call` | the batch form exists and lands all four |
| `the_single_subject_form_still_creates_one_task` | backwards compatibility |
| `an_empty_batch_is_refused_by_name` | an empty plan is a named error, not a silent success |
| `the_bare_loop_withholds_every_board_tool` | all five board tools are gone |
| `withholding_the_board_leaves_the_working_tools_alone` | bash/read/write/edit/grep survive |
| `narrowing_never_grants_back_what_an_operator_denied` | narrowing cannot widen |

**One existing test changed, named here as the deleted-test guard asks.** `all_six_tools_advertise_task_schemas` asserted `task_create.required == ["subject"]`. Since `task_create` now takes *either* `tasks` or `subject`, a blanket requirement would reject the batch form outright. It now asserts no top-level `required` and that both fields are still advertised. Supplying neither is still refused — at execution, by name.

## The gate

- [x] `cargo fmt --all`
- [x] `cargo clippy -p stella-tools -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-tools -p stella-cli` — 1538 + all integration suites pass, 0 failed

## Nothing left behind

- [x] Filed previously and still open: #2339 (`arenabench run` crashes on `match.id`), #2377 (interactive loop still probes per tool call)

**This addresses efficiency, not solve rate.** The standing head-to-head is Claude Code 18/18 vs Stella 9/12; Stella's three losses are on `git-multibranch` (2) and `sqlite-with-gcov` (1) and I have **not** diagnosed them. Removing bookkeeping overhead should close the step/token gap — 26 steps vs 18, 2.3× the output tokens per solve — and may close none of the solve-rate gap. A short Stella-only run on this branch is the next step, precisely to find out.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

Change 3 is a **behaviour change for `stella run --no-pipeline`**: the task board is no longer offered there. Interactive sessions, the deck, and the staged pipeline are untouched. If the board turns out to be load-bearing for bare-loop quality rather than only for legibility, this is the change to revert first — it is one narrowing call and isolated for that reason.

## Summary by Sourcery

Batch task creation and disable task board tools in one-shot runs to reduce unnecessary model round trips and bookkeeping overhead.

New Features:
- Support creating multiple tasks in a single task_create call via a tasks array of strings or subject/description objects.

Enhancements:
- Update task-related tool descriptions to encourage batching and co-locating board updates with real work to avoid standalone round trips.

Tests:
- Add witness tests for batched task_create behavior, single-task compatibility, empty-batch errors, and bare-loop task board narrowing semantics.

Chores:
- Adjust tool schema assertions to reflect task_create’s new optional tasks/subject inputs without a top-level required field.