### PR TITLE
fix(stella-tools): make the three git readers an explicit ladder

### DIFF
--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -400,8 +400,16 @@ fn git_section(root: &Path) -> Value {
         "branch_count": branch_total,
         "branch_convention": convention,
         "recent_commits": commits,
-        "note": "orientation only — `repo_history` goes deeper (position log, \
-                 full branch list) and `repo_recover` finds commits no branch points at",
+        // The routing hint, and this is the first call of a session, so it is
+        // the earliest chance to get the ladder right. It named the two deeper
+        // rungs and skipped the cheapest one (#2575) — `repo_status` costs a
+        // single git call, needs no arguments, and already answers the
+        // question the other two are usually reached for.
+        "note": "orientation only — `repo_status` is the next step for live state \
+                 (ahead/behind, changed files, shelved count, commits no ref points at); \
+                 `repo_history` goes deeper (position log, full branch list); \
+                 `repo_recover` searches the object store for commits even the reflog \
+                 has forgotten",
     })
 }
 

--- a/crates/stella-tools/src/repo.rs
+++ b/crates/stella-tools/src/repo.rs
@@ -815,8 +815,22 @@ impl Tool for RepoStatusTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "repo_status".into(),
-            description: "Repository status: current branch, commits ahead/behind upstream, \
-                          and the changed files as structured rows."
+            // Names the WHOLE payload, and says where the next rung starts
+            // (#2575). It used to describe three of ten fields, so nothing
+            // told a model that the cheap zero-argument tool already answers
+            // "where did my commit go" — which is how three git tools came to
+            // look interchangeable when only their descriptions were.
+            description: "Repository state right now, in one git call and with no arguments: \
+                          current branch, commits ahead/behind upstream, changed files as \
+                          structured rows, the HEAD commit, whether this is a linked worktree, \
+                          how many changes are shelved (git stash), and up to 20 commits that \
+                          no branch, tag or remote points at. Reach for this FIRST, including \
+                          when work seems to have gone missing after a checkout or reset — a \
+                          detached position, a shelved change, or a commit under `unreachable` \
+                          is usually the entire answer. Escalate only if it is not: \
+                          `repo_history` adds the commit log, the position log (git reflog), \
+                          and every branch's ahead/behind; `repo_recover` scans the object \
+                          store for commits even the reflog has forgotten."
                 .into(),
             input_schema: serde_json::json!({ "type": "object", "properties": {} }),
             read_only: true,

--- a/crates/stella-tools/src/repo/history.rs
+++ b/crates/stella-tools/src/repo/history.rs
@@ -538,15 +538,24 @@ impl Tool for RepoHistoryTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "repo_history".into(),
+            // No longer claims to be the first stop for missing work (#2575):
+            // `repo_status` costs one git call, takes no arguments, and
+            // already reports the detached position, the shelved count and
+            // the orphaned commits. What is only here is the HISTORY those
+            // facts sit inside — when the position moved, and how far each
+            // branch has diverged.
             description: "Where this repository has BEEN: recent commits, every branch with \
-                          its ahead/behind vs the default branch, shelved changes (git \
-                          stash), and the log of where the working position has moved (git \
-                          reflog) — plus whether the position is currently detached. One \
-                          call, no shell. Reach for this before `bash git log`/`git \
-                          branch`/`git stash list`, and FIRST when work seems to have gone \
-                          missing after a branch switch: a detached position or a stash \
-                          entry usually answers it outright. If nothing here explains it, \
-                          `repo_recover` searches the commits no branch points at."
+                          its ahead/behind vs the default branch, each shelved change with \
+                          the selector that addresses it (`stash@{0}`), and the log of where \
+                          the working position has moved (git reflog). One call, no shell — \
+                          reach for it instead of `bash git log`/`git branch`/`git reflog`. \
+                          `repo_status` is cheaper and already answers the current branch, a \
+                          detached position, the shelved COUNT and the orphaned commits the \
+                          reflog still reaches, so start there; come here when you need the \
+                          history around those facts — which commit the position moved to and \
+                          when, how far every branch has diverged, or a stash's selector so \
+                          you can address it. If a commit appears in none of it, \
+                          `repo_recover` searches the object store itself."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -608,15 +617,28 @@ impl Tool for RepoRecoverTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "repo_recover".into(),
-            description: "Find committed work that no branch points at — the commits a \
-                          checkout strands. Returns each one's subject, author, date, \
-                          parents, and `sits_on_target` (true when it sits directly on the \
-                          target and can be integrated by fast-forward). Use when work is \
-                          missing and `repo_history` showed no stash and no detached \
-                          position. Walks the whole object store, so it is the slower \
-                          second move, not the first. Stella's own candidate-workspace \
-                          snapshot commits are excluded and counted separately — they are \
-                          unreachable by construction and are never the user's lost work."
+            // The escalation clause used to route through `repo_history` for
+            // "no stash and no detached position" — written before
+            // `repo_status` reported either (#2551), so it sent a caller to
+            // the middle rung for facts the cheapest one already had (#2575).
+            // It now names what is genuinely only here: a caller-chosen
+            // `target`, fast-forwardability, and the reach past the reflog.
+            description: "Find committed work that no branch points at, judged against a \
+                          reference you name (`target`, default HEAD). Searches the whole \
+                          object store (git fsck) UNIONed with the position log, so it is the \
+                          only tool that reaches commits the reflog has already expired, and \
+                          the only one that answers \"unreferenced relative to THIS ref\". \
+                          Returns each commit's sha, subject, author, date, parents, and \
+                          `sits_on_target` (true when it sits directly on the target and can \
+                          be integrated by fast-forward rather than a merge that could \
+                          conflict); commits already contained in the target are omitted as \
+                          found, not lost. This is the slow last resort — scanning every \
+                          object is why `repo_status` does not do it on every call — so reach \
+                          for it only once `repo_status` has shown no shelved change, no \
+                          detached position and nothing under `unreachable`. Stella's own \
+                          candidate-workspace snapshot commits are excluded and counted \
+                          separately — they are unreachable by construction and are never the \
+                          user's lost work."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -749,6 +771,87 @@ mod tests {
         let json = serde_json::to_string(&recovery).expect("serialize");
         assert!(json.contains("\"sits_on_target\":true"));
         assert!(json.contains("\"pipeline_commits_excluded\":2"));
+    }
+
+    /// The three git readers are a LADDER, and each one's schema description
+    /// is the only thing that tells a model which rung it is standing on.
+    ///
+    /// #2551 and #2538 diagnosed the same `fix-git` trial independently and
+    /// landed minutes apart, so this surface is the residue of a merge rather
+    /// than a decision (#2575). What the merge actually broke was not the
+    /// overlap — `repo_recover` really does reach commits the other two
+    /// cannot — it was the *disclosure*: `repo_status` grew `unreachable` and
+    /// a shelved count while its description still named three of its ten
+    /// payload fields, and `repo_recover`'s description went on sending
+    /// callers to `repo_history` to rule out a stash that `repo_status` now
+    /// answered in one git call. Three tools that overlap are a design; three
+    /// whose descriptions do not say where the boundaries are is what makes
+    /// selection guesswork, in exactly the situation these exist to serve.
+    ///
+    /// Asserted against the schema text because that is the only thing the
+    /// model ever reads. A comment stating the same boundaries is what was
+    /// already there, and it did not fail when they stopped being true.
+    #[test]
+    fn each_git_reader_names_its_boundary_and_the_next_rung() {
+        let history_backend: Arc<dyn HistoryBackend> = Arc::new(GitCli);
+        let repo_backend: Arc<dyn crate::repo::RepoBackend> = Arc::new(GitCli);
+        let status = crate::repo::RepoStatusTool(repo_backend)
+            .schema()
+            .description;
+        let history = RepoHistoryTool(history_backend.clone())
+            .schema()
+            .description;
+        let recover = RepoRecoverTool(history_backend).schema().description;
+
+        // Rung 1 must advertise the payload that makes it the first call —
+        // these are the exact fields whose omission hid the fact that the
+        // cheapest tool already answers "where did my commit go".
+        for named in ["unreachable", "shelved", "ahead/behind", "FIRST"] {
+            assert!(
+                status.contains(named),
+                "repo_status does not advertise `{named}`, so nothing tells a model the \
+                 cheap tool answers it: {status}"
+            );
+        }
+        for deeper in ["repo_history", "repo_recover"] {
+            assert!(
+                status.contains(deeper),
+                "repo_status must name `{deeper}` as the next rung: {status}"
+            );
+        }
+
+        // Rung 2 sends the cheap case back down and the object-store case up.
+        assert!(
+            history.contains("repo_status"),
+            "repo_history must defer the facts repo_status answers more cheaply: {history}"
+        );
+        assert!(
+            history.contains("repo_recover"),
+            "repo_history must name the rung above it: {history}"
+        );
+
+        // Rung 3 defers to the CHEAPEST rung, not the middle one. The stale
+        // sentence is named exactly rather than banning any mention of
+        // `repo_history`, which would forbid a legitimate future reference.
+        assert!(
+            recover.contains("repo_status"),
+            "repo_recover must name repo_status as its prerequisite: {recover}"
+        );
+        assert!(
+            !recover.contains("`repo_history` showed"),
+            "repo_recover routes the stash/detached check through repo_history again — \
+             repo_status answers both in one git call (#2575): {recover}"
+        );
+
+        // …and it states what is only here, or it has no claim to be a tool
+        // of its own rather than a flag on repo_status.
+        for only_here in ["target", "sits_on_target", "fsck"] {
+            assert!(
+                recover.contains(only_here),
+                "repo_recover does not state `{only_here}`, the capability that earns it a \
+                 separate tool: {recover}"
+            );
+        }
     }
 
     /// The whole point of these two tools: they survive the read-only

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -168,16 +168,16 @@ These 49 tools register in every session — no configuration, no prerequisites.
 
 <CardGrid size="md">
   <ToolCard name="repo_status" access="read">
-    Current branch, commits ahead/behind upstream, and the changed files as structured rows.
+    Repository state right now, in one git call with no arguments: current branch, commits ahead/behind upstream, changed files as structured rows, the HEAD commit, linked-worktree context, how many changes are shelved (`git stash`), and up to 20 commits no branch, tag or remote points at. The first rung of the three git readers — including when work seems to have gone missing, since a detached position, a shelved change, or an orphaned commit is usually the whole answer.
   </ToolCard>
   <ToolCard name="repo_diff" access="read">
     The pending changes as patch hunks plus a per-file +added/-removed summary — self-review before committing. Unstaged by default, `staged: true` for staged changes, optionally scoped to `paths`; the patch is capped with a loud elision marker.
   </ToolCard>
   <ToolCard name="repo_history" access="read">
-    Where the repository has *been*: recent commits, every branch with its ahead/behind vs the default, shelved changes (`git stash`), the working-position log (`git reflog`), and whether the position is currently detached. One call, no shell — and the first move when work seems to have gone missing after a branch switch.
+    Where the repository has *been*: recent commits, every branch with its ahead/behind vs the default, each shelved change with the selector that addresses it (`stash@{0}`), and the working-position log (`git reflog`). One call, no shell. The second rung — `repo_status` answers the current branch, a detached position and the shelved count more cheaply, so come here for the history *around* those facts: when the position moved, how far each branch diverged, or a stash's selector.
   </ToolCard>
   <ToolCard name="repo_recover" access="read">
-    Find committed work no branch points at — the commits a checkout strands. Each carries `sits_on_target`, so a fast-forward is distinguishable from a merge that could conflict. Walks the whole object store, so it is the slower second move after `repo_history`; stella's own candidate-workspace snapshot commits are excluded and counted separately.
+    Find committed work no branch points at, judged against a reference you name (`target`, default `HEAD`). Searches the whole object store (`git fsck`) unioned with the position log, so it is the only one of the three that reaches commits the reflog has already expired, and the only one that answers "unreferenced relative to *this* ref". Each commit carries `sits_on_target`, so a fast-forward is distinguishable from a merge that could conflict. Scanning every object is why `repo_status` does not do it on every call — the slow last rung, once `repo_status` has shown no shelved change, no detached position and nothing unreachable. Stella's own candidate-workspace snapshot commits are excluded and counted separately.
   </ToolCard>
   <ToolCard name="repo_commit" access="mutating">
     Commit exactly the named paths — there is no stage-everything mode.


### PR DESCRIPTION
## Decision: option 1 — keep all three, make them an explicit ladder

The full decision record with evidence is on the issue: https://github.com/macanderson/stella/issues/2575#issuecomment-5234389747

### Why not 2 or 3

Refuted by the code, not declined on taste. `repo_status` walks refs rather than the object store *precisely because* — in its own doc comment — `git fsck` "scans every object in the store" and "only one of them is affordable to run on every `repo_status` call." Folding `repo_recover` in has two outcomes and both are worse than the overlap: put an object-store scan on the most-called repo tool, or keep the cheap walk and drop what `fsck` uniquely reaches.

Five capabilities have no `repo_status` counterpart, so "fold it in" is really "delete these":

| Only in `repo_recover` | Why `repo_status` cannot express it |
|---|---|
| `target` | `repo_status` has **no input schema at all** (`properties: {}`) — folding turns a zero-argument call into a parameterized one, on the tool whose whole value is needing no thought |
| `sits_on_target` | per-commit `merge-base --is-ancestor` against a caller-chosen ref |
| the `fsck` arm | reaches commits the reflog has **already expired** — invisible to a ref walk |
| already-integrated filter | "not lost, just old"; same per-commit ancestor test |
| `pipeline_commits_excluded` | `repo_status` drops the same snapshot commits with **no counter** |

The two walks are not even nested: `repo_status`'s `--not --branches --tags --remotes` excludes commits living on *other branches*, while `repo_recover` at `target=HEAD` reports them. Neither is a superset. Option 3 is premised on option 2, so it falls with it.

### What the merge actually broke: disclosure, not surface area

`repo_status`'s description, in full, was:

> Repository status: current branch, commits ahead/behind upstream, and the changed files as structured rows.

That is **three of its ten payload fields**. `head`, `worktree`, `unreachable`, `unreachable_truncated` and `stashes` were undocumented at the schema level — including the two that let it answer "where did my commit go" in one git call with no arguments. Meanwhile `repo_recover` still said "use when `repo_history` showed no stash and no detached position", written before #2551 gave `repo_status` both facts.

So a model choosing among these three saw two tools claiming to find missing work and a third that looked like it only listed changed files. Selection was guesswork because the boundaries were undisclosed, not because three tools exist.

### Changes

All three descriptions rewritten as rungs that name their own boundary and the next one:

1. **`repo_status`** — names its whole payload, declares itself FIRST (including for missing work), points at both deeper rungs.
2. **`repo_history`** — stops claiming to be FIRST for missing work; defers those facts down to `repo_status`; keeps what is only here (commit log, position log, per-branch ahead/behind, and stash *selectors* rather than a count).
3. **`repo_recover`** — stale `repo_history` routing gone; defers to `repo_status`; states the `target` / `sits_on_target` / whole-object-store reach that earns it a separate tool.

`project_overview`'s `git` note had the same omission on the tool that runs first in every session — it named the two deeper rungs and skipped `repo_status`. Fixed.

### Witness

The boundaries **were already documented**, in code comments, and those comments did not fail when they stopped being true. A prose-only fix would decay the same way. So this adds `each_git_reader_names_its_boundary_and_the_next_rung`, asserting against the schema text the model actually reads.

Both tripwires falsified independently:

- Reverting `crates/stella-tools/src/repo.rs` to `main` (which restores the old `repo_status` description while leaving the test intact) fails it with:
  > `repo_status does not advertise `unreachable`, so nothing tells a model the cheap tool answers it: Repository status: current branch, commits ahead/behind upstream, and the changed files as structured rows.`
- Re-introducing the stale routing sentence into `repo_recover` fails it with:
  > `repo_recover routes the stash/detached check through repo_history again — repo_status answers both in one git call (#2575)`

Had this test existed, the #2551/#2538 collision would have failed on merge rather than shipping a surface nobody chose.

The stale-routing assertion names the exact phrase rather than banning any mention of `repo_history`, so a legitimate future cross-reference is still allowed.

### Not in scope here

No tool is removed: `catalog.rs` is untouched and the `49 always-on` / `61 native` counts do not move. Doc cards for all three are updated to match; the read-only and speculation-safe prose partitions are unchanged because no name or access marker changed, so `docs_in_sync` sees no row difference.

### Deleted tests

None.

Closes #2575

## Summary by Sourcery

Clarify and enforce the three git readers as an explicit ladder for discovering missing work and repository state.

New Features:
- Define an explicit rung-based workflow among repo_status, repo_history, and repo_recover for inspecting git state and recovering missing work.

Enhancements:
- Expand repo_status, repo_history, and repo_recover schema descriptions to fully describe their payloads, boundaries, and when to escalate from one to the next.
- Update project_overview's git note to route users through repo_status first before deeper git tools.
- Add a test that asserts each git reader’s schema description advertises its role, boundaries, and relationship to the other rungs to prevent future regressions.

Documentation:
- Revise user-facing documentation cards for repo_status, repo_history, and repo_recover to match the new ladder semantics and clearly explain each tool’s purpose and scope.