### PR TITLE
ci(deck-fit): measure every deck slide on every presentation change (closes #2425)

### DIFF
--- a/.github/workflows/deck-fit.yml
+++ b/.github/workflows/deck-fit.yml
@@ -1,0 +1,109 @@
+name: deck-fit
+
+# Every slide of every deck under website/public/presentations/ fits the fixed
+# 1600x900 canvas it is authored in, at four viewports plus a webfont-blocked
+# pass (scripts/deck-fit.mjs).
+#
+# Why this exists: #2373's overflow was invisible for a full revision because
+# checking it meant opening the deck and looking. The script was written to turn
+# that into a measurement -- and then ran nowhere, which is the same bug wearing
+# the script's clothes: anyone editing a slide's copy could push a clipping deck
+# and every check stayed green (#2425).
+#
+# Why it is not a `make gate` step: the gate is toolchain-free guards plus
+# cargo, and this needs a browser (AGENTS.md § "The gate"). CI is the right home.
+#
+# Why it is its own workflow rather than a job in docs-guards.yml: that
+# workflow triggers on `**/*.rs`, so a job there would launch a browser on
+# essentially every pull request in the repository. `wire-schema.yml` exists for
+# exactly this reason in the other direction -- a check whose trigger paths are
+# disjoint from an existing workflow's gets its own file, so neither one has to
+# widen its path set to carry the other (#1439).
+on:
+  pull_request:
+    paths:
+      - "website/public/presentations/**"
+      - "website/public/brand/fonts/**"
+      - "scripts/deck-fit.mjs"
+      - ".github/workflows/deck-fit.yml"
+  push:
+    branches: [main]
+    paths:
+      - "website/public/presentations/**"
+      - "website/public/brand/fonts/**"
+      - "scripts/deck-fit.mjs"
+      - ".github/workflows/deck-fit.yml"
+  workflow_dispatch:
+
+# Checkout plus a read-only measurement.
+permissions:
+  contents: read
+
+jobs:
+  fit:
+    name: deck slides fit the canvas
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      # Pinned for the same reason the actions above are: an unpinned tool is an
+      # unreproducible check. `--no-save` keeps it out of any manifest -- this is
+      # a one-shot measurement dependency, not something the repository ships.
+      - name: install playwright-core
+        run: npm i --no-save --no-package-lock playwright-core@1.62.1
+
+      # deck-fit.mjs exits 2 with the word "skipping" when the import fails.
+      # That is a red job either way, but the word invites a reader to shrug at
+      # it, so the install is proven here where the message is unambiguous.
+      - name: playwright-core resolves
+        run: node -e "import('playwright-core').then(() => console.log('playwright-core ok'))"
+
+      # The runner's preinstalled Chrome, rather than a downloaded Chromium: it
+      # costs no download, and the alternative pins a browser build we would then
+      # have to bump by hand. The version is logged because a layout result that
+      # changes with no deck change is a browser bump, and the log is where that
+      # gets diagnosed instead of guessed at.
+      - name: resolve a chrome
+        run: |
+          for candidate in \
+            /usr/bin/google-chrome \
+            /usr/bin/google-chrome-stable \
+            /usr/bin/chromium-browser \
+            /usr/bin/chromium
+          do
+            if [ -x "$candidate" ]; then
+              echo "CHROME=$candidate" >> "$GITHUB_ENV"
+              echo "deck-fit: $candidate — $("$candidate" --version 2>&1 | head -1)"
+              exit 0
+            fi
+          done
+          echo "deck-fit: no chrome found on this runner. Tried:" >&2
+          echo "  /usr/bin/google-chrome /usr/bin/google-chrome-stable" >&2
+          echo "  /usr/bin/chromium-browser /usr/bin/chromium" >&2
+          echo "If the runner image dropped Chrome, install one explicitly:" >&2
+          echo "  npx --yes playwright-core@1.62.1 install chromium" >&2
+          exit 1
+
+      # Every deck in the directory, not just the investor deck: a second deck
+      # added later is covered the day it lands rather than the day someone
+      # remembers this file exists.
+      - name: every slide fits the canvas at every viewport
+        run: |
+          shopt -s nullglob
+          decks=(website/public/presentations/*.html)
+          if [ ${#decks[@]} -eq 0 ]; then
+            echo "deck-fit: no decks under website/public/presentations/" >&2
+            exit 1
+          fi
+          status=0
+          for deck in "${decks[@]}"; do
+            echo "::group::$deck"
+            node scripts/deck-fit.mjs "$deck" || status=1
+            echo "::endgroup::"
+          done
+          exit $status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,15 @@ all three trigger on the `docs/**` and `*.md` paths `ci.yml` ignores; and
 because a PR that hand-edits a generated schema and nothing else starts neither
 of the other two (#1439).
 
+A fourth workflow, `deck-fit.yml`, runs no gate step at all: it measures every
+slide of every deck under `website/public/presentations/` against the fixed
+1600x900 canvas the decks are authored in (`scripts/deck-fit.mjs`). It needs a
+browser, which is why it is not in `make gate`, and it has its own file rather
+than a job in `docs-guards.yml` because that workflow triggers on `**/*.rs` and
+would launch a browser on nearly every PR — the same disjoint-paths reasoning
+that gave `wire-schema.yml` its own file. It is deliberately not a required
+check yet (#2425).
+
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
 id — `doc:context-reuse §4`. Moving the file cannot break it. A document with no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,11 @@ and `command-docs` — on their own because they trigger on the `docs/**` and
 same reason in the other direction — a PR that only hand-edits a generated
 schema under `docs/wire/` starts neither of the others (#1439).
 
+One more workflow runs no gate step: `deck-fit.yml` measures every slide of
+every deck under `website/public/presentations/` against the fixed 1600x900
+canvas they are authored in. It needs a browser, so it cannot live in `make
+gate`, and it triggers only on the presentation paths (#2425).
+
 **Cite a document by its id, not its path.** `doc:context-reuse §4` resolves no
 matter where the file moves; a document with no frontmatter `id` is not citable
 at all (`make doc-adopt DOC=…` gives it one). Legacy path citations repair

--- a/scripts/deck-fit.mjs
+++ b/scripts/deck-fit.mjs
@@ -12,7 +12,8 @@
 // one answer — and this script is the thing that takes it.
 //
 // It is deliberately NOT a `make gate` step: it needs a browser, and CI's gate
-// runs toolchain-free guards plus cargo. Run it by hand when you touch a deck.
+// runs toolchain-free guards plus cargo. `.github/workflows/deck-fit.yml` runs
+// it on every change under website/public/presentations/ instead (#2425).
 //
 //   node scripts/deck-fit.mjs                       # default deck, default sizes
 //   node scripts/deck-fit.mjs path/to/deck.html


### PR DESCRIPTION
## What & why

`scripts/deck-fit.mjs` measures every slide of a deck against the fixed 1600x900
canvas it is authored in, at four viewports plus a webfont-blocked pass. It is
the only thing that can answer "does this deck still fit?" — and it ran nowhere.
Anyone editing a slide's copy could push a clipping deck with both the gate and
CI green, which is the same shape of bug the script was written for (#2373): a
measurement nobody takes is the same as no measurement.

This adds `.github/workflows/deck-fit.yml`, triggered on changes under
`website/public/presentations/**`, the bundled fonts, the script, and itself.

Closes #2425

### Why its own workflow, not a job in `docs-guards.yml`

The issue suggested `docs-guards.yml`. That workflow triggers on `**/*.rs`, so a
job there would launch a browser on nearly every pull request in the repository.
`wire-schema.yml` already exists for the same reason in the other direction — a
check whose trigger paths are disjoint from an existing workflow's gets its own
file rather than widening someone else's path set (#1439). Exemplar named
because it is a structural choice, not taste.

Two smaller calls, both in the workflow's header comment:

- **The runner's preinstalled Chrome, not a downloaded Chromium.** No download,
  and no browser build to bump by hand. The resolved binary's `--version` is
  logged, because a layout result that changes with no deck change is a browser
  bump and the log is where that gets diagnosed instead of guessed at. If a
  runner image ever drops Chrome the job fails with the candidate list and the
  exact `npx playwright-core@1.62.1 install chromium` fallback.
- **The job loops over every deck in the directory**, not `investor-deck.html` by
  name, so a second deck is covered the day it lands rather than the day someone
  remembers this file exists.

`playwright-core` is pinned to `1.62.1` (`--no-save`, so it enters no manifest —
it is a measurement dependency, not something the repository ships). There is a
separate step asserting the import resolves, because `deck-fit.mjs` exits 2 with
the word "skipping" when it does not; that is a red job either way, but the word
invites a reader to shrug at it.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: it is CI wiring;
      there is no Rust behavior to witness.

Verified both directions locally against Chrome 151.0.7922.77 by extracting the
workflow's own `run:` block and executing it verbatim (not a paraphrase of it):

```
::group::website/public/presentations/investor-deck.html
PASS  1440x900 · laptop  —  21 slides, 0 overflowing
PASS  1280x800 · small laptop  —  21 slides, 0 overflowing
PASS  1920x1080 · projector  —  21 slides, 0 overflowing
PASS  2560x1440 · large display  —  21 slides, 0 overflowing
PASS  1440x900 · webfont blocked  —  21 slides, 0 overflowing
```

and with twelve filler sentences appended to slide 06's footnote — exit 1, all
five passes red, slide named:

```
FAIL  1440x900 · laptop  —  21 slides, 1 overflowing
  slide 06  +25px tall  +0px wide  the proof: same model, same tasks, 15.7 poin
```

Every `run:` block was also syntax-checked with `bash -n`, and the workflow
parses as YAML with all `uses:` SHA-pinned (`check-action-pins`: 66/66).

**The issue's suggested repro does not work, and that is worth knowing.** Adding
three sentences to slide 06's footnote changes the measurement by *nothing* —
byte-identical output on the pristine and edited decks. The frame is a flex
column whose `.body` child is `flex: 1 1 auto`, so it shrinks by exactly what the
footnote grows (431 -> 392 layout px) and the frame's height never moves. Slide
06 carries about nine filler sentences of slack; the tenth is the first that
overflows. I nearly concluded the guard was blind on the strength of the issue's
own repro passing.

## The gate

- [x] `make guards-fast` green (the rung the pre-push hook picks for a push that
      reaches no crate), including `check-action-pins`, `check-gate-parity`,
      `check-doc-links`, `check-brand-case`, `cargo fmt --check`
- [x] Docs updated: AGENTS.md and CONTRIBUTING.md each enumerate the CI workflow
      split and now name the fourth; `scripts/deck-fit.mjs`'s header no longer
      says "run it by hand when you touch a deck"
- [x] `Closes #2425` appears both here and as a commit trailer

No Rust changed, so clippy/test/rustdoc are unaffected by this diff.

## Nothing left behind

- [x] Filed: #2475 — `deck-fit` reports one overflow as three different numbers.
      `overH` takes `Math.max` of a **layout**-px reading (`scrollHeight -
      clientHeight`) and a **visual**-px one (the `getBoundingClientRect` sweep,
      scaled by the stage's `--k`), so the same 25-layout-px overflow prints as
      `+25` / `+30` / `+40` across viewports. The **verdict is sound** — both
      readings are exactly 0 when nothing overflows and the layout reading is
      never scaled down, so nothing can round away to green — only the reported
      magnitude is unit-inconsistent. Deliberately not fixed here: this PR wires
      up a guard, and changing what the guard measures in the same breath would
      mean the verification above no longer describes the shipped script.
- [x] Commented on #2472 (`main` over its own file-size ceilings): it is six
      files now, not three, with current numbers — plus the trap that from a
      stale base the same check exits non-zero and blames *your* branch.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

`playwright-core@1.62.1` is installed inside the CI job only, `--no-save`, and
appears in no manifest or lockfile the repository ships.

## Anything reviewers should know?

**It is deliberately not a required check** — the issue asks for it to run green
for a while first, and nothing here touches branch protection.

The one thing I could not verify locally is the runner-side Chrome resolution:
the candidate list is written against GitHub's `ubuntu-latest` image, and if it
is wrong the job fails loudly with the list and the fallback command rather than
skipping. That is the failure mode I chose on purpose — for a guard whose entire
history is "it silently did not run", a silent skip is the one outcome worth
engineering against.

## Summary by Sourcery

Add a dedicated CI workflow to automatically verify that all presentation deck slides fit within the authored canvas on each relevant change.

CI:
- Introduce deck-fit.yml workflow to run deck-fit measurements on presentation decks for pull requests, main pushes, and manual dispatches.

Documentation:
- Document the new deck-fit CI workflow and its scope in AGENTS.md and CONTRIBUTING.md.