### PR TITLE
fix(stella-cli): reflection selects its digest instead of truncating the tail — and reads tool results for the first time (#2460)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -74,14 +74,14 @@ use outcome::{
 };
 pub(crate) use outcome::{pipeline_execution_closeout, settled_cost_since};
 use output::*;
-use reflect::{reflect_on_interactive_turn, reflection_json};
-pub(crate) use reflect::{FrictionTap, surface_reflection};
 pub(crate) use persistence::{
     PersistOutcome, TurnBracket, close_event_stream, persist_event, persist_event_detailed,
     record_execution_end, spawn_renderer, warn_store_write_failed,
 };
 pub(crate) use presence::SessionPresence;
 pub(crate) use prompt::*;
+pub(crate) use reflect::{FrictionTap, surface_reflection};
+use reflect::{reflect_on_interactive_turn, reflection_json};
 pub(crate) use skill_usage::stamp_and_record_skill_usage;
 // `tool_policy` is a top-level module (`main.rs`); the re-export keeps every
 // session driver's `agent::PolicyToolSet` reading as "the agent's tool stack".

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -38,8 +38,8 @@ use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::failure::CliFailure;
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
 use crate::memory::{
-    ReflectionReport, SessionMemory, inject_recall_block, reflect_routed, reflection_tail,
-    should_reflect_on, turn_warrants_reflection,
+    ReflectionReport, SessionMemory, TurnEvidence, TurnFriction, inject_recall_block,
+    reflect_routed, should_reflect_on, turn_warrants_reflection,
 };
 use crate::plain::{self, accent};
 use crate::runtime::{SystemClock, TokioSleeper};
@@ -56,6 +56,7 @@ mod output;
 mod persistence;
 mod presence;
 mod prompt;
+mod reflect;
 pub(crate) mod resume;
 mod skill_usage;
 mod tools;
@@ -73,6 +74,8 @@ use outcome::{
 };
 pub(crate) use outcome::{pipeline_execution_closeout, settled_cost_since};
 use output::*;
+use reflect::{reflect_on_interactive_turn, reflection_json};
+pub(crate) use reflect::{FrictionTap, surface_reflection};
 pub(crate) use persistence::{
     PersistOutcome, TurnBracket, close_event_stream, persist_event, persist_event_detailed,
     record_execution_end, spawn_renderer, warn_store_write_failed,
@@ -359,6 +362,11 @@ async fn run_pipeline_one_shot(
     }
     let mut budget = crate::runtime::one_shot_budget_guard(budget_limit, cfg.turn_budget);
     budget.begin_turn();
+    // Reflection's only view of this turn's cost, wall clock, retries and loop
+    // firings: the worker's tool-calling turns are deliberately kept out of
+    // `messages` here (planner context hygiene, L-E6), so the event stream is
+    // not merely a better source than the transcript — it is the only one.
+    let friction = FrictionTap::default();
 
     let result = {
         let customs = CustomToolSet::new(base_tools, custom_tools, cfg.workspace_root.clone());
@@ -456,7 +464,7 @@ async fn run_pipeline_one_shot(
             steering: None,
         };
 
-        let events = pipeline_event_sender(&tx, format);
+        let events = friction.tap(pipeline_event_sender(&tx, format));
         let pipeline = resume_frame::pipeline(&cfg.durability, ports, events, pipeline_config)
             .with_calibration(&calibration);
         pipeline.run(prompt, &mut messages, &mut budget).await
@@ -515,7 +523,9 @@ async fn run_pipeline_one_shot(
                 name: stella_protocol::StageKind::Reflect,
             });
         }
-        let mut reflect_transcript = reflection_tail(&messages);
+        // The whole planner history, not its tail: the digest selects (#2460),
+        // and pre-truncating here would drop the middle it selects for.
+        let mut reflect_transcript = messages.clone();
         if let Ok(outcome) = &result
             && !outcome.final_text.trim().is_empty()
         {
@@ -531,16 +541,20 @@ async fn run_pipeline_one_shot(
                 "(files changed this turn: {changed})"
             )));
         }
+        let observed = friction.snapshot();
         let mut report = reflect_routed(
             m,
             cfg,
             &*provider,
-            &reflect_transcript,
+            TurnEvidence {
+                transcript: &reflect_transcript,
+                friction: &observed,
+                succeeded: matches!(
+                    &result,
+                    Ok(outcome) if matches!(outcome.status, PipelineStatus::Completed)
+                ),
+            },
             format != OutputFormat::Text,
-            matches!(
-                &result,
-                Ok(outcome) if matches!(outcome.status, PipelineStatus::Completed)
-            ),
             remaining_budget(&budget),
         )
         .await;
@@ -1161,99 +1175,6 @@ pub(crate) async fn record_turn_episode<E>(
         .await;
 }
 
-/// Post-turn reflection for one interactive REPL turn, shared by the plain
-/// prompt handler and `/goal` — the two carried byte-identical copies of
-/// this block, which is exactly the drift this helper removes.
-///
-/// Failures reflect too (the one-shot pipeline path has always treated a
-/// failed run as a high-value learning signal); only a user-chosen soft stop
-/// is excluded (`should_reflect_on`, issue #373 item 7). The gate reads only
-/// this turn's message slice (`turn_start..`) so a conversational turn never
-/// spends a model call.
-async fn reflect_on_interactive_turn<E: std::fmt::Display>(
-    provider: &dyn Provider,
-    cfg: &Config,
-    memory: &mut Option<SessionMemory>,
-    messages: &[CompletionMessage],
-    turn_start: usize,
-    result: &Result<(), E>,
-    budget: &mut BudgetGuard,
-) {
-    if should_reflect_on(result)
-        && turn_warrants_reflection(&messages[turn_start..])
-        && let Some(m) = memory
-    {
-        let mut report = reflect_routed(
-            m,
-            cfg,
-            provider,
-            messages,
-            false,
-            result.is_ok(),
-            remaining_budget(budget),
-        )
-        .await;
-        settle_reflection_budget(&mut report, budget);
-        surface_reflection(&report, OutputFormat::Text);
-    }
-}
-
-/// Surface a post-turn [`ReflectionReport`] for human text output. Machine
-/// streams route reflection events through their execution renderer so
-/// `Complete` remains the unique final frame; this helper never writes a
-/// second, unframed stdout sequence after that terminal barrier.
-pub(crate) fn surface_reflection(report: &ReflectionReport, format: OutputFormat) {
-    if format == OutputFormat::Text {
-        for event in &report.events {
-            match event {
-                AgentEvent::StepUsage {
-                    role,
-                    provider,
-                    model,
-                    input_tokens,
-                    output_tokens,
-                    cost_usd,
-                    retries,
-                    complete,
-                    ..
-                } => eprintln!(
-                    "  {} {:?} {provider}/{model}: {input_tokens} in, {output_tokens} out, \
-                     ${cost_usd:.4}, {retries} retries, complete={complete}",
-                    "✦".magenta(),
-                    role
-                ),
-                AgentEvent::UsageIncomplete {
-                    role,
-                    provider,
-                    model,
-                    reason,
-                    retries,
-                    ..
-                } => eprintln!(
-                    "  {} {:?} {provider}/{model}: usage incomplete ({reason:?}, retries={retries:?})",
-                    "!".yellow(),
-                    role
-                ),
-                _ => {}
-            }
-        }
-    }
-    if let Some(err) = &report.model_error {
-        eprintln!(
-            "  {} post-turn reflection skipped — model call failed: {err}",
-            "!".yellow()
-        );
-    }
-}
-
-fn reflection_json(report: &ReflectionReport) -> serde_json::Value {
-    serde_json::json!({
-        "recorded": report.recorded,
-        "error": report.model_error,
-        "cost_usd": report.cost_usd,
-        "events": report.events,
-    })
-}
 /// The shared init flow behind `stella init` and the `/init` chat command:
 /// infer the domain taxonomy (model-assisted when a provider is available,
 /// directory heuristic otherwise), build the code-graph index, persist

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -202,7 +202,7 @@ pub(crate) async fn run_raw_one_shot(
         && let Some(m) = &mut memory
     {
         // No friction ledger on this path yet: the raw step loop's events ride a
-        // bare `UnboundedSender`, so there is nothing to wrap (#2470). The
+        // bare `UnboundedSender`, so there is nothing to wrap (#2483). The
         // transcript here does carry every tool call and its typed result, which
         // is what the digest selects on.
         let mut report = crate::memory::reflect_routed(
@@ -394,7 +394,7 @@ pub async fn run_goal_cmd(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
-        // Transcript-only evidence, as on the raw one-shot above (#2470).
+        // Transcript-only evidence, as on the raw one-shot above (#2483).
         let mut report = crate::memory::reflect_routed(
             m,
             cfg,

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -201,13 +201,16 @@ pub(crate) async fn run_raw_one_shot(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
+        // No friction ledger on this path yet: the raw step loop's events ride a
+        // bare `UnboundedSender`, so there is nothing to wrap (#2470). The
+        // transcript here does carry every tool call and its typed result, which
+        // is what the digest selects on.
         let mut report = crate::memory::reflect_routed(
             m,
             cfg,
             &*provider,
-            &messages,
+            crate::memory::TurnEvidence::from_transcript(&messages, outcome.is_ok()),
             format != OutputFormat::Text,
-            outcome.is_ok(),
             crate::agent::remaining_budget(&budget),
         )
         .await;
@@ -391,13 +394,13 @@ pub async fn run_goal_cmd(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
+        // Transcript-only evidence, as on the raw one-shot above (#2470).
         let mut report = crate::memory::reflect_routed(
             m,
             cfg,
             &*provider,
-            &messages,
+            crate::memory::TurnEvidence::from_transcript(&messages, outcome.is_ok()),
             false,
-            outcome.is_ok(),
             crate::agent::remaining_budget(&budget),
         )
         .await;

--- a/crates/stella-cli/src/agent/reflect.rs
+++ b/crates/stella-cli/src/agent/reflect.rs
@@ -1,0 +1,161 @@
+//! Post-turn reflection at the CLI's turn boundaries: the interactive-turn
+//! dispatch, the friction tap that gives reflection its event-derived evidence,
+//! and the two report renderers.
+//!
+//! Split verbatim out of `agent.rs` — no behavior change in the move — because
+//! that file sits at its file-size ratchet ceiling and this cluster is a
+//! coherent unit: everything here is about what happens *after* a turn's last
+//! model call, and nothing else in `agent.rs` calls into it.
+
+use colored::Colorize;
+use stella_core::{BudgetGuard, EventSender};
+use stella_protocol::{AgentEvent, CompletionMessage, Provider};
+
+use super::{
+    OutputFormat, ReflectionReport, SessionMemory, TurnEvidence, TurnFriction, reflect_routed,
+    remaining_budget, settle_reflection_budget, should_reflect_on, turn_warrants_reflection,
+};
+use crate::config::Config;
+
+/// The live fold that gives reflection what a transcript cannot carry.
+///
+/// A [`TurnFriction`] has to be built from the turn's [`AgentEvent`] stream, and
+/// the only place that stream is complete *and* still in this process's hands is
+/// the sender every producer emits on. So the tap wraps that sender: fold, then
+/// forward untouched.
+///
+/// It deliberately does not read the persisted journal instead. Events reach
+/// `store.db` from the renderer task (`agent::persistence::spawn_renderer`),
+/// which is still draining when reflection runs, so a read there would return a
+/// prefix of the turn whose length depends on scheduling — and the digest would
+/// stop being a function of the turn.
+#[derive(Clone, Default)]
+pub(crate) struct FrictionTap {
+    ledger: std::sync::Arc<std::sync::Mutex<TurnFriction>>,
+}
+
+impl FrictionTap {
+    /// Wrap `downstream` so every event folded here is still delivered there.
+    ///
+    /// A poisoned lock is stepped over rather than propagated: this is a
+    /// best-effort observation of a turn that has already happened, and a panic
+    /// on the event path would take down a turn to protect a digest.
+    pub(crate) fn tap(&self, downstream: EventSender) -> EventSender {
+        let ledger = self.ledger.clone();
+        EventSender::from_fn(move |event| {
+            ledger
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .observe(&event);
+            downstream.send(event)
+        })
+    }
+
+    /// What the tap has folded so far. Cloned rather than drained: the turn's
+    /// senders may still be live (reflection's own accounting events ride the
+    /// same channel), and a drain would make this method's result depend on how
+    /// many times it had been called.
+    pub(crate) fn snapshot(&self) -> TurnFriction {
+        self.ledger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+/// Post-turn reflection for one interactive REPL turn, shared by the plain
+/// prompt handler and `/goal` — the two carried byte-identical copies of
+/// this block, which is exactly the drift this helper removes.
+///
+/// Failures reflect too (the one-shot pipeline path has always treated a
+/// failed run as a high-value learning signal); only a user-chosen soft stop
+/// is excluded (`should_reflect_on`, issue #373 item 7). The gate reads only
+/// this turn's message slice (`turn_start..`) so a conversational turn never
+/// spends a model call.
+///
+/// The whole history is handed to reflection, not the tail of it: selection is
+/// the digest's job now (#2460), and pre-truncating here would hide exactly the
+/// middle the selection exists to find.
+pub(super) async fn reflect_on_interactive_turn<E: std::fmt::Display>(
+    provider: &dyn Provider,
+    cfg: &Config,
+    memory: &mut Option<SessionMemory>,
+    messages: &[CompletionMessage],
+    turn_start: usize,
+    result: &Result<(), E>,
+    budget: &mut BudgetGuard,
+) {
+    if should_reflect_on(result)
+        && turn_warrants_reflection(&messages[turn_start..])
+        && let Some(m) = memory
+    {
+        let mut report = reflect_routed(
+            m,
+            cfg,
+            provider,
+            TurnEvidence::from_transcript(messages, result.is_ok()),
+            false,
+            remaining_budget(budget),
+        )
+        .await;
+        settle_reflection_budget(&mut report, budget);
+        surface_reflection(&report, OutputFormat::Text);
+    }
+}
+
+/// Surface a post-turn [`ReflectionReport`] for human text output. Machine
+/// streams route reflection events through their execution renderer so
+/// `Complete` remains the unique final frame; this helper never writes a
+/// second, unframed stdout sequence after that terminal barrier.
+pub(crate) fn surface_reflection(report: &ReflectionReport, format: OutputFormat) {
+    if format == OutputFormat::Text {
+        for event in &report.events {
+            match event {
+                AgentEvent::StepUsage {
+                    role,
+                    provider,
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    cost_usd,
+                    retries,
+                    complete,
+                    ..
+                } => eprintln!(
+                    "  {} {:?} {provider}/{model}: {input_tokens} in, {output_tokens} out, \
+                     ${cost_usd:.4}, {retries} retries, complete={complete}",
+                    "✦".magenta(),
+                    role
+                ),
+                AgentEvent::UsageIncomplete {
+                    role,
+                    provider,
+                    model,
+                    reason,
+                    retries,
+                    ..
+                } => eprintln!(
+                    "  {} {:?} {provider}/{model}: usage incomplete ({reason:?}, retries={retries:?})",
+                    "!".yellow(),
+                    role
+                ),
+                _ => {}
+            }
+        }
+    }
+    if let Some(err) = &report.model_error {
+        eprintln!(
+            "  {} post-turn reflection skipped — model call failed: {err}",
+            "!".yellow()
+        );
+    }
+}
+
+pub(super) fn reflection_json(report: &ReflectionReport) -> serde_json::Value {
+    serde_json::json!({
+        "recorded": report.recorded,
+        "error": report.model_error,
+        "cost_usd": report.cost_usd,
+        "events": report.events,
+    })
+}

--- a/crates/stella-cli/src/command_deck/authoring.rs
+++ b/crates/stella-cli/src/command_deck/authoring.rs
@@ -106,12 +106,15 @@ pub(super) async fn record_and_reflect_turn(
         return;
     }
     let Some(memory) = memory else { return };
+    // Transcript-only evidence: the deck's driver events ride a bare
+    // `UnboundedSender` with no `EventSender` seam to wrap (#2470). Every tool
+    // call and its typed result are in `messages`, which is what the digest
+    // selects on.
     let mut report = crate::memory::reflect_routed(
         memory,
         cfg,
         provider,
-        messages,
-        true,
+        crate::memory::TurnEvidence::from_transcript(messages, true),
         true,
         crate::agent::remaining_budget(budget),
     )

--- a/crates/stella-cli/src/command_deck/authoring.rs
+++ b/crates/stella-cli/src/command_deck/authoring.rs
@@ -107,7 +107,7 @@ pub(super) async fn record_and_reflect_turn(
     }
     let Some(memory) = memory else { return };
     // Transcript-only evidence: the deck's driver events ride a bare
-    // `UnboundedSender` with no `EventSender` seam to wrap (#2470). Every tool
+    // `UnboundedSender` with no `EventSender` seam to wrap (#2483). Every tool
     // call and its typed result are in `messages`, which is what the digest
     // selects on.
     let mut report = crate::memory::reflect_routed(

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -224,9 +224,10 @@ fn deterministic_task_id(clock: &dyn Clock) -> String {
 }
 
 mod reflection;
-pub(crate) use reflection::{ReflectionPosture, reflect_routed, reflection_tail};
+pub(crate) use reflection::{ReflectionPosture, reflect_routed};
 pub use reflection::{
-    ReflectionReport, reflect_on_turn, should_reflect_on, turn_warrants_reflection,
+    ReflectionReport, TurnEvidence, TurnFriction, reflect_on_turn, should_reflect_on,
+    turn_warrants_reflection,
 };
 
 /// Session-scoped memory state: the context store, the CGP host that

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -14,10 +14,10 @@ use stella_core::skills::appraisal::EvalEvidence;
 use stella_core::skills::{
     self, AutoCreateConfig, AutoCreateDecision, SkillMineConfig, SkillObservation,
 };
-use stella_protocol::{CompletionMessage, Provider};
+use stella_protocol::Provider;
 
 use super::{
-    LessonKind, ReflectionLesson, ReflectionReport, SessionMemory, reflect_on_turn,
+    LessonKind, ReflectionLesson, ReflectionReport, SessionMemory, TurnEvidence, reflect_on_turn,
     skill_paths_on_disk,
 };
 
@@ -45,8 +45,8 @@ impl SessionMemory {
     /// in whichever output format it speaks; the report distinguishes a genuine
     /// model-call failure from the common, correct "nothing worth recording."
     ///
-    /// `succeeded` controls the reflection prompt template (Proposal 1):
-    /// a failed turn gets a failure-analysis prompt that asks the model to
+    /// `evidence.succeeded` controls the reflection prompt template (Proposal
+    /// 1): a failed turn gets a failure-analysis prompt that asks the model to
     /// identify the root cause — the highest-value learning signal in the
     /// system. A succeeded turn gets the conventional "what worked?" prompt.
     ///
@@ -55,19 +55,12 @@ impl SessionMemory {
     /// `execution_reflection` half the Observatory's self-improve panels read.
     /// It rides here rather than in a call of its own because the model already
     /// has this transcript in front of it.
-    // Seven parameters, and the lint is wrong here for the same reason it is
-    // on `reflect_on_turn` below it: each is an independent fact about this
-    // one dispatch that only the caller holds. A parameter object would move
-    // the argument list to a struct literal at every call site and decide
-    // nothing.
-    #[allow(clippy::too_many_arguments)]
     pub async fn reflect_and_record(
         &mut self,
         provider: &dyn Provider,
         model_hint: &str,
-        transcript: &[CompletionMessage],
+        evidence: TurnEvidence<'_>,
         quiet: bool,
-        succeeded: bool,
         budget_limit: Option<f64>,
         posture: crate::memory::ReflectionPosture,
     ) -> ReflectionReport {
@@ -75,9 +68,8 @@ impl SessionMemory {
             provider,
             model_hint,
             &self.workspace_root,
-            transcript,
+            evidence,
             &self.domains.names(),
-            succeeded,
             budget_limit,
             posture,
         )

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -1,5 +1,9 @@
 //! Reflection gating, accounted provider dispatch, and response parsing.
 
+/// How a turn is rendered for the reflecting model: selection under a character
+/// budget, never a tail window (#2460).
+pub(crate) mod digest;
+
 /// What the prompt must and must not say. A child module so it can drive
 /// [`reflect_on_turn`] directly rather than through the whole record path.
 #[cfg(test)]
@@ -8,10 +12,10 @@ mod tests;
 use std::path::Path;
 
 use stella_model::provider::Provider;
-use stella_protocol::{
-    AgentEvent, CompletionMessage, CompletionRequest, MessageRole, ReasoningEffort,
-};
+use stella_protocol::{AgentEvent, CompletionMessage, CompletionRequest, ReasoningEffort};
 use stella_store::reflection::SelfReviewRow;
+
+pub use digest::{TurnEvidence, TurnFriction};
 
 use super::ReflectionLesson;
 
@@ -45,10 +49,6 @@ pub fn should_reflect_on<E: std::fmt::Display>(result: &Result<(), E>) -> bool {
         Err(reason) => !reason.to_string().contains(stella_core::SOFT_STOP_REASON),
     }
 }
-
-/// How much of the transcript the reflection digest reads ([`reflect_on_turn`]
-/// takes exactly this many messages off the tail).
-const REFLECTED_TAIL_MESSAGES: usize = 12;
 
 /// What reflection is asked to **write**: at most three short lesson objects
 /// plus a five-field self-review. Thinking room is added on top by
@@ -84,17 +84,6 @@ pub(crate) struct ReflectionPosture {
     pub(crate) effort: Option<ReasoningEffort>,
 }
 
-/// The slice of `messages` worth copying for a reflection transcript.
-///
-/// A caller that appends turn context (the final answer, a files-changed
-/// note) before reflecting should clone this tail, never the whole history:
-/// [`reflect_on_turn`] digests only the last [`REFLECTED_TAIL_MESSAGES`]
-/// messages, so on a long session everything earlier was memcpy'd to be
-/// dropped (#1847's call-site nit).
-pub(crate) fn reflection_tail(messages: &[CompletionMessage]) -> Vec<CompletionMessage> {
-    messages[messages.len().saturating_sub(REFLECTED_TAIL_MESSAGES)..].to_vec()
-}
-
 /// Post-turn reflection on the cheap tier (#1847): resolve the reflection
 /// route, then run [`super::SessionMemory::reflect_and_record`] on whichever
 /// provider it lands on — the configured triage model when routable
@@ -112,9 +101,8 @@ pub(crate) async fn reflect_routed(
     memory: &mut super::SessionMemory,
     cfg: &crate::config::Config,
     worker: &dyn Provider,
-    transcript: &[CompletionMessage],
+    evidence: TurnEvidence<'_>,
     quiet: bool,
-    succeeded: bool,
     budget_limit: Option<f64>,
 ) -> ReflectionReport {
     let routed =
@@ -128,15 +116,7 @@ pub(crate) async fn reflect_routed(
         None => (worker, cfg.model_id.as_str()),
     };
     memory
-        .reflect_and_record(
-            provider,
-            model_hint,
-            transcript,
-            quiet,
-            succeeded,
-            budget_limit,
-            posture,
-        )
+        .reflect_and_record(provider, model_hint, evidence, quiet, budget_limit, posture)
         .await
 }
 
@@ -144,60 +124,33 @@ pub(crate) async fn reflect_routed(
 /// `SessionMemory::reflect_and_record`, in the same pass that stamps
 /// `task_id`, from the session clock — so neither this dispatch nor the parser
 /// below ever reads a clock, and the mining log they feed is reproducible.
-// Eight parameters, and the lint is wrong here: every one is an independent
-// fact about THIS dispatch that the caller alone knows (which provider, which
-// model slug, which workspace, which transcript slice, which domain
-// vocabulary, whether the turn succeeded, what budget is left, what posture
-// the route declared). Bundling them into a struct would rename the arguments
-// without reducing what a caller must decide, and this is a leaf dispatch with
-// three call sites — the shape the lint exists to catch is a growing function
-// that has become several, which this is not.
-#[allow(clippy::too_many_arguments)]
+// The remaining parameters each carry a fact about THIS dispatch that the
+// caller alone knows — which provider, which model slug, which workspace, which
+// domain vocabulary, what budget is left, what posture the route declared — so
+// they stay positional. What the turn *is* does not: `transcript`, `succeeded`
+// and the event-derived friction are one question with one answer, and bundling
+// them as [`TurnEvidence`] is what keeps this at seven arguments while adding
+// evidence rather than at nine with an `#[allow]` (#2460).
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,
     workspace_root: &Path,
-    transcript: &[CompletionMessage],
+    evidence: TurnEvidence<'_>,
     domain_names: &[String],
-    succeeded: bool,
     budget_limit: Option<f64>,
     posture: ReflectionPosture,
 ) -> Result<
     (ReflectionParse, Option<SelfReviewRow>, f64, Vec<AgentEvent>),
     crate::accounted_call::StandaloneCallError,
 > {
-    let digest = transcript
-        .iter()
-        .rev()
-        .take(REFLECTED_TAIL_MESSAGES)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .map(|message| {
-            let role = match message.role {
-                MessageRole::System => "system",
-                MessageRole::User => "user",
-                MessageRole::Assistant => "assistant",
-                MessageRole::Tool => "tool",
-            };
-            let content: String = message.content.chars().take(300).collect();
-            let tools = if message.tool_calls.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    " [called: {}]",
-                    message
-                        .tool_calls
-                        .iter()
-                        .map(|call| call.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
-            format!("{role}: {content}{tools}")
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    // Selection, not the last twelve messages truncated to 300 characters: the
+    // expensive part of a turn is in the middle, and a `Tool` message's payload
+    // is not in `content` at all, so the old digest showed reflection the string
+    // `"tool: "` for every tool result it had ever produced. See
+    // [`digest`]'s module docs for both defects and the budget that replaces
+    // them.
+    let digest = digest::build(evidence);
+    let succeeded = evidence.succeeded;
     // Ask first for facts about the CODEBASE, and only then for notes about
     // the agent. The order is the point.
     //

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -620,54 +620,64 @@ fn classify(evidence: TurnEvidence<'_>) -> Vec<Priority> {
 /// did not already know last turn. Recalled context is a `User` message
 /// (`memory/recall.rs::inject_recall_block`) and is therefore kept.
 fn render(message: &CompletionMessage, names: &HashMap<&str, &str>, cap: usize) -> String {
-    match message.role {
-        MessageRole::System => String::new(),
-        MessageRole::User => prefixed("user", &clip(&message.content, cap)),
-        MessageRole::Assistant => {
-            let mut body = clip(&message.content, cap);
-            for call in &message.tool_calls {
-                let _ = write!(
-                    body,
-                    "\n  → calls {}({})",
-                    call.name,
-                    clip(&compact(&call.input), TOOL_INPUT_CHARS)
-                );
-            }
-            prefixed("assistant", &body)
-        }
-        MessageRole::Tool => {
-            // The half the old digest could not see at any window size: a
-            // `Tool` message's payload is `tool_results`, and its `content` is
-            // empty by construction.
-            let share = (cap / message.tool_results.len().max(1)).max(MIN_RESULT_CHARS);
-            let mut body = clip(&message.content, cap);
-            for result in &message.tool_results {
-                let name = names
-                    .get(result.call_id.as_str())
-                    .copied()
-                    .unwrap_or("tool");
-                match &result.output {
-                    ToolOutput::Error { message } => {
-                        let _ = write!(body, "\n  {name} FAILED: {}", clip(message, share));
-                    }
-                    ToolOutput::Ok { content } => {
-                        let _ = write!(body, "\n  {name} ok: {}", clip(content, share));
-                    }
-                }
-            }
-            prefixed("tool", &body)
-        }
+    if message.role == MessageRole::System {
+        return String::new();
+    }
+    let mut parts: Vec<String> = Vec::new();
+    let content = clip(&message.content, cap);
+    if !content.is_empty() {
+        parts.push(content);
+    }
+    for call in &message.tool_calls {
+        parts.push(format!(
+            "→ calls {}({})",
+            call.name,
+            clip(&compact(&call.input), TOOL_INPUT_CHARS)
+        ));
+    }
+    // The half the old digest could not see at any window size: a `Tool`
+    // message's payload is `tool_results`, and its `content` is empty by
+    // construction.
+    let share = (cap / message.tool_results.len().max(1)).max(MIN_RESULT_CHARS);
+    for result in &message.tool_results {
+        let name = names
+            .get(result.call_id.as_str())
+            .copied()
+            .unwrap_or("tool");
+        parts.push(match &result.output {
+            ToolOutput::Error { message } => format!("{name} FAILED: {}", clip(message, share)),
+            ToolOutput::Ok { content } => format!("{name} ok: {}", clip(content, share)),
+        });
+    }
+    prefixed(role_label(message.role), parts)
+}
+
+/// The digest's name for a message's author.
+fn role_label(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
     }
 }
 
-/// `role: body`, or nothing when the body is empty — an empty rendering is
-/// dropped rather than emitted as a bare role label, which is exactly what the
-/// old digest did to every tool result.
-fn prefixed(role: &str, body: &str) -> String {
-    if body.trim().is_empty() {
+/// `role: part`, or `role: first` with the remaining parts indented beneath it.
+///
+/// Nothing at all when there are no parts. A message that would render as a bare
+/// role label is dropped instead, because a bare label is exactly what the old
+/// digest emitted for every tool result Stella ever produced: it reads like
+/// evidence while carrying none.
+fn prefixed(role: &str, parts: Vec<String>) -> String {
+    let mut parts = parts.into_iter().filter(|part| !part.trim().is_empty());
+    let Some(first) = parts.next() else {
         return String::new();
+    };
+    let mut out = format!("{role}: {first}");
+    for part in parts {
+        let _ = write!(out, "\n  {part}");
     }
-    format!("{role}: {body}")
+    out
 }
 
 /// A tool call's arguments as one line. `Value::to_string` is already compact; a

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -485,6 +485,17 @@ impl Priority {
 }
 
 /// Build the digest reflection reads. Deterministic in `evidence` alone.
+///
+/// The result passes through [`stella_core::redact::redact_secrets`] before it is
+/// returned. That is new here and it is required by this change rather than
+/// inherited from it: the old tail digest carried tool *names* and no tool output
+/// whatsoever, so it could not carry a credential. This one renders tool
+/// arguments and tool results, which is exactly where one shows up — a
+/// `read_file` of `.env`, a `bash` that printed `env`, a token echoed in an error
+/// message. Reflection also dispatches on the **triage** route (#1847), which may
+/// be a different vendor than the worker the turn ran on, so "the provider has
+/// seen it already" is not a safe assumption. Redaction is a pure function over
+/// the string, so it costs the module none of its testability.
 pub(crate) fn build(evidence: TurnEvidence<'_>) -> String {
     let transcript = evidence.transcript;
     let names = call_names(evidence);
@@ -512,7 +523,7 @@ pub(crate) fn build(evidence: TurnEvidence<'_>) -> String {
             kept[index] = Some(body);
         }
     }
-    stitch(&kept, evidence.friction)
+    stella_core::redact::redact_secrets(&stitch(&kept, evidence.friction)).text
 }
 
 /// Join the kept renderings in transcript order, replacing each run of dropped

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -55,6 +55,12 @@
 //! reflection runs, so reading it here would race and the digest would stop
 //! being a function of the turn.
 
+/// The selection's mechanics, and the before/after cost measurement #2460's
+/// definition of done asks for. A child module so it can reach the private
+/// helpers (`clip`, `human_ms`) and the caps without widening their visibility.
+#[cfg(test)]
+mod tests;
+
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -24,8 +24,8 @@
 //!
 //! ## What replaces it
 //!
-//! [`build`] renders the turn under a total character budget
-//! ([`DIGEST_BUDGET_CHARS`]), spending it in priority order rather than in
+//! `build` renders the turn under a total character budget
+//! (`DIGEST_BUDGET_CHARS`), spending it in priority order rather than in
 //! reverse transcript order:
 //!
 //! 1. **Pinned** — the goal (the turn's first user message) and the last few
@@ -139,7 +139,7 @@ struct ToolPass {
     call_id: String,
     /// Empty when the ledger saw the result but not the start (a tap installed
     /// mid-turn, or the entry cap). The transcript's own tool calls can still
-    /// name it — see [`call_names`].
+    /// name it — see `call_names`.
     name: String,
     duration_ms: u64,
     /// The failure message when the output was [`ToolOutput::Error`]. `None` is
@@ -157,7 +157,7 @@ struct ToolPass {
 ///
 /// [`Default`] is an honest empty ledger, not a degraded one. A surface with no
 /// tap wired still selects on the transcript's own typed tool results, and the
-/// friction section is simply omitted — nothing here is required for [`build`]
+/// friction section is simply omitted — nothing here is required for `build`
 /// to be correct.
 #[derive(Debug, Clone, Default)]
 pub struct TurnFriction {
@@ -316,7 +316,7 @@ impl TurnFriction {
     }
 
     /// The `tools` entries this ledger says a reflection must see: every call
-    /// that failed, and the [`FRICTION_TOP_N`] that dominated wall clock.
+    /// that failed, and the `FRICTION_TOP_N` that dominated wall clock.
     fn flagged(&self) -> Vec<&str> {
         let mut flagged: Vec<&str> = self
             .tools
@@ -433,7 +433,7 @@ impl TurnFriction {
 ///
 /// One argument rather than three, because the three are one question and were
 /// already threaded separately through four surfaces. The bundle is also what
-/// makes [`build`] a pure function of the turn: there is nothing else it may
+/// makes `build` a pure function of the turn: there is nothing else it may
 /// consult.
 #[derive(Clone, Copy)]
 pub struct TurnEvidence<'a> {

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -1,0 +1,735 @@
+//! What reflection is allowed to read of a turn: a *selection*, not a tail.
+//!
+//! ## The two defects this module replaces (#2460)
+//!
+//! Reflection used to build its digest by taking the last twelve messages and
+//! truncating each to 300 characters. Both halves of that were wrong, and the
+//! second is worse than the issue title says.
+//!
+//! **The window was in the wrong place.** A turn's expensive part is in the
+//! MIDDLE — the approach taken at step 4 and abandoned at step 22, the tool
+//! that errored and was never read again, the command that ran for twenty
+//! minutes against the wrong target. The tail of a turn that went well is the
+//! summary and the sign-off. So reflection was asked what would have made the
+//! turn faster by a witness that could not see where it was slow.
+//!
+//! **And a `Tool` message carries no `content` at all.** The engine builds it
+//! as `content: String::new()` with the payload in `tool_results` —
+//! [`stella_protocol::CompletionMessage`]'s own field docs say so, and
+//! `stella_core`'s driver is where it happens. The old digest read
+//! `message.content`, so every tool result on every surface rendered as the six
+//! characters `"tool: "`. Reflection had never seen what a tool returned — not
+//! truncated, *absent*. The 300-character cut was never reached on the messages
+//! it was meant to bound.
+//!
+//! ## What replaces it
+//!
+//! [`build`] renders the turn under a total character budget
+//! ([`DIGEST_BUDGET_CHARS`]), spending it in priority order rather than in
+//! reverse transcript order:
+//!
+//! 1. **Pinned** — the goal (the turn's first user message) and the last few
+//!    messages (its outcome). These say what was asked and what was delivered,
+//!    and they are bounded by count, so they are admitted before the budget is
+//!    consulted at all.
+//! 2. **Friction** — every message carrying an errored tool result, every
+//!    assistant message that *requested* one, and every message naming a tool
+//!    the event stream flagged as costly or failed ([`TurnFriction`]). This is
+//!    the middle the tail window dropped.
+//! 3. **Filler** — everything else, in transcript order, while the budget
+//!    lasts.
+//!
+//! Whatever is not admitted is replaced by an explicit `… N messages elided …`
+//! marker, so the model reading the digest knows it holds a selection and can
+//! say so instead of reasoning confidently across a gap it cannot see.
+//!
+//! ## Purity
+//!
+//! Everything here is a pure function over borrowed data: no clock, no
+//! filesystem, no store. `reflect_on_turn` reads no clock and assigns no
+//! instant (#2320), and the mining log it feeds is reproducible only while that
+//! holds — a digest that varied with the time of day would break replay
+//! (`memory/replay.rs`) without anything failing. [`TurnFriction`] is a fold
+//! over events the caller already observed, never a read-back of the journal:
+//! the journal is written by the renderer task, which is still draining while
+//! reflection runs, so reading it here would race and the digest would stop
+//! being a function of the turn.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
+
+use stella_protocol::{AgentEvent, CompletionMessage, MessageRole, ModelCallRole, ToolOutput};
+
+/// The whole digest's character ceiling.
+///
+/// Chosen against what it replaces rather than picked round: the old tail
+/// digest could reach 12 × ~310 ≈ 3.7k characters, so this raises the *ceiling*
+/// by roughly 1.6× (~1.5k tokens of transcript). The realized input grows by
+/// more than that on a tool-heavy turn, because the old digest rendered tool
+/// results as nothing at all and so almost never approached its own ceiling —
+/// the honest framing is that reflection now pays for evidence it was
+/// previously billed nothing to ignore. Reflection dispatches pinned-low with a
+/// 2048-token output cap on every tool-using turn, so this is the number to
+/// argue about if its per-turn cost has to come down; #2155 (narrow the
+/// trigger) is the other side of that trade.
+pub(crate) const DIGEST_BUDGET_CHARS: usize = 6_000;
+
+/// How many trailing messages are the turn's *outcome*, and pinned as such.
+const OUTCOME_TAIL_MESSAGES: usize = 4;
+
+/// Per-message character cap for a pinned message (the goal, the outcome).
+const PINNED_CHARS: usize = 700;
+
+/// Per-message character cap for a friction message. An error message and the
+/// call that provoked it are short and are the entire point, so they get the
+/// same room as the outcome.
+const FRICTION_CHARS: usize = 700;
+
+/// Per-message character cap for ordinary narration.
+const FILLER_CHARS: usize = 200;
+
+/// Floor on a single tool result's share of its message's cap.
+///
+/// A `Tool` message can carry several results (parallel calls), and dividing
+/// the cap evenly can leave each too small to hold the assertion that actually
+/// failed. Such a message may exceed its nominal cap; a truncated error message
+/// is worth nothing, and the budget check below still bounds the digest.
+const MIN_RESULT_CHARS: usize = 160;
+
+/// Per-call character cap on a tool call's rendered arguments.
+///
+/// The arguments are load-bearing in a way the old `[called: bash]` rendering
+/// was not: "ran the wrong command for twenty minutes" is a fact about the
+/// argument, not about the tool.
+const TOOL_INPUT_CHARS: usize = 140;
+
+/// How many costliest steps and slowest tools the friction section names.
+const FRICTION_TOP_N: usize = 3;
+
+/// How many errored calls, retries and loop firings the friction section names
+/// before it says how many more there were.
+const FRICTION_LIST_CAP: usize = 6;
+
+/// How many entries [`TurnFriction`] retains per kind before it counts drops
+/// instead of growing. A turn cannot produce more friction than this and still
+/// have a summarizable shape, and an unbounded fold on a long-running turn is a
+/// leak in a best-effort path.
+const FRICTION_ENTRY_CAP: usize = 512;
+
+/// One model call's metering record, as [`AgentEvent::StepUsage`] reported it.
+#[derive(Debug, Clone)]
+struct StepCost {
+    step: usize,
+    role: String,
+    cost_usd: f64,
+    duration_ms: u64,
+    tool_calls: usize,
+}
+
+/// One tool call's pass through the turn — opened by [`AgentEvent::ToolStart`],
+/// closed by its [`AgentEvent::ToolResult`].
+#[derive(Debug, Clone)]
+struct ToolPass {
+    call_id: String,
+    /// Empty when the ledger saw the result but not the start (a tap installed
+    /// mid-turn, or the entry cap). The transcript's own tool calls can still
+    /// name it — see [`call_names`].
+    name: String,
+    duration_ms: u64,
+    /// The failure message when the output was [`ToolOutput::Error`]. `None` is
+    /// a success: a call still in flight is simply not closed yet, and one that
+    /// never closes keeps its zero duration.
+    error: Option<String>,
+}
+
+/// What a turn's event stream says about where its time and money went.
+///
+/// Folded live by the surface that owns the turn's [`AgentEvent`] stream and
+/// handed to reflection as evidence the transcript does not carry: a
+/// `CompletionMessage` records what was said, never what it cost or how long it
+/// took, and a retry or a loop-detector firing leaves no message at all.
+///
+/// [`Default`] is an honest empty ledger, not a degraded one. A surface with no
+/// tap wired still selects on the transcript's own typed tool results, and the
+/// friction section is simply omitted — nothing here is required for [`build`]
+/// to be correct.
+#[derive(Debug, Clone, Default)]
+pub struct TurnFriction {
+    steps: Vec<StepCost>,
+    tools: Vec<ToolPass>,
+    /// Calls awaiting their result: `call_id` → index into `tools`.
+    open: HashMap<String, usize>,
+    retries: Vec<String>,
+    loops: Vec<String>,
+    dropped: usize,
+}
+
+impl TurnFriction {
+    /// Fold one event into the ledger.
+    ///
+    /// Total over the variants that carry friction and deliberately silent on
+    /// every other. The wildcard arm is a decision, not laziness: a new
+    /// `AgentEvent` variant must not change what a turn's friction *is* until
+    /// someone decides that it should.
+    pub fn observe(&mut self, event: &AgentEvent) {
+        match event {
+            AgentEvent::ToolStart { call } => {
+                if self.tools.len() >= FRICTION_ENTRY_CAP {
+                    self.dropped += 1;
+                    return;
+                }
+                self.open.insert(call.call_id.clone(), self.tools.len());
+                self.tools.push(ToolPass {
+                    call_id: call.call_id.clone(),
+                    name: call.name.clone(),
+                    duration_ms: 0,
+                    error: None,
+                });
+            }
+            AgentEvent::ToolResult {
+                call_id,
+                output,
+                duration_ms,
+                ..
+            } => {
+                let Some(index) = self.close(call_id) else {
+                    return;
+                };
+                let pass = &mut self.tools[index];
+                pass.duration_ms = *duration_ms;
+                pass.error = match output {
+                    ToolOutput::Error { message } => Some(message.clone()),
+                    ToolOutput::Ok { .. } => None,
+                };
+            }
+            AgentEvent::StepUsage {
+                step,
+                role,
+                cost_usd,
+                duration_ms,
+                tool_calls,
+                ..
+            } => {
+                if self.steps.len() >= FRICTION_ENTRY_CAP {
+                    self.dropped += 1;
+                    return;
+                }
+                self.steps.push(StepCost {
+                    step: *step,
+                    role: role_token(*role),
+                    cost_usd: *cost_usd,
+                    duration_ms: *duration_ms,
+                    tool_calls: *tool_calls,
+                });
+            }
+            AgentEvent::Retry { attempt, reason } => {
+                self.push_retry(format!("attempt {attempt}: {reason}"));
+            }
+            AgentEvent::RetriesExhausted {
+                attempts, reasons, ..
+            } => {
+                let last = reasons.last().map(String::as_str).unwrap_or("no reason given");
+                self.push_retry(format!("exhausted after {attempts} attempts: {last}"));
+            }
+            AgentEvent::LoopDetected {
+                kind,
+                pattern,
+                repeats,
+                aborted,
+                ..
+            } => {
+                if self.loops.len() >= FRICTION_ENTRY_CAP {
+                    self.dropped += 1;
+                    return;
+                }
+                let outcome = if *aborted { "aborted" } else { "steered" };
+                self.loops.push(format!(
+                    "{kind} ×{repeats} on [{}] — {outcome}",
+                    pattern.join(" → ")
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    /// The `tools` slot a result belongs in, opening one for a result whose
+    /// start was never seen. `None` means the entry cap refused it.
+    fn close(&mut self, call_id: &str) -> Option<usize> {
+        if let Some(index) = self.open.remove(call_id) {
+            return Some(index);
+        }
+        if self.tools.len() >= FRICTION_ENTRY_CAP {
+            self.dropped += 1;
+            return None;
+        }
+        self.tools.push(ToolPass {
+            call_id: call_id.to_string(),
+            name: String::new(),
+            duration_ms: 0,
+            error: None,
+        });
+        Some(self.tools.len() - 1)
+    }
+
+    fn push_retry(&mut self, entry: String) {
+        if self.retries.len() >= FRICTION_ENTRY_CAP {
+            self.dropped += 1;
+            return;
+        }
+        self.retries.push(entry);
+    }
+
+    /// Whether this ledger has anything to say. An empty one renders no section
+    /// at all rather than an encouraging header over nothing.
+    fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+            && self.tools.is_empty()
+            && self.retries.is_empty()
+            && self.loops.is_empty()
+    }
+
+    /// A shared empty ledger, so [`TurnEvidence::from_transcript`] can hand out
+    /// a reference without every caller owning a `Default`.
+    fn empty() -> &'static Self {
+        static EMPTY: std::sync::OnceLock<TurnFriction> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(TurnFriction::default)
+    }
+
+    /// Tool names the event stream saw, by call id — the half of the
+    /// call-id → name map the transcript cannot supply on the staged pipeline
+    /// path, where the worker's tool turns are deliberately kept out of
+    /// `messages` for planner-context hygiene.
+    fn call_names(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.tools
+            .iter()
+            .filter(|pass| !pass.name.is_empty())
+            .map(|pass| (pass.call_id.as_str(), pass.name.as_str()))
+    }
+
+    /// The `tools` entries this ledger says a reflection must see: every call
+    /// that failed, and the [`FRICTION_TOP_N`] that dominated wall clock.
+    fn flagged(&self) -> Vec<&str> {
+        let mut flagged: Vec<&str> = self
+            .tools
+            .iter()
+            .filter(|pass| pass.error.is_some())
+            .map(|pass| pass.call_id.as_str())
+            .collect();
+        flagged.extend(
+            self.by_duration()
+                .into_iter()
+                .take(FRICTION_TOP_N)
+                .map(|pass| pass.call_id.as_str()),
+        );
+        flagged
+    }
+
+    /// Closed calls, slowest first. Ties break on `call_id` so the ordering is
+    /// total — two calls of equal duration must not reorder between runs, or
+    /// the digest stops being a function of the turn.
+    fn by_duration(&self) -> Vec<&ToolPass> {
+        let mut passes: Vec<&ToolPass> = self
+            .tools
+            .iter()
+            .filter(|pass| pass.duration_ms > 0)
+            .collect();
+        passes.sort_by(|a, b| {
+            b.duration_ms
+                .cmp(&a.duration_ms)
+                .then_with(|| a.call_id.cmp(&b.call_id))
+        });
+        passes
+    }
+
+    /// The friction section: where this turn actually spent itself, bounded.
+    ///
+    /// Deliberately first in the digest. It is the part reflection could not
+    /// have reconstructed at any window size, and it is short — putting it
+    /// behind several thousand characters of transcript would make it the first
+    /// thing a narrating model skims past.
+    fn section(&self) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+        let mut out = String::from("Where this turn spent itself (from its event stream):\n");
+        if !self.steps.is_empty() {
+            let calls = self.steps.len();
+            let cost: f64 = self.steps.iter().map(|step| step.cost_usd).sum();
+            let wall: u64 = self.steps.iter().map(|step| step.duration_ms).sum();
+            let _ = writeln!(
+                out,
+                "- {calls} model calls, ${cost:.4}, {} of model wall clock",
+                human_ms(wall)
+            );
+            let mut costliest: Vec<&StepCost> = self.steps.iter().collect();
+            costliest.sort_by(|a, b| {
+                b.cost_usd
+                    .total_cmp(&a.cost_usd)
+                    .then_with(|| a.step.cmp(&b.step))
+            });
+            for step in costliest.iter().take(FRICTION_TOP_N) {
+                let _ = writeln!(
+                    out,
+                    "- costliest: step {} ({}) ${:.4}, {}, {} tool calls",
+                    step.step,
+                    step.role,
+                    step.cost_usd,
+                    human_ms(step.duration_ms),
+                    step.tool_calls
+                );
+            }
+        }
+        for pass in self.by_duration().iter().take(FRICTION_TOP_N) {
+            let _ = writeln!(
+                out,
+                "- slowest tool: {} took {}",
+                tool_label(pass),
+                human_ms(pass.duration_ms)
+            );
+        }
+        let failed: Vec<&ToolPass> = self
+            .tools
+            .iter()
+            .filter(|pass| pass.error.is_some())
+            .collect();
+        if !failed.is_empty() {
+            let _ = writeln!(out, "- {} tool calls FAILED:", failed.len());
+            for pass in failed.iter().take(FRICTION_LIST_CAP) {
+                let message = pass.error.as_deref().unwrap_or_default();
+                let _ = writeln!(
+                    out,
+                    "  - {}: {}",
+                    tool_label(pass),
+                    clip(message, FRICTION_CHARS)
+                );
+            }
+            if failed.len() > FRICTION_LIST_CAP {
+                let _ = writeln!(out, "  - … {} more", failed.len() - FRICTION_LIST_CAP);
+            }
+        }
+        write_list(&mut out, "model call retried", &self.retries);
+        write_list(&mut out, "loop detector fired", &self.loops);
+        if self.dropped > 0 {
+            let _ = writeln!(
+                out,
+                "- ({} further friction records were not retained)",
+                self.dropped
+            );
+        }
+        out
+    }
+}
+
+/// Everything reflection reads about the turn it is judging.
+///
+/// One argument rather than three, because the three are one question and were
+/// already threaded separately through four surfaces. The bundle is also what
+/// makes [`build`] a pure function of the turn: there is nothing else it may
+/// consult.
+#[derive(Clone, Copy)]
+pub struct TurnEvidence<'a> {
+    /// The turn's messages, oldest first. May be a whole session's history (the
+    /// REPL passes all of it) or a slice (the staged pipeline passes its planner
+    /// messages plus the final answer).
+    pub transcript: &'a [CompletionMessage],
+    /// What the turn's event stream said about cost, wall clock, retries and
+    /// loop firings.
+    pub friction: &'a TurnFriction,
+    /// Whether the turn succeeded — which reflection prompt template applies.
+    pub succeeded: bool,
+}
+
+impl<'a> TurnEvidence<'a> {
+    /// Evidence from a transcript alone: the shape every caller with no event
+    /// ledger uses, and the shape every test uses.
+    pub fn from_transcript(transcript: &'a [CompletionMessage], succeeded: bool) -> Self {
+        Self {
+            transcript,
+            friction: TurnFriction::empty(),
+            succeeded,
+        }
+    }
+}
+
+/// How much of the budget one message is entitled to, and in what order it is
+/// spent. Declaration order is allocation order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Priority {
+    /// The goal and the outcome. Admitted before the budget is consulted.
+    Pinned,
+    /// The middle the tail window dropped: errors, and what provoked them.
+    Friction,
+    /// Ordinary narration, admitted while the budget lasts.
+    Filler,
+}
+
+impl Priority {
+    const ALL: [Priority; 3] = [Priority::Pinned, Priority::Friction, Priority::Filler];
+
+    fn cap(self) -> usize {
+        match self {
+            Priority::Pinned => PINNED_CHARS,
+            Priority::Friction => FRICTION_CHARS,
+            Priority::Filler => FILLER_CHARS,
+        }
+    }
+}
+
+/// Build the digest reflection reads. Deterministic in `evidence` alone.
+pub(crate) fn build(evidence: TurnEvidence<'_>) -> String {
+    let transcript = evidence.transcript;
+    let names = call_names(evidence);
+    let priorities = classify(evidence);
+    let mut kept: Vec<Option<String>> = vec![None; transcript.len()];
+    let mut spent = 0usize;
+    for tier in Priority::ALL {
+        for (index, priority) in priorities.iter().enumerate() {
+            if *priority != tier {
+                continue;
+            }
+            let body = render(&transcript[index], &names, tier.cap());
+            if body.is_empty() {
+                continue;
+            }
+            let weight = body.chars().count();
+            // Pinned messages are bounded by count (one goal plus
+            // OUTCOME_TAIL_MESSAGES, each capped) and are admitted whatever the
+            // budget says: a digest that dropped the goal to fit an error would
+            // ask the model to judge work it cannot see the point of.
+            if tier != Priority::Pinned && spent + weight > DIGEST_BUDGET_CHARS {
+                continue;
+            }
+            spent += weight;
+            kept[index] = Some(body);
+        }
+    }
+    stitch(&kept, evidence.friction)
+}
+
+/// Join the kept renderings in transcript order, replacing each run of dropped
+/// messages with a marker saying how many went missing.
+fn stitch(kept: &[Option<String>], friction: &TurnFriction) -> String {
+    let mut out = friction.section();
+    let elided = kept.iter().filter(|body| body.is_none()).count();
+    if elided > 0 {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        let _ = writeln!(
+            out,
+            "The transcript below is a SELECTION of {} messages — {elided} are not \
+             included, and every gap is marked. Do not assume anything about a gap; \
+             if the evidence you need is inside one, say so instead.",
+            kept.len()
+        );
+    }
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    let mut run = 0usize;
+    for body in kept {
+        match body {
+            Some(body) => {
+                if run > 0 {
+                    let _ = writeln!(out, "… {run} messages elided …");
+                    run = 0;
+                }
+                out.push_str(body);
+                out.push('\n');
+            }
+            None => run += 1,
+        }
+    }
+    if run > 0 {
+        let _ = writeln!(out, "… {run} messages elided …");
+    }
+    // Writing line-wise leaves a trailing newline; the digest is interpolated
+    // into a prompt, where a stray blank line is noise.
+    while out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+/// `call_id` → tool name, from both sources that know one.
+///
+/// The transcript knows it whenever the assistant's tool-calling message is in
+/// the slice; the event ledger knows it whenever a tap was wired. Neither is
+/// sufficient alone — the staged pipeline path has the events and not the
+/// messages — so the map is the union, transcript last so a name recorded in
+/// both resolves to the transcript's.
+fn call_names<'a>(evidence: TurnEvidence<'a>) -> HashMap<&'a str, &'a str> {
+    let mut names: HashMap<&str, &str> = evidence.friction.call_names().collect();
+    for message in evidence.transcript {
+        for call in &message.tool_calls {
+            names.insert(call.call_id.as_str(), call.name.as_str());
+        }
+    }
+    names
+}
+
+/// Assign every message its budget tier.
+fn classify(evidence: TurnEvidence<'_>) -> Vec<Priority> {
+    let transcript = evidence.transcript;
+    let flagged: HashSet<&str> = transcript
+        .iter()
+        .flat_map(|message| message.tool_results.iter())
+        .filter(|result| result.output.is_error())
+        .map(|result| result.call_id.as_str())
+        .chain(evidence.friction.flagged())
+        .collect();
+    let outcome_from = transcript.len().saturating_sub(OUTCOME_TAIL_MESSAGES);
+    let goal = transcript
+        .iter()
+        .position(|message| message.role == MessageRole::User);
+    transcript
+        .iter()
+        .enumerate()
+        .map(|(index, message)| {
+            if index >= outcome_from || goal == Some(index) {
+                return Priority::Pinned;
+            }
+            let carries_friction = message
+                .tool_results
+                .iter()
+                .any(|result| flagged.contains(result.call_id.as_str()))
+                || message
+                    .tool_calls
+                    .iter()
+                    .any(|call| flagged.contains(call.call_id.as_str()));
+            if carries_friction {
+                Priority::Friction
+            } else {
+                Priority::Filler
+            }
+        })
+        .collect()
+}
+
+/// Render one message, capped.
+///
+/// Returns the empty string for a message that is not turn evidence: a `System`
+/// message is the prompt prefix, byte-stable by design (invariant 7) and
+/// identical on every turn, so budget spent on it teaches reflection nothing it
+/// did not already know last turn. Recalled context is a `User` message
+/// (`memory/recall.rs::inject_recall_block`) and is therefore kept.
+fn render(message: &CompletionMessage, names: &HashMap<&str, &str>, cap: usize) -> String {
+    match message.role {
+        MessageRole::System => String::new(),
+        MessageRole::User => prefixed("user", &clip(&message.content, cap)),
+        MessageRole::Assistant => {
+            let mut body = clip(&message.content, cap);
+            for call in &message.tool_calls {
+                let _ = write!(
+                    body,
+                    "\n  → calls {}({})",
+                    call.name,
+                    clip(&compact(&call.input), TOOL_INPUT_CHARS)
+                );
+            }
+            prefixed("assistant", &body)
+        }
+        MessageRole::Tool => {
+            // The half the old digest could not see at any window size: a
+            // `Tool` message's payload is `tool_results`, and its `content` is
+            // empty by construction.
+            let share = (cap / message.tool_results.len().max(1)).max(MIN_RESULT_CHARS);
+            let mut body = clip(&message.content, cap);
+            for result in &message.tool_results {
+                let name = names
+                    .get(result.call_id.as_str())
+                    .copied()
+                    .unwrap_or("tool");
+                match &result.output {
+                    ToolOutput::Error { message } => {
+                        let _ = write!(body, "\n  {name} FAILED: {}", clip(message, share));
+                    }
+                    ToolOutput::Ok { content } => {
+                        let _ = write!(body, "\n  {name} ok: {}", clip(content, share));
+                    }
+                }
+            }
+            prefixed("tool", &body)
+        }
+    }
+}
+
+/// `role: body`, or nothing when the body is empty — an empty rendering is
+/// dropped rather than emitted as a bare role label, which is exactly what the
+/// old digest did to every tool result.
+fn prefixed(role: &str, body: &str) -> String {
+    if body.trim().is_empty() {
+        return String::new();
+    }
+    format!("{role}: {body}")
+}
+
+/// A tool call's arguments as one line. `Value::to_string` is already compact; a
+/// string argument loses its quotes, because the digest is prose, not JSON.
+fn compact(input: &serde_json::Value) -> String {
+    match input {
+        serde_json::Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Truncate on a character boundary, naming what was dropped.
+///
+/// The count matters: a model told "1.2k more characters" can report that the
+/// evidence it needed was cut, which an unmarked truncation makes impossible.
+fn clip(text: &str, cap: usize) -> String {
+    let text = text.trim();
+    let total = text.chars().count();
+    if total <= cap {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(cap).collect();
+    format!("{head}… [{} more characters]", total - cap)
+}
+
+/// `450ms`, `1.2s`, `3m18s` — the shape a person reads a duration in.
+fn human_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+    let secs = ms / 1_000;
+    if secs < 60 {
+        return format!("{}.{}s", secs, (ms % 1_000) / 100);
+    }
+    format!("{}m{:02}s", secs / 60, secs % 60)
+}
+
+/// The wire token for a call role (`plan_repair`, not `PlanRepair`), so a
+/// reflection's account of a turn greps against `stella-events.jsonl` — which
+/// is the record anyone checking the claim will open.
+fn role_token(role: ModelCallRole) -> String {
+    match serde_json::to_value(role) {
+        Ok(serde_json::Value::String(token)) => token,
+        // `ModelCallRole` is a plain `#[serde(rename_all)]` enum, so this arm is
+        // unreachable in practice. It is a label, not a fallback to reason
+        // about: nothing branches on it.
+        _ => "unknown".to_string(),
+    }
+}
+
+/// `name (call_id)`, or just the id when the ledger never saw the call's start.
+fn tool_label(pass: &ToolPass) -> String {
+    if pass.name.is_empty() {
+        return pass.call_id.clone();
+    }
+    format!("{} ({})", pass.name, pass.call_id)
+}
+
+/// One capped `- label:` block per non-empty list.
+fn write_list(out: &mut String, label: &str, entries: &[String]) {
+    if entries.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "- {label} {} times:", entries.len());
+    for entry in entries.iter().take(FRICTION_LIST_CAP) {
+        let _ = writeln!(out, "  - {}", clip(entry, FRICTION_CHARS));
+    }
+    if entries.len() > FRICTION_LIST_CAP {
+        let _ = writeln!(out, "  - … {} more", entries.len() - FRICTION_LIST_CAP);
+    }
+}

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -234,7 +234,10 @@ impl TurnFriction {
             AgentEvent::RetriesExhausted {
                 attempts, reasons, ..
             } => {
-                let last = reasons.last().map(String::as_str).unwrap_or("no reason given");
+                let last = reasons
+                    .last()
+                    .map(String::as_str)
+                    .unwrap_or("no reason given");
                 self.push_retry(format!("exhausted after {attempts} attempts: {last}"));
             }
             AgentEvent::LoopDetected {

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -130,7 +130,10 @@ fn the_goal_and_the_outcome_are_never_dropped() {
         "the first user message is the goal; judging a turn without it is \
          judging work whose point is invisible\n\n{out}"
     );
-    assert!(out.contains("gave up"), "the outcome is pinned too\n\n{out}");
+    assert!(
+        out.contains("gave up"),
+        "the outcome is pinned too\n\n{out}"
+    );
 }
 
 #[test]

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -1,0 +1,510 @@
+//! The selection's mechanics: what it keeps, what it says it dropped, what it
+//! costs, and that it is a function of the turn alone.
+//!
+//! The end-to-end witnesses live one level up, in
+//! `memory::reflection::tests` — they drive `reflect_on_turn` and assert against
+//! the prompt that actually went on the wire, which is what makes them
+//! witnesses. These are the unit tests underneath them.
+
+use super::*;
+use stella_protocol::{ModelCallRole, ToolCall, ToolResult};
+
+fn user(text: &str) -> CompletionMessage {
+    CompletionMessage::user(text)
+}
+
+fn assistant(text: &str) -> CompletionMessage {
+    CompletionMessage::assistant(text)
+}
+
+/// An assistant message that calls one tool.
+fn calls(call_id: &str, name: &str, input: serde_json::Value) -> CompletionMessage {
+    CompletionMessage {
+        role: MessageRole::Assistant,
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.into(),
+            name: name.into(),
+            input,
+        }],
+        tool_results: Vec::new(),
+        attachments: Vec::new(),
+    }
+}
+
+/// The `Tool` message answering it — built the way the engine builds it, with
+/// `content` empty and the payload in `tool_results`.
+fn answers(call_id: &str, output: ToolOutput) -> CompletionMessage {
+    CompletionMessage {
+        role: MessageRole::Tool,
+        content: String::new(),
+        tool_calls: Vec::new(),
+        tool_results: vec![ToolResult {
+            call_id: call_id.into(),
+            output,
+        }],
+        attachments: Vec::new(),
+    }
+}
+
+fn ok(content: &str) -> ToolOutput {
+    ToolOutput::Ok {
+        content: content.into(),
+    }
+}
+
+fn failed(message: &str) -> ToolOutput {
+    ToolOutput::Error {
+        message: message.into(),
+    }
+}
+
+/// `steps` routine tool exchanges around one that failed at `at`.
+fn long_turn(steps: usize, at: usize, failure: &str) -> Vec<CompletionMessage> {
+    let mut transcript = vec![user("make the suite green")];
+    for step in 0..steps {
+        let id = format!("call_{step}");
+        transcript.push(calls(&id, "bash", serde_json::json!({"cmd": "cargo test"})));
+        transcript.push(answers(
+            &id,
+            if step == at {
+                failed(failure)
+            } else {
+                ok(&format!("step {step} fine"))
+            },
+        ));
+    }
+    transcript.push(assistant("gave up"));
+    transcript
+}
+
+#[test]
+fn a_tool_result_is_rendered_from_tool_results_not_from_content() {
+    let transcript = vec![
+        user("read the config"),
+        calls("c1", "read_file", serde_json::json!({"path": "Cargo.toml"})),
+        answers("c1", ok("[workspace]\nmembers = [\"crates/*\"]")),
+    ];
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    assert!(
+        out.contains("read_file ok: [workspace]"),
+        "a `Tool` message's payload is in `tool_results` and its `content` is \
+         empty, so reading `content` renders every tool result as nothing — the \
+         defect this module exists to fix.\n\n{out}"
+    );
+    assert!(
+        !out.contains("tool: \n") && !out.ends_with("tool:"),
+        "a bare `tool:` line with no payload is the old rendering\n\n{out}"
+    );
+}
+
+#[test]
+fn a_failed_call_survives_the_middle_of_a_long_turn() {
+    let transcript = long_turn(40, 6, "linker error: undefined symbol _stella_main");
+    let out = build(TurnEvidence::from_transcript(&transcript, false));
+    assert!(
+        out.contains("linker error: undefined symbol _stella_main"),
+        "the failure is the point of the turn and it is 60 messages from the \
+         end\n\n{out}"
+    );
+    assert!(
+        out.contains("bash FAILED:"),
+        "a failure must be labelled as one, not left for the model to sniff out \
+         of prose\n\n{out}"
+    );
+}
+
+#[test]
+fn the_goal_and_the_outcome_are_never_dropped() {
+    let transcript = long_turn(60, 3, "boom");
+    let out = build(TurnEvidence::from_transcript(&transcript, false));
+    assert!(
+        out.contains("make the suite green"),
+        "the first user message is the goal; judging a turn without it is \
+         judging work whose point is invisible\n\n{out}"
+    );
+    assert!(out.contains("gave up"), "the outcome is pinned too\n\n{out}");
+}
+
+#[test]
+fn elisions_are_declared_and_counted() {
+    let transcript = long_turn(60, 3, "boom");
+    let out = build(TurnEvidence::from_transcript(&transcript, false));
+    assert!(
+        out.contains("is a SELECTION of"),
+        "a model reading a selection must be told it is reading one, or it will \
+         reason confidently across a gap\n\n{out}"
+    );
+    assert!(
+        out.contains("messages elided …"),
+        "every gap is marked in place, not merely counted in the header\n\n{out}"
+    );
+}
+
+/// Nothing is elided when nothing needs to be: a short turn renders whole, with
+/// no selection header and no gap markers to explain away.
+#[test]
+fn a_short_turn_carries_no_selection_notice() {
+    let transcript = vec![
+        user("bump the version"),
+        calls("c1", "edit_file", serde_json::json!({"path": "Cargo.toml"})),
+        answers("c1", ok("1 replacement")),
+        assistant("done"),
+    ];
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    assert!(
+        !out.contains("SELECTION") && !out.contains("elided"),
+        "a turn that fits needs no apology\n\n{out}"
+    );
+}
+
+/// The budget is the cost control, and it binds. Measured on a turn far larger
+/// than any real one so the ceiling is the thing under test, not the fixture.
+#[test]
+fn the_digest_stays_inside_its_character_budget() {
+    let mut transcript = vec![user("port the whole module")];
+    for step in 0..300 {
+        let id = format!("call_{step}");
+        transcript.push(calls(
+            &id,
+            "read_file",
+            serde_json::json!({"path": format!("crates/stella-core/src/file_{step}.rs")}),
+        ));
+        transcript.push(answers(&id, ok(&"x".repeat(20_000))));
+    }
+    transcript.push(assistant("done"));
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    let spent = out.chars().count();
+    // Pinned messages are admitted outside the budget by design — one goal plus
+    // OUTCOME_TAIL_MESSAGES, each capped at PINNED_CHARS — so the ceiling is the
+    // budget plus that bounded allowance, never unbounded.
+    let ceiling = DIGEST_BUDGET_CHARS + (OUTCOME_TAIL_MESSAGES + 1) * PINNED_CHARS;
+    assert!(
+        spent <= ceiling,
+        "the digest spent {spent} characters against a {ceiling} ceiling; the \
+         budget is what keeps reflection's per-turn cost arguable"
+    );
+}
+
+/// The measurement #2460's definition of done asks for, as a test rather than a
+/// sentence in a PR description: what the old tail digest and the new selection
+/// each spend on the same turn.
+///
+/// It asserts only the direction and the bound. The exact numbers move with every
+/// prompt edit, and a test that pinned them would fail for reasons that are not
+/// about cost.
+#[test]
+fn the_selection_costs_more_than_the_tail_it_replaces_and_says_how_much() {
+    let transcript = long_turn(40, 6, "linker error: undefined symbol _stella_main");
+
+    // The digest as it was: the last twelve messages, each `content` truncated
+    // to 300 characters. Reproduced here to make the comparison a measurement
+    // instead of a recollection.
+    let old: String = transcript
+        .iter()
+        .rev()
+        .take(12)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|message| {
+            let role = match message.role {
+                MessageRole::System => "system",
+                MessageRole::User => "user",
+                MessageRole::Assistant => "assistant",
+                MessageRole::Tool => "tool",
+            };
+            let content: String = message.content.chars().take(300).collect();
+            let tools = if message.tool_calls.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " [called: {}]",
+                    message
+                        .tool_calls
+                        .iter()
+                        .map(|call| call.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            format!("{role}: {content}{tools}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let new = build(TurnEvidence::from_transcript(&transcript, false));
+
+    let (before, after) = (old.chars().count(), new.chars().count());
+    assert!(
+        before < 400,
+        "the old digest of an 82-message tool-heavy turn was {before} \
+         characters. If this ever grows, the premise of the comparison has \
+         changed — a tool message rendered as the six characters `tool: ` is \
+         why it was so small:\n\n{old}"
+    );
+    assert!(
+        after > before,
+        "the selection costs {after} characters against the tail's {before}. It \
+         is SUPPOSED to cost more — it carries evidence the tail did not — and a \
+         version that costs the same is one that stopped reading tool results."
+    );
+    assert!(
+        after <= DIGEST_BUDGET_CHARS + (OUTCOME_TAIL_MESSAGES + 1) * PINNED_CHARS,
+        "the extra spend is bounded by the budget, not open-ended: {after}"
+    );
+}
+
+/// A `System` message is the byte-stable prompt prefix (invariant 7), identical
+/// on every turn of the session. Spending digest budget on it buys nothing.
+#[test]
+fn the_system_prompt_is_not_turn_evidence() {
+    let transcript = vec![
+        CompletionMessage::system("You are Stella. NEVER_IN_A_DIGEST"),
+        user("do it"),
+        assistant("done"),
+    ];
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    assert!(
+        !out.contains("NEVER_IN_A_DIGEST"),
+        "the system prompt is the same every turn — reflection already knows \
+         it\n\n{out}"
+    );
+}
+
+#[test]
+fn a_tool_calls_arguments_are_shown_because_the_argument_is_often_the_mistake() {
+    let transcript = vec![
+        user("run the tests"),
+        calls(
+            "c1",
+            "bash",
+            serde_json::json!({"cmd": "cargo test --workspace --release"}),
+        ),
+        answers("c1", ok("finished in 41m")),
+    ];
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    assert!(
+        out.contains("cargo test --workspace --release"),
+        "`[called: bash]` cannot tell a reflection that the turn spent forty \
+         minutes because the command was wrong\n\n{out}"
+    );
+}
+
+fn step_usage(step: usize, role: ModelCallRole, cost_usd: f64, duration_ms: u64) -> AgentEvent {
+    AgentEvent::StepUsage {
+        step,
+        role,
+        provider: "anthropic".into(),
+        output_text: None,
+        model: "claude".into(),
+        input_tokens: 1_000,
+        output_tokens: 100,
+        cached_input_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: None,
+        estimated_input_tokens: 0,
+        cost_usd,
+        duration_ms,
+        retries: 0,
+        tool_calls: 2,
+        complete: true,
+        finish_reason: None,
+    }
+}
+
+#[test]
+fn the_friction_section_names_the_costliest_step_by_its_wire_role() {
+    let mut friction = TurnFriction::default();
+    friction.observe(&step_usage(1, ModelCallRole::Triage, 0.001, 900));
+    friction.observe(&step_usage(7, ModelCallRole::WitnessAuthor, 0.31, 61_000));
+    let section = friction.section();
+    assert!(
+        section.contains("step 7 (witness_author) $0.3100"),
+        "the role is spelled as the wire spells it, so a reflection's account of \
+         a turn greps against stella-events.jsonl — the record anyone checking \
+         the claim will open\n\n{section}"
+    );
+    assert!(
+        section.contains("1m01s"),
+        "wall clock reads as a duration, not as a count of \
+         milliseconds\n\n{section}"
+    );
+}
+
+#[test]
+fn the_friction_section_names_every_failed_tool_and_the_loop_detector() {
+    let mut friction = TurnFriction::default();
+    friction.observe(&AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c1".into(),
+            name: "bash".into(),
+            input: serde_json::json!({}),
+        },
+    });
+    friction.observe(&AgentEvent::ToolResult {
+        call_id: "c1".into(),
+        output: failed("exit 101: could not compile stella-core"),
+        duration_ms: 96_000,
+        speculated: false,
+    });
+    friction.observe(&AgentEvent::Retry {
+        attempt: 1,
+        reason: "overloaded_error".into(),
+    });
+    friction.observe(&AgentEvent::LoopDetected {
+        turn_instance: 0,
+        kind: "short_cycle".into(),
+        pattern: vec!["read_file".into(), "bash".into()],
+        repeats: 3,
+        evidence: "same two calls, three times".into(),
+        aborted: true,
+    });
+    let section = friction.section();
+    for expected in [
+        "bash (c1): exit 101: could not compile stella-core",
+        "slowest tool: bash (c1) took 1m36s",
+        "attempt 1: overloaded_error",
+        "short_cycle ×3 on [read_file → bash] — aborted",
+    ] {
+        assert!(
+            section.contains(expected),
+            "{expected:?} missing from the friction section\n\n{section}"
+        );
+    }
+}
+
+/// A result whose `ToolStart` was never folded still records — the duration and
+/// the failure are the signal, and the name is recoverable from the transcript.
+#[test]
+fn a_result_without_its_start_is_recorded_under_its_call_id() {
+    let mut friction = TurnFriction::default();
+    friction.observe(&AgentEvent::ToolResult {
+        call_id: "orphan".into(),
+        output: failed("no such file"),
+        duration_ms: 5,
+        speculated: false,
+    });
+    assert!(
+        friction.section().contains("orphan: no such file"),
+        "dropping it would lose a failure to bookkeeping"
+    );
+    let transcript = vec![
+        user("read it"),
+        calls("orphan", "read_file", serde_json::json!({"path": "x"})),
+        answers("orphan", failed("no such file")),
+    ];
+    let out = build(TurnEvidence {
+        transcript: &transcript,
+        friction: &friction,
+        succeeded: false,
+    });
+    assert!(
+        out.contains("read_file FAILED: no such file"),
+        "the transcript supplies the name the ledger lacked\n\n{out}"
+    );
+}
+
+/// An empty ledger renders no section — a surface with no tap wired must not get
+/// a header promising evidence it has none of (#2483).
+#[test]
+fn an_empty_ledger_renders_no_friction_section() {
+    assert!(TurnFriction::default().section().is_empty());
+    let transcript = vec![user("hi"), assistant("hello")];
+    let out = build(TurnEvidence::from_transcript(&transcript, true));
+    assert!(
+        !out.contains("Where this turn spent itself"),
+        "no ledger, no section\n\n{out}"
+    );
+}
+
+/// The property replay rests on: the digest is a function of the turn.
+///
+/// `reflect_on_turn` reads no clock and assigns no instant (#2320), and the
+/// mining log it feeds is reproducible only while that holds. A digest that
+/// varied — iteration order over the ledger's map, a tie between two equally
+/// slow tools breaking differently — would break replay with nothing failing.
+#[test]
+fn the_digest_is_a_function_of_the_turn() {
+    let build_once = || {
+        let mut friction = TurnFriction::default();
+        for step in 0..8 {
+            let id = format!("c{step}");
+            friction.observe(&AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: id.clone(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                },
+            });
+            friction.observe(&AgentEvent::ToolResult {
+                call_id: id,
+                // Every duration identical, so the tie-break is what orders them.
+                output: ok("fine"),
+                duration_ms: 1_000,
+                speculated: false,
+            });
+            friction.observe(&step_usage(step, ModelCallRole::Worker, 0.01, 1_000));
+        }
+        let transcript = long_turn(30, 4, "boom");
+        build(TurnEvidence {
+            transcript: &transcript,
+            friction: &friction,
+            succeeded: false,
+        })
+    };
+    let first = build_once();
+    for _ in 0..12 {
+        assert_eq!(
+            build_once(),
+            first,
+            "the digest must not vary between builds of the same turn"
+        );
+    }
+}
+
+/// Multibyte content must not panic the clip, and must not be counted in bytes
+/// where the contract says characters.
+#[test]
+fn clipping_respects_character_boundaries() {
+    let text = "日本語のテキスト".repeat(200);
+    let clipped = clip(&text, 10);
+    assert_eq!(clipped.chars().take(10).collect::<String>(), text[..30]);
+    assert!(
+        clipped.contains("more characters]"),
+        "a truncation says how much it cut, so the model can report that the \
+         evidence it needed was outside the cut"
+    );
+}
+
+#[test]
+fn durations_read_as_durations() {
+    assert_eq!(human_ms(0), "0ms");
+    assert_eq!(human_ms(999), "999ms");
+    assert_eq!(human_ms(1_000), "1.0s");
+    assert_eq!(human_ms(1_250), "1.2s");
+    assert_eq!(human_ms(59_999), "59.9s");
+    assert_eq!(human_ms(60_000), "1m00s");
+    assert_eq!(human_ms(3_678_000), "61m18s");
+}
+
+/// The fold is bounded: a turn cannot make the ledger grow without limit, and
+/// what it refuses is counted rather than silently dropped.
+#[test]
+fn the_ledger_is_bounded_and_reports_what_it_refused() {
+    let mut friction = TurnFriction::default();
+    for step in 0..(FRICTION_ENTRY_CAP + 25) {
+        friction.observe(&AgentEvent::Retry {
+            attempt: 1,
+            reason: format!("reason {step}"),
+        });
+    }
+    assert_eq!(friction.retries.len(), FRICTION_ENTRY_CAP);
+    assert_eq!(friction.dropped, 25);
+    assert!(
+        friction
+            .section()
+            .contains("25 further friction records were not retained"),
+        "a silent truncation reads as \"this was everything\"\n\n{}",
+        friction.section()
+    );
+}

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -168,6 +168,137 @@ fn a_short_turn_carries_no_selection_notice() {
     );
 }
 
+/// The whole rendering, spelled out — a golden a reviewer can read.
+///
+/// Every other test here asserts one property and would pass over a digest that
+/// was correct and unreadable. This one is the shape itself: the friction section
+/// first, then the transcript, one line per message part. If it fails, read the
+/// diff and decide whether the new shape is better; do not re-bless it unread.
+///
+/// The elided form is `elisions_are_declared_and_counted`; this turn fits, and a
+/// turn that fits carries no selection notice.
+#[test]
+fn the_whole_rendering_reads_like_this() {
+    let mut friction = TurnFriction::default();
+    friction.observe(&step_usage(3, ModelCallRole::Worker, 0.0812, 31_400));
+    friction.observe(&AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c2".into(),
+            name: "bash".into(),
+            input: serde_json::json!({}),
+        },
+    });
+    friction.observe(&AgentEvent::ToolResult {
+        call_id: "c2".into(),
+        output: failed("error[E0599]: no method named `parse_amount`"),
+        duration_ms: 12_800,
+        speculated: false,
+    });
+
+    let transcript = vec![
+        user("make the money test pass"),
+        calls(
+            "c0",
+            "read_file",
+            serde_json::json!({"path": "src/money.rs"}),
+        ),
+        answers(
+            "c0",
+            ok("pub fn to_cents(v: f64) -> i64 { (v * 100.0) as i64 }"),
+        ),
+        calls("c1", "read_file", serde_json::json!({"path": "src/lib.rs"})),
+        answers("c1", ok("pub mod money;")),
+        calls(
+            "c2",
+            "bash",
+            serde_json::json!({"cmd": "cargo test -p money"}),
+        ),
+        answers("c2", failed("error[E0599]: no method named `parse_amount`")),
+        calls(
+            "c3",
+            "edit_file",
+            serde_json::json!({"path": "src/money.rs"}),
+        ),
+        answers("c3", ok("1 replacement")),
+        assistant("used money::parse_amount; the test is green"),
+    ];
+
+    let out = build(TurnEvidence {
+        transcript: &transcript,
+        friction: &friction,
+        succeeded: true,
+    });
+    // Ten messages under a 6k budget: nothing is elided, so there is no
+    // selection notice and no gap marker. That is the point of the pairing with
+    // `elisions_are_declared_and_counted` — the notice appears when, and only
+    // when, something was actually dropped.
+    //
+    // Tool arguments render as the JSON the model produced, not as a bare value.
+    // The key is the readable half: `{"cmd": …}` and `{"path": …}` say what kind
+    // of mistake an argument was, which is the whole reason the arguments are
+    // here instead of the old `[called: bash]`.
+    let expected = "\
+Where this turn spent itself (from its event stream):
+- 1 model calls, $0.0812, 31.4s of model wall clock
+- costliest: step 3 (worker) $0.0812, 31.4s, 2 tool calls
+- slowest tool: bash (c2) took 12.8s
+- 1 tool calls FAILED:
+  - bash (c2): error[E0599]: no method named `parse_amount`
+
+user: make the money test pass
+assistant: → calls read_file({\"path\":\"src/money.rs\"})
+tool: read_file ok: pub fn to_cents(v: f64) -> i64 { (v * 100.0) as i64 }
+assistant: → calls read_file({\"path\":\"src/lib.rs\"})
+tool: read_file ok: pub mod money;
+assistant: → calls bash({\"cmd\":\"cargo test -p money\"})
+tool: bash FAILED: error[E0599]: no method named `parse_amount`
+assistant: → calls edit_file({\"path\":\"src/money.rs\"})
+tool: edit_file ok: 1 replacement
+assistant: used money::parse_amount; the test is green";
+    assert_eq!(out, expected, "\n--- actual ---\n{out}\n--- end ---");
+}
+
+/// A credential in a tool argument or a tool result never reaches the digest.
+///
+/// This is not inherited caution. The old tail digest carried tool *names* and no
+/// tool output at all, so it could not leak a token; this one renders arguments
+/// and results, which is precisely where one appears — a `read_file` of `.env`, a
+/// `bash` that printed `env`. Reflection also dispatches on the triage route,
+/// which may be a different vendor than the worker, so "that provider has seen it
+/// already" does not hold. Mirrors the dataset exporter's own planted-key test.
+#[test]
+fn a_planted_credential_never_reaches_the_digest() {
+    const PLANTED: &str = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let transcript = vec![
+        user("why is auth failing"),
+        calls("c1", "read_file", serde_json::json!({"path": ".env"})),
+        answers("c1", ok(&format!("ANTHROPIC_API_KEY={PLANTED}"))),
+        calls(
+            "c2",
+            "bash",
+            serde_json::json!({"cmd": format!("curl -H 'x-api-key: {PLANTED}' https://api")}),
+        ),
+        answers("c2", failed(&format!("401 unauthorized for {PLANTED}"))),
+        assistant("the key is revoked"),
+    ];
+    let out = build(TurnEvidence::from_transcript(&transcript, false));
+    assert!(
+        !out.contains(PLANTED),
+        "a credential reached the reflection prompt, which routes to the triage \
+         model and not necessarily to the provider that already saw it\n\n{out}"
+    );
+    assert!(
+        out.contains(stella_core::redact::PLACEHOLDER),
+        "the redaction must be visible where it happened, so a reader knows the \
+         digest was edited rather than that the turn said nothing\n\n{out}"
+    );
+    assert!(
+        out.contains("ANTHROPIC_API_KEY=") && out.contains("401 unauthorized for"),
+        "only the secret is replaced — the surrounding evidence is the whole \
+         point of showing the tool result\n\n{out}"
+    );
+}
+
 /// The budget is the cost control, and it binds. Measured on a turn far larger
 /// than any real one so the ceiling is the thing under test, not the fixture.
 #[test]

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -60,6 +60,10 @@ fn failed(message: &str) -> ToolOutput {
 }
 
 /// `steps` routine tool exchanges around one that failed at `at`.
+///
+/// Each routine result is deliberately longer than [`FILLER_CHARS`], so a turn
+/// of any real length actually exhausts the budget — a fixture of terse
+/// one-liners fits inside it and elides nothing, which tests the wrong thing.
 fn long_turn(steps: usize, at: usize, failure: &str) -> Vec<CompletionMessage> {
     let mut transcript = vec![user("make the suite green")];
     for step in 0..steps {
@@ -70,7 +74,10 @@ fn long_turn(steps: usize, at: usize, failure: &str) -> Vec<CompletionMessage> {
             if step == at {
                 failed(failure)
             } else {
-                ok(&format!("step {step} fine"))
+                ok(&format!(
+                    "step {step}: {}",
+                    "running 412 tests ... ok ".repeat(30)
+                ))
             },
         ));
     }
@@ -93,7 +100,7 @@ fn a_tool_result_is_rendered_from_tool_results_not_from_content() {
          defect this module exists to fix.\n\n{out}"
     );
     assert!(
-        !out.contains("tool: \n") && !out.ends_with("tool:"),
+        !out.lines().any(|line| line.trim() == "tool:"),
         "a bare `tool:` line with no payload is the old rendering\n\n{out}"
     );
 }

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -242,6 +242,16 @@ fn the_selection_costs_more_than_the_tail_it_replaces_and_says_how_much() {
     let new = build(TurnEvidence::from_transcript(&transcript, false));
 
     let (before, after) = (old.chars().count(), new.chars().count());
+    // Reported, not just asserted: `cargo test -- --nocapture
+    // the_selection_costs_more` is how the number in the PR description is
+    // obtained, so it can be re-derived instead of trusted.
+    println!(
+        "#2460 digest cost on an {}-message tool-heavy turn: tail={before} chars \
+         (~{} tokens) → selection={after} chars (~{} tokens)",
+        transcript.len(),
+        before / 4,
+        after / 4
+    );
     assert!(
         before < 400,
         "the old digest of an 82-message tool-heavy turn was {before} \

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -15,13 +15,17 @@
 //! nothing here can. They pin the two things that were actually wrong: that the
 //! discard test is present at all, and that the construct which carried the
 //! anti-example both times has not come back.
+//!
+//! The witnesses at the bottom of the file pin something else: what the prompt
+//! is allowed to *see*. Both fail on the tail-window digest #2460 replaced, each
+//! on a different one of its two defects.
 
 use std::sync::Mutex;
 
 use async_trait::async_trait;
 use stella_protocol::{
     CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
-    Provider, ProviderError, ReasoningEffort,
+    Provider, ProviderError, ReasoningEffort, ToolCall, ToolOutput, ToolResult,
 };
 
 /// Records the prompt it is asked to complete — and the request's dispatch
@@ -251,4 +255,167 @@ async fn dispatch_shape(
     let shape = *provider.shape.lock().expect("shape lock");
     let reasoning = *provider.reasoning.lock().expect("reasoning lock");
     (shape, reasoning)
+}
+
+/// One assistant message that calls one tool, and the `Tool` message answering
+/// it. Built as the engine builds them — `content` empty, payload in
+/// `tool_results` — because that construction is the whole of defect two.
+fn tool_exchange(call_id: &str, name: &str, output: ToolOutput) -> Vec<CompletionMessage> {
+    vec![
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: call_id.to_string(),
+                name: name.to_string(),
+                input: serde_json::json!({"cmd": "cargo test -p stella-core"}),
+            }],
+            tool_results: Vec::new(),
+            attachments: Vec::new(),
+        },
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: Vec::new(),
+            tool_results: vec![ToolResult {
+                call_id: call_id.to_string(),
+                output,
+            }],
+            attachments: Vec::new(),
+        },
+    ]
+}
+
+/// WITNESS (#2460, defect one — the window is in the wrong place).
+///
+/// A thirty-message turn whose only learnable fact sits at index 8. The old
+/// digest read the last twelve messages, so index 8 of 30 was outside the window
+/// by construction and the fact could not reach the prompt at any truncation
+/// length. Selection keeps it because the tool call it provoked errored.
+#[tokio::test]
+async fn a_fact_in_the_middle_of_a_long_turn_reaches_the_reflection_prompt() {
+    const THE_FACT: &str = "withTenantDb must be opened before the migration lock or the \
+                            leak reappears silently";
+    let mut transcript = vec![CompletionMessage::user("fix the tenancy leak")];
+    for step in 0..14 {
+        if step == 4 {
+            // The fact, and the failure that taught it, in the middle.
+            transcript.push(CompletionMessage::assistant(THE_FACT));
+            transcript.extend(tool_exchange(
+                "call_middle",
+                "bash",
+                ToolOutput::Error {
+                    message: "migration lock held by another connection".into(),
+                },
+            ));
+            continue;
+        }
+        transcript.extend(tool_exchange(
+            &format!("call_{step}"),
+            "read_file",
+            ToolOutput::Ok {
+                content: format!("routine step {step}, nothing to learn here"),
+            },
+        ));
+    }
+    transcript.push(CompletionMessage::assistant("done — tests pass"));
+    assert!(
+        transcript.len() > 24,
+        "the fact must sit well outside a twelve-message tail, or this witness \
+         proves nothing"
+    );
+
+    let prompt = prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, true)).await;
+    assert!(
+        prompt.contains(THE_FACT),
+        "reflection is being asked what it learned by a witness that cannot see \
+         where the turn went wrong: the fact at index 5 of {} never reached the \
+         prompt.\n\nprompt was:\n{prompt}",
+        transcript.len()
+    );
+}
+
+/// WITNESS (#2460, defect two — a `Tool` message's payload is not in `content`).
+///
+/// Four messages, so every one of them is inside even the old twelve-message
+/// tail: the window is not what this pins. The old digest rendered
+/// `message.content`, which the engine leaves EMPTY on a `Tool` message, so
+/// every tool result Stella has ever produced reached reflection as the six
+/// characters `"tool: "` — the 300-character cut never even applied.
+#[tokio::test]
+async fn a_failed_tool_result_reaches_the_reflection_prompt() {
+    const THE_ERROR: &str = "assertion failed: expected 1_15 minor units, got 1_14";
+    let mut transcript = vec![CompletionMessage::user("make the money test pass")];
+    transcript.extend(tool_exchange(
+        "call_1",
+        "bash",
+        ToolOutput::Error {
+            message: THE_ERROR.into(),
+        },
+    ));
+    transcript.push(CompletionMessage::assistant("gave up"));
+
+    let prompt = prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, false)).await;
+    assert!(
+        prompt.contains(THE_ERROR),
+        "the tool result that failed is the highest-value evidence in the turn, \
+         and it is not in the prompt.\n\nprompt was:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("bash"),
+        "a failed result must name the tool that produced it — the name lives on \
+         the call, not the result, so it has to be joined by call id"
+    );
+}
+
+/// The event-derived half of the evidence (#2460's definition of done, item 1):
+/// cost, wall clock, retries and loop firings leave no message at all, so no
+/// window over the transcript can reach them.
+#[tokio::test]
+async fn the_prompt_names_where_the_turn_spent_itself() {
+    let mut friction = super::TurnFriction::default();
+    friction.observe(&stella_protocol::AgentEvent::StepUsage {
+        step: 9,
+        role: stella_protocol::ModelCallRole::Worker,
+        provider: "anthropic".into(),
+        output_text: None,
+        model: "claude".into(),
+        input_tokens: 120_000,
+        output_tokens: 900,
+        cached_input_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: None,
+        estimated_input_tokens: 0,
+        cost_usd: 0.42,
+        duration_ms: 42_000,
+        retries: 0,
+        tool_calls: 3,
+        complete: true,
+        finish_reason: None,
+    });
+    friction.observe(&stella_protocol::AgentEvent::LoopDetected {
+        turn_instance: 0,
+        kind: "stagnation".into(),
+        pattern: vec!["bash".into()],
+        repeats: 4,
+        evidence: "same command, no progress".into(),
+        aborted: false,
+    });
+    let transcript = vec![CompletionMessage::user("fix it")];
+    let prompt = prompt_for_evidence(super::TurnEvidence {
+        transcript: &transcript,
+        friction: &friction,
+        succeeded: false,
+    })
+    .await;
+    assert!(
+        prompt.contains("step 9 (worker)") && prompt.contains("$0.4200"),
+        "the costliest step is where a turn's money went, and it is nowhere in \
+         the transcript.\n\nprompt was:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("stagnation ×4"),
+        "a loop-detector firing leaves no message behind, so a transcript window \
+         can never recover it.\n\nprompt was:\n{prompt}"
+    );
 }

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -368,6 +368,59 @@ async fn a_failed_tool_result_reaches_the_reflection_prompt() {
     );
 }
 
+/// #2460's definition of done, item 2: what reflection costs per turn, reported
+/// rather than asserted into invisibility.
+///
+/// The digest half of the comparison lives in `digest::tests` (which can measure
+/// the old tail rendering directly). This one measures the whole billed prompt —
+/// instructions plus digest — because that is the number an operator pays, and
+/// the instruction block is the larger of the two on a short turn.
+///
+/// Run it with `--nocapture` to read the numbers. The assertion is only a
+/// ceiling: pinning an exact size would fail on every prompt edit, for reasons
+/// that are not about cost.
+#[tokio::test]
+async fn the_billed_prompt_size_is_reported_and_bounded() {
+    let bare = vec![CompletionMessage::user("fix the leak")];
+    let instructions = prompt_for_evidence(super::TurnEvidence::from_transcript(&bare, true))
+        .await
+        .chars()
+        .count();
+
+    let mut heavy = vec![CompletionMessage::user("make the suite green")];
+    for step in 0..40 {
+        let id = format!("call_{step}");
+        heavy.extend(tool_exchange(
+            &id,
+            "bash",
+            ToolOutput::Ok {
+                content: format!("step {step}: {}", "running 412 tests ... ok ".repeat(30)),
+            },
+        ));
+    }
+    heavy.push(CompletionMessage::assistant("done"));
+    let loaded = prompt_for_evidence(super::TurnEvidence::from_transcript(&heavy, true))
+        .await
+        .chars()
+        .count();
+
+    println!(
+        "#2460 reflection prompt: instructions alone = {instructions} chars \
+         (~{} tokens); with a full {}-message turn selected = {loaded} chars \
+         (~{} tokens)",
+        instructions / 4,
+        heavy.len(),
+        loaded / 4
+    );
+    assert!(
+        loaded <= instructions + super::digest::DIGEST_BUDGET_CHARS + 4_000,
+        "the billed prompt is {loaded} chars, past the instruction block plus the \
+         digest budget plus its bounded pinned allowance. The budget is the one \
+         knob that keeps reflection's per-turn cost arguable — if this fires, it \
+         moved without anyone deciding to move it"
+    );
+}
+
 /// The event-derived half of the evidence (#2460's definition of done, item 1):
 /// cost, wall clock, retries and loop firings leave no message at all, so no
 /// window over the transcript can reach them.

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -71,20 +71,25 @@ impl Provider for CapturingProvider {
 
 /// Drive the real prompt builder and hand back exactly what it sent.
 async fn prompt_for(succeeded: bool) -> String {
-    let dir = tempfile::tempdir().expect("tempdir");
-    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
-    let provider = CapturingProvider::default();
     let transcript = vec![
         CompletionMessage::user("fix the leak"),
         CompletionMessage::assistant("swapped db() for withTenantDb"),
     ];
+    prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, succeeded)).await
+}
+
+/// The same, for a caller that has already assembled the turn's evidence — the
+/// selection tests below build transcripts and friction ledgers of their own.
+async fn prompt_for_evidence(evidence: super::TurnEvidence<'_>) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".stella")).expect("workspace");
+    let provider = CapturingProvider::default();
     super::reflect_on_turn(
         &provider,
         "capturing",
         dir.path(),
-        &transcript,
+        evidence,
         &["testing".to_string()],
-        succeeded,
         None,
         super::ReflectionPosture::default(),
     )
@@ -236,9 +241,8 @@ async fn dispatch_shape(
         &provider,
         "capturing",
         dir.path(),
-        &transcript,
+        super::TurnEvidence::from_transcript(&transcript, true),
         &["testing".to_string()],
-        true,
         None,
         posture,
     )

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -355,7 +355,8 @@ async fn a_failed_tool_result_reaches_the_reflection_prompt() {
     ));
     transcript.push(CompletionMessage::assistant("gave up"));
 
-    let prompt = prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, false)).await;
+    let prompt =
+        prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, false)).await;
     assert!(
         prompt.contains(THE_ERROR),
         "the tool result that failed is the highest-value evidence in the turn, \

--- a/crates/stella-cli/src/memory/replay.rs
+++ b/crates/stella-cli/src/memory/replay.rs
@@ -329,9 +329,8 @@ impl<'a> Replayer<'a> {
                 .reflect_and_record(
                     &provider,
                     "replay",
-                    &transcript,
+                    crate::memory::TurnEvidence::from_transcript(&transcript, turn.succeeded),
                     true,
-                    turn.succeeded,
                     None,
                     crate::memory::ReflectionPosture::default(),
                 )

--- a/crates/stella-cli/src/memory/replay/trace.rs
+++ b/crates/stella-cli/src/memory/replay/trace.rs
@@ -89,9 +89,14 @@ pub(crate) struct TraceTurn {
     /// nothing in the harness ever reads the wall clock (#2320).
     pub at: i64,
     pub prompt: String,
-    /// The transcript stub the reflection prompt digests. Only the tail matters
-    /// — `reflect_on_turn` reverses and takes twelve — so a stub need not be a
-    /// whole transcript.
+    /// The transcript stub the reflection prompt digests.
+    ///
+    /// A stub need not be a whole transcript: the digest selects under a
+    /// character budget (`memory::reflection::digest`), so a short stub renders
+    /// whole. What a stub CAN now change is which messages survive — the digest
+    /// promotes an errored `tool_results` entry and the call that provoked it —
+    /// so a fixture that wants the failure in the prompt must carry a real
+    /// `ToolOutput::Error`, not prose describing one (#2460).
     #[serde(default)]
     pub transcript: Vec<TraceMessage>,
     /// What the model would have said, replayed through the scripted provider.

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -867,8 +867,7 @@ async fn reflect_and_record_stores_the_models_self_review_against_its_execution(
         .reflect_and_record(
             &StubProvider,
             "stub",
-            &transcript,
-            true,
+            crate::memory::TurnEvidence::from_transcript(&transcript, true),
             true,
             None,
             crate::memory::ReflectionPosture::default(),
@@ -969,8 +968,10 @@ async fn without_an_execution_id_the_self_review_is_dropped_not_misattributed() 
         .reflect_and_record(
             &StubProvider,
             "stub",
-            &[msg(MessageRole::User, "convert the totals")],
-            true,
+            crate::memory::TurnEvidence::from_transcript(
+                &[msg(MessageRole::User, "convert the totals")],
+                true,
+            ),
             true,
             None,
             crate::memory::ReflectionPosture::default(),
@@ -1079,8 +1080,7 @@ async fn reflect_and_record_writes_lessons_to_log_and_store() {
         .reflect_and_record(
             &StubProvider,
             "stub",
-            &transcript,
-            true,
+            crate::memory::TurnEvidence::from_transcript(&transcript, true),
             true,
             None,
             crate::memory::ReflectionPosture::default(),
@@ -1194,8 +1194,10 @@ async fn an_unreadable_reflection_is_recorded_and_an_empty_one_is_not() {
             .reflect_and_record(
                 &Scripted(response),
                 "scripted",
-                &[msg(MessageRole::User, "convert the totals")],
-                true,
+                crate::memory::TurnEvidence::from_transcript(
+                    &[msg(MessageRole::User, "convert the totals")],
+                    true,
+                ),
                 true,
                 None,
                 crate::memory::ReflectionPosture::default(),
@@ -1270,8 +1272,7 @@ async fn reflection_preserves_settled_cost_when_budget_rejects_model_output() {
         .reflect_and_record(
             &PaidReflection,
             "paid-reflection-model",
-            &[msg(MessageRole::User, "worked")],
-            true,
+            crate::memory::TurnEvidence::from_transcript(&[msg(MessageRole::User, "worked")], true),
             true,
             Some(0.001),
             crate::memory::ReflectionPosture::default(),

--- a/crates/stella-cli/src/memory/tests/determinism.rs
+++ b/crates/stella-cli/src/memory/tests/determinism.rs
@@ -84,8 +84,7 @@ async fn reflection_log_at(at: i64) -> (tempfile::TempDir, String) {
         .reflect_and_record(
             &ScriptedReflection,
             "scripted",
-            &transcript,
-            true,
+            crate::memory::TurnEvidence::from_transcript(&transcript, true),
             true,
             None,
             crate::memory::ReflectionPosture::default(),
@@ -197,8 +196,7 @@ async fn the_context_store_shares_the_session_clock() {
         .reflect_and_record(
             &ScriptedReflection,
             "scripted",
-            &transcript,
-            true,
+            crate::memory::TurnEvidence::from_transcript(&transcript, true),
             true,
             None,
             crate::memory::ReflectionPosture::default(),

--- a/docs/prompts/reflection.md
+++ b/docs/prompts/reflection.md
@@ -68,6 +68,45 @@ Transcript:
 {digest}
 ```
 
+## What `{digest}` contains
+
+A **selection** of the turn under a character budget, built by
+`crates/stella-cli/src/memory/reflection/digest.rs` — never a window over the
+tail. Budget is spent in three tiers:
+
+| Tier | What | Per-message cap |
+|---|---|---|
+| Pinned | the goal (first user message) and the last 4 messages | 700 chars |
+| Friction | every message carrying an errored `ToolResult`, the assistant message that requested it, and anything the event stream flagged as costly or failed | 700 chars |
+| Filler | everything else, in transcript order, while budget lasts | 200 chars |
+
+Total budget is 6,000 characters (~1.5k tokens). Anything not admitted is
+replaced in place by `… N messages elided …`, and a digest that elided anything
+says so in a header, so the model can report that the evidence it needed was
+outside the selection rather than reason across a gap it cannot see. `System`
+messages are excluded entirely: the prompt prefix is byte-stable by design
+(AGENTS.md invariant 7) and identical on every turn.
+
+When the calling surface folded a friction ledger from the turn's `AgentEvent`
+stream, the digest opens with a short section naming where the turn spent
+itself — costliest steps by wire call-role, slowest tools, every failed tool
+call, retries, loop-detector firings. None of that is recoverable from a
+transcript at any window size. That ledger is wired on the staged-pipeline
+one-shot today; #2483 tracks the other three surfaces.
+
+**Why this replaced a tail window (#2460).** The digest was the last 12 messages
+with each `content` truncated to 300 characters. Two things were wrong. The
+window was in the wrong place — a turn's expensive part is in the middle, and
+the tail of a successful turn is the summary and the sign-off. And a `Tool`
+message carries no `content` at all: the engine builds it as
+`content: String::new()` with the payload in `tool_results`, so **every tool
+result on every surface rendered as the six characters `tool: `**. Reflection
+had never seen what a tool returned. Measured on an 82-message tool-heavy turn:
+the old digest was 195 characters (~48 tokens); the selection is ~6.2k
+characters (~1.55k tokens), taking the whole billed prompt from ~730 to ~2,255
+tokens. `memory::reflection::tests::the_billed_prompt_size_is_reported_and_bounded`
+prints both numbers under `--nocapture`.
+
 ## Why the self-review is asked for last
 
 `self_review` rides along in this same call rather than costing a second one —


### PR DESCRIPTION
Closes #2460

## What was wrong

Reflection built its transcript digest by taking the **last 12 messages, each truncated to 300 characters**. #2460 names one defect. Investigating it found a second, worse one.

**1. The window was in the wrong place.** A turn's expensive part is in the middle — the approach taken at step 4 and abandoned at step 22, the tool that errored and was never read again. The tail of a turn that went well is the summary and the sign-off. So reflection was asked *what would have made this faster* by a witness that could not see where it was slow.

**2. Reflection had never seen a single tool result, on any surface.** A `Tool` message carries no `content` at all: the engine builds it as `content: String::new()` with the payload in `tool_results` (`stella-core/src/driver.rs`, and `CompletionMessage::content`'s own field docs say so). The digest read `message.content`. So every tool result Stella has ever produced reached reflection as the six characters `tool: `. The 300-character cut was never even reached on the messages it was supposed to bound.

The baseline witness run prints it verbatim — this is the digest `main` sends for a turn whose test failed with `expected 1_15 minor units, got 1_14`:

```
user: make the money test pass
assistant:  [called: bash]
tool: 
assistant: gave up
```

## What replaces it

A new pure module, `crates/stella-cli/src/memory/reflection/digest.rs` — no clock, no filesystem, no store, so `reflect_on_turn` keeps the #2320 property that makes the mining log replayable. It spends a **6,000-character budget in priority order** instead of in reverse transcript order:

| Tier | What | Cap |
|---|---|---|
| Pinned | the goal (first user message) and the last 4 messages | 700 |
| Friction | every message carrying an errored `ToolResult`, the assistant message that requested it, anything the event stream flagged | 700 |
| Filler | everything else, in transcript order, while budget lasts | 200 |

Anything not admitted becomes an explicit `… N messages elided …` marker, and a digest that elided anything says so in a header — so the model can report that the evidence it needed was outside the selection rather than reason across a gap it cannot see. `System` messages are excluded: the prompt prefix is byte-stable by design (invariant 7) and identical every turn.

Errors are found the typed way — `ToolOutput::is_error()`, documented as "the one place a consumer should branch on tool failure" — never by sniffing prose.

**`TurnFriction`** is the event-derived half: a fold over the turn's `AgentEvent` stream giving per-step cost and wall clock (`StepUsage`), tool durations and failures (`ToolStart` → `ToolResult`), retries, and loop-detector firings. None of that is in a `CompletionMessage`, so no window at any size recovers it. It is folded **live**, through a `FrictionTap` wrapping the `EventSender` — deliberately not read back from `store.db`, because the journal is written by the renderer task, which is still draining while reflection runs, so a read there would return a scheduling-dependent prefix and the digest would stop being a function of the turn.

`transcript` + `succeeded` + `friction` become one `TurnEvidence` argument. That is what lets `reflect_on_turn` **add** evidence while going from 8 positional arguments with an `#[allow(clippy::too_many_arguments)]` to 7 with none.

## One thing this change *added* a need for: redaction

The digest now passes through `stella_core::redact::redact_secrets`. That is required by this change rather than inherited from it — the old tail digest carried tool *names* and no tool output whatsoever, so it could not carry a credential. This one renders tool arguments and tool results, which is exactly where one shows up: a `read_file` of `.env`, a `bash` that printed `env`, a token echoed into a 401. And reflection dispatches on the **triage** route (#1847), which may be a different vendor than the worker the turn ran on, so "that provider has already seen it" is not a safe assumption.

`a_planted_credential_never_reaches_the_digest` pins it, and pins that only the secret is replaced — `ANTHROPIC_API_KEY=[redacted]` keeps the evidence that made the tool result worth showing.

## Correctness — the witnesses actually failed on main

Both were transcribed onto `main`'s signature and run against `origin/main` at `f70ebc29`:

```
failures:
    witness_a_fact_in_the_middle_of_a_long_turn_reaches_the_reflection_prompt
    witness_a_failed_tool_result_reaches_the_reflection_prompt
test result: FAILED. 25 passed; 2 failed
```

They pass here. Each isolates one defect: the first puts the only learnable fact at index 9 of 31, and asserts that position is outside a 12-message tail before asserting anything else; the second uses a 4-message turn, so the *window* is not what it pins — only that a `Tool` message's payload is not in `content`.

`the_prompt_names_where_the_turn_spent_itself` covers the event-derived half.

`the_whole_rendering_reads_like_this` is a spelled-out golden of the complete output, so a reviewer can read the shape rather than infer it from a dozen `contains` assertions.
 `digest/tests.rs` adds 17 more: budget bound, pinning under pressure, elision marking, multibyte clipping, ledger bounds with a drop count, and `the_digest_is_a_function_of_the_turn` (12 rebuilds byte-identical — the property replay rests on, and the reason ties break on `call_id`).

## Cost, reported (#2460 DoD item 2)

Measured, not estimated — `cargo test -p stella-cli --bin stella the_billed_prompt_size -- --nocapture` and `... the_selection_costs_more -- --nocapture` print these, so they can be re-derived rather than trusted:

On an **82-message tool-heavy turn**:

| | chars | ~tokens |
|---|---|---|
| digest, old tail | 195 | 48 |
| digest, selection | 6,212 | 1,553 |
| **billed prompt**, old (instructions 2,735 + digest) | 2,930 | ~730 |
| **billed prompt**, new | 9,021 | ~2,255 |

**+~1,520 input tokens per reflecting turn, roughly 3.1×.** It costs more, and it is supposed to: the old number was small because it was showing nothing. At haiku-4.5 input pricing that is about +$0.0015 per turn, against a turn that burned hundreds of thousands of tokens. Stated plainly so it is a decision and not a side effect — #2155 (narrow the trigger) is the other side of the trade, and `DIGEST_BUDGET_CHARS` is the one knob if it has to come down.

## What I did NOT finish — please read

**The friction ledger is wired on one surface of four.** `stella run`'s staged pipeline gets it, because that path deliberately keeps the worker's tool turns out of `messages` (L-E6) and so has no transcript to select from at all — there the events are the only source. The REPL, `/goal` and the deck pass `TurnEvidence::from_transcript`.

They are **not** blind: their transcripts carry every tool call and its typed result, which is what the selection runs on, so both defects above are fixed on all four. What those three still cannot see is cost, wall clock, retries and loop firings. The blocker is mechanical and real: those paths hand a bare `tokio::sync::mpsc::UnboundedSender<AgentEvent>` to `Engine::run_turn` / `run_goal`, and `FrictionTap` wraps an `EventSender` — so completing it means promoting those seams, which touches `stella-core` engine signatures and the deck forwarder.

Filed as **#2483**, written as a handoff, and referenced from a comment at each of the three call sites. Item 1 of #2460's definition of done is therefore satisfied for the transcript-derived signals everywhere and for the event-derived signals on the primary surface; #2483 closes the remainder.

## Structural note

`crates/stella-cli/src/agent.rs` was at its **exact** ratchet ceiling (2270/2270), so the plan routed new lines elsewhere from the start. The reflection helpers (`reflect_on_interactive_turn`, `surface_reflection`, `reflection_json`) moved verbatim into a new sibling `crates/stella-cli/src/agent/reflect.rs`, which now also holds `FrictionTap`. Paths are unchanged via `pub(crate) use`. `agent.rs` is **2183**, so this change gives the file 87 lines of headroom rather than consuming any. No baseline entry was added or raised.

Exemplar for the digest's shape: `rust-analyzer`'s `ide-db`-style pure render-under-budget helpers — a scoring pass over borrowed data, then one deterministic serializer, with every cap a named constant carrying the argument for its value.

## Tests deleted

None.

## Gate

`make gate CARGO_SCOPE="-p stella-cli"` — exit 0. `cargo test -p stella-cli` — 1595 + integration, all green. The `check-file-size` output notes 6 **inherited** bench-Python drifts, present in the base tree at `f70ebc29` and not caused by this change; per the guard's own instruction those land on their own from a fresh `main`, not folded in here.
