### PR TITLE
bench(harbor_adapter): let a claim run turn research and plan down

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -599,6 +599,65 @@ What this does and does not invalidate:
 - `preflight_effort.sh` now defaults `EXPECT_DIGEST` to `6c7fc70c`. A rig still
   holding `c8536200` will fail preflight — that is the gate working.
 
+#### 8.4.6 The read-only roles became selectable and no digest moved (#2549)
+
+The fourth boundary, and the first that is not one: a capability was added to
+the posture and **every registered arm keeps the digest it was registered
+under**. It is recorded here anyway, because "did anything move?" is the
+question this section exists to answer, and a silent no is indistinguishable
+from nobody having checked.
+
+`research` and `plan` became configurable engine roles in #2553, and this
+harness could not reach them. It could not simply start emitting them either.
+The two roles inherit the **worker** field by field — `AgentEngineAgents::get`
+is a straight per-role lookup with no fallback, and `over_worker`
+(`crates/stella-cli/src/agent/engine.rs`) merges each role's own tuning over the
+worker's — so a claim run pinning `agents.worker.effort = xhigh` pinned research
+to `xhigh` with it. On match `7d025330abad` that was 76s across 15 research
+calls to emit a few hundred reasoning tokens, against 8.5s for the single plan
+call.
+
+Emitting `agents.research` and `agents.plan` unconditionally would have fixed
+the reachability and re-hashed every arm in 8.4.2 to describe postures that
+behave exactly as the recorded ones already do — spending the comparability
+8.4.4 shows is expensive, for no measurement. So the rows are **opt-in**, the
+same rule every selector in `_benchmark_engine_posture` follows:
+
+- Unset — the default, and what a tree merely *carrying* this code produces —
+  emits no `agents` row and no flat key, so the canonical JSON is byte-identical
+  and so is its SHA-256.
+- Selected, the row is emitted whole (`effort` and `reasoning`, like every other
+  role), with the unselected half filled from what the role already inherits:
+  the run's own worker tier, and the worker's `reasoning: on`. Materialising the
+  row is therefore a behavioural no-op, and only a field an operator chose moves
+  anything. A one-knob arm is a one-variable change.
+
+| model | on `main` before this change | with this change, unset |
+|---|---|---|
+| `anthropic/claude-sonnet-5` | `6c7fc70c…` | `6c7fc70c…` |
+| `openrouter/deepseek/deepseek-v4-pro` | `1191911e…` | `1191911e…` |
+| `openrouter/z-ai/glm-5.1` | `20de1e34…` | `20de1e34…` |
+| `openrouter/anthropic/claude-sonnet-5` | `da82edd0…` | `da82edd0…` |
+
+Both columns were recomputed from `_benchmark_engine_posture` itself, on either
+side of this change, in the control arm *and* with a pinned verifier — eight
+pairs, all equal. The first row is the value 8.4.5 left standing, which is what
+ties this table to the one above it. `preflight_effort.sh` keeps
+`EXPECT_DIGEST=6c7fc70c`; there is nothing to re-freeze and no rig to update.
+
+What this does and does not invalidate:
+
+- **Nothing is invalidated.** Every published number keeps describing the
+  posture that produced it, and cross-boundary digest equality — the thing
+  8.4.4 lost — is preserved across this one.
+- **A run that selects an arm is a new arm**, as always: the row lands in the
+  hash and the manifest states it. Registering one means quoting its digest,
+  not reusing a row above.
+- The selectors are `STELLA_RESEARCH_EFFORT` / `_REASONING` / `_MODEL` and
+  `STELLA_PLAN_EFFORT` / `_REASONING` / `_MODEL`, host-only like every other
+  one: read on the host, reaching Stella only inside the hashed posture, never
+  forwarded into the container.
+
 ### 8.5 The measured baseline
 
 See `bench/evidence/` for the run manifest, per-trial rows, per-task results and

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -97,24 +97,14 @@ from .loop_mode import is_truthy as _is_truthy
 from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
-    _CANDIDATES_ENV,
     _ENGINE_POSTURE_VERSION,
-    _VERIFIER_EVIDENCE_DEMAND_ENV,
-    _MAX_REVISIONS_ENV,
-    _MODEL_TIMEOUT_ENV,
-    _TRIAGE_MODEL_ENV,
     _WITNESS_AUTHOR_ENV,
-    _WORKER_EFFORT_ENV,
+    POSTURE_SELECTOR_ENV,
     PostureBuilder,
     _benchmark_assurance_tiers,
     _benchmark_engine_posture,
     assurance_tiers_from_posture,
-    resolve_candidates,
-    resolve_verifier_evidence_demand,
-    resolve_max_revisions,
-    resolve_model_timeout,
-    resolve_triage_model,
-    resolve_worker_effort,
+    read_posture_selectors,
 )
 from .stream_envelope import (
     _extract_metrics,
@@ -242,23 +232,16 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         # the run rather than enabling the policy. See `turn_budget`.
         _TURN_BUDGET_ENV,
         _WITNESS_AUTHOR_ENV,
-        # Worker effort and triage author: host-only like the witness author,
-        # reaching Stella only inside the hashed posture. Registering them is
-        # load-bearing, not tidy — the ambient check fails closed, and an
-        # unlisted `STELLA_TURN_BUDGET` killed all ten trials of a run.
-        _WORKER_EFFORT_ENV,
-        _TRIAGE_MODEL_ENV,
-        # The attempt-count selectors (#1211 §6.7, §6.8). Same bucket and same
-        # reason as the three above: read on the host, expressed only inside
-        # the hashed posture, never forwarded into the container. Registering
-        # them is the load-bearing half — the ambient check fails closed, so an
-        # unlisted selector refuses the run instead of enabling the arm.
-        _MAX_REVISIONS_ENV,
-        _CANDIDATES_ENV,
-        _VERIFIER_EVIDENCE_DEMAND_ENV,
-        # The third coupled ceiling (#1211 §6.2). Same bucket again: read on the
-        # host, reaching Stella only inside the hashed posture.
-        _MODEL_TIMEOUT_ENV,
+        # Every posture selector — worker effort, the triage/research/plan pins,
+        # the attempt counts, the coupled ceiling. Host-only like the witness
+        # author: read here, expressed only inside the hashed posture, never
+        # forwarded into the container. Unpacked from the tuple `posture.py`
+        # defines beside the selectors themselves, because registering them is
+        # load-bearing rather than tidy — the ambient check fails closed, and an
+        # unlisted `STELLA_TURN_BUDGET` killed all ten trials of a run. A
+        # hand-kept second copy of this list is how a new selector (#1211 §6.2,
+        # §6.7, §6.8; the read-only roles of #2549) arrives unregistered.
+        *POSTURE_SELECTOR_ENV,
         # The bare-loop selector; :mod:`loop_mode` says why it is host-only.
         NO_PIPELINE_ENV,
         # The portability target triple and glibc floor (#1018). `env.sh` exports
@@ -1239,22 +1222,7 @@ class StellaAgent(BaseInstalledAgent):
         return _benchmark_engine_posture(
             model,
             verifier=verifier,
-            worker_effort=resolve_worker_effort(
-                self._configured_value(_WORKER_EFFORT_ENV)
-            ),
-            triage_model=resolve_triage_model(
-                self._configured_value(_TRIAGE_MODEL_ENV)
-            ),
-            max_revisions=resolve_max_revisions(
-                self._configured_value(_MAX_REVISIONS_ENV)
-            ),
-            candidates=resolve_candidates(self._configured_value(_CANDIDATES_ENV)),
-            verifier_evidence_demand=resolve_verifier_evidence_demand(
-                self._configured_value(_VERIFIER_EVIDENCE_DEMAND_ENV)
-            ),
-            model_timeout_secs=resolve_model_timeout(
-                self._configured_value(_MODEL_TIMEOUT_ENV)
-            ),
+            **read_posture_selectors(self._configured_value),
         )
 
     def _verifier_model(self) -> str | None:

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -71,6 +71,51 @@ _ADMISSIBLE_WORKER_EFFORTS = ("high", "xhigh", "max")
 # selector existed still describes the posture that produced it.
 _TRIAGE_MODEL_ENV = "STELLA_TRIAGE_MODEL"
 
+# Host-side selectors for the two read-only pipeline roles. Research greps a
+# tree and reports what it found; plan writes the one work order every later
+# stage is judged against. Until #2553 neither could be configured at all — the
+# engine had no `research`/`plan` surface, so the roles resolved purely by
+# inheritance and there was nothing for a posture to select.
+#
+# What they inherit is the WORKER, field by field, not the `default` row: see
+# `over_worker` in `crates/stella-cli/src/agent/engine.rs`, which merges each
+# role's own tuning over the worker's and leaves an unset field on the worker's
+# value. So a claim run that pins `agents.worker.effort = xhigh` pins research
+# to `xhigh` with it. On match `7d025330abad` that was 76s across 15 research
+# calls to emit a few hundred reasoning tokens, against 8.5s for the single
+# plan call. #2553 built the knob that turns that down; this is the harness
+# reaching it.
+#
+# Unset omits the row, and here that rule carries more weight than anywhere
+# else in this file. The digest identifies every registered arm
+# (`bench/READINESS.md` §8.4.4), so emitting two rows unconditionally would
+# re-hash every arm already registered in order to describe postures that
+# behave exactly as the recorded ones did — spending the comparability that
+# digest exists to provide, for nothing. A rename did precisely that once
+# (#1394) and ended cross-boundary comparison; this is the same hazard with a
+# cheaper answer, because a row nobody asked for is a row that need not exist.
+_RESEARCH_EFFORT_ENV = "STELLA_RESEARCH_EFFORT"
+_RESEARCH_REASONING_ENV = "STELLA_RESEARCH_REASONING"
+_RESEARCH_MODEL_ENV = "STELLA_RESEARCH_MODEL"
+_PLAN_EFFORT_ENV = "STELLA_PLAN_EFFORT"
+_PLAN_REASONING_ENV = "STELLA_PLAN_REASONING"
+_PLAN_MODEL_ENV = "STELLA_PLAN_MODEL"
+
+# All five tiers, where the worker admits three. The worker's list is short
+# because its rule is parity — spend what the comparator spends — and a
+# head-to-head worker at `low` is not a posture anyone would register. These
+# two roles have the opposite rule: the reason to configure them at all is to
+# spend *less* than the worker, so the tiers below it are the ones that matter.
+# `max` stays admissible because refusing a measurement someone might want is
+# not this file's job; the enum exists to catch a typo, not to pick an arm.
+_ADMISSIBLE_ROLE_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+
+# The worker's frozen `reasoning` value, named once because two places depend
+# on it meaning "what research and plan inherit today": the `worker` row below
+# and `_role_row`, which uses it as the value an unselected `reasoning` takes so
+# that emitting a row changes nothing an operator did not ask for.
+_WORKER_REASONING = "on"
+
 # Host-side selectors for the two pipeline knobs that decide how many times a
 # task may be attempted: revision turns after a *failed* verification, and
 # best-of-N candidate executions. Both were fully implemented in the pipeline
@@ -328,27 +373,72 @@ def resolve_candidates(value: str | None) -> int | None:
     )
 
 
-def resolve_verifier_evidence_demand(value: str | None) -> bool | None:
-    """Resolve the corroboration-ask arm, or ``None`` to inherit the default.
+def _validated_toggle(value: str, *, label: str) -> bool:
+    """Parse a host-side on/off selector, or refuse it with the reason.
 
     Fails closed on anything that is not one of the four accepted spellings,
     for the reason every selector here does: a run scored under a configuration
     nobody chose is worse than a run that refused to start. In particular a
     bare ``"false"`` is *not* silently read as off — the accepted vocabulary is
-    the one the setting itself uses (``on``/``off``), plus ``1``/``0`` for the
-    shell that has an integer to hand.
+    the one the settings themselves use (``on``/``off``), plus ``1``/``0`` for
+    the shell that has an integer to hand.
     """
-    if value is None:
-        return None
     text = value.strip().lower()
     if text in ("on", "1"):
         return True
     if text in ("off", "0"):
         return False
-    raise ValueError(
-        "benchmark verifier evidence demand must be one of on/off/1/0; "
-        f"got `{value}`"
-    )
+    raise ValueError(f"benchmark {label} must be one of on/off/1/0; got `{value}`")
+
+
+def resolve_verifier_evidence_demand(value: str | None) -> bool | None:
+    """Resolve the corroboration-ask arm, or ``None`` to inherit the default."""
+    if value is None:
+        return None
+    return _validated_toggle(value, label="verifier evidence demand")
+
+
+def resolve_role_effort(value: str | None, *, role: str) -> str | None:
+    """Resolve a read-only role's effort tier, or ``None`` to emit no row.
+
+    Unlike the worker's tier this has no frozen default to fall back to, and
+    that asymmetry is the design: absent means *omit the row entirely*, which is
+    the posture every registered arm was hashed under. An explicitly empty value
+    is still refused, for the reason `resolve_worker_effort` refuses one — it
+    means an operator meant to select an arm and the value was lost on the way
+    here, which is exactly when inheriting silently would attribute the run to a
+    tier nobody chose.
+    """
+    if value is None:
+        return None
+    return _validated_role_effort(value, role)
+
+
+def resolve_role_reasoning(value: str | None, *, role: str) -> bool | None:
+    """Resolve a read-only role's thinking toggle, or ``None`` to emit no row.
+
+    The tier is only half of what makes research expensive. Turning effort down
+    while `reasoning` still rides the worker's `on` leaves the role thinking on
+    every call, which on a lookup that reports what it read is most of the cost
+    #2553 measured — so the two are selectable separately, and either one alone
+    materialises the row.
+    """
+    if value is None:
+        return None
+    return _validated_toggle(value, label=f"{role} reasoning")
+
+
+def resolve_role_model(value: str | None) -> str | None:
+    """Resolve a per-role model pin, or ``None`` to inherit.
+
+    Whitespace-only is treated as unset, because unlike the effort tier "no pin"
+    is a meaningful and previously-default configuration for every role that has
+    one — so an empty value cannot be the lost-arm case that refusal exists to
+    catch.
+    """
+    if value is None:
+        return None
+    return value.strip() or None
 
 
 def resolve_model_timeout(value: str | None) -> int | None:
@@ -386,12 +476,71 @@ def resolve_triage_model(value: str | None) -> str | None:
 
     Same shape as the witness author: the pin has to be asked for, so a tree
     that merely carries this code keeps producing the historical posture.
-    Whitespace-only is treated as unset here because, unlike the effort tier,
-    "no pin" is a meaningful and previously-default configuration.
     """
-    if value is None:
-        return None
-    return value.strip() or None
+    return resolve_role_model(value)
+
+
+#: Every host-side posture selector, in one tuple.
+#:
+#: The adapter registers these as host-only environment (`_HOST_ONLY_STELLA_ENV`)
+#: and its ambient check fails **closed**, so a selector this module reads and
+#: that list does not name refuses the run instead of enabling the arm — an
+#: unregistered `STELLA_TURN_BUDGET` once killed all ten trials of a run. One
+#: tuple, unpacked there, is what keeps the two lists from being two lists.
+#: The witness author is deliberately absent: it reaches the builder as
+#: ``verifier=``, resolved by `StellaAgent._verifier_model`, not through here.
+POSTURE_SELECTOR_ENV = (
+    _WORKER_EFFORT_ENV,
+    _TRIAGE_MODEL_ENV,
+    _RESEARCH_EFFORT_ENV,
+    _RESEARCH_REASONING_ENV,
+    _RESEARCH_MODEL_ENV,
+    _PLAN_EFFORT_ENV,
+    _PLAN_REASONING_ENV,
+    _PLAN_MODEL_ENV,
+    _MAX_REVISIONS_ENV,
+    _CANDIDATES_ENV,
+    _VERIFIER_EVIDENCE_DEMAND_ENV,
+    _MODEL_TIMEOUT_ENV,
+)
+
+
+def read_posture_selectors(get: Callable[[str], str | None]) -> dict[str, Any]:
+    """Resolve every host-side selector into `_benchmark_engine_posture` kwargs.
+
+    ``get`` reads one configured value by name — `StellaAgent._configured_value`
+    on the adapter, a plain dict lookup in a test.
+
+    It lives beside the selectors rather than at the call site because the call
+    site is reached **twice**: once when trial metadata is collected, and again
+    when the exec boundary recomputes the posture and refuses the run unless it
+    matches byte for byte. Two spellings of "read the selectors" is two chances
+    for those to disagree, and a disagreement there is a refused run at best.
+    Keeping the list here also keeps it in one place with `POSTURE_SELECTOR_ENV`,
+    which is the half the ambient check reads.
+    """
+    return {
+        "worker_effort": resolve_worker_effort(get(_WORKER_EFFORT_ENV)),
+        "triage_model": resolve_triage_model(get(_TRIAGE_MODEL_ENV)),
+        "research_effort": resolve_role_effort(
+            get(_RESEARCH_EFFORT_ENV), role="research"
+        ),
+        "research_reasoning": resolve_role_reasoning(
+            get(_RESEARCH_REASONING_ENV), role="research"
+        ),
+        "research_model": resolve_role_model(get(_RESEARCH_MODEL_ENV)),
+        "plan_effort": resolve_role_effort(get(_PLAN_EFFORT_ENV), role="plan"),
+        "plan_reasoning": resolve_role_reasoning(
+            get(_PLAN_REASONING_ENV), role="plan"
+        ),
+        "plan_model": resolve_role_model(get(_PLAN_MODEL_ENV)),
+        "max_revisions": resolve_max_revisions(get(_MAX_REVISIONS_ENV)),
+        "candidates": resolve_candidates(get(_CANDIDATES_ENV)),
+        "verifier_evidence_demand": resolve_verifier_evidence_demand(
+            get(_VERIFIER_EVIDENCE_DEMAND_ENV)
+        ),
+        "model_timeout_secs": resolve_model_timeout(get(_MODEL_TIMEOUT_ENV)),
+    }
 
 
 def _validated_role_model(model: str, candidate: str, role: str) -> str:
@@ -434,6 +583,85 @@ def _validated_worker_effort(worker_effort: str) -> str:
             f"{', '.join(_ADMISSIBLE_WORKER_EFFORTS)}; got `{worker_effort}`"
         )
     return effort
+
+
+def _validated_role_effort(value: str, role: str) -> str:
+    """Return a read-only role's effort tier, or refuse an unrecognised one.
+
+    Same fail-closed rule as the worker's tier over a wider vocabulary, and the
+    refusal matters more here rather than less: the tiers this admits and the
+    worker's do not overlap on the low end, so a typo that fell back to the
+    worker would produce a run measuring the exact configuration the arm was
+    selected to move away from.
+    """
+    effort = value.strip().lower()
+    if effort not in _ADMISSIBLE_ROLE_EFFORTS:
+        raise ValueError(
+            f"benchmark {role} effort must be one of "
+            f"{', '.join(_ADMISSIBLE_ROLE_EFFORTS)}; got `{value}`"
+        )
+    return effort
+
+
+def _role_row(
+    *, role: str, effort: str | None, reasoning: bool | None, worker_effort: str
+) -> dict[str, str] | None:
+    """The ``agents.<role>`` row for a read-only role, or ``None`` to omit it.
+
+    Emitted whole or not at all, and the unselected half takes the value the
+    role inherits *today* — the worker's tier, and the worker's ``reasoning:
+    on``. Two properties follow, and both are the point:
+
+    * the row's mere presence is a behavioural no-op, so a one-knob arm moves
+      one variable rather than two; and
+    * every row this writes has the same two fields as every other role's,
+      which is what lets the manifest schema keep validating an exact shape
+      instead of accepting whatever a partial row happened to carry.
+
+    It validates rather than trusting its caller, for the reason
+    ``_validated_worker_effort`` is called inside the builder and not beside the
+    selector: the builder is the one function *both* the collection path and the
+    exec-boundary recompute call, so a check anywhere else is a check one of
+    them can skip.
+    """
+    if effort is None and reasoning is None:
+        return None
+    if reasoning is not None and not isinstance(reasoning, bool):
+        raise ValueError(
+            f"benchmark {role} reasoning must be a bool or None; got {reasoning!r}"
+        )
+    thinking = _WORKER_REASONING == "on" if reasoning is None else reasoning
+    return {
+        "effort": (
+            worker_effort if effort is None else _validated_role_effort(effort, role)
+        ),
+        "reasoning": "on" if thinking else "off",
+    }
+
+
+def _pin_role_model(
+    posture: dict[str, Any], *, model: str, pin: str, role: str
+) -> None:
+    """Pin one role's model in its flat key and widen the model vocabulary.
+
+    The flat root key, never ``agents.<role>.model``. Both resolve — the engine
+    reads ``agents.<role>.model`` first and falls through to the flat key
+    (``AgentEngineConfig::model_for``) — but the flat key is what
+    ``settings_check`` and ``stella config`` report as the role's origin, so the
+    disclosed posture and the engine's own account of its wiring name the same
+    field.
+
+    ``allowed_models`` has to widen with it, and that half is load-bearing: the
+    vocabulary is a whitelist, so a pin outside it is refused at resolve time
+    and the role drops back to whatever it inherits — billing one model while
+    the digest claims another.
+    """
+    validated = _validated_role_model(model, pin, role)
+    posture[_FLAT_ROLE_MODEL_KEY[role]] = validated
+    allowed = list(posture["allowed_models"])
+    if validated not in allowed:
+        allowed.append(validated)
+    posture["allowed_models"] = allowed
 
 
 def _validated_verifier(model: str, verifier: str) -> str:
@@ -480,6 +708,12 @@ def _benchmark_engine_posture(
     verifier: str | None = None,
     worker_effort: str = "xhigh",
     triage_model: str | None = None,
+    research_effort: str | None = None,
+    research_reasoning: bool | None = None,
+    research_model: str | None = None,
+    plan_effort: str | None = None,
+    plan_reasoning: bool | None = None,
+    plan_model: str | None = None,
     max_revisions: int | None = None,
     candidates: int | None = None,
     verifier_evidence_demand: bool | None = None,
@@ -524,6 +758,14 @@ def _benchmark_engine_posture(
     (#2411), leaving the model's catalog maximum and the task's own wall clock.
     It is a key like any other — selecting it changes the digest, leaving it
     unset reproduces every historical one.
+
+    The six ``research_*``/``plan_*`` arguments are the same rule applied to the
+    two read-only roles (#2549). All six default to ``None``, which emits
+    neither an ``agents`` row nor a flat key, so a tree that merely carries this
+    code still returns byte-identical JSON — and therefore an identical digest —
+    for every arm registered before these roles were configurable. Selecting any
+    of them is a posture change that says so in the digest, which is the only
+    way the registered numbers keep describing the postures that produced them.
     """
     selected_model = model.strip()
     if not selected_model or "/" not in selected_model:
@@ -603,14 +845,20 @@ def _benchmark_engine_posture(
                 "effort": "xhigh",
                 "reasoning": "on",
             },
-            # Only the worker's tier moves with the arm. `default` stays at
-            # `xhigh` deliberately: it governs roles with no explicit entry
-            # below, and letting it track the worker would silently retune
-            # those roles too — a second, undeclared variable inside a digest
-            # that claims to describe one.
+            # Only the worker's tier moves with the arm, and `default` stays at
+            # `xhigh` rather than tracking it so the arm moves one variable.
+            #
+            # It does NOT stand in for the roles with no entry below, and that
+            # correction is the whole of #2549. `AgentEngineAgents::get` is a
+            # straight per-role lookup with no fallback, and `over_worker`
+            # (`crates/stella-cli/src/agent/engine.rs`) merges research and plan
+            # over the **worker** field by field. So the roles this row was
+            # believed to govern actually follow `worker` — and the arm's tier
+            # did silently retune them, which is exactly the undeclared second
+            # variable the old reading here claimed to prevent.
             "worker": {
                 "effort": selected_effort,
-                "reasoning": "on",
+                "reasoning": _WORKER_REASONING,
             },
             "verifier": {
                 "effort": "xhigh",
@@ -645,20 +893,35 @@ def _benchmark_engine_posture(
         # number this digest misdescribes.
         posture["pipeline_verifier_model"] = author
         posture["allowed_models"] = [selected_model, author]
-    if triage_model is not None:
-        # Same flat-key reasoning as the verifier pin above: `settings_check` and
-        # `stella config` report the flat key as the role's origin, so the
-        # disclosed posture and the engine's own account of its wiring name the
-        # same field. `allowed_models` has to widen with it — the vocabulary is
-        # a whitelist, and a triage pin outside it is refused at resolve time,
-        # which would drop triage back onto the worker and bill the expensive
-        # model for the cheap role while the digest claimed otherwise.
-        triage = _validated_role_model(selected_model, triage_model, "triage")
-        posture["pipeline_triage_model"] = triage
-        allowed = list(posture["allowed_models"])
-        if triage not in allowed:
-            allowed.append(triage)
-        posture["allowed_models"] = allowed
+    # Triage, research and plan pin identically — flat key plus a widened
+    # vocabulary — so they share `_pin_role_model` rather than three copies of
+    # it. The verifier above deliberately does not: it *replaces*
+    # `allowed_models` rather than appending to it, because the treatment arm's
+    # vocabulary is exactly the two models it names.
+    for role, pin in (
+        ("triage", triage_model),
+        ("research", research_model),
+        ("plan", plan_model),
+    ):
+        if pin is not None:
+            _pin_role_model(posture, model=selected_model, pin=pin, role=role)
+    # The read-only roles' tuning rows (#2549). Absent unless asked for: this is
+    # the one place in this function where a row that merely *exists* would
+    # re-hash arms registered years of runs ago, so "unset omits" is not a
+    # stylistic echo of the keys above it but the reason the digest still means
+    # what `bench/READINESS.md` §8.4.4 says it means.
+    for role, effort, reasoning in (
+        ("research", research_effort, research_reasoning),
+        ("plan", plan_effort, plan_reasoning),
+    ):
+        row = _role_row(
+            role=role,
+            effort=effort,
+            reasoning=reasoning,
+            worker_effort=selected_effort,
+        )
+        if row is not None:
+            posture["agents"][role] = row
     # The attempt-count knobs are omitted entirely when unselected rather than
     # written at their default value, and that is load-bearing: the digest is
     # taken over this dict, so emitting `"pipeline_max_revisions": 2` would
@@ -705,7 +968,22 @@ _FLAT_ROLE_MODEL_KEY = {
     "worker": "pipeline_worker_model",
     "verifier": "pipeline_verifier_model",
     "triage": "pipeline_triage_model",
+    "research": "pipeline_research_model",
+    "plan": "pipeline_plan_model",
 }
+
+#: The roles whose UNPINNED default is the worker's model, not ``default_model``.
+#:
+#: Every other role has a standing identity — unpinned, triage and the verifier
+#: still have a model of their own, and ``default_model`` is it. These two are
+#: documented as "run whatever the worker runs"
+#: (``own_model_spec_for``, ``crates/stella-cli/src/engine_config.rs``), so
+#: falling through to ``default_model`` for them would split them onto a
+#: different model the moment anything re-points the worker without touching
+#: settings. The two coincide in the frozen posture below, where the worker
+#: carries no pin of its own — which is exactly why a resolver that got this
+#: wrong would keep agreeing with reality until the first arm that pinned one.
+_WORKER_INHERITING_ROLES = frozenset({"research", "plan"})
 
 
 def _posture_model_value(value: Any, key: str) -> str | None:
@@ -754,7 +1032,10 @@ def resolve_posture_role_model(
 
     Mirrors ``AgentEngineConfig::model_for`` (``crates/stella-cli/src/settings.rs``)
     key for key: ``agents.<role>.model`` outranks the flat ``pipeline_<role>_model``,
-    which outranks ``default_model``. Mirroring it *exactly* is the whole point —
+    which outranks ``default_model`` — except for the two roles that inherit the
+    worker instead on that last rung (``_WORKER_INHERITING_ROLES``, which is the
+    engine's own split between ``model_spec_for`` and ``own_model_spec_for``, not
+    an approximation of it). Mirroring it *exactly* is the whole point —
     a declaration that resolves roles by a different rule than the engine does is
     free to disagree with the run it describes, which is the shape of #2134 and of
     #1147 before it.
@@ -778,6 +1059,15 @@ def resolve_posture_role_model(
     ):
         if value is not None:
             return value, key
+    # Unpinned, and the last rung differs by role (see
+    # `_WORKER_INHERITING_ROLES`). Recursing resolves the worker through the
+    # same two rungs above, so "research inherits the worker" reports the key
+    # that actually decided the worker's model rather than asserting
+    # `default_model` and being right only by coincidence.
+    if role in _WORKER_INHERITING_ROLES:
+        return resolve_posture_role_model(
+            posture, "worker", default_model=default_model
+        )
     return default_model, "default_model"
 
 

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -36,16 +36,19 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     _benchmark_assurance_tiers,
     _benchmark_engine_posture,
     _stream_to_envelope,
-    resolve_candidates,
-    resolve_verifier_evidence_demand,
-    resolve_max_revisions,
-    resolve_model_timeout,
 )
 
-# Imported from the module rather than the package: an internal of the
-# posture's ceiling policy, not part of what the adapter re-exports.
+# Imported from the module rather than the package: internals of the posture's
+# ceiling and selector policy, not part of what the adapter re-exports. The
+# selector resolvers joined them when the adapter stopped calling them one by
+# one — `read_posture_selectors` is the package-level entry point now, and a
+# re-export kept alive only for a test is a public surface nobody asked for.
 from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
     _BENCHMARKED_SLUGS,
+    resolve_candidates,
+    resolve_max_revisions,
+    resolve_model_timeout,
+    resolve_verifier_evidence_demand,
 )
 
 
@@ -293,7 +296,7 @@ class TestWorkerEffortAndTriageArms:
         # authority's 20 keys, failing a legitimate `model_timeout_secs`
         # posture while claiming the launcher would refuse it.
         assert set(posture) <= _engine_root_fields()
-        assert set(posture["agents"]) <= {"default", "worker", "verifier", "triage"}
+        assert set(posture["agents"]) <= _engine_agent_names()
         # Every pinned role is in the whitelist, or it cannot be resolved.
         for role_key in ("pipeline_verifier_model", "pipeline_triage_model"):
             assert posture[role_key] in posture["allowed_models"]
@@ -1039,6 +1042,29 @@ def _engine_root_fields() -> frozenset[str]:
     fields = _parse_rust_str_slice(source, "ENGINE_ROOT_FIELDS")
     assert fields, "ENGINE_ROOT_FIELDS parsed to zero entries"
     return fields
+
+
+def _engine_agent_names() -> frozenset[str]:
+    """`ENGINE_AGENT_NAMES` out of `unknown.rs` — the role vocabulary.
+
+    Parsed for the same reason `_engine_root_fields` is, and against the same
+    failure: the literal this replaced named the four roles the posture happened
+    to emit, so it could only ever agree with the posture — it could not answer
+    the question it looked like it was answering, which is whether the launcher
+    would accept a role the posture newly emits (#2549).
+    """
+    try:
+        source = _UNKNOWN_RS.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AssertionError(
+            f"cannot read the launcher vocabulary at {_UNKNOWN_RS}: "
+            f"{exc.strerror}. That path is a literal in this file, not a "
+            "resolved crate location — if the crate moved, update "
+            "`_UNKNOWN_RS` to match."
+        ) from exc
+    names = _parse_rust_str_slice(source, "ENGINE_AGENT_NAMES")
+    assert names, "ENGINE_AGENT_NAMES parsed to zero entries"
+    return names
 
 
 def _parse_output_ceilings(source: str) -> dict[str, int]:

--- a/bench/harbor_adapter/tests/test_role_arms.py
+++ b/bench/harbor_adapter/tests/test_role_arms.py
@@ -1,0 +1,420 @@
+"""The read-only roles as selectable, hashed arms (#2549).
+
+Companion to `test_posture.py`, split from it for the reason that file was split
+from `test_adapter.py`: the file-size gate treats a separable concern as its own
+module rather than as more length on one already near its ceiling.
+
+The subject. A Terminal-Bench claim run pins `agents.worker.effort` — typically
+`xhigh` — and `research` and `plan` carried no row at all. They do not inherit
+`agents.default`: `AgentEngineAgents::get` is a straight per-role lookup with no
+fallback, and `over_worker` (`crates/stella-cli/src/agent/engine.rs`) merges each
+role's own tuning over **the worker's**, field by field. So the arm's worker tier
+reached both roles, and on match `7d025330abad` research spent 76s across 15
+calls to emit a few hundred reasoning tokens. #2553 gave the engine the knob;
+this harness could not reach it.
+
+The constraint, and why every test below is really one test. Emitting the two
+rows unconditionally would have re-hashed every registered arm — the posture
+digest identifies the SUT (`bench/READINESS.md` §8.4.4) — to describe postures
+that behave exactly as the recorded ones already did. A rename did that once
+(#1394) and ended cross-boundary comparison. So the rows are **opt-in**, and the
+first test here is the one that matters: unset, the builder returns the byte
+for byte identical posture it always did.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from stella_harbor import (  # noqa: E402 - after importorskip by design
+    _HOST_ONLY_STELLA_ENV,
+    _benchmark_engine_posture,
+)
+from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    _ADMISSIBLE_ROLE_EFFORTS,
+    _PLAN_EFFORT_ENV,
+    _PLAN_MODEL_ENV,
+    _PLAN_REASONING_ENV,
+    _RESEARCH_EFFORT_ENV,
+    _RESEARCH_MODEL_ENV,
+    _RESEARCH_REASONING_ENV,
+    POSTURE_SELECTOR_ENV,
+    read_posture_selectors,
+    resolve_posture_role_model,
+    resolve_role_effort,
+    resolve_role_reasoning,
+)
+
+_MODEL = "openrouter/anthropic/claude-sonnet-5"
+_CHEAP = "openrouter/anthropic/claude-haiku-4.5"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ANALYSIS_DIR = _REPO_ROOT / "bench" / "terminal_bench_analysis"
+
+
+def _posture_schema():
+    """The study-manifest posture schema, imported from the analysis package.
+
+    A path literal and a `sys.path` insert rather than a dependency, for the
+    reason `test_posture.py` reads `unknown.rs` off a literal path: the two
+    packages install separately and neither depends on the other, but the
+    contract between them is real and nothing else checks it. A crate or
+    directory move is fixed here, and the assertion says so.
+    """
+    if not _ANALYSIS_DIR.is_dir():
+        raise AssertionError(
+            f"cannot find the analysis package at {_ANALYSIS_DIR}. That path is "
+            "a literal in this file, not a resolved location — if the package "
+            "moved, update `_ANALYSIS_DIR` to match."
+        )
+    if str(_ANALYSIS_DIR) not in sys.path:
+        sys.path.insert(0, str(_ANALYSIS_DIR))
+    import tb21_posture_schema
+
+    return tb21_posture_schema
+
+
+class TestUnsetReproducesTheRegisteredPosture:
+    """The load-bearing half: carrying this code changes no recorded digest."""
+
+    def test_unset_selectors_emit_neither_row_nor_flat_key(self) -> None:
+        """Absence is the encoding of "inherit", exactly as for every arm above.
+
+        Writing `agents.research = {"effort": "xhigh", "reasoning": "on"}` — the
+        values the role already resolves to — would change every hash in the
+        tree to describe a posture identical to the one they already described.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(_MODEL)
+        assert set(posture["agents"]) == {"default", "worker", "verifier", "triage"}
+        assert "pipeline_research_model" not in posture
+        assert "pipeline_plan_model" not in posture
+
+    def test_the_registered_digest_is_byte_identical(self) -> None:
+        """The pinned digest, asserted from this side too.
+
+        `test_adapter.py` pins it as the registered SUT's identity. It is pinned
+        again here because this module is where a change would come from, and a
+        digest that moves on an unselected arm is not a test failure to be
+        re-blessed — it is every registered arm re-hashed.
+        """
+        _posture, _normalized, digest = _benchmark_engine_posture(
+            "openrouter/deepseek/deepseek-v4-pro"
+        )
+        assert digest == (
+            "1191911e2bc5aeef2949f0592a0c3d2da31f55e05b464018a8440febe0e94bd3"
+        )
+
+
+class TestRoleArmsReachThePosture:
+    """What a selected arm puts in the posture, and what it leaves alone."""
+
+    def test_effort_alone_moves_effort_and_inherits_the_workers_reasoning(
+        self,
+    ) -> None:
+        """A one-knob arm must be a one-variable change.
+
+        The row is emitted whole — both fields, like every other role — so the
+        manifest schema can keep validating an exact shape. The half nobody
+        selected therefore has to carry the value the role *already* resolved
+        to, or materialising the row would itself be a second variable.
+        """
+        base, _base_json, base_digest = _benchmark_engine_posture(_MODEL)
+        armed, _armed_json, armed_digest = _benchmark_engine_posture(
+            _MODEL, research_effort="low"
+        )
+        assert armed["agents"]["research"] == {"effort": "low", "reasoning": "on"}
+        assert "plan" not in armed["agents"], "plan is a separate arm"
+        assert armed_digest != base_digest
+        for role in ("default", "worker", "verifier", "triage"):
+            assert armed["agents"][role] == base["agents"][role]
+
+    def test_reasoning_alone_moves_reasoning_and_inherits_the_selected_tier(
+        self,
+    ) -> None:
+        """The inherited half tracks the *arm's* worker, not the frozen literal.
+
+        Turning effort down while `reasoning` still rides the worker's `on`
+        leaves the role thinking on every call, which on a lookup that reports
+        what it read is most of the cost. So the two are separately selectable —
+        and the effort this fills in must be the worker effort this run chose.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL, worker_effort="high", research_reasoning=False
+        )
+        assert posture["agents"]["research"] == {"effort": "high", "reasoning": "off"}
+
+    def test_both_roles_arm_independently(self) -> None:
+        """Research and plan are two arms, not one switch.
+
+        Plan writes the work order every later stage is judged against — the one
+        short call where thinking is the product — so an arm that turns research
+        down must be able to leave plan alone.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL,
+            research_effort="low",
+            research_reasoning=False,
+            plan_effort="medium",
+        )
+        assert posture["agents"]["research"] == {"effort": "low", "reasoning": "off"}
+        assert posture["agents"]["plan"] == {"effort": "medium", "reasoning": "on"}
+
+    def test_a_model_pin_lands_in_the_flat_key_and_widens_the_vocabulary(
+        self,
+    ) -> None:
+        """`allowed_models` is a whitelist; a pin outside it resolves to nothing.
+
+        Same shape as the triage pin, and the same failure if the vocabulary is
+        not widened with it: the pin is refused at resolve time, the role drops
+        back to what it inherits, and the run bills the worker's model while the
+        digest claims another.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL, research_model=_CHEAP, plan_model=_CHEAP
+        )
+        assert posture["pipeline_research_model"] == _CHEAP
+        assert posture["pipeline_plan_model"] == _CHEAP
+        assert _CHEAP in posture["allowed_models"]
+        assert _MODEL in posture["allowed_models"]
+        assert posture["allowed_models"].count(_CHEAP) == 1, "widened once, not twice"
+
+    def test_a_model_pin_alone_emits_no_tuning_row(self) -> None:
+        """Who runs the role and how hard it thinks are two questions.
+
+        A pin says nothing about effort, so it must not synthesise a row — that
+        would make every model arm silently a tuning arm as well.
+        """
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL, research_model=_CHEAP
+        )
+        assert "research" not in posture["agents"]
+
+
+class TestRoleArmsFailClosed:
+    """A run scored under a configuration nobody chose is worse than no run."""
+
+    def test_an_unrecognised_tier_is_refused_not_defaulted(self) -> None:
+        """The refusal matters more here than for the worker, not less.
+
+        The tiers this admits and the worker's do not overlap at the low end, so
+        a typo that fell back to inheriting would produce a number measuring the
+        exact configuration the arm was selected to move away from.
+        """
+        with pytest.raises(ValueError, match="research effort must be one of"):
+            _benchmark_engine_posture(_MODEL, research_effort="lowish")
+        with pytest.raises(ValueError, match="plan effort must be one of"):
+            _benchmark_engine_posture(_MODEL, plan_effort="")
+
+    def test_every_admissible_tier_is_accepted(self) -> None:
+        """The vocabulary exists to catch a typo, not to pick an arm."""
+        for tier in _ADMISSIBLE_ROLE_EFFORTS:
+            posture, _normalized, _digest = _benchmark_engine_posture(
+                _MODEL, research_effort=tier
+            )
+            assert posture["agents"]["research"]["effort"] == tier
+
+    def test_reasoning_takes_the_settings_vocabulary_not_a_json_bool(self) -> None:
+        """`on`/`off` — plus `1`/`0` for the shell that has an integer to hand.
+
+        A bare `"false"` is deliberately not a second spelling of off: it is the
+        shape a lost or mistyped value takes, and reading it as a selection is
+        how a run gets attributed to an arm nobody chose.
+        """
+        assert resolve_role_reasoning("off", role="research") is False
+        assert resolve_role_reasoning("0", role="research") is False
+        assert resolve_role_reasoning("on", role="plan") is True
+        assert resolve_role_reasoning(None, role="plan") is None
+        with pytest.raises(ValueError, match="research reasoning must be one of"):
+            resolve_role_reasoning("false", role="research")
+
+    def test_unset_is_inherit_and_empty_is_a_refusal(self) -> None:
+        """`None` never reaches the posture; an empty string never silently does."""
+        assert resolve_role_effort(None, role="research") is None
+        with pytest.raises(ValueError, match="research effort"):
+            resolve_role_effort("   ", role="research")
+
+    def test_a_pin_must_share_the_workers_provider(self) -> None:
+        """One provider credential reaches a trial, over the anonymous FD.
+
+        A pin on a second provider has nothing to authenticate with and would
+        fail every call it is used for — refused here, before anything is spent.
+        """
+        for kwargs in (
+            {"research_model": "anthropic/claude-haiku-4.5"},
+            {"plan_model": "anthropic/claude-haiku-4.5"},
+        ):
+            role = next(iter(kwargs)).split("_", 1)[0]
+            with pytest.raises(ValueError, match=f"{role} model must share"):
+                _benchmark_engine_posture(_MODEL, **kwargs)
+
+
+class TestTheArmSurvivesEverySeamItCrosses:
+    """Three fail-closed boundaries stand between this dict and a running trial."""
+
+    def test_every_selector_is_registered_host_only(self) -> None:
+        """The ambient check fails closed: unregistered is a refused run.
+
+        Not a tidiness assertion — an unlisted `STELLA_TURN_BUDGET` killed all
+        ten trials of a run. `POSTURE_SELECTOR_ENV` exists so the reading list
+        and the registration list cannot be two hand-kept copies, and this is
+        the check that they are in fact the same list.
+        """
+        assert set(POSTURE_SELECTOR_ENV) <= _HOST_ONLY_STELLA_ENV
+        for env in (
+            _RESEARCH_EFFORT_ENV,
+            _RESEARCH_REASONING_ENV,
+            _RESEARCH_MODEL_ENV,
+            _PLAN_EFFORT_ENV,
+            _PLAN_REASONING_ENV,
+            _PLAN_MODEL_ENV,
+        ):
+            assert env in POSTURE_SELECTOR_ENV
+
+    def test_the_selectors_resolve_through_one_reader(self) -> None:
+        """Collection and the exec boundary must resolve a selector identically.
+
+        The exec boundary rebuilds the posture and refuses the run unless it
+        matches byte for byte, so two spellings of "read the selectors" is a
+        refused run waiting to happen. Both paths call `read_posture_selectors`.
+        """
+        selected = {
+            _RESEARCH_EFFORT_ENV: "low",
+            _RESEARCH_REASONING_ENV: "off",
+            _PLAN_MODEL_ENV: _CHEAP,
+        }
+        kwargs = read_posture_selectors(selected.get)
+        assert kwargs["research_effort"] == "low"
+        assert kwargs["research_reasoning"] is False
+        assert kwargs["plan_model"] == _CHEAP
+        assert kwargs["plan_effort"] is None
+        posture, _normalized, _digest = _benchmark_engine_posture(_MODEL, **kwargs)
+        assert posture["agents"]["research"] == {"effort": "low", "reasoning": "off"}
+
+    def test_an_armed_posture_stays_inside_the_launcher_vocabulary(self) -> None:
+        """`trusted_engine_config_shape_is_strict` refuses the RUN on an unknown key.
+
+        The seam fails closed rather than dropping what it does not recognise,
+        so a posture naming a key or a role the launcher has never heard of does
+        not degrade to the control arm — the trial dies at launch. Both
+        vocabularies are parsed from `unknown.rs`, never copied.
+        """
+        # Imported rather than restated, inverting the call `test_posture.py`
+        # makes for its one-line `_bare_agent` factory: these two parse Rust
+        # source off a path literal, and a second copy of that is exactly the
+        # hand-maintained duplicate they exist to replace.
+        from tests.test_posture import _engine_agent_names, _engine_root_fields
+
+        posture, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL,
+            research_effort="low",
+            research_reasoning=False,
+            research_model=_CHEAP,
+            plan_effort="medium",
+            plan_model=_CHEAP,
+        )
+        assert set(posture) <= _engine_root_fields()
+        assert set(posture["agents"]) <= _engine_agent_names()
+
+    def test_the_manifest_schema_accepts_every_key_the_builder_can_emit(
+        self,
+    ) -> None:
+        """The analysis refuses a manifest whose posture it cannot describe.
+
+        `_validate_engine_posture_manifest_schema` demanded exact equality, so a
+        selected arm's key was "extra" and its manifest was refused — and the
+        required-key list had already fallen behind every optional key the
+        builder grew. Derived from the builder rather than restated, because a
+        restated list is the thing that fell behind.
+        """
+        schema = _posture_schema()
+        armed, _normalized, _digest = _benchmark_engine_posture(
+            _MODEL,
+            verifier="openrouter/anthropic/claude-fable-5",
+            triage_model=_CHEAP,
+            research_effort="low",
+            research_reasoning=False,
+            research_model=_CHEAP,
+            plan_effort="medium",
+            plan_model=_CHEAP,
+            max_revisions=4,
+            candidates=2,
+            verifier_evidence_demand=True,
+            model_timeout_secs=1572,
+        )
+        permitted = (
+            schema.STUDY_MANIFEST_ENGINE_POSTURE_FIELDS
+            | schema.STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_FIELDS
+        )
+        assert set(armed) <= permitted, "a selected arm's key is not 'extra'"
+        assert set(armed) >= schema.STUDY_MANIFEST_ENGINE_POSTURE_FIELDS, (
+            "the required keys are required of every arm"
+        )
+        permitted_roles = (
+            schema.STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES
+            | schema.STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_AGENT_ROLES
+        )
+        assert set(armed["agents"]) <= permitted_roles
+        # Optional means optional in BOTH directions: the unarmed posture must
+        # still satisfy the required half on its own, or every historical
+        # manifest is refused by the schema that claims to describe it.
+        unarmed, _unarmed_json, _unarmed_digest = _benchmark_engine_posture(_MODEL)
+        assert set(unarmed["agents"]) == (
+            schema.STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES
+        )
+        # Every row the builder can emit is shaped exactly as the schema says.
+        for role, row in armed["agents"].items():
+            assert (
+                set(row)
+                == schema.STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE[role]
+            )
+
+
+class TestUnpinnedTheseRolesInheritTheWorker:
+    """The rung `model_for` does not have, and the resolver used to guess at."""
+
+    def test_an_unpinned_role_resolves_to_the_worker_not_default_model(self) -> None:
+        """`own_model_spec_for`'s split, mirrored rather than approximated.
+
+        Triage and the verifier have a standing identity — unpinned, they still
+        have a model of their own, and `default_model` is it. These two are
+        documented as "run whatever the worker runs", so resolving them to
+        `default_model` reports one model for a role that buys another the
+        moment anything re-points the worker. In the frozen posture the two
+        coincide, which is exactly why a resolver that got this wrong would keep
+        agreeing with reality until the first arm that pinned the worker.
+        """
+        posture = {
+            "default_model": _MODEL,
+            "pipeline_worker_model": _CHEAP,
+        }
+        for role in ("research", "plan"):
+            model, origin = resolve_posture_role_model(
+                posture, role, default_model=_MODEL
+            )
+            assert (model, origin) == (_CHEAP, "pipeline_worker_model")
+        # Triage keeps the standing-identity rung, and that contrast is the point.
+        assert resolve_posture_role_model(posture, "triage", default_model=_MODEL) == (
+            _MODEL,
+            "default_model",
+        )
+
+    def test_a_pin_still_outranks_the_inheritance(self) -> None:
+        """Both rungs above the fallback keep working, in the engine's order."""
+        posture = {
+            "default_model": _MODEL,
+            "pipeline_worker_model": _CHEAP,
+            "pipeline_research_model": _MODEL,
+            "agents": {"plan": {"model": _CHEAP}},
+        }
+        assert resolve_posture_role_model(
+            posture, "research", default_model=_MODEL
+        ) == (_MODEL, "pipeline_research_model")
+        assert resolve_posture_role_model(posture, "plan", default_model=_MODEL) == (
+            _CHEAP,
+            "agents.plan.model",
+        )

--- a/bench/terminal_bench_analysis/pyproject.toml
+++ b/bench/terminal_bench_analysis/pyproject.toml
@@ -27,6 +27,7 @@ py-modules = [
     "tb21_analysis",
     "tb21_evidence_contract",
     "tb21_hybrid_analysis",
+    "tb21_posture_schema",
     "tb21_study_seed",
 ]
 

--- a/bench/terminal_bench_analysis/tb21_analysis.py
+++ b/bench/terminal_bench_analysis/tb21_analysis.py
@@ -24,6 +24,17 @@ from github_public_timing import (
 from github_public_timing import FIXED_REPOSITORY, LivePublicTimingAudit
 from github_public_timing import verify_public_timing as verify_github_public_timing
 
+# Re-exported, not merely used: callers reach these through `tb21_analysis`, and
+# the split that gave them a module (#2549) is a size boundary, not a new address.
+from tb21_posture_schema import (
+    STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE,
+    STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES,
+    STUDY_MANIFEST_ENGINE_POSTURE_FIELDS,
+    STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_AGENT_ROLES,
+    STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_FIELDS,
+    STUDY_MANIFEST_ENGINE_POSTURE_RECORD_FIELDS,
+)
+
 try:
     from harbor.models.trajectories import Trajectory
 except ImportError:  # pragma: no cover - the pinned runtime dependency supplies it.
@@ -631,35 +642,6 @@ STUDY_MANIFEST_CALIBRATION_FIELDS = frozenset(
         "excluded_ledger_sha256",
     }
 )
-STUDY_MANIFEST_ENGINE_POSTURE_RECORD_FIELDS = frozenset(
-    {"version", "posture", "sha256"}
-)
-STUDY_MANIFEST_ENGINE_POSTURE_FIELDS = frozenset(
-    {
-        "default_model",
-        "allowed_models",
-        "auto_mode",
-        "effort_auto",
-        "reasoning_auto",
-        "headless_scope_bypass",
-        "agents",
-    }
-)
-STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES = frozenset(
-    {"default", "worker", "verifier", "triage"}
-)
-# Per-role field shapes. Every role is now the same shape — `effort` and
-# `reasoning`, no `params` — because no role carries an output cap (#2411).
-# The split existed to let the outcome-bearing roles hold `params.max_tokens`
-# while triage kept the engine default; with the cap gone there is nothing for
-# `params` to contain, and a posture that grows one has to be reviewed rather
-# than accepted by a set that still permits the key.
-STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE: dict[str, frozenset[str]] = {
-    "default": frozenset({"effort", "reasoning"}),
-    "worker": frozenset({"effort", "reasoning"}),
-    "verifier": frozenset({"effort", "reasoning"}),
-    "triage": frozenset({"effort", "reasoning"}),
-}
 STUDY_MANIFEST_CONFIRMATORY_FIELDS = frozenset({"job_name", "n_concurrent_trials"})
 
 JOB_CONFIG_ALLOWED_FIELDS = frozenset(
@@ -2277,18 +2259,31 @@ def _require_exact_manifest_fields(
     expected_fields: frozenset[str],
     label: str,
     reasons: list[str],
+    optional_fields: frozenset[str] = frozenset(),
 ) -> None:
-    """Reject both extension fields and omissions from the frozen v6 contract."""
+    """Reject both extension fields and omissions from the frozen v6 contract.
+
+    ``optional_fields`` names keys that may be present or absent and nothing
+    else: an unlisted key is still "extra", a missing *required* key is still
+    "missing". Empty by default, so every existing caller keeps the exact
+    equality it had.
+
+    It exists for the one case where exact equality cannot express the contract
+    — a selectable arm whose unset state must stay byte-identical to the
+    postures registered before the arm existed, so its key cannot be required,
+    and whose set state is a real configuration, so its key cannot be rejected
+    (#2549).
+    """
     if not isinstance(section, dict):
         reasons.append(
             f"Study manifest {label} must be an object with the exact v6 fields."
         )
         return
     observed_fields = set(section)
-    if observed_fields == expected_fields:
-        return
     missing = sorted(expected_fields - observed_fields)
-    extra = sorted(observed_fields - expected_fields)
+    extra = sorted(observed_fields - expected_fields - optional_fields)
+    if not missing and not extra:
+        return
     reasons.append(
         f"Study manifest {label} fields differ from the exact v6 schema; "
         f"missing={missing!r}; extra={extra!r}."
@@ -2305,6 +2300,7 @@ def _validate_engine_posture_manifest_schema(
         STUDY_MANIFEST_ENGINE_POSTURE_FIELDS,
         label,
         reasons,
+        optional_fields=STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_FIELDS,
     )
     if not isinstance(posture, dict):
         return
@@ -2314,10 +2310,14 @@ def _validate_engine_posture_manifest_schema(
         STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES,
         f"{label}.agents",
         reasons,
+        optional_fields=STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_AGENT_ROLES,
     )
     if not isinstance(agents, dict):
         return
-    for role in sorted(STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES):
+    for role in sorted(
+        STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES
+        | STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_AGENT_ROLES
+    ):
         if role not in agents:
             continue
         _require_exact_manifest_fields(

--- a/bench/terminal_bench_analysis/tb21_posture_schema.py
+++ b/bench/terminal_bench_analysis/tb21_posture_schema.py
@@ -1,0 +1,106 @@
+"""The shape a study manifest's recorded engine posture must have.
+
+Split out of `tb21_analysis` when the read-only roles arrived (#2549), for the
+reason `stella_harbor.posture` was split out of its own package root: the
+file-size gate treats a separable concern as its own module rather than as more
+length on an already-oversized one. It is a genuine seam — six frozen sets and
+no logic, describing one contract, with no dependency on the analysis around
+them.
+
+The contract has two halves, and the split between them is the whole subject:
+
+* **Required.** The seven root keys and four `agents` roles every posture has
+  carried since the protocol was frozen. A manifest missing one is malformed;
+  a manifest carrying an unlisted key is describing a posture nobody reviewed.
+* **Optional.** The keys a *selected arm* adds. Each is absent in the
+  historical posture and present only when an operator asked for it — which is
+  precisely why they cannot be required: the posture digest identifies every
+  registered arm (`bench/READINESS.md` §8.4.4), so requiring a key that
+  historical postures do not have would refuse every manifest recorded before
+  the arm existed. And they cannot be rejected either, because a set arm is
+  real configuration the manifest must be able to state.
+
+That is why the validator this feeds takes an `optional_fields` argument rather
+than exact equality alone. "Exact" was the right instrument while the posture
+had no arms; it silently became the wrong one as the builder grew selectors,
+and the required-root-key set had already fallen behind every one of them —
+a treatment-arm manifest naming `pipeline_verifier_model` would have been
+refused as "extra" by a schema that claims to describe it.
+
+`test_posture.py::TestManifestSchemaCoversEverySelectableKey` derives both
+halves from `stella_harbor.posture` rather than trusting the lists below, so
+the next selector fails there instead of on a paid run's manifest.
+"""
+
+from __future__ import annotations
+
+#: The `engine_posture` record wrapping one posture: what it is, and its hash.
+STUDY_MANIFEST_ENGINE_POSTURE_RECORD_FIELDS = frozenset(
+    {"version", "posture", "sha256"}
+)
+
+#: The root keys every posture carries, arm or no arm.
+STUDY_MANIFEST_ENGINE_POSTURE_FIELDS = frozenset(
+    {
+        "default_model",
+        "allowed_models",
+        "auto_mode",
+        "effort_auto",
+        "reasoning_auto",
+        "headless_scope_bypass",
+        "agents",
+    }
+)
+
+#: Root keys a posture MAY carry — one per selectable arm.
+#:
+#: Absent is the historical posture; present is a declared configuration that
+#: moved the digest. Every entry is a key `_benchmark_engine_posture` emits only
+#: when its selector was set, and the parity test named in this module's
+#: docstring is what keeps that correspondence true.
+STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_FIELDS = frozenset(
+    {
+        "pipeline_verifier_model",
+        "pipeline_triage_model",
+        "pipeline_research_model",
+        "pipeline_plan_model",
+        "pipeline_max_revisions",
+        "pipeline_candidates",
+        "pipeline_verifier_evidence_demand",
+        "model_timeout_secs",
+    }
+)
+
+#: The `agents` rows every posture carries.
+STUDY_MANIFEST_ENGINE_POSTURE_AGENT_ROLES = frozenset(
+    {"default", "worker", "verifier", "triage"}
+)
+
+#: The `agents` rows a posture MAY carry (#2549).
+#:
+#: `research` and `plan` inherit the worker field by field unless an arm turns
+#: them down (`over_worker`, `crates/stella-cli/src/agent/engine.rs`), so a
+#: posture that does not turn them down has nothing to say about them and says
+#: nothing — which is what keeps its digest identical to the arms registered
+#: before these roles were configurable at all.
+STUDY_MANIFEST_ENGINE_POSTURE_OPTIONAL_AGENT_ROLES = frozenset({"research", "plan"})
+
+#: Per-role field shapes. Every role is the same shape — `effort` and
+#: `reasoning`, no `params` — because no role carries an output cap (#2411).
+#: The split existed to let the outcome-bearing roles hold `params.max_tokens`
+#: while triage kept the engine default; with the cap gone there is nothing for
+#: `params` to contain, and a posture that grows one has to be reviewed rather
+#: than accepted by a set that still permits the key.
+#:
+#: The optional rows are listed at the same exact shape as the required ones,
+#: which is only possible because the builder emits them whole or not at all
+#: (`_role_row` in the adapter's `posture.py`). A partial row would make "exact"
+#: unenforceable for exactly the two roles that most need reviewing.
+STUDY_MANIFEST_ENGINE_POSTURE_AGENT_FIELDS_BY_ROLE: dict[str, frozenset[str]] = {
+    "default": frozenset({"effort", "reasoning"}),
+    "worker": frozenset({"effort", "reasoning"}),
+    "verifier": frozenset({"effort", "reasoning"}),
+    "triage": frozenset({"effort", "reasoning"}),
+    "research": frozenset({"effort", "reasoning"}),
+    "plan": frozenset({"effort", "reasoning"}),
+}


### PR DESCRIPTION
Closes #2549
Refs #2553

## The decision the issue asked for, up front

**Opt-in. No registered digest moves.** Recorded as `bench/READINESS.md` §8.4.6,
which is the first entry in that section where the answer to "did anything
move?" is no — stated explicitly, because a silent no is indistinguishable from
nobody having checked.

| model | on `main` | with this change, unset |
|---|---|---|
| `anthropic/claude-sonnet-5` | `6c7fc70c…` | `6c7fc70c…` |
| `openrouter/deepseek/deepseek-v4-pro` | `1191911e…` | `1191911e…` |
| `openrouter/z-ai/glm-5.1` | `20de1e34…` | `20de1e34…` |
| `openrouter/anthropic/claude-sonnet-5` | `da82edd0…` | `da82edd0…` |

Recomputed from `_benchmark_engine_posture` on either side of the change, in the
control arm *and* with a pinned verifier — eight pairs, all equal.

## Why not just emit the rows

The digest identifies every registered arm (§8.4.4). Emitting two rows
unconditionally would re-hash every arm already registered in order to describe
postures that behave exactly as the recorded ones do. That is the trade #1394
made once, and it ended cross-boundary digest comparison for good. Here it buys
nothing, because a row nobody asked for is a row that need not exist.

## The shape

Six host-side selectors — `STELLA_{RESEARCH,PLAN}_{EFFORT,REASONING,MODEL}` —
host-only like every other one: read on the host, reaching Stella only inside
the hashed posture, never forwarded into the container.

- **Unset** emits no `agents` row and no flat key. Byte-identical JSON.
- **Selected**, the row is emitted **whole** (`effort` and `reasoning`, like
  every other role), with the unselected half filled from what the role already
  inherits — the run's own worker tier, and the worker's `reasoning: on`.

That second point is the design. Materialising the row is a behavioural no-op,
so a one-knob arm moves one variable rather than two; and every row has the same
two fields as every other role's, which is what lets the manifest schema keep
validating an *exact* shape instead of accepting whatever a partial row carried.

Effort admits all five tiers where the worker admits three: the worker's list is
short because its rule is parity with the comparator, and these two roles have
the opposite rule — the reason to configure them is to spend *less*.

## Three things the issue did not name

Found while wiring it, each fixed here because it is the code this change
touches:

1. **`agents.default` does not govern the roles with no row.** The comment in
   `posture.py` said it did, and that keeping `default` at `xhigh` stopped the
   arm silently retuning them. `AgentEngineAgents::get` is a straight per-role
   lookup with no fallback, and `over_worker`
   (`crates/stella-cli/src/agent/engine.rs:750`) merges research and plan over
   the **worker** field by field — so the arm's tier *did* reach them. The
   comment described the opposite of the mechanism, and the protection it
   claimed did not exist.
2. **`resolve_posture_role_model`'s last rung was wrong for these two.** It
   documents mirroring `model_for` key for key; unpinned, research and plan
   inherit the worker rather than `default_model` (`own_model_spec_for`, and its
   doc says why). The two coincide in the frozen posture — which is exactly why
   a resolver that got this wrong would keep agreeing with reality until the
   first arm that pinned the worker.
3. **`_validate_engine_posture_manifest_schema` refused a selected arm.** It
   demanded exact equality, so any optional key was "extra" — and the
   required-key set had already fallen behind *every* optional key the builder
   grew, `pipeline_verifier_model` included. A treatment-arm manifest would have
   been refused by the schema that claims to describe it. It now takes an
   `optional_fields` argument (empty by default, so every other caller keeps
   exact equality), and a parity test derives both halves from the builder
   rather than restating them — a restated list is the thing that fell behind.

## Structure, and why

`tb21_analysis.py` and `stella_harbor/__init__.py` are both grandfathered god
files closed to growth, so new lines could not land in either:

- The six posture-schema constants moved to a new
  `bench/terminal_bench_analysis/tb21_posture_schema.py` and are re-exported, so
  no caller's address changes. It also lets the parity test import the contract
  without pulling in an 8,300-line module.
- Selector reading moved to `posture.py::read_posture_selectors`, beside the
  selectors and beside `POSTURE_SELECTOR_ENV` (the tuple the adapter's
  fail-closed ambient registration now unpacks — one list, not two hand-kept
  copies). `__init__.py` ends **30 lines smaller** than it started.

No baseline was raised. `make file-size` is green.

## Witness

`bench/harbor_adapter/tests/test_role_arms.py` (new, 20 tests). On `main`, every
one of the six knobs raises `TypeError: unexpected keyword argument` and the
posture carries four roles — verified in a detached worktree at `origin/main`
with the test file copied in. Here they resolve, and the unset digest still
matches the pinned `1191911e…`.

It covers the digest floor, both arms independently, effort-only and
reasoning-only inheritance, the model pin's flat key + vocabulary widening, that
a model pin alone emits no tuning row, every refusal path, all three fail-closed
seams (host-only registration, one selector reader for both the collection and
exec-boundary paths, the launcher vocabulary parsed from `unknown.rs`), the
manifest-schema parity, and the worker-inheritance rung.

One bug was caught by writing them: the builder accepted an invalid tier,
because only the resolver validated. The builder is the one function both paths
call, so validation belongs there — `_role_row` now validates.

`test_posture.py` gains `_engine_agent_names()`, parsing `ENGINE_AGENT_NAMES`
from `unknown.rs`. The literal it replaces named the four roles the posture
happened to emit, so it could only ever agree with the posture — it could not
answer whether the launcher would accept a role the posture newly emits.

## Verification

- `bench/harbor_adapter`: **630 passed, 2 skipped**
- `bench/terminal_bench_analysis`: **270 passed**
- `file-size`, `god-files`, `role-names` (now 6 roles across every producer),
  `left-behind`, `no-scratch`, `no-secrets`: green
- `ruff`: 4 findings in the files touched, all 4 pre-existing on `main` (main has
  5; this incidentally fixes one)

No new dependency.

## Filed, not fixed

- Three constants in `secure_launcher.py` (`_ENGINE_POSTURE_FIELDS`,
  `_ENGINE_POSTURE_AGENT_ROLES`, `_ENGINE_POSTURE_AGENT_FIELDS`) are defined,
  documented as "kept in step with `posture.py`", and referenced by nothing.
  They enforce no contract and no test checks the claim. Deliberately left
  untouched here rather than updated — editing dead code in a god file spends
  its ceiling for zero behaviour — filed as #2579 with the decision (delete vs
  wire) and its verify steps written out.

## Summary by Sourcery

Introduce opt-in configuration arms for research and plan roles in the Harbor adapter while preserving existing engine posture digests and updating manifest schema and tests accordingly.

New Features:
- Add host-side selectors and posture wiring to configure research and plan effort, reasoning, and model as independent, opt-in arms without changing unset digests.

Bug Fixes:
- Correct engine posture role model resolution so research and plan inherit the worker model rather than default_model when unpinned.
- Fix manifest schema validation to allow optional engine posture fields and agent roles emitted by selectable arms instead of rejecting valid treatment manifests.
- Ensure role effort and reasoning selectors and builder logic validate inputs and fail closed rather than silently defaulting on invalid values.

Enhancements:
- Centralize reading of all posture-related environment selectors into a single helper used by both collection and exec-boundary recomputation.
- Refine engine posture building for per-role model pins and read-only roles to keep posture structure consistent with the launcher vocabulary and analysis contracts.
- Extract engine posture schema constants into a dedicated tb21_posture_schema module and re-export them from tb21_analysis for better modularity.

Documentation:
- Extend bench/READINESS.md with a new section documenting research/plan role selectability, selector names, and confirmation that existing digests remain unchanged.

Tests:
- Add a dedicated test_role_arms suite covering selector behaviour, posture construction, digest invariance, failure modes, and cross-package schema parity for research and plan arms.
- Enhance posture tests to derive engine agent names from the Rust launcher source instead of a hard-coded list, ensuring compatibility when new roles are emitted.
