### PR TITLE
fix(stella-pipeline): let a verify_done receipt grant the deterministic pass

### DIFF
--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -515,6 +515,14 @@ impl LadderInputs {
     /// evidence, so neither can be blind. Only the total absence qualifies.
     pub fn evidence_is_blind(&self) -> bool {
         !self.flip_achieved
+            // A `verify_done` receipt is an evidence channel like any other,
+            // and omitting it here is a latent bug with a live trigger: this
+            // predicate is checked at rung 3, *above* the credit at rung 4, so
+            // a turn whose only observation was that receipt reads as "nothing
+            // could look" and the abstention swallows it before it can be
+            // credited. The field was added after this predicate was written
+            // and never joined it.
+            && !self.verify_done_flip
             && self.touched_tests_passed.is_none()
             && !self.diff_available
             && self.file_change_events == 0
@@ -664,8 +672,29 @@ pub fn ladder_decision(inputs: &LadderInputs) -> LadderDecision {
     //    opted-in, new warnings) drop this rung through to escalation. Lint
     //    stays excluded from the oracle — it can veto a submit, never
     //    verify one.
-    if inputs.flip_achieved
-        && inputs.touched_tests_passed == Some(true)
+    //
+    //    **Either receipt counts.** `flip_achieved` is the configured
+    //    command's own fail→pass; `verify_done_flip` is the worker's
+    //    `verify_done` run — a pinned baseline, a shadow worktree, the test
+    //    files copied in, red there and green here. Both are deterministic
+    //    observations of the same shape, and #2588 said so in as many words
+    //    ("a configured same-command fail-to-pass flip **or** a typed built-in
+    //    `verify_done` request replayed against the sealed final tree").
+    //
+    //    It stopped being read when the veto conjuncts came back, and the
+    //    consequence is not small: with no `--test-command` the oracle never
+    //    arms, and nothing authors a witness any more, so `flip_achieved` can
+    //    never be true — which made this rung unreachable for every task that
+    //    does not ship its own test command. `verify_done` is the replacement
+    //    the model-free design leans on; it has to be able to grant the pass
+    //    it earns.
+    if (inputs.flip_achieved || inputs.verify_done_flip)
+        // A configured-command flip must also leave the suite it belongs to
+        // green. A `verify_done` receipt has no such companion — it ran both
+        // trees itself — so demanding one would reject the very evidence this
+        // arm exists to credit. A *red* suite never reaches here either way:
+        // rung 1 returned `Revise`.
+        && (!inputs.flip_achieved || inputs.touched_tests_passed == Some(true))
         && inputs.diff_lines <= inputs.diff_budget
         && inputs.new_diag_errors == 0
         && (!inputs.veto_warnings || inputs.new_diag_warnings == 0)

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -229,6 +229,96 @@ fn full_deterministic_pass_submits_fast() {
     assert_eq!(decision, LadderDecision::SubmitFast);
 }
 
+/// **The witness.** A `verify_done` receipt grants the deterministic pass on
+/// its own, with no configured test command anywhere in sight.
+///
+/// This is the shape the model-free pipeline actually runs in. With no
+/// `--test-command` the flip oracle never arms, and nothing authors a witness
+/// any more, so `flip_achieved` can never be true — which left this rung
+/// unreachable for every task that does not ship its own test command, and on
+/// Terminal-Bench that is all of them. `verify_done` is the replacement the
+/// design leans on, so it has to be able to grant the pass it earns.
+///
+/// Two things had to be true for it to work, and both were false:
+/// the credit at rung 4 has to *read* the field, and the abstention at rung 3
+/// has to stop swallowing the turn first — `evidence_is_blind` did not count
+/// the receipt as a channel, so a `verify_done`-only turn read as "nothing
+/// could look".
+#[test]
+fn a_verify_done_receipt_alone_submits_fast() {
+    let inputs = LadderInputs {
+        // No configured command: the oracle never armed and no suite ran.
+        flip_achieved: false,
+        touched_tests_passed: None,
+        // The worker's own shadow-worktree run: red on the pinned baseline,
+        // green on the change.
+        verify_done_flip: true,
+        no_test_surface: true,
+        diff_lines: 12,
+        diff_budget: 400,
+        diff_available: true,
+        file_change_events: 1,
+        mutating_actions: 3,
+        ..Default::default()
+    };
+    assert!(
+        !inputs.evidence_is_blind(),
+        "a verify_done receipt is an observation; a turn carrying one is not blind"
+    );
+    assert_eq!(
+        ladder_decision(&inputs),
+        LadderDecision::SubmitFast,
+        "a deterministic fail→pass receipt is completion authority whether the oracle \
+         or the worker's verify_done produced it"
+    );
+}
+
+/// The receipt is credited, not waved through: the refutations that apply to a
+/// configured flip apply to it too.
+#[test]
+fn a_verify_done_receipt_is_still_subject_to_the_refutations() {
+    let sound = LadderInputs {
+        verify_done_flip: true,
+        diff_lines: 12,
+        diff_budget: 400,
+        diff_available: true,
+        file_change_events: 1,
+        mutating_actions: 3,
+        ..Default::default()
+    };
+    assert_eq!(ladder_decision(&sound), LadderDecision::SubmitFast);
+
+    let over_budget = LadderInputs {
+        diff_lines: 5_000,
+        ..sound
+    };
+    assert_eq!(
+        ladder_decision(&over_budget),
+        LadderDecision::Unverified,
+        "a receipt does not account for a change far larger than it"
+    );
+
+    let regressed = LadderInputs {
+        new_diag_errors: 1,
+        ..sound
+    };
+    assert_eq!(
+        ladder_decision(&regressed),
+        LadderDecision::Unverified,
+        "the #861 veto applies to either receipt"
+    );
+
+    let red = LadderInputs {
+        touched_tests_passed: Some(false),
+        ..sound
+    };
+    assert_eq!(
+        ladder_decision(&red),
+        LadderDecision::Revise,
+        "a red suite is a deterministic failure whatever else was receipted"
+    );
+}
+
 /// The Terminal-Bench trial from #973, reconstructed as ladder inputs:
 /// the task directory is not a git repository so `git diff` cannot read it,
 /// there is no test command so the oracle never armed and no tests ran, and


### PR DESCRIPTION
## Problem

#2588 stated completion authority as:

> a configured same-command fail-to-pass flip **or a typed built-in `verify_done`
> request replayed against the sealed final tree**

The second half is not wired. On `origin/main` today:

- `verify_done_flip` is computed — `pipeline/evidence.rs`, from
  `state.signals.verify_done_confirmations > 0`
- it is read in **exactly one place**: `LadderInputs::verifier_pass_stands_alone`,
  a predicate about a *model verifier's* pass, which no longer exists
- `ladder_decision` never reads it
- `verify_done` appears **0 times** in `pipeline.rs`, and `verify_done_request`
  appears nowhere in `crates/stella-pipeline/src`

So the receipt is computed, carried onto the snapshot, and discarded.

## Why it matters

This is not a cosmetic gap, because of what else changed around it. With no
`--test-command` the flip oracle never arms, and nothing authors a witness any
more, so `flip_achieved` **can never be true**. `verify_done` was the only other
route to a receipt.

Net effect on `main`: **`SubmitFast` is unreachable for any task that does not
ship its own test command.** On Terminal-Bench that is all of them — every run
ends `Unverified`, and the deterministic pass the model-free design was built
around cannot be earned.

`verify_done` is precisely the mechanism the design leans on in place of the
retired witness author: a pinned baseline, a shadow worktree, the test files
copied in, red there and green here. It has to be able to grant the pass it
earns.

## The fix

Two changes, and both are needed, because the abstention sits *above* the credit:

1. **Rung 4 accepts either receipt.** A configured-command flip must still leave
   the suite it belongs to green; a `verify_done` receipt has no companion suite
   — it ran both trees itself — so demanding one would reject the very evidence
   this arm exists to credit. A *red* suite never reaches here either way: rung 1
   already returned `Revise`.

   Every refutation still applies to both receipts: diff budget, the #861
   diagnostics veto, the #870 mutation audit, #1291 coverage. This widens what
   counts as a receipt, not what counts as proof.

2. **`evidence_is_blind` counts the receipt as a channel.** It was written before
   `verify_done_flip` existed and never joined it. Because rung 3 runs before
   rung 4, a turn whose *only* observation was that receipt read as "nothing
   could look" and was swallowed by the abstention before it could be credited.

## Witness

`a_verify_done_receipt_alone_submits_fast` — no configured command, no suite
result, a `verify_done` receipt and a visible diff.

`a_verify_done_receipt_is_still_subject_to_the_refutations` — the same receipt
over budget, beside a fresh diagnostic error, and beside a red suite.

Both **fail on `main`'s `verify.rs`** with `Unverified` where `SubmitFast` is
expected, and pass here. Checked the artisanal way, by swapping
`git show origin/main:crates/stella-pipeline/src/verify.rs` into place and
re-running.

## Verification

`stella-pipeline`, `stella-protocol`, `stella-tui` — build, test and clippy all
exit `0`.

`cargo build --workspace` does **not** pass, and not because of this change:
`crates/stella-cli/src/export/tests.rs` on `main` has a `for rounded in [...]`
loop whose body still references `literal`, a half-applied rename. This branch
touches no `stella-cli` file (`git diff origin/main --stat -- crates/stella-cli`
is empty). #2645 and #2646 are both already open to fix it.

Refs #2588, #2612, #2569

## Summary by Sourcery

Allow a verify_done receipt to grant a deterministic SubmitFast decision and ensure it is treated as observable evidence rather than ignored.

Bug Fixes:
- Treat verify_done_flip as an evidence channel so verify_done-only turns are no longer classified as blind and blocked before credit can be given.
- Allow either a configured flip or a verify_done receipt to satisfy the deterministic pass rung, restoring SubmitFast for tasks without a test command.

Tests:
- Add tests confirming that a lone verify_done receipt can submit fast and that it remains subject to all existing refutation rules (budget, diagnostics, red suites).