### PR TITLE
feat(design-system): put the published benchmark pages and the playbook on the instrument system

### DIFF
--- a/crates/stella-cli/tests/design_token_parity.rs
+++ b/crates/stella-cli/tests/design_token_parity.rs
@@ -214,6 +214,53 @@ fn surfaces() -> Vec<Surface> {
                 // No `identity`, for the same reason as the client above.
             ],
         },
+        // The two published benchmark pages. They are the reference the
+        // instrument palette was drawn FROM, and the report already agreed
+        // with the Observatory value for value — it simply had nothing
+        // holding it there, which is the drift condition, not the absence of
+        // it. The index did not agree: it carried a warm editorial palette and
+        // a bronze accent while the report one click away was achromatic, so a
+        // reader crossing that link watched the page change temperature.
+        //
+        // Both take the explicit `data-theme` gates rather than the media
+        // query, for the same reason `canonical()` does: identical values, and
+        // it is the gate a reader's own toggle reaches.
+        //
+        // These are published surfaces, and #2594 is right that a published
+        // surface is not automatically an instrument — but an index to a set
+        // of measurements, and the measurements themselves, are. Neither
+        // carries `identity`: the benchmark scores stella against another
+        // harness, so the same reasoning that keeps stella's mark out of the
+        // arena's chrome applies here.
+        Surface {
+            file: "docs/benchmarks/index.html",
+            dark: (r#":root[data-theme="dark"]{"#, "}"),
+            light: (r#":root[data-theme="light"]{"#, "}"),
+            names: &[
+                ("ground", "--bg"),
+                ("surface", "--sub"),
+                ("text", "--ink"),
+                ("text-2", "--ink-2"),
+                ("text-3", "--ink-3"),
+                ("ok", "--pass"),
+                // No `bad`: an index lists reports, and none of them is a
+                // failure state. No `warn` for the same reason.
+            ],
+        },
+        Surface {
+            file: "docs/benchmarks/terminal-bench-2-1-glm-5-2.html",
+            dark: (r#":root[data-theme="dark"]{"#, "}"),
+            light: (r#":root[data-theme="light"]{"#, "}"),
+            names: &[
+                ("ground", "--bg"),
+                ("surface", "--sub"),
+                ("text", "--ink"),
+                ("text-2", "--ink-2"),
+                ("text-3", "--ink-3"),
+                ("ok", "--pass"),
+                ("bad", "--fail"),
+            ],
+        },
     ]
 }
 

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -3,58 +3,108 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Benchmarks · Stella</title>
-<meta name="description" content="Pre-registered benchmark reports for Stella, published with the raw per-trial data.">
+<title>Benchmarks · stella</title>
+<meta name="description" content="Pre-registered benchmark reports for stella, published with the raw per-trial data.">
 <style>
+/* The benchmark index — the page a reader lands on before opening a report.
+
+   It is on the web instrument system, in the SAME token vocabulary as
+   terminal-bench-2-1-glm-5-2.html beside it, so the two can be held together
+   by crates/stella-cli/tests/design_token_parity.rs against the Observatory's
+   single definition (crates/stella-observatory/src/assets/index.html).
+
+   It was not. This file carried a warm editorial palette (--bg #F7F5F3, --ink
+   #1A1614), a Georgia serif body, a third family for headings, and a bronze
+   --a #B4741C spent on link and card hover — while the report one click away
+   was already achromatic and monospaced. A reader crossing that link watched
+   the page change temperature and typeface, which reads as two different
+   sites rather than one index and its child. An index to a set of
+   measurements is an instrument, whatever else the published surfaces are
+   (#2594).
+
+   The accent hue is gone rather than re-pointed. On a page whose only job is
+   to hand a reader a number, a hue in the chrome competes with --pass, which
+   is the one colour here that means something; hover is a value change
+   instead. */
 *,*::before,*::after{box-sizing:border-box}
 body,h1,h2,p,ul{margin:0} ul{list-style:none;padding:0}
 :root{
-  --bg:#F7F5F3; --panel:#FFFFFF; --ink:#1A1614; --ink-2:#5C534D; --ink-3:#8B8078;
-  --rule:#E2DCD6; --rule-2:#CFC7BF; --a:#B4741C; --pass:#3F7A50;
+  --bg:#FFFFFF; --sub:#FAFAFA; --panel:#FFFFFF;
+  --ink:#0A0A0A; --ink-2:#525252; --ink-3:#8F8F8F;
+  --rule:#EAEAEA; --rule-2:#D4D4D4; --pass:#11703A;
+  --wash:rgba(10,10,10,.06);
+  --mono:"JetBrains Mono",ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  /* The Instrument scale. Prose runs at 14/1.7/300 and caps at 68ch; labels
+     are 11px uppercase at .16em; a headline measurement is tabular. */
+  --fs-label:11px; --fs-sm:12px; --fs-base:13px; --fs-prose:14px; --fs-lg:22px;
+  --fw-prose:300; --fw-ui:500; --fw-metric:600;
+  --tr-label:.16em; --tr-display:-.03em;
+  --measure:68ch; --lh-prose:1.7;
+  --sp-4:4px; --sp-8:8px; --sp-12:12px; --sp-16:16px; --sp-24:24px;
+  --sp-32:32px; --sp-48:48px; --sp-64:64px;
+  --dur-state:120ms;
 }
 @media (prefers-color-scheme:dark){:root{
-  --bg:#14110F; --panel:#1C1815; --ink:#F2EDE7; --ink-2:#B5AAA1; --ink-3:#7E736B;
-  --rule:#2C2622; --rule-2:#3D352F; --a:#E8A33D; --pass:#6FB183;}}
+  --bg:#0A0A0A; --sub:#0F0F0F; --panel:#111111;
+  --ink:#EDEDED; --ink-2:#A1A1A1; --ink-3:#6E6E6E;
+  --rule:#1F1F1F; --rule-2:#2E2E2E; --pass:#4CC38A;
+  --wash:rgba(237,237,237,.08);}}
 :root[data-theme="dark"]{
-  --bg:#14110F; --panel:#1C1815; --ink:#F2EDE7; --ink-2:#B5AAA1; --ink-3:#7E736B;
-  --rule:#2C2622; --rule-2:#3D352F; --a:#E8A33D; --pass:#6FB183;}
+  --bg:#0A0A0A; --sub:#0F0F0F; --panel:#111111;
+  --ink:#EDEDED; --ink-2:#A1A1A1; --ink-3:#6E6E6E;
+  --rule:#1F1F1F; --rule-2:#2E2E2E; --pass:#4CC38A;
+  --wash:rgba(237,237,237,.08);}
 :root[data-theme="light"]{
-  --bg:#F7F5F3; --panel:#FFFFFF; --ink:#1A1614; --ink-2:#5C534D; --ink-3:#8B8078;
-  --rule:#E2DCD6; --rule-2:#CFC7BF; --a:#B4741C; --pass:#3F7A50;}
+  --bg:#FFFFFF; --sub:#FAFAFA; --panel:#FFFFFF;
+  --ink:#0A0A0A; --ink-2:#525252; --ink-3:#8F8F8F;
+  --rule:#EAEAEA; --rule-2:#D4D4D4; --pass:#11703A;
+  --wash:rgba(10,10,10,.06);}
 body{background:var(--bg); color:var(--ink);
-  font:400 17px/1.62 Georgia,"Iowan Old Style","Times New Roman",serif;
+  font:400 var(--fs-base)/1.55 var(--mono);
+  font-variant-numeric:tabular-nums;
   -webkit-font-smoothing:antialiased}
-.mono{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; font-variant-numeric:tabular-nums}
-.wrap{max-width:820px; margin:0 auto; padding:0 24px}
-.crumb{border-bottom:1px solid var(--rule); font-family:ui-monospace,Menlo,monospace;
-  font-size:11.5px; letter-spacing:.06em}
-.crumb .wrap{display:flex; gap:10px; align-items:center; padding:13px 24px}
-.crumb a{color:var(--ink-3); text-decoration:none} .crumb a:hover{color:var(--a)}
+.mono{font-family:var(--mono); font-variant-numeric:tabular-nums}
+.wrap{max-width:820px; margin:0 auto; padding:0 var(--sp-24)}
+.crumb{border-bottom:1px solid var(--rule); font-size:var(--fs-label);
+  letter-spacing:.06em}
+.crumb .wrap{display:flex; gap:var(--sp-8); align-items:center; padding:var(--sp-12) var(--sp-24)}
+.crumb a{color:var(--ink-3); text-decoration:none; transition:color var(--dur-state) linear}
+.crumb a:hover{color:var(--ink)}
 .crumb .sep{color:var(--rule-2)} .crumb .here{color:var(--ink-2)}
-header{padding:56px 0 34px; border-bottom:1px solid var(--rule)}
-.eyebrow{font-family:ui-monospace,Menlo,monospace; font-size:11.5px; letter-spacing:.16em;
-  text-transform:uppercase; color:var(--ink-3); margin-bottom:14px}
-h1{font-family:ui-sans-serif,-apple-system,"Segoe UI",sans-serif; font-weight:750;
-  letter-spacing:-.028em; font-size:clamp(28px,4vw,42px); line-height:1.08; margin-bottom:14px}
-.dek{color:var(--ink-2); max-width:58ch}
-main{padding:34px 0 64px}
+header{padding:var(--sp-48) 0 var(--sp-32); border-bottom:1px solid var(--rule-2)}
+.eyebrow{font-size:var(--fs-label); letter-spacing:var(--tr-label); font-weight:var(--fw-ui);
+  text-transform:uppercase; color:var(--ink-3); margin-bottom:var(--sp-12)}
+h1{font-weight:var(--fw-metric); letter-spacing:var(--tr-display);
+  font-size:clamp(28px,4vw,42px); line-height:1.08; margin-bottom:var(--sp-12)}
+.dek{color:var(--ink-2); max-width:var(--measure);
+  font-size:var(--fs-prose); font-weight:var(--fw-prose); line-height:var(--lh-prose)}
+main{padding:var(--sp-32) 0 var(--sp-64)}
+/* A report card. Square, hairlined, and raised by a value step rather than by
+   a shadow — the same way a panel is raised everywhere else in the system. */
 .rep{display:block; text-decoration:none; color:inherit; border:1px solid var(--rule);
-  background:var(--panel); padding:22px 24px; margin-bottom:14px}
-.rep:hover{border-color:var(--a)}
-.rep .t{font-family:ui-sans-serif,-apple-system,sans-serif; font-weight:700; font-size:20px;
-  letter-spacing:-.02em; margin-bottom:6px}
-.rep .d{color:var(--ink-2); font-size:15.5px; margin-bottom:14px}
-.rep .m{display:flex; flex-wrap:wrap; gap:16px; font-family:ui-monospace,Menlo,monospace;
-  font-size:11.5px; color:var(--ink-3); letter-spacing:.05em}
-.rep .m b{color:var(--pass); font-weight:700}
-.note{margin-top:26px; color:var(--ink-3); font-size:14.5px; max-width:58ch}
-a.dl{color:var(--a); text-decoration-color:var(--rule-2); text-underline-offset:3px}
-:focus-visible{outline:2px solid var(--a); outline-offset:3px}
+  background:var(--panel); padding:var(--sp-24); margin-bottom:var(--sp-12);
+  transition:background var(--dur-state) linear, border-color var(--dur-state) linear}
+.rep:hover{border-color:var(--rule-2); background:var(--sub)}
+.rep .t{font-weight:var(--fw-metric); font-size:var(--fs-lg);
+  letter-spacing:var(--tr-display); margin-bottom:var(--sp-8)}
+.rep .d{color:var(--ink-2); font-size:var(--fs-prose); font-weight:var(--fw-prose);
+  line-height:var(--lh-prose); max-width:var(--measure); margin-bottom:var(--sp-12)}
+.rep .m{display:flex; flex-wrap:wrap; gap:var(--sp-16);
+  font-size:var(--fs-label); color:var(--ink-3); letter-spacing:.05em}
+/* The score is the one value on this page a reader came for, so it is the one
+   thing that takes a colour. */
+.rep .m b{color:var(--pass); font-weight:var(--fw-metric)}
+.note{margin-top:var(--sp-24); color:var(--ink-3); font-size:var(--fs-sm);
+  max-width:var(--measure); line-height:var(--lh-prose)}
+a.dl{color:var(--ink); text-decoration-color:var(--rule-2); text-underline-offset:3px}
+a.dl:hover{background:var(--wash)}
+:focus-visible{outline:2px solid var(--ink); outline-offset:3px}
+@media (prefers-reduced-motion:reduce){*{animation:none !important; transition:none !important}}
 </style>
 </head>
 <body>
 <div class="crumb"><div class="wrap">
-  <a href="https://stella.oxagen.sh">Stella</a><span class="sep">/</span>
+  <a href="https://stella.oxagen.sh">stella</a><span class="sep">/</span>
   <span class="here">Benchmarks</span>
 </div></div>
 
@@ -69,7 +119,7 @@ a.dl{color:var(--a); text-decoration-color:var(--rule-2); text-underline-offset:
 <main class="wrap">
   <a class="rep" href="/benchmarks/terminal-bench-2-1-glm-5-2.html">
     <div class="t">Terminal-Bench 2.1 — same model, different harness</div>
-    <div class="d">Stella and Claude Code ran the same 89 terminal tasks on the same model,
+    <div class="d">Both stella and Claude Code ran the same 89 terminal tasks on the same model,
       on the same machine, at the same hour. Isolating the harness from the model.</div>
     <div class="m">
       <span>2026-07-31</span>

--- a/docs/benchmarks/terminal-bench-2-1-glm-5-2.html
+++ b/docs/benchmarks/terminal-bench-2-1-glm-5-2.html
@@ -5,13 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="A paired 89-task Terminal-Bench 2.1 comparison holding the model fixed and changing only the agent harness. Every trial inspectable.">
 <meta property="og:title" content="Terminal-Bench 2.1: same model, different harness">
-<meta property="og:description" content="Stella 58, Claude Code 44, on identical GLM-5.2. Every trial inspectable.">
+<meta property="og:description" content="stella 58, Claude Code 44, on identical GLM-5.2. Every trial inspectable.">
 <style>*,*::before,*::after{box-sizing:border-box}
 body,h1,h2,p,ul,pre{margin:0} ul{list-style:none;padding:0}
 button{font:inherit;color:inherit} table{border-collapse:collapse}</style>
 </head>
 <body>
-<title>Terminal-Bench 2.1: same model, different harness · Stella Benchmarks</title>
+<title>Terminal-Bench 2.1: same model, different harness · stella Benchmarks</title>
 <style>
 /* Neutral monochrome, per the docs house style: no accent hue in the chrome.
    The only colour on this page is semantic — a task passed or it did not. */
@@ -51,7 +51,7 @@ h1,h2,h3{letter-spacing:-.022em; text-wrap:balance; font-weight:640; margin:0}
 a{color:var(--ink); text-decoration:underline; text-decoration-color:var(--rule-2);
   text-underline-offset:3px}
 a:hover{text-decoration-color:var(--ink)}
-:focus-visible{outline:2px solid var(--ink); outline-offset:3px; border-radius:2px}
+:focus-visible{outline:2px solid var(--ink); outline-offset:3px; border-radius:0}
 
 .crumb{border-bottom:1px solid var(--rule)}
 .crumb .wrap{display:flex; gap:9px; align-items:center; padding:13px 28px;
@@ -111,7 +111,7 @@ strong{font-weight:625}
 .toolbar{display:flex; flex-wrap:wrap; gap:7px; align-items:center; margin:0 0 15px}
 .chip{font-family:ui-monospace,Menlo,monospace; font-size:11.5px; padding:6px 12px;
   border:1px solid var(--rule-2); background:transparent; color:var(--ink-2); cursor:pointer;
-  border-radius:3px; letter-spacing:.02em}
+  border-radius:0; letter-spacing:.02em}
 .chip:hover{border-color:var(--ink-3); color:var(--ink)}
 .chip[aria-pressed="true"]{background:var(--ink); color:var(--bg); border-color:var(--ink)}
 .count{margin-left:auto; font-family:ui-monospace,Menlo,monospace; font-size:11.5px; color:var(--ink-3)}
@@ -133,7 +133,7 @@ td.task{text-align:left; font-size:13px; color:var(--ink); max-width:270px; over
   text-overflow:ellipsis}
 td.sep{border-left:1px solid var(--rule)}
 .v{display:inline-block; font-size:10.5px; letter-spacing:.05em; text-transform:uppercase;
-  padding:3px 7px; border-radius:3px; font-weight:600}
+  padding:3px 7px; border-radius:0; font-weight:600}
 .v.ok{color:var(--pass); background:var(--pass-bg)}
 .v.no{color:var(--fail); background:var(--fail-bg)}
 .v.err{color:var(--ink-3); background:var(--code)}
@@ -161,7 +161,7 @@ tr.detail>td{padding:0; background:var(--code); border-bottom:1px solid var(--ru
 pre{background:var(--code); border:1px solid var(--rule); padding:15px 17px; overflow-x:auto;
   font-family:ui-monospace,Menlo,monospace; font-size:12.5px; line-height:1.62; margin:20px 0}
 code{font-family:ui-monospace,Menlo,monospace; font-size:.9em; background:var(--code);
-  padding:1.5px 5px; border:1px solid var(--rule); border-radius:2px}
+  padding:1.5px 5px; border:1px solid var(--rule); border-radius:0}
 pre code{background:none; border:none; padding:0}
 ul{padding-left:19px; margin:0 0 17px} li{margin-bottom:9px}
 footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,monospace; font-size:11.5px}
@@ -174,7 +174,7 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
 </style>
 
 <div class="crumb"><div class="wrap">
-  <a href="https://stella.oxagen.sh">Stella</a><span class="sep">/</span>
+  <a href="https://stella.oxagen.sh">stella</a><span class="sep">/</span>
   <a href="/benchmarks/">Benchmarks</a><span class="sep">/</span>
   <span class="here">Terminal-Bench 2.1</span>
 </div></div>
@@ -186,7 +186,7 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
     <p class="dek">Two agents ran the same 89 terminal tasks on the same model, on the same
       machine, at the same hour. One solved fourteen more of them.</p>
     <div class="score">
-      <div class="sc win"><div class="who">Stella</div><div class="big">58</div>
+      <div class="sc win"><div class="who">stella</div><div class="big">58</div>
         <div class="sub">of 89 · 65.2%</div></div>
       <div class="sc"><div class="who">Claude Code</div><div class="big">44</div>
         <div class="sub">of 89 · 49.4%</div></div>
@@ -244,10 +244,10 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
   </div>
   <div class="grid2">
     <div class="hd"></div><div class="hd">Claude Code solved</div><div class="hd">Claude Code failed</div>
-    <div class="hd">Stella solved</div>
+    <div class="hd">stella solved</div>
     <div><div class="cell">36<small>both — no signal</small></div></div>
-    <div class="key"><div class="cell">22<small>Stella only</small></div></div>
-    <div class="hd">Stella failed</div>
+    <div class="key"><div class="cell">22<small>stella only</small></div></div>
+    <div class="hd">stella failed</div>
     <div><div class="cell">8<small>Claude Code only</small></div></div>
     <div><div class="cell">23<small>neither — model ceiling</small></div></div>
   </div>
@@ -267,16 +267,16 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
   <div class="prose">
     <p>The failure classes explain more than the totals do. Claude Code recorded
       <strong>25 non-zero-exit failures</strong> — the agent stopped and left the workspace
-      short of the goal. Stella recorded <strong>2</strong>. In the other direction, Stella
+      short of the goal. stella recorded <strong>2</strong>. In the other direction, stella
       spent more of its failures on the clock, still working when time ran out.</p>
     <p>That is the shape the thesis predicts. A harness that verifies before it stops converts
       "I think I'm done" into another attempt. The cost shows up exactly where you would
       expect: more tool actions, more tokens, more wall-clock — and more tasks finished.</p>
     <p>The tool-count gap deserves its own sentence, because read carelessly it looks like
-      waste. Claude Code funnels nearly everything through one general-purpose shell; Stella
+      waste. Claude Code funnels nearly everything through one general-purpose shell; stella
       ships many small single-purpose tools — one that reads, one that edits, one that inspects
       what changed, one that runs tests. More calls is the design, not the inefficiency. The
-      efficiency question is answered by cost per success, and there Stella is
+      efficiency question is answered by cost per success, and there stella is
       <strong>cheaper</strong>: $1.35 against $1.44.</p>
   </div>
 </section>
@@ -286,7 +286,7 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
   <div class="toolbar">
     <button class="chip" data-f="all" aria-pressed="true">All 89</button>
     <button class="chip" data-f="disc" aria-pressed="false">Disagreements (30)</button>
-    <button class="chip" data-f="a" aria-pressed="false">Stella only (22)</button>
+    <button class="chip" data-f="a" aria-pressed="false">stella only (22)</button>
     <button class="chip" data-f="b" aria-pressed="false">Claude Code only (8)</button>
     <button class="chip" data-f="both" aria-pressed="false">Both solved (36)</button>
     <button class="chip" data-f="none" aria-pressed="false">Neither (23)</button>
@@ -295,7 +295,7 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
   <div class="tscroll"><table>
     <thead><tr>
       <th data-s="k">Task<span class="ar"></span></th>
-      <th class="grp" data-s="av">Stella<span class="ar"></span></th>
+      <th class="grp" data-s="av">stella<span class="ar"></span></th>
       <th data-s="at">Tools<span class="ar"></span></th>
       <th data-s="ao">Out tok<span class="ar"></span></th>
       <th data-s="ac">Cost<span class="ar"></span></th>
@@ -318,7 +318,7 @@ footer{padding:38px 0 66px; color:var(--ink-3); font-family:ui-monospace,Menlo,m
     <div class="sk">Effort</div><div>max, reasoning enabled, for every role that affects the outcome</div>
     <div class="sk">Budget</div><div>No spend cap on either agent</div>
     <div class="sk">Attempts</div><div>1 per task, 0 retries, both agents</div>
-    <div class="sk">Endpoint</div><div>Stella → OpenRouter · Claude Code → z.ai <em>(the one intended difference)</em></div>
+    <div class="sk">Endpoint</div><div>stella → OpenRouter · Claude Code → z.ai <em>(the one intended difference)</em></div>
     <div class="sk">Host</div><div>One machine, both agents concurrently, same clock</div>
     <div class="sk">Pre-registered</div><div>Commit, binary hash, config hash and task list fixed before launch</div>
   </div>
@@ -411,18 +411,18 @@ function detail(r){
     ["Steps",r.a&&r.a.st,r.b&&r.b.st,"lower"],["Tool actions",r.a&&r.a.t,r.b&&r.b.t,null],
     ["Input tokens",r.a&&r.a.i,r.b&&r.b.i,"lower"],["Output tokens",r.a&&r.a.o,r.b&&r.b.o,"lower"],
     ["Cost",r.a&&r.a.c,r.b&&r.b.c,"lower"],["Wall clock",r.a&&r.a.w,r.b&&r.b.w,"lower"],
-    // Stella-only telemetry, and marked as such (#1211 §6.5). This is read
+    // stella-only telemetry, and marked as such (#1211 §6.5). This is read
     // from `stella-events.jsonl`, which the Claude Code arm does not write, so
     // its 0 on all 89 rows is the absence of a source — not a measurement of
     // zero. Rendered as a comparison with "lower is better" it handed Claude
     // Code a win on every row and totalled to a 106-vs-0 that reads as a
-    // finding about the agents. The Stella figure is itself inferred (a step
+    // finding about the agents. The stella figure is itself inferred (a step
     // that spent >=16K output tokens and called no tool) against a 64K
     // ceiling, so it over-counts long answers as truncations; the reported
     // `finish_reason` now replaces that inference on new runs.
-    ["Output-cap hits (Stella telemetry only)",r.a&&r.a.cap,null,null]];
+    ["Output-cap hits (stella telemetry only)",r.a&&r.a.cap,null,null]];
   let h='<div class="dpanel"><p class="dhead">'+r.k+' — full telemetry, side by side</p><div class="cmp">'
-    +'<div class="lab hdr"></div><div class="hdr">Stella</div><div class="hdr">Claude Code</div>';
+    +'<div class="lab hdr"></div><div class="hdr">stella</div><div class="hdr">Claude Code</div>';
   for(const [lab,av,bv,better] of rows){
     if(lab==="Verdict"){ h+='<div class="lab">'+lab+'</div><div>'+av+'</div><div>'+bv+'</div>'; continue; }
     if(bv===null){
@@ -430,7 +430,7 @@ function detail(r){
       // the other side has no source, rather than printing a 0 that reads as
       // a measured result.
       h+='<div class="lab">'+lab+'</div><div>'+fmt(av||0)+'</div>'
-        +'<div class="v">not measured — no Stella telemetry on this arm</div>';
+        +'<div class="v">not measured — no stella telemetry on this arm</div>';
       continue;
     }
     const A=av||0,B=bv||0,mx=Math.max(A,B,1);

--- a/docs/playbooks/self-improving-model.html
+++ b/docs/playbooks/self-improving-model.html
@@ -3,27 +3,81 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Self-Improving Model · Stella Playbook</title>
+<title>Self-Improving Model · stella Playbook</title>
 <style>
+  /* This playbook was on the retired blue family — --bg #0a0e14 through a full
+     hue wheel (--accent2 #58d3ff ice blue, --violet, --gold, --amber), two
+     radial gradients under the body, and an inset-highlight drop shadow. That
+     palette was tried on main for about seven hours and reverted wholesale; a
+     document still wearing it is carrying a dead system, not an alternative
+     one.
+
+     The token NAMES are unchanged and the values are re-pointed, which is the
+     same move arenabench made: ~29 rules below spell these names, and renaming
+     a token is how a page ends up painting elements with nothing. What each
+     name now means:
+
+       --bg/--bg2/--card/--card2   ground / surface / raised / sunken — a card
+                                   reads as raised by a value step of 1–2
+                                   rather than by a shadow
+       --accent                    labels and section numerals. Achromatic:
+                                   they are differentiated by TREATMENT
+                                   (uppercase, tracked, small), not by hue,
+                                   which is the whole instrument premise
+       --accent2                   the secondary label tone
+       --gold/--violet             were categorical marks; now positions on the
+                                   lightness ramp, the one channel that
+                                   survives greyscale printing, colour-vision
+                                   deficiency and a projector
+       --green/--red/--amber       the only real colour here, and only on a
+                                   verdict: ok / bad / warn
+
+     Light is new. The document was dark-only, so half its readers opened a
+     black page on a white desktop. Both schemes are declared at :root with the
+     media query only overriding — never define a colour solely inside a media
+     query, or an explicit choice cannot win. */
   :root{
-    --bg:#0a0e14; --bg2:#0f141c; --card:#131922; --card2:#1a212e;
-    --line:#232b3a; --line2:#2e3849;
-    --ink:#e6edf3; --dim:#8b98a9; --faint:#5c6777;
-    --accent:#7ee787; --accent2:#58d3ff; --warn:#ff9580; --gold:#ffd479; --violet:#c499ff;
-    --green:#56d364; --red:#ff7b72; --amber:#e3b341;
-    --mono:'SF Mono','JetBrains Mono','Fira Code',ui-monospace,Menlo,Consolas,monospace;
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
-    --shadow:0 1px 0 rgba(255,255,255,.04) inset, 0 8px 24px rgba(0,0,0,.4);
+    --bg:#0A0A0A; --bg2:#0F0F0F; --card:#111111; --card2:#151515;
+    --line:#1F1F1F; --line2:#2E2E2E;
+    --ink:#EDEDED; --dim:#A1A1A1; --faint:#6E6E6E;
+    --accent:#6E6E6E; --accent2:#A1A1A1; --warn:#C9A227; --gold:#A1A1A1; --violet:#6E6E6E;
+    --green:#4CC38A; --red:#E5715F; --amber:#C9A227;
+    --mono:"JetBrains Mono",ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+    /* One face. `--sans` survives as a name because rules below spell it, and
+       it now resolves to the same mono stack — the brand has one face and a
+       playbook is not the place it grows a second. */
+    --sans:var(--mono);
+    /* No shadows, ever. A shadow says "floating"; a hairline says "boundary",
+       and this document is a sequence of boundaries. */
+    --shadow:none;
   }
+  @media (prefers-color-scheme:light){:root{
+    --bg:#FFFFFF; --bg2:#FAFAFA; --card:#FFFFFF; --card2:#F6F6F6;
+    --line:#EAEAEA; --line2:#D4D4D4;
+    --ink:#0A0A0A; --dim:#525252; --faint:#8F8F8F;
+    --accent:#8F8F8F; --accent2:#525252; --warn:#7A5C00; --gold:#525252; --violet:#8F8F8F;
+    --green:#11703A; --red:#A32F1F; --amber:#7A5C00;}}
+  :root[data-theme="light"]{
+    --bg:#FFFFFF; --bg2:#FAFAFA; --card:#FFFFFF; --card2:#F6F6F6;
+    --line:#EAEAEA; --line2:#D4D4D4;
+    --ink:#0A0A0A; --dim:#525252; --faint:#8F8F8F;
+    --accent:#8F8F8F; --accent2:#525252; --warn:#7A5C00; --gold:#525252; --violet:#8F8F8F;
+    --green:#11703A; --red:#A32F1F; --amber:#7A5C00;}
   *{box-sizing:border-box}
   html{scroll-behavior:smooth}
   body{
-    margin:0;background:
-      radial-gradient(1200px 600px at 80% -10%, rgba(126,231,135,.05), transparent 60%),
-      radial-gradient(900px 500px at 0% 30%, rgba(88,211,255,.04), transparent 55%),
-      var(--bg);
-    color:var(--ink);font-family:var(--sans);line-height:1.6;
-    font-size:15px;-webkit-font-smoothing:antialiased;
+    /* Flat. The two radial gradients that used to sit here changed the
+       apparent value of every mark drawn over them, which on a document full
+       of measurements is a readability cost paid for decoration that carries
+       no information. */
+    margin:0;background:var(--bg);
+    color:var(--ink);font-family:var(--mono);line-height:1.6;
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    font-variant-numeric:tabular-nums;
+  }
+  @media (prefers-reduced-motion:reduce){
+    html{scroll-behavior:auto}
+    *{animation:none !important;transition:none !important}
   }
   /* layout */
   .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
@@ -34,12 +88,12 @@
   h1 .grad{background:linear-gradient(100deg,var(--accent),var(--accent2));-webkit-background-clip:text;background-clip:text;color:transparent}
   .lede{font-size:18px;color:var(--dim);max-width:680px;margin:0 0 28px}
   .meta{display:flex;gap:10px;flex-wrap:wrap}
-  .pill{font-family:var(--mono);font-size:11px;padding:5px 10px;border:1px solid var(--line2);border-radius:999px;color:var(--dim);background:var(--card)}
+  .pill{font-family:var(--mono);font-size:11px;padding:5px 10px;border:1px solid var(--line2);border-radius:0;color:var(--dim);background:var(--card)}
   .pill .dot{display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--accent);margin-right:6px;vertical-align:middle}
   /* nav */
   nav.toc{position:sticky;top:0;z-index:20;background:rgba(10,14,20,.82);backdrop-filter:blur(10px);border-bottom:1px solid var(--line);margin:0 -24px;padding:0 24px}
   nav.toc ul{list-style:none;display:flex;gap:2px;margin:0;padding:8px 0;overflow-x:auto;white-space:nowrap}
-  nav.toc a{display:block;padding:8px 12px;font-size:13px;color:var(--dim);text-decoration:none;border-radius:6px;transition:.15s}
+  nav.toc a{display:block;padding:8px 12px;font-size:13px;color:var(--dim);text-decoration:none;border-radius:0;transition:.15s}
   nav.toc a:hover{color:var(--ink);background:var(--card)}
   nav.toc a .n{font-family:var(--mono);color:var(--faint);margin-right:6px;font-size:11px}
   /* sections */
@@ -58,7 +112,7 @@
   li{margin:6px 0}
   /* step cards */
   .steps{display:flex;flex-direction:column;gap:20px}
-  .step{background:linear-gradient(180deg,var(--card),var(--card2));border:1px solid var(--line);border-radius:14px;padding:24px 28px;position:relative;box-shadow:var(--shadow);transition:.2s}
+  .step{background:linear-gradient(180deg,var(--card),var(--card2));border:1px solid var(--line);border-radius:0;padding:24px 28px;position:relative;box-shadow:var(--shadow);transition:.2s}
   .step:hover{border-color:var(--line2)}
   .step-head{display:flex;align-items:baseline;gap:14px;margin-bottom:10px}
   .step-no{font-family:var(--mono);font-size:13px;color:var(--accent);flex-shrink:0;width:28px}
@@ -66,13 +120,13 @@
   .step-body{color:var(--dim)}
   .step-body p{margin:8px 0}
   /* code */
-  pre{background:#0b0f16;border:1px solid var(--line);border-radius:10px;padding:16px 18px;overflow-x:auto;margin:14px 0;font-family:var(--mono);font-size:13px;line-height:1.55}
+  pre{background:#0b0f16;border:1px solid var(--line);border-radius:0;padding:16px 18px;overflow-x:auto;margin:14px 0;font-family:var(--mono);font-size:13px;line-height:1.55}
   pre code{color:#c9d4e3;background:none;padding:0}
-  code.inline{background:var(--card2);border:1px solid var(--line2);padding:2px 6px;border-radius:5px;color:var(--accent2)}
+  code.inline{background:var(--card2);border:1px solid var(--line2);padding:2px 6px;border-radius:0;color:var(--accent2)}
   .tok-kw{color:var(--violet)} .tok-fn{color:var(--accent2)} .tok-str{color:var(--accent)}
   .tok-com{color:var(--faint);font-style:italic} .tok-typ{color:var(--gold)} .tok-att{color:var(--amber)}
   /* callout */
-  .callout{border-left:3px solid var(--accent2);background:rgba(88,211,255,.05);padding:14px 18px;border-radius:0 8px 8px 0;margin:16px 0}
+  .callout{border-left:3px solid var(--accent2);background:rgba(88,211,255,.05);padding:14px 18px;border-radius:0;margin:16px 0}
   .callout.warn{border-color:var(--warn);background:rgba(255,149,128,.06)}
   .callout.key{border-color:var(--accent);background:rgba(126,231,135,.05)}
   .callout .lbl{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--accent2);margin-bottom:4px}
@@ -80,7 +134,7 @@
   .callout p{margin:2px 0;color:var(--dim)}
   /* component map */
   .map-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:14px;margin:20px 0}
-  .crate{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:16px;transition:.15s}
+  .crate{background:var(--card);border:1px solid var(--line);border-radius:0;padding:16px;transition:.15s}
   .crate:hover{border-color:var(--line2);transform:translateY(-2px)}
   .crate .cn{font-family:var(--mono);font-size:13px;color:var(--accent);margin-bottom:2px}
   .crate .cd{font-size:13px;color:var(--dim);margin:0}
@@ -96,10 +150,10 @@
   th{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--faint)}
   td{color:var(--dim)} td code{color:var(--accent2)}
   /* diagram */
-  .diagram{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:28px;margin:20px 0;text-align:center}
+  .diagram{background:var(--card);border:1px solid var(--line);border-radius:0;padding:28px;margin:20px 0;text-align:center}
   .diagram svg{max-width:100%;height:auto}
   /* phase band */
-  .phase-band{display:flex;gap:0;margin:24px 0;border-radius:10px;overflow:hidden;border:1px solid var(--line)}
+  .phase-band{display:flex;gap:0;margin:24px 0;border-radius:0;overflow:hidden;border:1px solid var(--line)}
   .phase{flex:1;padding:18px 14px;background:var(--card2);border-right:1px solid var(--line);text-align:center}
   .phase:last-child{border-right:none}
   .phase .pi{font-family:var(--mono);font-size:11px;color:var(--faint);margin-bottom:4px}
@@ -107,7 +161,7 @@
   .phase .pd{font-size:11px;color:var(--dim);margin-top:2px}
   /* footer */
   footer{padding:48px 0 64px;color:var(--faint);font-size:13px}
-  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:4px;background:var(--card);border:1px solid var(--line2);color:var(--dim);margin:0 4px}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:0;background:var(--card);border:1px solid var(--line2);color:var(--dim);margin:0 4px}
   @media(max-width:640px){h1{font-size:30px}.phase-band{flex-direction:column}.phase{border-right:none;border-bottom:1px solid var(--line)}}
 </style>
 </head>
@@ -116,9 +170,9 @@
 <!-- ============ HERO ============ -->
 <header class="hero">
   <div class="wrap">
-    <p class="eyebrow">Playbook · Stella × Self-Improvement</p>
-    <h1>Build a <span class="grad">Self-Improving Model</span><br>into Stella</h1>
-    <p class="lede">A step-by-step engineering plan to close the loop — collect traces, extract rewards from Stella's verify→verdict ladder, fine-tune, re-evaluate on the bench harness, and redeploy through the <code class="mono">Provider</code> trait — without breaking the pipeline's guarantees.</p>
+    <p class="eyebrow">Playbook · stella × Self-Improvement</p>
+    <h1>Build a <span class="grad">Self-Improving Model</span><br>into stella</h1>
+    <p class="lede">A step-by-step engineering plan to close the loop — collect traces, extract rewards from stella's verify→verdict ladder, fine-tune, re-evaluate on the bench harness, and redeploy through the <code class="mono">Provider</code> trait — without breaking the pipeline's guarantees.</p>
     <div class="meta">
       <span class="pill"><span class="dot"></span>17 crates · Rust workspace</span>
       <span class="pill">Provider trait · stella-protocol</span>
@@ -150,7 +204,7 @@
 <section id="map">
   <div class="wrap">
     <h2><span class="num">00</span>Terrain map — what already exists</h2>
-    <p class="sec-sub">Stella already ships most of the machinery a self-improvement loop needs. The work is wiring, not greenfield. Know these surfaces before you touch anything.</p>
+    <p class="sec-sub">stella already ships most of the machinery a self-improvement loop needs. The work is wiring, not greenfield. Know these surfaces before you touch anything.</p>
     <div class="map-grid">
       <div class="crate"><p class="cn">stella-protocol</p><p class="cd">The <code>Provider</code> trait + <code>CompletionRequest/Result</code>. Every model — including your fine-tuned one — plugs in here.</p></div>
       <div class="crate"><p class="cn">stella-model</p><p class="cd">Concrete adapters: Z.ai (GLM 5.2), Anthropic, OpenAI, Gemini, Vertex, Bedrock. <code>factory.rs</code>, <code>catalog.rs</code>.</p></div>
@@ -163,7 +217,7 @@
     </div>
     <div class="callout key">
       <p class="lbl">Key realization</p>
-      <p>You are not building a self-improvement system from zero. Stella already has a <strong>closed feedback loop</strong> (verify→verdict→revise), a <strong>persistent memory</strong> (ContextStore), and an <strong>eval harness</strong> (bench/). Self-improvement = adding a training step on the cold path between "the loop produced an outcome" and "the loop runs again with a better model."</p>
+      <p>You are not building a self-improvement system from zero. stella already has a <strong>closed feedback loop</strong> (verify→verdict→revise), a <strong>persistent memory</strong> (ContextStore), and an <strong>eval harness</strong> (bench/). Self-improvement = adding a training step on the cold path between "the loop produced an outcome" and "the loop runs again with a better model."</p>
     </div>
   </div>
 </section>
@@ -172,7 +226,7 @@
 <section id="loop">
   <div class="wrap">
     <h2><span class="num">01</span>The self-improvement loop</h2>
-    <p class="sec-sub">One sentence: <strong>run → record → reward → refine → re-evaluate → redeploy → run.</strong> Each phase maps onto an existing Stella subsystem.</p>
+    <p class="sec-sub">One sentence: <strong>run → record → reward → refine → re-evaluate → redeploy → run.</strong> Each phase maps onto an existing stella subsystem.</p>
 
     <div class="diagram">
       <svg viewBox="0 0 900 240" xmlns="http://www.w3.org/2000/svg">
@@ -238,13 +292,13 @@
 <section id="collect">
   <div class="wrap">
     <h2><span class="num">02</span>Phase 1 — Collect execution traces</h2>
-    <p class="sec-sub">Before a model can improve, you need structured records of what it did and what happened. Stella already emits <code class="mono">AgentEvent</code>s at every pipeline stage boundary and routes lifecycle telemetry through the hooks system. Capture them.</p>
+    <p class="sec-sub">Before a model can improve, you need structured records of what it did and what happened. stella already emits <code class="mono">AgentEvent</code>s at every pipeline stage boundary and routes lifecycle telemetry through the hooks system. Capture them.</p>
 
     <div class="steps">
       <div class="step">
         <div class="step-head"><span class="step-no">2.1</span><h3>Tap the hooks channel</h3></div>
         <div class="step-body">
-          <p>The <code class="mono">HookRunner</code> trait (<code class="mono">stella-core/src/hooks.rs:249</code>) is Stella's lifecycle telemetry bus. It fires at every step boundary with a structured JSON payload. Implement a hook that writes each event to an append-only trace store — a JSONL file or a SQLite table.</p>
+          <p>The <code class="mono">HookRunner</code> trait (<code class="mono">stella-core/src/hooks.rs:249</code>) is stella's lifecycle telemetry bus. It fires at every step boundary with a structured JSON payload. Implement a hook that writes each event to an append-only trace store — a JSONL file or a SQLite table.</p>
 <pre><code><span class="tok-com">// stella-observatory or a new crate: stella-trace</span>
 <span class="tok-kw">pub struct</span> <span class="tok-typ">TraceSink</span> {
     out: <span class="tok-typ">Mutex</span>&lt;<span class="tok-typ">LineWriter</span>&gt;,
@@ -308,7 +362,7 @@
 <section id="reward">
   <div class="wrap">
     <h2><span class="num">03</span>Phase 2 — Extract reward signal</h2>
-    <p class="sec-sub">This is Stella's superpower for self-improvement: the pipeline already <strong>verifies</strong> every outcome through a deterministic-first ladder and an independent model judge. That verdict <em>is</em> your reward. You don't need to build a reward model from scratch — you need to export the one Stella already computes.</p>
+    <p class="sec-sub">This is stella's superpower for self-improvement: the pipeline already <strong>verifies</strong> every outcome through a deterministic-first ladder and an independent model judge. That verdict <em>is</em> your reward. You don't need to build a reward model from scratch — you need to export the one stella already computes.</p>
 
     <div class="steps">
       <div class="step">
@@ -325,7 +379,7 @@
           </table>
           <div class="callout key">
             <p class="lbl">Why this matters</p>
-            <p>Stella's ladder is <strong>deterministic-first</strong> — it only spends a model judge call on genuinely inconclusive evidence (design lesson L-E11). That means most of your reward labels are grounded in real test execution, not another model's opinion. This is rare and valuable training signal.</p>
+            <p>stella's ladder is <strong>deterministic-first</strong> — it only spends a model judge call on genuinely inconclusive evidence (design lesson L-E11). That means most of your reward labels are grounded in real test execution, not another model's opinion. This is rare and valuable training signal.</p>
           </div>
         </div>
       </div>
@@ -333,7 +387,7 @@
       <div class="step">
         <div class="step-head"><span class="step-no">3.2</span><h3>Enrich the reward with cost and efficiency</h3></div>
         <div class="step-body">
-          <p>A purely outcome-based reward ignores that the model took 12 steps and $0.40 to do what should take 3 steps and $0.05. Stella already meters both:</p>
+          <p>A purely outcome-based reward ignores that the model took 12 steps and $0.40 to do what should take 3 steps and $0.05. stella already meters both:</p>
           <ul>
             <li><strong>Step count</strong> — from <code class="mono">EngineConfig::max_steps</code> tracking; fewer is better.</li>
             <li><strong>USD cost</strong> — <code class="mono">BudgetGuard</code> meters every completion into per-role envelopes (triage/worker/judge).</li>
@@ -350,7 +404,7 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
       <div class="step">
         <div class="step-head"><span class="step-no">3.3</span><h3>Respect the feedback airlock when labeling</h3></div>
         <div class="step-body">
-          <p>Critical subtlety: Stella's <strong>feedback airlock</strong> (<code class="mono">witness::airlock</code>) redacts model-authored text (judge reasoning, distress guidance) before it reaches the worker, to prevent the worker from gaming sealed test material. When you export reward labels, use the <em>deterministic outcome</em> as ground truth — treat judge reasoning as soft signal only, never as a training target. Otherwise you risk training the model to fool the judge.</p>
+          <p>Critical subtlety: stella's <strong>feedback airlock</strong> (<code class="mono">witness::airlock</code>) redacts model-authored text (judge reasoning, distress guidance) before it reaches the worker, to prevent the worker from gaming sealed test material. When you export reward labels, use the <em>deterministic outcome</em> as ground truth — treat judge reasoning as soft signal only, never as a training target. Otherwise you risk training the model to fool the judge.</p>
           <div class="callout warn">
             <p class="lbl">Guardrail</p>
             <p>Never train on the <em>content</em> of distress-guidance prompts or judge reasoning as if they were correct outputs. They are steering text, not ground truth. The deterministic flip oracle and test execution are your only hard labels.</p>
@@ -393,7 +447,7 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
       <div class="step">
         <div class="step-head"><span class="step-no">4.2</span><h3>Preference pairs — for DPO</h3></div>
         <div class="step-body">
-          <p>For the same prompt where you have a <em>chosen</em> (high-reward) and <em>rejected</em> (low-reward) trajectory, build Direct Preference Optimization pairs. Stella's best-of-N candidate isolation (<code class="mono">stella-pipeline/src/candidate.rs</code>) already generates multiple candidates per task and scores them — mine it for natural preference pairs.</p>
+          <p>For the same prompt where you have a <em>chosen</em> (high-reward) and <em>rejected</em> (low-reward) trajectory, build Direct Preference Optimization pairs. stella's best-of-N candidate isolation (<code class="mono">stella-pipeline/src/candidate.rs</code>) already generates multiple candidates per task and scores them — mine it for natural preference pairs.</p>
 <pre><code>{
   "prompt": ...,
   "chosen":  &lt;completion from CandidateScore::DeterministicPass&gt;,
@@ -405,7 +459,7 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
       <div class="step">
         <div class="step-head"><span class="step-no">4.3</span><h3>RL rollout set — for online improvement</h3></div>
         <div class="step-body">
-          <p>For RL (GRPO/PPO), you don't pre-label — you need a set of <em>tasks</em> the model can attempt, with a <em>verifier</em> that returns reward. Stella <em>is</em> that verifier. Define the rollout set as repeatable bench tasks (see Phase 4) and let the verify ladder score each rollout live.</p>
+          <p>For RL (GRPO/PPO), you don't pre-label — you need a set of <em>tasks</em> the model can attempt, with a <em>verifier</em> that returns reward. stella <em>is</em> that verifier. Define the rollout set as repeatable bench tasks (see Phase 4) and let the verify ladder score each rollout live.</p>
         </div>
       </div>
 
@@ -427,13 +481,13 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
 <section id="train">
   <div class="wrap">
     <h2><span class="num">05</span>Phase 3 — Fine-tune the model</h2>
-    <p class="sec-sub">The training itself happens outside Stella (on a GPU cluster with your framework of choice — Axolotl, TRL, OpenRLHF). Stella's job ends at producing clean data and a reliable verifier. Start simple, escalate only when returns plateau.</p>
+    <p class="sec-sub">The training itself happens outside stella (on a GPU cluster with your framework of choice — Axolotl, TRL, OpenRLHF). stella's job ends at producing clean data and a reliable verifier. Start simple, escalate only when returns plateau.</p>
 
     <div class="steps">
       <div class="step">
         <div class="step-head"><span class="step-no">5.1</span><h3>Stage A — Supervised fine-tuning (SFT) on winners</h3></div>
         <div class="step-body">
-          <p>Always start here. SFT on the proven-winner dataset (4.1). This teaches the model Stella's <em>style</em> — the staged reasoning, tool-call format, when to stop. It's the cheapest, most reliable first improvement and it de-risks everything after.</p>
+          <p>Always start here. SFT on the proven-winner dataset (4.1). This teaches the model stella's <em>style</em> — the staged reasoning, tool-call format, when to stop. It's the cheapest, most reliable first improvement and it de-risks everything after.</p>
           <p><strong>Base model:</strong> a small open model in <code class="mono">stella-model</code>'s catalog (e.g. a GLM-class or Llama-class model you can host). Keep parameter count modest — the goal is agentic behavior, not world knowledge.</p>
         </div>
       </div>
@@ -446,12 +500,12 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
       </div>
 
       <div class="step">
-        <div class="step-head"><span class="step-no">5.3</span><h3>Stage C — Online RL with Stella as the verifier (advanced)</h3></div>
+        <div class="step-head"><span class="step-no">5.3</span><h3>Stage C — Online RL with stella as the verifier (advanced)</h3></div>
         <div class="step-body">
-          <p>The endgame: the model attempts bench tasks, Stella's verify ladder scores each attempt in real time, and the reward backpropagates. This closes the loop fully — the model literally learns from Stella's own verification. Wire the reward function (3.2) as the RL reward and the <code class="mono">FlipOracle</code> / test execution as the environment.</p>
+          <p>The endgame: the model attempts bench tasks, stella's verify ladder scores each attempt in real time, and the reward backpropagates. This closes the loop fully — the model literally learns from stella's own verification. Wire the reward function (3.2) as the RL reward and the <code class="mono">FlipOracle</code> / test execution as the environment.</p>
           <div class="callout">
             <p class="lbl">Architecture</p>
-            <p>RL training loop → calls Stella <code class="mono">Engine::run_turn</code> on a bench task → pipeline produces <code class="mono">LadderDecision</code> + cost → reward scalar → gradient step. The <code class="mono">Provider</code> trait is the interface the training server speaks to dispatch completions to the in-training model.</p>
+            <p>RL training loop → calls stella <code class="mono">Engine::run_turn</code> on a bench task → pipeline produces <code class="mono">LadderDecision</code> + cost → reward scalar → gradient step. The <code class="mono">Provider</code> trait is the interface the training server speaks to dispatch completions to the in-training model.</p>
           </div>
         </div>
       </div>
@@ -463,7 +517,7 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
 <section id="eval">
   <div class="wrap">
     <h2><span class="num">06</span>Phase 4 — Re-evaluate on the bench harness</h2>
-    <p class="sec-sub">Never trust training loss. Prove the new model is better on Stella's frozen evaluation suite before it touches production. The <code class="mono">bench/</code> directory is your battleground.</p>
+    <p class="sec-sub">Never trust training loss. Prove the new model is better on stella's frozen evaluation suite before it touches production. The <code class="mono">bench/</code> directory is your battleground.</p>
 
     <div class="steps">
       <div class="step">
@@ -496,7 +550,7 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
       <div class="step">
         <div class="step-head"><span class="step-no">6.3</span><h3>Gate the deploy on a regression check</h3></div>
         <div class="step-body">
-          <p>A model that gains 3% on SWE-bench but regresses 15% on loop-bench is a net loss. Define a promotion gate: candidate must beat baseline on the primary metric <em>and</em> not regress beyond a threshold on any secondary. This mirrors Stella's own philosophy — proportionate verification, escalate on evidence.</p>
+          <p>A model that gains 3% on SWE-bench but regresses 15% on loop-bench is a net loss. Define a promotion gate: candidate must beat baseline on the primary metric <em>and</em> not regress beyond a threshold on any secondary. This mirrors stella's own philosophy — proportionate verification, escalate on evidence.</p>
           <div class="callout warn">
             <p class="lbl">Watch for reward hacking</p>
             <p>If resolve rate rises but step count and cost spike, the model may be brute-forcing. If judge-escalation drops but resolve rate is flat, it may be gaming the flip oracle. Always read metrics <em>together</em>, never in isolation.</p>
@@ -518,13 +572,13 @@ reward = outcome_label            <span class="tok-com"># +1 / -1 / +0.5 / -0.5<
 <section id="deploy">
   <div class="wrap">
     <h2><span class="num">07</span>Phase 4 — Redeploy through the Provider trait</h2>
-    <p class="sec-sub">Stella's clean port architecture makes deployment trivial in principle. The <code class="mono">Provider</code> trait (<code class="mono">stella-protocol/src/provider.rs:69</code>) is the single integration surface — your fine-tuned model is just another adapter.</p>
+    <p class="sec-sub">stella's clean port architecture makes deployment trivial in principle. The <code class="mono">Provider</code> trait (<code class="mono">stella-protocol/src/provider.rs:69</code>) is the single integration surface — your fine-tuned model is just another adapter.</p>
 
     <div class="steps">
       <div class="step">
         <div class="step-head"><span class="step-no">7.1</span><h3>Serve the fine-tuned model behind an OpenAI-compatible endpoint</h3></div>
         <div class="step-body">
-          <p>The path of least resistance: host your fine-tuned model with vLLM, TGI, or llama.cpp server — all expose an OpenAI-compatible chat completions API. Stella's existing <code class="mono">openai.rs</code> adapter then points at your endpoint with zero new code.</p>
+          <p>The path of least resistance: host your fine-tuned model with vLLM, TGI, or llama.cpp server — all expose an OpenAI-compatible chat completions API. stella's existing <code class="mono">openai.rs</code> adapter then points at your endpoint with zero new code.</p>
 <pre><code><span class="tok-com"># stella settings: point the openai adapter at your served model</span>
 [model.stella-self]
 provider = <span class="tok-str">"openai"</span>
@@ -557,7 +611,7 @@ api_key = <span class="tok-str">"local"</span></code></pre>
           <p>Add the model to <code class="mono">stella-model/src/catalog.rs</code> and ensure <code class="mono">ProviderResolver::provider_for</code> (<code class="mono">stella-pipeline/src/ports.rs:34</code>) routes <code class="mono">ModelRef</code>s for your model to your adapter. The pipeline's role system (triage/worker/judge) lets you deploy selectively — e.g. use the fine-tuned model as the <em>worker</em> while keeping a frontier model as the <em>judge</em>, preserving the independence guarantee (judge ≠ worker, L-E11).</p>
           <div class="callout key">
             <p class="lbl">Preserve judge independence</p>
-            <p>Stella requires the judge to be a <em>different model</em> than the worker. If you fine-tune for the worker role, keep the judge on a frontier model. The pipeline degrades the authored-witness path when judge == worker — don't lose that safety net.</p>
+            <p>stella requires the judge to be a <em>different model</em> than the worker. If you fine-tune for the worker role, keep the judge on a frontier model. The pipeline degrades the authored-witness path when judge == worker — don't lose that safety net.</p>
           </div>
         </div>
       </div>
@@ -607,10 +661,10 @@ api_key = <span class="tok-str">"local"</span></code></pre>
 <section id="guardrails">
   <div class="wrap">
     <h2><span class="num">09</span>Guardrails — what can go wrong</h2>
-    <p class="sec-sub">Self-improvement is a power tool. These are the ways it cuts you, and how Stella's existing design helps you avoid each.</p>
+    <p class="sec-sub">Self-improvement is a power tool. These are the ways it cuts you, and how stella's existing design helps you avoid each.</p>
 
     <table>
-      <tr><th>Risk</th><th>Mechanism</th><th>Mitigation (Stella-native)</th></tr>
+      <tr><th>Risk</th><th>Mechanism</th><th>Mitigation (stella-native)</th></tr>
       <tr>
         <td><strong>Reward hacking</strong></td>
         <td>Model learns to game the flip oracle or write tests that trivially pass</td>
@@ -639,7 +693,7 @@ api_key = <span class="tok-str">"local"</span></code></pre>
       <tr>
         <td><strong>Cost runaway</strong></td>
         <td>RL rollouts or best-of-N eval burns GPU/API budget</td>
-        <td>Stella's <code class="mono">BudgetGuard</code> meters every call. Wrap the training cycle in a USD ceiling, same as a production turn.</td>
+        <td>stella's <code class="mono">BudgetGuard</code> meters every call. Wrap the training cycle in a USD ceiling, same as a production turn.</td>
       </tr>
     </table>
 
@@ -661,7 +715,7 @@ api_key = <span class="tok-str">"local"</span></code></pre>
       <span class="tag">stella-model</span>
       <span class="tag">bench/</span>
     </p>
-    <p style="margin-top:16px">This playbook references the Stella workspace as indexed. Every crate, trait, and file path is real and current. Adapt training infrastructure (GPU cluster, RL framework) to your environment.</p>
+    <p style="margin-top:16px">This playbook references the stella workspace as indexed. Every crate, trait, and file path is real and current. Adapt training infrastructure (GPU cluster, RL framework) to your environment.</p>
     <p style="color:var(--accent);margin-top:8px;font-family:var(--mono);font-size:12px">run → record → reward → refine → re-evaluate → redeploy → run</p>
   </div>
 </footer>


### PR DESCRIPTION
## What this is

The second half of the design-system sweep: the **published** HTML surfaces.
#2628 (the unbreak plus the three rendered surfaces) has since merged as 89ef5353, so this branch is based on plain `main` and stands alone.

## The benchmark pages were on two different design systems, one click apart

`docs/benchmarks/terminal-bench-2-1-glm-5-2.html` already agreed with the
Observatory **value for value** — it is the reference the instrument palette
was drawn from. `docs/benchmarks/index.html`, which links to it, carried a warm
editorial palette (`--bg #F7F5F3`, `--ink #1A1614`), a Georgia serif body, a
*third* family for headings, and a bronze `--a #B4741C` spent on link and card
hover. A reader crossing that link watched the page change temperature and
typeface — it reads as two sites rather than an index and its child.

The index is now on the same tokens as the report: one face, the achromatic
ramp, square corners, hairlines, the Instrument type and spacing scale, tabular
figures, `prefers-reduced-motion`, and a 68ch measure on every block of prose.
The accent hue is **removed rather than re-pointed** — on a page whose only job
is to hand a reader a number, a hue in the chrome competes with `--pass`, which
is the one colour there that means anything. Hover is a value change instead.

**Both files now join `design_token_parity.rs`**, so they cannot drift apart
again. The report needed no change to join: it was already correct and merely
unguarded, which is the drift condition rather than the absence of it.

## The playbook was still wearing the Nebula

`docs/playbooks/self-improving-model.html` carried kit v2.0 — `--bg #0a0e14`
through a full hue wheel including `--accent2 #58d3ff` ice blue, two radial
gradients under the body, and an inset-highlight drop shadow. That palette
lived on `main` for about seven hours before being reverted wholesale. A
document still on it is carrying a dead system, not an alternative one.

Token **names** are unchanged and the values re-pointed — the same move
arenabench made — because ~29 rules spell them, and renaming a token is how a
page ends up painting elements with nothing. Gradients and the shadow are gone,
the body is one face, a light scheme is added at `:root` with the media query
only overriding, and every surface corner is square. The one `50%` radius
stays: it is a 6px status dot, a mark rather than a surface, and the Instrument
system's own chips carry a glyph.

## The wordmark, on every HTML page

47 occurrences of `Stella` across the playbook and the benchmark report are now
lowercase, which the brand rule states without qualification.

`scripts/check-brand-case.sh` enumerates `*.mdx` only, so **no tracked `.html`
has ever been checked** — the same hole that shipped a capitalised wordmark in
the export dashboard. Filed as **#2648**; fixing the guard needs care
(compound identifiers, and `brand-guidelines.html` must be able to write
"never `Stella`" to state the rule), so it is not folded in here.

I verified first that neither file contains a compound identifier
(`StellaError`, `StellaHome`) — the guard deliberately exempts those, and a
blanket rewrite would have corrupted them.

## Witness

Against the pre-rewrite index, the parity contract reports **12 divergences**:

```
docs/benchmarks/index.html: dark  `--bg`    (role `ground`) is #14110f, the observatory says #0a0a0a
docs/benchmarks/index.html: light `--bg`    (role `ground`) is #f7f5f3, the observatory says #ffffff
docs/benchmarks/index.html: dark  scheme declares no `--sub` (role `surface`)
docs/benchmarks/index.html: light scheme declares no `--sub` (role `surface`)
docs/benchmarks/index.html: dark  `--ink`   (role `text`)   is #f2ede7, the observatory says #ededed
…
```

Against the rewrite it passes. No test was deleted or renamed in this branch.

## What I deliberately left alone

- **`docs/papers/stella-foundry.html`** — already one face (JetBrains Mono),
  but on the brand kit with gold used freely, including `--gold-deep #A37200`,
  which #2591 measures under AA. A paper is a publication, and #2594 is
  explicit that a published surface may legitimately be entitled to more gold
  than an instrument. That is the decision in #2627, not mine to make here.
- **`docs/brand/**`** — normative source. Restyling the file that *defines* the
  brand against a system derived from it is circular.
- **`website/src/app/*.css`, `website/public/presentations/*.html`** — the live
  docs site and the decks. This is the substance of #2594, and it overlaps
  #2627: whether the published surfaces share the instrument roles at all is
  the open question, not an implementation detail.
- **`.stella/skills/ultra-audit/assets/report.template.html`** — 10px corners
  and two families, but it is local skill content rather than a shipped
  surface.

## Verification

```
cargo test -p stella-cli --test design_token_parity   # 8 passed
make guards-fast                                      # all guards OK
```

**Not verified:** no browser was available in this session, so nothing here was
visually confirmed in a rendered page. The index was rewritten wholesale and
the playbook's tokens re-pointed in place; both should be opened before merge.
Neither file is served by `website/` today — there is no build step copying
`docs/benchmarks|playbooks|papers` — so the blast radius is repo artifacts and
the pages cited as the design reference, not production.

Refs #2594, #2591, #2627, #2648
