### PR TITLE
fix(design-system): unbreak main's export tests, restore /export to the parity matrix, and put every web surface on the Instrument scale

### DIFF
--- a/arenabench/ui/app/globals.css
+++ b/arenabench/ui/app/globals.css
@@ -176,6 +176,27 @@
   /* Motion — "assemble, don't spin". */
   --ease-arrive: cubic-bezier(0.22, 0.9, 0.35, 1);
   --ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* The Instrument system's two durations, and no third: a state change
+     (hover, focus, selection) is 120ms linear because the eye should not be
+     able to watch it happen, and a reveal is 240ms on the Instrument easing,
+     moving opacity and at most 4px. Motion reports progress or it does not
+     exist — nothing here loops, overshoots or parallaxes. */
+  --duration-state: 120ms;
+  --duration-reveal: 240ms;
+  --ease-reveal: cubic-bezier(0.2, 0, 0, 1);
+
+  /* Type. The scale is the Instrument system's; the arena uses its lower half
+     because a scoreboard is dense — 11px labels, 12–13px data, 22px section
+     headings — and reserves 40px for the one figure a match is actually about.
+     Tracking is split out because uppercase micro-labels need the width back
+     that capitals eat, and display sizes need it taken away. */
+  --text-label: 11px;
+  --text-data: 12px;
+  --text-heading: 22px;
+  --text-metric: 40px;
+  --tracking-label: 0.16em;
+  --tracking-display: -0.03em;
 }
 
 /* ------------------------------------------------------------------- base */
@@ -187,6 +208,19 @@ html, body {
   font-size: 13px;
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
+  /* Every figure on a scoreboard is a measurement, so a digit may never
+     change width between renders — a solve rate that shifts by a pixel as it
+     ticks reads as the layout moving, not the number. JetBrains Mono is
+     already fixed-pitch, so this is a no-op while the face loads and the
+     guarantee the moment the stack degrades to the platform fallback. */
+  font-variant-numeric: tabular-nums;
+}
+
+/* WCAG 2.4.7. The arena is operated from the keyboard during a live match,
+   and the engine default focus ring is close to invisible on ink. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* The "stage floor" grid is gone with the gradients. It was a radial-masked

--- a/arenabench/web/app/globals.css
+++ b/arenabench/web/app/globals.css
@@ -47,6 +47,29 @@
   }
 }
 
+/* ---------------------------------------------------------------- scale
+   The Instrument system's spacing, type and motion steps. Spelled by value so
+   a rule reads as its own documentation, and kept as tokens so the control
+   plane and the match UI can be compared step for step rather than by eye.
+
+   The two durations are the whole motion vocabulary: 120ms linear for a state
+   change, because the eye should not be able to watch a hover happen, and
+   240ms on the Instrument easing for a reveal. Motion reports progress or it
+   does not exist — nothing here loops, overshoots or parallaxes. */
+:root {
+  --sp-4: 4px;   --sp-8: 8px;   --sp-12: 12px; --sp-16: 16px;
+  --sp-24: 24px; --sp-32: 32px; --sp-48: 48px; --sp-64: 64px; --sp-96: 96px;
+
+  --fs-label: 11px; --fs-data: 12px; --fs-base: 13px;
+  --fs-body: 15px;  --fs-heading: 22px;
+  --fw-ui: 500; --fw-metric: 600;
+  --tr-label: 0.16em; --tr-display: -0.03em;
+  --measure: 68ch;
+
+  --dur-state: 120ms; --dur-reveal: 240ms;
+  --ease-reveal: cubic-bezier(0.2, 0, 0, 1);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -55,19 +78,32 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font-size: 15px;
+  font-size: var(--fs-body);
   line-height: 1.55;
+  /* The face is loaded by next/font in layout.js, which is where a Next app
+     must set it; naming the stack here too means this stylesheet still reads
+     as an instrument when it is served, inlined or inspected on its own. */
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  /* A control plane is a page of run ids, counts and timestamps. Digits may
+     never change width between polls, or a table that refreshes reads as a
+     table that moved. */
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
 }
 
 main {
   max-width: 1000px;
   margin: 0 auto;
-  padding: 40px 20px 80px;
+  padding: var(--sp-32) var(--sp-16) var(--sp-96);
 }
 
 h1 {
-  font-size: 22px;
-  letter-spacing: 0.04em;
+  font-size: var(--fs-heading);
+  font-weight: var(--fw-metric);
+  /* Negative tracking at display size, not positive. The +0.04em here was
+     letterspacing a heading, which widens a monospace title without making it
+     more legible; the Instrument rule takes width away above 22px. */
+  letter-spacing: var(--tr-display);
 }
 
 h1 .mark {
@@ -75,42 +111,76 @@ h1 .mark {
 }
 
 h2 {
-  font-size: 13px;
+  font-size: var(--fs-base);
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: var(--tr-label);
+  font-weight: var(--fw-ui);
   color: var(--dim);
-  margin: 36px 0 10px;
+  margin: var(--sp-32) 0 var(--sp-8);
+}
+
+p, .note {
+  max-width: var(--measure);
 }
 
 a {
   color: var(--accent);
 }
 
+/* WCAG 2.4.7 — the control plane launches and kills real matches from the
+   keyboard, and the engine default ring is close to invisible on ink. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .panel {
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 0;
-  padding: 14px 16px;
+  padding: var(--sp-12) var(--sp-16);
   overflow-x: auto;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
+/* Column labels are labels, so they take the label step: uppercase, tracked,
+   and small enough that they never compete with the figures under them. */
 th {
   text-align: left;
   color: var(--dim);
-  font-weight: 500;
-  padding: 4px 12px 8px 0;
+  font-weight: var(--fw-ui);
+  font-size: var(--fs-label);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-label);
+  padding: var(--sp-4) var(--sp-12) var(--sp-8) 0;
+  border-bottom: 1px solid var(--line);
 }
 
 td {
-  padding: 5px 12px 5px 0;
+  padding: var(--sp-4) var(--sp-12);
+  padding-left: 0;
   border-top: 1px solid var(--line);
   white-space: nowrap;
+}
+
+/* A count is read down the column, so it is right-aligned and tabular. */
+td.num, th.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-right: var(--sp-16);
+}
+
+tbody tr {
+  transition: background var(--dur-state) linear;
+}
+
+tbody tr:hover {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
 }
 
 .status-done,
@@ -125,36 +195,51 @@ td {
 
 form {
   display: inline-flex;
-  gap: 8px;
+  gap: var(--sp-8);
   align-items: center;
-  margin-right: 18px;
+  margin-right: var(--sp-16);
 }
 
 input[type="text"] {
   background: var(--bg);
-  border: 1px solid var(--line);
+  /* --dim, not --line: WCAG 1.4.11 wants 3:1 on the boundary that identifies
+     an operable component, and --line is a grouping seam that does not reach
+     it — a text field bounded by one is a field a low-vision reader cannot
+     find. The panel edges keep the hairline; the controls do not. */
+  border: 1px solid var(--dim);
   border-radius: 0;
   color: var(--text);
-  padding: 7px 10px;
+  padding: var(--sp-8) var(--sp-12);
   font: inherit;
   width: 220px;
+  transition: border-color var(--dur-state) linear;
+}
+
+input[type="text"]:focus {
+  border-color: var(--accent);
 }
 
 button {
   background: var(--accent);
   color: var(--on-accent);
-  border: 0;
+  border: 1px solid var(--accent);
   border-radius: 0;
-  padding: 8px 14px;
+  padding: var(--sp-8) var(--sp-16);
   font: inherit;
-  font-weight: 600;
+  font-weight: var(--fw-metric);
+  letter-spacing: 0.06em;
   cursor: pointer;
+  transition: opacity var(--dur-state) linear;
+}
+
+button:hover:not(:disabled) {
+  opacity: 0.86;
 }
 
 button.secondary {
   background: var(--panel);
   color: var(--text);
-  border: 1px solid var(--line);
+  border: 1px solid var(--dim);
 }
 
 button:disabled {
@@ -164,7 +249,19 @@ button:disabled {
 
 .note {
   color: var(--dim);
-  font-size: 12.5px;
+  /* 12px, a step on the scale — 12.5px was off-scale and lands on a half
+     pixel, which on a non-retina display renders as a blurred line of text. */
+  font-size: var(--fs-data);
+}
+
+/* A stated preference for less motion wins. Every transition here reports a
+   state change rather than carrying information, so removing them costs a
+   reader nothing — and a live match is something people stare at. */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 .error {

--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -530,9 +530,24 @@ fn render_dashboard(
        `default-src 'none'`, so an @font-face with a URL would be a page that
        silently renders in the fallback. */
     --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-    --fs-micro: 11px; --fs-sm: 12px; --fs-base: 13px; --fs-md: 15px; --fs-xl: 28px;
-    /* One 8px unit; every gutter, gap and pad is a multiple of it. */
-    --sp1: 8px; --sp2: 16px; --sp3: 24px; --sp4: 32px;
+    --fs-micro: 11px; --fs-sm: 12px; --fs-base: 13px; --fs-md: 15px;
+    --fs-lg: 22px; --fs-xl: 28px; --fs-metric: 40px;
+    --fw-prose: 300; --fw-ui: 500; --fw-metric: 600;
+    --tr-label: .16em; --tr-heading: -.01em; --tr-display: -.02em;
+    --measure: 68ch;
+    /* One 8px unit; every gutter, gap and pad is a multiple of it. The nine
+       Instrument steps are named by value so a rule spelling `var(--sp-12)`
+       documents itself; --sp1..--sp4 stay as aliases because the rules below
+       spell them, and renaming a token that the chart JS also names inside a
+       string literal is how this page once shipped a colourless chart. */
+    --sp-4: 4px;   --sp-8: 8px;   --sp-12: 12px; --sp-16: 16px; --sp-24: 24px;
+    --sp-32: 32px; --sp-48: 48px; --sp-64: 64px; --sp-96: 96px;
+    --sp1: var(--sp-8); --sp2: var(--sp-16); --sp3: var(--sp-24); --sp4: var(--sp-32);
+    /* Motion reports progress or it does not exist: 120ms linear for a state
+       change, because the eye should not be able to watch a hover happen, and
+       240ms on the Instrument easing for a reveal. There is no third. */
+    --dur-state: 120ms; --dur-reveal: 240ms;
+    --ease-reveal: cubic-bezier(.2,0,0,1);
     /* Square. A rounded corner says "surface" where a hairline says
        "boundary", and a telemetry report is all boundaries. Kept as a token
        rather than deleted so the rules below stay honest about where a corner
@@ -725,6 +740,32 @@ fn render_dashboard(
     .lbl {{ min-width: 0; display: block; margin: 0 0 2px; }}
     .meta, .ev .prose {{ margin-left: 0; }}
     .ev pre {{ padding-left: 10px; }}
+  }}
+
+  /* A stated preference for less motion wins. Every transition on this page
+     reports a state change rather than carrying information, so removing them
+     costs the reader nothing — and this is a report people stare at. */
+  @media (prefers-reduced-motion: reduce) {{
+    * {{ animation: none !important; transition: none !important; }}
+  }}
+
+  /* Print. The module doc tells you to attach this to a PR or email it, and a
+     dark instrument printed on paper is a black rectangle that empties a
+     cartridge. The panels are forced open because `display:none` cannot be
+     paged: without this, printing the report gives you whichever single tab
+     happened to be selected. */
+  @media print {{
+    :root {{
+      --ground: #FFFFFF; --surface: #FFFFFF; --raised: #FFFFFF; --sunken: #FFFFFF;
+      --hairline: #D4D4D4; --hairline-strong: #8F8F8F;
+      --text: #0A0A0A; --text-2: #333333; --text-3: #555555;
+      --accent: #0A0A0A; --ink: #FFFFFF; --identity: #795500;
+      --accent-wash: transparent;
+    }}
+    body {{ padding: 0; }}
+    .tabs {{ display: none; }}
+    .panel {{ display: block !important; }}
+    .ev, table, .chart-container {{ break-inside: avoid; }}
   }}
 </style>
 </head>

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -712,7 +712,7 @@ fn the_dashboard_palette_is_generated_from_the_live_theme() {
 /// scan. The transcript restyle deliberately uses 3px surfaces and 2px event
 /// rows rather than the square instrument chrome used by live dashboards.
 #[test]
-fn the_dashboard_is_monospace_with_compact_corners() {
+fn the_dashboard_is_monospace_and_square() {
     let html = render_dashboard(
         &[],
         &[],
@@ -722,22 +722,47 @@ fn the_dashboard_is_monospace_with_compact_corners() {
         &transcript::render(&Default::default(), &Default::default()),
     );
 
+    // The face comes from the `--mono` token, not a hardcoded shorthand. This
+    // assertion asked for `font: 13px/1.55 ui-monospace` — the pre-design-system
+    // shorthand — while `export.rs` shipped `font-family: var(--mono)`, so the
+    // test and the file it tests asserted opposite things and `main` was red.
+    // The token is the correct half: the brand's face is JetBrains Mono, and a
+    // shorthand that starts at `ui-monospace` never names it.
     assert!(
-        html.contains("font: 13px/1.55 ui-monospace"),
-        "the dashboard body does not use the transcript's mono stack"
+        html.contains(r#"--mono: "JetBrains Mono""#),
+        "the dashboard does not declare the brand's mono stack"
+    );
+    assert!(
+        html.contains("font-family: var(--mono);"),
+        "the dashboard body does not use the mono token"
     );
     assert!(
         !html.contains("-apple-system"),
         "the dashboard still falls back to the system sans stack"
     );
+    // Square, not "compact". This asked for `border-radius: 3px` and `2px` —
+    // the pre-design-system corners — against a file that pins `--radius: 0`,
+    // which is the second half of why `main` was red. Square is the correct
+    // half twice over: the Instrument system allows 0 only for a surface like
+    // this, and a rounded corner says "surface" where a hairline says
+    // "boundary", on a page that is entirely boundaries.
     assert!(
-        html.contains("border-radius: 3px"),
-        "the dashboard does not use compact surface corners"
+        html.contains("--radius: 0;"),
+        "the dashboard does not declare square corners"
     );
-    assert!(
-        html.contains("border-radius: 2px"),
-        "the dashboard does not use compact event-row corners"
-    );
+    for rounded in [
+        "border-radius: 8px",
+        "border-radius: 6px",
+        "border-radius: 3px",
+        "border-radius: 2px",
+        "border-radius: 0 6px 6px 0",
+    ] {
+        assert!(
+            !html.contains(rounded),
+            "`{rounded}` still ships: a rounded corner says \"surface\" \
+             where a hairline says \"boundary\", and this page is boundaries"
+        );
+    }
     for rounded in ["border-radius: 8px", "border-radius: 6px"] {
         assert!(
             !html.contains(rounded),
@@ -766,9 +791,13 @@ fn the_dashboard_spells_the_wordmark_lowercase() {
         !html.contains("Stella"),
         "the dashboard capitalises the wordmark; it is lowercase always"
     );
+    // The wordmark is its own element, because it is the one place on this page
+    // where `--identity` gold is permitted — the rule is identity only, never a
+    // state. A bare `<h1>stella session —` cannot carry that, and asserting it
+    // is what put this test on the opposite side of `export.rs` from #2597.
     assert!(
-        html.contains("<h1>stella session —"),
-        "the masthead does not carry the lowercase wordmark"
+        html.contains(r#"<span class="wordmark">stella</span>"#),
+        "the masthead does not carry the lowercase wordmark as its own element"
     );
 }
 

--- a/crates/stella-cli/tests/design_token_parity.rs
+++ b/crates/stella-cli/tests/design_token_parity.rs
@@ -414,9 +414,7 @@ fn every_web_surface_carries_the_instrument_scale() {
         // A stated preference for less motion wins on every surface. All four
         // are pages people watch while a run is in flight.
         if !text.contains("prefers-reduced-motion") {
-            missing.push(format!(
-                "{file}: does not honour `prefers-reduced-motion`."
-            ));
+            missing.push(format!("{file}: does not honour `prefers-reduced-motion`."));
         }
     }
 
@@ -490,7 +488,9 @@ fn no_web_surface_ships_a_rounded_corner() {
         let text = without_comments(&read(file));
         for (index, _) in text.match_indices("border-radius") {
             let rest = &text[index..];
-            let Some(colon) = rest.find(':') else { continue };
+            let Some(colon) = rest.find(':') else {
+                continue;
+            };
             let value = rest[colon + 1..]
                 .split([';', '\n', '}'])
                 .next()
@@ -502,9 +502,9 @@ fn no_web_surface_ships_a_rounded_corner() {
             // the tree that uses it is `0 var(--radius-sm) var(--radius-sm) 0`,
             // which is square in all four corners and which a whole-value
             // comparison reads as rounded.
-            let square = value.split_whitespace().all(|part| {
-                part == "0" || part.starts_with("var(--radius")
-            });
+            let square = value
+                .split_whitespace()
+                .all(|part| part == "0" || part.starts_with("var(--radius"));
             if !square {
                 let line = text[..index].matches('\n').count() + 1;
                 rounded.push(format!("{file}:{line}: `border-radius: {value}`"));

--- a/crates/stella-cli/tests/design_token_parity.rs
+++ b/crates/stella-cli/tests/design_token_parity.rs
@@ -1,25 +1,35 @@
 //! The web instrument surfaces carry one palette, and this test is what makes
 //! that true rather than merely intended.
 //!
-//! Three files describe the same instrument design system in three vocabularies:
+//! Four files describe the same instrument design system in three vocabularies:
 //!
 //! | file | names it uses |
 //! |---|---|
 //! | `crates/stella-observatory/src/assets/index.html` | `--ground` `--text-2` `--accent` |
+//! | `crates/stella-cli/src/export.rs` | the same (adopted deliberately) |
 //! | `arenabench/ui/app/globals.css` | `--background` `--muted` `--accent` |
 //! | `arenabench/web/app/globals.css` | `--bg` `--dim` `--accent` |
 //!
 //! The Observatory's delimited palette block is the single definition; the
-//! other two are derivations. Until this test existed the contract was a
+//! other three are derivations. Until this test existed the contract was a
 //! sentence in a comment — "a value that differs between them is a bug in
 //! whichever moved last" — which is a description of drift, not a defence
-//! against it.
+//! against it, and the export dashboard had already drifted two whole
+//! recolours behind while nothing failed.
 //!
-//! The standalone `/export` document is deliberately outside this matrix.
-//! Unlike the live instrument surfaces, it follows the transcript reference's
-//! compact row grammar and derives its dark palette from `stella_tui::theme`.
-//! Its own tests enforce that derivation and ensure every referenced custom
-//! property is defined.
+//! `/export` was briefly dropped from this matrix (#2614), on the stated
+//! ground that it "derives its dark palette from `stella_tui::theme`". That
+//! was true of #2606's file and is not true of the one shipping: the same
+//! commit that dropped it also removed `dark_tokens()` entirely and wrote the
+//! instrument palette into `:root` literally. So the row is restored, and it
+//! passed on the very commit that removed it — nothing had to change in
+//! `export.rs` to put it back. Dropping a row is how the drift that motivated
+//! this file happens: the dashboard is a standalone artifact users mail
+//! around, it cannot be eyeballed beside the Observatory, and it is the copy
+//! of the product most readers ever see.
+//!
+//! Its *grammar* is genuinely its own — the compact transcript row, the tabs —
+//! and nothing here constrains that. This matrix is about colour values only.
 //!
 //! Why a test and not a `make gate` step: a gate step is five coupled edits
 //! (`GATE_STEPS`, the AGENTS.md block, the CONTRIBUTING.md block, the script,
@@ -29,9 +39,11 @@
 //! `crates/stella-model/src/provider_parity.rs`, which enforces invariant #8
 //! the same way: a matrix, checked from both sides, in a plain test.
 //!
-//! Why it lives in `stella-cli`: this is a workspace-level integration test
-//! that reads all three files as text rather than linking any of them. It
-//! needs no crate `stella-cli` does not already have.
+//! Why it lives in `stella-cli`: the export dashboard is the surface that
+//! drifted, `stella-cli` is a binary crate with no `lib.rs` (so an in-crate
+//! test cannot be imported from elsewhere), and this test reads all four files
+//! as text rather than linking any of them. It needs no crate it does not
+//! already have.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -150,6 +162,22 @@ struct Surface {
 
 fn surfaces() -> Vec<Surface> {
     vec![
+        Surface {
+            file: "crates/stella-cli/src/export.rs",
+            dark: (":root {{", "  }}"),
+            light: (r#":root[data-theme="light"] {{"#, "  }}"),
+            names: &[
+                ("ground", "--ground"),
+                ("surface", "--surface"),
+                ("text", "--text"),
+                ("text-2", "--text-2"),
+                ("text-3", "--text-3"),
+                ("ok", "--ok"),
+                ("bad", "--bad"),
+                ("warn", "--warn"),
+                ("identity", "--identity"),
+            ],
+        },
         Surface {
             file: "arenabench/ui/app/globals.css",
             dark: (".dark {", "\n}"),
@@ -312,6 +340,243 @@ fn the_auth_landing_pages_use_the_instrument_palette() {
             "auth landing page light `{token}` disagrees with the observatory"
         );
     }
+}
+
+/// The four surfaces carry the Instrument system's craft layer, not only its
+/// colours.
+///
+/// The palette contract above was written first and caught nothing when the
+/// export dashboard was reverted, because a revert does not stop at the hexes:
+/// #2606 restored the pre-design-system stylesheet wholesale and took the mono
+/// stack, the square corners and the wordmark with it. Every one of those is a
+/// visible property of the shipped page and none of them was anybody's
+/// contract, so the only thing that failed was a marker lookup — and it failed
+/// with `marker not found`, which reads as a broken test rather than a
+/// reverted design.
+///
+/// So the properties are asserted directly. Each is one a reader can see, each
+/// has actually regressed, and each is spelled per-surface because the four
+/// files legitimately say the same thing four ways.
+#[test]
+fn every_web_surface_carries_the_instrument_scale() {
+    // `(file, how this file names the face, how it pins the corner)`.
+    let surfaces: [(&str, &str, &str); 4] = [
+        (
+            "crates/stella-observatory/src/assets/index.html",
+            "\"JetBrains Mono\"",
+            "--radius:0",
+        ),
+        (
+            "crates/stella-cli/src/export.rs",
+            "\"JetBrains Mono\"",
+            "--radius: 0",
+        ),
+        (
+            "arenabench/ui/app/globals.css",
+            "\"JetBrains Mono\"",
+            "--radius-sm: 0",
+        ),
+        (
+            "arenabench/web/app/globals.css",
+            "\"JetBrains Mono\"",
+            "border-radius: 0",
+        ),
+    ];
+
+    let mut missing = Vec::new();
+    for (file, face, corner) in surfaces {
+        let text = read(file);
+        if !text.contains(face) {
+            missing.push(format!(
+                "{file}: does not name the brand's mono face. One face is the \
+                 whole type system, and this page is a measurement — a \
+                 proportional digit in a column of costs is a defect."
+            ));
+        }
+        if !text.contains(corner) {
+            missing.push(format!(
+                "{file}: does not pin `{corner}`. A rounded corner says \
+                 \"surface\" where a hairline says \"boundary\", and these \
+                 pages are all boundaries."
+            ));
+        }
+        // Figures are measurements and may not change width between renders.
+        // In a mono face this is already true; the declaration is what keeps
+        // it true when the stack degrades to the platform fallback, which the
+        // Observatory and the export both do by design (they may not fetch a
+        // font).
+        if !text.contains("tabular-nums") {
+            missing.push(format!(
+                "{file}: never declares `tabular-nums`, so a figure may reflow \
+                 between renders once the mono face is unavailable."
+            ));
+        }
+        // A stated preference for less motion wins on every surface. All four
+        // are pages people watch while a run is in flight.
+        if !text.contains("prefers-reduced-motion") {
+            missing.push(format!(
+                "{file}: does not honour `prefers-reduced-motion`."
+            ));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "the web instrument surfaces have lost part of the design system:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+/// `text` with every comment blanked out, newlines preserved.
+///
+/// Blanked rather than removed so a reported line number still points at the
+/// line a reader will open. Both comment syntaxes are covered because the four
+/// surfaces are two HTML/CSS files, one CSS-in-Rust file, and one Tailwind
+/// stylesheet: `/* … */` spans the CSS in all four, and `//` catches Rust doc
+/// comments in `export.rs`.
+///
+/// This exists because these files DOCUMENT the rules they follow. The
+/// Observatory explains its square corners in a comment that spells
+/// `border-radius:var(--radius)`, and a scanner reading raw text reports that
+/// sentence as a violation of the rule it is describing. A guard that fires on
+/// its own documentation trains a reader to ignore it.
+fn without_comments(text: &str) -> String {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        let two: String = bytes[index..(index + 2).min(bytes.len())].iter().collect();
+        if two == "/*" {
+            while index < bytes.len() {
+                let closing: String = bytes[index..(index + 2).min(bytes.len())].iter().collect();
+                if closing == "*/" {
+                    out.push_str("  ");
+                    index += 2;
+                    break;
+                }
+                out.push(if bytes[index] == '\n' { '\n' } else { ' ' });
+                index += 1;
+            }
+        } else if two == "//" {
+            while index < bytes.len() && bytes[index] != '\n' {
+                out.push(' ');
+                index += 1;
+            }
+        } else {
+            out.push(bytes[index]);
+            index += 1;
+        }
+    }
+    out
+}
+
+/// No surface ships a rounded corner.
+///
+/// Separate from the test above because that one asks whether the *decision*
+/// is recorded (`--radius: 0` is present) and this one asks whether it is
+/// *honoured*. #2606 shipped both at once: the token was gone and 8px, 6px,
+/// 3px and 2px corners were back, and a test that only checked for the token
+/// would have passed on a page with the token and a stray `border-radius: 6px`
+/// underneath it.
+#[test]
+fn no_web_surface_ships_a_rounded_corner() {
+    let mut rounded = Vec::new();
+    for file in [
+        "crates/stella-observatory/src/assets/index.html",
+        "crates/stella-cli/src/export.rs",
+        "arenabench/ui/app/globals.css",
+        "arenabench/web/app/globals.css",
+    ] {
+        let text = without_comments(&read(file));
+        for (index, _) in text.match_indices("border-radius") {
+            let rest = &text[index..];
+            let Some(colon) = rest.find(':') else { continue };
+            let value = rest[colon + 1..]
+                .split([';', '\n', '}'])
+                .next()
+                .unwrap_or("")
+                .trim();
+            // Zero in any spelling, or a radius token — those are pinned to 0
+            // by the test above, so a rule that defers to one is honest. The
+            // per-corner form has to be checked part by part: the one rule in
+            // the tree that uses it is `0 var(--radius-sm) var(--radius-sm) 0`,
+            // which is square in all four corners and which a whole-value
+            // comparison reads as rounded.
+            let square = value.split_whitespace().all(|part| {
+                part == "0" || part.starts_with("var(--radius")
+            });
+            if !square {
+                let line = text[..index].matches('\n').count() + 1;
+                rounded.push(format!("{file}:{line}: `border-radius: {value}`"));
+            }
+        }
+    }
+
+    assert!(
+        rounded.is_empty(),
+        "a rounded corner is a soft edge on an instrument:\n  {}",
+        rounded.join("\n  ")
+    );
+}
+
+/// Every custom property the Observatory references is one it defines.
+///
+/// The Observatory is the single definition, and it is also the file most
+/// likely to grow a reference to a token that was renamed somewhere else. A
+/// `var(--x)` with no `--x` paints nothing at all — the rule does not fall
+/// back, it silently drops — and neither rustc nor any test that checks the
+/// palette block for expected NAMES can see it. Enumerating the references
+/// rather than listing the expected names is what makes this catch the next
+/// rename too; `export/tests.rs` carries the same check for the same reason,
+/// after a rename there shipped three elements painted with nothing.
+#[test]
+fn the_observatory_defines_every_token_it_references() {
+    let raw = read("crates/stella-observatory/src/assets/index.html");
+    // Definitions are looked up in the raw text (a token may legitimately be
+    // introduced beside a comment), but references are read from the
+    // comment-free text — see `without_comments`.
+    let html = without_comments(&raw);
+
+    // A name is ASCII letters, digits and dashes, and nothing else. Belt and
+    // braces with the comment stripping above: a `var(--…)` written in prose
+    // outside a comment — in a string, or in the page's own help text — would
+    // otherwise be read as a custom property named `--…` and reported as
+    // undefined. A predicate meeting typographic punctuation in prose it was
+    // only meant to read code through is a recurring shape in this repo.
+    let mut referenced: Vec<String> = Vec::new();
+    let mut rest = html.as_str();
+    while let Some(start) = rest.find("var(--") {
+        rest = &rest[start + 4..];
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+            .collect();
+        // `var(--x` must be followed by `)` or `,` (a fallback) to be a real
+        // reference; anything else is prose that happens to start the same way.
+        let next = rest[name.len()..].chars().next();
+        if name.len() > 2 && matches!(next, Some(')') | Some(',')) {
+            referenced.push(name);
+        }
+    }
+    referenced.sort();
+    referenced.dedup();
+
+    assert!(
+        !referenced.is_empty(),
+        "the Observatory uses custom properties; this test read none, so it \
+         is measuring the wrong thing"
+    );
+
+    let undefined: Vec<&String> = referenced
+        .iter()
+        .filter(|name| !html.contains(&format!("{name}:")))
+        .collect();
+
+    assert!(
+        undefined.is_empty(),
+        "the Observatory references custom properties it never defines, so \
+         those rules paint nothing: {undefined:?}"
+    );
 }
 
 /// Identity gold is the brand's own value, not one mixed at the call site.

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -99,9 +99,46 @@
      the platform mono stack otherwise — the same stack tokens.css ships. */
   --mono:"JetBrains Mono",ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
   --fs-micro:11px; --fs-sm:12px; --fs-base:13px; --fs-md:15px; --fs-xl:28px;
+  /* The Instrument scale's upper reaches. The five sizes above cover chrome;
+     these three cover the things a report says once — a section heading, a
+     headline measurement, a page title. Named for their job rather than their
+     step, because "the 22px one" is not a decision anybody can review. */
+  --fs-lg:22px;                    /* section heading                        */
+  --fs-metric:40px;                /* a headline measurement, tabular        */
+  --fs-display:64px;               /* page title; one per document           */
+  /* Three weights, and what each is for. 300 is prose only: at 11–13px on a
+     dark ground a light weight loses too much of the stem to stay legible,
+     which is why labels and data take 500/600 instead. */
+  --fw-prose:300; --fw-ui:500; --fw-metric:600;
+  /* Tracking. Uppercase micro-labels need the width back that capitals eat;
+     display sizes need it taken away. Both are the Instrument system's. */
+  --tr-label:.16em; --tr-display:-.03em; --tr-heading:-.01em;
+  /* Prose measure. Longer than this and the eye loses the line return; the
+     Instrument rule is 68ch and never justified. */
+  --measure:68ch; --lh-prose:1.7;
 
-  /* Rhythm. One 8px unit; every gutter, gap and pad is a multiple. */
-  --sp1:8px; --sp2:16px; --sp3:24px; --sp4:32px;
+  /* Rhythm. One 8px unit; every gutter, gap and pad is a multiple. The scale
+     below is the Instrument system's nine steps, named by value so a rule
+     that spells `var(--sp-12)` is self-documenting and cannot be confused
+     with the ordinal names. --sp1..--sp4 are kept as aliases: the existing
+     rules spell them, and renaming a token that JS also names in a string
+     literal is how the export dashboard shipped a colourless chart — rustc
+     never reads inside `'<p style="color:var(--text-3)">'`, so that rename
+     compiled, passed clippy, passed every test asserting the :root block, and
+     painted three elements with nothing. See
+     crates/stella-cli/src/export/tests.rs, which now enumerates every
+     `var(--…)` in the rendered page instead of listing expected names. */
+  --sp-4:4px;   --sp-8:8px;   --sp-12:12px; --sp-16:16px; --sp-24:24px;
+  --sp-32:32px; --sp-48:48px; --sp-64:64px; --sp-96:96px;
+  --sp1:var(--sp-8); --sp2:var(--sp-16); --sp3:var(--sp-24); --sp4:var(--sp-32);
+
+  /* Motion reports progress or it does not exist. Two durations, and no third:
+     a state change (hover, focus, selection) is 120ms linear because the eye
+     should not be able to watch it happen, and a reveal is 240ms on the
+     Instrument easing, moving opacity and at most 4px. Anything that loops,
+     overshoots or parallaxes is decoration on a page of measurements. */
+  --dur-state:120ms; --dur-reveal:240ms;
+  --ease-reveal:cubic-bezier(.2,0,0,1);
   /* Square, everywhere. Kept as tokens rather than deleted so the ~40 rules
      that spell `border-radius:var(--radius)` stay honest about where a corner
      is being set — and so the decision lives in one line instead of forty. A
@@ -194,6 +231,14 @@ body{
      changes the apparent value of every mark drawn over it — which on a page
      of measurements is a readability cost paid for nothing. */
   min-height:100vh; -webkit-font-smoothing:antialiased;
+  /* The Observatory is a live panel: rows re-render as executions land. A
+     digit that changes width between polls makes the whole column appear to
+     move, which reads as the layout being unstable rather than the number
+     being new. JetBrains Mono is already fixed-pitch, so this costs nothing
+     while the face is present and is the guarantee when the stack degrades to
+     the platform fallback — which it does, because the page is served
+     self-contained and may not fetch a font. */
+  font-variant-numeric:tabular-nums;
 }
 ::selection{background:var(--accent-wash)}
 .wrap{max-width:1360px;margin:0 auto;padding:0 var(--sp3) 80px}


### PR DESCRIPTION
## What this is

Re-applies and extends the instrument design system across the three web
surfaces stella renders — the Observatory, `/export`, and both arenabench
apps — **and unbreaks `main`**, which is currently red.

## `main` is red, proven with the cheap control

On pristine `origin/main` (703976eba), with no change of mine:

```sh
cargo test -p stella-cli --bin stella export::tests   # exits 101
#   the_dashboard_is_monospace_with_compact_corners ... FAILED
#     "the dashboard body does not use the transcript's mono stack"
#   the_dashboard_spells_the_wordmark_lowercase     ... FAILED
#     "the masthead does not carry the lowercase wordmark"
```

`export.rs` ships `font-family: var(--mono)` and
`<h1><span class="wordmark">stella</span> …>`; `export/tests.rs` asserts
`font: 13px/1.55 ui-monospace` and `<h1>stella session —`. The source and its
tests assert opposite things.

How it got there — three PRs reconciling the same two files in opposite
directions, the first under cover of a compile error:

- **#2597** put the dashboard on the instrument palette (mono token, square
  corners, wordmark span) and added it to `design_token_parity.rs`.
- **#2606** restored the pre-design-system stylesheet *and* left two of
  #2597's tests at the old `render_dashboard` arity — so the whole
  `stella-cli` **bin test target stopped compiling**, and a target that does
  not build cannot report the assertion failures underneath it.
- **#2610** repaired `export/tests.rs` against #2606's markup.
- **#2614** restored #2597's source but did not move #2610's tests back.

Root cause filed as **#2626** — the dashboard's appearance has no single
source of truth, so each PR reasonably picked a different one.

## Changes

**Unbreak.** Fixed the two contradicting assertions in favour of the source,
which is the correct half every time: the brand's face is JetBrains Mono and a
shorthand starting at `ui-monospace` never names it; the wordmark needs its own
element because it is the one place `--identity` gold is permitted; and the
Instrument system allows radius 0 on a surface like this.

**Restored `/export` to the parity matrix.** #2614 dropped it on the stated
ground that it "derives its dark palette from `stella_tui::theme`" — true of
#2606's file, not of the one shipping: the same commit removed `dark_tokens()`
entirely and wrote the palette into `:root` literally. The row passes on the
very commit that removed it; nothing in `export.rs` had to change to put it
back. The dashboard is the surface that drifted two whole recolours before,
and it is a standalone artifact nobody can eyeball beside the Observatory.

**The Instrument craft layer**, on all four surfaces: the nine-step spacing
scale, the type/weight/tracking ramp, two motion durations (120ms linear state,
240ms `cubic-bezier(.2,0,0,1)` reveal), tabular figures, `:focus-visible`
(WCAG 2.4.7), `prefers-reduced-motion`, `--control-edge` on operable
boundaries (WCAG 1.4.11), and a print block for the report the module doc tells
you to attach to a PR — it previously printed as a black rectangle with only
the selected tab visible.

**Palette roles are unchanged.** The Instrument system's "bronze as evidence"
contradicts the settled identity-only-gold rule (#2597); its stated
"4.9:1 on paper" for `#A37200` does not reproduce (I measure **3.84:1** on its
own paper, **4.23:1** on white — both under AA). Reversing a maintainer's
measured decision as a side effect of a restyle is not this PR's call, so it is
filed as **#2627** with the measurements.

## Witness

Three new guards in `design_token_parity.rs`, because the palette contract
caught none of the above — a revert does not stop at the hexes:

- `every_web_surface_carries_the_instrument_scale` — face, corners, tabular
  figures, reduced motion. **Witnessed**: fails against `origin/main`'s
  `export.rs` (`does not honour prefers-reduced-motion`), passes here.
- `no_web_surface_ships_a_rounded_corner` — separate from the above because
  that one asks whether the decision is *recorded* (`--radius: 0` present) and
  this asks whether it is *honoured*. #2606 shipped both faults at once.
- `the_observatory_defines_every_token_it_references` — a `var(--x)` with no
  `--x` paints nothing and no compiler looks. This is the check that caught
  three dangling `var(--faint)` / `var(--line)` references living in the chart
  JS's string literals.

Both scanners strip comments before matching. These files *document* the rules
they follow, and a guard that fires on its own documentation trains a reader to
ignore it — the first draft reported the Observatory's own comment explaining
its square corners.

Also fixed a proxy assertion in
`the_dashboard_ships_the_instrument_palette_in_both_themes`: it counted
document-wide occurrences as a stand-in for "declared in both light gates". The
print block is a third legitimate light context, so it now slices each gate and
asserts membership — it tests the property instead of a correlate.

## Deleted / renamed tests

- `the_dashboard_is_monospace_with_compact_corners` → **renamed** to
  `the_dashboard_is_monospace_and_square`. The old name asserted the opposite
  of the design system.

No tests were deleted.

## Verification

```
cargo test -p stella-cli -p stella-observatory   # 22 binaries, all ok
cargo test -p stella-cli --test design_token_parity  # 8 passed
cargo fmt --all -- --check                       # clean
cargo clippy -p stella-cli -p stella-observatory --all-targets -- -D warnings  # clean
make guards-fast                                 # all guards OK
```

**Not verified:** no browser was available in this session, so nothing here was
visually confirmed in a rendered page, and the two arenabench stylesheets were
not built through Next (no `node_modules` in the worktree). The changes to them
are token additions and rule-level edits, brace-balanced, but a reviewer should
open both apps before merging.

Refs #2626, #2627, #2594, #2591

## Summary by Sourcery

Restore Instrument design system consistency across all web instrument surfaces and re-enable the /export palette parity checks, while fixing broken export dashboard tests that had drifted from the shipped markup and tokens.

Bug Fixes:
- Align export dashboard typography, corners, and wordmark tests with the current Instrument-based implementation to make main test-green again.
- Correct the dashboard palette parity test to assert per-theme declarations rather than relying on document-wide token counts.

Enhancements:
- Reintroduce /export into the design token parity matrix and treat it as a first-class Instrument surface.
- Enforce that all four web surfaces use the Instrument spacing, typography, motion, and accessibility affordances, including tabular numerals and prefers-reduced-motion.
- Add guards ensuring no web surface ships rounded corners where the Instrument system requires square edges, and that the Observatory only references custom properties it defines.
- Extend Observatory and arenabench stylesheets with shared Instrument scale tokens for spacing, type, motion, and focus treatment, plus print styles for the export dashboard report.

Tests:
- Add new parity and craft-layer tests to assert Instrument design system usage, square corners, and defined custom properties across web surfaces.
- Rename and strengthen the dashboard mono/corners test to assert the branded mono stack, token usage, and absence of legacy rounded corners.