### PR TITLE
test(stella-cli): the #2460 witness derives the planted fact's index instead of naming a wrong one

### DIFF
--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -319,18 +319,23 @@ async fn a_fact_in_the_middle_of_a_long_turn_reaches_the_reflection_prompt() {
         ));
     }
     transcript.push(CompletionMessage::assistant("done — tests pass"));
+    let at = transcript
+        .iter()
+        .position(|message| message.content == THE_FACT)
+        .expect("the fact was planted");
     assert!(
-        transcript.len() > 24,
-        "the fact must sit well outside a twelve-message tail, or this witness \
-         proves nothing"
+        transcript.len() - at > 12,
+        "the fact sits at index {at} of {}, inside a twelve-message tail — this \
+         witness would pass on the old digest and prove nothing",
+        transcript.len()
     );
 
     let prompt = prompt_for_evidence(super::TurnEvidence::from_transcript(&transcript, true)).await;
     assert!(
         prompt.contains(THE_FACT),
         "reflection is being asked what it learned by a witness that cannot see \
-         where the turn went wrong: the fact at index 5 of {} never reached the \
-         prompt.\n\nprompt was:\n{prompt}",
+         where the turn went wrong: the fact at index {at} of {} never reached \
+         the prompt.\n\nprompt was:\n{prompt}",
         transcript.len()
     );
 }


### PR DESCRIPTION
Refs #2460

A one-file follow-up to #2494, which auto-merged while I was still editing it — this commit landed a minute too late to ride along.

`a_fact_in_the_middle_of_a_long_turn_reaches_the_reflection_prompt` is the witness for #2460's first defect: the digest read the last 12 messages, so a fact in the middle of a turn could not reach the reflection prompt at any truncation length. Two things about how it was written:

- **Its failure message named the wrong index.** It said "the fact at index 5", and the fixture plants it at index 9. A witness whose failure message misdirects the reader is worse than one with no message.
- **Its guard asserted a proxy.** `transcript.len() > 24` says the transcript is long. What the witness needs is that *the planted fact* is outside a 12-message tail — which is a different statement, and the one that would actually catch a future edit that moved the plant closer to the end and quietly made the witness pass on the old digest too.

Both now derive from the fixture: the index is found with `position(…)`, and the guard is `transcript.len() - at > 12`, stated with the numbers in the message so a failure explains itself.

No production code changes. No behavior change. `cargo test -p stella-cli --bin stella memory::reflection` — 28 passed.

## Witness

Not applicable: this is a test-quality change to an existing witness, not a behavior change. The witness it strengthens was verified against `origin/main` in #2494 — it failed there, on the real pre-#2460 digest, and passes after.

## Tests deleted

None.

## Summary by Sourcery

Strengthen the reflection digest witness test to derive the planted fact’s index from the transcript and ensure it genuinely lies outside the twelve-message tail.

Tests:
- Tighten the guard condition in the reflection witness test to assert the planted fact falls beyond the digest’s twelve-message tail.
- Update the witness failure messages to report the actual planted fact index and transcript length derived from the fixture.