### PR TITLE
fix(stella-pipeline): keep the tautology and diff-coverage guards fed

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -93,6 +93,7 @@ use stella_protocol::ToolOutput;
 
 use crate::flip_halt::{FlipHalt, command_of};
 use crate::verify::coverage::DiffCoverage;
+use crate::verify::mutation::MutationAudit;
 use crate::verify::{
     FlipOracle, LadderDecision, LadderInputs, deterministic_fail_evidence,
     deterministic_pass_evidence, evidence_demand_is_worth_a_turn, ladder_decision,
@@ -757,11 +758,10 @@ struct CandidateState {
     /// from the still-pristine session tree. `None` also covers "probe
     /// unavailable", and the veto degrades open either way.
     lint_baseline: Option<Vec<LintRecord>>,
-    /// The mutation audit's finding (#870): Some(true) = the witness
-    /// failed under at least one mutant (it constrains the change);
-    /// Some(false) = it stayed green under every observed mutant
-    /// (tautological — the fast-submit was withheld); None = never run.
-    witness_mutation: Option<bool>,
+    /// The mutation audit's finding (#870), tri-state so "never run" is a
+    /// value of its own rather than a `false` that reads as innocence
+    /// (#2607): see [`MutationAudit`].
+    witness_mutation: MutationAudit,
     /// The diff-coverage audit's finding (#1291): whether the passing test
     /// run executed the lines this candidate added. `Unmeasured` both before
     /// the audit runs and wherever it cannot be made — the two are the same
@@ -1942,7 +1942,7 @@ impl<'a> Pipeline<'a> {
                 self.touches.mutations_recorded()
             },
             lint_baseline,
-            witness_mutation: None,
+            witness_mutation: MutationAudit::Unmeasured,
             diff_coverage: DiffCoverage::Unmeasured,
             revisions: 0,
             evidence_demands: 0,
@@ -2231,8 +2231,8 @@ impl<'a> Pipeline<'a> {
                         }
                     }
                     if observed > 0 {
-                        state.witness_mutation = Some(killed);
-                        inputs.witness_tautological = !killed;
+                        state.witness_mutation = MutationAudit::from_killed(killed);
+                        inputs.witness_mutation = state.witness_mutation;
                     }
                 }
             }

--- a/crates/stella-pipeline/src/pipeline/evidence.rs
+++ b/crates/stella-pipeline/src/pipeline/evidence.rs
@@ -39,7 +39,7 @@ impl<'a> Pipeline<'a> {
             new_diag_errors: 0,
             new_diag_warnings: 0,
             veto_warnings: self.config.diagnostics_veto_warnings,
-            witness_tautological: false,
+            witness_mutation: MutationAudit::Unmeasured,
             diff_coverage: DiffCoverage::Unmeasured,
             require_diff_coverage: self.config.require_diff_coverage,
             verify_done_flip: state.signals.verify_done_confirmations > 0,

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -323,7 +323,7 @@ impl<'a> Pipeline<'a> {
             // The pre-execution lint snapshot died with the process; the
             // regression veto (#861) sits out a resumed run (module docs).
             lint_baseline: None,
-            witness_mutation: None,
+            witness_mutation: MutationAudit::Unmeasured,
             diff_coverage: DiffCoverage::Unmeasured,
             revisions: 0,
             evidence_demands: 0,

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -35,6 +35,13 @@ mod untracked_render_bound;
 /// beside the only tests that script it.
 mod diff_coverage;
 
+/// The wiring guard for the two mechanical checks on the deterministic rung
+/// (#2607) — a child module for the same two reasons `flip_halt_arming` is,
+/// and because it is the only place both probes are wired on one run. Its
+/// module doc states what it is protecting and why a verdict assertion alone
+/// cannot.
+mod guard_wiring;
+
 /// #860 acceptance: a baseline that TIMES OUT observed no failing assertion,
 /// so a candidate whose suite then passes has no fail→pass flip — the run
 /// must escalate to the model verifier, never credit `DeterministicPass`. Before
@@ -509,6 +516,52 @@ async fn without_a_lint_probe_the_flip_still_fast_submits() {
     assert!(why.contains("baseline:fail → candidate:pass"), "got: {why}");
     let events = drain(&mut rx);
     assert!(!stages(&events).contains(&StageKind::Verdict));
+}
+
+/// A scripted coverage probe (#1291): answers with a fixed report, or `None`
+/// for "no tooling could measure this", and counts the runs it was asked for.
+///
+/// Lives beside [`ScriptedMutation`] rather than in `diff_coverage` because
+/// two child modules script it — `guard_wiring` wires both probes on one run
+/// to pin that neither guard has stopped being fed (#2607).
+pub(super) struct ScriptedCoverage {
+    report: Option<crate::verify::coverage::CoverageReport>,
+    calls: std::sync::atomic::AtomicU32,
+}
+
+impl ScriptedCoverage {
+    pub(super) fn measuring(entries: &[(&str, &[u32])]) -> Self {
+        Self {
+            report: Some(
+                entries
+                    .iter()
+                    .map(|(path, lines)| ((*path).to_string(), lines.iter().copied().collect()))
+                    .collect(),
+            ),
+            calls: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+    pub(super) fn unavailable() -> Self {
+        Self {
+            report: None,
+            calls: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+    pub(super) fn calls(&self) -> u32 {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl crate::ports::CoverageProbe for ScriptedCoverage {
+    async fn covered_lines(
+        &self,
+        _root: Option<&str>,
+        _invocation: &TestInvocation,
+    ) -> Option<crate::verify::coverage::CoverageReport> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.report.clone()
+    }
 }
 
 /// A scripted mutation probe (#870): every mutant gets the same outcome,

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/diff_coverage.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/diff_coverage.rs
@@ -1,51 +1,11 @@
 //! The #1291 diff-coverage half of the verification hardening series: does
 //! the authored witness actually execute the lines the change touched?
-//! Split out of the parent module to keep it under the 1500-line ratchet;
-//! the scripted probe lives here beside the only tests that script it.
+//! Split out of the parent module to keep it under the 1500-line ratchet.
+//! The scripted probe used to live here beside the only tests that scripted
+//! it; `guard_wiring` is the second scripter, so it moved up to the parent
+//! where [`super::ScriptedMutation`] already sits.
 
 use super::*;
-
-/// A scripted coverage probe (#1291): answers with a fixed report, or `None`
-/// for "no tooling could measure this", and counts the runs it was asked for.
-struct ScriptedCoverage {
-    report: Option<crate::verify::coverage::CoverageReport>,
-    calls: std::sync::atomic::AtomicU32,
-}
-
-impl ScriptedCoverage {
-    fn measuring(entries: &[(&str, &[u32])]) -> Self {
-        Self {
-            report: Some(
-                entries
-                    .iter()
-                    .map(|(path, lines)| ((*path).to_string(), lines.iter().copied().collect()))
-                    .collect(),
-            ),
-            calls: std::sync::atomic::AtomicU32::new(0),
-        }
-    }
-    fn unavailable() -> Self {
-        Self {
-            report: None,
-            calls: std::sync::atomic::AtomicU32::new(0),
-        }
-    }
-    fn calls(&self) -> u32 {
-        self.calls.load(std::sync::atomic::Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl crate::ports::CoverageProbe for ScriptedCoverage {
-    async fn covered_lines(
-        &self,
-        _root: Option<&str>,
-        _invocation: &TestInvocation,
-    ) -> Option<crate::verify::coverage::CoverageReport> {
-        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        self.report.clone()
-    }
-}
 
 /// A run whose flip is real and whose diff touches `src/lib.rs` line 12 —
 /// the shape both coverage scenarios below share, so only the probe differs.

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/guard_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/guard_wiring.rs
@@ -1,0 +1,310 @@
+//! The two mechanical guards on the deterministic rung must stay **fed**
+//! (#2607) — a child module for the same two reasons `flip_halt_arming` is,
+//! and for one of its own.
+//!
+//! Verification's deterministic ladder has exactly two checks that stop a
+//! *trivially-passing* test from earning the strongest badge the system
+//! issues: the tautology audit (#870 — a witness that kills no mutant is not
+//! proof) and the diff-coverage overlap (#1291 — a run that executed none of
+//! the changed lines is not proof of those lines). While a model verdict sat
+//! behind them they were belt-and-braces; as judgement stops buying a model
+//! call, they become the only thing between a test nobody vetted and a
+//! `deterministic` pass.
+//!
+//! Both are plumbed as **fields on an inputs struct**, and both defaults mean
+//! "no problem found". So deleting the code that computes them is not a
+//! compile error and not a test failure — it is a silent downgrade to
+//! "everything is fine". #2607 is the record of a branch that did exactly
+//! that: `witness_tautological` survived as the literal `false`,
+//! `diff_coverage` never left `Unmeasured`, both guard modules stayed in the
+//! tree with no non-test caller, and nothing went red.
+//!
+//! Every test here therefore asserts on the *feeding*, not only on the
+//! verdict: that the probe was called, and that the ladder snapshot carries a
+//! **measured** value rather than the benign default. Those two assertions
+//! are what a deletion cannot satisfy.
+//!
+//! Two tests rather than the one the shape suggests, because the guards run
+//! in sequence under the same `SubmitFast` precondition: coverage is checked
+//! first, and a withheld credit there means the mutation audit is never
+//! reached (`ordering_leaves_the_mutation_audit_unpaid_for` pins that). A
+//! single scenario that is bad on both axes would prove only the first guard
+//! is wired — so each guard gets a scenario where it is the *sole* reason the
+//! credit is withheld.
+
+use super::*;
+
+/// The lines `MUTABLE_DIFF` adds to `src/fix.rs`, on the new side: the hunk
+/// starts at 1 and both added lines are ones a coverage tool attributes.
+const CHANGED_LINES: &[u32] = &[1, 2];
+
+/// The candidate's changed file — the path both guards read out of the diff.
+const CHANGED_FILE: &str = "src/fix.rs";
+
+/// One authored-witness run over both probes: an isolated candidate whose
+/// suite goes fail→pass and whose diff is `MUTABLE_DIFF`, so the mutation
+/// generator has two mutable lines and the coverage overlap has two changed
+/// ones.
+///
+/// The mutation audit only ever runs for an AUTHORED witness, which is why
+/// this is the isolated-workspace path rather than the `--test-command` one
+/// `diff_coverage` uses.
+async fn run_with_both_guards(
+    mutation: &dyn MutationProbe,
+    coverage: &dyn crate::ports::CoverageProbe,
+    provider: &ScriptedProvider,
+) -> (PipelineOutcome, Vec<AgentEvent>) {
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let candidate = FakeWorkspace::new(0, vec![true, true], Ok(vec![]), log.clone())
+        .with_diff(MUTABLE_DIFF)
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/witness.rs", "w1")],
+        ]));
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
+    );
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
+
+    let resolver = OneProvider(provider);
+    let diagnostics = NeverRunner;
+    let repo_status = NeverRepoStatus;
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &diagnostics,
+            tests: &diagnostics,
+            lint: None,
+            mutation: Some(mutation),
+            coverage: Some(coverage),
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(&port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the retry bug", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+    (outcome, drain(&mut rx))
+}
+
+/// The provider script every scenario here shares: triage → worker →
+/// witness author. No fourth result is needed — the withheld credit is
+/// terminal (`LadderDecision::Unverified` asks nobody), which the tests
+/// assert directly.
+fn scripted_roles() -> ScriptedProvider {
+    ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("wrote the test.\nTEST_COMMAND: cargo test --test witness witness -- --exact"),
+    ])
+}
+
+/// The tautology guard, alone on the wire (#2607). Coverage is measured and
+/// **overlapping**, so it credits the pass and the mutation audit is the only
+/// thing that can withhold it: a witness that stays green under every mutant
+/// of the changed lines must not fast-submit.
+///
+/// The two assertions a silent unwiring cannot satisfy are the probe's call
+/// count and the snapshot's `witness_mutation`. Reading `None` there — the
+/// benign default — is precisely the state this test exists to catch, and it
+/// is a distinguishable value only because the ladder input is tri-state.
+#[tokio::test]
+async fn the_tautology_guard_is_fed_and_withholds_the_deterministic_credit() {
+    let provider = scripted_roles();
+    let mutation = ScriptedMutation::new(MutantOutcome::Witness { passed: true });
+    let coverage = ScriptedCoverage::measuring(&[(CHANGED_FILE, CHANGED_LINES)]);
+    let (outcome, events) = run_with_both_guards(&mutation, &coverage, &provider).await;
+
+    assert_eq!(
+        coverage.calls(),
+        1,
+        "the coverage guard ran — this scenario is not the one testing it, but an \
+         unfed coverage probe would make the mutation assertions below vacuous"
+    );
+    assert!(
+        mutation.calls() > 0,
+        "THE guard assertion: the mutation audit was fed. A pipeline that stopped \
+         calling it reaches this line with 0 and a `witness_tautological`-shaped \
+         default that reads as innocence"
+    );
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(
+        verdict.passed,
+        "a tautological witness is not a finding that the change is wrong"
+    );
+    assert!(
+        !verdict.deterministic,
+        "what it loses is the deterministic credit: {}",
+        verdict.summary
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Verdict),
+        "the withheld credit is terminal — no model is asked to overrule it"
+    );
+    let snapshot = verdict
+        .ladder
+        .as_deref()
+        .expect("the verdict carries its snapshot");
+    assert_eq!(
+        snapshot.witness_mutation,
+        Some(false),
+        "the provenance must record a MEASURED tautology; `None` here is the \
+         unfed-guard state, not a finding"
+    );
+    assert_eq!(
+        snapshot.diff_coverage.as_deref(),
+        Some("covered"),
+        "and the other guard measured, so the withheld credit is attributable"
+    );
+    assert!(
+        verdict.summary.contains("witness_mutation=tautological"),
+        "a withheld credit must NAME the guard that withheld it — a reader who has \
+         only the verdict must not have to open a snapshot to learn which of the two \
+         objected: {}",
+        verdict.summary
+    );
+}
+
+/// The coverage guard, alone on the wire (#2607). The witness WOULD kill a
+/// mutant — it constrains the change — so the measured non-overlap is the
+/// only thing that can withhold the credit.
+///
+/// It also pins the ordering the module doc turns on: coverage is checked
+/// first and its finding drops the `SubmitFast` precondition, so the mutation
+/// audit is never reached. That is deliberate (one instrumented run is
+/// cheaper than up to three witness runs) and it is why the tautology guard
+/// needs its own scenario above rather than sharing this one.
+#[tokio::test]
+async fn the_coverage_guard_is_fed_and_ordering_leaves_the_mutation_audit_unpaid_for() {
+    let provider = scripted_roles();
+    let mutation = ScriptedMutation::new(MutantOutcome::Witness { passed: false });
+    // The suite ran, and it ran OTHER lines of the changed file.
+    let coverage = ScriptedCoverage::measuring(&[(CHANGED_FILE, &[40, 41])]);
+    let (outcome, events) = run_with_both_guards(&mutation, &coverage, &provider).await;
+
+    assert_eq!(
+        coverage.calls(),
+        1,
+        "THE guard assertion: the coverage audit was fed. A pipeline that stopped \
+         calling it reaches this line with 0 and a `DiffCoverage::Unmeasured` that \
+         credits the pass"
+    );
+    assert_eq!(
+        mutation.calls(),
+        0,
+        "ordering: a credit already withheld makes the dearer audit moot, so it is \
+         not paid for"
+    );
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(verdict.passed, "unproven is not failed");
+    assert!(!verdict.deterministic, "{}", verdict.summary);
+    assert!(!stages(&events).contains(&StageKind::Verdict));
+    let snapshot = verdict
+        .ladder
+        .as_deref()
+        .expect("the verdict carries its snapshot");
+    assert_eq!(
+        snapshot.diff_coverage.as_deref(),
+        Some("not_covered"),
+        "a MEASURED non-overlap; `unmeasured` here is the unfed-guard state"
+    );
+    assert_eq!(
+        snapshot.witness_mutation, None,
+        "and the audit that never ran says so, rather than reporting the \
+         innocence a `false` used to imply (#2607)"
+    );
+    assert!(
+        verdict.summary.contains("diff_coverage=not_covered"),
+        "the other guard's withheld credit must name ITSELF, not the generic \
+         'the deterministic checks did not combine into a pass' the two used to \
+         share: {}",
+        verdict.summary
+    );
+}
+
+/// The control both scenarios above need. Without it, "withhold when a guard
+/// objects" is indistinguishable from "never credit a deterministic pass
+/// again" — the failure mode that would make this module pass while the
+/// ladder was broken in the opposite direction.
+///
+/// Same run, same probes, both guards satisfied: the witness kills the first
+/// mutant and the suite executed the changed lines, so the strongest badge is
+/// earned in full and both findings are on the record.
+#[tokio::test]
+async fn both_guards_satisfied_still_earns_the_deterministic_badge() {
+    let provider = scripted_roles();
+    let mutation = ScriptedMutation::new(MutantOutcome::Witness { passed: false });
+    let coverage = ScriptedCoverage::measuring(&[(CHANGED_FILE, CHANGED_LINES)]);
+    let (outcome, events) = run_with_both_guards(&mutation, &coverage, &provider).await;
+
+    assert_eq!(coverage.calls(), 1);
+    assert_eq!(
+        mutation.calls(),
+        1,
+        "the first killed mutant proves the witness; the second is never paid for"
+    );
+
+    let verdict = outcome.verdict.expect("a verdict was produced");
+    assert!(
+        verdict.passed && verdict.deterministic,
+        "{}",
+        verdict.summary
+    );
+    assert!(!stages(&events).contains(&StageKind::Verdict));
+    assert_eq!(
+        outcome.score,
+        Some(crate::candidate::CandidateScore::DeterministicPass),
+        "two measured guards that both cleared the candidate is the ladder's \
+         strongest result, unchanged"
+    );
+    let snapshot = verdict
+        .ladder
+        .as_deref()
+        .expect("the verdict carries its snapshot");
+    assert_eq!(snapshot.witness_mutation, Some(true));
+    assert_eq!(snapshot.diff_coverage.as_deref(), Some("covered"));
+}
+
+/// The unwired shape stated as a value, so the difference this module guards
+/// is written down in one place a reader can check without running a
+/// pipeline: the state a deleted audit leaves behind is the state that
+/// credits a pass, on BOTH axes. That is why the tests above assert on the
+/// call counts and the snapshot rather than on the verdict alone — a verdict
+/// assertion cannot tell an unfed guard from a satisfied one.
+#[test]
+fn the_unfed_state_of_both_guards_is_the_state_that_credits_a_pass() {
+    use crate::verify::coverage::DiffCoverage;
+    use crate::verify::mutation::MutationAudit;
+
+    assert!(MutationAudit::default().credits_a_deterministic_pass());
+    assert!(DiffCoverage::default().credits_a_deterministic_pass(false));
+    // ...and each is distinguishable from the audit that ran and cleared the
+    // candidate, which is the whole of #2607's second half.
+    assert_ne!(MutationAudit::default(), MutationAudit::Constrains);
+    assert_ne!(DiffCoverage::default(), DiffCoverage::Covered);
+    assert_eq!(MutationAudit::default().recorded(), None);
+}

--- a/crates/stella-pipeline/src/pipeline/verify_probes.rs
+++ b/crates/stella-pipeline/src/pipeline/verify_probes.rs
@@ -193,7 +193,10 @@ impl<'a> Pipeline<'a> {
             new_diag_errors: inputs.new_diag_errors,
             new_diag_warnings: inputs.new_diag_warnings,
             witness_intact,
-            witness_mutation: state.witness_mutation,
+            // #2607: the wire shape was already tri-state (`None` = never
+            // measured), so the enum states map onto it without a schema
+            // change — `recorded()` is the whole conversion.
+            witness_mutation: state.witness_mutation.recorded(),
             // #1291: always stated, including `unmeasured` — a reader must be
             // able to tell "the test ran the change" from "nobody looked",
             // and the absence of the field would be a third, unintended

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -446,12 +446,17 @@ pub struct LadderInputs {
     /// fast-submit (errors always do). Carried here so the ladder stays a
     /// pure function of one input value.
     pub veto_warnings: bool,
-    /// The witness stayed green under EVERY trivial mutation of the changed
-    /// lines (#870) — it reacts to the change without constraining it, so
-    /// its flip may not buy a deterministic pass. `false` both when the
-    /// check found the witness sound and when it never ran: the downgrade
-    /// requires positive evidence of tautology, never its absence.
-    pub witness_tautological: bool,
+    /// What the trivial-mutation audit found about the authored witness
+    /// (#870): does it constrain the changed lines, or merely react to them?
+    /// A [`mutation::MutationAudit::Tautological`] witness may not buy a
+    /// deterministic pass.
+    ///
+    /// Tri-state rather than a `bool` (#2607). The downgrade still requires
+    /// positive evidence of tautology and never its absence — but "the audit
+    /// cleared this witness" and "no audit ever ran" are now different
+    /// values, so the code that feeds this field cannot be deleted into a
+    /// finding of innocence. See [`mutation::MutationAudit`].
+    pub witness_mutation: mutation::MutationAudit,
     /// Whether the passing test run actually executed the lines the change
     /// added (#1291). [`coverage::DiffCoverage::Unmeasured`] — the default —
     /// is "nobody could tell", which is a different answer from "it did not"
@@ -664,7 +669,12 @@ pub fn ladder_decision(inputs: &LadderInputs) -> LadderDecision {
         && inputs.diff_lines <= inputs.diff_budget
         && inputs.new_diag_errors == 0
         && (!inputs.veto_warnings || inputs.new_diag_warnings == 0)
-        && !inputs.witness_tautological
+        // #870: a witness that stays green under every observed mutant of the
+        // changed lines reacts to the change without constraining it. An
+        // audit that never ran credits the pass — the probe is optional and
+        // degrades open — but it is a distinguishable value (#2607), not the
+        // same `false` as a cleared witness.
+        && inputs.witness_mutation.credits_a_deterministic_pass()
         // #1291: a test that never executed the changed lines passed for some
         // other reason. Withholding the deterministic credit sends the turn to
         // the verifier — "unproven" — and is never a failure; an *unmeasured*
@@ -828,6 +838,26 @@ pub fn unverified_evidence(inputs: &LadderInputs, tracked_cmd: Option<&str>) -> 
         "a flip was observed, but the touched tests could not be run, so nothing confirmed the \
          change left the rest of the suite green"
             .to_string()
+    } else if !inputs
+        .diff_coverage
+        .credits_a_deterministic_pass(inputs.require_diff_coverage)
+    {
+        // #2607: the two mechanical guards are the commonest reason a flipped
+        // candidate lands here, and until now the reader was told only that
+        // "the deterministic checks did not combine into a pass" — a sentence
+        // that names neither the guard nor its finding, and reads identically
+        // whichever one objected. Each states itself, in the guard's own
+        // words, so a withheld credit is legible without opening a snapshot.
+        // Coverage first, matching the order the audits actually run in.
+        format!(
+            "a flip was observed, but {}",
+            inputs.diff_coverage.explain()
+        )
+    } else if !inputs.witness_mutation.credits_a_deterministic_pass() {
+        format!(
+            "a flip was observed, but {}",
+            inputs.witness_mutation.explain()
+        )
     } else {
         "the deterministic checks did not combine into a pass".to_string()
     };
@@ -896,7 +926,7 @@ pub struct StrippedDiff {
 /// billed against the diff budget on every escalated verdict and guidance
 /// call. What the verifier needs to know about the witness it already gets
 /// from the trusted evidence summary (`witness_tamper_check`,
-/// `witness_tautological`, the oracle trace); the test's text says nothing
+/// `witness_mutation`, the oracle trace); the test's text says nothing
 /// about the change under review.
 ///
 /// Paths are matched the way [`coverage::changed_lines`] excludes them: each

--- a/crates/stella-pipeline/src/verify/mutation.rs
+++ b/crates/stella-pipeline/src/verify/mutation.rs
@@ -18,6 +18,109 @@
 
 use crate::ports::LineMutation;
 
+/// What the mutation audit observed about the authored witness (#870).
+///
+/// Three values because the question has three answers, and #2607 is the
+/// record of what happens when it is spelled with two. This was a
+/// `witness_tautological: bool` on the ladder inputs, and `false` meant both
+/// "the audit ran and the witness constrains the change" and "no audit ever
+/// ran" — so deleting the code that computes it was not a compile error, not
+/// a test failure, and not visible in a verdict: it was a silent downgrade to
+/// "everything is fine" wearing the ladder's strongest badge. A guard whose
+/// benign default is indistinguishable from its answer is a guard that can
+/// stop being fed without anyone noticing.
+///
+/// Deliberately shaped like [`crate::verify::coverage::DiffCoverage`], the
+/// other half of the same pair: `Unmeasured` is a statement about the
+/// instrument and never a finding about the work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MutationAudit {
+    /// No mutant was ever *observed*: the probe was not wired, the diff
+    /// proposed no mutable line, or every proposed mutant came back
+    /// [`crate::ports::MutantOutcome::Unavailable`]. The default, and never a
+    /// finding about the witness.
+    #[default]
+    Unmeasured,
+    /// At least one mutant broke the changed lines and the witness went red —
+    /// it constrains the change, and the audit stopped there (a killed mutant
+    /// is proof; the remaining ones are not paid for).
+    Constrains,
+    /// Mutants WERE observed and the witness stayed green under every one of
+    /// them: it reacts to the change without constraining it. The flip stands
+    /// as an observation, but it may not buy a deterministic pass.
+    Tautological,
+}
+
+impl MutationAudit {
+    /// The finding of an audit that DID observe at least one mutant run:
+    /// `killed` says whether any of them sent the witness red.
+    ///
+    /// The `observed > 0` precondition belongs to the caller, and it is the
+    /// whole distinction this type exists to keep — an audit that observed
+    /// nothing is [`MutationAudit::Unmeasured`] and must never arrive here as
+    /// a `false`.
+    #[must_use]
+    pub fn from_killed(killed: bool) -> Self {
+        if killed {
+            MutationAudit::Constrains
+        } else {
+            MutationAudit::Tautological
+        }
+    }
+
+    /// The audit's finding as the wire snapshot spells it (#865):
+    /// `Some(true)` = constrains, `Some(false)` = tautological, `None` =
+    /// never measured. The wire shape predates this enum and is deliberately
+    /// unchanged — it was already tri-state, which is precisely why the
+    /// *provenance* stayed honest while the ladder input could not.
+    #[must_use]
+    pub fn recorded(self) -> Option<bool> {
+        match self {
+            MutationAudit::Unmeasured => None,
+            MutationAudit::Constrains => Some(true),
+            MutationAudit::Tautological => Some(false),
+        }
+    }
+
+    /// A sentence a verifier (or a human reading a verdict) can act on, in
+    /// the same register as [`crate::verify::coverage::DiffCoverage::explain`]:
+    /// what was observed, and what it does NOT mean.
+    #[must_use]
+    pub fn explain(self) -> &'static str {
+        match self {
+            MutationAudit::Unmeasured => {
+                "witness_mutation=unmeasured (no mutant run was observed for this witness, so \
+                 whether it constrains the change is UNKNOWN — this is not a finding that it \
+                 does not)"
+            }
+            MutationAudit::Constrains => {
+                "witness_mutation=constrains (the witness went red when a changed line was \
+                 broken under it)"
+            }
+            MutationAudit::Tautological => {
+                "witness_mutation=tautological (the witness stayed green under EVERY observed \
+                 mutant of the changed lines — it reacts to the change without constraining it, \
+                 which is not a finding that the change is wrong)"
+            }
+        }
+    }
+
+    /// Whether this finding may carry a deterministic fast-submit — that is,
+    /// whether the ladder may *skip the verifier*.
+    ///
+    /// `Unmeasured` credits, for the reason every probe in this ladder
+    /// degrades open: the mutation probe is optional, and an absent one must
+    /// leave the pre-#870 ladder rather than manufacture a tautology finding.
+    /// The downgrade requires positive evidence, never its absence — which is
+    /// why the *guard* against an unfed audit is a wiring test
+    /// (`pipeline/tests/verification_hardening/guard_wiring.rs`) and not this
+    /// method.
+    #[must_use]
+    pub fn credits_a_deterministic_pass(self) -> bool {
+        !matches!(self, MutationAudit::Tautological)
+    }
+}
+
 /// Ceiling on proposed mutants: bounded cost, one witness run per mutant,
 /// spent only on a candidate about to be credited a deterministic pass (the
 /// pre-submit audit gates it) — in best-of-N that is per fast-submitting
@@ -128,6 +231,23 @@ mod tests {
 +    // boundary now inclusive
  }
 ";
+
+    /// The tri-state's whole point (#2607): "the audit never ran" and "the
+    /// audit ran and cleared the witness" are different values, so a ladder
+    /// input that stopped being fed cannot impersonate a finding. Both still
+    /// credit a fast-submit — the probe is optional and degrades open — but a
+    /// reader, a verdict snapshot, and a test can now tell them apart.
+    #[test]
+    fn an_unmeasured_audit_is_not_the_same_value_as_a_cleared_one() {
+        assert_ne!(MutationAudit::Unmeasured, MutationAudit::Constrains);
+        assert_eq!(MutationAudit::default(), MutationAudit::Unmeasured);
+        assert_eq!(MutationAudit::Unmeasured.recorded(), None);
+        assert_eq!(MutationAudit::Constrains.recorded(), Some(true));
+        assert_eq!(MutationAudit::Tautological.recorded(), Some(false));
+        assert!(MutationAudit::Unmeasured.credits_a_deterministic_pass());
+        assert!(MutationAudit::Constrains.credits_a_deterministic_pass());
+        assert!(!MutationAudit::Tautological.credits_a_deterministic_pass());
+    }
 
     #[test]
     fn mutants_come_from_added_lines_with_correct_positions() {

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -956,7 +956,7 @@ fn a_tautological_witness_blocks_the_fast_submit() {
     };
     assert_eq!(ladder_decision(&sound), LadderDecision::SubmitFast);
     let tautological = LadderInputs {
-        witness_tautological: true,
+        witness_mutation: crate::verify::mutation::MutationAudit::Tautological,
         ..sound
     };
     assert_eq!(


### PR DESCRIPTION
## What & why

Verification's deterministic ladder has two mechanical guards that stop a *trivially-passing* test from earning a `deterministic` pass: the tautology audit (#870 — a witness that kills no mutant is not proof) and the diff-coverage overlap (#1291 — a run that executed none of the changed lines is not proof of those lines). As judgement stops buying a model call, they become the only thing between a test nobody vetted and the strongest label the system issues.

Both were plumbed as **fields on an inputs struct whose defaults mean "no problem found"**, so deleting the code that computes them was not a compile error, not a test failure, and not visible in a verdict — a silent downgrade to "everything is fine". Three changes, in descending order of importance:

**1. A wiring guard** — `crates/stella-pipeline/src/pipeline/tests/verification_hardening/guard_wiring.rs`. Three end-to-end scenarios with *both* probes wired on one run (the first place in the tree that happens), each asserting that the probe was **called** and that the ladder snapshot carries a **measured** value. Those are the two assertions a deletion cannot satisfy; a verdict assertion alone cannot tell an unfed guard from a satisfied one. Plus a control proving a satisfied pair still earns the badge, so "withhold when a guard objects" stays distinguishable from "never credit a deterministic pass again".

Two scenarios rather than the one the issue's shape suggests: the audits share a `SubmitFast` precondition and run in sequence, so a run that is bad on *both* axes never reaches the second guard and would prove only the first is wired. Each guard therefore gets a scenario where it is the sole reason the credit is withheld, and the ordering itself is pinned (`mutation.calls() == 0` when coverage already objected).

**2. The benign default made distinguishable** — `LadderInputs::witness_tautological: bool` becomes `witness_mutation: MutationAudit`, a tri-state (`Unmeasured` / `Constrains` / `Tautological`) shaped deliberately like the `DiffCoverage` it pairs with, down to `explain()` and `credits_a_deterministic_pass()`. "The audit cleared this witness" and "no audit ever ran" were the same `false`; they are now different values. `Unmeasured` still credits — the probe is optional and every probe in this ladder degrades open — but the state is legible in a snapshot, in a test, and to a reader. The wire shape was already tri-state (`Option<bool>`), so `docs/wire/` is untouched and `MutationAudit::recorded()` is the whole conversion.

This is DoD item 2 of #2607 taken in full rather than deferred.

**3. A withheld credit now names the guard that withheld it.** Both guards previously fell through to `unverified_evidence`'s generic `"the deterministic checks did not combine into a pass"` — identical prose whichever one objected, so a reader had to open the snapshot to learn which. `MutationAudit::explain` and `DiffCoverage::explain` now feed that sentence. This is also what gives `explain()` a real caller: adding an unwired method in the PR that exists to stop unwired guards would be the exact defect under repair.

The scripted coverage probe moves from `diff_coverage` up to the shared parent beside `ScriptedMutation`, now that two child modules script it.

Refs #2607

Deliberately **not** `Closes`: #2607's item 3 is a constraint on whatever lands #2559, which this PR cannot satisfy. See [my comment there](https://github.com/macanderson/stella/issues/2607#issuecomment-5236034978) for the finding that matters most to that work — the tautology audit is gated on `witness.is_some()` (`pipeline.rs:2196`), so removing the witness author does not merely risk unwiring the guard, it makes it structurally unreachable.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

**Change 3 is a fail-on-`main` / pass-here flip in the ordinary sense.** Reverting only the `unverified_evidence` hunk, with the tests in place:

```
the_coverage_guard_is_fed_and_ordering_leaves_the_mutation_audit_unpaid_for ... FAILED
the_tautology_guard_is_fed_and_withholds_the_deterministic_credit ... FAILED
  the other guard's withheld credit must name ITSELF, not the generic 'the
  deterministic checks did not combine into a pass' the two used to share:
  UNVERIFIED — the deterministic checks did not combine into a pass. ...
```

**Changes 1 and 2 are guards, and their flip is against the defect rather than against `main`** — the wiring is present on `main`, which is the state being protected. #2607 states the same thing ("fails today on `3425bc077` and passes on `main` and on #2584"). Demonstrated by unwiring each guard in the working tree exactly as `3425bc077` does — replacing the `matches!(ladder_decision(&inputs), LadderDecision::SubmitFast)` precondition on each audit block with `false` — and running the suite:

| unwired | result |
|---|---|
| both guards | 3 of 4 `guard_wiring` tests FAILED |
| mutation only | `the_tautology_guard_is_fed…`, `both_guards_satisfied…` FAILED; the coverage scenario stayed green |
| coverage only | `the_coverage_guard_is_fed…`, `both_guards_satisfied…` FAILED, plus both existing `diff_coverage` scenarios |

Each test is sensitive to its own guard and only its own — the cross-checks are what rule out a test that fails for an unrelated reason. The first failure in every case is the call-count assertion, i.e. the guard reports *unfed* before it reports a wrong verdict.

The fourth test (`the_unfed_state_of_both_guards_is_the_state_that_credits_a_pass`) passes under every unwiring by design: it is a value-level statement that the unfed state is the crediting state on both axes, which is *why* the other three assert on call counts.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1648 passed, **2 pre-existing failures unrelated to this PR** (see below)
- [x] Docs updated where behavior changed — doc comments on `MutationAudit`, `LadderInputs::witness_mutation`, `CandidateState::witness_mutation`, and the new module's `//!` block, which states what it protects and why a verdict assertion alone cannot
- [x] `make gate` — every step run and green except `shellcheck`, which is **not installed in this container**; this diff touches no shell script, and CI runs it
- [x] `file-size` gains no baseline entry: `pipeline.rs` is a god file and is **2860 lines before and after** — the tri-state's mapping went into `MutationAudit::from_killed` so the call site stayed two lines, and new logic landed in `verify/mutation.rs` and the new test module

**About the 2 test failures:** `export::tests::the_dashboard_is_monospace_with_compact_corners` and `…the_dashboard_spells_the_wordmark_lowercase`, in `stella-cli`. They fail identically on a clean tree at `703976e` (verified by stashing this branch's changes and re-running), and they are the subject of #2626, which names the same two tests and the same commit. Nothing in this diff touches `stella-cli`. I have not folded a fix in — that is a separate change from a fresh `main`.

## Nothing left behind

- [x] Filed: **#2640** — the #861 regression veto still reports the generic `UNVERIFIED` shortfall, now that the two guards report themselves. Written as a handoff: the file and function, the arms to copy, the design call left open (`new_diag_errors` has no `explain()`-style renderer), and the existing scenario to extend for a witness.
- Recorded on #2607 rather than duplicated: the `witness.is_some()` gate that makes the tautology audit structurally unreachable once #2559 removes the author. It belongs on the issue that governs that work, and #2607 item 3 is the checkbox it hangs off.

DoD item 4 holds and is now stronger: `verify/mutation.rs` and `verify/coverage.rs` each had non-test callers on `main` (`pipeline.rs:2178`, `2181`, `2198`), and this PR adds a second kind of caller for both — the `explain()` renderers feeding the verdict summary.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary type — the wire shape (`LadderSnapshot::witness_mutation: Option<bool>`) is unchanged, which `wire-schema` confirms

## Anything reviewers should know?

**The exemplar for `MutationAudit` is `DiffCoverage` in the sibling module**, not an outside crate: the two guards are a pair, they are read at the same point in the ladder, and the strongest thing available here is that a reader who knows one knows the other. `Unmeasured` as the `#[default]` variant carrying the "no finding" reading is the same shape `std::cmp::Ordering`-style tri-states use, and the `credits_a_deterministic_pass()` naming is lifted verbatim from `DiffCoverage` so the ladder conjunct reads as one sentence.

**What this PR deliberately does not do:** make the unfed state fail closed. It cannot, and claiming otherwise would be the false comfort this issue is about — both probes are genuinely optional, and a host with no coverage tooling or no mutation runner must not be told its honest work is tautological. `Unmeasured` therefore still credits a fast-submit, exactly as before. What changes is that it is a *distinguishable* value, and that three tests fail the moment the code that produces a measured one stops running. #2607's item 2 asks for "an `Option` / explicit `Unmeasured` that the ladder must branch on" and that is what this is — the guarantee is legibility plus a test, not a compile error.

**No test was deleted or renamed.** The two existing single-guard scenarios (`a_tautological_witness_is_downgraded_to_the_verifier`, and the `diff_coverage` pair) are untouched and still pass; `guard_wiring` is additive, and covers the joint case neither of them could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TGd2RbX3Pt7yzSU9EHsxG

---
_Generated by [Claude Code](https://claude.ai/code/session_011TGd2RbX3Pt7yzSU9EHsxG)_

## Summary by Sourcery

Harden the deterministic verification pipeline so tautology and diff-coverage guards remain fed, are distinguishable when unmeasured, and surface their findings directly in verdicts.

New Features:
- Introduce a tri-state MutationAudit for witness mutation results, aligned with DiffCoverage and exposed through ladder inputs and snapshots.
- Add guard-wiring tests that exercise both mutation and coverage probes together to ensure they are invoked and produce measured values before deterministic credit is granted.

Enhancements:
- Refine unverified evidence messaging so withheld deterministic credit explicitly names whether diff-coverage or mutation audit caused the downgrade.
- Move the scripted coverage probe from the diff_coverage test module up to the parent verification_hardening test module for shared use.
- Ensure the unfed state of both guards is explicitly modeled as the crediting state, while remaining distinguishable from a cleared audit in snapshots and tests.

Tests:
- Add end-to-end verification_hardening guard_wiring scenarios covering tautology-only, coverage-only, and both-guards-satisfied paths, plus a value-level assertion of the unfed guard state.
- Extend mutation verification tests to cover MutationAudit’s tri-state semantics and its mapping to the wire snapshot.