### PR TITLE
feat(stella-core): rank and gate tool-foundry proposals on reuse ratio

### DIFF
--- a/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
+++ b/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
@@ -4,9 +4,11 @@
 //! never against the developer's real `~/.claude/projects`. That is not
 //! squeamishness: a test that read the real corpus would pass or fail based on
 //! what its author happened to have typed that month, and would put real user
-//! content in front of CI. The one test that touches the real corpus is
-//! [`the_real_corpus_adapts_when_opted_in`], which no-ops unless
-//! `STELLA_REPLAY_CC_CORPUS` is set.
+//! content in front of CI. The two tests that touch the real corpus are
+//! [`the_real_corpus_adapts_when_opted_in`] and
+//! [`the_real_corpus_measures_the_foundry_inbox_when_opted_in`], both of which
+//! no-op unless `STELLA_REPLAY_CC_CORPUS` is set and both of which print counts
+//! only.
 
 use super::*;
 use crate::memory::replay::Replayer;
@@ -307,21 +309,20 @@ async fn a_directory_of_transcripts_becomes_a_replayable_trace() {
 #[tokio::test]
 async fn a_recurring_shape_across_adapted_sessions_mints_a_tool() {
     let dir = tempfile::tempdir().expect("tempdir");
-    for (index, (day, path)) in [
-        ("10", "crates/stella-core/src/driver.rs"),
-        ("11", "crates/stella-cli/src/agent.rs"),
-        ("12", "crates/stella-model/src/openai.rs"),
-    ]
-    .iter()
-    .enumerate()
-    {
+    // The same two greps in every session: two argument sets, each retyped
+    // three times, which is what the detector's reuse floor asks for (#2378).
+    // Three *different* greps would be `rg`, not a tool.
+    for (index, day) in ["10", "11", "12"].iter().enumerate() {
         std::fs::write(
             dir.path().join(format!("s{index}.jsonl")),
             transcript(&[
                 user_line(&format!("2026-07-{day}T09:00:00Z"), "an ask"),
                 assistant_bash(
                     &format!("2026-07-{day}T09:00:05Z"),
-                    &[&format!("rg -n \"unwrap\" {path}")],
+                    &[
+                        "rg -n \"unwrap\" crates/stella-core/src/driver.rs",
+                        "rg -n \"expect\" crates/stella-cli/src/agent.rs",
+                    ],
                 ),
             ]),
         )
@@ -335,8 +336,8 @@ async fn a_recurring_shape_across_adapted_sessions_mints_a_tool() {
         .expect("replays");
     assert!(
         !summary.tools.is_empty(),
-        "one shape with three argument sets, mined from adapted transcripts: \
-         {summary:?}"
+        "one shape reused across two argument sets, mined from adapted \
+         transcripts: {summary:?}"
     );
 }
 
@@ -384,4 +385,71 @@ async fn the_real_corpus_adapts_when_opted_in() {
     }
     println!("adapted {adapted} project(s): {turns} turn(s), {commands} command(s)");
     assert!(adapted > 0, "the opt-in was set but nothing adapted");
+}
+
+/// The #2378 measurement, made reproducible: how many tools the foundry would
+/// propose from the whole real corpus, with and without the reuse floor.
+///
+/// It exists because that number was first obtained from a scratch test that
+/// was thrown away, leaving nobody able to re-check it. **No-ops unless
+/// `STELLA_REPLAY_CC_CORPUS` is set.** Counts and ratios only — no signature,
+/// no command text, nothing derived from a private corpus is printed or
+/// written (§7.1), which is also why this asserts nothing about the *size* of
+/// the inbox: that number is a property of one developer's history, and
+/// hard-coding a bound for it would be asserting a hope.
+#[tokio::test]
+async fn the_real_corpus_measures_the_foundry_inbox_when_opted_in() {
+    use stella_core::tool_foundry::{GapDetectionConfig, ShellInvocation, detect_tool_gaps};
+
+    let Some(root) = opted_in_corpus_root() else {
+        return;
+    };
+    let mut history: Vec<ShellInvocation> = Vec::new();
+    for (name, path) in project_directories(&root) {
+        let Ok(trace) = trace_from_directory(&path, &name) else {
+            continue;
+        };
+        for (_, turn) in trace.turns() {
+            history.extend(turn.shell.iter().map(|sh| ShellInvocation {
+                command: sh.command.clone(),
+                succeeded: sh.succeeded,
+            }));
+        }
+    }
+    assert!(
+        !history.is_empty(),
+        "the opt-in was set but no commands read"
+    );
+
+    // The floor disabled is the pre-#2378 behaviour, exactly.
+    let without_floor = GapDetectionConfig {
+        min_reuse_ratio: 1.0,
+        ..GapDetectionConfig::default()
+    };
+    let before = detect_tool_gaps(&history, without_floor);
+    let after = detect_tool_gaps(&history, GapDetectionConfig::default());
+    println!(
+        "foundry over {} invocation(s): {} proposal(s) without the reuse floor, \
+         {} with it (default {:.1}x)",
+        history.len(),
+        before.len(),
+        after.len(),
+        GapDetectionConfig::default().min_reuse_ratio,
+    );
+    for (label, low, high) in [
+        ("1.0x–1.5x", 1.0, 1.5),
+        ("1.5x–3.0x", 1.5, 3.0),
+        ("3.0x–10x", 3.0, 10.0),
+        ("10x+", 10.0, f64::INFINITY),
+    ] {
+        let n = before
+            .iter()
+            .filter(|p| p.reuse_ratio() >= low && p.reuse_ratio() < high)
+            .count();
+        println!("  {label:>10}: {n} proposal(s)");
+    }
+    assert!(
+        after.len() <= before.len(),
+        "the reuse floor is a filter; it can never admit more"
+    );
 }

--- a/crates/stella-cli/src/memory/replay/tests.rs
+++ b/crates/stella-cli/src/memory/replay/tests.rs
@@ -25,7 +25,10 @@
 //! `cargo test -p <crate>` yields a *different signature per crate* and can
 //! never cluster, while `rg -n "<pattern>" <path>` clusters immediately. Right
 //! behaviour — a bareword is usually a subcommand — but a fixture that varies a
-//! bareword measures nothing.
+//! bareword measures nothing. Since #2378 the converse is also true: a fixture
+//! that varies its arguments on *every* invocation measures nothing either,
+//! because `min_reuse_ratio` reads 1.0× reuse as the shell itself rather than a
+//! tool. A fixture must make its argument sets **recur**.
 //!
 //! **3. A file only lands under a trusted project.** With
 //! `include_workspace_skills` false, `write_candidates` and `induce_rules` both
@@ -552,31 +555,39 @@ async fn a_one_off_lesson_does_not_become_a_skill() {
     );
 }
 
-// ---- §5 assertion 4: the foundry needs variation --------------------------
+// ---- §5 assertion 4: the foundry needs variation *and* reuse --------------
 
-/// A shape recurring with **≥2 distinct argument sets** yields a tool proposal;
-/// the identical command repeated yields none.
+/// A shape recurring with **≥2 distinct argument sets, each retyped**, yields a
+/// tool proposal; the identical command repeated yields none.
 ///
 /// The negative half is the interesting one: an exact repeat is loop detection's
 /// business, not the foundry's, and `min_distinct_arguments: 2` draws that line.
+/// The other end of the same line — variation with no reuse at all — is
+/// [`a_shape_whose_arguments_never_repeat_is_not_minted`].
 #[tokio::test]
 async fn a_shape_with_varying_arguments_mints_a_tool_and_an_exact_repeat_does_not() {
+    // Two argument sets, each reconstructed on all three days: the incantation
+    // shape the foundry exists for, at 3.0× reuse.
+    let recurring_greps = shell(&[
+        "rg -n \"unwrap\" crates/stella-core/src/driver.rs",
+        "rg -n \"expect\" crates/stella-cli/src/agent.rs",
+    ]);
     let varied = trace(
-        "one shape, three argument sets",
+        "one shape, two argument sets, each retyped three times",
         one_task_each(vec![
             TraceTurn {
-                shell: shell(&["rg -n \"unwrap\" crates/stella-core/src/driver.rs"]),
+                shell: recurring_greps.clone(),
                 ..turn(T0, "Grepping for unwrap is how the panic audit starts")
             },
             TraceTurn {
-                shell: shell(&["rg -n \"expect\" crates/stella-cli/src/agent.rs"]),
+                shell: recurring_greps.clone(),
                 ..turn(
                     T0 + DAY,
                     "The agent loop lives in crates/stella-cli/src/agent.rs",
                 )
             },
             TraceTurn {
-                shell: shell(&["rg -n \"panic\" crates/stella-model/src/openai.rs"]),
+                shell: recurring_greps,
                 ..turn(
                     T0 + 2 * DAY,
                     "OpenAI's adapter is crates/stella-model/src/openai.rs",
@@ -587,8 +598,8 @@ async fn a_shape_with_varying_arguments_mints_a_tool_and_an_exact_repeat_does_no
     let (with_variation, _a) = replay(&varied).await;
     assert!(
         !with_variation.tools.is_empty(),
-        "three invocations of one shape with three argument sets should propose \
-         a tool: {with_variation:?}"
+        "one shape reused across two argument sets should propose a tool: \
+         {with_variation:?}"
     );
 
     let repeated = trace(
@@ -619,6 +630,52 @@ async fn a_shape_with_varying_arguments_mints_a_tool_and_an_exact_repeat_does_no
         without_variation.tools.is_empty(),
         "an exact repeat is a loop, not a parameterized tool: {:?}",
         without_variation.tools
+    );
+}
+
+/// The other end of the same line: a shape whose arguments are *never* repeated
+/// mints nothing, however often the program name recurs.
+///
+/// This is the half assertion 4 was missing. `min_distinct_arguments` is a floor
+/// on variation, so unbounded variation cleared it — and against a real 81,684-
+/// command history that asymmetry proposed 2,073 tools, almost all of them the
+/// shell wearing a costume (#2378). Nine invocations here, nine argument sets,
+/// zero proposals: `rg -n <str> <path>` at 1.0× reuse is `rg`, not a tool.
+#[tokio::test]
+async fn a_shape_whose_arguments_never_repeat_is_not_minted() {
+    let files = [
+        "crates/stella-core/src/driver.rs",
+        "crates/stella-cli/src/agent.rs",
+        "crates/stella-model/src/openai.rs",
+    ];
+    let turns: Vec<TraceTurn> = files
+        .iter()
+        .enumerate()
+        .map(|(day, path)| {
+            let commands: Vec<String> = ["unwrap", "expect", "panic"]
+                .iter()
+                .map(|needle| format!("rg -n \"{needle}-{day}\" {path}"))
+                .collect();
+            let borrowed: Vec<&str> = commands.iter().map(String::as_str).collect();
+            TraceTurn {
+                shell: shell(&borrowed),
+                ..turn(
+                    T0 + day as i64 * DAY,
+                    "Grepping for unwrap is how the panic audit starts",
+                )
+            }
+        })
+        .collect();
+
+    let (summary, _dir) = replay(&trace(
+        "one shape, nine argument sets",
+        one_task_each(turns),
+    ))
+    .await;
+    assert!(
+        summary.tools.is_empty(),
+        "a shape with one argument set per use is the shell, not a tool: {:?}",
+        summary.tools
     );
 }
 

--- a/crates/stella-cli/src/tool_foundry.rs
+++ b/crates/stella-cli/src/tool_foundry.rs
@@ -191,8 +191,9 @@ fn run_tools_author_in(
                 "  {}",
                 format!(
                     "none right now — a shape must recur ≥{} times across ≥{} distinct \
-                     argument sets in the last {HISTORY_WINDOW} bash receipts",
-                    config.min_occurrences, config.min_distinct_arguments
+                     argument sets, each reused ≥{:.1}×, in the last {HISTORY_WINDOW} \
+                     bash receipts",
+                    config.min_occurrences, config.min_distinct_arguments, config.min_reuse_ratio
                 )
                 .dimmed()
             );
@@ -204,8 +205,11 @@ fn run_tools_author_in(
                 "·".dimmed(),
                 p.name.bright_magenta(),
                 format!(
-                    "— `{}` ({}× across {} argument sets)",
-                    p.signature, p.occurrences, p.distinct_arguments
+                    "— `{}` ({}× across {} argument sets, {:.1}× reuse)",
+                    p.signature,
+                    p.occurrences,
+                    p.distinct_arguments,
+                    p.reuse_ratio()
                 )
                 .dimmed()
             );
@@ -333,15 +337,26 @@ mod tests {
         }
     }
 
-    /// A store seeded with the given bash commands under one execution.
+    /// How many times each seeded command is recorded. The detector's shipping
+    /// [`GapDetectionConfig::min_reuse_ratio`] asks that *argument sets* recur,
+    /// not just program names (#2378), and these fixtures are about the store →
+    /// inbox wiring rather than about ranking — so each command is retyped
+    /// three times, exactly as a real recurring incantation would be.
+    const SEEDED_REPEATS: usize = 3;
+
+    /// A store seeded with the given bash commands under one execution, each
+    /// recorded [`SEEDED_REPEATS`] times under a distinct call id.
     fn store_with(commands: &[(&str, &str, bool)]) -> Store {
         let store = Store::in_memory().expect("store");
         let id = store
             .begin_execution("run", "p", "zai", "glm-5.2")
             .expect("execution");
-        let rows: Vec<ToolCallRow> = commands
-            .iter()
-            .map(|(cid, cmd, ok)| bash_row(cid, cmd, *ok))
+        let rows: Vec<ToolCallRow> = (0..SEEDED_REPEATS)
+            .flat_map(|round| {
+                commands
+                    .iter()
+                    .map(move |(cid, cmd, ok)| bash_row(&format!("{cid}-{round}"), cmd, *ok))
+            })
             .collect();
         store.record_tool_calls(id, &rows).expect("record");
         store

--- a/crates/stella-cli/src/tool_foundry/adopt/tests.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt/tests.rs
@@ -7,8 +7,15 @@ use stella_store::{ToolCallRow, ToolCallState};
 use super::*;
 use crate::tool_foundry::run_tools_author_in;
 
+/// How many times each seeded command is recorded. The detector's shipping
+/// `GapDetectionConfig::min_reuse_ratio` asks that *argument sets* recur, not
+/// just program names (#2378); these fixtures are about the adoption protocol,
+/// so each command is retyped three times the way a real incantation would be.
+const SEEDED_REPEATS: usize = 3;
+
 /// A workspace with a real on-disk store, seeded with the `bash` receipts the
-/// detector mines. Returns the root and the store.
+/// detector mines — each command recorded [`SEEDED_REPEATS`] times. Returns the
+/// root and the store.
 fn workspace(commands: &[&str]) -> (tempfile::TempDir, Store) {
     let ws = tempfile::tempdir().expect("tmp");
     let store = Store::open(ws.path()).expect("store");
@@ -17,6 +24,8 @@ fn workspace(commands: &[&str]) -> (tempfile::TempDir, Store) {
         .expect("execution");
     let rows: Vec<ToolCallRow> = commands
         .iter()
+        .cycle()
+        .take(commands.len() * SEEDED_REPEATS)
         .enumerate()
         .map(|(i, command)| ToolCallRow {
             call_id: format!("c{i}"),

--- a/crates/stella-cli/tests/fixtures/traces/simulated-months.json
+++ b/crates/stella-cli/tests/fixtures/traces/simulated-months.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "description": "one engineer, one repository, six simulated months - a tool-registration convention re-encountered across five distinct tasks in four naturally-varied wordings plus one near-restatement, a recurring `rg -n <pattern> <path>` shape, one unreadable reflection, and several unrelated one-off facts so the corpus stays multi-topic",
+  "description": "one engineer, one repository, six simulated months - a tool-registration convention re-encountered across five distinct tasks in four naturally-varied wordings plus one near-restatement, a `git log --oneline -N` incantation retyped across sessions (the reusable shape the foundry mints from), a never-repeating `rg -n <pattern> <path>` shape that deliberately does not clear the reuse floor, one unreadable reflection, and several unrelated one-off facts so the corpus stays multi-topic",
   "workspace": {
     "domains": [
       "tools",
@@ -40,7 +40,7 @@
             "kind": "lessons",
             "lessons": [
               {
-                "lesson": "Tool registration happens in crates/stella-tools/src/registry.rs — add the entry there.",
+                "lesson": "Tool registration happens in crates/stella-tools/src/registry.rs \u2014 add the entry there.",
                 "domains": [
                   "tools"
                 ],
@@ -52,6 +52,10 @@
           "shell": [
             {
               "command": "rg -n \"impl Tool\" crates/stella-tools/src/registry.rs",
+              "succeeded": true
+            },
+            {
+              "command": "git log --oneline -5",
               "succeeded": true
             }
           ],
@@ -86,6 +90,10 @@
           "shell": [
             {
               "command": "rg -n \"complete_ref\" crates/stella-model/src/anthropic.rs",
+              "succeeded": true
+            },
+            {
+              "command": "git log --oneline -20",
               "succeeded": true
             }
           ],
@@ -127,6 +135,10 @@
             {
               "command": "rg -n \"budget\" crates/stella-core/src/driver.rs",
               "succeeded": true
+            },
+            {
+              "command": "git log --oneline -5",
+              "succeeded": true
             }
           ],
           "succeeded": true
@@ -160,6 +172,10 @@
           "shell": [
             {
               "command": "rg -n \"BudgetGuard\" crates/stella-cli/src/agent.rs",
+              "succeeded": true
+            },
+            {
+              "command": "git log --oneline -5",
               "succeeded": true
             }
           ],
@@ -201,6 +217,10 @@
             {
               "command": "rg -n \"TestBackend\" crates/stella-tui/src/deck_render.rs",
               "succeeded": true
+            },
+            {
+              "command": "git log --oneline -20",
+              "succeeded": true
             }
           ],
           "succeeded": true
@@ -218,7 +238,12 @@
             "kind": "unreadable",
             "text": "Let me think about what I learned. Actually, nothing much!"
           },
-          "shell": [],
+          "shell": [
+            {
+              "command": "git log --oneline -5",
+              "succeeded": true
+            }
+          ],
           "succeeded": true
         },
         {
@@ -290,6 +315,10 @@
           "shell": [
             {
               "command": "rg -n \"unwrap\" crates/stella-core/src/driver.rs",
+              "succeeded": true
+            },
+            {
+              "command": "git log --oneline -5",
               "succeeded": true
             }
           ],

--- a/crates/stella-core/src/tool_foundry.rs
+++ b/crates/stella-core/src/tool_foundry.rs
@@ -42,7 +42,25 @@
 //! never merged. The cost is that a value carried as a plain bareword
 //! (`-n my-namespace`) is not recognized as a hole; that is an accepted
 //! first-slice limitation, not a bug.
+//!
+//! **Variation is required, but unbounded variation is not evidence.**
+//! [`GapDetectionConfig::min_distinct_arguments`] is a *floor* on variation,
+//! and the reason it exists is sound: one argument set is an exact repeat, and
+//! that is loop detection's territory. But a floor alone made the two ends of
+//! the same argument asymmetric — a shape invoked 1,954 times with 1,938
+//! distinct argument sets cleared it a thousand times over while being
+//! maximally *un*-reusable. That is not a tool; that is `sed`, and minting a
+//! "tool" for it would wrap the shell in the shell. Pointed at a real 81,684-
+//! command history, that asymmetry produced 2,073 proposals — an inbox nobody
+//! would ever read (#2378).
+//!
+//! [`GapDetectionConfig::min_reuse_ratio`] is the missing upper half: uses per
+//! distinct argument set. A recurring *incantation* — the same command with
+//! the same handful of arguments, retyped — scores high; the shell wearing a
+//! costume scores 1.0. It is both a gate and the **primary sort key**, so the
+//! top of the inbox is the shape a human is most likely to accept.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 /// The kind of value a parameter hole stands for. Kept deliberately small:
@@ -146,9 +164,30 @@ pub struct ProposedTool {
     pub examples: Vec<String>,
 }
 
+impl ProposedTool {
+    /// Uses per distinct argument set — how *reusable* the shape is, as
+    /// opposed to how often it was typed. `1.0` means every invocation carried
+    /// arguments never seen before (the shell itself, not a tool); a high
+    /// ratio means the same incantation keeps getting reconstructed, which is
+    /// the whole reason the foundry exists.
+    ///
+    /// Always finite: a proposal is only ever built from a cluster with at
+    /// least one observation, so `distinct_arguments` is at least `1`. The
+    /// guard is there so a hand-built [`ProposedTool`] cannot produce a NaN.
+    pub fn reuse_ratio(&self) -> f64 {
+        if self.distinct_arguments == 0 {
+            return 0.0;
+        }
+        self.occurrences as f64 / self.distinct_arguments as f64
+    }
+}
+
 /// Thresholds for [`detect_tool_gaps`]. `Default` gives sensible starting
 /// values; callers may tune per workspace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Not `Eq`: [`GapDetectionConfig::min_reuse_ratio`] is a ratio, and a ratio
+/// whose useful range is 1.0–5.0 has nothing to say in integers.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GapDetectionConfig {
     /// Matching invocations required before a shape is worth proposing. `0`
     /// or `1` disable detection — a shape used once is not a pattern.
@@ -160,6 +199,23 @@ pub struct GapDetectionConfig {
     /// zero-hole commands can only ever produce one distinct (empty) argument
     /// set.
     pub min_distinct_arguments: usize,
+    /// Uses per distinct argument set required — the *ceiling* on variation
+    /// that [`GapDetectionConfig::min_distinct_arguments`] is the floor of, and
+    /// the primary ranking key.
+    ///
+    /// `occurrences / distinct_arguments`: `1.0` is a shape whose arguments
+    /// were never once repeated (`sed -n <str> <path>` seen 1,954 times with
+    /// 1,938 argument sets — that is `sed`), while a recurring incantation
+    /// scores far higher (`sleep <num> && echo done`, 342 uses across 5
+    /// argument sets, 68×). Without it the detector rewards exactly the
+    /// commands least worth minting a tool from (#2378).
+    ///
+    /// A value at or below `1.0` disables the gate — every cluster has at
+    /// least one use per argument set by construction — which is how a caller
+    /// asks for shape detection alone. A non-finite value (`NaN`, `+∞`)
+    /// rejects every proposal rather than admitting one on an unordered
+    /// comparison.
+    pub min_reuse_ratio: f64,
     /// Require at least one *successful* invocation in the cluster. A shape
     /// that never worked is a different kind of gap (a failing operation), not
     /// a tool to mint from — so the first slice skips it by default.
@@ -170,15 +226,23 @@ pub struct GapDetectionConfig {
 }
 
 impl Default for GapDetectionConfig {
-    /// Three occurrences across at least two distinct argument sets, at least
-    /// one of which succeeded — enough to rule out coincidence and to prove
-    /// the shape is genuinely reused with variation. `3` mirrors the "same
-    /// incantation reconstructed three times" framing of the driving issue and
-    /// [`crate::loop_detect::LoopDetectionConfig`]'s own rule-of-thumb.
+    /// Three occurrences across at least two distinct argument sets, each
+    /// argument set carrying its weight three times over, at least one
+    /// invocation of which succeeded — enough to rule out coincidence and to
+    /// prove the shape is genuinely *reused* with variation. `3` mirrors the
+    /// "same incantation reconstructed three times" framing of the driving
+    /// issue and [`crate::loop_detect::LoopDetectionConfig`]'s own
+    /// rule-of-thumb, and it is the same `3` on both axes for the same reason.
+    ///
+    /// Taken together the floor is six invocations (three uses each of two
+    /// argument sets) — deliberately higher than the three the occurrence
+    /// threshold alone admitted, because the evidence a proposal needs is that
+    /// the *arguments* recurred, not just the program name.
     fn default() -> Self {
         Self {
             min_occurrences: 3,
             min_distinct_arguments: 2,
+            min_reuse_ratio: 3.0,
             require_success: true,
             max_examples: 3,
         }
@@ -190,11 +254,12 @@ impl Default for GapDetectionConfig {
 ///
 /// `invocations` is a recent window of `bash` commands in any order — the
 /// caller decides how much history to hand in. The result is deterministic:
-/// proposals are sorted by evidence strength (occurrences, then distinct
-/// argument count, both descending) and finally by name, so the same history
-/// always yields byte-identical output. Never panics on any input — empty
-/// history, unparseable commands, and a zeroed-out `config` all yield an empty
-/// `Vec`.
+/// proposals are sorted by **reuse ratio** first (uses per distinct argument
+/// set — the evidence that the shape is an incantation rather than the shell),
+/// then by raw occurrences and distinct argument count, both descending, and
+/// finally by name, so the same history always yields byte-identical output.
+/// Never panics on any input — empty history, unparseable commands, and a
+/// zeroed-out `config` all yield an empty `Vec`.
 pub fn detect_tool_gaps(
     invocations: &[ShellInvocation],
     config: GapDetectionConfig,
@@ -222,14 +287,36 @@ pub fn detect_tool_gaps(
         .filter_map(|(signature, cluster)| cluster.into_proposal(signature, config))
         .collect();
 
-    // Strongest evidence first; name breaks ties for total determinism.
+    // Most reusable first — a shape typed 1,954 times with 1,938 different
+    // argument sets is worse evidence than one typed 46 times with 2, so raw
+    // occurrences is a tie-break, never the lead. Name closes the order.
     proposals.sort_by(|a, b| {
-        b.occurrences
-            .cmp(&a.occurrences)
+        reuse_cmp(b, a)
+            .then(b.occurrences.cmp(&a.occurrences))
             .then(b.distinct_arguments.cmp(&a.distinct_arguments))
             .then(a.name.cmp(&b.name))
     });
     proposals
+}
+
+/// Order two proposals by reuse ratio *without dividing*: with both
+/// denominators positive, `a.occ / a.distinct` versus `b.occ / b.distinct` is
+/// exactly `a.occ * b.distinct` versus `b.occ * a.distinct`. `u128` makes the
+/// cross product unoverflowable for any history that fits in memory, and the
+/// comparison stays a total order — which a float ratio, and its `partial_cmp`,
+/// would not guarantee.
+fn reuse_cmp(a: &ProposedTool, b: &ProposedTool) -> Ordering {
+    (a.occurrences as u128 * b.distinct_arguments as u128)
+        .cmp(&(b.occurrences as u128 * a.distinct_arguments as u128))
+}
+
+/// Does a cluster clear the reuse floor — `occurrences / distinct_arguments >=
+/// min_reuse_ratio`? Tested as a multiplication so a zero denominator is
+/// impossible and no division rounds. A `NaN` or `+∞` floor makes the
+/// comparison false and so rejects everything, which is the safe direction for
+/// a knob nobody should be setting to either.
+fn meets_reuse_ratio(occurrences: usize, distinct_arguments: usize, floor: f64) -> bool {
+    occurrences as f64 >= floor * distinct_arguments as f64
 }
 
 /// A signature and the raw material to build a proposal from it: the invariant
@@ -306,6 +393,7 @@ impl Cluster {
         let distinct_arguments = self.distinct_args.len();
         if self.occurrences < config.min_occurrences
             || distinct_arguments < config.min_distinct_arguments
+            || !meets_reuse_ratio(self.occurrences, distinct_arguments, config.min_reuse_ratio)
             || self.hole_count == 0
             || (config.require_success && self.successes == 0)
         {
@@ -325,11 +413,12 @@ impl Cluster {
             .collect();
         let command_template = render_template(&signature);
         let description = format!(
-            "You ran this shell shape {} times across {} distinct argument sets. \
-             A reusable `{}` tool taking {} parameter(s) would replace the hand-built \
-             `{}`. Proposed only — not installed.",
+            "You ran this shell shape {} times across {} distinct argument sets \
+             ({:.1}× reuse). A reusable `{}` tool taking {} parameter(s) would replace \
+             the hand-built `{}`. Proposed only — not installed.",
             self.occurrences,
             distinct_arguments,
+            self.occurrences as f64 / distinct_arguments as f64,
             name,
             parameters.len(),
             signature,
@@ -724,6 +813,31 @@ mod tests {
         ShellInvocation::ok(command)
     }
 
+    /// The shipping config with the reuse gate relaxed to "any reuse at all".
+    ///
+    /// For the tests that pin **normalization** — which tokens become holes,
+    /// which commands cluster to one shape — rather than inbox policy. Three
+    /// invocations with three argument sets is the clearest way to *state* a
+    /// shape, and by construction it carries exactly one use per argument set,
+    /// which the shipping [`GapDetectionConfig::min_reuse_ratio`] rejects for a
+    /// reason those tests are not about. The ratio itself is pinned by the
+    /// tests that keep the default, immediately below.
+    fn shapes_only() -> GapDetectionConfig {
+        GapDetectionConfig {
+            min_reuse_ratio: 1.0,
+            ..GapDetectionConfig::default()
+        }
+    }
+
+    /// Each command repeated `times`, in a stable interleaved order — a history
+    /// where argument sets genuinely recur, which is what the default config
+    /// asks for.
+    fn each_repeated(commands: &[&str], times: usize) -> Vec<ShellInvocation> {
+        (0..times)
+            .flat_map(|_| commands.iter().map(|c| ok(c)))
+            .collect()
+    }
+
     fn failed(command: &str) -> ShellInvocation {
         ShellInvocation {
             command: command.into(),
@@ -738,24 +852,101 @@ mod tests {
 
     #[test]
     fn the_motivating_jq_case_is_proposed() {
-        // The issue's own example: `extract_json_path`-shaped hand-work.
-        let history = vec![
-            ok("jq '.items[0]' a.json"),
-            ok("jq '.name' b.json"),
-            ok("jq '.error.code' c.json"),
-        ];
+        // The issue's own example: `extract_json_path`-shaped hand-work — three
+        // extractions, each reconstructed by hand three times over. The repeats
+        // are the load-bearing part: a *reusable* shape is one whose arguments
+        // recur, not merely one whose program name does.
+        let history = each_repeated(
+            &[
+                "jq '.items[0]' a.json",
+                "jq '.name' b.json",
+                "jq '.error.code' c.json",
+            ],
+            3,
+        );
         let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
         assert_eq!(proposals.len(), 1, "one shape, one proposal");
         let p = &proposals[0];
         assert_eq!(p.signature, "jq <str> <path>");
         assert_eq!(p.command_template, "jq {p1} {p2}");
-        assert_eq!(p.occurrences, 3);
+        assert_eq!(p.occurrences, 9);
         assert_eq!(p.distinct_arguments, 3);
+        assert_eq!(p.reuse_ratio(), 3.0);
         assert_eq!(p.parameters.len(), 2);
         assert_eq!(p.parameters[0].kind, ParamKind::Str);
         assert_eq!(p.parameters[1].kind, ParamKind::Path);
         assert!(is_valid_tool_name(&p.name), "name `{}` invalid", p.name);
         assert_eq!(p.name, "jq");
+    }
+
+    #[test]
+    fn a_shape_with_no_argument_reuse_is_not_proposed() {
+        // `sed -n <str> <path>` — the top proposal on a real 81k-command
+        // history, and the whole defect: 1.0× reuse is not a tool, it is `sed`
+        // (#2378). Six invocations clear `min_occurrences` twice over and
+        // `min_distinct_arguments` three times over, and it is still noise.
+        let history: Vec<ShellInvocation> = (0..6)
+            .map(|i| ok(&format!("sed -n '{i}p' file{i}.txt")))
+            .collect();
+        assert!(
+            detect_tool_gaps(&history, GapDetectionConfig::default()).is_empty(),
+            "a shape with one argument set per use must not reach the inbox"
+        );
+        // Only the reuse gate rejected it: relax that one knob and the shape is
+        // detected exactly as before.
+        let proposals = detect_tool_gaps(&history, shapes_only());
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].signature, "sed -n <str> <path>");
+        assert_eq!(proposals[0].reuse_ratio(), 1.0);
+    }
+
+    #[test]
+    fn reuse_outranks_raw_occurrences() {
+        // The two shapes from the issue's own measurement, side by side: a
+        // high-volume, never-repeating `rg` (12 uses, 12 argument sets) against
+        // a retyped incantation (6 uses, 2 argument sets). Occurrences alone
+        // would rank the noise first.
+        let mut history: Vec<ShellInvocation> = (0..12)
+            .map(|i| ok(&format!("rg -n '{i}' src/file{i}.rs")))
+            .collect();
+        history.extend(each_repeated(
+            &["sleep 5 && echo done", "sleep 30 && echo done"],
+            3,
+        ));
+
+        let ranked = detect_tool_gaps(&history, shapes_only());
+        assert_eq!(ranked.len(), 2, "both shapes clear the shape-only bar");
+        assert_eq!(
+            ranked[0].signature, "sleep <num> && echo done",
+            "the 3.0× shape must outrank the 1.0× one despite half the uses"
+        );
+        assert!(
+            ranked[0].occurrences < ranked[1].occurrences,
+            "and it must win *while* being the rarer shape, or this proves nothing"
+        );
+
+        // Under the shipping default the noisy shape is not merely demoted —
+        // it never reaches the inbox at all.
+        let shipped = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(shipped.len(), 1);
+        assert_eq!(shipped[0].signature, "sleep <num> && echo done");
+    }
+
+    #[test]
+    fn a_non_finite_reuse_floor_rejects_everything() {
+        // Nobody should set this, but a NaN comparison is false in both
+        // directions and an unordered floor must fail closed, not open.
+        let history = each_repeated(&["jq '.a' a.json", "jq '.b' b.json"], 5);
+        for floor in [f64::NAN, f64::INFINITY] {
+            let config = GapDetectionConfig {
+                min_reuse_ratio: floor,
+                ..GapDetectionConfig::default()
+            };
+            assert!(
+                detect_tool_gaps(&history, config).is_empty(),
+                "a {floor} floor admitted a proposal"
+            );
+        }
     }
 
     #[test]
@@ -766,7 +957,7 @@ mod tests {
             ok("git log --oneline -10"),
             ok("git log --oneline -20"),
         ];
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         assert_eq!(proposals.len(), 1);
         let p = &proposals[0];
         assert_eq!(p.signature, "git log --oneline <num>");
@@ -782,7 +973,7 @@ mod tests {
             ok("curl --retry=5 https://b.test/y"),
             ok("curl --retry=1 https://c.test/z"),
         ];
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         assert_eq!(proposals.len(), 1);
         let p = &proposals[0];
         assert_eq!(p.signature, "curl --retry=<num> <path>");
@@ -797,7 +988,7 @@ mod tests {
             ok("jq '.b' two.json | head"),
             ok("jq '.c' three.json | head"),
         ];
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         assert_eq!(proposals.len(), 1);
         assert_eq!(proposals[0].signature, "jq <str> <path> | head");
     }
@@ -843,11 +1034,11 @@ mod tests {
             failed("weirdcmd --flag b.json"),
             failed("weirdcmd --flag c.json"),
         ];
-        assert!(detect_tool_gaps(&history, GapDetectionConfig::default()).is_empty());
+        assert!(detect_tool_gaps(&history, shapes_only()).is_empty());
         // …but a caller can opt in to failing shapes.
         let permissive = GapDetectionConfig {
             require_success: false,
-            ..GapDetectionConfig::default()
+            ..shapes_only()
         };
         assert_eq!(detect_tool_gaps(&history, permissive).len(), 1);
     }
@@ -859,10 +1050,7 @@ mod tests {
             ok("jq '.y' b.json"),
             failed("jq '.z' c.json"),
         ];
-        assert_eq!(
-            detect_tool_gaps(&history, GapDetectionConfig::default()).len(),
-            1
-        );
+        assert_eq!(detect_tool_gaps(&history, shapes_only()).len(), 1);
     }
 
     #[test]
@@ -870,7 +1058,7 @@ mod tests {
         let history: Vec<ShellInvocation> = (0..20)
             .map(|i| ok(&format!("jq '.f{i}' file{i}.json")))
             .collect();
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         assert_eq!(proposals.len(), 1);
         let p = &proposals[0];
         assert!(
@@ -888,7 +1076,8 @@ mod tests {
 
     #[test]
     fn output_is_deterministic_and_sorted_by_evidence() {
-        // Two shapes: `jq` seen 4×, `sed` seen 3×. Strongest first.
+        // Two shapes at the same 1.0× reuse, so the occurrence tie-break
+        // decides: `jq` seen 4×, `sed` seen 3×. Strongest first.
         let history = vec![
             ok("jq '.a' a.json"),
             ok("sed 's/a/b/' one.txt"),
@@ -898,8 +1087,8 @@ mod tests {
             ok("sed 's/e/f/' three.txt"),
             ok("jq '.d' d.json"),
         ];
-        let a = detect_tool_gaps(&history, GapDetectionConfig::default());
-        let b = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let a = detect_tool_gaps(&history, shapes_only());
+        let b = detect_tool_gaps(&history, shapes_only());
         assert_eq!(a, b, "detection must be deterministic");
         assert_eq!(a.len(), 2);
         assert_eq!(a[0].signature, "jq <str> <path>");
@@ -931,7 +1120,7 @@ mod tests {
             ok("env RUST_LOG=trace cargo test"),
             ok("env RUST_LOG=info cargo test"),
         ];
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         assert_eq!(proposals.len(), 1);
         assert_eq!(proposals[0].signature, "env RUST_LOG=<str> cargo test");
         assert_eq!(proposals[0].parameters.len(), 1);
@@ -946,7 +1135,7 @@ mod tests {
             ok("./weird-script.sh b.json"),
             ok("./weird-script.sh c.json"),
         ];
-        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let proposals = detect_tool_gaps(&history, shapes_only());
         for p in &proposals {
             assert!(is_valid_tool_name(&p.name), "invalid name: {}", p.name);
         }
@@ -960,7 +1149,7 @@ mod tests {
             ok("grep 'still open b.rs"),
             ok("grep 'again c.rs"),
         ];
-        let _ = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let _ = detect_tool_gaps(&history, shapes_only());
     }
 
     #[test]
@@ -1006,20 +1195,33 @@ mod tests {
         })
     }
 
+    /// Reuse floors worth exercising: the sane band, plus the two non-finite
+    /// values a caller should never pass but the detector must survive.
+    fn arb_reuse_floor() -> impl Strategy<Value = f64> {
+        prop_oneof![
+            8 => 0.0f64..6.0,
+            1 => Just(f64::NAN),
+            1 => Just(f64::INFINITY),
+        ]
+    }
+
     proptest! {
         /// `detect_tool_gaps` never panics, for any history and any config,
-        /// including the degenerate zero thresholds.
+        /// including the degenerate zero thresholds and a non-finite reuse
+        /// floor.
         #[test]
         fn never_panics(
             history in proptest::collection::vec(arb_invocation(), 0..40),
             min_occurrences in 0usize..6,
             min_distinct_arguments in 0usize..6,
+            min_reuse_ratio in arb_reuse_floor(),
             require_success in any::<bool>(),
             max_examples in 0usize..6,
         ) {
             let config = GapDetectionConfig {
                 min_occurrences,
                 min_distinct_arguments,
+                min_reuse_ratio,
                 require_success,
                 max_examples,
             };
@@ -1027,28 +1229,41 @@ mod tests {
         }
 
         /// Every proposal is well-formed: a valid name, a non-empty parameter
-        /// list, and evidence at or above the configured thresholds.
+        /// list, and evidence at or above the configured thresholds — and the
+        /// list is ordered most-reusable-first, whatever the history.
         #[test]
         fn proposals_respect_their_contract(
             history in proptest::collection::vec(arb_invocation(), 0..60),
             min_occurrences in 2usize..6,
             min_distinct_arguments in 2usize..6,
+            min_reuse_ratio in 0.0f64..4.0,
         ) {
             let config = GapDetectionConfig {
                 min_occurrences,
                 min_distinct_arguments,
+                min_reuse_ratio,
                 require_success: true,
                 max_examples: 3,
             };
-            for p in detect_tool_gaps(&history, config) {
+            let proposals = detect_tool_gaps(&history, config);
+            for p in &proposals {
                 prop_assert!(is_valid_tool_name(&p.name), "invalid name {}", p.name);
                 prop_assert!(!p.parameters.is_empty(), "zero-parameter proposal");
                 prop_assert!(p.occurrences >= min_occurrences);
                 prop_assert!(p.distinct_arguments >= min_distinct_arguments);
+                prop_assert!(p.reuse_ratio() >= min_reuse_ratio, "ratio floor breached");
                 prop_assert!(p.examples.len() <= 3);
                 // Parameter count matches the placeholder count in the template.
                 let holes = p.command_template.matches("{p").count();
                 prop_assert_eq!(holes, p.parameters.len());
+            }
+            for pair in proposals.windows(2) {
+                prop_assert!(
+                    pair[0].reuse_ratio() >= pair[1].reuse_ratio(),
+                    "ranking is not most-reusable-first: {} then {}",
+                    pair[0].signature,
+                    pair[1].signature,
+                );
             }
         }
 

--- a/crates/stella-tools/src/foundry_author.rs
+++ b/crates/stella-tools/src/foundry_author.rs
@@ -275,8 +275,10 @@ fn provenance_header(proposal: &ProposedTool, name: &str) -> String {
          # To adopt:       stella tools --adopt {name}    (runs its witness)\n\
          # To enable:      stella tools --enable {name}   (the human approval)\n\
          #\n\
-         # Evidence: {} invocations, {} distinct argument sets.\n",
-        proposal.occurrences, proposal.distinct_arguments,
+         # Evidence: {} invocations, {} distinct argument sets ({:.1}x reuse).\n",
+        proposal.occurrences,
+        proposal.distinct_arguments,
+        proposal.reuse_ratio(),
     ));
     for line in comment_lines(&format!("signature: {}", proposal.signature)) {
         out.push_str(&format!("# {line}\n"));
@@ -311,9 +313,15 @@ mod tests {
 
     /// Run the real detector over a history and return its proposals — every
     /// test authors from genuine detector output, never hand-built structs.
+    ///
+    /// Each command is retyped three times, because the detector's shipping
+    /// [`GapDetectionConfig::min_reuse_ratio`] asks that *argument sets* recur
+    /// rather than merely vary (#2378). Authorship is indifferent to the
+    /// counts; what these tests need is that the real default proposes at all.
     fn proposals_for(commands: &[&str]) -> Vec<ProposedTool> {
-        let history: Vec<ShellInvocation> =
-            commands.iter().map(|c| ShellInvocation::ok(*c)).collect();
+        let history: Vec<ShellInvocation> = (0..3)
+            .flat_map(|_| commands.iter().map(|c| ShellInvocation::ok(*c)))
+            .collect();
         detect_tool_gaps(&history, GapDetectionConfig::default())
     }
 
@@ -443,7 +451,9 @@ mod tests {
     fn provenance_header_carries_evidence_and_stays_valid_toml() {
         let authored = author_one(&["jq '.a' a.json", "jq '.b' b.json", "jq '.c' c.json"]);
         assert!(authored.manifest_toml.contains("STAGED ONLY"));
-        assert!(authored.manifest_toml.contains("3 invocations"));
+        // Three argument sets, each retyped three times by `proposals_for`.
+        assert!(authored.manifest_toml.contains("9 invocations"));
+        assert!(authored.manifest_toml.contains("3 distinct argument sets"));
         assert!(authored.manifest_toml.contains("$ jq '.a' a.json"));
         // The whole file — comments included — is valid TOML.
         toml::from_str::<toml::Value>(&authored.manifest_toml).expect("valid TOML");

--- a/crates/stella-tools/src/foundry_witness/tests.rs
+++ b/crates/stella-tools/src/foundry_witness/tests.rs
@@ -90,7 +90,12 @@ fn staged(root: &Path, name: &str, body: &str, witness_input: Value) -> CustomTo
 /// into `root`, exactly as `stella tools --author` does. Returns the parsed
 /// tool the witness will be run against.
 fn authored_in(root: &Path, commands: &[&str]) -> CustomTool {
-    let history: Vec<ShellInvocation> = commands.iter().map(|c| ShellInvocation::ok(*c)).collect();
+    // Each command retyped three times: the detector's shipping
+    // `min_reuse_ratio` asks that argument sets recur, not just vary (#2378),
+    // and what this fixture needs is a proposal from the real default.
+    let history: Vec<ShellInvocation> = (0..3)
+        .flat_map(|_| commands.iter().map(|c| ShellInvocation::ok(*c)))
+        .collect();
     let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
     assert_eq!(proposals.len(), 1, "expected exactly one proposal");
     let authored = foundry_author::author(&proposals[0]).expect("authorship succeeds");

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -237,7 +237,7 @@ Each pins a mechanism that today has no end-to-end proof.
 | 1 | A lesson repeated across **≥3 distinct tasks** yields a rule proposal; the same lesson repeated across 3 turns of **one** task does not | distinct-task counting — the exact confusion `set_task_id` exists to fix |
 | 2 | A proposal reaching `auto_activate_at_confidence` (default **85**, `crates/stella-cli/src/settings/context.rs:130`) auto-activates as an **advisory** record — never blocking, never clobbering an existing file (#737) | promotion gating |
 | 3 | A repeated skill-shaped lesson produces a `SKILL.md` on disk; a one-off does not | `mine_skill_candidates` → `decide_auto_creation` threshold and session cap |
-| 4 | A shell shape recurring with **≥2 distinct argument sets** yields a foundry proposal; the same command with one argument set yields none | typed-hole normalization and the `min_occurrences < 2` disable path |
+| 4 | A shell shape recurring with **≥2 distinct argument sets, each retyped** yields a foundry proposal; the same command with one argument set yields none, and so does a shape whose arguments never repeat | typed-hole normalization, the `min_occurrences < 2` disable path, and the `min_reuse_ratio` floor that separates a reusable incantation from the shell itself (#2378) |
 | 5 | A tombstoned lesson is **never re-learned**, including when the corpus later restates it in different words | `retain_unforgotten` matches by restatement, not equality — so the corpus must paraphrase, or the assertion is vacuous |
 | 6 | A retired record stops rendering into the prompt | truth sweep + the volatile channel |
 | 7 | A corpus of `Unreadable` reflections builds **nothing** and the harness **says so loudly** | the starvation guard — a clean `recorded: 0` on every turn must not read as "the agent keeps getting things right" |
@@ -443,7 +443,7 @@ document stays true to the tree. **Everything here was measured by replaying the
 real loop; none of it is visible from reading any single module**, which is the
 harness earning its keep before it shipped.
 
-### 13.1 Four measurements that changed the fixtures
+### 13.1 Five measurements that changed the fixtures
 
 1. **The dedup filter and the skill miner used the same metric at the same
    threshold, so a corpus of natural repetitions built nothing.** Filed as
@@ -477,6 +477,15 @@ harness earning its keep before it shipped.
 4. **`Path::starts_with` is lexical**, so `root/../escaped.txt` satisfies it and
    the obvious seed-path guard passed a fixture that escapes. It walks
    components now.
+5. **A fixture that varies its arguments every single time proves nothing after
+   #2378.** The corpus's `rg -n "<pattern>" <path>` history had one distinct
+   argument set per invocation — the exact 1.0×-reuse shape the detector now
+   declines to propose, because pointed at a real 81,684-command history that
+   shape is what produced 2,073 unreadable proposals. Assertion 4 is stated on
+   both ends now (variation *and* reuse), and the committed corpus grew a
+   `git log --oneline -N` incantation retyped across sessions — a shape a
+   working engineer genuinely does retype — while the never-repeating `rg`
+   history stays exactly where it was, as the negative half.
 
 ### 13.2 Where the implementation diverges from §3, §4 and §5
 

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -93,8 +93,12 @@ stella tools --foundry           # what was adopted, and what it has been worth
 ## Self-authored tools
 
 When the agent keeps reconstructing the same shell shape by hand, the tool foundry
-proposes a reusable tool in `/inbox`. `--author` turns one proposal into a reviewable
-manifest + script pair. The generated script expands every parameter as a quoted
+proposes a reusable tool in `/inbox`. What qualifies is a shape that is genuinely
+*reused*: it must recur across at least two distinct argument sets, each of them
+retyped about three times over. A command whose arguments are different every single
+time — `sed -n '<expr>' <file>` across a thousand files — is the shell, not a tool, and
+never reaches the inbox. Proposals are listed most-reused-first, not most-run-first.
+`--author` turns one proposal into a reviewable manifest + script pair. The generated script expands every parameter as a quoted
 `"$STELLA_INPUT_*"` reference, so parameter values stay data rather than shell syntax.
 
 An authored tool carries a `[foundry]` table, and a manifest carrying one registers only


### PR DESCRIPTION
## What &amp; why

Pointed at a real 81,684-command history, `detect_tool_gaps` proposed **2,073 tools**. The count was the symptom. The defect was that `GapDetectionConfig` could express *variation* but not *reusability*: `min_distinct_arguments` is a floor, so `sed -n <str> <path>` — 1,954 invocations, 1,938 distinct argument sets — cleared it a thousand times over while being maximally un-reusable. That is not a tool; it is `sed`, and minting one for it would wrap the shell in the shell.

`min_reuse_ratio` (default **3.0**) is the missing upper half of the argument `min_distinct_arguments`'s own doc comment already makes about the lower half: **uses per distinct argument set**. It is both a gate and the **primary sort key**, so a recurring incantation — the same command with the same handful of arguments, retyped — leads the inbox, and 1.0×-reuse noise never reaches it. Direction (1) of the issue only; (2), the proposal cap, is filed and deliberately not done here, as the issue asks.

Two arithmetic choices worth a reviewer's eye:

- **Ranking compares ratios by cross-multiplication in `u128`** (`a.occ * b.distinct` vs `b.occ * a.distinct`), so the order is exact and a *total* order — `f64::partial_cmp` would be neither. Exemplar: the integer-ratio comparison `cargo`'s semver ordering uses rather than a float projection.
- **The gate compares by multiplication too**, so no denominator can be zero and no division rounds. A `NaN`/`+∞` floor makes the comparison false and therefore **fails closed** — pinned by a test, because an unordered comparison silently admitting everything is the failure mode that matters.

`GapDetectionConfig` loses its `Eq` derive (keeps `Copy`/`PartialEq`): the useful range of a reuse floor is 1.0–5.0, which has nothing to say in integers. Nothing depended on `Eq`.

**Fixture consequence, and the honest part of this PR.** A history that varies its arguments on *every* invocation now measures nothing — which is what several fixtures were built from. Rather than relax the gate for tests, the fixtures were made to state what they actually pin: normalization tests use an explicit `shapes_only()` config (reuse floor at 1.0, one knob, documented why), while every test about *policy* keeps `::default()`. The committed replay corpus grew a `git log --oneline -N` incantation retyped across sessions — a shape an engineer genuinely does retype — and its never-repeating `rg` history stays exactly where it was, now as the negative half of assertion 4.

Refs #2378

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, in `crates/stella-core/src/tool_foundry.rs`:

- `a_shape_with_no_argument_reuse_is_not_proposed` — the `sed -n` case: six invocations, six argument sets, clearing both existing thresholds, and now excluded. It also asserts the *only* thing that rejected it was the reuse gate (relaxing that one knob detects the shape unchanged).
- `reuse_outranks_raw_occurrences` — the DoD test: a 12-use/12-argument-set `rg` against a 6-use/2-argument-set incantation. The rarer shape must rank first, and under the shipping default the noisy one is excluded outright.

Checked by restoring the pre-change behaviour in place (floor → 1.0, sort → occurrence-first) rather than `git stash`, because the type itself changed and `main`'s tests cannot reference `min_reuse_ratio`:

```
with the floor at 1.0:            a_shape_with_no_argument_reuse_is_not_proposed ... FAILED
with occurrence-first ranking:    reuse_outranks_raw_occurrences ... FAILED
with the change:                  25 passed; 0 failed
```

End-to-end, the replay harness gained `a_shape_whose_arguments_never_repeat_is_not_minted` (§5 assertion 4's missing half), and the property test now asserts the ranking is most-reusable-first for *any* history, plus the ratio floor holds for every proposal.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — run in two halves (`--exclude`d set, then those crates alone) because the container ran out of writable disk on a single full-workspace link; all green, no failures in either half. `make guards`, `make self-driving-test` (60 checks), `doc-warnings`, `file-size`, `god-files`, `left-behind`, `wire-schema`, `invariants`, `doc-links`, `command-docs` all green. **`shellcheck` is not installed in this container** and could not run; this PR touches no shell script.
- [x] Docs updated: the module docs state the asymmetry and the fix; `doc:trace-replay-learning-harness` §5 assertion 4 now reads on both ends and §13.1 records the fixture lesson; `website/content/docs/commands/tools.mdx` tells a user what now qualifies and that proposals are listed most-reused-first.
- [x] CLA signed
- [x] `Refs #2378` appears above and as a commit trailer — `Refs`, not `Closes`: the issue's DoD asks for a measurement on a real corpus that this environment cannot produce (see below).

## Nothing left behind

- [x] Filed: #2438, #2439, #2440

- **#2438** — the unmeasured half of #2378's DoD. This was developed in a container whose `~/.claude/projects` held one 230-line transcript (this session's own), so **the "tens, not thousands" claim is not verified here**; what is proven is only that the floor is a filter and the count can only fall. Rather than leave that as a scratch test nobody can re-run, the measurement is now a second opt-in test — `the_real_corpus_measures_the_foundry_inbox_when_opted_in`, counts and a ratio histogram only, no signature or command text — so one command on a machine with a corpus produces the before/after numbers.
- **#2439** — direction (2), the proposal cap, with the note that its default should be chosen from #2438's histogram rather than guessed.
- **#2440** — `GapDetectionConfig` says "callers may tune per workspace" and no caller can: all three production call sites hardcode `::default()` and there is no settings surface. Noticed while raising the effective bar, not introduced by it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

- **The default is a judgement, and it is the issue's.** 3.0× plus the existing thresholds means a proposal now needs six invocations, up from three. The motivating `jq` fixture had to gain repeats to survive — which is the change working, not the change breaking it: three *different* `jq` invocations are 1.0× reuse, structurally identical to the `sed -n` noise the issue rejects.
- **Rejected alternative:** an integer `min_reuse_ratio: usize`, which would have kept `Eq` and exactness in one type. Dropped because the interesting tuning region is between 2 and 3, where an integer has nothing to say — and the float is confined to the threshold comparison, never the ordering.
- `make gate` in full was not runnable end-to-end here (disk + missing `shellcheck`); every step was run individually and is listed above.

---

## Summary by Sourcery

Introduce reuse-based gating and ranking for tool-foundry proposals so only genuinely reused shell shapes are proposed and listed most-reused-first.

New Features:
- Add a reuse ratio threshold and ranking key to tool gap detection so proposals require recurring argument sets rather than just frequent commands.
- Expose reuse evidence (invocations, distinct argument sets, reuse ratio) in CLI output, authored tool manifests, and foundry witness tooling.
- Add an opt-in measurement test over the real corpus to report proposal counts and reuse-ratio distribution with and without the reuse floor.

Bug Fixes:
- Exclude shapes whose arguments never repeat from tool-foundry proposals, preventing noisy one-off command histories from flooding the inbox.

Enhancements:
- Adjust default gap detection thresholds to require stronger evidence of reuse, and update tests and fixtures to reflect reuse-aware behaviour.
- Refine replay harness assertions and fixtures so they require both variation and argument reuse for foundry proposals.
- Ensure non-finite reuse floor values fail closed, rejecting all proposals rather than silently admitting them.

Documentation:
- Update spec documentation and website docs to explain the reuse-based proposal criteria, ranking, and fixture changes based on real-corpus measurements.

Tests:
- Extend unit, property, and replay tests to cover reuse gating, ranking order, non-repeating argument shapes, and real-corpus measurement paths.
