### PR TITLE
fix(stella-tools): unbreak main — overview.rs defines git_lines twice (E0428)

### DIFF
--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -235,20 +235,36 @@ const OVERVIEW_BRANCHES: usize = 8;
 /// Non-empty stdout lines from one `git` read, or `None` when git is absent,
 /// the directory is not a repository, or the command failed.
 ///
-/// Direct argv — no shell, nothing interpolated into a command string — and
-/// the full spawn-env policy, so an ambient `GIT_DIR` from a surrounding
-/// hook cannot re-aim these reads at another repository and have the
-/// overview report its branches as this workspace's.
+/// Direct argv — no shell, nothing interpolated into a command string.
 ///
 /// Synchronous on purpose: every caller here already runs on the blocking
 /// pool (`build_overview` is dispatched there), and these are single ref
 /// reads.
+///
+/// `current_dir` is **not** sufficient to say which repository this reads.
+/// `GIT_DIR` overrides it, and git *exports* `GIT_DIR` to every hook it runs —
+/// so an overview assembled from inside a pre-push hook would report the outer
+/// repository's branches, remotes and languages as this workspace's, silently
+/// and with no error to notice. `an_ambient_git_dir_cannot_retarget_the_overview`
+/// is the witness.
+///
+/// [`scrub_spawn_std_env`](crate::subprocess_env::scrub_spawn_std_env) is the
+/// whole answer and the only correct call here: it removes the retargeting
+/// family (`GIT_REPO_ENV_VARS`) and the forced-colour family *before*
+/// delegating to the credential/ambient-authority scrub. Reaching for
+/// `scrub_sensitive_std_env` and re-removing `GIT_REPO_ENV_VARS` by hand is
+/// the exact partial application that helper exists to prevent — and it
+/// silently drops the colour half, which matters because this output goes to
+/// a captured pipe rather than a terminal.
 fn git_lines(root: &Path, args: &[&str]) -> Option<Vec<String>> {
     let mut command = std::process::Command::new("git");
     command
         .args(args)
         .current_dir(root)
-        .stdin(std::process::Stdio::null());
+        // Nothing here reads stdin; inheriting it lets a git that decides to
+        // prompt (a credential helper on a remote URL) hang the overview.
+        .stdin(std::process::Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0");
     crate::subprocess_env::scrub_spawn_std_env(&mut command);
     let output = command.output().ok()?;
     if !output.status.success() {
@@ -525,50 +541,6 @@ fn tracked_languages(root: &Path) -> Vec<&'static str> {
         }
     }
     found.into_iter().collect()
-}
-
-/// Non-empty stdout lines from a `git` invocation, or `None` when git failed.
-///
-/// Synchronous on purpose: every caller here already runs on the blocking pool
-/// (`build_overview` is dispatched there), and these are single ref reads.
-///
-/// `current_dir` is **not** sufficient to say which repository this reads.
-/// `GIT_DIR` overrides it, and git *exports* `GIT_DIR` to every hook it runs —
-/// so an overview assembled from inside a pre-push hook would report the outer
-/// repository's branches, remotes and languages as this workspace's, silently
-/// and with no error to notice.
-///
-/// Both scrubs are needed and neither subsumes the other, which is easy to get
-/// wrong: `scrub_sensitive_std_env` drops credentials and the *ambient
-/// authority* set — `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF` and friends, the
-/// vars that make git run someone else's code — but the *retargeting* vars
-/// live in [`crate::exec::GIT_REPO_ENV_VARS`] and are removed by name. A first
-/// draft of this used only the former and still read the wrong repository;
-/// `an_ambient_git_dir_cannot_retarget_the_overview` is what caught it.
-fn git_lines(root: &Path, args: &[&str]) -> Option<Vec<String>> {
-    let mut command = std::process::Command::new("git");
-    command
-        .args(args)
-        .current_dir(root)
-        // Nothing here reads stdin; inheriting it lets a git that decides to
-        // prompt (a credential helper on a remote URL) hang the overview.
-        .stdin(std::process::Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0");
-    crate::subprocess_env::scrub_sensitive_std_env(&mut command);
-    for var in crate::exec::GIT_REPO_ENV_VARS {
-        command.env_remove(var);
-    }
-    let out = command.output().ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    Some(
-        String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(str::to_string)
-            .collect(),
-    )
 }
 
 fn open_graph(root: &Path) -> Option<crate::graph::OpenedGraph> {


### PR DESCRIPTION
## main does not compile

```
error[E0428]: the name `git_lines` is defined multiple times
   --> crates/stella-tools/src/overview.rs:548
    |
246 | fn git_lines(root: &Path, args: &[&str]) -> Option<Vec<String>> {
    | --------------------------------------------------------------- previous definition
...
548 | fn git_lines(root: &Path, args: &[&str]) -> Option<Vec<String>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `git_lines` redefined here
```

`cargo test`, `cargo clippy` and `cargo doc` all fail on `origin/main` at `dbefb3b1d`.

## How it landed

#2561 was authored against a main where `git_lines` sat near the bottom of `overview.rs`. #2538 had already unified two copies of that same helper into one near the top. Both merged; **git reported no conflict**, because neither side's lines overlap the other's. The result has two definitions of the same private function.

This is the third time today this exact shape has landed — two branches adding the same private helper to `overview.rs` at different offsets, merging clean, compiling not at all. A textual merge cannot see it, and `mergeable: MERGEABLE` is not evidence that a merge compiles.

## The fix

One definition survives, keeping every property either side had.

| Property | Kept from | Note |
|---|---|---|
| `scrub_spawn_std_env` | #2538 | **Strict superset** of #2561's hand-rolled pair |
| `GIT_TERMINAL_PROMPT=0` | #2561 | Real addition — a prompting credential helper would hang the overview |
| stdin null | both | |
| blank-line filter | both | |
| argv, no shell | both | |

On the scrub specifically: `scrub_spawn_std_env_except` removes `GIT_REPO_ENV_VARS` **and** `FORCED_COLOR_ENV_VARS` before delegating to `scrub_sensitive_std_env_except` (`subprocess_env.rs:350-358`). So calling `scrub_sensitive_std_env` and re-removing the git vars by name is the exact partial application that helper's own doc names as the mistake `bash`, `start_process` and the hook runner each made in turn — and it silently drops the colour half, which matters here because this output goes to a captured pipe, never a terminal.

#2561's doc comment claimed "both scrubs are needed and neither subsumes the other". True of `scrub_sensitive_std_env`; not true of the spawn helper. Corrected rather than carried forward.

## Verification

- `cargo test -p stella-tools` — **842 passed, 0 failed**, including #2561's witness `an_ambient_git_dir_cannot_retarget_the_overview`, which still passes under the superset scrub (that is the check that the consolidation kept #2561's guarantee, not just its code).
- `cargo clippy -p stella-tools --all-targets` — clean.
- `make doc-warnings CARGO_SCOPE="-p stella-tools"` — clean.
- `cargo fmt --all -- --check` — clean.
- `git show --stat dbefb3b1d` shows #2561 touched **only** this file, so the breakage is confined to it.

No new witness test: this is a build break, and the compiler is the witness — it fails on `main` and passes here.

Refs #2561, #2538

## Summary by Sourcery

Fix build break in stella-tools by consolidating duplicate git_lines helper into a single, correct implementation that uses the unified spawn environment scrub.

Bug Fixes:
- Resolve compilation error from overview.rs defining git_lines twice on main, restoring successful builds for tests, clippy, and docs.

Enhancements:
- Clarify git_lines documentation around repository selection, environment scrubbing, and non-interactive behavior when invoking git.