### PR TITLE
feat(stella-core): give the wall clock a journal axis and a pipeline rung

### DIFF
--- a/crates/stella-cli/src/accounted_call.rs
+++ b/crates/stella-cli/src/accounted_call.rs
@@ -136,6 +136,18 @@ pub(crate) async fn complete_standalone(
                 events: settled_events,
             })
         }
+        // Unreachable in practice — this path builds its guard from
+        // `build_budget_guard`, which arms no task deadline — but stated
+        // rather than swept into a catch-all, so arming one here later is a
+        // decision someone makes on purpose.
+        Err(AccountedCallError::Deadline { .. }) => {
+            let _ = store.finish_execution_accounted(execution_id, "aborted", 0.0, false);
+            Err(StandaloneCallError {
+                message: "model call skipped: the task deadline had already passed".into(),
+                cost_usd: 0.0,
+                events: settled_events,
+            })
+        }
     }
 }
 

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1959,13 +1959,12 @@ pub(crate) fn settle_reflection_budget(report: &mut ReflectionReport, guard: &mu
         let _ = guard.record_spend(report.cost_usd);
     }
     if had_accounting {
-        report.events.push(AgentEvent::BudgetTick {
-            spent_usd: guard.spent_usd(),
-            limit_usd: guard.turn_limit_usd(),
-            mode: guard.mode(),
-            session_spent_usd: None,
-            session_limit_usd: None,
-        });
+        // Through the guard's own constructor, not a literal: the session axis
+        // was hardcoded `None` here while this very guard tracked one, and the
+        // wall-clock axis (#2240) would have gone missing the same way.
+        report
+            .events
+            .push(guard.tick_event(std::time::Instant::now()));
     }
 }
 /// Open the workspace SQLite store (`.stella/private/store.db`). Persistence is

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1354,6 +1354,7 @@ fn reflection_budget_tick_is_rebased_to_the_caller_session() {
             mode: BudgetMode::Enforced,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         }],
     };
 

--- a/crates/stella-core/src/accounted_call.rs
+++ b/crates/stella-core/src/accounted_call.rs
@@ -9,7 +9,7 @@ use stella_protocol::{
 };
 use tokio::time::timeout;
 
-use crate::budget::{BudgetGuard, BudgetOutcome};
+use crate::budget::{BudgetGuard, BudgetOutcome, DeadlineOutcome};
 use crate::event_sender::EventSender;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
@@ -97,6 +97,21 @@ pub enum AccountedCallError {
     /// [`AccountedCall::timeout`] expired before the call resolved.
     #[error("the call's deadline expired before the provider responded")]
     Timeout,
+    /// The task's wall-clock deadline (`BudgetGuard::set_task_deadline`) had
+    /// already passed when this call was reached, so nothing was dispatched
+    /// and nothing was spent (#2238).
+    ///
+    /// Distinct from [`Self::Timeout`], which is one call outrunning its own
+    /// per-call ceiling: this is the *task* being out of time, and it is a
+    /// fact about the run rather than about the provider. Distinct from
+    /// [`Self::Budget`] for the reason `DeadlineOutcome` is distinct from
+    /// `BudgetOutcome` — seconds are not dollars, and `Budget` carries a
+    /// committed result this variant by construction has none of.
+    #[error("the task deadline had already passed when this call was reached")]
+    Deadline {
+        /// How long ago the deadline passed.
+        overrun: Duration,
+    },
     /// The call succeeded, but settling its cost breached an enforced budget.
     #[error("the call committed, but settling its cost breached an enforced budget")]
     Budget {
@@ -110,6 +125,13 @@ pub enum AccountedCallError {
 /// Dispatch one provider call with retry, per-call timeout, budget metering,
 /// and the full accounting event trail (`UsageIncomplete` per failed attempt,
 /// `Retry` per committed retry, then `StepUsage` + `BudgetTick`).
+///
+/// Gated on the *task's* wall clock before anything is dispatched: a guard
+/// whose `task_deadline` has already passed returns
+/// [`AccountedCallError::Deadline`] having spent nothing and emitted nothing
+/// (#2238). Callers with a degraded path should take it — that stop is the
+/// run declining to buy work it has no time to use, not a failure of this
+/// call.
 ///
 /// Every failed attempt reports its own content-free `UsageIncomplete`
 /// envelope synchronously, before a later attempt can succeed: a successful
@@ -136,6 +158,23 @@ pub async fn run_accounted_call(
     sleeper: &dyn Sleeper,
 ) -> Result<CompletionResult, AccountedCallError> {
     let started = Instant::now();
+    // The task's wall clock, checked BEFORE the dispatch (#2238). This seam is
+    // between model calls by construction — an `AccountedCall` carries no
+    // tools, so there is never anything in flight to interrupt — which makes
+    // it the one place invariant 6 permits the check for every non-engine
+    // caller. The engine's own step loop has the equivalent rung in
+    // `crate::driver::settlement::check_budget`; until this existed, the
+    // engine stopped itself at its deadline and the pipeline plane above it
+    // ran triage, research, plan, scope, witness, verify and verdict straight
+    // through the ceiling, one paid call at a time.
+    //
+    // Reactive only (`check_deadline`, a zero reserve): this seam has no pace
+    // estimate to anticipate with, and inventing one here would be a second,
+    // invisible policy on top of the operator's — the anticipatory rung lives
+    // where the measurement does, in the step loop.
+    if let DeadlineOutcome::Exceeded { overrun } = budget.check_deadline(started) {
+        return Err(AccountedCallError::Deadline { overrun });
+    }
     // True only while a provider dispatch is actually being polled — cleared
     // for the backoff sleeps between attempts. A per-call timeout wraps the
     // whole retry future (sleeps included), so its expiry must not attribute a
@@ -294,13 +333,7 @@ pub async fn run_accounted_call(
         finish_reason: result.finish_reason,
     });
     let budget_outcome = budget.record_spend(result.cost_usd);
-    let _ = events.send(AgentEvent::BudgetTick {
-        spent_usd: budget.spent_usd(),
-        limit_usd: budget.turn_limit_usd(),
-        mode: budget.mode(),
-        session_spent_usd: Some(budget.session_spent_usd()),
-        session_limit_usd: budget.session_limit_usd(),
-    });
+    let _ = events.send(budget.tick_event(Instant::now()));
     if let BudgetOutcome::Warn {
         spent_usd,
         limit_usd,
@@ -634,6 +667,149 @@ mod tests {
                 AgentEvent::StepManifest { .. } | AgentEvent::BlockRegistered { .. }
             )),
             "an opt-out caller records cost only, and never its prompt bytes"
+        );
+    }
+
+    /// A provider that fails the test if it is ever reached — the only honest
+    /// way to assert "nothing was dispatched".
+    struct NeverDispatched;
+
+    #[async_trait]
+    impl Provider for NeverDispatched {
+        fn id(&self) -> &str {
+            "never"
+        }
+
+        async fn complete_ref(
+            &self,
+            _request: CompletionRequestRef<'_>,
+        ) -> Result<CompletionResult, ProviderError> {
+            panic!("no provider call may be dispatched after the task deadline has passed");
+        }
+    }
+
+    fn one_call(provider: &dyn Provider, role: ModelCallRole) -> AccountedCall<'_> {
+        AccountedCall {
+            provider,
+            role,
+            model_hint: "configured-model".into(),
+            request: CompletionRequest {
+                messages: vec![CompletionMessage::user("work")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: Vec::new(),
+                reasoning: None,
+                params: None,
+            },
+            retry_policy: RetryPolicy::new(1, 0, 0),
+            timeout: None,
+            estimated_input_tokens: 1,
+            receipt: None,
+        }
+    }
+
+    /// #2238 witness: the task's wall clock gates this seam, not just the
+    /// engine's step loop. Before this, `BudgetGuard::set_task_deadline` was
+    /// honoured in exactly one place — `driver::settlement::check_budget` —
+    /// so every management role the pipeline dispatches through here (triage,
+    /// plan, verdict, guidance) metered dollars and never the clock, and a run
+    /// whose deadline had already blown still bought all of them.
+    #[tokio::test]
+    async fn an_expired_task_deadline_refuses_the_call_before_it_is_dispatched() {
+        let provider = NeverDispatched;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        budget.set_task_deadline(Some(Instant::now() - Duration::from_secs(5)));
+
+        let result = run_accounted_call(
+            one_call(&provider, ModelCallRole::Triage),
+            &mut budget,
+            &EventSender::new(tx),
+            &NoopSleeper,
+        )
+        .await;
+
+        match result {
+            Err(AccountedCallError::Deadline { overrun }) => {
+                assert!(overrun >= Duration::from_secs(5), "overrun: {overrun:?}");
+            }
+            other => panic!("an expired deadline must refuse the call: {other:?}"),
+        }
+        assert_eq!(budget.spent_usd(), 0.0, "a refused call spends nothing");
+        // Not even a `UsageIncomplete`: nothing was in flight, so there is no
+        // unknown provider-side spend to account for. An envelope here would
+        // invent a failed attempt that never happened.
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            events.is_empty(),
+            "a call that never dispatched owes no accounting: {events:?}"
+        );
+    }
+
+    /// The other side of the same gate: a deadline still ahead is not a stop.
+    /// Without this, "refuse everything" would pass the witness above.
+    #[tokio::test]
+    async fn a_deadline_still_ahead_dispatches_normally() {
+        let provider = Succeeds;
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        budget.set_task_deadline(Some(Instant::now() + Duration::from_secs(600)));
+
+        let result = run_accounted_call(
+            one_call(&provider, ModelCallRole::Triage),
+            &mut budget,
+            &EventSender::new(tx),
+            &NoopSleeper,
+        )
+        .await;
+
+        assert!(result.is_ok(), "an unexpired deadline gates nothing");
+        assert_eq!(budget.spent_usd(), 0.01);
+    }
+
+    /// #2240 witness: the tick states the wall-clock axis, so a journal can
+    /// answer "was a deadline armed?" without anyone reconstructing argv.
+    /// `None` and `Some(_)` are the two facts that used to be indistinguishable.
+    #[tokio::test]
+    async fn the_budget_tick_reports_whether_a_task_deadline_was_armed() {
+        async fn tick_for(deadline: Option<Instant>) -> Option<u64> {
+            let provider = Succeeds;
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+            budget.set_task_deadline(deadline);
+            let _ = run_accounted_call(
+                one_call(&provider, ModelCallRole::Triage),
+                &mut budget,
+                &EventSender::new(tx),
+                &NoopSleeper,
+            )
+            .await;
+            let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+            match events
+                .iter()
+                .find(|event| matches!(event, AgentEvent::BudgetTick { .. }))
+                .expect("a settled call emits a tick")
+            {
+                AgentEvent::BudgetTick {
+                    deadline_remaining_ms,
+                    ..
+                } => *deadline_remaining_ms,
+                _ => unreachable!("filtered above"),
+            }
+        }
+
+        assert_eq!(
+            tick_for(None).await,
+            None,
+            "an unarmed deadline must be reported as unarmed, not as zero time left"
+        );
+        let armed = tick_for(Some(Instant::now() + Duration::from_secs(900)))
+            .await
+            .expect("an armed deadline reports its remaining clock");
+        assert!(
+            (800_000..=900_000).contains(&armed),
+            "the tick must report the real remaining clock, got {armed}ms"
         );
     }
 

--- a/crates/stella-core/src/budget.rs
+++ b/crates/stella-core/src/budget.rs
@@ -57,7 +57,7 @@
 
 use std::time::{Duration, Instant};
 
-use stella_protocol::BudgetMode;
+use stella_protocol::{AgentEvent, BudgetMode};
 
 /// Which scope a [`BudgetOutcome`] is reporting against. A guard configured
 /// with both a turn and a session limit checks them independently — the
@@ -347,6 +347,47 @@ impl BudgetGuard {
             return DeadlineOutcome::Closing { remaining };
         }
         DeadlineOutcome::Continue
+    }
+
+    /// Wall clock left before [`task_deadline`](Self::task_deadline) as of
+    /// `now`, or `None` when no deadline is armed. Pure, for the same reason
+    /// [`check_deadline`](Self::check_deadline) is.
+    ///
+    /// `Some(Duration::ZERO)` is an armed deadline that has already passed —
+    /// deliberately distinct from `None`, because "out of time" and "nobody
+    /// was timing this" are the two answers a reader needs to tell apart.
+    #[must_use]
+    pub fn deadline_remaining(&self, now: Instant) -> Option<Duration> {
+        self.task_deadline
+            .map(|deadline| deadline.saturating_duration_since(now))
+    }
+
+    /// The [`AgentEvent::BudgetTick`] describing this guard as of `now`.
+    ///
+    /// Every emitter goes through here rather than writing the literal, so
+    /// "each axis reaches the journal" is structural instead of a convention
+    /// three call sites happen to keep. It was a convention until #2240: the
+    /// wall-clock axis existed in the guard and in no tick, and reconstructing
+    /// whether a killed trial had a deadline armed at all meant reading the
+    /// adapter, the runner, the harness, and the trial's `config.json`.
+    ///
+    /// Takes `now` rather than reading the clock (module docs, invariant 2):
+    /// the caller is at a settled boundary and already holds one.
+    #[must_use]
+    pub fn tick_event(&self, now: Instant) -> AgentEvent {
+        AgentEvent::BudgetTick {
+            spent_usd: self.spent_usd(),
+            limit_usd: self.turn_limit_usd(),
+            mode: self.mode(),
+            session_spent_usd: Some(self.session_spent_usd()),
+            session_limit_usd: self.session_limit_usd(),
+            deadline_remaining_ms: self
+                .deadline_remaining(now)
+                // Saturating, not `as`: a deadline armed absurdly far out
+                // would otherwise wrap to a small number, which reads as
+                // "nearly out of time" — the exact inversion of the truth.
+                .map(|left| u64::try_from(left.as_millis()).unwrap_or(u64::MAX)),
+        }
     }
 
     /// Remaining headroom before the *tightest* configured limit trips, or

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -1546,6 +1546,14 @@ impl<'a> Engine<'a> {
                 });
                 return 0.0;
             }
+            // Refused before dispatch (#2238): nothing spent, nothing misbehaved.
+            Err(AccountedCallError::Deadline { .. }) => {
+                let _ = events.send(AgentEvent::Error {
+                    message: "overflow summarizer skipped: the task deadline passed".into(),
+                    retryable: false,
+                });
+                return 0.0;
+            }
         };
         let cost_usd = result.cost_usd;
         let text = result.text.trim();
@@ -1902,8 +1910,10 @@ impl<'a> Engine<'a> {
                 return Err(format!("model call failed: {message}"));
             }
         };
-        let budget_outcome = record_settled_cost(budget, result.cost_usd, warnings, events);
-        let call_duration_ms = call_started.elapsed().as_millis() as u64;
+        // One boundary read: the call's duration and the tick's clock axis.
+        let now = std::time::Instant::now();
+        let call_duration_ms = now.duration_since(call_started).as_millis() as u64;
+        let budget_outcome = record_settled_cost(budget, result.cost_usd, warnings, events, now);
 
         // Deferred-flush: these `Retry` events only reach the wire now
         // that the step has actually committed (see module docs).

--- a/crates/stella-core/src/driver/settlement.rs
+++ b/crates/stella-core/src/driver/settlement.rs
@@ -70,20 +70,18 @@ pub(super) fn emit_budget_warning(
     });
 }
 
+/// `now` is the caller's own boundary clock read — the tick reports the
+/// wall-clock axis too (#2240) and this module holds no clock of its own
+/// (invariant 2, and `crate::budget`'s module docs).
 pub(super) fn record_settled_cost(
     budget: &mut BudgetGuard,
     cost_usd: f64,
     warnings: &mut BudgetWarnings,
     events: &EventSender,
+    now: std::time::Instant,
 ) -> BudgetOutcome {
     let outcome = budget.record_spend(cost_usd);
-    let _ = events.send(AgentEvent::BudgetTick {
-        spent_usd: budget.spent_usd(),
-        limit_usd: budget.turn_limit_usd(),
-        mode: budget.mode(),
-        session_spent_usd: Some(budget.session_spent_usd()),
-        session_limit_usd: budget.session_limit_usd(),
-    });
+    let _ = events.send(budget.tick_event(now));
     emit_budget_warning(outcome, warnings, events);
     outcome
 }
@@ -127,6 +125,15 @@ impl super::Engine<'_> {
         state: &mut TurnState,
         events: &EventSender,
     ) -> Option<TurnOutcome> {
+        // The one clock read on this path — `crate::budget`'s guard is pure
+        // and takes `now` as an owned parameter (module docs), mirroring how
+        // `run_step_inner` reads `state.started_at.elapsed()` for the
+        // existing per-turn `ContinuationBudget` rather than letting a pure
+        // decision function read the clock itself. Read once and shared with
+        // the settlement tick below, so the boundary's two answers — what is
+        // left on the clock, and whether that is already too little — cannot
+        // disagree about when "now" was.
+        let now = std::time::Instant::now();
         let child_spend = self.tools.drain_sub_agent_spend_usd();
         if child_spend > 0.0 {
             record_settled_cost(
@@ -134,21 +141,17 @@ impl super::Engine<'_> {
                 child_spend,
                 &mut state.memos.warnings,
                 events,
+                now,
             );
             state.total_cost_usd += child_spend;
         }
-        // The one clock read on this path — `crate::budget`'s guard is pure
-        // and takes `now` as an owned parameter (module docs), mirroring how
-        // `run_step_inner` reads `state.started_at.elapsed()` for the
-        // existing per-turn `ContinuationBudget` rather than letting a pure
-        // decision function read the clock itself.
         check_budget(
             &state.budget,
             state.total_cost_usd,
             state.last_step,
             &mut state.memos.warnings,
             events,
-            std::time::Instant::now(),
+            now,
         )
     }
 }

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -735,13 +735,7 @@ impl Engine<'_> {
         // The parent's own post-settlement numbers, since the child's ticks
         // were dropped at the boundary and a HUD would otherwise sit stale
         // for the whole child run.
-        let _ = events.send(AgentEvent::BudgetTick {
-            spent_usd: budget.spent_usd(),
-            limit_usd: budget.turn_limit_usd(),
-            mode: budget.mode(),
-            session_spent_usd: Some(budget.session_spent_usd()),
-            session_limit_usd: budget.session_limit_usd(),
-        });
+        let _ = events.send(budget.tick_event(std::time::Instant::now()));
 
         let absorbed_messages = messages.len().saturating_sub(seeded);
         let steps = tally.steps();

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -136,7 +136,7 @@ use fanout_stage::SerialCreates;
 use raw_usage::{RawCall, RawCallError};
 pub use run_error::{PipelineError, PipelineRunError};
 use run_error::{RoleResolveError, WitnessAuthorIndependence};
-use stage_budget::{PipelineBudgetAbort, Spend, budget_abort};
+use stage_budget::{PipelineStageAbort, Spend, budget_abort};
 use task_frame::TaskFrame;
 use verifier_stage::{VerdictDegradation, VerifierNotices};
 use witness_stage::{BoundHookRunner, WitnessAuthoring};
@@ -259,10 +259,21 @@ pub struct PipelineConfig {
     /// engine turn: a multi-step plan runs one engine turn per step plus the
     /// witness author's and every revision's, so metering the run's elapsed
     /// time against a per-turn allowance under-reported the remaining clock
-    /// and refused repairs a long run could still afford (#1507). Like
-    /// `turn_budget` it enforces nothing — no future is cancelled when it
-    /// elapses — and `None` means "nobody is measuring": the clock axis
-    /// abstains rather than inventing a deadline the caller never declared.
+    /// and refused repairs a long run could still afford (#1507).
+    ///
+    /// **This field is an estimate, not a ceiling.** Nothing is cancelled when
+    /// it elapses and no call is refused because of it; it sizes the repair
+    /// gate's headroom question and the witness-repair bound, and `None` means
+    /// "nobody is measuring" — the clock axis abstains rather than inventing a
+    /// deadline the caller never declared.
+    ///
+    /// The enforcing wall clock is a different field elsewhere:
+    /// `BudgetGuard::set_task_deadline`, an absolute instant on the guard
+    /// threaded into [`Pipeline::run`]. That one IS honoured — by the engine's
+    /// step loop (`stella_core::driver::settlement`) and, since #2238, before
+    /// every raw stage dispatch (`stella_core::run_accounted_call`). Both are
+    /// fed the same `--turn-budget` by `stella-cli`, which is exactly why they
+    /// are easy to confuse and worth this paragraph.
     pub run_budget: Option<Duration>,
     /// Per-role request overrides (`agent_engine_config`) for the raw
     /// triage/verifier completion calls.
@@ -1356,7 +1367,9 @@ impl<'a> Pipeline<'a> {
             .await
         {
             Ok(result) => result.text,
-            Err(RawCallError::Budget(abort)) => {
+            // The conversational path IS the whole run — there is no executed
+            // work either ceiling could settle with, so both stop the same way.
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => {
                 return Ok(self.aborted_before_execute(
                     TaskClass::SimpleLookup,
                     *total_cost,
@@ -1417,7 +1430,7 @@ impl<'a> Pipeline<'a> {
         repo_structure: &str,
         revision: Option<&str>,
         spend: &mut Spend<'_>,
-    ) -> Result<Vec<PlanStep>, PipelineBudgetAbort> {
+    ) -> Result<Vec<PlanStep>, PipelineStageAbort> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Plan,
         });
@@ -1450,7 +1463,9 @@ impl<'a> Pipeline<'a> {
             .await
         {
             Ok(r) => r,
-            Err(RawCallError::Budget(abort)) => return Err(abort),
+            // Still before execute: a fallback plan here would only buy the
+            // worker turns the run has no clock left to run.
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
             Err(RawCallError::Provider | RawCallError::Timeout) => return Ok(fallback_plan()),
         };
 
@@ -1479,7 +1494,7 @@ impl<'a> Pipeline<'a> {
                     return Ok(steps);
                 }
             }
-            Err(RawCallError::Budget(abort)) => return Err(abort),
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
             Err(RawCallError::Provider | RawCallError::Timeout) => {}
         }
 

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -12,7 +12,7 @@ use stella_protocol::{
     ReasoningEffort,
 };
 
-use super::stage_budget::{PipelineBudgetAbort, budget_abort};
+use super::stage_budget::{PipelineStageAbort, budget_abort, deadline_abort};
 use super::{Pipeline, ResolvedRole, RoleCallOverrides};
 
 pub(super) struct RawCall<'r, 'a> {
@@ -43,7 +43,18 @@ pub(super) struct RawCall<'r, 'a> {
 pub(super) enum RawCallError {
     Provider,
     Timeout,
-    Budget(PipelineBudgetAbort),
+    Budget(PipelineStageAbort),
+    /// The task's wall-clock deadline had already passed, so this call was
+    /// never dispatched and cost nothing (#2238).
+    ///
+    /// Separate from [`Self::Budget`] because the two want opposite handling
+    /// *after* execute: a dollar breach is the run being unable to afford the
+    /// next call at all, while an expired clock on a run that has already
+    /// produced a diff wants a pivot — skip the remaining assurance stages and
+    /// settle the work that exists, so a partially-solved task is still
+    /// scorable. Every match site therefore states its own answer rather than
+    /// sharing the budget arm.
+    Deadline(PipelineStageAbort),
 }
 
 /// Headroom added to every management role's *visible-output* budget so a
@@ -353,6 +364,11 @@ impl<'a> Pipeline<'a> {
             }
             Err(AccountedCallError::Provider(_)) => Err(RawCallError::Provider),
             Err(AccountedCallError::Timeout) => Err(RawCallError::Timeout),
+            // Nothing was dispatched, so `total` is untouched — the run's
+            // settled cost stays exactly what it was before this call.
+            Err(AccountedCallError::Deadline { overrun }) => {
+                Err(RawCallError::Deadline(deadline_abort(overrun)))
+            }
             Err(AccountedCallError::Budget { result, outcome }) => {
                 *total += result.cost_usd;
                 Err(RawCallError::Budget(

--- a/crates/stella-pipeline/src/pipeline/stage_budget.rs
+++ b/crates/stella-pipeline/src/pipeline/stage_budget.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use stella_core::{AbortKind, BudgetGuard, BudgetOutcome};
 use stella_protocol::AgentEvent;
 
@@ -29,14 +31,22 @@ pub(super) struct Spend<'a> {
     pub(super) total: &'a mut f64,
 }
 
-/// A settled stage call crossed an enforced budget. Kept distinct from
-/// provider/routing failures so raw stages must propagate the stop.
+/// A stage call hit a ceiling the run may not spend past — dollars or wall
+/// clock. Kept distinct from provider/routing failures so raw stages must
+/// propagate the stop rather than degrade through it.
+///
+/// One type for both axes because the *consequence* is identical at every
+/// call site (stop at this safe boundary, report why), and the axes stay
+/// distinguishable where it matters — in `reason`, which is what reaches the
+/// stream. Named for the stop rather than for dollars since #2238 taught it
+/// the clock: the old name, `PipelineBudgetAbort`, would have described what
+/// the type used to be while it carried "the task deadline passed".
 #[derive(Debug, Clone)]
-pub(super) struct PipelineBudgetAbort {
+pub(super) struct PipelineStageAbort {
     pub(super) reason: String,
 }
 
-pub(super) fn budget_abort(outcome: BudgetOutcome) -> Option<PipelineBudgetAbort> {
+pub(super) fn budget_abort(outcome: BudgetOutcome) -> Option<PipelineStageAbort> {
     let BudgetOutcome::AbortTurn {
         spent_usd,
         limit_usd,
@@ -45,11 +55,27 @@ pub(super) fn budget_abort(outcome: BudgetOutcome) -> Option<PipelineBudgetAbort
     else {
         return None;
     };
-    Some(PipelineBudgetAbort {
+    Some(PipelineStageAbort {
         reason: format!(
             "budget exceeded after this call: spent ${spent_usd:.4} against a ${limit_usd:.2} limit"
         ),
     })
+}
+
+/// The stop for a stage reached after the task's wall-clock deadline passed
+/// (#2238), phrased like `crate::driver::settlement`'s so the two rungs of the
+/// same mechanism read the same way in a transcript.
+///
+/// "before spending anything further" is load-bearing: unlike the dollar
+/// abort above, no call was made and no money changed hands — the run is
+/// declining to start work it has no time to finish.
+pub(super) fn deadline_abort(overrun: Duration) -> PipelineStageAbort {
+    PipelineStageAbort {
+        reason: format!(
+            "task deadline exceeded by {:.1}s — stopping before spending anything further",
+            overrun.as_secs_f64()
+        ),
+    }
 }
 
 /// The terminal `Error` event and the `Aborted` outcome for a run that stopped

--- a/crates/stella-pipeline/src/pipeline/tests/terminal_outcomes.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/terminal_outcomes.rs
@@ -1,6 +1,7 @@
 //! Terminal-outcome witnesses: a red final verdict reports
 //! `VerificationFailed` rather than `Completed`, an enforced budget breach in
-//! triage settles its spend and starts no further paid stage, and an
+//! triage settles its spend and starts no further paid stage, an expired task
+//! deadline stops the run before it dispatches anything at all, and an
 //! unresolvable independent witness author degrades the run instead of
 //! aborting it.
 
@@ -283,6 +284,106 @@ async fn enforced_budget_breach_in_triage_stops_before_the_next_paid_stage() {
         provider.remaining().await,
         2,
         "the next paid stage must not start after triage crosses the cap"
+    );
+}
+
+/// #2238 witness: an already-expired task deadline stops the run before it
+/// dispatches a single paid stage call.
+///
+/// Fails on `main`, where `BudgetGuard::set_task_deadline` was honoured only
+/// by the engine's step loop (`driver::settlement::check_budget`): every raw
+/// stage went through `Pipeline::dispatch_raw`, whose one budget rung matched
+/// `BudgetOutcome::AbortTurn` — a dollar rung — so triage dispatched here
+/// regardless of the clock, and research, plan, scope, witness, verify and
+/// verdict followed it against a harness already about to SIGKILL the
+/// container.
+///
+/// The dollar axes are deliberately unarmed (`BudgetMode::Off`, no limits):
+/// the only ceiling in this fixture is the wall clock, so nothing but the
+/// clock can be what stopped it.
+#[tokio::test]
+async fn an_expired_task_deadline_stops_the_run_before_any_paid_stage() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("multi"),
+        text_result(r#"["plan must never run"]"#),
+        text_result("worker must never run"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    budget.set_task_deadline(Some(
+        std::time::Instant::now() - std::time::Duration::from_secs(7),
+    ));
+
+    let outcome = pipeline
+        .run(
+            "Refactor the parser and update all callers",
+            &mut messages,
+            &mut budget,
+        )
+        .await
+        .expect("an expired deadline is a typed outcome, not a run error");
+
+    assert!(
+        matches!(
+            outcome.status,
+            PipelineStatus::Aborted {
+                kind: AbortKind::DeliberateStop,
+                ..
+            }
+        ),
+        "stopping on the clock is a deliberate stop, not a failure: {:?}",
+        outcome.status
+    );
+    assert_eq!(
+        outcome.total_cost_usd, 0.0,
+        "nothing was dispatched, so nothing was spent"
+    );
+    assert_eq!(
+        provider.remaining().await,
+        3,
+        "not one scripted completion may be consumed after the deadline has passed"
+    );
+    let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { message, .. } if message.contains("task deadline exceeded by")
+        )),
+        "the stream must name the clock as the reason, not leave it to argv: {events:?}"
     );
 }
 

--- a/crates/stella-pipeline/src/pipeline/tests/usage.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/usage.rs
@@ -69,7 +69,7 @@ async fn run_triage_only(
     config: PipelineConfig,
     budget: &mut BudgetGuard,
 ) -> (
-    Result<TaskAssessment, PipelineBudgetAbort>,
+    Result<TaskAssessment, PipelineStageAbort>,
     f64,
     Vec<AgentEvent>,
 ) {

--- a/crates/stella-pipeline/src/pipeline/triage_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/triage_stage.rs
@@ -27,7 +27,7 @@ impl Pipeline<'_> {
         goal: &str,
         budget: &mut BudgetGuard,
         total: &mut f64,
-    ) -> Result<(TaskAssessment, Vec<String>), PipelineBudgetAbort> {
+    ) -> Result<(TaskAssessment, Vec<String>), PipelineStageAbort> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Triage,
         });
@@ -89,7 +89,10 @@ impl Pipeline<'_> {
             .await
         {
             Ok(result) => Some(result.text),
-            Err(RawCallError::Budget(abort)) => return Err(abort),
+            // Triage is the run's first paid call: an expired clock here means
+            // nothing has been produced, so stopping is honest — there is no
+            // partial work a pivot could settle with.
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
             Err(RawCallError::Provider | RawCallError::Timeout) => None,
         };
         let assessment = response.as_deref().and_then(parse_triage_response);

--- a/crates/stella-pipeline/src/pipeline/verifier_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/verifier_stage.rs
@@ -61,7 +61,7 @@ impl<'a> Pipeline<'a> {
         prompt: ManagementPrompt,
         budget: &mut BudgetGuard,
         total: &mut f64,
-    ) -> Result<Option<String>, PipelineBudgetAbort> {
+    ) -> Result<Option<String>, PipelineStageAbort> {
         let resolved = match self.resolve_provider(Role::Verifier) {
             Ok(resolved) => resolved,
             Err(_) => return Ok(None),
@@ -102,7 +102,14 @@ impl<'a> Pipeline<'a> {
                 }
             }
             Err(RawCallError::Budget(abort)) => Err(abort),
-            Err(RawCallError::Provider | RawCallError::Timeout) => Ok(None),
+            // Post-execute, so the clock joins the best-effort arm rather than
+            // the abort one (#2238): guidance exists to improve a revision the
+            // run no longer has time to make, and discarding the executed diff
+            // to report "out of time" would throw away the only scorable thing
+            // the run produced.
+            Err(RawCallError::Provider | RawCallError::Timeout | RawCallError::Deadline(_)) => {
+                Ok(None)
+            }
         }
     }
 
@@ -116,7 +123,7 @@ impl<'a> Pipeline<'a> {
         prompt: ManagementPrompt,
         inputs: &LadderInputs,
         spend: &mut Spend<'_>,
-    ) -> Result<ModelVerifierVerdict, PipelineBudgetAbort> {
+    ) -> Result<ModelVerifierVerdict, PipelineStageAbort> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Verdict,
         });
@@ -182,6 +189,15 @@ impl<'a> Pipeline<'a> {
             Err(RawCallError::Budget(abort)) => Err(abort),
             Err(RawCallError::Provider | RawCallError::Timeout) => {
                 self.warn_verifier_fallback(degradation, "the verifier call failed or timed out");
+                Ok(heuristic_fallback(inputs))
+            }
+            // The pivot (#2238): the work is done and the clock is gone, so
+            // grade it with the deterministic ladder rather than abort and
+            // report nothing. `heuristic_fallback` is conservative (L-E11), so
+            // this trades a model verdict for a stricter one — never for an
+            // unearned pass.
+            Err(RawCallError::Deadline(abort)) => {
+                self.warn_verifier_fallback(degradation, &abort.reason);
                 Ok(heuristic_fallback(inputs))
             }
         }

--- a/crates/stella-pipeline/src/replay.rs
+++ b/crates/stella-pipeline/src/replay.rs
@@ -1032,6 +1032,7 @@ mod tests {
             mode: BudgetMode::Observed,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         }
     }
     fn complete() -> AgentEvent {

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -534,6 +534,25 @@ pub enum AgentEvent {
         /// `session_spent_usd`.
         #[serde(default)]
         session_limit_usd: Option<f64>,
+        /// Wall clock left before the task deadline at this tick — the third
+        /// axis, and the only one a journal could not otherwise state (#2240).
+        ///
+        /// `None` means **no deadline was armed**, which is exactly the
+        /// distinction that used to require reading argv: a trial killed by its
+        /// harness emitted dozens of these against a dollar cap it never
+        /// approached, while the 900s wall clock that actually stopped it
+        /// appeared nowhere in the journal. `Some(0)` is the opposite fact — a
+        /// deadline is armed and has already passed.
+        ///
+        /// Milliseconds rather than a `Duration` because this is a wire type
+        /// (invariant 4): a whole-millisecond integer round-trips through JSON
+        /// byte-for-byte, where a float of seconds would not.
+        ///
+        /// `serde(default)` — absent on every journal written before this
+        /// field existed, where it reads as "unarmed". That is the honest
+        /// decode: those journals genuinely could not say otherwise.
+        #[serde(default)]
+        deadline_remaining_ms: Option<u64>,
     },
     /// One committed model call — the metering record. Emitted exactly once
     /// per step that lands, carrying the normalized usage envelope plus

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -123,13 +123,14 @@ fn parked_wait_events_roundtrip_under_their_own_tags() {
 }
 
 #[test]
-fn budget_tick_roundtrips_with_session_axis() {
+fn budget_tick_roundtrips_with_session_and_deadline_axes() {
     let event = AgentEvent::BudgetTick {
         spent_usd: 0.42,
         limit_usd: Some(2.5),
         mode: BudgetMode::Enforced,
         session_spent_usd: Some(1.75),
         session_limit_usd: Some(10.0),
+        deadline_remaining_ms: Some(842_137),
     };
     let json = serde_json::to_string(&event).unwrap();
     let back: AgentEvent = serde_json::from_str(&json).unwrap();
@@ -140,19 +141,23 @@ fn budget_tick_roundtrips_with_session_axis() {
             mode,
             session_spent_usd,
             session_limit_usd,
+            deadline_remaining_ms,
         } => {
             assert_eq!(spent_usd, 0.42);
             assert_eq!(limit_usd, Some(2.5));
             assert_eq!(mode, BudgetMode::Enforced);
             assert_eq!(session_spent_usd, Some(1.75));
             assert_eq!(session_limit_usd, Some(10.0));
+            // Byte-for-byte (invariant 4) — the reason the axis is a
+            // whole-millisecond integer and not a float of seconds.
+            assert_eq!(deadline_remaining_ms, Some(842_137));
         }
         other => panic!("unexpected variant: {other:?}"),
     }
 }
 
 #[test]
-fn budget_tick_without_session_fields_parses_with_none() {
+fn budget_tick_without_session_or_deadline_fields_parses_with_none() {
     // A stream recorded BEFORE the session axis existed must still parse,
     // with both new fields defaulting to `None` (not `0.0`, which would
     // read as a real "spent nothing").
@@ -161,10 +166,15 @@ fn budget_tick_without_session_fields_parses_with_none() {
         Ok(AgentEvent::BudgetTick {
             session_spent_usd,
             session_limit_usd,
+            deadline_remaining_ms,
             ..
         }) => {
             assert_eq!(session_spent_usd, None);
             assert_eq!(session_limit_usd, None);
+            // `None` is the honest decode for a pre-#2240 journal: it could
+            // not say whether a deadline was armed, and `Some(0)` would be
+            // this parser inventing "already out of time".
+            assert_eq!(deadline_remaining_ms, None);
         }
         other => panic!("old stream must parse: {other:?}"),
     }
@@ -1270,6 +1280,7 @@ fn type_tag_matches_the_serde_type_wire_tag() {
             mode: BudgetMode::Off,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         },
         AgentEvent::UsageIncomplete {
             role: ModelCallRole::Worker,

--- a/crates/stella-protocol/src/event/tests/tag_table.rs
+++ b/crates/stella-protocol/src/event/tests/tag_table.rs
@@ -75,6 +75,7 @@ fn type_tag_matches_the_serde_type_wire_tag() {
             mode: BudgetMode::Off,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         },
         AgentEvent::UsageIncomplete {
             role: ModelCallRole::Worker,

--- a/crates/stella-protocol/tests/wire_contract.rs
+++ b/crates/stella-protocol/tests/wire_contract.rs
@@ -856,6 +856,7 @@ fn sample_events() -> Vec<AgentEvent> {
                 mode,
                 session_spent_usd: Some(1.75),
                 session_limit_usd: Some(10.0),
+                deadline_remaining_ms: Some(842_137),
             },
             AgentEvent::BudgetTick {
                 spent_usd: 0.42,
@@ -863,6 +864,7 @@ fn sample_events() -> Vec<AgentEvent> {
                 mode,
                 session_spent_usd: None,
                 session_limit_usd: None,
+                deadline_remaining_ms: None,
             },
         ]
     }));

--- a/crates/stella-store/src/journal.rs
+++ b/crates/stella-store/src/journal.rs
@@ -760,6 +760,7 @@ mod tests {
                     mode: stella_protocol::BudgetMode::Observed,
                     session_spent_usd: None,
                     session_limit_usd: None,
+                    deadline_remaining_ms: None,
                 },
             },
             JournalRecord::Pipeline { on: false },
@@ -771,6 +772,7 @@ mod tests {
                     mode: stella_protocol::BudgetMode::Observed,
                     session_spent_usd: None,
                     session_limit_usd: None,
+                    deadline_remaining_ms: None,
                 },
             },
         ];

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -215,6 +215,7 @@ async fn main() -> std::io::Result<()> {
                             mode: stella_protocol::BudgetMode::Observed,
                             session_spent_usd: Some(0.054),
                             session_limit_usd: limit_usd,
+                            deadline_remaining_ms: None,
                         },
                     });
                 }
@@ -437,6 +438,7 @@ async fn mini_run(tx: &mpsc::UnboundedSender<Inbound>, id: &str) {
             mode: stella_protocol::BudgetMode::Observed,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         }),
         ev(AgentEvent::Complete {
             model: "glm-5.2".into(),

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -477,6 +477,7 @@ fn budget_tick_sets_live_spend_without_double_counting_step_usage() {
             mode: stella_protocol::BudgetMode::Observed,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         },
     ));
     assert_eq!(w.agents[0].cost_usd, 0.42, "the tick is authoritative");

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -193,6 +193,7 @@ fn text_deltas_accumulate_as_a_preview_the_authoritative_text_replaces() {
         mode: BudgetMode::Observed,
         session_spent_usd: None,
         session_limit_usd: None,
+        deadline_remaining_ms: None,
     });
     model.apply(&text("Hello!"));
     assert!(
@@ -264,6 +265,7 @@ fn replaying_a_log_with_deltas_is_deterministic() {
             mode: BudgetMode::Observed,
             session_spent_usd: None,
             session_limit_usd: None,
+            deadline_remaining_ms: None,
         },
         text("Hello"),
         AgentEvent::Complete {
@@ -286,6 +288,7 @@ fn budget_tick_folds_into_the_hud_gauge_but_never_the_transcript() {
         mode: BudgetMode::Enforced,
         session_spent_usd: None,
         session_limit_usd: None,
+        deadline_remaining_ms: None,
     });
     assert_eq!(model.hud.spent_usd, 0.42);
     assert_eq!(model.hud.limit_usd, Some(2.0));

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -258,6 +258,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 mode: stella_protocol::BudgetMode::Observed,
                 session_spent_usd: Some(0.021),
                 session_limit_usd: Some(7.50),
+                deadline_remaining_ms: None,
             },
         ),
         // ── the witness is authored before the worker executes ──────────
@@ -382,6 +383,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 mode: stella_protocol::BudgetMode::Observed,
                 session_spent_usd: Some(0.039),
                 session_limit_usd: Some(7.50),
+                deadline_remaining_ms: None,
             },
         ),
         // ── the oracle replays against the patched tree ─────────────────
@@ -492,6 +494,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 mode: stella_protocol::BudgetMode::Observed,
                 session_spent_usd: None,
                 session_limit_usd: None,
+                deadline_remaining_ms: None,
             },
         ),
         ev(

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1027,6 +1027,7 @@ mod tests {
                 mode: BudgetMode::Observed,
                 session_spent_usd: None,
                 session_limit_usd: None,
+                deadline_remaining_ms: None,
             },
             AgentEvent::ProviderFallback {
                 from: "a".into(),

--- a/crates/stella-tui/src/views/agents.rs
+++ b/crates/stella-tui/src/views/agents.rs
@@ -508,6 +508,7 @@ mod tests {
                 mode: stella_protocol::BudgetMode::Observed,
                 session_spent_usd: None,
                 session_limit_usd: None,
+                deadline_remaining_ms: None,
             },
         });
 

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1384,6 +1384,26 @@ export type AgentEvent = {
   ts?: number;
   type: "compaction";
 } | {
+  /**
+   * Wall clock left before the task deadline at this tick — the third
+   * axis, and the only one a journal could not otherwise state (#2240).
+   *
+   * `None` means **no deadline was armed**, which is exactly the
+   * distinction that used to require reading argv: a trial killed by its
+   * harness emitted dozens of these against a dollar cap it never
+   * approached, while the 900s wall clock that actually stopped it
+   * appeared nowhere in the journal. `Some(0)` is the opposite fact — a
+   * deadline is armed and has already passed.
+   *
+   * Milliseconds rather than a `Duration` because this is a wire type
+   * (invariant 4): a whole-millisecond integer round-trips through JSON
+   * byte-for-byte, where a float of seconds would not.
+   *
+   * `serde(default)` — absent on every journal written before this
+   * field existed, where it reads as "unarmed". That is the honest
+   * decode: those journals genuinely could not say otherwise.
+   */
+  deadline_remaining_ms?: number | null;
   limit_usd?: number | null;
   mode: BudgetMode;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -2298,6 +2298,16 @@
     {
       "description": "Emitted after every provider/media call that spends money. The TUI HUD\nrenders spend live from this stream; nothing user-visible about spend\nis derived from state that isn't also in this event.",
       "properties": {
+        "deadline_remaining_ms": {
+          "default": null,
+          "description": "Wall clock left before the task deadline at this tick — the third\naxis, and the only one a journal could not otherwise state (#2240).\n\n`None` means **no deadline was armed**, which is exactly the\ndistinction that used to require reading argv: a trial killed by its\nharness emitted dozens of these against a dollar cap it never\napproached, while the 900s wall clock that actually stopped it\nappeared nowhere in the journal. `Some(0)` is the opposite fact — a\ndeadline is armed and has already passed.\n\nMilliseconds rather than a `Duration` because this is a wire type\n(invariant 4): a whole-millisecond integer round-trips through JSON\nbyte-for-byte, where a float of seconds would not.\n\n`serde(default)` — absent on every journal written before this\nfield existed, where it reads as \"unarmed\". That is the honest\ndecode: those journals genuinely could not say otherwise.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "limit_usd": {
           "format": "double",
           "type": [

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -246,6 +246,26 @@ export type AgentEvent = {
   superseded_blocks?: string[];
   type: "compaction";
 } | {
+  /**
+   * Wall clock left before the task deadline at this tick — the third
+   * axis, and the only one a journal could not otherwise state (#2240).
+   *
+   * `None` means **no deadline was armed**, which is exactly the
+   * distinction that used to require reading argv: a trial killed by its
+   * harness emitted dozens of these against a dollar cap it never
+   * approached, while the 900s wall clock that actually stopped it
+   * appeared nowhere in the journal. `Some(0)` is the opposite fact — a
+   * deadline is armed and has already passed.
+   *
+   * Milliseconds rather than a `Duration` because this is a wire type
+   * (invariant 4): a whole-millisecond integer round-trips through JSON
+   * byte-for-byte, where a float of seconds would not.
+   *
+   * `serde(default)` — absent on every journal written before this
+   * field existed, where it reads as "unarmed". That is the honest
+   * decode: those journals genuinely could not say otherwise.
+   */
+  deadline_remaining_ms?: number | null;
   limit_usd?: number | null;
   mode: BudgetMode;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -503,6 +503,16 @@
         {
           "description": "Emitted after every provider/media call that spends money. The TUI HUD\nrenders spend live from this stream; nothing user-visible about spend\nis derived from state that isn't also in this event.",
           "properties": {
+            "deadline_remaining_ms": {
+              "default": null,
+              "description": "Wall clock left before the task deadline at this tick — the third\naxis, and the only one a journal could not otherwise state (#2240).\n\n`None` means **no deadline was armed**, which is exactly the\ndistinction that used to require reading argv: a trial killed by its\nharness emitted dozens of these against a dollar cap it never\napproached, while the 900s wall clock that actually stopped it\nappeared nowhere in the journal. `Some(0)` is the opposite fact — a\ndeadline is armed and has already passed.\n\nMilliseconds rather than a `Duration` because this is a wire type\n(invariant 4): a whole-millisecond integer round-trips through JSON\nbyte-for-byte, where a float of seconds would not.\n\n`serde(default)` — absent on every journal written before this\nfield existed, where it reads as \"unarmed\". That is the honest\ndecode: those journals genuinely could not say otherwise.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "limit_usd": {
               "format": "double",
               "type": [


### PR DESCRIPTION
## What & why

Two halves of the same mechanism — `BudgetGuard`'s per-task wall-clock deadline — which until now was armed but neither reported nor obeyed above the engine loop.

**The journal axis (#2240).** `AgentEvent::BudgetTick` gains `deadline_remaining_ms: Option<u64>`. `None` means *no deadline was armed* — the distinction `stella-events.jsonl` could not state, so working out whether a killed trial had a wall clock at all meant reading the adapter, the runner, Harbor's `trial/trial.py` and the trial's own `config.json`, for a fact one field now states. `Some(0)` is the opposite fact: armed, and already passed.

Every emitter now goes through a new `BudgetGuard::tick_event(now)` instead of writing the struct literal, which makes "each axis reaches the journal" structural rather than a convention four call sites happen to keep. That convention had already drifted: `stella-cli`'s `settle_reflection_budget` hardcoded a `None` session axis against a guard that tracked one.

`#[serde(default)]`, so every already-written journal still parses, and `docs/wire/` is regenerated (`make wire-schema-update`) — the diff is purely additive.

**The pipeline rung (#2238).** `run_accounted_call` now checks the task deadline *before* it dispatches. The deadline used to be honoured in exactly one place, `driver::settlement::check_budget`, so the plane above the engine metered dollars and never the clock: a run whose deadline had already blown still bought triage, research, plan, scope review, the witness author, verify and verdict — one model call at a time, against a harness about to SIGKILL the container. `rg -n check_deadline crates/` returned `stella-core` only.

The check sits before the dispatch rather than as an outer `tokio::time::timeout`, so it is between model calls by construction (invariant 6) — an `AccountedCall` carries no tools, so there is never anything in flight to interrupt. The guard stays pure: the caller reads the clock and hands in `now`, exactly as `settlement.rs` does (invariant 2).

An expired clock and a blown dollar cap want **different** handling after execute, which is why `RawCallError::Deadline` is its own variant rather than reusing the budget arm:

- **Before execute** (triage, plan, plan-repair, the conversational path) — nothing has been produced, so stopping is honest: abort with `AbortKind::DeliberateStop`.
- **After execute** (verdict, distress guidance) — the valuable behaviour is a *pivot*, not an abort. Both fall onto their existing degraded paths, settling the executed diff with the conservative deterministic ladder (`heuristic_fallback`, L-E11) rather than discarding the only scorable work the run produced. That trades a model verdict for a stricter one, never for an unearned pass.

Two naming/doc consequences: `PipelineBudgetAbort` becomes `PipelineStageAbort` now that it carries wall clock as well as dollars, and `PipelineConfig::run_budget`'s doc comment stops implying it is the enforcing ceiling — it never was, and the field that *is* now lives one paragraph away.

Closes #2240
Closes #2238

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four, in two crates:

| Test | Proves |
|---|---|
| `accounted_call::an_expired_task_deadline_refuses_the_call_before_it_is_dispatched` | A provider that panics if reached is never reached; nothing spent, and *no* `UsageIncomplete` either — a call that never dispatched owes no accounting |
| `accounted_call::a_deadline_still_ahead_dispatches_normally` | The negative control, so "refuse everything" cannot pass the one above |
| `accounted_call::the_budget_tick_reports_whether_a_task_deadline_was_armed` | Unarmed → `None`; armed 900s out → a tick reporting the real remaining clock |
| `pipeline::tests::terminal_outcomes::an_expired_task_deadline_stops_the_run_before_any_paid_stage` | The end-to-end stop, with the dollar axes deliberately unarmed so only the clock can be what stopped it |

The pipeline witness was checked the artisanal way, against a detached worktree at `HEAD` with only the test file copied in:

```
assertion `left == right` failed: nothing was dispatched, so nothing was spent
  left: 0.0002
 right: 0.0
```

On `main` the run spends real money on two calls dispatched past a deadline that passed seven seconds earlier. On this branch it consumes none of the three scripted completions and emits an `error` naming the clock.

### Tests renamed (for `check-deleted-tests`)

Two `stella-protocol` tests were **renamed, not deleted** — each keeps every assertion it had and gains one for the new axis:

- `budget_tick_roundtrips_with_session_axis` → `budget_tick_roundtrips_with_session_and_deadline_axes` — now also asserts `deadline_remaining_ms` survives serde byte-for-byte (invariant 4).
- `budget_tick_without_session_fields_parses_with_none` → `budget_tick_without_session_or_deadline_fields_parses_with_none` — now also asserts a pre-#2240 journal decodes the field as `None`, the honest default, rather than `Some(0)`.

No test lost coverage. The guard keys on the bare function name, so a rename reads as a deletion until someone says it was one; naming them is the whole cost.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 7211 passed, 0 failed (re-run after merging `main` at 652c518)
- [x] `check-deleted-tests` against `origin/main` — OK, 2 removed tests, each named
- [x] Docs updated where behavior changed (doc comments on `BudgetTick`, `AccountedCallError`, `run_accounted_call`, `PipelineConfig::run_budget`, `PipelineStageAbort`)
- [x] `Closes #N` appears both here and as commit trailers

Also run green: `invariants`, `doc-links`, `command-docs`, `brand-case`, `file-size`, `god-files`, `gate-parity`, `left-behind`, `role-names`, `stat-portability`, `module-reachability`, `typed-errors`, `wire-schema`, `doc-warnings`, `self-driving-test` (60 checks). `shellcheck` is not installed in this environment and no shell script is touched by this diff.

## Nothing left behind

- [x] Filed: #2432, #2433, #2435, #2436

- **#2432** — the new raw-stage rung is reactive only; `DeadlineOutcome::Closing` is unreachable at that seam because it has no pace estimate to forecast from, so a stage that starts with 2s left still overruns. Deliberately not fixed here: picking a reserve at that seam without a measurement would be a second, invisible policy on top of the operator's `--turn-budget`, and the issue lays out the three candidate sources.
- **#2433** — `repair_gate::repair_headroom` and `witness_stage::remaining_run_budget` still read the advisory `run_budget` rather than the armed deadline. They agree by luck today because `stella-cli` feeds both from `--turn-budget`; they diverge for any embedder that arms one without the other.
- **#2435** — the new `deadline_remaining_ms` is produced and nothing renders it. The deck HUD and the Observatory show dollars only, so the field is currently write-only telemetry.
- **#2436** — `stella-pipeline/src/pipeline/tests.rs` sits at *exactly* its file-size ceiling, so no new test module can be declared there. This is why the pipeline witness lives in `terminal_outcomes.rs` (a defensible home, but not a freely chosen one) rather than a module of its own.

## Ground-rule check

- [x] No I/O added to `stella-core` — `BudgetGuard` stays pure; both new methods (`deadline_remaining`, `tick_event`) take `now` as an owned parameter, and every clock read happens at a caller's boundary
- [x] No new deps
- [x] No new outbound network calls
- [x] New cross-boundary field round-trips through serde, with a test, plus the regenerated `docs/wire/` contract

## Anything reviewers should know?

**Blast radius of the `BudgetTick` field.** `AgentEvent` is the wire format for three surfaces (the TUI folds it, `--output-format stream-json` prints it, `stella-serve` streams it over SSE). The change is additive and `serde(default)`, and `docs/wire/agentevent.schema.json` / `.d.ts` / the two `serveframe.*` artifacts are regenerated and committed in the same commit — `make wire-schema` is green. Nothing in the replay layer keys off the new field: `replay::event_tag` renders `budget_tick:{mode:?}`, so replay tags and golden fixtures are unaffected, and no deck snapshot renders the value.

**One behaviour change beyond the two issues, called out deliberately.** Routing `settle_reflection_budget` through `tick_event` changes its `session_spent_usd` from a hardcoded `None` to the guard's real session total. That is a fix — this *is* the session guard — but it is a change a reviewer should see rather than discover.

**The compaction summarizer's new arm.** `run_accounted_call` is also the engine's overflow-summarizer seam, so a blown deadline can now refuse a compaction pass. That path is nearly unreachable (the step loop's own deadline rung aborts the turn at the boundary *before* compaction runs) and it is deliberately **not** a health failure: the summarizer did not misbehave, and latching a give-up against it would blame the wrong component in the journal. The fallback is drop-oldest eviction, which costs nothing.

**Exhaustiveness over catch-alls.** `AccountedCallError::Deadline` is stated at all three `run_accounted_call` call sites, including `stella-cli`'s standalone path where it is unreachable in practice (that path's guard arms no deadline). Sweeping it into an `Err(_)` would have been shorter and would have made arming a deadline there later an invisible decision.

**God files.** Both `stella-core/src/driver.rs` and `stella-pipeline/src/pipeline.rs` are closed to growth and the first pass of this change pushed each past its ceiling (+8 and +1). No baseline was raised: the additions were tightened until `make file-size` went green on its own. The new pipeline logic lives in `stage_budget.rs` and `raw_usage.rs`, not in `pipeline.rs`.

**Exemplar.** The `DeadlineOutcome`-as-its-own-type shape, and the "pure decision function takes `now`" discipline, follow `crates/stella-core/src/driver/settlement.rs`, which is this repository's own prior art for the same question one layer down.