### PR TITLE
bench: no trial carries a spend or token ceiling, for any agent

### DIFF
--- a/arenabench/arenabench/agents.py
+++ b/arenabench/arenabench/agents.py
@@ -62,8 +62,9 @@ KNOB_MODEL = "model"
 KNOB_REASONING = "reasoning"
 KNOB_EFFORT = "effort"
 KNOB_BASE_URL = "base_url"
-KNOB_BUDGET = "budget"
-KNOB_MAX_TOKENS = "max_tokens"
+# No `budget` or `max_tokens` knob. They are not knobs an agent may or may not
+# honour any more — no engine can carry one, so there is nothing to declare and
+# nothing to report as unhonoured (#2411).
 KNOB_ROLES = "roles"
 
 
@@ -133,10 +134,6 @@ class AgentSpec:
         missed: list[str] = []
         if engine.base_url and KNOB_BASE_URL not in self.honours:
             missed.append("base_url")
-        if engine.budget_usd is not None and KNOB_BUDGET not in self.honours:
-            missed.append("budget_usd")
-        if engine.max_tokens is not None and KNOB_MAX_TOKENS not in self.honours:
-            missed.append("max_tokens")
         if engine.roles and KNOB_ROLES not in self.honours:
             missed.append("per-role pipeline config")
         if not engine.reasoning and KNOB_REASONING not in self.honours:
@@ -162,8 +159,6 @@ STELLA = AgentSpec(
             KNOB_REASONING,
             KNOB_EFFORT,
             KNOB_BASE_URL,
-            KNOB_BUDGET,
-            KNOB_MAX_TOKENS,
             KNOB_ROLES,
         }
     ),

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -323,7 +323,6 @@ def _cmd_template(args: argparse.Namespace) -> int:
                         "api": "openrouter",
                         "model": "z-ai/glm-5.2",
                         "effort": "medium",
-                        "max_tokens": 128000,
                         "roles": {
                             "judge": {"model": "openai/gpt-5.5", "effort": "xhigh"},
                             "triage": {"model": "z-ai/glm-4.7-flash", "effort": "low"},

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -41,6 +41,7 @@ from .model import (
     Engine,
     MatchSpec,
     RoleConfig,
+    declared_cap_keys,
     declared_flag,
     is_credential_name,
 )
@@ -121,6 +122,18 @@ def _declared_env(
 
 
 def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> Engine:
+    # A per-trial ceiling is refused outright, not dropped. Dropping it would
+    # run the match the author wanted UNCAPPED while their template still said
+    # otherwise, and the two would disagree about what was measured — the
+    # failure mode #2411 documents, in reverse. Name the key and say what to do
+    # instead, because the author had a real worry and it has a real answer.
+    for key in declared_cap_keys(raw):
+        problems.append(
+            f"{where}: engine.{key} is refused — a per-trial ceiling stops the "
+            "agent where the work finishes, so the score reports our limit as "
+            "its capability (#2411). Bound the spend at the provider key, "
+            "which fails a run visibly instead of truncating a trial into a loss"
+        )
     # Refused rather than coerced: a human wrote `bare_loop = "no"` and meant
     # something by it, and the one outcome a selector must never have is to
     # silently run the arm it was spelled to decline. `declared_flag` returns
@@ -151,6 +164,15 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
             if not isinstance(entry, dict):
                 problems.append(f"{where}: role {name!r} must be a table")
                 continue
+            # The same refusal one level down. A role table is the older way to
+            # spell an output ceiling and would otherwise be the hole left in
+            # the wall the engine-level check just built.
+            for key in declared_cap_keys(entry):
+                problems.append(
+                    f"{where}: engine.roles.{name}.{key} is refused for the same "
+                    "reason as the engine-level key — no role runs under a "
+                    "ceiling the comparator does not also run under (#2411)"
+                )
             role = RoleConfig.from_json(entry)
             if not role.is_empty:
                 roles[_role_key(name)] = role
@@ -161,12 +183,6 @@ def _engine_from_toml(raw: dict[str, Any], problems: list[str], where: str) -> E
         reasoning=reasoning,
         effort=str(raw.get("effort") or "high"),
         base_url=(str(raw["base_url"]).strip() or None) if raw.get("base_url") else None,
-        budget_usd=(
-            float(raw["budget_usd"]) if raw.get("budget_usd") not in (None, "") else None
-        ),
-        max_tokens=(
-            int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
-        ),
         bare_loop=bare_loop,
         roles=roles,
     )
@@ -484,10 +500,6 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
             # This agent *can* be routed off its default endpoint, so leave the
             # knob visible-but-commented rather than silently absent.
             out.append('  # base_url = "https://..."   # route this seat elsewhere')
-        if engine.max_tokens is not None:
-            out.append("  " + _line("max_tokens", engine.max_tokens))
-        if engine.budget_usd is not None:
-            out.append("  " + _line("budget_usd", engine.budget_usd))
         if engine.bare_loop:
             # Emitted only when true, so every existing template renders back
             # byte-identical and a saved match cannot gain an arm it never had.

--- a/arenabench/arenabench/harbor_agent.py
+++ b/arenabench/arenabench/harbor_agent.py
@@ -137,8 +137,13 @@ def arena_posture(
                 "effort": resolved.effort or "high",
                 "reasoning": "on" if resolved.reasoning else "off",
             }
-        if resolved.max_tokens:
-            entry["params"] = {"max_tokens": int(resolved.max_tokens)}
+        # No `params.max_tokens`. Omitting it is what asks for the model's own
+        # ceiling: the engine seeds `max_output_tokens` from the catalog entry
+        # and an explicit cap is the only thing that can lower it
+        # (`stella-cli/src/agent/engine.rs`, `tuned_engine_config` — "the
+        # DEFAULT is always the model's maximum"). Sending a number instead
+        # would require knowing every booked model's real ceiling, and picking
+        # one without knowing it is exactly what #2128 was.
         agents[role] = entry
 
         override_model = engine.role(role).model

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -32,12 +32,14 @@ __all__ = [
     "DIMENSIONS",
     "DIMENSIONS_BY_KEY",
     "EFFORTS",
+    "FORBIDDEN_CAP_KEYS",
     "ROLES",
     "Contestant",
     "Dimension",
     "Engine",
     "MatchSpec",
     "RoleConfig",
+    "declared_cap_keys",
     "is_credential_name",
     "parse_dotenv",
     "screen_env",
@@ -200,6 +202,47 @@ EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 #: ``default`` and say so in :attr:`AgentSpec.honours`.
 ROLES: tuple[str, ...] = ("default", "worker", "verifier", "triage")
 
+#: Engine keys that once pinned a per-trial ceiling. Declaring one is now a
+#: template error, and no type in this module has a field to hold it.
+#:
+#: A cap is not a tuning knob — it is a second experiment running inside the
+#: first, and it always terminates the run at the end, where the work finishes.
+#: Match ``5292a68cdabf`` is the witness (#2411): Stella was given
+#: ``budget_usd = 1.0`` while the comparator's was ``null``, and all three of
+#: its losses are the same event. Every one was killed by the guard at roughly
+#: a third of the 900s the task allowed, with the answer in reach —
+#: ``sqlite-with-gcov`` had already proved its instrumented build decoded real
+#: coverage counters and was denied on the step that put the binary on ``PATH``,
+#: which is the one assertion the grader then failed it for. Two ``git-multibranch``
+#: trials died at the moment they turned to verifying their own work. The
+#: scoreboard read 9/12 against 18/18 and was measuring the ceiling, not the agent.
+#:
+#: The rule the adapter already stated for output tokens — *never be the side
+#: that stops first* — is the same rule, and it generalises: a ceiling below
+#: what the other side may spend reports our own limit as their capability.
+#:
+#: This costs no spend protection. A wallet is guarded at the provider key,
+#: where exhaustion fails the run honestly and visibly, never mid-step inside a
+#: trial that then scores as a loss.
+FORBIDDEN_CAP_KEYS: tuple[str, ...] = ("budget_usd", "max_tokens")
+
+
+def declared_cap_keys(raw: Any) -> tuple[str, ...]:
+    """The :data:`FORBIDDEN_CAP_KEYS` a raw engine table declares.
+
+    Authoring surfaces call this and refuse what it returns; readers of
+    archived matches do not, because a spec that already ran capped must stay
+    loadable as the evidence it is.
+
+    A key present but empty still counts. ``budget_usd = ""`` reads as "no cap"
+    to the loaders below, so ignoring it here would let the word survive in a
+    committed template — and the next hand that fills the value in gets no
+    error at all.
+    """
+    if not isinstance(raw, dict):
+        return ()
+    return tuple(key for key in FORBIDDEN_CAP_KEYS if key in raw)
+
 
 @dataclass(frozen=True)
 class RoleConfig:
@@ -214,14 +257,12 @@ class RoleConfig:
     model: str | None = None
     reasoning: bool | None = None
     effort: str | None = None
-    max_tokens: int | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
             "model": self.model,
             "reasoning": self.reasoning,
             "effort": self.effort,
-            "max_tokens": self.max_tokens,
         }
 
     @classmethod
@@ -233,29 +274,15 @@ class RoleConfig:
                 return value.strip().lower() in ("on", "true", "yes", "1")
             return bool(value)
 
-        def _opt_int(value: Any) -> int | None:
-            if value in (None, ""):
-                return None
-            try:
-                return int(value)
-            except (TypeError, ValueError):
-                return None
-
         return cls(
             model=(str(raw["model"]).strip() or None) if raw.get("model") else None,
             reasoning=_opt_bool(raw.get("reasoning")),
             effort=(str(raw["effort"]).strip() or None) if raw.get("effort") else None,
-            max_tokens=_opt_int(raw.get("max_tokens")),
         )
 
     @property
     def is_empty(self) -> bool:
-        return (
-            self.model is None
-            and self.reasoning is None
-            and self.effort is None
-            and self.max_tokens is None
-        )
+        return self.model is None and self.reasoning is None and self.effort is None
 
 
 #: Stella's own truthy vocabulary (``crates/stella-cli/src/settings.rs``),
@@ -320,17 +347,6 @@ class Engine:
     effort: str = "high"
     #: Explicit base URL override. ``None`` uses the api's default route.
     base_url: str | None = None
-    #: Per-trial USD target handed to the agent, if it supports one.
-    budget_usd: float | None = None
-    #: Output-token ceiling per step. Leave ``None`` to take the model's own
-    #: maximum, which is nearly always right. A model spends up to whatever
-    #: ceiling it is handed, so a cap pinned BELOW its real one cuts the step
-    #: off mid-reasoning and the call comes back ``length`` with no answer and
-    #: no tool call. That is what #2128 actually was: not effort overrunning a
-    #: budget the model was told about — it is not supposed to do that — but a
-    #: cap we chose without knowing the model's real ceiling. See the Stella
-    #: adapter's note in ``posture.py`` for the measurement.
-    max_tokens: int | None = None
     #: Run the agent's raw step loop instead of its staged pipeline. For Stella
     #: that is ``--no-pipeline``, which settles triage, witness and verify at
     #: once because all three ARE the pipeline. Declared on the engine rather
@@ -385,7 +401,6 @@ class Engine:
             model=override.model or None,
             reasoning=self.reasoning if override.reasoning is None else override.reasoning,
             effort=override.effort or self.effort,
-            max_tokens=override.max_tokens or self.max_tokens,
         )
 
     def to_json(self) -> dict[str, Any]:
@@ -396,8 +411,6 @@ class Engine:
             "reasoning": self.reasoning,
             "effort": self.effort,
             "base_url": self.base_url,
-            "budget_usd": self.budget_usd,
-            "max_tokens": self.max_tokens,
             "bare_loop": self.bare_loop,
             "roles": {name: role.to_json() for name, role in self.roles.items()},
         }
@@ -422,12 +435,11 @@ class Engine:
             reasoning=declared_flag(raw.get("reasoning", True)) is not False,
             effort=str(raw.get("effort") or "high"),
             base_url=(str(raw["base_url"]) or None) if raw.get("base_url") else None,
-            budget_usd=(
-                float(raw["budget_usd"]) if raw.get("budget_usd") not in (None, "") else None
-            ),
-            max_tokens=(
-                int(raw["max_tokens"]) if raw.get("max_tokens") not in (None, "") else None
-            ),
+            # A cap key surviving in an archived `spec.json` is read past, never
+            # refused: `from_json` restores historical matches (`runner.py`'s
+            # match reload), and a match that RAN capped is exactly the evidence
+            # a reader needs. Refusal belongs on the authoring surfaces, which
+            # call `declared_cap_keys` — see that function for the split.
             # Closed on anything that does not declare a boolean: this side is
             # fed by round-tripped machine output, so a value neither `true`
             # nor `false` is corruption, and corruption must not select an arm.

--- a/arenabench/arenabench/presets.py
+++ b/arenabench/arenabench/presets.py
@@ -193,8 +193,8 @@ def _preset(key: str, worker: str, title: str, blurb: str) -> dict[str, Any]:
         "reasoning": True,
         "effort": _EFFORT,
         # No base_url: first-party Anthropic, authenticated by the
-        # subscription token. No budget_usd: Claude Code honours no spend cap,
-        # and on the plan the quota is the ceiling.
+        # subscription token. Claude Code honours no spend cap, and on the plan
+        # the quota is the ceiling.
     }
     stella_engine = {
         "api": "openrouter",
@@ -202,11 +202,11 @@ def _preset(key: str, worker: str, title: str, blurb: str) -> dict[str, Any]:
         # The parity invariant, by construction rather than by transcription.
         "reasoning": cc_engine["reasoning"],
         "effort": cc_engine["effort"],
-        # Fable-class output ceiling, same number on both routes (#1211 §6.2).
-        "max_tokens": 128000,
-        # Per-trial cap (becomes STELLA_BUDGET): one runaway trial cannot eat
-        # the other nine tasks' budget.
-        "budget_usd": 12.0,
+        # Neither seat carries a ceiling, and this preset is where that stopped
+        # being true by accident: the comparator above has never had one, while
+        # this seat used to declare `max_tokens = 128000` and
+        # `budget_usd = 12.0` — a handicap written three lines under the
+        # sentence explaining that the other side has none (#2411).
         "roles": {
             "verifier": {
                 "model": f"anthropic/{verifier}",

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -943,8 +943,11 @@ class MatchRunner:
         # The engine config the ArenaBench Stella adapter reads back.
         env[ARENA_ENGINE_ENV] = json.dumps(contestant.engine.to_json())
         engine = contestant.engine
-        if engine.budget_usd is not None:
-            env["STELLA_BUDGET"] = str(engine.budget_usd)
+        # `STELLA_BUDGET` is deliberately never exported. `_base_environment`
+        # scrubs every ambient `STELLA_*`, so not setting it here is the whole
+        # guarantee: no path reaches the agent with a session cap, and a trial
+        # ends because the work finished or the clock ran out — the two reasons
+        # that mean something about the agent (#2411).
         if engine.base_url:
             env["STELLA_BASE_URL"] = engine.base_url
         if engine.bare_loop:

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -71,7 +71,7 @@ from .credentials import (
     credentials_path,
     missing_required_credentials,
 )
-from .model import EFFORTS, ROLES, MatchSpec
+from .model import EFFORTS, ROLES, MatchSpec, declared_cap_keys
 from .presets import preset_listing
 from .recorder import preflight as recorder_preflight
 from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
@@ -113,6 +113,33 @@ LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "localhost", "::1", "[:
 
 def is_loopback(host: str) -> bool:
     return host.strip().lower() in LOOPBACK_HOSTS
+
+
+def _declared_caps(payload: dict[str, Any]) -> list[tuple[str, str]]:
+    """``(seat, key)`` for every per-trial ceiling a create payload declares.
+
+    Every seat and every role is reported rather than the first one found, so
+    an operator editing a two-seat match fixes both in one round trip instead
+    of discovering the second only after resubmitting.
+    """
+    found: list[tuple[str, str]] = []
+    raw_contestants = payload.get("contestants")
+    if not isinstance(raw_contestants, list):
+        return found
+    for index, contestant in enumerate(raw_contestants):
+        if not isinstance(contestant, dict):
+            continue
+        seat = str(contestant.get("name") or contestant.get("id") or f"seat {index}")
+        engine = contestant.get("engine")
+        found.extend((seat, f"engine.{key}") for key in declared_cap_keys(engine))
+        roles = engine.get("roles") if isinstance(engine, dict) else None
+        if isinstance(roles, dict):
+            for role_name, entry in roles.items():
+                found.extend(
+                    (seat, f"engine.roles.{role_name}.{key}")
+                    for key in declared_cap_keys(entry)
+                )
+    return found
 
 
 #: Ports `serve` sweeps looking for an arena that is already up. The default
@@ -334,6 +361,25 @@ class ArenaServer:
     def create_match(self, payload: dict[str, Any]) -> Any:
         payload = dict(payload)
         payload.setdefault("id", uuid.uuid4().hex[:12])
+        # Read off the raw payload, before `from_json`, which drops these keys
+        # silently so archived specs stay loadable. Creating a match is an
+        # authoring act, so here the silence would be the bug: the operator
+        # would be told the seat was configured and the run would ignore it.
+        capped = _declared_caps(payload)
+        if capped:
+            # The fourth refusal, and a sibling of the one below: both protect
+            # the meaning of the number rather than the apparatus. A ceiling
+            # only one seat carries stops that agent where the work finishes,
+            # and the scoreboard then reports our limit as its capability —
+            # measured in match 5292a68cdabf, where every one of the capped
+            # seat's three losses was the budget guard firing at roughly a
+            # third of the task's allowed wall clock (#2411).
+            raise ValueError(
+                "; ".join(f"{seat}: {key}" for seat, key in capped)
+                + " — per-trial ceilings are refused. Bound spend at the "
+                "provider key, which fails a run visibly instead of "
+                "truncating a trial into a loss"
+            )
         spec = MatchSpec.from_json(payload)
         # A seat's declared credential names resolve from the arena's own
         # environment first, then the saved credential set, then — for a seat

--- a/arenabench/matches/fable5-cc-vs-stella-10task.toml
+++ b/arenabench/matches/fable5-cc-vs-stella-10task.toml
@@ -92,8 +92,9 @@ color = "#FF6B9D"
   # xhigh timed out on every step budget it was given; medium finished.
   effort = "medium"
   # No base_url: this seat runs at Anthropic, authenticated by the subscription
-  # token. No budget_usd either — Claude Code does not honour a spend cap, and
-  # on the plan the marginal spend is zero; the plan's quota is the ceiling.
+  # token. No per-trial ceiling either — now the rule for every seat rather
+  # than a property of this one: ArenaBench refuses `budget_usd` and
+  # `max_tokens` outright (#2411).
 
   [contestant.env]
   # Names only — never values.
@@ -110,12 +111,9 @@ color = "#FFB000"
   model = "anthropic/claude-fable-5"
   reasoning = true
   effort = "medium"
-  # Fable's real output ceiling, same number on both routes (#1211 §6.2).
-  max_tokens = 128000
-  # Per-trial cap (becomes STELLA_BUDGET). Ten trials x $12 = $120 worst case,
-  # with per-trial isolation: one runaway trial cannot eat the other nine
-  # tasks' budget. In practice only the three hard trials approach the cap.
-  budget_usd = 12.0
+  # No ceiling on either axis, matching the seat above. The run's envelope is
+  # bounded at the provider key, where exhaustion fails the whole run visibly
+  # instead of truncating one trial into a loss.
 
   # Per-role overrides — the "full pipeline" arm. Every model named here is in
   # Stella's OFFLINE seed catalog under `openrouter`: the adapter pins

--- a/arenabench/matches/fable5-claude-code-vs-stella.toml
+++ b/arenabench/matches/fable5-claude-code-vs-stella.toml
@@ -62,9 +62,9 @@ color = "#FF6B9D"
   # produced that measurement — the wrong direction to raise effort in.
   effort = "medium"
   # No base_url: this seat runs at Anthropic itself, authenticated by the
-  # subscription token. No budget_usd either — Claude Code does not honour a
-  # spend cap, and on the plan the marginal spend is zero; the plan's own
-  # quota is the ceiling.
+  # subscription token. No per-trial ceiling either — and that is now every
+  # seat's rule rather than this one's property: ArenaBench refuses
+  # `budget_usd` and `max_tokens` outright (#2411).
 
   [contestant.env]
   # Names only — never values. Any ONE of these credentials the seat;
@@ -82,12 +82,9 @@ color = "#FFB000"
   model = "anthropic/claude-fable-5"
   reasoning = true
   effort = "medium"
-  # Fable's real output ceiling, same number on both routes (#1211 §6.2).
-  max_tokens = 128000
-  # Per-trial cap (becomes STELLA_BUDGET). Six trials x $16 = $96, inside the
-  # $100-per-agent envelope for the run, with per-trial isolation: one
-  # runaway trial cannot eat the other five tasks' budget.
-  budget_usd = 16.0
+  # No ceiling on either axis, matching the seat above. The run's envelope is
+  # bounded at the provider key, where exhaustion fails the whole run visibly
+  # instead of truncating one trial into a loss.
 
   # Per-role overrides — the "full pipeline" arm. Every model named here is in
   # Stella's OFFLINE seed catalog under `openrouter`: the adapter pins

--- a/arenabench/matches/glm52-claude-code-vs-stella.toml
+++ b/arenabench/matches/glm52-claude-code-vs-stella.toml
@@ -80,10 +80,10 @@ color = "#FFB000"
   # tasks with every failure a wall-clock timeout at 13-22s per step. Medium ran
   # 3.8-7.1s per step and took the same set to 4/5.
   effort = "medium"
-  # The model's real output ceiling. 64000 was carried over from a stale
-  # constant that claimed to be "the model's own ceiling".
-  max_tokens = 128000
-  budget_usd = 6.0
+  # No output ceiling and no per-trial budget: both are refused now (#2411).
+  # Omitting the ceiling is what asks for the model's own, which the engine
+  # seeds from the catalog — a number written here could only match it or sit
+  # below it, and below it is a handicap this seat's opponent never carries.
   base_url = "https://api.z.ai/api/coding/paas/v4"
 
   # Per-role overrides — this is the "full pipeline" arm. Every model named

--- a/arenabench/matches/sonnet5-cc-vs-stella-bare-loop.toml
+++ b/arenabench/matches/sonnet5-cc-vs-stella-bare-loop.toml
@@ -100,9 +100,11 @@ color = "#FF6B9D"
   # xhigh timed out on every step budget it was given; medium finished.
   effort = "medium"
   # No base_url: this seat runs at Anthropic, authenticated by the
-  # subscription token. No budget_usd either — Claude Code honours no spend
-  # cap, and on the plan the marginal spend is zero; the plan's quota is the
-  # ceiling.
+  # subscription token. No per-trial ceiling either — and now that is the rule
+  # for every seat rather than a property of this one. ArenaBench refuses
+  # `budget_usd` and `max_tokens` outright (#2411), because the arm that
+  # carries one stops where the work finishes and the scoreboard reads that as
+  # the other arm being better.
 
   [contestant.env]
   # Names only — never values.
@@ -119,17 +121,13 @@ color = "#FFB000"
   model = "anthropic/claude-sonnet-5"
   reasoning = true
   effort = "medium"
-  # Sonnet 5's real output ceiling, the same number on both routes — asserted
-  # as an equality in stella-model's catalog tests, not transcribed here.
-  max_tokens = 128000
+  # No output ceiling: omitting it is what asks for the model's own, which the
+  # engine seeds from the catalog. Naming a number here could only ever match
+  # that ceiling or sit under it, and the second one is a handicap.
+  #
   # The whole point of this file: raw step loop, no triage, no witness, no
   # verify, no second model anywhere in the run.
   bare_loop = true
-  # Per-trial cap (becomes STELLA_BUDGET), with per-trial isolation so one
-  # runaway trial cannot eat the other nine tasks' budget. Held at the
-  # pipeline arm's $12 rather than cut: a bare loop spends less per trial
-  # (one role, not three), and a cap that binds would measure the cap.
-  budget_usd = 12.0
 
   [contestant.env]
   required = ["OPENROUTER_API_KEY"]

--- a/arenabench/matches/stella-solo-vs-recorded-bar.toml
+++ b/arenabench/matches/stella-solo-vs-recorded-bar.toml
@@ -1,0 +1,83 @@
+# arenabench match — Stella ALONE, measured against a bar already on record
+#
+#   local:  arenabench run matches/stella-solo-vs-recorded-bar.toml --progress
+#   cloud:  arenabench cloud run matches/stella-solo-vs-recorded-bar.toml
+#
+# One seat. There is no Claude Code arm in this file, and that is the point.
+#
+# Claude Code is the number Stella has to beat, not a subject under study. A
+# bar only has to be established once; re-running it re-measures a constant,
+# and every trial spent on it is a trial Stella's arm did not get. The bar for
+# these four tasks was established by match `5292a68cdabf` and is quoted below
+# rather than re-earned.
+#
+#   THE BAR — Claude Code (Opus 5, xhigh), match 5292a68cdabf
+#
+#     git-multibranch            4/4 scored   (1 trial aborted, excluded)
+#     sqlite-with-gcov           5/5 scored   (1 trial aborted, excluded)
+#     regex-log                  5/5 scored
+#     large-scale-text-editing   4/4 scored   (2 trials aborted, excluded)
+#     ------------------------------------------------------------
+#     total                     18/18
+#
+#   Aborts are trials the rig killed, not trials the agent failed, and they are
+#   excluded from both the numerator and the denominator. A trial that never
+#   ran is not a win — see the "a dead arm scores as a win" defect class.
+#
+# Stella's arm in that same match scored 9/12, and that number is not usable as
+# a capability comparison: its seat carried `budget_usd = 1.0` while the
+# comparator's was `null`, and all three losses were the budget guard firing at
+# roughly a third of each task's 900s allowance, every one within a step or
+# four of finishing (#2411). Per-trial ceilings are refused now, which is why
+# this run is worth doing at all — it is the first measurement of these tasks
+# where nothing stops Stella before the work does.
+#
+# Re-run the comparator only when the task set, the worker model, or the
+# harness changes in a way that makes the recorded number inapplicable — and
+# say which, out loud, before spending.
+#
+# SIZING. Checked before writing, not after: the OpenRouter account had $35.72
+# remaining on 2026-08-08 ($1,110 purchased, $1,074.28 used). At the ~$1.20 a
+# trial measured in 5292a68cdabf, 24 trials is ~$29 and fits; the 6 attempts
+# below are chosen from that number, not from a preference for six. Re-check
+# the balance before running — if it has moved, move `attempts` with it.
+#
+# This file carries no secrets. Export OPENROUTER_API_KEY before running; in
+# the cloud it is read from an SSM parameter under /arenabench/, and a seat
+# whose credential is absent is refused at submit time rather than scored as a
+# loss.
+
+[match]
+name = "stella solo: opus 5, no ceilings, against the recorded bar"
+dataset = "terminal-bench-2.1"
+tasks = [
+  "sqlite-with-gcov",
+  "git-multibranch",
+  "regex-log",
+  "large-scale-text-editing",
+]
+# Six per task = 24 trials. Repeats go here, on the arm under test, because
+# this is where the variance is and where resolving it buys something.
+attempts = 6
+concurrency = 4
+
+[[contestant]]
+id = "stella"
+name = "Stella (Opus 5, xhigh)"
+agent = "stella"
+color = "#FFB000"
+
+  [contestant.engine]
+  api = "openrouter"
+  model = "anthropic/claude-opus-5"
+  reasoning = true
+  # `xhigh` matches what the recorded bar ran at, which is the whole reason the
+  # bar is quotable instead of needing a fresh comparator.
+  effort = "xhigh"
+  # No `budget_usd` and no `max_tokens`: both are refused (#2411). Omitting the
+  # output ceiling is what asks for the model's own, which the engine seeds
+  # from the catalog.
+
+  [contestant.env]
+  # Names only — never values.
+  required = ["OPENROUTER_API_KEY"]

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -115,7 +115,7 @@ class TestEngine:
     def test_round_trips_through_json(self):
         engine = Engine(
             api="anthropic", model="claude-opus-5", effort="max", reasoning=False,
-            max_tokens=64000, roles={"worker": RoleConfig(model="claude-sonnet-5")},
+            roles={"worker": RoleConfig(model="claude-sonnet-5")},
         )
         assert Engine.from_json(engine.to_json()) == engine
 

--- a/arenabench/tests/test_matches.py
+++ b/arenabench/tests/test_matches.py
@@ -24,7 +24,7 @@ import pytest
 
 from arenabench.agents import resolve_agent
 from arenabench.config import match_from_toml
-from arenabench.model import MatchSpec
+from arenabench.model import Engine, MatchSpec
 
 MATCHES = Path(__file__).resolve().parent.parent / "matches"
 
@@ -53,8 +53,8 @@ class TestCommittedMatches:
 
         `unhonoured` reports only knobs the operator actually set, so this
         fails exactly when a file describes a configuration its seat never
-        received — a `base_url` on an agent with nowhere to put one, a
-        `budget_usd` on an agent that honours no spend cap.
+        received — a `base_url` on an agent with nowhere to put one, or a
+        per-role pipeline on an agent that runs a single loop.
         """
         for seat in _spec(path).contestants:
             missed = resolve_agent(seat.agent).unhonoured(seat.engine)
@@ -76,3 +76,97 @@ class TestCommittedMatches:
                     f"{path.name}: seat {seat.id!r} runs the bare loop but pins "
                     f"roles {sorted(seat.engine.roles)}"
                 )
+
+    def test_no_committed_template_declares_a_per_trial_ceiling(
+        self, path: Path
+    ) -> None:
+        """The regression this repository actually shipped, checked on the files.
+
+        All four of these templates once carried the same asymmetry: a Claude
+        Code seat whose comment said the comparator honours no spend cap, and a
+        Stella seat a few lines below declaring `max_tokens` and `budget_usd`.
+        Match `5292a68cdabf` ran that shape, and all three of Stella's losses
+        were the budget guard firing rather than the agent failing (#2411).
+
+        `_engine_from_toml` refuses the keys now, so a template carrying one
+        fails `_spec` before reaching this assertion. What this adds is a check
+        on the *text*, which still catches the key arriving inside a table the
+        loader has not been taught to walk.
+        """
+        offenders = [
+            f"line {number}: {line.strip()}"
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            )
+            # A commented mention is the file explaining the rule rather than
+            # breaking it, and every one of these templates now carries such a
+            # sentence.
+            if not line.lstrip().startswith("#")
+            and ("budget_usd" in line or "max_tokens" in line)
+        ]
+        assert not offenders, f"{path.name} declares a per-trial ceiling: {offenders}"
+
+
+class TestPerTrialCeilingsAreRefused:
+    """#2411: a ceiling one seat carries and the other does not is a handicap.
+
+    The witness for the change. Before it, every declaration below parsed into
+    an `Engine` field, was exported to the agent, and decided matches.
+    """
+
+    def _template(self, engine_extra: dict, *, role: bool = False) -> dict:
+        engine: dict = {"api": "openrouter", "model": "z-ai/glm-5.2"}
+        if role:
+            engine["roles"] = {"worker": engine_extra}
+        else:
+            engine.update(engine_extra)
+        return {
+            "match": {"dataset": "terminal-bench-2.1"},
+            "contestant": [
+                {"id": "stella", "name": "Stella", "agent": "stella", "engine": engine}
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        "key, value", [("budget_usd", 1.0), ("max_tokens", 64000)]
+    )
+    def test_an_engine_level_ceiling_is_refused_by_name(
+        self, key: str, value: object
+    ) -> None:
+        with pytest.raises(Exception) as caught:
+            match_from_toml(self._template({key: value}))
+        assert key in str(caught.value)
+
+    def test_a_role_level_output_cap_is_refused_too(self) -> None:
+        """The hole an engine-level check alone would leave open."""
+        with pytest.raises(Exception) as caught:
+            match_from_toml(self._template({"max_tokens": 64000}, role=True))
+        assert "max_tokens" in str(caught.value)
+
+    def test_an_empty_ceiling_is_still_refused(self) -> None:
+        """`budget_usd = ""` reads as "no cap" to a loader and as a live knob to
+        the next person editing the file, so the word is what gets refused."""
+        with pytest.raises(Exception) as caught:
+            match_from_toml(self._template({"budget_usd": ""}))
+        assert "budget_usd" in str(caught.value)
+
+    def test_an_archived_spec_that_ran_capped_still_loads(self) -> None:
+        """Refusal is for authoring; reading history is not authoring.
+
+        `runner.py` restores a match from its `spec.json`, and the specs worth
+        reading most are precisely the ones that ran under a cap —
+        `5292a68cdabf` is the evidence for this change. Refusing them would
+        make the argument unreadable in support of its own conclusion.
+        """
+        engine = Engine.from_json(
+            {
+                "api": "openrouter",
+                "model": "z-ai/glm-5.2",
+                "budget_usd": 1.0,
+                "max_tokens": 32000,
+            }
+        )
+        assert engine.model == "z-ai/glm-5.2"
+        assert not hasattr(engine, "budget_usd")
+        assert "budget_usd" not in engine.to_json()
+        assert "max_tokens" not in engine.to_json()

--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -527,7 +527,7 @@ from, `openrouter/` prefix and all. The prefix is part of the hashed dict, so
 different digests; an abbreviated label here is what let three rows pair a
 prefixed left column with a bare right one.
 
-| model | published as (`judge`) | now (`verifier`) |
+| model | published as (`judge`) | after the rename (`verifier`) |
 |---|---|---|
 | `openrouter/deepseek/deepseek-v4-pro` | `9d7ad135…` | `0d732c3e…` |
 | `openrouter/z-ai/glm-5.2` | `7e9da633…` | `41f9be3b…` |
@@ -538,9 +538,10 @@ prefixed left column with a bare right one.
 | `openrouter/anthropic/claude-fable-5` | `18a1ba22…` | `e5059092…` |
 
 Every left-column value reproduces from the pre-rename `_benchmark_engine_posture`
-for the model string on its row, and every right-column value from the current
-one. `bench/terminal-bench-2.1-protocol.md` records the same model strings for
-the first three.
+for the model string on its row, and every right-column value from the posture
+as it stood between that rename and 8.4.5 below — which moved them all again.
+`bench/terminal-bench-2.1-protocol.md` records the same model strings for the
+first three.
 
 What this does and does not invalidate:
 
@@ -557,6 +558,46 @@ What this does and does not invalidate:
   holding the old default will fail preflight — that is the gate working.
 
 Anyone re-freezing an arm across this boundary should quote both digests.
+
+#### 8.4.5 The output cap left the posture entirely (#2411)
+
+The third boundary, and the first where a digest moved because the arm actually
+changed rather than because a key was renamed.
+
+`params.max_tokens` is no longer sent for any role, on any model. Omitting it is
+what asks for the model's own ceiling: `tuned_engine_config` seeds
+`max_output_tokens` from the catalog entry, and only an explicit cap can lower
+it. The posture therefore stopped carrying a number whose sole correct value
+was a copy of one the engine already reads from the authority.
+
+What forced it was the dollar axis of the same rule. Match `5292a68cdabf` ran
+Stella under `budget_usd = 1.0` against a comparator configured `null`, and all
+three of Stella's losses were the budget guard firing — at roughly a third of
+each task's 900s allowance, every one of them within a step or four of done.
+The `sqlite-with-gcov` trial had already proved its instrumented build decoded
+real coverage counters and was denied on the step that would have put the
+binary on `PATH`; that missing binary is the single assertion the grader failed
+it for. ArenaBench now refuses `budget_usd` and `max_tokens` outright, and the
+frozen posture holds neither.
+
+| model | after the rename | now (uncapped) |
+|---|---|---|
+| `anthropic/claude-sonnet-5` | `c8536200…` | `6c7fc70c…` |
+| `anthropic/claude-fable-5` | `642746e4…` | `2099a1a4…` |
+| `openrouter/anthropic/claude-fable-5` | `e5059092…` | `b5755ccf…` |
+
+What this does and does not invalidate:
+
+- **No published number is wrong, and none becomes comparable.** Every recorded
+  run ran the posture its own digest describes. A Sonnet arm published under
+  `c8536200…` asked for 64,000 output tokens; one published under `6c7fc70c…`
+  asks for the model's 128,000. Those are different arms and the digests say so
+  — which is the mechanism working, not a wrinkle to smooth over.
+- **A re-run is not a regression test against an older number.** Comparing a
+  post-#2411 solve rate with a pre-#2411 one compares two configurations, so
+  quote both digests and say which is which.
+- `preflight_effort.sh` now defaults `EXPECT_DIGEST` to `6c7fc70c`. A rig still
+  holding `c8536200` will fail preflight — that is the gate working.
 
 ### 8.5 The measured baseline
 

--- a/bench/evidence/run/preflight_effort.sh
+++ b/bench/evidence/run/preflight_effort.sh
@@ -26,7 +26,10 @@ set -uo pipefail
 
 MODEL="${1:-claude-sonnet-5}"
 TIER="${2:-xhigh}"
-EXPECT_DIGEST="${3:-c8536200}"
+# The uncapped Sonnet posture (READINESS.md 8.4.5). Was `c8536200`, which is
+# the same arm still asking for a 64,000-token output cap; a rig pinned to that
+# fails preflight, which is the gate doing its job.
+EXPECT_DIGEST="${3:-6c7fc70c}"
 ENV_FILE="${TB_ANTHROPIC_ENV_FILE:-$HOME/.env.harbor-anthropic.local}"
 REPO="${TB_REPO:-$HOME/stella}"
 

--- a/bench/harbor_adapter/README.md
+++ b/bench/harbor_adapter/README.md
@@ -51,7 +51,8 @@ STELLA_BUILD_GIT_SHA="$claim_sha" \
 
 export STELLA_BINARY="$PWD/target/x86_64-unknown-linux-gnu/release/stella"
 export STELLA_SOURCE_COMMIT="$claim_sha"
-export STELLA_BUDGET=0.17
+# No STELLA_BUDGET: a trial runs under no per-trial spend cap, and the launcher
+# refuses one if it is exported (#2411).
 export STELLA_DISABLE_REFLECTION=1
 export PATH="$claim_venv/bin:$PATH"
 ```
@@ -104,7 +105,7 @@ test "$(command -v harbor)" = "$claim_venv/bin/harbor"
 test "$(harbor --version)" = 0.6.1
 test -x "$STELLA_BINARY"
 test "${#STELLA_SOURCE_COMMIT}" = 40
-test "$STELLA_BUDGET" = 0.17
+test -z "${STELLA_BUDGET:-}"
 test "$STELLA_DISABLE_REFLECTION" = 1
 umask 077
 claim_adapter_root="$claim_repo/bench/harbor_adapter"

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -168,7 +168,6 @@ _TELEMETRY_INCOMPLETE = "stella-adapter: TELEMETRY-INCOMPLETE"
 
 # Defaults when neither Harbor nor the environment specify a value.
 _DEFAULT_MODEL = "anthropic/claude-fable-5"
-_DEFAULT_BUDGET = "5.0"
 
 # What a run with no per-trial spend cap discloses as its cap. A word rather
 # than an omission, because the metadata dict drops `None` values entirely and
@@ -1378,31 +1377,38 @@ class StellaAgent(BaseInstalledAgent):
         return value
 
     def _configured_budget(self) -> str | None:
-        """Resolve the per-trial spend cap, where **empty means no cap**.
+        """Always ``None`` — a benchmark trial runs under no spend cap.
 
-        ``--budget`` is ``Option<f64>`` in the CLI and is documented as "omit to
-        meter spend for the cost summary without ever blocking", so "no cap" is
-        a state the contract already has — reachable only by *omitting* the
-        flag. ``_configured_value`` cannot express it: ``os.environ.get`` treats
-        an exported empty string as a present value, so ``_DEFAULT_BUDGET``
-        never fires and the empty string is forwarded as though it were a
-        number. It then reaches clap's ``parse_budget``, which rejects it
-        (```` is not a number``) and exits 2 **before the turn starts** — a
-        failure Harbor can only record as ``NonZeroAgentExitCodeError``, which
-        is arithmetically indistinguishable from the agent failing the task.
+        This used to resolve a cap, defaulting to ``5.0`` when nothing was
+        exported, with "no cap" reachable only by exporting an empty string.
+        The reasoning for allowing that state was already correct and is now
+        simply the whole rule: *a head-to-head against a comparator that has no
+        spend ceiling has to say "no ceiling" on this side too, or the cap is a
+        difference between the agents that is not the one being measured.*
 
-        A head-to-head against a comparator that has no spend ceiling has to be
-        able to say "no ceiling" on this side too, or the cap is a difference
-        between the agents that is not the one being measured. Empty resolves to
-        ``None`` and every caller omits: the flag, the forwarded variable, and
-        the recorded value alike. ``None`` in the manifest reads as "no cap",
-        which is the truth; ``_DEFAULT_BUDGET`` there would be a number no run
-        ever enforced.
+        #2411 is what closed the argument. In match ``5292a68cdabf`` the capped
+        seat lost three trials, and every one was the guard firing rather than
+        the agent failing: at roughly a third of each task's 900s, each within a
+        step or four of finishing. The ``sqlite-with-gcov`` trial had already
+        proved its instrumented build decoded real coverage counters, and was
+        denied on the step that would have put the binary on ``PATH`` — the one
+        assertion the grader then failed it for.
+
+        A non-empty ``STELLA_BUDGET`` is refused rather than ignored. Ignoring
+        it would let an operator believe a run was bounded when it was not,
+        which is the same class of mistake pointed the other way.
         """
-        budget = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)
-        if budget is None or not str(budget).strip():
-            return None
-        return budget
+        declared = self._configured_value("STELLA_BUDGET", None)
+        if declared is not None and str(declared).strip():
+            raise RuntimeError(
+                f"STELLA_BUDGET={declared!r} is refused: a benchmark trial runs "
+                "under no spend cap, because a ceiling only one side carries "
+                "stops that agent where the work finishes and the score reads "
+                "it as the other agent being better (#2411). Bound spend at the "
+                "provider key, which fails a run visibly instead of truncating "
+                "a trial into a loss."
+            )
+        return None
 
     def _configured_turn_budget(self) -> str | None:
         """Resolve the turn deadline in seconds, or ``None`` for no deadline.

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -138,26 +138,19 @@ _CANDIDATES_CEILING = 5
 # timeout and reports it as a task failure.
 _MODEL_TIMEOUT_CEILING = 21_600
 
-# The output cap, per model, and the silence ceiling that has to absorb it.
+# There is no output-cap table here any more, and its absence is load-bearing.
 #
-# These were one shared number (64000) until the Fable ceiling set was
-# approved (#1211 §6.2). One number was only ever right by coincidence: it is
-# the *model's* ceiling, and models differ. Fable 5 answers up to 128,000
-# output tokens; capping its trials at 64,000 stopped it at half the height
-# the comparator is allowed to fill, and the score then reported that as a
-# capability difference rather than as our own ceiling.
+# It held one number per model, pinned against `catalog.rs` by
+# `TestOutputCeilingParity` so the two could not drift. That guarded the right
+# hazard with the wrong instrument: the safe value of a benchmark output cap is
+# always exactly the model's ceiling, and a table whose every correct entry is
+# a copy of another table is a synchronisation problem invented for no gain.
+# Sending nothing gets the same number from the authority itself (#2411).
 #
-# Keyed by the bare model slug, so a model reached directly
-# (`anthropic/claude-fable-5`) and the same model reached through a gateway
-# (`openrouter/anthropic/claude-fable-5`) get the same ceilings. Booking route
-# is not a model property.
-#
-# `TestOutputCeilingParity` pins the caps here against
-# `crates/stella-model/src/catalog.rs`, which is the authority. Change the
-# catalog and this must follow, which is the point: the two numbers used to be
-# able to drift apart silently, both still looking deliberate.
-_DEFAULT_OUTPUT_CAP = 64_000
-_OUTPUT_CAP_BY_SLUG = {"claude-fable-5": 128_000}
+# What survives is the check that the authority HAS a number:
+# `test_every_bookable_model_has_a_seeded_ceiling`. A booked model missing its
+# catalog ceiling falls back to the engine's global 16384, which is the one way
+# an uncapped posture can still run capped.
 
 # The models an arm can actually book, by bare slug: worker, the two verifiers,
 # and triage. `TestOutputCeilingParity` checks the caps above against
@@ -180,38 +173,22 @@ _BENCHMARKED_SLUGS = frozenset(
     }
 )
 
-# Caps deliberately set BELOW the model's own ceiling, and why.
+# There is no sub-ceiling rationale map either, and it is worth recording what
+# it taught before it went.
 #
-# The default rule is that an arm asks for the model's whole budget — "never be
-# the side that stops first". Every exception is a real decision someone made,
-# so it is written here with its reason rather than living as a literal that
-# merely looks intentional. A slug absent from this map must match its catalog
-# ceiling exactly; that is what `TestOutputCeilingParity` enforces.
-_SUB_CEILING_RATIONALE: dict[str, str] = {
-    "claude-sonnet-5": (
-        "64,000 on purpose, not inherited (#1290). Sonnet 5's own ceiling is "
-        "128,000 — the catalog said 64,000 for months and that was wrong, but "
-        "it was wrong as a statement about the MODEL, not as a statement about "
-        "this comparison. 64,000 is where Claude Code's steps were measured "
-        "stopping, twice landing on it exactly and still finishing the task. "
-        "Matching what the other side actually does is the whole point of a "
-        "head-to-head, so this number stays while the catalog's moves. "
-        "Correcting the catalog is what made this an explicit choice rather "
-        "than a coincidence the two numbers used to share."
-    ),
-    "kimi-k3": (
-        "64,000 against a 131,072 ceiling. This row carried no ceiling at all "
-        "until #1290 seeded it from models.dev, so the posture never diverged "
-        "from anything — the divergence appeared the moment the catalog "
-        "learned a number, which is exactly when it should become a decision "
-        "rather than stay a silence. Kept at the default because kimi-k3 is "
-        "booked as arm B's VERIFIER: it emits a verdict, not a solution, so the "
-        "cap has never bound and 'never be the side that stops first' is a "
-        "claim about the worker's budget. Raising it would also owe a "
-        "`_MODEL_TIMEOUT_BY_SLUG` entry derived from an observed token rate "
-        "this model has never been measured at."
-    ),
-}
+# It let a cap sit below the model's ceiling when someone wrote down why, and
+# both of its entries were honest. The Sonnet 5 one even had the strongest
+# argument available: cap at 64,000 because that is where the comparator's
+# steps were measured stopping, and matching the other side is what a
+# head-to-head is for.
+#
+# It is still the wrong shape. "Where the comparator was measured stopping" is
+# not a ceiling the comparator was given — Claude Code is handed none — it is
+# where a model chose to stop on the tasks someone happened to measure. Turning
+# that observation into OUR limit is how a measurement becomes a handicap while
+# every comment around it still reads as deliberate. A rationale map cannot
+# catch that, because a well-argued entry is exactly what it is designed to
+# accept (#2411).
 
 # The timeout is DERIVED from the cap, not chosen independently, which is why
 # it lives in the same table. It bounds silence between stream fragments, so it
@@ -242,7 +219,7 @@ _ENGINE_DEFAULT_MODEL_TIMEOUT_SECS = 816
 
 # A benchmarked slug with NO `_MODEL_TIMEOUT_BY_SLUG` row inherits the 816s
 # engine default — and that inherit must read as a decision, not an omission
-# (#2070). Same pattern as `_SUB_CEILING_RATIONALE` above: every silence is
+# (#2070). Same pattern the removed sub-ceiling map used: every silence is
 # written down with its reason, so the next slug added to
 # `_BENCHMARKED_SLUGS` fails the suite until someone decides. Deliberately
 # NOT a posture row: writing `model_timeout_secs: 816` explicitly was
@@ -279,9 +256,6 @@ def _model_slug(model: str) -> str:
     return model.rsplit("/", 1)[-1].strip().lower()
 
 
-def default_output_cap(model: str) -> int:
-    """The output-token cap this model's benchmark posture uses."""
-    return _OUTPUT_CAP_BY_SLUG.get(_model_slug(model), _DEFAULT_OUTPUT_CAP)
 
 
 def default_model_timeout(model: str) -> int | None:
@@ -545,19 +519,16 @@ def _benchmark_engine_posture(
     every posture recorded before the knobs were reachable at all.
 
     ``model_timeout_secs`` is the same shape again, for the ceiling that used to
-    be the exception (#1211 §6.2). The output cap is set per role below and the
-    turn budget is a per-trial flag, but the per-generation silence ceiling was
-    an engine constant — so a Fable-class arm, which needs it scaled with the
-    output cap or it merely stops on the timeout instead, could not be
-    expressed as a posture at all. It is now a key like any other: selecting it
-    changes the digest, leaving it unset reproduces every historical one.
+    be the exception (#1211 §6.2). It is the last per-generation ceiling this
+    posture still sets: the output cap and the turn budget are both gone
+    (#2411), leaving the model's catalog maximum and the task's own wall clock.
+    It is a key like any other — selecting it changes the digest, leaving it
+    unset reproduces every historical one.
     """
     selected_model = model.strip()
     if not selected_model or "/" not in selected_model:
         raise ValueError("benchmark model must be a non-empty provider/model spec")
     selected_effort = _validated_worker_effort(worker_effort)
-    # The model's own ceilings, unless the operator selected otherwise below.
-    output_cap = default_output_cap(selected_model)
     posture: dict[str, Any] = {
         "default_model": selected_model,
         "allowed_models": [selected_model],
@@ -595,53 +566,42 @@ def _benchmark_engine_posture(
         # exception to it: it emits a three-line classification and never edits
         # the workspace, so raising it would change what Stella *is* rather than
         # what it was allowed to spend.
-        # `params.max_tokens` raises the engine's 16384 output cap, and at
-        # xhigh it is load-bearing rather than a tuning knob. Measured, not
-        # assumed: in the first xhigh smoke, 2 of 3 Stella trials died with
+        # No role carries `params.max_tokens`, and its ABSENCE is the setting.
         #
-        #   output_tokens=16384, tool_calls=0
-        #   "reached its output-token limit before producing any visible
-        #    response — its budget was likely spent on reasoning"
+        # The engine seeds `max_output_tokens` from the model's catalog entry
+        # and nothing but an explicit cap can lower it — "the DEFAULT is always
+        # the model's maximum" (`stella-cli/src/agent/engine.rs`,
+        # `tuned_engine_config`). So omitting the key asks for the model's own
+        # ceiling on every role, on every model, without this file having to
+        # know what that number is. Writing one here could only ever match the
+        # catalog or sit under it, and the history below is four years of
+        # rediscovering that the second one is a handicap:
         #
-        # The engine default carries a comment saying 16k was itself a raise
-        # from 8k for exactly this failure on glm-5.2, and names per-model caps
-        # as the real fix — which is the accurate reading. The model is not
-        # overrunning a budget it was told about; it is being cut off at a
-        # number we picked without knowing its real ceiling, so the step ends
-        # mid-reasoning with no tool call at all. Effort raises how much of the
-        # ceiling gets spent, but the ceiling is the thing that has to be right.
+        #   16384 -> 32000 -> 64000, each raise chasing the same failure —
+        #   a step ending with `output_tokens` exactly at the cap and
+        #   `tool_calls=0`, the model cut off mid-reasoning with no visible
+        #   answer. On the gate, four trials died at exactly 32000; Claude
+        #   Code passed all four on the same model, same API, same effort,
+        #   spending 45,001, 64,000, 64,000 and 25,965 output tokens. Two
+        #   landed on precisely its ceiling and still emitted the tool call.
         #
-        # 64000, which is the model's own ceiling and therefore the
-        # comparator's. The previous value was 32000, held there because
-        # `model_timeout` was 600s and a 64000-token step would not fit inside
-        # it — one self-imposed ceiling justifying another. Both moved
-        # together; `model_timeout` is now 816s, and neither binds first.
+        # Each fix moved one ceiling while the others held, because the cap,
+        # `model_timeout` and the turn budget are one budget and the rule
+        # governing all three is the same: never be the side that stops first.
+        # #2411 finished the thought — a per-trial dollar budget is that same
+        # ceiling wearing a different unit, and ArenaBench now refuses one.
         #
-        # The 32000 value was falsified directly. On the gate, four trials
-        # ended on a step that emitted exactly 32000 output tokens with zero
-        # tool calls. Claude Code passed all four of those tasks (reward 1.0)
-        # on the same model, same API and same effort, and its winning steps
-        # on them spent 45,001, 64,000, 64,000 and 25,965 output tokens. Two
-        # landed on precisely 64,000 — its ceiling — and still had room to
-        # emit the tool call. Sonnet fills whatever budget it is given in
-        # either agent; the only variable is who stops it first.
+        # `model_timeout` does not become the new binding ceiling. It bounds
+        # IDLE SILENCE between stream fragments, never elapsed time, so a
+        # generation that keeps streaming is never cut by it however long it
+        # runs (see `_ENGINE_DEFAULT_MODEL_TIMEOUT_SECS`).
         #
-        # That is also why 16384 -> 32000 did not fix truncation and 64000
-        # "merely traded truncation for a model_timeout": each attempt moved
-        # one ceiling while the others held. The output cap, `model_timeout`
-        # and the turn budget are one budget, and the rule that sets all three
-        # is the same — never be the side that stops first.
-        #
-        # This is not compute handed to one side. Claude Code does not cap
-        # itself, so every number below the model's ceiling was a Stella-side
-        # handicap and removing it restores parity rather than breaking it.
-        # `triage` keeps the engine default: it runs at low effort and emits a
-        # three-line classification, so the cap was never near binding for it.
+        # This hands compute to nobody: Claude Code does not cap itself, so
+        # every number below the model's ceiling was a Stella-side handicap.
         "agents": {
             "default": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": output_cap},
             },
             # Only the worker's tier moves with the arm. `default` stays at
             # `xhigh` deliberately: it governs roles with no explicit entry
@@ -651,12 +611,10 @@ def _benchmark_engine_posture(
             "worker": {
                 "effort": selected_effort,
                 "reasoning": "on",
-                "params": {"max_tokens": output_cap},
             },
             "verifier": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": output_cap},
             },
             "triage": {"effort": "low", "reasoning": "off"},
         },

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -45,13 +45,54 @@ _CANONICAL_DATASET_ARGUMENT = (
     "terminal-bench/terminal-bench-2-1@"
     "sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a"
 )
-_CANONICAL_BUDGET = "0.17"
+# A FORECAST, not a cap. Nothing enforces it: no trial runs under a per-trial
+# ceiling (#2411), and the only bound that can stop spending is the dedicated
+# key's hard limit below. It exists so a pre-registered intent states what the
+# run is expected to cost before it runs, and so the analyzer can check the
+# published claim against what was declared.
+#
+# Derived from measurement rather than chosen. In match 5292a68cdabf, Stella's
+# four trials that finished under the old $1.00 cap spent $0.6554, $0.8306,
+# $0.9553 and $0.9659 — mean $0.85. The other eight are censored: they hit the
+# cap, so their true cost is only known to exceed $1.00, and the three that
+# lost were each a step or four from done. $1.20 sits above the censored bound
+# with room for the tail, which is the honest direction to err for a number
+# whose only job is to not under-state what a run will cost.
+#
+# The old value was `0.17`, and it was an enforced cap. Reading it as a
+# forecast now would be a 7x under-statement — see `_DEDICATED_KEY_HARD_LIMIT_USD`
+# for why that arithmetic matters.
+_CANONICAL_PER_TRIAL_FORECAST_USD = 1.20
 _CANONICAL_DISABLE_REFLECTION = "1"
 _CANONICAL_ADAPTER_VERSION = "0.6.0"
 _CANONICAL_HARBOR_VERSION = "0.6.1"
 _CANONICAL_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _CANONICAL_PROVIDER_ROUTE_POLICY = "openrouter-auto"
-_DEDICATED_KEY_HARD_LIMIT_USD = 180.0
+# The only bound that can actually stop a claim run spending, now that no
+# trial carries one (#2411). It sits at the provider, so exhausting it fails
+# the run visibly rather than truncating a trial into a loss — which is the
+# whole reason a wallet is guarded here and never inside a trial.
+#
+# It is now load-bearing arithmetic rather than a backstop, and it moved from
+# $180 to $600 because of it. The confirmatory stage requests 445 trials: at
+# the frozen $0.17 cap that projected to $75.65, comfortably inside $180
+# *because the cap made it so*, and at the measured forecast above it projects
+# to $534. The old limit did not bound the run's cost — it bounded how much of
+# each task the agent was allowed to finish, and the projection only fit
+# because trials were being stopped short.
+#
+# So this is not new spending appetite; it is the same run, priced honestly for
+# the first time. It is also a PROVISIONING REQUIREMENT, not an authorisation:
+# on 2026-08-08 the account behind this key had $35.72 left of $1,110, so a
+# confirmatory stage cannot run at any per-trial price until it is funded.
+#
+# Nothing here spends money or grants permission to. The real gate is the
+# live-credit check in `_verify_public_paid_intent`, which reads the key's
+# actual remaining credit rather than this constant — so an unfunded key fails
+# preflight instead of launching and abandoning trials that would then score as
+# losses. This number only says what the key must be provisioned to before the
+# stage is runnable at all.
+_DEDICATED_KEY_HARD_LIMIT_USD = 600.0
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _OPENROUTER_KEYS_URL = "https://openrouter.ai/api/v1/keys"
 _OPENROUTER_CREDITS_URL = "https://openrouter.ai/api/v1/credits"
@@ -269,7 +310,7 @@ _INTENT_FIELDS = frozenset(
         "attempts_per_task",
         "n_concurrent_trials",
         "retry_max_retries",
-        "per_trial_budget_usd",
+        "per_trial_forecast_usd",
         "artifacts",
         "execution",
         "provider_key",
@@ -1125,7 +1166,7 @@ def _validate_current_intent(
         or intent.get("attempts_per_task") != int(options["--n-attempts"][0])
         or intent.get("n_concurrent_trials") != int(options["--n-concurrent"][0])
         or intent.get("retry_max_retries") != int(options["--max-retries"][0])
-        or intent.get("per_trial_budget_usd") != float(_CANONICAL_BUDGET)
+        or intent.get("per_trial_forecast_usd") != float(_CANONICAL_PER_TRIAL_FORECAST_USD)
         or intent.get("preregistration_commit") != subject_commit
     ):
         raise RuntimeError(
@@ -1677,7 +1718,11 @@ def _validate_confirmatory_manifest(
         "agent_version": runtime_identity["agent_version"],
         "adapter_version": runtime_identity["adapter_version"],
         "adapter_sha256": runtime_identity["adapter_sha256"],
-        "budget_usd": float(_CANONICAL_BUDGET),
+        # `None` is the disclosure, not an omission: the SUT genuinely runs
+        # under no per-trial cap (#2411). The forecast lives on the intent,
+        # where it describes what the run is expected to cost; putting a number
+        # here would describe a ceiling no trial was ever held to.
+        "budget_usd": None,
         "disable_reflection": True,
         "base_url": runtime_identity["base_url"],
         "provider_route_policy": runtime_identity["provider_route_policy"],
@@ -1954,7 +1999,7 @@ def _historical_outcomes_by_job_id(
         "attempts_per_task",
         "n_concurrent_trials",
         "retry_max_retries",
-        "per_trial_budget_usd",
+        "per_trial_forecast_usd",
         "preregistration_commit",
     )
     nullable_outcome_fields = _OUTCOME_FIELDS - {
@@ -2118,8 +2163,8 @@ def _prior_public_intent_expectation(
     requested = _finite_nonnegative_number(
         intent.get("requested_trials"), label=f"prior {stage} requested trials"
     )
-    budget = _finite_nonnegative_number(
-        intent.get("per_trial_budget_usd"), label=f"prior {stage} trial budget"
+    forecast = _finite_nonnegative_number(
+        intent.get("per_trial_forecast_usd"), label=f"prior {stage} trial forecast"
     )
     return {
         "kind": stage,
@@ -2128,7 +2173,7 @@ def _prior_public_intent_expectation(
         "runtime_identity": _runtime_identity_from_intent(intent),
         "provider_key": dict(intent["provider_key"]),
         "prior_stage_outcome": prior_stage_outcome,
-        "projected_spend_usd": requested * budget,
+        "projected_spend_usd": requested * forecast,
         "intent_sha256": digest,
     }
 
@@ -2261,7 +2306,11 @@ def _readiness_replay_reasons(
         "adapter_sha256": artifacts.get("adapter_sha256"),
         "harbor_version": artifacts.get("harbor_version"),
         "harbor_sha256": artifacts.get("harbor_sha256"),
-        "budget_usd": intent.get("per_trial_budget_usd"),
+        # Not the intent's forecast: this identity is matched against what the
+        # trials actually ran under, and they ran under no cap (#2411). Reading
+        # the forecast in here would assert every row was capped at a number
+        # that never reached the agent.
+        "budget_usd": None,
         "disable_reflection": execution.get("disable_reflection"),
         "base_url": execution.get("base_url"),
         "provider_route_policy": execution.get("provider_route_policy"),
@@ -2343,7 +2392,14 @@ def _calibration_replay_reasons(
         or intent.get("attempts_per_task") != 2
         or intent.get("n_concurrent_trials") != 3
         or intent.get("retry_max_retries") != 0
-        or intent.get("per_trial_budget_usd") != sut["budget_usd"]
+        # The forecast is checked against the frozen constant, not against
+        # `sut["budget_usd"]`. Those two used to be the same number because a
+        # cap was both the projection and the enforcement; now the SUT declares
+        # `None` (no cap) and the intent declares what the run should cost, so
+        # tying them to each other would only assert `None == 1.20` (#2411).
+        or intent.get("per_trial_forecast_usd")
+        != float(_CANONICAL_PER_TRIAL_FORECAST_USD)
+        or sut["budget_usd"] is not None
         or intent.get("artifacts") != expected_artifacts
         or intent.get("execution") != expected_execution
         or intent.get("preregistration_commit")
@@ -2798,7 +2854,7 @@ def _validate_live_provider_key(
     ):
         raise RuntimeError("live OpenRouter management key record differs from intent")
     projected = float(intent["requested_trials"]) * float(
-        intent["per_trial_budget_usd"]
+        intent["per_trial_forecast_usd"]
     )
     projected_remaining = live_remaining - projected
     if projected_remaining < -1e-9:
@@ -3560,9 +3616,18 @@ def _verifier_env_name() -> str:
 
 def _validate_claim_environment(environ: Mapping[str, str]) -> tuple[Path, str]:
     """Validate immutable claim controls and the exact host Stella artifact."""
-    if environ.get("STELLA_BUDGET") != _CANONICAL_BUDGET:
+    # Inverted by #2411: this used to require the exact frozen cap, and now
+    # requires that there be none. A claim run is where a per-trial ceiling
+    # does the most damage — it measures an agent in order to publish the
+    # number, and a trial the guard stops publishes our ceiling as the agent's
+    # limit.
+    if str(environ.get("STELLA_BUDGET") or "").strip():
         raise RuntimeError(
-            f"secure launcher requires exact STELLA_BUDGET={_CANONICAL_BUDGET}"
+            "secure launcher requires STELLA_BUDGET to be unset: a claim run "
+            "carries no per-trial spend cap. The spend bound is the dedicated "
+            f"provider key's ${_DEDICATED_KEY_HARD_LIMIT_USD:.2f} hard limit, "
+            "which fails the run visibly instead of truncating a trial into a "
+            "loss."
         )
     if environ.get("STELLA_DISABLE_REFLECTION") != _CANONICAL_DISABLE_REFLECTION:
         raise RuntimeError(

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -285,7 +285,6 @@ class TestBuildCommand:
         # Global flags must precede the `run` subcommand; `--output-format`
         # is a flag OF `run` since stella#1493 and must follow it.
         assert cmd.index("--model") < cmd.index("run")
-        assert cmd.index("--budget") < cmd.index("run")
         assert cmd.index("--output-format") > cmd.index("run")
         assert cmd[:3] == [
             _INSTALL_PATH,
@@ -293,13 +292,14 @@ class TestBuildCommand:
             "anthropic/claude-fable-5",
         ]
         assert cmd[cmd.index("--output-format") + 1] == "stream-json"
-        assert cmd[cmd.index("--budget") + 1] == "5.0"  # default budget
+        # No `--budget`, ever: a trial runs under no spend cap (#2411).
+        assert "--budget" not in cmd
         assert cmd[-5:] == ["run", "--output-format", "stream-json", "--", "Fix the bug"]
         assert "--base-url" not in cmd  # not set
 
     def test_env_overrides_and_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("STELLA_MODEL", "zai/glm-5.2")
-        monkeypatch.setenv("STELLA_BUDGET", "10.0")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("STELLA_BASE_URL", "https://api.z.ai/api/coding/paas/v4")
         agent = _bare_agent()
         agent.model_name = None  # env should win when Harbor didn't set one
@@ -307,7 +307,7 @@ class TestBuildCommand:
         cmd = agent._build_command("Add a feature")
 
         assert cmd[cmd.index("--model") + 1] == "zai/glm-5.2"
-        assert cmd[cmd.index("--budget") + 1] == "10.0"
+        assert "--budget" not in cmd
         assert cmd[cmd.index("--base-url") + 1] == (
             "https://api.z.ai/api/coding/paas/v4"
         )
@@ -474,17 +474,24 @@ class TestNoBudgetCap:
 
         assert "--budget" not in agent._build_command("Fix the bug")
 
-    def test_unset_budget_still_takes_the_development_default(
+    def test_unset_budget_is_no_cap_rather_than_a_development_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No cap must be *opt-in*. Unset keeps the cap it always had."""
+        """No cap is the only state now — it used to be opt-in.
+
+        Unset resolved to `_DEFAULT_BUDGET` ("5.0"), so a trial run without a
+        deliberate `STELLA_BUDGET=""` carried a ceiling nobody chose for it.
+        Match `5292a68cdabf` is what that costs: three losses, every one the
+        guard firing at roughly a third of the task's allowed wall clock with
+        the work all but done (#2411).
+        """
         monkeypatch.delenv("STELLA_BUDGET", raising=False)
         agent = _bare_agent()
         agent.model_name = "openrouter/z-ai/glm-5.2"
 
         cmd = agent._build_command("Fix the bug")
 
-        assert cmd[cmd.index("--budget") + 1] == "5.0"
+        assert "--budget" not in cmd
 
     def test_empty_budget_is_not_forwarded_into_the_container(
         self, monkeypatch: pytest.MonkeyPatch
@@ -501,16 +508,22 @@ class TestNoBudgetCap:
 
         assert "STELLA_BUDGET" not in agent._forwarded_env()
 
-    def test_a_cap_that_is_set_is_still_forwarded(
+    def test_a_cap_that_is_set_is_refused_rather_than_forwarded(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Refused loudly, not dropped quietly.
+
+        Silently ignoring an exported cap would leave an operator believing a
+        run was bounded when it was not — the same class of mistake as running
+        capped without meaning to, pointed the other way. The message names
+        the variable and where the bound belongs instead.
+        """
         monkeypatch.setenv("STELLA_BUDGET", "0.17")
         agent = _bare_agent()
         agent.model_name = "openrouter/z-ai/glm-5.2"
 
-        assert agent._forwarded_env()["STELLA_BUDGET"] == "0.17"
-        cmd = agent._build_command("Fix the bug")
-        assert cmd[cmd.index("--budget") + 1] == "0.17"
+        with pytest.raises(RuntimeError, match="STELLA_BUDGET"):
+            agent._build_command("Fix the bug")
 
     def test_no_cap_is_recorded_as_no_cap_rather_than_as_the_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -592,13 +605,14 @@ class TestForwardedEnv:
             "model" not in role and "provider" not in role
             for role in posture["agents"].values()
         )
-        # `xhigh` matches the comparator and the raised cap travels with the
-        # tier: at `xhigh` the 16384 default is spent before any tool call.
+        # `xhigh` matches the comparator, and no role carries `params` at all:
+        # the absent output cap is what asks for the model's own ceiling, which
+        # at `xhigh` is the difference between a step that emits a tool call and
+        # one that spends its whole budget reasoning (#2411).
         for role in ("default", "worker", "verifier"):
             assert posture["agents"][role] == {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 64000},
             }
         assert posture["agents"]["triage"] == {"effort": "low", "reasoning": "off"}
         assert json.loads(normalized) == posture
@@ -606,7 +620,7 @@ class TestForwardedEnv:
         # edits land here deliberately. Keep it in step with the superseding
         # table in bench/READINESS.md, not the protocol's earlier `max` table.
         assert digest == (
-            "0d732c3e42a394a059be359de78ed153eb840477b946f167b8a0f3048023ff84"
+            "1191911e2bc5aeef2949f0592a0c3d2da31f55e05b464018a8440febe0e94bd3"
         )
 
     def test_excludes_all_provider_keys_and_selects_only_effective_provider(
@@ -621,13 +635,13 @@ class TestForwardedEnv:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-real")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-real")
         monkeypatch.setenv("STELLA_MODEL", "anthropic/claude-fable-5")
-        monkeypatch.setenv("STELLA_BUDGET", "5.0")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("_ADAPTER_TEST_SENTINEL", "not-a-key")
 
         env = _bare_agent()._forwarded_env()
 
         assert "STELLA_MODEL" not in env
-        assert env["STELLA_BUDGET"] == "5.0"
+        assert "STELLA_BUDGET" not in env
         assert "ANTHROPIC_API_KEY" not in env
         assert "OPENAI_API_KEY" not in env
         assert "_ADAPTER_TEST_SENTINEL" not in env
@@ -1384,7 +1398,7 @@ class TestRun:
     def test_mounted_internal_stream_is_source_of_truth_and_is_not_overwritten(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         source_envelope = _trajectory_envelope()
         durable_stream = _stream_for(source_envelope)
@@ -1462,7 +1476,7 @@ class TestRun:
     def test_nonzero_exit_persists_stream_context_and_atif_before_raising(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         agent = _bare_agent()
         agent.logs_dir = tmp_path
@@ -1484,7 +1498,7 @@ class TestRun:
                 assert command[command.index("--base-url") + 1] == (
                     "https://openrouter.ai/api/v1"
                 )
-                assert env["STELLA_BUDGET"] == "0.17"
+                assert "STELLA_BUDGET" not in env
                 assert env["STELLA_DISABLE_REFLECTION"] == "1"
                 assert env["STELLA_NO_ENV_FILE"] == "1"
                 assert env["STELLA_NO_SETTINGS"] == "1"
@@ -1531,7 +1545,7 @@ class TestRun:
         assert trajectory.agent.extra["binary_sha256_verified_in_container"] is True
         assert trajectory.agent.extra["source_commit"] == "d9caba12359a"
         assert trajectory.agent.extra["adapter_version"] == _ADAPTER_VERSION
-        assert trajectory.agent.extra["budget_usd"] == "0.17"
+        assert trajectory.agent.extra["budget_usd"] == "unbounded"
         assert trajectory.agent.extra["credential_handoff"] == "anonymous-fd"
         assert trajectory.agent.extra["launcher_controls"] == {
             "process_invocation": "docker-compose-direct-argv",
@@ -1556,7 +1570,7 @@ class TestRun:
         assert context.metadata["stella_binary_sha256_verified_in_container"] is True
         assert context.metadata["stella_source_commit"] == "d9caba12359a"
         assert context.metadata["stella_adapter_version"] == _ADAPTER_VERSION
-        assert context.metadata["stella_budget_usd"] == "0.17"
+        assert context.metadata["stella_budget_usd"] == "unbounded"
         assert context.metadata["stella_disable_reflection"] == "1"
         assert context.metadata["stella_reflection_policy"] == (
             "disabled_for_ephemeral_benchmark"
@@ -1824,7 +1838,9 @@ class TestPopulateContext:
         assert ctx.metadata["stella_steps"] == 2
         assert ctx.metadata["stella_return_code"] == 0
         assert ctx.metadata["stella_adapter_version"] == "0.6.0"
-        assert ctx.metadata["stella_budget_usd"] == "5.0"
+        # `unbounded`, not a number: no trial runs under a spend cap (#2411),
+        # and the manifest must not name a ceiling that was never in force.
+        assert ctx.metadata["stella_budget_usd"] == "unbounded"
         assert ctx.metadata["stella_disable_reflection"] == "1"
         assert ctx.metadata["stella_host_credential_source"] == ("environment-fallback")
         assert ctx.metadata["stella_host_credential_bundle_count"] == 0

--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -165,7 +165,7 @@ class TestRolesConfigReachesTheDeclaration:
         nothing had examined — for a run whose engine had an independent author
         the whole time.
         """
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
 
@@ -191,7 +191,7 @@ class TestRolesConfigReachesTheDeclaration:
         was diagnosed by opening `stella_engine_posture` and
         `stella_assurance_tiers` side by side in one `result.json`.
         """
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
 
@@ -213,7 +213,7 @@ class TestRolesConfigReachesTheDeclaration:
         used to call the base builder's inputs — which for a roles-config run
         describes a posture the run would never have used.
         """
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
         (tmp_path / "stella-events.jsonl").write_text(

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -42,11 +42,10 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     resolve_model_timeout,
 )
 
-# Imported from the module rather than the package: these two are internals of
-# the posture's ceiling policy, not part of what the adapter re-exports.
+# Imported from the module rather than the package: an internal of the
+# posture's ceiling policy, not part of what the adapter re-exports.
 from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
     _BENCHMARKED_SLUGS,
-    _SUB_CEILING_RATIONALE,
 )
 
 
@@ -335,14 +334,18 @@ class TestAttemptCountArms:
         """The one digest an external gate already checks by prefix.
 
         `bench/evidence/run/preflight_effort.sh` defaults `EXPECT_DIGEST` to
-        this value and `bench/READINESS.md` §8.4.3 registers it. Pinning it
+        this value and `bench/READINESS.md` §8.4.5 registers it. Pinning it
         here means a posture change is caught in unit tests rather than by a
         preflight on the rig, where the feedback costs a run.
+
+        It moved once, from `c8536200`, when the output cap left the posture
+        (#2411). That is the mechanism working: an arm that asks for a
+        different budget is a different arm and must not reuse the old hash.
         """
         _posture, _normalized, digest = _benchmark_engine_posture(
             "anthropic/claude-sonnet-5"
         )
-        assert digest.startswith("c8536200")
+        assert digest.startswith("6c7fc70c")
 
     def test_each_selector_moves_the_digest_and_only_its_own_key(self) -> None:
         """Two arms, two hashes — and neither disturbs the rest of the posture."""
@@ -490,7 +493,7 @@ class TestModelTimeoutArm:
         # again from this arm's own test so a regression here cannot be read as
         # someone else's failure.
         assert _benchmark_engine_posture("anthropic/claude-sonnet-5")[2].startswith(
-            "c8536200"
+            "6c7fc70c"
         )
 
     def test_a_selected_timeout_lands_in_the_digest_and_moves_nothing_else(
@@ -543,13 +546,15 @@ class TestModelTimeoutArm:
         with pytest.raises(ValueError, match="model timeout must be between"):
             resolve_model_timeout("86400")
 
-    def test_the_three_ceilings_can_be_selected_together(self) -> None:
-        """The point of the knob: one posture that scales the whole budget.
+    def test_selecting_the_silence_ceiling_adds_no_output_cap(self) -> None:
+        """The knob scales the one ceiling left, and cannot smuggle back another.
 
-        A Fable-class arm raises the output cap AND the silence ceiling that
-        has to absorb it. Expressing only one is how `16384 -> 32000 -> 64000`
-        each relocated the cliff instead of removing it — the recorded history
-        of this very posture.
+        It used to be checked as a set: a Fable-class arm raised the output cap
+        AND the silence ceiling that absorbs it, because expressing only one is
+        how `16384 -> 32000 -> 64000` each relocated the cliff instead of
+        removing it. Removing the cap ended that sequence (#2411), so what this
+        now pins is the other direction — selecting a timeout must not
+        reintroduce a `max_tokens` on any role.
         """
         posture, _normalized, _digest = _benchmark_engine_posture(
             self._MODEL, model_timeout_secs=1572
@@ -558,63 +563,69 @@ class TestModelTimeoutArm:
         capped = [
             role
             for role, agent in posture["agents"].items()
-            if "params" in agent and "max_tokens" in agent["params"]
+            if "max_tokens" in (agent.get("params") or {})
         ]
-        assert sorted(capped) == ["default", "verifier", "worker"]
+        assert capped == []
 
 
 class TestFableCeilingSet:
-    """The approved Fable ceiling set (#1211 §6.2): 128,000 output, 1,572s.
+    """What is left of the Fable ceiling set (#1211 §6.2) after #2411.
 
-    Both ceilings are properties of the model now, not one shared constant.
-    One shared number was only ever right by coincidence — it is the model's
-    own ceiling, and models differ. Fable 5 answers up to 128,000 output
-    tokens, so capping its trials at Sonnet's 64,000 stopped it at half the
-    height the comparator is allowed to fill, and the score reported that as
-    a capability difference rather than as our own ceiling.
+    It was two ceilings, 128,000 output and 1,572s of silence. The output
+    half is gone with every other cap: 128,000 was Fable's own maximum, which
+    is exactly what the engine takes from the catalog when nothing is sent, so
+    the posture was restating the authority and owning a copy that could drift.
+
+    The silence ceiling stays, and matters more rather than less. It is the
+    one per-generation ceiling still set here, and it now has to absorb a
+    generation nothing else bounds.
     """
 
-    def test_fable_gets_both_approved_ceilings(self) -> None:
+    def test_fable_keeps_its_silence_ceiling_and_asks_for_no_cap(self) -> None:
         posture, _normalized, _digest = _benchmark_engine_posture(
             "anthropic/claude-fable-5"
         )
         for role in ("default", "worker", "verifier"):
-            assert posture["agents"][role]["params"]["max_tokens"] == 128_000
+            assert "max_tokens" not in (posture["agents"][role].get("params") or {})
         assert posture["model_timeout_secs"] == 1_572
 
-    def test_the_timeout_is_never_left_behind_when_the_cap_moves(self) -> None:
-        """The two ceilings ship together or the raise does nothing.
+    def test_an_uncapped_generation_still_has_a_ceiling_to_absorb_it(self) -> None:
+        """The half of the old pairing that survives, and why it survives.
 
-        Raising the cap alone relocates the cliff instead of removing it: the
-        step stops on the timeout rather than the cap, which looks the same in
-        the results and is just as much us stopping first. This is the
-        recorded history of this posture — 16384 -> 32000 -> 64000 each moved
-        one ceiling while the others held — so it gets a test, not a comment.
+        The rule was that the cap and the timeout ship together, because
+        raising one alone relocates the cliff rather than removing it — the
+        recorded history of this posture, where 16384 -> 32000 -> 64000 each
+        moved one ceiling while the others held.
+
+        Removing the cap outright is the end of that sequence, not another
+        step in it: the generation is now bounded by the model's own maximum.
+        But Fable is the model whose maximum is large enough to have needed a
+        bespoke silence ceiling in the first place, so that row must not be
+        swept away with the cap it was derived from.
         """
         for model in ("anthropic/claude-fable-5", "openrouter/anthropic/claude-fable-5"):
             posture, _normalized, _digest = _benchmark_engine_posture(model)
-            raised = posture["agents"]["worker"]["params"]["max_tokens"] > 64_000
-            assert raised, f"{model} should carry the raised cap"
             assert posture.get("model_timeout_secs") is not None, (
-                f"{model} raised its output cap without raising the silence "
-                "ceiling that has to absorb it"
+                f"{model} lost the silence ceiling that has to absorb a "
+                "generation now bounded only by the model's own maximum"
             )
 
-    def test_sonnet_is_untouched_and_its_registered_digest_holds(self) -> None:
-        """The approval covered Fable. Sonnet's arm must be bit-identical.
+    def test_sonnet_asks_for_no_cap_and_its_new_digest_is_registered(self) -> None:
+        """Sonnet's arm moved too, and that is the point of the change.
 
-        Its comparator stops at 64,000 — Claude Code landed steps on exactly
-        that number twice and still emitted the tool call — so parity says
-        Sonnet stays. `c8536200…` is registered in `bench/READINESS.md` and
-        defaulted by `preflight_effort.sh`, so moving it would silently
-        invalidate an already-published number.
+        It used to pin 64,000 — where Claude Code's steps were measured
+        stopping — against a model that can write 128,000. That was the
+        best-argued cap in the file and still a cap: a number the comparator
+        was never given, imposed on the seat that was being measured against
+        it. `6c7fc70c…` is registered in `bench/READINESS.md` 8.4.5 and
+        defaulted by `preflight_effort.sh`.
         """
         posture, _normalized, digest = _benchmark_engine_posture(
             "anthropic/claude-sonnet-5"
         )
-        assert posture["agents"]["worker"]["params"]["max_tokens"] == 64_000
+        assert "max_tokens" not in (posture["agents"]["worker"].get("params") or {})
         assert "model_timeout_secs" not in posture
-        assert digest.startswith("c8536200")
+        assert digest.startswith("6c7fc70c")
 
     def test_the_booking_route_is_not_a_model_property(self) -> None:
         """Direct and gateway reach the same model, so the ceilings match.
@@ -648,10 +659,10 @@ class TestFableCeilingSet:
         describes a configuration nobody registered.
         """
         assert _benchmark_engine_posture("anthropic/claude-fable-5")[2] == (
-            "642746e411685b8c4018b6772e4def9478f1e2231713f315e6ecc90ceb1f276f"
+            "2099a1a48c0080974429964e13e0eee39e1f8af378c45e309318f34e03390e9b"
         )
         assert _benchmark_engine_posture("openrouter/anthropic/claude-fable-5")[2] == (
-            "e505909221f2da7aa41d5f9ea3b79761b38fb29cf4157e51629f517f66cc97a5"
+            "b5755ccf6a8cebe050606ffb8611fcc291d8b501efabcf222bf4159022bdaccc"
         )
 
 
@@ -855,7 +866,7 @@ class TestWitnessArmEndToEnd:
         """
         worker = "openrouter/z-ai/glm-5.1"
         author = "openrouter/deepseek/deepseek-v4-pro"
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.setenv(_WITNESS_AUTHOR_ENV, author)
 
@@ -929,7 +940,7 @@ class TestWitnessArmEndToEnd:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The disabled tier is a field, not a log line — the point of #1007."""
-        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
         reason = (
@@ -1297,56 +1308,59 @@ class TestOutputCeilingParity:
             f"(16384) instead of their own budget."
         )
 
-    def test_posture_caps_every_bookable_model_at_its_own_ceiling(self) -> None:
-        """The cap matches the model's ceiling, or the gap is declared.
+    def test_no_role_of_any_bookable_model_asks_for_an_output_cap(self) -> None:
+        """The posture sends no `max_tokens`, for any role, on any model.
 
-        Two distinct failures live here and only one of them is a bug:
+        This replaces a check that a cap EQUALLED the catalog ceiling unless a
+        rationale excused the gap. Both of that check's outcomes are now
+        wrong to write: matching the ceiling is a copy of a number the engine
+        already reads from the authority itself, and sitting under it is the
+        handicap #2411 measured — an arm stopped where the work finishes,
+        scored as the other arm being better.
 
-        - Capping ABOVE the ceiling is always wrong. It is not a longer
-          answer, it is a request the provider rejects.
-        - Capping BELOW the ceiling is sometimes right — matching a
-          comparator that stops lower is the point of a head-to-head — but it
-          must be a decision someone recorded, not a literal that drifted out
-          of step with the catalog and still looks deliberate.
-
-        So a gap is legal exactly when `_SUB_CEILING_RATIONALE` explains it.
-        That is what turns "both numbers look intentional" from the hazard
-        this class was written about into a property the suite can check.
+        Absence is what asks for the model's maximum. `tuned_engine_config`
+        seeds `max_output_tokens` from the catalog entry and only an explicit
+        cap can lower it, so the strongest thing this suite can assert is that
+        no explicit cap is ever sent.
         """
         checked = 0
-        for model, ceiling in _seeded_output_ceilings().items():
-            slug = model.rsplit("/", 1)[-1]
-            if slug not in _BENCHMARKED_SLUGS:
+        for model in _seeded_output_ceilings():
+            if model.rsplit("/", 1)[-1] not in _BENCHMARKED_SLUGS:
                 # Not bookable, so it has no posture to be wrong about; see
                 # `_BENCHMARKED_SLUGS` for why the scope is deliberate.
                 continue
             posture, _, _ = _benchmark_engine_posture(model)
             for role, agent in posture["agents"].items():
-                params = agent.get("params")
-                if params is None:
-                    # `triage` keeps the engine default deliberately: it emits
-                    # a three-line classification, so the cap never binds.
-                    assert role == "triage", f"{role} unexpectedly has no cap"
-                    continue
-                cap = params["max_tokens"]
                 checked += 1
-                assert cap <= ceiling, (
-                    f"{model} role {role}: the posture asks for {cap} but the "
-                    f"model's ceiling is {ceiling}. Over-asking is refused by "
-                    "the provider on every step, not answered at length."
-                )
-                if cap == ceiling:
-                    continue
-                assert _SUB_CEILING_RATIONALE.get(slug, "").strip(), (
-                    f"{model} role {role}: the posture caps at {cap} while the "
-                    f"catalog seeds the model's ceiling at {ceiling}, and "
-                    "nothing says why. If the benchmark should stop lower "
-                    "than the model can write, record the reason in "
-                    "`_SUB_CEILING_RATIONALE`; if it should not, raise the "
-                    "posture. An undeclared gap is the benchmark capping "
-                    "itself away from the comparator by accident."
+                assert "max_tokens" not in (agent.get("params") or {}), (
+                    f"{model} role {role} pins an output cap. Every value it "
+                    "could hold is either the catalog's number restated or a "
+                    "ceiling the comparator does not run under — delete the "
+                    "key and the engine takes the model's own maximum (#2411)."
                 )
         assert checked, "no bookable model was checked — the loop is inert"
+
+    def test_no_role_of_any_bookable_model_is_handed_a_spend_cap(self) -> None:
+        """The dollar axis of the same rule.
+
+        An output cap and a per-trial budget are one ceiling in two units, and
+        the budget is the one that actually decided a match: in
+        ``5292a68cdabf`` all three of the capped seat's losses were the guard
+        firing at roughly a third of the task's 900s, each within a step or
+        four of done. Nothing in a frozen posture may reintroduce it under
+        another spelling.
+        """
+        banned = {"budget", "budget_usd", "max_tokens", "turn_budget_usd"}
+        for model in _seeded_output_ceilings():
+            if model.rsplit("/", 1)[-1] not in _BENCHMARKED_SLUGS:
+                continue
+            posture, _, _ = _benchmark_engine_posture(model)
+            offenders = sorted(banned & set(posture)) + sorted(
+                f"agents.{role}.{key}"
+                for role, agent in posture["agents"].items()
+                for key in banned & set(agent)
+            )
+            assert not offenders, f"{model}: posture declares {offenders}"
 
 
 class TestLauncherVocabularyParity:

--- a/bench/harbor_adapter/tests/test_secure_launcher.py
+++ b/bench/harbor_adapter/tests/test_secure_launcher.py
@@ -187,7 +187,8 @@ def _claim_environment(binary: Path, **overrides: str) -> dict[str, str]:
         "OPENROUTER_MANAGEMENT_API_KEY": _TEST_MANAGEMENT_CREDENTIAL,
         "STELLA_BINARY": str(binary),
         "STELLA_SOURCE_COMMIT": _TEST_SOURCE_COMMIT,
-        "STELLA_BUDGET": "0.17",
+        # No `STELLA_BUDGET`. A claim run carries no per-trial spend cap, and
+        # the launcher refuses one rather than pinning it (#2411).
         "STELLA_DISABLE_REFLECTION": "1",
     }
     environment.update(overrides)
@@ -288,7 +289,7 @@ def _confirmatory_command(jobs_dir: Path, job_name: str) -> list[str]:
 
 
 class _FakeProviderKeyReader:
-    def __init__(self, *, usage: float = 0.0, credits: float = 200.0) -> None:
+    def __init__(self, *, usage: float = 0.0, credits: float = 700.0) -> None:
         self.key = {
             "data": {
                 "byok_usage": 0.0,
@@ -300,8 +301,8 @@ class _FakeProviderKeyReader:
                 "is_free_tier": False,
                 "is_management_key": False,
                 "label": "sk-or-v1-tes...cret",
-                "limit": 180.0,
-                "limit_remaining": 180.0 - usage,
+                "limit": 600.0,
+                "limit_remaining": 600.0 - usage,
                 "limit_reset": None,
                 "usage": usage,
                 "usage_daily": usage,
@@ -328,8 +329,8 @@ class _FakeProviderKeyReader:
                 "hash": "",
                 "include_byok_in_limit": True,
                 "label": "sk-or-v1-tes...cret",
-                "limit": 180.0,
-                "limit_remaining": 180.0 - usage,
+                "limit": 600.0,
+                "limit_remaining": 600.0 - usage,
                 "limit_reset": None,
                 "name": "stella-tb21-dedicated-key-v1",
                 "updated_at": "2026-07-21T00:00:00Z",
@@ -475,7 +476,9 @@ class _FakePublicIntentReader:
                 "attempts_per_task": attempts,
                 "n_concurrent_trials": concurrency,
                 "retry_max_retries": 0,
-                "per_trial_budget_usd": 0.17,
+                "per_trial_forecast_usd": (
+                    launcher_module._CANONICAL_PER_TRIAL_FORECAST_USD
+                ),
                 "artifacts": artifacts,
                 "execution": {
                     "base_url": "https://openrouter.ai/api/v1",
@@ -487,7 +490,7 @@ class _FakePublicIntentReader:
                         "provider_key_fingerprint_sha256"
                     ],
                     "label": "stella-tb21-dedicated-key-v1",
-                    "limit_usd": 180.0,
+                    "limit_usd": 600.0,
                     "usage_before_usd": 0.0,
                     "snapshot_at": declared_at.replace("10Z", "09Z"),
                 },
@@ -712,7 +715,7 @@ class _FakePublicIntentReader:
                     "attempts_per_task": None,
                     "n_concurrent_trials": None,
                     "retry_max_retries": None,
-                    "per_trial_budget_usd": None,
+                    "per_trial_forecast_usd": None,
                     "artifacts": {
                         "binary_sha256": None,
                         "source_commit": None,
@@ -808,7 +811,9 @@ class _FakePublicIntentReader:
                 "agent_version": runtime_identity["agent_version"],
                 "adapter_version": runtime_identity["adapter_version"],
                 "adapter_sha256": runtime_identity["adapter_sha256"],
-                "budget_usd": 0.17,
+                # `None`, not a number: the SUT declares that no trial ran
+                # under a spend cap (#2411).
+                "budget_usd": None,
                 "disable_reflection": True,
                 "base_url": runtime_identity["base_url"],
                 "provider_route_policy": runtime_identity["provider_route_policy"],
@@ -1925,7 +1930,10 @@ def test_claim_environment_rejects_runtime_assembled_version_literals(
 @pytest.mark.parametrize(
     ("name", "value", "message"),
     [
-        ("STELLA_BUDGET", "0.170", "exact STELLA_BUDGET=0.17"),
+        # Inverted by #2411: the drift that matters is a cap being present at
+        # all, not one differing from a frozen value. `0.17` was that frozen
+        # value and is now refused like any other.
+        ("STELLA_BUDGET", "0.17", "STELLA_BUDGET to be unset"),
         (
             "STELLA_DISABLE_REFLECTION",
             "true",
@@ -2550,7 +2558,7 @@ def test_public_intent_waits_two_seconds_then_records_final_get(tmp_path: Path) 
         "available_credits_usd",
         "fetched_at_utc",
     }
-    assert provider_snapshot["limit_usd"] == 180.0
+    assert provider_snapshot["limit_usd"] == 600.0
 
 
 def test_public_intent_rejects_existing_but_mismatched_runtime_source(

--- a/bench/tb21_preregistration.py
+++ b/bench/tb21_preregistration.py
@@ -61,7 +61,7 @@ from stella_harbor import (  # noqa: E402
     _harbor_version,
 )
 from stella_harbor.secure_launcher import (  # noqa: E402
-    _CANONICAL_BUDGET,
+    _CANONICAL_PER_TRIAL_FORECAST_USD,
     _DEDICATED_KEY_HARD_LIMIT_USD,
     _DEDICATED_KEY_LABEL,
     _FIXED_ANALYZER_PATH,
@@ -201,7 +201,7 @@ def _build_intent(stage: str, hi: dict, source_hashes: dict) -> dict:
         "attempts_per_task": s["attempts"],
         "n_concurrent_trials": s["n_concurrent"],
         "retry_max_retries": 0,
-        "per_trial_budget_usd": float(_CANONICAL_BUDGET),
+        "per_trial_forecast_usd": float(_CANONICAL_PER_TRIAL_FORECAST_USD),
         "artifacts": artifacts,
         "execution": {
             "base_url": BASE_URL,
@@ -250,7 +250,7 @@ def do_frozen() -> int:
     print(f"study_id                : {_FIXED_STUDY_ID}")
     print(f"ledger schema           : {LEDGER_SCHEMA}")
     print(f"ledger path             : {LEDGER_PATH}")
-    print(f"per-trial budget (usd)  : {_CANONICAL_BUDGET}")
+    print(f"per-trial budget (usd)  : {_CANONICAL_PER_TRIAL_FORECAST_USD}")
     print(f"dedicated key label     : {_DEDICATED_KEY_LABEL}")
     print(f"dedicated key limit usd : {_DEDICATED_KEY_HARD_LIMIT_USD}")
     print("\nfrozen source/artifact hashes (as the launcher computes them):")

--- a/bench/terminal-bench-2.1-protocol.md
+++ b/bench/terminal-bench-2.1-protocol.md
@@ -197,9 +197,24 @@ raw trials, and disclosed comparator below.
 - Container utilities: the adapter uploads only the frozen Stella binary; it
   never provisions host `rg`, `fd`, or other convenience tools, so each trial
   retains the canonical task image's utility set
-- Per-trial target budget: `$0.17`, enforced after each completed model call;
-  the call that crosses the boundary can overshoot, so this is not called a
-  strict billing ceiling
+- Per-trial spend cap: **none**. A trial ends because the work finished or the
+  task's own wall clock expired, and for no other reason. The protocol
+  previously enforced a `$0.17` target after each completed model call; that
+  was withdrawn (#2411) after match `5292a68cdabf` showed what such a ceiling
+  measures. Three of that run's losses were the budget guard firing rather than
+  the agent failing — each at roughly a third of the task's 900s allowance and
+  within a step or four of done, including a `sqlite-with-gcov` trial that had
+  already proved its instrumented build decoded real coverage counters and was
+  denied on the step that would have put the binary on `PATH`. A cap stops an
+  agent where the work finishes, so the score reports our ceiling as its
+  capability. Spend is bounded at the provider key instead, where exhaustion
+  fails a run visibly rather than truncating a trial into a loss.
+- Per-trial spend **forecast**: `$1.20`, declared in the pre-registered intent
+  and enforced by nothing. It exists so a run states its expected cost in
+  advance and the analyzer can check the published claim against it. Derived
+  from measurement: the four `5292a68cdabf` trials that completed under the old
+  cap spent $0.6554–$0.9659 (mean $0.85), and the other eight are censored at
+  $1.00, so the true mean is above it
 - Reflection setting: `STELLA_DISABLE_REFLECTION=1`. This opt-out disables only
   Stella's post-answer headless memory-reflection call. Terminal-Bench trials
   are isolated and ephemeral, so that call cannot improve a later trial; the
@@ -354,17 +369,37 @@ operational ceiling.
 
 The conservative historical bound is frozen as `H_safe=$15.00`: it exceeds the
 known `$0.2429614978` plus nine canceled DeepSeek trials bounded by one completed
-`$0.17` call and one maximum-context `$0.9123` in-flight call apiece. The
-dedicated key therefore has one no-reset hard limit of `$180.00`, which is below
-`$200.00 - H_safe` and leaves at least `$5.00` further safety under the all-in
-authorization. An unknown cancellation charge is not silently treated as zero.
+call and one maximum-context `$0.9123` in-flight call apiece. An unknown
+cancellation charge is not silently treated as zero.
 
-| Stage | Planned model spend at the nominal $0.17 target |
+The dedicated key's no-reset hard limit was `$180.00`, chosen to sit below
+`$200.00 - H_safe`. It is now `$600.00`, for the reason given under the spend
+table below: with no per-trial cap the confirmatory stage projects `$534.00`,
+and the old figure only ever fit because trials were being cut short. It is the
+limit the key must be **provisioned** to; nothing about it authorizes spending,
+and the launcher gates on the key's live remaining credit rather than on this
+number.
+
+| Stage | Planned model spend at the $1.20 per-trial forecast |
 |---|---:|
-| One synthetic readiness attempt | $0.17 |
-| 60-trial calibration (3 models x 10 tasks x 2 x $0.17) | $10.20 |
-| Fixed GLM-5.1 primary (89 tasks x 5 x $0.17) | $75.65 |
-| **Executable v6 nominal new-call plan** | **$86.02** |
+| One synthetic readiness attempt | $1.20 |
+| 60-trial calibration (3 models x 10 tasks x 2 x $1.20) | $72.00 |
+| Fixed GLM-5.1 primary (89 tasks x 5 x $1.20) | $534.00 |
+| **Nominal new-call plan** | **$607.20** |
+
+This table is the clearest statement of what the withdrawn cap was actually
+doing. The same three stages planned to `$86.02` at `$0.17` — and that
+arithmetic was true only because trials were being stopped part-way through the
+work. The plan did not get seven times more expensive; it is the same plan,
+priced for the first time at what finishing the tasks costs.
+
+Two consequences follow, and both are decisions rather than details. The
+dedicated key's hard limit moves from `$180.00` to `$600.00`, which is a
+**provisioning requirement and not an authorization** — on 2026-08-08 the
+account behind it held `$35.72` of `$1,110.00`, so no confirmatory stage is
+runnable until it is funded. And the comparator arm is not re-run to produce
+these numbers: Claude Code is the bar, established once and quoted, so every
+trial in the plan above belongs to the arm actually under test.
 
 A possible selected-winner run would add up to `$75.65`, but v6 deliberately
 provides no executable contract for it. It is not part of this plan and cannot

--- a/bench/terminal_bench_analysis/README.md
+++ b/bench/terminal_bench_analysis/README.md
@@ -100,7 +100,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
     "agent_version": "REPLACE_AFTER_FREEZE_WITH_EXACT_REPORTED_VERSION",
     "adapter_version": "0.6.0",
     "adapter_sha256": "REPLACE_AFTER_FINAL_ADAPTER_FREEZE_WITH_64_HEX",
-    "budget_usd": 0.17,
+    "budget_usd": null,
     "disable_reflection": true,
     "base_url": "https://openrouter.ai/api/v1",
     "provider_route_policy": "openrouter-auto",
@@ -122,7 +122,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
         "triage": {"effort": "low", "reasoning": "off"}
       }
     },
-    "engine_posture_sha256": "8ce2e82029af25d9c9ee5d3f0f024f6e97c08fe39543486edb66926cb55b84a9"
+    "engine_posture_sha256": "20de1e34756b0ee86ced24a37fcc5f99ad743cd5c6e91921cd28d1e0570c160e"
   },
   "analysis": {
     "sha256": "REPLACE_AFTER_FINAL_ANALYZER_FREEZE_WITH_64_HEX",
@@ -242,7 +242,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "0d732c3e42a394a059be359de78ed153eb840477b946f167b8a0f3048023ff84"
+        "sha256": "1191911e2bc5aeef2949f0592a0c3d2da31f55e05b464018a8440febe0e94bd3"
       },
       "openrouter/z-ai/glm-5.2": {
         "version": "stella-tb21-engine-posture-v1",
@@ -258,7 +258,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "41f9be3b5f290529b10a94fcd87e3ad87b4798bdd4dd605bb7e678ecaa5d227d"
+        "sha256": "ebfc67c5d3f2f94f689ad341d53878939ee4576d89651d654d117acb4aee2a28"
       },
       "openrouter/x-ai/grok-4.5": {
         "version": "stella-tb21-engine-posture-v1",
@@ -274,7 +274,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "4505a9f8a582b25872c7c93bf1c63f3d6a335bac02e474ee5231e240f485802f"
+        "sha256": "2aee47fdf9d277918a48f67b8a53fe569333cce9c3c9041fefeb83a7f386762f"
       }
     },
     "job_name": "stella-tb21-calibration-20260721",
@@ -380,7 +380,7 @@ Claim mode also requires `--run-ledger`. Its exact top-level schema is
         "attempts_per_task": 1,
         "n_concurrent_trials": 1,
         "retry_max_retries": 0,
-        "per_trial_budget_usd": 0.17,
+        "per_trial_forecast_usd": 1.20,
         "artifacts": {
           "binary_sha256": "64_lowercase_hex",
           "source_commit": "40_lowercase_hex",

--- a/bench/terminal_bench_analysis/tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tb21_analysis.py
@@ -47,6 +47,12 @@ CANONICAL_DATASET_REF = (
 )
 CANONICAL_AGENT_IMPORT_PATH = "stella_harbor:StellaAgent"
 CANONICAL_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+#: How a trial row spells "this run had no per-trial spend cap" (#2411). Must
+#: match `_NO_BUDGET_CAP` in `stella_harbor/__init__.py`, which is the writer.
+#: A word rather than a null, because the metadata dict drops `None` values and
+#: an absent key would then read the same as a disclosed absence of a cap.
+_NO_BUDGET_CAP_DISCLOSURE = "unbounded"
 CANONICAL_PROVIDER_ROUTE_POLICY = "openrouter-auto"
 CANONICAL_HOST_CREDENTIAL_SOURCE = "anonymous-seekable-fd-v1"
 CANONICAL_HOST_CREDENTIAL_NAME = "OPENROUTER_API_KEY"
@@ -77,20 +83,20 @@ def canonical_engine_posture(model: str) -> tuple[dict[str, Any], str, str]:
         "reasoning_auto": "off",
         "headless_scope_bypass": "on",
         "agents": {
+            # No `params.max_tokens` on any role: omitting it is what asks for
+            # the model's own ceiling, and a number here would be a cap the
+            # comparator never carried (#2411).
             "default": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 64000},
             },
             "worker": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 64000},
             },
             "verifier": {
                 "effort": "xhigh",
                 "reasoning": "on",
-                "params": {"max_tokens": 64000},
             },
             "triage": {"effort": "low", "reasoning": "off"},
         },
@@ -642,16 +648,18 @@ STUDY_MANIFEST_ENGINE_POSTURE_FIELDS = frozenset(
 STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES = frozenset(
     {"default", "worker", "verifier", "triage"}
 )
-# Per-role field shapes: the outcome-bearing roles carry the raised output cap
-# (`params.max_tokens`); triage deliberately keeps the engine default, so its
-# exact shape has no `params` key. One flat set cannot express both.
+# Per-role field shapes. Every role is now the same shape — `effort` and
+# `reasoning`, no `params` — because no role carries an output cap (#2411).
+# The split existed to let the outcome-bearing roles hold `params.max_tokens`
+# while triage kept the engine default; with the cap gone there is nothing for
+# `params` to contain, and a posture that grows one has to be reviewed rather
+# than accepted by a set that still permits the key.
 STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE: dict[str, frozenset[str]] = {
-    "default": frozenset({"effort", "reasoning", "params"}),
-    "worker": frozenset({"effort", "reasoning", "params"}),
-    "verifier": frozenset({"effort", "reasoning", "params"}),
+    "default": frozenset({"effort", "reasoning"}),
+    "worker": frozenset({"effort", "reasoning"}),
+    "verifier": frozenset({"effort", "reasoning"}),
     "triage": frozenset({"effort", "reasoning"}),
 }
-STUDY_MANIFEST_ENGINE_POSTURE_AGENT_PARAMS_FIELDS = frozenset({"max_tokens"})
 STUDY_MANIFEST_CONFIRMATORY_FIELDS = frozenset({"job_name", "n_concurrent_trials"})
 
 JOB_CONFIG_ALLOWED_FIELDS = frozenset(
@@ -803,7 +811,7 @@ INTENT_FIELDS = frozenset(
         "attempts_per_task",
         "n_concurrent_trials",
         "retry_max_retries",
-        "per_trial_budget_usd",
+        "per_trial_forecast_usd",
         "artifacts",
         "execution",
         "provider_key",
@@ -1984,7 +1992,13 @@ def _trial_row(
         "source_commit_verified_in_binary": _boolish(
             metadata.get("stella_source_commit_verified_in_binary")
         ),
-        "budget_usd": _nonnegative_float(metadata.get("stella_budget_usd")),
+        # Carried raw, not through `_nonnegative_float`. The adapter discloses
+        # "no cap" as the word `unbounded` exactly so it cannot be read as a
+        # ceiling that was in force, and a numeric normaliser maps that word to
+        # `None` — which every consumer here treats as "field missing". No cap
+        # and no record would then be the same reading, which is the confusion
+        # the sentinel exists to prevent (#2411).
+        "budget_usd": metadata.get("stella_budget_usd"),
         "disable_reflection": _boolish(metadata.get("stella_disable_reflection")),
         "base_url": metadata.get("stella_base_url"),
         "provider_route_policy": metadata.get("stella_provider_route_policy"),
@@ -2312,18 +2326,10 @@ def _validate_engine_posture_manifest_schema(
             f"{label}.agents.{role}",
             reasons,
         )
-        role_config = agents[role]
-        if (
-            isinstance(role_config, dict)
-            and "params" in STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE[role]
-            and "params" in role_config
-        ):
-            _require_exact_manifest_fields(
-                role_config["params"],
-                STUDY_MANIFEST_ENGINE_POSTURE_AGENT_PARAMS_FIELDS,
-                f"{label}.agents.{role}.params",
-                reasons,
-            )
+    # No `params` sub-shape is validated here any more, because no role may
+    # carry the key at all: `_require_exact_manifest_fields` above rejects it
+    # for every role (#2411). Validating its contents would only describe a
+    # posture the check above has already refused.
 
 
 def _matches_setting(actual: Any, expected: Any) -> bool:
@@ -4265,7 +4271,7 @@ def _validate_run_ledger(
                 "attempts_per_task",
                 "n_concurrent_trials",
                 "retry_max_retries",
-                "per_trial_budget_usd",
+                "per_trial_forecast_usd",
                 "preregistration_commit",
             }
             if any(intent.get(name) is not None for name in nullable_fields):
@@ -4412,13 +4418,20 @@ def _validate_run_ledger(
             reasons.append(f"Paid {stage} intent concurrency is not canonical.")
         if intent.get("retry_max_retries") != 0:
             reasons.append(f"Paid {stage} intent must freeze retry_max_retries=0.")
-        if not math.isclose(
-            _nonnegative_float(intent.get("per_trial_budget_usd")) or -1.0,
-            _nonnegative_float(sut.get("budget_usd")) or -2.0,
-            rel_tol=0,
-            abs_tol=1e-12,
-        ):
-            reasons.append(f"Paid {stage} intent budget differs from sut.budget_usd.")
+        # These two used to be required equal, because one number was both the
+        # projection and the enforced cap. They are now different kinds of
+        # thing: the intent forecasts what a trial should cost, and the SUT
+        # declares that no trial was capped (#2411). Equality would assert
+        # `None == 1.20`, so what is checked is that each is the right kind.
+        if _nonnegative_float(intent.get("per_trial_forecast_usd")) is None:
+            reasons.append(
+                f"Paid {stage} intent must declare a per_trial_forecast_usd."
+            )
+        if sut.get("budget_usd") is not None:
+            reasons.append(
+                f"Paid {stage} sut.budget_usd must be null: a trial that ran "
+                "under a spend cap is not the arm this study claims to measure."
+            )
         if intent.get("preregistration_commit") != expected_prereg_commit:
             reasons.append(
                 f"Paid {stage} intent binds the wrong preregistration commit."
@@ -4578,10 +4591,10 @@ def _validate_run_ledger(
                     "prior_stage_outcome": prior_stage_outcome,
                     "projected_spend_usd": (
                         _nonnegative_float(intent.get("requested_trials"))
-                        * _nonnegative_float(intent.get("per_trial_budget_usd"))
+                        * _nonnegative_float(intent.get("per_trial_forecast_usd"))
                         if _nonnegative_float(intent.get("requested_trials"))
                         is not None
-                        and _nonnegative_float(intent.get("per_trial_budget_usd"))
+                        and _nonnegative_float(intent.get("per_trial_forecast_usd"))
                         is not None
                         else None
                     ),
@@ -6335,12 +6348,15 @@ def validate_study(
             "Study manifest field sut.source_commit must be a full 40-character "
             "Git commit."
         )
-    normalized_budget = _nonnegative_float(budget_usd)
-    if budget_usd is not _MISSING and (
-        normalized_budget is None or normalized_budget <= 0
-    ):
+    # `None` is the only value a present `sut.budget_usd` may now take, and it
+    # is a claim rather than an absence: the trials ran under no per-trial
+    # spend cap (#2411). A number here says the opposite, and the study's whole
+    # subject is an agent that was not stopped short of finishing.
+    if budget_usd is not _MISSING and budget_usd is not None:
         structural_reasons.append(
-            "Study manifest field sut.budget_usd must be a positive number."
+            "Study manifest field sut.budget_usd must be null — a per-trial "
+            "spend cap stops the agent where the work finishes, so a capped "
+            "run cannot support the claim this study publishes."
         )
     if disable_reflection is not _MISSING and not isinstance(disable_reflection, bool):
         structural_reasons.append(
@@ -6725,11 +6741,15 @@ def validate_study(
         True,
         normalize=_boolish,
     )
+    # The manifest declares no cap as JSON `null`; a trial row discloses the
+    # same fact as the word `unbounded`, so the expectation is translated
+    # rather than compared across the two spellings. A row that still carries a
+    # number fails here, which is the point: it ran under a ceiling this study
+    # does not describe (#2411).
     check_trial_field(
         "budget_usd",
         "per-trial budget_usd",
-        _MISSING if budget_usd is _MISSING else normalized_budget,
-        normalize=_nonnegative_float,
+        _NO_BUDGET_CAP_DISCLOSURE if budget_usd is None else budget_usd,
     )
     check_trial_field(
         "disable_reflection",

--- a/bench/terminal_bench_analysis/tests/test_posture_digest.py
+++ b/bench/terminal_bench_analysis/tests/test_posture_digest.py
@@ -26,12 +26,20 @@ import tb21_analysis as analysis_module
 
 _MODEL = analysis_module.PRIMARY_MODEL
 
-# The digest every registered TB2.1 arm was claimed under. Re-frozen when the
-# `judge` agent slot became `verifier`: a slot rename is a NEW posture
-# generation, not a cosmetic edit, because runs under `8530a36f…` booked an
-# agent under the old key and are not hash-comparable with runs under this one.
+# The digest every registered TB2.1 arm was claimed under. Re-frozen twice.
+#
+# First when the `judge` agent slot became `verifier`: a slot rename is a NEW
+# posture generation, not a cosmetic edit, because runs under `8530a36f…`
+# booked an agent under the old key and are not hash-comparable with runs
+# under this one.
+#
+# Again when the output cap left the posture (#2411), which is the first
+# re-freeze where the arm itself changed rather than a key being renamed. Runs
+# under `8ce2e820…` asked for 64,000 output tokens; runs under this digest ask
+# for the model's own ceiling. Those are different arms, and comparing their
+# solve rates compares two configurations.
 _REGISTERED_POSTURE_SHA256 = (
-    "8ce2e82029af25d9c9ee5d3f0f024f6e97c08fe39543486edb66926cb55b84a9"
+    "20de1e34756b0ee86ced24a37fcc5f99ad743cd5c6e91921cd28d1e0570c160e"
 )
 
 

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -618,7 +618,7 @@ def _study_manifest(
             "agent_version": _AGENT_VERSION,
             "adapter_version": "0.6.0",
             "adapter_sha256": _ADAPTER_SHA256,
-            "budget_usd": 0.17,
+            "budget_usd": None,
             "disable_reflection": True,
             "base_url": CANONICAL_OPENROUTER_BASE_URL,
             "provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,
@@ -779,7 +779,7 @@ def _intent_payload(
         "attempts_per_task": attempts_per_task,
         "n_concurrent_trials": concurrency,
         "retry_max_retries": 0,
-        "per_trial_budget_usd": 0.17,
+        "per_trial_forecast_usd": 0.17,
         "artifacts": {
             "binary_sha256": _BINARY_SHA256,
             "source_commit": _SOURCE_COMMIT,
@@ -898,7 +898,7 @@ def _receipt_public_intent_attestation(
         **intent["execution"],
         "provider_key_fingerprint_sha256": intent["provider_key"]["fingerprint_sha256"],
     }
-    projected = intent["requested_trials"] * intent["per_trial_budget_usd"]
+    projected = intent["requested_trials"] * intent["per_trial_forecast_usd"]
     remaining = intent["provider_key"]["limit_usd"] - usage_before
     return {
         "schema_version": analysis_module.PUBLIC_INTENT_ATTESTATION_SCHEMA,
@@ -1285,7 +1285,7 @@ def _write_complete_study_job(
                 "stella_binary_sha256_verified_in_container": True,
                 "stella_source_commit": _SOURCE_COMMIT,
                 "stella_source_commit_verified_in_binary": True,
-                "stella_budget_usd": 0.17,
+                "stella_budget_usd": "unbounded",
                 "stella_disable_reflection": "1",
                 "stella_base_url": CANONICAL_OPENROUTER_BASE_URL,
                 "stella_provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,
@@ -1525,7 +1525,7 @@ def _synthetic_calibration_rows() -> list[dict]:
                     "adapter_version": "0.6.0",
                     "adapter_sha256": _ADAPTER_SHA256,
                     "analysis_sha256": ANALYSIS_CONTENT_SHA256,
-                    "budget_usd": 0.17,
+                    "budget_usd": None,
                     "disable_reflection": True,
                     "base_url": CANONICAL_OPENROUTER_BASE_URL,
                     "provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,
@@ -1708,7 +1708,7 @@ def _synthetic_calibration_ledger_rows() -> list[dict]:
         "atif_engine_posture_record_json": _READINESS_POSTURE_JSON,
         "atif_engine_posture_sha256": _READINESS_POSTURE_SHA256,
         "atif_valid": True,
-        "budget_usd": 0.17,
+        "budget_usd": None,
         "disable_reflection": True,
         "base_url": CANONICAL_OPENROUTER_BASE_URL,
         "provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,
@@ -1868,7 +1868,7 @@ def test_secure_receipt_v2_exactly_binds_public_intent_preflight() -> None:
             expected_provider_key=intent["provider_key"],
             expected_prior_stage_outcome=public_intent["prior_stage_outcome"],
             expected_projected_spend_usd=(
-                intent["requested_trials"] * intent["per_trial_budget_usd"]
+                intent["requested_trials"] * intent["per_trial_forecast_usd"]
             ),
             label="Confirmatory Harbor job",
         )
@@ -1894,7 +1894,7 @@ def test_secure_receipt_v2_exactly_binds_public_intent_preflight() -> None:
         expected_provider_key=intent["provider_key"],
         expected_prior_stage_outcome=public_intent["prior_stage_outcome"],
         expected_projected_spend_usd=(
-            intent["requested_trials"] * intent["per_trial_budget_usd"]
+            intent["requested_trials"] * intent["per_trial_forecast_usd"]
         ),
         label="Confirmatory Harbor job",
     )
@@ -2134,7 +2134,7 @@ def _historical_intent(job_id: str, index: int) -> dict:
         "attempts_per_task": None,
         "n_concurrent_trials": None,
         "retry_max_retries": None,
-        "per_trial_budget_usd": None,
+        "per_trial_forecast_usd": None,
         "artifacts": {
             "binary_sha256": None,
             "source_commit": None,


### PR DESCRIPTION
A per-trial cap is a second experiment running inside the first, and it always
terminates the run at the end — where the work finishes.

Match `5292a68cdabf` is the witness. Stella ran under `budget_usd = 1.0` while
the comparator's was `null`, and **all three of Stella's losses were the budget
guard firing rather than the agent failing** — each at roughly a third of the
task's 900s allowance, within a step or four of done:

- `sqlite-with-gcov` had already proved its instrumented build decoded real
  coverage counters (`Lines executed:15.87% of 58950`) and was denied on the
  step that would have put the binary on `PATH` — the one assertion the grader
  then failed it for. The last model call it bought was a `task_start` card.
- Both `git-multibranch` trials were killed at the moment they turned to
  verifying their own work.

The scoreboard read 9/12 against 18/18 and was measuring the ceiling.

## What changed

**The capability is gone, not defaulted off.** `budget_usd` and `max_tokens` are
removed from `Engine` and `RoleConfig`, so no type can hold one. Authoring
surfaces refuse the keys by name — the TOML loader (role tables included) and
the HTTP create path, which reads the raw payload because `from_json` drops
them. Archive restore still loads a spec that ran capped: those are the specs
worth reading most.

**No path reaches an agent with a cap.** The runner never exports
`STELLA_BUDGET`; the adapter refuses an exported one rather than ignoring it,
and its `_DEFAULT_BUDGET = "5.0"` — which capped every run that did not opt out
— is removed. The claim launcher, which pinned a tighter `$0.17`, now requires
the variable unset.

**Omitting `params.max_tokens` is what asks for the model's ceiling.**
`tuned_engine_config` seeds `max_output_tokens` from the catalog and only an
explicit cap can lower it, so the posture's cap tables go: a table whose every
correct entry copies `catalog.rs` is a synchronisation problem invented for no
gain. `_SUB_CEILING_RATIONALE` goes too — its best-argued entry capped Sonnet at
64,000 because that is where the comparator's steps were *measured stopping*,
which is not a ceiling the comparator was ever given.

**All four committed head-to-head templates carried the asymmetry**, each with a
comment saying Claude Code honours no spend cap and a Stella seat declaring both
keys a few lines below.

## The arithmetic this exposes

The certified stages planned to `$86.02` at `$0.17` and plan to `$607.20` at the
`$1.20` forecast measured from real trials. The plan did not get seven times
dearer — it is the same plan, priced for the first time at what finishing the
tasks costs. The key's hard limit moves `$180 -> $600` as a **provisioning
requirement, not an authorization**: the account behind it held `$35.72` of
`$1,110` on 2026-08-08, and the launcher gates on live remaining credit.

## Also: the comparator stops being re-run

Adds `matches/stella-solo-vs-recorded-bar.toml` — one seat, no Claude Code arm.
The bar is established once and quoted (18/18 from `5292a68cdabf`); every trial
spent re-measuring a constant is a trial the arm under test did not get. Its 6
attempts are sized from the `$35.72` actually remaining, not chosen and then
funded.

## Witness

`TestPerTrialCeilingsAreRefused` (`arenabench/tests/test_matches.py`) fails on
`main`, where each declaration parses into an `Engine` field and reaches the
agent. `test_no_committed_template_declares_a_per_trial_ceiling` also fails on
`main`: each template carries 2 uncommented cap lines there, 0 here.

## Digests moved, and no published run is relabelled

Posture digests re-froze — the mechanism working, since an arm asking for a
different budget is a different arm. Registered in `READINESS.md` **8.4.5 as a
new boundary** rather than by overwriting the rename table, so nothing already
published is retitled. `preflight_effort.sh` defaults to the new Sonnet digest.

## Tests renamed, not deleted

`test_unset_budget_still_takes_the_development_default` ->
`test_unset_budget_is_no_cap_rather_than_a_development_default`;
`test_a_cap_that_is_set_is_still_forwarded` ->
`test_a_cap_that_is_set_is_refused_rather_than_forwarded`;
`test_posture_caps_every_bookable_model_at_its_own_ceiling` ->
`test_no_role_of_any_bookable_model_asks_for_an_output_cap` (+ a new spend-axis
sibling); `test_the_three_ceilings_can_be_selected_together` ->
`test_selecting_the_silence_ceiling_adds_no_output_cap`;
`test_fable_gets_both_approved_ceilings` ->
`test_fable_keeps_its_silence_ceiling_and_asks_for_no_cap`;
`test_the_timeout_is_never_left_behind_when_the_cap_moves` ->
`test_an_uncapped_generation_still_has_a_ceiling_to_absorb_it`;
`test_sonnet_is_untouched_and_its_registered_digest_holds` ->
`test_sonnet_asks_for_no_cap_and_its_new_digest_is_registered`.
`STUDY_MANIFEST_ENGINE_POSTURE_AGENT_PARAMS_FIELDS` is removed: with no role
permitted a `params` key, validating its contents describes a posture the field
check already refuses.

Suites: `arenabench`, `bench/harbor_adapter` (612), `bench/terminal_bench_analysis` (270) all green.

Closes #2411

## Summary by Sourcery

Remove per-trial spend and token ceilings from ArenaBench and Harbor, treating trials as uncapped while bounding spend only at the provider key and updating posture digests, protocol docs, and study/launcher accounting to use a per-trial spend forecast instead of an enforced budget.

New Features:
- Introduce per-trial spend forecast fields in intents and accounting, decoupled from enforcement, and surface a sentinel value to explicitly disclose uncapped trials in run metadata.
- Add a single-seat stella-solo-vs-recorded-bar match template that measures Stella alone against the previously recorded Claude Code bar without re-running the comparator.

Bug Fixes:
- Refuse per-trial budget and output-cap keys in match templates, authoring surfaces, and agent environments so no seat can silently run under a ceiling the comparator does not carry.
- Ensure archived capped specs still load but drop now-invalid cap fields, preserving historical evidence without reintroducing ceilings into current runs.

Enhancements:
- Simplify engine and role configuration models by removing budget_usd and max_tokens fields and standardising agent posture shapes to omit params for all roles.
- Update Harbor posture generation to rely on catalog-derived model ceilings instead of maintaining a separate output-cap table and rationale map, and adjust associated digests and readiness boundaries.
- Increase the dedicated provider key hard limit and related test fixtures to reflect realistic uncapped trial costs while keeping the live-credit gate as the true authorization check.

Documentation:
- Revise terminal-bench-2.1 protocol and Harbor/analysis READMEs to document the removal of per-trial caps, the new spend forecast, updated posture digests, and the rationale for treating the comparator’s recorded performance as the fixed bar.
- Clarify match templates and preset comments so Claude Code and Stella seats are described as running without per-trial ceilings, aligning textual guidance with the enforced configuration.

Tests:
- Rename and rewrite posture, adapter, launcher, arena, and analysis tests to assert absence and refusal of per-trial caps, updated posture digests, uncapped budget metadata, and new forecast semantics, while keeping suite coverage for seeded model ceilings and timeout behaviour.