### PR TITLE
fix(stella-pipeline): stop the witness failing on the pipeline's own commits

### DIFF
--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -16,6 +16,22 @@ fn snapshot_identity_matches_the_verify_done_walk_vocabulary() {
     );
 }
 
+/// The third copy: the witness author is told to exclude commits by this
+/// identity, and a stale spelling there is worse than a missing note — the
+/// author would filter on an address that matches nothing and write exactly
+/// the enumeration that cannot pass. `stella-pipeline` depends on neither of
+/// the other two crates, so this test is the only place all three meet.
+#[test]
+fn snapshot_identity_matches_what_the_witness_author_is_told_to_exclude() {
+    assert_eq!(
+        SNAPSHOT_IDENT[3],
+        format!(
+            "user.email={}",
+            stella_pipeline::witness::MACHINERY_COMMIT_EMAIL
+        )
+    );
+}
+
 #[test]
 fn candidate_port_keeps_the_exact_host_operation_journal() {
     let journal: Arc<dyn stella_media::MediaOperationJournal> = Arc::new(

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -23,9 +23,14 @@ fn snapshot_identity_matches_the_verify_done_walk_vocabulary() {
 /// the other two crates, so this test is the only place all three meet.
 #[test]
 fn snapshot_identity_matches_what_the_witness_author_is_told_to_exclude() {
+    let email_entry = SNAPSHOT_IDENT
+        .iter()
+        .find(|entry| entry.starts_with("user.email="))
+        .expect("SNAPSHOT_IDENT must contain a user.email entry");
+
     assert_eq!(
-        SNAPSHOT_IDENT[3],
-        format!(
+        email_entry,
+        &format!(
             "user.email={}",
             stella_pipeline::witness::MACHINERY_COMMIT_EMAIL
         )

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -777,6 +777,62 @@ pub const WITNESS_SYSTEM_PROMPT: &str = "You are the WITNESS AUTHOR for a coding
 /// snapshot's directory carries a pid and a sequence number, so naming it
 /// would put per-run noise into a prompt that wants to cache (invariant 7),
 /// and it is not the root the goal's paths are written against anyway.
+/// The committer email on the pipeline's own plumbing commits, as the witness
+/// author must spell it to exclude them.
+///
+/// `stella-tools::verify::CANDIDATE_SNAPSHOT_EMAIL` and `stella-cli`'s
+/// `SNAPSHOT_IDENT` are the other two copies. This crate depends on neither, so
+/// the spellings are pinned together by the parity test in `stella-cli` rather
+/// than shared — the same arrangement those two already use.
+pub const MACHINERY_COMMIT_EMAIL: &str = "pipeline@stella.invalid";
+
+/// Warn the author off the pipeline's own commits.
+///
+/// A candidate workspace is a detached-HEAD shadow, and the pipeline seals a
+/// baseline commit into it before the agent starts. That commit is authored by
+/// [`MACHINERY_COMMIT_EMAIL`], is reachable only from a `refs/worktree/` pin,
+/// and is therefore **indistinguishable from a lost commit** to any check that
+/// enumerates history — `git rev-list --all --reflog --not master`,
+/// `git fsck --dangling`, and every variation an author reaches for.
+///
+/// On Terminal-Bench `fix-git` — whose goal is literally "find my lost changes
+/// and merge them into master" — an author wrote exactly that enumeration. It
+/// returned the one commit the task hid *and two of the pipeline's own*, so the
+/// witness could not pass however correctly the agent merged the real one:
+///
+/// ```text
+/// WITNESS FAIL: found lost change(s) not merged into master:
+///   3ba48af stella: candidate baseline snapshot   <- the pipeline's
+///   7fa97c1 stella: candidate baseline snapshot   <- the pipeline's
+///   c499730 Move to Stanford                      <- the task's
+/// ```
+///
+/// The agent merged `c499730`, the witness stayed red on the other two, and the
+/// run spent its remaining budget on a defect that did not exist. A witness the
+/// agent cannot satisfy by doing the task correctly is worse than no witness:
+/// it converts a solved task into a deadline.
+///
+/// Told to the author rather than filtered afterwards because only the author
+/// knows what its check enumerates. There is no arrangement of refs that hides
+/// a commit object from every git query — `--all` sees the pin, `--reflog` sees
+/// the HEAD move, `fsck` sees it dangling if we remove both — so the honest fix
+/// is to name the identity and let the check exclude it.
+const MACHINERY_COMMIT_NOTE: &str = concat!(
+    "\nIMPORTANT if your check enumerates repository history (`git log`, \
+     `git rev-list`, `git fsck`, reflog walks): this workspace is an isolated \
+     copy in which the pipeline has committed its OWN bookkeeping snapshots, \
+     authored by `",
+    "pipeline@stella.invalid",
+    "` with subjects beginning `stella: `. They sit on a detached HEAD and so \
+     look exactly like unreachable or lost commits, but they are not part of \
+     the task and the agent cannot merge, remove or otherwise dispose of them. \
+     EXCLUDE them — for example `git log --invert-grep --author=",
+    "pipeline@stella.invalid",
+    "` or by filtering that author out of any commit list you build. A witness \
+     that counts them can never pass, however correctly the agent does the \
+     task.\n"
+);
+
 pub fn witness_prompt(
     goal: &str,
     recall: &[RecalledFrame],
@@ -817,6 +873,7 @@ pub fn witness_prompt(
                  `TEST_COMMAND: sh <path-to-script>`. Do NOT write a pytest, cargo, or \
                  other framework test here: nothing exists to collect it.\n",
             );
+            s.push_str(MACHINERY_COMMIT_NOTE);
         }
     }
     if !repo_structure.trim().is_empty() {

--- a/crates/stella-pipeline/src/witness/tests.rs
+++ b/crates/stella-pipeline/src/witness/tests.rs
@@ -728,6 +728,63 @@ fn a_shell_only_workspace_prompts_a_shell_witness() {
     );
 }
 
+/// A shell-witness author enumerating history must be told to skip the
+/// pipeline's own commits.
+///
+/// A candidate workspace is a detached-HEAD shadow carrying a pipeline-authored
+/// baseline snapshot, which is reachable only from a `refs/worktree/` pin and so
+/// is indistinguishable from a lost commit to `git rev-list --all --reflog`,
+/// `git fsck --dangling`, or anything similar.
+///
+/// On Terminal-Bench `fix-git` — goal: "find my lost changes and merge them
+/// into master" — an author wrote precisely that enumeration and the witness
+/// returned the task's one hidden commit plus TWO of the pipeline's. The agent
+/// merged the real one; the witness stayed red on the machinery it could not
+/// dispose of, and the run spent the rest of its budget chasing a defect that
+/// did not exist. A witness the agent cannot satisfy by doing the task
+/// correctly turns a solved task into a deadline.
+#[test]
+fn a_shell_witness_author_is_told_to_exclude_the_pipelines_own_commits() {
+    let p = witness_prompt(
+        "find my lost changes and merge them into master",
+        &[],
+        "README.md",
+        &["sh".to_string()],
+        "",
+    );
+    assert!(
+        p.contains(crate::witness::MACHINERY_COMMIT_EMAIL),
+        "the identity to exclude must be named verbatim so a filter can match it: {p}"
+    );
+    assert!(
+        p.contains("EXCLUDE them"),
+        "naming the commits without saying to drop them is not guidance: {p}"
+    );
+    assert!(
+        p.contains("git fsck") && p.contains("rev-list"),
+        "the note must reach the enumerations an author actually reaches for: {p}"
+    );
+}
+
+/// …and it is not spent on workspaces that cannot hit it. A toolchain witness
+/// is a framework test, not a history walk, and the note is prompt budget on
+/// every single authoring call — so it rides with the shell-only branch that
+/// tells the author to assert a git fact in the first place.
+#[test]
+fn the_machinery_commit_note_rides_only_with_the_shell_witness_guidance() {
+    let with_cargo = witness_prompt(
+        "add a parser",
+        &[],
+        "Cargo.toml",
+        &["cargo".to_string(), "sh".to_string()],
+        "",
+    );
+    assert!(
+        !with_cargo.contains(crate::witness::MACHINERY_COMMIT_EMAIL),
+        "{with_cargo}"
+    );
+}
+
 /// #2130's prompt half: the author is TOLD the frame it is authoring in.
 ///
 /// The goal routinely phrases deliverables in the project's absolute paths


### PR DESCRIPTION
## What

A candidate workspace is a detached-HEAD shadow, and the pipeline seals a baseline commit into it before the agent starts. That commit is authored by `pipeline@stella.invalid` and reachable only from a `refs/worktree/` pin — so it is **indistinguishable from a lost commit** to any check that enumerates history.

On Terminal-Bench `fix-git` (goal: *"find my lost changes and merge them into master"*) that turned a correct solve into a deadline.

PR #2531 had just fixed triage so this task finally authored a shell witness — and the author did the right thing, reaching for a git fact exactly as #2064's guidance intends. It wrote `git rev-list --all --reflog --not master`. The result:

```
WITNESS FAIL: found lost change(s) not merged into master:
  3ba48af stella: candidate baseline snapshot   <- the pipeline's
  7fa97c1 stella: candidate baseline snapshot   <- the pipeline's
  c499730 Move to Stanford                      <- the task's
```

The agent merged `c499730` correctly. The witness stayed red on two commits it cannot merge, remove, or dispose of, and the run spent its remaining budget chasing a defect that did not exist — match `7d025330abad`: 817s, deadline, reward 0.0, against Claude Code's 91s pass.

**A witness the agent cannot satisfy by doing the task correctly is worse than no witness.** It converts a solved task into a deadline.

## Why the prompt and not a filter

Only the author knows what its check enumerates, and there is no arrangement of refs that hides a commit object from every git query: `--all` sees the pin, `--reflog` sees the HEAD move, and `fsck` sees it dangling if we remove both. Naming the identity so the check can exclude it is the honest fix.

It rides with the shell-only branch that already tells the author to assert a git fact, so a toolchain workspace — which authors a framework test, not a history walk — pays no prompt budget for it.

## Witness tests

- `a_shell_witness_author_is_told_to_exclude_the_pipelines_own_commits` — verified the artisanal way: fails with the note suppressed, passes with it.
- `the_machinery_commit_note_rides_only_with_the_shell_witness_guidance` — the note is not spent on workspaces that cannot hit the bug.
- `snapshot_identity_matches_what_the_witness_author_is_told_to_exclude` — this is the **third** copy of the identity. `stella-pipeline` depends on neither `stella-tools` nor `stella-cli`, so the parity test in `stella-cli` is the only place all three meet. A stale spelling here would be worse than a missing note: the author would filter on an address matching nothing and write exactly the enumeration that cannot pass.

## Verification

- `cargo test -p stella-pipeline` — 714 pass
- `cargo test -p stella-cli --bins snapshot_identity` — 2 pass
- `cargo clippy -p stella-pipeline --all-targets` — clean
- `scripts/check-file-size.sh` — OK

Refs #2374

## Summary by Sourcery

Clarify witness author guidance so pipeline bookkeeping commits do not cause unsatisfiable witnesses in detached candidate workspaces.

Bug Fixes:
- Prevent witness checks from treating the pipeline's own baseline snapshot commits as unmergeable lost changes.

Enhancements:
- Add explicit prompt note instructing shell witnesses that enumerate git history to exclude pipeline-authored snapshot commits.
- Introduce a shared constant for the pipeline machinery commit email and tie its spelling to existing snapshot identity configuration via a parity test.
- Scope the new guidance so it is only included for shell-only witness prompts and not for toolchain/framework-based witnesses.

Tests:
- Add witness prompt tests to ensure machinery commit guidance is present for shell witnesses and omitted for toolchain witnesses.
- Add a candidate workspace test to verify the snapshot identity email matches the witness author exclusion identity.