### PR TITLE
ci(dependency-review): exempt sharp's LGPL libvips tuples from the license gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,22 +38,58 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
+          # Two exemptions, each for code that reaches nothing this project
+          # distributes. Vulnerability review still applies to every package
+          # named here — this input excludes them from the LICENSE check only.
+          #
           # Swatinem/rust-cache is LGPL-3.0 and has been in ci.yml, release.yml
           # and live-smoke.yml since long before this gate existed — the action
           # only surfaces in a review when a PR adds a workflow file that uses
           # it, which is how a settled dependency turned up as a new finding on
           # #1233. It caches a target directory on the runner; nothing it
           # touches is distributed, so the AGPL/dual-license reasoning in the
-          # header does not apply to it. Vulnerability review still does — this
-          # input excludes the package from the LICENSE check only.
+          # header does not apply to it.
+          #
+          # The @img/sharp-* tuples arrive through arenabench/web: `next` lists
+          # `sharp` in optionalDependencies, so npm records every platform tuple
+          # in that lockfile whatever the host is, and the ones shipping a
+          # prebuilt libvips are LGPL-3.0-or-later. Three independent reasons
+          # the header's LINKED-code reasoning cannot reach them: arenabench/web
+          # is `"private": true` and Apache-2.0, so it is in neither the AGPL
+          # workspace nor the commercial binary; it is not distributed at all,
+          # being the arenabench.org control plane behind Vercel Authentication;
+          # and it imports no `next/image`, so sharp is never even loaded. Only
+          # the tuples that actually carry the LGPL are listed — their
+          # Apache-2.0 siblings pass the allow-list on their own merits and stay
+          # under the gate.
           #
           # Must stay ABOVE `allow-licenses`: check-license-allowlist-parity.sh
           # reads that key's folded scalar by consuming every following indented
-          # line, so a sibling key underneath it would be parsed as an SPDX id.
+          # line, so a sibling key underneath it — and now a whole folded list
+          # of purls — would be parsed as SPDX ids.
           #
-          # The version in a purl is ignored when matching, so re-pinning the
-          # action above does not require touching this line.
-          allow-dependencies-licenses: pkg:githubactions/Swatinem/rust-cache
+          # purlsMatch (the action's src/purl.ts) compares namespace/name
+          # case-insensitively and ignores the version, so re-pinning the action
+          # or bumping sharp never touches this list. It has no globs, and a
+          # namespace-only `pkg:npm/%40img` parses to the name "img" and matches
+          # nothing — so a NEW libvips tuple reds this gate again and has to be
+          # added by hand. #2532 tracks removing the recurrence instead.
+          allow-dependencies-licenses: >-
+            pkg:githubactions/Swatinem/rust-cache,
+            pkg:npm/%40img/sharp-libvips-darwin-arm64,
+            pkg:npm/%40img/sharp-libvips-darwin-x64,
+            pkg:npm/%40img/sharp-libvips-linux-arm,
+            pkg:npm/%40img/sharp-libvips-linux-arm64,
+            pkg:npm/%40img/sharp-libvips-linux-ppc64,
+            pkg:npm/%40img/sharp-libvips-linux-riscv64,
+            pkg:npm/%40img/sharp-libvips-linux-s390x,
+            pkg:npm/%40img/sharp-libvips-linux-x64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-arm64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-x64,
+            pkg:npm/%40img/sharp-wasm32,
+            pkg:npm/%40img/sharp-win32-arm64,
+            pkg:npm/%40img/sharp-win32-ia32,
+            pkg:npm/%40img/sharp-win32-x64
           allow-licenses: >-
             AGPL-3.0-only, Apache-2.0, Apache-2.0 WITH LLVM-exception, MIT,
             BSD-2-Clause, BSD-3-Clause, ISC, Zlib, BSL-1.0, MPL-2.0, Unlicense,


### PR DESCRIPTION
## What & why

`dependency-review` fails on PR #2523 (Dependabot: `next` 15.5.23 → 16.3.0), job
93279433381, with fourteen rejected packages:

```
The following dependencies have incompatible licenses:
arenabench/web/package-lock.json » @img/sharp-libvips-darwin-arm64@1.3.2 – LGPL-3.0-or-later
... (10 × @img/sharp-libvips-*@1.3.2, LGPL-3.0-or-later)
arenabench/web/package-lock.json » @img/sharp-wasm32@0.35.3 – Apache-2.0 AND LGPL-3.0-or-later AND MIT
... (3 × @img/sharp-win32-*@0.35.3, Apache-2.0 AND LGPL-3.0-or-later)
```

`next` lists `sharp` in `optionalDependencies`, so npm records **every** `@img/sharp-*`
platform tuple in that lockfile whatever the host is; the fourteen shipping a prebuilt
libvips carry `LGPL-3.0-or-later`, which is not on `allow-licenses`. They were already in
the tree at 1.2.4 / 0.34.5 — the version bump makes them `added` changes again, which is
what put them in front of the gate.

This adds those fourteen to `allow-dependencies-licenses`, the file's existing
per-package escape hatch, with the reasoning written into the file next to them.

### Why the exemption is legitimate

The header's rule is that the hatch is for code that is not LINKED into anything
distributed. Three independent reasons it applies here:

- `arenabench/web/package.json` is `"private": true` and its README carries
  `SPDX-License-Identifier: Apache-2.0` — it is in neither the AGPL Rust workspace nor
  the commercial binary.
- It is not distributed: it is the arenabench.org control plane, deployed behind Vercel
  Authentication (team only).
- It imports no `next/image` (`rg 'next/image|<Image' arenabench/web` is empty), so sharp
  is never loaded even at runtime. It is inert weight from a transitive optional dep.

Only the tuples that **actually carry the LGPL** are listed. Their Apache-2.0 siblings
(including the two new ones this bump introduces, `@img/sharp-freebsd-wasm32` and
`@img/sharp-webcontainers-wasm32`) pass the allow-list on their own merits and stay under
the gate. Vulnerability review is untouched — this input excludes packages from the
LICENSE check only.

Refs #2532
Refs #2533

## The witness

- [x] No witness needed (pure refactor / docs / **CI**) — because the change is a
      workflow input; there is no Rust surface to test.

Verified instead by **replaying the real failure through the action's own matcher**,
which is stronger than a re-run and does not need a CI round trip:

1. Transliterated `parsePURL` / `purlsMatch` verbatim from
   `actions/dependency-review-action` at the SHA this workflow pins
   (`a1d282b`, `src/purl.ts`), plus `parseList` from `src/config.ts`.
2. Fed them the real `GET /repos/macanderson/stella/dependency-graph/compare/<base>...<head>`
   payload for #2523 (75 changes, 39 added at `runtime` scope).

| exclusion list | forbidden | over-excluded |
|---|---|---|
| **before** (rust-cache only) | **14** — byte-for-byte the packages the red job named | 0 |
| **after** (this PR) | **0** | **0** |

The over-exclusion column is the part worth checking: every package this PR exempts
genuinely carries the LGPL, so none of them is being hidden from a gate it would have
passed anyway.

All 15 entries also pass the action's own zod validation (`PackageURLString` in
`src/schemas.ts`: parseable purl with a non-null `name`).

## The gate

- [x] `cargo fmt --check` — green (via `make guards-fast`)
- [x] `make guards-fast` — all 21 toolchain-free guards green, including
      `license-allowlist-parity` (still reads 17 licenses, so the new multi-line folded
      scalar is **not** being slurped as SPDX ids), `action-pins`, and `left-behind`
- [ ] `cargo clippy` / `cargo test --workspace` — not run: the diff is one YAML file and
      touches no crate, which is exactly the case `guards-fast` exists for
- [x] Docs updated where behavior changed — the reasoning lives in the workflow file
      itself, which is where the existing rust-cache rationale lives

## Nothing left behind

- [x] Filed: #2532, #2533

- **#2532** — this exemption **cannot converge**. `purlsMatch` compares
  `type` + `namespace/name` case-insensitively and ignores the version, so a sharp bump
  never touches this list — but there are **no globs**, and a namespace-only
  `pkg:npm/%40img` parses to `{namespace: null, name: "img"}` and matches nothing. So the
  next libvips platform tuple reds this gate again on whatever unrelated Dependabot PR
  carries it. This bump alone introduced two new tuples. The issue lays out the three
  candidate root fixes (stop pulling sharp; take the lockfile out of the review surface;
  or accept it and make the edit one minute instead of an investigation).
- **#2533** — every failing run of this job also emits
  `##[warning]Unable to write summary to pull-request`: `comment-summary-in-pr: on-failure`
  is configured but the workflow only grants `contents: read`, so the summary comment has
  never posted. Left out of this PR deliberately — it is a permissions decision, not part
  of unblocking #2523.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**How this reaches #2523.** For `pull_request` events, Actions reads the workflow from the
PR's merge ref, so #2523 picks this up once it is merged **and the merge ref is
recomputed** — a bare re-run of the failed job may reuse the cached ref. After merging,
either click *Update branch* on #2523 or comment `@dependabot rebase`.

**Placement is load-bearing.** `allow-dependencies-licenses` must stay **above**
`allow-licenses`: `scripts/check-license-allowlist-parity.sh` parses the latter by
consuming every indented line that follows it, so a folded list of purls underneath it
would be read as SPDX ids and fail the gate with a confusing diff. The file already
carried that warning; this PR extends it now that the scalar is multi-line.

**Rejected alternative.** Widening `allow-licenses` to include LGPL — this is what
AGENTS.md and CLAUDE.md explicitly forbid ("do not widen the allow-list without a
licensing decision"), and it would also have to be mirrored into `deny.toml` for the
parity guard, applying an npm dashboard's problem to every Rust crate in the workspace.

## Summary by Sourcery

CI:
- Extend dependency-review workflow configuration to allow listed sharp-related npm packages and Swatinem/rust-cache to bypass license checks via allow-dependencies-licenses, without changing the allowed license set.