### PR TITLE
fix(settings): retire the two inert knobs left by the verdict removal

### DIFF
--- a/crates/stella-cli/src/config/tests.rs
+++ b/crates/stella-cli/src/config/tests.rs
@@ -362,9 +362,9 @@ fn reload_from_disk_reapplies_the_settings_scope_chain() {
 /// it was.
 ///
 /// The settings file below is well-formed — it parses, and every switch in it
-/// is individually legal — but `verifier_weight: 2.0` puts the judged weight
-/// above the deterministic one, which `reward_policy()` refuses by name rather
-/// than clamping. That is the only fallible step downstream of the load, so it
+/// is individually legal — but `deterministic_weight: 0.0` gives the reward
+/// scale a unit with no directions in it, which `reward_policy()` refuses by
+/// name rather than clamping. That is the only fallible step downstream of the load, so it
 /// is the lever that separates "derive, then commit" from "assign as you go":
 /// with the assignments interleaved, `enable_recap` and the `bash` switch are
 /// already written by the time the reward weights are rejected, and the
@@ -378,14 +378,14 @@ fn a_failed_reload_leaves_every_field_untouched() {
 
     std::fs::write(
         home.join(".stella").join("settings.json"),
-        r#"{"enable_recap": "on", "tools": {"bash": "off"}, "reward": {"verifier_weight": 2.0}}"#,
+        r#"{"enable_recap": "on", "tools": {"bash": "off"}, "reward": {"deterministic_weight": 0.0}}"#,
     )
     .unwrap();
 
     let error = cfg
         .reload_from_disk()
-        .expect_err("a verifier outranking a test must not resolve");
-    assert!(error.contains("verifier_weight"), "{error}");
+        .expect_err("a scale with no unit must not resolve");
+    assert!(error.contains("deterministic_weight"), "{error}");
 
     assert!(
         !cfg.enable_recap,
@@ -551,7 +551,7 @@ fn a_configured_reward_policy_reaches_the_config() {
     // mutate the one field instead of restating the struct.
     let mut settings = crate::settings::Settings::default();
     settings.reward = Some(crate::settings::RewardSettings {
-        verifier_weight: Some(0.2),
+        deterministic_weight: Some(0.2),
         ..Default::default()
     });
     let cfg = Config::load_with_settings(
@@ -562,15 +562,15 @@ fn a_configured_reward_policy_reaches_the_config() {
         std::path::PathBuf::from("/tmp/ws"),
     )
     .expect("a legal weight loads");
-    assert_eq!(cfg.reward_policy.outcome.judged, 0.2);
+    assert_eq!(cfg.reward_policy.outcome.deterministic, 0.2);
     assert_eq!(
-        cfg.reward_policy.outcome.deterministic, 1.0,
+        cfg.reward_policy.shaping.per_step, 0.02,
         "an unset weight stays at its default"
     );
 }
 
-/// A verifier weight that outranks a test fails the LAUNCH, by name — it does not
-/// get clamped to something legal and then quietly applied.
+/// A reward weight that cannot carry a scale fails the LAUNCH, by name — it does
+/// not get clamped to something legal and then quietly applied.
 ///
 /// This is the whole reason `reward_policy()` returns a `Result`. A substituted
 /// weight would produce correctly-shaped labels for every turn thereafter,
@@ -583,7 +583,7 @@ fn an_impossible_reward_weight_fails_the_launch_instead_of_being_clamped() {
     // mutate the one field instead of restating the struct.
     let mut settings = crate::settings::Settings::default();
     settings.reward = Some(crate::settings::RewardSettings {
-        verifier_weight: Some(3.0),
+        deterministic_weight: Some(0.0),
         ..Default::default()
     });
     let error = Config::load_with_settings(
@@ -593,8 +593,7 @@ fn an_impossible_reward_weight_fails_the_launch_instead_of_being_clamped() {
         &settings,
         std::path::PathBuf::from("/tmp/ws"),
     )
-    .expect_err("a verifier outranking a test must not launch");
-    assert!(error.contains("verifier_weight"), "{error}");
+    .expect_err("a scale with no unit must not launch");
     assert!(error.contains("deterministic_weight"), "{error}");
 }
 

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -506,24 +506,6 @@ pub struct AgentEngineConfig {
     /// which is what makes the two arms one binary and one posture key apart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pipeline_verifier_evidence_demand: Option<Toggle>,
-    /// Legacy (#1795), retained so existing settings files keep decoding:
-    /// **setting it changes nothing about a run.**
-    ///
-    /// It once refused a run whose VERDICT call would resolve to the worker's
-    /// own model. Verification makes no model calls now, so there is no
-    /// self-graded verdict left to refuse, and `PipelineConfig` no longer
-    /// carries the field this fed — the accessor that read it went with it.
-    /// The surviving independence question is about the *witness author*, and
-    /// it is answered by `pipeline_require_independent_witness` via
-    /// `agent::engine::trusted_posture_requires_independent_witness`, not by
-    /// this key.
-    ///
-    /// Deliberately still parsed rather than rejected, because a key that
-    /// hard-errors would break settings files written against a shipped
-    /// release. Retiring it — silently accepting a no-op key is its own defect
-    /// — is tracked in #2616.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pipeline_require_independent_verifier: Option<Toggle>,
     /// Seconds of provider silence that end a single generation
     /// (`stella_core::EngineConfig::model_timeout`). Absent keeps the engine's
     /// own default, which is what every run used before this key existed.
@@ -844,7 +826,6 @@ impl AgentEngineConfig {
         take!(pipeline_candidates);
         take!(pipeline_verifier_evidence_demand);
         take!(pipeline_require_diff_coverage);
-        take!(pipeline_require_independent_verifier);
         take!(model_timeout_secs);
         take!(compaction_budget_tokens);
         take!(tool_result_horizon_steps);
@@ -1245,27 +1226,20 @@ impl ToolsSettings {
 /// it becomes a training label (#1043).
 ///
 /// Every field optional, and an absent field means the stated default rather
-/// than zero: a workspace that only wants to distrust its verifier writes
-/// `verifier_weight` alone and inherits the rest.
+/// than zero: a workspace that only wants a cheaper step price writes
+/// `per_step` alone and inherits the rest.
 ///
-/// The reason this is configurable at all is that `verifier_weight`'s default of
-/// `0.5` describes *one* verifier's measured accuracy, and a workspace pointing a
-/// weaker model at the verifier role — or working in a domain where the verifier keeps
-/// mistaking house style for a defect — is entitled to trust it less. Lower is
-/// supported; higher than `deterministic_weight` is refused, because there a
-/// model's opinion would outrank a test's observation. See
-/// [`stella_pipeline::reward`] for the full argument.
+/// `verifier_weight` used to live here, scaling a model verifier's opinion
+/// against a test's observation. Verification makes no model call, so no rung
+/// carries that magnitude and the key is retired — named as such by
+/// `unknown::retirement` at load rather than parsed into a number nothing
+/// multiplies. See [`stella_pipeline::reward`] for the full argument.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct RewardSettings {
     /// Magnitude of a deterministic pass or fail. Default `1.0`, and the unit
-    /// every other weight is measured against.
+    /// the whole reward scale is expressed in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deterministic_weight: Option<f64>,
-    /// Magnitude of a model verifier's pass or fail. Default `0.5`. `0.0` discards
-    /// judged turns instead of scoring them — which is a different record from
-    /// a `0.0` score, deliberately.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub verifier_weight: Option<f64>,
     /// Reward subtracted per model call. Default `0.02`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub per_step: Option<f64>,
@@ -1290,7 +1264,6 @@ impl RewardSettings {
                 deterministic: self
                     .deterministic_weight
                     .unwrap_or(defaults.outcome.deterministic),
-                judged: self.verifier_weight.unwrap_or(defaults.outcome.judged),
             },
             shaping: RewardShaping {
                 per_step: self.per_step.unwrap_or(defaults.shaping.per_step),

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -435,23 +435,13 @@ impl Settings {
             {
                 // Which vocabulary applies is a property of the FORMAT, not the
                 // scope — `agents` is a valid root in TOML and a typo in JSON.
-                let unknown = if toml_config::path_is_toml(path) {
+                let found = if toml_config::path_is_toml(path) {
                     super::unknown::unknown_toml_keys_in(path)
                 } else {
                     super::unknown::unknown_keys_in(path)
                 };
-                if !unknown.is_empty() {
-                    eprintln!(
-                        "  ! {}: unrecognized key{} ignored ({}) — check the spelling; \
-                         stella reads none of them",
-                        path.display(),
-                        if unknown.len() == 1 { "" } else { "s" },
-                        unknown
-                            .iter()
-                            .map(|key| key.escape_debug().to_string())
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
+                for line in super::unknown::notices(&path.display().to_string(), found) {
+                    eprintln!("{line}");
                 }
             }
         }

--- a/crates/stella-cli/src/settings/tests/toml.rs
+++ b/crates/stella-cli/src/settings/tests/toml.rs
@@ -56,7 +56,7 @@ fn a_toml_config_and_its_json_equivalent_produce_identical_settings() {
           "enable_recap": "off",
           "trace_capture": "on",
           "ui": {"theme": "stella-dark"},
-          "reward": {"verifier_weight": 0.25, "per_usd": 0.75},
+          "reward": {"deterministic_weight": 0.25, "per_usd": 0.75},
           "mcp": {"registry_url": "https://registry.example"}
         }"#,
     );
@@ -73,7 +73,7 @@ recap = "off"
 trace_capture = "on"
 
 [reward]
-verifier_weight = 0.25
+deterministic_weight = 0.25
 per_usd = 0.75
 
 [providers.anthropic]
@@ -143,34 +143,29 @@ registry_url = "https://registry.example"
     assert_eq!(from_json.ui, from_toml.ui, "ui");
     assert_eq!(from_json.reward, from_toml.reward, "reward");
     assert_eq!(
-        from_toml.reward_policy().unwrap().outcome.judged,
+        from_toml.reward_policy().unwrap().outcome.deterministic,
         0.25,
-        "[reward].verifier_weight resolves into the policy"
+        "[reward].deterministic_weight resolves into the policy"
     );
     assert_eq!(
-        from_toml.reward_policy().unwrap().outcome.deterministic,
-        1.0,
+        from_toml.reward_policy().unwrap().shaping.per_step,
+        0.02,
         "an unset weight is the default, not zero"
     );
     assert_eq!(from_json.mcp, from_toml.mcp, "mcp");
 }
 
-/// A workspace that distrusts its verifier writes one key and inherits the rest.
-/// The alternative — an absent key meaning `0.0` — would silently discard every
-/// judged turn for anyone who set only `per_step`.
+/// A workspace that reprices one term writes one key and inherits the rest.
+/// The alternative — an absent key meaning `0.0` — would silently give the
+/// reward scale no unit for anyone who set only `per_step`.
 #[test]
 fn an_absent_reward_key_is_the_default_not_zero() {
     let dir = tempfile::tempdir().unwrap();
-    let path = write(
-        dir.path(),
-        "stella.toml",
-        "[reward]\nverifier_weight = 0.1\n",
-    );
+    let path = write(dir.path(), "stella.toml", "[reward]\nper_step = 0.1\n");
     let settings = load_toml(&path, ConfigScope::User).unwrap();
     let policy = settings.reward_policy().unwrap();
-    assert_eq!(policy.outcome.judged, 0.1);
+    assert_eq!(policy.shaping.per_step, 0.1);
     assert_eq!(policy.outcome.deterministic, 1.0);
-    assert_eq!(policy.shaping.per_step, 0.02);
     assert_eq!(policy.shaping.per_usd, 0.5);
     assert_eq!(policy.shaping.per_revision, 0.1);
 }
@@ -189,25 +184,24 @@ fn no_reward_block_is_exactly_the_defaults() {
     );
 }
 
-/// A verifier weight above the deterministic one is refused at load, by name.
+/// A reward weight that cannot carry a scale is refused at load, by name.
 /// Loud beats clamping: a silently-substituted weight produces correctly-shaped
 /// labels that mean something the operator never asked for.
 #[test]
-fn a_verifier_weight_above_the_ceiling_fails_the_load_by_name() {
+fn an_impossible_reward_weight_fails_the_load_by_name() {
     let dir = tempfile::tempdir().unwrap();
     let path = write(
         dir.path(),
         "stella.toml",
-        "[reward]\nverifier_weight = 2.0\n",
+        "[reward]\ndeterministic_weight = 0.0\n",
     );
     let settings = load_toml(&path, ConfigScope::User).unwrap();
     let error = settings
         .reward_policy()
-        .expect_err("a verifier outranking a test must not load");
-    assert!(error.contains("verifier_weight"), "{error}");
+        .expect_err("a scale with no unit must not load");
     assert!(error.contains("deterministic_weight"), "{error}");
     // The message has to say what to do, not just that something is wrong.
-    assert!(error.contains("Lower it"), "{error}");
+    assert!(error.contains("greater than zero"), "{error}");
 }
 
 #[test]

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -202,8 +202,6 @@ pub struct AgentsSection {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pipeline_require_diff_coverage: Option<Toggle>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pipeline_require_independent_verifier: Option<Toggle>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_timeout_secs: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction_budget_tokens: Option<u64>,
@@ -621,7 +619,6 @@ pub fn raise_agents(cfg: &AgentEngineConfig) -> (AgentsSection, ModelsSection) {
         pipeline_candidates: cfg.pipeline_candidates,
         pipeline_verifier_evidence_demand: cfg.pipeline_verifier_evidence_demand,
         pipeline_require_diff_coverage: cfg.pipeline_require_diff_coverage,
-        pipeline_require_independent_verifier: cfg.pipeline_require_independent_verifier,
         model_timeout_secs: cfg.model_timeout_secs,
         compaction_budget_tokens: cfg.compaction_budget_tokens,
         tool_result_horizon_steps: cfg.tool_result_horizon_steps,
@@ -702,7 +699,6 @@ fn lower_agents(agents: AgentsSection, models: ModelsSection) -> Option<AgentEng
         pipeline_candidates: agents.pipeline_candidates,
         pipeline_verifier_evidence_demand: agents.pipeline_verifier_evidence_demand,
         pipeline_require_diff_coverage: agents.pipeline_require_diff_coverage,
-        pipeline_require_independent_verifier: agents.pipeline_require_independent_verifier,
         model_timeout_secs: agents.model_timeout_secs,
         compaction_budget_tokens: agents.compaction_budget_tokens,
         tool_result_horizon_steps: agents.tool_result_horizon_steps,

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -19,6 +19,21 @@
 //! `context_providers` and the hook matcher lists are open maps whose keys are
 //! user-chosen names (a tool name, a provider id), so an unrecognized key there
 //! is data, not a mistake — those are descended into, not flagged.
+//!
+//! # Retired keys are not typos
+//!
+//! A key that shipped in a release and was then removed lands in the same
+//! bucket as `"enable_recapp"` — nothing reads it — but "check the spelling" is
+//! false advice for it: the operator spelled a real key correctly, and the
+//! feature behind it is gone. [`RETIRED`] is the closed list of those, each
+//! with the one sentence that makes the difference actionable, and
+//! [`retirement`] is what the caller consults to say the right thing.
+//!
+//! Deliberately separate from the field lists above rather than a variant
+//! inside them. Those lists are also the trusted launcher's strict vocabulary
+//! (`config::trusted_engine_config_shape_is_strict`), which fails **closed** —
+//! a benchmark posture naming a retired knob must be refused at launch, not
+//! warned about and run.
 
 use std::path::Path;
 
@@ -67,11 +82,90 @@ const UI_FIELDS: &[&str] = &["theme"];
 /// until they pool the traces.
 const REWARD_FIELDS: &[&str] = &[
     "deterministic_weight",
-    "verifier_weight",
     "per_step",
     "per_usd",
     "per_revision",
 ];
+
+/// Keys that were correct in a shipped release and read nothing now, each with
+/// the sentence an operator needs: what it used to do, and why there is no
+/// replacement to point them at.
+///
+/// Both entries are the same removal seen from two angles — the pipeline stopped
+/// asking a model for a verdict, so neither the knob that demanded an
+/// independent verifier nor the weight that priced its opinion has anything
+/// left to steer. A key belongs here only while a settings file in the wild
+/// plausibly still carries it; the list is meant to be pruned, not grown.
+///
+/// Paths are dotted and format-specific, because the two documents name the
+/// same knob differently: `agent_engine_config` in JSON is `agents` in TOML.
+const RETIRED: &[(&str, &str)] = &[
+    (
+        "agent_engine_config.pipeline_require_independent_verifier",
+        "refused a run whose verdict call would resolve to the worker's own \
+         model; verification makes no model call, so there is no self-graded \
+         verdict left to refuse",
+    ),
+    (
+        "agents.pipeline_require_independent_verifier",
+        "refused a run whose verdict call would resolve to the worker's own \
+         model; verification makes no model call, so there is no self-graded \
+         verdict left to refuse",
+    ),
+    (
+        "reward.verifier_weight",
+        "scaled a model verifier's opinion against a test's observation; no \
+         rung carries that magnitude any more, so a reward label is priced by \
+         `deterministic_weight` alone",
+    ),
+];
+
+/// Why `key` is no longer read, when it is a retired key rather than a typo.
+///
+/// `key` is one of the dotted paths [`unknown_keys_in`] and
+/// [`unknown_toml_keys_in`] return; anything else — including a genuine
+/// misspelling — is `None`.
+pub(super) fn retirement(key: &str) -> Option<&'static str> {
+    RETIRED
+        .iter()
+        .find_map(|(retired, why)| (*retired == key).then_some(*why))
+}
+
+/// The lines to print for the keys `found` in the file at `path`, in the order
+/// they should appear. Empty when there is nothing to say.
+///
+/// A pure function over owned data rather than a `for` loop around `eprintln!`
+/// at the call site, so the split — a typo wants re-spelling, a retired key is
+/// spelled right — is a thing a test can read. The caller's only job is to
+/// print what comes back.
+pub(super) fn notices(path: &str, found: Vec<String>) -> Vec<String> {
+    let (retired, unknown): (Vec<_>, Vec<_>) =
+        found.into_iter().partition(|key| retirement(key).is_some());
+
+    let mut lines = Vec::new();
+    if !unknown.is_empty() {
+        lines.push(format!(
+            "  ! {path}: unrecognized key{} ignored ({}) — check the spelling; \
+             stella reads none of them",
+            if unknown.len() == 1 { "" } else { "s" },
+            unknown
+                .iter()
+                .map(|key| key.escape_debug().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+    // One line each rather than a joined list: the whole value of this notice
+    // is the reason, and reasons do not join.
+    lines.extend(retired.iter().map(|key| {
+        format!(
+            "  ! {path}: `{}` is retired and reads nothing — it {}. Delete the key.",
+            key.escape_debug(),
+            retirement(key).unwrap_or_default(),
+        )
+    }));
+    lines
+}
 
 /// `hooks` — the PascalCase lifecycle-event keys `stella_core::hooks::Hooks`
 /// renames its fields to. A misspelled event name is the highest-consequence
@@ -471,6 +565,98 @@ mod tests {
                 "agent_engine_config.agents.verifier.params.temperatur".to_string(),
             ]
         );
+    }
+
+    /// The witness for #2586. Both keys were correct in a shipped release and
+    /// read nothing now; the file must still LOAD (serde tolerance, asserted
+    /// rather than assumed) and each key must be told apart from a misspelling,
+    /// because "check the spelling" sends its author hunting for a mistake they
+    /// did not make.
+    #[test]
+    fn a_retired_key_is_named_as_retired_rather_than_as_a_typo() {
+        let json = r#"{
+             "agent_engine_config": { "pipeline_require_independent_verifier": "on" },
+             "reward": { "verifier_weight": 0.25 }
+           }"#;
+        // It parses. A key that hard-errored would break a settings file
+        // written against a release that accepted it.
+        let parsed: super::super::Settings = serde_json::from_str(json).expect("still loads");
+        assert!(
+            parsed
+                .reward
+                .is_some_and(|reward| reward == super::super::RewardSettings::default()),
+            "the retired key contributes nothing to the typed value"
+        );
+
+        let found = scan(json);
+        assert_eq!(
+            found,
+            vec![
+                "agent_engine_config.pipeline_require_independent_verifier".to_string(),
+                "reward.verifier_weight".to_string(),
+            ],
+            "both are reported — silent acceptance is the failure mode"
+        );
+        for key in &found {
+            assert!(
+                retirement(key).is_some(),
+                "{key} must carry its own reason, not the spelling advice"
+            );
+        }
+
+        // ...and what the operator actually reads: one line per retired key,
+        // each naming it, and not a word about spelling.
+        let lines = notices("settings.json", found);
+        assert_eq!(lines.len(), 2, "{lines:#?}");
+        for (line, key) in lines.iter().zip([
+            "agent_engine_config.pipeline_require_independent_verifier",
+            "reward.verifier_weight",
+        ]) {
+            assert!(line.contains(key), "{line}");
+            assert!(line.contains("is retired and reads nothing"), "{line}");
+            assert!(
+                !line.contains("check the spelling"),
+                "a retired key was spelled correctly: {line}"
+            );
+        }
+    }
+
+    /// A file with both kinds gets both notices, and neither swallows the
+    /// other: the typo still gets its spelling advice, and it is reported
+    /// first because it is the one that is probably a live mistake.
+    #[test]
+    fn a_typo_and_a_retired_key_in_one_file_each_get_their_own_notice() {
+        let lines = notices(
+            "stella.toml",
+            scan(
+                r#"{
+                     "reward": { "verifier_weight": 0.25, "per_stepp": 0.1 }
+                   }"#,
+            ),
+        );
+        assert_eq!(lines.len(), 2, "{lines:#?}");
+        assert!(lines[0].contains("per_stepp"), "{}", lines[0]);
+        assert!(lines[0].contains("check the spelling"), "{}", lines[0]);
+        assert!(
+            !lines[0].contains("verifier_weight"),
+            "the retired key must not ride along in the typo list: {}",
+            lines[0]
+        );
+        assert!(lines[1].contains("verifier_weight"), "{}", lines[1]);
+        assert!(lines[1].contains("is retired"), "{}", lines[1]);
+    }
+
+    /// ...and the converse, so the split cannot degrade into labelling every
+    /// unknown key "retired": a genuine misspelling has no retirement reason.
+    #[test]
+    fn a_misspelling_carries_no_retirement_reason() {
+        for key in [
+            "reward.verifier_weightt",
+            "agent_engine_config.default_modle",
+            "enable_recapp",
+        ] {
+            assert_eq!(retirement(key), None, "{key}");
+        }
     }
 
     /// A malformed or missing file is the typed loader's problem, and it

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -150,7 +150,7 @@ fn seeded_workspace() -> (tempfile::TempDir, i64, i64) {
     let store = Store::open(dir.path()).expect("store");
     std::fs::write(
         dir.path().join(".stella").join("settings.json"),
-        r#"{"reward":{"deterministic_weight":1.0,"verifier_weight":0.5,"per_step":0.02,"per_usd":0.5,"per_revision":0.1}}"#,
+        r#"{"reward":{"deterministic_weight":1.0,"per_step":0.02,"per_usd":0.5,"per_revision":0.1}}"#,
     )
     .expect("settings");
 

--- a/crates/stella-pipeline/src/reward.rs
+++ b/crates/stella-pipeline/src/reward.rs
@@ -3,36 +3,31 @@
 //! label it at all.
 //!
 //! The verify stage already computes a tiered, evidence-based verdict for
-//! every outcome: deterministic first, a model verifier only on genuinely
-//! inconclusive evidence, an abstention when nothing could see. That verdict
-//! *is* the reward signal this project has been generating all along. This
-//! module is the (pure, I/O-free) mapping from it to a label, and the rules it
-//! encodes are all about **what not to claim**.
+//! every outcome: deterministic evidence when an instrument could observe the
+//! turn, an abstention when nothing could see. That verdict *is* the reward
+//! signal this project has been generating all along. This module is the
+//! (pure, I/O-free) mapping from it to a label, and the rules it encodes are
+//! all about **what not to claim**.
 //!
-//! # Two tiers of confidence, and one refusal
+//! # One tier of confidence, and every other rung refused
 //!
 //! | Rung | Label | Why |
 //! |---|---|---|
 //! | [`LadderRung::SubmitFast`] | **+1.0** | A fail→pass flip of the tracked command. A hard label: a test observed it. |
 //! | [`LadderRung::Revise`] | **−1.0** | Touched tests red. Equally hard, in the other direction. |
-//! | [`LadderRung::Unverified`] | **discarded** | Verification ran and did not settle it. There is no longer a model opinion to discount — see below. |
+//! | [`LadderRung::Unverified`] | **discarded** | Verification ran and did not settle it. There is no model opinion to fall back on — see below. |
 //! | everything else | **discarded** | See below. |
 //!
-//! # Why the magnitudes are configurable, and why only downward
+//! # Why the magnitude is configurable
 //!
-//! The 0.5 is an estimate of one verifier's accuracy, and the verifier in question is
-//! whichever model a workspace pointed at it. A workspace whose verifier is worse
-//! than the one that produced the 46% figure — a cheaper model, an unfamiliar
-//! domain, a house style the verifier keeps mistaking for a defect — is entitled to
-//! trust it less, so [`OutcomeWeights`] carries both magnitudes and a workspace
-//! can lower the judged one.
-//!
-//! It cannot raise it past the deterministic weight. Above that line a model's
-//! opinion outranks a test's observation, which inverts the premise the whole
-//! ladder is built on: deterministic evidence is tried *first* precisely because
-//! it is worth more. [`OutcomeWeights::validate`] refuses it, at config load and
-//! again at [`label`], so a policy that got past one path cannot get past the
-//! other.
+//! [`OutcomeWeights::deterministic`] is the unit the scale is expressed in, and
+//! a workspace pooling its rows with someone else's may need it to match
+//! theirs. It is the only outcome magnitude there is: the judged tier that once
+//! sat under it — a model verifier's opinion, priced at half a test's
+//! observation — went with the verifier call itself, and the settings key that
+//! scaled it (`reward.verifier_weight`) is retired: a file still carrying it
+//! loads and is told the key reads nothing, rather than being quietly obeyed
+//! in a way that changes no run.
 //!
 //! **Refused, not clamped** — deliberately the opposite posture to
 //! `stella_context`'s retrieval tuning, which sanitizes an out-of-range knob
@@ -42,22 +37,17 @@
 //! weight writes permanently mislabelled training data that is perfectly
 //! well-formed — there is no turn to fail, and nothing downstream can tell that
 //! a substituted weight was ever applied. So this one fails at launch, naming
-//! the key, before any work starts.
-//!
-//! A judged weight of exactly `0.0` is legal and means something specific: *do
-//! not train on this verifier at all*. It maps to [`DiscardReason::VerifierDistrusted`]
-//! rather than to a `0.0` scalar, because a zero reward is a claim — "we watched
-//! and it came out neutral" — and this setting is the opposite of a claim. That
-//! is the same distinction the abstain rungs exist to preserve, applied to a
-//! knob instead of a rung.
+//! the key, before any work starts. [`OutcomeWeights::validate`] runs at config
+//! load and again inside [`label`], so a policy that got past one path cannot
+//! get past the other.
 //!
 //! # The policy travels with the label
 //!
 //! Every [`RewardLabel`] carries the [`RewardPolicy`] it was computed under.
 //! Without it, two workspaces on different weights emit rows that are
 //! arithmetically indistinguishable and silently incomparable — pooling them
-//! would average a 0.5-scale judged pass against a 0.2-scale one as though they
-//! were the same measurement. With it, a reader can renormalize, or select one
+//! would average a 1.0-scale pass against a 0.2-scale one as though they were
+//! the same measurement. With it, a reader can renormalize, or select one
 //! policy and drop the rest. `stella_core::comparison::ComparisonReport` already
 //! stamps its own `RewardWeights` for the same reason; this is that rule applied
 //! to the per-turn label.
@@ -102,32 +92,27 @@ use stella_protocol::{LadderRung, VerdictEvidence};
 /// Default magnitude of a label backed by a deterministic test observation.
 const DETERMINISTIC_WEIGHT: f64 = 1.0;
 
-/// Default magnitude of a label backed only by a model verifier's opinion. Half,
-/// and the halving is measured rather than aesthetic: across an 89-task
-/// Terminal-Bench run the verifier agreed with the benchmark's grader 46% of the
-/// time.
-const JUDGED_WEIGHT: f64 = 0.5;
-
-/// What each tier of evidence is worth, before shaping.
+/// What evidence is worth, before shaping.
 ///
-/// Two numbers, one ordering rule: a verifier's opinion may be worth less than a
-/// test's observation, never more. See the module docs for why the ceiling is
-/// not negotiable and why `judged = 0.0` is a discard rather than a zero.
+/// One number, because there is one scoring tier: only a deterministic
+/// observation prices a rung. A second field held the judged magnitude until
+/// the verifier call it described was removed; it is gone rather than retained
+/// at a value nothing multiplies.
+///
+/// A struct rather than a bare `f64` so the wire shape (`{"deterministic": …}`)
+/// and [`RewardPolicy`]'s two-half split survive the loss of the tier, and so a
+/// future tier joins here instead of re-splitting the policy.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct OutcomeWeights {
-    /// Magnitude of a deterministic pass or fail. The unit the judged weight
-    /// is measured against.
+    /// Magnitude of a deterministic pass or fail — the unit the whole scale is
+    /// expressed in.
     pub deterministic: f64,
-    /// Magnitude of a model verifier's pass or fail. `0.0` discards judged turns
-    /// instead of scoring them.
-    pub judged: f64,
 }
 
 impl Default for OutcomeWeights {
     fn default() -> Self {
         Self {
             deterministic: DETERMINISTIC_WEIGHT,
-            judged: JUDGED_WEIGHT,
         }
     }
 }
@@ -146,12 +131,6 @@ pub enum WeightError {
     /// zero has no directions in it, and a negative one silently inverts every
     /// label's sign.
     DeterministicNotPositive,
-    /// A negative judged weight. It would label a verifier's *pass* as a penalty,
-    /// which no configuration can have meant.
-    JudgedNegative,
-    /// The judged weight exceeds the deterministic one — an opinion outranking
-    /// an observation. See the module docs.
-    JudgedAboveDeterministic,
     /// A negative shaping price, which would pay a trajectory for spending
     /// more. See [`RewardShaping::validate`].
     ShapingNegative,
@@ -165,17 +144,7 @@ impl WeightError {
             WeightError::NotFinite => "must be a finite number",
             WeightError::DeterministicNotPositive => {
                 "deterministic_weight must be greater than zero — it is the unit \
-                 every other weight is measured against"
-            }
-            WeightError::JudgedNegative => {
-                "verifier_weight must not be negative — a negative weight scores a \
-                 verifier's pass as a penalty"
-            }
-            WeightError::JudgedAboveDeterministic => {
-                "verifier_weight must not exceed deterministic_weight — above it a \
-                 model's opinion outranks a test's observation, which inverts \
-                 the verification ladder. Lower it (0.0 discards judged turns \
-                 entirely) rather than raising the ceiling"
+                 the whole reward scale is expressed in"
             }
             WeightError::ShapingNegative => {
                 "shaping prices must not be negative — a negative price pays a \
@@ -186,22 +155,16 @@ impl WeightError {
 }
 
 impl OutcomeWeights {
-    /// Check the ordering rule. Called at config load so a bad value is a loud
-    /// launch failure, and again inside [`label`] so a policy that arrived by
-    /// some other path (a deserialized record, a direct struct literal) is
-    /// still refused rather than applied.
+    /// Check that the unit is a usable one. Called at config load so a bad
+    /// value is a loud launch failure, and again inside [`label`] so a policy
+    /// that arrived by some other path (a deserialized record, a direct struct
+    /// literal) is still refused rather than applied.
     pub fn validate(&self) -> Result<(), WeightError> {
-        if !self.deterministic.is_finite() || !self.judged.is_finite() {
+        if !self.deterministic.is_finite() {
             return Err(WeightError::NotFinite);
         }
         if self.deterministic <= 0.0 {
             return Err(WeightError::DeterministicNotPositive);
-        }
-        if self.judged < 0.0 {
-            return Err(WeightError::JudgedNegative);
-        }
-        if self.judged > self.deterministic {
-            return Err(WeightError::JudgedAboveDeterministic);
         }
         Ok(())
     }
@@ -317,13 +280,15 @@ pub enum DiscardReason {
     CostNotFinite,
     /// The workspace set its judged weight to `0.0`: this verifier is not trusted
     /// to label anything. Distinct from a `0.0` reward, which would assert that
-    /// a neutral outcome was observed — see the module docs.
+    /// a neutral outcome was observed.
     ///
     /// **Retired**, and in the strongest possible sense: the workspace's
     /// distrust of the model verifier is now the architecture rather than a
-    /// weight, because the call it distrusted is not made. Retained for the
-    /// same reason as [`Self::VerifierUnavailable`] — stored labels must keep
-    /// parsing.
+    /// weight, because the call it distrusted is not made. The weight that
+    /// produced it is gone too — `reward.verifier_weight` is named as a retired
+    /// key at load rather than parsed and ignored — so nothing can construct
+    /// this variant any more. Retained for the same reason as
+    /// [`Self::VerifierUnavailable`] — stored labels must keep parsing.
     VerifierDistrusted,
     /// The [`RewardPolicy`] itself is invalid, so no scalar computed under it
     /// would mean anything. The rung is still published, because the rung is
@@ -431,8 +396,8 @@ pub struct RewardLabel {
     /// The policy this label was computed under, stamped so the number above is
     /// interpretable outside the workspace that produced it. Always present,
     /// including on a discard — a reader pooling records has to be able to tell
-    /// a `VerifierDistrusted` discard from a `judged = 0.5` workspace that simply
-    /// never reached the verifier.
+    /// a discard from a scored row computed on a different scale, and the two
+    /// are indistinguishable once the policy is dropped.
     pub policy: RewardPolicy,
 }
 
@@ -514,10 +479,8 @@ pub fn label(settlement: Settlement, cost: TrajectoryCost, policy: &RewardPolicy
 /// **Only deterministic rungs score.** Every other rung is a discard with a
 /// named reason, never a `0.0`, because a zero asserts that a neutral outcome
 /// was observed and none of them observed anything. The judged tier is gone
-/// along with the call that produced it: there is no longer a rung whose
-/// magnitude comes from a model's opinion, so `weights.judged` is read by
-/// nothing here (its removal is tracked separately — it is a serde-config
-/// decision, not a verification one).
+/// along with the call that produced it: there is no rung whose magnitude comes
+/// from a model's opinion, which is why [`OutcomeWeights`] carries one number.
 pub fn outcome_term(
     rung: LadderRung,
     passed: bool,

--- a/crates/stella-pipeline/src/reward/tests.rs
+++ b/crates/stella-pipeline/src/reward/tests.rs
@@ -226,52 +226,38 @@ fn a_non_finite_cost_withholds_the_scalar_only() {
     }
 }
 
-/// A policy with a helper for the common case: lower the verifier, keep the rest.
-fn distrusting(judged: f64) -> RewardPolicy {
+/// A policy on a different scale, keeping the rest: the common case now that
+/// `deterministic` is the only outcome magnitude there is.
+fn scaled(deterministic: f64) -> RewardPolicy {
     RewardPolicy {
-        outcome: OutcomeWeights {
-            judged,
-            ..OutcomeWeights::default()
-        },
+        outcome: OutcomeWeights { deterministic },
         ..RewardPolicy::default()
     }
 }
 
-/// The ceiling: a judged weight above the deterministic one is refused, at both
-/// the places it can arrive. Above that line a model's opinion outranks a
-/// test's observation, which inverts the ladder.
+/// The unit must be a usable one, and it is refused at both the places a bad
+/// policy can arrive — config load and [`label`] itself.
 #[test]
-fn a_verifier_weight_above_the_deterministic_one_is_refused() {
-    let inverted = distrusting(1.5);
+fn a_non_positive_unit_is_refused_at_both_gates() {
+    let unusable = scaled(0.0);
     assert_eq!(
-        inverted.validate(),
-        Err(WeightError::JudgedAboveDeterministic)
+        unusable.validate(),
+        Err(WeightError::DeterministicNotPositive)
     );
     // ...and `label` refuses it too, rather than trusting that whoever built
     // the policy validated it first.
     let label = label(
-        settled(LadderRung::Unverified, true),
+        settled(LadderRung::SubmitFast, true),
         cost(1, 0.0, 0),
-        &inverted,
+        &unusable,
     );
     assert_eq!(label.reward, None);
     assert_eq!(label.discard, Some(DiscardReason::PolicyInvalid));
     assert_eq!(
         label.rung,
-        Some(LadderRung::Unverified),
+        Some(LadderRung::SubmitFast),
         "the rung is still true even when the arithmetic is refused"
     );
-}
-
-/// Equal weights are legal. The ceiling is `>`, not `>=`.
-///
-/// Validation only: the judged weight no longer prices any rung, so there is
-/// no scoring behaviour left to assert about it. The rule is still enforced
-/// because the field is still settings-visible, and a policy that fails its
-/// own stated bound must not be accepted whatever reads it.
-#[test]
-fn a_verifier_weight_equal_to_the_deterministic_one_is_allowed() {
-    assert_eq!(distrusting(1.0).validate(), Ok(()));
 }
 
 /// Every other way a policy can be nonsense, and the distinct reason each one
@@ -279,18 +265,8 @@ fn a_verifier_weight_equal_to_the_deterministic_one_is_allowed() {
 #[test]
 fn each_impossible_policy_names_its_own_rule() {
     let cases = [
-        (distrusting(-0.1), WeightError::JudgedNegative),
-        (distrusting(f64::NAN), WeightError::NotFinite),
-        (
-            RewardPolicy {
-                outcome: OutcomeWeights {
-                    deterministic: 0.0,
-                    judged: 0.0,
-                },
-                ..RewardPolicy::default()
-            },
-            WeightError::DeterministicNotPositive,
-        ),
+        (scaled(f64::NAN), WeightError::NotFinite),
+        (scaled(-0.1), WeightError::DeterministicNotPositive),
         (
             RewardPolicy {
                 shaping: RewardShaping {
@@ -346,7 +322,7 @@ fn a_negative_shaping_price_cannot_pay_a_trajectory_to_spend_more() {
 /// are arithmetically indistinguishable and silently incomparable.
 #[test]
 fn every_label_carries_the_policy_it_was_computed_under() {
-    let policy = distrusting(0.25);
+    let policy = scaled(0.25);
     let scored = label(
         settled(LadderRung::Unverified, true),
         cost(2, 0.1, 0),
@@ -354,7 +330,7 @@ fn every_label_carries_the_policy_it_was_computed_under() {
     );
     assert_eq!(scored.policy, policy);
     // A discard carries it too — a reader pooling records has to tell a
-    // distrusted verifier from a workspace that simply never reached one.
+    // discard from a scored row computed on a different scale.
     for settlement in [
         settled(LadderRung::Unverifiable, true),
         Settlement::Absent,
@@ -432,14 +408,14 @@ fn a_label_has_no_free_text_leaves() {
         LadderRung::Waived,
     ] {
         for passed in [true, false] {
-            // Every policy the stamp can carry, including the two that produce
-            // the new discard reasons: the stamp must add numbers and nothing
-            // else, whatever it holds.
+            // Every policy the stamp can carry, including the invalid one
+            // that produces `PolicyInvalid`: the stamp must add numbers and
+            // nothing else, whatever it holds.
             for policy in [
                 RewardPolicy::default(),
-                distrusting(0.0),
-                distrusting(0.2),
-                distrusting(f64::NAN),
+                scaled(0.2),
+                scaled(2.0),
+                scaled(f64::NAN),
             ] {
                 let value =
                     serde_json::to_value(label(settled(rung, passed), cost(3, 0.2, 1), &policy))
@@ -526,7 +502,6 @@ proptest! {
         revisions in 0u32..1_000,
         which in 0usize..7,
         deterministic in -2.0f64..4.0,
-        judged in -2.0f64..4.0,
         per_step in -1.0f64..1.0,
         per_usd in -1.0f64..1.0,
         per_revision in -1.0f64..1.0,
@@ -541,7 +516,7 @@ proptest! {
             LadderRung::Waived,
         ];
         let policy = RewardPolicy {
-            outcome: OutcomeWeights { deterministic, judged },
+            outcome: OutcomeWeights { deterministic },
             shaping: RewardShaping { per_step, per_usd, per_revision },
         };
         let label = label(
@@ -575,17 +550,15 @@ proptest! {
         revisions in 0u32..50,
         passed in any::<bool>(),
         deterministic in 0.01f64..4.0,
-        judged_fraction in 0.0f64..1.0,
         per_step in 0.0f64..1.0,
         per_usd in 0.0f64..1.0,
         per_revision in 0.0f64..1.0,
         which in 0usize..2,
     ) {
         let policy = RewardPolicy {
-            // Constructed to be valid by shape: the judged weight is expressed
-            // as a fraction of the deterministic one, which is the ordering
-            // rule written as arithmetic instead of checked after the fact.
-            outcome: OutcomeWeights { deterministic, judged: deterministic * judged_fraction },
+            // Constructed to be valid by shape: a strictly positive unit is
+            // the whole of `OutcomeWeights::validate`.
+            outcome: OutcomeWeights { deterministic },
             shaping: RewardShaping { per_step, per_usd, per_revision },
         };
         prop_assume!(policy.validate().is_ok());

--- a/docs/spec/config-system/stella.today.toml
+++ b/docs/spec/config-system/stella.today.toml
@@ -546,20 +546,18 @@ theme = "stella-dark"   # stella-dark | stella-light
 # What a finished turn's verdict is worth when it becomes a training label
 # (#1043). Whole-block last-wins across scopes, like `[ui]`; carries no
 # credential or egress authority, so no trust restoration — a project setting a
-# weight is stating an opinion about its own verifier, not borrowing permission.
+# weight is stating an opinion about its own scale, not borrowing permission.
 #
-# WHY THIS IS CONFIGURABLE AT ALL: `verifier_weight = 0.5` is an estimate of ONE
-# verifier's accuracy — across an 89-task Terminal-Bench run the model verifier
-# agreed with the benchmark's own grader 46% of the time. A workspace pointing
-# a weaker model at the verifier role, or working in a domain where the verifier
-# keeps reading house style as a defect, is entitled to trust it less.
+# WHY THIS IS CONFIGURABLE AT ALL: `deterministic_weight` is the unit the whole
+# reward scale is expressed in, and a workspace pooling its rows with someone
+# else's may need it to match theirs.
 #
-# LOWER IS SUPPORTED. HIGHER THAN `deterministic_weight` IS REFUSED: above that
-# line a model's opinion outranks a test's observation, which inverts the
-# premise the verification ladder is built on. `verifier_weight = 0.0` is legal and
-# means "do not train on this verifier at all" — those turns are DISCARDED (with
-# the reason `verifier_distrusted`), not scored as zero. A zero is a claim that a
-# neutral outcome was observed; a discard is the refusal to claim anything.
+# `verifier_weight` USED TO SIT BESIDE IT and is now RETIRED: it scaled a model
+# verifier's opinion against a test's observation, and verification makes no
+# model call, so no rung carries that magnitude. A file that still sets it loads
+# — stella names it at startup as retired rather than as a misspelling — but
+# nothing reads it. Delete it. The `verifier_distrusted` discard reason it once
+# produced is likewise unreachable, retained only so stored labels keep parsing.
 #
 # UNLIKE `[context.retrieval]` ABOVE, AN OUT-OF-RANGE VALUE HERE IS REJECTED,
 # NOT CLAMPED. The postures differ because the failures differ: a bad retrieval
@@ -577,7 +575,6 @@ theme = "stella-dark"   # stella-dark | stella-light
 
 [reward]
 deterministic_weight = 1.0    # a fail->pass flip, or touched tests red
-verifier_weight         = 0.5    # a model verifier's opinion; 0.0 discards instead
 per_step             = 0.02   # subtracted per model call
 per_usd              = 0.5    # subtracted per USD
 per_revision         = 0.1    # subtracted per verification round after the first

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -316,19 +316,13 @@ theme = "stella-light"
 
 What a finished turn's verdict is worth as a training label (#1043). Whole-block last-wins,
 like `[ui]`; carries no credential or egress authority, so a project setting a weight is
-stating an opinion about its own verifier, not borrowing permission.
+stating an opinion about its own scale, not borrowing permission.
 
 <CardGrid size="sm">
   <OptionCard name="reward.deterministic_weight" defaultValue="1.0">
-    Magnitude of a deterministic pass or fail — the unit every other weight is measured
-    against.
-  </OptionCard>
-  <OptionCard name="reward.verifier_weight" defaultValue="0.5">
-    Magnitude of a model verifier's pass or fail. `0.0` **discards** judged turns from
-    training rather than scoring them as zero — a discard is a refusal to claim anything; a
-    zero is a claim that a neutral outcome was observed. A value above
-    `deterministic_weight` is refused: a model's opinion may never outrank a test's
-    observation.
+    Magnitude of a deterministic pass or fail — the unit the whole reward scale is
+    expressed in, and the only outcome magnitude there is. Zero or negative is refused
+    at launch rather than clamped.
   </OptionCard>
   <OptionCard name="reward.per_step" defaultValue="0.02">
     Subtracted per model call.
@@ -343,8 +337,15 @@ stating an opinion about its own verifier, not borrowing permission.
 
 ```toml title="stella.toml"
 [reward]
-verifier_weight = 0.3   # trust this workspace's verifier less than the 0.5 default
+per_usd = 1.0   # price a dollar of spend twice as dearly as the default
 ```
+
+<Callout type="warn">
+  **`reward.verifier_weight` is retired.** It scaled a model verifier's opinion against a
+  test's observation. Verification makes no model call, so no rung carries that magnitude —
+  a label is priced by `deterministic_weight` alone. A file that still sets the key loads,
+  and stella names it at startup as retired rather than as a misspelling. Delete it.
+</Callout>
 
 ### `[authority]` — managed scope only
 


### PR DESCRIPTION
## What & why

#2584 removed the model verdict from the pipeline and left two operator-visible
settings behind it. Both parsed, both merged across the three scopes, both were
documented, and neither reached anything. An inert knob is worse than a missing
one: the operator who sets it believes the run's posture changed, and the run
behaves identically.

**1. `agent_engine_config.pipeline_require_independent_verifier`** refused a run
whose verdict call would resolve to the worker's own model. There is no verdict
call, so the field, its `take!` merge entry, and its two `toml_config` mapping
sites go.

**2. `reward.verifier_weight`** scaled `OutcomeWeights::judged`, which priced a
model verifier's pass or fail. `outcome_term` scores only `SubmitFast` and
`Revise`, so no rung carried that magnitude — yet `validate` still *refused a
policy* over a number that priced nothing. The field, `JUDGED_WEIGHT`, the two
`WeightError` arms (`JudgedNegative`, `JudgedAboveDeterministic`), and the
settings key go with it. `OutcomeWeights` keeps `deterministic` as the unit the
scale is expressed in — a struct rather than a bare `f64` so the wire shape and
`RewardPolicy`'s two-half split survive, and so a future tier joins there instead
of re-splitting the policy.

`DiscardReason::{VerifierUnavailable, VerifierDistrusted}` are **retained** as
the issue asks: that enum labels stored trajectories, and a written label must
keep parsing. Their doc comments now say the knob that produced them is gone too.

### Deleting the keys silently would have been the other half of the same bug

Both keys were spelled *correctly* in a shipped release. Dropping them makes them
unknown to `settings::unknown`, whose advice is "check the spelling" — false, and
it sends the author hunting for a mistake they did not make. So that module gains
a closed `RETIRED` list and a pure `notices()` function that splits the two: a
typo still gets the spelling line, a retired key gets its own line naming what it
used to do and telling the operator to delete it.

The list is deliberately **not** folded into the field vocabularies
(`ENGINE_ROOT_FIELDS` and friends), because those are also the trusted launcher's
strict seam (`config::trusted_engine_config_shape_is_strict`), which fails
*closed*. A benchmark posture naming a retired knob must be refused at launch, not
warned about and run.

Exemplar: cargo's "unused manifest key" warning, which the surrounding module
already cites as its model for the tolerant-parse-plus-warning posture.

Closes #2586
Refs #2616, #1866

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/settings/unknown.rs`:

- **`a_retired_key_is_named_as_retired_rather_than_as_a_typo`** — a settings file
  carrying **both** keys still deserializes into `Settings` (the issue's "assert
  it rather than assume it" for serde's unknown-field tolerance), both keys are
  reported, and neither notice line mentions spelling.
- **`a_typo_and_a_retired_key_in_one_file_each_get_their_own_notice`** — pins the
  split from the other side: the typo keeps its spelling advice and the retired
  key does not ride along in its list.

Honest note on the witness: `retirement()` and `notices()` do not exist on `main`,
so the file fails to *compile* there rather than failing an assertion. The
behavioural half is still real and would fail on `main` on its own —
`scan()` returns only one key there, because `verifier_weight` is a live member of
`REWARD_FIELDS`.

## The gate

- [x] `cargo fmt --check` (ran `cargo fmt --all`; no further drift)
- [x] `cargo clippy -p stella-cli -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo test -p stella-cli -p stella-pipeline` — see caveat below
- [x] Docs updated: `website/content/docs/configuration/stella-toml.mdx` (the
      `verifier_weight` OptionCard is replaced by a retirement callout) and
      `docs/spec/config-system/stella.today.toml` (which
      `the_shipped_reference_config_loads_with_no_unrecognized_keys` gate-checks,
      so it could not have been left stale)
- [x] `make guards-fast` equivalents: `invariants`, `doc-links`, `command-docs`,
      `brand-case`, `file-size`, `god-files`, `gate-parity`, `left-behind`,
      `role-names`, `stat-portability`, `module-reachability`, `typed-errors`,
      `wire-schema`, `doc-warnings` — all green
- [x] `Closes #2586` appears above **and** as a commit trailer

**Test caveat, stated rather than buried:** `cargo test -p stella-cli` is red on
two tests — `export::tests::the_dashboard_is_monospace_with_compact_corners` and
`export::tests::the_dashboard_spells_the_wordmark_lowercase`. They are **not
mine**. I ran the cheap control before drawing any conclusion: a detached
worktree at `703976e` (this branch's base, untouched) fails the same two tests
with the same two assertions. They are already tracked as #2626, which names this
exact commit and repro. Everything else passes: 1651 of 1653.

Two `shellcheck`-gated guards could not run here — `shellcheck` is not installed
in this environment. This PR touches no shell script.

## Nothing left behind

- [x] Filed: nothing new to file — everything I noticed was already tracked.

Specifically: #2616 items **1** (`RunError::VerifierNotIndependent`, a
wire-visible enum variant whose removal is its own compat decision) and **4** (a
comment in `roster_wiring.rs` naming the old field) are deliberately left alone
and remain tracked there; items 2 and 3 are what this PR does. #1866 is already
closed. The two red export tests are #2626.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] `OutcomeWeights` / `RewardPolicy` still round-trip through serde
      (`reward::tests::a_label_round_trips`)

## Anything reviewers should know?

**One downstream-visible artifact change.** `RewardPolicy` is stamped onto every
exported `RewardLabel`, so `stella dataset export` rows lose
`policy.outcome.judged`. Old rows still decode — none of these types set
`deny_unknown_fields` — but a consumer reading that key *by name* will see it
disappear. #2616 flags this as the reason `judged`'s removal is a decision rather
than a cleanup. I removed it because the alternative is worse: keeping the field
records a weight that priced nothing in the run that emitted it, which is a false
claim about how the label was computed.

**One judgement call worth a second opinion.** The issue offered "reject the key"
or "an explicit deprecation path a human chose". I took a third reading that I
believe is what both were reaching for: the file still *loads* (a hard error would
break settings written against a shipped release, which the removed doc comment
itself argued), and the key is *named* at startup as retired. If you would rather
these hard-error, the change is small and localized to `merge.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgrfkKtwhvvL8GnDJfgJaF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgrfkKtwhvvL8GnDJfgJaF)_

## Summary by Sourcery

Retire two unused, operator-visible settings related to model verdicts and adjust reward configuration and export to reflect a single deterministic scoring tier, while introducing explicit retirement handling for legacy keys.

Bug Fixes:
- Stop accepting no-op settings for independent model verifier requirements and verifier weighting that previously had no effect on pipeline behaviour.

Enhancements:
- Simplify reward policy to use only a deterministic outcome magnitude while preserving wire shape and validation, ensuring invalid scales fail loudly at config load and launch.
- Add structured handling for retired configuration keys so settings files still load but operators are warned with targeted messages instead of generic typo advice.

Documentation:
- Update configuration reference and website docs to remove `reward.verifier_weight`, document its retirement, and align reward policy descriptions with the deterministic-only scale.

Tests:
- Add tests covering retired-key reporting versus typos, reward policy validation on the deterministic unit, and propagation of configured reward policies through settings and config reload behaviour.