### PR TITLE
feat(arenabench): measure the opponent's harness live, and record which product it was

### DIFF
--- a/arenabench/README.md
+++ b/arenabench/README.md
@@ -164,6 +164,7 @@ agent = "stella"
 id = "claude-code"
 name = "Claude Code"
 agent = "claude-code"
+agent_version = "2.1.226"                  # pin the opponent's release too
 
   [contestant.engine]
   api = "openrouter"
@@ -189,6 +190,12 @@ spelling still loads.
 routes that seat there — Claude Code reads `ANTHROPIC_BASE_URL`, and because
 OpenRouter serves an Anthropic-shaped `/v1/messages`, both arms above hit one
 endpoint with one key. Same provider, same quota, no routing confound.
+
+**`agent_version` is the `sut_ref` of the other side.** Without it, Harbor
+installs that CLI fresh per container from its vendor's script and the match
+races whatever shipped that hour — see
+[Which product did you actually race](#which-product-did-you-actually-race).
+It is refused on a `stella` seat, which is pinned by commit instead.
 
 ---
 
@@ -439,6 +446,105 @@ scoring it 0 would move the flip earlier than the truth.
 
 Capture is off by default and degrades to nothing — no Docker, or no `git` in
 the task image, yields a run with no snapshots and a warning.
+
+---
+
+## Which product did you actually race
+
+The system under test was always pinned — `sut_ref` names the Stella commit, and
+provenance records the binary's hash. The **opponent** was not, and an opponent
+ships most days.
+
+Harbor installs a self-installing CLI fresh in every task container, from the
+vendor's own script, with no version pin. So a match races whatever that vendor
+published that hour. The local archive shows what that costs: Claude Code arms
+spanning **eight product versions** with nothing recording any of them, and one
+match that ran **two versions inside a single arm** — a release landed between
+two of its trials, so half its tasks were graded against a product the other
+half never saw. That arm's solve rate is a blend of two agents, and nothing on
+the scoreboard could say so.
+
+Pin the seat:
+
+```toml
+[[contestant]]
+name = "Claude Code"
+agent = "claude-code"
+agent_version = "2.1.226"     # the sut_ref of the other side
+```
+
+Then check what the whole archive actually ran:
+
+```bash
+arenabench provenance
+# 2 arm(s) ran more than one product version:
+#   f23fbcd61adc   claude-code    2.1.223 + 2.1.224
+# Such an arm's numbers are a blend of those releases, not a measurement of
+# any one of them.
+```
+
+The product version joins the dataset digest and the Harbor version in a
+match's **comparability key**, so two arms four releases apart no longer group
+into one series and read their difference as noise.
+
+**A pin is checked, not believed.** It is an instruction to an installer, and an
+installer can fall back, resolve a range, or serve a cached build. After the
+trials, provenance compares the pin against what ran and reports a
+`violated_pin` rather than quietly resolving it — the key then names what ran,
+never what was asked for. A pin believed without checking is worth less than no
+pin, because the belief is what makes the comparison quotable.
+
+Versions are recovered for **matches that already ran**, too: ATIF has carried
+`agent.version` all along and nothing read it. `arenabench provenance --migrate`
+labels the existing archive.
+
+---
+
+## How the other harness spends its turn
+
+A solve rate cannot tell you that two arms tied at 5/8 got there differently.
+`arenabench harness <match>` reads what each agent's own harness disclosed and
+how it behaved:
+
+```bash
+arenabench harness b952369cafd8
+# === b952369cafd8-claude-code-opus-5-xhigh  (6 trials)
+#   product        2.1.226
+#   model          claude-opus-5
+#   permission     bypassPermissions
+#   credential     none
+#   tools offered  25  (Task, Bash, Edit, Read, Skill, Write, …)
+#   subagents      claude, Explore, general-purpose, Plan, statusline-setup
+#   turns          134 model steps, 176 tool calls, 5 of them errors
+#   tool mix       Bashx167 (2549s), Readx5 (2s), Writex4 (1s)
+#   clock          1688s wall, 956s in provider calls, 2553s in tools
+```
+
+167 of 176 tool calls being `Bash` is a fact about that harness, not about the
+model — and it is the sort of fact a head-to-head is supposed to surface.
+
+**Where this comes from, and why not hooks.** Claude Code can be instrumented
+with `PreToolUse`/`PostToolUse` hooks written into `$CLAUDE_CONFIG_DIR`, which
+Harbor points at `/logs/agent/sessions`. That was the obvious design and it is
+the wrong one: a hook is a process spawn on the critical path of the arm whose
+numbers are the bar. Perturbing the reference to observe it buys a worse
+measurement than the one already on disk — Harbor tees the CLI's
+`--output-format=stream-json` to `agent/claude-code.txt` as the agent works, and
+only one field of it was ever read.
+
+So the instrument costs the measured arm nothing, is **live** (the arm used to
+report 0 steps, 0 tools, 0 tokens and $0 for the whole length of a match, and
+only became real at teardown), and works on every archived match.
+
+Two details that would otherwise produce plausible wrong numbers:
+
+- The stream **re-emits a message once per content block**, so a naive sum over
+  events overstates output tokens by 1.76× and steps by 2.4× on measured data.
+  Usage is credited per message id, as a delta, so the incremental reader agrees
+  with a one-shot one.
+- A seat routed through `ANTHROPIC_BASE_URL` to a non-Anthropic gateway streams
+  **zeroed** usage counters while its transcript carries the real figures. That
+  is reported as "the stream said nothing", never as a free trial.
 
 ---
 

--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -379,6 +379,124 @@ def _cmd_datasets(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_harness(args: argparse.Namespace) -> int:
+    """What each arm's harness disclosed, and how it spent its turn.
+
+    The half of a head-to-head that a solve rate cannot express. Two agents at
+    5/8 that reached it with 22 shell calls and with 7 reads plus an edit did
+    not do the same thing, and neither did two arms whose tool rosters, memory
+    files or permission modes differed while a match description said they were
+    "the same configuration". This prints the evidence rather than the claim.
+
+    Reads only artifacts, like everything else here, so it works the same on a
+    live match and on an archive — and running it cannot perturb what it reads.
+    """
+    from .harness import STREAM_NAME, HarnessProfile, StreamReader
+
+    match_dir = Path(args.workspace).expanduser() / "matches" / args.match
+    if not match_dir.is_dir():
+        print(f"no such match: {match_dir}")
+        return 1
+
+    reader = StreamReader()
+    #: seat → (profile, summed behaviour across its trials, trial count)
+    seats: dict[str, tuple[HarnessProfile, dict, int]] = {}
+    for job_dir in sorted((match_dir / "jobs").glob("*")):
+        if not job_dir.is_dir():
+            continue
+        for trial_dir in sorted(job_dir.glob("*")):
+            read = reader.read(trial_dir / STREAM_NAME)
+            if read is None:
+                continue
+            profile, totals = read
+            name = job_dir.name
+            _, summed, count = seats.get(name, (profile, {}, 0))
+            payload = totals.to_json()
+            for key, value in payload.items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    summed[key] = summed.get(key, 0) + value
+                elif isinstance(value, dict):
+                    bucket = summed.setdefault(key, {})
+                    for tool, n in value.items():
+                        bucket[tool] = bucket.get(tool, 0) + n
+            seats[name] = (profile, summed, count + 1)
+
+    if not seats:
+        print(
+            f"{args.match}: no arm published a harness stream.\n"
+            "Only agents run through a stream-json CLI do — today that is the "
+            "Claude Code seat. A Stella arm's equivalent is its own event "
+            "stream; see `arenabench transcript`."
+        )
+        return 0
+
+    for name, (profile, totals, trials) in seats.items():
+        print(f"\n=== {name}  ({trials} trial{'s' if trials != 1 else ''})")
+        print(f"  product        {profile.version or '?'}")
+        print(f"  model          {profile.model or '?'}")
+        print(f"  permission     {profile.permission_mode or '?'}")
+        print(f"  credential     {profile.api_key_source or '?'}")
+        print(f"  tools offered  {len(profile.tools)}  ({', '.join(profile.tools)})")
+        if profile.mcp_servers:
+            print(f"  mcp servers    {', '.join(profile.mcp_servers)}")
+        if profile.skills:
+            print(f"  skills         {len(profile.skills)}")
+        if profile.subagents:
+            print(f"  subagents      {', '.join(profile.subagents)}")
+        calls = totals.get("tool_calls") or {}
+        elapsed = totals.get("tool_ms") or {}
+        print(
+            f"  turns          {totals.get('steps', 0)} model steps, "
+            f"{totals.get('tools', 0)} tool calls, "
+            f"{totals.get('tool_errors', 0)} of them errors"
+        )
+        if calls:
+            print("  tool mix       " + ", ".join(
+                f"{tool}x{n}"
+                + (f" ({elapsed[tool] / 1000:.0f}s)" if tool in elapsed else "")
+                for tool, n in sorted(calls.items(), key=lambda kv: -kv[1])
+            ))
+        counted = totals.get("tokens_out", 0) or totals.get("prompt_tokens", 0)
+        if counted:
+            print(
+                f"  spend          {totals.get('tokens_out', 0)} out, "
+                f"{totals.get('prompt_tokens', 0)} in "
+                f"({totals.get('cache_read', 0)} from cache), "
+                f"{totals.get('thinking_tokens', 0)} reasoning (est.), "
+                f"${totals.get('total_cost', 0.0):.4f} self-reported"
+            )
+        else:
+            # Zeroed usage on the wire is a real, route-dependent thing: a seat
+            # pointed at a non-Anthropic endpoint through ANTHROPIC_BASE_URL
+            # gets `{"input_tokens": 0, "output_tokens": 0}` on every streamed
+            # message while the session transcript carries the true figures. It
+            # is not "this trial was free", and printing a 0 beside a nonzero
+            # cost would read as exactly that.
+            print(
+                f"  spend          stream reported no usage "
+                f"(gateway route); {totals.get('thinking_tokens', 0)} reasoning "
+                f"(est.), ${totals.get('total_cost', 0.0):.4f} self-reported"
+            )
+            print(
+                "                 token counts for this arm come from the ATIF "
+                "trajectory instead — see `arenabench series`"
+            )
+        print(
+            f"  clock          {totals.get('duration_ms', 0) / 1000:.0f}s wall, "
+            f"{totals.get('api_ms', 0) / 1000:.0f}s in provider calls, "
+            f"{totals.get('tool_wall_ms', 0) / 1000:.0f}s in tools"
+        )
+        # Deliberately not subtracted into an "overhead" figure: Harbor runs
+        # this CLI with background tasks forced on, so tools and provider calls
+        # overlap and the difference goes negative on real trials.
+    print(
+        "\nCost is the agent's own figure and is never compared across seats — "
+        "each vendor prices from its own table. `arenabench series` recomputes "
+        "both arms at one rate."
+    )
+    return 0
+
+
 def _cmd_provenance(args: argparse.Namespace) -> int:
     """Show — and with ``--migrate``, backfill — what each match was measured with.
 
@@ -395,6 +513,8 @@ def _cmd_provenance(args: argparse.Namespace) -> int:
 
     rows: list[tuple[str, str, str]] = []
     backfilled = 0
+    blended: list[tuple[str, str, list[str]]] = []
+    violated: list[tuple[str, str, list[str]]] = []
     for match_dir in sorted(p for p in root.iterdir() if p.is_dir()):
         record = provenance.read_match(match_dir)
         state = "recorded"
@@ -412,6 +532,22 @@ def _cmd_provenance(args: argparse.Namespace) -> int:
             record = rebuilt
         elif record.source == provenance.SOURCE_BACKFILLED:
             state = "backfilled"
+        elif args.migrate:
+            # A recorded match still learns its opponent's version late: the
+            # trials had not run when the record was written.
+            stamped = provenance.stamp_agent_versions(match_dir)
+            if stamped is not None:
+                record = stamped
+        for seat_id in record.mixed_version_seats:
+            blended.append(
+                (
+                    match_dir.name,
+                    seat_id,
+                    [str(v) for v in record.agent_seats[seat_id].get("versions") or []],
+                )
+            )
+        for seat_id, ran in record.violated_pins.items():
+            violated.append((match_dir.name, seat_id, ran))
         rows.append((match_dir.name, record.comparability_key, state))
 
     width = max((len(key) for _, key, _ in rows), default=20)
@@ -432,6 +568,25 @@ def _cmd_provenance(args: argparse.Namespace) -> int:
             count = sum(1 for _, k, _ in rows if k == key)
             print(f"  {count:>3}  {key}")
         print("Numbers from different keys are different experiments. Label, never sum.")
+
+    # Louder than the key listing, because a blended arm is not a different
+    # experiment sitting tidily beside the others — it is one number that is
+    # secretly two, inside a single match nobody has any reason to distrust.
+    if blended:
+        print(f"\n{len(blended)} arm(s) ran more than one product version:")
+        for match_name, seat_id, versions in blended:
+            print(f"  {match_name:14} {seat_id:<28} {' + '.join(versions)}")
+        print(
+            "Such an arm's numbers are a blend of those releases, not a "
+            "measurement of any one of them. Pin the seat's `agent_version` "
+            "to make the next run comparable."
+        )
+    if violated:
+        print(f"\n{len(violated)} pinned arm(s) ran something else:")
+        for match_name, seat_id, ran in violated:
+            print(f"  {match_name:14} {seat_id:<28} actually ran {', '.join(ran)}")
+        print("The installer did not honour the pin; the key names what ran.")
+
     if args.migrate and backfilled:
         print(f"\nbackfilled {backfilled} match(es).")
     elif not args.migrate and any(state == "would backfill" for _, _, state in rows):
@@ -905,6 +1060,14 @@ def main(argv: list[str] | None = None) -> int:
 
     datasets_parser = subparsers.add_parser("datasets", help="list registered datasets")
     datasets_parser.set_defaults(func=_cmd_datasets)
+
+    harness_parser = subparsers.add_parser(
+        "harness",
+        help="what each arm's harness disclosed, and how it spent its turn",
+    )
+    harness_parser.add_argument("match", help="match id under <workspace>/matches")
+    harness_parser.add_argument("--workspace", default=str(default_workspace()))
+    harness_parser.set_defaults(func=_cmd_harness)
 
     provenance_parser = subparsers.add_parser(
         "provenance",

--- a/arenabench/arenabench/harness.py
+++ b/arenabench/arenabench/harness.py
@@ -1,0 +1,575 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Reading a third-party agent's own harness while it runs.
+
+Stella publishes ``agent/stella-events.jsonl`` per event, so every number on
+the scoreboard is current for a Stella arm and stale for nobody. Its opponents
+publish ATIF — ``agent/trajectory.json`` — which is written **once, at the
+end**. The consequence was that a Claude Code arm read zero steps, zero tools,
+zero tokens and zero cost for the entire length of a match, and only became
+real at teardown. :func:`arenabench.telemetry._liveness_age` made it look alive
+throughout, because file mtimes moved; nothing measured it.
+
+The fix needed no new instrumentation. Harbor runs Claude Code with
+``--verbose --output-format=stream-json`` and tees stdout to
+``/logs/agent/claude-code.txt``, which lands in the trial directory and is
+appended **as the agent works**. That file has always carried more than ATIF
+ever exposed, and only one field of it was ever read (Harbor's own parser digs
+out ``total_cost_usd`` after the run). This module reads the rest.
+
+# Why not hooks
+
+Claude Code can be instrumented properly, with ``PreToolUse``/``PostToolUse``
+hooks written into ``$CLAUDE_CONFIG_DIR/settings.json`` — which Harbor points
+at ``/logs/agent/sessions``, so the seam is available. That was the obvious
+design and it is the wrong one for the *measured* arm: a hook is a process
+spawn on the agent's critical path, twice per tool call, in the arm whose
+numbers are the bar everything else is compared against. Perturbing the
+reference to observe it buys a worse measurement than the one already sitting
+on disk.
+
+So the stream is the instrument, and it costs the arm nothing. Hooks remain the
+right answer for the two behaviours the stream genuinely cannot show —
+compaction and permission prompts — and belong behind an explicit opt-in that
+is recorded in provenance, because an instrumented arm is a different apparatus
+from an uninstrumented one and the two must never average together.
+
+# What the stream says
+
+``system`` / ``subtype: init``
+    The harness describing itself at boot: product version, model, the tool
+    roster it will choose from, permission mode, credential source, MCP
+    servers, skills, subagents. This is the half of a head-to-head that is
+    normally argued about from documentation rather than from evidence.
+``assistant``
+    One model turn: ``message.usage`` (tokens and cache, both directions) and
+    ``message.content`` split into ``thinking`` / ``text`` / ``tool_use``.
+``user``
+    Tool outcomes, as ``tool_result`` blocks plus a ``tool_use_result``
+    payload. Joined to the ``tool_use`` that requested them by id, which is
+    what turns two timestamps into a tool's wall clock.
+``system`` / ``subtype: thinking_tokens``
+    A cumulative reasoning-token estimate, emitted continuously — 38,389 lines
+    in one 7.8 MB trial, roughly 99% of the file by count. Only the last one
+    matters, so the drain recognises them without parsing them.
+``result``
+    The final word: cost, turn count, stop reason, permission denials, and
+    whether the run ended in an API error.
+
+# Cursors, not re-reads
+
+The file is append-only and reaches tens of megabytes, so a live dashboard
+cannot re-parse it per poll. :class:`StreamReader` keeps a byte offset and a
+running :class:`HarnessTotals` per path and parses only what arrived since last
+time. A torn final line — guaranteed, since the file is being written while it
+is read — is left unconsumed rather than skipped, so the event it belongs to is
+counted exactly once when the rest of it lands.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "STREAM_NAME",
+    "HarnessProfile",
+    "HarnessTotals",
+    "StreamReader",
+    "reduce_stream",
+]
+
+#: Where Harbor tees the Claude Code CLI's stream-json stdout, relative to a
+#: trial directory. Named here, beside the only reader of it, for the same
+#: reason :func:`arenabench.telemetry.seat_manifest_path` is.
+STREAM_NAME = "agent/claude-code.txt"
+
+#: Substring that identifies the continuous reasoning-token estimate without
+#: parsing the line. These are ~99% of the stream by count and each one
+#: supersedes the last, so the drain keeps only the most recent and parses it
+#: alone. Matched on the raw text because `json.loads` on 38k lines per poll is
+#: the entire cost of reading the file.
+_THINKING_MARK = '"thinking_tokens"'
+
+#: Content-block types that mean the model asked for a tool.
+_TOOL_USE = "tool_use"
+
+
+@dataclass
+class HarnessProfile:
+    """What an agent's harness disclosed about itself at boot.
+
+    Every field is what the agent *said*, never what ArenaBench configured —
+    which is the point. A seat's declared posture and the harness's own account
+    of its wiring are two statements that can disagree, and only one of them
+    was on the wire. ``permission_mode`` and ``api_key_source`` have each been
+    the explanation for a whole arm's result: a Claude Code seat booting with
+    ``apiKeySource: none`` fails every trial with an authentication error that
+    scores as a loss (:func:`arenabench.agents.dead_seat_reason`), and this is
+    where that would have been visible on trial one instead of at the post-mortem.
+    """
+
+    version: str = ""
+    model: str = ""
+    permission_mode: str = ""
+    api_key_source: str = ""
+    output_style: str = ""
+    cwd: str = ""
+    #: The tool roster the harness offered the model. A head-to-head between
+    #: two agents with different tool surfaces is a different comparison from
+    #: one between two agents with the same surface, and until this was read
+    #: nothing recorded which of the two a match had been.
+    tools: tuple[str, ...] = ()
+    mcp_servers: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    subagents: tuple[str, ...] = ()
+    slash_commands: int = 0
+    session_id: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "model": self.model,
+            "permission_mode": self.permission_mode,
+            "api_key_source": self.api_key_source,
+            "output_style": self.output_style,
+            "cwd": self.cwd,
+            "tools": list(self.tools),
+            "mcp_servers": list(self.mcp_servers),
+            "skills": list(self.skills),
+            "subagents": list(self.subagents),
+            "slash_commands": self.slash_commands,
+            "session_id": self.session_id,
+        }
+
+
+@dataclass
+class HarnessTotals:
+    """One trial's stream, folded to the dimensions a scoreboard compares.
+
+    Deliberately the same vocabulary as
+    :class:`arenabench.telemetry.TrialMetrics` uses for a Stella arm, so the
+    two arms are described in one language and a reader is never quietly
+    comparing "steps" against something else. Where the two agents genuinely
+    differ the field says so rather than being forced into a shared name:
+    ``turns`` is Claude Code's own count and is not Stella's ``steps``.
+    """
+
+    steps: int = 0
+    tools: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cache_read: int = 0
+    cache_write: int = 0
+    #: What the harness said it spent, from the final ``result`` event. Kept
+    #: for the record and never compared across seats — see
+    #: :mod:`arenabench.pricing` on why two vendors' price tables subtracted
+    #: from each other is not a cost difference.
+    total_cost: float = 0.0
+    #: The harness's own cumulative reasoning-token estimate. Not summed into
+    #: ``tokens_out``: it is an *estimate* the CLI publishes for its own UI,
+    #: and adding an estimate to a measurement makes the measurement an
+    #: estimate too.
+    thinking_tokens: int = 0
+    #: Model ids seen on the wire, first-seen order.
+    models: tuple[str, ...] = ()
+    #: How many times each tool was called. The behavioural half of the
+    #: comparison: two agents that solve the same task with 35 `Bash` calls and
+    #: with 7 `Read` plus one `Edit` did not do the same thing, and a solve
+    #: rate cannot tell them apart.
+    tool_calls: dict[str, int] = field(default_factory=dict)
+    #: Summed wall clock per tool, milliseconds, from the gap between the
+    #: ``tool_use`` block and the ``tool_result`` that answered it. Absent for
+    #: a call whose result never arrived — a trial killed mid-tool.
+    tool_ms: dict[str, int] = field(default_factory=dict)
+    #: Tool calls that came back flagged as errors. An agent that spends half
+    #: its turns recovering from its own failed commands is a different agent
+    #: from one that does not, at identical solve rates.
+    tool_errors: int = 0
+    #: Turns the harness itself counted, from the ``result`` event.
+    turns: int = 0
+    #: ``True`` once the ``result`` event has landed — the agent's own
+    #: statement that it finished, as distinct from Harbor tearing the trial
+    #: down around it.
+    complete: bool = False
+    #: The harness's final self-report. ``api_error`` non-empty is the shape
+    #: that scored three trials as Claude Code losses when the truth was a 429
+    #: (#1480) — recorded here so it is visible during the match rather than
+    #: reconstructed from it.
+    stop_reason: str = ""
+    terminal_reason: str = ""
+    api_error: str = ""
+    is_error: bool = False
+    permission_denials: int = 0
+    #: Milliseconds the harness reports it spent inside provider calls, versus
+    #: the trial's whole wall clock. The difference is the harness's own
+    #: overhead, which is exactly what "compare the harnesses" means.
+    api_ms: int = 0
+    duration_ms: int = 0
+
+    @property
+    def tool_wall_ms(self) -> int:
+        """Total measured time inside tools.
+
+        Deliberately **not** subtracted from :attr:`duration_ms` to derive a
+        "harness overhead". Harbor runs Claude Code with
+        ``FORCE_AUTO_BACKGROUND_TASKS=1``, so tools and provider calls overlap:
+        on a measured trial the three figures were 380.7 s in tools, 180.2 s in
+        the API and 447.3 s of wall clock, and the subtraction is negative.
+        Concurrency is a real property of the harness worth comparing; a
+        derived number that goes negative is not.
+        """
+        return sum(self.tool_ms.values())
+
+    @property
+    def prompt_tokens(self) -> int:
+        """Input tokens in ATIF's sense: fresh input plus both cache legs.
+
+        The wire keeps the three apart and so does this class, because they are
+        three different prices. ATIF does not — Harbor's trajectory writer sums
+        them into ``total_prompt_tokens`` — and every Claude Code cost and
+        cache figure ever recorded by ArenaBench was read through that
+        convention. So the fold lives here, named, and the scoreboard keeps
+        using the one convention it has always used rather than silently
+        changing what "tokens in" means for one arm mid-archive.
+        """
+        return self.tokens_in + self.cache_read + self.cache_write
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "steps": self.steps,
+            "tools": self.tools,
+            "tokens_in": self.tokens_in,
+            "prompt_tokens": self.prompt_tokens,
+            "tokens_out": self.tokens_out,
+            "cache_read": self.cache_read,
+            "cache_write": self.cache_write,
+            "total_cost": round(self.total_cost, 6),
+            "thinking_tokens": self.thinking_tokens,
+            "models": list(self.models),
+            "tool_calls": dict(sorted(self.tool_calls.items())),
+            "tool_ms": dict(sorted(self.tool_ms.items())),
+            "tool_wall_ms": self.tool_wall_ms,
+            "tool_errors": self.tool_errors,
+            "turns": self.turns,
+            "complete": self.complete,
+            "stop_reason": self.stop_reason,
+            "terminal_reason": self.terminal_reason,
+            "api_error": self.api_error,
+            "is_error": self.is_error,
+            "permission_denials": self.permission_denials,
+            "api_ms": self.api_ms,
+            "duration_ms": self.duration_ms,
+        }
+
+
+def _iso_ms(stamp: Any) -> float | None:
+    """An ISO-8601 timestamp as epoch milliseconds, or ``None``.
+
+    Tolerant of the trailing ``Z`` the CLI writes, which
+    :meth:`datetime.fromisoformat` refused before Python 3.11 and which is not
+    worth a dependency to handle.
+    """
+    if not isinstance(stamp, str) or not stamp:
+        return None
+    from datetime import datetime
+
+    try:
+        parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.timestamp() * 1000.0
+
+
+#: The four usage counters, in the order they are credited.
+_USAGE_FIELDS = (
+    ("input_tokens", "tokens_in"),
+    ("output_tokens", "tokens_out"),
+    ("cache_read_input_tokens", "cache_read"),
+    ("cache_creation_input_tokens", "cache_write"),
+)
+
+
+class _StreamState:
+    """Everything a drain must remember between two reads of one file."""
+
+    __slots__ = (
+        "offset",
+        "pending",
+        "profile",
+        "totals",
+        "open_calls",
+        "seen_models",
+        "credited",
+        "counted_calls",
+    )
+
+    def __init__(self) -> None:
+        self.offset = 0
+        #: The trailing bytes of the last read that did not end in a newline.
+        #: Held rather than dropped: the file is being appended to, so a torn
+        #: line is the normal case and discarding it would lose whole events.
+        self.pending = b""
+        self.profile = HarnessProfile()
+        self.totals = HarnessTotals()
+        #: ``tool_use_id`` → ``(tool name, requested-at ms)`` for calls whose
+        #: result has not arrived yet. A call still open when the trial ends
+        #: contributes its count but no duration — the honest reading of "we
+        #: never saw it finish".
+        self.open_calls: dict[str, tuple[str, float | None]] = {}
+        self.seen_models: list[str] = []
+        #: Usage already credited per assistant message id. **The stream emits
+        #: one event per content block of the same message**, each carrying
+        #: that message's full usage — 48 events for 20 messages in a measured
+        #: trial — so summing every event over-counts tokens by 1.76× and
+        #: over-counts steps by 2.4×. Both are the shape of bug this repository
+        #: treats as worse than a crash: a plausible number nobody questions.
+        #:
+        #: Credited as a *delta* against what this id was last charged rather
+        #: than by keeping the last value, because the reader is incremental:
+        #: "last value wins" needs the whole file, and this needs only the
+        #: bytes that just arrived.
+        self.credited: dict[str, tuple[int, int, int, int]] = {}
+        #: ``tool_use_id``s already counted, for the same reason.
+        self.counted_calls: set[str] = set()
+
+
+def _profile_from_init(event: dict[str, Any], profile: HarnessProfile) -> None:
+    """Fill a profile from a ``system``/``init`` event, in place."""
+
+    def names(value: Any) -> tuple[str, ...]:
+        """A roster field as plain names.
+
+        The CLI spells these three ways across versions — a list of strings, a
+        list of objects with a ``name``, or a mapping keyed by name — so all
+        three are accepted rather than pinning the reader to whichever shape
+        the current release happens to use.
+        """
+        if isinstance(value, dict):
+            return tuple(str(key) for key in value)
+        if isinstance(value, list):
+            out: list[str] = []
+            for item in value:
+                if isinstance(item, str):
+                    out.append(item)
+                elif isinstance(item, dict):
+                    name = item.get("name") or item.get("id")
+                    if name:
+                        out.append(str(name))
+            return tuple(out)
+        return ()
+
+    profile.version = str(event.get("claude_code_version") or "") or profile.version
+    profile.model = str(event.get("model") or "") or profile.model
+    profile.permission_mode = str(event.get("permissionMode") or "")
+    profile.api_key_source = str(event.get("apiKeySource") or "")
+    profile.output_style = str(event.get("output_style") or "")
+    profile.cwd = str(event.get("cwd") or "")
+    profile.session_id = str(event.get("session_id") or "")
+    profile.tools = names(event.get("tools"))
+    profile.mcp_servers = names(event.get("mcp_servers"))
+    profile.skills = names(event.get("skills"))
+    profile.subagents = names(event.get("agents"))
+    commands = event.get("slash_commands")
+    profile.slash_commands = len(commands) if isinstance(commands, (list, dict)) else 0
+
+
+def _apply(event: dict[str, Any], state: _StreamState) -> None:
+    """Fold one parsed stream event into the running state."""
+    totals = state.totals
+    kind = event.get("type")
+
+    if kind == "system":
+        if event.get("subtype") == "init":
+            _profile_from_init(event, state.profile)
+        return
+
+    if kind == "result":
+        totals.complete = True
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)):
+            totals.total_cost = float(cost)
+        for name, attr in (
+            ("num_turns", "turns"),
+            ("duration_api_ms", "api_ms"),
+            ("duration_ms", "duration_ms"),
+        ):
+            value = event.get(name)
+            if isinstance(value, (int, float)):
+                setattr(totals, attr, int(value))
+        totals.stop_reason = str(event.get("stop_reason") or "")
+        totals.terminal_reason = str(event.get("terminal_reason") or "")
+        totals.api_error = str(event.get("api_error_status") or "")
+        totals.is_error = bool(event.get("is_error"))
+        denials = event.get("permission_denials")
+        if isinstance(denials, list):
+            totals.permission_denials = len(denials)
+        elif isinstance(denials, (int, float)):
+            totals.permission_denials = int(denials)
+        return
+
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return
+    stamp = _iso_ms(event.get("timestamp"))
+    content = message.get("content")
+    blocks = content if isinstance(content, list) else []
+
+    if kind == "assistant":
+        message_id = str(message.get("id") or "")
+        # One *message*, not one event. The stream re-emits a message once per
+        # content block, so counting events reports 87 steps for a trial that
+        # took 29 turns. A message with no id cannot be deduplicated and is
+        # counted as its own step, which is the conservative reading.
+        if not message_id or message_id not in state.credited:
+            totals.steps += 1
+        model = str(message.get("model") or "")
+        if model and model not in state.seen_models:
+            state.seen_models.append(model)
+            totals.models = tuple(state.seen_models)
+
+        usage = message.get("usage")
+        if isinstance(usage, dict):
+            # The four counters stay apart, because they are four prices. ATIF
+            # folds three of them into one `total_prompt_tokens`, which is a
+            # lossy summary the wire does not oblige us to adopt; the fold is
+            # available as `HarnessTotals.prompt_tokens` for the callers that
+            # need ATIF's convention, and nothing here throws the split away.
+            current = tuple(
+                int(usage.get(wire) or 0) for wire, _ in _USAGE_FIELDS
+            )
+            before = state.credited.get(message_id, (0, 0, 0, 0))
+            for (_, attr), now, was in zip(_USAGE_FIELDS, current, before):
+                # `max(0, …)` because a revision must never *subtract*. A
+                # provider that reports a smaller figure on a later chunk is
+                # correcting itself, and un-crediting tokens the trial really
+                # spent would understate exactly the arm we are measuring.
+                setattr(totals, attr, getattr(totals, attr) + max(0, now - was))
+            if message_id:
+                state.credited[message_id] = current  # type: ignore[assignment]
+
+        for block in blocks:
+            if not isinstance(block, dict) or block.get("type") != _TOOL_USE:
+                continue
+            call_id = str(block.get("id") or "")
+            if call_id and call_id in state.counted_calls:
+                continue
+            name = str(block.get("name") or "")
+            totals.tools += 1
+            totals.tool_calls[name] = totals.tool_calls.get(name, 0) + 1
+            if call_id:
+                state.counted_calls.add(call_id)
+                state.open_calls[call_id] = (name, stamp)
+        return
+
+    if kind == "user":
+        for block in blocks:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            call_id = str(block.get("tool_use_id") or "")
+            opened = state.open_calls.pop(call_id, None)
+            if block.get("is_error"):
+                totals.tool_errors += 1
+            if opened is None:
+                continue
+            name, started = opened
+            if started is not None and stamp is not None:
+                elapsed = max(0, int(stamp - started))
+                totals.tool_ms[name] = totals.tool_ms.get(name, 0) + elapsed
+
+
+class StreamReader:
+    """Incremental reader for one or many Claude Code stream files.
+
+    Holds a byte offset and running totals per path, so a live dashboard pays
+    only for what the agent appended since the last poll. That matters at the
+    observed sizes: one archived trial's stream is 15 MB and 99% of its lines
+    are superseded reasoning-token estimates, so a re-parse per poll would cost
+    more than everything else the arena does put together.
+
+    Shrinking or replaced files reset rather than corrupt: a path whose size
+    fell below the cursor is read again from zero, because the only ways that
+    happens are a rerun into the same directory or a truncated archive, and
+    both want a fresh reading rather than a continuation of a file that no
+    longer exists.
+    """
+
+    def __init__(self) -> None:
+        self._states: dict[Path, _StreamState] = {}
+
+    def read(self, path: Path) -> tuple[HarnessProfile, HarnessTotals] | None:
+        """Drain any new bytes and return the running profile and totals.
+
+        ``None`` when the file does not exist — which is every non-Claude-Code
+        arm, and a Claude Code trial that has not started. Distinct from a file
+        that exists and is empty, which reads as a real zero.
+        """
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return None
+        state = self._states.get(path)
+        if state is None or size < state.offset:
+            state = _StreamState()
+            self._states[path] = state
+        if size > state.offset:
+            self._drain(path, state, size)
+        return state.profile, state.totals
+
+    def forget(self, path: Path) -> None:
+        """Drop a path's cursor, so the next read starts over."""
+        self._states.pop(path, None)
+
+    @staticmethod
+    def _drain(path: Path, state: _StreamState, size: int) -> None:
+        try:
+            with path.open("rb") as handle:
+                handle.seek(state.offset)
+                chunk = handle.read(size - state.offset)
+        except OSError:
+            return
+        state.offset += len(chunk)
+        buffer = state.pending + chunk
+        lines = buffer.split(b"\n")
+        # The last element is whatever followed the final newline: either an
+        # empty string (the chunk ended cleanly) or a partial line still being
+        # written. Either way it is not ready, and it is carried rather than
+        # parsed — the cursor has already moved past those bytes, so dropping
+        # them would lose the event permanently.
+        state.pending = lines.pop()
+
+        thinking: bytes | None = None
+        for raw in lines:
+            if not raw or not raw.lstrip().startswith(b"{"):
+                continue
+            if _THINKING_MARK.encode() in raw:
+                # Cumulative and self-superseding: only the last one in this
+                # drain can matter, so 38,000 JSON parses become one.
+                thinking = raw
+                continue
+            try:
+                event = json.loads(raw)
+            except ValueError:
+                continue
+            if isinstance(event, dict):
+                _apply(event, state)
+        if thinking is not None:
+            try:
+                event = json.loads(thinking)
+            except ValueError:
+                return
+            estimated = event.get("estimated_tokens")
+            if isinstance(estimated, (int, float)):
+                state.totals.thinking_tokens = int(estimated)
+
+
+def reduce_stream(path: Path) -> tuple[HarnessProfile, HarnessTotals] | None:
+    """One-shot read of a complete stream, for an archived trial.
+
+    A thin wrapper over :class:`StreamReader` for callers with no reason to
+    keep a cursor — ``arenabench harness`` reporting on a finished match, or a
+    test. A live caller wants the reader itself.
+    """
+    return StreamReader().read(path)

--- a/arenabench/arenabench/harness.py
+++ b/arenabench/arenabench/harness.py
@@ -296,14 +296,14 @@ class _StreamState:
     """Everything a drain must remember between two reads of one file."""
 
     __slots__ = (
+        "counted_calls",
+        "credited",
         "offset",
+        "open_calls",
         "pending",
         "profile",
-        "totals",
-        "open_calls",
         "seen_models",
-        "credited",
-        "counted_calls",
+        "totals",
     )
 
     def __init__(self) -> None:
@@ -323,8 +323,8 @@ class _StreamState:
         #: Usage already credited per assistant message id. **The stream emits
         #: one event per content block of the same message**, each carrying
         #: that message's full usage — 48 events for 20 messages in a measured
-        #: trial — so summing every event over-counts tokens by 1.76× and
-        #: over-counts steps by 2.4×. Both are the shape of bug this repository
+        #: trial — so summing every event over-counts tokens by 1.76x and
+        #: over-counts steps by 2.4x. Both are the shape of bug this repository
         #: treats as worse than a crash: a plausible number nobody questions.
         #:
         #: Credited as a *delta* against what this id was last charged rather
@@ -441,7 +441,7 @@ def _apply(event: dict[str, Any], state: _StreamState) -> None:
                 int(usage.get(wire) or 0) for wire, _ in _USAGE_FIELDS
             )
             before = state.credited.get(message_id, (0, 0, 0, 0))
-            for (_, attr), now, was in zip(_USAGE_FIELDS, current, before):
+            for (_, attr), now, was in zip(_USAGE_FIELDS, current, before, strict=True):
                 # `max(0, …)` because a revision must never *subtract*. A
                 # provider that reports a smaller figure on a later chunk is
                 # correcting itself, and un-crediting tokens the trial really

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -585,6 +585,23 @@ class Contestant:
     #: meaningful on a ``stella`` seat; :meth:`MatchSpec.validate` refuses it
     #: anywhere else rather than ignoring it in silence.
     sut_ref: str | None = None
+    #: Which *release* of a self-installing agent this seat runs, e.g.
+    #: ``"2.1.226"``. Empty means "whatever the vendor is shipping when the
+    #: container builds", which is the historical behaviour and is not a
+    #: constant: Harbor installs Claude Code per trial from
+    #: ``claude.ai/install.sh`` with no pin, so the archive holds arms spanning
+    #: eight product versions and one match that ran two of them *inside a
+    #: single arm* because a release landed between two of its trials.
+    #:
+    #: This is the ``sut_ref`` of the other side. Stella's identity was always
+    #: pinnable and the opponent's was not, so a head-to-head could hold our
+    #: variable fixed and let theirs drift — and every such comparison reads as
+    #: a measurement of us. Passed to Harbor as ``--agent-kwarg version=…``,
+    #: which its installed-agent base turns into a versioned install.
+    #:
+    #: Meaningless on a ``stella`` seat, which is pinned by ``sut_ref``;
+    #: :meth:`MatchSpec.validate` refuses it there rather than ignoring it.
+    agent_version: str = ""
 
     @property
     def slug(self) -> str:
@@ -608,6 +625,7 @@ class Contestant:
             "required_env": list(self.required_env),
             "color": self.color,
             "sut_ref": self.sut_ref,
+            "agent_version": self.agent_version,
         }
 
     @classmethod
@@ -660,6 +678,10 @@ class Contestant:
             sut_ref=(
                 None if raw.get("sut_ref") is None else str(raw["sut_ref"]).strip()
             ),
+            # No absent/empty distinction here, unlike `sut_ref`: there is no
+            # match-level default for a vendor's release to inherit, so empty
+            # and unset both mean "whatever installs".
+            agent_version=str(raw.get("agent_version") or "").strip(),
         )
 
 
@@ -804,6 +826,16 @@ class MatchSpec:
                 problems.append(
                     f"{contestant.name}: sut_ref applies only to a stella "
                     f"seat — {contestant.agent!r} runs no Stella binary"
+                )
+            if contestant.agent_version and contestant.agent == "stella":
+                # The mirror of the rule above, refused for the same reason: a
+                # Stella seat is pinned by commit through `sut_ref`, and a
+                # version string beside it would name a second, unread
+                # identity — the exact ambiguity per-seat provenance exists to
+                # remove.
+                problems.append(
+                    f"{contestant.name}: agent_version applies only to a "
+                    "self-installing agent — pin a stella seat with sut_ref"
                 )
         return problems
 

--- a/arenabench/arenabench/provenance.py
+++ b/arenabench/arenabench/provenance.py
@@ -13,11 +13,42 @@ things define that apparatus, and both can change under you:
   number, and those numbers are not comparable: a Harbor that predates a task
   setting drops it (pydantic ``extra="ignore"``) and grades against a
   different container topology. Nothing errors. Nothing looks wrong.
+* **each contestant's own product version.** The system under test was always
+  pinned — :attr:`Provenance.sut_commit` names the Stella that ran — but the
+  *opponent* was not, and an opponent is a moving target too. Claude Code ships
+  most days; it gets better and worse exactly like we do, and a scoreboard that
+  labels our commit while leaving theirs blank is measuring one variable and
+  reporting two.
 
-So every match writes a :class:`Provenance` beside its jobs, and the pair
-``(dataset_digest, harbor_version)`` is its :attr:`~Provenance.comparability_key`.
-Two matches with the same key may be compared; two with different keys may be
-*shown together*, but only labelled, never summed.
+So every match writes a :class:`Provenance` beside its jobs, and the tuple
+``(dataset_digest, harbor_version, sut, agent products)`` is its
+:attr:`~Provenance.comparability_key`. Two matches with the same key may be
+compared; two with different keys may be *shown together*, but only labelled,
+never summed.
+
+# Why the opponent's version is observed rather than resolved
+
+Stella's identity is resolved before launch: ArenaBench builds the binary, so
+it knows the commit and can hash the artifact. Every other contestant installs
+itself **inside the task container**, per trial, from its vendor's installer —
+Harbor's Claude Code agent runs ``curl -fsSL https://claude.ai/install.sh``
+with no version pin unless one is given. The host therefore cannot know the
+opponent's version at launch, and only learns it from what the trials left
+behind: Harbor's ATIF trajectory records ``agent.version`` for every agent that
+supports the format.
+
+That makes agent versions a **second write**. :func:`write_match` records the
+apparatus before the first trial, because a match killed mid-run must still be
+attributable; :func:`stamp_agent_versions` adds what only the finished trials
+could say. Both are best-effort, and a missing stamp reads as unknown.
+
+This is not hypothetical drift. At the time this was written the local archive
+held Claude Code arms spanning **eight** product versions (2.1.220 through
+2.1.226) with nothing recording any of them, and match ``f23fbcd61adc`` ran
+*two* versions inside a single arm — a release landed between two trials of one
+job, so half its tasks were graded against a product the other half never saw.
+That match's solve rate is a blend of two agents, and until :attr:`mixed_version_seats`
+existed nothing on the scoreboard could say so.
 
 # Why history is labelled rather than guessed
 
@@ -45,10 +76,14 @@ from pathlib import Path
 from typing import Any
 
 __all__ = [
+    "AGENT_SOURCE_OBSERVED",
+    "AGENT_SOURCE_PINNED",
     "PROVENANCE_FILE",
     "Provenance",
     "backfill_match",
+    "observe_agent_versions",
     "read_match",
+    "stamp_agent_versions",
     "write_match",
 ]
 
@@ -64,6 +99,17 @@ _POST_0_20_JOB_FIELDS = ("install_only", "extra_instruction_paths")
 #: reconstructed afterwards from what Harbor happened to leave on disk.
 SOURCE_RECORDED = "recorded"
 SOURCE_BACKFILLED = "backfilled"
+
+#: How a seat's product version was learned. ``observed`` means it was read
+#: back from what the trials wrote, which is the only channel available for an
+#: agent that installs itself in the container. ``pinned`` means the operator
+#: named the version and the installer was told to fetch exactly it — the
+#: stronger fact, because it holds for trials that have not run yet.
+AGENT_SOURCE_OBSERVED = "observed"
+AGENT_SOURCE_PINNED = "pinned"
+
+#: Where an agent that speaks ATIF records the product that ran.
+_TRAJECTORY_NAME = "agent/trajectory.json"
 
 
 @dataclass
@@ -109,6 +155,18 @@ class Provenance:
     #: records written before per-seat pins existed and for matches with no
     #: Stella seat; readers fall back to the single fields then.
     sut_seats: dict[str, dict[str, str]] = field(default_factory=dict)
+    #: Per-seat **product** identity for contestants ArenaBench does not build,
+    #: keyed by contestant id: ``{"agent", "name", "versions", "source",
+    #: "trials", "unversioned"}``. ``versions`` is a sorted list because one
+    #: seat can genuinely run more than one — an agent that installs itself per
+    #: trial picks up whatever its vendor published that hour — and collapsing
+    #: that to a single value would erase the very fact worth recording.
+    #:
+    #: Stella seats are deliberately absent: their identity is the SUT pin in
+    #: :attr:`sut_seats`, which is finer-grained (a commit and a binary hash)
+    #: than any version string, and recording it twice invites the two copies
+    #: to disagree.
+    agent_seats: dict[str, dict[str, Any]] = field(default_factory=dict)
     arenabench_version: str = ""
     recorded_at: float = field(default_factory=time.time)
     source: str = SOURCE_RECORDED
@@ -122,6 +180,53 @@ class Provenance:
         else:
             grader = "harbor?"
         return f"{self.dataset_key or 'unknown'}@{digest}/{grader}/{sut}"
+
+    @staticmethod
+    def _product_label(seat: dict[str, Any]) -> str:
+        """One seat's product as a key component, e.g. ``claude-code2.1.226``.
+
+        A seat that ran several versions names them all, joined by ``+``, for
+        the same reason :attr:`comparability_key` names several SUT commits: a
+        blend is its own apparatus and must never collapse into the key of
+        either half. A seat with no observed version gets a trailing ``?`` —
+        unknown, and visibly so.
+        """
+        agent = str(seat.get("agent") or "agent")
+        versions = [str(v) for v in (seat.get("versions") or []) if v]
+        if not versions:
+            return f"{agent}?"
+        label = f"{agent}{'+'.join(sorted(versions))}"
+        # A seat that also produced trials with no version at all is only
+        # partly known, and saying "2.1.226" flat would overclaim.
+        return f"{label}+?" if seat.get("unversioned") else label
+
+    @property
+    def agent_products(self) -> tuple[str, ...]:
+        """Every non-Stella seat's product label, sorted by contestant id."""
+        return tuple(
+            self._product_label(self.agent_seats[seat_id])
+            for seat_id in sorted(self.agent_seats)
+        )
+
+    @property
+    def mixed_version_seats(self) -> tuple[str, ...]:
+        """Contestant ids whose arm ran more than one product version.
+
+        Such an arm's numbers are a blend, and no single version label is true
+        of it. Surfaced as its own property rather than left implicit in the
+        key because the key is a grouping token an operator compares, while
+        this is a warning an operator has to *read* — the failure it catches
+        looks exactly like a normal result until someone asks which product
+        produced it.
+        """
+        return tuple(
+            seat_id
+            for seat_id in sorted(self.agent_seats)
+            if len(
+                {v for v in (self.agent_seats[seat_id].get("versions") or []) if v}
+            )
+            > 1
+        )
 
     @property
     def sut_commits(self) -> tuple[str, ...]:
@@ -156,17 +261,34 @@ class Provenance:
             sut = f"stella{commits[0][:8]}" if commits[0] else "stella?"
         else:
             sut = "stella" + "+".join(c[:8] if c else "?" for c in commits)
-        return self._key(sut)
+        key = self._key(sut)
+        # Appended only when something is known, so every key written before
+        # agent versions were recorded keeps its exact spelling and the whole
+        # archive stays groupable against itself. A match that DID record the
+        # opponent is a different apparatus from one that could not, and the
+        # longer key says so rather than pretending they are the same.
+        products = self.agent_products
+        return f"{key}/{'+'.join(products)}" if products else key
 
     def comparability_key_for(self, contestant_id: str) -> str:
         """The key for one arm of the match.
 
         Two arms — from the same match or different ones — are comparable
-        exactly when their keys differ in nothing but the ``stella<commit>``
-        half, which is the variable under test. Everything else differing
-        (dataset digest, grader) makes them different measurements, and this
-        key is what refuses to let that difference hide (#2082).
+        exactly when their keys differ in nothing but the product half, which
+        is the variable under test. Everything else differing (dataset digest,
+        grader) makes them different measurements, and this key is what refuses
+        to let that difference hide (#2082).
+
+        Which product that is depends on the seat. A Stella seat is identified
+        by the commit ArenaBench built; every other seat by the version its
+        vendor shipped. Before agent versions were recorded this returned
+        ``stella?`` for a Claude Code arm — a key that names the wrong product
+        entirely, so two Claude Code arms four releases apart grouped as one
+        series and their difference read as noise.
         """
+        agent_seat = self.agent_seats.get(contestant_id)
+        if agent_seat is not None:
+            return self._key(self._product_label(agent_seat))
         seat = self.sut_seats.get(contestant_id)
         commit = (seat.get("commit") or "") if seat else self.sut_commit
         return self._key(f"stella{commit[:8]}" if commit else "stella?")
@@ -183,11 +305,15 @@ class Provenance:
         # without having to reimplement how it is built.
         out["comparability_key"] = self.comparability_key
         out["measured"] = self.measured
-        if self.sut_seats:
+        seats = {*self.sut_seats, *self.agent_seats}
+        if seats:
             out["comparability_key_by_seat"] = {
                 seat_id: self.comparability_key_for(seat_id)
-                for seat_id in self.sut_seats
+                for seat_id in sorted(seats)
             }
+        if self.agent_seats:
+            out["agent_products"] = list(self.agent_products)
+            out["mixed_version_seats"] = list(self.mixed_version_seats)
         return out
 
     @classmethod
@@ -220,6 +346,143 @@ def read_match(match_dir: Path) -> Provenance | None:
         return Provenance.from_json(json.loads(path.read_text(encoding="utf-8")))
     except (OSError, ValueError, TypeError):
         return None
+
+
+def _seat_of(job_dir: Path) -> dict[str, Any] | None:
+    """The launch record beside a job directory, or ``None``.
+
+    Reuses the runner's existing seat manifest (``<job>.seat.json``) rather
+    than parsing the job's name. The name is ``<match id>-<contestant slug>``
+    and a slug may itself contain a dash, so splitting it is ambiguous exactly
+    where seats are most likely to be named descriptively; the manifest states
+    the contestant id outright.
+    """
+    path = job_dir.with_name(job_dir.name + ".seat.json")
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def observe_agent_versions(match_dir: Path) -> dict[str, dict[str, Any]]:
+    """Which product each non-Stella seat actually ran, read off its trials.
+
+    ATIF is the channel: every Harbor agent that opts into the format writes
+    ``agent.version`` into ``agent/trajectory.json``, and for a self-installing
+    CLI that is the only statement of the version that exists anywhere on the
+    host. Trials are counted as well as versioned, so ``unversioned`` can say
+    how much of the arm the answer covers — a seat whose version is known for
+    two of eight trials is not the same fact as one known for all eight, and
+    :meth:`Provenance._product_label` marks the difference.
+
+    Stella seats are skipped: :attr:`Provenance.sut_seats` already identifies
+    them by commit, and a version string derived from the same build would be
+    a second copy of a fact that is better recorded once.
+
+    Best-effort throughout. A trial with no trajectory, a torn JSON file, a job
+    with no seat manifest — each subtracts from what is known and none of them
+    raises, because a benchmark that refuses to report because one artifact is
+    unreadable is worse than one that reports what it has and says so.
+    """
+    seats: dict[str, dict[str, Any]] = {}
+    for job_dir in sorted(match_dir.glob("jobs/*")):
+        if not job_dir.is_dir():
+            continue
+        record = _seat_of(job_dir)
+        agent = str((record or {}).get("agent") or "")
+        if agent == "stella":
+            continue
+        seat_id = str((record or {}).get("contestant") or "") or job_dir.name
+        name = str((record or {}).get("name") or "")
+
+        versions: set[str] = set()
+        trials = 0
+        unversioned = 0
+        for trajectory_path in sorted(job_dir.glob(f"*/{_TRAJECTORY_NAME}")):
+            payload = _load_trajectory(trajectory_path)
+            if payload is None:
+                continue
+            trials += 1
+            version = str(payload.get("version") or "")
+            if version and version.lower() != "unknown":
+                versions.add(version)
+            else:
+                unversioned += 1
+            # An archive with no seat manifest still knows what ran, because
+            # ATIF names the agent. Trusted only as a fallback: the manifest is
+            # what the launcher *asked for*, which outranks what the artifact
+            # reports about itself.
+            agent = agent or str(payload.get("name") or "")
+
+        if not trials:
+            continue
+        # The Stella skip has to be re-tested here, not only against the
+        # manifest. Every archive predating the seat manifest has no manifest
+        # to skip on, so the check above passes an empty `agent` for both arms
+        # and a Stella seat would be recorded as a product version — competing
+        # with the SUT pin that already identifies it, in a spelling
+        # (`stella 0.6.76 [binary-sha256:…]`) that no key should ever carry.
+        if agent == "stella":
+            continue
+        seats[seat_id] = {
+            "agent": agent or "agent",
+            "name": name,
+            "versions": sorted(versions),
+            "source": AGENT_SOURCE_OBSERVED,
+            "trials": trials,
+            "unversioned": unversioned,
+        }
+    return seats
+
+
+def _load_trajectory(path: Path) -> dict[str, Any] | None:
+    """The ``agent`` block of an ATIF trajectory, or ``None``."""
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    agent = loaded.get("agent")
+    return agent if isinstance(agent, dict) else None
+
+
+def stamp_agent_versions(match_dir: Path) -> Provenance | None:
+    """Fold observed agent versions into a match's record, in place.
+
+    The second of provenance's two writes. :func:`write_match` runs before the
+    first trial so a killed match is still attributable; this runs after the
+    trials, because an agent that installs itself in the container cannot be
+    interrogated any earlier. Idempotent — re-reading finished trials yields
+    the same answer, so a match may be stamped again after a partial run
+    completes.
+
+    Returns the updated record, or ``None`` when there is no record to update
+    or nothing new to say. Never *removes* a version already recorded: a
+    pinned version outranks an observation, and a re-stamp against a
+    half-deleted archive must not silently downgrade a known apparatus to an
+    unknown one.
+    """
+    record = read_match(match_dir)
+    if record is None:
+        return None
+    observed = observe_agent_versions(match_dir)
+    if not observed:
+        return None
+    changed = False
+    for seat_id, seat in observed.items():
+        existing = record.agent_seats.get(seat_id)
+        if existing and existing.get("source") == AGENT_SOURCE_PINNED:
+            continue
+        if existing == seat:
+            continue
+        record.agent_seats[seat_id] = seat
+        changed = True
+    if not changed:
+        return record
+    write_match(match_dir, record)
+    return record
 
 
 def _job_configs(match_dir: Path) -> list[dict[str, Any]]:
@@ -336,6 +599,12 @@ def backfill_match(match_dir: Path, dataset_key: str = "") -> Provenance | None:
         harbor_version=None,
         harbor_bound=bound,
         harbor_bin="",
+        # Unlike the Harbor version, the opponent's product IS recoverable from
+        # history: ATIF has carried `agent.version` all along and nothing read
+        # it. So a backfill recovers the one half of the apparatus that was
+        # always on disk, and the whole existing archive becomes groupable by
+        # the product that produced it rather than by our commit alone.
+        agent_seats=observe_agent_versions(match_dir),
         arenabench_version=__version__,
         source=SOURCE_BACKFILLED,
     )

--- a/arenabench/arenabench/provenance.py
+++ b/arenabench/arenabench/provenance.py
@@ -190,9 +190,18 @@ class Provenance:
         blend is its own apparatus and must never collapse into the key of
         either half. A seat with no observed version gets a trailing ``?`` —
         unknown, and visibly so.
+
+        A seat whose **pin was violated** is labelled by what ran, never by
+        what was asked for. The pin is the intent and the observation is the
+        apparatus; a key that reported the intent would group a match with
+        others that genuinely ran that release, which is the precise error the
+        pin was added to prevent.
         """
         agent = str(seat.get("agent") or "agent")
-        versions = [str(v) for v in (seat.get("versions") or []) if v]
+        source = seat.get("versions") or []
+        if seat.get("pin_violated"):
+            source = seat.get("observed") or seat["pin_violated"]
+        versions = [str(v) for v in source if v]
         if not versions:
             return f"{agent}?"
         label = f"{agent}{'+'.join(sorted(versions))}"
@@ -222,11 +231,29 @@ class Provenance:
         return tuple(
             seat_id
             for seat_id in sorted(self.agent_seats)
-            if len(
-                {v for v in (self.agent_seats[seat_id].get("versions") or []) if v}
-            )
-            > 1
+            if len(self._observed_versions(self.agent_seats[seat_id])) > 1
         )
+
+    @property
+    def violated_pins(self) -> dict[str, list[str]]:
+        """Seats told to run one release that ran another, and what they ran.
+
+        Empty is the normal case, including for every unpinned seat — a seat
+        with no pin cannot violate one. Non-empty means a match believed it was
+        holding the opponent fixed and was not, which is worse than never
+        pinning, because the belief is what makes the comparison quotable.
+        """
+        return {
+            seat_id: list(seat["pin_violated"])
+            for seat_id, seat in sorted(self.agent_seats.items())
+            if seat.get("pin_violated")
+        }
+
+    @staticmethod
+    def _observed_versions(seat: dict[str, Any]) -> set[str]:
+        """What a seat actually ran, preferring evidence over intent."""
+        source = seat.get("observed") or seat.get("versions") or []
+        return {str(v) for v in source if v}
 
     @property
     def sut_commits(self) -> tuple[str, ...]:
@@ -314,6 +341,7 @@ class Provenance:
         if self.agent_seats:
             out["agent_products"] = list(self.agent_products)
             out["mixed_version_seats"] = list(self.mixed_version_seats)
+            out["violated_pins"] = self.violated_pins
         return out
 
     @classmethod
@@ -459,10 +487,15 @@ def stamp_agent_versions(match_dir: Path) -> Provenance | None:
     completes.
 
     Returns the updated record, or ``None`` when there is no record to update
-    or nothing new to say. Never *removes* a version already recorded: a
-    pinned version outranks an observation, and a re-stamp against a
-    half-deleted archive must not silently downgrade a known apparatus to an
-    unknown one.
+    or nothing new to say. Never *downgrades*: a re-stamp against a
+    half-deleted archive must not turn a known apparatus into an unknown one.
+
+    A **pinned** seat keeps its pin but is still checked against what ran. A
+    pin is an instruction to an installer, not evidence — the installer can
+    fall back, resolve a range, or fail to a cached build — and a pin believed
+    without checking is worth less than no pin at all, because it is believed.
+    A disagreement is recorded on the seat as ``pin_violated`` rather than
+    quietly resolved in either direction.
     """
     record = read_match(match_dir)
     if record is None:
@@ -474,6 +507,13 @@ def stamp_agent_versions(match_dir: Path) -> Provenance | None:
     for seat_id, seat in observed.items():
         existing = record.agent_seats.get(seat_id)
         if existing and existing.get("source") == AGENT_SOURCE_PINNED:
+            pinned = {str(v) for v in (existing.get("versions") or []) if v}
+            actually = {str(v) for v in (seat.get("versions") or []) if v}
+            violated = sorted(actually - pinned)
+            if violated and existing.get("pin_violated") != violated:
+                existing["pin_violated"] = violated
+                existing["observed"] = sorted(actually)
+                changed = True
             continue
         if existing == seat:
             continue

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -1067,6 +1067,32 @@ class MatchRunner:
             match.snapshots.stop()
 
         match.finished_at = time.time()
+
+        # Provenance's second write. The opponent's product version cannot be
+        # known at launch — an agent that installs itself from its vendor's
+        # script inside each task container only exists once a trial has run —
+        # so it is folded in here, from the trajectories those trials left.
+        # Runs on a cancelled match too: trials that completed before the
+        # cancellation are real results, and their apparatus is worth
+        # recording even though the match as a whole proved nothing.
+        try:
+            stamped = provenance.stamp_agent_versions(match.workspace)
+        except Exception:  # never let bookkeeping fail a finished match
+            log.exception("could not stamp agent versions for %s", match.spec.id)
+        else:
+            if stamped is not None:
+                match.provenance = stamped
+                for seat_id in stamped.mixed_version_seats:
+                    versions = stamped.agent_seats[seat_id].get("versions") or []
+                    log.warning(
+                        "match %s seat %s ran %d product versions (%s): its "
+                        "numbers are a blend, not a measurement of either",
+                        match.spec.id,
+                        seat_id,
+                        len(versions),
+                        ", ".join(str(v) for v in versions),
+                    )
+
         if match.status != "cancelled":
             # "finished" is a claim that a contest happened. A match whose
             # every seat died without producing a single trial — Docker down,

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -145,8 +145,23 @@ def _provenance_for(
         version, binary = resolved.version, resolved.binary
 
     sut_seats: dict[str, dict[str, str]] = {}
+    agent_seats: dict[str, dict[str, Any]] = {}
     for contestant in match.spec.contestants:
         if contestant.agent != "stella":
+            # A pinned release is knowable *before* the trials, unlike an
+            # observed one, so it is recorded at launch alongside the SUT.
+            # `stamp_agent_versions` will not overwrite it: the pin is what the
+            # installer was told to fetch, which outranks a reading taken from
+            # one trial's artifacts.
+            if contestant.agent_version:
+                agent_seats[contestant.id] = {
+                    "agent": contestant.agent,
+                    "name": contestant.name,
+                    "versions": [contestant.agent_version],
+                    "source": provenance.AGENT_SOURCE_PINNED,
+                    "trials": 0,
+                    "unversioned": 0,
+                }
             continue
         pin = match.sut_pin_for(contestant)
         sut_seats[contestant.id] = {
@@ -175,6 +190,7 @@ def _provenance_for(
         sut_commit=sut_commit,
         sut_sha256=sut_sha256,
         sut_seats=sut_seats,
+        agent_seats=agent_seats,
         arenabench_version=__version__,
         source=provenance.SOURCE_RECORDED,
     )
@@ -791,6 +807,14 @@ class MatchRunner:
                 "--agent-timeout-multiplier",
                 str(match.spec.agent_timeout_multiplier),
             ]
+        if contestant.agent_version:
+            # The opponent's `sut_ref`. Harbor's installed-agent base takes a
+            # `version` kwarg and hands it to the vendor's installer, so this
+            # is the difference between "we ran Claude Code" and "we ran Claude
+            # Code 2.1.226" — and, across a series, between a trend and a
+            # sequence of measurements of different products.
+            command += ["--agent-kwarg", f"version={contestant.agent_version}"]
+            run.notes.append(f"{contestant.agent} pinned to {contestant.agent_version}")
         # Task names are namespaced by the *registry*, not by the task itself.
         # Filtering a ref'd dataset therefore needs `<namespace>/<task>`, while
         # an export on disk is just directories and answers to the bare name.

--- a/arenabench/arenabench/telemetry.py
+++ b/arenabench/arenabench/telemetry.py
@@ -54,7 +54,9 @@ from pathlib import Path
 from stat import S_ISDIR
 from typing import Any
 
+from . import harness as harness_mod
 from .artifacts import mp4_is_finalized
+from .harness import HarnessProfile, HarnessTotals
 from .pricing import Price, price_for, price_for_route, price_on_route, trial_cost
 from .proof import TrialProof, distill
 
@@ -335,6 +337,23 @@ class TrialMetrics:
     #: empty rail there is the absence of the machinery rather than a
     #: failure of it.
     proof: TrialProof | None = None
+    #: What the opponent's harness disclosed about itself at boot — product
+    #: version, model, tool roster, permission mode, credential source
+    #: (:class:`arenabench.harness.HarnessProfile`). ``None`` for an arm that
+    #: publishes no such stream, which today is every agent but Claude Code.
+    #:
+    #: This is the half of a head-to-head that used to be argued from
+    #: documentation. "Both arms ran the same model at the same effort" is a
+    #: claim; this is the evidence, and it has already contradicted the claim
+    #: once — an ``api_key_source`` of ``none`` on trials that were scored as
+    #: losses.
+    harness: HarnessProfile | None = None
+    #: How the opponent spent its turn: calls per tool, wall clock per tool,
+    #: tool errors, reasoning tokens, and the harness's own final verdict
+    #: (:class:`arenabench.harness.HarnessTotals`). Two agents at the same
+    #: solve rate that reached it with 22 shell calls and with 2 reads did not
+    #: do the same thing, and the solve rate cannot say so.
+    behaviour: HarnessTotals | None = None
 
     @property
     def usage_measured(self) -> bool:
@@ -502,6 +521,10 @@ class TrialMetrics:
             "flip_elapsed": self.flip_elapsed,
             "wasted_elapsed": self.wasted_elapsed,
             "proof": self.proof.to_json() if self.proof is not None else None,
+            "harness": self.harness.to_json() if self.harness is not None else None,
+            "behaviour": (
+                self.behaviour.to_json() if self.behaviour is not None else None
+            ),
         }
 
 
@@ -613,6 +636,12 @@ class MetricsReader:
     def __init__(self) -> None:
         self._events: dict[Path, tuple[int, dict[str, Any]]] = {}
         self._seats: dict[Path, dict[str, Any] | None] = {}
+        #: Cursors into the opponents' stdout streams. Kept on the reader
+        #: rather than rebuilt per read for the reason the whole class exists:
+        #: one archived stream is 15 MB and 99% of it is superseded reasoning
+        #: estimates, so re-parsing it per poll would cost more than every
+        #: other thing a live dashboard does.
+        self._harness = harness_mod.StreamReader()
 
     def _seat_record(self, trial_dir: Path) -> dict[str, Any] | None:
         """The launch record of this trial's seat, or ``None``.
@@ -677,6 +706,45 @@ class MetricsReader:
                 if isinstance(extra, dict):
                     metrics.cache_write = int(extra.get("total_cache_write_tokens") or 0)
 
+        # The opponent's own stdout stream, where it has one. Richer than the
+        # trajectory and — the whole point — *current*: ATIF is written once at
+        # teardown, so before this a Claude Code arm read 0 steps, 0 tools, 0
+        # tokens and $0 for the entire length of a match and only became real
+        # when it was over. Same precedence as the trajectory it supersedes:
+        # Stella's stream below still wins on a Stella seat, which has no
+        # `claude-code.txt` to read anyway.
+        harness = self._harness.read(trial_dir / harness_mod.STREAM_NAME)
+        if harness is not None:
+            profile, totals = harness
+            metrics.harness = profile
+            metrics.behaviour = totals
+            metrics.steps = totals.steps or metrics.steps
+            metrics.tools = totals.tools or metrics.tools
+            # ATIF's convention, deliberately — `prompt_tokens`, not
+            # `tokens_in`. Every Claude Code cost and cache-hit figure in the
+            # archive was computed with cache legs folded into the input side,
+            # and switching conventions here would move every historical number
+            # without a single line of the measurement having changed.
+            metrics.tokens_in = totals.prompt_tokens or metrics.tokens_in
+            metrics.tokens_out = totals.tokens_out or metrics.tokens_out
+            metrics.cache_read = totals.cache_read or metrics.cache_read
+            metrics.cache_write = totals.cache_write or metrics.cache_write
+            metrics.total_cost = totals.total_cost or metrics.total_cost
+            if totals.models:
+                metrics.models = totals.models
+            metrics.declared_complete = totals.complete
+            metrics.status = "done" if totals.complete else "running"
+            if totals.api_error:
+                # The harness's own account of how it died. Recorded as the
+                # late error because that is what it is — and because this
+                # exact shape (a 429 swallowed into a nonzero exit) scored
+                # three trials as Claude Code losses when the agent had never
+                # completed a single call (#1480).
+                metrics.late_error = (
+                    f"api_error_status:{totals.api_error}"
+                    + (f" ({totals.terminal_reason})" if totals.terminal_reason else "")
+                )
+
         # Stella's own stream is richer and current, so it wins where it speaks.
         if events is not None:
             metrics.steps = events["steps"] or metrics.steps
@@ -695,13 +763,19 @@ class MetricsReader:
             # `.get` rather than `[…]`: a cached reduction from a reader that
             # predates the proof rail has no such key.
             metrics.proof = events.get("proof")
-        elif metrics.age_s is not None:
+        elif harness is None and metrics.age_s is not None:
             # Liveness artifacts and no verdict yet mean the trial is in
-            # flight even though nothing streams — every trajectory-only arm
+            # flight even though nothing streams — a trajectory-only arm
             # mid-run looks like this. Without it the stall rule could never
             # see such an arm hang: a "pending" trial is not expected to be
             # writing, so its silence would never be suspicious (#1571).
             # `result.json` below still forces "done" once Harbor concludes.
+            #
+            # Skipped when the harness stream spoke, because that is a real
+            # statement about the agent and this is an inference from file
+            # mtimes. Unguarded it would overwrite `declared_complete`'s
+            # status with "running" for an agent that had just said it was
+            # finished — the inference beating the evidence.
             metrics.status = "running"
 
         configured = ""

--- a/arenabench/tests/test_harness.py
+++ b/arenabench/tests/test_harness.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Reading a Claude Code arm out of the stream it was already writing.
+
+The bias, as in :mod:`tests.test_telemetry`, is toward the paths where a bug
+yields a *plausible* number: the message-id deduplication (a naive sum
+overstates output tokens by 1.76x on measured data), the incremental cursor,
+and the token convention the archive's historical cache figures were computed
+under.
+
+No Docker, no network, no key: every fixture is a synthetic stream.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from arenabench.harness import STREAM_NAME, HarnessTotals, StreamReader, reduce_stream
+from arenabench.telemetry import MetricsReader
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+def init_event(**kwargs) -> dict:
+    base = {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "s-1",
+        "claude_code_version": "2.1.226",
+        "model": "claude-opus-5",
+        "permissionMode": "bypassPermissions",
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "output_style": "default",
+        "cwd": "/app",
+        "tools": ["Bash", "Read", "Edit"],
+        "mcp_servers": [],
+        "skills": ["debug"],
+        "agents": ["Explore"],
+        "slash_commands": ["/init", "/review"],
+    }
+    base.update(kwargs)
+    return base
+
+
+def assistant(
+    message_id: str,
+    *,
+    blocks: list[dict] | None = None,
+    usage: dict | None = None,
+    timestamp: str = "2026-08-09T00:00:00.000Z",
+    model: str = "claude-opus-5",
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "message": {
+            "id": message_id,
+            "role": "assistant",
+            "model": model,
+            "content": blocks if blocks is not None else [{"type": "text", "text": "hi"}],
+            "usage": usage
+            if usage is not None
+            else {
+                "input_tokens": 2,
+                "output_tokens": 6,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 10,
+            },
+        },
+    }
+
+
+def tool_result(call_id: str, *, timestamp: str, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "timestamp": timestamp,
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": call_id, "is_error": is_error}
+            ],
+        },
+    }
+
+
+def result_event(**kwargs) -> dict:
+    base = {
+        "type": "result",
+        "subtype": "success",
+        "total_cost_usd": 0.6929,
+        "num_turns": 25,
+        "duration_ms": 447305,
+        "duration_api_ms": 180235,
+        "stop_reason": "end_turn",
+        "terminal_reason": "completed",
+        "is_error": False,
+        "permission_denials": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+def write_stream(path: Path, events: list[dict], *, tail: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+        if tail:
+            handle.write(tail)
+
+
+# --------------------------------------------------------------------------
+# the projection bugs
+# --------------------------------------------------------------------------
+
+
+def test_one_message_emitted_per_block_is_counted_once(tmp_path: Path) -> None:
+    """The stream re-emits a message per content block; the fold must not.
+
+    Measured on a real trial: 48 assistant events for 20 distinct message ids,
+    so summing events reports 208 output tokens where the truth is 118 — 1.76x
+    — and 48 steps where the truth is 20. Neither number looks wrong, which is
+    exactly why it needs a test rather than a reviewer.
+    """
+    path = tmp_path / STREAM_NAME
+    usage = {
+        "input_tokens": 2,
+        "output_tokens": 6,
+        "cache_read_input_tokens": 100,
+        "cache_creation_input_tokens": 10,
+    }
+    write_stream(path, [init_event(), *[assistant("msg_a", usage=usage)] * 3])
+
+    result = reduce_stream(path)
+    assert result is not None
+    _, totals = result
+    assert totals.steps == 1
+    assert totals.tokens_out == 6
+    assert totals.tokens_in == 2
+    assert totals.cache_read == 100
+    assert totals.cache_write == 10
+
+
+def test_a_revised_usage_credits_only_the_difference(tmp_path: Path) -> None:
+    """Usage that grows across re-emissions of one message is not double-counted.
+
+    The CLI accumulates usage as a turn streams, so the same message id can
+    arrive several times with rising numbers. Crediting the delta is what makes
+    an *incremental* reader agree with a one-shot one — "keep the last value"
+    would need the whole file on every poll.
+    """
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(),
+            assistant("msg_a", usage={"input_tokens": 1, "output_tokens": 4}),
+            assistant("msg_a", usage={"input_tokens": 1, "output_tokens": 40}),
+            assistant("msg_a", usage={"input_tokens": 1, "output_tokens": 400}),
+        ],
+    )
+    result = reduce_stream(path)
+    assert result is not None
+    _, totals = result
+    assert totals.tokens_out == 400
+    assert totals.tokens_in == 1
+    assert totals.steps == 1
+
+
+def test_a_shrinking_usage_never_subtracts(tmp_path: Path) -> None:
+    """A provider correcting itself downward must not un-credit real spend."""
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(),
+            assistant("msg_a", usage={"input_tokens": 1, "output_tokens": 400}),
+            assistant("msg_a", usage={"input_tokens": 1, "output_tokens": 4}),
+        ],
+    )
+    result = reduce_stream(path)
+    assert result is not None
+    assert result[1].tokens_out == 400
+
+
+def test_prompt_tokens_keeps_atifs_convention(tmp_path: Path) -> None:
+    """`prompt_tokens` folds both cache legs in; the wire counters stay apart.
+
+    Every Claude Code cache-hit figure in the archive was computed with the
+    cache legs folded into the input side, so the scoreboard keeps that
+    convention. Losing the split would make the rate a ratio of a number to
+    itself plus other things.
+    """
+    totals = HarnessTotals(tokens_in=37, cache_read=551_258, cache_write=18_006)
+    assert totals.prompt_tokens == 569_301
+    assert totals.tokens_in == 37
+
+
+# --------------------------------------------------------------------------
+# the incremental cursor
+# --------------------------------------------------------------------------
+
+
+def test_a_torn_final_line_is_held_not_dropped(tmp_path: Path) -> None:
+    """A half-written event counts once, when the rest of it lands.
+
+    The file is appended to while it is read, so a torn tail is the normal
+    case. The cursor has already moved past those bytes, which is what makes
+    dropping them permanent rather than merely late.
+    """
+    path = tmp_path / STREAM_NAME
+    reader = StreamReader()
+    partial = json.dumps(assistant("msg_a", usage={"output_tokens": 9}))
+    write_stream(path, [init_event()], tail=partial[:40])
+
+    first = reader.read(path)
+    assert first is not None and first[1].tokens_out == 0
+
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(partial[40:] + "\n")
+
+    second = reader.read(path)
+    assert second is not None and second[1].tokens_out == 9
+
+
+def test_incremental_drain_matches_a_single_pass(tmp_path: Path) -> None:
+    """Reading in pieces and reading at once must agree.
+
+    The whole reason for a cursor is cost, and a cursor that changes the answer
+    is worse than the cost it saves.
+    """
+    path = tmp_path / STREAM_NAME
+    reader = StreamReader()
+    batches = [
+        [init_event()],
+        [
+            assistant(
+                "msg_a",
+                blocks=[{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+                timestamp="2026-08-09T00:00:00.000Z",
+            )
+        ],
+        [tool_result("t1", timestamp="2026-08-09T00:00:02.500Z")],
+        [assistant("msg_b", usage={"output_tokens": 11})],
+        [result_event()],
+    ]
+    for batch in batches:
+        write_stream(path, batch)
+        reader.read(path)
+    incremental = reader.read(path)
+
+    oneshot = reduce_stream(path)
+    assert incremental is not None and oneshot is not None
+    assert incremental[1].to_json() == oneshot[1].to_json()
+    assert incremental[0].to_json() == oneshot[0].to_json()
+
+
+def test_a_replaced_file_is_read_from_the_start(tmp_path: Path) -> None:
+    """A rerun into the same directory resets rather than continues."""
+    path = tmp_path / STREAM_NAME
+    reader = StreamReader()
+    write_stream(path, [init_event(), assistant("msg_a", usage={"output_tokens": 50})])
+    assert reader.read(path)[1].tokens_out == 50
+
+    path.write_text("", encoding="utf-8")
+    write_stream(path, [init_event(), assistant("msg_z", usage={"output_tokens": 7})])
+    assert reader.read(path)[1].tokens_out == 7
+
+
+def test_the_reasoning_estimate_is_the_last_one_not_their_sum(tmp_path: Path) -> None:
+    """`thinking_tokens` is cumulative and self-superseding.
+
+    99% of a real stream's lines by count are these, which is why the drain
+    recognises them by substring instead of parsing them — and why summing
+    them would report a number tens of thousands of times too large.
+    """
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [init_event()]
+        + [
+            {
+                "type": "system",
+                "subtype": "thinking_tokens",
+                "estimated_tokens": n,
+                "estimated_tokens_delta": 100,
+            }
+            for n in (100, 200, 4619)
+        ],
+    )
+    assert reduce_stream(path)[1].thinking_tokens == 4619
+
+
+# --------------------------------------------------------------------------
+# behaviour
+# --------------------------------------------------------------------------
+
+
+def test_a_tool_gets_its_wall_clock_from_the_join(tmp_path: Path) -> None:
+    """Tool duration is the gap between the request and the result answering it."""
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(),
+            assistant(
+                "msg_a",
+                blocks=[
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}},
+                    {"type": "tool_use", "id": "t2", "name": "Read", "input": {}},
+                ],
+                timestamp="2026-08-09T00:00:00.000Z",
+            ),
+            tool_result("t1", timestamp="2026-08-09T00:00:02.500Z"),
+            tool_result("t2", timestamp="2026-08-09T00:00:00.960Z", is_error=True),
+        ],
+    )
+    _, totals = reduce_stream(path)
+    assert totals.tools == 2
+    assert totals.tool_calls == {"Bash": 1, "Read": 1}
+    assert totals.tool_ms == {"Bash": 2500, "Read": 960}
+    assert totals.tool_wall_ms == 3460
+    assert totals.tool_errors == 1
+
+
+def test_a_tool_that_never_returned_counts_but_has_no_duration(tmp_path: Path) -> None:
+    """A trial killed mid-tool reports the call, not an invented elapsed time."""
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(),
+            assistant(
+                "msg_a",
+                blocks=[{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+            ),
+        ],
+    )
+    _, totals = reduce_stream(path)
+    assert totals.tool_calls == {"Bash": 1}
+    assert totals.tool_ms == {}
+
+
+def test_the_harness_discloses_its_own_configuration(tmp_path: Path) -> None:
+    """The boot event is the evidence behind "both arms ran the same thing"."""
+    path = tmp_path / STREAM_NAME
+    write_stream(path, [init_event()])
+    profile, _ = reduce_stream(path)
+    assert profile.version == "2.1.226"
+    assert profile.model == "claude-opus-5"
+    assert profile.permission_mode == "bypassPermissions"
+    assert profile.api_key_source == "ANTHROPIC_API_KEY"
+    assert profile.tools == ("Bash", "Read", "Edit")
+    assert profile.skills == ("debug",)
+    assert profile.subagents == ("Explore",)
+    assert profile.slash_commands == 2
+
+
+def test_a_roster_of_objects_reads_the_same_as_a_roster_of_names(tmp_path: Path) -> None:
+    """The CLI has spelled these three ways; all three must read alike."""
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(
+                tools=[{"name": "Bash"}, {"name": "Read"}],
+                mcp_servers={"github": {}, "linear": {}},
+            )
+        ],
+    )
+    profile, _ = reduce_stream(path)
+    assert profile.tools == ("Bash", "Read")
+    assert profile.mcp_servers == ("github", "linear")
+
+
+def test_the_final_verdict_carries_the_api_error(tmp_path: Path) -> None:
+    """A swallowed 401/429 is the shape that scored real trials as losses.
+
+    Harbor names such a trial `NonZeroAgentExitCodeError` — an *agent* failure
+    — so the credential guard never sees it and the scoreboard reads "lost the
+    task" when the agent never completed a call (#1480). The harness said so
+    itself, in the file, all along.
+    """
+    path = tmp_path / STREAM_NAME
+    write_stream(
+        path,
+        [
+            init_event(apiKeySource="none"),
+            result_event(
+                api_error_status="403",
+                terminal_reason="api_error",
+                is_error=True,
+                total_cost_usd=0.0,
+                num_turns=1,
+            ),
+        ],
+    )
+    profile, totals = reduce_stream(path)
+    assert profile.api_key_source == "none"
+    assert totals.api_error == "403"
+    assert totals.terminal_reason == "api_error"
+    assert totals.is_error is True
+    assert totals.complete is True
+
+
+def test_no_stream_reads_as_absence_not_as_zero(tmp_path: Path) -> None:
+    """Every non-Claude-Code arm has no such file, and that is not a measurement."""
+    assert reduce_stream(tmp_path / STREAM_NAME) is None
+
+
+# --------------------------------------------------------------------------
+# the witness: a mid-run arm is no longer dark
+# --------------------------------------------------------------------------
+
+
+def test_a_claude_code_trial_reports_its_metrics_before_it_finishes(
+    tmp_path: Path,
+) -> None:
+    """**The witness.** A running Claude Code trial is measured, not blank.
+
+    Fails on the code this replaced: ATIF is written once in
+    `populate_context_post_run`, so a trial with no `trajectory.json` and no
+    `result.json` yet — i.e. every Claude Code arm for the whole length of a
+    match — reported 0 steps, 0 tools, 0 tokens and $0 while the agent worked.
+    `_liveness_age` made it *look* alive off file mtimes; nothing measured it.
+    """
+    trial = tmp_path / "sqlite-with-gcov__abc"
+    write_stream(
+        trial / STREAM_NAME,
+        [
+            init_event(),
+            assistant(
+                "msg_a",
+                blocks=[{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+                usage={
+                    "input_tokens": 37,
+                    "output_tokens": 118,
+                    "cache_read_input_tokens": 551_258,
+                    "cache_creation_input_tokens": 18_006,
+                },
+                timestamp="2026-08-09T00:00:00.000Z",
+            ),
+            tool_result("t1", timestamp="2026-08-09T00:00:02.500Z"),
+        ],
+    )
+    # Deliberately no trajectory.json and no result.json: this is what the
+    # directory looks like while the agent is still working.
+    assert not (trial / "trajectory.json").exists()
+
+    metrics = MetricsReader().read(trial, task="sqlite-with-gcov")
+
+    assert metrics.status == "running"
+    assert metrics.steps == 1
+    assert metrics.tools == 1
+    assert metrics.tokens_out == 118
+    assert metrics.tokens_in == 569_301  # ATIF's convention: input + both cache legs
+    assert metrics.cache_read == 551_258
+    assert metrics.usage_measured is True
+    assert metrics.harness is not None
+    assert metrics.harness.version == "2.1.226"
+    assert metrics.behaviour is not None
+    assert metrics.behaviour.tool_calls == {"Bash": 1}
+    assert metrics.behaviour.tool_ms == {"Bash": 2500}
+
+
+def test_a_stella_trial_is_untouched_by_the_harness_reader(tmp_path: Path) -> None:
+    """A Stella arm writes no such stream, so nothing about it changes."""
+    trial = tmp_path / "sqlite-with-gcov__def"
+    events = trial / "agent" / "stella-events.jsonl"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    events.write_text(
+        json.dumps(
+            {
+                "type": "step_usage",
+                "model": "anthropic/claude-opus-5",
+                "input_tokens": 500,
+                "output_tokens": 40,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics = MetricsReader().read(trial, task="sqlite-with-gcov")
+    assert metrics.harness is None
+    assert metrics.behaviour is None
+    assert metrics.tokens_in == 500
+    assert metrics.tokens_out == 40

--- a/arenabench/tests/test_harness.py
+++ b/arenabench/tests/test_harness.py
@@ -13,6 +13,7 @@ No Docker, no network, no key: every fixture is a synthetic stream.
 
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 
@@ -488,3 +489,74 @@ def test_a_stella_trial_is_untouched_by_the_harness_reader(tmp_path: Path) -> No
     assert metrics.behaviour is None
     assert metrics.tokens_in == 500
     assert metrics.tokens_out == 40
+
+
+# --------------------------------------------------------------------------
+# the operator's view
+# --------------------------------------------------------------------------
+
+
+def test_the_harness_command_reports_an_arm(tmp_path: Path, capsys) -> None:
+    """`arenabench harness <match>` prints the evidence, not the claim."""
+    from arenabench.cli import _cmd_harness
+
+    trial = tmp_path / "matches" / "m1" / "jobs" / "m1-claude-code" / "t__a"
+    write_stream(
+        trial / STREAM_NAME,
+        [
+            init_event(),
+            assistant(
+                "msg_a",
+                blocks=[{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+                usage={"input_tokens": 5, "output_tokens": 9},
+                timestamp="2026-08-09T00:00:00.000Z",
+            ),
+            tool_result("t1", timestamp="2026-08-09T00:00:01.000Z"),
+            result_event(),
+        ],
+    )
+    args = argparse.Namespace(workspace=str(tmp_path), match="m1")
+    assert _cmd_harness(args) == 0
+    out = capsys.readouterr().out
+    assert "2.1.226" in out
+    assert "Bashx1" in out
+    assert "bypassPermissions" in out
+
+
+def test_the_harness_command_says_so_when_no_arm_streams(
+    tmp_path: Path, capsys
+) -> None:
+    """A Stella-only match is not an error; it just has no such stream."""
+    from arenabench.cli import _cmd_harness
+
+    (tmp_path / "matches" / "m1" / "jobs" / "m1-stella").mkdir(parents=True)
+    args = argparse.Namespace(workspace=str(tmp_path), match="m1")
+    assert _cmd_harness(args) == 0
+    assert "no arm published a harness stream" in capsys.readouterr().out
+
+
+def test_zeroed_stream_usage_is_disclosed_not_printed_as_free(
+    tmp_path: Path, capsys
+) -> None:
+    """A gateway-routed seat streams zeros; that is not "this trial was free".
+
+    Printing `0 tokens` beside a nonzero self-reported cost reads as a
+    contradiction at best and as an efficiency claim at worst — and the seats
+    it happens to are exactly the ones a cost comparison is about.
+    """
+    from arenabench.cli import _cmd_harness
+
+    trial = tmp_path / "matches" / "m1" / "jobs" / "m1-claude-code" / "t__a"
+    write_stream(
+        trial / STREAM_NAME,
+        [
+            init_event(model="glm-5.2"),
+            assistant("msg_a", usage={"input_tokens": 0, "output_tokens": 0}),
+            result_event(total_cost_usd=3.02),
+        ],
+    )
+    args = argparse.Namespace(workspace=str(tmp_path), match="m1")
+    assert _cmd_harness(args) == 0
+    out = capsys.readouterr().out
+    assert "stream reported no usage" in out
+    assert "3.0200" in out

--- a/arenabench/tests/test_provenance.py
+++ b/arenabench/tests/test_provenance.py
@@ -1,0 +1,377 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""What a result set was measured *with*, including the opponent.
+
+Provenance always pinned our side and the grading stack. These cover the third
+axis — each contestant's own product version — and the failure it exists to
+catch: an arm whose numbers blend two releases of the agent under comparison.
+
+The bias is the module's own: a fabricated version is worse than an absent one,
+so every test that could accept a guess checks that it does not.
+
+No Docker, no network: every fixture is a synthetic match tree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from arenabench import provenance
+from arenabench.provenance import (
+    AGENT_SOURCE_OBSERVED,
+    AGENT_SOURCE_PINNED,
+    Provenance,
+)
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+def make_trial(
+    job_dir: Path, trial: str, *, agent: str, version: str | None
+) -> None:
+    """A trial directory carrying an ATIF trajectory, as Harbor leaves it."""
+    path = job_dir / trial / "agent" / "trajectory.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    agent_block: dict = {"name": agent, "model_name": "claude-opus-5"}
+    if version is not None:
+        agent_block["version"] = version
+    path.write_text(
+        json.dumps({"schema_version": "ATIF-v1.2", "agent": agent_block, "steps": []}),
+        encoding="utf-8",
+    )
+
+
+def make_job(
+    match_dir: Path,
+    job: str,
+    *,
+    agent: str,
+    contestant: str,
+    versions: list[str | None],
+    seat_manifest: bool = True,
+) -> Path:
+    job_dir = match_dir / "jobs" / job
+    job_dir.mkdir(parents=True, exist_ok=True)
+    if seat_manifest:
+        (job_dir.parent / f"{job}.seat.json").write_text(
+            json.dumps(
+                {"schema": 1, "contestant": contestant, "agent": agent, "name": agent}
+            ),
+            encoding="utf-8",
+        )
+    for index, version in enumerate(versions):
+        make_trial(job_dir, f"task-{index}__aaa{index}", agent=agent, version=version)
+    return job_dir
+
+
+def base_record(**kwargs) -> Provenance:
+    defaults = dict(
+        dataset_key="terminal-bench-2.1",
+        dataset_digest="sha256:abcd1234ef",
+        harbor_version="0.6.1",
+        sut_commit="deadbeefcafe1234",
+    )
+    defaults.update(kwargs)
+    return Provenance(**defaults)
+
+
+# --------------------------------------------------------------------------
+# observing what actually ran
+# --------------------------------------------------------------------------
+
+
+def test_the_opponents_version_is_read_off_its_trials(tmp_path: Path) -> None:
+    """ATIF has carried `agent.version` all along; nothing read it."""
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.226", "2.1.226"],
+    )
+    seats = provenance.observe_agent_versions(tmp_path)
+    assert seats["cc"]["agent"] == "claude-code"
+    assert seats["cc"]["versions"] == ["2.1.226"]
+    assert seats["cc"]["trials"] == 2
+    assert seats["cc"]["source"] == AGENT_SOURCE_OBSERVED
+
+
+def test_an_arm_that_blended_two_releases_is_named_as_one(tmp_path: Path) -> None:
+    """**The witness.** A match whose arm ran two products says so.
+
+    Not hypothetical: match ``f23fbcd61adc`` in the local archive ran Claude
+    Code 2.1.223 and 2.1.224 across the trials of a single job, because Harbor
+    installs the CLI per container from the vendor's script with no pin and a
+    release landed mid-match. Its solve rate is a blend of two agents. Before
+    this, nothing in the record could say so, and its key was identical to a
+    match that ran either one alone.
+    """
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.223", "2.1.224", "2.1.223"],
+    )
+    record = base_record(agent_seats=provenance.observe_agent_versions(tmp_path))
+
+    assert record.mixed_version_seats == ("cc",)
+    assert record.agent_products == ("claude-code2.1.223+2.1.224",)
+    assert "2.1.223+2.1.224" in record.comparability_key
+
+
+def test_two_releases_of_the_opponent_do_not_share_a_key(tmp_path: Path) -> None:
+    """The whole point: they are different apparatus, so different keys."""
+    older = base_record(
+        agent_seats={
+            "cc": {"agent": "claude-code", "versions": ["2.1.220"], "trials": 5}
+        }
+    )
+    newer = base_record(
+        agent_seats={
+            "cc": {"agent": "claude-code", "versions": ["2.1.226"], "trials": 5}
+        }
+    )
+    assert older.comparability_key != newer.comparability_key
+    assert older.comparability_key_for("cc") != newer.comparability_key_for("cc")
+
+
+def test_an_arms_key_names_its_own_product_not_ours(tmp_path: Path) -> None:
+    """A Claude Code arm used to key as `stella?`, which names the wrong agent.
+
+    Two Claude Code arms four releases apart therefore grouped into one series,
+    and the difference between them read as noise around a single number.
+    """
+    record = base_record(
+        sut_seats={"st": {"name": "Stella", "commit": "deadbeefcafe1234"}},
+        agent_seats={
+            "cc": {"agent": "claude-code", "versions": ["2.1.226"], "trials": 5}
+        },
+    )
+    assert record.comparability_key_for("st").endswith("/stelladeadbeef")
+    assert record.comparability_key_for("cc").endswith("/claude-code2.1.226")
+
+
+def test_an_unknown_version_is_marked_never_guessed(tmp_path: Path) -> None:
+    """A trial whose trajectory names no version leaves the label partial."""
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.226", None, "unknown"],
+    )
+    seats = provenance.observe_agent_versions(tmp_path)
+    assert seats["cc"]["unversioned"] == 2
+    record = base_record(agent_seats=seats)
+    assert record.agent_products == ("claude-code2.1.226+?",)
+
+
+def test_a_stella_seat_is_left_to_its_commit(tmp_path: Path) -> None:
+    """Stella's identity is the SUT pin; a second copy would only disagree."""
+    make_job(
+        tmp_path, "m1-stella", agent="stella", contestant="st", versions=["0.7.4-dev.ab"]
+    )
+    assert provenance.observe_agent_versions(tmp_path) == {}
+
+
+def test_a_stella_seat_is_skipped_without_a_seat_manifest(tmp_path: Path) -> None:
+    """Every archive predating the seat manifest still has to skip Stella.
+
+    The manifest is what normally answers "which agent is this job"; without it
+    the skip has to fall back to what the trajectory says about itself, or a
+    Stella seat is recorded as a product version spelled
+    ``stella 0.7.4-dev.… [binary-sha256:…]`` — competing with the pin that
+    already identifies it.
+    """
+    make_job(
+        tmp_path,
+        "m1-stella",
+        agent="stella",
+        contestant="st",
+        versions=["stella 0.6.76 [binary-sha256:3e4256b6]"],
+        seat_manifest=False,
+    )
+    assert provenance.observe_agent_versions(tmp_path) == {}
+
+
+def test_a_job_with_no_trajectories_is_absent_not_empty(tmp_path: Path) -> None:
+    """A seat that produced nothing has no product to record."""
+    (tmp_path / "jobs" / "m1-claude-code").mkdir(parents=True)
+    assert provenance.observe_agent_versions(tmp_path) == {}
+
+
+# --------------------------------------------------------------------------
+# the key stays compatible with everything already archived
+# --------------------------------------------------------------------------
+
+
+def test_a_record_with_no_agent_versions_keys_exactly_as_before() -> None:
+    """Every key written before this existed must keep its spelling.
+
+    The archive has to stay groupable against itself: a key that changed shape
+    would split every existing series at the commit that shipped this.
+    """
+    record = base_record()
+    assert record.comparability_key == (
+        "terminal-bench-2.1@abcd1234/harbor0.6.1/stelladeadbeef"
+    )
+
+
+def test_recording_the_opponent_is_itself_a_different_apparatus() -> None:
+    """A match that knows what it raced is not the same as one that does not."""
+    blind = base_record()
+    knowing = base_record(
+        agent_seats={"cc": {"agent": "claude-code", "versions": ["2.1.226"]}}
+    )
+    assert blind.comparability_key != knowing.comparability_key
+
+
+# --------------------------------------------------------------------------
+# pinning, and checking the pin
+# --------------------------------------------------------------------------
+
+
+def test_a_pin_survives_a_stamp(tmp_path: Path) -> None:
+    """An observation does not overwrite what the installer was told to fetch."""
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.226"],
+    )
+    provenance.write_match(
+        tmp_path,
+        base_record(
+            agent_seats={
+                "cc": {
+                    "agent": "claude-code",
+                    "versions": ["2.1.226"],
+                    "source": AGENT_SOURCE_PINNED,
+                }
+            }
+        ),
+    )
+    stamped = provenance.stamp_agent_versions(tmp_path)
+    assert stamped is not None
+    assert stamped.agent_seats["cc"]["source"] == AGENT_SOURCE_PINNED
+    assert stamped.violated_pins == {}
+
+
+def test_a_pin_the_installer_ignored_is_reported_not_believed(tmp_path: Path) -> None:
+    """A pin is an instruction, not evidence — so it gets checked.
+
+    A pin believed without checking is worth less than no pin, because the
+    belief is what makes the comparison quotable. The key names what ran.
+    """
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.229", "2.1.229"],
+    )
+    provenance.write_match(
+        tmp_path,
+        base_record(
+            agent_seats={
+                "cc": {
+                    "agent": "claude-code",
+                    "versions": ["2.1.226"],
+                    "source": AGENT_SOURCE_PINNED,
+                }
+            }
+        ),
+    )
+    stamped = provenance.stamp_agent_versions(tmp_path)
+    assert stamped is not None
+    assert stamped.violated_pins == {"cc": ["2.1.229"]}
+    # Labelled by what ran, never by what was asked for.
+    assert stamped.agent_products == ("claude-code2.1.229",)
+    assert "2.1.229" in stamped.comparability_key
+
+
+def test_stamping_twice_changes_nothing(tmp_path: Path) -> None:
+    """Idempotent, so a partial match can be stamped again when it completes."""
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.226"],
+    )
+    provenance.write_match(tmp_path, base_record())
+    first = provenance.stamp_agent_versions(tmp_path)
+    second = provenance.stamp_agent_versions(tmp_path)
+    assert first is not None and second is not None
+    assert first.to_json()["agent_seats"] == second.to_json()["agent_seats"]
+    assert first.comparability_key == second.comparability_key
+
+
+def test_a_stamp_with_no_record_does_not_invent_one(tmp_path: Path) -> None:
+    """A match that recorded nothing is backfilled deliberately, not by a stamp."""
+    make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.226"],
+    )
+    assert provenance.stamp_agent_versions(tmp_path) is None
+
+
+# --------------------------------------------------------------------------
+# history
+# --------------------------------------------------------------------------
+
+
+def test_a_backfill_recovers_the_version_the_archive_always_had(
+    tmp_path: Path,
+) -> None:
+    """Unlike the Harbor version, this one *is* on disk for every old match.
+
+    So a backfill labels the whole existing archive by the product that
+    produced it, rather than by our commit alone.
+    """
+    job_dir = make_job(
+        tmp_path,
+        "m1-claude-code",
+        agent="claude-code",
+        contestant="cc",
+        versions=["2.1.222"],
+    )
+    (job_dir / "config.json").write_text(
+        json.dumps({"datasets": [{"name": "terminal-bench/terminal-bench-2-1"}]}),
+        encoding="utf-8",
+    )
+    record = provenance.backfill_match(tmp_path)
+    assert record is not None
+    assert record.source == provenance.SOURCE_BACKFILLED
+    # The grading stack stays honestly unknown; the product does not have to.
+    assert record.harbor_version is None
+    assert record.agent_seats["cc"]["versions"] == ["2.1.222"]
+
+
+def test_a_record_round_trips_through_json(tmp_path: Path) -> None:
+    """Whatever is written has to read back as the same record."""
+    record = base_record(
+        agent_seats={
+            "cc": {
+                "agent": "claude-code",
+                "name": "Claude Code",
+                "versions": ["2.1.226"],
+                "source": AGENT_SOURCE_OBSERVED,
+                "trials": 8,
+                "unversioned": 0,
+            }
+        }
+    )
+    provenance.write_match(tmp_path, record)
+    back = provenance.read_match(tmp_path)
+    assert back is not None
+    assert back.agent_seats == record.agent_seats
+    assert back.comparability_key == record.comparability_key


### PR DESCRIPTION
Two gaps in how ArenaBench measures the opponent, both of which have already corrupted results in the local archive.

## 1. The Claude Code arm was dark for the whole match

Stella publishes `agent/stella-events.jsonl` per event, so every scoreboard number is current for a Stella arm. Claude Code publishes ATIF, written **once** in `populate_context_post_run`. So a Claude Code arm read 0 steps, 0 tools, 0 tokens and $0 for the entire length of a match and only became real at teardown. `_liveness_age` made it *look* alive off file mtimes; nothing measured it.

Hooks were the assumed mechanism. They are the wrong one here: a hook is a process spawn on the critical path of the arm whose numbers are the bar, twice per tool call. And they turned out to be unnecessary — Harbor has always run the CLI with `--verbose --output-format=stream-json` and teed stdout to `agent/claude-code.txt`, appended as the agent works. **One field of that file was ever read** (Harbor's own parser digs `total_cost_usd` out of it after the run).

It carries:

- `system`/`init` — the harness describing itself at boot: `claude_code_version`, model, the full tool roster, permission mode, credential source, MCP servers, skills, subagents, output style.
- `assistant` — per-turn `message.usage` and content split into `thinking` / `text` / `tool_use`, timestamped.
- `user` — tool outcomes, joinable to the `tool_use` that requested them, which turns two timestamps into a tool's wall clock.
- `system`/`thinking_tokens` — a cumulative reasoning estimate (38,389 lines in one 7.8 MB trial, ~99% of the file by count).
- `result` — cost, turns, stop reason, permission denials, API error status.

`arenabench/arenabench/harness.py` reads it incrementally: 7.8 MB drains in 12 ms, so a live dashboard can poll it. `MetricsReader` consults it before ATIF, and `arenabench harness <match>` reports it.

### Two projection bugs it had to avoid

**The stream re-emits a message once per content block.** Measured on a real trial: 48 assistant events for 20 distinct message ids. Summing events reports 208 output tokens where the truth is 118 (**1.76x**) and 48 steps where the truth is 20. Neither number looks wrong. Usage is credited per message id as a delta, which is also what lets the reader stay incremental.

**A gateway-routed seat streams zeroed usage.** A seat pointed at a non-Anthropic endpoint through `ANTHROPIC_BASE_URL` gets `{"input_tokens": 0, "output_tokens": 0}` on every message while its transcript carries the truth. Reported as "the stream said nothing", never as a free trial. Live tokens for those seats are #2520.

## 2. The opponent's product version was never recorded

`Provenance` pinned our side (`sut_commit`, `sut_sha256`) and the grading stack (`harbor_version`), and left the opponent blank. `comparability_key` hardcoded `stella<commit>`, so a Claude Code arm keyed as `stella?` — naming the wrong product entirely.

What that cost, measured on `~/.arenabench/matches`:

- Claude Code arms span **eight product versions**, 2.1.220 → 2.1.226, with nothing recording any of them.
- Match `f23fbcd61adc` ran **two versions inside one arm** (2.1.223 and 2.1.224). Harbor installs the CLI per trial container from `claude.ai/install.sh` with no pin, so a release landed between two of its trials. Half its tasks were graded against a product the other half never saw. Its solve rate is a blend of two agents and its key was identical to a match that ran either alone.

The version was in `trajectory.json` → `agent.version` the whole time, unread. So:

- `Provenance.agent_seats` records per-seat product identity, observed from the trials.
- It joins the comparability key — appended only when known, so **every key written before this keeps its exact spelling** and the archive stays groupable against itself.
- `mixed_version_seats` names an arm that blended releases; `arenabench provenance` prints it.
- `backfill_match` recovers it for history, so `arenabench provenance --migrate` labels the existing archive.
- `agent_version` on a seat becomes `harbor run --agent-kwarg version=…` — the `sut_ref` of the other side.
- **The pin is checked, not believed.** It is an instruction to an installer, which can fall back or serve a cached build. After the trials, the pin is compared against what ran and a `violated_pin` is recorded; the key then names what ran.

## Witness

`test_a_claude_code_trial_reports_its_metrics_before_it_finishes` — a trial directory with a live stream and no `trajectory.json`/`result.json`, which is what a Claude Code arm looks like mid-match.

Checked the artisanal way against `eb877ac22` (`git archive` into a scratch tree, same script both sides):

```
=== ON BASE eb877ac22 (expect FAIL)
  status=running steps=0 tools=0 tokens_in=0 tokens_out=0 usage_measured=False
  harness=<field does not exist>
WITNESS FAILS (as it must on the old code)

=== ON THE CHANGE (expect PASS)
  status=running steps=1 tools=1 tokens_in=569301 tokens_out=118 usage_measured=True
WITNESS PASSES: the running arm is measured.
```

`test_an_arm_that_blended_two_releases_is_named_as_one` is the witness for the second half, built on the shape `f23fbcd61adc` actually has.

## Verification

- `python3 -m pytest tests/` — all green; 33 new tests across `test_harness.py` and `test_provenance.py`.
- `ruff check arenabench/` — 18 errors before this branch, 18 after. No new ones; the pre-existing ones are untouched.
- Validated against real archived trials throughout, not only synthetic fixtures. `arenabench harness b952369cafd8` reports 176 tool calls of which 167 are `Bash`, 2549s in tools against 956s in provider calls.
- The reader found a dead seat the scoreboard had recorded as a loss: `git-multibranch__2zJHPcY` booted with `apiKeySource: none`, model `<synthetic>`, and died on a 403. That is the shape of #1480, now visible on trial one.

No new dependencies — ArenaBench stays standard-library only.

## Deliberately not in this PR

- Hooks for compaction and permission prompts, the two behaviours the stream genuinely cannot show — #2521. Opt-in, and it has to reach the comparability key, because an instrumented arm is a different apparatus.
- The Stella side of `arenabench harness`, so the comparison is symmetric — #2519.
- Live tokens for gateway-routed seats, which need the session transcript — #2520.

I did not run `arenabench provenance --migrate` against the real archive; that rewrites records under `~/.arenabench` and is the operator's call.

Refs #2519, #2520, #2521

## Summary by Sourcery

Measure and expose opponents’ harness behaviour and product versions so ArenaBench can compare arms against the actual agent releases they ran, both live and in archived matches.

New Features:
- Add harness stream reader for Claude Code to provide live per-trial metrics about model turns, tool usage, timing, and cost.
- Introduce `arenabench harness` CLI command to report how each arm’s harness is configured and how it spent its turns in a match.
- Allow specifying an `agent_version` for self-installing contestants and propagate it into Harbor runs and provenance.

Enhancements:
- Extend provenance to track per-seat agent product identity, incorporate it into comparability keys, and surface mixed-version seats and violated agent pins.
- Update metrics collection to merge harness stream data into opponent trial metrics, making Claude Code arms measurable while running.
- Support backfilling agent versions for existing archived matches using ATIF trajectories and expose migration and reporting via the provenance CLI.

Documentation:
- Expand README with guidance on pinning opponent agent versions, interpreting comparability keys, migrating history, and using the new harness inspection command.

Tests:
- Add comprehensive tests for harness stream reduction, incremental reading, CLI reporting, and integration with trial metrics.
- Add provenance tests covering agent version observation, mixed-version detection, pin handling, comparability keys, backfill behaviour, and JSON round-tripping.