### PR TITLE
fix(stella-tools): unbreak main — public docs linked to private items

### DIFF
--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -160,8 +160,8 @@ pub struct RepoStatus {
     /// answer and had to go to raw `git fsck` / `git reflog` to learn anything
     /// (observed on Terminal-Bench `fix-git`, whose whole task is this shape).
     ///
-    /// Capped at [`MAX_UNREACHABLE_ROWS`]; the pipeline's own bookkeeping
-    /// commits are never listed (see [`GitCli::unreachable_commits`]).
+    /// Capped at `MAX_UNREACHABLE_ROWS`; the pipeline's own bookkeeping
+    /// commits are never listed (see `GitCli::unreachable_commits`).
     pub unreachable: Vec<CommitRef>,
     /// True when the unreachable list was truncated at the cap.
     pub unreachable_truncated: bool,


### PR DESCRIPTION
## What

Unbreaks `main`. `cargo doc -D warnings` — the `doc-warnings` gate step — has failed on **every** main commit since #2551 merged:

```
error: public documentation for `unreachable` links to private item `MAX_UNREACHABLE_ROWS`
  --> crates/stella-tools/src/repo.rs:163
error: public documentation for `unreachable` links to private item `GitCli::unreachable_commits`
  --> crates/stella-tools/src/repo.rs:164
error: could not document `stella-tools`
```

Confirmed identical on three consecutive main runs: [31336031383](https://github.com/macanderson/stella/actions/runs/31336031383) (#2551), [31336038099](https://github.com/macanderson/stella/actions/runs/31336038099) (#2553), [31336048947](https://github.com/macanderson/stella/actions/runs/31336048947) (#2554).

## Why it happens

`RepoStatus::unreachable` is a public field. Both items its doc comment linked are private — `MAX_UNREACHABLE_ROWS` is a bare `const` (`repo.rs:55`) and `unreachable_commits` is a private method on the public `GitCli` (`repo.rs:446`) — so `rustdoc::private_intra_doc_links` fires under `-D warnings`.

It reached main because the gate runs `--document-private-items`, under which the link *does* resolve; rustdoc emits the error precisely to say it "will break without" that flag.

## The fix

Both references become plain code spans. That is not a workaround — it is what the sibling field two lines up already does with exactly this shape of reference:

```rust
/// Changed files, capped at `MAX_CHANGED_ROWS`.
```

Making either item `pub` would also fix the link, but it would widen the crate's public API to satisfy a doc comment, and `MAX_CHANGED_ROWS` had already settled that question the other way inside this same struct.

## Verification

- `make doc-warnings CARGO_SCOPE="-p stella-tools"` — clean (this is the exact gate command, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --keep-going`).
- **This is the whole unbreak, not the first of several.** In each red run `cargo doc` was the *only* failing step: `cargo fmt --check`, `cargo clippy -D warnings`, the wire-schema check, the prompt-cache golden fixtures, `cargo test`, `stella context validate` and the release smoke build all passed in the same job. The gate does not stop at the first red step, so nothing is hidden behind this one.

No witness test: this is a rustdoc lint on a doc comment, and the gate step itself is the check that fails before and passes after.

Refs #2551

## Summary by Sourcery

Fix stella-tools documentation so rustdoc no longer reports private intra-doc links for the public RepoStatus::unreachable field, restoring the doc-warnings gate on main.

Bug Fixes:
- Resolve rustdoc private intra-doc link errors in stella-tools by removing links from public documentation to private items.

Documentation:
- Adjust RepoStatus::unreachable field documentation to reference internal constants and methods as code spans instead of links, keeping the public docs accurate without exposing additional API.