### PR TITLE
fix(stella-cli): unbreak main — settle the export corner on #2597's square

### DIFF
--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -706,13 +706,27 @@ fn the_dashboard_palette_is_generated_from_the_live_theme() {
     }
 }
 
-/// The report is monospace with compact corners, like the transcript reference.
+/// The report is monospace and square.
 ///
-/// Sans-serif body text and 8px cards made the archived evidence harder to
-/// scan. The transcript restyle deliberately uses 3px surfaces and 2px event
-/// rows rather than the square instrument chrome used by live dashboards.
+/// Sans-serif body text and 8px corners were this file's most visible
+/// divergence from the Observatory and arenabench — and it is the surface
+/// users mail around, so it was the copy of the product most readers ever saw.
+///
+/// **The corner is a settled question, and this test is where it stays
+/// settled.** #2597 made every web surface stella renders square, arguing that
+/// a rounded corner says "surface" where a hairline says "boundary" and this
+/// page is all boundaries. #2606 then landed the transcript carrying the
+/// reference's 3px/2px corners, and the two repairs of the resulting collision
+/// (#2610, #2614) resolved it in opposite directions — one rewriting this test
+/// to demand 3px, the other restoring the square CSS — which is how `main`
+/// came to hold one design's stylesheet and the other's assertions.
+///
+/// It resolves to #2597 because that PR owns the decision repo-wide and argued
+/// it; the transcript's contribution was its ROW GRAMMAR, not its palette or
+/// its geometry. Anyone re-opening it should change `--radius` in the token
+/// block, where one line moves every corner, and not here.
 #[test]
-fn the_dashboard_is_monospace_with_compact_corners() {
+fn the_dashboard_is_monospace_and_square() {
     let html = render_dashboard(
         &[],
         &[],
@@ -723,25 +737,33 @@ fn the_dashboard_is_monospace_with_compact_corners() {
     );
 
     assert!(
-        html.contains("font: 13px/1.55 ui-monospace"),
-        "the dashboard body does not use the transcript's mono stack"
+        html.contains(r#"--mono: "JetBrains Mono""#),
+        "the dashboard does not declare the brand's mono stack"
+    );
+    assert!(
+        html.contains("font-family: var(--mono);"),
+        "the dashboard body does not use the mono token"
     );
     assert!(
         !html.contains("-apple-system"),
         "the dashboard still falls back to the system sans stack"
     );
     assert!(
-        html.contains("border-radius: 3px"),
-        "the dashboard does not use compact surface corners"
+        html.contains("--radius: 0;"),
+        "the dashboard does not declare the square corner token"
     );
-    assert!(
-        html.contains("border-radius: 2px"),
-        "the dashboard does not use compact event-row corners"
-    );
-    for rounded in ["border-radius: 8px", "border-radius: 6px"] {
+    // Every corner goes through the token, so the decision lives in one line
+    // rather than in forty rules — including the transcript's, which is the
+    // densest surface here and the easiest place to reintroduce a stray value.
+    for literal in [
+        "border-radius: 8px",
+        "border-radius: 6px",
+        "border-radius: 3px",
+        "border-radius: 2px",
+    ] {
         assert!(
-            !html.contains(rounded),
-            "`{rounded}` still ships: the archive has regressed to app-sized corners"
+            !html.contains(literal),
+            "`{literal}` bypasses `--radius`: set the token, not the rule"
         );
     }
 }
@@ -767,8 +789,8 @@ fn the_dashboard_spells_the_wordmark_lowercase() {
         "the dashboard capitalises the wordmark; it is lowercase always"
     );
     assert!(
-        html.contains("<h1>stella session —"),
-        "the masthead does not carry the lowercase wordmark"
+        html.contains(r#"<span class="wordmark">stella</span>"#),
+        "the masthead does not carry the wordmark"
     );
 }
 


### PR DESCRIPTION
## What & why

**`main` is red: `cargo test -p stella-cli` fails two tests.** The crate
compiles — `main` holds one design's stylesheet and the other design's
assertions.

How it got there, in order:

| PR | What it did to `export.rs` |
|---|---|
| #2597 | Made every web surface stella renders **square** (`--radius: 0`) and mono (`var(--mono)`) |
| #2606 | Landed the session transcript, carrying the reference's **3px/2px** corners into that same file |
| #2610 | Repaired the collision by rewriting #2597's tests to demand **3px** |
| #2614 | Repaired the collision by restoring #2597's **square** CSS |

#2610 and #2614 landed within minutes of each other and resolved the same
conflict in **opposite directions**. Each was green against the tree its author
could see. The result compiles and fails.

## The call

Settled on **#2597**. It owns the decision repo-wide and argued it: a rounded
corner says "surface" where a hairline says "boundary", and this page is all
boundaries. The transcript's contribution was its **row grammar** — the `.ev`
row with its timestamp, kind label and content — which is untouched here. The
geometry and the palette were never its to decide.

Two assertions move to match the CSS that is already shipping:

- **the corner/type test** asserts `--radius: 0` and `font-family: var(--mono)`,
  and now fails on **any** `border-radius:` literal — 3px and 2px included, not
  just the 8px/6px it used to reject. A stray value is now caught at the rule
  instead of silently disagreeing with the token.
- **the wordmark test** asserts the `<span class="wordmark">stella</span>`
  masthead again.

The doc comment records why the corner is settled and where to re-open it
(`--radius`, one line, moves every corner) so the next person does not do it in
a test.

## Renamed test — declaring it

`the_dashboard_is_monospace_with_compact_corners` →
`the_dashboard_is_monospace_and_square`, restoring #2597's original name.
**Nothing is deleted.** Calling it out because `check-deleted-tests` compares
base against merge result and reads a rename as a deletion.

## The witness

- [x] No witness needed — this repairs a merge collision. The proof is that
      **both** PRs' suites pass together: 41 tests in `export::`, where `main`
      has 39 passing and 2 failing right now.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo test --workspace` — green
- [x] `make guards` — exit 0
- [x] `make cache-correctness` — exit 0

## Nothing left behind

- [x] Filed already: **#2613** — a PR can be green while its merge result is
      broken; nothing checks the merge commit. This is the second incident from
      that same gap in under an hour, and the first one it did not predict:
      #2613 describes a *compile* break, and this one **compiles fine**. Two
      repairs racing each other is its own failure mode, and I have added it to
      that issue rather than filing a near-duplicate.

Unaffected and still open from the transcript work: **#2604** (`events.ts` is
second-resolution, so the transcript's elapsed column can only show whole
seconds) and **#2605** (`days_from_civil` has three private copies).

## Anything reviewers should know?

Merge this ahead of reviewing it closely — red `main` reds every open PR.

If you want the transcript's gold accent and 3px corners back, that is a change
to `--radius` and the palette tokens in #2597's block, argued there. It is not
a change to this PR, and it should not be made by editing an assertion.

## Summary by Sourcery

Align stella-cli export dashboard tests and documentation with the repo-wide square, monospace design to resolve the current merge collision and restore a passing test suite.

Enhancements:
- Document the decision to use square corners on the exported dashboard and centralise future corner changes on the `--radius` token rather than test code.

Tests:
- Update the dashboard style test to assert the mono font token and square corner token while rejecting any hard-coded border-radius literals.
- Rename the dashboard style test to reflect the square monospace design and avoid it being treated as a deleted test.
- Adjust the wordmark test to assert the current masthead markup using the dedicated wordmark span.