### PR TITLE
fix(stella-cli): unbreak main — a merge left an unbound `literal` in the export tests

### DIFF
--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -777,12 +777,6 @@ fn the_dashboard_is_monospace_and_square() {
              where a hairline says \"boundary\", and this page is boundaries"
         );
     }
-    for rounded in ["border-radius: 8px", "border-radius: 6px"] {
-        assert!(
-            !html.contains(literal),
-            "`{literal}` bypasses `--radius`: set the token, not the rule"
-        );
-    }
 }
 
 /// The wordmark is lowercase, everywhere the report says it.


### PR DESCRIPTION
## main does not compile

```
$ cargo test -p stella-cli --bin stella export::tests
error[E0425]: cannot find value `literal` in this scope
   --> crates/stella-cli/src/export/tests.rs:782:28
    |
782 |             !html.contains(literal),
    |                            ^^^^^^^ not found in this scope
error: could not compile `stella-cli` (bin "stella" test) due to 2 previous errors
```

`cargo test --workspace` is a `make gate` step, so this reds every PR branched
from `main` until it lands.

## What happened

Two PRs added a rounded-corner assertion to the same test. #2628 added

```rust
for rounded in ["border-radius: 8px", "border-radius: 6px",
                "border-radius: 3px", "border-radius: 2px",
                "border-radius: 0 6px 6px 0"] {
    assert!(!html.contains(rounded), …);
}
```

and another added

```rust
for literal in ["border-radius: 8px", "border-radius: 6px"] {
    assert!(!html.contains(literal), "`{literal}` bypasses `--radius`…");
}
```

The merge kept **both bodies** but only one header, leaving a loop that binds
`rounded` and reads `literal`. Textually clean — git had no conflict to report,
because neither side's lines were deleted. It is the same shape as the
test-file collisions in #1976 and #1860, one level down: not a lost test, a
lost *binding*.

## The fix

Deleted the second loop rather than rebinding it. Its two literals are a subset
of the five above, both loops assert the same property against the same `html`,
and one assertion in one place is the point of the first loop. Nothing is lost:
`border-radius: 8px` and `6px` are still asserted absent.

## Verification

```
cargo test -p stella-cli --bin stella export::tests   # 26 passed, 0 failed
cargo fmt --all -- --check                            # clean
```

No test was deleted or renamed — a redundant loop *inside* a surviving test was
removed, and the test's assertions are unchanged in effect.

## Why this keeps happening

Fourth time in two days that `crates/stella-cli/src/export/tests.rs` has gone
red from a two-sided edit. The underlying reason — the export dashboard's
appearance has no single source of truth, so independent PRs keep encoding the
same decision in the same file from different directions — is **#2626**.

Refs #2626

## Summary by Sourcery

Bug Fixes:
- Resolve an unbound variable in the export dashboard test that prevented stella-cli from compiling and running tests.