### PR TITLE
fix(stella-mcp): make MCP wire names injective and drop colliding routes (#2675)

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -2438,6 +2438,7 @@ fn spawn_mcp_connect(
                             &set.connected_names(),
                             set.failed_servers(),
                             &set.over_advertising_servers(),
+                            set.wire_name_collisions(),
                         )));
                         // `set` is infallible here (the cell is set exactly once,
                         // by this task); an in-flight turn keeps its resolved

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -179,7 +179,7 @@ fn extract_skill_md_unwraps_a_fenced_block_or_frontmatter() {
 
 #[test]
 fn mcp_outcome_report_lists_connected_servers_by_name() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files", "search"], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files", "search"], &[], &[], &[]);
     assert_eq!(report, "2 MCP server(s) connected: files, search");
 }
 
@@ -189,7 +189,7 @@ fn mcp_outcome_report_names_each_failure_with_its_reason() {
         "slow".to_string(),
         "connect timed out after 10000ms".to_string(),
     )];
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &failed, &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &failed, &[], &[]);
     let lines: Vec<&str> = report.lines().collect();
     assert_eq!(lines[0], "1 MCP server(s) connected: files");
     assert_eq!(
@@ -201,7 +201,7 @@ fn mcp_outcome_report_names_each_failure_with_its_reason() {
 #[test]
 fn mcp_outcome_report_states_total_failure_outright() {
     let failed = vec![("a".to_string(), "spawn failed".to_string())];
-    let report = crate::mcp_cmd::mcp_outcome_report(&[], &failed, &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&[], &failed, &[], &[]);
     assert!(
         report.starts_with("no MCP servers connected"),
         "the degraded mode is stated, not implied: {report}"
@@ -214,7 +214,7 @@ fn mcp_outcome_report_states_total_failure_outright() {
 /// no consumer, so the model silently had fewer tools than the server offered.
 #[test]
 fn mcp_outcome_report_reports_a_truncated_server_as_connected_not_unavailable() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["greedy"], &[], &[("greedy", 12)]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["greedy"], &[], &[("greedy", 12)], &[]);
     let lines: Vec<&str> = report.lines().collect();
     assert_eq!(lines[0], "1 MCP server(s) connected: greedy");
     assert!(
@@ -239,7 +239,7 @@ fn mcp_outcome_report_reports_a_truncated_server_as_connected_not_unavailable() 
 #[test]
 fn mcp_outcome_report_carries_truncation_and_failure_together() {
     let failed = vec![("dead".to_string(), "spawn failed".to_string())];
-    let report = crate::mcp_cmd::mcp_outcome_report(&["greedy"], &failed, &[("greedy", 3)]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["greedy"], &failed, &[("greedy", 3)], &[]);
     assert!(report.contains("MCP server `dead` unavailable: spawn failed"));
     assert!(report.contains("`greedy` advertised more than"));
 }
@@ -248,8 +248,35 @@ fn mcp_outcome_report_carries_truncation_and_failure_together() {
 /// zero is noise that trains operators to ignore the real one.
 #[test]
 fn mcp_outcome_report_is_silent_when_nothing_was_truncated() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &[], &[], &[]);
     assert_eq!(report, "1 MCP server(s) connected: files");
+}
+
+/// #2675: a contested wire name is reported with every claimant, and the
+/// claimant servers stay "connected" — their uncontested tools route
+/// normally, so `unavailable` would be a lie (the same reasoning as
+/// truncation above).
+#[test]
+fn mcp_outcome_report_names_every_claimant_of_a_contested_wire_name() {
+    let collisions = vec![stella_mcp::WireNameCollision {
+        wire_name: "mcp__acme___status".to_string(),
+        claimants: vec![
+            ("acme_".to_string(), "status".to_string()),
+            ("acme".to_string(), "_status".to_string()),
+        ],
+    }];
+    let report = crate::mcp_cmd::mcp_outcome_report(&["acme_", "acme"], &[], &[], &collisions);
+    assert!(report.contains("`mcp__acme___status`"), "{report}");
+    assert!(report.contains("`acme_` tool `status`"), "{report}");
+    assert!(report.contains("`acme` tool `_status`"), "{report}");
+    assert!(
+        report.contains("every claimant dropped"),
+        "the resolution is stated — no connect-order winner: {report}"
+    );
+    assert!(
+        !report.contains("unavailable"),
+        "claimant servers are connected, not down: {report}"
+    );
 }
 
 /// Drive [`DeckAskUserIo::prompt`] with a scripted answer and inspect the

--- a/crates/stella-cli/src/deck_mcp.rs
+++ b/crates/stella-cli/src/deck_mcp.rs
@@ -70,10 +70,11 @@ pub(crate) async fn mcp_snapshot(
             let card = config.card(name).expect("name came from the config");
             let enabled = !disabled_set.contains(name);
             let connected_now = connected.contains(name);
-            let prefix = format!("mcp__{name}__");
             let tool_count = schemas
                 .iter()
-                .filter(|s| s.name.starts_with(&prefix))
+                .filter(|s| {
+                    stella_mcp::split_wire_name(&s.name).is_some_and(|(server, _)| server == name)
+                })
                 .count();
             let health = crate::mcp_cmd::health_label(&health, name);
             let calls: u64 = usage

--- a/crates/stella-cli/src/mcp_cmd.rs
+++ b/crates/stella-cli/src/mcp_cmd.rs
@@ -79,10 +79,16 @@ pub fn resolve_registry_url(workspace_root: &Path) -> String {
 /// and their kept tools route normally, so calling them "unavailable" would be
 /// false. Without this the cap is entirely silent — the model simply has fewer
 /// tools than the server offers and nothing says so (#689).
+/// `collisions` carries the wire names more than one `(server, tool)` pair
+/// claimed (#2675); every claimant's route was dropped rather than letting
+/// connect order pick which server answers. Reported separately from `failed`
+/// for the same reason truncation is: the claimant servers are connected and
+/// their uncontested tools route normally.
 pub(crate) fn mcp_outcome_report(
     connected: &[&str],
     failed: &[(String, String)],
     truncated: &[(&str, usize)],
+    collisions: &[stella_mcp::WireNameCollision],
 ) -> String {
     let mut lines = match connected.len() {
         0 => vec!["no MCP servers connected — continuing with native tools only".to_string()],
@@ -101,7 +107,26 @@ pub(crate) fn mcp_outcome_report(
             .iter()
             .map(|(name, dropped)| truncation_note(name, *dropped)),
     );
+    lines.extend(collisions.iter().map(collision_note));
     lines.join("\n")
+}
+
+/// One contested wire name's notice, shared by deck and text mode so the
+/// wording cannot drift between them. Names every claimant: the operator's
+/// next move is to rename one of those servers, so the sentence must say
+/// which ones are fighting over the name.
+pub(crate) fn collision_note(collision: &stella_mcp::WireNameCollision) -> String {
+    let claimants: Vec<String> = collision
+        .claimants
+        .iter()
+        .map(|(server, tool)| format!("`{server}` tool `{tool}`"))
+        .collect();
+    format!(
+        "MCP wire name `{}` is claimed by multiple servers ({}) — every claimant \
+         dropped and not callable this session; rename one of the servers",
+        collision.wire_name,
+        claimants.join(", ")
+    )
 }
 
 /// One server's truncation notice, shared by deck and text mode so the wording
@@ -133,6 +158,9 @@ pub(crate) fn print_connect_diagnostics(set: &stella_mcp::McpToolSet) {
     }
     for (name, dropped) in set.over_advertising_servers() {
         eprintln!("  {} {}", "!".yellow(), truncation_note(name, dropped));
+    }
+    for collision in set.wire_name_collisions() {
+        eprintln!("  {} {}", "!".yellow(), collision_note(collision));
     }
     if set.connected_count() > 0 {
         println!(

--- a/crates/stella-mcp/README.md
+++ b/crates/stella-mcp/README.md
@@ -53,9 +53,14 @@ it crosses.
 `ToolExecutor` port `stella-tools`' `ToolRegistry` implements, so composing it
 over the native set (`McpToolSet::connect(...).wrapping(native)`) makes MCP
 tools indistinguishable from built-ins. Every MCP tool is advertised as
-`mcp__<server>__<tool>`; a server name that is empty or contains the reserved
-`__` separator is skipped into `failed_servers()` rather than producing an
-ambiguous prefix. A non-`mcp__` name falls through to the native executor; an
+`mcp__<server>__<tool>` — composed by the one public `wire_name` function
+(inverse: `split_wire_name`); a server name that is empty, contains the
+reserved `__` separator, or starts/ends with `_` is skipped into
+`failed_servers()` rather than producing an ambiguous wire name — those rules
+make the encoding injective, and if two `(server, tool)` pairs collide anyway,
+both routes are dropped and reported via `wire_name_collisions()` instead of
+letting connect order pick a winner (#2675). A non-`mcp__` name falls through
+to the native executor; an
 `mcp__…` name that matches no route is a model-visible error and never falls
 through. `stella-cli` builds the set once per session
 (`load_mcp_plan` → `connect_mcp_servers` in

--- a/crates/stella-mcp/src/lib.rs
+++ b/crates/stella-mcp/src/lib.rs
@@ -94,5 +94,8 @@ pub use registry::{
     RegistryPage, RegistryServer,
 };
 pub use stdio::StdioTransport;
-pub use toolset::{DEFAULT_CALL_TIMEOUT, DisabledServers, McpToolSet, ServerIdentity};
+pub use toolset::{
+    DEFAULT_CALL_TIMEOUT, DisabledServers, McpToolSet, ServerIdentity, WireNameCollision,
+    split_wire_name, wire_name,
+};
 pub use transport::Transport;

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -6,13 +6,20 @@
 //!
 //! # Namespacing
 //!
-//! Every MCP tool is advertised as `mcp__<server>__<tool>` so tools from
-//! different servers (and from the native set) never collide. Server names
-//! are required to be non-empty and free of the `__` separator; a server whose
-//! name violates that is skipped and recorded in
-//! [`McpToolSet::failed_servers`]. With that guarantee the prefix uniquely
-//! identifies the server and the remainder is the raw tool name, so routing is
-//! unambiguous.
+//! Every MCP tool is advertised as `mcp__<server>__<tool>` — composed by
+//! [`wire_name`], the one place the encoding lives — so tools from different
+//! servers (and from the native set) never collide. Server names are required
+//! to be non-empty, free of the `__` separator, and free of a leading or
+//! trailing `_`; a server whose name violates that is skipped and recorded in
+//! [`McpToolSet::failed_servers`]. Those rules make the encoding **injective**
+//! (see [`wire_name`]), so the prefix uniquely identifies the server, the
+//! remainder is the raw tool name, and routing is unambiguous.
+//!
+//! Injectivity is also enforced, not merely argued: if two `(server, tool)`
+//! pairs ever map to one wire name anyway, route building drops **every**
+//! claimant's route and records the clash in
+//! [`McpToolSet::wire_name_collisions`], so connect order can never silently
+//! pick which third-party server answers a call (#2675).
 //!
 //! # Composition & fall-through
 //!
@@ -37,7 +44,7 @@
 //! instead of aborting the agent. Per-server state is surfaced by
 //! [`McpToolSet::health`] for a non-fatal CLI/TUI/telemetry diagnostic.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -106,12 +113,37 @@ pub struct ServerIdentity {
     pub protocol_version: String,
 }
 
+/// One wire name claimed by more than one `(server, tool)` pair (#2675).
+///
+/// The `namespace_rejection` rules make [`wire_name`] injective, so this should
+/// never occur — but MCP servers are third-party and their tool lists are
+/// untrusted, and a misroute here delivers a call meant for one server to a
+/// different one. When it does occur, **every** claimant's route is dropped
+/// (never a connect-order winner) and this record is the operator-visible
+/// diagnostic, in the [`McpToolSet::failed_servers`] /
+/// [`McpToolSet::over_advertising_servers`] style: bounded, named, non-fatal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WireNameCollision {
+    /// The contested `mcp__…` name. Not advertised and not callable this
+    /// session.
+    pub wire_name: String,
+    /// Every `(server, tool)` pair that encodes to `wire_name`, in client
+    /// connect order. Always at least two entries, always distinct servers
+    /// (one server's duplicate tool names are deduped at ingest).
+    pub claimants: Vec<(String, String)>,
+}
+
 /// A set of connected MCP servers exposed to the engine as one
 /// `ToolExecutor`, optionally composed over an inner native executor.
 pub struct McpToolSet {
     clients: Vec<McpClient>,
-    /// Namespaced tool name -> (client index, raw tool name).
+    /// Namespaced tool name -> (client index, raw tool name). A wire name
+    /// claimed by more than one client is absent here and recorded in
+    /// `collisions` instead — routing never has a connect-order winner.
     routes: HashMap<String, (usize, String)>,
+    /// Wire names more than one `(server, tool)` pair claimed, with every
+    /// claimant. See [`McpToolSet::wire_name_collisions`].
+    collisions: Vec<WireNameCollision>,
     /// Servers that could not be connected or had invalid names: `(name,
     /// reason)`. They advertise no tools but never block the rest.
     failed: Vec<(String, String)>,
@@ -159,11 +191,8 @@ impl McpToolSet {
             .collect();
 
         for config in configs {
-            if !is_namespaceable(&config.name) {
-                failed.push((
-                    config.name.clone(),
-                    "server name is empty or contains the reserved `__` separator".into(),
-                ));
+            if let Some(reason) = namespace_rejection(&config.name) {
+                failed.push((config.name.clone(), reason.into()));
                 continue;
             }
             if !seen.insert(config.name.clone()) {
@@ -188,6 +217,7 @@ impl McpToolSet {
         let mut set = Self {
             clients,
             routes: HashMap::new(),
+            collisions: Vec::new(),
             failed,
             native: None,
             usage: None,
@@ -208,11 +238,8 @@ impl McpToolSet {
 
         for client in clients {
             let name = client.name().to_string();
-            if !is_namespaceable(&name) {
-                failed.push((
-                    name,
-                    "server name is empty or contains the reserved `__` separator".into(),
-                ));
+            if let Some(reason) = namespace_rejection(&name) {
+                failed.push((name, reason.into()));
                 continue;
             }
             if !seen.insert(name.clone()) {
@@ -225,6 +252,7 @@ impl McpToolSet {
         let mut set = Self {
             clients: kept,
             routes: HashMap::new(),
+            collisions: Vec::new(),
             failed,
             native: None,
             usage: None,
@@ -424,6 +452,23 @@ impl McpToolSet {
             .collect()
     }
 
+    /// Wire names claimed by more than one `(server, tool)` pair, with every
+    /// claimant — sorted by wire name (#2675). Each contested name routes
+    /// nowhere this session: dropping every claimant is the only answer that
+    /// does not let connect order decide which third-party server receives a
+    /// call meant for another.
+    ///
+    /// Deliberately **not** folded into [`McpToolSet::failed_servers`], for
+    /// the same reason [`McpToolSet::over_advertising_servers`] is not: the
+    /// claimant servers are connected and their uncontested tools route
+    /// normally, so rendering them "unavailable" would be a lie. Empty
+    /// whenever every server name passes `namespace_rejection`, which makes
+    /// [`wire_name`] injective — this is the defense-in-depth record for the
+    /// day that guarantee is weakened.
+    pub fn wire_name_collisions(&self) -> &[WireNameCollision] {
+        &self.collisions
+    }
+
     /// How many advertised tools this session refused across *every* connected
     /// server — the single number a status line can carry ("2 servers
     /// truncated, 31 tools dropped") without iterating
@@ -458,17 +503,40 @@ impl McpToolSet {
     }
 
     /// (Re)build the routing map from the current clients. Server names are
-    /// validated unique + namespaceable, which makes the usual case
-    /// unambiguous — but `mcp__<server>__<tool>` can still collide when a
-    /// server name ends in `_` and another's tool starts with `_`
-    /// (`acme` + `_status` == `acme_` + `status`), and the later client then
-    /// wins the route silently.
+    /// validated unique + namespaceable, which makes [`wire_name`] injective
+    /// and every wire name single-claimant. Should two `(server, tool)` pairs
+    /// map to one wire name anyway, **every** claimant's route is dropped and
+    /// the clash recorded in [`McpToolSet::wire_name_collisions`] — before
+    /// #2675 the later-connected client silently won the route, which handed
+    /// a third-party server a way to shadow another server's tools by
+    /// choosing colliding names.
     fn rebuild_routes(&mut self) {
         self.routes.clear();
+        self.collisions.clear();
+        // BTreeMap so the collision report is ordered by wire name, not by
+        // hash order — diagnostics are rendered to the operator and must not
+        // shuffle between runs.
+        let mut claims: BTreeMap<String, Vec<(usize, String)>> = BTreeMap::new();
         for (idx, client) in self.clients.iter().enumerate() {
             for tool in client.tools() {
-                let namespaced = namespaced_name(client.name(), &tool.name);
-                self.routes.insert(namespaced, (idx, tool.name.clone()));
+                claims
+                    .entry(wire_name(client.name(), &tool.name))
+                    .or_default()
+                    .push((idx, tool.name.clone()));
+            }
+        }
+        for (name, pairs) in claims {
+            match pairs.as_slice() {
+                [(idx, tool)] => {
+                    self.routes.insert(name, (*idx, tool.clone()));
+                }
+                _ => self.collisions.push(WireNameCollision {
+                    wire_name: name,
+                    claimants: pairs
+                        .into_iter()
+                        .map(|(idx, tool)| (self.clients[idx].name().to_string(), tool))
+                        .collect(),
+                }),
             }
         }
     }
@@ -504,16 +572,41 @@ impl McpToolSet {
     }
 }
 
-/// Which server a namespaced tool belongs to — `mcp__<server>__<tool>`.
+/// Compose the wire name for a server/tool pair: `mcp__<server>__<tool>`.
 ///
-/// Server names are guaranteed free of the `__` separator (`is_namespaceable`
-/// rejects the rest at connect), so the segment between the prefix and the
-/// first separator is unambiguous.
+/// **This is the one place the encoding lives** — no other `format!` may
+/// build an `mcp__…` name, so a future tool-contract registry (#2716) can
+/// call this single function and its collision check covers every advertised
+/// name.
+///
+/// **Injectivity.** Over server names accepted by `namespace_rejection`
+/// (non-empty, no `__`, no leading or trailing `_`), the encoding is
+/// injective: two distinct `(server, tool)` pairs cannot share a wire name.
+/// Equality would force one server to be the other plus a trailing `_`
+/// (`wire_name("acme_", "status") == wire_name("acme", "_status")` is the
+/// whole collision family — any longer suffix puts a non-`_` byte where the
+/// other name needs the `__` separator), and a trailing `_` is rejected.
+/// [`split_wire_name`] is the inverse. Defense in depth for the day the name
+/// rule is weakened lives in [`McpToolSet::wire_name_collisions`] (#2675).
+pub fn wire_name(server: &str, tool: &str) -> String {
+    format!("{NS_PREFIX}{server}{NS_SEP}{tool}")
+}
+
+/// The inverse of [`wire_name`]: `(server, tool)` for an `mcp__…` name, or
+/// `None` for a name outside the MCP namespace.
+///
+/// Splits at the **first** `__` after the prefix, which is exact because
+/// accepted server names never contain the separator. The tool half may
+/// contain `__` freely — only the server segment is constrained.
+pub fn split_wire_name(namespaced: &str) -> Option<(&str, &str)> {
+    namespaced.strip_prefix(NS_PREFIX)?.split_once(NS_SEP)
+}
+
+/// Which server a namespaced tool belongs to, or `""` for a name outside the
+/// MCP namespace — the total-function convenience over [`split_wire_name`]
+/// that `budget_segment`'s fold wants.
 fn server_of(namespaced: &str) -> &str {
-    namespaced
-        .strip_prefix(NS_PREFIX)
-        .and_then(|rest| rest.split_once(NS_SEP))
-        .map_or("", |(server, _)| server)
+    split_wire_name(namespaced).map_or("", |(server, _)| server)
 }
 
 /// Roughly what one schema costs in the serialized tools block: its name, its
@@ -603,9 +696,10 @@ impl McpToolSet {
                 continue;
             }
             for tool in client.tools() {
-                let namespaced = namespaced_name(client.name(), &tool.name);
+                let namespaced = wire_name(client.name(), &tool.name);
                 // Only advertise tools that actually route back to this client
-                // (defends against any skipped/collided entry).
+                // — a collided wire name has no route at all (see
+                // `wire_name_collisions`), so no claimant advertises it.
                 if self.routes.get(&namespaced).map(|(i, _)| *i) == Some(idx) {
                     mcp.push(ToolSchema {
                         name: namespaced,
@@ -786,11 +880,6 @@ impl ToolExecutor for CandidateMcpView {
     }
 }
 
-/// Compose the namespaced tool name for a server/tool pair.
-fn namespaced_name(server: &str, tool: &str) -> String {
-    format!("{NS_PREFIX}{server}{NS_SEP}{tool}")
-}
-
 /// Whether `schema` can be called with an empty `{}` — no `required` array,
 /// or an empty one. Used ONLY to decide whether [`McpToolSet::prefetch_candidate_context`]
 /// may call a tool blind; never to synthesize a value for a required field.
@@ -801,11 +890,28 @@ fn accepts_empty_input(schema: &Value) -> bool {
         .is_none_or(|required| required.is_empty())
 }
 
-/// A server name may be used as a namespace segment only if it is non-empty
-/// and does not contain the `__` separator (which would make the prefix
-/// ambiguous).
-fn is_namespaceable(name: &str) -> bool {
-    !name.is_empty() && !name.contains(NS_SEP)
+/// Why `name` may not be used as a namespace segment, or `None` if it may.
+///
+/// Three rules, each protecting [`wire_name`]'s injectivity: the name must be
+/// non-empty, must not contain the `__` separator (which would make the
+/// server prefix ambiguous), and must not start or end with `_` — a trailing
+/// `_` is exactly what lets two pairs collide
+/// (`wire_name("acme_", "status") == wire_name("acme", "_status")`, #2675),
+/// and a leading `_` is rejected symmetrically so the boundary between the
+/// `mcp__` prefix and the server segment stays visually and lexically crisp.
+fn namespace_rejection(name: &str) -> Option<&'static str> {
+    if name.is_empty() {
+        Some("server name is empty")
+    } else if name.contains(NS_SEP) {
+        Some("server name contains the reserved `__` separator")
+    } else if name.starts_with('_') || name.ends_with('_') {
+        Some(
+            "server name starts or ends with `_`, which would make \
+             `mcp__<server>__<tool>` wire names ambiguous",
+        )
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-mcp/src/toolset/tests.rs
+++ b/crates/stella-mcp/src/toolset/tests.rs
@@ -419,6 +419,127 @@ async fn duplicate_and_invalid_server_names_are_recorded_not_advertised() {
     assert!(reasons.iter().any(|r| r.contains("reserved")));
 }
 
+/// Witness for #2675's name-rule half. `wire_name("acme_", "status")` and
+/// `wire_name("acme", "_status")` are the same string, and before this change
+/// both servers connected and the later one silently won the route — a call
+/// meant for `acme` could be answered by `acme_` (or vice versa) purely on
+/// connect order, which a hostile third-party server can exploit by choosing
+/// its names. On main this fails: `acme_` is accepted, both servers connect,
+/// and nothing is recorded in `failed_servers`.
+#[tokio::test]
+async fn a_trailing_underscore_server_name_is_rejected_not_silently_shadowing() {
+    let spoofer = connected_client("acme_", "status").await;
+    let victim = connected_client("acme", "_status").await;
+    let set = McpToolSet::from_clients(vec![spoofer, victim]);
+
+    assert_eq!(
+        set.connected_count(),
+        1,
+        "the underscore-suffixed name must be refused at registration"
+    );
+    assert_eq!(set.failed_servers().len(), 1);
+    let (name, reason) = &set.failed_servers()[0];
+    assert_eq!(name, "acme_");
+    assert!(
+        reason.contains("ambiguous"),
+        "the reason names the hazard: {reason}"
+    );
+
+    // The surviving server owns the wire name outright…
+    let claimed: Vec<_> = set
+        .schemas()
+        .into_iter()
+        .filter(|s| s.name == "mcp__acme___status")
+        .collect();
+    assert_eq!(claimed.len(), 1, "exactly one advertised claimant");
+    // …and a call routes to it, never to whoever connected later.
+    assert_eq!(
+        set.execute("mcp__acme___status", &Value::Null).await,
+        ToolOutput::Ok {
+            content: "mcp ran".into()
+        }
+    );
+}
+
+/// A leading `_` is rejected by the same rule (symmetry half of #2675).
+#[tokio::test]
+async fn a_leading_underscore_server_name_is_rejected() {
+    let set = McpToolSet::from_clients(vec![connected_client("_acme", "status").await]);
+    assert_eq!(set.connected_count(), 0);
+    assert_eq!(set.failed_servers().len(), 1);
+    assert_eq!(set.failed_servers()[0].0, "_acme");
+}
+
+/// Defense in depth for #2675: should colliding names ever reach
+/// `rebuild_routes` anyway (the name rule weakened, or a construction path
+/// that skips it), **both** routes are dropped and the clash is a named
+/// diagnostic — connect order never picks a winner. Drives the private
+/// machinery directly because `from_clients` now refuses `acme_` outright,
+/// which is exactly why this layer exists as a second wall.
+#[tokio::test]
+async fn colliding_wire_names_drop_every_claimant_and_are_reported() {
+    let spoofer = connected_client("acme_", "status").await;
+    let victim = connected_client("acme", "_status").await;
+    let mut set = McpToolSet {
+        clients: vec![spoofer, victim],
+        routes: HashMap::new(),
+        collisions: Vec::new(),
+        failed: Vec::new(),
+        native: None,
+        usage: None,
+        disabled: None,
+        candidate_safe: HashSet::new(),
+    };
+    set.rebuild_routes();
+
+    assert_eq!(
+        set.wire_name_collisions(),
+        [WireNameCollision {
+            wire_name: "mcp__acme___status".into(),
+            claimants: vec![
+                ("acme_".into(), "status".into()),
+                ("acme".into(), "_status".into()),
+            ],
+        }],
+        "the diagnostic names the contested wire name and every claimant"
+    );
+    // Neither claimant is advertised…
+    assert!(
+        set.schemas().iter().all(|s| s.name != "mcp__acme___status"),
+        "a contested wire name must not be advertised"
+    );
+    // …and neither is callable: the contested name routes nowhere.
+    match set.execute("mcp__acme___status", &Value::Null).await {
+        ToolOutput::Error { message } => {
+            assert!(message.contains("unknown MCP tool"), "{message}")
+        }
+        other => panic!("expected the contested name to route nowhere, got {other:?}"),
+    }
+}
+
+/// The encode/decode pair: `split_wire_name` inverts `wire_name`, and the
+/// one collision family the doc comment claims is real.
+#[test]
+fn wire_name_round_trips_and_the_collision_family_is_the_documented_one() {
+    assert_eq!(wire_name("files", "read"), "mcp__files__read");
+    assert_eq!(split_wire_name("mcp__files__read"), Some(("files", "read")));
+    // The tool half may contain `__`; the split stays at the first separator.
+    assert_eq!(
+        split_wire_name(&wire_name("files", "read__all")),
+        Some(("files", "read__all"))
+    );
+    assert_eq!(split_wire_name("bash"), None, "outside the namespace");
+    // The exact ambiguity `namespace_rejection` exists to exclude:
+    assert_eq!(wire_name("acme_", "status"), wire_name("acme", "_status"));
+    assert!(namespace_rejection("acme_").is_some());
+    assert!(namespace_rejection("_acme").is_some());
+    assert!(namespace_rejection("acme").is_none());
+    assert!(
+        namespace_rejection("acme_corp").is_none(),
+        "an interior `_` is fine — only the edges are ambiguous"
+    );
+}
+
 #[tokio::test]
 async fn usage_ledger_records_a_successful_call_with_server_tool_and_reason() {
     let client = connected_client("files", "read").await;

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -94,7 +94,7 @@ A server entry needs a `transport` discriminant — `stdio` or `http` — and th
   </OptionCard>
 </CardGrid>
 
-Either way, stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide, and the entry's name in `mcp.toml` is what shows up in the middle segment.
+Either way, stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide, and the entry's name in `mcp.toml` is what shows up in the middle segment. To keep that encoding unambiguous, an entry name may not contain `__` and may not begin or end with `_` — a name that breaks the rule is reported as unavailable rather than risking one server's tools shadowing another's.
 
 <Callout type="warn">
 A stdio MCP subprocess runs with a **scrubbed environment** — ambient shell variables (including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`) are **not** inherited. Any variable the server needs must be listed explicitly in the entry's `env` table, e.g. `env = { GITHUB_TOKEN = "…" }`. The single exception is `PATH`, which is inherited so a bare runner (`npx`, `uvx`, `docker`) can resolve at all; an `env` entry named `PATH` overrides it.


### PR DESCRIPTION
## What & why

MCP tool wire names (`mcp__<server>__<tool>`) collided when one server's name was another's plus a trailing underscore — server `acme_` + tool `status` produces the same wire name as server `acme` + tool `_status` — and the later-connected client **silently won the route** (`toolset.rs`, old `rebuild_routes`). Since MCP servers are third-party, that was a connect-order-dependent spoofing vector: a server could shadow another server's tools by choosing colliding names.

This PR ships both fixes the issue proposed:

1. **Injective encoding (primary).** The server-name rule (`namespace_rejection`, formerly `is_namespaceable`) now also rejects a leading or trailing `_`. Equality of two wire names forces one server to be the other plus a trailing `_` (any longer suffix puts a non-`_` byte where the other name needs the `__` separator), so with that rejection the encoding is injective. Rejected names are recorded in `failed_servers` with an actionable reason, exactly like the existing empty/`__` rejections. No in-tree config or fixture uses an underscore-edged server name, so nothing legitimate breaks.
2. **Collision detection (defense in depth).** `rebuild_routes` now groups claims per wire name; a name claimed by more than one `(server, tool)` pair routes **nowhere** — every claimant dropped, never a connect-order winner — and the clash is recorded in the new `McpToolSet::wire_name_collisions()` diagnostic (`WireNameCollision { wire_name, claimants }`, sorted by wire name for deterministic rendering). It is deliberately not folded into `failed_servers`, for the same reason `over_advertising_servers` isn't: the claimant servers are connected and their uncontested tools route normally. Surfaced to the operator in both text mode (`print_connect_diagnostics`) and the deck (`mcp_outcome_report`, via the shared `collision_note` so the wording cannot drift — the `truncation_note` pattern).

**Tool-first alignment (#2716):** the encoding now lives in exactly **one** public function, `stella_mcp::wire_name` (inverse: `split_wire_name`), with the injectivity property stated in its doc comment — a future ToolContract registry calls that single function and its post-mangling collision check covers every advertised name. The one scattered wire-name `format!` outside the crate (`deck_mcp.rs`'s prefix matching) now uses the inverse instead.

Exemplar for the shape: rustc's interner/encoder discipline — one canonical encode with a documented inverse, callers never re-derive the format.

Closes #2675
Refs #2716

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-mcp/src/toolset/tests.rs::a_trailing_underscore_server_name_is_rejected_not_silently_shadowing` — on main it fails with `connected_count == 2` and an empty `failed_servers` (both servers connect; connect order picks who answers `mcp__acme___status`); with this change `acme_` is refused at registration and the surviving server owns the name outright. Verified the artisanal way (`git stash` on the source, new test over main's `toolset.rs`): both underscore witnesses FAILED on main, pass here.

`colliding_wire_names_drop_every_claimant_and_are_reported` pins the defense-in-depth layer (it drives `rebuild_routes` directly, because `from_clients` now refuses the colliding name before routes are ever built — which is exactly why the second wall exists). `wire_name_round_trips_and_the_collision_family_is_the_documented_one` pins the encode/decode pair and the documented collision family. `mcp_outcome_report_names_every_claimant_of_a_contested_wire_name` pins the deck rendering.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-mcp -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-mcp` (126 lib + integration) and `cargo test -p stella-cli` (1665+) — plus `make guards-fast` and rustdoc `-D warnings` on stella-mcp
- [x] Docs updated: `toolset.rs` module doc, `crates/stella-mcp/README.md` key-concepts paragraph, `website/content/docs/agent-tools/mcp.mdx` naming note
- [x] CLA signed
- [x] `Closes #2675` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

- `command_deck.rs` (a grandfathered god file) gains exactly one line: the fourth argument at the single `mcp_outcome_report` call site. 4550 lines stays under its 4565 baseline ceiling; the new logic itself lives in `mcp_cmd.rs` and `toolset.rs`.
- Behavior change worth naming: a server whose `mcp.toml` entry name begins or ends with `_` now fails registration with `server name starts or ends with `_`, which would make `mcp__<server>__<tool>` wire names ambiguous` instead of connecting. The trailing-`_` rejection is what buys injectivity; the leading-`_` rejection is the symmetric hygiene half the issue proposed.

## Summary by Sourcery

Ensure MCP tool wire names are uniquely mapped to servers and tools and surface any collisions to operators.

Bug Fixes:
- Reject MCP server names that would produce ambiguous wire names to prevent one server from shadowing another's tools.
- Drop all routes for MCP tools whose encoded wire names collide instead of letting connect order choose a winner.

Enhancements:
- Centralize MCP wire-name encoding/decoding into shared `wire_name` and `split_wire_name` functions and expose collision diagnostics via `McpToolSet::wire_name_collisions`.
- Extend CLI/deck reporting to include MCP wire-name collisions alongside failed and over-advertising servers.

Documentation:
- Update MCP documentation and README to describe the stricter server naming rules and collision handling semantics.

Tests:
- Add tests covering underscore-edged server name rejection, wire-name collision handling and reporting, and wire-name encode/decode round-tripping.