### PR TITLE
chore(arenabench): drop the dead sharp install-script approval

### DIFF
--- a/arenabench/web/README.md
+++ b/arenabench/web/README.md
@@ -15,6 +15,17 @@ on Auth.js — is #2100, and replaces the interim wall rather than stacking
 on it. The Claude Code credential lifecycle (connect/verify/renew from the
 UI) is #2101.
 
+**Install scripts**: npm records the dependency install scripts a project has
+reviewed in an `allowScripts` block in `package.json` — advisory on npm 11, and
+blocking on npm 12. Approvals are pinned to an exact version, so one survives
+a dependency bump only by accident. This app deliberately declares no block:
+nothing in `package-lock.json` sets `hasInstallScript`, because the only
+dependency that ever needed approval was `sharp` — reached optionally through
+`next` — and the 0.35.3 it resolves to today ships prebuilt `@img/sharp-*`
+binaries rather than the `install` hook 0.34.5 ran. Re-add a block with
+`npm approve-scripts`, never by hand, and only when an install reports a
+dependency that actually declares a script.
+
 Environment (all optional — defaults target the deployed stack):
 
 | Variable | Default |

--- a/arenabench/web/package.json
+++ b/arenabench/web/package.json
@@ -17,8 +17,5 @@
     "next": "^16.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
-  },
-  "allowScripts": {
-    "sharp@0.34.5": true
   }
 }


### PR DESCRIPTION
## What & why

`arenabench/web/package.json` carried npm's install-script allowlist:

```json
"allowScripts": { "sharp@0.34.5": true }
```

`allowScripts` records the dependency install scripts a project has reviewed —
advisory on npm 11, blocking on npm 12. Approvals are pinned to an **exact
version**, so one survives a dependency bump only by accident, and this one did
not: #2523 moved `next` to 16.3.0, which resolves `sharp` **0.35.3**, and 0.35.3
ships prebuilt `@img/sharp-*` binaries instead of the `install` hook that 0.34.5
ran. The block was approving a script that no longer exists, on a version that is
not installed.

The reason moves into `arenabench/web/README.md`, because package.json cannot
carry a comment and a bare deletion teaches the next reader nothing — including
the rule that a future block comes from `npm approve-scripts`, never by hand.

Found while triaging #2524. That PR is a superseded duplicate of #2523 with a
genuinely empty diff, and is being closed rather than merged, per the instruction
`scripts/check-empty-diff.sh` prints.

## The witness

- [x] No witness needed (pure config / docs) — because the change removes an
      inert manifest key and adds prose; there is no code path to flip.

It is still **demonstrated rather than asserted**, on the two claims that matter:

1. **Nothing in the tree declares an install script.** Every entry in
   `arenabench/web/package-lock.json` was parsed: zero set `hasInstallScript`.
   Confirmed independently against the registry — `sharp` 0.34.5 declares
   `"install": "node install/check.js || npm run build"`, and 0.35.3 declares no
   `install`/`preinstall`/`postinstall` at all.
2. **Removing the key changes no resolution.** `npm install --package-lock-only`
   run against the edited manifest reproduces the committed
   `package-lock.json` **byte for byte** (`diff` clean), and
   `npm ci --dry-run` completes with no error and no unreviewed-script warning.
   The lockfile's root entry never mirrored `allowScripts`, so `npm ci` could not
   have desynced in either direction.

## The gate

- [x] `make guards-fast` — every toolchain-free guard plus `cargo fmt --check`,
      green. This is the rung the pre-push hook selects for a diff that reaches
      no crate and cannot touch the wire contract; this diff is confined to
      `arenabench/web/`.
- [ ] `cargo clippy` / `cargo test` — not run locally: no crate is touched, so
      there is nothing for them to say that CI's own run will not.
- [x] Docs updated where behavior changed (`arenabench/web/README.md`)

## Nothing left behind

Two open Dependabot alerts on `main`, both unrelated to this change and neither
tracked by an issue, were noticed while triaging #2524: `js-yaml` 4.3.0 (high) in
`website/pnpm-lock.yaml` and `h2` 4.3.0 (moderate) in
`bench/terminal_bench_analysis/uv.lock`. They are being fixed directly rather
than filed — see the companion PR.

## Anything reviewers should know?

The alternative was re-pinning the key to `sharp@0.35.3`. That would be worse
than useless: it would assert a review of a script that does not exist, and would
go stale again at the next bump. `npm approve-scripts` would not write it either,
since npm has nothing to approve.

## Summary by Sourcery

Remove obsolete npm install-script approval from arenabench/web and document the install-script policy in the README.

Enhancements:
- Clarify npm install-script handling and the absence of an allowScripts block in arenabench/web/README.md.

Chores:
- Drop the dead allowScripts entry for sharp from arenabench/web/package.json, as the approved install script no longer exists for the resolved version.