### PR TITLE
fix(stella-cli): make the #2410 bare-loop board-withholding witness actually witness it

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -7,39 +7,68 @@
 
 use super::*;
 
+/// The caller's config with the task board withheld — what the bare step loop
+/// actually runs on.
+///
+/// The board is what makes a long autonomous run legible and resumable — and a
+/// one-shot turn has nothing to resume, so here it is pure overhead charged at
+/// the most expensive rate there is: a model round trip per card. Measured over
+/// nine solved Terminal-Bench trials, 26% of every tool call this loop made was
+/// board bookkeeping and 14% of its steps did nothing else — steps that read
+/// nothing, changed no file, and still paid for a full request under a 900s
+/// ceiling.
+///
+/// Narrowed rather than switched off at construction:
+/// [`narrow_with`](stella_tools::policy::ToolPolicy::narrow_with) can only ever
+/// remove capability, so an operator who has already disabled something keeps
+/// it disabled, and this cannot grant anything back. It is the same seam
+/// `tools.bash: "off"` travels through, which is why the board disappears from
+/// MCP-wrapped and custom tool stacks too rather than only from the built-in
+/// registry.
+///
+/// # Blast radius
+///
+/// `task` is a **group** key, and the catalog puts sub-agent delegation (the
+/// tool literally named `task`) in that group alongside the six `task_*` board
+/// tools — so the bare loop loses delegation too. That is #2410's shipped
+/// behaviour, pinned by a test below rather than left to be rediscovered; #2580
+/// asks whether it was intended, since the measurement above is about
+/// bookkeeping, not about spend.
+///
+/// # Why this is a function
+///
+/// Both the bare loop and its witnesses must run *this* expression. When the
+/// narrowing was four inline lines and the tests re-implemented it in a local
+/// helper, all three passed with the production narrowing deleted: they
+/// witnessed `narrow_with`, a `stella-tools` property that was already true
+/// (#2511).
+fn bare_loop_config(cfg: &Config) -> Config {
+    let mut bare = cfg.clone();
+    bare.tool_policy
+        .narrow_with(&stella_tools::policy::ToolPolicy::from_switches([(
+            "task".to_string(),
+            false,
+        )]));
+    bare
+}
+
 /// Run a one-shot prompt through the raw step-loop (Engine::run_turn).
 /// Selected via `--no-pipeline`.
+///
+/// The parameter is `full_cfg`, not `cfg`, deliberately: the loop below runs on
+/// the narrowed [`bare_loop_config`] and nothing else, so dropping that call
+/// leaves `cfg` unbound and fails to compile. A shadowing `let cfg = …` would
+/// have let the same deletion fall silently back to the un-narrowed argument —
+/// the half of #2511 no unit test can reach, since this function builds a
+/// provider, connects MCP and opens the store.
 pub(crate) async fn run_raw_one_shot(
-    cfg: &Config,
+    full_cfg: &Config,
     prompt: &str,
     budget_limit: Option<f64>,
     format: OutputFormat,
 ) -> Result<(), crate::failure::CliFailure> {
-    // The bare step loop withholds the task board.
-    //
-    // The board is what makes a long autonomous run legible and resumable —
-    // and a one-shot turn has nothing to resume, so here it is pure overhead
-    // charged at the most expensive rate there is: a model round trip per
-    // card. Measured over nine solved Terminal-Bench trials, 26% of every tool
-    // call this loop made was board bookkeeping and 14% of its steps did
-    // nothing else — steps that read nothing, changed no file, and still paid
-    // for a full request under a 900s ceiling.
-    //
-    // Narrowed rather than switched off at construction: `narrow_with` can
-    // only ever remove capability, so an operator who has already disabled
-    // something keeps it disabled, and this cannot grant anything back. It is
-    // the same seam `tools.bash: "off"` travels through, which is why the
-    // board disappears from MCP-wrapped and custom tool stacks too rather than
-    // only from the built-in registry.
-    let cfg = &{
-        let mut bare = cfg.clone();
-        bare.tool_policy
-            .narrow_with(&stella_tools::policy::ToolPolicy::from_switches([(
-                "task".to_string(),
-                false,
-            )]));
-        bare
-    };
+    let bare = bare_loop_config(full_cfg);
+    let cfg = &bare;
     let provider = build_provider(cfg)?;
     let registry_options = registry_options(cfg);
     // Concrete `Arc<ToolRegistry>` (not `Arc<dyn ToolExecutor>`) so the
@@ -996,19 +1025,33 @@ impl stella_core::ToolExecutor for VerifierScopedTools<'_> {
 
 #[cfg(test)]
 mod bare_loop_board_tests {
+    use super::*;
+    use crate::config::PROVIDERS;
     use stella_tools::policy::ToolPolicy;
 
-    /// The narrowing `run_raw_one_shot` applies, asserted at the seam it uses.
+    /// The policy the bare step loop ends up running under, given whatever the
+    /// operator configured.
     ///
-    /// Fails on main, where the bare loop narrowed nothing and every board
-    /// tool was offered: 26% of its tool calls and 14% of its steps went on
-    /// bookkeeping that a one-shot turn can never resume.
-    fn bare_loop_policy(base: ToolPolicy) -> ToolPolicy {
-        let mut policy = base;
-        policy.narrow_with(&ToolPolicy::from_switches([("task".to_string(), false)]));
-        policy
+    /// This calls the production [`bare_loop_config`], which is the entire
+    /// point of these three tests. The previous version re-applied
+    /// `narrow_with` in a local helper, so it witnessed
+    /// [`ToolPolicy::narrow_with`] — a `stella-tools` property true long before
+    /// the bare loop ever narrowed anything — and stayed green with the
+    /// narrowing deleted from production (#2511).
+    ///
+    /// The provider row is arbitrary: nothing below the narrowing reads it, and
+    /// [`Config::for_tests`] needs one only because [`Config`] has the field.
+    fn bare_loop_policy(operator: ToolPolicy) -> ToolPolicy {
+        let provider = PROVIDERS[0].clone();
+        let model_id = provider.default_model.to_string();
+        let mut cfg = Config::for_tests(provider, model_id);
+        cfg.tool_policy = operator;
+        bare_loop_config(&cfg).tool_policy
     }
 
+    /// All six tools `stella_tools::tasks` registers, not the five that were
+    /// listed while `task_assign` shipped: the assertion has to name the whole
+    /// board, or regrouping the one tool it omits goes unnoticed (#2511).
     #[test]
     fn the_bare_loop_withholds_every_board_tool() {
         let policy = bare_loop_policy(ToolPolicy::allow_all());
@@ -1018,9 +1061,27 @@ mod bare_loop_board_tests {
             "task_start",
             "task_complete",
             "task_cancel",
+            "task_assign",
         ] {
             assert!(!policy.allows(tool), "{tool} should be withheld");
         }
+    }
+
+    /// The switch is the `task` **group**, and the catalog files sub-agent
+    /// delegation — the tool named `task` — in it, so the bare loop loses
+    /// delegation along with the board.
+    ///
+    /// Pinned rather than merely true: it is a real capability difference that
+    /// #2410's measurement (board bookkeeping) does not by itself justify, so
+    /// changing it should have to change a test. #2580 asks whether it was
+    /// intended.
+    #[test]
+    fn withholding_the_board_also_withholds_sub_agent_delegation() {
+        let policy = bare_loop_policy(ToolPolicy::allow_all());
+        assert!(
+            !policy.allows("task"),
+            "the `task` group key takes sub-agent delegation with the board"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The three tests #2410 shipped to witness the bare loop withholding the task board **pass with the
narrowing deleted from production**. They re-implement the production expression in a local helper:

```rust
// before — mod bare_loop_board_tests
fn bare_loop_policy(base: ToolPolicy) -> ToolPolicy {
    let mut policy = base;
    policy.narrow_with(&ToolPolicy::from_switches([("task".to_string(), false)]));
    policy
}
```

That is a verbatim copy of the four lines inside `run_raw_one_shot`, so what the tests actually
assert is that `ToolPolicy::narrow_with` composes correctly — a `stella-tools` property that was
already true before #2410. The production call site was never in the assertion's causal path.

This matters because #2410's own PR description nominates this change as the first thing to revert
if bare-loop quality drops ("it is one narrowing call and isolated for that reason"). A change
singled out as the first thing to revert is exactly the change whose accidental removal must be
caught.

Closes #2511
Refs #2410, #2580

### The fix — one lever per half of "delete or invert"

**Invert.** Extract the narrowing into a named, pure `bare_loop_config(&Config) -> Config`, which
the tests now call. `run_raw_one_shot` reduces to two lines. Nothing about the narrowing itself
changed — same `narrow_with`, same `task` switch, same seam. The rationale comment moves onto the
function as a doc comment.

**Delete.** Extraction alone does not close the hole: dropping the *call* leaves `bare_loop_config`
sitting unused and every test still green. The old `let cfg = &{…}` shadowed the `cfg` parameter,
which is what made the deletion invisible — remove it and the body silently falls back to the
un-narrowed argument. Renaming the parameter to `full_cfg` removes that fallback, so the same
deletion is a compile error. The name is also just truer: it says "this is the caller's config, and
it is not what the loop runs on."

```rust
pub(crate) async fn run_raw_one_shot(
    full_cfg: &Config,
    …
) -> Result<(), crate::failure::CliFailure> {
    let bare = bare_loop_config(full_cfg);
    let cfg = &bare;
```

### Two things found while in here

- **`task_assign` was missing from the withheld-tools assertion.** `stella-tools/src/tasks.rs`
  registers six board tools; the test named five. It is in the `task` group so it *is* withheld —
  the test simply did not say so, and regrouping that one tool would have gone unnoticed. Now named.
  (Called out in #2511.)
- **The bare loop also lost sub-agent delegation, and nothing said so.** `"task"` is a *group* key,
  and `catalog.rs` files the delegation tool — literally named `task` — in that group alongside the
  six `task_*` tools. So since #2410, `stella run --no-pipeline` cannot spawn a sub-agent. This PR
  does not change that behaviour; it pins it with a test and states it in a `# Blast radius` doc
  section, so a future change to it has to change a test instead of happening silently. **#2580**
  asks whether it was intended — #2410's evidence is about board bookkeeping, which does not by
  itself justify removing a spending capability, and that is a measured call, not a drive-by one.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Checked the artisanal way, both halves, on this branch:

**Invert** — neuter `bare_loop_config` to `cfg.clone()`:

```
$ cargo test -p stella-cli --bin stella bare_loop_board
test the_bare_loop_withholds_every_board_tool ... FAILED
    task_create should be withheld
test withholding_the_board_also_withholds_sub_agent_delegation ... FAILED
    the `task` group key takes sub-agent delegation with the board
test narrowing_never_grants_back_what_an_operator_denied ... FAILED
    an operator grant must not resurrect the board here

test result: FAILED. 1 passed; 3 failed
```

3 of 4 red. `withholding_the_board_leaves_the_working_tools_alone` correctly stays green — an
identity narrowing does leave the working tools alone; that test is not about the narrowing's
content. This is the run that was `ok. 3 passed; 0 failed` before this PR.

**Delete** — comment out the call in `run_raw_one_shot`, the exact deletion in #2511:

```
error[E0423]: expected value, found macro `cfg`
   (×30 use sites — the build does not proceed)
```

Restored, then `4 passed; 0 failed`.

That the second half is a compile error rather than a red test is deliberate and is the honest
description of what is achievable here: `run_raw_one_shot` builds a provider, connects MCP, opens
the store and runs a real turn, so no unit test can call it. A compile error is the stronger
guarantee available at that seam — the revert cannot land at all rather than landing and being
reported. Making the call site itself unit-testable means putting the whole one-shot assembly behind
a port, which is a much larger change than #2511 asks for and is not attempted here.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed — no behaviour or flag changed; the rationale
      comment moved onto `bare_loop_config` as a doc comment and gained a `# Blast radius` section
- [x] `Closes #2511` appears both above and as a commit trailer

`make gate` green (full run, all steps). One thing it caught on the way: rustdoc runs with
`--document-private-items`, so the intra-doc link in `bare_loop_config`'s own doc comment is
checked even though the function is private — `[`ToolPolicy::narrow_with`]` does not resolve in
`goal.rs`, which imports only the full path. Now written as
`[`narrow_with`](stella_tools::policy::ToolPolicy::narrow_with)`.

## Nothing left behind

- [x] Filed: **#2580** — the bare loop lost sub-agent delegation as a side effect of #2410's
      task-group switch; written as a handoff with both options, the files, and what would settle it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**No deleted tests.** All three of #2410's tests survive with their assertions intact — the module
gains one test (`withholding_the_board_also_withholds_sub_agent_delegation`) and one name
(`task_assign`) in an existing list. `bare_loop_policy` is still the helper's name, but it now
delegates to production rather than re-implementing it.

**File size.** `goal.rs` 1120 → 1180 lines, under the 1500 ceiling; it is not grandfathered.
`agent.rs` is untouched, as #2511 requires (it is at its 2270-line ceiling).

**The test fixture.** `bare_loop_config` takes a `Config`, so the tests build one via the existing
`Config::for_tests` with `PROVIDERS[0]`. The provider row is arbitrary and nothing below the
narrowing reads it — noted in the helper's doc comment so the next reader does not go looking for
significance in the choice.

**Rejected alternative:** extracting `bare_loop_policy(&ToolPolicy) -> ToolPolicy` instead of taking
the whole `Config`. It witnesses less: the config-level application (`bare.tool_policy = …`) would
stay inline and un-witnessed, and the `full_cfg` rename would not have a call to protect.

**Rebased onto current main.** The first branch point (`868af3e05`) predated
`4be059883 fix(stella-tui): unbreak main — restore the research and plan rows to the /models golden (#2583)`,
so the local gate inherited main's red `deck_render_snapshots_pin_the_floating_cards`. Not this
change — `stella-tui` does not depend on `stella-cli`, so that test binary was byte-identical to the
base commit's. Rebased (main never touched `goal.rs`) and re-ran the whole gate green.

## Summary by Sourcery

Ensure the bare step loop’s board-withholding behavior is exercised via the production configuration helper instead of a reimplemented local copy, and harden the call site against accidental removal of the narrowing.

Bug Fixes:
- Make the bare-loop board-withholding tests actually cover the production narrowing used by `run_raw_one_shot` rather than only `ToolPolicy::narrow_with`.
- Add coverage that the bare loop also withholds sub-agent delegation via the `task` group key, matching current shipped behavior.
- Include the `task_assign` tool in the withheld-board assertion so regrouping it cannot silently escape test coverage.

Enhancements:
- Extract the bare-loop configuration narrowing into a dedicated `bare_loop_config` helper used by both production and tests, with expanded documentation of its rationale and blast radius.
- Rename the one-shot runner’s config parameter to `full_cfg` and structure the body so removing the narrowing call becomes a compile-time error instead of a silent behavior change.

Documentation:
- Add detailed documentation on the bare loop’s board-withholding configuration, including performance motivation and the scope of capabilities affected.

Tests:
- Extend the bare-loop board tests to drive the actual configuration helper, enumerate all board tools including `task_assign`, and explicitly assert loss of sub-agent delegation through the `task` group key.