### PR TITLE
fix(bench): the analyzer's SUT expectation must speak the row's spelling of "no cap"

### DIFF
--- a/bench/terminal_bench_analysis/tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tb21_analysis.py
@@ -5490,7 +5490,13 @@ def _validate_calibration(
         "stella_agent_version": agent_version,
         "adapter_version": adapter_version,
         "adapter_sha256": adapter_sha256,
-        "budget_usd": _nonnegative_float(budget_usd),
+        # Matched against a trial row, which spells "no cap" as the word
+        # `unbounded` (#2411). `_nonnegative_float` would map both that word and
+        # the manifest's `null` to `None`, so the expectation is translated
+        # instead — otherwise the two sides agree only by both being unreadable.
+        "budget_usd": (
+            _NO_BUDGET_CAP_DISCLOSURE if budget_usd is None else budget_usd
+        ),
         "disable_reflection": disable_reflection,
         "base_url": base_url,
         "provider_route_policy": provider_route_policy,

--- a/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tests/test_tb21_analysis.py
@@ -1525,7 +1525,9 @@ def _synthetic_calibration_rows() -> list[dict]:
                     "adapter_version": "0.6.0",
                     "adapter_sha256": _ADAPTER_SHA256,
                     "analysis_sha256": ANALYSIS_CONTENT_SHA256,
-                    "budget_usd": None,
+                    # The row spelling of "no cap" — the word, as the adapter
+                    # writes it; `sut.budget_usd` is the one that is `null`.
+                    "budget_usd": "unbounded",
                     "disable_reflection": True,
                     "base_url": CANONICAL_OPENROUTER_BASE_URL,
                     "provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,
@@ -1708,7 +1710,10 @@ def _synthetic_calibration_ledger_rows() -> list[dict]:
         "atif_engine_posture_record_json": _READINESS_POSTURE_JSON,
         "atif_engine_posture_sha256": _READINESS_POSTURE_SHA256,
         "atif_valid": True,
-        "budget_usd": None,
+        # A trial row spells "no cap" the way the adapter writes it, as the
+        # word rather than a null — the manifest's `sut.budget_usd` is what
+        # carries JSON `null` (#2411).
+        "budget_usd": "unbounded",
         "disable_reflection": True,
         "base_url": CANONICAL_OPENROUTER_BASE_URL,
         "provider_route_policy": CANONICAL_PROVIDER_ROUTE_POLICY,


### PR DESCRIPTION
Follow-up to #2461, which merged while this was being written.

`identity_expectations` still normalized `budget_usd` through
`_nonnegative_float`, which maps **both** the manifest's `null` and a trial
row's `unbounded` to `None`. The two sides then agreed only by both being
unreadable — and a row that still carried a real number would have matched a
manifest declaring no cap, which is precisely the thing #2461 exists to make
impossible.

Translating the expectation into the row's vocabulary makes the comparison mean
something, and the fixtures now carry what the adapter actually writes:

| where | spelling of "no cap" |
|---|---|
| `sut.budget_usd` in the study manifest | JSON `null` |
| `budget_usd` on a normalized trial row | the word `unbounded` |

Same fact, two vocabularies, and the distinction is deliberate:
`_NO_BUDGET_CAP` exists because the metadata dict drops `None` values, so a
null row value is indistinguishable from an adapter that never recorded one.
Before this, two of the row fixtures said `None` — they were not mirroring a
real run, and the suite passed because the expectation was equally unreadable.

`bench/terminal_bench_analysis`: 270 passed.

Closes #2411

## Summary by Sourcery

Align budget cap expectations between study manifest SUT and trial rows by using the row’s "unbounded" spelling for no cap instead of normalizing to None, and update calibration fixtures to mirror real adapter output.

Bug Fixes:
- Prevent calibration analysis from treating manifest null and trial row "unbounded" budget caps as identical None values, ensuring rows with real numeric budgets no longer erroneously match a manifest declaring no cap.

Tests:
- Adjust synthetic calibration row and ledger row fixtures so budget_usd uses "unbounded" to represent no cap, matching actual adapter-written trial rows.