### PR TITLE
feat(stella-cli): the plain surface renders markdown, stages, reasoning and git diffs (#2421)

### DIFF
--- a/crates/stella-cli/Cargo.toml
+++ b/crates/stella-cli/Cargo.toml
@@ -70,7 +70,7 @@ clap.workspace = true
 clap_complete.workspace = true
 colored.workspace = true
 # Not for rendering — `stella-tui` owns every ratatui surface. This is here so
-# the two raw-truecolor banners in this crate (`tui.rs`'s wordmark,
+# the two raw-truecolor banners in this crate (`plain.rs`'s wordmark,
 # `init_fx.rs`'s cinematic) can read their stops OUT of `stella_tui::theme`
 # instead of hard-coding hexes beside it. Two recolours' worth of drift got in
 # through exactly that gap; a `Color::Rgb` match closes it.

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -41,7 +41,7 @@ use crate::memory::{
     ReflectionReport, SessionMemory, inject_recall_block, reflect_routed, reflection_tail,
     should_reflect_on, turn_warrants_reflection,
 };
-use crate::plain;
+use crate::plain::{self, accent};
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::{OutputFormat, config::Config, resume_frame};
 use stella_context::EpisodeOutcome;
@@ -957,10 +957,8 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 // so re-printing it would silently ignore the change.
                 println!(
                     "  {} {}\n",
-                    "◆".color(plain::accent()),
-                    format!("accent set to {name}")
-                        .color(plain::accent())
-                        .bold()
+                    "◆".color(accent()),
+                    format!("accent set to {name}").color(accent()).bold()
                 );
             }
             continue;

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -42,7 +42,7 @@ use crate::memory::{
     should_reflect_on, turn_warrants_reflection,
 };
 use crate::runtime::{SystemClock, TokioSleeper};
-use crate::tui;
+use crate::plain;
 use crate::{OutputFormat, config::Config, resume_frame};
 use stella_context::EpisodeOutcome;
 
@@ -277,7 +277,7 @@ async fn run_pipeline_one_shot(
     let calibration = seed_calibration(&store, cfg);
 
     if format == OutputFormat::Text {
-        tui::section_header("Stella (pipeline)");
+        plain::section_header("Stella (pipeline)");
         println!("  {}\n", prompt.dimmed());
     }
 
@@ -639,14 +639,14 @@ async fn run_pipeline_one_shot(
             }
 
             if format == OutputFormat::Text {
-                tui::files_touched_panel(&files);
-                tui::cost_summary(
+                plain::files_touched_panel(&files);
+                plain::cost_summary(
                     outcome.total_cost_usd + reflection_report.cost_usd,
                     &wiring.worker_model.to_string(),
                     turn_start.elapsed(),
                 );
                 if cfg.enable_recap {
-                    tui::recap_panel(&outcome.status, outcome.verdict.as_ref(), &files);
+                    plain::recap_panel(&outcome.status, outcome.verdict.as_ref(), &files);
                 }
                 println!();
             }
@@ -758,7 +758,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     // telemetry, then sharpened by every turn in this REPL.
     let calibration = seed_calibration(&store, cfg);
 
-    tui::welcome_banner(
+    plain::welcome_banner(
         cfg.provider.id,
         &cfg.model_id,
         &cfg.workspace_root.display().to_string(),
@@ -870,7 +870,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             continue;
         }
         if input == "/files" {
-            tui::files_touched_panel(&registry.files_touched());
+            plain::files_touched_panel(&registry.files_touched());
             println!();
             continue;
         }
@@ -942,7 +942,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             continue;
         }
         if let Some(title) = input.strip_prefix("/rename ") {
-            tui::rename_tab(title.trim());
+            plain::rename_tab(title.trim());
             println!(
                 "  {}\n",
                 format!("tab renamed to `{}`", title.trim()).dimmed()
@@ -951,14 +951,14 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         }
         if let Some(color) = input.strip_prefix("/color ") {
             let name = color.trim();
-            if tui::set_accent(name) {
+            if plain::set_accent(name) {
                 // Acknowledge in the newly-set accent itself — the welcome
                 // banner uses a fixed palette and can't reflect the accent,
                 // so re-printing it would silently ignore the change.
                 println!(
                     "  {} {}\n",
-                    "◆".color(tui::accent()),
-                    format!("accent set to {name}").color(tui::accent()).bold()
+                    "◆".color(plain::accent()),
+                    format!("accent set to {name}").color(plain::accent()).bold()
                 );
             }
             continue;
@@ -1447,7 +1447,7 @@ pub async fn run_init(
     let workspace_root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
 
-    tui::section_header("Stella init");
+    plain::section_header("Stella init");
 
     let (provider, model_hint) =
         match Config::load(model_override, api_key_override, base_url_override) {
@@ -1694,7 +1694,7 @@ fn policy_reason(policy: &stella_tools::policy::ToolPolicy, name: &str) -> Strin
 pub fn run_tools_listing() -> Result<(), String> {
     let workspace_root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
-    tui::section_header("Stella tools");
+    plain::section_header("Stella tools");
 
     // The listing mirrors a real session: the registry builds the full
     // surface, and the operator's `"tools"` switches decide what survives.
@@ -1831,7 +1831,7 @@ pub fn run_tools_listing() -> Result<(), String> {
 pub fn run_tools_validation(dir: Option<&std::path::Path>) -> Result<(), String> {
     let workspace_root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
-    tui::section_header("Custom tool manifests — validation");
+    plain::section_header("Custom tool manifests — validation");
 
     let report = match dir {
         Some(dir) => {
@@ -2206,8 +2206,8 @@ async fn run_turn(
     match outcome {
         TurnOutcome::Completed { cost_usd, .. } => {
             if format == OutputFormat::Text {
-                tui::files_touched_panel(&files);
-                tui::cost_summary(
+                plain::files_touched_panel(&files);
+                plain::cost_summary(
                     cost_usd,
                     &format!("{}/{}", cfg.provider.id, cfg.model_id),
                     turn_start.elapsed(),

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -41,8 +41,8 @@ use crate::memory::{
     ReflectionReport, SessionMemory, inject_recall_block, reflect_routed, reflection_tail,
     should_reflect_on, turn_warrants_reflection,
 };
-use crate::runtime::{SystemClock, TokioSleeper};
 use crate::plain;
+use crate::runtime::{SystemClock, TokioSleeper};
 use crate::{OutputFormat, config::Config, resume_frame};
 use stella_context::EpisodeOutcome;
 
@@ -958,7 +958,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 println!(
                     "  {} {}\n",
                     "◆".color(plain::accent()),
-                    format!("accent set to {name}").color(plain::accent()).bold()
+                    format!("accent set to {name}")
+                        .color(plain::accent())
+                        .bold()
                 );
             }
             continue;

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -88,7 +88,7 @@ pub(crate) async fn run_raw_one_shot(
     let calibration = seed_calibration(&store, cfg);
 
     if format == OutputFormat::Text {
-        tui::section_header("Stella");
+        plain::section_header("Stella");
         println!("  {}\n", prompt.dimmed());
     }
 
@@ -287,7 +287,7 @@ pub async fn run_goal_cmd(
     let store = open_store(&cfg.workspace_root);
     let calibration = seed_calibration(&store, cfg);
 
-    tui::section_header("Stella — goal mode");
+    plain::section_header("Stella — goal mode");
     println!("  {}\n", goal.dimmed());
 
     // Persona matches the driver: pipeline rounds get the pipeline worker
@@ -555,7 +555,7 @@ pub(crate) async fn run_goal_turn(
             );
         }
     }
-    tui::files_touched_panel(&files);
+    plain::files_touched_panel(&files);
 
     match outcome {
         GoalOutcome::Met {
@@ -569,7 +569,7 @@ pub(crate) async fn run_goal_turn(
                 if rounds == 1 { "" } else { "s" },
                 verdict
             );
-            tui::cost_summary(
+            plain::cost_summary(
                 cost_usd,
                 &format!("{}/{}", cfg.provider.id, cfg.model_id),
                 turn_start.elapsed(),
@@ -583,7 +583,7 @@ pub(crate) async fn run_goal_turn(
             cost_usd,
             kind,
         } => {
-            tui::cost_summary(
+            plain::cost_summary(
                 cost_usd,
                 &format!("{}/{}", cfg.provider.id, cfg.model_id),
                 turn_start.elapsed(),
@@ -858,14 +858,14 @@ async fn run_goal_pipeline_turn(
             });
 
             if verdict.met {
-                tui::files_touched_panel(&registry.files_touched());
+                plain::files_touched_panel(&registry.files_touched());
                 println!(
                     "\n  {} goal met after {round} round{}: {}",
                     "✓".green().bold(),
                     if round == 1 { "" } else { "s" },
                     verdict.reasoning
                 );
-                tui::cost_summary(
+                plain::cost_summary(
                     total_cost_usd,
                     &format!("{}/{}", cfg.provider.id, cfg.model_id),
                     turn_start.elapsed(),
@@ -886,7 +886,7 @@ async fn run_goal_pipeline_turn(
             (Some(r), _) => r,
             (None, true) => Ok(()),
             (None, false) => {
-                tui::cost_summary(
+                plain::cost_summary(
                     total_cost_usd,
                     &format!("{}/{}", cfg.provider.id, cfg.model_id),
                     turn_start.elapsed(),
@@ -924,7 +924,7 @@ async fn run_goal_pipeline_turn(
             );
         }
     }
-    tui::files_touched_panel(&files);
+    plain::files_touched_panel(&files);
     goal_result
 }
 

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -219,7 +219,7 @@ pub(crate) fn spawn_renderer(
                 OutputFormat::Text => match &event {
                     AgentEvent::ToolStart { call } => {
                         tool_names.insert(call.call_id.clone(), call.name.clone());
-                        tui::tool_call_card(&call.name, &call.input, "running");
+                        plain::tool_call_card(&call.name, &call.input, "running");
                     }
                     AgentEvent::ToolResult {
                         call_id,
@@ -235,14 +235,14 @@ pub(crate) fn spawn_renderer(
                             ToolOutput::Ok { content } => content.clone(),
                             ToolOutput::Error { message } => message.clone(),
                         };
-                        tui::tool_result_card(
+                        plain::tool_result_card(
                             name,
                             &content,
                             output.is_error(),
                             Duration::from_millis(*duration_ms),
                         );
                     }
-                    other => tui::render_event(other),
+                    other => plain::render_event(other),
                 },
             }
         }

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -419,7 +419,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
     {
         warn_store_write_failed("the audit record (files touched / memory citations / outcome)");
     }
-    tui::files_touched_panel(&files);
+    plain::files_touched_panel(&files);
     if let Some(set) = &mcp {
         set.close_all().await;
     }
@@ -432,7 +432,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         };
         println!("\n  {mark} {line}");
     }
-    tui::cost_summary(
+    plain::cost_summary(
         cost_usd,
         &format!("{}/{}", cfg.provider.id, cfg.model_id),
         turn_start.elapsed(),

--- a/crates/stella-cli/src/auth_cmd.rs
+++ b/crates/stella-cli/src/auth_cmd.rs
@@ -380,7 +380,7 @@ fn list_lines(file: &CredentialsFile, settings: &Settings) -> Vec<String> {
 
 fn run_list() -> Result<(), String> {
     let file = load_file()?;
-    crate::tui::section_header("Stored credentials");
+    crate::plain::section_header("Stored credentials");
     let lines = {
         // Best-effort: a malformed settings.json costs the provider-config
         // lookup its overrides, never the listing itself.

--- a/crates/stella-cli/src/connect_cmd.rs
+++ b/crates/stella-cli/src/connect_cmd.rs
@@ -130,7 +130,7 @@ fn finish(
 }
 
 fn run_github(paste_token: bool) -> Result<(), String> {
-    crate::tui::section_header("Connect GitHub");
+    crate::plain::section_header("Connect GitHub");
     let rt = runtime()?;
     let connection = if paste_token {
         let token = prompt_secret("  GitHub personal access token (repo scope): ")?;
@@ -154,7 +154,7 @@ fn run_github(paste_token: bool) -> Result<(), String> {
 }
 
 fn run_linear(force_api_key: bool) -> Result<(), String> {
-    crate::tui::section_header("Connect Linear");
+    crate::plain::section_header("Connect Linear");
     let rt = runtime()?;
     let oauth = if force_api_key {
         None
@@ -200,7 +200,7 @@ fn run_linear(force_api_key: bool) -> Result<(), String> {
 }
 
 fn run_status() -> Result<(), String> {
-    crate::tui::section_header("Tracker connections");
+    crate::plain::section_header("Tracker connections");
     let connections = store()?.connections()?;
     if connections.is_empty() {
         println!(

--- a/crates/stella-cli/src/doctor.rs
+++ b/crates/stella-cli/src/doctor.rs
@@ -41,7 +41,7 @@ use std::path::{Path, PathBuf};
 use colored::Colorize;
 use stella_store::integrity;
 
-use crate::tui;
+use crate::plain;
 
 /// Problem rows printed under a failing check before the rest are summarized.
 /// SQLite can emit a hundred findings for one damaged page; the first handful
@@ -413,7 +413,7 @@ pub(crate) fn verdict(checks: &[Check]) -> Result<(), String> {
 }
 
 fn render(checks: &[Check]) {
-    tui::section_header("Doctor — local state checks");
+    plain::section_header("Doctor — local state checks");
     for check in checks {
         let mark = match check.status {
             CheckStatus::Pass => "✓".green(),

--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -170,7 +170,7 @@ fn redact_dump(json: &str) -> String {
 /// around. Generating the values means the export cannot disagree with the
 /// terminal it came from.
 fn css_hex(color: ratatui::style::Color) -> String {
-    let (r, g, b) = crate::tui::token_rgb(color);
+    let (r, g, b) = crate::plain::token_rgb(color);
     format!("#{r:02x}{g:02x}{b:02x}")
 }
 

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -26,8 +26,8 @@ use colored::Colorize;
 use serde::Serialize;
 use stella_fleet::{DispatchClaim, Ledger};
 
-use crate::query_format::{QueryFormat, Rows};
 use crate::plain;
+use crate::query_format::{QueryFormat, Rows};
 
 /// One claim, as `--format json` reports it.
 ///

--- a/crates/stella-cli/src/fleet_claims.rs
+++ b/crates/stella-cli/src/fleet_claims.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use stella_fleet::{DispatchClaim, Ledger};
 
 use crate::query_format::{QueryFormat, Rows};
-use crate::tui;
+use crate::plain;
 
 /// One claim, as `--format json` reports it.
 ///
@@ -117,7 +117,7 @@ pub(crate) fn claims(root: &Path, all: bool, format: QueryFormat) -> Result<(), 
             println!("{json}");
         }
         QueryFormat::Text => {
-            tui::section_header("Stella — fleet dispatch claims");
+            plain::section_header("Stella — fleet dispatch claims");
             print!("{}", render(&rows, all));
         }
     }

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -61,8 +61,8 @@ use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::agent;
 use crate::config::Config;
-use crate::runtime::{SystemClock, TokioSleeper, WallClock};
 use crate::plain;
+use crate::runtime::{SystemClock, TokioSleeper, WallClock};
 
 /// Cap on the per-task summary line so the report table stays a table.
 const SUMMARY_CHARS: usize = 96;

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -62,7 +62,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use crate::agent;
 use crate::config::Config;
 use crate::runtime::{SystemClock, TokioSleeper, WallClock};
-use crate::tui;
+use crate::plain;
 
 /// Cap on the per-task summary line so the report table stays a table.
 const SUMMARY_CHARS: usize = 96;
@@ -98,7 +98,7 @@ pub async fn run_fleet(
     .await
     .map_err(|e| format!("cannot resolve the fleet base ref: {e}"))?;
 
-    tui::section_header("Stella — fleet");
+    plain::section_header("Stella — fleet");
     println!(
         "  {} task(s) from {}, base {}, ≤{} concurrent\n",
         plan.tasks.len(),

--- a/crates/stella-cli/src/fleet_gc.rs
+++ b/crates/stella-cli/src/fleet_gc.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use colored::Colorize;
 use stella_fleet::{BranchAction, Gc, GcOptions, GcReport, Ledger, SystemGitCli, WorktreeAction};
 
-use crate::tui;
+use crate::plain;
 
 /// Sweep the workspace's finished worktrees and `fleet/*` branches.
 pub(crate) async fn clean(root: &Path, opts: &GcOptions) -> Result<(), String> {
@@ -60,7 +60,7 @@ pub(crate) async fn clean(root: &Path, opts: &GcOptions) -> Result<(), String> {
 }
 
 fn print_report(report: &GcReport) {
-    tui::section_header("Stella — fleet clean");
+    plain::section_header("Stella — fleet clean");
     println!(
         "  base {}{}\n",
         report.base_ref,

--- a/crates/stella-cli/src/init_fx.rs
+++ b/crates/stella-cli/src/init_fx.rs
@@ -451,7 +451,10 @@ mod tests {
             Ink::Star.rgb(),
             Some(crate::plain::token_rgb(theme::TEXT_TERTIARY))
         );
-        assert_eq!(Ink::Shell.rgb(), Some(crate::plain::token_rgb(theme::VIOLET)));
+        assert_eq!(
+            Ink::Shell.rgb(),
+            Some(crate::plain::token_rgb(theme::VIOLET))
+        );
         // And the star/flame pair stays warm — the comet's Phosphor Gold is
         // r > g > b — so the cinematic can never drift back to the retired
         // electric blue while still passing. (This clause read "cool, not

--- a/crates/stella-cli/src/init_fx.rs
+++ b/crates/stella-cli/src/init_fx.rs
@@ -191,11 +191,11 @@ impl Ink {
     fn rgb(self) -> Option<(u8, u8, u8)> {
         use stella_tui::theme;
         match self {
-            Ink::Flame => Some(crate::tui::token_rgb(theme::ACCENT_DEEP)),
-            Ink::Star => Some(crate::tui::token_rgb(theme::TEXT_TERTIARY)),
-            Ink::StarBright => Some(crate::tui::token_rgb(theme::ACCENT)),
+            Ink::Flame => Some(crate::plain::token_rgb(theme::ACCENT_DEEP)),
+            Ink::Star => Some(crate::plain::token_rgb(theme::TEXT_TERTIARY)),
+            Ink::StarBright => Some(crate::plain::token_rgb(theme::ACCENT)),
             // Categorical, not brand — the deck's data-mark violet.
-            Ink::Shell => Some(crate::tui::token_rgb(theme::VIOLET)),
+            Ink::Shell => Some(crate::plain::token_rgb(theme::VIOLET)),
             Ink::Dim | Ink::Plain => None,
         }
     }
@@ -441,17 +441,17 @@ mod tests {
         use stella_tui::theme;
         assert_eq!(
             Ink::StarBright.rgb(),
-            Some(crate::tui::token_rgb(theme::ACCENT))
+            Some(crate::plain::token_rgb(theme::ACCENT))
         );
         assert_eq!(
             Ink::Flame.rgb(),
-            Some(crate::tui::token_rgb(theme::ACCENT_DEEP))
+            Some(crate::plain::token_rgb(theme::ACCENT_DEEP))
         );
         assert_eq!(
             Ink::Star.rgb(),
-            Some(crate::tui::token_rgb(theme::TEXT_TERTIARY))
+            Some(crate::plain::token_rgb(theme::TEXT_TERTIARY))
         );
-        assert_eq!(Ink::Shell.rgb(), Some(crate::tui::token_rgb(theme::VIOLET)));
+        assert_eq!(Ink::Shell.rgb(), Some(crate::plain::token_rgb(theme::VIOLET)));
         // And the star/flame pair stays warm — the comet's Phosphor Gold is
         // r > g > b — so the cinematic can never drift back to the retired
         // electric blue while still passing. (This clause read "cool, not

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -77,6 +77,11 @@ mod memory_index;
 mod memory_retire_cmd;
 mod model_catalog;
 mod paths;
+// The plain terminal surface — the line-oriented renderer `term_policy`
+// falls back to when the Command Deck cannot run. Named for the decision
+// that selects it (`--plain`, `STELLA_PLAIN`, `plain_fallback`); it was
+// `tui` until #2421, which was the one name it is not.
+mod plain;
 mod scoreboard_cmd;
 mod self_driving_cmd;
 // The `/profile` posture planner (fast · balanced · pro · ultra).
@@ -106,7 +111,6 @@ mod tool_foundry;
 mod tool_policy;
 mod tool_switches;
 mod trace;
-mod tui;
 mod tune_cmd;
 mod turn_diff;
 mod usage_cmd;

--- a/crates/stella-cli/src/mcp_cmd.rs
+++ b/crates/stella-cli/src/mcp_cmd.rs
@@ -439,7 +439,7 @@ fn runtime() -> Result<tokio::runtime::Runtime, String> {
 }
 
 fn run_list(workspace_root: &Path) -> Result<(), String> {
-    crate::tui::section_header("Configured MCP servers");
+    crate::plain::section_header("Configured MCP servers");
     let cfg = load_config(workspace_root)?;
     if cfg.names().is_empty() {
         println!(
@@ -483,7 +483,7 @@ fn run_list(workspace_root: &Path) -> Result<(), String> {
 
 fn run_search(workspace_root: &Path, query: &str, limit: u32) -> Result<(), String> {
     let registry_url = resolve_registry_url(workspace_root);
-    crate::tui::section_header(&format!("MCP registry search — {registry_url}"));
+    crate::plain::section_header(&format!("MCP registry search — {registry_url}"));
     let query_opt = (!query.trim().is_empty()).then_some(query);
     let page = runtime()?.block_on(search(&registry_url, query_opt, None, limit))?;
     if page.entries.is_empty() {
@@ -559,7 +559,7 @@ fn run_remove(workspace_root: &Path, name: &str) -> Result<(), String> {
 }
 
 fn run_login(workspace_root: &Path, name: &str) -> Result<(), String> {
-    crate::tui::section_header(&format!("OAuth login — {name}"));
+    crate::plain::section_header(&format!("OAuth login — {name}"));
     runtime()?.block_on(oauth_login(
         workspace_root,
         name,
@@ -596,7 +596,7 @@ fn run_logout(workspace_root: &Path, name: &str) -> Result<(), String> {
 }
 
 fn run_usage(workspace_root: &Path) -> Result<(), String> {
-    crate::tui::section_header("MCP tool usage (.stella/private/store.db)");
+    crate::plain::section_header("MCP tool usage (.stella/private/store.db)");
     let stats = usage_stats(workspace_root)?;
     if stats.is_empty() {
         println!(

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -1,13 +1,40 @@
-//! Terminal UI — streaming text, tool-call cards, cost tracking.
+//! The **plain surface** — the line-oriented renderer: streaming text,
+//! tool-call cards, inline diffs, stage rules, cost tracking.
 //!
-//! Designed for speed and engagement: tool calls appear as cards with
-//! status, and the model's response prints as soon as it's ready.
+//! This module was called `tui` until #2421, which was the one thing it is
+//! not: there is no screen here, no layout and no input loop, just `colored`
+//! and `println!` writing lines that scroll. The Command Deck in
+//! [`stella_tui`] is the TUI. This is what runs when the deck cannot — and
+//! that is not a rare fallback: `stella run` never opens the deck at all
+//! (`main.rs`'s `Command::Run` arm), every supervised child writes here
+//! because its stdout is a console *file* rather than a terminal, and
+//! `stella daemon logs`/`attach` replay those bytes. For a great many runs
+//! this surface is the only transcript that ever exists.
 //!
-//! `render_event` is the TUI's one entry point onto `stella_core::Engine`'s
-//! event stream (L-T1: the TUI renders exclusively
-//! from `AgentEvent`s — no panel owns state that isn't reconstructible by
-//! replaying the event log). It's deliberately a thin dispatcher onto the
-//! existing per-kind print helpers below, not a rewrite of them.
+//! The name follows the decision that selects it:
+//! [`crate::term_policy::plain_fallback`], `--plain`, `STELLA_PLAIN`.
+//!
+//! `render_event` is this surface's one entry point onto `stella_core::Engine`'s
+//! event stream (L-T1: it renders exclusively from `AgentEvent`s — no panel
+//! owns state that isn't reconstructible by replaying the event log). It's
+//! deliberately a thin dispatcher onto the per-kind print helpers below, not a
+//! rewrite of them.
+//!
+//! # What is shared with the deck, and what is not
+//!
+//! Both surfaces fold the same event stream, so they always agree on *what
+//! happened*; they disagree on paint, and the split is deliberate:
+//!
+//! - **Shared**, because two copies drift: the event→text wording
+//!   ([`stella_tui::textline`], #66), the stage vocabulary
+//!   ([`stella_tui::textline::stage_label`]), the markdown parse
+//!   ([`stella_tui::markdown`]) and the diff layout ([`stella_tui::diff`]).
+//! - **Not shared**, because the media genuinely differ: this surface writes
+//!   into the user's own scrollback and paints no ground, so prose keeps the
+//!   terminal's default foreground instead of the deck's explicit
+//!   `theme::INK` — inheriting that would fight a light terminal profile.
+//!   The deck can also expand a diff in place (ctrl+o); a scrollback line
+//!   cannot be revisited, so this surface commits to one capped rendering.
 //!
 //! There is deliberately no animated "thinking" spinner: the Phase 0/1
 //! version had one, but it only ticked a fixed 3 frames *before* dispatching

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -41,19 +41,50 @@
 //! the network call, then froze for the entire real wait — a decorative
 //! pre-roll, not a live indicator. A correct live spinner would need its own
 //! concurrent task racing the event-draining task below, both writing to the
-//! terminal — real interleaving risk for a cosmetic win. `Stage::Execute`
-//! below gives one clean, immediate "thinking" line instead. There is no
+//! terminal — real interleaving risk for a cosmetic win. [`stage_rule`] gives
+//! one clean, immediate line per stage instead (it replaced a lone dim
+//! `thinking…` on `Execute` in #2421). There is no
 //! decorative "rocket"/spinner animation either — activity is reported by the
 //! command deck's honest run progress bar (`stella_tui::progress`), never by a
 //! cosmetic character-noise loop.
 
 use std::io::{self, Write};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use colored::{Color, ColoredString, Colorize};
-use stella_protocol::{AgentEvent, BudgetMode, StageKind};
+use stella_protocol::{AgentEvent, BudgetMode, FileChangeKind, StageKind};
+use stella_tui::ansi::AnsiPalette;
+use stella_tui::render::{INLINE_DIFF_CAP, THINKING_ROWS};
 use stella_tui::textline::{self, EventLine, Tone, fmt_cost};
+
+/// Width of the stage rules and the banner's closing rule.
+///
+/// A constant rather than the terminal's width: this surface's output is
+/// routinely *not* going to a terminal at all (a supervised run's console
+/// file, a pipe, CI), and a rule sized to whatever `stella` happened to see at
+/// launch would make two runs of the same task diff against each other for no
+/// reason. The banner already picked 60 for the same reason.
+const RULE_WIDTH: usize = 60;
+
+/// How this surface dresses the shared renderers' output.
+///
+/// The colour decision is `colored`'s, not ours — it already folds `NO_COLOR`,
+/// `CLICOLOR_FORCE`, `TERM=dumb` (via [`crate::term_policy`]) and a non-tty
+/// stream, and a second opinion here is how the two would drift apart.
+///
+/// [`stella_tui::theme::INK`] is transparent because this surface paints no
+/// ground: the deck asserts an explicit white for prose over its own black
+/// frame, and inheriting that would put our idea of "text" on a reader's light
+/// terminal profile. The structure around the prose keeps its colours.
+fn palette() -> AnsiPalette {
+    if colored::control::SHOULD_COLORIZE.should_colorize() {
+        AnsiPalette::colored().with_transparent_fg(stella_tui::theme::INK)
+    } else {
+        AnsiPalette::monochrome()
+    }
+}
 
 /// Truncate `s` to at most `max` characters, appending `…` when it was
 /// shortened. Char-boundary-safe: operates on `char`s, never byte indices,
@@ -299,10 +330,27 @@ pub fn section_header(title: &str) {
     );
 }
 
-/// Print the assistant's complete response (after streaming).
+/// Print the assistant's complete response (after streaming), rendered as
+/// markdown.
+///
+/// Agent responses are markdown-capable and this surface used to print them
+/// with a bare `println!`, so headings arrived as `### text`, emphasis as
+/// literal asterisks and code blocks as rows of backticks. That is the
+/// transcript a `stella run` leaves behind, and the *only* one a supervised
+/// run leaves behind — the deck's readers were never the ones who needed this
+/// most.
+///
+/// The parse is [`stella_tui::markdown`]'s, the same one the deck folds with:
+/// a second markdown implementation here would be a second set of edge cases
+/// (the `snake_case`-outranks-`_emphasis_` rule alone is a page of reasoning)
+/// drifting out of step with the first.
 pub fn assistant_response(text: &str) {
-    if !text.is_empty() {
-        println!("\n{}", text);
+    if text.is_empty() {
+        return;
+    }
+    println!();
+    for line in stella_tui::markdown::render_ansi(text, &palette()) {
+        println!("{line}");
     }
 }
 
@@ -403,7 +451,144 @@ pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
     println!("  {}\n", "─".repeat(60).dimmed());
 }
 
+/// Print a stage divider — the plain surface's form of the deck's section
+/// rule.
+///
+/// Until #2421 this surface printed one dim `thinking…` for `Execute` and
+/// nothing whatever for the other eleven stages, so a staged `stella run` — the
+/// default path — rendered as an undifferentiated wall of tool calls with no
+/// sign that triage, planning, witness authoring, verification and the verdict
+/// had each happened. The stage vocabulary is
+/// [`stella_tui::textline::stage_label`], shared with the deck, so the two
+/// surfaces cannot come to call the same stage different things (#1465 was
+/// exactly that bug, five surfaces wide).
+///
+/// The label alone, without the word "stage": the divider already says what
+/// kind of thing this is.
+pub fn stage_rule(stage: StageKind) {
+    let label = textline::stage_label(stage);
+    // "  " + "──" + " " + label + " " — what the trailing rule has to clear.
+    let used = label.chars().count() + 5;
+    let tail = RULE_WIDTH.saturating_sub(used);
+    println!(
+        "\n  {} {} {}",
+        "──".dimmed(),
+        label.bold(),
+        "─".repeat(tail).dimmed()
+    );
+}
+
+/// The chain of thought accumulated since the last non-`Reasoning` event.
+///
+/// `Reasoning` arrives as token-sized deltas, so it has to be coalesced before
+/// it can be measured or previewed; the deck coalesces into a
+/// `TranscriptEntry::Reasoning` it can re-render, and this surface cannot
+/// re-render anything it has already written, so it buffers until the thought
+/// is over and prints once.
+///
+/// A `Mutex<String>` rather than a channel or a field because `render_event`
+/// is a free function called from a single event-draining task — the same
+/// reason [`ACCENT`] is a static. Poisoning is recovered from rather than
+/// propagated: a panic elsewhere must not turn the transcript off.
+static REASONING: Mutex<String> = Mutex::new(String::new());
+
+/// Buffer a reasoning delta (see [`REASONING`]).
+fn reasoning_delta(delta: &str) {
+    let mut buf = match REASONING.lock() {
+        Ok(buf) => buf,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    buf.push_str(delta);
+}
+
+/// Print the buffered thought, if any, and clear it.
+///
+/// Bounded to [`THINKING_ROWS`] — the deck's own preview depth, shared rather
+/// than re-chosen — and dimmed. Reasoning was dropped entirely here before
+/// #2421, with no comment saying why, which is the signature of an omission
+/// rather than a policy: every other suppression in [`render_event`] states
+/// its reason. Printing it *whole* is the other wrong answer, since a long
+/// thought is the largest text a turn produces and this surface is often
+/// writing to a log file.
+fn flush_reasoning() {
+    let mut buf = match REASONING.lock() {
+        Ok(buf) => buf,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if buf.trim().is_empty() {
+        buf.clear();
+        return;
+    }
+    let text = std::mem::take(&mut *buf);
+    drop(buf);
+
+    // Blank lines are dropped rather than previewed: in a window this small a
+    // paragraph break costs a row of thought and says nothing. Same call the
+    // deck makes.
+    let rows: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    let total = rows.len();
+    println!("  {} {}", "✻".dimmed(), format!("{total} lines").dimmed());
+    for row in rows.iter().take(THINKING_ROWS) {
+        println!("    {}", row.trim_end().dimmed().italic());
+    }
+    if let Some(folded) = total.checked_sub(THINKING_ROWS).filter(|n| *n > 0) {
+        println!("    {}", format!("⋯ {folded} more").dimmed());
+    }
+}
+
+/// Print a file mutation and the diff it produced, capped.
+///
+/// This is the surface's answer to "what actually changed", and until #2421 it
+/// had none: the row said `± write src/foo.rs` and stopped, while the diff rode
+/// the very same event unread. The deck has shown a capped inline diff for some
+/// time; the surface that a `stella run` and every supervised run actually
+/// write to had never shown one.
+///
+/// Layout comes from [`stella_tui::diff`] — the one implementation of "how a
+/// diff looks" — in its inline form, which drops the file header and the
+/// counts footer because the row above already carries both.
+///
+/// [`INLINE_DIFF_CAP`] bounds it, and the withheld count is *printed*: a
+/// truncation nobody announces reads as the whole change. Unlike the deck
+/// there is no ctrl+o here — a scrollback line cannot be revisited — so the
+/// cap is the final answer and has to say so.
+pub fn file_change_card(
+    path: &str,
+    kind: FileChangeKind,
+    added: u32,
+    removed: u32,
+    diff: Option<&str>,
+) {
+    let line = textline::file_change(path, kind);
+    // Counts ride the event from the emitter's own LCS measurement. They are
+    // never recounted from the diff text: `changed_region_diff` is a bounded,
+    // coarse rendering of the changed span and disagrees with the real delta
+    // by any shared line.
+    let counts = if added == 0 && removed == 0 {
+        String::new()
+    } else {
+        format!(" {}", format!("+{added} −{removed}").dimmed())
+    };
+    println!("  {}{}", styled_event_line(&line), counts);
+
+    let Some(diff) = diff.filter(|d| !d.trim().is_empty()) else {
+        return;
+    };
+    let (body, hidden) =
+        stella_tui::diff::body_lines_inline_ansi(diff, Some(path), INLINE_DIFF_CAP, &palette());
+    for row in body {
+        println!("    {row}");
+    }
+    if hidden > 0 {
+        println!(
+            "    {}",
+            format!("⋯ {hidden} more line{}", if hidden == 1 { "" } else { "s" }).dimmed()
+        );
+    }
+}
+
 /// Render one `AgentEvent` from `stella_core::Engine::run_turn`'s stream.
+///
 /// `ToolStart`/`ToolResult` are intentionally a no-op here: `ToolResult`
 /// doesn't carry the tool's name (only `call_id`), so the call site keeps a
 /// small `call_id -> name` map and calls `tool_call_card`/`tool_result_card`
@@ -412,23 +597,39 @@ pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
 /// `Text` — the engine emits one per step, not just at turn-end, since a
 /// step with tool calls can still carry commentary text) is rendered here.
 ///
-/// Wording comes from `stella_tui::textline` — the one event→text table
-/// both this surface and the deck consume (issue #66); the arms below carry
-/// only this surface's *policy* (what to suppress, what goes to stderr) and
-/// styling. A new annotation variant needs a `textline` entry, nothing here.
+/// **Everything shared is shared, and the rest is policy.** Wording comes from
+/// `stella_tui::textline` (the one event→text table both surfaces consume,
+/// #66), stage names from its `stage_label`, prose from
+/// `stella_tui::markdown`, diffs from `stella_tui::diff` (#2421). What the
+/// arms below own is only this surface's *policy* — what to suppress, what
+/// goes to stderr, how deep to preview — and its styling. A new annotation
+/// variant needs a `textline` entry, nothing here.
+///
+/// Every suppression states its reason. An arm that silently drops an event
+/// is how `Reasoning` went unrendered for as long as it did.
 pub fn render_event(event: &AgentEvent) {
+    // A thought ends the instant anything else lands — the same positional
+    // rule the deck uses (`render::entry::reasoning_is_live`) rather than a
+    // liveness flag or a timer. Doing it here, once, is what keeps every arm
+    // below from having to remember it.
+    if !matches!(event, AgentEvent::Reasoning { .. }) {
+        flush_reasoning();
+    }
     match event {
-        AgentEvent::Stage {
-            name: StageKind::Execute,
-        } => {
-            println!("  {}", "thinking…".dimmed());
-        }
-        AgentEvent::Stage { .. } | AgentEvent::ToolStart { .. } | AgentEvent::ToolResult { .. } => {
-            // Complete-stage and ToolStart/ToolResult: handled inline at the
-            // call site or by a more specific event (see the module doc).
+        AgentEvent::Stage { name } => stage_rule(*name),
+        AgentEvent::ToolStart { .. } | AgentEvent::ToolResult { .. } => {
+            // Handled inline at the call site, which holds the `call_id ->
+            // name` correlation this event pair needs (see the module doc).
         }
         AgentEvent::Text { text } => assistant_response(text),
-        AgentEvent::Reasoning { .. } => {}
+        AgentEvent::FileChange {
+            path,
+            kind,
+            added,
+            removed,
+            diff,
+        } => file_change_card(path, *kind, *added, *removed, diff.as_deref()),
+        AgentEvent::Reasoning { delta } => reasoning_delta(delta),
         AgentEvent::BudgetTick {
             mode: BudgetMode::Off,
             ..

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -466,16 +466,23 @@ pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
 /// The label alone, without the word "stage": the divider already says what
 /// kind of thing this is.
 pub fn stage_rule(stage: StageKind) {
+    println!("\n{}", stage_rule_line(stage));
+}
+
+/// [`stage_rule`]'s composition, kept pure so the layout is testable without
+/// capturing stdout — the same split [`crate::term_policy`] uses for its
+/// decisions, and for the same reason.
+fn stage_rule_line(stage: StageKind) -> String {
     let label = textline::stage_label(stage);
     // "  " + "──" + " " + label + " " — what the trailing rule has to clear.
     let used = label.chars().count() + 5;
     let tail = RULE_WIDTH.saturating_sub(used);
-    println!(
-        "\n  {} {} {}",
+    format!(
+        "  {} {} {}",
         "──".dimmed(),
         label.bold(),
         "─".repeat(tail).dimmed()
-    );
+    )
 }
 
 /// The chain of thought accumulated since the last non-`Reasoning` event.
@@ -521,19 +528,31 @@ fn flush_reasoning() {
     }
     let text = std::mem::take(&mut *buf);
     drop(buf);
+    for line in reasoning_block(&text) {
+        println!("{line}");
+    }
+}
 
-    // Blank lines are dropped rather than previewed: in a window this small a
-    // paragraph break costs a row of thought and says nothing. Same call the
-    // deck makes.
+/// [`flush_reasoning`]'s composition, kept pure (see [`stage_rule_line`]).
+///
+/// Blank lines are dropped rather than previewed: in a window this small a
+/// paragraph break costs a row of thought and says nothing — the same call the
+/// deck makes.
+fn reasoning_block(text: &str) -> Vec<String> {
     let rows: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
     let total = rows.len();
-    println!("  {} {}", "✻".dimmed(), format!("{total} lines").dimmed());
+    let mut out = vec![format!(
+        "  {} {}",
+        "✻".dimmed(),
+        format!("{total} lines").dimmed()
+    )];
     for row in rows.iter().take(THINKING_ROWS) {
-        println!("    {}", row.trim_end().dimmed().italic());
+        out.push(format!("    {}", row.trim_end().dimmed().italic()));
     }
     if let Some(folded) = total.checked_sub(THINKING_ROWS).filter(|n| *n > 0) {
-        println!("    {}", format!("⋯ {folded} more").dimmed());
+        out.push(format!("    {}", format!("⋯ {folded} more").dimmed()));
     }
+    out
 }
 
 /// Print a file mutation and the diff it produced, capped.
@@ -559,6 +578,19 @@ pub fn file_change_card(
     removed: u32,
     diff: Option<&str>,
 ) {
+    for line in file_change_lines(path, kind, added, removed, diff) {
+        println!("{line}");
+    }
+}
+
+/// [`file_change_card`]'s composition, kept pure (see [`stage_rule_line`]).
+fn file_change_lines(
+    path: &str,
+    kind: FileChangeKind,
+    added: u32,
+    removed: u32,
+    diff: Option<&str>,
+) -> Vec<String> {
     let line = textline::file_change(path, kind);
     // Counts ride the event from the emitter's own LCS measurement. They are
     // never recounted from the diff text: `changed_region_diff` is a bounded,
@@ -569,22 +601,21 @@ pub fn file_change_card(
     } else {
         format!(" {}", format!("+{added} −{removed}").dimmed())
     };
-    println!("  {}{}", styled_event_line(&line), counts);
+    let mut out = vec![format!("  {}{}", styled_event_line(&line), counts)];
 
     let Some(diff) = diff.filter(|d| !d.trim().is_empty()) else {
-        return;
+        return out;
     };
     let (body, hidden) =
         stella_tui::diff::body_lines_inline_ansi(diff, Some(path), INLINE_DIFF_CAP, &palette());
-    for row in body {
-        println!("    {row}");
-    }
+    out.extend(body.into_iter().map(|row| format!("    {row}")));
     if hidden > 0 {
-        println!(
+        out.push(format!(
             "    {}",
             format!("⋯ {hidden} more line{}", if hidden == 1 { "" } else { "s" }).dimmed()
-        );
+        ));
     }
+    out
 }
 
 /// Render one `AgentEvent` from `stella_core::Engine::run_turn`'s stream.
@@ -808,6 +839,185 @@ mod tests {
             strip_ansi(&styled_event_line(&textline::budget_tick(0.42, None))),
             "$ spend: $0.4200"
         );
+    }
+
+    // ── #2421: what the plain surface stopped throwing away ────────────────
+    //
+    // Four witnesses, one per gap. Each asserts on the *visible* text, so a
+    // restyling does not break them but a silent drop does. On `main` before
+    // #2421 every one of them fails, and fails for the right reason: the
+    // renderer it exercises did not exist.
+
+    /// Prose is markdown, and this surface used to print it raw.
+    #[test]
+    fn assistant_prose_is_rendered_not_printed_with_its_delimiters() {
+        let out = stella_tui::markdown::render_ansi(
+            "## Heading\n\nSome **bold** and `code`.\n\n- one\n- two\n",
+            &AnsiPalette::colored().with_transparent_fg(stella_tui::theme::INK),
+        );
+        let visible: String = out
+            .iter()
+            .map(|l| strip_ansi(l).into_owned())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // The delimiters are consumed, not shown.
+        assert!(
+            !visible.contains("**") && !visible.contains('`') && !visible.contains("## "),
+            "markdown delimiters survived into the output:\n{visible}"
+        );
+        // …and the content they wrapped is still there.
+        for word in ["Heading", "bold", "code", "one", "two"] {
+            assert!(visible.contains(word), "lost {word:?} from:\n{visible}");
+        }
+        // A bullet became a glyph rather than vanishing.
+        assert!(visible.contains('•'), "no bullet glyph in:\n{visible}");
+    }
+
+    /// Prose must NOT be given a foreground: this surface paints no ground, so
+    /// the deck's explicit `theme::INK` would fight a light terminal profile.
+    /// The structure around it still gets colour — that is the whole point of
+    /// the transparency, and a palette that simply dropped colour would pass a
+    /// weaker version of this test while losing the headings.
+    #[test]
+    fn prose_keeps_the_readers_foreground_while_structure_keeps_colour() {
+        let palette = AnsiPalette::colored().with_transparent_fg(stella_tui::theme::INK);
+        let plain = stella_tui::markdown::render_ansi("just prose", &palette);
+        assert_eq!(plain, vec!["just prose".to_string()], "prose was tinted");
+
+        let heading = stella_tui::markdown::render_ansi("# Title", &palette);
+        assert!(
+            heading[0].contains('\u{1b}'),
+            "the heading lost its styling too: {:?}",
+            heading[0]
+        );
+    }
+
+    /// Every stage draws a rule. Before #2421 only `Execute` printed anything
+    /// at all, and what it printed was the word "thinking…".
+    #[test]
+    fn every_stage_draws_a_rule_naming_itself() {
+        for (stage, label) in [
+            (StageKind::Triage, "triage"),
+            (StageKind::Plan, "plan"),
+            (StageKind::Witness, "witness"),
+            (StageKind::Execute, "execute"),
+            (StageKind::Verdict, "verdict"),
+        ] {
+            let line = strip_ansi(&stage_rule_line(stage)).into_owned();
+            assert!(line.contains(label), "stage rule lost its label: {line:?}");
+            assert!(line.contains('─'), "stage rule drew no rule: {line:?}");
+            // The vocabulary is `textline`'s, not a local copy — #1465 was
+            // five surfaces disagreeing about one stage's name.
+            assert!(
+                line.contains(textline::stage_label(stage)),
+                "stage rule stopped using the shared label: {line:?}"
+            );
+        }
+    }
+
+    /// A chain of thought is previewed and *counted*, never dropped and never
+    /// dumped whole.
+    #[test]
+    fn reasoning_is_previewed_bounded_and_says_how_much_it_withheld() {
+        let thought: String = (1..=12).map(|n| format!("step {n}\n")).collect();
+        let block = reasoning_block(&thought);
+        let visible: Vec<String> = block.iter().map(|l| strip_ansi(l).into_owned()).collect();
+
+        assert!(
+            visible[0].contains("12 lines"),
+            "no total in the header: {:?}",
+            visible[0]
+        );
+        // Header + the preview + the fold marker, and nothing beyond.
+        assert_eq!(visible.len(), THINKING_ROWS + 2, "preview is unbounded");
+        assert!(visible[1].contains("step 1"));
+        assert!(
+            visible.last().unwrap().contains(&format!("{} more", 12 - THINKING_ROWS)),
+            "withheld count not stated: {:?}",
+            visible.last()
+        );
+        // The 12th step must not have reached the terminal.
+        assert!(
+            !visible.iter().any(|l| l.contains("step 12")),
+            "the whole thought was dumped"
+        );
+    }
+
+    /// Blank lines cost a row of thought and say nothing, so they are dropped
+    /// before the budget is spent — the same call the deck makes.
+    #[test]
+    fn reasoning_spends_its_budget_on_content_not_paragraph_breaks() {
+        let spaced = "a\n\n\nb\n\n\nc\n";
+        let visible: Vec<String> = reasoning_block(spaced)
+            .iter()
+            .map(|l| strip_ansi(l).into_owned())
+            .collect();
+        assert!(visible[0].contains("3 lines"), "blanks were counted");
+        assert_eq!(visible.len(), 4, "blanks were previewed: {visible:?}");
+    }
+
+    /// The headline gap: a mutation prints the diff that rode its own event.
+    #[test]
+    fn a_file_change_prints_its_diff_and_its_measured_counts() {
+        let diff = "@@ -1,3 +1,3 @@\n fn main() {\n-    let x = 1;\n+    let x = 2;\n }\n";
+        let visible: Vec<String> =
+            file_change_lines("src/main.rs", FileChangeKind::Modified, 1, 1, Some(diff))
+                .iter()
+                .map(|l| strip_ansi(l).into_owned())
+                .collect();
+        let all = visible.join("\n");
+
+        assert!(all.contains("src/main.rs"), "path missing:\n{all}");
+        // Counts come off the event, not off the diff text.
+        assert!(all.contains("+1 −1"), "measured counts missing:\n{all}");
+        // The actual change, both sides of it.
+        assert!(all.contains("let x = 1;"), "removed line missing:\n{all}");
+        assert!(all.contains("let x = 2;"), "added line missing:\n{all}");
+        assert!(
+            visible.len() > 1,
+            "the row printed but the diff did not:\n{all}"
+        );
+    }
+
+    /// A big diff is capped and *says* it was capped. An unannounced
+    /// truncation reads as the whole change, and unlike the deck there is no
+    /// ctrl+o here to prove otherwise.
+    #[test]
+    fn a_large_diff_is_capped_and_names_the_lines_it_withheld() {
+        let mut diff = String::from("@@ -1,80 +1,80 @@\n");
+        for n in 0..80 {
+            diff.push_str(&format!("-old {n}\n+new {n}\n"));
+        }
+        let visible: Vec<String> =
+            file_change_lines("big.rs", FileChangeKind::Modified, 80, 80, Some(&diff))
+                .iter()
+                .map(|l| strip_ansi(l).into_owned())
+                .collect();
+
+        // One header row, at most the shared cap of diff rows, one fold note.
+        assert!(
+            visible.len() <= INLINE_DIFF_CAP + 2,
+            "diff flooded the transcript: {} lines",
+            visible.len()
+        );
+        assert!(
+            visible.last().unwrap().contains("more line"),
+            "truncated silently: {:?}",
+            visible.last()
+        );
+    }
+
+    /// A read is not a change: no counts, no diff, just the row.
+    #[test]
+    fn a_read_prints_one_row_with_no_diff_and_no_counts() {
+        let visible: Vec<String> =
+            file_change_lines("src/lib.rs", FileChangeKind::Read, 0, 0, None)
+                .iter()
+                .map(|l| strip_ansi(l).into_owned())
+                .collect();
+        assert_eq!(visible.len(), 1, "a read grew a body: {visible:?}");
+        assert!(!visible[0].contains('+'), "a read reported a delta");
     }
 
     // ── wordmark ───────────────────────────────────────────────────────────

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -933,7 +933,10 @@ mod tests {
         assert_eq!(visible.len(), THINKING_ROWS + 2, "preview is unbounded");
         assert!(visible[1].contains("step 1"));
         assert!(
-            visible.last().unwrap().contains(&format!("{} more", 12 - THINKING_ROWS)),
+            visible
+                .last()
+                .unwrap()
+                .contains(&format!("{} more", 12 - THINKING_ROWS)),
             "withheld count not stated: {:?}",
             visible.last()
         );

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -131,6 +131,12 @@ const PALETTE: [(&str, Color); 7] = [
 static ACCENT: AtomicUsize = AtomicUsize::new(0);
 
 /// The session accent color (defaults to the brand gold, `PALETTE[0]`).
+///
+/// `agent.rs` imports this **by name** rather than reaching for it through the
+/// module path. That is not style: `plain::accent()` is two characters longer
+/// than the `tui::accent()` it replaced in #2421, which was enough to make
+/// rustfmt wrap a call site and push that god file two lines over its ceiling.
+/// A rename must not cost a baseline bump.
 pub fn accent() -> Color {
     PALETTE[ACCENT.load(Ordering::Relaxed) % PALETTE.len()].1
 }

--- a/crates/stella-cli/src/tool_foundry.rs
+++ b/crates/stella-cli/src/tool_foundry.rs
@@ -185,7 +185,7 @@ fn run_tools_author_in(
     let proposals = detect_tool_gaps(&invocations, config);
 
     let Some(name) = name else {
-        crate::tui::section_header("Tool-foundry proposals");
+        crate::plain::section_header("Tool-foundry proposals");
         if proposals.is_empty() {
             println!(
                 "  {}",
@@ -259,7 +259,7 @@ fn run_tools_author_in(
     std::fs::write(&manifest_path, &authored.manifest_toml)
         .map_err(|e| format!("cannot write {}: {e}", manifest_path.display()))?;
 
-    crate::tui::section_header("Tool staged — not installed");
+    crate::plain::section_header("Tool staged — not installed");
     println!(
         "  {} {}\n  {} {}",
         "·".green(),

--- a/crates/stella-cli/src/tool_foundry/adopt.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt.rs
@@ -47,7 +47,7 @@ pub(crate) fn run_tools_adopt(name: &str) -> Result<(), String> {
     let adopted = adopt_in(&root, &store, name)?;
     let (manifest, script) = adopted_paths(&root, name);
 
-    crate::tui::section_header("Tool adopted — still disabled");
+    crate::plain::section_header("Tool adopted — still disabled");
     println!(
         "  {} {}\n  {} {}",
         "·".green(),
@@ -72,7 +72,7 @@ pub(crate) fn run_tools_enable(name: &str, enabled: bool) -> Result<(), String> 
     set_enabled_in(&root, &store, name, enabled)?;
 
     if enabled {
-        crate::tui::section_header("Tool enabled");
+        crate::plain::section_header("Tool enabled");
         println!(
             "  {} {} {}",
             "·".green(),
@@ -80,7 +80,7 @@ pub(crate) fn run_tools_enable(name: &str, enabled: bool) -> Result<(), String> 
             "is now offered to the model".dimmed()
         );
     } else {
-        crate::tui::section_header("Tool disabled");
+        crate::plain::section_header("Tool disabled");
         println!(
             "  {} {} {}",
             "·".yellow(),

--- a/crates/stella-tui/src/ansi.rs
+++ b/crates/stella-tui/src/ansi.rs
@@ -349,7 +349,10 @@ mod tests {
     #[test]
     fn a_line_level_style_reaches_its_spans() {
         let line = Line::styled("whole", Style::new().fg(Color::Red));
-        assert_eq!(line_to_ansi(&line, &AnsiPalette::colored()), "\u{1b}[31mwhole\u{1b}[0m");
+        assert_eq!(
+            line_to_ansi(&line, &AnsiPalette::colored()),
+            "\u{1b}[31mwhole\u{1b}[0m"
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/ansi.rs
+++ b/crates/stella-tui/src/ansi.rs
@@ -1,20 +1,35 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The one shared ANSI escape-sequence stripper (#934).
+//! The one shared ANSI escape-sequence module — stripping (#934) and
+//! emission (#2421).
 //!
-//! Tool output reaches the transcript verbatim, and any child process that
-//! detects a TTY colourises it. `ratatui`'s `styled_graphemes` drops the ESC
-//! control byte but renders the rest of the sequence (`[0;32m`) literally, so
-//! unstripped output turns into visible garbage that eats the reader's line
-//! budget. The strip is applied **once, where output folds into the
-//! transcript** — never per frame, because the fold cache would retain the
+//! **Stripping.** Tool output reaches the transcript verbatim, and any child
+//! process that detects a TTY colourises it. `ratatui`'s `styled_graphemes`
+//! drops the ESC control byte but renders the rest of the sequence (`[0;32m`)
+//! literally, so unstripped output turns into visible garbage that eats the
+//! reader's line budget. The strip is applied **once, where output folds into
+//! the transcript** — never per frame, because the fold cache would retain the
 //! escapes and re-stripping every paint would be wasted work.
 //!
-//! This module exists so callers stop growing private copies (three grew in
-//! `stella-cli` alone before it was extracted).
+//! **Emission** is the inverse, and it is what lets the deck and the plain
+//! surface share a *renderer* rather than merely a vocabulary. Modules like
+//! [`crate::markdown`] and [`crate::diff`] do real work — parsing markdown,
+//! laying out a diff — and express the result as `ratatui` [`Line`]s. The
+//! plain surface in `stella-cli` cannot consume those: it writes bytes to a
+//! scrollback, and that crate carries `ratatui` explicitly *not* for rendering
+//! (see its `Cargo.toml`). [`lines_to_ansi`] closes the gap, so one parse and
+//! one layout serve both surfaces and the second copy that would otherwise
+//! grow in `stella-cli` never has to exist.
+//!
+//! This module exists so callers stop growing private copies (three strippers
+//! grew in `stella-cli` alone before it was extracted).
 
 use std::borrow::Cow;
+use std::fmt::Write as _;
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
 
 /// Remove ANSI escape sequences, leaving the visible text.
 ///
@@ -74,6 +89,158 @@ pub fn strip_ansi(s: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+/// How a [`Line`] is dressed when a surface writes ANSI bytes directly.
+///
+/// Two knobs, both of which exist because the plain surface is not the deck:
+/// it writes into a terminal it does not own.
+#[derive(Debug, Clone, Copy)]
+pub struct AnsiPalette {
+    /// Emit escapes at all. `false` yields the visible text only — the caller
+    /// passes its own colour decision (`colored`'s, which already folds
+    /// `NO_COLOR`, `CLICOLOR_FORCE`, `TERM=dumb` and a non-tty stream), so
+    /// this module never second-guesses it.
+    pub color: bool,
+    /// The foreground meaning "the surface's own default ink". A span in this
+    /// colour emits no foreground escape, so prose inherits the reader's
+    /// terminal profile.
+    ///
+    /// The deck paints its own black ground and is therefore entitled to state
+    /// that prose is [`crate::theme::INK`]; a scrollback line is drawn on
+    /// whatever background the user chose, so the same explicit white would be
+    /// wrong about half the time. Rendering the *structure* (headings, code,
+    /// bullets, diff signs) while leaving the *prose* alone is the difference.
+    pub transparent_fg: Option<Color>,
+}
+
+impl AnsiPalette {
+    /// Colour on, nothing transparent — every style rendered as written.
+    #[must_use]
+    pub const fn colored() -> Self {
+        Self {
+            color: true,
+            transparent_fg: None,
+        }
+    }
+
+    /// Colour off — visible text only.
+    #[must_use]
+    pub const fn monochrome() -> Self {
+        Self {
+            color: false,
+            transparent_fg: None,
+        }
+    }
+
+    /// Treat `fg` as the surface's default ink (see [`Self::transparent_fg`]).
+    #[must_use]
+    pub const fn with_transparent_fg(mut self, fg: Color) -> Self {
+        self.transparent_fg = Some(fg);
+        self
+    }
+}
+
+/// Render one styled line as a string of visible text and SGR escapes.
+///
+/// Each span is opened with its own SGR introducer and closed with a reset, so
+/// a line is self-contained: nothing leaks into the next line of scrollback if
+/// output is interleaved with another writer's. A span whose style resolves to
+/// nothing at all is written bare rather than wrapped in an empty escape pair.
+#[must_use]
+pub fn line_to_ansi(line: &Line<'_>, palette: &AnsiPalette) -> String {
+    let mut out = String::new();
+    for span in &line.spans {
+        // The line's own style is the backdrop for every span in it —
+        // `Line::styled` sets it there rather than on each span, and dropping
+        // it would silently lose the style of any line built that way.
+        let style = line.style.patch(span.style);
+        match sgr_params(style, palette) {
+            Some(params) => {
+                let _ = write!(out, "\u{1b}[{params}m{}\u{1b}[0m", span.content);
+            }
+            None => out.push_str(&span.content),
+        }
+    }
+    out
+}
+
+/// [`line_to_ansi`] over a slice — the shape every caller actually wants,
+/// since the modules that produce lines produce them a block at a time.
+#[must_use]
+pub fn lines_to_ansi(lines: &[Line<'_>], palette: &AnsiPalette) -> Vec<String> {
+    lines.iter().map(|l| line_to_ansi(l, palette)).collect()
+}
+
+/// The `;`-joined SGR parameters for a style, or `None` when it asks for
+/// nothing visible (colour disabled, or an unstyled span).
+fn sgr_params(style: Style, palette: &AnsiPalette) -> Option<String> {
+    if !palette.color {
+        return None;
+    }
+    let mut params: Vec<String> = Vec::new();
+
+    for (modifier, code) in [
+        (Modifier::BOLD, "1"),
+        (Modifier::DIM, "2"),
+        (Modifier::ITALIC, "3"),
+        (Modifier::UNDERLINED, "4"),
+        (Modifier::REVERSED, "7"),
+        (Modifier::CROSSED_OUT, "9"),
+    ] {
+        if style.add_modifier.contains(modifier) {
+            params.push(code.to_string());
+        }
+    }
+
+    if let Some(fg) = style.fg
+        && palette.transparent_fg != Some(fg)
+        && let Some(code) = color_params(fg, false)
+    {
+        params.push(code);
+    }
+    if let Some(bg) = style.bg
+        && let Some(code) = color_params(bg, true)
+    {
+        params.push(code);
+    }
+
+    (!params.is_empty()).then(|| params.join(";"))
+}
+
+/// SGR parameters for one colour, or `None` for `Reset` (which is the absence
+/// of a colour, not a colour to select).
+fn color_params(color: Color, background: bool) -> Option<String> {
+    // Foreground codes; the background is the same table plus ten, which is
+    // how SGR is defined and is why one table serves both.
+    let base = match color {
+        Color::Reset => return None,
+        Color::Black => 30,
+        Color::Red => 31,
+        Color::Green => 32,
+        Color::Yellow => 33,
+        Color::Blue => 34,
+        Color::Magenta => 35,
+        Color::Cyan => 36,
+        Color::Gray => 37,
+        Color::DarkGray => 90,
+        Color::LightRed => 91,
+        Color::LightGreen => 92,
+        Color::LightYellow => 93,
+        Color::LightBlue => 94,
+        Color::LightMagenta => 95,
+        Color::LightCyan => 96,
+        Color::White => 97,
+        Color::Rgb(r, g, b) => {
+            let lead = if background { 48 } else { 38 };
+            return Some(format!("{lead};2;{r};{g};{b}"));
+        }
+        Color::Indexed(i) => {
+            let lead = if background { 48 } else { 38 };
+            return Some(format!("{lead};5;{i}"));
+        }
+    };
+    Some((base + if background { 10 } else { 0 }).to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,5 +280,85 @@ mod tests {
         assert_eq!(strip_ansi("done\u{1b}[1;3"), "done");
         // A trailing lone ESC is dropped.
         assert_eq!(strip_ansi("done\u{1b}"), "done");
+    }
+
+    // ── emission ───────────────────────────────────────────────────────────
+
+    use ratatui::text::Span;
+
+    /// The two halves of this module must invert each other: whatever
+    /// [`line_to_ansi`] adds, [`strip_ansi`] must take away and leave exactly
+    /// the visible text. This is the property that keeps the emitter honest
+    /// without pinning byte-exact escape sequences in every test.
+    #[test]
+    fn emitted_escapes_strip_back_to_the_visible_text() {
+        let line = Line::from(vec![
+            Span::styled("head", Style::new().fg(Color::Rgb(1, 2, 3))),
+            Span::raw(" plain "),
+            Span::styled(
+                "tail",
+                Style::new()
+                    .fg(Color::Green)
+                    .bg(Color::Indexed(240))
+                    .add_modifier(Modifier::BOLD | Modifier::ITALIC),
+            ),
+        ]);
+        let rendered = line_to_ansi(&line, &AnsiPalette::colored());
+        assert!(rendered.contains('\u{1b}'), "nothing was styled at all");
+        assert_eq!(strip_ansi(&rendered), "head plain tail");
+    }
+
+    #[test]
+    fn monochrome_emits_no_escapes_at_all() {
+        let line = Line::from(Span::styled(
+            "loud",
+            Style::new().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+        assert_eq!(line_to_ansi(&line, &AnsiPalette::monochrome()), "loud");
+    }
+
+    /// The reason [`AnsiPalette::transparent_fg`] exists: prose must be able to
+    /// keep the reader's own foreground while the structure around it stays
+    /// coloured. A palette that dropped *every* colour could not do this.
+    #[test]
+    fn transparent_fg_frees_prose_without_freeing_the_structure() {
+        let palette = AnsiPalette::colored().with_transparent_fg(Color::White);
+        let prose = Line::from(Span::styled("body", Style::new().fg(Color::White)));
+        assert_eq!(
+            line_to_ansi(&prose, &palette),
+            "body",
+            "the surface's own ink must emit no escape"
+        );
+
+        // Same colour, but the span also asks for bold: the modifier is not
+        // the foreground and must survive.
+        let heading = Line::from(Span::styled(
+            "H1",
+            Style::new().fg(Color::White).add_modifier(Modifier::BOLD),
+        ));
+        assert_eq!(line_to_ansi(&heading, &palette), "\u{1b}[1mH1\u{1b}[0m");
+
+        // And a different colour is untouched by the transparency rule.
+        let code = Line::from(Span::styled("fn", Style::new().fg(Color::Cyan)));
+        assert_eq!(line_to_ansi(&code, &palette), "\u{1b}[36mfn\u{1b}[0m");
+    }
+
+    /// `Line::styled` puts the style on the line, not the spans. Patching it
+    /// under each span's own style is what keeps such a line from rendering
+    /// bare — and the deck builds lines both ways.
+    #[test]
+    fn a_line_level_style_reaches_its_spans() {
+        let line = Line::styled("whole", Style::new().fg(Color::Red));
+        assert_eq!(line_to_ansi(&line, &AnsiPalette::colored()), "\u{1b}[31mwhole\u{1b}[0m");
+    }
+
+    #[test]
+    fn background_codes_are_the_foreground_table_plus_ten() {
+        assert_eq!(color_params(Color::Red, false).as_deref(), Some("31"));
+        assert_eq!(color_params(Color::Red, true).as_deref(), Some("41"));
+        assert_eq!(color_params(Color::White, false).as_deref(), Some("97"));
+        assert_eq!(color_params(Color::White, true).as_deref(), Some("107"));
+        // `Reset` is the absence of a colour, not a colour to select.
+        assert_eq!(color_params(Color::Reset, false), None);
     }
 }

--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -157,6 +157,29 @@ pub fn body_lines_inline(
     render_body(diff, path, cap, multi)
 }
 
+/// [`body_lines_inline`] dressed as ANSI strings for the plain surface
+/// (#2421), returning the same `(body, hidden)` pair.
+///
+/// The deck shows a capped diff and reveals the rest with ctrl+o. A scrollback
+/// line cannot be revisited, so the plain surface commits to the capped
+/// rendering and says how many lines it withheld — which is why `hidden` is
+/// returned here too rather than dropped: an unannounced truncation reads as
+/// "that was the whole change".
+///
+/// Prose transparency is deliberately *not* applied to a diff: every colour
+/// here is semantic (`+` green, `-` red, hunk headers, the intra-line
+/// highlight), so there is no "default ink" to yield to.
+#[must_use]
+pub fn body_lines_inline_ansi(
+    diff: &str,
+    path: Option<&str>,
+    cap: usize,
+    palette: &crate::ansi::AnsiPalette,
+) -> (Vec<String>, usize) {
+    let (lines, hidden) = body_lines_inline(diff, path, cap);
+    (crate::ansi::lines_to_ansi(&lines, palette), hidden)
+}
+
 fn render_body(
     diff: &str,
     path: Option<&str>,

--- a/crates/stella-tui/src/markdown.rs
+++ b/crates/stella-tui/src/markdown.rs
@@ -14,6 +14,7 @@
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::ansi::AnsiPalette;
 use crate::syntax;
 use crate::theme;
 
@@ -122,6 +123,24 @@ pub fn render(text: &str) -> Vec<Line<'static>> {
     }
 
     out
+}
+
+/// [`render`] dressed as ANSI strings, for a surface that writes bytes into a
+/// scrollback rather than cells into a frame (#2421).
+///
+/// The *parse* is the valuable part and there is exactly one of it: the plain
+/// surface in `stella-cli` used to print agent prose with a bare `println!`,
+/// so a reader of `stella run` — or of any supervised run's console log, which
+/// is the only transcript such a run ever has — saw literal `**asterisks**`
+/// and fence backticks. Reimplementing markdown there would have been a second
+/// parser to keep in step; this is the same one, differently dressed.
+///
+/// Callers pass [`AnsiPalette::transparent_fg`]`(`[`theme::INK`]`)` when their
+/// surface does not paint its own ground — see that field for why prose in
+/// particular must not be given an explicit colour.
+#[must_use]
+pub fn render_ansi(text: &str, palette: &AnsiPalette) -> Vec<String> {
+    crate::ansi::lines_to_ansi(&render(text), palette)
 }
 
 // ── Inline parsing ─────────────────────────────────────────────────────────

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -543,10 +543,23 @@ pub const INLINE_DIFF_CAP: usize = 20;
 pub use entry::THINKING_ROWS;
 
 /// Resolve a tool result's [`InlineDiffRef`] to the diff text it may render,
-/// or `None` when the reference went stale: the diff shown must be the one
-/// this call produced, so it only resolves while the path's `changes` counter
-/// still matches the seq recorded at fold time (a later mutation of the same
-/// path bumps it) and the path still carries a diff.
+/// or `None` when the reference can no longer be honoured.
+///
+/// The diff shown must be the one *this* call produced, so the lookup is by the
+/// `changes` seq recorded at fold time — never "the path's latest diff", which
+/// would misattribute an later edit's change to an earlier row.
+///
+/// It resolves for as long as that mutation is still remembered:
+/// [`FileState`] keeps the last
+/// [`DIFF_HISTORY`](crate::model::file_state::DIFF_HISTORY) diffs per path, so
+/// the common "edit the same file a few times in one turn" shape keeps every
+/// row's diff, and only the ones aged out past that depth — or evicted with
+/// their path at [`MAX_TRACKED_FILES`](crate::model::file_state::MAX_TRACKED_FILES)
+/// — degrade to naming their change.
+///
+/// This used to say the reference went stale the moment a later mutation
+/// bumped the counter, which described the behaviour before that history
+/// existed and read as though almost every diff were hidden.
 fn resolve_inline_diff<'a>(dref: &InlineDiffRef, files: &'a [FileState]) -> Option<&'a str> {
     files
         .iter()

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -531,7 +531,16 @@ pub(crate) fn render_slash_popup(
 /// Most styled diff lines a collapsed tool result shows inline before folding
 /// the rest behind ctrl+o — a mutation stays glanceable in the transcript
 /// without a large diff flooding it uninvited.
-pub(crate) const INLINE_DIFF_CAP: usize = 20;
+///
+/// Public because the plain surface renders the same capped diff (#2421) and
+/// a second number would be a second policy: "how much diff is glanceable" is
+/// one judgement about reading, not about ratatui.
+pub const INLINE_DIFF_CAP: usize = 20;
+
+/// Re-exported for the same reason as [`INLINE_DIFF_CAP`]: the plain surface
+/// previews a chain of thought to the same depth the deck does, and the depth
+/// is a reading judgement both surfaces should lose or keep together.
+pub use entry::THINKING_ROWS;
 
 /// Resolve a tool result's [`InlineDiffRef`] to the diff text it may render,
 /// or `None` when the reference went stale: the diff shown must be the one

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -152,7 +152,7 @@ fn plural(n: u64, one: &str, many: &str) -> String {
 /// the same height whether it is following a live thought or previewing a
 /// settled one — the stream stopping must not resize the block under the
 /// reader.
-const THINKING_ROWS: usize = 5;
+pub const THINKING_ROWS: usize = 5;
 
 /// The fold marker on a collapsed reasoning block. Sits *below* a settled
 /// preview (there is more after what you can see) and *above* a live tail


### PR DESCRIPTION
## What

Stella has two renderers over one `AgentEvent` stream. #66 ("Consolidate
duplicate TUI rendering surfaces") closed having consolidated only the
*wording*, and the rest of the divergence lived in a module comment and no
issue. This closes it, and adds the diff rendering the plain surface never had.

The surface this affects is not a rare fallback. `stella run` never opens the
deck at all (`main.rs`'s `Command::Run` arm), every supervised child writes here
because its stdout is a console *file* rather than a terminal, and
`stella daemon logs|attach` replay those bytes. For a great many runs this is
the only transcript that ever exists.

## Before / after

Before, a mutation printed one row and stopped, with the diff riding the very
same event unread:

```
  ± modified crates/stella-core/src/driver.rs
```

After:

```
  ── execute ────────────────────────────────────────────────

  ± modified crates/stella-core/src/driver.rs +2 −1
      14      pub fn step(&mut self) -> Result<Step, Error> {
      15 -        let budget = self.budget.remaining();
      15 +        let budget = self.budget.remaining()?;
      16 +        self.guard.observe(budget);
      17          self.dispatch(budget)
      18      }

  ✻ 7 lines
    The step loop never armed the dispatch timeout.
    Tools that block before their first poll are the gap.
    Check driver.rs first.
    Then settlement.rs.
    Then the bus.
    ⋯ 2 more

◈ What changed

The budget guard now runs observe() per step.

• armed the timeout
• covered by a witness
```

(Colour stripped for this description; in a terminal the gutter is grey, the
`-`/`+` pair sits on tinted grounds with the changed span picked out, and
context keeps its syntax colours.)

## The five changes

1. **`stella-cli/src/tui.rs` → `plain.rs`.** The module held no screen, no
   layout and no input loop — just `colored` and `println!`. The TUI is the
   Command Deck. The new name follows the decision that selects the surface
   (`term_policy::plain_fallback`, `--plain`, `STELLA_PLAIN`).

2. **Prose is markdown-rendered.** It was printed with a bare `println!`, so
   readers saw literal `**asterisks**`, `## headings` and fence backticks.

3. **Every stage draws a rule.** Only `Execute` printed anything before, and
   what it printed was the word `thinking…` — so a staged `stella run` rendered
   as an undifferentiated wall of tool calls with no sign that triage, planning,
   witness authoring, verification and the verdict had each happened.

4. **A chain of thought is previewed, bounded, instead of dropped.**
   `AgentEvent::Reasoning { .. } => {}` carried no comment, while every other
   suppression in `render_event` states its reason — the signature of an
   omission rather than a policy. It is now shown to the deck's own preview
   depth, with the withheld count named.

5. **A mutation prints its diff, capped.** The headline gap.

## Design: shared renderers, not a shared vocabulary

The existing `textline` module shares *wording*. This shares the actual
renderers, which is what stops the two surfaces drifting:

- `stella_tui::ansi` gains an **emit** half beside its stripper:
  `lines_to_ansi` renders `ratatui` `Line`s as SGR strings. `stella-cli` carries
  `ratatui` explicitly *not* for rendering (its `Cargo.toml` says so), so the
  ratatui types stay inside `stella-tui` and the CLI sees `Vec<String>` only.
- `markdown::render_ansi` and `diff::body_lines_inline_ansi` are thin wrappers
  over the existing parse and layout. There is no second markdown parser (the
  `snake_case`-outranks-`_emphasis_` rule alone is a page of reasoning) and no
  second diff layout.
- `INLINE_DIFF_CAP` and `THINKING_ROWS` are now shared rather than re-chosen:
  "how much is glanceable" is one reading judgement, not a ratatui detail.

**What is deliberately not shared.** Prose keeps the reader's own foreground.
The deck paints its own black ground and is entitled to assert `theme::INK`;
a scrollback line is drawn on whatever background the user chose, so the same
explicit white would be wrong about half the time. `AnsiPalette::transparent_fg`
renders the *structure* while leaving the *prose* alone. Likewise the deck can
expand a diff in place (ctrl+o) and a scrollback line cannot be revisited, so
this surface commits to one capped rendering — and prints the withheld count,
because a truncation nobody announces reads as the whole change.

Exemplar for the ANSI layer: `anstyle`/`nu-ansi-term`'s split between a parsed
style and its SGR serialisation — the style type does not know about escapes
until something asks it to render.

## Witness tests

Seven, each asserting *visible* text (styling can change; a silent drop cannot).
All fail on `main` — the renderer each one exercises is absent:

- `assistant_prose_is_rendered_not_printed_with_its_delimiters`
- `prose_keeps_the_readers_foreground_while_structure_keeps_colour`
- `every_stage_draws_a_rule_naming_itself`
- `reasoning_is_previewed_bounded_and_says_how_much_it_withheld`
- `reasoning_spends_its_budget_on_content_not_paragraph_breaks`
- `a_file_change_prints_its_diff_and_its_measured_counts`
- `a_large_diff_is_capped_and_names_the_lines_it_withheld`
- `a_read_prints_one_row_with_no_diff_and_no_counts`

Plus five in `stella_tui::ansi`, including the round-trip property that keeps
the emitter honest: whatever `line_to_ansi` adds, `strip_ansi` takes away.

Each printer splits into a pure composer so the tests read strings rather than
capturing stdout — the split `term_policy` already uses in this crate.

No tests were deleted or renamed.

## Notes for review

- **No baseline was raised.** `plain::accent()` is two characters longer than
  `tui::accent()`, which wrapped one call site and pushed `agent.rs` two lines
  over its ceiling. Fixed by importing `accent` by name, not by bumping the
  number. `check-file-size` reports "nothing went over by this change".
- **The deck is untouched.** All 820 `stella-tui` unit tests and every golden
  deck frame pass unchanged; the `stella-tui` changes are purely additive.
- `plain.rs` is now 1121 lines. Under the 1500 limit and not grandfathered, but
  it is the file to watch — the next substantial addition should land in a
  sibling module.
- **Counts are transported, never recounted.** `+n −m` comes off the event's own
  LCS measurement; `changed_region_diff` is a bounded, coarse rendering of the
  changed span and disagrees with the real delta by any shared line.

## Gate

`fmt`, `clippy --all-targets -D warnings`, `rustdoc -D warnings`, and the full
`stella-cli` + `stella-tui` suites: green. `make guards-fast` (every
toolchain-free guard, including `file-size`, `god-files`, `left-behind`,
`gate-parity`, `module-reachability`): green.

The full-workspace `make gate` was **not** run locally — a real `stella run` and
an arenabench watcher were live on this machine and a 22-crate test-profile
rebuild would have contended with them. Nothing outside `stella-cli` and
`stella-tui` is touched, and CI runs the rest.

Closes #2421

## Summary by Sourcery

Rename the CLI’s text-based renderer module to `plain` and extend it to share rendering capabilities with the Command Deck, including markdown, stage dividers, reasoning previews, and inline diffs for file changes.

New Features:
- Render assistant prose as markdown on the plain surface using the shared stella-tui markdown parser.
- Display per-stage divider rules and labels in the plain text transcript instead of only a generic execute thinking line.
- Preview chains of thought in the plain transcript with bounded, counted reasoning blocks matching the deck’s preview depth.
- Show capped inline diffs for file mutations in the plain transcript, including line-change counts and withheld-line markers.
- Provide ANSI emission utilities in stella-tui so markdown and diff renderers can output styled text as ANSI strings for non-TUI surfaces.

Enhancements:
- Unify event vocabulary and preview policies between the Command Deck and the plain surface by sharing textline wording, stage labels, markdown parsing, diff layout, and diff/preview caps.
- Introduce an ANSI palette abstraction that supports transparent foregrounds so prose can respect the user’s terminal theme while structural elements remain styled.
- Refactor CLI code to route all text-mode rendering through the renamed `plain` module, keeping the deck untouched but consolidating line-oriented rendering.
- Expose shared constants for inline diff cap and reasoning preview depth so both surfaces use the same reading-oriented limits.

Tests:
- Add witness-style tests for the plain surface verifying markdown rendering, stage rules, reasoning previews and truncation, diff rendering and capping, and read-only file events.
- Add round-trip tests for ANSI emission ensuring that emitted escape sequences strip back to the original visible text, and verifying palette behaviours like monochrome output and transparent foreground handling.