### PR TITLE
perf(stella-tools): stop verify_done rebuilding the same shadow twice in one turn

### DIFF
--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -202,6 +202,9 @@ pub struct ToolRegistry {
     /// construction so no capture can race a reconfiguration. See
     /// [`RegistryOptions::probe_ignore_policy`].
     probe_ignore_policy: crate::shell_touch::IgnorePolicy,
+    /// The turn-scoped shadow-run memo shared with the registered
+    /// `verify_done`, armed and cleared by the turn bracket in `turn_probe`.
+    shadow_memo: crate::verify::ShadowMemoHandle,
     /// The session's memory-citation ledger, shared with the registered
     /// `cite_memory` tool instance and drained per execution by
     /// [`ToolRegistry::take_memory_citations`].
@@ -420,6 +423,7 @@ impl ToolRegistry {
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
         let sub_agent_dispatcher: crate::subagent::DispatcherSlot = Arc::default();
         let sub_agent_spend: stella_core::subagent::SubAgentSpendLedger = Arc::default();
+        let shadow_memo: crate::verify::ShadowMemoHandle = Arc::default();
         // One read-state ledger per registry (#331): `read_file` and
         // `read_symbol` (which reads through the same instance) record what
         // the model saw; `edit_file` attributes match failures against it and
@@ -468,6 +472,7 @@ impl ToolRegistry {
             entries.extend(process_tools::builtins(
                 task_board.clone(),
                 spawn_queue.clone(),
+                shadow_memo.clone(),
             ));
             // The web family registers by default, like every other built-in.
             // A fetched page is untrusted input and an egress channel, which is
@@ -577,6 +582,7 @@ impl ToolRegistry {
             mutations: std::sync::atomic::AtomicU64::new(0),
             process_free,
             probe_ignore_policy: options.effective_probe_ignore_policy(process_free),
+            shadow_memo,
         }
     }
 

--- a/crates/stella-tools/src/registry/process_tools.rs
+++ b/crates/stella-tools/src/registry/process_tools.rs
@@ -8,6 +8,7 @@ use super::Tool;
 pub(super) fn builtins(
     task_board: crate::tasks::TaskBoardHandle,
     spawn_queue: crate::tasks::SpawnQueue,
+    shadow_memo: crate::verify::ShadowMemoHandle,
 ) -> Vec<Arc<dyn Tool>> {
     let processes: crate::process::ProcessTableHandle = Arc::default();
     let repo: Arc<dyn crate::repo::RepoBackend> = Arc::new(crate::repo::GitCli);
@@ -17,7 +18,7 @@ pub(super) fn builtins(
         // an operator who wants it gone writes `"tools": {"bash": "off"}`,
         // which the policy layer above enforces for MCP and custom tools too.
         Arc::new(crate::bash::Bash),
-        Arc::new(crate::verify::VerifyDone),
+        Arc::new(crate::verify::VerifyDone::with_memo(shadow_memo)),
         Arc::new(crate::project::BuildProject),
         Arc::new(crate::project::RunTests),
         Arc::new(crate::diagnostics::Diagnostics),

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -858,6 +858,7 @@ mod partial_belief;
 mod private_state;
 mod schema_gate;
 mod touch;
+mod verify_memo;
 
 /// The no-clobber guarantee, end to end and across two independent sessions.
 ///

--- a/crates/stella-tools/src/registry/tests/verify_memo.rs
+++ b/crates/stella-tools/src/registry/tests/verify_memo.rs
@@ -1,0 +1,122 @@
+//! The wiring between the registry's turn bracket and `verify_done`'s
+//! shadow-run memo (#2208).
+//!
+//! `verify.rs` proves the memo's behaviour against a directly-constructed
+//! tool. This module proves the half that only the registry can: that the
+//! `verify_done` a real session dispatches shares the memo the turn bracket
+//! arms and clears. Without it the memo could be correct and reach no user —
+//! which is the failure mode the "nothing left behind" rule names.
+
+use super::*;
+
+/// A git repo with a committed "previous version", an uncommitted new one,
+/// and a witness script that appends a line to `shadow-runs` on every run
+/// that happens inside a linked worktree — i.e. once per shadow build.
+fn repo_with_counting_witness() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "t@t.t"],
+        &["config", "user.name", "t"],
+    ] {
+        git(root, args);
+    }
+    std::fs::write(root.join("impl.txt"), "old behavior\n").expect("write impl");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "previous version"]);
+
+    std::fs::write(root.join("impl.txt"), "new behavior\n").expect("rewrite impl");
+    std::fs::write(
+        root.join("witness.sh"),
+        format!(
+            "if [ ! -d .git ]; then printf 'r\\n' >> '{}'; fi\ngrep -q 'new behavior' impl.txt\n",
+            root.join("shadow-runs").display()
+        ),
+    )
+    .expect("write witness");
+    dir
+}
+
+/// `git <args>` in `root`, with the hook-exported `GIT_*` vars scrubbed the
+/// way every production path scrubs them — without it, running the suite from
+/// inside the pre-push hook re-targets each command at the host repo.
+fn git(root: &std::path::Path, args: &[&str]) {
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(args).current_dir(root);
+    for var in crate::exec::GIT_REPO_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    let out = cmd.output().expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn shadow_runs(root: &std::path::Path) -> usize {
+    std::fs::read_to_string(root.join("shadow-runs"))
+        .map(|text| text.lines().count())
+        .unwrap_or(0)
+}
+
+fn witness_input() -> Value {
+    serde_json::json!({
+        "test_cmd": "bash witness.sh",
+        "test_files": ["witness.sh"],
+        "timeout_secs": 60
+    })
+}
+
+/// #2208 witness, at the seam that ships: the registry's turn bracket is what
+/// arms the memo, so two identical dispatches inside one bracket build one
+/// shadow and the same pair across a settle builds two.
+#[tokio::test]
+async fn the_turn_bracket_scopes_the_dispatched_verify_dones_memo() {
+    let dir = repo_with_counting_witness();
+    let root = dir.path().to_path_buf();
+    let reg = ToolRegistry::new(root.clone(), RegistryOptions::default());
+
+    reg.begin_workspace_probe();
+    let first = reg.execute("verify_done", &witness_input()).await;
+    assert!(!first.is_error(), "{first:?}");
+    let second = reg.execute("verify_done", &witness_input()).await;
+    assert!(!second.is_error(), "{second:?}");
+    assert_eq!(
+        shadow_runs(&root),
+        1,
+        "the registered verify_done must share the bracket's memo"
+    );
+
+    // Settling ends the turn: the tree the next turn measures is not this one.
+    reg.settle_workspace_probe();
+    let after = reg.execute("verify_done", &witness_input()).await;
+    assert!(!after.is_error(), "{after:?}");
+    assert_eq!(
+        shadow_runs(&root),
+        2,
+        "an observation must not survive the turn that made it"
+    );
+}
+
+/// The fail-open default: a host that never brackets a turn has told the
+/// registry nothing about when observations expire, so nothing is reused.
+#[tokio::test]
+async fn an_unbracketed_session_reuses_nothing() {
+    let dir = repo_with_counting_witness();
+    let root = dir.path().to_path_buf();
+    let reg = ToolRegistry::new(root.clone(), RegistryOptions::default());
+
+    assert!(
+        !reg.execute("verify_done", &witness_input())
+            .await
+            .is_error()
+    );
+    assert!(
+        !reg.execute("verify_done", &witness_input())
+            .await
+            .is_error()
+    );
+    assert_eq!(shadow_runs(&root), 2);
+}

--- a/crates/stella-tools/src/registry/turn_probe.rs
+++ b/crates/stella-tools/src/registry/turn_probe.rs
@@ -32,7 +32,14 @@ impl ToolRegistry {
     /// Latches this session as turn-bracketing, which is what turns the
     /// per-call probe in [`Self::execute`] off. Calling this once commits the
     /// session to turn granularity; the two never run together.
+    ///
+    /// Also opens `verify_done`'s shadow-run memo
+    /// ([`crate::verify::ShadowMemo`]), because this pair is the only turn
+    /// boundary a registry is told about. A host that never brackets never
+    /// arms it, and an unarmed memo serves nothing — the same fail-open
+    /// default an unbracketed session already gets from the probe itself.
     pub fn begin_workspace_probe(&self) {
+        self.shadow_memo.arm();
         self.turn_bracketing
             .store(true, std::sync::atomic::Ordering::Relaxed);
         self.bracket_opaque_calls
@@ -63,6 +70,11 @@ impl ToolRegistry {
     /// folds repeats, so an edit that a tool declared and the tree confirms
     /// stays one entry rather than becoming two.
     pub fn settle_workspace_probe(&self) {
+        // The turn is over, so every shadow observation it memoised is over
+        // with it. Unconditional and ahead of the early return below: an
+        // observation must not survive its turn even on a settle that has no
+        // before-image to attribute.
+        self.shadow_memo.invalidate();
         let Some(before) = self
             .workspace_probe
             .lock()

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -59,18 +59,45 @@
 //! is a *compile error* (the test references symbols that don't exist on
 //! HEAD) is a much weaker witness than an assertion failure — the agent
 //! (and any verifier) should check the tail for WHY the old code failed.
+//!
+//! # Running the same proof twice
+//!
+//! The shadow half is a pure function of `(baseline, test files, command,
+//! timeout)` — nothing else in the working tree is visible from inside a
+//! fresh checkout — so an identical call inside one turn reuses its
+//! observation rather than rebuilding for it ([`ShadowMemo`], #2208). The
+//! working-tree half is never reused.
+
+mod memo;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 use tokio::process::Command;
 
+use memo::{ShadowKey, ShadowObservation};
+pub use memo::{ShadowMemo, ShadowMemoHandle};
+
 use crate::registry::Tool;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 300;
 const TAIL_BYTES: usize = 4_000;
 
-pub struct VerifyDone;
+#[derive(Default)]
+pub struct VerifyDone {
+    /// This session's turn-scoped shadow-run memo, shared with the
+    /// [`crate::registry::ToolRegistry`] that brackets the turn. Default
+    /// (unshared, never armed) is inert, so a standalone instance behaves
+    /// exactly as it did before the memo existed.
+    memo: ShadowMemoHandle,
+}
+
+impl VerifyDone {
+    /// Register with the memo the owning registry brackets.
+    pub fn with_memo(memo: ShadowMemoHandle) -> Self {
+        Self { memo }
+    }
+}
 
 /// Run `command` via `bash -c` in `dir` with a process-group kill on
 /// timeout — the shared runner in [`crate::exec`]. Its 30k middle-out cap is
@@ -321,6 +348,85 @@ impl Drop for ShadowDirGuard {
     }
 }
 
+/// Run the witness test against the previous version of the code: a detached
+/// shadow worktree at `baseline_sha`, with `resolved`'s test files (and
+/// nothing else from the working tree) layered in.
+///
+/// This is the expensive half — a fresh checkout and a cold build — and it is
+/// a pure function of its arguments, which is exactly what makes [`memo`]
+/// sound. Keep it that way: a reader added here would silently widen what a
+/// memo key has to cover.
+///
+/// `Err` carries a complete, user-facing message; `Ok` is the run's
+/// `(exit code, output)`.
+async fn run_against_baseline(
+    root: &std::path::Path,
+    baseline_sha: &str,
+    resolved: &[(String, std::path::PathBuf, std::path::PathBuf)],
+    root_rel: &std::path::Path,
+    test_cmd: &str,
+    timeout_secs: u64,
+) -> Result<(i32, String), String> {
+    // Shadow names carry pid + a process-wide counter: two concurrent
+    // verify_done calls (parallel tools, parallel tests) must never collide on
+    // the same worktree path — a timestamp alone can.
+    static SHADOW_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let shadow = std::env::temp_dir().join(format!(
+        "stella_verify_{}_{}",
+        std::process::id(),
+        SHADOW_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    match git_in(root)
+        .args(["worktree", "add", "--detach"])
+        .arg(&shadow)
+        .arg(baseline_sha)
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            return Err(format!(
+                "could not create the shadow worktree for the previous version: {}",
+                String::from_utf8_lossy(&out.stderr)
+            ));
+        }
+        Err(e) => return Err(format!("could not run git worktree add: {e}")),
+    }
+    // Armed the instant the directory exists. Everything below awaits — the
+    // file copies, and above all the shadow test run, which is where a
+    // cancelled turn actually lands — and none of it is reached when this
+    // future is dropped.
+    let _shadow_dir = ShadowDirGuard {
+        shadow: shadow.clone(),
+    };
+
+    // Layer ONLY the test files onto the previous version.
+    for (rel, src, relpath) in resolved {
+        let dst = shadow.join(relpath);
+        if let Some(parent) = dst.parent()
+            && let Err(e) = tokio::fs::create_dir_all(parent).await
+        {
+            cleanup_shadow(root, &shadow).await;
+            return Err(format!(
+                "could not stage test file `{rel}` in the shadow: {e}"
+            ));
+        }
+        if let Err(e) = tokio::fs::copy(src, &dst).await {
+            cleanup_shadow(root, &shadow).await;
+            return Err(format!(
+                "could not copy test file `{rel}` into the shadow: {e}"
+            ));
+        }
+    }
+
+    // Run in the shadow subdirectory matching the workspace root, so a
+    // relative `test_cmd` (e.g. `cargo test`) resolves the same package it
+    // would in the real working tree — not the repo toplevel.
+    let shadow_run = run(test_cmd, &shadow.join(root_rel), timeout_secs).await;
+    cleanup_shadow(root, &shadow).await;
+    shadow_run.map_err(|e| format!("shadow run against the previous version failed to run: {e}"))
+}
+
 #[async_trait]
 impl Tool for VerifyDone {
     fn schema(&self) -> ToolSchema {
@@ -517,78 +623,61 @@ impl Tool for VerifyDone {
             };
         }
 
-        // Half 2: the previous code (HEAD + your new tests) must fail.
-        // Shadow names carry pid + a process-wide counter: two concurrent
-        // verify_done calls (parallel tools, parallel tests) must never
-        // collide on the same worktree path — a timestamp alone can.
-        static SHADOW_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-        let shadow = std::env::temp_dir().join(format!(
-            "stella_verify_{}_{}",
-            std::process::id(),
-            SHADOW_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
-        let added = git_in(root)
-            .args(["worktree", "add", "--detach"])
-            .arg(&shadow)
-            .arg(&baseline.sha)
-            .output()
-            .await;
-        match added {
-            Ok(out) if out.status.success() => {}
-            Ok(out) => {
-                return ToolOutput::Error {
-                    message: format!(
-                        "could not create the shadow worktree for the previous version: {}",
-                        String::from_utf8_lossy(&out.stderr)
-                    ),
-                };
-            }
-            Err(e) => {
-                return ToolOutput::Error {
-                    message: format!("could not run git worktree add: {e}"),
-                };
-            }
-        }
-        // Armed the instant the directory exists. Everything below awaits —
-        // the file copies, and above all the shadow test run, which is where
-        // a cancelled turn actually lands — and none of it is reached when
-        // this future is dropped.
-        let _shadow_dir = ShadowDirGuard {
-            shadow: shadow.clone(),
-        };
-
-        // Layer ONLY the test files onto the previous version.
-        for (rel, src, relpath) in &resolved {
-            let dst = shadow.join(relpath);
-            if let Some(parent) = dst.parent()
-                && let Err(e) = tokio::fs::create_dir_all(parent).await
-            {
-                cleanup_shadow(root, &shadow).await;
-                return ToolOutput::Error {
-                    message: format!("could not stage test file `{rel}` in the shadow: {e}"),
-                };
-            }
-            if let Err(e) = tokio::fs::copy(src, &dst).await {
-                cleanup_shadow(root, &shadow).await;
-                return ToolOutput::Error {
-                    message: format!("could not copy test file `{rel}` into the shadow: {e}"),
-                };
-            }
-        }
-
-        // Run in the shadow subdirectory matching the workspace root, so a
-        // relative `test_cmd` (e.g. `cargo test`) resolves the same package it
-        // would in the real working tree — not the repo toplevel.
-        let shadow_cwd = shadow.join(&root_rel);
-        let shadow_run = run(test_cmd, &shadow_cwd, timeout_secs).await;
-        cleanup_shadow(root, &shadow).await;
-        let (old_exit, old_output) = match shadow_run {
-            Ok(pair) => pair,
-            Err(e) => {
-                return ToolOutput::Error {
-                    message: format!("shadow run against the previous version failed to run: {e}"),
-                };
-            }
+        // Half 2: the previous code (the baseline + your new tests) must fail.
+        // An identical call earlier in this turn already answered this: the
+        // shadow sees only the baseline commit, the copied test files, and the
+        // command, so a memo over exactly those is the whole determinant of
+        // the run rather than a guess at it (#2208 — 250s, 24% of a trial's
+        // budget, spent re-deriving one observation on `extract-elf`). No key
+        // means no memo: the run happens.
+        let memo_key = ShadowKey::compute(
+            &canon_toplevel,
+            &root_rel,
+            &baseline.sha,
+            test_cmd,
+            timeout_secs,
+            &resolved,
+        )
+        .await;
+        let (old_exit, old_output, reused) =
+            match memo_key.as_ref().and_then(|key| self.memo.get(key)) {
+                Some(observed) => (observed.exit, observed.output, true),
+                None => {
+                    let (exit, output) = match run_against_baseline(
+                        root,
+                        &baseline.sha,
+                        &resolved,
+                        &root_rel,
+                        test_cmd,
+                        timeout_secs,
+                    )
+                    .await
+                    {
+                        Ok(pair) => pair,
+                        Err(message) => return ToolOutput::Error { message },
+                    };
+                    if let Some(key) = memo_key {
+                        self.memo.insert(
+                            key,
+                            ShadowObservation {
+                                exit,
+                                output: output.clone(),
+                            },
+                        );
+                    }
+                    (exit, output, false)
+                }
+            };
+        // Every verdict below says whether the previous-code run behind it
+        // happened on this call. A reader auditing a proof must never have to
+        // guess that, and the truncated tail it is reading is now evidence
+        // from a run they cannot see in this call's wall clock.
+        let reuse_note = if reused {
+            "\n(previous-code observation REUSED from an identical verify_done call earlier in \
+             this turn — same baseline, same test files, same command, and nothing else in the \
+             working tree is visible from the shadow)"
+        } else {
+            ""
         };
 
         if old_exit == 0 {
@@ -598,7 +687,7 @@ impl Tool for VerifyDone {
                      (baseline {}, {}). It does not witness your change: either the behavior \
                      already existed, the test doesn't exercise the new behavior, or your \
                      change isn't wired in. Strengthen the test so it fails without your \
-                     change.\n--- previous-code output tail ---\n{}",
+                     change.{reuse_note}\n--- previous-code output tail ---\n{}",
                     baseline.short(),
                     baseline.provenance,
                     tail(&old_output)
@@ -624,7 +713,8 @@ impl Tool for VerifyDone {
                      import and fail on the assertion), so the old code fails on the \
                      assertion rather than the import.\n\
                      - new code:      `{test_cmd}` exit 0 (PASS)\n\
-                     - previous code: baseline {} ({}) → exit {old_exit}, before any test ran\n\
+                     - previous code: baseline {} ({}) → exit {old_exit}, before any test \
+                     ran{reuse_note}\n\
                      --- previous-code output tail ---\n{}",
                     baseline.short(),
                     baseline.provenance,
@@ -637,7 +727,8 @@ impl Tool for VerifyDone {
             content: format!(
                 "WITNESS CONFIRMED — deterministic definition of done met:\n\
                  - new code:      `{test_cmd}` exit 0 (PASS)\n\
-                 - previous code: baseline {} ({}) + your test files → exit {old_exit} (FAIL)\n\
+                 - previous code: baseline {} ({}) + your test files → exit {old_exit} \
+                 (FAIL){reuse_note}\n\
                  Check the tail below: an assertion failure is a strong witness; a compile \
                  error (test references symbols that don't exist on the baseline) is weaker \
                  — prefer behavioral assertions when possible.\n\
@@ -657,7 +748,7 @@ mod tests {
     /// Build a tiny git repo with a committed "previous version" and an
     /// uncommitted "new version" + witness test, both as shell scripts (no
     /// toolchain dependency: the "test" greps the implementation file).
-    async fn scaffold(tag: &str) -> std::path::PathBuf {
+    pub(super) async fn scaffold(tag: &str) -> std::path::PathBuf {
         let root = std::env::temp_dir().join(format!(
             "stella_verify_test_{tag}_{}_{}",
             std::process::id(),
@@ -710,7 +801,7 @@ mod tests {
         std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -740,7 +831,7 @@ mod tests {
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
         let _trace = crate::subprocess_env::test_support::ScopedEnvVar::set("GIT_TRACE", "1");
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -765,7 +856,7 @@ mod tests {
         // A test that passes on old AND new code witnesses nothing.
         std::fs::write(root.join("witness.sh"), "grep -q 'behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -801,7 +892,7 @@ mod tests {
         scratch_git(&root, &["commit", "-q", "-m", "agent work, sealed"]);
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -835,7 +926,7 @@ mod tests {
         scratch_git(&root, &["commit", "-q", "-m", "trial work"]);
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -879,7 +970,7 @@ mod tests {
         );
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -934,7 +1025,7 @@ mod tests {
         );
         std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -971,7 +1062,7 @@ mod tests {
         )
         .unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -1021,7 +1112,7 @@ mod tests {
         // Test demands behavior nobody implemented.
         std::fs::write(root.join("witness.sh"), "grep -q 'nonexistent' impl.txt\n").unwrap();
 
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({
                     "test_cmd": "bash witness.sh",
@@ -1041,7 +1132,7 @@ mod tests {
     #[tokio::test]
     async fn missing_inputs_and_missing_files_are_named_errors() {
         let root = scaffold("inputs").await;
-        let no_files = VerifyDone
+        let no_files = VerifyDone::default()
             .execute(
                 &serde_json::json!({"test_cmd": "true", "test_files": []}),
                 &root,
@@ -1049,7 +1140,7 @@ mod tests {
             .await;
         assert!(no_files.is_error());
 
-        let ghost = VerifyDone
+        let ghost = VerifyDone::default()
             .execute(
                 &serde_json::json!({"test_cmd": "true", "test_files": ["ghost.sh"]}),
                 &root,
@@ -1138,7 +1229,7 @@ mod tests {
             "test_files": ["witness.sh"],
             "timeout_secs": 60
         });
-        match VerifyDone.execute(&input, &root).await {
+        match VerifyDone::default().execute(&input, &root).await {
             ToolOutput::Error { message } => assert!(message.contains("NOT DONE"), "{message}"),
             other => panic!("expected NOT DONE, got {other:?}"),
         }
@@ -1150,7 +1241,12 @@ mod tests {
 
         // Idempotent: a second run over an already-clean repo prunes nothing
         // and reaches the same verdict.
-        assert!(VerifyDone.execute(&input, &root).await.is_error());
+        assert!(
+            VerifyDone::default()
+                .execute(&input, &root)
+                .await
+                .is_error()
+        );
         assert_eq!(registrations(&root), 0);
 
         std::fs::remove_dir_all(&root).ok();
@@ -1184,7 +1280,7 @@ mod tests {
 
         let run_root = root.clone();
         let handle = tokio::spawn(async move {
-            VerifyDone
+            VerifyDone::default()
                 .execute(
                     &serde_json::json!({
                         "test_cmd": "bash witness.sh",
@@ -1254,7 +1350,7 @@ mod tests {
         let root = std::env::temp_dir().join(format!("stella_verify_nogit_{}", std::process::id()));
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("witness.sh"), "true\n").unwrap();
-        let out = VerifyDone
+        let out = VerifyDone::default()
             .execute(
                 &serde_json::json!({"test_cmd": "true", "test_files": ["witness.sh"]}),
                 &root,

--- a/crates/stella-tools/src/verify/memo.rs
+++ b/crates/stella-tools/src/verify/memo.rs
@@ -1,0 +1,486 @@
+//! The turn-scoped memo over `verify_done`'s previous-code run.
+//!
+//! # What is memoised, and why only that
+//!
+//! `verify_done` runs two halves. The first runs the witness test against the
+//! working tree, and is **never** memoised: it is the answer to "does my
+//! change work *now*", and the tree it reads changes under the agent's own
+//! hands. The second builds a detached shadow worktree at the witness
+//! baseline, copies the test files in, and runs the suite there — a fresh
+//! checkout with a cold build, which is where the wall clock goes. On
+//! `extract-elf` in match `cc00894779ff` a worker re-ran it with identical
+//! arguments inside one turn and paid 250s, 24% of the trial's budget, for an
+//! observation the run already held (#2208).
+//!
+//! That second half is memoisable because its inputs are *closed*. The only
+//! things that reach the shadow are the baseline commit, the test files copied
+//! into it, the command, and the timeout — nothing else in the working tree is
+//! visible from inside a fresh checkout. So the key below is not a heuristic
+//! summary of the call: it is the complete determinant of the run, which is
+//! what makes a hit sound rather than merely likely. A worker that edits the
+//! *implementation* between two calls still gets a fresh shadow verdict for
+//! free, because the shadow never saw the implementation and its verdict
+//! cannot have moved; the half that *does* see the edit re-runs every time.
+//!
+//! # Turn scoping, and why the key alone is not the whole answer
+//!
+//! A wrong memo is worse than no memo: this tool is the flip oracle's evidence
+//! source, so a false hit is a false proof — the failure class #2067 fixed.
+//! Two guards, and both must hold before an entry is served:
+//!
+//! 1. the key covers every input the shadow reads, so a changed test file, a
+//!    moved baseline, or a different command all miss;
+//! 2. entries live for exactly one turn, which bounds what the key cannot
+//!    cover — a flaky suite, a clock, a network resource, an environment the
+//!    host changed between turns. Without that bound one unlucky observation
+//!    would stick for the life of the session.
+//!
+//! Anything short of certainty fails open (no memo, run the shadow): an
+//! unreadable test file, a non-UTF-8 path, or a turn that was never bracketed
+//! all yield no key and no entry.
+//!
+//! # Where the turn boundary comes from
+//!
+//! The registry's workspace-probe bracket, which is the only turn boundary a
+//! `ToolRegistry` is told about: `begin_workspace_probe` arms
+//! ([`ShadowMemo::arm`]) and `settle_workspace_probe` clears
+//! ([`ShadowMemo::invalidate`]). A host that never brackets never arms, and an
+//! unarmed memo stores and serves nothing — exactly the behaviour that shipped
+//! before this existed.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// The shared handle: one per [`crate::registry::ToolRegistry`], held by the
+/// registry (which brackets the turn) and by the `verify_done` instance it
+/// registered (which reads and writes it).
+pub type ShadowMemoHandle = Arc<ShadowMemo>;
+
+/// How many distinct shadow observations one turn may hold.
+///
+/// A turn that witnesses more than this many *different* things is not the
+/// shape this exists for, and an unbounded map would let a pathological turn
+/// hold every test output it produced. Past the cap the memo simply stops
+/// recording — the run happens, exactly as it did before.
+const MAX_ENTRIES: usize = 16;
+
+/// Domain separator, so a key can never be confused with any other digest in
+/// the tree, and a version so a change to the encoding cannot silently be read
+/// as the old one.
+const KEY_DOMAIN: &str = "stella/verify_done/shadow/v1";
+
+/// What one shadow run observed: the pair the verdict is read from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ShadowObservation {
+    pub(super) exit: i32,
+    pub(super) output: String,
+}
+
+/// The complete determinant of a shadow run, hashed.
+///
+/// Deliberately built from the *resolved* values rather than the raw
+/// model-supplied argument strings: `verify_done` derives the shadow copy
+/// destination from the canonical root-relative path, so two calls naming one
+/// file differently are the same run, and two different files that happen to
+/// share a spelling are not.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) struct ShadowKey(String);
+
+impl ShadowKey {
+    /// Hash everything the shadow run reads, or `None` when any part of it
+    /// cannot be read exactly — an unreadable test file (it may vanish
+    /// mid-turn), or a path that is not UTF-8. `None` means "no memo", never
+    /// "no match".
+    ///
+    /// `resolved` is `verify_done`'s own `(display name, canonical source,
+    /// toplevel-relative destination)` triple; the display name is ignored
+    /// because it is the model's spelling, not an input to the run.
+    pub(super) async fn compute(
+        toplevel: &Path,
+        root_rel: &Path,
+        baseline_sha: &str,
+        test_cmd: &str,
+        timeout_secs: u64,
+        resolved: &[(String, std::path::PathBuf, std::path::PathBuf)],
+    ) -> Option<Self> {
+        // Sorted and deduplicated by destination: the copy order cannot change
+        // what the shadow contains (the destinations are distinct paths), so
+        // two calls that list the same files in a different order describe one
+        // run and must hash to one key.
+        let mut files: BTreeMap<&str, String> = BTreeMap::new();
+        for (_, src, dst) in resolved {
+            let dst = dst.to_str()?;
+            let bytes = tokio::fs::read(src).await.ok()?;
+            files.insert(dst, crate::staleness::hex_sha256(&bytes));
+        }
+
+        let mut buf = String::new();
+        for field in [
+            KEY_DOMAIN,
+            toplevel.to_str()?,
+            root_rel.to_str()?,
+            baseline_sha,
+            test_cmd,
+            &timeout_secs.to_string(),
+        ] {
+            push_field(&mut buf, field);
+        }
+        for (dst, digest) in &files {
+            push_field(&mut buf, dst);
+            push_field(&mut buf, digest);
+        }
+        Some(Self(crate::staleness::hex_sha256(buf.as_bytes())))
+    }
+}
+
+/// Append one length-prefixed field. Length-prefixing rather than a separator
+/// byte because a separator has to be a byte the fields cannot contain, and a
+/// `test_cmd` is an arbitrary shell string — the one field where that
+/// assumption is not ours to make.
+fn push_field(buf: &mut String, field: &str) {
+    use std::fmt::Write as _;
+
+    let _ = write!(buf, "{}:{field}", field.len());
+}
+
+/// One turn's shadow observations.
+#[derive(Default)]
+pub struct ShadowMemo {
+    state: Mutex<State>,
+}
+
+#[derive(Default)]
+struct State {
+    /// Whether a host has ever bracketed a turn on this registry. Latched by
+    /// [`ShadowMemo::arm`] and never cleared, because it answers "does this
+    /// host mark turn boundaries?" — not "is a turn open?". The pipeline arms
+    /// once per candidate and settles once per round, so disarming on settle
+    /// would leave every turn after the first without a memo.
+    armed: bool,
+    entries: HashMap<ShadowKey, ShadowObservation>,
+}
+
+impl ShadowMemo {
+    /// Open the memo for a bracketed session, discarding anything a previous
+    /// bracket left.
+    pub fn arm(&self) {
+        let mut state = self.lock();
+        state.armed = true;
+        state.entries.clear();
+    }
+
+    /// End the turn: every observation was true of *that* turn only.
+    pub fn invalidate(&self) {
+        self.lock().entries.clear();
+    }
+
+    pub(super) fn get(&self, key: &ShadowKey) -> Option<ShadowObservation> {
+        let state = self.lock();
+        if !state.armed {
+            return None;
+        }
+        state.entries.get(key).cloned()
+    }
+
+    pub(super) fn insert(&self, key: ShadowKey, observation: ShadowObservation) {
+        let mut state = self.lock();
+        if !state.armed || state.entries.len() >= MAX_ENTRIES {
+            return;
+        }
+        state.entries.insert(key, observation);
+    }
+
+    /// A poisoned memo is recovered rather than propagated: the worst a panic
+    /// mid-update can leave behind is a missing entry, and refusing to serve
+    /// the tool for the rest of the session over that would be a far larger
+    /// failure than re-running one shadow build.
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+    use stella_protocol::tool::ToolOutput;
+
+    use super::*;
+    use crate::registry::Tool;
+    use crate::verify::VerifyDone;
+    // The git-repo fixture the tool's own tests already build. Shared rather
+    // than re-scaffolded here so a change to what a witness workspace looks
+    // like cannot leave these two suites describing different worlds.
+    use crate::verify::tests::scaffold;
+
+    /// Write a witness script that is a flip AND a shadow-run counter: it
+    /// appends one line to `marker` on every run that happens inside a linked
+    /// worktree (where `.git` is a file, not a directory), which is exactly
+    /// the shadow. `salt` changes the file's bytes without changing what it
+    /// asserts — the memo keys on content, so this is how a caller says "same
+    /// proof, different test file".
+    fn counting_witness(root: &Path, marker: &Path, salt: &str) {
+        std::fs::write(
+            root.join("witness.sh"),
+            format!(
+                "# {salt}\nif [ ! -d .git ]; then printf 'r\\n' >> '{}'; fi\ngrep -q 'new \
+                 behavior' impl.txt\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+    }
+
+    /// How many shadow builds have happened.
+    fn shadow_runs(marker: &Path) -> usize {
+        std::fs::read_to_string(marker)
+            .map(|text| text.lines().count())
+            .unwrap_or(0)
+    }
+
+    fn witness_input() -> Value {
+        serde_json::json!({
+            "test_cmd": "bash witness.sh",
+            "test_files": ["witness.sh"],
+            "timeout_secs": 60
+        })
+    }
+
+    /// #2208 witness. An identical `verify_done` inside one turn pays for the
+    /// shadow worktree once: its verdict is a function of the baseline, the
+    /// test files and the command, and none of those moved. Changing the test
+    /// file moves one of them, and the second build happens.
+    ///
+    /// Fails on `main`, where every call built a shadow — 250s, 24% of the
+    /// trial budget, on `extract-elf` in match `cc00894779ff`.
+    #[tokio::test]
+    async fn an_identical_call_in_one_turn_builds_one_shadow() {
+        let root = scaffold("memo_hit").await;
+        let marker = root.join("shadow-runs");
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        counting_witness(&root, &marker, "first");
+
+        let memo: ShadowMemoHandle = Arc::new(ShadowMemo::default());
+        memo.arm();
+        let tool = VerifyDone::with_memo(memo.clone());
+
+        let first = tool.execute(&witness_input(), &root).await;
+        assert!(
+            matches!(&first, ToolOutput::Ok { content } if content.contains("WITNESS CONFIRMED")),
+            "{first:?}"
+        );
+        assert_eq!(
+            shadow_runs(&marker),
+            1,
+            "the first call must build a shadow"
+        );
+
+        let second = tool.execute(&witness_input(), &root).await;
+        match &second {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("WITNESS CONFIRMED"), "{content}");
+                assert!(
+                    content.contains("REUSED"),
+                    "a reused observation must say so: {content}"
+                );
+            }
+            other => panic!("expected the same verdict, got {other:?}"),
+        }
+        assert_eq!(
+            shadow_runs(&marker),
+            1,
+            "an identical call re-derived nothing and must not rebuild"
+        );
+
+        // A different test file is a different proof, whatever else matches.
+        counting_witness(&root, &marker, "second");
+        let third = tool.execute(&witness_input(), &root).await;
+        assert!(
+            matches!(&third, ToolOutput::Ok { content } if !content.contains("REUSED")),
+            "{third:?}"
+        );
+        assert_eq!(
+            shadow_runs(&marker),
+            2,
+            "a changed test file must be re-measured"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The two fail-open halves of the memo, which are what keep a stale hit
+    /// from ever manufacturing a proof: a host that marks no turn boundaries
+    /// gets no memo at all, and an observation never outlives the turn that
+    /// made it.
+    #[tokio::test]
+    async fn nothing_is_reused_across_a_turn_or_without_one() {
+        let root = scaffold("memo_scope").await;
+        let marker = root.join("shadow-runs");
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        counting_witness(&root, &marker, "only");
+
+        // No bracket: exactly the behaviour that shipped before the memo.
+        let unbracketed = VerifyDone::default();
+        assert!(
+            !unbracketed
+                .execute(&witness_input(), &root)
+                .await
+                .is_error()
+        );
+        assert!(
+            !unbracketed
+                .execute(&witness_input(), &root)
+                .await
+                .is_error()
+        );
+        assert_eq!(
+            shadow_runs(&marker),
+            2,
+            "an unarmed memo must serve nothing"
+        );
+
+        let memo: ShadowMemoHandle = Arc::new(ShadowMemo::default());
+        memo.arm();
+        let tool = VerifyDone::with_memo(memo.clone());
+        assert!(!tool.execute(&witness_input(), &root).await.is_error());
+        assert_eq!(shadow_runs(&marker), 3);
+
+        // The turn ends — the tree may move under any observation it made.
+        memo.invalidate();
+        assert!(!tool.execute(&witness_input(), &root).await.is_error());
+        assert_eq!(
+            shadow_runs(&marker),
+            4,
+            "an observation must not outlive its turn"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    fn observation(exit: i32) -> ShadowObservation {
+        ShadowObservation {
+            exit,
+            output: format!("exit {exit}"),
+        }
+    }
+
+    fn key(text: &str) -> ShadowKey {
+        ShadowKey(text.to_string())
+    }
+
+    /// An unarmed memo is inert in both directions — the fail-open default for
+    /// a host that marks no turn boundaries.
+    #[test]
+    fn an_unarmed_memo_stores_and_serves_nothing() {
+        let memo = ShadowMemo::default();
+        memo.insert(key("k"), observation(1));
+        assert_eq!(memo.get(&key("k")), None);
+    }
+
+    #[test]
+    fn an_armed_memo_serves_what_it_stored_until_the_turn_ends() {
+        let memo = ShadowMemo::default();
+        memo.arm();
+        memo.insert(key("k"), observation(1));
+        assert_eq!(memo.get(&key("k")), Some(observation(1)));
+        assert_eq!(memo.get(&key("other")), None);
+
+        memo.invalidate();
+        assert_eq!(
+            memo.get(&key("k")),
+            None,
+            "an entry must not outlive its turn"
+        );
+
+        // Still armed: the pipeline arms once and settles once per round, so
+        // the turn after a settle must be able to memoise again.
+        memo.insert(key("k"), observation(2));
+        assert_eq!(memo.get(&key("k")), Some(observation(2)));
+    }
+
+    #[test]
+    fn a_pathological_turn_stops_recording_rather_than_growing() {
+        let memo = ShadowMemo::default();
+        memo.arm();
+        for i in 0..MAX_ENTRIES + 4 {
+            memo.insert(key(&i.to_string()), observation(i as i32));
+        }
+        assert_eq!(memo.get(&key("0")), Some(observation(0)));
+        assert_eq!(
+            memo.get(&key(&MAX_ENTRIES.to_string())),
+            None,
+            "past the cap the run happens instead"
+        );
+    }
+
+    /// Length-prefixing, not separators: a `test_cmd` is an arbitrary shell
+    /// string, so no byte can be reserved as a field boundary. Two calls whose
+    /// concatenated fields are identical must still key differently.
+    #[test]
+    fn field_boundaries_survive_a_command_that_contains_them() {
+        let mut a = String::new();
+        push_field(&mut a, "ab");
+        push_field(&mut a, "c");
+        let mut b = String::new();
+        push_field(&mut b, "a");
+        push_field(&mut b, "bc");
+        assert_ne!(a, b);
+    }
+
+    /// The key is over the resolved destinations and the bytes behind them, so
+    /// argument order cannot split one run into two, and a changed test file
+    /// cannot be served a stale observation.
+    #[tokio::test]
+    async fn the_key_is_order_free_but_content_sensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.sh"), "a\n").unwrap();
+        std::fs::write(root.join("b.sh"), "b\n").unwrap();
+        let entry = |name: &str| {
+            (
+                name.to_string(),
+                root.join(name),
+                std::path::PathBuf::from(name),
+            )
+        };
+        async fn compute(
+            root: &Path,
+            resolved: Vec<(String, std::path::PathBuf, std::path::PathBuf)>,
+        ) -> Option<ShadowKey> {
+            ShadowKey::compute(
+                root,
+                std::path::Path::new(""),
+                "deadbeef",
+                "bash a.sh",
+                60,
+                &resolved,
+            )
+            .await
+        }
+
+        let forward = compute(root, vec![entry("a.sh"), entry("b.sh")]).await;
+        let backward = compute(root, vec![entry("b.sh"), entry("a.sh")]).await;
+        assert!(forward.is_some());
+        assert_eq!(
+            forward, backward,
+            "argument order is not an input to the run"
+        );
+
+        std::fs::write(root.join("b.sh"), "b changed\n").unwrap();
+        assert_ne!(
+            forward,
+            compute(root, vec![entry("a.sh"), entry("b.sh")]).await,
+            "a changed test file must change the key"
+        );
+
+        // A file that vanishes mid-turn yields no key at all, never a key that
+        // silently omits it.
+        std::fs::remove_file(root.join("b.sh")).unwrap();
+        assert_eq!(
+            compute(root, vec![entry("a.sh"), entry("b.sh")]).await,
+            None
+        );
+    }
+}


### PR DESCRIPTION
## What & why

`verify_done` runs two halves: the witness test against the working tree, and the
same test against a detached shadow worktree at the witness baseline. The second is
a fresh checkout with a cold build, and it is where the wall clock goes — **250s,
24% of the trial's budget**, on `extract-elf` in match `cc00894779ff`, spent
re-deriving an observation the run already held. This was direction 4 of #2129's
analysis, which #2191 did not land.

The shadow half is memoisable because its inputs are **closed**: the only things
that reach a fresh checkout are the baseline commit, the test files copied into it,
the command, and the timeout. So the key is the *complete determinant* of the run
rather than a summary of the call — which is what makes a hit sound instead of
merely likely. Two consequences worth stating plainly:

- A worker that edits the **implementation** between two calls still gets a fresh
  shadow verdict for free, because the shadow never saw the implementation and its
  verdict cannot have moved.
- The half that **does** see that edit — the working-tree run — is never memoised,
  so "does my change work now" is re-measured on every call.

The key is built from the **resolved** values (canonical toplevel, root-relative
shadow cwd, baseline SHA, command, timeout, and a sha256 per toplevel-relative
destination), never the raw model-supplied argument string, per #2208's DoD.
Destinations are sorted and deduplicated, so argument order cannot split one run
into two. Fields are length-prefixed rather than separator-joined: a `test_cmd` is
an arbitrary shell string, so no byte can be reserved as a boundary.

Two guards, because a false hit here is a false proof — #2067's failure class:

1. the key covers every input the shadow reads (a changed test file, a moved
   baseline, a different command all miss);
2. entries live for exactly **one turn**, which bounds what a key cannot cover — a
   flaky suite, a clock, a network resource, a host that changed the environment
   between turns.

The turn boundary is the registry's workspace-probe bracket, the only one a
`ToolRegistry` is told about: `begin_workspace_probe` arms and
`settle_workspace_probe` clears. A host that never brackets gets an inert memo and
exactly today's behaviour. **Anything short of certainty fails open** (run the
shadow): an unreadable test file — it may vanish mid-turn — a non-UTF-8 path, a
turn past the entry cap, or an unbracketed session. Every verdict now says when its
previous-code observation was reused rather than re-measured; `WITNESS CONFIRMED`,
`VACUOUS TEST` and `WITNESS_INCONCLUSIVE_BUILD_ERROR` keep their exact markers.

Exemplar for the shape: `std::collections`-backed, handle-shared session state
built the way this crate's own `ReadLedger` and `CitationLedger` are — one owner
per registry, cloned into the tool that reads it, no globals.

Closes #2208

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, at two seams, both counting *actual shadow builds*: the witness script appends
a line to a marker file whenever it runs inside a linked worktree (where `.git` is
a file, not a directory), which is exactly the shadow.

- `crates/stella-tools/src/verify/memo.rs` —
  `an_identical_call_in_one_turn_builds_one_shadow`: two identical calls build one
  shadow, the second says `REUSED`, and a call whose test file changed in between
  builds a second. This is #2208's DoD item 3 verbatim.
- `crates/stella-tools/src/registry/tests/verify_memo.rs` —
  `the_turn_bracket_scopes_the_dispatched_verify_dones_memo`: the same at the seam
  that ships, through `ToolRegistry::execute("verify_done", …)`, so the memo cannot
  be correct and reach no user. A settle in between rebuilds.

Checked the artisanal way — with `ShadowMemo::get` stubbed to return `None`, both
fail (`left: 2, right: 1`) and the two fail-open controls
(`nothing_is_reused_across_a_turn_or_without_one`,
`an_unbracketed_session_reuses_nothing`) still pass, which is what makes them
controls rather than duplicates.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (128 test binaries, exit 0)
- [x] `make invariants`, `doc-links`, `command-docs`, `brand-case`, `file-size`,
      `god-files`, `gate-parity`, `left-behind`, `role-names`, `stat-portability`,
      `module-reachability`, `typed-errors`, `wire-schema`, `doc-warnings` — all OK
      (`shellcheck` is not installed in this environment; no shell scripts changed)
- [x] Docs updated: `verify.rs`'s module header gains a "Running the same proof
      twice" section; the memo carries its own module doc
- [x] `Closes #2208` in this description **and** as a commit trailer

**God files, respected rather than raised.** `registry.rs` is grandfathered at 2181
and sits at **2180** after this change — three lines of field, one local, one
argument, one initializer, and no baseline edit. The new logic lands in a sibling
submodule (`verify/memo.rs`) and the arm/clear calls in `registry/turn_probe.rs`,
per AGENTS.md § "God files — plan around them, never into them". `verify.rs` is not
grandfathered, so it stays under 1500: the memo's own tests live with the memo,
which is where they belong anyway, and the shadow half moves out of `execute` into
`run_against_baseline` unchanged.

## Nothing left behind

- [x] Filed: **#2424** — `verify_done` still re-runs the working-tree half on an
      identical call in one turn. Deliberately not fixed here: half 1's determinant
      is the whole working tree, and memoising it on this key would be unsound.
      The issue says to measure the two halves' split from `stella-events.jsonl`
      first (join `tool_start` → `tool_result`) before building anything, and names
      the fail-open cases a probe-fingerprint key would have to honour.
- [x] Commented on **#2377** — the interactive multi-turn loop never arms a
      bracket, so it now also gets no memo. Same fix, already tracked; noted there
      so the fix is not later narrowed to the probe alone.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all (`sha2` arrives via
      the existing `crate::staleness::hex_sha256`)
- [x] No new outbound network calls
- [x] No new cross-boundary types — `ShadowMemo` never crosses a crate boundary or
      serializes

## Anything reviewers should know?

**A mutation to a memoised path does invalidate its entry** — #2208's DoD item 2 —
but by construction rather than by a hook: the key carries a sha256 of every
resolved test file, so a mutated memoised path yields a different key and the old
entry is unreachable. That is strictly stronger than a mutation hook, which races
the write; a content digest cannot. The third assertion in
`an_identical_call_in_one_turn_builds_one_shadow` is exactly this case.

What is deliberately **not** invalidated is a mutation to a path that is not in the
key — an implementation file. It is not a memoised path: it is never copied into the
shadow and a fresh checkout of the baseline cannot see it, so the shadow's verdict
cannot have moved, and the half that *does* see the edit re-runs every call. Hooking
implementation edits would cost most of the benefit in the edit-then-reverify loop
for no correctness, and would not be sound alone anyway — in a bracketing session
`bash`-driven writes are attributed at settle, so mid-turn they move no counter.

**The one judgement worth arguing with** is memoising only half 2. #2208 frames turn
scoping as what prevents a false `WITNESS CONFIRMED`; on this design the *key* is
what prevents it, and turn scoping bounds nondeterminism the key structurally
cannot see. Both are implemented, so the disagreement is about which is load-bearing
— but if you think the shadow can observe something outside
`(baseline, test files, command, timeout)`, that is the thing to name, because it
would be a hole in the key. `run_against_baseline` carries a comment saying so: a
reader added there silently widens what the key has to cover.

`MAX_ENTRIES = 16` is a backstop against a pathological turn holding every test
output it produced, not a tuned number; past it the run simply happens.