### PR TITLE
fix(arenabench): stop `run` dying on match.id after it has already started the trials

### DIFF
--- a/arenabench/arenabench/cli.py
+++ b/arenabench/arenabench/cli.py
@@ -38,6 +38,34 @@ def _configure_logging(verbose: bool) -> None:
     )
 
 
+def _watch_line(match_id: str, watch_port: int | None) -> str:
+    """Where to watch a started match, as the operator-facing ``watch`` line.
+
+    A pure function of the two facts that were each wrong when this was
+    inlined in :func:`_cmd_run`, and that nothing executed until an operator
+    ran a real match:
+
+    * **which id** — the CLI read ``match.id``, which :class:`~.runner.Match`
+      does not define (it holds the spec rather than copying its identity).
+      The ``AttributeError`` landed *after* ``runner.start``, so every
+      ``arenabench run`` launched its trials and then died on the line telling
+      the operator where to watch them: harbor kept running unsupervised, no
+      ``--results`` snapshot was written, and the arena reported the match
+      ``finished`` while its container was still up.
+    * **which URL** — the client is one static export whose only routes are
+      ``/``, ``/_not-found`` and ``/transcript``, and it selects a match from
+      the ``match`` query parameter. A ``/matches/<id>`` path falls through to
+      static file serving and 404s.
+
+    ``watch_port`` is already resolved by the caller so this stays free of
+    I/O — a string an operator pastes into a browser is worth being able to
+    assert on directly.
+    """
+    if watch_port is None:
+        return f"arenabench serve   (then open match {match_id})"
+    return f"http://127.0.0.1:{watch_port}/?match={match_id}"
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     """Run a committed ``arenabench.toml`` headlessly — the CI entry point.
 
@@ -159,11 +187,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
     # headless by contract and must not start a server, but it knows the match
     # id and the operator's next question is always "where do I watch it" —
     # answered previously by starting another arena and forgetting the port.
+    #
+    # The id is `spec.id`, not `match.id`: `Match` holds the spec rather than
+    # copying its identity, and the server reads it the same way (its match
+    # list emits `match.spec.id`).
     watch_port = find_running_arena(workspace, "127.0.0.1")
-    if watch_port is not None:
-        print(f"watch     : http://127.0.0.1:{watch_port}/matches/{match.id}")
-    else:
-        print(f"watch     : arenabench serve   (then open match {match.id})")
+    print(f"watch     : {_watch_line(match.spec.id, watch_port)}")
     # The built-in supervisor: the same rules `arenabench watch` runs from
     # another process, reported inline so a CI log shows a dead arm at the
     # minute it died rather than in the postmortem (#1480).

--- a/arenabench/tests/test_cli_watch_line.py
+++ b/arenabench/tests/test_cli_watch_line.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The ``watch`` line ``arenabench run`` prints after starting a match.
+
+Witness for a regression that broke the primary command outright: the line was
+inlined in ``_cmd_run``, read a ``Match.id`` that does not exist, and pointed at
+a ``/matches/<id>`` path the static client does not route. Because it sat
+*after* ``runner.start``, every ``run`` launched its trials and then died — the
+containers came up, harbor kept going unsupervised, and no ``--results``
+snapshot was ever written.
+"""
+
+from __future__ import annotations
+
+from arenabench.cli import _watch_line
+from arenabench.runner import Match
+
+
+def test_watch_url_carries_the_id_as_a_query_parameter() -> None:
+    """The client routes a match from ``?match=``, never a path segment.
+
+    The export publishes only ``/``, ``/_not-found`` and ``/transcript``, so a
+    ``/matches/<id>`` URL falls through to static file serving and 404s. This
+    pins the shape an operator can actually paste into a browser.
+    """
+    assert _watch_line("940485cdd079", 8900) == (
+        "http://127.0.0.1:8900/?match=940485cdd079"
+    )
+
+
+def test_watch_line_without_a_running_arena_still_names_the_match() -> None:
+    """No arena is not an error — the id is what the operator needs next."""
+    line = _watch_line("940485cdd079", None)
+    assert "arenabench serve" in line
+    assert "940485cdd079" in line
+
+
+def test_match_defines_no_id_so_the_line_must_read_spec_id() -> None:
+    """The invariant that forced ``match.spec.id`` at the call site.
+
+    ``Match`` holds its :class:`MatchSpec` rather than copying the identity out
+    of it, which is why the server's match list emits ``match.spec.id``. Asserted
+    on the class so this costs no construction: if someone later adds a
+    ``Match.id``, this fails and the two readers get looked at together rather
+    than drifting apart again.
+    """
+    assert not hasattr(Match, "id")


### PR DESCRIPTION
## What

`arenabench run` crashed with `AttributeError: 'Match' object has no attribute 'id'` on the line that tells the operator where to watch the match. That line sits **after** `runner.start`, so the failure was quiet in the worst way: the trials were already up, harbor kept executing them with no supervisor, nothing polled the match, no `--results` snapshot was written, and the arena reported the match `finished` while its container was still running. The trial data lands on disk regardless, which is what makes it easy to miss.

`Match` holds its `MatchSpec` rather than copying the identity out of it, so the id is `match.spec.id` — which is how the server's own match list already reads it.

## The second bug, not in #2339

The same line pointed at `/matches/<id>`. The client is a single static export publishing only `/`, `/_not-found` and `/transcript`, and it selects a match from the `match` query parameter (`ui/components/app-shell.tsx`). A `/matches/<id>` path falls through to static file serving and 404s — measured against a live arena while diagnosing this.

Both facts now live in `_watch_line`, a pure function of the id and the already-resolved port. The seam is the point: a string an operator pastes into a browser should be assertable, and nothing executed this one until a real match ran.

## Correcting #2339's premise

The issue recorded `main` as clean, with the block present only at the heads of #2308 and #2322. **#2322 has since merged (`661d00a91`), so the crash is on `main` now** — reproduced today launching a real Terminal-Bench 2.1 match, which orphaned its harbor subprocess exactly as described.

## Witness

`arenabench/tests/test_cli_watch_line.py` — pins the `?match=` URL shape, the no-arena fallback, and the `Match`-has-no-`id` invariant that forces `spec.id`.

Fails on `main`: `_watch_line` does not exist there (`git show origin/main:arenabench/arenabench/cli.py | rg -c '_watch_line'` → 0), so the import fails. Passes here — 3 passed.

There was no CLI test file before this; the command's operator-facing output had no coverage at all, which is how a one-day-old regression reached `main` and stayed.

Closes #2339

## Summary by Sourcery

Fix the operator-facing watch URL emitted by `arenabench run` and add regression coverage for it.

Bug Fixes:
- Prevent `arenabench run` from crashing after starting trials by reading the match ID from `match.spec.id` instead of a non-existent `match.id`.
- Correct the printed watch link to use the `?match=` query parameter on the root path that the static client actually routes, instead of a `/matches/<id>` URL that 404s.

Tests:
- Add CLI tests for the `_watch_line` helper to pin the watch URL format, no-arena fallback messaging, and the invariant that `Match` has no `id` attribute.