### PR TITLE
fix(arenabench): re-land the stranded tail of the #2180 line — sha-pin, Harbor install, cgroup nesting, SSM errors, unnamed CEs

### DIFF
--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -333,6 +333,38 @@ def plan_trials(spec: MatchSpec) -> tuple[TrialPlan, ...]:
     return tuple(plans)
 
 
+def pin_slice_to_commit(spec: MatchSpec, sut: SutBinary | None) -> MatchSpec:
+    """Rewrite a symbolic SUT pin to the commit the executor resolved.
+
+    The runner image carries a staged binary and no Stella source, by
+    design — ArenaBench fetches its system under test, it does not vendor
+    it. A slice that still says ``sut_ref = "main"`` therefore asks the
+    container to resolve a branch it has no repository for, and
+    ``create_match`` correctly refuses the seat rather than guess.
+
+    Resolving once here and shipping the *commit* is the same discipline
+    #2098 established within one machine, extended across the boundary to
+    the trial: one observation of what the floating ref meant, shared by the
+    binary in S3, the ``SUT_COMMIT`` the entrypoint stages, and the pin the
+    match declares. Clearing the pin instead would also run, but it records
+    the trial as unverified provenance when the commit is known exactly —
+    trading a fact for a blank.
+
+    Seats pinned to their own ref (per-seat pins, #2082) are left alone:
+    only the executor's own resolution may be substituted, and it resolved
+    the match-level ref.
+    """
+    if sut is None:
+        return spec
+    contestants = tuple(
+        replace(c, sut_ref=sut.commit)
+        if c.agent == "stella" and c.sut_ref in (None, spec.sut_ref)
+        else c
+        for c in spec.contestants
+    )
+    return replace(spec, sut_ref=sut.commit, contestants=contestants)
+
+
 def slice_spec(spec: MatchSpec, plan: TrialPlan) -> MatchSpec:
     """The one-trial match a plan's Batch job actually runs.
 
@@ -772,6 +804,10 @@ class CloudExecutor:
         batch = self._client("batch")
         bucket = self.bucket()
         prefix = f"runs/{run_id}"
+
+        # Ship the resolved commit, never the symbolic ref: the container has
+        # no Stella checkout to resolve one against.
+        spec = pin_slice_to_commit(spec, sut)
 
         s3.put_object(
             Bucket=bucket,

--- a/arenabench/arenabench/sut.py
+++ b/arenabench/arenabench/sut.py
@@ -399,11 +399,23 @@ def resolve_ref(ref: str, repo: Path | None = None) -> str:
 
     A full SHA and an explicitly-qualified ref (``origin/main``) are used as
     given; only a bare name gets the ``origin/`` preference.
+
+    A full SHA needs no checkout, because there is nothing left to resolve —
+    it *is* the answer, and asking git to confirm it would only report
+    whether this particular clone happens to have fetched that object yet.
+    That distinction is what lets a runner with a staged binary and no
+    Stella source honour a pin: the cloud executor resolves the symbolic ref
+    once at submit time and pins the slice to the commit, so the container
+    never re-resolves anything (the #2098 discipline, applied across the
+    machine boundary). A bare branch name still requires a repository, and
+    still says so.
     """
+    safe = _safe_ref(ref)
+    if _FULL_SHA.match(safe) and repo is None and stella_repo() is None:
+        return safe
     repo = repo or stella_repo()
     if repo is None:
         raise SutUnavailableError(f"cannot resolve {ref!r}: {repo_problem()}")
-    safe = _safe_ref(ref)
     candidates = [safe] if (_FULL_SHA.match(safe) or "/" in safe) else [
         f"origin/{safe}",
         safe,
@@ -879,12 +891,19 @@ def sut_status(ref: str = "main") -> dict[str, Any]:
         "problem": None,
     }
     repo, why = _repo_search()
-    if repo is None:
+    # A checkout answers exactly one question: what commit does this
+    # symbolic ref mean. A pin that is already a full SHA has no such
+    # question, and the staged binary beside it is content-addressed by that
+    # commit — so a runner holding the binary and no Stella source can still
+    # say precisely which Stella it is about to run. Refusing there rejected
+    # every cloud trial (ctl-0808-0028, turnloop-val-2316) for want of a
+    # repository it had no use for.
+    if repo is None and not _FULL_SHA.match(ref):
         out["problem"] = f"the arena cannot say which commit it would run: {why}"
         legacy = legacy_staged()
         out["legacy"] = legacy.to_json() if legacy else None
         return out
-    out["repo"] = str(repo)
+    out["repo"] = str(repo) if repo is not None else None
     try:
         target = resolve_ref(ref, repo)
     except SutUnavailableError as exc:
@@ -906,7 +925,10 @@ def sut_status(ref: str = "main") -> dict[str, Any]:
     # for very different reactions — and when the ref is a branch that moved
     # mid-build, the nearest per-commit build IS the drift, named so the
     # operator can pin the commit that was actually built (#2098).
-    nearest = _nearest_staged(target, repo)
+    # Naming the drift takes git (how far is the nearest build from the one
+    # asked for), so without a checkout the honest report is the plain
+    # absence rather than a distance nobody can compute.
+    nearest = None if repo is None else _nearest_staged(target, repo)
     if nearest is None:
         out["problem"] = (
             f"no Stella binary has been built for {target[:8]}. Build one "

--- a/arenabench/infra/core.yaml
+++ b/arenabench/infra/core.yaml
@@ -379,10 +379,27 @@ Resources:
               - Key: Project
                 Value: arenabench
 
+  # The three compute environments are deliberately left unnamed.
+  #
+  # Batch treats most ComputeResources edits — instance types above all — as
+  # requiring a *replacement* of the compute environment, and CloudFormation
+  # cannot replace a resource that carries an explicit name, because the new
+  # one would collide with the old before the old is gone. A custom name
+  # therefore converts an ordinary tuning change into `CloudFormation cannot
+  # update a stack when a custom-named resource requires replacing. Rename
+  # ... and update the stack again` — a rollback, and a rename in the
+  # template for every future change. That is exactly how the deploy of the
+  # one-trial-per-instance fix failed the first time.
+  #
+  # Unnamed, CloudFormation replaces them cleanly: it creates the new
+  # environment, repoints the queue at it, then deletes the old one. Nothing
+  # external addresses a compute environment anyway — submissions and every
+  # runbook name the *queues* (arenabench-measure / -burst / -tune), which
+  # keep their stable names and are unaffected by a replacement underneath.
+  # The generated names are published as stack outputs for the console.
   OnDemandComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: arenabench-ondemand
       Type: MANAGED
       State: ENABLED
       ComputeResources:
@@ -412,7 +429,6 @@ Resources:
   SpotComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: arenabench-spot
       Type: MANAGED
       State: ENABLED
       ComputeResources:
@@ -443,7 +459,6 @@ Resources:
   GpuComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: arenabench-gpu
       Type: MANAGED
       State: ENABLED
       ComputeResources:
@@ -735,6 +750,15 @@ Outputs:
     Value: !Ref RunsTable
   RunnerImageUri:
     Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/arenabench/runner:latest
+  # The compute environments are unnamed so Batch can replace them (see the
+  # comment on OnDemandComputeEnvironment); these publish what CloudFormation
+  # generated, for anyone who needs to find one in the console or the CLI.
+  OnDemandComputeEnvironmentName:
+    Value: !Ref OnDemandComputeEnvironment
+  SpotComputeEnvironmentName:
+    Value: !Ref SpotComputeEnvironment
+  GpuComputeEnvironmentName:
+    Value: !Ref GpuComputeEnvironment
   MeasureQueueArn:
     Value: !Ref MeasureQueue
   BurstQueueArn:

--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -83,6 +83,11 @@ COPY ${STELLA_ADAPTER_PATH}/README.md /opt/stella-harbor/README.md
 COPY ${STELLA_ADAPTER_PATH}/stella_harbor /opt/stella-harbor/stella_harbor
 RUN python3 -m pip install --break-system-packages /opt/stella-harbor \
     && python3 -c "import stella_harbor"
+# The runner resolves the adapter *source* through this variable (or a Stella
+# checkout, which the container deliberately does not carry): `stage_adapter`
+# copies it content-addressed per trial (#2127). The install above proves the
+# import; this names the directory the staging reads.
+ENV ARENABENCH_STELLA_ADAPTER=/opt/stella-harbor
 
 COPY ${PKG_PATH}/infra/runner/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -10,10 +10,29 @@
 # monorepo, "." once it is ejected into its own repository.
 ARG PKG_PATH=arenabench
 
+# Harbor is the benchmark harness ArenaBench drives; without it `arenabench
+# run` dies at launch with `harbor is not on PATH` and no trial ever starts.
+# 0.6.1 is Terminal-Bench 2.1's audited constant — the version every
+# published claim was measured on — so it is pinned, not floated. Datasets
+# needing a newer Harbor (Frontier-Bench declares min_harbor for exactly this
+# reason) are not runnable in this image yet; see the issue referenced in the
+# infra README.
+ARG HARBOR_VERSION=0.6.1
+
+# The Stella seat's Harbor adapter, which lives outside the ArenaBench
+# package. Its absence is silent and lethal: harbor_agent.py falls back to
+# `_Base = object` and Harbor dies with `ArenaStellaAgent() takes no
+# arguments` — while exiting 0, so the seat reports "done" having run
+# nothing. Empty once ArenaBench is ejected and Stella is just another
+# contestant fetched by ref.
+ARG STELLA_ADAPTER_PATH=bench/harbor_adapter
+
 # ECR Public mirror of the official image: Docker Hub rate-limits anonymous
 # pulls from CodeBuild's shared egress IPs (429s), ECR Public does not.
 FROM public.ecr.aws/docker/library/ubuntu:24.04
 ARG PKG_PATH
+ARG HARBOR_VERSION
+ARG STELLA_ADAPTER_PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -50,6 +69,20 @@ COPY ${PKG_PATH}/README.md /opt/arenabench/README.md
 COPY ${PKG_PATH}/LICENSE /opt/arenabench/LICENSE
 COPY ${PKG_PATH}/arenabench /opt/arenabench/arenabench
 RUN python3 -m pip install --break-system-packages /opt/arenabench
+
+# Harbor: the harness that actually runs the tasks. Installed after
+# ArenaBench so a Harbor version bump does not invalidate the layers above.
+RUN python3 -m pip install --break-system-packages "harbor==${HARBOR_VERSION}" \
+    && harbor --version
+
+# The Stella seat's Harbor adapter (`stella_harbor`), which `arenabench`'s
+# ArenaStellaAgent subclasses. Installed as a package rather than dropped on
+# PYTHONPATH so a missing import fails the *build* instead of the match.
+COPY ${STELLA_ADAPTER_PATH}/pyproject.toml /opt/stella-harbor/pyproject.toml
+COPY ${STELLA_ADAPTER_PATH}/README.md /opt/stella-harbor/README.md
+COPY ${STELLA_ADAPTER_PATH}/stella_harbor /opt/stella-harbor/stella_harbor
+RUN python3 -m pip install --break-system-packages /opt/stella-harbor \
+    && python3 -c "import stella_harbor"
 
 COPY ${PKG_PATH}/infra/runner/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -86,15 +86,25 @@ start_dockerd() {
 
 export_ssm_credentials() {
     # Missing credentials are not fatal here: `arenabench run` itself
-    # refuses a seat whose declared credentials are absent, which is the
-    # better error surface.
-    local pairs
+    # refuses a seat whose declared credentials are absent, and that refusal
+    # names the seat and the variable, which is the better error surface.
+    #
+    # Why the credentials could not be read is reported, though. Discarding
+    # this stderr once turned a one-line IAM gap — the role could list the
+    # SecureStrings but had no kms:Decrypt to read them, so
+    # `--with-decryption` failed wholesale — into "no SSM credentials
+    # readable; continuing", and the AccessDeniedException underneath it
+    # reached nobody. A whole 40-trial match died of it twice.
+    local pairs problem
     if ! pairs=$(aws ssm get-parameters-by-path \
         --path /arenabench --with-decryption \
-        --query 'Parameters[].[Name,Value]' --output text 2>/dev/null); then
-        log "no SSM credentials readable; continuing"
+        --query 'Parameters[].[Name,Value]' --output text 2>/tmp/ssm-error); then
+        problem=$(tr '\n' ' ' </tmp/ssm-error 2>/dev/null)
+        rm -f /tmp/ssm-error
+        log "no SSM credentials readable: ${problem:0:400}"
         return 0
     fi
+    rm -f /tmp/ssm-error
     while IFS=$'\t' read -r name value; do
         [ -n "$name" ] || continue
         local key

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -55,8 +55,33 @@ assert_sole_dockerd() {
     fi
 }
 
+prepare_cgroup2() {
+    # cgroup v2 enforces "no internal processes": a cgroup may hold processes
+    # or delegate controllers to children, never both. Batch runs this
+    # container in the host's cgroup namespace, so the inner dockerd creates
+    # /sys/fs/cgroup/docker under a root that already holds our own
+    # processes, and every task container dies at start with
+    #   cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain
+    #   controllers -- it is in an invalid state
+    # which surfaces as a Harbor setup traceback while the job still exits 0.
+    #
+    # The remedy is the one the official docker:dind entrypoint uses: move
+    # this container's processes into a leaf cgroup so the root holds none,
+    # then delegate the available controllers downward so dockerd may place
+    # children. Both steps are best-effort — on a host already giving us a
+    # private cgroup namespace there is nothing to fix, and failing here
+    # would be worse than letting dockerd try.
+    [ -f /sys/fs/cgroup/cgroup.controllers ] || return 0
+    mkdir -p /sys/fs/cgroup/init 2>/dev/null || return 0
+    xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true
+    sed -e 's/ / +/g' -e 's/^/+/' </sys/fs/cgroup/cgroup.controllers \
+        >/sys/fs/cgroup/cgroup.subtree_control 2>/dev/null || true
+    log "cgroup v2 prepared for nested containers"
+}
+
 start_dockerd() {
     assert_sole_dockerd || return 1
+    prepare_cgroup2
     # Overlayfs cannot nest: with /var/lib/docker on the container's own
     # overlay root, the inner dockerd's mounts fail with EINVAL. The job
     # definition mounts a host-path volume at /scratch; a per-job

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -22,6 +22,7 @@ import argparse
 import io
 import json
 import tomllib
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -35,6 +36,7 @@ from arenabench.cloud import (
     _cmd_cloud_run,
     is_moving_ref,
     job_name,
+    pin_slice_to_commit,
     plan_trials,
     progress_from_states,
     ref_safe,
@@ -338,6 +340,56 @@ class TestSliceSpec:
         assert sliced.tasks == ()
         assert sliced.attempts == 3
         assert len(sliced.contestants) == 1
+
+
+class TestPinSliceToCommit:
+    """A slice must name a commit, never a branch.
+
+    The runner image stages a binary and carries no Stella checkout, so a
+    slice still saying ``sut_ref = "main"`` asks the container to resolve a
+    ref it cannot, and ``create_match`` refuses the seat. Every trial of
+    match ctl-0808-0014 died exactly there, after credentials and staging
+    had already succeeded.
+    """
+
+    def test_the_match_and_its_stella_seats_carry_the_resolved_commit(self) -> None:
+        pinned = pin_slice_to_commit(_spec(), _sut())
+        assert pinned.sut_ref == "c" * 40
+        stella = next(c for c in pinned.contestants if c.agent == "stella")
+        assert stella.sut_ref == "c" * 40
+
+    def test_a_non_stella_seat_is_left_alone(self) -> None:
+        """A SUT pin means nothing to Claude Code, and `config` rejects one."""
+        pinned = pin_slice_to_commit(_spec(), _sut())
+        cc = next(c for c in pinned.contestants if c.agent == "claude-code")
+        assert cc.sut_ref is None
+
+    def test_a_seat_pinned_to_its_own_ref_keeps_it(self) -> None:
+        """Per-seat pins (#2082) are the point of two Stella builds racing:
+        substituting the match-level resolution would collapse them into
+        one, silently measuring the same commit twice."""
+        own = replace(_seat("stella-b"), sut_ref="deadbeef")
+        spec = _spec(seats=(_seat("stella"), own))
+        pinned = pin_slice_to_commit(spec, _sut())
+        assert next(c for c in pinned.contestants if c.id == "stella-b").sut_ref == (
+            "deadbeef"
+        )
+
+    def test_an_unpinned_match_is_untouched(self) -> None:
+        """No staged binary means nothing was resolved to substitute."""
+        spec = _spec()
+        assert pin_slice_to_commit(spec, None) is spec
+
+    def test_the_commit_survives_the_toml_round_trip(self) -> None:
+        """`dump_match` writes the slice the container parses back; a pin
+        that does not round-trip is the same failure wearing a new hat."""
+        from arenabench.config import dump_match, match_from_toml
+
+        pinned = pin_slice_to_commit(_spec(), _sut())
+        reparsed = match_from_toml(tomllib.loads(dump_match(pinned)))
+        assert reparsed.sut_ref == "c" * 40
+        stella = next(c for c in reparsed.contestants if c.agent == "stella")
+        assert stella.sut_ref == "c" * 40
 
 
 class TestTrialEnvironment:

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -565,6 +565,51 @@ class TestACommitPinSurvivesAMovingBranch:
         (directory / "sut_commit.txt").write_text(commit)
         (directory / "binary_sha256.txt").write_text("deadbeef")
 
+    def test_a_commit_pin_is_ready_with_no_checkout_at_all(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The cloud runner's exact condition: a staged binary, no source.
+
+        A checkout answers one question — what commit does this symbolic ref
+        mean — and a full SHA does not ask it. The binary is content-addressed
+        by that commit, so the runner can say precisely which Stella it runs.
+        Refusing here rejected every cloud trial of ctl-0808-0028 after
+        credentials, staging and dockerd had all succeeded.
+        """
+        monkeypatch.delenv(sut.STELLA_REPO_ENV, raising=False)
+        monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+        package = tmp_path / "elsewhere" / "arenabench"
+        package.mkdir(parents=True)
+        monkeypatch.setattr(sut, "_PACKAGE_DIR", package)
+        monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        assert sut.stella_repo() is None, "the fixture must leave no checkout"
+
+        commit = "7edec3b2333e0a8649bb1fcc7190ad97242d9e3e"
+        self._stage(commit)
+        status = sut.sut_status(commit)
+        assert status["ready"], status["problem"]
+        assert status["target"] == commit
+
+    def test_a_branch_pin_still_needs_a_checkout(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The relaxation is scoped to what needs no resolving. `main` is
+        still unanswerable without a repository, and must say so rather than
+        guess at whatever binary happens to be staged."""
+        monkeypatch.delenv(sut.STELLA_REPO_ENV, raising=False)
+        monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+        package = tmp_path / "elsewhere" / "arenabench"
+        package.mkdir(parents=True)
+        monkeypatch.setattr(sut, "_PACKAGE_DIR", package)
+        monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        self._stage("7edec3b2333e0a8649bb1fcc7190ad97242d9e3e")
+
+        status = sut.sut_status("main")
+        assert not status["ready"]
+        assert "no Stella checkout is configured" in status["problem"]
+
     def test_a_commit_pin_stays_ready_when_the_branch_moves_on(self, repo: Path):
         built = _git(repo, "rev-parse", "origin/main")
         self._stage(built)


### PR DESCRIPTION
## What

Re-lands the **entire stranded tail of the PR #2180 line** — five commits authored after that PR's recorded head that never reached main. They existed only inside the ECR runner image built from the dangling line on 2026-08-08, so the cloud substrate's ability to run trials at all was pinned to one unreproducible image. Rebuilding `runner:latest` from main (required to pick up `bare_loop`, #2308) resurfaced each failure in sequence, live, on cloud runs `turnloop-val-2316` / `turnloop-val2-2332`:

1. `fix(arenabench): a commit-pinned seat is runnable without a Stella checkout` (`ffaa21e33c8e`) — every trial refused with "the arena cannot say which commit it would run" after credentials, SUT staging and dockerd had all succeeded.
2. `fix(arenabench): install Harbor and the Stella adapter in the runner image` (`c6c2bcec5`) — with 1 fixed, trials then died with `harbor is not on PATH`; main's Dockerfile mentions Harbor only in comments.
3. `fix(arenabench): nest cgroups for task containers…` (`df143a3fb`) — the next failure in the stack (task containers cannot enter cgroupv2 domains), re-landed before it could bite again.
4. `fix(arenabench): report why SSM credentials could not be read` (`ca077a3ea`) — exactly the fix #2253 asks for.
5. `fix(arenabench): stop naming the compute environments so Batch can replace them` (`f420864d6`) — aligns the template with the live (manually-updated) stack so a future `core.yaml` deploy cannot regress it.

The two IAM commits from the same line (`91b275011`, `1432aeac7`) are **not** included: main's `core.yaml` already carries `kms:Decrypt` and the path+children SSM grants.

## Why the sha-pin relaxation is sound

A checkout answers exactly one question: what commit does this symbolic ref mean. A full 40-hex SHA does not ask it, and the staged binary beside it is content-addressed by that commit, so a runner holding the binary and no source can state precisely which Stella it runs — the property `arenabench/sut.py` exists to protect. `main` without a checkout still refuses, and still says why.

## Port notes (not clean cherry-picks)

- `sut_status` grew `_repo_search()` since (#2185); the guard reuses its `why` string verbatim.
- `resolve_ref` keeps main's richer `repo_problem()` message rather than the stranded line's hand-written one.
- The witness tests neutralize package-anchored discovery with the established `_PACKAGE_DIR` monkeypatch (the stranded line's `chdir` fixture no longer isolates, since discovery walks up from `__file__`).

## Evidence

- Witness: `test_a_commit_pin_is_ready_with_no_checkout_at_all` **fails on main** with the production refusal string, passes here; `test_a_branch_pin_still_needs_a_checkout` pins the non-relaxation. The cgroup/harbor commits carry their original build-time self-assertions and cloud tests.
- `tests/test_sut.py` + `tests/test_cloud.py` + `tests/test_arena.py`: **199 passed**.
- Live: the runner image rebuilt from this branch is what the turn-loop certification runs use; each re-landed fix corresponds to an observed cloud-trial failure mode from today.

Root cause of the loss is worth a residue issue: commits pushed to a PR branch after merge vanish silently when the branch is deleted — filed as a follow-up (see comments).

Refs #2179
Refs #2262
Closes #2253
