### PR TITLE
fix(stella-cli): stop a candidate worktree moving the graded tree's refs

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -27,6 +27,23 @@
 //! was, a user edit or a candidate that wrote outside its snapshot (see
 //! [`adopt::PathDivergence`]).
 //!
+//! # What isolation does NOT cover: the ref namespace (#2541)
+//!
+//! A shadow worktree isolates the working **tree**, not the **ref**
+//! namespace: it shares one `.git` with the graded tree, so `refs/heads/*`,
+//! `refs/tags/*` and `refs/stash` are the same objects the user's checkout
+//! reads. Git's own interlock refuses to check out a branch another worktree
+//! holds, but a worker can defeat it (`git checkout
+//! --ignore-other-worktrees`) and then move the graded tree's branch out from
+//! under its index. Two guards close the observed hole, both on the seal:
+//! [`ref_escape::detach_head`] re-detaches a `HEAD` the worker attached, so a
+//! machinery commit — witness scaffolding included — can never land in a
+//! history the user keeps; and [`GitCandidateWorkspace::escaped_refs_inner`]
+//! refuses to seal a candidate whose work has reached a shared ref, naming
+//! what moved and how to put it back. Detection and refusal, not repair:
+//! nothing here writes to the real repository. The structural fix — a
+//! substrate that cannot reach those refs at all — is #1383.
+//!
 //! # What a candidate's engine can reach
 //!
 //! Candidates drive the built-in [`stella_tools::ToolRegistry`] PLUS the session's custom
@@ -75,7 +92,7 @@
 //! `InteractiveToolSet` in a candidate's stack for either MCP phase to
 //! reintroduce it through.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -97,6 +114,7 @@ use crate::agent::{
 
 mod adopt;
 mod escape;
+mod ref_escape;
 mod snapshot_gaps;
 mod task_events;
 mod witness_tools;
@@ -345,6 +363,9 @@ impl GitCandidateWorkspaces {
         let dir_str = dir
             .to_str()
             .ok_or_else(|| snap("temp dir path is not valid UTF-8".to_string()))?;
+        // The ref namespace this candidate is about to share with the graded
+        // tree, recorded before it can move (#2541) — see [`ref_escape`].
+        let refs_at_create = ref_escape::shared_refs(&toplevel).await;
         git(&toplevel, &["worktree", "add", "--detach", dir_str, &head])
             .await
             .map_err(snap)?;
@@ -429,6 +450,7 @@ impl GitCandidateWorkspaces {
                     dir: dir.clone(),
                     root: ws_root.display().to_string(),
                     baseline,
+                    refs_at_create,
                     sealed: Mutex::new(None),
                     tools,
                     witness_tools,
@@ -640,6 +662,11 @@ pub(crate) struct GitCandidateWorkspace {
     root: String,
     /// Immutable baseline commit representing the session tree at creation.
     baseline: String,
+    /// The real repository's refs, and their values, as of this candidate's
+    /// creation. A candidate worktree shares `.git` with the graded tree, so
+    /// this is the only record of what the shared ref namespace looked like
+    /// before the worker could reach it (#2541) — see [`ref_escape`].
+    refs_at_create: BTreeMap<String, String>,
     /// Latest candidate commit whose exact bytes were verified.
     sealed: Mutex<Option<String>>,
     /// The candidate's tool surface: snapshot-rooted registry + custom tools,
@@ -675,6 +702,21 @@ impl GitCandidateWorkspace {
             reason,
             workspace: self.dir.display().to_string(),
         };
+        // #2541: the seal is the moment this candidate's bytes are certified,
+        // so it is also where a candidate that wrote into the GRADED tree's
+        // ref namespace is refused. A worktree isolates files, not refs; the
+        // audit runs before anything else so a candidate that already escaped
+        // never gets a further commit built on top of the damage.
+        let escaped_refs = self.escaped_refs_inner().await;
+        if !escaped_refs.is_empty() {
+            return Err(fail(ref_escape::refusal(&escaped_refs)));
+        }
+        // And the other half: a worker may have attached HEAD to a branch the
+        // user keeps, which would land this machinery commit — witness
+        // scaffolding included — in a history nobody asked to change.
+        // Detaching rewrites HEAD only; the candidate's tree and index are
+        // exactly as the worker left them.
+        ref_escape::detach_head(&self.dir).await.map_err(fail)?;
         git(&self.dir, &["add", "-A"]).await.map_err(fail)?;
         let mut commit_args: Vec<&str> = SNAPSHOT_IDENT.to_vec();
         commit_args.extend([

--- a/crates/stella-cli/src/candidate_ws/ref_escape.rs
+++ b/crates/stella-cli/src/candidate_ws/ref_escape.rs
@@ -50,7 +50,16 @@
 //! is detection, not repair: nothing here writes to the real repository, so
 //! the refusal quotes the value recorded at creation and the one command that
 //! puts it back. The structural fix — a candidate substrate that cannot reach
-//! the graded tree's refs at all — is #1383.
+//! the graded tree's refs at all — is #1383, and the residual repair gap is
+//! #2641.
+//!
+//! One coupling to know before changing either: the attribution probes run
+//! against the REAL repository yet name the candidate's private `baseline` and
+//! `HEAD`, which is only resolvable because the two share an object store —
+//! the very property this module exists to police. A substrate that separates
+//! the object stores (#1383) makes this module unnecessary *and* breaks its
+//! probes in the same stroke; it must be retired with that change, not ported
+//! across it.
 
 use std::collections::BTreeMap;
 use std::path::Path;

--- a/crates/stella-cli/src/candidate_ws/ref_escape.rs
+++ b/crates/stella-cli/src/candidate_ws/ref_escape.rs
@@ -1,0 +1,432 @@
+//! Shared-ref escape detection (#2541) — did this candidate write into the
+//! ref namespace the GRADED tree depends on? A child module of
+//! `candidate_ws`, like [`super::escape`], whose file-level sibling it is:
+//! same seam (immediately around the seal), same best-effort contract, same
+//! insistence on a signature a mid-run *user* action cannot forge.
+//!
+//! [`super::escape`] answers the question for file bytes. This one answers it
+//! for refs, because candidate isolation isolates the working **tree** and not
+//! the **ref namespace**: `git worktree add` gives the candidate its own
+//! checkout but the *same* `.git`, so `refs/heads/*`, `refs/tags/*` and
+//! `refs/stash` are one shared object the graded tree also reads. Git's own
+//! interlock refuses to check out a branch another worktree holds, which is
+//! why the observed failure had to defeat it explicitly
+//! (`git checkout --ignore-other-worktrees master`) — after which every
+//! subsequent commit moved the graded tree's `master` out from under its
+//! index, and the graded tree's `git status` read as a staged reversal of the
+//! entire task.
+//!
+//! # The signature
+//!
+//! A shared ref that simply *moved* proves nothing: a user committing in
+//! their own checkout while a run is in flight moves refs too, and blaming a
+//! candidate for that would be the false positive [`super::escape`] goes to
+//! the same lengths to avoid. A move is this candidate's iff **the ref's new
+//! value is work only this candidate has**, which is exactly two shapes:
+//!
+//! * the new value is an ancestor-or-equal of the candidate's live `HEAD` —
+//!   the candidate committed *onto* the shared branch (the observed shape:
+//!   after `--ignore-other-worktrees`, candidate `HEAD` and `refs/heads/master`
+//!   are the same commit); or
+//! * the candidate's private baseline commit is an ancestor of the new value —
+//!   the candidate's snapshot history was *merged or grafted into* the shared
+//!   ref, which is also how a banned `git stash` shows up (`refs/stash`'s
+//!   first parent is the candidate's `HEAD`).
+//!
+//! Both are qualified by a third probe that removes the one collision either
+//! would otherwise admit: a ref moved **backwards into history the graded
+//! tree already had** (`git reset --hard HEAD~1` in the user's own checkout)
+//! lands on a commit that is trivially an ancestor of the candidate's `HEAD`,
+//! and is a user action, not an escape. So a divergence counts only when the
+//! new value was *not* already reachable from the value recorded at creation.
+//!
+//! # Boundaries, accepted and documented
+//!
+//! Best-effort, like its sibling: every failed probe reports "no escape"
+//! rather than failing a candidate on broken forensics, so this check can
+//! only ever *add* a detection. A **deleted** ref carries no new value to
+//! sign and is deliberately out of scope, as is a rewind to an unrelated
+//! commit — for those the graded tree's own history is the record. And this
+//! is detection, not repair: nothing here writes to the real repository, so
+//! the refusal quotes the value recorded at creation and the one command that
+//! puts it back. The structural fix — a candidate substrate that cannot reach
+//! the graded tree's refs at all — is #1383.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::{GitCandidateWorkspace, git};
+
+/// Ceiling on refs named in one refusal. A candidate that moved more refs
+/// than this has already made the point; the message stays readable and the
+/// probe count stays bounded.
+const MAX_NAMED: usize = 8;
+
+/// One shared ref whose new value is provably this candidate's work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RefEscape {
+    /// Full ref name, e.g. `refs/heads/master`.
+    pub(super) name: String,
+    /// The value recorded when this candidate was created — `None` when the
+    /// candidate created the ref outright.
+    pub(super) before: Option<String>,
+    /// What the ref points at now.
+    pub(super) after: String,
+}
+
+/// Every ref of `toplevel` and its object id, keyed by full ref name.
+///
+/// Read from the real repository, so it sees the shared namespace plus the
+/// *main* worktree's own per-worktree refs — never a candidate's
+/// `refs/worktree/*`, which is what keeps the pipeline's own
+/// [`stella_tools::verify::WITNESS_BASELINE_WORKTREE_REF`] pin out of this
+/// comparison by construction.
+///
+/// Best-effort: an unreadable ref store yields an empty map, which can only
+/// make the later comparison quieter.
+pub(super) async fn shared_refs(toplevel: &Path) -> BTreeMap<String, String> {
+    let Ok(listing) = git(
+        toplevel,
+        &["for-each-ref", "--format=%(objectname) %(refname)"],
+    )
+    .await
+    else {
+        return BTreeMap::new();
+    };
+    listing
+        .lines()
+        .filter_map(|line| {
+            // Ref names cannot contain a space, so the first one splits the
+            // record exactly.
+            let (oid, name) = line.trim_end().split_once(' ')?;
+            Some((name.to_string(), oid.to_string()))
+        })
+        .collect()
+}
+
+/// `git merge-base --is-ancestor <ancestor> <descendant>` in `repo`.
+///
+/// Exit 0 is "yes"; git spells "no" as exit 1 and a broken argument as exit
+/// 128, and [`git`] flattens both into `Err` — which is the conservative
+/// answer for every caller here, since a failed probe must never manufacture
+/// an escape.
+async fn is_ancestor(repo: &Path, ancestor: &str, descendant: &str) -> bool {
+    git(repo, &["merge-base", "--is-ancestor", ancestor, descendant])
+        .await
+        .is_ok()
+}
+
+/// Detach `HEAD` in `dir` if the worker attached it to a branch.
+///
+/// The seal is machinery: it must land in the candidate's private history and
+/// nowhere else. When a worker has pointed the candidate's `HEAD` at a shared
+/// branch, an ordinary `git commit` moves that branch instead — which is how
+/// witness scaffolding reached a branch the user keeps (#2541). Rewriting
+/// `HEAD` itself (`--no-deref`) to the commit it already resolves to detaches
+/// it without touching the index or a single file in the worktree, so the
+/// candidate's work is exactly as the worker left it.
+///
+/// A `HEAD` that is symbolic but unresolvable (a worker's `git checkout
+/// --orphan`) is an error, not a silent pass: committing from there would
+/// mint a new shared branch, which is the very thing this prevents.
+pub(super) async fn detach_head(dir: &Path) -> Result<(), String> {
+    // `symbolic-ref -q HEAD` exits non-zero exactly when HEAD is detached.
+    if git(dir, &["symbolic-ref", "-q", "HEAD"]).await.is_err() {
+        return Ok(());
+    }
+    let head = git(dir, &["rev-parse", "HEAD"])
+        .await
+        .map_err(|e| format!("candidate HEAD is attached to a branch with no commit on it: {e}"))?;
+    git(dir, &["update-ref", "--no-deref", "HEAD", head.trim()])
+        .await
+        .map(|_| ())
+}
+
+impl GitCandidateWorkspace {
+    /// Shared refs of the real repository whose current value is provably
+    /// this candidate's work — see the module docs for the signature.
+    ///
+    /// Cost on a well-behaved candidate: exactly one `git` invocation (the
+    /// ref enumeration against the real repo), because nothing has moved and
+    /// no attribution probe is ever paid.
+    pub(super) async fn escaped_refs_inner(&self) -> Vec<RefEscape> {
+        let now = shared_refs(&self.toplevel).await;
+        let moved: Vec<(&String, &String)> = now
+            .iter()
+            .filter(|(name, after)| self.refs_at_create.get(*name) != Some(*after))
+            .take(MAX_NAMED)
+            .collect();
+        if moved.is_empty() {
+            return Vec::new();
+        }
+        // The candidate's live HEAD, read once: the first signature compares
+        // every moved ref against it.
+        let Ok(head) = git(&self.dir, &["rev-parse", "HEAD"]).await else {
+            return Vec::new();
+        };
+        let head = head.trim().to_string();
+
+        let mut escaped = Vec::new();
+        for (name, after) in moved {
+            let before = self.refs_at_create.get(name);
+            // A ref rewound into history the graded tree already had is the
+            // user's own doing — screen it out before either signature can
+            // read it as candidate work.
+            if let Some(before) = before
+                && is_ancestor(&self.toplevel, after, before).await
+            {
+                continue;
+            }
+            let committed_onto = is_ancestor(&self.toplevel, after, &head).await;
+            let grafted_in =
+                !committed_onto && is_ancestor(&self.toplevel, &self.baseline, after).await;
+            if committed_onto || grafted_in {
+                escaped.push(RefEscape {
+                    name: name.clone(),
+                    before: before.cloned(),
+                    after: after.clone(),
+                });
+            }
+        }
+        escaped
+    }
+}
+
+/// The seal refusal for a candidate that moved refs the graded tree shares.
+///
+/// Says what moved, what it was, and the one command that puts it back —
+/// this module never writes to the real repository, so recovery has to be
+/// spelled out rather than performed.
+pub(super) fn refusal(escaped: &[RefEscape]) -> String {
+    let mut named: Vec<String> = Vec::with_capacity(escaped.len());
+    let mut recovery: Vec<String> = Vec::new();
+    for esc in escaped {
+        match &esc.before {
+            Some(before) => {
+                named.push(format!("{} (was {}, now {})", esc.name, before, esc.after));
+                recovery.push(format!("git update-ref {} {}", esc.name, before));
+            }
+            None => {
+                named.push(format!("{} (created, now {})", esc.name, esc.after));
+                recovery.push(format!("git update-ref -d {}", esc.name));
+            }
+        }
+    }
+    format!(
+        "this candidate moved refs the graded tree shares: {}. A candidate worktree isolates the \
+         working tree but not the ref namespace — it shares `.git` with the real repository, so a \
+         ref write escapes isolation even though every file write is contained. Nothing was \
+         restored; `{}` puts the real repository back",
+        named.join("; "),
+        recovery.join(" && ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_pipeline::ports::CandidateWorkspace;
+    use stella_tools::RegistryOptions;
+
+    use super::super::tests::{scaffold, scratch_git};
+    use super::super::{GitCandidateWorkspaces, git};
+    use super::{RefEscape, refusal};
+
+    fn port(root: std::path::PathBuf) -> GitCandidateWorkspaces {
+        GitCandidateWorkspaces::new(
+            root,
+            RegistryOptions::default(),
+            Default::default(),
+            Vec::new(),
+            crate::rules::ResolvedRules::default(),
+        )
+    }
+
+    /// The branch the scaffold's `git init` produced — `master` or `main`
+    /// depending on the host's `init.defaultBranch`.
+    fn default_branch(root: &std::path::Path) -> String {
+        scratch_git(root, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .trim()
+            .to_string()
+    }
+
+    /// The observed Terminal-Bench `fix-git` shape (#2541): the worker
+    /// defeats git's worktree interlock, commits onto the branch the graded
+    /// tree has checked out, and the graded tree's ref moves out from under
+    /// its index. The seal must refuse and name the ref.
+    #[tokio::test]
+    async fn committing_onto_the_graded_trees_branch_refuses_the_seal() {
+        let root = scaffold("refesc-hijack");
+        let branch = default_branch(&root);
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+
+        // Exactly the observed escape: git refuses a plain checkout of a
+        // branch another worktree holds, so the worker overrides it.
+        scratch_git(
+            ws.dir(),
+            &["checkout", "--ignore-other-worktrees", "-q", &branch],
+        );
+        std::fs::write(ws.dir().join("hijack.txt"), "worker\n").unwrap();
+        scratch_git(ws.dir(), &["add", "hijack.txt"]);
+        scratch_git(ws.dir(), &["commit", "-q", "-m", "worker commit"]);
+
+        let err = ws.seal().await.unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("refs/heads/{branch}")),
+            "the refusal must name the moved ref: {err}"
+        );
+        assert!(
+            err.contains("git update-ref"),
+            "the refusal must spell out recovery: {err}"
+        );
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The other half of #2541: witness scaffolding reached a branch the user
+    /// keeps because the seal committed wherever the worker had left `HEAD`.
+    /// The seal detaches first, so the shared branch cannot receive it — and
+    /// the candidate's own work is untouched by the detach.
+    #[tokio::test]
+    async fn the_seal_never_lands_on_a_branch_the_user_keeps() {
+        let root = scaffold("refesc-detach");
+        let branch = default_branch(&root);
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+        let branch_ref = format!("refs/heads/{branch}");
+        let before = scratch_git(&root, &["rev-parse", &branch_ref])
+            .trim()
+            .to_string();
+
+        // The worker attaches HEAD but commits nothing: the only thing that
+        // would move the shared branch is Stella's own seal.
+        scratch_git(
+            ws.dir(),
+            &["checkout", "--ignore-other-worktrees", "-q", &branch],
+        );
+        std::fs::write(ws.dir().join("witness_lost_changes.sh"), "#!/bin/sh\n").unwrap();
+
+        ws.seal().await.expect("an unescaped candidate still seals");
+
+        assert_eq!(
+            scratch_git(&root, &["rev-parse", &branch_ref]).trim(),
+            before,
+            "the seal must not move a branch the graded tree depends on"
+        );
+        assert!(
+            git(ws.dir(), &["symbolic-ref", "-q", "HEAD"])
+                .await
+                .is_err(),
+            "the seal must leave the candidate's HEAD detached"
+        );
+        // The detach is metadata only — the worker's file is still there and
+        // is what the seal captured.
+        assert!(ws.dir().join("witness_lost_changes.sh").exists());
+        assert!(
+            ws.sealed_is_unchanged().await.unwrap(),
+            "the seal captured the candidate's tree as the worker left it"
+        );
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A user committing in their own checkout while a run is in flight moves
+    /// a shared ref too. That is the false positive this signature exists to
+    /// exclude — the candidate must still seal.
+    #[tokio::test]
+    async fn a_mid_run_user_commit_is_not_a_ref_escape() {
+        let root = scaffold("refesc-user-commit");
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+
+        std::fs::write(root.join("user.txt"), "user\n").unwrap();
+        scratch_git(&root, &["add", "user.txt"]);
+        scratch_git(&root, &["commit", "-q", "-m", "the user's own commit"]);
+
+        ws.seal()
+            .await
+            .expect("a user's own commit must never fail a candidate's seal");
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A branch rewound into history the graded tree already had is trivially
+    /// an ancestor of the candidate's HEAD — and is still the user's doing.
+    #[tokio::test]
+    async fn a_mid_run_user_rewind_is_not_a_ref_escape() {
+        let root = scaffold("refesc-user-rewind");
+        // Two commits so there is somewhere to rewind to.
+        std::fs::write(root.join("second.txt"), "second\n").unwrap();
+        scratch_git(&root, &["add", "second.txt"]);
+        scratch_git(&root, &["commit", "-q", "-m", "second"]);
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+
+        scratch_git(&root, &["reset", "--hard", "-q", "HEAD~1"]);
+
+        ws.seal()
+            .await
+            .expect("a user's own rewind must never fail a candidate's seal");
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The module's other signature: candidate history reaching a shared ref
+    /// without the candidate ever committing onto it. `git stash` is the
+    /// everyday shape — `refs/stash`'s first parent is the candidate's HEAD —
+    /// and the stash is shared machine state the module doc bans outright.
+    #[tokio::test]
+    async fn stashing_from_a_candidate_refuses_the_seal() {
+        let root = scaffold("refesc-stash");
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+
+        std::fs::write(ws.dir().join("tracked.txt"), "base\ndirty\ncandidate\n").unwrap();
+        scratch_git(ws.dir(), &["stash", "push", "-q", "-m", "escape"]);
+
+        let err = ws.seal().await.unwrap_err().to_string();
+        assert!(
+            err.contains("refs/stash"),
+            "the refusal must name the stash ref: {err}"
+        );
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A candidate that touches no ref pays one enumeration and seals.
+    #[tokio::test]
+    async fn an_ordinary_candidate_seals_with_no_ref_findings() {
+        let root = scaffold("refesc-clean");
+        let ws = port(root.clone()).create_workspace().await.unwrap();
+
+        std::fs::write(ws.dir().join("answer.js"), "const answer = 42;\n").unwrap();
+        ws.seal().await.unwrap();
+
+        assert_eq!(ws.escaped_refs_inner().await, Vec::new());
+
+        ws.remove().await;
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn the_refusal_names_a_created_ref_with_a_delete_recovery() {
+        let reason = refusal(&[RefEscape {
+            name: "refs/heads/scratch".to_string(),
+            before: None,
+            after: "abc1234".to_string(),
+        }]);
+        assert!(reason.contains("refs/heads/scratch (created, now abc1234)"));
+        assert!(reason.contains("git update-ref -d refs/heads/scratch"));
+    }
+
+    #[test]
+    fn the_refusal_quotes_the_value_recorded_at_creation() {
+        let reason = refusal(&[RefEscape {
+            name: "refs/heads/master".to_string(),
+            before: Some("1111111".to_string()),
+            after: "2222222".to_string(),
+        }]);
+        assert!(reason.contains("refs/heads/master (was 1111111, now 2222222)"));
+        assert!(reason.contains("git update-ref refs/heads/master 1111111"));
+    }
+}

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -65,7 +65,7 @@ fn candidate_port_keeps_the_exact_host_operation_journal() {
 /// (the verify_done test discipline — without it, running the suite from
 /// inside a git hook re-targets every command at the HOST repo) and
 /// return stdout. Panics on failure: these are test fixtures.
-fn scratch_git(root: &Path, args: &[&str]) -> String {
+pub(super) fn scratch_git(root: &Path, args: &[&str]) -> String {
     let mut cmd = std::process::Command::new("git");
     stella_tools::exec::scrub_sensitive_std_env(&mut cmd);
     cmd.args(args).current_dir(root);


### PR DESCRIPTION
## What & why

Candidate isolation isolates the working **tree**, not the **ref namespace**. A
shadow worktree shares one `.git` with the graded tree, so `refs/heads/*`,
`refs/tags/*` and `refs/stash` are the same objects the user's checkout reads.
Git's own interlock refuses to check out a branch another worktree holds — which
is why the observed failure had to defeat it explicitly
(`git checkout --ignore-other-worktrees master`). After that, the seal commit —
witness scaffolding included — landed on `master`, and the graded tree's
`git status` read as a staged reversal of the entire task.

Two guards, both on the seal, in a new `candidate_ws::ref_escape` module that is
the file-level sibling of `candidate_ws::escape` (#1538) and follows its shape
exactly — same seam, same best-effort contract, same insistence on a signature a
mid-run *user* action cannot forge:

- **`detach_head`** re-detaches a `HEAD` the worker attached to a branch, by
  rewriting `HEAD` itself (`update-ref --no-deref`) to the commit it already
  resolves to. Index and worktree are untouched, so the candidate's work is
  exactly as the worker left it — and a machinery commit can never land in a
  history the user keeps. This is the "witness scaffolding cannot reach a branch
  the user keeps" half of the issue's Done-when.
- **`escaped_refs_inner`** refuses to seal a candidate whose work has reached a
  shared ref, naming what moved, what it was at creation, and the
  `git update-ref` that puts it back. This is the "a guard that refuses and says
  why" branch of the Done-when.

Attribution is the part worth reviewing. A ref that merely *moved* proves
nothing — a user committing in their own checkout mid-run moves refs too. A move
counts only when the new value is work solely this candidate has, which is two
shapes: the new value is an ancestor-or-equal of the candidate's live `HEAD` (it
committed *onto* the shared branch — the observed shape), or the candidate's
private baseline is an ancestor of the new value (its history was merged or
grafted in — also how a banned `git stash` surfaces). Both are qualified by a
third probe that drops a ref which merely rewound into history the graded tree
already had, since `git reset --hard HEAD~1` in the user's own checkout lands on
a commit trivially descended-from by the candidate.

Cost on a well-behaved candidate: exactly one extra `git` invocation per seal
(the ref enumeration). No attribution probe is paid unless something moved.

**Exemplar:** the module is modelled on this repository's own
`candidate_ws/escape.rs` — its `PathDivergence` classification is the direct
precedent for refusing to blame a candidate for a user's concurrent action, and
the two modules are meant to be read side by side.

Closes #2541
Refs #2540
Refs #1383

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Checked the artisanal way — enforcement disabled in `seal_inner` (the audit and
the detach), everything else including the tests left in place:

```
test result: FAILED. 5 passed; 3 failed
failures:
    committing_onto_the_graded_trees_branch_refuses_the_seal
    stashing_from_a_candidate_refuses_the_seal
    the_seal_never_lands_on_a_branch_the_user_keeps
```

The three behavioural tests fail; the five controls — including the two
false-positive guards `a_mid_run_user_commit_is_not_a_ref_escape` and
`a_mid_run_user_rewind_is_not_a_ref_escape` — stay green, which is what makes
the failure attributable to the enforcement rather than to the fixtures. With
enforcement restored, all 8 pass.

`committing_onto_the_graded_trees_branch_refuses_the_seal` reproduces the
Terminal-Bench `fix-git` shape from the issue verbatim, `--ignore-other-worktrees`
included.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — see "Anything reviewers should know?" below
- [x] Docs updated where behavior changed (new `# What isolation does NOT cover:
      the ref namespace` section in the `candidate_ws` module doc; full rationale
      in the new module's own doc)
- [x] `Closes #2541` appears both above and as a commit trailer

Every `make gate` guard runs green except `shellcheck`, which is not installed in
this environment; this PR touches no shell.

No tests were deleted.

## Nothing left behind

- [x] Filed: #2641 — a refused ref escape leaves the graded tree's ref moved
      (refusal names the recovery but never performs it), plus the two accepted
      detection gaps: a *deleted* ref carries no new value to sign, and a rewind
      to an unrelated commit is excluded by the same probe that protects the
      user's own rewind.

Two unrelated test failures were hit and are already tracked, not introduced
here: #2626 (`export::tests` — `main` is red at `703976eb` independent of this
branch) and #2393 (`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`
flakes under load; 2 of 3 solo runs pass on this branch).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `stella-pipeline`'s `ports.rs` and
      `pipeline.rs` are untouched; the refusal travels in the existing
      `WorkspaceError::Seal`, which the pipeline already reports as a candidate
      abort

## Anything reviewers should know?

**This is detection and refusal, not prevention or repair, and that is a
deliberate limit.** The issue's Done-when offers three routes — object-store
separation, a ref-namespace remap, or a guard that refuses and says why — and
this takes the third. The first two were explored and rejected for this PR:

- **Object-store separation** (a private repo with the real one as an
  `objects/info/alternates`) is the honest structural fix, but a fresh `git init`
  does not inherit the real repository's local config. A Git LFS repo would
  check out pointer files raw, `core.autocrlf` and `.gitattributes` filters would
  diverge, and `extensions.objectFormat` / `refStorage` each need matching by
  hand. That is a large surface of git edge cases to be wrong about for years,
  and it is what #1383 tracks.
- **A per-worktree `core.hooksPath` + `reference-transaction` hook** would be
  genuinely enforced, but reaching it needs `extensions.worktreeConfig` enabled
  on the *user's* repository, which breaks this module's stated invariant that
  every command against the real repo is read-only.

So the graded tree is still reachable; what changes is that reaching it now
fails the candidate loudly, in the round that caused it, with recovery spelled
out — and that Stella's own machinery can no longer be the thing that reaches it.
The residual repair gap is #2641.

**`escaped_refs_inner` fails the seal rather than getting its own port method.**
`escape.rs`'s path check has one (`CandidateWorkspace::escaped_paths`), and
symmetry argued for a second. Against it: `ports.rs` sits at 1478 lines and a
documented trait method would push it over the 1500-line ratchet, and
`pipeline.rs` is a grandfathered god file closed to growth. Failing the seal
needs neither file — the pipeline already aborts a candidate on a seal error and
surfaces the reason. If a reviewer prefers the port method, it wants a `ports.rs`
split first, which is its own PR.

**Refusal wording.** `WorkspaceError::Seal`'s reason is prose because that is the
established shape of that variant and no caller branches on it (AGENTS.md
invariant 5's own test: a `String` is a defect when a caller must branch on it).
The `RefEscape` records behind it are typed, so a future caller that does need to
branch has something to branch on without re-parsing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZH9b6SuFBpKHBtVhwXDTg)_

## Summary by Sourcery

Detect and refuse candidate workspaces that modify shared git refs relied on by the graded tree during sealing, ensuring machinery commits cannot land on user branches.

Bug Fixes:
- Prevent candidate worktrees from moving the graded tree’s branch or stash refs during sealing, avoiding unintended changes to the user’s repository state.

Enhancements:
- Document the limits of candidate isolation around the git ref namespace and reference the structural follow-up tracked in #1383.

Tests:
- Add integration tests covering ref escape detection (committing onto graded branches, using git stash), safe mid-run user actions (commits and rewinds), and HEAD detachment behavior for seals.