### PR TITLE
fix(stella-core): delete the dead Engine::run_session_start_hooks — SessionStart has one owner, the host (#2674)

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -453,6 +453,13 @@ pub(crate) fn verifier_engine_config_for(cfg: &Config) -> EngineConfig {
 /// session context `stella_core::hooks` documents. `None` when no hooks are
 /// configured or they printed nothing. Called once per session by each
 /// driver, never per turn.
+///
+/// This is the single owner of `SessionStart` firing (#2674). The engine
+/// deliberately has no method for it: every driver fires hooks here, while
+/// assembling the system prompt — before any `Engine` exists — and the
+/// diagnostics below must reach stderr, which the no-I/O engine cannot do.
+/// `stella-parity`'s `hooks.lifecycle` row pins that no second owner grows
+/// back.
 pub(crate) async fn session_start_hook_context(cfg: &Config) -> Option<String> {
     let hooks = cfg.hooks.as_ref()?;
     let outcome = stella_core::hooks::run_hooks(

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -226,9 +226,12 @@ system message and the latest user message are never touched.
 - **Bus observers must return `Err`, never panic.** `catch_unwind` contains a
   panic only under an unwinding profile, and the workspace `release` profile sets
   `panic = "abort"` ([`../Cargo.toml`](../Cargo.toml)).
-- **`run_session_start_hooks` is not called by `run_turn`.** `SessionStart` is a
-  session-level event and `run_turn` runs many times per session; the caller
-  invokes it once and folds the output into the system prompt it builds.
+- **No engine method fires `SessionStart` — it is a host obligation (#2674).**
+  `SessionStart` is a session-level event and `run_turn` runs many times per
+  session; the host fires [`src/hooks.rs`](src/hooks.rs)'s `run_hooks` once,
+  while assembling the system prompt it owns (`run_turn` only borrows history),
+  and surfaces the diagnostics this no-I/O crate cannot print. `stella-parity`'s
+  `hooks.lifecycle` row pins that a second, engine-side owner never grows back.
 - **`Engine::with_sleeper` is the only *public* constructor,** and it cannot
   carry `gate`/`steering`/`hooks` — those are builder-set private fields. A
   nested turn built through it silently drops all three, which is the bug

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -759,34 +759,6 @@ impl<'a> Engine<'a> {
         }
     }
 
-    /// Fire `SessionStart` hooks once and return any stdout they produced —
-    /// the additional system-prompt context described in `crate::hooks`.
-    ///
-    /// This is deliberately NOT called from [`Engine::run_turn`].
-    /// `SessionStart` is a session-level event ("runs once before the
-    /// turn"), but `run_turn` is per-turn and a REPL or fleet worker calls
-    /// it many times per session — firing it inside would re-run session
-    /// setup on every turn. Prompt assembly is the caller's concern anyway
-    /// (`run_turn` takes history by `&mut` and never owns the system
-    /// prompt), so the caller invokes this once, before the first turn, and
-    /// folds the returned context into the system message it builds.
-    /// Returns `None` when no hooks are attached or the hooks printed
-    /// nothing.
-    pub async fn run_session_start_hooks(&self) -> Option<String> {
-        let handle = self.hooks?;
-        let outcome = run_hooks(
-            handle.runner,
-            Some(handle.hooks),
-            &HookPayload::session_start(self.config.cwd.clone()),
-        )
-        .await;
-        if outcome.output.is_empty() {
-            None
-        } else {
-            Some(outcome.output)
-        }
-    }
-
     /// Drive one turn to completion or a clean abort, appending every
     /// message to `messages` and streaming an `AgentEvent` for every
     /// boundary over `events`. `budget` is `&mut` because spend

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -2828,10 +2828,12 @@ async fn no_hooks_configured_leaves_the_turn_path_unchanged() {
 }
 
 #[tokio::test]
-async fn session_start_hooks_run_via_the_helper_not_per_turn() {
-    // SessionStart is exposed as an explicit once-per-session helper
-    // (Engine::run_session_start_hooks); run_turn must never fire it, so
-    // a REPL calling run_turn repeatedly does not re-run session setup.
+async fn run_turn_never_fires_session_start_hooks() {
+    // SessionStart is a session-level event and a host obligation (#2674):
+    // the host fires it once, via `hooks::run_hooks`, while assembling the
+    // system prompt. run_turn is per-turn — a REPL calls it many times per
+    // session — so it must never fire SessionStart, or every turn would
+    // re-run session setup.
     let provider = ScriptedProvider {
         id: "scripted".into(),
         script: TokioMutex::new(vec![Ok(text_result("hi there"))]),
@@ -2858,12 +2860,6 @@ async fn session_start_hooks_run_via_the_helper_not_per_turn() {
     let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
         .with_hooks(&hooks, &runner);
 
-    // The helper fires SessionStart once and returns its stdout as the
-    // additional system-prompt context.
-    let context = engine.run_session_start_hooks().await;
-    assert_eq!(context.as_deref(), Some("on-call: alice"));
-
-    // A full turn must NOT fire SessionStart a second time.
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -2874,12 +2870,12 @@ async fn session_start_hooks_run_via_the_helper_not_per_turn() {
     assert!(matches!(outcome, TurnOutcome::Completed { .. }));
 
     let payloads = payloads.lock().await.clone();
-    assert_eq!(
-        payloads.len(),
-        1,
-        "run_turn must not fire SessionStart — only the helper does"
+    assert!(
+        !payloads
+            .iter()
+            .any(|p| p.contains("\"event\":\"SessionStart\"")),
+        "run_turn fired SessionStart — session setup would re-run on every turn"
     );
-    assert!(payloads[0].contains("\"event\":\"SessionStart\""));
 }
 
 #[test]

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -394,9 +394,13 @@ pub static CAPABILITIES: &[Capability] = &[
     Capability {
         id: "hooks.lifecycle",
         engine_home: "stella-core hooks (PreToolUse/PostToolUse/SessionStart) and the observer-only HookBus",
-        engine_entries: &["with_hooks", "run_session_start_hooks", "with_bus"],
+        engine_entries: &["with_hooks", "with_bus"],
         cli: SurfacePosture::ShippedUnwitnessed {
-            mechanism: "workspace hooks wired via with_session_hook_context on every driver path",
+            mechanism: "workspace hooks wired via with_session_hook_context on every driver \
+                        path. SessionStart firing is a HOST obligation (#2674): the engine \
+                        deliberately has no method for it — a host fires hooks::run_hooks once \
+                        while it assembles the system prompt, before any Engine exists, and \
+                        owns surfacing the diagnostics the no-I/O engine cannot print",
             missing: "a CLI-side test pinning that a configured workspace hook actually fires \
                       through agent wiring (core has hook tests; the CLI wiring has none)",
         },
@@ -806,6 +810,43 @@ mod tests {
                  record it"
             );
         }
+    }
+
+    /// SessionStart firing is a host obligation, never an engine entry
+    /// (#2674). `Engine::run_session_start_hooks` shipped with no production
+    /// caller: every CLI driver fires SessionStart while assembling the
+    /// system prompt — before any Engine exists (the pipeline and fleet
+    /// paths never construct one; `Pipeline::run` builds its own, per
+    /// stage) — and must surface the hook diagnostics the no-I/O engine
+    /// cannot print (#373), while the serve host deliberately keeps shell
+    /// hooks unreachable. Two owners of one obligation is the drift the
+    /// consolidated turn loop exists to end, so the dead engine copy was
+    /// deleted; this pins both halves so a second owner cannot grow back
+    /// silently, and that the row keeps naming who does own the firing.
+    #[test]
+    fn session_start_is_a_host_obligation_not_an_engine_entry() {
+        let row = capability("hooks.lifecycle").expect("the row is declared");
+        assert!(
+            !row.engine_entries.contains(&"run_session_start_hooks"),
+            "hooks.lifecycle claims run_session_start_hooks again — SessionStart firing is a \
+             host obligation (#2674); an engine-side owner is the duplication that PR removed"
+        );
+        let (SurfacePosture::Shipped { mechanism, .. }
+        | SurfacePosture::ShippedUnwitnessed { mechanism, .. }) = &row.cli
+        else {
+            panic!("hooks.lifecycle's CLI posture moved — keep naming the SessionStart owner");
+        };
+        assert!(
+            mechanism.contains("with_session_hook_context") && mechanism.contains("obligation"),
+            "the row no longer names the single host owner of SessionStart firing"
+        );
+        assert!(
+            !engine_sources()
+                .iter()
+                .any(|source| source.contains("fn run_session_start_hooks")),
+            "an engine source defines run_session_start_hooks again — the host obligation has \
+             grown a second, engine-side owner (#2674)"
+        );
     }
 
     /// Every claimed engine entry actually exists in the swept sources —


### PR DESCRIPTION
## What & why

`Engine::run_session_start_hooks` (`crates/stella-core/src/driver.rs`) had **no production caller** — every CLI driver fires SessionStart itself via `session_start_hook_context` / `with_session_hook_context` (`crates/stella-cli/src/agent/engine.rs`) while assembling the system prompt. Two implementations of one obligation, one dead: exactly the drift shape the consolidated turn loop (`crates/stella-core/src/driver/drive.rs` module doc) exists to end.

**Owner picked: the host, not the engine** — the issue's alternative branch, because routing the CLI through the engine method is structurally blocked on three counts:

1. **SessionStart fires before any Engine exists.** The CLI fires it at system-prompt assembly, once per session. The pipeline path (`crates/stella-cli/src/agent.rs:325`) and fleet path (`fleet_cmd.rs`) never construct an Engine at all — `Pipeline::run` builds its own engines internally, per stage, after the prompt exists; interactive engines are built per turn (`with_calibration`'s doc: "engines are constructed per turn"). Routing through the engine would mean assembling a throwaway Engine (Provider + ToolExecutor + full EngineConfig) purely to call a method that reads two fields.
2. **The engine copy loses diagnostics.** `session_start_hook_context` prints `outcome.diagnostics` to stderr so a typo'd hook doesn't silently contribute nothing all session (#373 item 6). The no-I/O engine (invariant #2) can never print them; the engine method silently dropped them.
3. **The next host must NOT inherit this obligation blindly.** `stella-serve` deliberately keeps shell hooks unreachable server-side (the `hooks.lifecycle` API mechanism) — so the engine method wasn't just dead, it was a footgun pointing the wrong way.

So, per the issue: the engine method is deleted, SessionStart is documented as a **host obligation**, and `stella-parity`'s `hooks.lifecycle` row now states it — with a witness test so a host-obligation regression fails a test **by name**.

Exemplar for the shape: this is `provider_parity`'s own pattern (declared posture + named witness) applied to the surface matrix that already existed for exactly this class of gap.

Closes #2674

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`session_start_is_a_host_obligation_not_an_engine_entry` (`crates/stella-parity/src/lib.rs`). It pins three things: the `hooks.lifecycle` row claims no `run_session_start_hooks` engine entry, the row's CLI mechanism names the single host owner, and no swept engine source defines the method again.

**Flip demonstrated:** the test alone, applied to `origin/main` (e57af4dd7) on a temp branch, fails —

```
thread 'tests::session_start_is_a_host_obligation_not_an_engine_entry' panicked:
hooks.lifecycle claims run_session_start_hooks again
test result: FAILED. 0 passed; 1 failed
```

— and passes on this branch (`cargo test -p stella-parity`: 9 passed).

**Deleted test, named per the deleted-test guard:** `session_start_hooks_run_via_the_helper_not_per_turn` (`crates/stella-core/src/driver/tests.rs`) tested the deleted method. Its surviving pin is kept, reshaped as `run_turn_never_fires_session_start_hooks` — run_turn with SessionStart hooks attached must fire zero SessionStart payloads.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, all guards OK)
- [x] `cargo clippy -p stella-core -p stella-cli -p stella-parity --all-targets -- -D warnings`
- [x] `cargo test -p stella-core -p stella-cli -p stella-parity` (core 1070 passed; all 14 CLI suites ok; parity 9 passed)
- [x] Docs updated: `crates/stella-core/README.md` gotcha rewritten (host obligation), `session_start_hook_context` doc names itself the single owner, parity row mechanism updated
- [x] `Closes #2674` appears above **and** as a commit trailer

Both god files this touches (`driver.rs`, `driver/tests.rs`, at their exact ceilings) only **lose** lines.

## Nothing left behind

- [x] Filed: #2726 — the `hooks.lifecycle` CLI posture stays `ShippedUnwitnessed` (pre-existing debt, counted by `UNWITNESSED_BASELINE`): no CLI-side test yet pins that a configured workspace hook fires through agent wiring. Written as a handoff with the promotion recipe.

## Ground-rule check

- [x] No I/O added to `stella-core` (only deleted from it); no new deps

## Anything reviewers should know?

The rejected alternative (issue's preferred branch) and why is spelled out above. The startup region PR #2711 touches (`command_deck.rs` beside `spawn_notification_poller`) is untouched here — `command_deck.rs:448`'s `with_session_hook_context` call site is unchanged.

## Summary by Sourcery

Remove the unused engine-level SessionStart hook entry and codify SessionStart firing as a host responsibility, enforced via parity metadata and tests.

Enhancements:
- Delete Engine::run_session_start_hooks and associated core test assertions, ensuring run_turn never fires SessionStart events.
- Update stella-core README and CLI session_start_hook_context docs to state that SessionStart is fired once per session by the host via hooks::run_hooks before any Engine is constructed.
- Adjust the hooks.lifecycle capability row to remove the Engine entry for run_session_start_hooks and clarify the CLI mechanism and ownership of SessionStart firing.

Documentation:
- Revise stella-core README and CLI engine documentation to describe SessionStart as a host-only lifecycle event and point to parity’s hooks.lifecycle row as the guardrail.

Tests:
- Add a parity test that asserts SessionStart is a host obligation with no corresponding engine entry and that no engine source reintroduces run_session_start_hooks.
- Retain and reshape the driver test to verify that Engine::run_turn never emits SessionStart events even when hooks are attached.