### PR TITLE
fix(stella-observatory): the ratings feed lists turns the model never graded (#2443)

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -157,10 +157,40 @@ and no query may join the two. AGENTS.md's glossary is the authority.
 
 A workspace that has never run `stella` renders an empty dashboard, not a 500.
 An absent file yields `None` and an empty payload at the call site; an absent
-*table* is caught by `is_missing_table` (`src/db.rs:843`), degrading
-`collect_rows`/`or_empty` to `[]`/`{}`. `global.rs` goes further — `query_rows`
-treats any `prepare` failure as empty, because a `usage.db` predating the hub
-replica has no `telemetry` table at all.
+table *or column* is caught by `is_missing_schema`, degrading
+`collect_rows`/`or_empty` to `[]`/`{}`. The column half matters as much as the
+table half: this crate never migrates, so a store no turn has touched since an
+upgrade is missing the newest columns while every table it reads exists —
+matching only "no such table" left the degradation unfired and the route 500'd
+anyway. `global.rs` goes further — `query_rows` treats any `prepare` failure as
+empty, because a `usage.db` predating the hub replica has no `telemetry` table
+at all.
+
+### A reflection row is not a rating
+
+`execution_reflection` has one row per turn and **three** producers writing
+disjoint columns (`stella_store::reflection`'s module doc): the derived half,
+the model's own grade, and — since store schema v23 — the excerpt of a
+reflection response that would not parse. Only the middle one records an
+assessment, so "a row exists" and "the model graded this turn" are different
+facts, and a reader that conflates them shows a turn nobody ever asked for a
+grade as one the model declined to grade (#2443).
+
+Both readers here filter on `HAS_SELF_REVIEW` (`src/db.rs`), the SQL mirror of
+`stella_store::SelfReviewRow::is_empty`: the ratings feed lists graded turns
+only, and the execution drawer reports `reflection: null` rather than a panel
+of blanks. The predicate is applied inside the query, before
+`MAX_LISTED_REFLECTIONS` — a broken reflection loop writes an ungraded row
+every turn, and filtering after the limit would let a few hundred of them push
+every real rating past the window.
+
+"Did this turn reflect at all" is a different question, answered on the same
+tab from `parse_error` itself (`/api/context-lifecycle`'s
+`unreadable_reflections`). Mirroring rather than calling `is_empty` is forced
+by the isolation above — this crate must not link `stella-store` — so
+[`tests/schema_conformance.rs`](tests/schema_conformance.rs) drives both
+readers against a store built by the real migration path, and a column renamed
+underneath the predicate fails there.
 
 ### Secrets never reach the browser
 

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2266,6 +2266,10 @@ function renderImprove(skills) {
   const refl = D.reflections ?? {};
   if (!changed("improve", refl, skills ?? [])) return;
   const lessons = refl.lessons ?? [];
+  /* Narrower than what the route sends, and deliberately so. `/api/reflections`
+     already drops the turns nobody graded (#2443), but it keeps a critique with
+     no number — a real assessment, and what `imp-improve` below is built from.
+     The chart and these two tiles need the numeric half, so they filter again. */
   const ratings = (refl.ratings ?? []).filter(r => r.self_rating != null || r.delivered != null);
   const rated = ratings.filter(r => r.self_rating != null);
   const delivered = ratings.filter(r => r.delivered != null);

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -34,6 +34,43 @@ pub(crate) const MAX_LISTED_EXECUTIONS: usize = 500;
 /// self-improvement tab's ratings line up with the runs the tables list.
 pub(crate) const MAX_LISTED_REFLECTIONS: usize = 500;
 
+/// The `execution_reflection` rows that carry an assessment, as a SQL
+/// predicate over the alias `er` (#2443).
+///
+/// The table has three producers owning disjoint columns
+/// (`stella_store::reflection`'s module doc): the derived half from
+/// `finalize_execution_reflection`, the model's own grade from
+/// `record_self_review`, and `parse_error` from
+/// `record_reflection_parse_failure`. Only the middle one records an
+/// assessment, so a row written by either of the others alone reads as a
+/// reflection the model *declined* to grade — when in truth none was ever
+/// attempted. Rows exist for turns that reflected unreadably; the Improve
+/// tab names those separately, from `parse_error` itself.
+///
+/// This is the SQL half of `stella_store::SelfReviewRow::is_empty`, mirrored
+/// rather than called: this crate must not link `stella-store` in production
+/// (see its manifest — `Store::open` migrates, and an observer never writes
+/// what it observes). `tests/schema_conformance.rs` is what keeps the mirror
+/// honest, driving both callers against a store built by the real migration
+/// path.
+///
+/// Trims the prose columns as `is_empty` does — whitespace is not an
+/// assessment. SQLite's two-argument `trim` takes a character set, so
+/// `char(32,9,10,13)` covers ASCII whitespace and not the wider Unicode set
+/// `str::trim` handles; the gap is unreachable through the writer, which
+/// refuses an empty review outright. A NULL prose column (possible only in a
+/// store this crate did not write) leaves the whole disjunction NULL, which
+/// excludes the row — the same answer, by the safe route.
+///
+/// Every column here predates the table's first shipped version, so this adds
+/// no schema dependency to either caller; both still degrade a missing table
+/// or column to an empty section via [`is_missing_schema`].
+pub(crate) const HAS_SELF_REVIEW: &str = "(er.delivered IS NOT NULL
+      OR er.self_rating IS NOT NULL
+      OR trim(er.what_went_well, char(32,9,10,13)) != ''
+      OR trim(er.what_to_improve, char(32,9,10,13)) != ''
+      OR trim(er.critique, char(32,9,10,13)) != '')";
+
 /// Newest tool calls the [`Observatory::tools`] leaderboard aggregates. This
 /// is the store's highest-cardinality table and the p50 needs every duration
 /// in the window materialized, so scanning all of history on every 5 s poll
@@ -335,10 +372,19 @@ impl Observatory {
                 }))
             },
         )?;
+        // The same "did the model actually grade this turn" test the ratings
+        // feed applies (#2443). A row left behind by finalize alone, or by a
+        // reflection whose response would not parse, carries nothing but
+        // blanks — and a Self-reflection panel of blanks tells the reader the
+        // model looked at the turn and had nothing to say. `reflection: null`
+        // says the true thing: it was never graded.
         let reflection = or_empty(conn.query_row(
-            "SELECT delivered, self_rating, what_went_well, what_to_improve,
-                    critique
-             FROM execution_reflection WHERE execution_id = ?1",
+            &format!(
+                "SELECT er.delivered, er.self_rating, er.what_went_well,
+                        er.what_to_improve, er.critique
+                 FROM execution_reflection er
+                 WHERE er.execution_id = ?1 AND {HAS_SELF_REVIEW}"
+            ),
             [id],
             |r| {
                 Ok(json!({
@@ -903,6 +949,12 @@ impl Observatory {
 
     /// The newest `MAX_LISTED_REFLECTIONS` post-turn self-reflections joined
     /// to their executions: the self-improvement tab's ratings feed.
+    ///
+    /// Only rows the model actually graded ([`HAS_SELF_REVIEW`]). Filtering in
+    /// SQL rather than after the fact is what makes the window mean "the newest
+    /// N ratings": the predicate applies before `LIMIT`, so a workspace whose
+    /// most recent `MAX_LISTED_REFLECTIONS` rows are all ungraded still shows
+    /// the ratings behind them instead of an empty chart (#2443).
     pub fn reflection_ratings(&self) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {
             return Ok(json!([]));
@@ -919,6 +971,7 @@ impl Observatory {
                         er.recorded_at
                  FROM execution_reflection er
                  LEFT JOIN executions e ON e.id = er.execution_id
+                 WHERE {HAS_SELF_REVIEW}
                  ORDER BY er.execution_id DESC LIMIT {MAX_LISTED_REFLECTIONS}"
             ),
             |r| {

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -950,7 +950,9 @@ impl Observatory {
     /// The newest `MAX_LISTED_REFLECTIONS` post-turn self-reflections joined
     /// to their executions: the self-improvement tab's ratings feed.
     ///
-    /// Only rows the model actually graded ([`HAS_SELF_REVIEW`]). Filtering in
+    /// Only rows the model actually graded — the crate-private
+    /// `HAS_SELF_REVIEW` predicate, deliberately not linked because this
+    /// method is public and that constant is not. Filtering in
     /// SQL rather than after the fact is what makes the window mean "the newest
     /// N ratings": the predicate applies before `LIMIT`, so a workspace whose
     /// most recent `MAX_LISTED_REFLECTIONS` rows are all ungraded still shows

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -562,13 +562,13 @@ fn reflection_ratings_are_bounded_to_the_newest_rows() {
 fn the_ratings_feed_lists_only_turns_the_model_graded() {
     let ws = seeded_workspace();
     let conn = Connection::open(ws.path().join(".stella/private/store.db")).unwrap();
-    // A third shape the shared fixture does not carry: prose with no numeric
-    // grade. It IS an assessment — the "what to improve" feed is built from
-    // exactly these — so the predicate must not key on `self_rating` alone.
-    // ...and a fourth: prose that is only whitespace, which
+    // Two shapes the shared fixture does not carry, on either side of the line.
+    // Execution 3 is prose with no numeric grade: an assessment, and what the
+    // "what to improve" feed is built from, so the predicate must not key on
+    // `self_rating` alone. Execution 4 is prose that is only whitespace, which
     // `SelfReviewRow::is_empty` trims before judging and the SQL mirror must
-    // too. Unreachable through the writer, which refuses an empty review — it
-    // is here because the mirror is the thing under test, not the writer.
+    // too — unreachable through the writer, which refuses an empty review, and
+    // here because the mirror is the thing under test rather than the writer.
     conn.execute_batch(
         "INSERT INTO execution_reflection (execution_id, critique)
          VALUES (3, 'landed, but the first diagnosis was wrong');

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -565,9 +565,15 @@ fn the_ratings_feed_lists_only_turns_the_model_graded() {
     // A third shape the shared fixture does not carry: prose with no numeric
     // grade. It IS an assessment — the "what to improve" feed is built from
     // exactly these — so the predicate must not key on `self_rating` alone.
+    // ...and a fourth: prose that is only whitespace, which
+    // `SelfReviewRow::is_empty` trims before judging and the SQL mirror must
+    // too. Unreachable through the writer, which refuses an empty review — it
+    // is here because the mirror is the thing under test, not the writer.
     conn.execute_batch(
         "INSERT INTO execution_reflection (execution_id, critique)
-         VALUES (3, 'landed, but the first diagnosis was wrong');",
+         VALUES (3, 'landed, but the first diagnosis was wrong');
+         INSERT INTO execution_reflection (execution_id, what_went_well)
+         VALUES (4, '  \t\n ');",
     )
     .unwrap();
 
@@ -581,8 +587,8 @@ fn the_ratings_feed_lists_only_turns_the_model_graded() {
     assert_eq!(
         listed,
         vec![1, 3],
-        "execution 2 reflected unreadably and was never graded, so it is not a \
-         rating; the prose-only row is one"
+        "execution 2 reflected unreadably and 4 said nothing — neither was \
+         graded, so neither is a rating; the prose-only row is one"
     );
 
     // The same row, through the other projection that reads this table. A

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -141,15 +141,21 @@ fn seeded_workspace() -> TempDir {
                wrote_files INTEGER NOT NULL DEFAULT 0,
                truncated INTEGER NOT NULL DEFAULT 0,
                recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-               -- Store schema v23 (#2175). Present but unpopulated here: the
-               -- populated case has its own fixture below, because a
-               -- parse-failure row in THIS one is also a reflection row, and
-               -- the ratings feed and the execution-detail route both count
-               -- them.
+               -- Store schema v23 (#2175).
                parse_error TEXT);
              INSERT INTO execution_reflection
                (execution_id, delivered, self_rating, what_to_improve)
              VALUES (1, 1, 8, 'read the failing test first');
+             -- Execution 2 reflected and its response would not parse: a row
+             -- with a `parse_error` and no assessment in it. Seeded in the
+             -- SHARED fixture on purpose (#2443) — it used to live only in a
+             -- private one because both readers of this table counted it as a
+             -- reflection, which is the bug. Every route below now sees a
+             -- store holding one graded turn and one ungraded one, so a
+             -- regression that conflates them fails here rather than in a test
+             -- written to look for it.
+             INSERT INTO execution_reflection (execution_id, parse_error)
+             VALUES (2, 'Let me analyze this turn. First, I should');
              CREATE TABLE rules (
                rule_id TEXT PRIMARY KEY, contents TEXT NOT NULL,
                source TEXT NOT NULL,
@@ -543,6 +549,100 @@ fn reflection_ratings_are_bounded_to_the_newest_rows() {
     );
 }
 
+/// #2443: "ratings" means the model graded the turn, not that a row exists.
+///
+/// `execution_reflection` has three producers writing disjoint columns, and
+/// only one of them records an assessment. A row left by finalize alone, or by
+/// a reflection whose response would not parse, carries NULL verdict, NULL
+/// rating and three empty strings — which the feed presented as a reflection
+/// the model looked at and declined to grade. The Improve tab already answers
+/// "did this turn reflect at all" from `parse_error` (#2175); this feed answers
+/// the narrower question its name promises.
+#[test]
+fn the_ratings_feed_lists_only_turns_the_model_graded() {
+    let ws = seeded_workspace();
+    let conn = Connection::open(ws.path().join(".stella/private/store.db")).unwrap();
+    // A third shape the shared fixture does not carry: prose with no numeric
+    // grade. It IS an assessment — the "what to improve" feed is built from
+    // exactly these — so the predicate must not key on `self_rating` alone.
+    conn.execute_batch(
+        "INSERT INTO execution_reflection (execution_id, critique)
+         VALUES (3, 'landed, but the first diagnosis was wrong');",
+    )
+    .unwrap();
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/reflections").body).unwrap();
+    let ratings = v["ratings"].as_array().unwrap();
+    let listed: Vec<i64> = ratings
+        .iter()
+        .map(|r| r["execution_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        listed,
+        vec![1, 3],
+        "execution 2 reflected unreadably and was never graded, so it is not a \
+         rating; the prose-only row is one"
+    );
+
+    // The same row, through the other projection that reads this table. A
+    // Self-reflection panel of blanks in the execution drawer says the model
+    // looked at the turn and had nothing to say; `null` says it never graded it.
+    let ungraded: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/execution?id=2").body).unwrap();
+    assert!(
+        ungraded["reflection"].is_null(),
+        "a parse-failure row is not a self-reflection: {:?}",
+        ungraded["reflection"]
+    );
+    let graded: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/execution?id=1").body).unwrap();
+    assert_eq!(
+        graded["reflection"]["self_rating"], 8,
+        "and a real self-review still reaches the drawer"
+    );
+}
+
+/// The second-order half of #2443: an ungraded row must not spend the window.
+///
+/// The bound is applied by SQL `LIMIT`, so filtering after the fact would leave
+/// a workspace whose newest `MAX_LISTED_REFLECTIONS` rows are all parse
+/// failures — a plausible shape, since that is precisely what a broken
+/// reflection loop produces every turn — showing an empty ratings chart while
+/// real ratings sat one row past the horizon. The predicate runs before the
+/// limit, so the window means "the newest N ratings".
+#[test]
+fn ungraded_rows_do_not_spend_the_ratings_window() {
+    use crate::db::MAX_LISTED_REFLECTIONS;
+    let ws = seeded_workspace();
+    let conn = Connection::open(ws.path().join(".stella/private/store.db")).unwrap();
+    conn.execute_batch("BEGIN").unwrap();
+    {
+        // Ids from 1000, all newer than the seeded graded turn: enough of them
+        // to fill the window on their own.
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO execution_reflection (execution_id, parse_error)
+                 VALUES (?1, 'I will now analyze the turn. First,')",
+            )
+            .unwrap();
+        for i in 0..MAX_LISTED_REFLECTIONS {
+            stmt.execute([1000 + i as i64]).unwrap();
+        }
+    }
+    conn.execute_batch("COMMIT").unwrap();
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/reflections").body).unwrap();
+    let ratings = v["ratings"].as_array().unwrap();
+    assert_eq!(
+        ratings.len(),
+        1,
+        "500 unreadable reflections must not crowd out the one real rating"
+    );
+    assert_eq!(ratings[0]["execution_id"], 1);
+}
+
 /// The tool leaderboard is the hottest query (every poll, highest-
 /// cardinality table): it aggregates a bounded recent window, so calls
 /// older than the window stop being rescanned every 5 s.
@@ -804,7 +904,12 @@ fn memories_rules_and_reflections_come_from_disk_and_db() {
         serde_json::from_slice(&respond(ws.path(), "/api/reflections").body).unwrap();
     assert_eq!(refl["lessons"].as_array().unwrap().len(), 2);
     let ratings = refl["ratings"].as_array().unwrap();
-    assert_eq!(ratings.len(), 1);
+    assert_eq!(
+        ratings.len(),
+        1,
+        "one of the fixture's two reflection rows is a parse failure, which is \
+         not a rating (#2443)"
+    );
     assert_eq!(ratings[0]["self_rating"], 8);
     assert_eq!(ratings[0]["what_to_improve"], "read the failing test first");
 }
@@ -816,8 +921,11 @@ fn memories_rules_and_reflections_come_from_disk_and_db() {
 /// was the whole of what the dashboard knew — so a workspace whose reflection
 /// responses had been unparseable for nine days got the same "no proposals in
 /// the ledger" copy as one opened five minutes ago. Its own fixture rather
-/// than the shared one: a parse-failure row is also an `execution_reflection`
-/// row, which the ratings feed and the execution-detail route both count.
+/// than the shared one because it exercises the *absent* `context.db` path:
+/// this route reads two databases and must still name the starved loop when
+/// only `store.db` exists. (The shared fixture carries a parse-failure row
+/// too, since #2443 — the routes that must not count it as a rating now say
+/// so themselves.)
 #[test]
 fn the_lifecycle_payload_names_reflections_that_produced_no_readable_lessons() {
     let ws = TempDir::new().unwrap();

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -642,11 +642,7 @@ fn the_ratings_feed_counts_only_graded_turns_against_the_real_schema() {
             "execution {id} reflected unreadably and was never graded, so it is \
              not a rating: {rating}"
         );
-        let prose = |key: &str| {
-            rating[key]
-                .as_str()
-                .is_some_and(|s| !s.trim().is_empty())
-        };
+        let prose = |key: &str| rating[key].as_str().is_some_and(|s| !s.trim().is_empty());
         assert!(
             !rating["self_rating"].is_null()
                 || !rating["delivered"].is_null()

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -598,6 +598,66 @@ fn every_route_survives_the_real_store_schema() {
     }
 }
 
+/// #2443, against the real schema: the ratings feed counts what the model
+/// graded, and the Improve tab's two panels agree about the same turn.
+///
+/// `crates/stella-observatory/src/db.rs`'s `HAS_SELF_REVIEW` is a SQL mirror of
+/// `stella_store::SelfReviewRow::is_empty` — mirrored because this crate must
+/// not link `stella-store` in production. This suite is what keeps the mirror
+/// honest: the store below is built through the real migration path by the real
+/// writers, so a column renamed underneath the predicate fails here.
+///
+/// The ids are read out of the payloads rather than assumed, which is also the
+/// product statement: the turn the lifecycle route names as unreadable is
+/// exactly the one the ratings feed must not present as an unrated reflection.
+#[test]
+fn the_ratings_feed_counts_only_graded_turns_against_the_real_schema() {
+    let workspace = real_store_workspace();
+    let root: &Path = workspace.path();
+
+    let lifecycle: serde_json::Value =
+        serde_json::from_slice(&respond(root, "/api/context-lifecycle").body).expect("json");
+    let unreadable: Vec<i64> = lifecycle["unreadable_reflections"]
+        .as_array()
+        .expect("unreadable_reflections")
+        .iter()
+        .map(|r| r["execution_id"].as_i64().expect("execution_id"))
+        .collect();
+    assert!(
+        !unreadable.is_empty(),
+        "the fixture seeds a parse failure through the real writer: {lifecycle}"
+    );
+
+    let reflections: serde_json::Value =
+        serde_json::from_slice(&respond(root, "/api/reflections").body).expect("json");
+    let ratings = reflections["ratings"].as_array().expect("ratings");
+    assert!(
+        !ratings.is_empty(),
+        "and a real self-review, which must still be listed: {reflections}"
+    );
+    for rating in ratings {
+        let id = rating["execution_id"].as_i64().expect("execution_id");
+        assert!(
+            !unreadable.contains(&id),
+            "execution {id} reflected unreadably and was never graded, so it is \
+             not a rating: {rating}"
+        );
+        let prose = |key: &str| {
+            rating[key]
+                .as_str()
+                .is_some_and(|s| !s.trim().is_empty())
+        };
+        assert!(
+            !rating["self_rating"].is_null()
+                || !rating["delivered"].is_null()
+                || prose("what_went_well")
+                || prose("what_to_improve")
+                || prose("critique"),
+            "a listed rating carries an assessment: {rating}"
+        );
+    }
+}
+
 /// The live projection, seen through the dashboard's own route.
 ///
 /// This is the end-to-end statement of the v18 change: a turn that has made


### PR DESCRIPTION
## What

`/api/reflections`'s ratings feed listed every `execution_reflection` row. That
table has three producers writing **disjoint** columns
(`stella_store::reflection`'s module doc), and only one of them records an
assessment — so a row written by `finalize_execution_reflection` alone, or
(since #2175) by a reflection whose response would not parse, arrived at the
Improve tab with `delivered: null`, `self_rating: null` and three empty
strings. It rendered as a reflection the model *declined* to grade. It was
never asked.

Closes #2443.

## Shape chosen: (a), filter to graded turns

The issue offered two and asked for an explicit pick. **(a)** — three reasons,
the third of which the issue did not anticipate:

1. It is what the panel is called, and `/api/context-lifecycle`'s
   `unreadable_reflections` (#2175) already answers "did this turn reflect at
   all" on the same tab.
2. The page has *always* wanted (a): `index.html` filtered client-side on
   `self_rating != null || delivered != null` before this PR, and
   `crates/stella-observatory/src/tests/execution_routes.rs:19` already asserted
   `"unreflected runs stay null"` for the drawer. Neither could be satisfied by
   the data the routes served.
3. **The filter has to be inside the query.** The feed is bounded by
   `ORDER BY execution_id DESC LIMIT MAX_LISTED_REFLECTIONS`, so filtering
   after the fact leaves a workspace whose newest 500 rows are ungraded showing
   an *empty* ratings chart while real ratings sit one row past the horizon —
   and "an ungraded row every turn" is exactly what a broken reflection loop
   produces. (b) cannot fix this; it is witnessed by
   `ungraded_rows_do_not_spend_the_ratings_window`.

## How

One predicate, `HAS_SELF_REVIEW` in `crates/stella-observatory/src/db.rs`,
applied by **both** readers of that table — `reflection_ratings` and the
execution drawer's reflection object. Sharing it is the point: they ask the same
question of the same row, and the issue notes the drawer is the other surface a
parse-failure row changes. It is the SQL mirror of
`stella_store::SelfReviewRow::is_empty`, trim and all; mirrored rather than
called because this crate must not link `stella-store` in production
(`Store::open` migrates, and an observer never writes what it observes).

Every column in the predicate predates the table's first version, so it adds no
schema dependency — and both callers go through `collect_rows`/`or_empty`
regardless, which degrade a missing table *or column* to an empty section.

## Witness tests

Checked the artisanal way (`git checkout HEAD~1 -- src/db.rs`): **four** tests
fail without the production change, two of them pre-existing.

| test | proves |
|---|---|
| `the_ratings_feed_lists_only_turns_the_model_graded` | a parse-failure row is not a rating; a critique with no number still is; whitespace prose is not |
| `ungraded_rows_do_not_spend_the_ratings_window` | 500 parse failures do not crowd out the one real rating |
| `the_ratings_feed_counts_only_graded_turns_against_the_real_schema` | the same, against a store built by the **real migration path** — this is what keeps the mirror of `is_empty` honest |
| `memories_rules_and_reflections_come_from_disk_and_db` *(existing)* | caught it once the shared fixture carried a parse-failure row |
| `execution_routes::execution_detail_includes_steps_tools_files` *(existing)* | its `"unreflected runs stay null"` assertion, which the old drawer projection violated the moment such a row existed |

The issue asked that seeding a parse-failure row in the **shared** fixture be
made safe, and then done. Both: `seeded_workspace` now holds one graded turn
and one ungraded one, so every route in the suite runs against a store that can
tell them apart.

No tests were deleted.

## Also in this PR

The README's "Missing is a state, never an error" section — the section the
issue cites as a constraint — named `is_missing_table`, which has not existed
since it became `is_missing_schema` and widened to cover a missing *column*.
That is the half a never-migrating crate depends on, so the stale name pointed
a reader at the wrong guarantee. Repaired, and the reflection-row contract
written down beside it.

## Gate

`make gate CARGO_SCOPE="-p stella-observatory"` — exit 0. The `file-size` guard
reports inherited drift in six `bench/` Python files; it names them as
pre-existing at the base and not caused by this change, and per AGENTS.md a
baseline regeneration lands on its own from a fresh `main`, not folded in here.

## Nothing left behind

No new issues to file. The one adjacent defect this work surfaced — the
drawer's blank reflection panel for an ungraded turn — is fixed here rather
than deferred, since it is the same predicate on the same row.

## Summary by Sourcery

Filter execution reflections to only include turns the model actually graded and align all consumers and documentation with this contract.

Bug Fixes:
- Prevent ungraded or parse-failure reflection rows from appearing as ratings in the self-improvement feed.
- Ensure ungraded reflection rows do not consume the bounded ratings window, so real ratings remain visible.
- Stop the execution detail drawer from showing a blank self-reflection panel for turns the model never graded.

Enhancements:
- Introduce a shared HAS_SELF_REVIEW SQL predicate to consistently identify graded reflections across routes.
- Refine the dashboard client to treat ratings as strictly numeric assessments while keeping prose-only critiques for improvement copy.

Documentation:
- Correct the README to reference is_missing_schema and document the distinction between reflection rows and ratings, including the graded-turn predicate contract.

Tests:
- Expand the shared test fixture to include both graded and ungraded reflections and add targeted tests for ratings filtering and window behavior.
- Add a schema conformance test that validates the graded-turn predicate against the real migrated store schema and cross-checks lifecycle and ratings payloads.
- Update existing tests to expect parse-failure reflection rows to be excluded from ratings while preserving real self-reviews.