### PR TITLE
feat(stella-cli): a reflection lesson's trigger decides what recall returns (closes #2459)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ dependencies = [
  "futures-util",
  "hmac",
  "libc",
+ "proptest",
  "ratatui",
  "reqwest",
  "rpassword",

--- a/crates/stella-cli/Cargo.toml
+++ b/crates/stella-cli/Cargo.toml
@@ -98,3 +98,11 @@ contextgraph-conformance.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 rusqlite.workspace = true
+# The reflection-trigger encoding (`memory/learning/applicability.rs`) claims to
+# be a total round trip over model prose, and that claim is what lets #2459 fold
+# a trigger into the embedded body without re-tuning the restatement band. A
+# table of hand-picked strings would only cover the cases the author imagined —
+# and the input that breaks a separator-based decoder is precisely a trigger
+# that spells the separator. Already a workspace dependency (stella-core,
+# -context, -fleet, -pipeline, -tui), so this adds no crate to the tree.
+proptest.workspace = true

--- a/crates/stella-cli/proptest-regressions/memory/learning/applicability/tests.txt
+++ b/crates/stella-cli/proptest-regressions/memory/learning/applicability/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 33be099d1c5ece80733cdc8d765f92eb1a9647a54007a6ac314153990a6ddd95 # shrinks to body = "", trigger = " (applies when: \u{e000}"

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -148,10 +148,18 @@ pub struct ReflectionLesson {
     /// instead of leaving them to be judged later by a reader who never saw
     /// the turn.
     ///
-    /// Recorded and mined; **not yet consulted at recall** — that wiring is
-    /// #2459. Folding it into the stored body would move the text that
-    /// `partition_known`'s restatement band was tuned on (#2358), which needs
-    /// the same measurement that band got and not an assumption.
+    /// Recorded, mined, **and folded into the memory body recall scores on**
+    /// (#2459) — which is where it earns its keep a second time: a trigger is
+    /// written in the register a *goal* is written in, so it is the half of a
+    /// lesson that lives in the space the retrieval query is asked in.
+    ///
+    /// The fold is why it cannot be done naively: `partition_known`'s
+    /// restatement band (#2358) compares candidate lessons against stored
+    /// bodies, and moving that text would move every similarity score in the
+    /// comparison at once. `memory::learning::applicability` carries the
+    /// encoding that keeps the band's input byte-identical, and the argument
+    /// for why folding beat a separate scored field and a post-retrieval
+    /// filter.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub trigger: String,
     /// What knowing this would have bought *in the turn that produced it* —

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -21,6 +21,11 @@ use super::{
     skill_paths_on_disk,
 };
 
+/// Where a lesson's `trigger` participates in retrieval (#2459), and the
+/// encoding that keeps [`SessionMemory::partition_known`]'s restatement band
+/// comparing exactly what it compared before.
+mod applicability;
+
 /// Spec §8 behavior-compatibility tests, written against the pre-migration
 /// loop. A child module rather than a sibling so it can reach
 /// [`SessionMemory::auto_create_skills`] without widening its visibility for
@@ -204,12 +209,28 @@ impl SessionMemory {
                 memories: novel
                     .iter()
                     .map(|l| {
-                        MemoryInput::reflection(&l.lesson, l.domains.iter().cloned())
-                            .with_recall_tier(l.kind.recall_tier())
-                            .with_anchors(crate::memory::anchors::resolve_anchors(
-                                &self.workspace_root,
-                                &l.lesson,
-                            ))
+                        // The lesson AND its trigger (#2459). `content` is what
+                        // `ContextStore::upsert` hashes to key a vector, so this
+                        // is the only string in a memory that recall can score —
+                        // and the trigger is the half of a lesson written in the
+                        // register a goal is written in. See
+                        // `applicability::recall_text` for why folding beats a
+                        // separate scored field or a post-retrieval filter, and
+                        // for why the restatement band above is unaffected.
+                        MemoryInput::reflection(
+                            applicability::recall_text(&l.lesson, &l.trigger),
+                            l.domains.iter().cloned(),
+                        )
+                        .with_recall_tier(l.kind.recall_tier())
+                        // Anchors resolve against the lesson alone: a trigger
+                        // names the *situation* a lesson applies in, not the
+                        // files it is about, so letting it anchor would claim
+                        // `verify.rs` is the subject of every lesson whose
+                        // condition merely mentions it.
+                        .with_anchors(crate::memory::anchors::resolve_anchors(
+                            &self.workspace_root,
+                            &l.lesson,
+                        ))
                     })
                     .collect(),
                 ..Default::default()
@@ -381,7 +402,20 @@ impl SessionMemory {
         let known: Vec<String> = match self.store.memory_nodes() {
             // Compare against the memory's own text, which is what a later
             // recall would inject — the display label is truncated.
-            Ok(nodes) => nodes.into_iter().map(|n| n.content).collect(),
+            //
+            // Bodies only, on both sides: since #2459 a stored memory's content
+            // also carries the lesson's trigger, so that it reaches the vector
+            // recall scores on. Comparing a bare candidate against that composed
+            // text would grow the union on one side alone and read every
+            // paraphrase as novel; comparing composed to composed would let
+            // trigger verbosity decide a question about facts (worked through in
+            // `applicability`). `lesson_body` is `recall_text`'s exact inverse,
+            // so the strings below are byte-for-byte the ones this band was
+            // tuned on in #2358 — the reason no re-measurement is owed.
+            Ok(nodes) => nodes
+                .into_iter()
+                .map(|n| applicability::lesson_body(&n.content).to_string())
+                .collect(),
             // A store we cannot read is not evidence that nothing is stored, so
             // keep the lessons rather than risk dropping the first ones a fresh
             // workspace ever learns.

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -227,10 +227,12 @@ impl SessionMemory {
                         // files it is about, so letting it anchor would claim
                         // `verify.rs` is the subject of every lesson whose
                         // condition merely mentions it.
-                        .with_anchors(crate::memory::anchors::resolve_anchors(
-                            &self.workspace_root,
-                            &l.lesson,
-                        ))
+                        .with_anchors(
+                            crate::memory::anchors::resolve_anchors(
+                                &self.workspace_root,
+                                &l.lesson,
+                            ),
+                        )
                     })
                     .collect(),
                 ..Default::default()

--- a/crates/stella-cli/src/memory/learning/applicability.rs
+++ b/crates/stella-cli/src/memory/learning/applicability.rs
@@ -47,8 +47,8 @@
 //! Trigger verbosity would decide a question about facts.
 //!
 //! So the band keeps comparing **bodies to bodies**, and this module is what
-//! lets it: [`recall_text`] composes on the way into the store and
-//! [`lesson_body`] recovers the body on the way out. They are exact inverses
+//! lets it: `recall_text` composes on the way into the store and
+//! `lesson_body` recovers the body on the way out. They are exact inverses
 //! for every lesson that has a trigger (`applicability/tests.rs` pins the round
 //! trip as a property over arbitrary bodies and triggers), so the strings
 //! `partition_known` compares are byte-identical to the ones it compared before
@@ -105,7 +105,7 @@ const APPLIES_WHEN_ESCAPED: &str = "applies when: ";
 /// stops being total. Rewriting the one substring that can do that makes the
 /// inverse exact for *every* pair of inputs, which is what
 /// `recomposing_any_body_and_trigger_recovers_the_body` asserts.
-pub(crate) fn recall_text(lesson: &str, trigger: &str) -> String {
+pub(super) fn recall_text(lesson: &str, trigger: &str) -> String {
     let trigger = trigger.trim();
     if trigger.is_empty() {
         return lesson.to_string();
@@ -129,7 +129,7 @@ pub(crate) fn recall_text(lesson: &str, trigger: &str) -> String {
 /// string on one side of a similarity score — and nothing is rewritten in the
 /// store, so the alternative (a marker byte in the content) would cost every
 /// reader a stripping step to avoid a case that has never occurred.
-pub(crate) fn lesson_body(stored: &str) -> &str {
+pub(super) fn lesson_body(stored: &str) -> &str {
     let Some(inner) = stored.strip_suffix(')') else {
         return stored;
     };

--- a/crates/stella-cli/src/memory/learning/applicability.rs
+++ b/crates/stella-cli/src/memory/learning/applicability.rs
@@ -1,0 +1,143 @@
+//! Where a lesson's trigger participates in retrieval, and how the restatement
+//! band stays out of its way (#2459).
+//!
+//! A [`ReflectionLesson`](crate::memory::ReflectionLesson) arrives with a
+//! `trigger` — the condition a future task has to satisfy for the lesson to be
+//! worth reading. That field is written in the register of a *goal* ("a task
+//! that touches the witness stage"), while the lesson body is written in the
+//! register of a *fact* ("the witness stage refuses a diff it has not read").
+//! Recall scores a memory by embedding its body and comparing it to the goal,
+//! so the trigger is the half of a lesson that lives in the space the query is
+//! asked in, and the body is the half that does not.
+//!
+//! ## Why the trigger is folded into the body
+//!
+//! Embeddings in `stella-context` are **content-addressed**: a vector is keyed
+//! `(sha256(content), embedder fingerprint)`, which is what makes the
+//! byte-compat skip in `L-C2` sound (`ContextStore::upsert`). A field that is
+//! not part of `content` therefore has no vector, and the lexical pass
+//! (`candidates::scan_terms`) reads `content` too. Folding is the only way the
+//! trigger reaches retrieval without a schema migration, a second embedding per
+//! memory, and a fusion weight nothing has data to tune.
+//!
+//! The two alternatives #2459 lists were both weighed and are worse here:
+//!
+//! * a **separate scored field** buys the ability to weight trigger-match
+//!   against body-match independently — a knob with no measurement behind it —
+//!   at the cost of a `stella-context` schema change, a second vector per
+//!   reflection memory, and a new join for `NodeMeta` to carry;
+//! * a **post-retrieval filter** turns a prose guess into a hard drop. Its
+//!   failure mode is silently withholding a memory that was correct, which is
+//!   strictly worse than today, where the memory at least competes.
+//!
+//! ## Why the restatement band does not move
+//!
+//! `SessionMemory::partition_known` decides whether a candidate lesson is novel
+//! or a paraphrase of one already held, by Jaccard over token sets at 0.5
+//! (`stella_store::is_suppressed`). It compares the candidate's body against
+//! each stored node's `content`. Folding the trigger into `content` without
+//! this module would make that comparison **asymmetric** — extra tokens on the
+//! stored side only, inflating the union and depressing every score at once, so
+//! genuine paraphrases would read as novel and flood the store.
+//!
+//! Composing *both* sides is not the repair; it is a worse break. Take a
+//! five-token body stored and restated verbatim, under two six-token triggers
+//! sharing two tokens: the pair scores 1.0 on bodies alone and
+//! `(5+2)/(5+10) = 0.47` composed — an exact duplicate fact, classified novel.
+//! Trigger verbosity would decide a question about facts.
+//!
+//! So the band keeps comparing **bodies to bodies**, and this module is what
+//! lets it: [`recall_text`] composes on the way into the store and
+//! [`lesson_body`] recovers the body on the way out. They are exact inverses
+//! for every lesson that has a trigger (`applicability/tests.rs` pins the round
+//! trip as a property over arbitrary bodies and triggers), so the strings
+//! `partition_known` compares are byte-identical to the ones it compared before
+//! this change — which is why #2459's re-measurement is discharged by
+//! construction rather than by a benchmark. A benchmark could only have
+//! reported the same equality with less confidence, and only for the corpus it
+//! happened to run on.
+//!
+//! The deliberate consequence: two lessons stating one fact under two different
+//! conditions collapse to one memory. That is right. Recall would otherwise
+//! spend two of five frames restating a single fact, and *which* fact it is has
+//! not changed — only when it was noticed.
+
+/// The separator that carries a lesson's trigger inside its stored body.
+///
+/// Chosen to read as ordinary prose in the recalled-context block, where a
+/// frame renders as `- [nod_…] label — content` on one line: a memory reads
+/// `the witness stage refuses a blind diff (applies when: a task edits the
+/// witness stage)`. A bracketed form would collide visually with the `[nod_…]`
+/// citation ids the same line carries.
+const APPLIES_WHEN: &str = " (applies when: ";
+
+/// [`APPLIES_WHEN`] without its leading space — the substring a trigger must
+/// not contain.
+///
+/// The leading space is deliberately excluded, and the property test is what
+/// found out why. [`recall_text`] trims the trigger, so a trigger of
+/// `" (applies when: x"` trims to `"(applies when: x"`, which contains no
+/// [`APPLIES_WHEN`] to escape — and then lands directly after the separator's
+/// own trailing space, *synthesizing* a second separator across the join.
+/// Escaping the paren-first form cannot be dodged that way: no space of ours
+/// can complete a match the trigger no longer contains.
+const APPLIES_WHEN_CORE: &str = "(applies when: ";
+
+/// What [`APPLIES_WHEN_CORE`] is rewritten to inside a trigger.
+///
+/// Dropping the paren is enough to break the match, and keeps the trigger
+/// readable rather than mangling it. See [`recall_text`] for why the
+/// substitution has to happen at all.
+const APPLIES_WHEN_ESCAPED: &str = "applies when: ";
+
+/// The text a lesson is stored and embedded as: the body, plus its trigger when
+/// it has one.
+///
+/// An empty trigger composes to the body alone, so a lesson mined before the
+/// field existed — or by a model that declined to state a condition — is stored
+/// exactly as it always was. That is not a fallback: `trigger` carries
+/// `#[serde(default, skip_serializing_if = "String::is_empty")]` precisely so
+/// the empty case is a first-class one.
+///
+/// The trigger is escaped rather than trusted. It is model prose, and a trigger
+/// that itself contained the separator would give the composed string two
+/// candidate split points — at which the round trip [`lesson_body`] guarantees
+/// stops being total. Rewriting the one substring that can do that makes the
+/// inverse exact for *every* pair of inputs, which is what
+/// `recomposing_any_body_and_trigger_recovers_the_body` asserts.
+pub(crate) fn recall_text(lesson: &str, trigger: &str) -> String {
+    let trigger = trigger.trim();
+    if trigger.is_empty() {
+        return lesson.to_string();
+    }
+    let trigger = trigger.replace(APPLIES_WHEN_CORE, APPLIES_WHEN_ESCAPED);
+    format!("{lesson}{APPLIES_WHEN}{trigger})")
+}
+
+/// The lesson body inside a stored memory — the exact inverse of
+/// [`recall_text`], and the string the restatement band compares.
+///
+/// Splits at the **last** separator, not the first. A body may legitimately
+/// contain the phrase (a lesson *about* this encoding, for one), and only the
+/// separator this module appended is guaranteed to be last, because
+/// [`recall_text`] escapes the trigger so it can contribute no later one.
+///
+/// A memory that does not end in `)` was never composed, and is returned whole.
+/// That leaves one benign misread: a memory written before this change whose
+/// own text happens to end in `)` *and* contain the separator would be trimmed
+/// here. The consequence is bounded to this comparison — a slightly shorter
+/// string on one side of a similarity score — and nothing is rewritten in the
+/// store, so the alternative (a marker byte in the content) would cost every
+/// reader a stripping step to avoid a case that has never occurred.
+pub(crate) fn lesson_body(stored: &str) -> &str {
+    let Some(inner) = stored.strip_suffix(')') else {
+        return stored;
+    };
+    match inner.rfind(APPLIES_WHEN) {
+        Some(at) => &stored[..at],
+        None => stored,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/memory/learning/applicability/tests.rs
+++ b/crates/stella-cli/src/memory/learning/applicability/tests.rs
@@ -1,0 +1,159 @@
+//! The encoding's two obligations: the composed text must carry the trigger
+//! into the embedded body, and the body must come back out **exactly**, because
+//! the restatement band compares what comes back out.
+//!
+//! The round trip is stated as a property rather than a table because the
+//! adversary is real: `trigger` is model prose, and the one input that can
+//! break a "split at the separator" decoder is a trigger that contains the
+//! separator. A table of hand-picked strings is a table of cases the author
+//! thought of.
+
+use proptest::prelude::*;
+
+use super::{lesson_body, recall_text};
+
+#[test]
+fn a_lesson_with_no_trigger_is_stored_exactly_as_it_always_was() {
+    let body = "the pre-push gate exports GIT_DIR to every hook it runs";
+    assert_eq!(
+        recall_text(body, ""),
+        body,
+        "a lesson mined before `trigger` existed, or by a model that declined \
+         to state a condition, must reach the store byte-for-byte unchanged — \
+         otherwise this change rewrites the corpus the restatement band was \
+         tuned on, which is the one thing #2459 exists to avoid"
+    );
+    assert_eq!(recall_text(body, "   \n  "), body, "whitespace is not a trigger");
+}
+
+#[test]
+fn the_trigger_lands_in_the_text_that_gets_embedded() {
+    let composed = recall_text(
+        "the witness stage refuses a diff it has not read",
+        "a task edits the witness stage",
+    );
+    assert_eq!(
+        composed,
+        "the witness stage refuses a diff it has not read (applies when: a \
+         task edits the witness stage)",
+        "the whole point is that the trigger is part of `content`: \
+         `ContextStore::upsert` keys a vector by sha256(content), so a field \
+         outside content has no vector and cannot be recalled on"
+    );
+}
+
+#[test]
+fn the_body_comes_back_out_and_the_band_sees_what_it_always_saw() {
+    let body = "commands are registered in registry.py";
+    let composed = recall_text(body, "a task adds or renames a CLI command");
+    assert_eq!(
+        lesson_body(&composed),
+        body,
+        "`partition_known` compares this string against the next candidate \
+         lesson's body; if the trigger leaked in, the union would grow on one \
+         side only and every paraphrase would read as novel"
+    );
+}
+
+#[test]
+fn a_body_that_looks_composed_does_not_confuse_its_own_trigger() {
+    // A lesson *about* this encoding is the realistic way a body acquires the
+    // separator. Splitting at the first occurrence would return "docs say" and
+    // silently shorten what the band compares.
+    let body = "docs say (applies when: x) is the stored form";
+    let composed = recall_text(body, "a task touches memory/learning");
+    assert_eq!(
+        lesson_body(&composed),
+        body,
+        "the decoder splits at the LAST separator, and `recall_text` escapes \
+         the trigger so no later one can exist"
+    );
+}
+
+#[test]
+fn a_trigger_that_spells_the_separator_is_escaped_not_trusted() {
+    let composed = recall_text("a fact", "x (applies when: y");
+    assert_eq!(
+        composed, "a fact (applies when: x applies when: y)",
+        "an unescaped trigger would give the composed string a second split \
+         point after the one we appended, and the round trip below would stop \
+         being total"
+    );
+    assert_eq!(lesson_body(&composed), "a fact");
+}
+
+/// The counterexample the property found, kept by name because the regression
+/// file that also holds it is a hash.
+///
+/// A trigger of `" (applies when: …"` **trims** to `"(applies when: …"`, which
+/// contains no separator to escape — and then lands immediately after the
+/// separator's own trailing space, synthesizing a second separator across the
+/// join. `lesson_body` split at that one and returned ` (applies when:` as the
+/// lesson. Escaping the paren-first form is what closes it: the trigger cannot
+/// borrow our space to complete a match.
+#[test]
+fn a_trigger_that_only_becomes_a_separator_after_trimming_is_still_escaped() {
+    let composed = recall_text("", " (applies when: x");
+    assert_eq!(lesson_body(&composed), "");
+    assert_eq!(composed, " (applies when: applies when: x)");
+}
+
+#[test]
+fn an_uncomposed_memory_is_returned_whole() {
+    for stored in [
+        "money is stored in integer minor units",
+        "the deck redraws on resize (see deck_ui.rs)",
+        "",
+    ] {
+        assert_eq!(
+            lesson_body(stored),
+            stored,
+            "every memory written before this change must read back \
+             unchanged, or the band's stored side moves for the whole \
+             existing corpus"
+        );
+    }
+}
+
+proptest! {
+    /// **The obligation.** For any body and any non-empty trigger, the body
+    /// survives the round trip byte-for-byte.
+    ///
+    /// This is what discharges #2459's "re-measure the restatement band"
+    /// requirement without a benchmark: the band's input is not approximately
+    /// preserved, it is *identical*, so there is no distribution left to
+    /// measure. The trigger is generated adversarially — it may contain the
+    /// separator, parens, and newlines — because it is model output and
+    /// nothing constrains it.
+    #[test]
+    fn recomposing_any_body_and_trigger_recovers_the_body(
+        body in ".{0,120}",
+        trigger in "[^ ]{0,20}( \\(applies when: |[a-z )(]){0,10}[^ ]{0,20}",
+    ) {
+        prop_assume!(!trigger.trim().is_empty());
+        let composed = recall_text(&body, &trigger);
+        prop_assert_eq!(
+            lesson_body(&composed),
+            body.as_str(),
+            "the decoder must be the exact inverse of the encoder for every \
+             trigger a model can emit — the restatement band's correctness \
+             rests on it"
+        );
+    }
+
+    /// Composition adds the trigger and changes nothing else: the composed
+    /// text always starts with the body it was built from.
+    #[test]
+    fn composition_only_ever_appends(
+        body in ".{0,120}",
+        trigger in ".{0,80}",
+    ) {
+        let composed = recall_text(&body, &trigger);
+        prop_assert!(
+            composed.starts_with(&body),
+            "a lesson's own words must reach the embedding unmodified; \
+             rewriting them would move the body's contribution to every \
+             similarity score in the store"
+        );
+    }
+}

--- a/crates/stella-cli/src/memory/learning/applicability/tests.rs
+++ b/crates/stella-cli/src/memory/learning/applicability/tests.rs
@@ -23,7 +23,11 @@ fn a_lesson_with_no_trigger_is_stored_exactly_as_it_always_was() {
          otherwise this change rewrites the corpus the restatement band was \
          tuned on, which is the one thing #2459 exists to avoid"
     );
-    assert_eq!(recall_text(body, "   \n  "), body, "whitespace is not a trigger");
+    assert_eq!(
+        recall_text(body, "   \n  "),
+        body,
+        "whitespace is not a trigger"
+    );
 }
 
 #[test]

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -267,11 +267,18 @@ async fn the_per_turn_lesson_cap_is_above_what_a_turn_typically_teaches() {
         "the parser truncates to a different number than the prompt promises, \
          so the model is told a cap it is not held to"
     );
-    assert!(
-        super::MAX_LESSONS_PER_TURN > 3,
-        "the cap is back below what a turn teaches, which makes it the decision \
-         again rather than a backstop"
-    );
+    // A `const` block, because the predicate is constant and clippy's
+    // `assertions_on_constants` is right that a runtime assert on it is
+    // theatre: it can only fail on a code change, never on a run. Const
+    // evaluation makes that literal — a cap put back below what a turn teaches
+    // stops the build rather than waiting for someone to run this test.
+    const {
+        assert!(
+            super::MAX_LESSONS_PER_TURN > 3,
+            "the cap is back below what a turn teaches, which makes it the \
+             decision again rather than a backstop"
+        );
+    }
 }
 
 /// #1847's request-shape half: reflection is a bounded management call.

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -17,6 +17,10 @@ mod record_channel;
 // Spec §8 (#737): the seam where auto-created skill files meet what is
 // already on disk — its own module, and the reason tests.rs fits the ratchet.
 mod skill_creation;
+// #2459: a lesson's `trigger` decides what recall returns. The experiment
+// needs two goals, two crossed lessons and a scripted provider to set up, so it
+// lives beside the other multi-fixture seams rather than inline here.
+mod trigger_recall;
 
 use super::*;
 

--- a/crates/stella-cli/src/memory/tests/trigger_recall.rs
+++ b/crates/stella-cli/src/memory/tests/trigger_recall.rs
@@ -1,0 +1,233 @@
+//! **The witness for #2459.** A lesson's `trigger` decides what recall returns.
+//!
+//! Reflection has asked for a trigger on every lesson — the condition a future
+//! task has to satisfy for it to be worth reading — since the counterfactual
+//! prompt landed, and nothing consulted it. A lesson that stated exactly when it
+//! applied was retrieved by the same embedding guess as one that did not.
+//!
+//! The experiment is built so that **only** the trigger can produce the result,
+//! and it is built *against* the change rather than for it. Each lesson's body
+//! is given a weak lexical tie to the goal the *other* lesson is meant to win,
+//! and each trigger a strong tie to its own. So the bodies alone rank the pair
+//! backwards, and a run in which the right lesson wins is a run in which
+//! something other than the body decided. There is no arrangement of body-only
+//! scores that passes this by luck — which is what makes it a witness rather
+//! than a plausible assertion (verified by reverting `recall_text` to the bare
+//! lesson: both assertions below fail).
+//!
+//! Everything reaches the store through `reflect_and_record`, the production
+//! write path, so what is pinned is the wiring and not a helper.
+
+use async_trait::async_trait;
+use stella_protocol::{
+    CompletionRequestRef, CompletionResult, CompletionUsage, Provider, ProviderError,
+};
+
+use super::msg;
+use crate::memory::*;
+
+/// The two goals, and the lesson each one should surface. Held as constants so
+/// the crossing is visible in one place: `RESIZE_GOAL` names the *body* of the
+/// ledger lesson and the *trigger* of the money lesson.
+const RESIZE_GOAL: &str = "the terminal resize path drops a redraw";
+const RETRY_GOAL: &str = "the provider retry backoff never settles";
+
+/// Answers reflection with two lessons whose bodies and triggers point at
+/// opposite goals.
+///
+/// The bodies are unrelated facts — 0 shared tokens, so both clear
+/// `partition_known`'s restatement band and both reach the store. Each carries
+/// one weak nod to the wrong goal (`retry` in the money lesson, `resize` in the
+/// ledger lesson) so that body-only ranking has a definite, wrong answer rather
+/// than a coin flip.
+struct CrossedTriggers;
+
+#[async_trait]
+impl Provider for CrossedTriggers {
+    fn id(&self) -> &str {
+        "crossed"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Ok(CompletionResult {
+            text: r#"{"lessons": [
+                {"lesson": "money is stored in integer minor units, so a retry that re-reads a total must not divide",
+                 "trigger": "the terminal resize path drops a redraw",
+                 "saves": "an afternoon spent on rounding drift",
+                 "kind": "domain", "domains": []},
+                {"lesson": "the spend ledger is append-only, and a resize of the window never rewrites a row",
+                 "trigger": "the provider retry backoff never settles",
+                 "saves": "a corrupted ledger",
+                 "kind": "domain", "domains": []}
+            ]}"#
+            .into(),
+            tool_calls: vec![],
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 1,
+                ..CompletionUsage::default()
+            },
+            model: "crossed".into(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Run one scripted reflection turn against a fresh workspace and hand back the
+/// session, so both goals below query one store.
+async fn session_with_crossed_lessons() -> (tempfile::TempDir, SessionMemory) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+    let mut memory = SessionMemory::open(dir.path(), false).expect("session memory");
+
+    let transcript = vec![
+        msg(MessageRole::User, "reconcile the spend ledger"),
+        msg(MessageRole::Assistant, "reconciled"),
+    ];
+    let report = memory
+        .reflect_and_record(&CrossedTriggers, "crossed", &transcript, true, true, None)
+        .await;
+    assert_eq!(
+        report.recorded, 2,
+        "both lessons must reach the store — they share no tokens, so neither \
+         is a restatement of the other: {report:?}"
+    );
+    (dir, memory)
+}
+
+/// The text of the highest-ranked recalled memory for `goal`.
+async fn top_frame(memory: &SessionMemory, goal: &str) -> String {
+    let recall = memory
+        .recalled_frames_reporting(goal, |_| {})
+        .await
+        .frames
+        .into_iter()
+        .next()
+        .expect("recall returned at least one frame");
+    recall.content
+}
+
+/// **The witness.** Each goal surfaces the lesson whose *trigger* it satisfies,
+/// not the one whose *body* it echoes.
+#[tokio::test]
+async fn a_goal_recalls_the_lesson_whose_trigger_it_satisfies() {
+    let (_dir, memory) = session_with_crossed_lessons().await;
+
+    let for_resize = top_frame(&memory, RESIZE_GOAL).await;
+    assert!(
+        for_resize.contains("minor units"),
+        "a task about the resize path must surface the lesson whose trigger \
+         names that path — even though the OTHER lesson's body is the one that \
+         says `resize`. Before #2459 the trigger was recorded and never read, \
+         so the body's word won and this returned the ledger lesson: {for_resize}"
+    );
+
+    let for_retry = top_frame(&memory, RETRY_GOAL).await;
+    assert!(
+        for_retry.contains("append-only"),
+        "and symmetrically: the retry goal must surface the lesson triggered on \
+         retry backoff, not the one whose body happens to say `retry`. Both \
+         halves are asserted because one alone could be satisfied by a store \
+         that simply ranks the same memory first for everything: {for_retry}"
+    );
+
+    assert_ne!(
+        for_resize, for_retry,
+        "two tasks satisfying different triggers must not be handed the same \
+         memory — that is the whole claim, stated without reference to which \
+         lesson is which"
+    );
+}
+
+/// The trigger reaches the prompt, not just the ranking.
+///
+/// Folding is what puts it in the embedded body (`ContextStore::upsert` keys a
+/// vector by `sha256(content)`, so a field outside `content` has no vector), and
+/// the same fold is what lets a recalled memory announce the condition it holds
+/// under instead of arriving as a bare assertion.
+#[tokio::test]
+async fn a_recalled_memory_states_the_condition_it_applies_under() {
+    let (_dir, memory) = session_with_crossed_lessons().await;
+    let block = memory
+        .recall_block(RESIZE_GOAL)
+        .await
+        .expect("the goal recalls something");
+
+    assert!(
+        block.contains("(applies when: the terminal resize path drops a redraw)"),
+        "the recalled-context block must carry the lesson's applicability, so \
+         the model can judge whether it holds here rather than guessing: {block}"
+    );
+}
+
+/// The restatement band is unmoved by the fold — the property #2459 makes
+/// conditional on this change.
+///
+/// A second turn re-learning the first turn's fact, in different words and
+/// under a *different* trigger, must still be diverted as a restatement. It is
+/// the same fact; the trigger records only when it was noticed. Storing it
+/// twice would spend two of five recall frames restating one thing, which is
+/// exactly the 61%-restatement store #2358 measured.
+#[tokio::test]
+async fn a_paraphrase_under_a_new_trigger_is_still_a_restatement() {
+    let (_dir, mut memory) = session_with_crossed_lessons().await;
+
+    struct Paraphrase;
+    #[async_trait]
+    impl Provider for Paraphrase {
+        fn id(&self) -> &str {
+            "paraphrase"
+        }
+        async fn complete_ref(
+            &self,
+            _req: CompletionRequestRef<'_>,
+        ) -> Result<CompletionResult, ProviderError> {
+            Ok(CompletionResult {
+                // Every token of the stored ledger lesson bar one, so the pair
+                // is comfortably over the 0.5 Jaccard bar on bodies alone —
+                // and a trigger that shares nothing with the stored one, which
+                // is what would drag a composed comparison under the bar.
+                text: r#"{"lessons": [
+                    {"lesson": "the spend ledger is append-only and a resize of the window never rewrites a row",
+                     "trigger": "a task prunes telemetry rows from store.db",
+                     "saves": "a corrupted ledger", "kind": "domain", "domains": []}
+                ]}"#
+                .into(),
+                tool_calls: vec![],
+                usage: CompletionUsage {
+                    reported: true,
+                    input_tokens: 1,
+                    ..CompletionUsage::default()
+                },
+                model: "paraphrase".into(),
+                cost_usd: 0.0,
+                finish_reason: None,
+            })
+        }
+    }
+
+    let before = memory.store.memory_nodes().expect("nodes readable").len();
+    let transcript = vec![
+        msg(MessageRole::User, "prune old telemetry"),
+        msg(MessageRole::Assistant, "pruned"),
+    ];
+    let report = memory
+        .reflect_and_record(&Paraphrase, "paraphrase", &transcript, true, true, None)
+        .await;
+    assert!(
+        report.model_error.is_none(),
+        "the scripted turn must reach the split, not fail before it: {report:?}"
+    );
+    let after = memory.store.memory_nodes().expect("nodes readable").len();
+
+    assert_eq!(
+        after, before,
+        "the band compares bodies to bodies on both sides; a comparison that \
+         let the trigger in would read this paraphrase as novel and store it, \
+         which is the silent flood #2459 required measuring for"
+    );
+}

--- a/crates/stella-cli/src/memory/tests/trigger_recall.rs
+++ b/crates/stella-cli/src/memory/tests/trigger_recall.rs
@@ -12,8 +12,13 @@
 //! backwards, and a run in which the right lesson wins is a run in which
 //! something other than the body decided. There is no arrangement of body-only
 //! scores that passes this by luck — which is what makes it a witness rather
-//! than a plausible assertion (verified by reverting `recall_text` to the bare
-//! lesson: both assertions below fail).
+//! than a plausible assertion.
+//!
+//! Checked, not assumed. Reverting the one call that folds the trigger in
+//! (`learning.rs`, `recall_text` → the bare lesson) fails both tests below, and
+//! fails them the predicted way: the resize goal comes back holding *the ledger
+//! lesson*, because "resize" appears in that lesson's body. The third test —
+//! the restatement band — passes on both sides, which is the point of it.
 //!
 //! Everything reaches the store through `reflect_and_record`, the production
 //! write path, so what is pinned is the wiring and not a helper.

--- a/docs/prompts/reflection.md
+++ b/docs/prompts/reflection.md
@@ -122,8 +122,13 @@ with:
 - **`trigger`** — what has to be true of a future task for it to matter. A
   lesson whose trigger the model cannot state is one it has not finished
   learning; requiring the condition prunes those where the transcript is still
-  there to check them against. Recorded and mined today, **not yet consulted at
-  recall** — that wiring is #2459.
+  there to check them against. It is also **folded into the memory body recall
+  scores on** (#2459), which is the second thing it buys: a trigger is written
+  in the register a goal is written in, so it is the half of a lesson that lives
+  in the space the retrieval query is asked in. The restatement band still
+  compares bodies to bodies — see
+  `crates/stella-cli/src/memory/learning/applicability.rs` for the encoding that
+  keeps those two facts compatible.
 - **`saves`** — what knowing it would have bought in the turn that produced it,
   pointing at the moment it would have changed. This is what makes a lesson
   refutable rather than merely asserted, and it is refutable against the very


### PR DESCRIPTION
## What & why

Reflection asks the model for a `trigger` on every lesson — the condition a
future task has to satisfy for the lesson to be worth reading — and records it.
Nothing read it. A lesson that stated exactly when it applied was retrieved by
the same embedding guess as one that did not.

**Where the trigger participates: folded into the memory body recall scores on.**
That is not a preference between three equal options. `ContextStore::upsert`
keys a vector `(sha256(content), embedder fingerprint)` — the byte-compat skip
`L-C2` rests on it — and the lexical fallback (`candidates::scan_terms`) reads
`content` too. A field outside `content` has no vector and cannot be recalled
on. The alternatives #2459 lists are worse *here*:

- a **separate scored field** costs a `stella-context` schema change, a second
  vector per reflection memory, and a fusion weight nothing has data to tune —
  a knob bought with no measurement;
- a **post-retrieval filter** turns model prose into a hard drop, and its
  failure mode is silently withholding a memory that was correct, which is
  strictly worse than today, where the memory at least competes.

### Why the restatement band does not move

This is the part #2459 said needed measuring, and it is discharged by
construction instead.

`partition_known` compares a candidate lesson against stored bodies at Jaccard
0.5. Folding naively makes that comparison **asymmetric** — extra tokens on the
stored side only, inflating the union — so paraphrases read as novel and flood
the store. Composing *both* sides is a worse break, not the repair: a five-token
body restated verbatim, under two six-token triggers sharing two tokens, scores
1.0 on bodies and `(5+2)/(5+10) = 0.47` composed. An exact duplicate fact,
classified novel, because trigger verbosity outvoted the fact.

So the band keeps comparing **bodies to bodies**. `memory/learning/applicability.rs`
is what lets it: `recall_text` composes into the store, `lesson_body` recovers
the body out of it, and they are exact inverses. The strings `partition_known`
compares are therefore **byte-identical** to the ones #2358 tuned it on. A
benchmark could only have reported that same equality with less confidence, and
only for the corpus it happened to run on.

The deliberate consequence: two lessons stating one fact under two different
conditions collapse to one memory. That is right — recall would otherwise spend
two of five frames restating a single fact.

Closes #2459

## The witness

- [x] This PR includes a witness test (fails on the base, passes here)

`crates/stella-cli/src/memory/tests/trigger_recall.rs`. Two lessons reach the
store through `reflect_and_record` (the production write path, not a helper),
each given a **weak lexical tie to the wrong goal in its body** and a strong tie
to its own goal in its trigger. So the bodies alone rank the pair backwards, and
there is no arrangement of body-only scores that passes.

Checked the artisanal way — reverting the single `recall_text` call to the bare
lesson fails both retrieval tests, and fails them the predicted way: the resize
goal comes back holding *the ledger lesson*, because `resize` appears in that
lesson's body. The third test (the restatement band) passes on both sides, which
is the point of it.

The round trip is a **property test**, not a table, because the input that breaks
a separator-based decoder is a trigger that spells the separator — and a table
covers the cases its author imagined. It earned its keep on the first run: a
trigger of `" (applies when: x"` **trims** to `"(applies when: x"`, which
contains no separator to escape, and then borrows the separator's own trailing
space to synthesize a second one across the join. Escaping the paren-first form
closes it; the counterexample is pinned by name and by the committed regression
file.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated — `docs/prompts/reflection.md` no longer says the trigger is
      unconsumed; the `ReflectionLesson::trigger` field doc no longer points at
      #2459 as pending work
- [x] `Closes #2459` in this description **and** as a commit trailer

Run as `make gate CARGO_SCOPE="-p stella-cli"`.

## Nothing left behind

- [x] Filed: #2476, #2477

- **#2476** — every recalled memory ships its own text **twice** into the
  prompt. `render_context_section` renders `- [{id}] {label} — {content}`, and a
  memory node's label is `truncate_label(content)`, which is the identity below
  80 chars. Verified in this PR's own witness output. Pre-existing, separate
  seam, real token cost against a 1200-token recall budget the pack does not
  even see (the duplication is added after the budget pack).
- **#2477** — measure whether the fold actually *improves* retrieval on real
  data. It cannot be measured yet: no `trigger` has ever been written by a real
  run (the field ships with #2465), so the only available corpus would have been
  synthetic — which measures the fixture author's guess about how models phrase
  triggers, the exact guess #2465 exists to stop making. Correctness is proven
  here; value is not, and the issue says so plainly, including the possibility
  that the honest result is a revert.

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] One new **dev**-dependency: `proptest` on `stella-cli`. Already a
      workspace dependency (`stella-core`, `-context`, `-fleet`, `-pipeline`,
      `-tui`), so it adds no crate to the tree. Justified above: the totality of
      the round trip is the load-bearing claim, and it is the claim a table
      cannot support.

## Anything reviewers should know?

**This PR is stacked on #2465** (`worktree-reflection-counterfactual`), which
adds the `trigger` field itself. #2459 is not implementable without it. Base is
that branch, so the diff here is only the wiring; retarget to `main` when #2465
merges.

**One inherited fix is in this diff.** `make gate` is red on the base branch at
`lint`: `crates/stella-cli/src/memory/reflection/tests.rs:270` runs `assert!` on
a constant predicate, which clippy rejects at `-D warnings`. `git blame` puts it
on #2465's own commit. This branch cannot be green without it, so it is fixed
here as a `const` block — which is the better assertion anyway, since a cap
regression now stops the build rather than waiting for someone to run the test.
Reported on #2465 rather than pushed there, since that branch is not mine; the
duplicate edit resolves cleanly if it is fixed there first.

**Deliberately not done:** the trigger does not anchor. `resolve_anchors` still
runs on the lesson alone — a trigger names the *situation* a lesson applies in,
not the files it is about, so letting it anchor would claim `verify.rs` is the
subject of every lesson whose condition merely mentions it.

**One known benign edge**, documented at `lesson_body`: a memory written before
this change whose text happens to both end in `)` and contain the separator
would be trimmed in the band's comparison. The consequence is bounded to one
similarity score, nothing in the store is rewritten, and the alternative — a
marker byte in the content — would tax every reader forever to avoid a case that
has never occurred.

## Summary by Sourcery

Fold reflection lesson triggers into stored memory content used for recall, while preserving existing restatement behavior and documenting the new applicability semantics.

New Features:
- Include a lesson’s trigger in the stored reflection memory text so retrieval can rank memories based on the conditions they apply under.

Enhancements:
- Introduce an applicability module that defines how lesson bodies and triggers are composed and decoded without changing restatement-band similarity inputs.
- Ensure anchors continue to resolve against lesson bodies only, keeping triggers from influencing file-based anchoring.
- Tighten the lesson-per-turn cap guarantee by turning a constant assertion into a compile-time const check.

Build:
- Add `proptest` as a dev-dependency for `stella-cli` to support property-based tests of the applicability encoding.

Documentation:
- Update reflection prompt and `ReflectionLesson::trigger` documentation to describe how triggers participate in recall and how the restatement band remains body-only.

Tests:
- Add integration tests proving that goals recall the lesson whose trigger they satisfy, that triggers appear in recalled context blocks, and that paraphrases under new triggers are still treated as restatements.
- Add property-based tests for the applicability encoding to ensure composed memory text round-trips lesson bodies exactly across arbitrary triggers.

Chores:
- Register the new trigger-focused recall test module in the memory test suite.