### PR TITLE
docs(claude): a claim ships with the evidence that establishes it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,30 @@
     cannot have both, state which one you are giving up and why, and let a
     human choose. Deciding it silently is how a reference implementation
     stops being one.
+- **Every factual claim ships with the evidence that establishes it, or it is
+  not made.** This is the general rule the bench rule below is one instance of,
+  and it governs everything you say to a human: what a build contains, when a
+  commit landed, why a run behaved as it did, whether a fix is present, what a
+  test proves. State the claim, name the command or file and line that shows
+  it, and — this is the half that gets skipped — **check that the evidence can
+  actually distinguish the claim from its opposite.** Evidence consistent with
+  both answers is not evidence; it is a coincidence you found agreeable.
+  - **An inference is not an observation, and must be labelled.** "The JSON
+    shows X, so the build predates Y" is a chain with a premise in it. Say
+    which link you verified and which you assumed, every time.
+  - **A commit message is a claim, not a fact.** So is a doc page, a code
+    comment, a PR description, and anything this file says. On 2026-08-09 a
+    session read "#2531 made `flip_achieved` tri-state" in a commit body and
+    reported the fix as present; the field was still `pub flip_achieved: bool`
+    in `verify.rs`, and the two signals it cited to date a benchmark run were
+    both present on *either* side of that commit. The conclusion was
+    unfalsifiable by the evidence offered and stated as fact anyway. Read the
+    code the claim is about.
+  - **"I do not know" is a complete answer** and is always cheaper than the
+    alternative. When the evidence runs out, say where it ran out and what
+    would settle it. Guessing confidently at a question a human asked because
+    they already suspected the answer is the single fastest way to become
+    worthless to them.
 - **A bench conclusion comes from the trace, never from a surface signal.**
   The measurement machinery is younger than the thing it measures, and its
   summary layer is a set of projections that each have their own bugs. On


### PR DESCRIPTION
## What

Adds one hard rule to CLAUDE.md: **every factual claim ships with the evidence that establishes it, or it is not made.**

It is the general form of the bench rule directly below it ("a bench conclusion comes from the trace, never from a surface signal"), which was already the same lesson scoped to one activity. Four clauses:

- **Check the evidence can distinguish the claim from its opposite.** Evidence consistent with both answers is not evidence.
- **An inference is not an observation, and must be labelled.** Say which link you verified and which you assumed.
- **A commit message is a claim, not a fact.** So is a doc page, a code comment, a PR description, and CLAUDE.md itself.
- **"I do not know" is a complete answer.**

## Why now

Written from a failure in the session that produced #2553.

Asked whether a benchmark trace predated the fix in #2531, the session answered "yes, it is from before it" and cited two fields from the verdict JSON: `flip_achieved: false` and `no_test_surface: true`.

Neither field supports that conclusion:

- `no_test_surface` was added **2026-08-07** in #2191 — *before* #2531. It appears on both sides.
- `flip_achieved` is still `pub flip_achieved: bool` at `crates/stella-pipeline/src/verify.rs:373`, even though #2531's own commit body says commit `9a4fde85e` made it tri-state.

So a run **with** #2531 emits byte-identical JSON to a run **without** it. The evidence could not tell the two apart, and the claim was stated as fact anyway — contradicting the maintainer, who had personally certified the benchmark ran on the tip.

Two distinct errors, both covered by the new clauses: citing evidence that does not discriminate, and reading a commit message as a fact about the code without opening the file it describes.

## Separately worth someone's attention

The discrepancy found while checking the above is **not** fixed here, because I have not established which side of it is wrong:

> #2531's commit body claims `flip_achieved` was made tri-state so that "the witness ran and did not flip" and "no witness was ever provisioned" stop rendering identically. `verify.rs:373` still declares it `bool`.

Either the tri-state landed somewhere other than `LadderInputs` and the field name in the commit body is loose, or the fix is incomplete and the confabulation chain #2531 was written to break is still reachable. That is worth an hour from whoever owns the verification ladder; I did not want to guess at it in a docs PR, which is the rule this PR adds.

## Note on scope

This branch originally also restored `docs/prompts/triage.md`, whose WITNESS paragraph still carried the guidance #2531 replaced ("a workspace with no test files or build manifest usually warrants WITNESS: no"). #2551 landed the identical correction on `main` first, so the cherry-pick dropped that half as already applied. Verified with `git diff origin/main HEAD -- docs/prompts/triage.md` — empty.

## Gates

Docs-only. `doc-links` exit 0, `file-size` OK, `left-behind` OK, `brand-case` OK. No code touched.

## Summary by Sourcery

Strengthen CLAUDE.md with a global rule that all factual claims must be backed by discriminative evidence, including explicit guidance on labeling inferences, treating commit messages and docs as claims, and preferring "I do not know" when evidence is insufficient.

Documentation:
- Add a hard documentation rule that every factual claim must include evidence that can distinguish it from its opposite.
- Clarify that inferences must be labeled as such rather than presented as direct observations.
- Document that commit messages, docs, comments, and PR descriptions are themselves claims and must be verified against the code.
- Emphasize that "I do not know" is an acceptable and often preferable response when evidence is lacking.