### PR TITLE
feat(stella-tui): the deck shows the clock that will stop the run, beside the money

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -431,6 +431,17 @@ pub struct Hud {
     pub spent_usd: f64,
     pub limit_usd: Option<f64>,
     pub budget_mode: Option<BudgetMode>,
+    /// Wall clock left before the task deadline, as the last `BudgetTick`
+    /// reported it (#2240, #2435). `None` is the load-bearing case and means
+    /// **no deadline is armed** — never "no time left", which is
+    /// `Some(0)`. The statline renders the two differently for exactly that
+    /// reason: a HUD showing `0s` for an unarmed run would put back into the
+    /// UI the confusion #2240 took out of the journal.
+    ///
+    /// Milliseconds rather than a `Duration` because that is the wire shape
+    /// (`AgentEvent::BudgetTick::deadline_remaining_ms`), and this struct is a
+    /// fold of the stream, not a reinterpretation of it.
+    pub deadline_remaining_ms: Option<u64>,
     pub stage: Option<StageKind>,
     pub model: Option<String>,
     /// [`Hud::spent_usd`] as it stood when the current turn began, so live turn
@@ -725,6 +736,7 @@ impl SessionModel {
                 spent_usd,
                 limit_usd,
                 mode,
+                deadline_remaining_ms,
                 ..
             } => {
                 // Gauge only — deliberately *not* pushed to the transcript.
@@ -746,6 +758,10 @@ impl SessionModel {
                 self.hud.spent_usd = *spent_usd;
                 self.hud.limit_usd = *limit_usd;
                 self.hud.budget_mode = Some(*mode);
+                // Assigned, never merged with what was there: an unarmed run
+                // must be able to go back to reporting nothing, and `or`-ing
+                // the old value would latch a stale clock onto it forever.
+                self.hud.deadline_remaining_ms = *deadline_remaining_ms;
             }
             AgentEvent::ProviderFallback { from, to, reason } => {
                 self.transcript.push(TranscriptEntry::ProviderFallback {

--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -876,6 +876,79 @@ mod tests {
         }
     }
 
+    /// One `BudgetTick` with the given wall-clock axis, folded into a running
+    /// model — the shape #2240 puts on the stream and #2435 renders.
+    fn model_with_deadline(remaining_ms: Option<u64>) -> WorkspaceModel {
+        let mut m = running_model();
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::BudgetTick {
+                spent_usd: 1.25,
+                limit_usd: None,
+                mode: stella_protocol::BudgetMode::Off,
+                session_spent_usd: None,
+                session_limit_usd: None,
+                deadline_remaining_ms: remaining_ms,
+            },
+        });
+        m
+    }
+
+    /// #2435 witness, half one: an armed deadline gets a cell beside SPEND.
+    /// Fails on `main`, where every consumer read the dollar fields and
+    /// dropped the wall-clock one — the HUD's own contract says nothing
+    /// user-visible about a run's ceilings comes from state that is not also
+    /// in this event, and the clock was in the event and on no screen.
+    #[test]
+    fn an_armed_deadline_shows_its_remaining_clock_beside_spend() {
+        let items = statline_items(&model_with_deadline(Some(120_000)), &DeckUi::default());
+        let clock = items
+            .iter()
+            .find(|i| i.key == "clock")
+            .expect("an armed deadline earns a CLOCK cell");
+        assert_eq!(clock.label, "CLOCK");
+        let text: String = clock.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "2m 00s", "the cell states the clock that remains");
+    }
+
+    /// #2435 witness, half two — and the half that matters more: an UNARMED
+    /// deadline renders nothing at all. `None` means nobody is timing this
+    /// run; a cell reading `0s` would put back into the UI exactly the
+    /// confusion #2240 removed from the journal.
+    #[test]
+    fn an_unarmed_deadline_renders_no_cell_rather_than_zero() {
+        let items = statline_items(&model_with_deadline(None), &DeckUi::default());
+        assert!(
+            !keys(&items).contains(&"clock"),
+            "an unarmed run must show no clock, never a zeroed one: {:?}",
+            keys(&items)
+        );
+    }
+
+    /// The two facts `deadline_remaining_ms` exists to separate must not read
+    /// alike: a crossed deadline is a word, an armed one is a quantity, and an
+    /// unarmed one (above) is nothing.
+    #[test]
+    fn a_crossed_deadline_reads_as_expired_not_as_a_duration() {
+        let items = statline_items(&model_with_deadline(Some(0)), &DeckUi::default());
+        let clock = items
+            .iter()
+            .find(|i| i.key == "clock")
+            .expect("a crossed deadline is still an armed one");
+        let text: String = clock.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "expired");
+    }
+
+    /// The countdown's own arithmetic, apart from the model that feeds it.
+    #[test]
+    fn the_clock_label_uses_the_coarsest_unit_that_still_resolves_the_wait() {
+        assert_eq!(fmt_remaining(0), "expired");
+        assert_eq!(fmt_remaining(400), "<1s");
+        assert_eq!(fmt_remaining(45_000), "45s");
+        assert_eq!(fmt_remaining(120_000), "2m 00s");
+        assert_eq!(fmt_remaining(3_600_000 + 420_000), "1h 07m");
+    }
+
     #[test]
     fn every_cell_labels_itself_for_the_row_above() {
         let model = running_model();

--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -294,6 +294,31 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
         ),
     ];
 
+    // CLOCK: only once a task deadline is armed. `BudgetTick` carries the
+    // wall-clock axis beside the dollar ones (#2240), and until #2435 nothing
+    // rendered it — the HUD's own contract says nothing user-visible about a
+    // run's ceilings is derived from state that is not also in that event, and
+    // the clock was in the event and on no screen.
+    //
+    // Absent rather than zeroed when unarmed, which is the whole point: `None`
+    // means nobody is timing this run and `Some(0)` means it is out of time.
+    // A cell reading `0s` for an unarmed run would put back into the UI the
+    // confusion #2240 removed from the journal, so the two get different
+    // renderings and the unarmed one gets no cell at all.
+    //
+    // Priority 6, tied with SPEND: ties resolve by declaration order and this
+    // cell is declared later, so on a narrowing row SPEND survives one column
+    // longer. It outranks CACHE/SAVED/WARMTH because it is the only cell here
+    // that says the run is about to stop.
+    if let Some(remaining_ms) = focused.and_then(|a| a.model.hud.deadline_remaining_ms) {
+        items.push(StatItem::new(
+            "clock",
+            "CLOCK",
+            6,
+            remaining_spans(remaining_ms),
+        ));
+    }
+
     // LANES: only once this session has spawned subagents — a solo run has
     // nothing to disambiguate and pays no columns for the cell. Priority 3,
     // *below* CACHE, even though it is the wider cell: at 150 columns a tie
@@ -570,6 +595,48 @@ fn warmth_spans(remaining_secs: Option<u64>) -> Vec<Span<'static>> {
         cache_panel::fmt_warmth(remaining_secs),
         Style::new().fg(color),
     )]
+}
+
+/// CLOCK cell: wall clock left before the armed task deadline.
+///
+/// Only ever called with an armed deadline — the unarmed run has no cell at
+/// all, because "nobody is timing this" is not a duration and must not be
+/// drawn as one (#2435).
+///
+/// Colored on the same three-rung ladder [`warmth_spans`] uses, and for the
+/// same reason: the number matters most exactly when it is small, and a
+/// glance should land on the color before it lands on the digits. `Some(0)`
+/// is the deadline already crossed, so it reads as a word rather than a
+/// quantity — `0s` invites "no deadline", which is the one thing it does not
+/// mean.
+fn remaining_spans(remaining_ms: u64) -> Vec<Span<'static>> {
+    let color = match remaining_ms {
+        0 => theme::DANGER_BRIGHT,
+        ms if ms < 60_000 => theme::WARNING_BRIGHT,
+        _ => theme::SUCCESS_BRIGHT,
+    };
+    vec![Span::styled(
+        fmt_remaining(remaining_ms),
+        Style::new().fg(color),
+    )]
+}
+
+/// The CLOCK cell's text: coarsest unit that still resolves the wait, so the
+/// cell stays narrow and stops jittering in width as it counts down.
+///
+/// Seconds are dropped above an hour on purpose — a run with an hour left is
+/// not one anybody is watching second by second, and a cell that changes
+/// width every tick costs its neighbours a column each time.
+fn fmt_remaining(remaining_ms: u64) -> String {
+    let secs = remaining_ms / 1_000;
+    match secs {
+        0 if remaining_ms == 0 => "expired".to_string(),
+        // Sub-second but not yet crossed: still armed, still counting.
+        0 => "<1s".to_string(),
+        s if s < 60 => format!("{s}s"),
+        s if s < 3_600 => format!("{}m {:02}s", s / 60, s % 60),
+        s => format!("{}h {:02}m", s / 3_600, (s % 3_600) / 60),
+    }
 }
 
 /// Which card/overlay is on top, for the collapse rule — the card enum for

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -786,3 +786,42 @@ fn deck_render_snapshots_diff_explains_a_trailing_newline() {
         "there is no differing character to point at:\n{report}"
     );
 }
+
+/// The statline's CLOCK cell (#2435): a run with an armed task deadline shows
+/// the wall clock it has left beside the money it has spent.
+///
+/// A golden rather than a `contains` assertion because a new cell **moves
+/// columns** — every cell to its right shifts, and only the whole grid can say
+/// whether the band still fits and what it dropped to make room.
+///
+/// The unarmed case needs no golden of its own: every other snapshot in this
+/// file is one, and none of them grew a cell when this landed. That is the
+/// evidence for "absent, not zeroed" — a `0s` would have shown up in all of
+/// them.
+#[test]
+fn deck_render_snapshots_pin_the_armed_deadline_statline() {
+    let mut model = fixture_model();
+    let mut ui = ui_for(DeckTab::Session);
+    let agent = model.agents[ui.focused].meta.id.clone();
+    model.apply_inbound(&stella_tui::envelope::Inbound::Event {
+        agent,
+        event: stella_protocol::AgentEvent::BudgetTick {
+            spent_usd: 3.77,
+            limit_usd: None,
+            mode: stella_protocol::BudgetMode::Off,
+            session_spent_usd: None,
+            session_limit_usd: None,
+            // 12m 34s — long enough to exercise the minutes form, and not a
+            // round number, so a golden that silently truncated would show it.
+            deadline_remaining_ms: Some(754_000),
+        },
+    });
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "statline_deadline_armed",
+        "the statline with a task deadline armed — CLOCK beside SPEND",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -1,0 +1,45 @@
+# deck golden · statline_deadline_armed
+# the statline with a task deadline armed — CLOCK beside SPEND
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────✦ stella ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ grep trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $3.7700  ·  off                                                                                                                │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 21 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│                                                                                                                      ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
+│                                                                                                                      ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
+│                                                                                                                      ││                                      │
+│── WITNESS ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                                                                                                      ││                                      │
+│● read_file    apps/app/automations/page.tsx                                                                          │└────────────────────── /plan reads it ┘
+│  ⎿ 312 lines                                                                                                     42ms│┌ DONE VERIFICATION ───────────────────┐
+│                                                                                                                      ││○ warrant  pending                    │
+│☰  plan  5/7  ·  Workflows canvas                                                                                     ││● witness  authored  apps/app/automat…│
+│                                                                                                                      ││● oracle   ✗ fails on base → ✓ passes…│
+│⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files                        ││○ tamper   pinned  sha256:9f3c1d2e4…  │
+│                                                                                                                      ││○ verdict  pending                    │
+└─────────────────────────────────────────── ↑ select · ⇞⇟ scroll · ⌃F find · ⌃N failure · ⌃Z fold · ⌃O expand · /plan ┘└──────────────────────────────────────┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ spend  $3.7700
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $3.7700  ·  1 line  ·  queue empty
+ MODEL                   │ EXECUTE     │ CPU         │ CONTEXT          │ SPEND          │ CACHE                 │ ENGINE   │ CLOCK   │ PR
+ worker: zai/glm-5.2-air │ Step 6 of 7 │ ▮▮▮▯▯▯  50% │ ▯▯▯▯▯▯ 8.2k/200k │ $3.79 of $7.50 │ 63% (18.0K rd · 0 wr) │ 3 active │ 12m 34s │ ⇢ #981 open …


### PR DESCRIPTION
## What

#2240 added `AgentEvent::BudgetTick::deadline_remaining_ms` and nothing read
it. `BudgetTick`'s own doc comment says the HUD renders spend live from this
stream and that *nothing user-visible about a run's ceilings is derived from
state that is not also in this event* — the wall clock was in the event and on
no screen.

The Command Deck's statline gains a **CLOCK** cell, folded from the tick into
`Hud::deadline_remaining_ms` and rendered beside SPEND.

## The three-way distinction, which is the whole point

| tick value | cell |
|---|---|
| `None` — no deadline armed | **no cell at all** |
| `Some(0)` — armed and already crossed | `expired` |
| `Some(n)` | `12m 34s` |

`None` renders as absent rather than `0s` because "nobody is timing this run"
and "this run is out of time" are the two facts the field exists to separate —
a zeroed cell would put back into the UI exactly the confusion #2240 removed
from the journal. `Some(0)` reads as a word rather than a quantity for the same
reason: `0s` invites "no deadline", which is the one thing it does not mean.

## Scope — stated explicitly, since the issue asks for that judgement

- **In: the deck HUD.** It folds the live event stream, so this is a pure
  rendering change with no persistence and no new privacy surface.
- **Out: the Observatory** — filed as **#2487**. `rg BudgetTick
  crates/stella-observatory/` returns nothing: the dashboard reads persisted
  `cost_usd` from SQLite and never sees a tick. Giving it this axis needs a new
  store column *and* an invariant-3 `content_free.rs` allowlist decision a
  human has to make. The issue also raises the prior question of whether a
  per-tick countdown is even worth persisting, given `task_deadline` is an
  absolute `Instant`.
- **Out: `journal.rs::last_spent_usd`** — it re-seeds spend on resume, and an
  absolute `Instant` cannot survive a process restart, so there is nothing
  coherent to re-seed. Covered in #2487.
- **Out: the collapsed statline** (a card overlay). The four-cell collapse rule
  is documented twice — the module doc and an inline comment — and I did not
  unilaterally amend someone's stated design. Happy to add it if you want it;
  say so and it is two lines.

## Design notes

- Colored on the same three-rung ladder `warmth_spans` already uses
  (danger/warning/success), not an invented threshold policy: the number
  matters most exactly when it is small, and a glance should land on the color
  before the digits.
- Priority 6, **tied with SPEND and declared after it**, so ties resolve by
  declaration order and a narrowing row drops CLOCK before SPEND. It outranks
  CACHE/SAVED/WARMTH/LANES because it is the only cell that says the run is
  about to stop.
- The fold **assigns** rather than merges: `or`-ing the previous value would
  latch a stale clock onto a run that stopped being timed.
- No god file grew. The cell and its two helpers live in `statline.rs` (1016
  lines, not grandfathered); `deck_ui.rs`, `deck_render.rs`,
  `views/engine.rs` and `views/session.rs` are untouched.

## Witness

Exactly the witness the issue specifies, in `statline.rs`'s test module —
`statline_items` is the single decision function and is unit-testable without a
buffer:

- `an_armed_deadline_shows_its_remaining_clock_beside_spend` —
  `deadline_remaining_ms: Some(120_000)` yields a CLOCK cell reading `2m 00s`.
- `a_crossed_deadline_reads_as_expired_not_as_a_duration` — `Some(0)`.
- `an_unarmed_deadline_renders_no_cell_rather_than_zero` — `None`.
- `the_clock_label_uses_the_coarsest_unit_that_still_resolves_the_wait` — the
  formatter's arithmetic apart from the model.

Checked that the two positive tests genuinely detect the feature rather than
passing vacuously, by neutering only the push and re-running:

```
an_armed_deadline_shows_its_remaining_clock_beside_spend ... FAILED
a_crossed_deadline_reads_as_expired_not_as_a_duration ... FAILED
an_unarmed_deadline_renders_no_cell_rather_than_zero ... ok
test result: FAILED. 18 passed; 2 failed
```

The `None` test passing in both directions is correct and worth naming: it is a
**regression guard**, not a witness — absence is `main`'s behaviour and must
survive.

## Golden frames

One new golden, `deck/statline_deadline_armed.txt`, because a new cell moves
columns and only the whole grid can say what the band dropped to make room.

**I read the diff.** Two things worth a reviewer's eye:

1. **No existing golden changed** — `git status` shows one added file and zero
   modified. That is the real evidence for "absent, not zeroed": a `0s` would
   have appeared in all twelve.
2. At 150 columns the armed band drops **LANES** to fit CLOCK:

```
unarmed: … │ SPEND          │ CACHE                 │ ENGINE   │ LANES              │ PR
armed:   … │ SPEND          │ CACHE                 │ ENGINE   │ CLOCK   │ PR
```

MODEL, the stage box, CPU, CONTEXT, SPEND, CACHE, ENGINE and PR all survive.
LANES is priority 3 and is the documented lowest survivor, so this is the
degradation ladder working as designed — but it is a real tradeoff and I would
rather you see it than find it.

`cargo test -p stella-tui` → **824 + 60 across the integration targets, all
green**; `cargo clippy -p stella-tui --all-targets -- -D warnings` clean;
`cargo build --workspace` clean; `check-file-size` OK.

## Notes for review

- No test deleted.
- No new dependency.

Closes #2435
Refs #2487

## Summary by Sourcery

Add a new CLOCK statline cell to the command deck HUD that surfaces the live task deadline countdown beside spend, driven directly from BudgetTick events.

New Features:
- Display remaining task deadline time in the deck statline as a CLOCK cell, with distinct rendering for armed, crossed, and unarmed deadlines.

Enhancements:
- Extend the HUD model and BudgetTick folding to carry deadline_remaining_ms as a first-class field used by the deck statline.
- Add snapshot and unit tests to pin the CLOCK cell’s behavior, formatting, and layout impact in the deck rendering.