### PR TITLE
fix(stella-cli): derive the resume advisory from the roster, not from prose

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -35,7 +35,7 @@
 //!   frame says it can** (#1671). A frame carrying the pipeline's progress
 //!   record — class, goal, plan cursor, test baseline — restores through
 //!   [`stella_pipeline::Pipeline::resume`]: the turn finishes, the unreached
-//!   plan steps run, and the witness/verify/verdict stages run on the
+//!   plan steps run, and the witness and verify stages run on the
 //!   completed work, with the residual losses (lint baseline, authored
 //!   witness) named up front. A frame without that record — an older writer,
 //!   a kill before execution — falls back to the plain engine turn, and
@@ -151,7 +151,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
     // Restoration (#1671): when the frame carries the pipeline's progress
     // record and the killed run was executing un-isolated, this resume
     // re-enters the staged pipeline — the interrupted turn continues and the
-    // witness/verify/verdict stages run on the completed work. `None` keeps
+    // witness and verify stages run on the completed work. `None` keeps
     // the honest bare-turn path with its full advisory, and validation lives
     // in `PipelineResume::from_progress` so "restore approximately" is not a
     // state this driver can reach.
@@ -340,7 +340,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
             };
             // A degraded resume does not get a green tick. The tick is this
             // surface's claim that the run finished as it was meant to, and a
-            // turn whose verify and verdict stages never ran did not.
+            // turn whose witness and verify stages never ran did not.
             let banner = matches!(outcome, TurnOutcome::Completed { .. })
                 .then(|| (!frame.degrades(), frame.completed_banner(step)));
             // The abort's typed `kind` decides the exit code here exactly as

--- a/crates/stella-cli/src/resume_frame.rs
+++ b/crates/stella-cli/src/resume_frame.rs
@@ -4,8 +4,8 @@
 //! What a killed turn was running *inside*, so a resume cannot silently give
 //! it back as something smaller (#1615).
 //!
-//! `stella run` drives the staged pipeline — triage, plan, witness, execute,
-//! verify, verdict — and the engine checkpoint that `stella daemon resume`
+//! `stella run` drives the staged pipeline — triage, plan, execute, witness,
+//! verify — and the engine checkpoint that `stella daemon resume`
 //! restores describes only the innermost of those: one worker turn. Resuming
 //! from it alone therefore hands the operator a run that answers but was never
 //! verified, which is the one thing this repository refuses to call done. The
@@ -66,8 +66,9 @@ pub struct PipelineFrame {
     /// See [`FRAME_VERSION`].
     pub version: u32,
     /// The deterministic verify ladder's command, when `--test-command` armed
-    /// it. `None` means every verification would have escalated to the model
-    /// verifier.
+    /// it. `None` means the run configured none, so the only command the
+    /// ladder could ever have observed was the one the witness stage authored
+    /// (`Pipeline::effective_test_command`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub test_command: Option<String>,
     /// Whether the witness stage would have had an independent model author a
@@ -88,8 +89,9 @@ pub struct PipelineFrame {
     ///
     /// The **whole** roster and not just the witness enablement, because every
     /// ablation has to survive a resume: before this, a run whose triage was
-    /// ablated and whose verdict was reassigned came back as neither, and the
-    /// resumed leg's transcript described a pipeline that had never run.
+    /// ablated and whose witness author was reassigned came back as neither,
+    /// and the resumed leg's transcript described a pipeline that had never
+    /// run.
     ///
     /// Additive, so no [`FRAME_VERSION`] bump — an older frame reads it as an
     /// empty map and is upgraded from [`Self::witness_writer`] alone, which is
@@ -111,7 +113,8 @@ pub struct PipelineFrame {
     /// turn writes into the workspace instead.
     #[serde(default)]
     pub isolation_possible: bool,
-    /// Revision rounds the verifier could still have demanded.
+    /// Revision rounds the deterministic verify ladder could still have
+    /// demanded (`stella_pipeline::verify::ladder_decision`'s `Revise` rung).
     #[serde(default)]
     pub max_revisions: u32,
     /// The facts the pipeline learned while running — task class, plan,
@@ -246,8 +249,13 @@ impl ResumeFrame {
     ///
     /// Written as a list of what will *not* run rather than a single sentence,
     /// because "the pipeline does not resume" is the summary an operator
-    /// already assumed was false; naming the verdict, the flip credit and the
-    /// candidate workspace individually is what makes it actionable.
+    /// already assumed was false; naming the verify stage, the flip credit and
+    /// the candidate workspace individually is what makes it actionable.
+    ///
+    /// Every line naming a *model call* is emitted by
+    /// [`unrestored_guarantee`] and reached only through a row of the run's
+    /// roster, so the set is derived rather than written out — see that
+    /// function for why (#2608).
     pub fn advisory(&self) -> Option<Vec<String>> {
         let frame = match self {
             Self::BareTurn => return None,
@@ -267,25 +275,30 @@ impl ResumeFrame {
         ];
         lines.push(match &frame.test_command {
             Some(command) => format!(
-                "  the verify stage will NOT re-run `{command}`, and no verdict is recorded"
+                "  the verify stage will NOT re-run `{command}`, so no evidence is recorded for \
+                 this work"
             ),
-            None => {
-                "  the verifier will NOT re-read this work, and no verdict is recorded".to_string()
-            }
+            None => "  the verify stage will NOT observe this work, so no evidence is recorded \
+                     for it"
+                .to_string(),
         });
-        // Through the roster, not the bool beside it, so this file reads the
-        // legacy field in exactly one place (#2458) — `PipelineFrame::roster`,
-        // which is also the only place that knows an old frame carries nothing
-        // else.
-        if frame.roster().enabled(ModelCallRole::WitnessAuthor) {
-            lines.push(
-                "  the witness test's fail→pass flip is NOT credited — nothing proves this done"
-                    .to_string(),
-            );
-        }
+        // The model calls, derived. Through the roster, not the bool beside it,
+        // so this file reads the legacy field in exactly one place (#2458) —
+        // `PipelineFrame::roster`, which is also the only place that knows an
+        // old frame carries nothing else. `assignments()` is in
+        // `ModelCallRole::ALL` order, so the advisory's order is fixed.
+        lines.extend(
+            frame
+                .roster()
+                .assignments()
+                .iter()
+                .filter(|row| row.enabled)
+                .filter_map(|row| unrestored_guarantee(row.responsibility))
+                .map(str::to_string),
+        );
         if frame.max_revisions > 0 {
             lines.push(format!(
-                "  up to {} revision round(s) the verifier could have demanded will NOT happen",
+                "  up to {} revision round(s) the verify ladder could have demanded will NOT happen",
                 frame.max_revisions
             ));
         }
@@ -331,6 +344,65 @@ impl ResumeFrame {
     }
 }
 
+/// The guarantee a bare-turn resume gives up by not re-running
+/// `responsibility`, or `None` when losing it costs the operator nothing they
+/// can act on.
+///
+/// **This is the join the advisory used to lack** (#2608). Every line of
+/// [`ResumeFrame::advisory`] that names a model call comes from here, and is
+/// reached only through a row of the run's [`stella_pipeline::Roster`] — so a
+/// responsibility the pipeline stops issuing loses its row in
+/// [`stella_pipeline::default_agent`] and its sentence disappears with it, in
+/// the same commit and with nothing to remember. Written as literals instead,
+/// the set of guarantees lived in two places: the pipeline that issues the
+/// stages and a string in this crate, joined by nothing. That is how this
+/// advisory came to describe a model verifier rendering a verdict on a `main`
+/// whose pipeline had stopped issuing either — with no compiler and no test
+/// able to see it, because each half was internally consistent.
+///
+/// The [`ModelCallRole::Verdict`] arm is the shape's own witness: a sentence
+/// **is** declared for it, and no advisory prints it, because
+/// `default_agent` answers `None` and no roster carries the row. Deleting the
+/// arm would make that indistinguishable from having forgotten it — the same
+/// reason invariant 8's parity matrix keeps a row per provider per axis rather
+/// than only the rows that are interesting today. If judgement ever returns to
+/// the pipeline, the sentence describing its loss returns with it.
+///
+/// Exhaustive over [`ModelCallRole`] for the other direction: a responsibility
+/// added to the pipeline fails to compile here with `E0004` until someone
+/// states what its absence costs — the same maintenance contract
+/// [`stella_pipeline::default_agent`] imposes one layer down.
+fn unrestored_guarantee(responsibility: ModelCallRole) -> Option<&'static str> {
+    match responsibility {
+        ModelCallRole::WitnessAuthor => {
+            Some("  the witness test's fail→pass flip is NOT credited — nothing proves this done")
+        }
+        ModelCallRole::Verdict => Some("  no verdict is recorded for the work this turn produced"),
+        // The stages the checkpoint already sits downstream of. Triage
+        // classified, research answered and the plan was authored before the
+        // turn that died, and the resumed turn continues the worker's own loop
+        // rather than replacing it — so not re-running any of these is what a
+        // resume is *for*, not something it loses.
+        ModelCallRole::Triage
+        | ModelCallRole::Research
+        | ModelCallRole::Plan
+        | ModelCallRole::Worker => None,
+        // Not on any roster (`default_agent` answers `None`), so unreachable
+        // through `assignments()`. Named rather than swept up by a wildcard so
+        // that a responsibility added to the pipeline cannot slip past this
+        // match by resembling one of them.
+        ModelCallRole::PlanRepair
+        | ModelCallRole::WitnessRepair
+        | ModelCallRole::DistressGuidance
+        | ModelCallRole::Unknown
+        | ModelCallRole::AgentAuthor
+        | ModelCallRole::SkillAuthor
+        | ModelCallRole::DomainInference
+        | ModelCallRole::Reflection
+        | ModelCallRole::Summarization => None,
+    }
+}
+
 /// What a resume can restore from `frame`, or `None` for the bare-turn path
 /// (#1671): a validated [`stella_pipeline::PipelineResume`] plus the frame's
 /// configuration half, which re-arms the pipeline with the run's *original*
@@ -358,7 +430,7 @@ pub fn restoration(
 pub fn restored_advisory() -> Vec<String> {
     vec![
         "this was a staged pipeline run — resuming INTO it: the interrupted turn \
-         continues, then the witness/verify/verdict stages run on the completed work"
+         continues, then the witness and verify stages run on the completed work"
             .to_string(),
         "  the pre-crash lint baseline is gone, so the lint-regression veto (#861) \
          sits out this run"
@@ -475,10 +547,25 @@ mod tests {
             text.contains("cargo test -p stella-core"),
             "the verify command that will not re-run is named: {text}"
         );
-        assert!(text.contains("no verdict is recorded"), "{text}");
-        assert!(text.contains("flip is NOT credited"), "{text}");
+        assert!(text.contains("no evidence is recorded"), "{text}");
         assert!(text.contains("revision round"), "{text}");
         assert!(text.contains("candidate worktree"), "{text}");
+
+        // The model-call half is asserted as the *derived* set, not as fixed
+        // strings (#2608): every responsibility this run's roster enables
+        // contributes its sentence, and every one it does not is absent. A
+        // literal here would re-create the drift the derivation removed.
+        let roster = pipeline_frame().roster();
+        for &responsibility in ModelCallRole::ALL {
+            let Some(sentence) = unrestored_guarantee(responsibility) else {
+                continue;
+            };
+            assert_eq!(
+                text.contains(sentence),
+                roster.enabled(responsibility),
+                "the advisory must name {responsibility:?} exactly when the roster runs it: {text}"
+            );
+        }
 
         // The delta: a plain engine turn is untouched by any of this.
         let bare = ResumeFrame::BareTurn;
@@ -486,6 +573,80 @@ mod tests {
         assert_eq!(bare.advisory(), None);
         assert_eq!(bare.completed_label(), "resumed_complete");
         assert!(!bare.completed_banner(7).contains("UNVERIFIED"));
+    }
+
+    /// **The #2608 witness.** The advisory names only responsibilities the
+    /// pipeline can actually issue, and it learns that from the roster rather
+    /// than from the sentences it was written with.
+    ///
+    /// On `main` this fails on the first assertion: the advisory prints
+    /// "and no verdict is recorded" unconditionally, while
+    /// `Roster::is_assignable(Verdict)` has been `false` since verification
+    /// went model-free — the two had drifted apart and nothing joined them.
+    ///
+    /// Both directions are checked, because a set that is derived has to be
+    /// derived *both* ways: a responsibility the pipeline cannot issue must
+    /// not be named even though [`unrestored_guarantee`] still declares its
+    /// sentence, and one it can issue must lose its sentence the moment the
+    /// run ablates it.
+    #[test]
+    fn the_advisory_names_no_responsibility_the_pipeline_cannot_issue() {
+        for test_command in [Some("cargo test".to_string()), None] {
+            let frame = ResumeFrame::Pipeline(Box::new(PipelineFrame {
+                test_command,
+                ..pipeline_frame()
+            }));
+            let text = frame
+                .advisory()
+                .expect("a pipeline frame advises")
+                .join("\n");
+            for &responsibility in ModelCallRole::ALL {
+                if stella_pipeline::Roster::is_assignable(responsibility) {
+                    continue;
+                }
+                let token = serde_json::to_value(responsibility)
+                    .ok()
+                    .and_then(|value| value.as_str().map(str::to_string))
+                    .expect("a fieldless role serializes to its wire token");
+                assert!(
+                    !text.contains(&token),
+                    "the advisory names `{token}`, which the staged pipeline does not issue — \
+                     an operator is being told a check was skipped that no longer exists: {text}"
+                );
+            }
+        }
+
+        // The sentence for the responsibility above IS declared; the roster is
+        // what keeps it off the page. Deleting the arm would make a removed
+        // guarantee indistinguishable from a forgotten one.
+        assert!(
+            unrestored_guarantee(ModelCallRole::Verdict).is_some(),
+            "the verdict's loss stays declared, so its return is one roster row away"
+        );
+
+        // The other direction: an ablation the run was launched with drops the
+        // sentence for what it ablated, and nothing else.
+        let witness_sentence =
+            unrestored_guarantee(ModelCallRole::WitnessAuthor).expect("the witness author advises");
+        let ablated = ResumeFrame::Pipeline(Box::new(PipelineFrame {
+            responsibilities: stella_pipeline::Roster::default()
+                .with_enabled(ModelCallRole::WitnessAuthor, false)
+                .overrides(),
+            witness_writer: false,
+            ..pipeline_frame()
+        }));
+        let text = ablated
+            .advisory()
+            .expect("a pipeline frame advises")
+            .join("\n");
+        assert!(
+            !text.contains(witness_sentence),
+            "a run that authored no witness must not be told its flip went uncredited: {text}"
+        );
+        assert!(
+            text.contains("revision round"),
+            "and nothing else may vanish with it: {text}"
+        );
     }
 
     /// A frame present but unreadable must never read as "no frame": the two

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -156,17 +156,17 @@ $ stella daemon resume ses-1785956826121
 
 The relaunch continues the **same session** — same id, same sidecar, the crashed attempt's console preserved — as a fresh supervised child. Completed steps are already in the checkpointed transcript, tool results included, so nothing re-runs and no tool effect is applied twice; the no-clobber staleness map rides the same checkpoint, so a file something else edited while the run was dead is refused rather than overwritten. A run that ended cleanly has nothing to resume, and `resume` says so instead of restarting it.
 
-A turn that was mid-*pipeline* now **re-enters the pipeline** when its frame permits: the pipeline records its progress — task class, goal, plan cursor, test baseline — beside every checkpoint, and `resume` finishes the interrupted turn, runs the plan steps the crash never reached, then runs the witness/verify/verdict stages on the completed work. A resume that ends with a verdict files its audit row as `resumed_complete_verified` and keeps the green tick.
+A turn that was mid-*pipeline* now **re-enters the pipeline** when its frame permits: the pipeline records its progress — task class, goal, plan cursor, test baseline — beside every checkpoint, and `resume` finishes the interrupted turn, runs the plan steps the crash never reached, then runs the witness and verify stages on the completed work. A resume that ends with a verdict files its audit row as `resumed_complete_verified` and keeps the green tick.
 
 ```text
 $ stella daemon resume ses-1785956826121
   resuming ses-1785956826121-25167 at step 14 — completed steps stay done, nothing re-runs
-  ! this was a staged pipeline run — resuming INTO it: the interrupted turn continues, then the witness/verify/verdict stages run on the completed work
+  ! this was a staged pipeline run — resuming INTO it: the interrupted turn continues, then the witness and verify stages run on the completed work
     the pre-crash lint baseline is gone, so the lint-regression veto (#861) sits out this run
     an authored witness cannot be re-created after a crash — verification proceeds on the unauthored ladder
 ```
 
-Two honest limits remain — and neither is silent. A turn that was executing in a **candidate worktree** resumes in the workspace as a plain engine turn, because the candidate died with the process. And a frame from an **older writer** (or a run killed before execution began) carries no progress record to restore from, so it too resumes as a plain turn. In both cases the run names every stage it is not restoring — the verify command that will not re-run, the witness flip that will not be credited — drops the green tick, and files its audit row as `resumed_complete_unverified` rather than `resumed_complete`. An unverified resume is a resume you can still act on; an unverified resume you were never told about is not. Re-verifying is `stella run` with the verifier of your choice.
+Two honest limits remain — and neither is silent. A turn that was executing in a **candidate worktree** resumes in the workspace as a plain engine turn, because the candidate died with the process. And a frame from an **older writer** (or a run killed before execution began) carries no progress record to restore from, so it too resumes as a plain turn. In both cases the run names every stage it is not restoring — the verify command that will not re-run, the witness flip that will not be credited — drops the green tick, and files its audit row as `resumed_complete_unverified` rather than `resumed_complete`. An unverified resume is a resume you can still act on; an unverified resume you were never told about is not. Re-verifying is `stella run` over the same goal.
 
 ## `resume-all`
 


### PR DESCRIPTION
## What & why

`ResumeFrame::advisory` — the "this resume comes back smaller" report a
degraded `stella daemon resume` prints before its first step — named a model
verifier re-reading the work, a verdict being recorded, and revision rounds
*the verifier* could have demanded. None of those exist. Verification went
model-free (#2584, on `main` as `0ab076d`): `default_agent` answers `None` for
`ModelCallRole::Verdict` and `DistressGuidance` (`roster.rs:242`), so no roster
carries a row for either, and `grep -n 'StageKind::'
crates/stella-pipeline/src/pipeline.rs` returns no `Verdict`.

The prose was accurate when it was written and became false without a line of
it changing, because the set of guarantees lived in two places — the pipeline
that issues the stages, and a string in `stella-cli` — joined by nothing. The
failure mode is the dangerous direction: an operator is told a check was
skipped that no longer exists, and (once more stages move) *not* told about one
that was.

**The fix is the join.** `unrestored_guarantee` maps one responsibility to the
sentence naming what its absence costs, and `advisory` reaches it only through a
row of the run's `Roster`. A responsibility the pipeline stops issuing loses its
row in `default_agent` and its sentence disappears in the same commit, with
nothing to remember. The match is exhaustive over `ModelCallRole`, so a
responsibility *added* to the pipeline fails to compile with `E0004` until
someone states what losing it costs — the same maintenance contract
`default_agent` imposes one layer down.

The `Verdict` arm stays **declared and unprinted**, deliberately. That is the
shape `stella-model`'s provider-parity matrix uses (invariant 8): deleting it
would make a removed guarantee indistinguishable from a forgotten one, and if
judgement ever returns to the pipeline the sentence describing its loss returns
with it. A test asserts both halves — the sentence exists, and no advisory
prints it.

Exemplar for the structure: `stella_pipeline::default_agent` itself
(`crates/stella-pipeline/src/roster.rs:190`) — an exhaustive match over
`ModelCallRole` whose `None` arms are a statement rather than a leftover. This
is the same table one layer out.

The deterministic lines (the verify command, the revision budget, candidates,
isolation) stay config-derived — they describe machinery that is still there —
and are restated to name the **verify ladder**, which is what demands a revision
now (`verify::ladder_decision`'s `Revise` rung).

Before / after, for a default-roster run with `--test-command`:

```diff
 this was a staged pipeline run — the resume continues its interrupted TURN, not the pipeline around it
-  the verify stage will NOT re-run `cargo test -p stella-core`, and no verdict is recorded
+  the verify stage will NOT re-run `cargo test -p stella-core`, so no evidence is recorded for this work
   the witness test's fail→pass flip is NOT credited — nothing proves this done
-  up to 2 revision round(s) the verifier could have demanded will NOT happen
+  up to 2 revision round(s) the verify ladder could have demanded will NOT happen
   execution MAY have been isolated in a candidate worktree, which died with the process — …
   re-verify it with `stella run` before treating this as done
```

Closes #2608

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`resume_frame::tests::the_advisory_names_no_responsibility_the_pipeline_cannot_issue`
asserts that no `ModelCallRole` failing `Roster::is_assignable` has its wire
token anywhere in the advisory, over both `test_command` branches — then, in the
other direction, that ablating `WitnessAuthor` drops its sentence and nothing
else.

Checked the artisanal way: with the new test in place, the *old* advisory
wording restored produces

```
the advisory names `verdict`, which the staged pipeline does not issue — an operator
is being told a check was skipped that no longer exists: this was a staged pipeline
run — the resume continues its interrupted TURN, not the pipeline around it
  the verify stage will NOT re-run `cargo test`, and no verdict is recorded
  …
```

`a_resumed_pipeline_run_reports_every_stage_it_cannot_restore` (#1615's witness,
which #2588 broke) still passes, and now asserts the **derived** set — for every
`ModelCallRole`, `advisory` contains its sentence exactly when the roster
enables it — rather than fixed strings. No test was deleted or renamed.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all 10 `resume_frame` tests pass. **Two
      failures in `export::tests` are inherited from `main`, not caused here**:
      confirmed by a control run in a detached worktree at `origin/main`
      (`703976e`) with this PR's changes absent, which fails the same two.
      Tracked as **#2626**. This PR touches no file under
      `crates/stella-cli/src/export/`. Details in
      [this comment](https://github.com/macanderson/stella/pull/2625#issuecomment-5235986668).
- [x] Docs updated where behavior/flags changed — `docs/commands/daemon.mdx`'s
      `resume` section quoted the advisory verbatim
- [x] CLA signed
- [x] `Closes #2608` appears **both** above and as a commit trailer

## Nothing left behind

- [x] Filed: #2622, #2623 — **or**
- [ ] There is nothing: everything I noticed is fixed in this PR

- **#2622** — `website/content/docs/inference-pipeline.mdx` §7 still documents
  the model verifier and distress guidance as live machinery, including a
  four-rung ladder whose fourth rung is "Model verifier". Same defect shape as
  this one, one layer out; deliberately not folded in because it is a docs
  rewrite with its own scope.
- **#2623** — `stella-pipeline`'s evidence-demand path
  (`verifier_pass_stands_alone`, `verifier_evidence_demand`,
  `evidence_demand_prompt`) is live and correct but named and documented for a
  model verifier that no longer exists. Not folded in because renaming
  `pipeline_verifier_evidence_demand` is a settings-compatibility change needing
  a serde alias, and because `pipeline.rs` is a god file closed to growth.
- **#2626** — filed independently by @macanderson while this PR was being
  written; linked rather than duplicated.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `PipelineFrame`'s serde shape is unchanged
      (doc comments only), and `a_frame_round_trips_through_json` still covers it

## Anything reviewers should know?

**The declared-but-unprinted `Verdict` arm is the deliberate part.** It is dead
today by construction, not by accident: the roster is what keeps it off the
page, and a test asserts exactly that. If you would rather the arm were deleted,
that is a real choice — but then a future reader cannot tell "we removed this
guarantee" from "we forgot this guarantee", which is the failure this PR
exists to close.

**Scope held deliberately.** Per #2608's constraints, `stella-cli`'s
`Result<_, String>` signatures are untouched (binary crate, not an invariant-5
violation). The stale-prose sweep stopped at this feature's own surface —
`resume_frame.rs`, the three stage lists in `agent/resume.rs`, and the `resume`
section of `daemon.mdx`. The wider drift in `stella-pipeline` and the pipeline
docs is #2623 and #2622 rather than a larger diff here. #2626's red `main` is
likewise not fixed here — folding a fix for a shared file into an unrelated PR
is what AGENTS.md warns against, and #2626 is precisely about three PRs having
already reconciled those two files in opposite directions.

**One thing this PR does not do.** It derives the *model-call* lines from the
roster. The deterministic lines (verify command, revision budget, candidates,
isolation) are still config-derived literals — correct today, and there is no
roster row to hang them on, but they are the same class of thing and would drift
the same way if the ladder's rungs changed. Nothing joins them to
`verify::ladder_decision`. I did not file that as an issue because I could not
name a mechanism better than the current one that does not invent a fourth
vocabulary (AGENTS.md § Glossary is explicit about that cost) — flagging it
here for a maintainer who may see one.

## Summary by Sourcery

Derive the degraded-resume advisory from the pipeline roster so it only reports guarantees the staged pipeline can actually issue, and align related comments and docs with the current witness/verify-only pipeline.

New Features:
- Add a roster-driven mapping from model-call responsibilities to advisory sentences so the resume output reflects the guarantees actually configured for a run.

Bug Fixes:
- Stop resume advisories from referencing a model verifier/verdict the pipeline no longer issues by computing model-call lines from roster assignments instead of fixed prose.

Enhancements:
- Clarify pipeline frame metadata and advisory wording around the verify ladder, evidence recording, and revision budgeting.
- Ensure tests assert the advisory’s derived relationship to roster-enabled responsibilities, preventing future drift between pipeline behavior and CLI messaging.

Documentation:
- Update daemon resume documentation to describe the current witness and verify stages, and adjust example advisories to match the new wording.