### PR TITLE
fix(stella-cli): unbreak main — drop a duplicated radius loop that lost its binding

### DIFF
--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -777,12 +777,6 @@ fn the_dashboard_is_monospace_and_square() {
              where a hairline says \"boundary\", and this page is boundaries"
         );
     }
-    for rounded in ["border-radius: 8px", "border-radius: 6px"] {
-        assert!(
-            !html.contains(literal),
-            "`{literal}` bypasses `--radius`: set the token, not the rule"
-        );
-    }
 }
 
 /// The wordmark is lowercase, everywhere the report says it.


### PR DESCRIPTION
## What & why

**`main` does not compile.**

```
error[E0425]: cannot find value `literal` in this scope
   crates/stella-cli/src/export/tests.rs:782
```

`the_dashboard_is_monospace_and_square` ended up with the same corner
assertion **twice**. Two repairs of the earlier export collision each wrote a
version of that loop, and the merge kept one loop's header over the other
loop's body:

```rust
for rounded in ["border-radius: 8px", "border-radius: 6px"] {
    assert!(
        !html.contains(literal),          // <- never bound
        "`{literal}` bypasses `--radius`: set the token, not the rule"
    );
}
```

Neither side is wrong on its own. Only the splice is — and git had no conflict
to report, because the two versions were written into the same region by
different PRs.

## The fix

Delete the orphan. The surviving loop directly above it is a **strict
superset** — it rejects `8px`, `6px`, `3px`, `2px` and `0 6px 6px 0`, where the
orphan rejected `8px` and `6px`. There is no assertion left to preserve, so
repairing the binding would only restore a duplicate.

**No test is deleted or renamed.** One duplicated loop inside a kept test goes.

## The witness

- [x] No witness needed — this repairs a merge splice. The proof is that the
      crate compiles and `export::` is 41/41, where `main` is 0/41 because the
      test binary does not build.

## The gate

- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo test --workspace` — green
- [x] `make guards` — exit 0

## Nothing left behind

- [x] Already filed: **#2613**, which now carries all three incidents from this
      one file. This is the third, and it is the cheapest to detect of the
      three: it does not compile. #2613 asks for CI to run against the merge
      result rather than the branch head, which would have caught this one
      before merge.

The pattern across all three is worth stating plainly, and it is in #2613:
`export.rs` and `export/tests.rs` took **five** PRs inside a few hours
(#2597, #2606, #2610, #2614, #2624). Every author was green on their own tree.
Three of the five merges produced a `main` that no author had ever run.

Unrelated and still open: **#2604** (`events.ts` is second-resolution) and
**#2605** (`days_from_civil` has three copies).

## Anything reviewers should know?

Merge ahead of close review — `main` not compiling blocks every other PR's CI.

There is nothing to weigh here: the deleted lines could not execute.

## Summary by Sourcery

Bug Fixes:
- Fix a compile error in stella-cli export tests by deleting an orphaned border-radius assertion loop that referenced an unbound variable.