### PR TITLE
feat: stop-on-proof and the prove-it gate — kill tools on oracle flip, fire the halt on verify_done, and make task mode earn its declaration

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -2020,9 +2020,9 @@ async fn run_turn(
         // every other driver path. Wrap the raw registry in `PolicyToolSet`
         // so disabled tools cannot be invoked here either.
         let permitted = PolicyToolSet::new(registry, session_tool_policy(cfg));
-        let engine =
-            Engine::with_sleeper(provider, &permitted, engine_config_for(cfg), &TokioSleeper)
-                .with_calibration(calibration);
+        let config = engine::engine_config_for_kind(cfg, kind);
+        let engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
+            .with_calibration(calibration);
         engine.run_turn_with_sender(messages, budget, &tx).await
     } else {
         let customs = CustomToolSet::new(
@@ -2046,9 +2046,9 @@ async fn run_turn(
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed)
             .with_activation(activated.clone());
         let hook_runner = ShellHookRunner;
-        let mut engine =
-            Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
-                .with_calibration(calibration);
+        let config = engine::engine_config_for_kind(cfg, kind);
+        let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
+            .with_calibration(calibration);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -196,6 +196,18 @@ pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
     )
 }
 
+/// [`engine_config_for`], with the prove-it completion gate (#2663) switched
+/// by the turn's execution kind: a headless `"run"` turn is graded on its
+/// result and must prove a mutation before its declaration stands; a
+/// `"chat"` turn is conversational and keeps the ungated shape. Keyed on the
+/// same `kind` string `begin_execution` records, so the gate and the
+/// telemetry cannot disagree about which mode a turn ran in.
+pub(crate) fn engine_config_for_kind(cfg: &Config, kind: &str) -> EngineConfig {
+    let mut engine = engine_config_for(cfg);
+    engine.completion_gate = kind == "run";
+    engine
+}
+
 /// EngineConfig for a pipeline's execute turns — the WORKER agent's tuning
 /// (plan and witness ride it too, matching the router's tiering).
 /// `worker_model` is [`EngineWiring::worker_model`]: the model the worker
@@ -203,11 +215,15 @@ pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
 /// `agents.worker.*` when set (issue #276), falling back to the session
 /// default (`cfg.provider`/`cfg.model_id`) when unset.
 pub(crate) fn pipeline_engine_config_for(cfg: &Config, worker_model: &ModelRef) -> EngineConfig {
-    tuned_engine_config(
+    let mut engine = tuned_engine_config(
         cfg,
         crate::settings::EngineAgentKind::Worker,
         (&worker_model.provider, &worker_model.model_id),
-    )
+    );
+    // A pipeline execute turn is always task mode: its declaration is graded,
+    // so it proves a mutation before the declaration stands (#2663).
+    engine.completion_gate = true;
+    engine
 }
 
 /// The safe default for CLI-owned headless surfaces: no host approval port,

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -334,14 +334,9 @@ pub trait TurnHalt: Send + Sync + std::fmt::Debug {
     /// `Some(reason)` ends the turn cleanly at the next step boundary;
     /// `None` lets it continue.
     ///
-    /// Called once per committed step AND from inside the dispatch loop —
-    /// between barrier groups and after each settled tool call (#2661) — so
-    /// it must be cheap and must not block. A predicate that fires
-    /// mid-dispatch kills the still-in-flight sibling tools (their process
-    /// groups die with their dropped futures) and answers every remaining
-    /// call synthetically, so the turn still ends with a well-paired
-    /// transcript; the work a fired predicate discards is, by the
-    /// predicate's own claim, already proven unnecessary.
+    /// Asked per committed step AND inside the dispatch loop (#2661): cheap,
+    /// never blocking. A mid-dispatch fire kills in-flight sibling tools and
+    /// answers their calls synthetically — the transcript stays paired.
     fn halt_reason(&self) -> Option<String>;
 }
 

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -310,18 +310,17 @@ pub struct EngineConfig {
     ///
     /// This exists because those are all *external* stopping conditions, and
     /// an agent that has already met its goal will happily keep spending
-    /// against them. Measured on Terminal-Bench 2.1 (run `or1`, task
-    /// `pypi-server`): Stella wrote a correct solution, then spent its
-    /// remaining wall clock re-litigating whether the verifier could see its
-    /// commits, and the harness killed it mid-sentence. The trial scored 1.0
-    /// only because the grader reads files on disk after the agent phase —
-    /// the same behaviour on a task where the late flailing *edits* the
-    /// answer converts a pass into a failure.
+    /// against them — the measured story (Terminal-Bench run `or1`, task
+    /// `pypi-server`) lives in `stella-pipeline::flip_halt`'s module doc.
     ///
     /// The host owns the predicate because only the host knows what "done"
     /// means. `stella-pipeline` supplies one that fires when its flip oracle
     /// observes the tracked test go fail→pass.
     pub turn_halt: Option<Arc<dyn TurnHalt>>,
+    /// Task-mode opt-in (#2663): a completing turn that mutated the workspace
+    /// with no confirmed `verify_done` is nudged once to prove its work
+    /// before the declaration is accepted (`confident_zero::check`, rung 4).
+    pub completion_gate: bool,
 }
 
 /// A caller's answer to "is the goal already met?", asked once per step
@@ -386,6 +385,7 @@ impl Default for EngineConfig {
             // the goal is met, and inventing one here would end turns that
             // had more to do.
             turn_halt: None,
+            completion_gate: false,
         }
     }
 }
@@ -2171,20 +2171,20 @@ impl<'a> Engine<'a> {
                     ContinuationPlan::AllowanceSpent => {}
                 }
             }
-            // The tool-less-completion legitimacy gate: empty-response abort
-            // and the #1477 confident-zero check, in order — see
-            // `confident_zero::check`.
-            if let Some(outcome) = confident_zero::check(
+            // The tool-less-completion legitimacy gate — empty-response
+            // abort, #1477 confident zero, #2663 prove-it nudge, in order.
+            match confident_zero::check(
                 messages,
                 &read_only_tools,
-                &result.text,
-                result.finish_reason,
-                result.usage.output_tokens,
+                &result,
                 out_of_time,
                 total_cost_usd,
+                self.config.completion_gate,
                 events,
             ) {
-                return Some(outcome);
+                confident_zero::CompletionRuling::Abort(outcome) => return Some(outcome),
+                confident_zero::CompletionRuling::Nudged => return None,
+                confident_zero::CompletionRuling::Clean => {}
             }
             // A non-empty answer truncated with the continuation allowance
             // spent: keep the partial answer (already emitted above) but tell

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -334,9 +334,14 @@ pub trait TurnHalt: Send + Sync + std::fmt::Debug {
     /// `Some(reason)` ends the turn cleanly at the next step boundary;
     /// `None` lets it continue.
     ///
-    /// Called once per committed step, so it must be cheap and must not
-    /// block. It is asked *between* steps and never mid-tool, which is what
-    /// lets the turn end with a well-paired transcript.
+    /// Called once per committed step AND from inside the dispatch loop —
+    /// between barrier groups and after each settled tool call (#2661) — so
+    /// it must be cheap and must not block. A predicate that fires
+    /// mid-dispatch kills the still-in-flight sibling tools (their process
+    /// groups die with their dropped futures) and answers every remaining
+    /// call synthetically, so the turn still ends with a well-paired
+    /// transcript; the work a fired predicate discards is, by the
+    /// predicate's own claim, already proven unnecessary.
     fn halt_reason(&self) -> Option<String>;
 }
 

--- a/crates/stella-core/src/driver/confident_zero.rs
+++ b/crates/stella-core/src/driver/confident_zero.rs
@@ -101,6 +101,24 @@ const ONGOING_ACTIVITY_PREFIXES: &[&str] = &[
     "checking ",
 ];
 
+/// The registered name of the built-in verification tool and the leading
+/// marker of its success output. Owned by `stella-tools/src/verify.rs` and
+/// mirrored (not imported — the engine holds no tool concretions) the same
+/// way `stella-pipeline`'s execute stage mirrors them: both halves must
+/// match before a call counts as proof, because the name alone could be
+/// shadowed by an attached MCP tool and the marker alone echoed by a shell.
+const VERIFY_DONE_TOOL: &str = "verify_done";
+const WITNESS_CONFIRMED_MARKER: &str = "WITNESS CONFIRMED";
+
+/// The prove-it nudge (#2663), and its once-only marker: the message is
+/// prefix-detected in the turn's own transcript, so "at most one nudge per
+/// turn" needs no state field and survives a checkpoint resume for free.
+const PROVE_IT_PREFIX: &str = "Before declaring this task complete:";
+const PROVE_IT_NUDGE: &str = "Before declaring this task complete: nothing in this turn proved \
+     the work. Run the task's own test or check command — or the `verify_done` tool — read what \
+     it actually says, and fix anything it reveals. If no check can exist for this change, say \
+     so explicitly and why, then declare completion.";
+
 /// This turn's tool-call tally, the evidence [`detect`] reasons over.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct TurnActivity {
@@ -183,6 +201,56 @@ fn detect(
     }
 }
 
+/// True when this turn did mutating work, no `verify_done` call this turn
+/// came back confirmed, and the prove-it nudge has not been issued yet —
+/// the #2663 condition: work was declared, never proven, and not yet asked
+/// about. Windowed to the current turn like every check in this module.
+fn wants_prove_it_nudge(messages: &[CompletionMessage], read_only_tools: &HashSet<String>) -> bool {
+    if turn_activity(messages, read_only_tools).artifact_calls == 0 {
+        return false;
+    }
+    let start = turn_start_index(messages);
+    let mut verify_ids: Vec<&str> = Vec::new();
+    for message in &messages[start..] {
+        match message.role {
+            MessageRole::User if message.content.starts_with(PROVE_IT_PREFIX) => {
+                // One nudge per turn: asked and answered, whatever the answer.
+                return false;
+            }
+            MessageRole::Assistant => verify_ids.extend(
+                message
+                    .tool_calls
+                    .iter()
+                    .filter(|call| call.name == VERIFY_DONE_TOOL)
+                    .map(|call| call.call_id.as_str()),
+            ),
+            MessageRole::Tool => {
+                for result in &message.tool_results {
+                    if verify_ids.contains(&result.call_id.as_str())
+                        && let stella_protocol::ToolOutput::Ok { content } = &result.output
+                        && content.starts_with(WITNESS_CONFIRMED_MARKER)
+                    {
+                        // Proven: the declaration may stand.
+                        return false;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
+/// [`check`]'s verdict on a tool-less completing step. `Nudged` means the
+/// declaration and the prove-it reply are already appended to the transcript
+/// and the caller should let the turn continue; `Clean` means proceed to
+/// build `Completed` normally.
+pub(super) enum CompletionRuling {
+    Abort(TurnOutcome),
+    Nudged,
+    Clean,
+}
+
 /// The tool-less-completion legitimacy gate `dispatch_completion` calls
 /// before it is willing to build a `TurnOutcome::Completed`. Runs, in order:
 ///
@@ -195,19 +263,29 @@ fn detect(
 ///    out of room" ending (`driver::truncation`), not a voluntary stop, and
 ///    `dispatch_completion`'s own next block already tells the user so.
 /// 3. The confident-zero check ([`detect`], #1477).
+/// 4. When `completion_gate` is set: the prove-it nudge (#2663) — a turn
+///    that mutated the workspace and closes with no confirmed `verify_done`
+///    is sent back once, with a message asking it to prove the work (or say
+///    why nothing can), before its declaration is accepted. Off by default:
+///    hosts running task mode (the CLI's headless run path, the pipeline's
+///    execute stage) opt in; a conversational turn is never gated because a
+///    turn with no mutating calls never trips the condition anyway.
 ///
-/// `None` means dispatch should proceed to build `Completed` normally.
-#[allow(clippy::too_many_arguments)]
+/// On `Nudged`, the step's own declaration and the prove-it reply are
+/// appended here, so the transcript reads claim-then-challenge and the
+/// caller only has to keep looping.
 pub(super) fn check(
-    messages: &[CompletionMessage],
+    messages: &mut Vec<CompletionMessage>,
     read_only_tools: &HashSet<String>,
-    text: &str,
-    finish_reason: Option<FinishReason>,
-    output_tokens: u64,
+    result: &stella_protocol::CompletionResult,
     out_of_time: bool,
     total_cost_usd: f64,
+    completion_gate: bool,
     events: &EventSender,
-) -> Option<TurnOutcome> {
+) -> CompletionRuling {
+    let text = &result.text;
+    let finish_reason = result.finish_reason;
+    let output_tokens = result.usage.output_tokens;
     if text.trim().is_empty() && !out_of_time {
         let reason = match finish_reason {
             // Advised `/compact` until #712; no such command exists, and
@@ -230,33 +308,45 @@ pub(super) fn check(
         // A `Failure`, not a deliberate stop: the model produced nothing
         // usable, which is the run falling over — unlike the confident-zero
         // close below, where the engine itself refuses a trailing-off turn.
-        return Some(TurnOutcome::Aborted {
+        return CompletionRuling::Abort(TurnOutcome::Aborted {
             reason,
             kind: AbortKind::Failure,
             cost_usd: total_cost_usd,
         });
     }
     if finish_reason == Some(FinishReason::Length) {
-        return None;
+        return CompletionRuling::Clean;
     }
-    let zero = detect(messages, read_only_tools, text)?;
-    let reason = format!(
-        "the model ended this turn after {} tool call(s) that changed nothing in the workspace, \
-         closing on a line that narrates ongoing activity rather than stating a result (\"{}\") \
-         — this reads as an abandoned attempt, not a finished answer. Retry, or continue with \
-         more specific direction.",
-        zero.tool_calls,
-        text.trim(),
-    );
-    let _ = events.send(AgentEvent::Error {
-        message: reason.clone(),
-        retryable: true,
-    });
-    Some(TurnOutcome::Aborted {
-        reason,
-        kind: AbortKind::DeliberateStop,
-        cost_usd: total_cost_usd,
-    })
+    if let Some(zero) = detect(messages, read_only_tools, text) {
+        let reason = format!(
+            "the model ended this turn after {} tool call(s) that changed nothing in the \
+             workspace, closing on a line that narrates ongoing activity rather than stating a \
+             result (\"{}\") — this reads as an abandoned attempt, not a finished answer. Retry, \
+             or continue with more specific direction.",
+            zero.tool_calls,
+            text.trim(),
+        );
+        let _ = events.send(AgentEvent::Error {
+            message: reason.clone(),
+            retryable: true,
+        });
+        return CompletionRuling::Abort(TurnOutcome::Aborted {
+            reason,
+            kind: AbortKind::DeliberateStop,
+            cost_usd: total_cost_usd,
+        });
+    }
+    if completion_gate && wants_prove_it_nudge(messages, read_only_tools) {
+        let _ = events.send(AgentEvent::Text {
+            text: "\n⚖ Completion declared without proof — asking the model to verify its work \
+                   before accepting it."
+                .to_string(),
+        });
+        messages.push(CompletionMessage::assistant(text));
+        messages.push(CompletionMessage::user(PROVE_IT_NUDGE));
+        return CompletionRuling::Nudged;
+    }
+    CompletionRuling::Clean
 }
 
 #[cfg(test)]
@@ -405,5 +495,130 @@ mod tests {
             detect(&messages, &read_only(&["read_file"]), "looking into it"),
             Some(ConfidentZero { tool_calls: 1 })
         );
+    }
+
+    fn done_result(text: &str) -> stella_protocol::CompletionResult {
+        stella_protocol::CompletionResult {
+            text: text.into(),
+            tool_calls: vec![],
+            usage: stella_protocol::CompletionUsage {
+                reported: true,
+                output_tokens: 5,
+                ..stella_protocol::CompletionUsage::default()
+            },
+            model: "scripted".into(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        }
+    }
+
+    fn events() -> crate::event_sender::EventSender {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        crate::event_sender::EventSender::new(tx)
+    }
+
+    /// **The #2663 witness.** A gated turn that mutated the workspace and
+    /// declares done with no confirmed `verify_done` is nudged exactly once:
+    /// the first ruling is `Nudged` (and appends claim-then-challenge), the
+    /// second — same declaration, nudge already on the transcript — is
+    /// `Clean`. Fails on the old `check`, which had no gate and no ruling.
+    #[test]
+    fn a_mutating_turn_declared_without_proof_is_nudged_exactly_once() {
+        let mut messages = vec![
+            CompletionMessage::user("fix the bug"),
+            assistant_call("edit_file", "c1"),
+            tool_result("c1", "ok"),
+        ];
+        let ruling = super::check(
+            &mut messages,
+            &read_only(&["read_file"]),
+            &done_result("Done — the bug is fixed."),
+            false,
+            0.0,
+            true,
+            &events(),
+        );
+        assert!(matches!(ruling, super::CompletionRuling::Nudged));
+        assert!(
+            messages
+                .last()
+                .is_some_and(|m| m.content.starts_with(super::PROVE_IT_PREFIX)),
+            "the challenge follows the claim on the transcript"
+        );
+
+        let again = super::check(
+            &mut messages,
+            &read_only(&["read_file"]),
+            &done_result("Done — the bug is fixed."),
+            false,
+            0.0,
+            true,
+            &events(),
+        );
+        assert!(
+            matches!(again, super::CompletionRuling::Clean),
+            "asked and answered: one nudge per turn, whatever the answer"
+        );
+    }
+
+    /// Proof stands down the gate: a `verify_done` call whose result opens
+    /// with the confirmed marker makes the same declaration `Clean` on the
+    /// first ask.
+    #[test]
+    fn a_confirmed_verify_done_makes_the_declaration_clean() {
+        let mut messages = vec![
+            CompletionMessage::user("fix the bug"),
+            assistant_call("edit_file", "c1"),
+            tool_result("c1", "ok"),
+            assistant_call(super::VERIFY_DONE_TOOL, "c2"),
+            tool_result("c2", "WITNESS CONFIRMED — fail→pass observed"),
+        ];
+        let ruling = super::check(
+            &mut messages,
+            &read_only(&["read_file"]),
+            &done_result("Done, and proven."),
+            false,
+            0.0,
+            true,
+            &events(),
+        );
+        assert!(matches!(ruling, super::CompletionRuling::Clean));
+    }
+
+    /// The gate off (every caller today except task mode) and the no-mutation
+    /// turn (a conversational answer) are both untouched.
+    #[test]
+    fn the_gate_never_fires_when_disabled_or_without_mutations() {
+        let mut mutated = vec![
+            CompletionMessage::user("fix the bug"),
+            assistant_call("edit_file", "c1"),
+            tool_result("c1", "ok"),
+        ];
+        let off = super::check(
+            &mut mutated,
+            &read_only(&["read_file"]),
+            &done_result("Done."),
+            false,
+            0.0,
+            false,
+            &events(),
+        );
+        assert!(matches!(off, super::CompletionRuling::Clean));
+
+        let mut read_only_turn = vec![
+            CompletionMessage::user("what does retry.rs do?"),
+            assistant_call("read_file", "c1"),
+            tool_result("c1", "contents"),
+        ];
+        let unmutated = super::check(
+            &mut read_only_turn,
+            &read_only(&["read_file"]),
+            &done_result("It implements the retry policy."),
+            false,
+            0.0,
+            true,
+            &events(),
+        );
+        assert!(matches!(unmutated, super::CompletionRuling::Clean));
     }
 }

--- a/crates/stella-core/src/driver/confident_zero.rs
+++ b/crates/stella-core/src/driver/confident_zero.rs
@@ -201,15 +201,30 @@ fn detect(
     }
 }
 
+/// The window a prove-it decision reasons over: from the last user message
+/// that is NOT itself a prove-it nudge. [`turn_start_index`] restarts at any
+/// user message — including the nudge — so the plain window would put the
+/// once-only marker outside its own scan. Measured on the gate's first field
+/// trial (run `gate-ab`, task pypi-server): three nudges in one turn, each
+/// re-armed by that reset, riding a refuted `verify_done` into the 900s
+/// ceiling — the exact spend the gate exists to stop.
+fn prove_it_turn_start(messages: &[CompletionMessage]) -> usize {
+    messages
+        .iter()
+        .rposition(|m| m.role == MessageRole::User && !m.content.starts_with(PROVE_IT_PREFIX))
+        .unwrap_or(0)
+}
+
 /// True when this turn did mutating work, no `verify_done` call this turn
 /// came back confirmed, and the prove-it nudge has not been issued yet —
 /// the #2663 condition: work was declared, never proven, and not yet asked
-/// about. Windowed to the current turn like every check in this module.
+/// about. Windowed with [`prove_it_turn_start`], so the nudge itself never
+/// reopens the window it closed.
 fn wants_prove_it_nudge(messages: &[CompletionMessage], read_only_tools: &HashSet<String>) -> bool {
     if turn_activity(messages, read_only_tools).artifact_calls == 0 {
         return false;
     }
-    let start = turn_start_index(messages);
+    let start = prove_it_turn_start(messages);
     let mut verify_ids: Vec<&str> = Vec::new();
     for message in &messages[start..] {
         match message.role {
@@ -558,6 +573,42 @@ mod tests {
         assert!(
             matches!(again, super::CompletionRuling::Clean),
             "asked and answered: one nudge per turn, whatever the answer"
+        );
+    }
+
+    /// **The `gate-ab` field regression, pinned.** The nudge is a user
+    /// message, so the plain turn window restarts right after it — and a
+    /// refuted `verify_done` plus one more edit then re-armed the nudge,
+    /// three times in one trial, into the 900s ceiling. With the window
+    /// anchored at the last NON-nudge user message, the answered nudge stays
+    /// in scope and the second declaration is `Clean`, whatever the
+    /// verification said. Fails on the `turn_start_index`-windowed code.
+    #[test]
+    fn a_refuted_verification_after_the_nudge_never_rearms_it() {
+        let mut messages = vec![
+            CompletionMessage::user("fix the bug"),
+            assistant_call("edit_file", "c1"),
+            tool_result("c1", "ok"),
+            CompletionMessage::assistant("Done — the bug is fixed."),
+            CompletionMessage::user(super::PROVE_IT_NUDGE),
+            assistant_call(super::VERIFY_DONE_TOOL, "c2"),
+            tool_result("c2", "WITNESS REFUTED — the test still fails"),
+            assistant_call("edit_file", "c3"),
+            tool_result("c3", "ok"),
+        ];
+        let ruling = super::check(
+            &mut messages,
+            &read_only(&["read_file"]),
+            &done_result("Done for real this time."),
+            false,
+            0.0,
+            true,
+            &events(),
+        );
+        assert!(
+            matches!(ruling, super::CompletionRuling::Clean),
+            "one nudge per turn means per TURN — its own message must not \
+             reopen the window it closed"
         );
     }
 

--- a/crates/stella-core/src/driver/dispatch.rs
+++ b/crates/stella-core/src/driver/dispatch.rs
@@ -7,11 +7,21 @@
 use std::collections::HashSet;
 
 use futures_util::StreamExt;
-use stella_protocol::{AgentEvent, ToolCall, ToolResult};
+use stella_protocol::{AgentEvent, ToolCall, ToolOutput, ToolResult};
 
 use super::{Engine, MAX_CONCURRENT_TOOL_CALLS, SPECULATION_DISCARD_HARVEST_MISMATCH};
 use crate::event_sender::EventSender;
 use crate::speculation::SpeculationPool;
+
+/// The synthetic answer for a call the mid-dispatch halt refused to finish.
+///
+/// A fixed string on purpose, twice over: the loop detector keys on
+/// `ToolOutput` content, so nothing volatile (a timing, a reason that varies
+/// per turn) may ride here; and [`crate::step::close_open_tool_calls`] set the
+/// precedent that a synthetic closure is an `Error` output with a steady
+/// message, mirrored onto the event stream with no `ToolStart`.
+const HALTED_TOOL_RESULT: &str = "not executed — the goal was proven met (turn halt fired) while this call \
+     was pending; its work is not needed and any process it started was killed";
 
 impl<'a> Engine<'a> {
     /// Execute one step's tool calls, preserving sequential semantics for
@@ -55,6 +65,24 @@ impl<'a> Engine<'a> {
     /// [`crate::ports::TurnSteering`], which contrasts exactly this against the
     /// soft stop). A caller that KEEPS a hard-cancelled turn's messages must
     /// close the pairing itself.
+    ///
+    /// # The mid-dispatch halt (kill the worker on oracle flip, #2661)
+    ///
+    /// [`crate::EngineConfig::turn_halt`] is consulted here too — after each
+    /// settled call and before each barrier group — not only at the step
+    /// boundary in `drive`. When the predicate fires (the pipeline's flip
+    /// oracle saw the tracked test go fail→pass), every call still pending is
+    /// spend past the proof: the in-flight stream is dropped, which drops the
+    /// tool futures, and a dropped tool future takes its child with it —
+    /// `kill_on_drop(true)` plus the setsid'd process-group SIGKILL guard in
+    /// `stella-tools` (`exec.rs`). Unfinished and never-started calls are then
+    /// answered with [`HALTED_TOOL_RESULT`], so the returned set still covers
+    /// every call and the transcript stays well-paired — which is why this
+    /// does not breach the "aborts at safe boundaries" discipline: that rule
+    /// exists so an interrupt never loses work or corrupts the history, and a
+    /// confirmed flip means the remaining work is, by proof, not work. The
+    /// halted turn then settles as `Completed` at the very next boundary check
+    /// in `drive` without paying for another model call.
     pub(super) async fn execute_tool_calls(
         &self,
         calls: &[ToolCall],
@@ -63,8 +91,15 @@ impl<'a> Engine<'a> {
         events: &EventSender,
     ) -> Vec<ToolResult> {
         let mut indexed: Vec<(usize, ToolResult)> = Vec::with_capacity(calls.len());
+        let mut halted = false;
         let mut i = 0;
         while i < calls.len() {
+            // Between barrier groups: a predicate that latched during the
+            // previous group makes everything not yet started dead spend.
+            if self.mid_dispatch_halt() {
+                halted = true;
+                break;
+            }
             let group_end = if dispatch_safe_tools.contains(&calls[i].name) {
                 let mut end = i + 1;
                 while end < calls.len() && dispatch_safe_tools.contains(&calls[end].name) {
@@ -131,15 +166,337 @@ impl<'a> Engine<'a> {
                         output,
                     },
                 ));
+                // The settled call may be the one whose result latched the
+                // halt (the pipeline's observer runs on the ToolResult event
+                // just sent). Ask now rather than draining the group: every
+                // sibling still in flight is work past the proof.
+                if self.mid_dispatch_halt() {
+                    halted = true;
+                    break;
+                }
             }
+            // On the halted arm this drop IS the kill: each still-pending
+            // future is dropped, and a dropped tool future takes its child
+            // process group with it (`kill_on_drop` + the SIGKILL group guard
+            // in stella-tools). On the normal arm the stream is already empty.
             drop(in_flight);
 
+            if halted {
+                break;
+            }
             i = group_end;
+        }
+        if halted {
+            // Answer everything the halt refused to run or finish, following
+            // `close_open_tool_calls`' shape exactly: an `Error` output with a
+            // steady message, mirrored onto the event stream with no
+            // `ToolStart`, so the returned set covers every call and a
+            // transcript reconstructed from events resolves the same way.
+            // Keyed by original index, not call_id: ids are only guaranteed
+            // unique within one response by SOME providers, and an id-keyed
+            // set would let one answered duplicate silently absorb the other.
+            let answered: HashSet<usize> = indexed.iter().map(|(index, _)| *index).collect();
+            for (index, call) in calls.iter().enumerate() {
+                if answered.contains(&index) {
+                    continue;
+                }
+                let output = ToolOutput::Error {
+                    message: HALTED_TOOL_RESULT.to_string(),
+                };
+                let _ = events.send(AgentEvent::ToolResult {
+                    call_id: call.call_id.clone(),
+                    output: output.clone(),
+                    duration_ms: 0,
+                    speculated: false,
+                });
+                indexed.push((
+                    index,
+                    ToolResult {
+                        call_id: call.call_id.clone(),
+                        output,
+                    },
+                ));
+            }
         }
         // Any pool entry no committed call ever claimed ran real I/O that
         // never reached the transcript — account for it, don't drop it (#370).
         self.discard_speculation_pool(speculation, SPECULATION_DISCARD_HARVEST_MISMATCH, events);
         indexed.sort_by_key(|(index, _)| *index);
         indexed.into_iter().map(|(_, result)| result).collect()
+    }
+
+    /// Whether [`crate::EngineConfig::turn_halt`] has fired, asked from inside
+    /// the dispatch loop. One consult point shared by the between-groups and
+    /// after-each-settle checks so the two cannot drift.
+    fn mid_dispatch_halt(&self) -> bool {
+        self.config
+            .turn_halt
+            .as_ref()
+            .and_then(|halt| halt.halt_reason())
+            .is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use tokio::sync::mpsc;
+
+    use super::super::TurnHalt;
+    use crate::event_sender::EventSender;
+    use crate::retry::Sleeper;
+    use crate::step::{BudgetSnapshot, CHECKPOINT_VERSION, Checkpoint, TurnState};
+    use crate::{Engine, EngineConfig, TurnOutcome};
+    use stella_protocol::{
+        AgentEvent, BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult,
+        CompletionUsage, Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
+    };
+
+    /// First call: two dispatch-safe (read-only) tools, so they run as one
+    /// concurrent group. Second call: text — reached only if no halt fires.
+    struct TwoParallelToolsThenText {
+        calls: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl Provider for TwoParallelToolsThenText {
+        fn id(&self) -> &str {
+            "scripted"
+        }
+        async fn complete_ref(
+            &self,
+            _req: CompletionRequestRef<'_>,
+        ) -> Result<CompletionResult, ProviderError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut result = CompletionResult {
+                text: String::new(),
+                tool_calls: vec![],
+                usage: CompletionUsage {
+                    reported: true,
+                    input_tokens: 1,
+                    ..CompletionUsage::default()
+                },
+                model: "scripted".into(),
+                cost_usd: 0.0,
+                finish_reason: None,
+            };
+            if call == 0 {
+                result.tool_calls = vec![
+                    ToolCall {
+                        call_id: "call_witness".into(),
+                        name: "witness".into(),
+                        input: serde_json::json!({}),
+                    },
+                    ToolCall {
+                        call_id: "call_eternal".into(),
+                        name: "eternal".into(),
+                        input: serde_json::json!({}),
+                    },
+                ];
+            } else {
+                result.text = "finished after the halt should have fired".into();
+            }
+            Ok(result)
+        }
+    }
+
+    /// `witness` completes instantly and raises the flag the halt reads;
+    /// `eternal` (when `hang`) never resolves — the long `pytest` a flip
+    /// used to have to wait out.
+    struct FlagAndHang {
+        flag: Arc<AtomicBool>,
+        hang: bool,
+    }
+
+    #[async_trait]
+    impl crate::ToolExecutor for FlagAndHang {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            ["witness", "eternal"]
+                .into_iter()
+                .map(|name| ToolSchema {
+                    name: name.into(),
+                    description: name.into(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    read_only: true,
+                    speculation_safe: false,
+                })
+                .collect()
+        }
+        async fn execute(&self, name: &str, _input: &Value) -> ToolOutput {
+            match name {
+                "witness" => {
+                    self.flag.store(true, Ordering::SeqCst);
+                    ToolOutput::Ok {
+                        content: "1 passed".into(),
+                    }
+                }
+                _ => {
+                    if self.hang {
+                        std::future::pending::<()>().await;
+                    }
+                    ToolOutput::Ok {
+                        content: "eternal finished".into(),
+                    }
+                }
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoopSleeper;
+    #[async_trait]
+    impl Sleeper for NoopSleeper {
+        async fn sleep(&self, _duration_ms: u64) {}
+    }
+
+    /// Fires once the executor's flag is up — the shape of the pipeline's
+    /// `FlipHalt`, which latches synchronously inside the `ToolResult` tap.
+    #[derive(Debug)]
+    struct AfterFlag {
+        flag: Arc<AtomicBool>,
+    }
+    impl TurnHalt for AfterFlag {
+        fn halt_reason(&self) -> Option<String> {
+            self.flag
+                .load(Ordering::SeqCst)
+                .then(|| "the tracked test flipped".to_string())
+        }
+    }
+
+    fn step_one() -> Checkpoint {
+        Checkpoint {
+            version: CHECKPOINT_VERSION,
+            step: 1,
+            messages: vec![
+                CompletionMessage::system("sys"),
+                CompletionMessage::user("keep going"),
+            ],
+            budget: BudgetSnapshot {
+                mode: BudgetMode::Off,
+                turn_limit_usd: None,
+                session_limit_usd: None,
+                turn_spent_usd: 0.0,
+                session_spent_usd: 0.0,
+            },
+            total_cost_usd: 0.0,
+            calibration_model: None,
+            loop_steered: false,
+            loop_steered_pattern: Vec::new(),
+            loop_steered_inputs: None,
+            transcript_rewrites: 0,
+        }
+    }
+
+    /// **The kill-on-flip witness (#2661).** A flip latched by one tool's
+    /// result must not wait for its never-finishing sibling: the sibling is
+    /// killed (its future dropped), its call answered synthetically, and the
+    /// turn settles `Completed` after exactly one model call. On the old
+    /// dispatch this test times out — the group is drained to the end, and
+    /// `eternal` has no end.
+    #[tokio::test]
+    async fn a_mid_dispatch_flip_kills_the_hung_sibling_and_pairs_its_call() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let calls = Arc::new(AtomicU32::new(0));
+        let provider = TwoParallelToolsThenText {
+            calls: calls.clone(),
+        };
+        let tools = FlagAndHang {
+            flag: flag.clone(),
+            hang: true,
+        };
+        let config = EngineConfig {
+            turn_halt: Some(Arc::new(AfterFlag { flag })),
+            ..EngineConfig::default()
+        };
+        let mut state = TurnState::from_checkpoint(step_one(), &config);
+        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let events = EventSender::new(tx);
+
+        let outcome =
+            tokio::time::timeout(Duration::from_secs(10), engine.drive(&mut state, &events))
+                .await
+                .expect("a fired flip must not wait for the hung sibling tool");
+
+        let TurnOutcome::Completed { .. } = outcome else {
+            panic!("a fired halt ends the turn as a success: {outcome:?}");
+        };
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the halted turn must not pay for another model call"
+        );
+
+        drop(events);
+        let mut eternal_result = None;
+        while let Some(event) = rx.recv().await {
+            if let AgentEvent::ToolResult {
+                call_id, output, ..
+            } = event
+                && call_id == "call_eternal"
+            {
+                eternal_result = Some(output);
+            }
+        }
+        match eternal_result {
+            Some(ToolOutput::Error { message }) => assert!(
+                message.contains("turn halt fired"),
+                "the killed sibling's synthetic answer names the halt: {message}"
+            ),
+            other => panic!(
+                "the killed sibling's call must still be answered on the \
+                 event stream (close_open_tool_calls' contract): {other:?}"
+            ),
+        }
+    }
+
+    /// The control: same two tools, nothing hangs, no halt configured — both
+    /// calls run to their real results and the turn ends on the second model
+    /// call, exactly as before the mid-dispatch consult existed.
+    #[tokio::test]
+    async fn an_unfired_halt_leaves_dispatch_untouched() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let calls = Arc::new(AtomicU32::new(0));
+        let provider = TwoParallelToolsThenText {
+            calls: calls.clone(),
+        };
+        let tools = FlagAndHang { flag, hang: false };
+        let config = EngineConfig::default();
+        let mut state = TurnState::from_checkpoint(step_one(), &config);
+        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let events = EventSender::new(tx);
+
+        let outcome = engine.drive(&mut state, &events).await;
+
+        let TurnOutcome::Completed { text, .. } = outcome else {
+            panic!("the control turn completes: {outcome:?}");
+        };
+        assert_eq!(text, "finished after the halt should have fired");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        drop(events);
+        let mut eternal_output = None;
+        while let Some(event) = rx.recv().await {
+            if let AgentEvent::ToolResult {
+                call_id, output, ..
+            } = event
+                && call_id == "call_eternal"
+            {
+                eternal_output = Some(output);
+            }
+        }
+        assert_eq!(
+            eternal_output,
+            Some(ToolOutput::Ok {
+                content: "eternal finished".into()
+            }),
+            "with no halt, the sibling's real result is untouched"
+        );
     }
 }

--- a/crates/stella-pipeline/src/flip_halt.rs
+++ b/crates/stella-pipeline/src/flip_halt.rs
@@ -120,8 +120,17 @@ pub fn command_of(input: &serde_json::Value) -> Option<&str> {
 pub struct FlipHalt {
     /// The tracked command in normalized form — compared, and quoted back in
     /// the halt reason so a reader can see which command ended the turn.
+    /// Empty for a latch built by [`FlipHalt::watching_verify_done_only`],
+    /// which has no command to watch and can only be fired by
+    /// [`FlipHalt::confirm_verify_done`].
     tracked: String,
     flipped: AtomicBool,
+    /// The second live "done" signal (#2661): a `verify_done` call whose
+    /// output opened with the confirmed marker. Deterministic proof by the
+    /// same contract the witness stage credits (#2129), so it may end the
+    /// turn even when no tracked command was ever armed — which on
+    /// Terminal-Bench is every bare-loop execute turn.
+    verify_confirmed: AtomicBool,
 }
 
 impl FlipHalt {
@@ -132,6 +141,21 @@ impl FlipHalt {
         Self {
             tracked: normalize_command(tracked),
             flipped: AtomicBool::new(false),
+            verify_confirmed: AtomicBool::new(false),
+        }
+    }
+
+    /// A latch with no tracked command: only a confirmed `verify_done` can
+    /// fire it. This is what covers the turns `run_candidate` never arms —
+    /// no configured test command, no failing baseline — where before #2661
+    /// a worker that had already *proven* its work done (the definition-of-
+    /// done contract, not a self-report) still ran until a limit ended it.
+    #[must_use]
+    pub fn watching_verify_done_only() -> Self {
+        Self {
+            tracked: String::new(),
+            flipped: AtomicBool::new(false),
+            verify_confirmed: AtomicBool::new(false),
         }
     }
 
@@ -147,6 +171,20 @@ impl FlipHalt {
         self.flipped.load(Ordering::SeqCst)
     }
 
+    /// Whether either done-signal has fired: the tracked-command flip or a
+    /// confirmed `verify_done`.
+    #[must_use]
+    pub fn fired(&self) -> bool {
+        self.is_flipped() || self.verify_confirmed.load(Ordering::SeqCst)
+    }
+
+    /// Feed a `verify_done` result that opened with the confirmed marker.
+    /// Returns `true` on the transition, same edge contract as
+    /// [`FlipHalt::observe`].
+    pub fn confirm_verify_done(&self) -> bool {
+        !self.verify_confirmed.swap(true, Ordering::SeqCst)
+    }
+
     /// The latch to hand a follow-up turn: `Some(self)` only while unfired.
     ///
     /// A latch that already fired belongs to the turn it stopped. A revision
@@ -157,7 +195,7 @@ impl FlipHalt {
     /// and that is exactly what an unfired latch delivers (#1793).
     #[must_use]
     pub fn unfired(self: &Arc<Self>) -> Option<Arc<Self>> {
-        (!self.is_flipped()).then(|| Arc::clone(self))
+        (!self.fired()).then(|| Arc::clone(self))
     }
 
     /// Feed one finished shell call. Returns `true` if this observation
@@ -165,9 +203,12 @@ impl FlipHalt {
     ///
     /// Requires BOTH that the command normalizes to the tracked one and that
     /// it exited zero. Anything else — a different command, a failure, output
-    /// with no exit marker — leaves the latch exactly as it was.
+    /// with no exit marker — leaves the latch exactly as it was. A latch with
+    /// no tracked command never matches: an empty pattern would otherwise
+    /// accept an empty command line, and "matches nothing" is the honest
+    /// reading of "watching nothing".
     pub fn observe(&self, command: &str, content: &str) -> bool {
-        if normalize_command(command) != self.tracked {
+        if self.tracked.is_empty() || normalize_command(command) != self.tracked {
             return false;
         }
         if exit_status(content) != Some(0) {
@@ -216,13 +257,22 @@ pub fn for_revision(armed: &Option<Arc<FlipHalt>>, tracked: FlipState) -> Option
 
 impl TurnHalt for FlipHalt {
     fn halt_reason(&self) -> Option<String> {
-        self.is_flipped().then(|| {
-            format!(
+        if self.is_flipped() {
+            return Some(format!(
                 "the tracked test now passes (`{}` went fail→pass), so the goal is met — stopping \
                  here rather than spending the rest of the turn against a solved task",
                 self.tracked
-            )
-        })
+            ));
+        }
+        if self.verify_confirmed.load(Ordering::SeqCst) {
+            return Some(
+                "verify_done confirmed the witness (fail→pass observed in a shadow worktree), so \
+                 the goal is proven met — stopping here rather than spending the rest of the turn \
+                 against a solved task"
+                    .to_string(),
+            );
+        }
+        None
     }
 }
 
@@ -363,5 +413,51 @@ mod tests {
                 .observe("pytest -q", "ok\n[exit code: 0]")
         );
         assert!(for_revision(&armed, FlipState::Failing).is_none());
+    }
+
+    /// **The #2661 seam-C witness.** A turn with no tracked command — every
+    /// bare-loop Terminal-Bench execute turn — can now be ended by the one
+    /// deterministic done-signal it does have: a confirmed `verify_done`.
+    /// Fails on the old `FlipHalt` because neither the constructor nor the
+    /// confirm edge exists there, and `halt_reason` only ever reported a
+    /// tracked-command flip.
+    #[test]
+    fn a_confirmed_verify_done_fires_a_latch_with_no_tracked_command() {
+        use stella_core::driver::TurnHalt as _;
+
+        let halt = FlipHalt::watching_verify_done_only();
+        assert!(halt.halt_reason().is_none(), "unfired means silent");
+
+        assert!(halt.confirm_verify_done(), "first confirmation is the edge");
+        assert!(
+            !halt.confirm_verify_done(),
+            "the edge is claimed exactly once, same contract as observe()"
+        );
+        let reason = halt.halt_reason().expect("a confirmed latch reports");
+        assert!(
+            reason.contains("verify_done confirmed"),
+            "the reason names the signal that ended the turn: {reason}"
+        );
+    }
+
+    /// The two safety properties of the command-less latch: it can never be
+    /// fired by a shell observation (watching nothing matches nothing, not
+    /// everything), and once fired by verify_done it is refused to follow-up
+    /// turns exactly like a command-fired one.
+    #[test]
+    fn a_verify_done_only_latch_ignores_commands_and_is_not_inherited() {
+        let halt = Arc::new(FlipHalt::watching_verify_done_only());
+        assert!(
+            !halt.observe("", "ok\n[exit code: 0]"),
+            "an empty command line must not match the empty pattern"
+        );
+        assert!(!halt.observe("pytest -q", "ok\n[exit code: 0]"));
+        assert!(halt.unfired().is_some(), "nothing has fired yet");
+
+        halt.confirm_verify_done();
+        assert!(
+            halt.unfired().is_none(),
+            "a latch fired via verify_done belongs to the turn it stopped"
+        );
     }
 }

--- a/crates/stella-pipeline/src/flip_halt.rs
+++ b/crates/stella-pipeline/src/flip_halt.rs
@@ -34,6 +34,26 @@
 //! test runs, the ones that tell it the work is finished, were invisible to
 //! it. This watches those runs as they happen.
 //!
+//! # How hard the stop lands
+//!
+//! The latch is read by the engine at two depths. The step boundary
+//! (`driver/drive.rs`) ends the turn without another model call. Since #2661
+//! the dispatch loop also consults it — between barrier groups and after each
+//! settled tool call — and a fired latch there *kills* the still-running
+//! sibling tools: their futures are dropped, `kill_on_drop` and the setsid'd
+//! SIGKILL group guard in `stella-tools` take the child processes with them,
+//! and the refused calls are answered synthetically so the transcript stays
+//! well-paired. Before that, a flip landing while a long tool was in flight
+//! waited for it — minutes on a `pytest` or a build, which on Terminal-Bench
+//! is exactly the `solved_then_timeout` window: proven done, still billed to
+//! the 900s ceiling.
+//!
+//! This is deliberately not a breach of the "aborts at safe boundaries only"
+//! discipline (invariant #6): that rule guards *budget* aborts, where an
+//! interrupt loses work someone still wants. A confirmed flip is the opposite
+//! state — the tracked test has already proven the goal, so what the kill
+//! discards is, by that proof, not work.
+//!
 //! # What it deliberately does not do
 //!
 //! It does not decide the verdict. The authoritative oracle in

--- a/crates/stella-pipeline/src/pipeline/execute_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/execute_stage.rs
@@ -178,18 +178,16 @@ impl<'a> Pipeline<'a> {
         signals: &mut ChangeSignals,
         flip_halt: Option<Arc<FlipHalt>>,
     ) -> TurnOutcome {
-        let (filtered, tallies) = self.filtered_turn_events(flip_halt.clone());
-        // A halted engine only when there is something to watch, so a turn
-        // with no armed flip runs on exactly the engine it always did.
-        let halted;
-        let engine = match flip_halt {
-            Some(halt) => {
-                halted = engine.with_turn_halt(halt as Arc<dyn TurnHalt>);
-                &halted
-            }
-            None => engine,
-        };
-        let outcome = engine
+        // Every execute turn gets a halt now (#2661): armed with the tracked
+        // command when `run_candidate` observed a failing baseline, otherwise
+        // watching only for a confirmed `verify_done` — the deterministic
+        // done-signal that needs no configured command. An unfired latch
+        // answers `None` at every consult, so an ordinary turn still runs
+        // exactly as it always did.
+        let halt = flip_halt.unwrap_or_else(|| Arc::new(FlipHalt::watching_verify_done_only()));
+        let (filtered, tallies) = self.filtered_turn_events(Some(halt.clone()));
+        let halted = engine.with_turn_halt(halt as Arc<dyn TurnHalt>);
+        let outcome = halted
             .run_turn_with_sender(messages, budget, &filtered)
             .await;
         tallies.fold_into(signals);
@@ -212,18 +210,14 @@ impl<'a> Pipeline<'a> {
         signals: &mut ChangeSignals,
         flip_halt: Option<Arc<FlipHalt>>,
     ) -> (TurnOutcome, Vec<CompletionMessage>, BudgetGuard) {
-        let (filtered, tallies) = self.filtered_turn_events(flip_halt.clone());
-        let halted;
-        let engine = match flip_halt {
-            Some(halt) => {
-                halted = engine.with_turn_halt(halt as Arc<dyn TurnHalt>);
-                &halted
-            }
-            None => engine,
-        };
+        // Same always-on halt as `run_engine_turn` (#2661) — the resumed
+        // path must not be the copy that forgot it.
+        let halt = flip_halt.unwrap_or_else(|| Arc::new(FlipHalt::watching_verify_done_only()));
+        let (filtered, tallies) = self.filtered_turn_events(Some(halt.clone()));
+        let halted = engine.with_turn_halt(halt as Arc<dyn TurnHalt>);
         let mut state =
             stella_core::step::TurnState::from_checkpoint(checkpoint, &self.config.engine);
-        let outcome = engine.drive(&mut state, &filtered).await;
+        let outcome = halted.drive(&mut state, &filtered).await;
         tallies.fold_into(signals);
         let budget = stella_core::step::BudgetSnapshot::of(state.budget()).restore();
         (outcome, state.into_messages(), budget)
@@ -315,9 +309,13 @@ impl<'a> Pipeline<'a> {
                         }
                     }
                     // Remember the command line so its result can be scored
-                    // against the tracked test. Only when a halt is armed —
-                    // otherwise this map is pure overhead on every turn.
-                    if halt_for_events.is_some()
+                    // against the tracked test. Only when the halt actually
+                    // watches a command — a verify_done-only latch (#2661)
+                    // has nothing to match, and this map would be pure
+                    // overhead on every turn.
+                    if halt_for_events
+                        .as_ref()
+                        .is_some_and(|halt| !halt.tracked().is_empty())
                         && let Some(command) = command_of(&call.input)
                         && let Ok(mut pending) = commands.lock()
                     {
@@ -372,6 +370,16 @@ impl<'a> Pipeline<'a> {
                         && content.starts_with(WITNESS_CONFIRMED_MARKER)
                     {
                         verify.fetch_add(1, Ordering::Relaxed);
+                        // A confirmed verify_done is deterministic proof the
+                        // goal is met (#2129) — the second live done-signal,
+                        // and the only one a turn with no tracked command has
+                        // (#2661). Firing the halt here is what lets the
+                        // engine's mid-dispatch consult kill anything still
+                        // in flight instead of spending the rest of the
+                        // ceiling against a solved task.
+                        if let Some(halt) = halt_for_events.as_ref() {
+                            halt.confirm_verify_done();
+                        }
                     }
                     // Scored off the result alone (#2125) — no call-id
                     // correlation, because the marker the census reads is the


### PR DESCRIPTION
## What

Directive from Mac: **SIGKILL the worker on oracle flip.** Once the flip oracle has watched the tracked test go fail→pass, everything still in flight is spend past the proof.

The live observation already existed (#1793, `FlipHalt`): the pipeline latches on the worker's own bash `ToolResult`. What was missing was the force — the halt only landed at the **step boundary**, so the current model stream and every in-flight sibling tool had to finish first. A flip landing while a `pytest` or a build was running kept a proven-done turn burning wall clock. On TB2.1 that is `solved_then_timeout`: measured **4 times** on the 2026-08-10 certification panel (run `turnloop-cert-panel1` + reruns), once at 955s against the 900s ceiling.

## How

`EngineConfig::turn_halt` is now consulted **inside the dispatch loop** (`crates/stella-core/src/driver/dispatch.rs`) — between barrier groups and after each settled tool call. On fire:

- the in-flight `buffer_unordered` stream is dropped; each dropped tool future takes its child **process group** with it (`kill_on_drop(true)` + the setsid'd `libc::kill(-pid, SIGKILL)` guard already in `stella-tools/src/exec.rs`);
- every unfinished or never-started call is answered synthetically, following `close_open_tool_calls`' exact shape — an `Error` output with a **steady** message (the loop detector keys on `ToolOutput` content, so nothing volatile rides it), mirrored onto the event stream with no `ToolStart`;
- the returned result set still covers every call, so the transcript stays well-paired, and the existing boundary check in `drive` settles the turn `Completed` (never `Aborted` — harnesses score non-zero exits as crashes) without another model call.

Synthesis is keyed by original call **index**, not `call_id` — ids are only guaranteed unique per response by some providers, and an id-keyed set would let one answered duplicate absorb the other.

## Invariant #6

Deliberately not a breach, and argued in the docs rather than waved past: the safe-boundaries rule guards **budget** aborts, where an interrupt loses work someone still wants and corrupts pairing. A confirmed flip is the opposite state — what the kill discards is, by the flip's own proof, not work — and pairing is preserved by construction. Docs updated: `TurnHalt` trait contract (both consult depths), `flip_halt.rs` module rationale ("How hard the stop lands"), dispatch doc-comment.

## Witness

`driver::dispatch::tests::a_mid_dispatch_flip_kills_the_hung_sibling_and_pairs_its_call`: one group, two dispatch-safe calls — `witness` settles instantly and raises the halt's flag, `eternal` never resolves. **Fails on the old dispatch** (times out draining the sibling; verified by splicing HEAD's implementation under these tests: `1 passed; 1 failed ... finished in 10.01s`), passes here in ~0.01s. The killed call's synthetic answer is asserted present on the event stream. A control test pins the unhalted path unchanged (real results, second model call).

`cargo test -p stella-core`: 1066 passed. `cargo test -p stella-pipeline`: green. Clippy clean.

## Exemplar

The synthetic-closure shape is `close_open_tool_calls` (`stella-core/src/step.rs`) applied at a second site, and the kill primitive is `stella-tools`' existing drop guard — no new mechanism, only a new consult point for an existing port.

## Second commit: verify_done fires the halt on every execute turn (#2661 point 4)

The kill only had a trigger where a tracked command's failing baseline was armed — on Terminal-Bench that is never the bare loop, and not the pipeline's first execute turn either. `verify_done`'s `WITNESS CONFIRMED` (already detected and tallied in the event filter, deterministic per #2129) now fires the same latch: `FlipHalt::confirm_verify_done` + `watching_verify_done_only`, with both engine-turn drivers attaching a halt unconditionally. An unfired latch answers `None` at every consult; the command-correlation map stays gated on a non-empty tracked command (zero overhead for turns watching nothing); a command-less latch can never be fired by a shell observation and is refused to follow-up turns once fired. Witnessed in `flip_halt` tests (fails on the old type — no such constructor or edge); the one unwitnessed link is the six-line closure call in `filtered_turn_events`, which mirrors the `halt.observe` call directly above it and has no existing test scaffolding — disclosed rather than waved past.

## Third commit: the prove-it completion gate (#2663)

The field A/B (run `stoponproof-ab`) showed the worker never calls `verify_done` on bench tasks, so stop-on-proof had no trigger and the bare loop's premature declarations (13-step wrong answers on kv-store-grpc/pypi-server) went unchallenged. `confident_zero::check` — already the tool-less-completion legitimacy gate — gains rung 4: with `EngineConfig::completion_gate` set, a completing turn that mutated the workspace with no confirmed `verify_done` is answered **once** with a prove-it nudge (claim-then-challenge appended, turn continues) instead of being accepted. Once per turn via transcript prefix detection (checkpoint-resume safe); a confirmed `verify_done` or a mutation-free conversational answer never trips it. Off by default; the CLI keys it on the execution kind it already records (`"run"` gated, `"chat"` not), and the pipeline worker config sets it unconditionally. Witnessed in `confident_zero` tests (fails on the old `check`: no gate, no ruling); both god files stay at their ceilings with no baseline change.

## Not in this PR (tracked)

- A durable event on the flip transition (today the observer deliberately emits nothing) — #2661 point 3; needed to measure halt latency in the field.

Closes #2661
Refs #2663
Refs #1793
