### PR TITLE
docs(bench): reconcile the 49.4% comparator with the public GLM-5.1 row (closes #2426)

### DIFF
--- a/website/public/presentations/BENCHMARK_METHODOLOGY.md
+++ b/website/public/presentations/BENCHMARK_METHODOLOGY.md
@@ -119,6 +119,73 @@ our run holds an open-weight model constant across both arms to isolate the
 harness. The two measurements answer different questions and the deck does
 not rank one against the other.
 
+### The GLM-5.1 row, and our 49.4% comparator
+
+One row on that board is about our own comparator, and it is nine points above
+what we measured, so it gets answered here rather than left for a reader to
+find:
+
+| Rank | Agent | Model | Accuracy |
+|---|---|---|---|
+| 17 | Claude Code | GLM-5.1 | **58.7% ± 1.2%** |
+
+*(tbench.ai, Terminal-Bench 2.1, re-checked 2026-08-09.)* We measured Claude
+Code at **44/89 = 49.44%**.
+
+**These are not the same measurement, and they do not disagree.** Three
+differences, of which the third is decisive:
+
+1. **A different model.** The row is GLM-5.1. Both of our arms ran `glm-5.2`,
+   because the design's binding rule was that the model is held constant across
+   the two arms, and the endpoint pair that makes a paired run possible —
+   OpenRouter for stella, z.ai's Anthropic-compatible endpoint for Claude Code —
+   served `glm-5.2`.
+
+2. **A different protocol.** Ours is one attempt per task, `max_retries = 0`,
+   all 89 tasks, one run, Harbor 0.6.1, our host, our timeouts at 1.0x,
+   concurrency 20, no per-trial budget cap. The leaderboard page publishes
+   neither the submission's harness configuration nor the metric behind its
+   percentage, so we cannot align ours to it even in principle.
+
+3. **A different precision — and this is the one that settles it.** 44 of 89 is
+   a single-run binomial estimate: its 95% exact interval is
+   **[38.67%, 60.25%]**, and 58.7% **falls inside it**. Symmetrically, ±1.2 is
+   not attainable from one 89-task pass@1 run — ours is roughly ±11 points, and
+   every row on that board carries ±1.2 to ±1.6 — so the published figures
+   aggregate more trials than we ran. **A single paired run cannot resolve a
+   nine-point difference in either direction, and this one does not claim to.**
+
+**What our comparator figure is, and is not.** It is the arm that ran beside
+stella's, on the same box, on the same day, against the same verifier. It is
+**not** an estimate of Claude Code's ceiling, and no claim in the deck should be
+read as one. The headline quantity is the **paired within-run difference** of
++15.73 points, which is what a matched design measures and the only thing it
+licenses.
+
+**Was the comparator arm handicapped?** We find no evidence of it, and the place
+to check is committed:
+
+- Every axis but the endpoint was matched (§ *Harness parity* above), and the
+  endpoint difference is forced, not chosen.
+- Neither arm carried a per-trial budget or token cap (`budget_usd_per_trial:
+  "unbounded"` in `run-manifest.json`); Claude Code ran at
+  `reasoning_effort: max` with thinking enabled, the same posture as stella's
+  worker.
+- Operational exceptions do not single out the comparator: **45 of 89** Arm A
+  trials and **48 of 89** Arm B trials recorded an exception, a near-identical
+  rate. (An exception does not imply a failed trial — a task can record one and
+  still pass.)
+
+If someone reads `comparator/trials.jsonl` and finds an asymmetry we missed,
+then the headline is wrong and we want to know; that file is committed for
+exactly that purpose.
+
+**Why we did not simply re-run the comparator on GLM-5.1.** Re-running one arm
+alone would produce a third, *unpaired* number with no contemporaneous stella arm
+beside it — the same unpaired comparison this whole section exists to refuse. A
+GLM-5.1 result worth reporting is a new paired run of both arms, which is a
+measurement to schedule, not a footnote to write.
+
 ## Raw results
 
 Everything needed to recompute the numbers is committed:

--- a/website/public/presentations/investor-deck.html
+++ b/website/public/presentations/investor-deck.html
@@ -1072,6 +1072,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <tr><td class="muted">contamination</td><td>both arms ran stock weights — nothing we trained touched this benchmark. When customer training ships, Terminal-Bench tasks are excluded from every corpus by protocol.</td></tr>
         <tr><td class="muted">identity</td><td>SUT commit 62a8ae2d&hellip; &middot; binary SHA-256 a6392dcc&hellip; &middot; every trial re-recorded commit, binary and posture digests — all 89 agree with the manifest.</td></tr>
         <tr><td class="muted">what it is not</td><td>not an audited leaderboard row — the manifest names five reasons in full. Witness tier off in this run, so 65.17% is a lower bound on the full verification ladder.</td></tr>
+        <tr><td class="muted">the public row</td><td>tbench.ai rank 17 lists Claude Code on GLM-5.1 at 58.7% &plusmn; 1.2% — a different model, at a precision no single 89-task pass@1 run can yield. Our comparator's own 95% interval [38.7%, 60.3%] <em>contains</em> 58.7%; the two do not disagree. Reconciled in full in BENCHMARK_METHODOLOGY.md.</td></tr>
       </table>
     </div>
     <div class="foot">


### PR DESCRIPTION
## What & why

tbench.ai rank 17 lists **Claude Code on GLM-5.1 at 58.7% ± 1.2%** — nine points
above the **44/89 = 49.44%** our preregistered paired run `tb21-hh10-20260731`
measured for the same comparator, and the deck offered nothing to reconcile it.
An investor or a diligence reviewer who opens the leaderboard sees our
comparator scoring nine points higher in public than we measured it. That is the
class of gap #2370 was opened to close.

This takes the issue's **option 1** (reconcile and say so), because the
reconciliation turns out to be decisive rather than a list of excuses.

Closes #2426

### The reconciliation

It was already latent in the committed artifacts:

- **44/89 carries a 95% exact-binomial interval of [38.67%, 60.25%] — which
  contains 58.7%.** The two numbers are not in conflict.
- **±1.2 is unattainable from one 89-task pass@1 run.** Ours is roughly ±11
  points, and *every* row on that board reports ±1.2 to ±1.6, so those figures
  aggregate more trials than we ran. The page publishes neither its harness
  configuration nor the metric behind the percentage.
- On top of that, the ordinary difference: the row is **GLM-5.1**, both our arms
  ran **`glm-5.2`**, because the design's binding rule was that the model is held
  constant across arms and the endpoint pair that makes a paired run possible
  served `glm-5.2`.

So they are different estimators at different precisions. A single paired run
cannot resolve a nine-point difference in either direction, and this one does not
claim to.

### Ruling out the third outcome rather than assuming it

The issue's outcome 3 — "if the comparator arm was genuinely under-configured,
that invalidates the headline" — is the one that had to be checked, not asserted.
Evidence, all committed:

- Every axis but the endpoint was matched, and the endpoint difference is forced
  (OpenRouter serves no `/v1/messages`), not chosen.
- Neither arm carried a per-trial budget or token cap
  (`budget_usd_per_trial: "unbounded"`); Claude Code ran `reasoning_effort: max`
  with thinking enabled, the same posture as stella's worker.
- **Operational exceptions do not single out the comparator: 45 of 89 Arm A
  trials and 48 of 89 Arm B trials recorded one** — a near-identical rate. This
  was the number most likely to hide a handicap, so it is stated explicitly, and
  the section says an exception does not imply a failed trial.

The doc invites the disconfirming read: if someone reads
`comparator/trials.jsonl` and finds an asymmetry we missed, the headline is wrong
and we want to know.

### What the deck now says it is *not*

Added plainly, because it is the honest limit of the design: our comparator
figure is the arm that ran beside stella's, on the same box, on the same day —
**not an estimate of Claude Code's ceiling**, and no claim in the deck should be
read as one. The headline quantity is the paired within-run difference of +15.73
points, which is the only thing a matched design licenses.

### Why not option 2 (re-measure)

Re-running the comparator alone on GLM-5.1 produces a **third, unpaired** number
with no contemporaneous stella arm beside it — the same unpaired comparison this
section exists to refuse. A GLM-5.1 result worth reporting is a new paired run of
*both* arms: a measurement to schedule, not a footnote to write. Said so in the
doc rather than left implicit.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: it is prose and
      one deck table row; no behavior changes.

How it was verified instead:

- **The leaderboard row was re-checked against the primary source on 2026-08-09**
  rather than taken from the issue: tbench.ai Terminal-Bench 2.1 confirms rank 17,
  Claude Code, GLM-5.1, 58.7% ± 1.2%.
- Every figure quoted traces to a committed artifact — `score.json`
  (44 passes, both CIs, `trials_with_an_exception`), `comparator/score.json`,
  `run-manifest.json` (`budget_usd_per_trial`, posture). Nothing is asserted from
  the deck's own prose.
- **The deck still fits**: `scripts/deck-fit.mjs` passes 21/21 slides on all five
  passes with the new appendix A1 row (Chrome 151.0.7922.77). Appendix A1 sits at
  its frame edge, so this was a real risk, not a formality — which is also why the
  full reconciliation went into `BENCHMARK_METHODOLOGY.md` and only one row into
  the slide.

## The gate

- [x] No Rust changed; `cargo fmt/clippy/test` unaffected by this diff
- [x] `BENCHMARK_METHODOLOGY.md` is the authoritative doc for every benchmark
      figure in the deck, and carries the full reconciliation; the deck's A1
      table carries one sourced sentence pointing at it

## Nothing left behind

- [x] There is nothing new: everything I noticed in this issue is fixed here.

Related work from the same session, filed separately: #2475 (deck-fit reports one
overflow as three different numbers), #2486 (`verify_done`'s cost is the shadow
worktree lifecycle). Neither is in scope here.

## Anything reviewers should know?

**The strongest sentence in the diff is checkable and I would like it checked**:
58.7% falling inside [38.67%, 60.25%] is what turns this from a list of excuses
into a reconciliation. Both bounds are in `comparator/score.json`
(`ci95_clopper_pearson`) and recompute from `comparator/trials.jsonl` via
`bench/evidence/score_dev_baseline.py`.

The one thing I did **not** establish is what the leaderboard's ± actually
denotes — the page does not say, so the doc claims only that ±1.2 is unattainable
from a single 89-task run and that the figures therefore aggregate more trials
than ours. That is deliberately weaker than "they ran it five times", which I
cannot source.

Depends on nothing; stacks cleanly with #2478 (which adds the CI job that would
have caught an A1 overflow here).

## Summary by Sourcery

Clarify and reconcile the discrepancy between the public tbench.ai GLM-5.1 leaderboard row for Claude Code and the preregistered comparator measurement, and surface that reconciliation in both the benchmark methodology doc and the investor deck.

Enhancements:
- Extend the investor deck appendix table with a succinct row that summarizes the reconciliation between the public GLM-5.1 leaderboard result and our comparator’s confidence interval, and points to the benchmark methodology for full details.

Documentation:
- Add a detailed methodology section explaining why the tbench.ai Claude Code GLM-5.1 leaderboard result and our 49.4% comparator measurement are different estimators that nonetheless agree within statistical confidence, including model, protocol, and precision differences.
- Document that the comparator arm was configured to match stella across all axes except the forced endpoint, and invite readers to inspect the committed trials for any hidden asymmetry.
- Explain why re-running the comparator alone on GLM-5.1 would produce an unacceptable unpaired measurement and that any new GLM-5.1 figure must come from a fresh paired run of both arms.