### PR TITLE
fix(stella-cli): unbreak main — drop the merge-scarred second radius loop

### DIFF
--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -777,12 +777,6 @@ fn the_dashboard_is_monospace_and_square() {
              where a hairline says \"boundary\", and this page is boundaries"
         );
     }
-    for rounded in ["border-radius: 8px", "border-radius: 6px"] {
-        assert!(
-            !html.contains(literal),
-            "`{literal}` bypasses `--radius`: set the token, not the rule"
-        );
-    }
 }
 
 /// The wordmark is lowercase, everywhere the report says it.


### PR DESCRIPTION
## What & why

`main` does not compile. Since #2628 merged at `2026-08-10T04:52Z`,
`crates/stella-cli/src/export/tests.rs` has held a loop whose header binds
`rounded` and whose body reads `literal`:

```rust
for rounded in ["border-radius: 8px", "border-radius: 6px"] {
    assert!(
        !html.contains(literal),
        "`{literal}` bypasses `--radius`: set the token, not the rule"
    );
}
```

`error[E0425]: cannot find value 'literal' in this scope`, twice.

### How it got there

#2624 and #2628 were two concurrent "unbreak main" PRs that each added a loop
asserting no hardcoded `border-radius` survives the `--radius: 0` token. They
chose different loop variables over different lists:

| PR | binds | list |
|---|---|---|
| #2624 | `literal` | `8px`, `6px`, `3px`, `2px` |
| #2628 | `rounded` | `8px`, `6px`, `3px`, `2px`, `0 6px 6px 0` |

The merge kept **both** loops, and fused #2628's header onto #2624's body. Git
had no conflict to report — this is the rename-vs-edit shape where each side
textually contains what the other lacks, so a clean three-way merge composes
into code that compiles on neither branch.

### Why it is expensive out of proportion to its size

The break is a **compile error in a test target**, not a failing assertion, so
it does not fail one check — it stops three, each of which has to build
`stella-cli`:

- `cargo clippy -D warnings`
- `prompt-cache correctness (golden fixtures)`
- `cargo test`

All three halt at the same two lines in run
[31357554730](https://github.com/macanderson/stella/actions/runs/31357554730).
And because nothing under the error compiles, every assertion in the CLI's test
target is currently unevaluated — a green run after this lands is the first
real signal since 04:52Z.

Every open PR inherits it. **#2644**, the `0.8.23` version sync, is red for
this reason and nothing else; its diff is version numbers.

## The fix

Delete the residual loop. It costs no coverage: both literals it names are the
first two entries of the surviving five-element list, which also covers `3px`,
`2px` and `0 6px 6px 0`. #2628's list is a strict superset of #2624's, and its
failure message is the one that survives.

Six deleted lines, no additions.

## Witness

`main` does not compile — the strongest fail-on-old/pass-on-new there is. The
fail half is observed in CI run 31357554730 rather than locally: a
Terminal-Bench match is occupying this machine, and per the standing rule the
workspace build is CI's job. **CI on this branch is the pass-on-new half — do
not merge this until it is green**, since I have not run the suite locally.

## Deleted tests (for `check-deleted-tests`)

None. No `#[test]` is removed; the deletion is a loop inside
`the_dashboard_is_monospace_and_square`, which stays and keeps asserting the
same thing over a longer list.

## Follow-ups filed

See the issues linked in the thread below — a duplicated-loop merge scar that
no guard catches, and a latent `evidence_is_blind` gap found while auditing
the other open PR.

## Summary by Sourcery

Tests:
- Delete the merge-introduced second border-radius loop in `the_dashboard_is_monospace_and_square`, retaining coverage via the existing superset loop.