### PR TITLE
test(stella-tui): unbreak main — restore the two roles a golden clobber dropped

### DIFF
--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -19,18 +19,18 @@
 │stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ transcript · 24 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
-│                                                                                                                      ││Refactor the automations store into a…│
-│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││○ 1. extract types                    │
-│                                                                                                                      ││○ 2. move hooks                       │
-│☰  plan  4/7  ·  Wire the triggers API                                                                                ││○ 3. update 9 imports                 │
-│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││                                      │
-│── WITNESS ────────────────────────────────│session   glm-5.2                                                     │───││                                      │
-│                                           │auto      model off · effort on · thinking off                        │   ││                                      │
-│── EXECUTE ────────────────────────────────│                                                                      │───││                                      │
+│                                           ┌ models  resolved routing ───────────────────────────────── esc close ┐   ││Refactor the automations store into a…│
+│  Planning the automations cluster: list, e│session   glm-5.2                                                     │   ││○ 1. extract types                    │
+│                                           │auto      model off · effort on · thinking off                        │   ││○ 2. move hooks                       │
+│☰  plan  4/7  ·  Wire the triggers API     │                                                                      │   ││○ 3. update 9 imports                 │
 │                                           │lead      zai/glm-5.2-air                                             │   ││                                      │
-│● read_file    apps/app/automations/page.ts│          medium · thinking on · from default_model                   │   ││                                      │
-│  ⎿ 312 lines                              │think     z-ai/glm-5.2                                    unassigned  │2ms││                                      │
-│                                           │          low · thinking off · from agents.triage.model               │   │└────────────────────── /plan reads it ┘
+│── WITNESS ────────────────────────────────│          medium · thinking on · from default_model                   │───││                                      │
+│                                           │think     z-ai/glm-5.2                                    unassigned  │   ││                                      │
+│── EXECUTE ────────────────────────────────│          low · thinking off · from agents.triage.model               │───││                                      │
+│                                           │research  zai/glm-5.2-air                                             │   ││                                      │
+│● read_file    apps/app/automations/page.ts│          low · thinking off · from default_model                     │   ││                                      │
+│  ⎿ 312 lines                              │plan      zai/glm-5.2-air                                             │2ms││                                      │
+│                                           │          medium · thinking on · from default_model                   │   │└────────────────────── /plan reads it ┘
 │☰  plan  5/7  ·  Workflows canvas          │work      zai/glm-5.2-air                                     served  │   │┌ PROOF ✓ proved ──────────────────────┐
 │                                           │          medium · thinking on · from default_model                   │   ││a test fails without this change and  │
 │⏸ plan  Refactor the automations store into│verify    anthropic/claude-opus-5                         unassigned  │   ││passes with it                        │


### PR DESCRIPTION
## Unbreak main — a deck golden lost two roles to a parallel-merge clobber

`main` has been red on `fmt + clippy + test` since 22:57 UTC: `deck_render_snapshots_pin_the_floating_cards` fails because `crates/stella-tui/tests/snapshots/deck/card_models.txt` no longer matches what the deck renders.

**Not a rendering regression. The golden is stale, and it got that way by being clobbered** — the exact shape `check-deleted-tests` exists for, on a fixture rather than a test.

### What happened

`git log` on the fixture, newest first:

```
9ce1c4506 feat(stella-tui): PROOF panel …            (#2568)
fba2695cb feat(stella-tui): recall as a table …      (#2566)
fa368a7ac feat(stella-cli): research and plan as independently configurable roles (#2553)
```

#2553 added the `research` and `plan` roles and blessed this golden with all six rows — `lead`, `think`, `research`, `plan`, `work`, `verify`. #2566 then blessed the same file from a base that predated #2553, so its version carries #2566's own changes **and the pre-#2553 four-row roster**. `research` and `plan` are simply absent:

```diff
 │lead      zai/glm-5.2-air                                             │
 │          medium · thinking on · from default_model                   │
 │think     z-ai/glm-5.2                                    unassigned  │
 │          low · thinking off · from agents.triage.model               │
-│research  zai/glm-5.2-air                                             │
-│          low · thinking off · from default_model                     │
-│plan      zai/glm-5.2-air                                             │
-│          medium · thinking on · from default_model                   │
 │work      zai/glm-5.2-air                                     served  │
```

Both PRs were green against the `main` they branched from, and the merge was textually clean — git had no conflict to report because one side simply did not contain the other's lines. #2568 then inherited the four-row roster and blessed on top of it.

The renderer still emits all six roles (#2553's code is untouched in `main`), so the golden is two rows short and every row below shifts. That is the whole failure.

### The fix

Re-blessed `card_models.txt` only, and read the diff. The result carries all three PRs' intended changes at once:

- `research` and `plan` rows restored (#2553);
- the transcript at 24 lines with the recall rendering (#2566);
- the `PROOF ✓ proved` panel in place of `DONE VERIFICATION` (#2568).

No other golden is affected — `research  zai` / `plan      zai` appear in no other snapshot, and `card_models.txt` was the only file carrying the stale roster.

No source changed. This is a fixture correction, so there is no witness test: the suite itself is the witness, and it goes green.

### Deleted tests

None.

### Left behind

The underlying hazard — a blessed golden silently reverting another PR's blessing of the same file — is not caught by anything today. `check-deleted-tests` compares the merge base against the merge result for `#[test]` function names, which is the same question one level up, but it does not look at fixture content.

Not filed separately: #2574 already tracks this class ("two green PRs can compose into a main that does not build"), and I added this as a fourth instance there — https://github.com/macanderson/stella/issues/2574#issuecomment-5234512925. It is the first instance that **compiles cleanly**, which is direct evidence for that issue's own note that a compile check is necessary but not sufficient: running the suite on `refs/pull/N/merge` would have caught it, a compile of the same ref would not.
