### PR TITLE
fix(stella-tui): unbreak main — restore the research and plan rows to the /models golden

### DIFF
--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -19,18 +19,18 @@
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ transcript · 24 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                                                                                                      ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
-│                                                                                                                      ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
-│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││                                      │
-│── WITNESS ────────────────────────────────│session   glm-5.2                                                     │───││                                      │
-│                                           │auto      model off · effort on · thinking off                        │   ││                                      │
-│── EXECUTE ────────────────────────────────│                                                                      │───││                                      │
+│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, e│session   glm-5.2                                                     │   ││○ 1. extract types                    │
+│                                           │auto      model off · effort on · thinking off                        │   ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API     │                                                                      │   ││○ 3. update 9 imports                 │
 │                                           │lead      zai/glm-5.2-air                                             │   ││                                      │
-│● read_file    apps/app/automations/page.ts│          medium · thinking on · from default_model                   │   ││                                      │
-│  ⎿ 312 lines                              │think     z-ai/glm-5.2                                    unassigned  │2ms││                                      │
-│                                           │          low · thinking off · from agents.triage.model               │   │└────────────────────── /plan reads it ┘
+│── WITNESS ────────────────────────────────│          medium · thinking on · from default_model                   │───││                                      │
+│                                           │think     z-ai/glm-5.2                                    unassigned  │   ││                                      │
+│── EXECUTE ────────────────────────────────│          low · thinking off · from agents.triage.model               │───││                                      │
+│                                           │research  zai/glm-5.2-air                                             │   ││                                      │
+│● read_file    apps/app/automations/page.ts│          low · thinking off · from default_model                     │   ││                                      │
+│  ⎿ 312 lines                              │plan      zai/glm-5.2-air                                             │2ms││                                      │
+│                                           │          medium · thinking on · from default_model                   │   │└────────────────────── /plan reads it ┘
 │☰  plan  5/7  ·  Workflows canvas          │work      zai/glm-5.2-air                                     served  │   │┌ PROOF ✓ proved ──────────────────────┐
 │                                           │          medium · thinking on · from default_model                   │   ││a test fails without this change and  │
 │⏸ plan  Refactor the automations store into│verify    anthropic/claude-opus-5                         unassigned  │   ││passes with it                        │


### PR DESCRIPTION
## What

`main` has been red since `fba2695cb` (#2566). One test fails:
`deck_render_snapshots_pin_the_floating_cards`, on the `card_models` golden.
This re-blesses that golden on `main` and changes no production code.

## Why it broke

Two PRs re-blessed `crates/stella-tui/tests/snapshots/deck/card_models.txt`
minutes apart, and **neither committed result is a frame the deck can render**:

| commit | PR | file | roles pinned | verdict |
|---|---|---|---|---|
| `9e641752e` | (last green) | 45 lines | 8 | valid |
| `fba2695cb` | #2566 | **49 lines** | 8 | impossible — 44 rows in a 40-row viewport |
| `9ce1c4506` | #2568 | 45 lines | **6** | valid render, stale base |

The golden's own header declares `viewport 160x40`, so a well-formed file is
5 header lines + 40 frame rows = 45. #2566's 49-line file is 44 rows — not a
render at all, but a **line-wise merge** of two branches that each blessed the
same file. #2568 then wrote a structurally valid 45-line golden blessed from a
base predating #2553, which silently dropped the `research` and `plan` rows —
the two roles `fa368a7ac` (#2553, "make research and plan independently
configurable roles") added, and which `crates/stella-tui/src/scenario.rs:658-676`
still declares in the routing fixture.

The card is bottom-anchored — `card_area` in `crates/stella-tui/src/views/cards.rs:37`
computes `y = frame.height - (h + bottom_gap)` — so its top row is a pure
function of body-row count. Eight roles (16 body rows) put the top border on
row 22; six roles put it on row 26. That four-row offset is the entire reported
diff, which is why the failure output reads as "the card moved" rather than
"two rows are missing".

## The fix is a union, not a revert

Re-blessed on `main` and read the diff. The new golden keeps every feature that
landed in the window:

- restores #2553's `research` / `plan` role rows (8 roles again, matching `scenario.rs`),
- keeps #2566's `transcript · 24 lines` recall-table rendering,
- keeps #2568's `PROOF ✓ proved` panel in the right rail.

Only `card_models.txt` changed; the other 20 deck goldens re-blessed byte-identically.
I also audited every golden's row count against its declared viewport — all are
consistent now.

## Verification

- `cargo test -p stella-tui --test deck_render_snapshots` fails on `868af3e05`
  with exactly the CI diff (reproduced locally, byte-for-byte) and passes here.
  That fail-to-pass flip on old-vs-new code is the witness; no new test is
  warranted for a stale fixture.
- `cargo test -p stella-tui` — 915 passed, 0 failed.

## How it got in

Worth stating, because the merge that produced it is reviewable and the
committed file is not:

- `814d387f0` is `Merge branch 'main' into feat/recall-presentation`. Its two
  parents (`8ba6a6f33` and `9e641752e`) each carry a valid 45-line golden; the
  merge carries 49. Git had no reason to conflict — the two sides' insertions
  do not overlap — so it returned their union. A union of two frames is not a
  frame.
- Protection on `main` is `strict: true` and `fmt + clippy + test` **is** a
  required check, but `enforce_admins: false`. Both PRs merged before that
  check on their final head had started: #2566 merged 22:57:38Z, check started
  22:57:48Z; #2568 merged 22:58:08Z, check started 22:58:15Z. Both then failed.
  The guard worked; it just reported after the merge it would have blocked.

## Follow-up

- **#2582** — the durable fix, and the half that needs no policy decision:
  there is no `.gitattributes` in this repo, so goldens are ordinary mergeable
  text. Marking the snapshot trees `merge=binary` makes git conflict instead of
  unioning, which would have caught *both* halves of this breakage.
- **#2574** — commented with this instance; it is the fourth recurrence of that
  class today and the first that is not a compile break, which answers the
  question its case 3 raised about whether a compile check would be sufficient.

## Summary by Sourcery

Update the stella-tui deck snapshot for card models to restore missing role rows and align the golden with the current rendering.

Bug Fixes:
- Fix failing deck_render_snapshots_pin_the_floating_cards test by correcting the card_models snapshot to a renderable frame.

Enhancements:
- Ensure the updated card_models golden incorporates all recently added deck UI features while remaining structurally consistent with its viewport.

Tests:
- Re-bless the card_models deck snapshot and verify all stella-tui tests pass, with other deck goldens remaining byte-identical.