### PR TITLE
perf(stella-tools): measure verify_done's phases instead of inferring them — the shadow lifecycle is 85% of a call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "stella-core",
+ "stella-diag",
  "stella-graph",
  "stella-home",
  "stella-media",

--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -821,6 +821,19 @@ pub(crate) fn registry_options(cfg: &Config) -> stella_tools::RegistryOptions {
         } else {
             stella_tools::shell_touch::IgnorePolicy::WalkAll
         },
+        // Where a built-in's own diagnostics go — `verify_done`'s per-phase
+        // wall clock today (#2486). Wired here, on the same "every session
+        // lane" reasoning as the line above, rather than through a
+        // post-construction setter beside `attach_events`: that setter would
+        // have to be remembered at ten call sites, and forgetting one fails
+        // silently by recording nothing.
+        //
+        // Always `Some`, never conditional on a log file existing:
+        // `diag_boot::dx()` returns a disabled handle before boot, and even a
+        // disabled one fills the crash ring — so a run that panics carries
+        // its last phase records into the dump whether or not anyone asked
+        // for a log.
+        diagnostics: Some(crate::diag_boot::dx()),
         ..Default::default()
     }
 }

--- a/crates/stella-cli/src/agent/tools/tests.rs
+++ b/crates/stella-cli/src/agent/tools/tests.rs
@@ -410,6 +410,31 @@ fn load_managed_config(
     (settings.unwrap(), cfg.unwrap(), options)
 }
 
+/// #2486: the diagnostic handle has to reach the registry, or `verify_done`
+/// measures every phase it crosses and reports them into a handle nobody
+/// wired — a measurement that silently does not exist.
+///
+/// Worth its own test because nothing else notices that line going missing:
+/// no build breaks, no verdict changes, and the only symptom is an empty
+/// census months later. `registry_options` is the single seam every session
+/// lane builds from, which is what makes one assertion here sufficient.
+#[test]
+fn registry_options_carry_the_diagnostic_handle() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let workspace = dir.path().join("workspace");
+    let managed = dir.path().join("managed.json");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(&managed, "{}").unwrap();
+
+    let (_settings, _cfg, options) = load_managed_config(&workspace, &home, &managed);
+    assert!(
+        options.diagnostics.is_some(),
+        "without a handle here, verify_done's per-phase record goes nowhere"
+    );
+}
+
 #[tokio::test]
 async fn managed_media_ceiling_flows_through_config_into_registry_enforcement() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/stella-tools/Cargo.toml
+++ b/crates/stella-tools/Cargo.toml
@@ -11,6 +11,11 @@ publish.workspace = true
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
 stella-core = { path = "../stella-core" }
+# `verify_done`'s per-phase wall clock (#2486). The diagnostic plane is the
+# only channel that can carry it: a tool's `ToolOutput` is what the loop
+# detector keys on, so an elapsed time there would blind it. stella-diag is a
+# leaf crate by construction, so this adds no cycle.
+stella-diag = { path = "../stella-diag" }
 stella-graph = { path = "../stella-graph" }
 stella-store = { path = "../stella-store" }
 stella-media = { path = "../stella-media" }

--- a/crates/stella-tools/README.md
+++ b/crates/stella-tools/README.md
@@ -184,6 +184,15 @@ got.
 
 ## Gotchas
 
+- **A tool's timings never go in its `ToolOutput`.** That value is what
+  `stella-core`'s loop detector keys on — `exact_repeat_threshold` counts identical
+  *(name + input + output)* calls and the stagnation rung counts byte-identical outputs
+  from one tool — so an elapsed time in a verdict makes both rungs permanently blind for
+  that tool. `verify_done` reports its per-phase wall clock to the diagnostic plane
+  instead (`tools.verify_done.phases`, `src/verify/phases.rs`, #2486), which the model
+  and the detector both never see. This crate's seam for that handle is
+  `RegistryOptions::diagnostics`; the codes it emits have no generated reference yet
+  (#2507), so they are listed here.
 - **`schemas()` is sorted by name deliberately.** The list is serialized verbatim at position 0
   of the prompt prefix and `HashMap` iteration order is per-process randomized. Prompt caching
   is a byte-level prefix match, so an unsorted list means every process writes a divergent cache

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -473,6 +473,7 @@ impl ToolRegistry {
                 task_board.clone(),
                 spawn_queue.clone(),
                 shadow_memo.clone(),
+                options.diagnostics.clone(),
             ));
             // The web family registers by default, like every other built-in.
             // A fetched page is untrusted input and an egress channel, which is

--- a/crates/stella-tools/src/registry/options.rs
+++ b/crates/stella-tools/src/registry/options.rs
@@ -28,6 +28,21 @@ pub struct RegistryOptions {
     /// policy is inert. Not a tool switch — it configures the registry's own
     /// observation machinery, which no MCP or custom tool ever routes around.
     pub probe_ignore_policy: crate::shell_touch::IgnorePolicy,
+    /// The process's diagnostic handle, when the host has one.
+    ///
+    /// `None` — the default — means the built-ins record nothing, which is
+    /// what a library consumer and every test get unless they ask otherwise.
+    /// A handle rides here rather than through a post-construction
+    /// `attach_*` setter because the tools that use it are built once, in
+    /// [`super::process_tools::builtins`], and a setter would have to be
+    /// remembered at each of the ten sites that already call
+    /// [`super::ToolRegistry::attach_events`] — a gap that fails silently, by
+    /// recording nothing, in exactly the runs this exists to explain.
+    ///
+    /// Only `verify_done` reads it today (#2486). It is the crate's seam for
+    /// the diagnostic plane, not that tool's private channel: a built-in with
+    /// a decision worth explaining takes it from here too.
+    pub diagnostics: Option<Arc<stella_diag::Dx>>,
 }
 
 impl RegistryOptions {

--- a/crates/stella-tools/src/registry/options.rs
+++ b/crates/stella-tools/src/registry/options.rs
@@ -34,10 +34,11 @@ pub struct RegistryOptions {
     /// what a library consumer and every test get unless they ask otherwise.
     /// A handle rides here rather than through a post-construction
     /// `attach_*` setter because the tools that use it are built once, in
-    /// [`super::process_tools::builtins`], and a setter would have to be
+    /// `registry::process_tools::builtins`, and a setter would have to be
     /// remembered at each of the ten sites that already call
-    /// [`super::ToolRegistry::attach_events`] — a gap that fails silently, by
-    /// recording nothing, in exactly the runs this exists to explain.
+    /// [`ToolRegistry::attach_events`](super::ToolRegistry::attach_events) —
+    /// a gap that fails silently, by recording nothing, in exactly the runs
+    /// this exists to explain.
     ///
     /// Only `verify_done` reads it today (#2486). It is the crate's seam for
     /// the diagnostic plane, not that tool's private channel: a built-in with

--- a/crates/stella-tools/src/registry/process_tools.rs
+++ b/crates/stella-tools/src/registry/process_tools.rs
@@ -9,6 +9,7 @@ pub(super) fn builtins(
     task_board: crate::tasks::TaskBoardHandle,
     spawn_queue: crate::tasks::SpawnQueue,
     shadow_memo: crate::verify::ShadowMemoHandle,
+    diagnostics: Option<Arc<stella_diag::Dx>>,
 ) -> Vec<Arc<dyn Tool>> {
     let processes: crate::process::ProcessTableHandle = Arc::default();
     let repo: Arc<dyn crate::repo::RepoBackend> = Arc::new(crate::repo::GitCli);
@@ -18,7 +19,7 @@ pub(super) fn builtins(
         // an operator who wants it gone writes `"tools": {"bash": "off"}`,
         // which the policy layer above enforces for MCP and custom tools too.
         Arc::new(crate::bash::Bash),
-        Arc::new(crate::verify::VerifyDone::with_memo(shadow_memo)),
+        Arc::new(crate::verify::VerifyDone::new(shadow_memo, diagnostics)),
         Arc::new(crate::project::BuildProject),
         Arc::new(crate::project::RunTests),
         Arc::new(crate::diagnostics::Diagnostics),

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -67,8 +67,18 @@
 //! fresh checkout — so an identical call inside one turn reuses its
 //! observation rather than rebuilding for it ([`ShadowMemo`], #2208). The
 //! working-tree half is never reused.
+//!
+//! # Where the wall clock goes
+//!
+//! Neither half, as it turns out. Every boundary a call crosses is timed and
+//! reported to the diagnostic plane as one [`phases`] record — see that
+//! module for why the measurement was needed (#2486) and why it cannot ride
+//! the tool's own output.
 
 mod memo;
+mod phases;
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -77,6 +87,7 @@ use tokio::process::Command;
 
 use memo::{ShadowKey, ShadowObservation};
 pub use memo::{ShadowMemo, ShadowMemoHandle};
+use phases::{Phase, Phases, Verdict};
 
 use crate::registry::Tool;
 
@@ -90,12 +101,27 @@ pub struct VerifyDone {
     /// (unshared, never armed) is inert, so a standalone instance behaves
     /// exactly as it did before the memo existed.
     memo: ShadowMemoHandle,
+    /// Where this call's [`Phases`] record goes, when the host wired a
+    /// diagnostic handle through
+    /// [`RegistryOptions::diagnostics`](crate::RegistryOptions::diagnostics).
+    /// `None` is inert: the phases are still measured (an `Instant` costs
+    /// nothing worth branching on) and simply not reported, so an unwired
+    /// host and a wired one execute the same code.
+    diagnostics: Option<Arc<stella_diag::Dx>>,
 }
 
 impl VerifyDone {
     /// Register with the memo the owning registry brackets.
     pub fn with_memo(memo: ShadowMemoHandle) -> Self {
-        Self { memo }
+        Self {
+            memo,
+            diagnostics: None,
+        }
+    }
+
+    /// The full seam: the turn's memo, and where to report per-call timings.
+    pub fn new(memo: ShadowMemoHandle, diagnostics: Option<Arc<stella_diag::Dx>>) -> Self {
+        Self { memo, diagnostics }
     }
 }
 
@@ -366,7 +392,9 @@ async fn run_against_baseline(
     root_rel: &std::path::Path,
     test_cmd: &str,
     timeout_secs: u64,
+    phases: &mut Phases,
 ) -> Result<(i32, String), String> {
+    let add = Phase::start();
     // Shadow names carry pid + a process-wide counter: two concurrent
     // verify_done calls (parallel tools, parallel tests) must never collide on
     // the same worktree path — a timestamp alone can.
@@ -376,13 +404,17 @@ async fn run_against_baseline(
         std::process::id(),
         SHADOW_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
-    match git_in(root)
+    let added = git_in(root)
         .args(["worktree", "add", "--detach"])
         .arg(&shadow)
         .arg(baseline_sha)
         .output()
-        .await
-    {
+        .await;
+    // Stopped before the match, so a checkout that failed *slowly* — the
+    // interesting case, and the one a lock contention or a cold object store
+    // produces — is measured rather than discarded with its error.
+    phases.worktree_add = add.stop();
+    match added {
         Ok(out) if out.status.success() => {}
         Ok(out) => {
             return Err(format!(
@@ -400,31 +432,53 @@ async fn run_against_baseline(
         shadow: shadow.clone(),
     };
 
-    // Layer ONLY the test files onto the previous version.
-    for (rel, src, relpath) in resolved {
-        let dst = shadow.join(relpath);
-        if let Some(parent) = dst.parent()
-            && let Err(e) = tokio::fs::create_dir_all(parent).await
-        {
-            cleanup_shadow(root, &shadow).await;
-            return Err(format!(
-                "could not stage test file `{rel}` in the shadow: {e}"
-            ));
-        }
-        if let Err(e) = tokio::fs::copy(src, &dst).await {
-            cleanup_shadow(root, &shadow).await;
-            return Err(format!(
-                "could not copy test file `{rel}` into the shadow: {e}"
-            ));
-        }
+    let stage = Phase::start();
+    let staged = stage_witness_files(&shadow, resolved).await;
+    phases.stage_tests = stage.stop();
+    if let Err(message) = staged {
+        let teardown = Phase::start();
+        cleanup_shadow(root, &shadow).await;
+        phases.cleanup = teardown.stop();
+        return Err(message);
     }
 
     // Run in the shadow subdirectory matching the workspace root, so a
     // relative `test_cmd` (e.g. `cargo test`) resolves the same package it
     // would in the real working tree — not the repo toplevel.
+    let half_two = Phase::start();
     let shadow_run = run(test_cmd, &shadow.join(root_rel), timeout_secs).await;
+    phases.shadow_run = half_two.stop();
+    let teardown = Phase::start();
     cleanup_shadow(root, &shadow).await;
+    phases.cleanup = teardown.stop();
     shadow_run.map_err(|e| format!("shadow run against the previous version failed to run: {e}"))
+}
+
+/// Layer ONLY the test files onto the previous version.
+///
+/// Split out of [`run_against_baseline`] so the copy loop has one exit and can
+/// therefore be timed as one phase — the caller owns the shadow's teardown on
+/// both paths, which it already did on every other error.
+async fn stage_witness_files(
+    shadow: &std::path::Path,
+    resolved: &[(String, std::path::PathBuf, std::path::PathBuf)],
+) -> Result<(), String> {
+    for (rel, src, relpath) in resolved {
+        let dst = shadow.join(relpath);
+        if let Some(parent) = dst.parent()
+            && let Err(e) = tokio::fs::create_dir_all(parent).await
+        {
+            return Err(format!(
+                "could not stage test file `{rel}` in the shadow: {e}"
+            ));
+        }
+        if let Err(e) = tokio::fs::copy(src, &dst).await {
+            return Err(format!(
+                "could not copy test file `{rel}` into the shadow: {e}"
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -452,15 +506,46 @@ impl Tool for VerifyDone {
         }
     }
 
+    /// Time the whole call, then report one [`Phases`] record — whatever the
+    /// verdict, including the refusals that never build a shadow at all.
+    /// Reporting only the calls that got far enough to be slow would censor
+    /// the fast end of the distribution and flatter every percentile #2486
+    /// exists to measure.
     async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
-        let test_cmd = match crate::input::required_str(input, "test_cmd") {
-            Ok(v) => v,
-            Err(err) => {
-                return ToolOutput::Error {
-                    message: err.to_string(),
-                };
-            }
+        let call = Phase::start();
+        let mut phases = Phases::default();
+        let (output, verdict) = match self.verify(input, root, &mut phases).await {
+            Ok(pair) => pair,
+            Err(message) => (ToolOutput::Error { message }, Verdict::Error),
         };
+        phases.verdict = verdict;
+        // Last, so it spans everything above it including the teardown.
+        phases.total = call.stop();
+        if let Some(dx) = &self.diagnostics {
+            phases.emit(dx);
+        }
+        output
+    }
+}
+
+impl VerifyDone {
+    /// The call itself, with each phase's wall clock written into `phases`.
+    ///
+    /// `Err` is a named refusal — an input this tool cannot act on, or a
+    /// workspace it cannot measure a flip in — and reaches the model as
+    /// `ToolOutput::Error` exactly as it did before, through the one arm in
+    /// [`Self::execute`]. `Ok` carries the four real verdicts *with* the
+    /// [`Verdict`] each one is, because the alternative is re-deriving it by
+    /// sniffing the prose this function just wrote, which is what
+    /// `ToolOutput`'s own doc comment forbids.
+    async fn verify(
+        &self,
+        input: &Value,
+        root: &std::path::Path,
+        phases: &mut Phases,
+    ) -> Result<(ToolOutput, Verdict), String> {
+        let setup = Phase::start();
+        let test_cmd = crate::input::required_str(input, "test_cmd").map_err(|e| e.to_string())?;
         let test_files: Vec<String> = input
             .get("test_files")
             .and_then(|v| v.as_array())
@@ -471,12 +556,11 @@ impl Tool for VerifyDone {
             })
             .unwrap_or_default();
         if test_files.is_empty() {
-            return ToolOutput::Error {
-                message: "missing required field `test_files` — name the new/changed test \
-                          file(s) that witness this change"
-                    .into(),
-            };
+            return Err("missing required field `test_files` — name the new/changed test \
+                        file(s) that witness this change"
+                .to_string());
         }
+        phases.test_files = u32::try_from(test_files.len()).unwrap_or(u32::MAX);
         let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
 
         // The shadow-worktree copy destination must be derived from the
@@ -485,14 +569,9 @@ impl Tool for VerifyDone {
         // shadow prefix and resolve back to the real working-tree file, and
         // `fs::copy(src, src)` truncates it — silently emptying the user's test
         // file and violating the "NEVER mutates the working tree" contract.
-        let canon_root = match root.canonicalize() {
-            Ok(r) => r,
-            Err(e) => {
-                return ToolOutput::Error {
-                    message: format!("could not canonicalize the workspace root: {e}"),
-                };
-            }
-        };
+        let canon_root = root
+            .canonicalize()
+            .map_err(|e| format!("could not canonicalize the workspace root: {e}"))?;
         // The shadow worktree mirrors the git TOPLEVEL, not the workspace root
         // — which may be a subdirectory of the repo. So test-file destinations
         // must be relative to the toplevel, and the shadow test must run in the
@@ -526,27 +605,18 @@ impl Tool for VerifyDone {
         for file in &test_files {
             match crate::resolve_within_root(root, file) {
                 Some(path) if path.is_file() => {
-                    let relpath = match path.strip_prefix(&canon_toplevel) {
-                        Ok(r) => r.to_path_buf(),
-                        Err(_) => {
-                            return ToolOutput::Error {
-                                message: format!(
-                                    "test file `{file}` resolved outside the git repository"
-                                ),
-                            };
-                        }
-                    };
-                    resolved.push((file.clone(), path, relpath));
+                    let relpath = path.strip_prefix(&canon_toplevel).map_err(|_| {
+                        format!("test file `{file}` resolved outside the git repository")
+                    })?;
+                    resolved.push((file.clone(), path.clone(), relpath.to_path_buf()));
                 }
                 Some(_) => {
-                    return ToolOutput::Error {
-                        message: format!("test file `{file}` does not exist in the workspace"),
-                    };
+                    return Err(format!(
+                        "test file `{file}` does not exist in the workspace"
+                    ));
                 }
                 None => {
-                    return ToolOutput::Error {
-                        message: format!("test file `{file}` escapes the workspace root"),
-                    };
+                    return Err(format!("test file `{file}` escapes the workspace root"));
                 }
             }
         }
@@ -576,15 +646,14 @@ impl Tool for VerifyDone {
                         }
                         _ => String::new(),
                     };
-                    return ToolOutput::Error {
-                        message: format!(
-                            "verify_done requires a git repository: the previous version of \
-                             the code is defined as git HEAD{detail}"
-                        ),
-                    };
+                    return Err(format!(
+                        "verify_done requires a git repository: the previous version of the \
+                         code is defined as git HEAD{detail}"
+                    ));
                 }
             }
         };
+        phases.setup = setup.stop();
 
         // Prune-on-start (#613): reclaim `.git/worktrees` registrations left
         // by a PREVIOUS run whose future was dropped. Such a run could only
@@ -596,31 +665,37 @@ impl Tool for VerifyDone {
         // registrations whose directory is already gone, so it is cheap,
         // idempotent, and can never disturb a live worktree (this run's or a
         // concurrent one's).
+        let prune = Phase::start();
         let _ = git_in(root).args(["worktree", "prune"]).output().await;
+        phases.prune = prune.stop();
 
         // Which commit is "the previous version" — see the module docs. HEAD
         // is only the default: inside a candidate workspace the pipeline has
         // already committed the work under proof on top of the baseline, and
         // comparing against it makes every real flip structurally impossible
         // while a missing build artifact fakes one (#2067).
-        let baseline = match resolve_witness_baseline(root, &head).await {
-            Ok(b) => b,
-            Err(message) => return ToolOutput::Error { message },
-        };
+        let resolve = Phase::start();
+        let baseline = resolve_witness_baseline(root, &head).await;
+        phases.baseline = resolve.stop();
+        let baseline = baseline?;
 
         // Half 1: the new code must pass.
-        let (new_exit, new_output) = match run(test_cmd, root, timeout_secs).await {
-            Ok(pair) => pair,
-            Err(e) => return ToolOutput::Error { message: e },
-        };
+        let half_one = Phase::start();
+        let new_run = run(test_cmd, root, timeout_secs).await;
+        phases.working_tree_run = half_one.stop();
+        let (new_exit, new_output) = new_run?;
         if new_exit != 0 {
-            return ToolOutput::Error {
-                message: format!(
-                    "NOT DONE — the witness test fails on your NEW code (exit {new_exit}). Fix \
-                     the implementation (or the test) and retry.\n--- output tail ---\n{}",
-                    tail(&new_output)
-                ),
-            };
+            return Ok((
+                ToolOutput::Error {
+                    message: format!(
+                        "NOT DONE — the witness test fails on your NEW code (exit {new_exit}). \
+                         Fix the implementation (or the test) and retry.\n--- output tail \
+                         ---\n{}",
+                        tail(&new_output)
+                    ),
+                },
+                Verdict::NotDone,
+            ));
         }
 
         // Half 2: the previous code (the baseline + your new tests) must fail.
@@ -643,19 +718,16 @@ impl Tool for VerifyDone {
             match memo_key.as_ref().and_then(|key| self.memo.get(key)) {
                 Some(observed) => (observed.exit, observed.output, true),
                 None => {
-                    let (exit, output) = match run_against_baseline(
+                    let (exit, output) = run_against_baseline(
                         root,
                         &baseline.sha,
                         &resolved,
                         &root_rel,
                         test_cmd,
                         timeout_secs,
+                        phases,
                     )
-                    .await
-                    {
-                        Ok(pair) => pair,
-                        Err(message) => return ToolOutput::Error { message },
-                    };
+                    .await?;
                     if let Some(key) = memo_key {
                         self.memo.insert(
                             key,
@@ -668,6 +740,7 @@ impl Tool for VerifyDone {
                     (exit, output, false)
                 }
             };
+        phases.shadow_reused = reused;
         // Every verdict below says whether the previous-code run behind it
         // happened on this call. A reader auditing a proof must never have to
         // guess that, and the truncated tail it is reading is now evidence
@@ -681,27 +754,31 @@ impl Tool for VerifyDone {
         };
 
         if old_exit == 0 {
-            return ToolOutput::Error {
-                message: format!(
-                    "VACUOUS TEST — the witness test ALSO PASSES on the previous code \
-                     (baseline {}, {}). It does not witness your change: either the behavior \
-                     already existed, the test doesn't exercise the new behavior, or your \
-                     change isn't wired in. Strengthen the test so it fails without your \
-                     change.{reuse_note}\n--- previous-code output tail ---\n{}",
-                    baseline.short(),
-                    baseline.provenance,
-                    tail(&old_output)
-                ),
-            };
+            return Ok((
+                ToolOutput::Error {
+                    message: format!(
+                        "VACUOUS TEST — the witness test ALSO PASSES on the previous code \
+                         (baseline {}, {}). It does not witness your change: either the \
+                         behavior already existed, the test doesn't exercise the new behavior, \
+                         or your change isn't wired in. Strengthen the test so it fails without \
+                         your change.{reuse_note}\n--- previous-code output tail ---\n{}",
+                        baseline.short(),
+                        baseline.provenance,
+                        tail(&old_output)
+                    ),
+                },
+                Verdict::Vacuous,
+            ));
         }
 
         // A failure while LOADING the test is not a failure OF the test:
         // classify before crediting, so a missing build artifact in the fresh
         // shadow checkout cannot fake a flip (#2067).
         if let Some(label) = import_failure_signature(&old_output) {
-            return ToolOutput::Error {
-                message: format!(
-                    "WITNESS_INCONCLUSIVE_BUILD_ERROR — the previous-code run failed with \
+            return Ok((
+                ToolOutput::Error {
+                    message: format!(
+                        "WITNESS_INCONCLUSIVE_BUILD_ERROR — the previous-code run failed with \
                      {label}, so the baseline could not be built or imported and no \
                      behavioural assertion ever ran: this failure is NOT evidence that your \
                      change is what flipped it. Two common causes, each with a fix:\n\
@@ -716,28 +793,33 @@ impl Tool for VerifyDone {
                      - previous code: baseline {} ({}) → exit {old_exit}, before any test \
                      ran{reuse_note}\n\
                      --- previous-code output tail ---\n{}",
+                        baseline.short(),
+                        baseline.provenance,
+                        tail(&old_output)
+                    ),
+                },
+                Verdict::InconclusiveBuildError,
+            ));
+        }
+
+        Ok((
+            ToolOutput::Ok {
+                content: format!(
+                    "WITNESS CONFIRMED — deterministic definition of done met:\n\
+                     - new code:      `{test_cmd}` exit 0 (PASS)\n\
+                     - previous code: baseline {} ({}) + your test files → exit {old_exit} \
+                     (FAIL){reuse_note}\n\
+                     Check the tail below: an assertion failure is a strong witness; a compile \
+                     error (test references symbols that don't exist on the baseline) is weaker \
+                     — prefer behavioral assertions when possible.\n\
+                     --- previous-code failure tail ---\n{}",
                     baseline.short(),
                     baseline.provenance,
                     tail(&old_output)
                 ),
-            };
-        }
-
-        ToolOutput::Ok {
-            content: format!(
-                "WITNESS CONFIRMED — deterministic definition of done met:\n\
-                 - new code:      `{test_cmd}` exit 0 (PASS)\n\
-                 - previous code: baseline {} ({}) + your test files → exit {old_exit} \
-                 (FAIL){reuse_note}\n\
-                 Check the tail below: an assertion failure is a strong witness; a compile \
-                 error (test references symbols that don't exist on the baseline) is weaker \
-                 — prefer behavioral assertions when possible.\n\
-                 --- previous-code failure tail ---\n{}",
-                baseline.short(),
-                baseline.provenance,
-                tail(&old_output)
-            ),
-        }
+            },
+            Verdict::Confirmed,
+        ))
     }
 }
 

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -556,9 +556,11 @@ impl VerifyDone {
             })
             .unwrap_or_default();
         if test_files.is_empty() {
-            return Err("missing required field `test_files` — name the new/changed test \
+            return Err(
+                "missing required field `test_files` — name the new/changed test \
                         file(s) that witness this change"
-                .to_string());
+                    .to_string(),
+            );
         }
         phases.test_files = u32::try_from(test_files.len()).unwrap_or(u32::MAX);
         let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -71,9 +71,10 @@
 //! # Where the wall clock goes
 //!
 //! Neither half, as it turns out. Every boundary a call crosses is timed and
-//! reported to the diagnostic plane as one [`phases`] record — see that
-//! module for why the measurement was needed (#2486) and why it cannot ride
-//! the tool's own output.
+//! reported to the diagnostic plane as one `tools.verify_done.phases` record.
+//! The `phases` submodule beside this one (`src/verify/phases.rs`) carries
+//! why the measurement was needed (#2486) and why it cannot ride the tool's
+//! own output.
 
 mod memo;
 mod phases;
@@ -511,8 +512,9 @@ impl Tool for VerifyDone {
         }
     }
 
-    /// Time the whole call, then report one [`Phases`] record — whatever the
-    /// verdict, including the refusals that never build a shadow at all.
+    /// Time the whole call, then report one `tools.verify_done.phases` record
+    /// — whatever the verdict, including the refusals that never build a
+    /// shadow at all.
     /// Reporting only the calls that got far enough to be slow would censor
     /// the fast end of the distribution and flatter every percentile #2486
     /// exists to measure.

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -383,6 +383,11 @@ impl Drop for ShadowDirGuard {
 /// sound. Keep it that way: a reader added here would silently widen what a
 /// memo key has to cover.
 ///
+/// `phases` is the one exception, and it is not one: it is written and never
+/// read, so nothing it carries can reach the result. A memo key covers what
+/// *determines* the observation, and how long producing it took is the one
+/// fact about a run that must never be part of that.
+///
 /// `Err` carries a complete, user-facing message; `Ok` is the run's
 /// `(exit code, output)`.
 async fn run_against_baseline(

--- a/crates/stella-tools/src/verify/phases.rs
+++ b/crates/stella-tools/src/verify/phases.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Per-phase wall clock for one `verify_done` call — the measurement #2486
+//! asks for before anything is optimised.
+//!
+//! # Why this exists
+//!
+//! `verify_done` runs the witness command twice, and across 61 local arena
+//! matches neither run was where the time went. Subtracting both from the
+//! call's `duration_ms` left a **median 1.5s and a p90 of 11.1s** of fixed
+//! machinery — the baseline resolution, `git worktree add`, the test-file
+//! copies, and the teardown. That number is an *estimate*: it comes from
+//! pairing each call against a shell invocation of the same command elsewhere
+//! in the trial, and three of 98 pairs estimated the working-tree run as
+//! larger than the whole call, which proves the proxy is noisy in both
+//! directions (#2424).
+//!
+//! So the estimate is not a finding to act on, it is a reason to measure.
+//! [`Phases`] carries every boundary the call actually has, and
+//! [`Phases::machinery`] is the same quantity the subtraction was reaching
+//! for — observed rather than inferred. An optimisation lands *after* one of
+//! these fields is shown to be the p90, not before.
+//!
+//! # Why the diagnostic plane and not the tool's own output
+//!
+//! `ToolOutput` is the only channel a [`Tool`](crate::registry::Tool) has into
+//! `stella-events.jsonl`, and it is the wrong one — `stella-core`'s loop
+//! detector keys on it. `LoopDetectionConfig::exact_repeat_threshold` counts
+//! consecutive identical **(name + input + output)** calls and the stagnation
+//! rung counts consecutive **byte-identical outputs** from one tool. A wall
+//! clock in the verdict text never repeats, so both rungs would go
+//! permanently blind for `verify_done` — the tool an agent stuck in a
+//! prove-it loop calls over and over. `ci.rs`'s probe path already carries
+//! this scar: it answers with one word, "deliberately free of run names,
+//! elapsed times, or counts — anything that changes poll-to-poll".
+//!
+//! The diagnostic plane has neither problem, and it is where
+//! `docs/spec/diagnostics.md` §2.1's routing rule sends this anyway: a phase
+//! duration explains *why the program behaved this way*. Every field below is
+//! a number, a bool, or a `&'static str` from a closed set, so §5.2's
+//! "content in a log does not compile" holds by construction — invariant 3 is
+//! not at risk here even though the subject is a path-bearing operation.
+//!
+//! # Reading a record
+//!
+//! One record per call, code `tools.verify_done.phases`, at `info` — so a
+//! `--log-file` (which floors at `info`) collects it and an ordinary run stays
+//! quiet. The record is **self-sufficient**: it carries every phase *and* the
+//! total, so a median/p90 per phase needs no join back to the `tool_result`
+//! event that measured the same call. That matters because a tool has no
+//! `call_id` to join on.
+//!
+//! The phases do not have to sum to [`Phases::total`], and the gap is
+//! deliberately left visible rather than folded into a neighbour: it is the
+//! `async` scheduling slack plus anything between the boundaries below. A
+//! reader who wants it computes `total - (sum of phases)`; a reader who sees
+//! it grow has found the next thing to name.
+
+use std::time::{Duration, Instant};
+
+use stella_diag::{Cx, Dx, Facet, Fields, Level};
+
+/// The stable diagnostic code every phase record carries (§11).
+pub(crate) const PHASES_CODE: &str = "tools.verify_done.phases";
+
+/// How a call ended, as a closed vocabulary — so a census can exclude the
+/// paths that never built a shadow at all (`not_done`, `error`) instead of
+/// letting their zeroes drag a machinery percentile down.
+///
+/// A `&'static str` rather than the raw verdict prose for the same reason
+/// every other field here is a number: the prose is assembled from a baseline
+/// provenance and a command line, and neither belongs in a log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Verdict {
+    /// The flip was proven: new code passed, the baseline failed.
+    Confirmed,
+    /// The witness also passed on the baseline.
+    Vacuous,
+    /// The witness failed on the new code, so no shadow was ever built.
+    NotDone,
+    /// The baseline run died loading the test rather than asserting (#2067).
+    InconclusiveBuildError,
+    /// A named refusal — bad input, no repo, no resolvable baseline, a
+    /// worktree that would not create.
+    Error,
+}
+
+impl Verdict {
+    /// The wire spelling. `snake_case` to match every other closed enum that
+    /// reaches a record.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirmed => "confirmed",
+            Self::Vacuous => "vacuous",
+            Self::NotDone => "not_done",
+            Self::InconclusiveBuildError => "inconclusive_build_error",
+            Self::Error => "error",
+        }
+    }
+}
+
+impl Default for Verdict {
+    /// A call that has not reached a verdict yet has, so far, only failed to
+    /// produce one. Defaulting to [`Verdict::Confirmed`] would let a panic or
+    /// an early return report a proof that never happened.
+    fn default() -> Self {
+        Self::Error
+    }
+}
+
+/// A running stopwatch for one phase.
+///
+/// Deliberately not a guard type: several phases below end at a `return`, and
+/// a `Drop`-based timer would have to guess which field it was filling.
+pub(crate) struct Phase(Instant);
+
+impl Phase {
+    pub(crate) fn start() -> Self {
+        Self(Instant::now())
+    }
+
+    /// Stop, and hand back what elapsed.
+    pub(crate) fn stop(self) -> Duration {
+        self.0.elapsed()
+    }
+}
+
+/// Every boundary one `verify_done` call has, in the order it crosses them.
+///
+/// All fields default to zero, which is also what a path that never reached
+/// them reports — a `not_done` verdict returns before any shadow exists, and
+/// a memo hit ([`crate::verify::ShadowMemo`], #2208) skips the four shadow
+/// phases outright. [`Self::shadow_reused`] and [`Self::verdict`] are what let
+/// a reader tell "this phase was free" from "this phase never ran", which a
+/// bare zero cannot.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Phases {
+    /// Argument validation, `root.canonicalize()`, `git rev-parse
+    /// --show-toplevel`, resolving every `test_files` entry, and `git
+    /// rev-parse HEAD`. Three of those are subprocesses, which is why this is
+    /// named rather than assumed negligible.
+    pub(crate) setup: Duration,
+    /// The prune-on-start that reclaims `.git/worktrees` registrations
+    /// stranded by a cancelled earlier run (#613).
+    pub(crate) prune: Duration,
+    /// [`crate::verify::resolve_witness_baseline`] — up to two `rev-parse`
+    /// calls and a `git log` walk past pipeline seal commits.
+    pub(crate) baseline: Duration,
+    /// Half 1: the witness command against the working tree.
+    pub(crate) working_tree_run: Duration,
+    /// `git worktree add --detach` — a full checkout of the baseline commit,
+    /// so its cost scales with the repository rather than with the diff.
+    pub(crate) worktree_add: Duration,
+    /// Copying the witness files into the shadow.
+    pub(crate) stage_tests: Duration,
+    /// Half 2: the witness command against the baseline.
+    pub(crate) shadow_run: Duration,
+    /// `git worktree remove --force`, `remove_dir_all`, and the trailing
+    /// `git worktree prune`.
+    pub(crate) cleanup: Duration,
+    /// The whole call, measured at `execute`'s entry and exit. The authority
+    /// for the total; the phases are a partition attempt, not a definition.
+    pub(crate) total: Duration,
+    /// Whether half 2 came from the turn-scoped memo instead of a fresh
+    /// shadow (#2208). When true the four shadow phases are legitimately
+    /// zero.
+    pub(crate) shadow_reused: bool,
+    /// How many witness files were staged — the copy loop's trip count, so a
+    /// slow [`Self::stage_tests`] can be read against its size.
+    pub(crate) test_files: u32,
+    /// How the call ended. Written once, at the single exit in
+    /// [`VerifyDone::execute`](crate::verify::VerifyDone).
+    pub(crate) verdict: Verdict,
+}
+
+impl Phases {
+    /// Everything that is not one of the two test runs: the quantity #2424
+    /// estimated as `verify_ms - 2 * half1_ms` and could only bound from
+    /// below. Here it is observed.
+    ///
+    /// Derived from [`Self::total`] rather than by summing the named phases,
+    /// so unattributed time counts as machinery instead of vanishing — an
+    /// optimisation must beat the honest number, not the flattering one.
+    /// Saturating because `total` is measured across the same span the two
+    /// runs sit inside and can only be shorter if a clock went backwards.
+    ///
+    /// Computed at full precision and truncated once, on the way into the
+    /// record. So a reader who instead subtracts the record's *millisecond*
+    /// fields — `total - working_tree_run - shadow_run` — can land up to 3ms
+    /// away, because truncation does not distribute over subtraction. That
+    /// gap is the field's resolution and nothing else; it is stated here
+    /// rather than hidden by re-rounding the parts to force the identity,
+    /// which would make the record self-consistent by making it less true.
+    pub(crate) fn machinery(&self) -> Duration {
+        self.total
+            .saturating_sub(self.working_tree_run)
+            .saturating_sub(self.shadow_run)
+    }
+
+    /// Emit this call's record.
+    ///
+    /// `Cx::EMPTY`: a [`Tool`](crate::registry::Tool) is handed an input and a
+    /// root and nothing else — no session, turn, or `call_id` — and §7.1
+    /// forbids reaching for an ambient one. The record is built to be read
+    /// without correlation for exactly this reason.
+    pub(crate) fn emit(&self, dx: &Dx) {
+        dx.emit_facet(self, module_path!(), Cx::EMPTY);
+    }
+}
+
+/// §5.1's per-crate facet: `stella-tools` owns this vocabulary, so it owns the
+/// rendering too and nobody edits a shared enum to add a phase.
+impl Facet for Phases {
+    fn code(&self) -> &'static str {
+        PHASES_CODE
+    }
+
+    /// `info`, not `debug`: `--log-file` floors at `info`, so an operator who
+    /// asked for a log file gets the measurement without also having to guess
+    /// a level. stderr stays at `warn`, so an ordinary run is unchanged.
+    fn level(&self) -> Level {
+        Level::Info
+    }
+
+    fn fields(&self) -> Fields {
+        Fields::new()
+            .with("verdict", self.verdict.as_str())
+            .with("shadow_reused", self.shadow_reused)
+            .with("test_files", self.test_files)
+            .with("setup", self.setup)
+            .with("prune", self.prune)
+            .with("baseline", self.baseline)
+            .with("working_tree_run", self.working_tree_run)
+            .with("worktree_add", self.worktree_add)
+            .with("stage_tests", self.stage_tests)
+            .with("shadow_run", self.shadow_run)
+            .with("cleanup", self.cleanup)
+            .with("machinery", self.machinery())
+            .with("total", self.total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use stella_diag::{FieldValue, Record};
+    use stella_protocol::tool::ToolOutput;
+
+    use super::*;
+    use crate::registry::Tool;
+    use crate::verify::{ShadowMemo, ShadowMemoHandle, VerifyDone};
+    // The git-repo fixture the tool's own tests already build — shared for the
+    // same reason `memo.rs` shares it.
+    use crate::verify::tests::scaffold;
+
+    fn uint(record: &Record, key: &str) -> u64 {
+        match record.fields.get(key) {
+            Some(FieldValue::Uint(value)) => *value,
+            other => panic!("field `{key}` is {other:?}, not a duration"),
+        }
+    }
+
+    fn text(record: &Record, key: &str) -> String {
+        match record.fields.get(key) {
+            Some(FieldValue::Str(value)) => value.as_str().to_string(),
+            other => panic!("field `{key}` is {other:?}, not a string"),
+        }
+    }
+
+    fn witness_input() -> serde_json::Value {
+        serde_json::json!({
+            "test_cmd": "bash witness.sh",
+            "test_files": ["witness.sh"],
+            "timeout_secs": 60
+        })
+    }
+
+    /// #2486 witness: a real call leaves a per-phase record behind.
+    ///
+    /// Fails on `main`, where a `verify_done` call reports one number — the
+    /// registry's `duration_ms` for the whole thing — and the 1.5s median /
+    /// 11.1s p90 of machinery inside it could only be reached by subtracting
+    /// a proxy measured somewhere else in the trial (#2424).
+    ///
+    /// The assertions are identities, not thresholds: a wall clock is the one
+    /// thing a test must never assert a bound on, and the point here is that
+    /// the phases are *reported*, not that this machine is slow.
+    #[tokio::test]
+    async fn a_call_reports_every_phase_it_crossed() {
+        let root = scaffold("phases_report").await;
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
+
+        let (dx, records) = Dx::capturing();
+        let tool = VerifyDone::new(Arc::default(), Some(Arc::new(dx)));
+        let out = tool.execute(&witness_input(), &root).await;
+        assert!(
+            matches!(&out, ToolOutput::Ok { content } if content.contains("WITNESS CONFIRMED")),
+            "{out:?}"
+        );
+
+        let record = records.find(PHASES_CODE).expect("one record per call");
+        assert_eq!(text(&record, "verdict"), "confirmed");
+        assert_eq!(uint(&record, "test_files"), 1);
+        assert_eq!(
+            record.fields.get("shadow_reused"),
+            Some(&FieldValue::Bool(false)),
+            "this call built its own shadow"
+        );
+
+        // The whole call contains both runs, and machinery is exactly what is
+        // left over — the quantity #2424 could only bound from below.
+        let total = uint(&record, "total");
+        let half_one = uint(&record, "working_tree_run");
+        let half_two = uint(&record, "shadow_run");
+        assert!(total > 0, "a call that ran two commands took some time");
+        assert!(
+            total >= half_one + half_two,
+            "total {total}ms cannot be under its two runs ({half_one}ms + {half_two}ms)"
+        );
+        // Not an equality: `machinery` is subtracted at full precision and
+        // truncated once, while this recomputes it from three already-
+        // truncated fields. Each truncation loses under a millisecond, so the
+        // two can disagree by up to 3 — see [`Phases::machinery`].
+        let machinery = uint(&record, "machinery");
+        assert!(
+            machinery.abs_diff(total - half_one - half_two) <= 3,
+            "machinery {machinery}ms is not the leftover of {total} - {half_one} - {half_two}"
+        );
+
+        // Every phase boundary the issue names is present, so an attribution
+        // never has to fall back to subtraction again.
+        for phase in [
+            "setup",
+            "prune",
+            "baseline",
+            "worktree_add",
+            "stage_tests",
+            "cleanup",
+        ] {
+            assert!(
+                record.fields.get(phase).is_some(),
+                "phase `{phase}` was not reported"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A memo hit (#2208) legitimately reports zero for all four shadow
+    /// phases. `shadow_reused` is what tells a census that those zeroes mean
+    /// "free", not "never measured" — without it the second call would drag
+    /// every machinery percentile down while looking exactly like a fast one.
+    #[tokio::test]
+    async fn a_memo_hit_reports_zero_shadow_phases_and_says_why() {
+        let root = scaffold("phases_memo").await;
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
+
+        let (dx, records) = Dx::capturing();
+        let memo: ShadowMemoHandle = Arc::new(ShadowMemo::default());
+        memo.arm();
+        let tool = VerifyDone::new(memo, Some(Arc::new(dx)));
+
+        assert!(!tool.execute(&witness_input(), &root).await.is_error());
+        assert!(!tool.execute(&witness_input(), &root).await.is_error());
+
+        let all = records.records();
+        let hits: Vec<_> = all
+            .iter()
+            .filter(|record| record.code.as_str() == PHASES_CODE)
+            .collect();
+        assert_eq!(hits.len(), 2, "one record per call, hit or miss");
+
+        assert_eq!(hits[0].fields.get("shadow_reused"), Some(&FieldValue::Bool(false)));
+        assert_eq!(hits[1].fields.get("shadow_reused"), Some(&FieldValue::Bool(true)));
+        for phase in ["worktree_add", "stage_tests", "shadow_run", "cleanup"] {
+            assert_eq!(
+                uint(hits[1], phase),
+                0,
+                "a reused observation ran no `{phase}`"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The record's code is what a census greps for, and the field names are
+    /// what it reads. Both are load-bearing for #2486's definition of done, so
+    /// they are pinned here rather than left to the emit site.
+    #[test]
+    fn the_record_names_every_phase() {
+        let (dx, records) = Dx::capturing();
+        Phases {
+            total: Duration::from_millis(900),
+            working_tree_run: Duration::from_millis(100),
+            shadow_run: Duration::from_millis(200),
+            verdict: Verdict::Confirmed,
+            ..Phases::default()
+        }
+        .emit(&dx);
+
+        let record = records.find(PHASES_CODE).expect("a record per call");
+        for field in [
+            "setup",
+            "prune",
+            "baseline",
+            "working_tree_run",
+            "worktree_add",
+            "stage_tests",
+            "shadow_run",
+            "cleanup",
+            "machinery",
+            "total",
+        ] {
+            assert!(
+                record.fields.get(field).is_some(),
+                "phase `{field}` missing from the record"
+            );
+        }
+        assert_eq!(
+            record.fields.get("verdict"),
+            Some(&stella_diag::FieldValue::Str(
+                stella_diag::StaticStr::new("confirmed")
+            ))
+        );
+    }
+
+    /// Machinery is the total minus the two runs — including any time the
+    /// named phases do not account for. Summing the named phases instead
+    /// would let unattributed time disappear, which is the direction that
+    /// flatters us.
+    #[test]
+    fn machinery_is_the_total_minus_both_runs_including_unattributed_time() {
+        let phases = Phases {
+            total: Duration::from_millis(1_000),
+            working_tree_run: Duration::from_millis(100),
+            shadow_run: Duration::from_millis(200),
+            // Deliberately less than the 700ms that remains: the rest is
+            // unattributed and must still count as machinery.
+            worktree_add: Duration::from_millis(50),
+            ..Phases::default()
+        };
+        assert_eq!(phases.machinery(), Duration::from_millis(700));
+    }
+
+    /// A clock that goes backwards must not panic — invariant #5 covers
+    /// arithmetic on runtime measurements too.
+    #[test]
+    fn machinery_saturates_rather_than_underflowing() {
+        let phases = Phases {
+            total: Duration::from_millis(1),
+            working_tree_run: Duration::from_millis(500),
+            shadow_run: Duration::from_millis(500),
+            ..Phases::default()
+        };
+        assert_eq!(phases.machinery(), Duration::ZERO);
+    }
+}

--- a/crates/stella-tools/src/verify/phases.rs
+++ b/crates/stella-tools/src/verify/phases.rs
@@ -349,6 +349,41 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// The last link in the chain: a handle put in
+    /// [`RegistryOptions`](crate::RegistryOptions) has to reach the tool.
+    ///
+    /// Everything else here builds a `VerifyDone` by hand, so a registry that
+    /// dropped the handle between `builtins` and the constructor would pass
+    /// every one of those tests and still record nothing in a real session —
+    /// the failure this whole change exists to prevent, and the one with no
+    /// symptom until someone goes looking for a measurement that was never
+    /// taken.
+    #[tokio::test]
+    async fn the_registry_hands_the_handle_to_the_tool() {
+        let root = scaffold("phases_wiring").await;
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        std::fs::write(root.join("witness.sh"), "grep -q 'new behavior' impl.txt\n").unwrap();
+
+        let (dx, records) = Dx::capturing();
+        let registry = crate::ToolRegistry::with_backends_and_options(
+            root.clone(),
+            None,
+            None,
+            crate::RegistryOptions {
+                diagnostics: Some(Arc::new(dx)),
+                ..Default::default()
+            },
+        );
+        let out = registry.execute("verify_done", &witness_input()).await;
+        assert!(!out.is_error(), "{out:?}");
+        assert!(
+            records.find(PHASES_CODE).is_some(),
+            "the registry built the tool without its diagnostic handle"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     /// A memo hit (#2208) legitimately reports zero for all four shadow
     /// phases. `shadow_reused` is what tells a census that those zeroes mean
     /// "free", not "never measured" — without it the second call would drag
@@ -374,8 +409,14 @@ mod tests {
             .collect();
         assert_eq!(hits.len(), 2, "one record per call, hit or miss");
 
-        assert_eq!(hits[0].fields.get("shadow_reused"), Some(&FieldValue::Bool(false)));
-        assert_eq!(hits[1].fields.get("shadow_reused"), Some(&FieldValue::Bool(true)));
+        assert_eq!(
+            hits[0].fields.get("shadow_reused"),
+            Some(&FieldValue::Bool(false))
+        );
+        assert_eq!(
+            hits[1].fields.get("shadow_reused"),
+            Some(&FieldValue::Bool(true))
+        );
         for phase in ["worktree_add", "stage_tests", "shadow_run", "cleanup"] {
             assert_eq!(
                 uint(hits[1], phase),
@@ -422,9 +463,9 @@ mod tests {
         }
         assert_eq!(
             record.fields.get("verdict"),
-            Some(&stella_diag::FieldValue::Str(
-                stella_diag::StaticStr::new("confirmed")
-            ))
+            Some(&stella_diag::FieldValue::Str(stella_diag::StaticStr::new(
+                "confirmed"
+            )))
         );
     }
 


### PR DESCRIPTION
## What & why

#2486 asked for a measurement before an optimisation, because the previous
guess (#2424's "half 1 must be significant") did not survive contact with
data. `verify_done` now times every boundary one call crosses and reports
them as a single diagnostic record, so the 1.5s median / 11.1s p90 of
"machinery" can be attributed to a **named phase** instead of inferred by
subtracting a proxy measured elsewhere in the trial.

**It already answered the question.** One call against this repository, warm,
with a trivial shell witness so both test runs are near-zero:

| phase | ms | share |
|---|---|---|
| `worktree_add` | **368** | **65%** |
| `cleanup` | **108** | **19%** |
| `baseline` | 37 | 7% |
| `prune` | 23 | 4% |
| `setup` | 11 | 2% |
| `working_tree_run` + `shadow_run` | 11 | 2% |
| **`machinery`** | **550** | **98%** |
| `total` | 562 | |

The shadow worktree's create and destroy are 85% of the call. That is one
warm reading on one repository, not a distribution — enough to pick a
direction, not enough to claim a p90 win, which is why the optimisation is
#2505 and not this PR.

## The design decision worth reviewing

**The timings deliberately do not ride `ToolOutput`.**

That is a tool's only channel into `stella-events.jsonl`, so it is the
obvious place to put them, and it is a trap: `stella-core`'s loop detector
keys on that value. `LoopDetectionConfig::exact_repeat_threshold` counts
consecutive identical *(name + input + output)* calls, and the stagnation
rung counts consecutive byte-identical outputs from one tool. A wall clock
in the verdict never repeats, so **both rungs would go permanently blind for
`verify_done`** — the tool an agent stuck in a prove-it loop calls over and
over. `ci.rs`'s probe path already carries this scar tissue for the same
reason ("deliberately free of run names, elapsed times, or counts").

So the record goes to the diagnostic plane, which is where
`docs/spec/diagnostics.md` §2.1's routing rule sends it anyway (it explains
*why the program behaved this way*), and which neither the model nor the
detector ever sees.

**Exemplar followed:** `stella-diag`'s own `Facet` pattern (§5.1 — "the crate
that owns the vocabulary owns the rendering too"), which is how
`stella-cli::diag_bridge` emits, and `VerifyDone`'s existing
`ShadowMemoHandle` for how a tool is handed a host-owned collaborator without
touching the `Tool` trait.

## Shape

- `crates/stella-tools/src/verify/phases.rs` (new) — `Phases`, the closed
  `Verdict` vocabulary, and the `Facet` impl. A sibling submodule because
  `verify.rs` is at 1449 of its 1500-line ceiling.
- `crates/stella-tools/src/verify.rs` — `execute` became a thin wrapper with
  one exit that stamps `total` and emits; the body moved to a private
  `verify` returning `Result<(ToolOutput, Verdict), String>`. The `Err` arm
  carries the named refusals, which reach the model exactly as before. This
  also gave the copy loop a single exit (`stage_witness_files`), which is
  what makes it timeable as one phase.
- `RegistryOptions::diagnostics` — the crate's seam for the diagnostic plane,
  wired once in `stella-cli`'s `registry_options()`, the single place every
  session lane (interactive, pipeline, deck, sub-session workers) builds from.
  Deliberately **not** a post-construction setter beside `attach_events`:
  that has ten call sites and forgetting one fails silently by recording
  nothing.

## New dependency

`stella-tools` gains `stella-diag`. It is a leaf crate by construction
(`serde` only), which AGENTS.md's crate table states explicitly — "anything
may depend on it" — so this adds no cycle. It is the only way to reach the
diagnostic plane, and the reason it must be reached is the loop-detector
argument above.

## Correctness

Every field on the record is a number, a bool, or a `&'static str` from a
closed set, so §5.2's "content in a log does not compile" holds by
construction: invariant 3 is not at risk even though the subject is a
path-bearing operation.

**Measured honestly, in two places it would have been easy not to:**

- `machinery` is derived from `total` minus the two runs, **not** by summing
  the named phases — so unattributed time counts as machinery rather than
  vanishing. An optimisation has to beat the honest number.
- The record is emitted on **every** verdict including the refusals. Emitting
  only calls that got far enough to be slow would censor the fast end and
  flatter every percentile the issue exists to measure. `verdict` and
  `shadow_reused` are what let a census exclude them on purpose — a memo hit
  (#2208) legitimately reports zero for all four shadow phases, and a bare
  zero cannot say whether a phase was free or never ran.
- `machinery` is truncated to milliseconds once, at full precision, so a
  reader subtracting the record's *millisecond* fields can land up to 3ms
  away. That is stated in the doc comment and asserted as a tolerance rather
  than hidden by re-rounding the parts to force the identity — which would
  have made the record self-consistent by making it less true.

## Witness

`verify::phases::tests::a_call_reports_every_phase_it_crossed` — a real
`verify_done` call, asserting the record exists and carries every boundary
#2486 names. Fails on `main`, where a call reports one number for the whole
thing and there is no record at all.

Three more cover the parts a single witness would not:

- `the_registry_hands_the_handle_to_the_tool` — the last link. Every other
  test builds a `VerifyDone` by hand, so a registry that dropped the handle
  would pass all of them and still record nothing in a real session.
- `a_memo_hit_reports_zero_shadow_phases_and_says_why` — the four zeroes a
  #2208 hit produces, and the flag that makes them readable.
- `registry_options_carry_the_diagnostic_handle` (stella-cli) — guards the
  one line whose absence nothing else notices: no build breaks, no verdict
  changes, and the only symptom is an empty census months later.

The assertions are identities, never thresholds — a test must not assert a
bound on a wall clock.

**No tests were deleted.**

## Verified

- `cargo test -p stella-tools` — 767 + 46 pass, 0 fail
- `cargo test -p stella-cli` — 1601 + 59 pass, 0 fail
- `cargo clippy -p stella-tools -p stella-cli --all-targets -- -D warnings` — clean
- `cargo check --workspace --all-targets` — clean (a new `RegistryOptions`
  field can break struct literals elsewhere; nothing constructs it without
  `..Default::default()`)
- `make guards-fast` — all guards pass. `check-file-size` reports inherited
  drift on six `bench/` Python files that were already over the line in the
  base tree; per AGENTS.md that is their own change's problem, landed on its
  own from a fresh main, and is deliberately not folded in here.

## Left behind — filed, not fixed

Stated out loud per CLAUDE.md, because two of these are gaps in what this PR
delivers rather than unrelated finds:

- **#2505** — the optimisation the measurement now points at (`worktree_add`
  + `cleanup` = 85%), with candidate directions and the hazard each carries.
  The before/after is a census of the fields this PR adds.
- **#2506** — **the honest limit of this PR.** The harbor adapter asks for no
  `--log-file`, so these records reach a developer's machine but *not* an
  arena match archive — the exact population #2486's numbers came from.
  Closing that means editing the adapter's argv, its source hashing, and two
  large Python test suites in a security-sensitive launcher, which is a
  bigger change than this one and belongs on its own.
- **#2507** — `docs/spec/diagnostics.md` §11 specifies a generated
  `docs/reference/diagnostics.md` and a `check-diagnostic-codes.sh` gate.
  Neither exists, so every diagnostic code in the tree is undocumented
  public surface. Noticed because there was nowhere to register the new one;
  it is listed in `crates/stella-tools/README.md` instead, as a stopgap the
  issue names.

Closes #2486

## Summary by Sourcery

Add per-phase wall-clock measurement and diagnostic reporting for verify_done calls without affecting tool outputs or loop detection, and wire the diagnostic handle through the registry and CLI so these measurements are recorded in real sessions.

New Features:
- Introduce a Phases diagnostic record for verify_done that captures per-phase timings, verdict, memo reuse, and test file count for each call.
- Add support for emitting verify_done phase diagnostics via the stella-diag crate into the diagnostic plane, separate from ToolOutput.

Enhancements:
- Refactor VerifyDone.execute into a thinner wrapper around a new verify function that returns both ToolOutput and a structured Verdict, enabling accurate diagnostic tagging.
- Extend RegistryOptions with a diagnostics handle and propagate it into builtin tool construction so built-in tools can emit diagnostics consistently.

Build:
- Declare stella-diag as a dependency of stella-tools to support diagnostic emission from verify_done.

Documentation:
- Document in stella-tools README that tool timings must not be placed in ToolOutput and reference the new verify_done phases diagnostic and its routing via RegistryOptions::diagnostics.

Tests:
- Add tests that verify per-phase diagnostics are emitted for real verify_done calls, including memo-hit behavior with zero-cost shadow phases and correct wiring from ToolRegistry.
- Add a CLI test ensuring registry_options always carry a diagnostic handle so verify_done phase measurements are not silently dropped.