### PR TITLE
fix(stella-home): retire STELLA_CONFIG_DIR, which named no resolver (closes #2442)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,8 +558,12 @@ error and leave the legacy files untouched.
 
 Everything **user-global** lives under `~/.stella` on every platform (like
 Claude Code's `~/.claude`) — no OS-specific data dir. `STELLA_HOME` moves the
-whole home; the narrower `STELLA_DATA_DIR` / `STELLA_CONFIG_DIR` still win
-where they always did. Key entries: `settings.json`, `credentials.toml`,
+whole home; the narrower `STELLA_DATA_DIR` still wins for the data tier where
+it always did. Those two are the entire list of redirecting overrides
+(`stella_home::OVERRIDE_ENV_VARS`), which is exact in both directions — a name
+on it that resolves nothing declines the legacy-layout migration for a process
+sitting on the defaults, which is what `STELLA_CONFIG_DIR` did until #2442
+retired it. Key entries: `settings.json`, `credentials.toml`,
 `skills/`, `agents/`, `rules/`, `tools/` (config); `usage.db` (the
 cross-project telemetry hub), `sessions/`, `notifications/`, `catalog.db`,
 `enterprise-telemetry.db`, `installation-id`, `cloud.json` (data). On first

--- a/crates/stella-cli/src/env_files.rs
+++ b/crates/stella-cli/src/env_files.rs
@@ -386,8 +386,13 @@ const DENIED_EXACT: &[&str] = &[
     // declare lifecycle hooks and context providers that the project scope is
     // gated away from — so a repository that could move `HOME` would walk
     // straight through the trust boundary `.stella/settings.json` is held to.
-    // `STELLA_HOME`/`STELLA_CONFIG_DIR`/`STELLA_DATA_DIR` are the same trunk
-    // for `~/.stella` (stella-store's `home.rs`).
+    // `STELLA_HOME`/`STELLA_DATA_DIR` are the same trunk for `~/.stella`
+    // (`stella-home`). `STELLA_CONFIG_DIR` names no resolver — it never did,
+    // and #2442 retired it — but it stays refused deliberately: an entry here
+    // costs a line, while a missing one costs a repository the ability to
+    // redirect a trusted scope, and a deny-list is the worst possible place
+    // to discover an omission. Denying names Stella itself does not read is
+    // already the rule here, not an exception (`GCONV_PATH`, `LD_*`).
     "HOME",
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -7,8 +7,10 @@
 //! macOS, Linux, and Windows all resolve to the home directory.
 //!
 //! Overrides: `STELLA_HOME` moves the whole home; the narrower
-//! `STELLA_DATA_DIR` / `STELLA_CONFIG_DIR` overrides still win where they
-//! always did (tests, sandboxes, org-managed layouts).
+//! `STELLA_DATA_DIR` moves the data tier alone and wins over it where it
+//! always did (tests, sandboxes, org-managed layouts). Those two are the
+//! entire list — see [`OVERRIDE_ENV_VARS`], which is exact in both
+//! directions on purpose.
 //!
 //! # Why this is its own crate
 //!
@@ -49,8 +51,6 @@ pub const STELLA_HOME_ENV: &str = "STELLA_HOME";
 /// Moves the user-tier data dir alone. Narrower than [`STELLA_HOME_ENV`], and
 /// wins over it.
 pub const STELLA_DATA_DIR_ENV: &str = "STELLA_DATA_DIR";
-/// Moves the user-tier config dir alone. Narrower than [`STELLA_HOME_ENV`].
-pub const STELLA_CONFIG_DIR_ENV: &str = "STELLA_CONFIG_DIR";
 
 /// The directory name stella keeps under the user's home.
 const DOT_STELLA: &str = ".stella";
@@ -68,8 +68,19 @@ const LEGACY_DOT_SELF_DRIVING_DIR: &str = ".fullauto";
 /// Every override that can point resolution away from the `~/.stella`
 /// defaults, in one list so a caller asking "is any of this redirected?"
 /// cannot answer with a stale subset.
-pub const OVERRIDE_ENV_VARS: [&str; 3] =
-    [STELLA_HOME_ENV, STELLA_DATA_DIR_ENV, STELLA_CONFIG_DIR_ENV];
+///
+/// Exact in **both** directions, and both are load-bearing. A redirecting
+/// variable missing from the list lets [`any_override_set`] answer `false`
+/// while resolution points elsewhere, which is how real user data gets moved
+/// out from under an override. A name on the list that redirects *nothing*
+/// is the opposite failure and is not merely cosmetic: it makes
+/// [`any_override_set`] answer `true` for a process whose paths all resolve
+/// to the defaults, silently declining work that should have run.
+/// `STELLA_CONFIG_DIR` sat here for its whole life without a resolver
+/// reading it and did exactly that to the legacy-layout migration (#2442).
+/// The soundness half is witnessed by
+/// `every_override_on_the_list_actually_redirects_a_resolved_path`.
+pub const OVERRIDE_ENV_VARS: [&str; 2] = [STELLA_HOME_ENV, STELLA_DATA_DIR_ENV];
 
 /// The user's home directory: `HOME`, else `USERPROFILE` (Windows).
 #[must_use]
@@ -228,6 +239,12 @@ pub fn resolve_legacy_self_driving_roots(
 /// The one-time legacy-layout migration consults this: moving real user data
 /// while an override redirects resolution would move it out from under
 /// whatever set the override.
+///
+/// The `i.e.` is the whole contract, and it was false for as long as
+/// `STELLA_CONFIG_DIR` was on the list (#2442): that name reached no
+/// resolver, so a process that set it declined the migration while every
+/// path it opened still resolved to the defaults. Keeping the list exact is
+/// what makes this predicate mean what it says.
 #[must_use]
 pub fn any_override_set() -> bool {
     OVERRIDE_ENV_VARS.iter().any(|var| read(var).is_some())
@@ -422,10 +439,60 @@ mod tests {
     fn the_override_list_names_every_redirecting_variable() {
         assert!(
             OVERRIDE_ENV_VARS.contains(&STELLA_HOME_ENV)
-                && OVERRIDE_ENV_VARS.contains(&STELLA_DATA_DIR_ENV)
-                && OVERRIDE_ENV_VARS.contains(&STELLA_CONFIG_DIR_ENV),
+                && OVERRIDE_ENV_VARS.contains(&STELLA_DATA_DIR_ENV),
             "a migration guard reading a stale subset would move data out from \
              under whichever override it forgot"
         );
+    }
+
+    /// Witness for #2442, and the direction the completeness test above cannot
+    /// see: a name on [`OVERRIDE_ENV_VARS`] must actually move a path some
+    /// resolver returns.
+    ///
+    /// `STELLA_CONFIG_DIR` was declared, documented as narrowing
+    /// `STELLA_HOME`, and listed there — but nothing ever read it to resolve a
+    /// path. Setting it therefore moved no file the CLI opens while still
+    /// making [`any_override_set`] answer `true`, which declined the
+    /// legacy-layout migration for a process sitting squarely on the defaults.
+    ///
+    /// Each entry is paired here with the resolution it claims to redirect,
+    /// driven through the pure halves. An entry with no pairing fails
+    /// outright: the unmatched arm *is* the assertion, not a gap in the cases.
+    #[test]
+    fn every_override_on_the_list_actually_redirects_a_resolved_path() {
+        const ELSEWHERE: &str = "/elsewhere";
+        let home = resolve_home_dir(os("/home/dev"), None);
+        let default_root = resolve_stella_home(None, home.clone());
+
+        for var in OVERRIDE_ENV_VARS {
+            let (tier, redirected, unset) = match var {
+                // The whole home — the root itself, and every tier under it.
+                STELLA_HOME_ENV => (
+                    "the stella root",
+                    resolve_stella_home(os(ELSEWHERE), home.clone()),
+                    default_root.clone(),
+                ),
+                // The data tier alone, over a root that has not moved.
+                STELLA_DATA_DIR_ENV => (
+                    "the data dir",
+                    Some(resolve_data_dir(os(ELSEWHERE), default_root.clone())),
+                    Some(resolve_data_dir(None, default_root.clone())),
+                ),
+                unread => panic!(
+                    "{unread} is listed as a redirecting override, but no \
+                     resolver in this crate reads it. Wire it to one, or take \
+                     it off OVERRIDE_ENV_VARS — a name on that list makes \
+                     `any_override_set` answer true, so an inert one declines \
+                     the legacy-layout migration for a process whose paths all \
+                     resolve to the defaults (#2442)."
+                ),
+            };
+            assert_eq!(
+                redirected,
+                Some(PathBuf::from(ELSEWHERE)),
+                "{var} is on OVERRIDE_ENV_VARS, so it must move {tier}, which \
+                 resolves to {unset:?} when it is unset"
+            );
+        }
     }
 }

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -64,10 +64,11 @@ fn file_len(path: &Path) -> u64 {
 /// Shared through `stella-home` rather than copied: this is the one resolver
 /// both sides must agree on, and the observatory may not link `stella-cli`.
 /// It honours `STELLA_HOME` because the loader does since #2178 — and only
-/// `STELLA_HOME`: `STELLA_CONFIG_DIR` moves nothing today, and honouring it
-/// here (as this once did) made the tab claim a `settings.json` the CLI never
-/// opens. If the loader grows another override, mirror it here in the same
-/// order.
+/// `STELLA_HOME`, which is the whole of what can move this path. This
+/// resolver used to honour `STELLA_CONFIG_DIR` too, which made the tab claim
+/// a `settings.json` the CLI never opens; that variable reached no resolver
+/// on either side and was retired in #2442. If the loader grows another
+/// override, mirror it here in the same order.
 pub fn user_config_dir() -> Option<PathBuf> {
     stella_home::stella_home()
 }
@@ -1004,24 +1005,20 @@ tags       = ["testing", "pins"]
 
     /// The config tab must name the settings file the CLI actually loads
     /// (`stella_cli::paths::stella_root`). Since #2178 that is `$STELLA_HOME`
-    /// when set, else `$HOME/.stella` — and still never `STELLA_CONFIG_DIR`,
-    /// which moves nothing on the CLI side; honouring it here once pointed the
-    /// tab at a `settings.json` the CLI never opens.
+    /// when set, else `$HOME/.stella` — and since #2442 there is no second
+    /// override to mirror: this test used to set `STELLA_CONFIG_DIR` and
+    /// assert it was ignored, which stopped being a claim about anything once
+    /// the variable named no resolver on either side and was retired.
     #[test]
     fn user_config_dir_mirrors_the_cli_settings_loader() {
-        // The old note here reasoned that no parallel test could observe the
-        // transient value because nothing else reads STELLA_CONFIG_DIR. That
-        // is an argument about one variable, and the hazard is the shared
-        // environment: this test also reads HOME, which other crates' tests
-        // override, and stella-store's `any_override_set` reads
-        // STELLA_CONFIG_DIR. Take the crate-wide lock like every other
-        // env-mutating test here (#1137).
+        // The hazard is the shared environment, not any one variable: this
+        // test reads HOME, which other crates' tests override. Take the
+        // crate-wide lock like every other env-mutating test here (#1137).
         let _env = crate::test_env::lock();
-        let _restore = crate::test_env::EnvRestore::capture(&["STELLA_CONFIG_DIR", "STELLA_HOME"]);
+        let _restore = crate::test_env::EnvRestore::capture(&["STELLA_HOME"]);
         // SAFETY: the lock is held for the whole test, and `_restore` undoes
-        // both on drop — including if `user_config_dir` panics.
+        // this on drop — including if `user_config_dir` panics.
         unsafe {
-            std::env::set_var("STELLA_CONFIG_DIR", "/tmp/elsewhere");
             std::env::remove_var("STELLA_HOME");
         }
         let home = std::env::var_os("HOME")
@@ -1030,8 +1027,7 @@ tags       = ["testing", "pins"]
         assert_eq!(
             user_config_dir(),
             Some(home.join(".stella")),
-            "STELLA_CONFIG_DIR moves nothing on the CLI side, so it must move \
-             nothing here"
+            "with nothing overriding it, the tab names the loader's default"
         );
 
         // SAFETY: same lock, same guard.

--- a/crates/stella-store/README.md
+++ b/crates/stella-store/README.md
@@ -187,7 +187,7 @@ Plus three file-backed stores under `~/.stella/`: `sessions/` (one JSON record
 per session, one writer per file), `sessions/<id>/` (the resume sidecar), and
 `notifications/`. `~/.stella` resolves the same on every platform — no OS
 data-dir guessing — with `STELLA_HOME` moving the whole home and
-`STELLA_DATA_DIR` / `STELLA_CONFIG_DIR` as narrower overrides. The resolution
+`STELLA_DATA_DIR` as the one narrower override. The resolution
 itself lives in [`stella-home`](../stella-home), a dependency-free leaf crate,
 because [`stella-observatory`](../stella-observatory) needs the same answer and
 must not link this one; [`home.rs`](src/home.rs) keeps the part that is

--- a/crates/stella-store/src/home.rs
+++ b/crates/stella-store/src/home.rs
@@ -7,8 +7,9 @@
 //! macOS, Linux, and Windows all resolve to the home directory.
 //!
 //! Overrides: `STELLA_HOME` moves the whole home; the narrower
-//! `STELLA_DATA_DIR` / `STELLA_CONFIG_DIR` overrides still win where they
-//! always did (tests, sandboxes, org-managed layouts).
+//! `STELLA_DATA_DIR` moves the data tier alone and wins over it where it
+//! always did (tests, sandboxes, org-managed layouts). Those two are the
+//! entire list (`stella_home::OVERRIDE_ENV_VARS`).
 //!
 //! [`migrate_legacy_global_dirs`] performs the one-time move from the old
 //! split layout (platform data dir + `~/.config/stella`) into `~/.stella`.
@@ -260,9 +261,14 @@ fn copy_into(src: &std::path::Path, dest: &std::path::Path) -> std::io::Result<(
 }
 
 /// One-time (per process), best-effort migration of the legacy split layout
-/// into `~/.stella`. A no-op when `STELLA_HOME`, `STELLA_DATA_DIR`, or
-/// `STELLA_CONFIG_DIR` is set (resolution isn't pointing at the defaults, so
-/// moving real user data would be wrong), or when there is nothing to move.
+/// into `~/.stella`. A no-op when `STELLA_HOME` or `STELLA_DATA_DIR` is set
+/// (resolution isn't pointing at the defaults, so moving real user data would
+/// be wrong), or when there is nothing to move.
+///
+/// Those two are the whole test, and the list they come from earns its
+/// exactness here: until #2442 it also carried `STELLA_CONFIG_DIR`, which no
+/// resolver read — so setting that variable declined this migration for a
+/// process whose every path still resolved to the defaults.
 pub fn migrate_legacy_global_dirs() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {

--- a/crates/stella-store/src/test_env.rs
+++ b/crates/stella-store/src/test_env.rs
@@ -5,9 +5,9 @@
 //! a thread pool, so a test that sets `STELLA_DATA_DIR` is mutating state that
 //! every concurrently-running test in the same binary can observe. That is not
 //! hypothetical here: [`crate::home::migrate_legacy_global_dirs`] silently
-//! no-ops whenever `STELLA_HOME`, `STELLA_DATA_DIR` or `STELLA_CONFIG_DIR` is
-//! set, and `UsageStore::open` calls it — so an unrelated test's override
-//! changes what a store-opening test does.
+//! no-ops whenever `STELLA_HOME` or `STELLA_DATA_DIR` is set, and
+//! `UsageStore::open` calls it — so an unrelated test's override changes what
+//! a store-opening test does.
 //!
 //! Two distinct hazards, and both need covering:
 //!


### PR DESCRIPTION
## What & why

`STELLA_CONFIG_DIR` was declared (`stella-home`'s `STELLA_CONFIG_DIR_ENV`),
documented as narrowing `STELLA_HOME`, and listed on `OVERRIDE_ENV_VARS` — but
nothing ever read it to resolve a path. Setting it moved no file the CLI opens.

It was not merely inert, and that is the part this fixes rather than documents.
`any_override_set()` is `OVERRIDE_ENV_VARS.iter().any(is_set)`, and the one-time
legacy-layout migration (`stella_store::home::migrate_legacy_global_dirs`)
consults it to avoid moving real user data out from under an override. A name on
that list that redirects nothing makes the predicate answer `true` for a process
whose every path resolves to the defaults — so setting `STELLA_CONFIG_DIR`
silently declined a migration that should have run. The variable's own doc
comment claimed it narrowed `STELLA_HOME`; the predicate's claimed "i.e. whether
resolution is pointing somewhere other than the defaults" was false for exactly
as long as this name sat on the list.

**Retired rather than implemented**, which is the choice #2442 poses and its own
reading of the answer. Three things decide it:

- #2178 (PR #2447) made `STELLA_HOME` move the **whole** user tier, so the
  isolation use case a config-tier override would serve is already covered.
- The config tier is now `paths::stella_root()` itself, which is also the trust
  root user-scope **extensions** load from (`paths::user_extension_home()` —
  rules, skills, custom tools). A third environment variable that redirects that,
  with no demonstrated caller, is threat surface rather than symmetry. It is a
  name on `env_files::DENIED_EXACT` for precisely that reason.
- The observatory had already convicted it once: `fsview::user_config_dir` used
  to honour it, and that was removed as a bug because the tab named a
  `settings.json` the CLI never opens.

`docs/spec/filesystem-layout.md`'s "Environment overrides" table never listed the
variable, so it becomes correct by omission rather than needing an edit.

Closes #2442

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`every_override_on_the_list_actually_redirects_a_resolved_path`
(`crates/stella-home/src/lib.rs`). It pairs each `OVERRIDE_ENV_VARS` entry with
the resolution it claims to redirect, driven through the pure halves, and fails
outright on an entry no resolver reads — the unmatched arm *is* the assertion.
That is the direction the existing
`the_override_list_names_every_redirecting_variable` (completeness) cannot see;
together the two make the list exact in both directions.

Checked the artisanal way rather than by assertion. `stella-home` has an empty
`[dependencies]` block, so `origin/main`'s source plus the new test compiles with
a bare `rustc --test --edition 2024` — no cargo, no workspace, nothing else in
the tree:

```
test tests::every_override_on_the_list_actually_redirects_a_resolved_path ... FAILED

STELLA_CONFIG_DIR is listed as a redirecting override, but no resolver in this
crate reads it. Wire it to one, or take it off OVERRIDE_ENV_VARS — a name on
that list makes `any_override_set` answer true, so an inert one declines the
legacy-layout migration for a process whose paths all resolve to the defaults
(#2442).
```

and passes on this branch.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (doc comments, AGENTS.md,
      `stella-store`'s README)
- [x] CLA signed
- [x] `Closes #2442` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2499

`STELLA_HOME` is on `env_files::DENIED_EXACT` but **not** on
`enterprise_telemetry::PRIVILEGED_ENV_NAMES`, the second-loader rollback behind
that deny-list — while the strictly narrower `STELLA_DATA_DIR` is on both. The
asymmetry was defensible until #2178 widened what `STELLA_HOME` moves; the list
that classifies it as privileged was not revisited. Adjacent to this change (same
comment block names all three variables) but not caused by it, and a different
question — that one is about a variable that does everything, this one about a
variable that did nothing. Filed with the witness shape spelled out.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] `stella-home` keeps its empty `[dependencies]` block (crate README §
      "Boundary")

No test was deleted or renamed.
`user_config_dir_mirrors_the_cli_settings_loader` keeps its name and both of its
real assertions; it loses only the half that set `STELLA_CONFIG_DIR` to prove it
was ignored, which stopped being a claim about anything once the variable named
no resolver on either side.

## Anything reviewers should know?

**One behaviour change, deliberate.** A process that sets `STELLA_CONFIG_DIR` and
nothing else now *runs* the legacy-layout migration instead of declining it.
That is the fix, not a side effect: the migration's precondition is "resolution
is pointing at the defaults", which was true the whole time. The migration is
best-effort, idempotent, per-entry, never overwrites an entry already at the
target, and leaves the legacy original in place on a failed move — and it is what
that process would have got on its very next run without the variable set.

**`env_files::DENIED_EXACT` keeps the name deliberately.** An entry there costs a
line; a missing one costs a repository the ability to redirect a trusted scope,
and a deny-list is the worst place to discover an omission. Denying names Stella
does not itself read is already the rule there (`GCONV_PATH`, `LD_*`), not an
exception. The comment says so, so the next reader does not "tidy" it away.

**Rejected alternative: implement it.** Adding `config_dir()` / `resolve_config_dir()`
is genuinely small now that #2447 unified `stella_root` — about ten lines. It was
rejected on the merits above, not on cost. If someone later wants a real
config/data split, the shape is `resolve_data_dir`'s and this PR does not
foreclose it; what it removes is a declaration with nothing behind it.

## Summary by Sourcery

Retire the unused STELLA_CONFIG_DIR override, tighten the override list semantics, and ensure the legacy layout migration and related components behave correctly when environment overrides are set.

Bug Fixes:
- Fix legacy global directory migration incorrectly being skipped when only STELLA_CONFIG_DIR was set, despite all paths resolving to defaults.

Enhancements:
- Make the OVERRIDE_ENV_VARS list exact in both directions and clarify its contract around any_override_set and migration guards.
- Align stella-observatory and stella-store documentation and comments with the current set of supported environment overrides.
- Preserve STELLA_CONFIG_DIR on the CLI deny-list as a refused name even though it no longer has a resolver.

Documentation:
- Update AGENTS.md and stella-store README to reflect that only STELLA_HOME and STELLA_DATA_DIR are supported redirecting overrides and document the retirement of STELLA_CONFIG_DIR.

Tests:
- Add a witness test ensuring every environment variable listed in OVERRIDE_ENV_VARS actually redirects a resolved path and adjust existing observatory tests to no longer rely on STELLA_CONFIG_DIR.