### PR TITLE
fix(transcript): decode tool results and name the tool, on every surface

### DIFF
--- a/arenabench/arenabench/toolout.py
+++ b/arenabench/arenabench/toolout.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Stella's tool events, decoded the way a human reads them.
+
+Every surface that shows a transcript — this package's SSE reader, the React
+transcript page it feeds, the MP4 recorder, Stella's own Command Deck — is
+looking at the same two events, and each one that decoded them by hand got it
+wrong in a different way. This module is the arena side's single owner of that
+decoding, so a fix lands once.
+
+Three facts about the wire that a hand-rolled reader reliably misses:
+
+**``ToolOutput`` is externally tagged.** A result arrives as
+``{"ok": {"content": …}}`` or ``{"error": {"message": …}}`` — never as a bare
+string. Passing that dict to ``str()`` yields a Python *repr*
+(``{'ok': {'content': '--- branches ---\\n* master …'}}``): single quotes, and
+every newline in the payload rendered as the two characters ``\\`` ``n`` on one
+enormous line. That is what every arena transcript showed until
+:func:`decode_tool_output` existed.
+
+**The tag is the verdict.** ``tool_result`` carries no ``error`` or
+``is_error`` field, and never has. A reader that asks for one gets ``None`` for
+every event, so *every failed tool call renders as a success* — in the success
+colour, with the failure message presented as output. Only
+``output["error"]`` says a call failed.
+
+**The name is on the call, not the result.** ``ToolResult`` is
+``{call_id, output, duration_ms, speculated}``. Recovering "which tool was
+this" means correlating back to the ``tool_start`` that shares its ``call_id``
+— which is exactly what :class:`~arenabench.transcript.TranscriptReader` now
+does, and what the deck has always done
+(``crates/stella-tui/src/model.rs``'s ``ToolResult`` fold).
+
+Stdlib only, and pure: every function here maps values to values, reads no
+file and holds no state. That is what lets ``recorder/render.py`` — which
+ships into a Docker image with no access to this package — carry an
+acknowledged copy of :func:`decode_tool_output` and :func:`strip_ansi` that a
+test holds to this one, input for input.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NamedTuple
+
+__all__ = [
+    "DecodedOutput",
+    "cap_middle",
+    "decode_tool_output",
+    "format_tool_input",
+    "strip_ansi",
+    "summarize",
+]
+
+
+class DecodedOutput(NamedTuple):
+    """One ``ToolOutput`` as the transcript needs it."""
+
+    #: The payload the model itself received — ``content`` or ``message``,
+    #: with its real line breaks intact.
+    text: str
+    #: ``False`` only for the ``error`` arm. Read from the tag, never sniffed
+    #: out of the prose.
+    ok: bool
+    #: Whether the value matched either arm of the enum. ``False`` means the
+    #: protocol grew a shape this reader predates; ``text`` then holds compact
+    #: JSON, which is at least readable and parseable, rather than a repr.
+    recognized: bool
+
+
+def decode_tool_output(output: Any) -> DecodedOutput:
+    """Decode the externally-tagged ``ToolOutput`` a ``tool_result`` carries.
+
+    The ``ok``/``error`` key is the success verdict, so it is read here and
+    nowhere else. Note the membership test is on the *key*, not on the value's
+    truthiness: a tool that legitimately produced no output at all sends
+    ``{"ok": {"content": ""}}``, and treating that as unrecognized would
+    replace an empty result with a JSON blob describing one.
+
+    An unrecognized shape degrades to compact JSON rather than to ``repr``.
+    Both are wrong to show a reader, but only one of them keeps the newlines
+    escaped and the quotes un-parseable.
+    """
+    if isinstance(output, dict):
+        ok_arm = output.get("ok")
+        if isinstance(ok_arm, dict) and "content" in ok_arm:
+            return DecodedOutput(_as_text(ok_arm["content"]), True, True)
+        error_arm = output.get("error")
+        if isinstance(error_arm, dict) and "message" in error_arm:
+            return DecodedOutput(_as_text(error_arm["message"]), False, True)
+    if output is None:
+        return DecodedOutput("", True, False)
+    if isinstance(output, str):
+        # A stream that predates the typed enum, or a synthetic event written
+        # by a test. Already the text; there is nothing to unwrap.
+        return DecodedOutput(output, True, False)
+    return DecodedOutput(_as_text(output), True, False)
+
+
+def _as_text(value: Any) -> str:
+    """A decoded arm's payload as a string, without ever reaching ``repr``.
+
+    ``content`` is a string on every stream this reader has seen. It is not
+    *guaranteed* to be one by anything the arena can check, and the failure
+    mode of assuming so is the exact bug this module exists to remove — so a
+    non-string is serialized, not repr'd.
+    """
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+# --- ANSI ----------------------------------------------------------------
+# A port of `crates/stella-tui/src/ansi.rs::strip_ansi`, state for state, so
+# the arena and the deck agree about what a colourised `cargo build` looks
+# like once it is text. Tool output reaches a transcript verbatim, and any
+# child process that detects a TTY colourises it; the escapes are invisible in
+# a terminal that understands them and visible garbage everywhere else — an
+# HTML `<pre>`, a React node, an MP4 frame.
+
+_CSI_FINAL = range(0x40, 0x7F)
+_NF_INTERMEDIATE = range(0x20, 0x30)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences, leaving the visible text.
+
+    Handles the three shapes that occur in practice: CSI (``ESC [`` through a
+    final byte in ``@..~``, which covers every SGR colour code), OSC (``ESC ]``
+    through BEL or ST, as emitted for hyperlinks and window titles), and the
+    residual two-byte ``ESC x`` escapes. A bare ``[`` not preceded by ESC is
+    legitimate content — ``error[E0308]`` — and always survives; over-eager
+    stripping would be a worse bug than the residue it removes.
+    """
+    if "\x1b" not in text:
+        return text
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch != "\x1b":
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        if i >= n:
+            break  # a trailing lone ESC introduces nothing
+        intro = text[i]
+        i += 1
+        if intro == "[":
+            while i < n and ord(text[i]) not in _CSI_FINAL:
+                i += 1
+            i += 1  # the final byte, or one past the end of a truncated run
+        elif intro == "]":
+            while i < n:
+                if text[i] == "\x07":
+                    i += 1
+                    break
+                if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "\\":
+                    i += 2
+                    break
+                i += 1
+        elif ord(intro) in _NF_INTERMEDIATE:
+            while i < n and ord(text[i]) in _NF_INTERMEDIATE:
+                i += 1
+            i += 1  # the single final byte
+    return "".join(out)
+
+
+# --- capping -------------------------------------------------------------
+
+#: The elision marker :func:`cap_middle` splices in, on its own lines so a
+#: capped payload still reads as a payload. Matches `stella-tui`'s.
+ELISION = "\n[… truncated …]\n"
+
+
+def cap_middle(text: str, budget: int, marker: str = ELISION) -> str:
+    """Cap ``text`` to ``budget`` characters, elided from the **middle**.
+
+    Head-truncation is the obvious implementation and the wrong one: the two
+    ends of a tool result are the two parts a reader wants. The head says what
+    the command was and how it started; the tail carries the error, the exit
+    code, and the summary line. A tail-truncated 8 KB clip of a failing build
+    is the one slice that answers nothing.
+    """
+    if budget <= 0 or len(text) <= budget:
+        return text
+    keep = max(0, budget - len(marker))
+    head = keep // 2
+    tail = keep - head
+    return text[:head] + marker + (text[len(text) - tail :] if tail else "")
+
+
+def summarize(text: str, budget: int = 200) -> str:
+    """One flat line standing in for a whole payload — a row label, not a body.
+
+    Caps *before* flattening. The replacement is one character in, one out, so
+    the two orders agree on the result while this one avoids copying a
+    multi-megabyte payload to throw all but 200 characters of it away.
+    """
+    return cap_middle(text, budget, "...").replace("\n", " ").replace("\r", " ")
+
+
+# --- tool arguments ------------------------------------------------------
+
+#: Tools whose *first* argument is worth the row on its own, in probe order.
+#: A port of `stella-tui`'s `format_tool_input`, and deliberately the same
+#: order: the deck and the arena must label the same call the same way, or a
+#: reader comparing a recording against a live run sees two different runs.
+_PRIMARY_FIELDS: tuple[tuple[tuple[str, ...], int], ...] = (
+    (("path", "file_path"), 0),
+    (("cmd", "command"), 120),
+    (("query", "pattern", "symbol"), 80),
+    (("question", "prompt"), 80),
+)
+
+
+def format_tool_input(name: str, arguments: Any) -> str:
+    """The one-line argument label beside a tool's name.
+
+    A tool call's whole object is rarely what a reader wants in a scrolling
+    transcript — the path, the command, or the query is. The full object stays
+    available (the reader keeps it as ``meta.raw``); this is the row.
+    """
+    if not isinstance(arguments, dict):
+        return summarize("" if arguments is None else _as_text(arguments))
+
+    # `apply_edits` carries its paths inside a batch rather than at the top
+    # level; surfacing them keeps its row reading like the other file tools'
+    # instead of falling through to the raw-JSON tail.
+    if name == "apply_edits" and isinstance(arguments.get("edits"), list):
+        paths: list[str] = []
+        for edit in arguments["edits"]:
+            if isinstance(edit, dict):
+                path = edit.get("path")
+                if isinstance(path, str) and path not in paths:
+                    paths.append(path)
+        if paths:
+            labels = [_truncate_field(p, 48) for p in paths]
+            if len(paths) == 1:
+                return labels[0]
+            return f"{', '.join(labels)}  ({len(paths)} files)"
+
+    for keys, width in _PRIMARY_FIELDS:
+        for key in keys:
+            value = arguments.get(key)
+            if not isinstance(value, str):
+                continue
+            if width == 0:
+                # A path stands alone, except that a write states its size —
+                # the one number that says whether this was a touch or a
+                # rewrite, and the one the diff below cannot show yet.
+                if name == "write_file" and isinstance(arguments.get("content"), str):
+                    return f"{value}  ({len(arguments['content'].splitlines())} lines)"
+                return value
+            return _truncate_field(value, width)
+
+    return summarize(json.dumps(arguments, ensure_ascii=False, separators=(",", ":")))
+
+
+def _truncate_field(text: str, limit: int) -> str:
+    """Clip one field to ``limit`` characters, flattened onto a single line."""
+    if len(text) <= limit:
+        return text.replace("\n", " ").replace("\r", " ")
+    return text[: max(0, limit - 1)].replace("\n", " ").replace("\r", " ") + "…"

--- a/arenabench/arenabench/transcript.py
+++ b/arenabench/arenabench/transcript.py
@@ -23,10 +23,27 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .toolout import (
+    cap_middle,
+    decode_tool_output,
+    format_tool_input,
+    strip_ansi,
+)
+
 __all__ = [
     "TranscriptReader",
     "TranscriptState",
 ]
+
+#: How much of one tool result the transcript keeps. Generous, because the
+#: page folds a long body behind a disclosure rather than making the reader
+#: leave — and because the cut is a *middle* elision (:func:`cap_middle`), so
+#: raising it costs bytes on the wire and never costs the end of a payload.
+TOOL_RESULT_BUDGET = 8000
+
+#: The same for a tool call's full argument object, kept beside the one-line
+#: label as ``meta.raw`` for the page's expanded view.
+TOOL_INPUT_BUDGET = 4000
 
 
 def _proof_line(step: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
@@ -119,6 +136,12 @@ class TranscriptState:
     open_entries: dict[str, int] = field(default_factory=dict)
     #: ``call_id`` -> entry sequence, so a tool result can find its call.
     tool_index: dict[str, int] = field(default_factory=dict)
+    #: ``call_id`` -> tool name. A ``tool_result`` carries only the id, so the
+    #: name a result row is labelled with is recovered from the ``tool_start``
+    #: that opened the call — the correlation the deck's fold has always done
+    #: (``crates/stella-tui/src/model.rs``) and this reader never did, which is
+    #: why every result in every arena transcript read "result".
+    tool_names: dict[str, str] = field(default_factory=dict)
     #: The last fragment-built text entry not yet superseded by its
     #: consolidated ``text`` event. Outlives ``open_entries`` on purpose:
     #: ``step_usage`` routinely closes the run *before* the consolidated
@@ -305,40 +328,59 @@ class TranscriptReader:
 
         if kind == "tool_start":
             call = event.get("call") if isinstance(event.get("call"), dict) else {}
-            call_id = str(call.get("id") or call.get("call_id") or "")
+            call_id = str(call.get("call_id") or call.get("id") or "")
+            name = str(call.get("name") or "tool")
             seq = self._next_seq(state)
             if call_id:
                 state.tool_index[call_id] = seq
-            arguments = call.get("arguments")
-            body = (
-                json.dumps(arguments, indent=2)[:4000]
-                if isinstance(arguments, (dict, list))
-                else str(arguments or "")[:4000]
-            )
+                state.tool_names[call_id] = name
+            # The arguments ride under `input` — `ToolCall { call_id, name,
+            # input }`. This read used to ask for `arguments`, a key the wire
+            # has never carried, so every tool row in every arena transcript
+            # rendered with an empty body: a `bash` call did not show its
+            # command, an `edit_file` did not show its path.
+            #
+            # The row gets the one-line label the deck puts beside the name;
+            # the whole object rides as `meta.raw` for the expanded view, so
+            # nothing is lost by summarizing here.
+            arguments = call.get("input", call.get("arguments"))
             return [
                 entry(
                     seq,
                     "tool",
-                    str(call.get("name") or "tool"),
-                    body,
+                    name,
+                    format_tool_input(name, arguments),
                     call_id=call_id,
                     state="running",
+                    raw=cap_middle(
+                        json.dumps(arguments, indent=2, ensure_ascii=False)
+                        if isinstance(arguments, (dict, list))
+                        else "",
+                        TOOL_INPUT_BUDGET,
+                    ),
                 )
             ]
 
         if kind == "tool_result":
             call_id = str(event.get("call_id") or "")
-            output = str(event.get("output") or event.get("result") or "")
-            is_error = bool(event.get("error") or event.get("is_error"))
+            # `ToolOutput` is externally tagged, and the tag is the verdict.
+            # Reading `event["error"]` — a key the wire does not carry — meant
+            # every failed call rendered as a success, in the success colour,
+            # with the failure message presented as ordinary output.
+            decoded = decode_tool_output(event.get("output", event.get("result")))
+            body = cap_middle(strip_ansi(decoded.text), TOOL_RESULT_BUDGET)
             return [
                 entry(
                     self._next_seq(state),
                     "tool_result",
-                    "error" if is_error else "result",
-                    output[:8000],
+                    state.tool_names.get(call_id, "tool"),
+                    body,
                     call_id=call_id,
-                    error=is_error,
+                    error=not decoded.ok,
+                    unrecognized=not decoded.recognized,
                     duration_ms=event.get("duration_ms"),
+                    speculated=bool(event.get("speculated")),
+                    lines=body.count("\n") + 1 if body else 0,
                 )
             ]
 

--- a/arenabench/recorder/render.py
+++ b/arenabench/recorder/render.py
@@ -34,6 +34,95 @@ import shutil
 import sys
 import textwrap
 import time
+from typing import Any
+
+# --- Stella's tool events, decoded ---------------------------------------
+# An ACKNOWLEDGED COPY of `arenabench.toolout.decode_tool_output` and
+# `strip_ansi`. This file is the entire Python payload of the recorder image —
+# its Docker build context is `arenabench/recorder/`, which cannot reach the
+# package — so importing the canonical module is not available here and a copy
+# is the honest alternative to a fifth hand-rolled decoder.
+#
+# The copy is not left to trust: `tests/test_toolout.py::
+# TestRecorderCopyStaysHonest` imports this file by path and holds both
+# functions to the canonical ones input for input. Change one, change the
+# other, or that test goes red. Keep the signatures identical (a plain tuple
+# stands in for the canonical NamedTuple) so the comparison stays direct.
+
+
+def decode_tool_output(output: Any) -> tuple[str, bool, bool]:
+    """``ToolOutput`` as ``(text, ok, recognized)`` — see the canonical copy.
+
+    The enum is externally tagged and the tag is the verdict: a `tool_result`
+    carries no `error` field, so `output["error"]` is the only thing that says
+    a call failed. Passing the dict to `str()` — which this file used to do —
+    puts a Python repr on screen with every newline escaped.
+    """
+    if isinstance(output, dict):
+        ok_arm = output.get("ok")
+        if isinstance(ok_arm, dict) and "content" in ok_arm:
+            return _as_text(ok_arm["content"]), True, True
+        error_arm = output.get("error")
+        if isinstance(error_arm, dict) and "message" in error_arm:
+            return _as_text(error_arm["message"]), False, True
+    if output is None:
+        return "", True, False
+    if isinstance(output, str):
+        return output, True, False
+    return _as_text(output), True, False
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+_CSI_FINAL = range(0x40, 0x7F)
+_NF_INTERMEDIATE = range(0x20, 0x30)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences, leaving the visible text.
+
+    The recorder paints its *own* colour, so a tool's escapes are not merely
+    ugly here — they reset the renderer's foreground mid-row and bleed the
+    tool's palette across the rest of the frame.
+    """
+    if "\x1b" not in text:
+        return text
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch != "\x1b":
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        if i >= n:
+            break
+        intro = text[i]
+        i += 1
+        if intro == "[":
+            while i < n and ord(text[i]) not in _CSI_FINAL:
+                i += 1
+            i += 1
+        elif intro == "]":
+            while i < n:
+                if text[i] == "\x07":
+                    i += 1
+                    break
+                if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "\\":
+                    i += 2
+                    break
+                i += 1
+        elif ord(intro) in _NF_INTERMEDIATE:
+            while i < n and ord(text[i]) in _NF_INTERMEDIATE:
+                i += 1
+            i += 1
+    return "".join(out)
+
 
 # --- palette -------------------------------------------------------------
 # 24-bit colour; xterm in the recorder image supports it. Chosen for contrast
@@ -176,6 +265,9 @@ class Renderer:
         }
         self.model = ""
         self.state = "waiting"
+        #: ``call_id`` -> tool name, so a result row can name the call it
+        #: answers. A `tool_result` carries only the id.
+        self.tool_names: dict[str, str] = {}
         #: Rendered body lines. Bounded: a long trial can emit tens of
         #: thousands, and only the last screenful can ever be visible.
         self.body: list[str] = []
@@ -296,18 +388,34 @@ class Renderer:
             self.line("stage", f"── {name} ".ljust(46, "─"))
         elif kind == "tool_start":
             call = event.get("call") or {}
-            args = call.get("arguments")
+            call_id = str(call.get("call_id") or call.get("id") or "")
+            name = str(call.get("name") or "tool")
+            # The arguments ride under `input` — `ToolCall { call_id, name,
+            # input }`. Asking for `arguments` (a key the wire never carried)
+            # rendered every tool row in every recording as a bare name with
+            # no command, path or query beside it.
+            args = call.get("input", call.get("arguments"))
             summary = (
-                json.dumps(args) if isinstance(args, (dict, list)) else str(args or "")
+                json.dumps(args, ensure_ascii=False)
+                if isinstance(args, (dict, list))
+                else str(args or "")
             )[:220]
+            if call_id:
+                self.tool_names[call_id] = name
             self.totals["tools"] += 1
-            self.line("tool", f"{call.get('name', 'tool')}  {summary}")
+            self.line("tool", f"{name}  {summary}")
         elif kind == "tool_result":
-            body = str(event.get("output") or event.get("result") or "").strip()
+            text, ok, _ = decode_tool_output(
+                event.get("output", event.get("result"))
+            )
+            body = strip_ansi(text).strip()
+            # The name is on the call, not the result: a video row reading
+            # `-> ok` names nothing a viewer can follow, and at video pace
+            # scrolling back to find the matching call is not an option.
+            name = self.tool_names.get(str(event.get("call_id") or ""), "tool")
             first = body.splitlines()[0][:220] if body else "(no output)"
             extra = f"  (+{body.count(chr(10))} lines)" if "\n" in body else ""
-            failed = bool(event.get("error") or event.get("is_error"))
-            self.line("error" if failed else "tool_result", first + extra)
+            self.line("error" if not ok else "tool_result", f"{name}  {first}{extra}")
         elif kind == "step_usage":
             self.totals["steps"] += 1
             self.totals["tin"] += int(event.get("input_tokens") or 0)

--- a/arenabench/tests/test_toolout.py
+++ b/arenabench/tests/test_toolout.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The tool-event decoding every arena transcript surface shares.
+
+Each test here is a witness for one defect that shipped: the four in
+:class:`TestDecodeToolOutput` / :class:`TestTranscriptToolRows` were all live
+in the reader at once, and each one alone is enough to make a transcript
+unreadable or — worse — quietly wrong about whether a tool call succeeded.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from arenabench.toolout import (
+    cap_middle,
+    decode_tool_output,
+    format_tool_input,
+    strip_ansi,
+    summarize,
+)
+from arenabench.transcript import TranscriptReader
+
+
+def write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+
+
+def ok_result(call_id: str, content: str, **extra) -> dict:
+    """A `tool_result` in the shape Stella actually emits."""
+    return {
+        "type": "tool_result",
+        "call_id": call_id,
+        "output": {"ok": {"content": content}},
+        "duration_ms": 12,
+        "speculated": False,
+        **extra,
+    }
+
+
+def start(call_id: str, name: str, arguments: dict) -> dict:
+    """A `tool_start` in the shape Stella actually emits — note `input`."""
+    return {
+        "type": "tool_start",
+        "call": {"call_id": call_id, "name": name, "input": arguments},
+    }
+
+
+class TestDecodeToolOutput:
+    def test_the_ok_arm_yields_its_content_with_real_line_breaks(self):
+        """The defect this module was written for.
+
+        `str()` on the tagged dict yields a Python *repr*: single quotes, and
+        every newline rendered as the two characters `\\` `n`, so an entire
+        `git reflog` arrived as one unreadable line.
+        """
+        payload = "--- reflog ---\nd7d3e4b HEAD@{0}: checkout\n\n[exit code: 0]"
+        decoded = decode_tool_output({"ok": {"content": payload}})
+        assert decoded.text == payload
+        assert decoded.text.count("\n") == 3
+        assert "\\n" not in decoded.text
+        assert "{'ok'" not in decoded.text
+
+    def test_the_error_arm_is_the_only_thing_that_says_a_call_failed(self):
+        """`tool_result` carries no `error`/`is_error` field and never has.
+
+        A reader asking for one gets `None` on every event, so every failed
+        tool call renders as a success. The tag is the verdict.
+        """
+        decoded = decode_tool_output({"error": {"message": "no such file"}})
+        assert decoded.ok is False
+        assert decoded.text == "no such file"
+
+    def test_an_empty_result_is_recognized_rather_than_re_encoded(self):
+        """A tool that legitimately produced nothing sends `{"content": ""}`.
+
+        Testing the arm's truthiness instead of its presence would classify
+        that as an unknown shape and replace the empty string with JSON
+        describing one.
+        """
+        decoded = decode_tool_output({"ok": {"content": ""}})
+        assert (decoded.text, decoded.ok, decoded.recognized) == ("", True, True)
+
+    def test_an_unknown_shape_degrades_to_json_never_to_a_repr(self):
+        """The protocol may grow an arm this reader predates. Both outcomes
+        are wrong to show a reader; only one keeps the quotes parseable and
+        the newlines real."""
+        decoded = decode_tool_output({"partial": {"chunk": "x"}})
+        assert decoded.recognized is False
+        assert json.loads(decoded.text) == {"partial": {"chunk": "x"}}
+
+    @pytest.mark.parametrize("value", [None, "already text", 42])
+    def test_non_dict_payloads_never_reach_repr(self, value):
+        assert "{'" not in decode_tool_output(value).text
+
+
+class TestStripAnsi:
+    def test_a_colourised_build_line_renders_clean(self):
+        line = "\x1b[0m\x1b[1m\x1b[32m    Finished\x1b[0m `dev` in 2.41s"
+        assert strip_ansi(line) == "    Finished `dev` in 2.41s"
+
+    def test_bare_brackets_without_esc_survive(self):
+        """Over-eager stripping is a worse bug than the residue it removes."""
+        line = "error[E0308]: mismatched types in [u8; 4]"
+        assert strip_ansi(line) == line
+
+    def test_osc_hyperlinks_and_titles_are_removed(self):
+        assert strip_ansi("\x1b]0;window title\x07visible") == "visible"
+        st = "\x1b]8;;https://example.com\x1b\\link text\x1b]8;;\x1b\\ after"
+        assert strip_ansi(st) == "link text after"
+
+    def test_truncated_and_two_byte_escapes_do_not_leak(self):
+        assert strip_ansi("a\x1b(Bb") == "ab"
+        # Capped output can cut a sequence mid-stream; swallow it rather than
+        # leaking a partial `[1;3` into the page.
+        assert strip_ansi("done\x1b[1;3") == "done"
+        assert strip_ansi("done\x1b") == "done"
+
+
+class TestCapMiddle:
+    def test_both_ends_of_a_failing_payload_survive(self):
+        """Head-truncation is the obvious implementation and the wrong one:
+        the exit code and the error live in the tail."""
+        text = "START" + ("x" * 5000) + "[exit code: 1]"
+        capped = cap_middle(text, 200)
+        assert capped.startswith("START")
+        assert capped.endswith("[exit code: 1]")
+        assert len(capped) <= 200
+
+    def test_an_in_budget_payload_is_returned_whole(self):
+        assert cap_middle("short", 200) == "short"
+
+    def test_summarize_flattens_onto_one_line(self):
+        assert "\n" not in summarize("a\nb\nc")
+
+
+class TestFormatToolInput:
+    def test_a_shell_call_shows_its_command(self):
+        assert format_tool_input("bash", {"cmd": "git status"}) == "git status"
+
+    def test_a_file_tool_shows_its_path(self):
+        assert format_tool_input("edit_file", {"path": "src/lib.rs"}) == "src/lib.rs"
+
+    def test_a_write_states_its_size(self):
+        label = format_tool_input("write_file", {"path": "a.rs", "content": "x\ny\nz"})
+        assert label == "a.rs  (3 lines)"
+
+    def test_a_batch_edit_surfaces_its_paths(self):
+        label = format_tool_input(
+            "apply_edits", {"edits": [{"path": "a.rs"}, {"path": "b.rs"}]}
+        )
+        assert label == "a.rs, b.rs  (2 files)"
+
+    def test_an_unrecognized_tool_falls_back_to_compact_json(self):
+        label = format_tool_input("mcp__x__y", {"alpha": 1})
+        assert label == '{"alpha":1}'
+
+
+class TestTranscriptToolRows:
+    """The reader's own rows, which is where each defect was visible."""
+
+    def test_a_result_body_is_the_decoded_content(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        payload = "--- branches ---\n* master d7d3e4b off the job market woo"
+        write_events(path, [
+            start("c1", "bash", {"cmd": "git branch -v"}),
+            ok_result("c1", payload),
+        ])
+        result = TranscriptReader().read(path)[-1]
+        assert result["body"] == payload
+        assert "{'ok'" not in result["body"]
+
+    def test_a_result_row_is_labelled_with_its_tools_name(self, tmp_path: Path):
+        """`ToolResult` carries only `call_id`; the name is recovered from the
+        `tool_start` that opened the call. Without it every result in every
+        transcript read `result`, and a reader scrolling a fan-out could not
+        tell which row answered which call."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "read_file", {"path": "a.rs"}),
+            ok_result("c1", "contents"),
+        ])
+        assert TranscriptReader().read(path)[-1]["title"] == "read_file"
+
+    def test_a_result_with_no_recorded_call_still_renders(self, tmp_path: Path):
+        """A reader that joined mid-stream has no `tool_start` to correlate.
+        The row falls back to a generic label rather than vanishing."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [ok_result("orphan", "x")])
+        assert TranscriptReader().read(path)[-1]["title"] == "tool"
+
+    def test_a_failed_call_is_marked_failed(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "read_file", {"path": "missing.rs"}),
+            {
+                "type": "tool_result",
+                "call_id": "c1",
+                "output": {"error": {"message": "no such file"}},
+                "duration_ms": 3,
+            },
+        ])
+        result = TranscriptReader().read(path)[-1]
+        assert result["meta"]["error"] is True
+        assert result["body"] == "no such file"
+
+    def test_a_tool_call_shows_its_arguments(self, tmp_path: Path):
+        """The arguments ride under `input`. The reader asked for `arguments`
+        — a key the wire has never carried — so every tool row rendered with
+        an empty body and a `bash` call did not show its command."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [start("c1", "bash", {"cmd": "git reflog"})])
+        row = TranscriptReader().read(path)[0]
+        assert row["body"] == "git reflog"
+        assert json.loads(row["meta"]["raw"]) == {"cmd": "git reflog"}
+
+    def test_ansi_escapes_never_reach_the_page(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "bash", {"cmd": "cargo build"}),
+            ok_result("c1", "\x1b[32mok\x1b[0m\nline two"),
+        ])
+        body = TranscriptReader().read(path)[-1]["body"]
+        assert body == "ok\nline two"
+        assert "\x1b" not in body
+
+    def test_speculation_and_line_count_reach_the_page(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "read_file", {"path": "a.rs"}),
+            ok_result("c1", "a\nb\nc", speculated=True),
+        ])
+        meta = TranscriptReader().read(path)[-1]["meta"]
+        assert meta["speculated"] is True
+        assert meta["lines"] == 3
+
+
+class TestRecorderCopyStaysHonest:
+    """`recorder/render.py` ships into a Docker image whose build context is
+    `arenabench/recorder/` alone, so it cannot import this package and carries
+    an acknowledged copy of the decoder. A copy nobody checks is how the two
+    drift; this is the check.
+    """
+
+    @staticmethod
+    def _render_module():
+        path = Path(__file__).resolve().parents[1] / "recorder" / "render.py"
+        spec = importlib.util.spec_from_file_location("_arena_render", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            {"ok": {"content": "a\nb"}},
+            {"ok": {"content": ""}},
+            {"error": {"message": "boom"}},
+            {"partial": {"chunk": "x"}},
+            None,
+            "bare string",
+        ],
+    )
+    def test_the_copy_decodes_identically(self, output):
+        mirror = self._render_module()
+        assert mirror.decode_tool_output(output) == tuple(decode_tool_output(output))
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "\x1b[0m\x1b[1m\x1b[32m    Finished\x1b[0m `dev`",
+            "error[E0308]: mismatched types in [u8; 4]",
+            "\x1b]0;title\x07visible",
+            "\x1b]8;;https://e.com\x1b\\link\x1b]8;;\x1b\\ after",
+            "a\x1b(Bb",
+            "done\x1b[1;3",
+            "done\x1b",
+            "no escapes here",
+        ],
+    )
+    def test_the_copy_strips_identically(self, text):
+        mirror = self._render_module()
+        assert mirror.strip_ansi(text) == strip_ansi(text)

--- a/arenabench/ui/components/arena/lane.tsx
+++ b/arenabench/ui/components/arena/lane.tsx
@@ -56,6 +56,9 @@ const KIND_TONE: Record<string, string> = {
   text: "text-foreground",
   tool: "text-acc-cyan",
   tool_result: "text-muted",
+  // A failed result reads in the failure colour, like everywhere else. The
+  // tone map is keyed by kind alone, so the error case is applied at the row
+  // (see `KIND_TONE` use below) rather than added here as a phantom kind.
   stage: "text-accent",
   error: "text-bad",
   verdict: "font-semibold text-ok",
@@ -74,10 +77,19 @@ function entryBody(entry: TranscriptEntry): string {
       ` · ${Math.round(((meta.duration_ms as number) || 0) / 100) / 10}s`
     );
   }
-  if (entry.kind === "tool") return `${entry.title ?? ""} ${body}`;
+  if (entry.kind === "tool") return `● ${entry.title ?? ""}  ${body}`;
   if (entry.kind === "tool_result") {
-    const lines = body.split("\n");
-    return lines.slice(0, 12).join("\n") + (lines.length > 12 ? `\n… +${lines.length - 12} lines` : "");
+    // The name, then the body. A `tool_result` carries only a `call_id` on
+    // the wire, so the lane used to show a bare payload with nothing saying
+    // which call produced it — and in a lane you are watching two seats race,
+    // where "which tool is it on" is most of what you are reading for.
+    const rail = meta.error ? "✗" : "⎿";
+    const head = `${rail} ${entry.title ?? "tool"}`;
+    const lines = body ? body.split("\n") : [];
+    const shown =
+      lines.slice(0, 12).join("\n") +
+      (lines.length > 12 ? `\n… +${lines.length - 12} lines` : "");
+    return shown ? `${head}\n${shown}` : head;
   }
   if (entry.kind === "stage" || entry.kind === "complete" || entry.kind === "verdict") {
     return (entry.title ?? "") + (body ? ` — ${body}` : "");
@@ -222,6 +234,12 @@ export function Lane({
                   "min-w-0 flex-1 whitespace-pre-wrap break-words",
                   KIND_TONE[entry.kind] ?? "text-foreground",
                   entry.kind === "usage" && "text-[10.5px]",
+                  // A failed tool call outranks its kind's tone. Until the
+                  // reader could see the ok/error tag at all, every failure
+                  // in the lane rendered in the ordinary result grey.
+                  entry.kind === "tool_result" &&
+                    Boolean((entry.meta as Record<string, unknown> | undefined)?.error) &&
+                    "text-bad",
                 )}
               >
                 {entryBody(entry)}

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { api } from "@/lib/api";
 import type { Cell, Snapshot, TranscriptEntry } from "@/lib/types";
-import { fmtClock, fmtMoney, fmtTokens } from "@/lib/format";
+import { fmtClock, fmtDuration, fmtMoney, fmtTokens } from "@/lib/format";
 import { cn, seatStyle } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -26,6 +26,15 @@ import { ProofPanel } from "@/components/arena/proof-panel";
  *   never outshouts the response.
  * - **The label is coloured, the value is read.** Tool names take the
  *   accent; bodies stay plain. A colour earns its place by being rare.
+ * - **The rails are the deck's**: `●` opens a call, `⎿` its result, `✗` a
+ *   failed one — a distinct glyph *and* column, so a failure is findable by
+ *   margin-scan alone (`crates/stella-tui/src/render/row.rs::Rail`).
+ *
+ * One deliberate departure: the deck renders a call and its result as one
+ * tight block that nothing can split, so the result row need not repeat the
+ * tool's name. Here the kind filters can hide every call row, which would
+ * leave a column of results naming nothing — so a result row carries its
+ * tool's name, subordinate to the call's.
  *
  * Playback matches the drawer it replaced: a finished trial replays paced by
  * each entry's own elapsed stamp, a live one streams. Search and filters are
@@ -221,43 +230,100 @@ function Entry({
   }
 
   if (entry.kind === "tool") {
+    // `● name  argument`, the deck's call row. The name is soft-padded to a
+    // common column so arguments line up down a run of calls — soft, not
+    // hard, because a long MCP name (`mcp__github__create_pull_request`)
+    // overruns the column rather than being truncated: the tool's identity
+    // outranks the alignment it would cost.
+    const meta = (entry.meta || {}) as Record<string, unknown>;
+    const raw = typeof meta.raw === "string" ? meta.raw : "";
+    const expandable = Boolean(raw) && raw !== "{}";
     return (
       <div>
-        <span className="text-acc-cyan">
-          ⚙ <Highlight text={entry.title ?? "tool"} query={query} />
-        </span>
-        {body && (
-          <div className="whitespace-pre-wrap break-words text-muted">
-            <Highlight text={body} query={query} />
-          </div>
+        <div className="flex items-baseline gap-2">
+          <span className="select-none text-dim">●</span>
+          <span className="min-w-[8.5rem] shrink-0 font-semibold text-accent">
+            <Highlight text={entry.title ?? "tool"} query={query} />
+          </span>
+          {body && (
+            <span className="min-w-0 flex-1 truncate text-muted">
+              <Highlight text={body} query={query} />
+            </span>
+          )}
+          {expandable && (
+            <button
+              type="button"
+              onClick={toggleResult}
+              aria-label={resultOpen ? "hide arguments" : "show arguments"}
+              className="shrink-0 cursor-pointer text-[10.5px] text-dim hover:text-muted"
+            >
+              {resultOpen ? "⏶" : "⋯"}
+            </button>
+          )}
+        </div>
+        {expandable && resultOpen && (
+          <pre className="ml-5 overflow-x-auto whitespace-pre-wrap break-words text-[11px] text-dim">
+            <Highlight text={raw} query={query} />
+          </pre>
         )}
       </div>
     );
   }
 
   if (entry.kind === "tool_result") {
-    const isError = Boolean((entry.meta as Record<string, unknown> | undefined)?.error);
-    const lines = body.split("\n");
+    // `⎿ name · 141ms · 12 lines`, then the body — the deck's result rail,
+    // subordinate to the call above it. A failure takes `✗` and its own
+    // colour so it is findable by margin-scan alone.
+    //
+    // The name is on the row rather than left implicit in the call above,
+    // which is where this page departs from the deck on purpose: the deck
+    // renders a call and its result as one tight block that cannot be split,
+    // while here the kind filters can hide every call row and leave a column
+    // of results naming nothing.
+    const meta = (entry.meta || {}) as Record<string, unknown>;
+    const isError = Boolean(meta.error);
+    const lines = body ? body.split("\n") : [];
     const folded = !resultOpen && lines.length > RESULT_PREVIEW_LINES;
     const shown = resultOpen ? lines : lines.slice(0, RESULT_PREVIEW_LINES);
+    const metrics = [
+      meta.duration_ms != null ? fmtDuration(meta.duration_ms) : null,
+      lines.length > 1 ? `${lines.length} lines` : null,
+      // ⚡ marks a speculated result: its duration overlapped the model's own
+      // streaming instead of following it, so the number is not latency the
+      // run actually spent waiting.
+      meta.speculated ? "⚡ speculated" : null,
+      // The protocol grew a `ToolOutput` arm this page predates. Say so
+      // rather than presenting the JSON fallback as if it were output.
+      meta.unrecognized ? "unrecognized output shape" : null,
+    ].filter(Boolean);
     return (
       <div>
-        <span className={cn("text-[10.5px]", isError ? "text-bad" : "text-dim")}>
-          ↳ {isError ? "error" : "result"}
-        </span>
-        <div
-          className={cn(
-            "whitespace-pre-wrap break-words",
-            isError ? "text-bad/90" : "text-muted",
+        <div className="flex items-baseline gap-2">
+          <span className={cn("select-none", isError ? "text-bad" : "text-dim")}>
+            {isError ? "✗" : "⎿"}
+          </span>
+          <span className={cn("font-medium", isError ? "text-bad" : "text-dim")}>
+            <Highlight text={entry.title ?? "tool"} query={query} />
+          </span>
+          {metrics.length > 0 && (
+            <span className="text-[10.5px] text-dim">· {metrics.join(" · ")}</span>
           )}
-        >
-          <Highlight text={shown.join("\n")} query={query} />
         </div>
+        {shown.length > 0 && (
+          <pre
+            className={cn(
+              "ml-5 overflow-x-auto whitespace-pre-wrap break-words",
+              isError ? "text-bad/90" : "text-muted",
+            )}
+          >
+            <Highlight text={shown.join("\n")} query={query} />
+          </pre>
+        )}
         {folded && (
           <button
             type="button"
             onClick={toggleResult}
-            className="cursor-pointer text-[10.5px] text-dim hover:text-muted"
+            className="ml-5 cursor-pointer text-[10.5px] text-dim hover:text-muted"
           >
             ⋯ {lines.length - RESULT_PREVIEW_LINES} more lines
           </button>
@@ -266,7 +332,7 @@ function Entry({
           <button
             type="button"
             onClick={toggleResult}
-            className="cursor-pointer text-[10.5px] text-dim hover:text-muted"
+            className="ml-5 cursor-pointer text-[10.5px] text-dim hover:text-muted"
           >
             ⏶ collapse
           </button>

--- a/arenabench/ui/lib/format.ts
+++ b/arenabench/ui/lib/format.ts
@@ -36,6 +36,28 @@ export function fmtPct(value: unknown): string {
   return (Number(value) || 0).toFixed(0) + "%";
 }
 
+/**
+ * A tool call's wall clock, in the Command Deck's exact vocabulary
+ * (`crates/stella-tui/src/render/row.rs::human_duration`): `84ms`, `4.2s`,
+ * `27s`, `2m05s`. Ported rather than approximated so the same call reads the
+ * same in the deck and on this page — the whole point of the transcript
+ * grammar is that a reader who lives in Stella does not relearn it here.
+ *
+ * Sub-10s keeps a decimal, because `4.2s` reads as distinct from `4.9s`; above
+ * that the tenth is noise beside the whole seconds.
+ */
+export function fmtDuration(value: unknown): string {
+  if (value == null) return "—";
+  const ms = Math.max(0, Math.round(Number(value) || 0));
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) {
+    const s = ms / 1000;
+    return s < 10 ? `${s.toFixed(1)}s` : `${Math.floor(ms / 1000)}s`;
+  }
+  const total = Math.floor(ms / 1000);
+  return `${Math.floor(total / 60)}m${String(total % 60).padStart(2, "0")}s`;
+}
+
 // A plain count of trials, drawn as absent when it was never measured — the
 // third time this discipline has had to be written down here, after fmtMoney
 // and fmtClock (#1599). It matters most for the proof dimensions: a seat with

--- a/arenabench/ui/package.json
+++ b/arenabench/ui/package.json
@@ -2,7 +2,7 @@
   "name": "arenabench-ui",
   "private": true,
   "version": "0.1.0",
-  "description": "ArenaBench's web client. Built to static files and committed into arenabench/web/, so the Python package never needs Node at runtime.",
+  "description": "ArenaBench's web client. `npm run build` static-exports it into arenabench/arenabench/web/ — the directory the Python server serves and the wheel ships — so the package never needs Node at runtime. That export is generated and gitignored, not committed: a checkout has to run this build before `arenabench serve` shows any UI change.",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev --port 3900",

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -1608,10 +1608,30 @@ function journalEntryHtml(e) {
     return `<div class="jrnl"><div class="kick">⏳ parked · ${esc(e.description ?? "")} · every ${esc(String(e.poll_interval_secs ?? "?"))}s, up to ${esc(String(e.deadline_secs ?? "?"))}s</div></div>`;
   if (e.type === "turn_woken")
     return `<div class="jrnl"><div class="kick">▶ woke · ${e.reason === "changed" ? "the watched state changed" : e.reason === "deadline_expired" ? "the deadline expired with no change" : esc(e.reason ?? "")} · ${esc(String(e.polls_used ?? 0))} probe(s)</div></div>`;
+  /* The Command Deck's rails (`crates/stella-tui/src/render/row.rs::Rail`):
+     `●` opens a call, `⎿` its result, `✗` a failed one — a distinct glyph for
+     the failure so it is findable by margin-scan alone. `stella observe` and
+     `stella run` are looking at the same journal, and a reader who lives in
+     one should not have to relearn the other.
+
+     The result row names its tool. `ToolResult` carries only a `call_id` on
+     the wire, so the name is resolved server-side from the matching
+     `tool_start` (`journal::tool_names`) — before that, every result row in
+     this dashboard read `✓ result` and a reader scrolling a fan-out could not
+     tell which row answered which call. */
+  const lines = e.body ? e.body.split("\n").length : 0;
+  const bits = [];
+  if (e.duration_ms != null) bits.push(fmtMs(e.duration_ms));
+  if (lines > 1) bits.push(`${lines} lines`);
+  /* ⚡ marks a speculated result: the call was read-only and began executing
+     while the model was still streaming, so its duration overlapped the model
+     call instead of following it — not latency the run spent waiting. */
+  if (e.speculated) bits.push("⚡ speculated");
   const head =
-    e.type === "tool_start" ? `▸ ${esc(e.name ?? "")}` :
-    e.type === "tool_result" ? `${e.ok ? "✓" : "✕"} result${e.duration_ms != null ? ` · ${fmtMs(e.duration_ms)}` : ""}${e.speculated ? " · speculated" : ""}` :
-    e.type === "reasoning" ? "reasoning" : "answer";
+    e.type === "tool_start" ? `● ${esc(e.name ?? "tool")}` :
+    e.type === "tool_result"
+      ? `${e.ok ? "⎿" : "✗"} ${esc(e.name ?? "tool")}${bits.length ? ` · ${bits.join(" · ")}` : ""}`
+    : e.type === "reasoning" ? "reasoning" : "answer";
   return `<div class="jrnl${e.type === "tool_result" && !e.ok ? " err" : ""}">
     <div class="kick">${head}${e.truncated ? ` · <span style="color:var(--warn)">clipped</span>` : ""}</div>
     ${e.body ? `<pre class="jrnl-body">${esc(e.body)}</pre>` : ""}</div>`;

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -88,12 +88,6 @@ pub(crate) const TOOL_CALL_SCAN_WINDOW: usize = 10_000;
 /// the stream enormous.
 pub(crate) const MAX_RUNNING_CALLS: usize = 200;
 
-/// Char cap on one transcript body in the default
-/// [`Observatory::execution_journal`] payload. A single `read_file` result
-/// can be megabytes; the drawer needs the shape of the turn, not the bytes,
-/// and `?full=1` is the escape hatch for the reader who wants them.
-pub(crate) const JOURNAL_BODY_CLIP: usize = 4_000;
-
 /// Everything that can go wrong serving observatory data.
 #[derive(Debug, thiserror::Error)]
 pub enum DbError {
@@ -439,40 +433,7 @@ impl Observatory {
         let Some(conn) = self.store() else {
             return Ok(Value::Array(Vec::new()));
         };
-        // `-1` rather than `0` when unfiltered: `seq` starts at 0
-        // (`Store::record_event`'s first call), and a sentinel of 0 would
-        // silently drop that opening row from every unfiltered fetch.
-        let after = after_seq.unwrap_or(-1);
-        let sql = "SELECT seq, ts, event_type, payload
-             FROM events
-             WHERE execution_id = ?1
-               AND seq > ?2
-               AND event_type IN ('stage', 'text', 'reasoning', 'tool_start',
-                                  'tool_result', 'speculation_discarded',
-                                  'turn_parked', 'turn_woken')
-             ORDER BY seq ASC";
-        let mut stmt = match conn.prepare(sql) {
-            Ok(stmt) => stmt,
-            Err(e) if is_missing_schema(&e) => return Ok(Value::Array(Vec::new())),
-            Err(e) => return Err(e.into()),
-        };
-        let mapped = stmt.query_map([id, after], |r| {
-            Ok(json!({
-                "seq": r.get::<_, i64>(0)?,
-                "ts": r.get::<_, String>(1)?,
-                "type": r.get::<_, String>(2)?,
-                "payload": r.get::<_, String>(3)?,
-            }))
-        })?;
-        let mut rows = Vec::new();
-        for row in mapped {
-            rows.push(row?);
-        }
-        Ok(Value::Array(
-            rows.into_iter()
-                .map(|row| journal_entry(row, full))
-                .collect(),
-        ))
+        crate::journal::entries(conn, id, full, after_seq)
     }
 
     /// One model call's **sent context** (#1475): the messages that call was
@@ -1230,99 +1191,6 @@ fn recall_timings(conn: &Connection, execution_id: i64) -> Result<Vec<Value>, Db
             }))
         },
     )
-}
-
-/// Shape one raw `events` row into the transcript entry the drawer renders.
-///
-/// The payload is the internally-tagged `AgentEvent` JSON the store
-/// persisted (`{"type":"text","text":…}`; rows written before #1886 spell
-/// the field `delta`, so `text` reads both). Only the fields the transcript
-/// needs are lifted out, keyed by the row's own `event_type` column. A
-/// payload that no longer parses (a hand-edited store, a variant this binary
-/// predates) keeps its seq/type header with no body rather than erroring —
-/// one unreadable row must not blank the transcript around it.
-fn journal_entry(row: Value, full: bool) -> Value {
-    let ty = row["type"].as_str().unwrap_or("").to_owned();
-    let payload: Value = row["payload"]
-        .as_str()
-        .and_then(|raw| serde_json::from_str(raw).ok())
-        .unwrap_or(Value::Null);
-    let mut out = json!({
-        "seq": row["seq"],
-        "ts": row["ts"],
-        "type": ty,
-    });
-    if payload.is_null() {
-        return out;
-    }
-    match ty.as_str() {
-        "stage" => {
-            out["label"] = payload["name"].clone();
-        }
-        "text" | "reasoning" => {
-            // `text` carries `text` since #1886, `delta` before; `reasoning`
-            // still carries `delta`. One bilingual read covers all three.
-            let body = payload["text"]
-                .as_str()
-                .or_else(|| payload["delta"].as_str());
-            set_journal_body(&mut out, body.unwrap_or(""), full);
-        }
-        "tool_start" => {
-            out["call_id"] = payload["call"]["call_id"].clone();
-            out["name"] = payload["call"]["name"].clone();
-            let args = serde_json::to_string_pretty(&payload["call"]["input"]).unwrap_or_default();
-            set_journal_body(&mut out, &args, full);
-        }
-        "tool_result" => {
-            out["call_id"] = payload["call_id"].clone();
-            out["duration_ms"] = payload["duration_ms"].clone();
-            out["speculated"] = json!(payload["speculated"].as_bool().unwrap_or(false));
-            // `ToolOutput` is externally tagged: `{"ok":{"content":…}}` or
-            // `{"error":{"message":…}}` — the tag is the ok/failed verdict.
-            out["ok"] = json!(!payload["output"]["ok"].is_null());
-            let body = payload["output"]["ok"]["content"]
-                .as_str()
-                .or_else(|| payload["output"]["error"]["message"].as_str())
-                .unwrap_or("");
-            set_journal_body(&mut out, body, full);
-        }
-        "speculation_discarded" => {
-            out["call_id"] = payload["call_id"].clone();
-            out["name"] = payload["name"].clone();
-            out["reason"] = payload["reason"].clone();
-        }
-        // A parked span is the one thing that explains a wall-clock gap with
-        // no events in it (#1857). Without its payload the row would say a
-        // park happened but not what was waited on or for how long — which
-        // is the entire question an operator opens this transcript to ask.
-        "turn_parked" => {
-            out["description"] = payload["description"].clone();
-            out["poll_interval_secs"] = payload["poll_interval_secs"].clone();
-            out["deadline_secs"] = payload["deadline_secs"].clone();
-        }
-        "turn_woken" => {
-            out["reason"] = payload["reason"].clone();
-            out["polls_used"] = payload["polls_used"].clone();
-        }
-        _ => {}
-    }
-    out
-}
-
-/// Attach `body` to a transcript entry, clipped to [`JOURNAL_BODY_CLIP`]
-/// unless `full`, and record which of the two happened.
-///
-/// Shared with the sent-context messages (`sent_context`), so the transcript
-/// and the reconstruction can never disagree about what "clipped" means or
-/// where the cut falls.
-pub(crate) fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
-    let clipped = !full && body.chars().count() > JOURNAL_BODY_CLIP;
-    entry["body"] = if clipped {
-        json!(truncate(body, JOURNAL_BODY_CLIP))
-    } else {
-        json!(body)
-    };
-    entry["truncated"] = json!(clipped);
 }
 
 /// The promoted-rules query, shared by [`Observatory::rules`] and

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -433,7 +433,7 @@ impl Observatory {
         let Some(conn) = self.store() else {
             return Ok(Value::Array(Vec::new()));
         };
-        crate::journal::entries(conn, id, full, after_seq)
+        crate::journal::entries(&conn, id, full, after_seq)
     }
 
     /// One model call's **sent context** (#1475): the messages that call was

--- a/crates/stella-observatory/src/journal.rs
+++ b/crates/stella-observatory/src/journal.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One execution's transcript, projected from its slice of the `events`
+//! journal — the answer text, reasoning and tool traffic the telemetry
+//! projections deliberately do not carry.
+//!
+//! Split out of `db.rs`, which had reached 1482 of the guard's 1500 lines with
+//! no baseline entry, so the next addition to it would have failed the gate
+//! outright. The seam is not the line count, though: `db.rs` answers *what the
+//! run cost and did* in aggregates, and this answers *what happened, in order,
+//! for a person reading along*. They share only the store handle.
+//!
+//! # The transcript grammar
+//!
+//! The projection exists so `stella observe` reads like `stella run`. A reader
+//! who lives in the Command Deck should not have to relearn the page, so the
+//! wire shape here carries exactly what the deck's fold carries
+//! (`crates/stella-tui/src/model.rs`) and `assets/index.html` renders it with
+//! the deck's rails (`crates/stella-tui/src/render/row.rs::Rail`).
+//!
+//! Two facts about the wire that a per-row projection cannot see on its own,
+//! and that this module therefore resolves for it:
+//!
+//! - **`ToolOutput` is externally tagged.** `{"ok":{"content":…}}` or
+//!   `{"error":{"message":…}}`, and the tag is the success verdict — a
+//!   `tool_result` carries no `error` field to consult.
+//! - **The tool's name is on the call, not the result.** `ToolResult` is
+//!   `{call_id, output, duration_ms, speculated}`, so a result row can only be
+//!   labelled by correlating back to the `tool_start` that shares its id. The
+//!   deck does this in its fold; every result row in this dashboard read
+//!   `✓ result` until [`tool_names`] existed.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+use serde_json::{Value, json};
+
+use crate::db::{DbError, is_missing_schema, truncate};
+
+/// Char cap on one transcript body in the default
+/// [`crate::db::Observatory::execution_journal`] payload. A single `read_file`
+/// result can be megabytes; the page needs the shape of the turn, not the
+/// bytes, and `?full=1` is the escape hatch for the reader who wants them.
+pub(crate) const JOURNAL_BODY_CLIP: usize = 4_000;
+
+/// One execution's transcript rows, in journal order.
+///
+/// This is the second sanctioned read of `events` (after `recall_timings`) and
+/// it obeys the same bargain: the filter is `execution_id`-first, which the
+/// store's `UNIQUE (execution_id, seq)` index serves directly. The whole
+/// transcript is fetched once on open; while the execution is still running
+/// the page polls back with `after_seq` set to the highest `seq` it already
+/// has (#1476), so a long run's transcript is never re-downloaded in full —
+/// the same index serves `seq > ?` directly. A cross-execution transcript view
+/// would need a projection, not a wider `WHERE`.
+///
+/// `text_delta` rows never appear: the journal's `text` event is the
+/// authoritative full answer and the deltas are a live-preview artifact. Most
+/// stores hold none (the journal drops them at write time), but the filter is
+/// contract, not assumption.
+pub(crate) fn entries(
+    conn: &Connection,
+    id: i64,
+    full: bool,
+    after_seq: Option<i64>,
+) -> Result<Value, DbError> {
+    // `-1` rather than `0` when unfiltered: `seq` starts at 0
+    // (`Store::record_event`'s first call), and a sentinel of 0 would silently
+    // drop that opening row from every unfiltered fetch.
+    let after = after_seq.unwrap_or(-1);
+    let sql = "SELECT seq, ts, event_type, payload
+         FROM events
+         WHERE execution_id = ?1
+           AND seq > ?2
+           AND event_type IN ('stage', 'text', 'reasoning', 'tool_start',
+                              'tool_result', 'speculation_discarded',
+                              'turn_parked', 'turn_woken')
+         ORDER BY seq ASC";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(Value::Array(Vec::new())),
+        Err(e) => return Err(e.into()),
+    };
+    let mapped = stmt.query_map([id, after], |r| {
+        Ok(json!({
+            "seq": r.get::<_, i64>(0)?,
+            "ts": r.get::<_, String>(1)?,
+            "type": r.get::<_, String>(2)?,
+            "payload": r.get::<_, String>(3)?,
+        }))
+    })?;
+    let mut rows = Vec::new();
+    for row in mapped {
+        rows.push(row?);
+    }
+    let names = tool_names(conn, id)?;
+    Ok(Value::Array(
+        rows.into_iter()
+            .map(|row| journal_entry(row, full, &names))
+            .collect(),
+    ))
+}
+
+/// `call_id` -> tool name for every call this execution opened.
+///
+/// Resolved over the **whole** execution rather than over the batch being
+/// returned, which is the detail that makes it correct under the incremental
+/// poll: a `tool_result` routinely arrives in a later `after_seq` page than
+/// the `tool_start` it answers, so a batch-local index would label the first
+/// fetch's rows and silently stop labelling every later one — the failure that
+/// looks like the feature working.
+///
+/// Only the two fields are read, via `json_extract`, so a long execution's
+/// full argument objects never leave SQLite. Same `execution_id`-first bargain
+/// as [`entries`]; a store predating the schema degrades to an empty map, and
+/// an unlabelled row then falls back to a generic name rather than failing the
+/// whole transcript.
+fn tool_names(conn: &Connection, id: i64) -> Result<HashMap<String, String>, DbError> {
+    let sql = "SELECT json_extract(payload, '$.call.call_id'),
+                      json_extract(payload, '$.call.name')
+               FROM events
+               WHERE execution_id = ?1 AND event_type = 'tool_start'";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) if is_missing_schema(&e) => return Ok(HashMap::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let rows = stmt.query_map([id], |r| {
+        Ok((r.get::<_, Option<String>>(0)?, r.get::<_, Option<String>>(1)?))
+    })?;
+    let mut out = HashMap::new();
+    for row in rows {
+        if let (Some(call_id), Some(name)) = row? {
+            out.insert(call_id, name);
+        }
+    }
+    Ok(out)
+}
+
+/// Shape one raw `events` row into the transcript entry the page renders.
+///
+/// The payload is the internally-tagged `AgentEvent` JSON the store persisted
+/// (`{"type":"text","text":…}`; rows written before #1886 spell the field
+/// `delta`, so `text` reads both). Only the fields the transcript needs are
+/// lifted out, keyed by the row's own `event_type` column. A payload that no
+/// longer parses (a hand-edited store, a variant this binary predates) keeps
+/// its seq/type header with no body rather than erroring — one unreadable row
+/// must not blank the transcript around it.
+fn journal_entry(row: Value, full: bool, names: &HashMap<String, String>) -> Value {
+    let ty = row["type"].as_str().unwrap_or("").to_owned();
+    let payload: Value = row["payload"]
+        .as_str()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .unwrap_or(Value::Null);
+    let mut out = json!({
+        "seq": row["seq"],
+        "ts": row["ts"],
+        "type": ty,
+    });
+    if payload.is_null() {
+        return out;
+    }
+    match ty.as_str() {
+        "stage" => {
+            out["label"] = payload["name"].clone();
+        }
+        "text" | "reasoning" => {
+            // `text` carries `text` since #1886, `delta` before; `reasoning`
+            // still carries `delta`. One bilingual read covers all three.
+            let body = payload["text"]
+                .as_str()
+                .or_else(|| payload["delta"].as_str());
+            set_journal_body(&mut out, body.unwrap_or(""), full);
+        }
+        "tool_start" => {
+            out["call_id"] = payload["call"]["call_id"].clone();
+            out["name"] = payload["call"]["name"].clone();
+            let args = serde_json::to_string_pretty(&payload["call"]["input"]).unwrap_or_default();
+            set_journal_body(&mut out, &args, full);
+        }
+        "tool_result" => {
+            let call_id = payload["call_id"].as_str().unwrap_or_default();
+            out["call_id"] = json!(call_id);
+            out["duration_ms"] = payload["duration_ms"].clone();
+            out["speculated"] = json!(payload["speculated"].as_bool().unwrap_or(false));
+            // The name the call was made under. A result that resolves to no
+            // call — a store whose `tool_start` rows were pruned, a journal
+            // read mid-write — is labelled generically rather than left
+            // anonymous or dropped.
+            out["name"] = json!(names.get(call_id).map_or("tool", String::as_str));
+            // `ToolOutput` is externally tagged: `{"ok":{"content":…}}` or
+            // `{"error":{"message":…}}` — the tag is the ok/failed verdict.
+            out["ok"] = json!(!payload["output"]["ok"].is_null());
+            let body = payload["output"]["ok"]["content"]
+                .as_str()
+                .or_else(|| payload["output"]["error"]["message"].as_str())
+                .unwrap_or("");
+            set_journal_body(&mut out, body, full);
+        }
+        "speculation_discarded" => {
+            out["call_id"] = payload["call_id"].clone();
+            out["name"] = payload["name"].clone();
+            out["reason"] = payload["reason"].clone();
+        }
+        // A parked span is the one thing that explains a wall-clock gap with
+        // no events in it (#1857). Without its payload the row would say a
+        // park happened but not what was waited on or for how long — which
+        // is the entire question an operator opens this transcript to ask.
+        "turn_parked" => {
+            out["description"] = payload["description"].clone();
+            out["poll_interval_secs"] = payload["poll_interval_secs"].clone();
+            out["deadline_secs"] = payload["deadline_secs"].clone();
+        }
+        "turn_woken" => {
+            out["reason"] = payload["reason"].clone();
+            out["polls_used"] = payload["polls_used"].clone();
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Attach `body` to a transcript entry, clipped to [`JOURNAL_BODY_CLIP`]
+/// unless `full`, and record which of the two happened.
+///
+/// Shared with the sent-context messages (`sent_context`), so the transcript
+/// and the reconstruction can never disagree about what "clipped" means or
+/// where the cut falls.
+pub(crate) fn set_journal_body(entry: &mut Value, body: &str, full: bool) {
+    let clipped = !full && body.chars().count() > JOURNAL_BODY_CLIP;
+    entry["body"] = if clipped {
+        json!(truncate(body, JOURNAL_BODY_CLIP))
+    } else {
+        json!(body)
+    };
+    entry["truncated"] = json!(clipped);
+}

--- a/crates/stella-observatory/src/journal.rs
+++ b/crates/stella-observatory/src/journal.rs
@@ -127,7 +127,10 @@ fn tool_names(conn: &Connection, id: i64) -> Result<HashMap<String, String>, DbE
         Err(e) => return Err(e.into()),
     };
     let rows = stmt.query_map([id], |r| {
-        Ok((r.get::<_, Option<String>>(0)?, r.get::<_, Option<String>>(1)?))
+        Ok((
+            r.get::<_, Option<String>>(0)?,
+            r.get::<_, Option<String>>(1)?,
+        ))
     })?;
     let mut out = HashMap::new();
     for row in rows {

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -49,6 +49,7 @@ mod context_diff;
 mod db;
 mod fsview;
 mod global;
+mod journal;
 mod live;
 mod self_driving;
 mod sent_context;

--- a/crates/stella-observatory/src/sent_context.rs
+++ b/crates/stella-observatory/src/sent_context.rs
@@ -513,7 +513,7 @@ pub(crate) fn reconstruct(
                 "role": message.role,
                 "blocks": Value::Array(message.blocks),
             });
-            crate::db::set_journal_body(&mut out, &message.body, full);
+            crate::journal::set_journal_body(&mut out, &message.body, full);
             out
         })
         .collect();

--- a/crates/stella-observatory/src/tests/execution_routes.rs
+++ b/crates/stella-observatory/src/tests/execution_routes.rs
@@ -128,12 +128,63 @@ fn execution_journal_after_seq_returns_only_newer_rows() {
     );
 }
 
-/// A body past [`db::JOURNAL_BODY_CLIP`] chars is clipped and flagged in the
+/// A tool result names the tool that produced it.
+///
+/// `ToolResult` is `{call_id, output, duration_ms, speculated}` — the name
+/// lives on the `ToolStart` that opened the call, so a result row can only be
+/// labelled by correlating back to it. Until it was, every result row in the
+/// dashboard read `✓ result`, and a reader scrolling a fan-out of parallel
+/// calls could not tell which row answered which.
+#[test]
+fn execution_journal_labels_a_result_with_its_tools_name() {
+    let ws = seeded_workspace();
+    let response = respond(ws.path(), "/api/execution-journal?id=1");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    let result = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["type"] == "tool_result")
+        .expect("the fixture seeds a tool_result");
+    assert_eq!(result["name"], "read_file");
+    assert_eq!(result["ok"], true);
+    // The body is the decoded `ok.content`, never the tagged wrapper.
+    assert_eq!(result["body"], "fn a() {}");
+}
+
+/// The name survives the incremental poll, which is where a batch-local index
+/// would fail.
+///
+/// A live transcript polls with `after_seq` set to the highest row it already
+/// has, so a `tool_result` routinely arrives in a page that does not contain
+/// the `tool_start` it answers. Resolving names only within the returned rows
+/// would label the first fetch and silently stop labelling every later one —
+/// the failure mode that looks exactly like the feature working.
+#[test]
+fn a_result_polled_without_its_call_is_still_named() {
+    let ws = seeded_workspace();
+    // Seq 3 is the `tool_start`; asking for rows after it excludes the call
+    // from the batch entirely.
+    let response = respond(ws.path(), "/api/execution-journal?id=1&after_seq=3");
+    let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    let batch = v.as_array().unwrap();
+    assert!(
+        !batch.iter().any(|e| e["type"] == "tool_start"),
+        "the call must not be in this batch, or the test proves nothing"
+    );
+    let result = batch
+        .iter()
+        .find(|e| e["type"] == "tool_result")
+        .expect("the result is in this batch");
+    assert_eq!(result["name"], "read_file");
+}
+
+/// A body past [`crate::journal::JOURNAL_BODY_CLIP`] chars is clipped and flagged in the
 /// default payload, and returned whole under `?full=1` — the elision must
 /// announce itself, never pose as the data.
 #[test]
 fn execution_journal_clips_long_bodies_unless_full() {
-    use crate::db::JOURNAL_BODY_CLIP;
+    use crate::journal::JOURNAL_BODY_CLIP;
     let ws = seeded_workspace();
     let long = "x".repeat(JOURNAL_BODY_CLIP + 100);
     Connection::open(ws.path().join(".stella/private/store.db"))
@@ -262,12 +313,12 @@ fn execution_context_without_receipts_says_so_instead_of_erroring() {
 }
 
 /// A reconstructed message obeys the transcript route's clip policy: past
-/// `db::JOURNAL_BODY_CLIP` chars it is cut and flagged, and `?full=1` returns
+/// `journal::JOURNAL_BODY_CLIP` chars it is cut and flagged, and `?full=1` returns
 /// the bytes. A system prompt is thousands of stable lines, so this is the
 /// common case here rather than the edge one.
 #[test]
 fn execution_context_clips_long_messages_unless_full() {
-    use crate::db::JOURNAL_BODY_CLIP;
+    use crate::journal::JOURNAL_BODY_CLIP;
     let ws = seeded_workspace();
     let long = "x".repeat(JOURNAL_BODY_CLIP + 100);
     Connection::open(ws.path().join(".stella/private/store.db"))


### PR DESCRIPTION
Four surfaces render the same `tool_start`/`tool_result` pair, in three languages, and each one re-derived the shape by hand. Three of the four got it wrong, each in a different way. This makes them agree with the one that was right — the Command Deck.

The reported symptom was a tool result arriving in the arena transcript as

```
{'ok': {'content': '--- branches (local) ---\n* master d7d3e4b off the job market woo\n--- reflog ---\n…'}}
```

— a Python `repr`, on one line, with every newline escaped and no tool name anywhere on the row.

## What was actually broken

| Surface | Unwraps `ToolOutput` | Tool name on result | ok/error verdict | Arguments |
|---|---|---|---|---|
| `stella run` — deck + plain, **the reference** | ✅ | ✅ | ✅ | ✅ |
| Observatory journal | ✅ | ❌ | ✅ | ✅ |
| arenabench `transcript.py` | ❌ repr | ❌ | ❌ | ❌ |
| arenabench `recorder/render.py` | ❌ repr | ❌ | ❌ | ❌ |

Three facts about the wire that a hand-rolled reader reliably misses, and that every fix here turns on:

1. **`ToolOutput` is externally tagged** — `{"ok":{"content":…}}` / `{"error":{"message":…}}`. `str()` on that dict is the reported bug.
2. **The tag is the verdict.** `tool_result` carries no `error` or `is_error` field and never has, so `bool(event.get("error"))` was `False` for every event — *every failed tool call in every arena transcript rendered as a success*, in the success colour, with the failure message presented as ordinary output.
3. **The name is on the call, not the result.** `ToolResult` is `{call_id, output, duration_ms, speculated}`.

And one that was arena-specific: the arguments ride under `ToolCall.input`, but the reader asked for `arguments` — a key the wire has never carried. So **every tool row in every arena transcript had an empty body**: a `bash` call did not show its command, an `edit_file` did not show its path.

## The changes

**`arenabench/toolout.py`** — new, stdlib-only, pure. The arena's single owner of this decoding: `decode_tool_output`, `strip_ansi`, `cap_middle`, `summarize`, `format_tool_input`, all ported from `crates/stella-tui`'s fold so the arena and the deck label the same call the same way. Two details worth review:

- The unrecognized-shape fallback is `json.dumps`, not `repr`. Both are wrong to show a reader; only one keeps the newlines real and the quotes parseable.
- Elision is **middle**, not tail. The old cap was `output[:8000]`; for a failing build that is the one slice that answers nothing, because the exit code and the error live in the tail.

**`recorder/render.py`** ships into a Docker image whose build context is `arenabench/recorder/` alone, so it cannot import the package and carries an acknowledged copy. The copy is not left to trust — `TestRecorderCopyStaysHonest` imports it by path and holds both functions to the canonical ones, input for input.

**`stella-observatory`** — `journal::tool_names` resolves `call_id → name` over the **whole execution**, not over the batch being returned. That is the detail that makes it correct under the incremental poll: a `tool_result` routinely arrives in a later `after_seq` page than its `tool_start`, so a batch-local index would label the first fetch and silently stop labelling every later one — the failure mode that looks exactly like the feature working. Only the two fields are read, via `json_extract`, so a long run's argument objects never leave SQLite.

The projection moves to `journal.rs`. `db.rs` stood at **1482 of the guard's 1500 lines with no baseline entry**, so the next addition to it would have failed the gate outright. The seam is the concern rather than the count: `db.rs` answers what a run cost and did in aggregates; `journal.rs` answers what happened, in order, for a person reading along. No baseline entry was added and none was raised.

**Both web surfaces adopt the deck's rails** (`render/row.rs::Rail`): `●` opens a call, `⎿` its result, `✗` a failed one — a distinct glyph *and* column, so a failure is findable by margin-scan alone. Plus duration, line count, and the `⚡ speculated` mark. `fmtDuration` is ported from `human_duration` rather than approximated.

One deliberate departure from the deck, noted in both files: the deck renders a call and its result as one tight block nothing can split, so its result row need not repeat the name. On the web surfaces the kind filters can hide every call row, which would leave a column of results naming nothing — so the result row carries its tool's name, subordinate to the call's.

## Witness

`arenabench/tests/test_toolout.py`, and two in `stella-observatory`.

The four behavioural assertions were run against `origin/main`'s reader and against this branch:

```
== origin/main (OLD) ==            == branch (NEW) ==
  [FAIL] body is decoded             [PASS] body is decoded
  [FAIL] result names its tool       [PASS] result names its tool
  [FAIL] call shows its arguments    [PASS] call shows its arguments
  [FAIL] a failed call is marked     [PASS] a failed call is marked
  4 failing assertion(s)             0 failing assertion(s)
```

The Observatory pair was confirmed the same way — both `FAILED` with the `out["name"]` assignment disabled, both `ok` with it restored. `a_result_polled_without_its_call_is_still_named` asserts the call is *absent* from the batch first, so it cannot pass vacuously.

Verified end to end against the real `stella-events.jsonl` of a TB2.1 `fix-git` trial, not a fixture: the SSE wire now carries `"kind":"tool_result","title":"bash"` with the reflog rendered as 24 real lines.

## Gates

- `cargo test -p stella-observatory` — 88 + 13 + others, 0 failed
- `cargo clippy -p stella-observatory --all-targets` — clean; `RUSTDOCFLAGS="-D warnings" cargo doc` — clean; `cargo fmt --all --check` — clean
- `make guards-fast` — all green, including `check-file-size` ("nothing went over by this change"), `check-god-files`, `check-module-reachability`; `make typed-errors` — clean
- `arenabench`: 696 passed; `ruff check` clean; `npm run typecheck` and `npm run build` clean

Not run: the full-workspace `make gate`. A TB2.1 trial was live on this machine for most of the session and a workspace build would have confounded it. Every crate this PR touches is covered above; CI is the backstop for the rest.

## Left behind

- **#2527** — ANSI escapes reach the Observatory transcript unstripped. The deck strips at fold time; the Observatory cannot, because the stripper lives in `stella-tui` (ratatui) and the Observatory deliberately links almost nothing. The correct fix is a zero-dependency leaf crate — the `stella-diff` shape from #1511 — not a fourth private copy, which `ansi.rs`'s own module doc forbids in as many words. Filed with the crate design, the gate checklist, and the witness test spelled out. **This is the one thing this PR leaves undone, and it is deliberate: a new workspace member is a separate reviewable change, not a rider on a formatting PR.**

## Notes for whoever lands this

- `arenabench/arenabench/web/` is a **gitignored build artifact**. `npm run build` in `arenabench/ui` is required before `arenabench serve` shows any of this. The `ui/package.json` description said the export was committed and named the wrong directory; corrected here.
- The recorder image needs `arenabench build-recorder` for the `render.py` fix to reach a video.

Refs #2527

## Summary by Sourcery

Unify tool event decoding across ArenaBench and the observatory so transcripts correctly show tool names, arguments, verdicts, and readable bodies on all surfaces.

New Features:
- Introduce a shared tool output decoding module in ArenaBench that extracts human-readable text, success status, and argument summaries for tool calls and results.
- Add support in ArenaBench transcript and UI for showing tool names, argument details, duration, line counts, speculation status, and output shape for each tool result.
- Provide a duration formatter in the web UI that matches the Command Deck’s timing vocabulary, aligning transcript grammar across surfaces.

Bug Fixes:
- Fix ArenaBench transcript and recorder to decode externally tagged ToolOutput correctly instead of rendering Python reprs with escaped newlines.
- Ensure tool results are labelled with their corresponding tool names and failure status across ArenaBench, the recorder, and stella-observatory, including incremental polling cases.
- Correct ArenaBench transcript to read tool arguments from the proper input field so tool calls display their commands, paths, or queries instead of empty bodies.
- Strip ANSI escape sequences from tool output in ArenaBench transcript and recorder so coloured child-process output renders cleanly in transcripts and videos.

Enhancements:
- Extract observatory execution journal projection into a dedicated module and share body clipping logic with sent-context reconstruction.
- Align web dashboards and arena UI with the Command Deck’s rail glyphs for tool calls and results, improving visual consistency and error discoverability.
- Refine lane and transcript rendering to make failed tool calls visually distinct and to support expandable views of full tool arguments and longer outputs.

Documentation:
- Update ArenaBench UI package description to clarify the build-and-export workflow and directory used for serving the static web assets.

Tests:
- Add comprehensive tests for tool output decoding, ANSI stripping, middle-capping, argument formatting, and transcript tool rows in ArenaBench, including parity checks for the recorder’s copied decoder.
- Extend stella-observatory execution journal tests to cover tool-name labelling, incremental polling behaviour, and updated body clipping constants.