### PR TITLE
fix(arenabench): unbreak the launch button, and put Stella's whole engine in the setup form

### DIFF
--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -271,6 +271,17 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
                 f"{where}: bare_loop applies only to a stella seat — "
                 f"{agent!r} has no staged pipeline to switch off"
             )
+        if engine.responsibilities and agent and agent != "stella":
+            # The same refusal, for the same reason, on the knob that arrived
+            # after it (#2381). A roster on a comparator seat parsed cleanly and
+            # was dropped on the floor: the template said the arm ablated a
+            # stage, the arm ran whole, and the published number described
+            # neither. Asymmetry here was an oversight, not a policy — a
+            # declaration that reaches nothing must fail the file, always.
+            problems.append(
+                f"{where}: engine.responsibilities applies only to a stella "
+                f"seat — {agent!r} has no pipeline stages to reassign"
+            )
 
         env_raw = entry.get("env")
         declared: tuple[str, ...] = ()
@@ -436,13 +447,22 @@ def match_to_toml_dict(spec: MatchSpec) -> dict[str, Any]:
                     **{
                         k: v
                         for k, v in c.engine.to_json().items()
-                        if k not in ("roles", "qualified_model") and v is not None
+                        if k not in ("roles", "responsibilities", "qualified_model")
+                        and v is not None
                     },
                     "roles": {
                         name: {
                             k: v for k, v in role.to_json().items() if v is not None
                         }
                         for name, role in c.engine.roles.items()
+                    },
+                    # Rebuilt rather than passed through, so the inner `None`s
+                    # are dropped the same way `roles` drops them. TOML has no
+                    # spelling for one, and an inherited axis written out as a
+                    # key would record a pin the arm never made.
+                    "responsibilities": {
+                        name: {k: v for k, v in row.to_json().items() if v is not None}
+                        for name, row in c.engine.responsibilities.items()
                     },
                 },
             }
@@ -543,6 +563,25 @@ def dump_match(spec: MatchSpec, env_by_seat: dict[str, list[str]] | None = None)
             for name, role in engine.roles.items():
                 out.append(f"    [contestant.engine.roles.{name}]")
                 for key, value in role.to_json().items():
+                    if value is not None:
+                        out.append("    " + _line(key, value))
+                out.append("")
+
+        if engine.responsibilities:
+            # The stage roster (#2381), on the same terms as `roles` above: only
+            # the fields the arm set, and nothing at all when it ablated nothing,
+            # so an existing template renders back byte-identical.
+            #
+            # Omitting this block was a silent drop on the one path whose entire
+            # purpose is reproducibility: "download this match" would hand back a
+            # .toml describing the full pipeline for a seat that had ablated a
+            # stage, and `arenabench run it.toml` would then run a different
+            # experiment than the one whose number was published.
+            out.append("")
+            out.append("  # Stage roster. Absent means the shipped binding, which is not `false`.")
+            for name, row in engine.responsibilities.items():
+                out.append(f"    [contestant.engine.responsibilities.{name}]")
+                for key, value in row.to_json().items():
                     if value is not None:
                         out.append("    " + _line(key, value))
                 out.append("")

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -313,6 +313,24 @@ RESPONSIBILITIES: tuple[str, ...] = (
     "verdict",
 )
 
+#: The agents a responsibility may be reassigned *to* — Stella's
+#: ``AgentId::BUILTIN`` (``crates/stella-pipeline/src/roster.rs``). Anything else
+#: is a ``RosterError::UnknownAgent`` that fails the run inside the container,
+#: after the image is built and the clock is running, so an authoring surface
+#: that offers free text charges a container build for a typo.
+#:
+#: **Derived, not copied.** It is :data:`ROLES` without ``default``, because
+#: ``default`` is the interactive step loop and owns no pipeline responsibility.
+#: A fourth hand-maintained spelling of a Rust vocabulary is precisely the drift
+#: ``scripts/check-role-names.sh`` was written for (#1449) — deriving from a set
+#: that guard already pins inherits the guard instead of needing a new one. The
+#: premise (that Stella's bindable agents are exactly its configurable non-default
+#: roles) is an inference, so it is asserted against the Rust source itself in
+#: ``tests/test_responsibilities.py::TestReassignmentTargets``.
+RESPONSIBILITY_AGENTS: tuple[str, ...] = tuple(
+    role for role in ROLES if role != "default"
+)
+
 
 @dataclass(frozen=True)
 class ResponsibilityConfig:

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -71,7 +71,14 @@ from .credentials import (
     credentials_path,
     missing_required_credentials,
 )
-from .model import EFFORTS, ROLES, MatchSpec, declared_cap_keys
+from .model import (
+    EFFORTS,
+    RESPONSIBILITIES,
+    RESPONSIBILITY_AGENTS,
+    ROLES,
+    MatchSpec,
+    declared_cap_keys,
+)
 from .presets import preset_listing
 from .recorder import preflight as recorder_preflight
 from .registry import DEFAULT_REGISTRY, Registry, sample_tasks
@@ -310,10 +317,20 @@ class ArenaServer:
         }
 
     def agents(self) -> Any:
+        """The seat-configuration vocabulary, served rather than duplicated.
+
+        Every list here is a Python constant the UI renders one control per.
+        Sending them means adding a role or a responsibility in ``model.py``
+        reaches the form with no TypeScript edit — and, more to the point, a
+        name the engine would refuse cannot appear in the form at all, because
+        the form has no other source for the names.
+        """
         return {
             "agents": [spec.to_json() for spec in AGENTS.values()],
             "efforts": list(EFFORTS),
             "roles": list(ROLES),
+            "responsibilities": list(RESPONSIBILITIES),
+            "responsibility_agents": list(RESPONSIBILITY_AGENTS),
         }
 
     def presets(self) -> Any:

--- a/arenabench/tests/test_responsibilities.py
+++ b/arenabench/tests/test_responsibilities.py
@@ -19,13 +19,28 @@ No Docker, no network, no model key: every fixture is synthetic.
 
 from __future__ import annotations
 
+import re
 import tomllib
+from pathlib import Path
 
 import pytest
 
-from arenabench.config import MatchTemplateError, match_from_toml
+from arenabench.config import MatchTemplateError, dump_match, match_from_toml
 from arenabench.harbor_agent import arena_posture
-from arenabench.model import Engine, ResponsibilityConfig
+from arenabench.model import (
+    RESPONSIBILITY_AGENTS,
+    Engine,
+    MatchSpec,
+    ResponsibilityConfig,
+)
+
+_ROSTER_RS = (
+    Path(__file__).resolve().parents[2]
+    / "crates"
+    / "stella-pipeline"
+    / "src"
+    / "roster.rs"
+)
 
 HEADER = """
 [match]
@@ -40,8 +55,12 @@ model = "z-ai/glm-5.2"
 """
 
 
+def _spec(body: str) -> MatchSpec:
+    return match_from_toml(tomllib.loads(HEADER + body))
+
+
 def _engine(body: str) -> Engine:
-    return match_from_toml(tomllib.loads(HEADER + body)).contestants[0].engine
+    return _spec(body).contestants[0].engine
 
 
 class TestDeclaration:
@@ -146,6 +165,33 @@ class TestRefusals:
             _engine(body)
         assert fragment in str(caught.value)
 
+    def test_a_roster_on_a_comparator_seat_refuses_the_template(self):
+        """A declaration that reaches nothing must fail the file.
+
+        `bare_loop` has been refused on a non-stella seat since #2308, three
+        lines above this key's own check, and for exactly the reason that
+        applies here: nothing reads it, so the template says the arm ablated a
+        stage, the arm runs whole, and the published number describes neither.
+        The asymmetry was an oversight, not a policy.
+        """
+        template = {
+            "match": {"id": "ablation", "dataset": "terminal-bench-2.1"},
+            "contestant": [
+                {
+                    "name": "claude code",
+                    "agent": "claude-code",
+                    "engine": {
+                        "api": "anthropic",
+                        "model": "claude-sonnet-5",
+                        "responsibilities": {"triage": {"enabled": False}},
+                    },
+                }
+            ],
+        }
+        with pytest.raises(MatchTemplateError) as caught:
+            match_from_toml(template)
+        assert "applies only to a stella seat" in str(caught.value)
+
     def test_a_string_false_is_read_as_the_arm_it_spells(self):
         """`enabled = "false"` declines, where `bool("false")` would consent.
 
@@ -156,3 +202,90 @@ class TestRefusals:
             '[contestant.engine.responsibilities.triage]\nenabled = "false"\n'
         )
         assert engine.responsibilities["triage"].enabled is False
+
+
+class TestTheDownloadPathKeepsIt:
+    """"Download this match" must hand back the arm that ran, roster included.
+
+    `dump_match` emitted `api`, `model`, `reasoning`, `effort`, `base_url`,
+    `bare_loop` and `roles` — and not `responsibilities`. So the one path whose
+    entire purpose is reproducibility silently dropped the ablation: the .toml
+    described the full pipeline, and `arenabench run it.toml` reran a different
+    experiment than the one whose number was published.
+
+    Latent while the roster could only be set by hand-editing TOML, and live the
+    moment the web form could set it.
+    """
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(
+                "[contestant.engine.responsibilities.triage]\nenabled = false\n",
+                id="ablation",
+            ),
+            # The other axis. `enabled` and `agent` are written independently, so
+            # a renderer can carry one and drop the other.
+            pytest.param(
+                '[contestant.engine.responsibilities.verdict]\nagent = "worker"\n',
+                id="reassignment",
+            ),
+            pytest.param(
+                "[contestant.engine.responsibilities.witness_author]\n"
+                'enabled = true\nagent = "verifier"\n',
+                id="both axes at once",
+            ),
+        ],
+    )
+    def test_a_roster_survives_render_and_reparse(self, body: str):
+        spec = _spec(body)
+        reparsed = match_from_toml(tomllib.loads(dump_match(spec)))
+        assert (
+            reparsed.contestants[0].engine.responsibilities
+            == spec.contestants[0].engine.responsibilities
+        )
+
+    def test_an_arm_that_ablates_nothing_renders_no_roster_block(self):
+        """Emitted only when set, so every existing template renders back
+        byte-identical and a saved match cannot gain a roster it never had."""
+        assert "responsibilities" not in dump_match(_spec(""))
+
+
+class TestReassignmentTargets:
+    """`RESPONSIBILITY_AGENTS` is derived, so the derivation gets asserted.
+
+    The list an authoring surface offers as reassignment targets is Stella's
+    `AgentId::BUILTIN`, and ArenaBench derives it as `ROLES` minus `default`
+    rather than keeping a fourth hand-maintained copy of a Rust vocabulary —
+    the drift `scripts/check-role-names.sh` exists for (#1449).
+
+    The premise, that Stella's bindable agents are exactly its configurable
+    non-default roles, is an *inference*. It holds today, and this reads the
+    Rust source to say so out loud: an unresolvable name is a
+    `RosterError::UnknownAgent` raised inside the container after the image is
+    built, so a select offering one spends a container build on a typo and
+    reports it as the seat failing.
+    """
+
+    def test_the_derived_list_is_stellas_builtin_agent_set(self) -> None:
+        source = _ROSTER_RS.read_text(encoding="utf-8")
+        match = re.search(
+            r"BUILTIN:\s*&'static\s*\[&'static\s*str\]\s*=\s*&\[(?P<names>[^\]]*)\]",
+            source,
+        )
+        assert match, f"could not find AgentId::BUILTIN in {_ROSTER_RS}"
+        builtin = tuple(re.findall(r'"([^"]+)"', match.group("names")))
+        assert builtin, "AgentId::BUILTIN parsed to zero names"
+        assert set(RESPONSIBILITY_AGENTS) == set(builtin), (
+            "the reassignment targets ArenaBench offers and the agents Stella "
+            f"resolves have diverged: {sorted(RESPONSIBILITY_AGENTS)} vs "
+            f"{sorted(builtin)}"
+        )
+
+    def test_the_interactive_default_is_not_a_reassignment_target(self) -> None:
+        """`default` is the step loop and owns no pipeline responsibility.
+
+        It is the one member of `ROLES` the derivation drops, so its absence is
+        the derivation's whole content and is asserted rather than assumed.
+        """
+        assert "default" not in RESPONSIBILITY_AGENTS

--- a/arenabench/tests/test_web_form.py
+++ b/arenabench/tests/test_web_form.py
@@ -12,8 +12,8 @@ whole draft object to the server with ``{...seat.engine}``.
 
 The server counts a cap key's *presence*, not its value, so a blank field was
 enough: **every** launch from the web UI was refused, with an error naming keys
-the operator could not see and had never set. The form was unusable for two
-days and nothing failed.
+the operator could not see and had never set. The form was unusable from the
+moment #2461 landed (2026-08-09) and nothing failed.
 
 Two lessons are pinned below. First, the cap keys must be absent from the form's
 source, checked on the text the way the templates are. Second — the one that

--- a/arenabench/tests/test_web_form.py
+++ b/arenabench/tests/test_web_form.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The web form is an authoring surface, and it is checked like one.
+
+#2411 removed per-trial ceilings from three authoring surfaces — the ``Engine``
+type, the TOML loader, and the HTTP create path — and added a guard reading the
+*text* of every committed template
+(``test_matches.py::test_no_committed_template_declares_a_per_trial_ceiling``).
+It left the fourth. ``ui/components/setup/seat-card.tsx`` kept rendering a
+"Budget $/task" and a "Max output tok" input, and ``matchPayload`` shipped the
+whole draft object to the server with ``{...seat.engine}``.
+
+The server counts a cap key's *presence*, not its value, so a blank field was
+enough: **every** launch from the web UI was refused, with an error naming keys
+the operator could not see and had never set. The form was unusable for two
+days and nothing failed.
+
+Two lessons are pinned below. First, the cap keys must be absent from the form's
+source, checked on the text the way the templates are. Second — the one that
+generalises — the form's engine literal and ``Engine.from_json`` must name the
+same fields, in both directions: a key the form sends that the engine does not
+read is #2411 again, and a key the engine reads that the form does not send is a
+Stella configuration an operator can only reach by hand-writing TOML, which is
+what ``bare_loop`` and ``responsibilities`` were.
+
+No Docker, no network, no model key: the sources and one in-process server.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from arenabench.harbor_agent import arena_posture
+from arenabench.model import RESPONSIBILITIES, RESPONSIBILITY_AGENTS, Engine, MatchSpec
+from arenabench.server import ArenaServer, _declared_caps
+
+_UI = Path(__file__).resolve().parents[1] / "ui"
+_SETUP_VIEW = _UI / "components" / "setup" / "setup-view.tsx"
+
+#: Line prefixes that make a mention prose rather than code. The templates guard
+#: skips ``#`` for the same reason: a file explaining the rule is not breaking
+#: it, and every source below now carries such a sentence.
+_COMMENT_PREFIXES = ("//", "/*", "*", "*/", "{/*")
+
+
+def _is_comment(line: str) -> bool:
+    return line.lstrip().startswith(_COMMENT_PREFIXES)
+
+
+def _ui_sources() -> list[Path]:
+    files = sorted(
+        path
+        for pattern in ("*.ts", "*.tsx")
+        for path in _UI.rglob(pattern)
+        if "node_modules" not in path.parts
+    )
+    assert files, f"no UI sources found under {_UI} — this guard would pass vacuously"
+    return files
+
+
+#: The two functions in ``setup-view.tsx`` that write an ``engine`` object
+#: literal, and what each one is. Both are checked, because they answer
+#: different questions and only the second one reaches the server.
+_ENGINE_LITERALS = {
+    "defaultSeat": "the draft a new seat starts as",
+    "matchPayload": "the object the launch POSTs",
+}
+
+
+def _engine_literal_keys(source: str, *, within: str) -> set[str]:
+    """Keys of the ``engine: {…}`` literal inside function ``within``.
+
+    Read off the source rather than restated here, because a restatement is
+    another copy of the same list and would agree with the form only until
+    somebody edited one of them.
+
+    Anchored on the function name, and that anchor is the whole point: written
+    to search the file from the top it silently read ``defaultSeat``'s literal
+    while its name and docstring said ``matchPayload``, and would then have
+    passed on a payload builder that still spread the raw draft — the exact
+    defect it exists to catch.
+    """
+    anchor = source.index(f"function {within}(")
+    start = source.index("engine: {", anchor)
+    depth = 0
+    keys: set[str] = set()
+    for line in source[start:].splitlines():
+        depth += line.count("{") - line.count("}")
+        # `name: value,` and the shorthand `name,` — both are keys on the wire.
+        if match := re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*[:,]", line):
+            if match.group(1) != "engine":
+                keys.add(match.group(1))
+        if depth == 0:
+            break
+    assert keys, (
+        f"{within}'s engine literal names no keys — it is a spread of some other "
+        "object, so nothing here can audit what it sends"
+    )
+    return keys
+
+
+def _authoring_engine_keys() -> set[str]:
+    """Engine root keys an operator may declare, derived from the type itself.
+
+    ``qualified_model`` is excluded because it is a computed property on the way
+    *out* — ``from_json`` reads ``api`` and ``model`` and never it — so a form
+    sending one would be stating a value the engine recomputes.
+    """
+    return set(Engine().to_json()) - {"qualified_model"}
+
+
+class TestNoPerTrialCeilingInTheForm:
+    """The regression this repository shipped, checked where it shipped it.
+
+    A live binding is what breaks a launch; a comment naming the key is the file
+    explaining why it has none.
+    """
+
+    def test_no_ui_source_names_a_per_trial_ceiling(self) -> None:
+        offenders = [
+            f"{path.relative_to(_UI)}:{number}: {line.strip()}"
+            for path in _ui_sources()
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            )
+            if not _is_comment(line)
+            and ("budget_usd" in line or "max_tokens" in line)
+        ]
+        assert not offenders, (
+            "the web form declares a per-trial ceiling, which the server refuses "
+            f"by presence — every launch from it fails: {offenders}"
+        )
+
+    def test_the_payload_the_form_sends_is_not_refused(self) -> None:
+        """The refusal that fired, on the shape the form now builds.
+
+        The old form put ``budget_usd: ""`` in this object and `_declared_caps`
+        counted it, so this is the assertion that would have caught it — with
+        the launch path's own reader, not a paraphrase of it.
+        """
+        sent = _engine_literal_keys(
+            _SETUP_VIEW.read_text(encoding="utf-8"), within="matchPayload"
+        )
+        payload = {
+            "contestants": [
+                {
+                    "id": "stella",
+                    "name": "Stella",
+                    "agent": "stella",
+                    "engine": dict.fromkeys(sorted(sent), ""),
+                }
+            ]
+        }
+        assert _declared_caps(payload) == []
+
+
+class TestEngineKeyParity:
+    """The form and the engine name the same configuration, both ways.
+
+    Scoped to the engine *root*. The nested ``roles`` and ``responsibilities``
+    tables have their own readers and their own tests
+    (``test_role_posture.py``, ``test_responsibilities.py``); what is checked
+    here is the boundary where the browser hands an object to Python.
+
+    Both literals are checked. ``defaultSeat``'s is what carried the blank cap
+    fields, and ``matchPayload``'s is what put them on the wire — the second is
+    the one that broke launches, and a form can fail either way round.
+    """
+
+    @pytest.mark.parametrize("within", sorted(_ENGINE_LITERALS))
+    def test_the_form_names_no_key_the_engine_does_not_read(self, within: str) -> None:
+        sent = _engine_literal_keys(_SETUP_VIEW.read_text(encoding="utf-8"), within=within)
+        extra = sent - _authoring_engine_keys()
+        assert not extra, (
+            f"{within} ({_ENGINE_LITERALS[within]}) names {sorted(extra)}, which "
+            "Engine.from_json ignores — either the engine grew a field and did "
+            "not, or this is #2411 again"
+        )
+
+    @pytest.mark.parametrize("within", sorted(_ENGINE_LITERALS))
+    def test_the_form_offers_every_key_the_engine_reads(self, within: str) -> None:
+        """The other direction, and the reason this class exists.
+
+        ``bare_loop`` (#2308) and ``responsibilities`` (#2381) both shipped on
+        the engine and never reached the form, so the only way to ablate a stage
+        was to hand-write an ``arenabench.toml`` — and a template that declared
+        one, loaded into the wizard, came back out with it silently dropped.
+        """
+        sent = _engine_literal_keys(_SETUP_VIEW.read_text(encoding="utf-8"), within=within)
+        missing = _authoring_engine_keys() - sent
+        assert not missing, (
+            f"the engine reads {sorted(missing)} and {within} "
+            f"({_ENGINE_LITERALS[within]}) does not — a Stella configuration "
+            "reachable only by hand-writing TOML"
+        )
+
+
+class TestTheVocabularyIsServed:
+    """Every list the form renders one control per comes from the server.
+
+    Hardcoding either list in TypeScript is the drift ``check-role-names.sh``
+    was written for (#1449): the engine refuses an unknown roster key at
+    validation time, inside the container, after the image is built — so a form
+    offering a name Python does not know charges a container build for a typo,
+    and reports it as the seat failing.
+    """
+
+    @pytest.fixture
+    def server(self, tmp_path: Path) -> ArenaServer:
+        return ArenaServer(tmp_path / "workspace")
+
+    def test_the_agents_endpoint_serves_the_roster_vocabulary(
+        self, server: ArenaServer
+    ) -> None:
+        payload = server.agents()
+        assert payload["responsibilities"] == list(RESPONSIBILITIES)
+        assert payload["responsibility_agents"] == list(RESPONSIBILITY_AGENTS)
+
+
+class TestTheFormsRosterReachesTheSeat:
+    """An ablation configured in the browser survives to the posture.
+
+    The chain the form's payload takes: JSON → ``MatchSpec`` → the seat's frozen
+    posture. Each hop has dropped this declaration before (see
+    ``test_responsibilities.py``), and a drop is invisible — the arm runs,
+    scores, and publishes under a posture naming an ablation that never
+    happened.
+    """
+
+    def _spec(self, engine: dict) -> MatchSpec:
+        return MatchSpec.from_json(
+            {
+                "id": "form",
+                "dataset": "terminal-bench-2.1",
+                "contestants": [
+                    {
+                        "id": "stella",
+                        "name": "Stella",
+                        "agent": "stella",
+                        "engine": {
+                            "api": "openrouter",
+                            "model": "z-ai/glm-5.2",
+                            **engine,
+                        },
+                    }
+                ],
+            }
+        )
+
+    def test_an_ablation_set_in_the_form_reaches_the_posture(self) -> None:
+        # `enabled: false` is what the form's "off" sends; "inherit" sends no
+        # key at all, which is a different arm.
+        engine = self._spec(
+            {"responsibilities": {"verdict": {"enabled": False}}}
+        ).contestants[0].engine
+        posture, _, _ = arena_posture("openrouter/z-ai/glm-5.2", engine)
+        assert posture["responsibilities"] == {"verdict": {"enabled": False}}
+
+    def test_a_reassignment_set_in_the_form_reaches_the_posture(self) -> None:
+        engine = self._spec(
+            {"responsibilities": {"witness_author": {"agent": "verifier"}}}
+        ).contestants[0].engine
+        posture, _, _ = arena_posture("openrouter/z-ai/glm-5.2", engine)
+        assert posture["responsibilities"] == {"witness_author": {"agent": "verifier"}}
+
+    def test_the_bare_loop_toggle_reaches_the_seat(self) -> None:
+        assert self._spec({"bare_loop": True}).contestants[0].engine.bare_loop is True
+        assert self._spec({}).contestants[0].engine.bare_loop is False
+
+    def test_an_untouched_form_declares_nothing(self) -> None:
+        """The default seat must stay byte-identical to what it was.
+
+        The posture is what a trial's digest covers, so a form that sent
+        ``responsibilities: {}`` unconditionally would still be fine — the empty
+        table emits no key — but a form that sent ``{"triage": {}}`` for every
+        listed responsibility would re-hash every arm that ablates nothing and
+        invalidate comparison against every run already recorded.
+        """
+        engine = self._spec({"responsibilities": {}, "bare_loop": False}).contestants[0].engine
+        posture, _, _ = arena_posture("openrouter/z-ai/glm-5.2", engine)
+        assert "responsibilities" not in posture

--- a/arenabench/ui/components/app-shell.tsx
+++ b/arenabench/ui/components/app-shell.tsx
@@ -40,6 +40,13 @@ export function AppShell() {
           agents: agents.agents,
           efforts: agents.efforts,
           roles: agents.roles,
+          // Both lists are Stella's vocabularies, and an unknown name in
+          // either fails the run rather than degrading, so neither has a
+          // client-side fallback: an older server that sends nothing yields
+          // no controls, which is honest, where a hardcoded list would offer
+          // names that build a container and then refuse the roster.
+          responsibilities: agents.responsibilities ?? [],
+          responsibility_agents: agents.responsibility_agents ?? [],
         });
       } catch (error) {
         if (!cancelled) setBootError(String(error));

--- a/arenabench/ui/components/setup/seat-card.tsx
+++ b/arenabench/ui/components/setup/seat-card.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import * as React from "react";
-import type { AgentInfo, ModelsPayload, RoleDraft, Seat } from "@/lib/types";
+import type {
+  AgentInfo,
+  ModelsPayload,
+  ResponsibilityDraft,
+  RoleDraft,
+  Seat,
+} from "@/lib/types";
 import { envStatus, CREDENTIALS } from "@/lib/env";
 import { cn, seatStyle } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -9,7 +15,17 @@ import { Field, Input, Textarea } from "@/components/ui/input";
 import { SimpleSelect } from "@/components/ui/select";
 import { Disclosure } from "@/components/ui/collapsible";
 
-const EMPTY_ROLE: RoleDraft = { model: "", effort: "", reasoning: "", max_tokens: "" };
+const EMPTY_ROLE: RoleDraft = { model: "", effort: "", reasoning: "" };
+const EMPTY_RESPONSIBILITY: ResponsibilityDraft = { enabled: "", agent: "" };
+
+/** Inherit, on, off — the three states every pipeline override has.
+ *  `""` is inherit and is not `"off"`: conflating them turns an untouched
+ *  stage into an ablated one, which is a different experiment. */
+const INHERIT_ON_OFF = [
+  { value: "", label: "inherit" },
+  { value: "on", label: "on" },
+  { value: "off", label: "off" },
+];
 
 export function SeatCard({
   seat,
@@ -17,6 +33,8 @@ export function SeatCard({
   agents,
   efforts,
   roles,
+  responsibilities,
+  responsibilityAgents,
   models,
   modelsError,
   removable,
@@ -29,6 +47,8 @@ export function SeatCard({
   agents: AgentInfo[];
   efforts: string[];
   roles: string[];
+  responsibilities: string[];
+  responsibilityAgents: string[];
   models: ModelsPayload | null;
   modelsError: string | null;
   removable: boolean;
@@ -78,6 +98,24 @@ export function SeatCard({
         roles: { ...s.engine.roles, [role]: { ...(s.engine.roles[role] ?? EMPTY_ROLE), ...patch } },
       },
     }));
+  const setResponsibility = (name: string, patch: Partial<ResponsibilityDraft>) =>
+    onChange((s) => ({
+      ...s,
+      engine: {
+        ...s.engine,
+        responsibilities: {
+          ...s.engine.responsibilities,
+          [name]: { ...(s.engine.responsibilities[name] ?? EMPTY_RESPONSIBILITY), ...patch },
+        },
+      },
+    }));
+
+  // A bare-loop arm has no staged pipeline, so every override below it is
+  // inert — the runner never consults `roles` once the loop is settled. The
+  // controls stay visible and disabled rather than hidden: a template that
+  // loaded with both set is exactly the incoherence an operator needs to see,
+  // and hiding it would present a coherent form for an arm that is not.
+  const pipelineInert = seat.engine.bare_loop;
 
   return (
     <div
@@ -152,7 +190,8 @@ export function SeatCard({
       <Disclosure
         className="mt-3.5"
         summary={
-          "advanced — base URL, budget, output cap" + (spec?.has_pipeline ? ", pipeline roles" : "")
+          "advanced — base URL" +
+          (spec?.has_pipeline ? ", loop mode, pipeline roles, stage roster" : "")
         }
       >
         <div className="mt-2.5 grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(150px,1fr))]">
@@ -164,24 +203,26 @@ export function SeatCard({
               onChange={(e) => setEngine({ base_url: e.target.value })}
             />
           </Field>
-          <Field label="Budget $/task" className="max-w-[130px]">
-            <Input
-              type="number"
-              step="0.01"
-              placeholder="none"
-              value={seat.engine.budget_usd}
-              onChange={(e) => setEngine({ budget_usd: e.target.value })}
-            />
-          </Field>
-          <Field label="Max output tok" className="max-w-[130px]">
-            <Input
-              type="number"
-              step="1000"
-              placeholder="agent default"
-              value={seat.engine.max_tokens}
-              onChange={(e) => setEngine({ max_tokens: e.target.value })}
-            />
-          </Field>
+          {/* No budget and no output cap, at engine or role level. A ceiling only
+              one seat carries stops that agent where the work finishes, and the
+              scoreboard then reports our limit as its capability — measured on
+              match 5292a68cdabf, where all three of the capped seat's losses
+              were the guard firing at a third of the allowed clock (#2411). The
+              server refuses the keys by name; offering them here made every
+              launch from this form fail. Bound spend at the provider key. */}
+          {spec?.has_pipeline && (
+            <Field label="Loop" className="max-w-[190px]">
+              <SimpleSelect
+                ariaLabel="loop mode"
+                value={seat.engine.bare_loop ? "bare" : "pipeline"}
+                onValueChange={(v) => setEngine({ bare_loop: v === "bare" })}
+                items={[
+                  { value: "pipeline", label: "staged pipeline" },
+                  { value: "bare", label: "bare loop (--no-pipeline)" },
+                ]}
+              />
+            </Field>
+          )}
         </div>
 
         {spec?.has_pipeline && (
@@ -190,6 +231,12 @@ export function SeatCard({
               Per-role overrides. Blank inherits the engine baseline above.
               {roleModelFallback && (
                 <span className="text-warn"> Model list unavailable ({roleModelFallback}) — free text.</span>
+              )}
+              {pipelineInert && (
+                <span className="text-warn">
+                  {" "}
+                  Inert — this seat runs the bare loop, so no staged role is consulted.
+                </span>
               )}
             </div>
             {roles.map((role) => {
@@ -209,13 +256,14 @@ export function SeatCard({
               return (
                 <div
                   key={role}
-                  className="grid items-center gap-2 [grid-template-columns:74px_1fr_108px_96px_96px] max-lg:[grid-template-columns:1fr_1fr]"
+                  className="grid items-center gap-2 [grid-template-columns:74px_1fr_108px_108px] max-lg:[grid-template-columns:1fr_1fr]"
                 >
                   <span className="font-mono text-[11.5px] text-muted">{role}</span>
                   {items ? (
                     <SimpleSelect
                       ariaLabel={`${role} model`}
                       size="sm"
+                      disabled={pipelineInert}
                       value={current.model}
                       onValueChange={(model) => setRole(role, { model })}
                       items={items}
@@ -225,6 +273,7 @@ export function SeatCard({
                       type="text"
                       placeholder="inherit model"
                       title={roleModelFallback ?? undefined}
+                      disabled={pipelineInert}
                       value={current.model}
                       onChange={(e) => setRole(role, { model: e.target.value })}
                       className="px-2 py-[5px] text-xs"
@@ -233,6 +282,7 @@ export function SeatCard({
                   <SimpleSelect
                     ariaLabel={`${role} effort`}
                     size="sm"
+                    disabled={pipelineInert}
                     value={current.effort}
                     onValueChange={(effort) => setRole(role, { effort })}
                     items={[
@@ -243,20 +293,67 @@ export function SeatCard({
                   <SimpleSelect
                     ariaLabel={`${role} reasoning`}
                     size="sm"
+                    disabled={pipelineInert}
                     value={current.reasoning}
                     onValueChange={(v) => setRole(role, { reasoning: v as RoleDraft["reasoning"] })}
-                    items={[
-                      { value: "", label: "inherit" },
-                      { value: "on", label: "on" },
-                      { value: "off", label: "off" },
-                    ]}
+                    items={INHERIT_ON_OFF}
                   />
-                  <Input
-                    type="number"
-                    placeholder="max tok"
-                    value={current.max_tokens}
-                    onChange={(e) => setRole(role, { max_tokens: e.target.value })}
-                    className="px-2 py-[5px] text-xs"
+                  {/* No per-role output cap. Omitting `max_tokens` is what asks
+                      for the model's own ceiling; sending a number would mean
+                      knowing every booked model's real limit, and guessing one
+                      is what #2128 was. */}
+                </div>
+              );
+            })}
+
+            {/* The stage roster (#2381): the narrow instrument next to the
+                bare loop's blunt one. Turning off exactly triage, or handing
+                the verdict to a different agent, is the only way a measured
+                difference can be attributed to one stage. */}
+            <div className="mt-3.5 text-[11.5px] text-muted">
+              Stage roster — ablate or reassign one responsibility.{" "}
+              <strong>inherit</strong> leaves the shipped binding alone; it is not{" "}
+              <strong>off</strong>.
+              {pipelineInert && (
+                <span className="text-warn">
+                  {" "}
+                  Inert under the bare loop, which settles every stage at once.
+                </span>
+              )}
+            </div>
+            {responsibilities.map((name) => {
+              const current = seat.engine.responsibilities[name] ?? EMPTY_RESPONSIBILITY;
+              return (
+                <div
+                  key={name}
+                  className="grid items-center gap-2 [grid-template-columns:150px_108px_1fr] max-lg:[grid-template-columns:1fr_1fr]"
+                >
+                  <span className="font-mono text-[11.5px] text-muted">{name}</span>
+                  <SimpleSelect
+                    ariaLabel={`${name} enabled`}
+                    size="sm"
+                    disabled={pipelineInert}
+                    value={current.enabled}
+                    onValueChange={(v) =>
+                      setResponsibility(name, {
+                        enabled: v as ResponsibilityDraft["enabled"],
+                      })
+                    }
+                    items={INHERIT_ON_OFF}
+                  />
+                  <SimpleSelect
+                    ariaLabel={`${name} agent`}
+                    size="sm"
+                    disabled={pipelineInert}
+                    value={current.agent}
+                    onValueChange={(agent) => setResponsibility(name, { agent })}
+                    items={[
+                      { value: "", label: "default agent" },
+                      ...responsibilityAgents.map((a) => ({
+                        value: a,
+                        label: `run by ${a}`,
+                      })),
+                    ]}
                   />
                 </div>
               );

--- a/arenabench/ui/components/setup/setup-view.tsx
+++ b/arenabench/ui/components/setup/setup-view.tsx
@@ -46,9 +46,9 @@ function defaultSeat(catalog: Catalog, agentSlug: string, index: number, id: str
       reasoning: true,
       effort: "high",
       base_url: "",
-      budget_usd: "",
-      max_tokens: "",
+      bare_loop: false,
       roles: {},
+      responsibilities: {},
     },
     env: "",
   };
@@ -80,15 +80,39 @@ function matchPayload(args: {
         if (cfg.model) entry.model = cfg.model;
         if (cfg.effort) entry.effort = cfg.effort;
         if (cfg.reasoning) entry.reasoning = cfg.reasoning;
-        if (cfg.max_tokens) entry.max_tokens = Number(cfg.max_tokens);
         if (Object.keys(entry).length) roles[role] = entry;
+      }
+      // Only the axes the operator actually set, per responsibility. A row
+      // spelling `enabled: true` for a stage nobody touched records a pin that
+      // was never made, and — because the posture is what the digest covers —
+      // re-hashes an arm that ablates nothing, making two runs of the same
+      // configuration incomparable.
+      const responsibilities: Record<string, Record<string, unknown>> = {};
+      for (const [name, cfg] of Object.entries(seat.engine.responsibilities)) {
+        const entry: Record<string, unknown> = {};
+        if (cfg.enabled) entry.enabled = cfg.enabled === "on";
+        if (cfg.agent.trim()) entry.agent = cfg.agent.trim();
+        if (Object.keys(entry).length) responsibilities[name] = entry;
       }
       return {
         id: seat.id,
         name: seat.name,
         agent: seat.agent,
         color: seat.color,
-        engine: { ...seat.engine, roles },
+        // Named field by field, never `{...seat.engine}`. The draft is a form
+        // shape and the payload is a wire contract; spreading one into the
+        // other is what shipped `budget_usd: ""` to a server that refuses the
+        // key by presence, so every launch from this form was refused (#2411).
+        engine: {
+          api: seat.engine.api,
+          model: seat.engine.model,
+          reasoning: seat.engine.reasoning,
+          effort: seat.engine.effort,
+          base_url: seat.engine.base_url,
+          bare_loop: seat.engine.bare_loop,
+          roles,
+          responsibilities,
+        },
         env: seat.env,
       };
     }),
@@ -282,8 +306,12 @@ export function SetupView({
             reasoning: c.engine.reasoning,
             effort: c.engine.effort,
             base_url: c.engine.base_url || "",
-            budget_usd: c.engine.budget_usd == null ? "" : String(c.engine.budget_usd),
-            max_tokens: c.engine.max_tokens == null ? "" : String(c.engine.max_tokens),
+            // Read, not dropped. Until #2374's roster knobs reached this
+            // applier, loading a template that ablated a stage produced a form
+            // showing the full pipeline and a launch that ran it — the operator
+            // told the ablation had loaded, and a number measuring the arm they
+            // did not configure.
+            bare_loop: !!c.engine.bare_loop,
             roles: Object.fromEntries(
               Object.entries(c.engine.roles || {}).map(([name, cfg]) => [
                 name,
@@ -295,7 +323,19 @@ export function SetupView({
                     : cfg.reasoning
                       ? "on"
                       : "off") as "" | "on" | "off",
-                  max_tokens: cfg.max_tokens == null ? "" : String(cfg.max_tokens),
+                },
+              ]),
+            ),
+            responsibilities: Object.fromEntries(
+              Object.entries(c.engine.responsibilities || {}).map(([name, cfg]) => [
+                name,
+                {
+                  enabled: (cfg.enabled == null
+                    ? ""
+                    : cfg.enabled
+                      ? "on"
+                      : "off") as "" | "on" | "off",
+                  agent: cfg.agent || "",
                 },
               ]),
             ),
@@ -707,6 +747,8 @@ export function SetupView({
                   agents={catalog.agents}
                   efforts={catalog.efforts}
                   roles={catalog.roles}
+                  responsibilities={catalog.responsibilities}
+                  responsibilityAgents={catalog.responsibility_agents}
                   models={models}
                   modelsError={modelsError}
                   removable={seats.length > 1}

--- a/arenabench/ui/lib/types.ts
+++ b/arenabench/ui/lib/types.ts
@@ -32,6 +32,14 @@ export interface Catalog {
   agents: AgentInfo[];
   efforts: string[];
   roles: string[];
+  /** Pipeline responsibilities an arm may ablate or reassign, from the server's
+   *  RESPONSIBILITIES. Never hardcoded here: the engine refuses a roster key it
+   *  does not know, so the form must offer only names the server named. */
+  responsibilities: string[];
+  /** Agents a responsibility may be reassigned to (Stella's AgentId::BUILTIN).
+   *  A name off this list fails inside the container after the image is built,
+   *  which is why this is a select and not a text field. */
+  responsibility_agents: string[];
 }
 
 /** One selectable model from /api/models (#2065). `benchmarked` mirrors the
@@ -53,18 +61,35 @@ export interface RoleDraft {
   model: string;
   effort: string;
   reasoning: "" | "on" | "off";
-  max_tokens: string;
 }
 
+/** One responsibility's ablation/reassignment as the form holds it (#2381).
+ *  `enabled: ""` is inherit — leave the shipped binding alone — which is not
+ *  the same as `"off"`, and conflating them would silently ablate a stage. */
+export interface ResponsibilityDraft {
+  enabled: "" | "on" | "off";
+  agent: string;
+}
+
+/** The engine as the *form* holds it, which is deliberately not the wire shape:
+ *  every field here is a string or a boolean a control can bind to.
+ *
+ *  No `budget_usd`, no `max_tokens`, at engine or role level. The server refuses
+ *  those keys by name on the create path, and it counts a key's *presence* — so
+ *  a draft field left blank was still enough to make every launch from this form
+ *  fail (#2411). The fix is structural: the type cannot hold one, and
+ *  `matchPayload` names the fields it sends rather than spreading this object. */
 export interface EngineDraft {
   api: string;
   model: string;
   reasoning: boolean;
   effort: string;
   base_url: string;
-  budget_usd: string;
-  max_tokens: string;
+  /** Run the agent's raw step loop instead of its staged pipeline
+   *  (Stella's `--no-pipeline`). Settles triage, witness and verify together. */
+  bare_loop: boolean;
   roles: Record<string, RoleDraft>;
+  responsibilities: Record<string, ResponsibilityDraft>;
 }
 
 export interface Seat {
@@ -493,16 +518,18 @@ export interface ParsedMatch {
       reasoning: boolean;
       effort: string;
       base_url?: string;
-      budget_usd?: number | string | null;
-      max_tokens?: number | string | null;
+      bare_loop?: boolean;
       roles?: Record<
         string,
         {
           model?: string;
           effort?: string;
           reasoning?: boolean | null;
-          max_tokens?: number | string | null;
         }
+      >;
+      responsibilities?: Record<
+        string,
+        { enabled?: boolean | null; agent?: string | null }
       >;
     };
   }>;


### PR DESCRIPTION
## What & why

**Every launch from the ArenaBench web UI was refused.** Starting a match produced:

```
Error: Stella: engine.budget_usd; Stella: engine.max_tokens — per-trial ceilings
are refused. Bound spend at the provider key, which fails a run visibly instead
of truncating a trial into a loss
```

naming two keys the operator could not see and had never set.

#2411 removed per-trial ceilings from three authoring surfaces — the `Engine`
type, the TOML loader, and the HTTP create path — and added a guard reading the
*text* of every committed template. It left the fourth. `seat-card.tsx` kept
rendering **Budget $/task** and **Max output tok**, and `matchPayload` shipped the
draft straight through with `{...seat.engine}`. The server counts a cap key's
*presence*, not its value, so a blank field was enough. Nothing failed, because
nothing checked the form.

### The launch fix

The keys are gone from `EngineDraft`, `RoleDraft`, `ParsedMatch` and every
control, so no type can hold one. The structural half is `matchPayload`: it now
**names the eight engine fields it sends** instead of spreading the draft. The
draft is a form shape and the payload is a wire contract; spreading one into the
other is what let a form-only field reach a server that refuses it.

### The whole engine, not most of it

`bare_loop` (#2308) and `responsibilities` (#2381) both shipped on the engine and
never reached the form, so ablating a single stage meant hand-writing TOML — and a
template that declared either one, loaded into the wizard, **came back out with it
silently dropped**, so the operator was told the ablation had loaded and got a
number for the arm they did not configure.

The seat card now carries a loop-mode select and a stage roster (each
responsibility: `inherit`/`on`/`off`, plus the agent it runs on), `applyMatch`
reads both, and a bare-loop seat greys out the role and roster rows it makes inert
rather than hiding the incoherence.

`RESPONSIBILITIES` and the reassignment targets come from `/api/agents`, never
hardcoded in TypeScript: an unknown roster key is a `RosterError::UnknownAgent`
raised inside the container *after the image is built*, so a select offering one
spends a container build on a typo and reports it as the seat failing. The target
list is **derived** as `ROLES` minus `default` rather than kept as a fourth copy of
a Rust vocabulary — the drift `scripts/check-role-names.sh` exists for (#1449) —
and because the derivation is an inference, it is asserted against
`AgentId::BUILTIN` in `crates/stella-pipeline/src/roster.rs`.

### Two silent drops found in the same seam, fixed here

- **`dump_match` never emitted `responsibilities`.** It writes `bare_loop` and
  `roles`; the roster fell on the floor. So "download this match" handed back a
  `.toml` describing the full pipeline for a seat that had ablated a stage — the
  one path whose entire purpose is reproducibility reran a different experiment
  than the one whose number was published. Latent while the roster was
  TOML-only; live the moment the form could set it.
- **A roster on a non-stella seat parsed cleanly and was ignored.** `bare_loop`
  has been refused there since #2308, three lines above, for exactly this reason.
  The asymmetry was an oversight, not a policy.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`arenabench/tests/test_web_form.py` is new and checks the form the way #2411
checked the templates. Measured against `origin/main`:

- `test_no_ui_source_names_a_per_trial_ceiling` — **19 live cap bindings** across
  `seat-card.tsx`, `setup-view.tsx` and `types.ts`.
- `TestEngineKeyParity` — on main, `matchPayload`'s engine literal **names no keys
  at all** (`engine: { ...seat.engine, roles }`), so nothing could audit what it
  sent; the assertion fires. `defaultSeat`'s literal names `budget_usd` and
  `max_tokens`, so the "no key the engine does not read" half fails there too.

The parity pair is the general form of the bug and the reason it is worth its
weight: *every engine root key the form names is one `Engine.from_json` reads, and
every key it reads is one the form offers* — both directions, both literals. One
direction catches #2411 recurring; the other catches the next `bare_loop`.

`test_responsibilities.py` gains three more, each failing on main: the
render→reparse round trip (main's renderer mentions `responsibilities` only in its
parser), the non-stella refusal, and the `AgentId::BUILTIN` derivation assertion.

One note in the interest of not overclaiming: `TestTheFormsRosterReachesTheSeat`
passes on main. The Python side already carried the roster correctly; those four
are regression cover for the chain the form now feeds, not witnesses.

A correction worth naming, since the guard's value depends on it: the literal
extractor initially searched the file from the top and so read `defaultSeat`'s
literal while its name said `matchPayload` — it would have passed on a payload
builder that still spread the draft, which is the exact defect it exists to catch.
It is anchored on the function name now, and both literals are checked.

## The gate

Rust is untouched by this change; the affected suites and guards were run.

- [x] `cargo fmt --check` — n/a, no Rust changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust changed
- [x] `cargo test --workspace` — n/a; **758 arenabench tests pass**
      (`uv run pytest` in `arenabench/`)
- [x] `make no-scratch`, `make file-size`, `make left-behind`, `make role-names` — all OK
- [x] `tsc --noEmit` clean, with all four edited files confirmed present in the
      program via `--listFiles`
- [x] `npm run build` — Next 16 production build compiles and syncs to
      `arenabench/arenabench/web/`
- [x] `/api/agents` on a live arena serves `responsibilities` and
      `responsibility_agents`, the latter equal to `AgentId::BUILTIN`
- [x] Docs: the affected prose is the doc comments on the changed types and the
      seat card's own labels, all updated in place. No README/`--help` surface changed.

**Operational note for anyone testing this:** `arenabench/arenabench/web/` is the
generated, gitignored bundle the Python server actually serves, so a checkout has
to run `npm run build` in `arenabench/ui/` before `arenabench serve` shows any of
this — and a long-running arena needs restarting.

## Nothing left behind

- [x] Filed: #2600, #2601

- **#2600** — `pipeline_max_revisions` and `pipeline_candidates` are in
  `_ENGINE_ROOT_FIELDS` (the seam would accept them) but no `Engine` field, no
  template key and no control can produce one. The reverse of the defect fixed
  here: not "reachable only by hand-writing TOML" but *unreachable*. Either wire
  them end to end or take them out of the allow-list.
- **#2601** — `arenabench/ui/` has no test runner, which is why this PR's form
  guard is a Python text scan rather than a real test of `matchPayload` and
  `applyMatch`. The text scan cannot catch a value-level regression (e.g. emitting
  `{"enabled": true}` for an untouched responsibility, which would re-hash every
  arm and break comparability while passing every key-name check).

## Ground-rule check

- **No expedients.** No `#[allow]`, no baseline raised, no `TODO`. The cap keys
  are removed from the types rather than defaulted to blank, and `matchPayload`
  names its fields rather than filtering the spread — the shortcut would have been
  a `delete payload.budget_usd`, which leaves the failure one edit away.
- **Measured honestly.** The witness numbers above (19 bindings, "no keys at all")
  were produced by running this PR's own predicates against `origin/main` via
  `git show`, not inferred from the diff. The one test class that does *not*
  witness anything is named as such.
- **Ports, not concretions.** The vocabularies are served from Python, not copied
  into TypeScript, and the one derived list is asserted against the Rust source
  that owns it — so this adds no new hand-maintained cross-language spelling.

## Summary by Sourcery

Fix ArenaBench web launch failures by removing unsupported per-trial ceiling fields from the UI engine model and fully surfacing Stella’s loop and stage roster controls, while ensuring configuration parity and reproducibility across UI, API, and TOML paths.

New Features:
- Expose Stella’s bare-loop toggle and per-stage responsibility roster in the setup form, driven by server-served vocabularies for responsibilities and reassignment agents.

Bug Fixes:
- Resolve web UI match launch failures by removing budget and max-tokens per-trial ceiling fields from the engine draft and sending an explicit, whitelisted engine payload instead of spreading the form state.
- Ensure templates that declare responsibilities or bare_loop are faithfully round-tripped through the UI and TOML paths rather than having those settings silently dropped.
- Reject responsibility rosters on non-Stella seats so templates cannot claim an ablation that is never applied.
- Include responsibilities in dumped match TOML so downloaded matches reproduce the actual ablated or reassigned pipeline.

Enhancements:
- Derive reassignment target agents from Stella’s built-in agent set and serve both responsibilities and reassignment agents from the backend, avoiding duplicated vocabularies in the UI.
- Align the UI engine draft and payload with the Engine.from_json schema, and clarify semantics around inherit/on/off in role and responsibility controls.

Tests:
- Add Python-based guards that scan UI sources for banned per-trial ceiling keys and enforce bidirectional key parity between the UI’s engine literals and the Engine model.
- Extend responsibility tests to cover roster round-trip through dump_match, non-Stella seat validation, and derivation of reassignment targets from Stella’s built-in agents.
- Add end-to-end style tests to ensure form-configured responsibilities and bare_loop reach the engine posture without introducing spurious defaults.