### PR TITLE
fix(stella-cli): restore sub-agent delegation to the bare step loop

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -7,6 +7,21 @@
 
 use super::*;
 
+/// The session task board, tool by tool — everything the catalog files under
+/// the `task` group *except* the delegation tool that shares the group name.
+///
+/// See [`bare_loop_config`]'s `# Blast radius` for why this is a name list and
+/// not the one-line group key, and for the catalog assertion that keeps it
+/// complete.
+const WITHHELD_BOARD_TOOLS: [&str; 6] = [
+    "task_create",
+    "task_list",
+    "task_start",
+    "task_complete",
+    "task_cancel",
+    "task_assign",
+];
+
 /// The caller's config with the task board withheld — what the bare step loop
 /// actually runs on.
 ///
@@ -28,12 +43,27 @@ use super::*;
 ///
 /// # Blast radius
 ///
-/// `task` is a **group** key, and the catalog puts sub-agent delegation (the
-/// tool literally named `task`) in that group alongside the six `task_*` board
-/// tools — so the bare loop loses delegation too. That is #2410's shipped
-/// behaviour, pinned by a test below rather than left to be rediscovered; #2580
-/// asks whether it was intended, since the measurement above is about
-/// bookkeeping, not about spend.
+/// The switch names the six board tools one at a time, and deliberately not
+/// the `task` **group** key #2410 shipped: the catalog files sub-agent
+/// delegation — the tool literally named `task` — in that same group, so the
+/// group key took delegation with the board and the bare loop could not spawn
+/// a child at all.
+///
+/// That was collateral, not a decision, and #2580 settled it that way: the
+/// measurement above, #2410's prose, its reviewer-facing behaviour-change note
+/// and all three of its witnesses say *the board* throughout. Delegation is a
+/// different capability with a different cost model — it does work and spends
+/// money, where a board call reads nothing and changes nothing — so none of
+/// the evidence for withholding the board reaches it. Restoring it is also
+/// what makes [`run_raw_one_shot`]'s
+/// [`install_for_session`](crate::subagent::install_for_session) pay for
+/// itself, rather than installing a dispatcher behind a tool the policy always
+/// stripped.
+///
+/// Naming the six costs the group's future-proofing — a seventh board tool
+/// would be offered here until someone added it to [`WITHHELD_BOARD_TOOLS`] —
+/// so `the_withheld_list_is_the_whole_board_minus_delegation` below reads the
+/// catalog and fails when the group grows.
 ///
 /// # Why this is a function
 ///
@@ -45,10 +75,9 @@ use super::*;
 fn bare_loop_config(cfg: &Config) -> Config {
     let mut bare = cfg.clone();
     bare.tool_policy
-        .narrow_with(&stella_tools::policy::ToolPolicy::from_switches([(
-            "task".to_string(),
-            false,
-        )]));
+        .narrow_with(&stella_tools::policy::ToolPolicy::from_switches(
+            WITHHELD_BOARD_TOOLS.map(|name| (name.to_string(), false)),
+        ));
     bare
 }
 
@@ -1052,6 +1081,10 @@ mod bare_loop_board_tests {
     /// All six tools `stella_tools::tasks` registers, not the five that were
     /// listed while `task_assign` shipped: the assertion has to name the whole
     /// board, or regrouping the one tool it omits goes unnoticed (#2511).
+    ///
+    /// Spelled out here rather than looped over [`WITHHELD_BOARD_TOOLS`] on
+    /// purpose — a test that reads the same list production reads passes for
+    /// any list at all, including an empty one.
     #[test]
     fn the_bare_loop_withholds_every_board_tool() {
         let policy = bare_loop_policy(ToolPolicy::allow_all());
@@ -1067,20 +1100,45 @@ mod bare_loop_board_tests {
         }
     }
 
-    /// The switch is the `task` **group**, and the catalog files sub-agent
-    /// delegation — the tool named `task` — in it, so the bare loop loses
-    /// delegation along with the board.
+    /// Sub-agent delegation survives the board's withdrawal.
     ///
-    /// Pinned rather than merely true: it is a real capability difference that
-    /// #2410's measurement (board bookkeeping) does not by itself justify, so
-    /// changing it should have to change a test. #2580 asks whether it was
-    /// intended.
+    /// #2410 narrowed with the `task` **group** key, and the catalog files
+    /// delegation — the tool named `task` — in that group, so the bare loop
+    /// silently lost the capability too. #2580 settled that as collateral
+    /// rather than a decision: the evidence for withholding the board is about
+    /// bookkeeping that reads nothing and changes nothing, and reaches no
+    /// tool that does work.
     #[test]
-    fn withholding_the_board_also_withholds_sub_agent_delegation() {
+    fn withholding_the_board_leaves_sub_agent_delegation_alone() {
         let policy = bare_loop_policy(ToolPolicy::allow_all());
         assert!(
-            !policy.allows("task"),
-            "the `task` group key takes sub-agent delegation with the board"
+            policy.allows("task"),
+            "sub-agent delegation shares the board's group but not its rationale"
+        );
+    }
+
+    /// What the group key gave for free and a name list does not: cover.
+    ///
+    /// [`WITHHELD_BOARD_TOOLS`] must be exactly the `task` group minus the
+    /// delegation tool, so a seventh board tool added to the catalog fails
+    /// here instead of being quietly offered to the bare loop. Asserted
+    /// against the group, not against a `task_*` name prefix — the group is
+    /// what `narrow_with` used to resolve, and a board tool named without the
+    /// prefix would slip a prefix test.
+    #[test]
+    fn the_withheld_list_is_the_whole_board_minus_delegation() {
+        let expected: Vec<&str> = stella_tools::catalog::CATALOG
+            .iter()
+            .filter(|entry| entry.group == "task" && entry.name != "task")
+            .map(|entry| entry.name)
+            .collect();
+        let mut withheld = WITHHELD_BOARD_TOOLS.to_vec();
+        withheld.sort_unstable();
+        let mut expected_sorted = expected.clone();
+        expected_sorted.sort_unstable();
+        assert_eq!(
+            withheld, expected_sorted,
+            "the `task` group changed: reconcile WITHHELD_BOARD_TOOLS with the catalog"
         );
     }
 
@@ -1105,6 +1163,27 @@ mod bare_loop_board_tests {
         assert!(
             !policy.allows("task_create"),
             "an operator grant must not resurrect the board here"
+        );
+    }
+
+    /// The other direction of the same guarantee, and the one this narrowing
+    /// newly depends on: handing delegation back must hand it back only to
+    /// operators who never took it away.
+    ///
+    /// An operator who switched the whole `task` group off has denied
+    /// delegation too — the group key means here exactly what it meant to
+    /// #2410 — and no longer naming that key in the narrowing must not turn
+    /// their denial into a grant.
+    #[test]
+    fn an_operator_who_denied_the_task_group_keeps_delegation_denied() {
+        let policy = bare_loop_policy(ToolPolicy::from_switches([("task".to_string(), false)]));
+        assert!(
+            !policy.allows("task"),
+            "the operator's group denial covers delegation and must survive"
+        );
+        assert!(
+            !policy.allows("task_create"),
+            "the operator's group denial covers the board too"
         );
     }
 }

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -219,6 +219,13 @@ turn. No triage, no verifier — the model works until it decides it's done.
 Cheapest and fastest; the right door for questions, small mechanical edits,
 and anything you'll eyeball anyway.
 
+The **session task board** is the one tool this door withholds: a one-shot
+turn has nothing to resume, so a card costs a model round trip and buys
+legibility no one is watching for. Everything else is unchanged, sub-agent
+delegation included — `task` spends money to do work, which is a different
+trade from `task_create`, and it is available here exactly as it is
+everywhere else.
+
 **Use it when** the task is well-defined and you don't need to watch.
 Prefer the pipeline default whenever the result must be *provably* right;
 drop to `--no-pipeline` when speed beats ceremony.


### PR DESCRIPTION
## What & why

#2580 asked a yes/no question: when #2410 withheld the task board from
`stella run --no-pipeline`, was losing **sub-agent delegation** along with it intended?

**It was not.** This PR takes option 2 and narrows by the six board tools by name
instead of by the `task` group key.

The record answers the question on its own — every artefact #2410 produced names the
board and nothing else:

| #2410 artefact | what it says |
| --- | --- |
| the measurement | 26% of tool calls were `task_create`/`task_start`/`task_complete`; 14% of steps did only that |
| the rationale | "A one-shot bare loop has **nothing to resume**" — a claim about the board's purpose |
| the reviewer-facing note | "the **task board** is no longer offered there" |
| the witness table | "the_bare_loop_withholds_every_board_tool — all five **board** tools are gone" |

Delegation appears in none of them. It also has a different cost model: the board reads
nothing and changes nothing, while `task` does work and spends money — so an argument
about free-of-work bookkeeping cannot reach it. The tell that nothing was decided is in
the code: `run_raw_one_shot` still calls `subagent::install_for_session`, paying to build
a dispatcher and provider behind a tool the policy then stripped from every advertised
schema.

Naming the six costs the group key's future-proofing, which #2580 flagged, so that is
replaced by a test that reads `catalog::CATALOG` and fails if the `task` group ever
stops being exactly those six plus delegation. It asserts against `entry.group`, not a
`task_*` name prefix — the group is what `narrow_with` used to resolve, and a board tool
named without the prefix would slip a prefix test.

Closes #2580

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

| test | proves |
| --- | --- |
| `withholding_the_board_leaves_sub_agent_delegation_alone` | the bare loop can spawn a sub-agent again |
| `an_operator_who_denied_the_task_group_keeps_delegation_denied` | handing delegation back does not override an operator's own `task: off` |
| `the_withheld_list_is_the_whole_board_minus_delegation` | the name list is exactly the catalog's `task` group minus delegation |

Checked the artisanal way rather than asserted: production `bare_loop_config` was
patched back to `("task", false)` and the module re-run —
`withholding_the_board_leaves_sub_agent_delegation_alone` failed at `goal.rs:1115`
("sub-agent delegation shares the board's group but not its rationale"), the other five
passed. Then restored, and all six pass. That check is why the witness is the *policy
answer* and not `narrow_with`'s behaviour: re-implementing the narrowing in a test
helper is exactly the failure #2511 fixed, so `the_bare_loop_withholds_every_board_tool`
still spells its six names out longhand rather than looping over the new
`WITHHELD_BOARD_TOOLS` — a test that reads the same list production reads passes for any
list, including an empty one.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — **two pre-existing failures, not from this diff**
- [x] Docs updated where behavior/flags changed
- [x] `Closes #2580` appears both above and as a commit trailer

`make gate CARGO_SCOPE="-p stella-cli"` plus `make self-driving-test` (60 checks) is
green except `export::tests::the_dashboard_is_monospace_with_compact_corners` and
`export::tests::the_dashboard_spells_the_wordmark_lowercase`. Both fail on a clean tree
at `703976e` with this branch stashed — the cheap control was run rather than assumed —
and they are #2626, already filed against this exact commit.

Docs: `website/content/docs/agent-engine-paths.mdx` gains a paragraph under
**Raw (`--no-pipeline`)**. The board withholding had never been documented anywhere
since #2410, so the paragraph states both halves — the board is withheld, delegation is
not.

## Nothing left behind

- [x] Filed: #2632 — the Terminal-Bench 2.1 arm this PR's definition of done asks for
      and this session could not run (see below). Pre-existing red already tracked in
      #2626.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**This is a behaviour change on a benchmarked path and it is unmeasured — that is the
merge gate, and it is why this PR is a draft.** #2580's definition of done asks for "a
bench arm showing the delegation restoration does not regress solve rate or cost". The
container this was written in has no provider API key, and Stella is BYOK, so
Terminal-Bench could not be started at all. Nothing here should be read as evidence
about solve rate or spend.

#2632 is the handoff for that arm. The short version: run 2.1 on both arms from the same
base commit with repeats, and read `stella-events.jsonl` rather than `result.json`. The
metrics that matter are not solve rate but **`task` dispatch count** (if the bare loop
never reaches for delegation, the arms are the same run and the comparison is silent),
**sub-agent spend** against the `$2` `Observed` pool ceiling, and **wall clock / timeout
count** under the 900s cap — a child that burns wall clock inside a parent step would
surface as a solve-rate loss with an entirely different cause.

If the arm shows a regression, the revert is one line back to the group key, and the
right move then is #2580's option 1 arrived at honestly: the doc comment's
`# Blast radius` section records that the measurement settled it rather than the
argument. That is a good outcome, not a failed PR.

Two things deliberately **not** done here, both from #2580's option-1 branch and both
wrong under option 2: `install_for_session` is left in `run_raw_one_shot` (it is no
longer dead setup cost — it is what makes the restored tool work), and no doc says
delegation is unavailable on this path, because it now is.

---
_Generated by [Claude Code](https://claude.ai/code/session_015eFrVZUeghP1ukdHFy2YoN)_

## Summary by Sourcery

Restore sub-agent delegation support in the bare step loop while continuing to withhold task board tools for `stella run --no-pipeline`.

Bug Fixes:
- Ensure sub-agent delegation remains available on the raw one-shot path instead of being unintentionally removed with the task board.

Enhancements:
- Narrow task board withholding by explicitly listing board tools rather than using the `task` group key, preserving future delegation behavior.
- Add catalog-based assertions and tests to guarantee the withheld tool list matches the task board group minus delegation and respects operator-level task group denial.

Documentation:
- Document raw (`--no-pipeline`) behavior so that task board withholding and continued sub-agent delegation availability are clearly described.