### PR TITLE
fix(deps): close the two open Dependabot alerts (js-yaml, h2)

### DIFF
--- a/bench/terminal_bench_analysis/uv.lock
+++ b/bench/terminal_bench_analysis/uv.lock
@@ -661,15 +661,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -1428,8 +1428,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   lightningcss-android-arm64@1.32.0:
@@ -3000,7 +3000,7 @@ snapshots:
       github-slugger: 2.0.0
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
       remark: 15.0.1
@@ -3034,7 +3034,7 @@ snapshots:
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
       fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@0.556.0(react@19.2.6))(next@16.2.11(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
       picomatch: 4.0.5
@@ -3223,7 +3223,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What & why

`main` carried two open Dependabot alerts. Both live in lockfiles **outside the
Cargo workspace**, which is why no step of `make gate` was watching them:
`cargo deny check advisories` covers the Rust crates only, and these are the pnpm
tree behind `website/` and the uv tree behind `bench/terminal_bench_analysis/`.
GitHub's alerts were the only thing looking, and an alert is not a check anyone
has to clear before merging.

Each package was pinned at exactly 4.3.0, and each needed one patch bump:

| Alert | Severity | Package | Manifest | Change |
| --- | --- | --- | --- | --- |
| [#34](https://github.com/macanderson/stella/security/dependabot/34) | high | `js-yaml` | `website/pnpm-lock.yaml` | 4.3.0 → **4.3.1** |
| [#36](https://github.com/macanderson/stella/security/dependabot/36) | moderate | `h2` | `bench/terminal_bench_analysis/uv.lock` | 4.3.0 → **4.4.1** |

Both are transitive, so both are resolved in place rather than pinned:

- `js-yaml` arrives through `fumadocs-core` and `fumadocs-mdx`, which each declare
  `^4.1.1` — a range the patched version already satisfies. So this needs **no**
  new entry beside the `postcss` / `sharp` floors in
  `website/pnpm-workspace.yaml`; those exist because Next pins those two
  transitively out of range, which is not the situation here.
- `h2` arrives through `httpx[http2]`.

The diff is **8 lines**. Nothing but the two packages moved — no lockfile churn
rode along.

## The witness

- [x] No witness needed (dependency lockfiles only) — no source file changes, so
      there is no behavior to flip. The claim being made is "the vulnerable
      versions are gone and nothing else broke", and that is verified below
      rather than asserted.

**Verification, by the commands CI itself runs:**

1. `pnpm install --frozen-lockfile` (the shape `docs.yml` runs) passes against
   the updated lockfile — the importers are unchanged, so nothing desynced.
2. The `minimumReleaseAge: 1440` supply-chain policy in
   `website/pnpm-workspace.yaml` **accepts** js-yaml 4.3.1: published
   2026-07-31, nine days old, well past the 24h floor. pnpm reports
   `Lockfile passes supply-chain policies`.
3. For the analyzer, `bench.yml`'s own two commands, run verbatim in
   `bench/terminal_bench_analysis/`:
   `uv sync --locked --extra dev` then `uv run --no-sync pytest -q` →
   **270 passed**.
4. `make guards-fast` green (every toolchain-free guard plus `cargo fmt
   --check`) — the rung the pre-push hook selects for a diff reaching no crate.

**Done means** this prints nothing:

```sh
gh api repos/macanderson/stella/dependabot/alerts \
  --jq '.[] | select(.state=="open") | "\(.number) \(.dependency.package.name)"'
```

## Nothing left behind

- [x] There is nothing: both alerts are fixed here.

Found while triaging #2524 (a superseded `sharp`/`next` bump, closed rather than
merged). The companion PR is #2547, which removes the dead `sharp@0.34.5`
install-script approval that bump left stranded.

## Anything reviewers should know?

`js-yaml` latest is 5.2.3, but `fumadocs-*` declares `^4.1.1`, so the tree
correctly stays on the 4.x line — 4.3.1 is the patched release for this advisory,
not a version held back. Moving to 5.x would be a `fumadocs` upgrade, not a
security fix, and is deliberately not in this PR.

## Summary by Sourcery

Update dependency lockfiles to resolve security alerts for transitive JavaScript and Python packages.

Bug Fixes:
- Address security vulnerability in js-yaml by updating the locked version in the website pnpm tree.
- Address security vulnerability in h2 by updating the locked version in the terminal bench analysis uv environment.

Enhancements:
- Ensure non-Cargo dependency lockfiles are aligned with CI checks and supply-chain policies to prevent future unnoticed alerts.

Chores:
- Clear all currently open Dependabot alerts related to js-yaml and h2 by updating their locked versions.