### PR TITLE
fix(stella-core): wire circuit-breaker feedback so provider failover trips (#2673)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -199,12 +199,11 @@ struct PipelineRunSummary {
 /// The `--output-format json` summary of a raw (`--no-pipeline`) step-loop run.
 /// A different key set from [`PipelineRunSummary`] — no verification ladder ran,
 /// and this path is the one that carries `files_touched` — but the same
-/// contract, so it declares the same [`crate::SUMMARY_SCHEMA_VERSION`]. The two
-/// can never drift: both read the one constant.
-///
-/// A struct rather than `serde_json::json!` so the version leads the object:
-/// `json!` builds a sorted map and would bury it mid-envelope. Key order is not
-/// contractual either way; this is for whoever reads the output by eye.
+/// contract, so it declares the same [`crate::SUMMARY_SCHEMA_VERSION`]; the two
+/// can never drift, both reading the one constant. A struct rather than
+/// `serde_json::json!` so the version leads the object (`json!` builds a sorted
+/// map and would bury it mid-envelope); key order is not contractual either
+/// way — this is for whoever reads the output by eye.
 #[derive(serde::Serialize)]
 struct RawRunSummary {
     schema_version: u32,
@@ -495,24 +494,21 @@ async fn run_pipeline_one_shot(
         .await;
     }
 
-    // Reflect on turns that did real work — success AND failure. A failed
-    // pipeline run is a high-value learning signal (root-cause prompt via
-    // `succeeded=false`).
-    //
+    // Reflect on turns that did real work — success AND failure (a failed
+    // pipeline run is a high-value root-cause signal via `succeeded=false`).
     // The gate is `did real work` = tool-calls in the transcript OR files
     // changed on disk. On the pipeline path the worker's tool-calling turns
     // are deliberately kept OUT of `messages` (planner context hygiene,
     // L-E6), so `turn_warrants_reflection(&messages)` alone is always false
-    // there and the whole self-improvement loop never fired on `stella run`.
-    // Falling back to `!files.is_empty()` — mirroring the episode gate above
+    // there and the self-improvement loop never fired on `stella run`;
+    // falling back to `!files.is_empty()` — mirroring the episode gate above
     // — is what makes the primary surface actually learn. The reflector is
-    // then handed an enriched transcript (final answer + a note of what
-    // changed) so it has signal even when the tool turns aren't in `messages`.
-    // Output format does not change Stella's learning semantics: text, JSON,
-    // and stream-JSON runs all reflect by default. Ephemeral automation may
-    // explicitly opt out with `STELLA_DISABLE_REFLECTION` when it must avoid a
-    // post-turn provider call (for example, a benchmark adapter that meters
-    // only the task-solving envelope).
+    // handed an enriched transcript (final answer + a note of what changed)
+    // so it has signal even when the tool turns aren't in `messages`. Output
+    // format does not change learning semantics: text, JSON, and stream-JSON
+    // runs all reflect by default; ephemeral automation opts out with
+    // `STELLA_DISABLE_REFLECTION` when it must avoid a post-turn provider
+    // call (e.g. a benchmark adapter metering only the task envelope).
     let mut reflection_report = ReflectionReport::default();
     if one_shot_reflection_enabled(format)
         && (turn_warrants_reflection(&messages) || !files.is_empty())
@@ -766,6 +762,11 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     // Session-scoped like `budget`: seeded once from prior sessions'
     // telemetry, then sharpened by every turn in this REPL.
     let calibration = seed_calibration(&store, cfg);
+    // Session-scoped like `calibration`: every turn's engine reports its
+    // call outcomes into this router's breaker (#2673) — the state a
+    // resolution (and #2679's mid-turn fallback) reads to route around a
+    // provider this session has watched fail.
+    let router = session_router(cfg, &ModelRef::new(cfg.provider.id, cfg.model_id.clone()));
 
     plain::welcome_banner(
         cfg.provider.id,
@@ -1093,6 +1094,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             &mut messages,
             &mut budget,
             &calibration,
+            &router,
             cfg,
             OutputFormat::Text,
             &store,
@@ -1239,9 +1241,9 @@ pub(crate) async fn init_workspace(
 /// snapshot. `None` when there is no index, it is empty, or any read fails —
 /// the tab then shows its "run stella init" hint instead of an empty graph.
 ///
-/// This is [`graph_snapshot_focus`] with no explicit focus, so the neighborhood
-/// centers on [`busiest_file`](stella_graph::CodeGraph::busiest_file) — the
-/// sensible default the deck opens on and can re-root away from via the picker.
+/// This is [`graph_snapshot_focus`] with no explicit focus: the neighborhood
+/// centers on [`busiest_file`](stella_graph::CodeGraph::busiest_file), which
+/// the deck opens on and can re-root away from via the picker.
 pub(crate) fn graph_snapshot(
     workspace_root: &std::path::Path,
 ) -> Option<stella_tui::GraphSnapshot> {
@@ -1828,12 +1830,10 @@ pub fn run_tools_validation(dir: Option<&std::path::Path>) -> Result<(), String>
 }
 
 /// Construct the budget guard from `--budget`. The limit lands on the
-/// session axis, so it caps cumulative spend across every turn and goal
-/// round of the run — `begin_turn` (called at the top of each turn/round)
-/// resets only the turn-scoped counter while the session accumulator
-/// survives it. The turn axis is left unset on purpose: turn spend can
-/// never exceed session spend (it is a reset-to-zero subset of it), so a
-/// turn limit equal to the session limit could never trip first and would
+/// session axis, capping cumulative spend across every turn and goal round
+/// of the run — `begin_turn` resets only the turn-scoped counter. The turn
+/// axis is left unset on purpose: turn spend is a reset-to-zero subset of
+/// session spend, so an equal turn limit could never trip first and would
 /// only mislabel a session breach as a turn one. No limit at all still
 /// meters spend (`BudgetMode::Observed`) so the cost summary and
 /// `BudgetTick` events stay meaningful even when nothing is enforced.
@@ -1905,13 +1905,11 @@ pub(crate) fn open_store(workspace_root: &std::path::Path) -> Option<Arc<Store>>
 
 /// Build the session's token-drift calibration, seeded from prior sessions'
 /// telemetry for the resolved provider/model (`Store::drift_samples`) so the
-/// estimator starts already corrected instead of re-learning each session.
-/// Best-effort like all persistence: no store (or a failed query) just means
-/// starting uncalibrated — factor 1.0, the pre-drift behavior.
-///
-/// The seeding, including the sample count, lives in
-/// [`stella_runtime::seed_calibration`]; this wrapper only unwraps the pin out
-/// of a [`Config`], which the runtime crate deliberately does not know about.
+/// estimator starts already corrected. Best-effort like all persistence: no
+/// store (or a failed query) means starting uncalibrated — factor 1.0. The
+/// seeding lives in [`stella_runtime::seed_calibration`]; this wrapper only
+/// unwraps the pin out of a [`Config`], which the runtime crate deliberately
+/// does not know about.
 pub(crate) fn seed_calibration(store: &Option<Arc<Store>>, cfg: &Config) -> CalibrationMap {
     stella_runtime::seed_calibration(store.as_ref(), cfg.provider.id, &cfg.model_id)
 }
@@ -1942,16 +1940,14 @@ pub(crate) fn begin_execution(
 }
 
 /// Run one full turn through `stella_core::Engine`, rendering its
-/// `AgentEvent` stream live via a spawned draining task running
-/// concurrently with the engine. Ordinary runs enqueue to an unbounded
-/// channel; benchmark stream-json runs synchronously append+flush each event
-/// before enqueueing it, so paid-call evidence survives a paused/cancelled
-/// renderer. Events still reach the renderer as soon as `run_turn` yields.
-/// The drain task ([`spawn_renderer`]) persists every event and each
-/// `StepUsage` to the workspace store when one is open. `registry` is the
-/// concrete tool registry (its CRUD ledger is read after the turn for the
-/// Files Touched panel); `base_tools` is the same registry as the engine's
-/// executor, possibly MCP-wrapped.
+/// `AgentEvent` stream live via a spawned draining task. Ordinary runs
+/// enqueue to an unbounded channel; benchmark stream-json runs synchronously
+/// append+flush each event before enqueueing it, so paid-call evidence
+/// survives a paused/cancelled renderer. The drain task ([`spawn_renderer`])
+/// persists every event and each `StepUsage` to the workspace store when one
+/// is open. `registry` is the concrete tool registry (its CRUD ledger feeds
+/// the Files Touched panel); `base_tools` is the same registry as the
+/// engine's executor, possibly MCP-wrapped.
 #[allow(clippy::too_many_arguments)]
 async fn run_turn(
     provider: &dyn Provider,
@@ -1961,6 +1957,8 @@ async fn run_turn(
     messages: &mut Vec<CompletionMessage>,
     budget: &mut BudgetGuard,
     calibration: &CalibrationMap,
+    // Session-scoped breaker feedback (#2673): the engine reports outcomes.
+    router: &Router,
     cfg: &Config,
     format: OutputFormat,
     store: &Option<Arc<Store>>,
@@ -2022,7 +2020,8 @@ async fn run_turn(
         let permitted = PolicyToolSet::new(registry, session_tool_policy(cfg));
         let config = engine::engine_config_for_kind(cfg, kind);
         let engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
-            .with_calibration(calibration);
+            .with_calibration(calibration)
+            .with_provider_outcomes(router);
         engine.run_turn_with_sender(messages, budget, &tx).await
     } else {
         let customs = CustomToolSet::new(
@@ -2048,7 +2047,8 @@ async fn run_turn(
         let hook_runner = ShellHookRunner;
         let config = engine::engine_config_for_kind(cfg, kind);
         let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
-            .with_calibration(calibration);
+            .with_calibration(calibration)
+            .with_provider_outcomes(router);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -1136,6 +1136,24 @@ pub(crate) fn resolve_cross_family_verifier(
     Some((verifier, decision.model_ref.provider))
 }
 
+/// The session-scoped role [`Router`] for a bare (non-pipeline) loop — the
+/// same wiring the pipeline paths build per run, held for the whole session
+/// so its breaker accumulates the observed outcome of every turn's model
+/// calls (#2673). The bare loops feed this router today and do not yet
+/// resolve from it (their provider is fixed at session start), which is why
+/// wiring notices are deliberately not surfaced here: none of the routing
+/// decisions they describe are operative on this path until mid-turn
+/// fallback (#2679) starts consulting the breaker at resolution time.
+pub(crate) fn session_router(cfg: &Config, worker_ref: &ModelRef) -> Router {
+    let configured = crate::config::discover_configured_providers();
+    let wiring = resolve_engine_wiring(cfg, worker_ref, &configured);
+    Router::new(
+        wiring.pins,
+        wiring.profiles,
+        CircuitBreaker::new(Box::new(SystemClock::new())),
+    )
+}
+
 /// Where post-turn reflection dispatches, and on what posture.
 ///
 /// [`Self::provider`] is `None` in the one case that is still a route: the

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -144,6 +144,9 @@ pub(crate) async fn run_raw_one_shot(
     let mut budget = build_budget_guard(budget_limit);
     let store = open_store(&cfg.workspace_root);
     let calibration = seed_calibration(&store, cfg);
+    // Breaker feedback for the bare one-shot turn (#2673) — one turn per
+    // process, so this is pure ledger today; #2679 reads it mid-turn.
+    let router = session_router(cfg, &ModelRef::new(cfg.provider.id, cfg.model_id.clone()));
 
     if format == OutputFormat::Text {
         plain::section_header("Stella");
@@ -216,6 +219,7 @@ pub(crate) async fn run_raw_one_shot(
         &mut messages,
         &mut budget,
         &calibration,
+        &router,
         cfg,
         format,
         &store,
@@ -818,7 +822,10 @@ async fn run_goal_pipeline_turn(
             verifier_engine_config_for(cfg),
             &TokioSleeper,
         )
-        .with_calibration(calibration);
+        .with_calibration(calibration)
+        // The round verifier's outcomes feed the same breaker the next
+        // round's pipeline resolves against (#2673).
+        .with_provider_outcomes(&router);
 
         let mut total_cost_usd = 0.0f64;
         let mut result: Option<Result<(), crate::failure::CliFailure>> = None;

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -1,72 +1,69 @@
-//! The step-driver: `Engine::run_turn`. One
-//! model call per step, message accumulation, `AgentEvent` emission at
-//! every boundary, retry+backoff, compaction, tool-output budget checks,
-//! loop detection, and (a first, structural cut of) malformed-call repair —
-//! wiring together every other module in this crate.
+//! The step-driver: `Engine::run_turn`. One model call per step, message
+//! accumulation, `AgentEvent` emission at every boundary, retry+backoff,
+//! compaction, tool-output budget checks, loop detection, and (a first,
+//! structural cut of) malformed-call repair — wiring together every other
+//! module in this crate.
 //!
 //! `Engine` drives through `&dyn Provider` (`stella_protocol`) and
 //! `&dyn ToolExecutor` (`crate::ports`) — no adapter-specific code and no
-//! direct filesystem access live here. Everything
-//! *inside* one step (compaction, loop detection, budget evaluation) is the
-//! plain synchronous logic from the other modules in this crate; `run_turn`
-//! is the one place that sequences them against real I/O.
+//! direct filesystem access live here. Everything *inside* one step
+//! (compaction, loop detection, budget evaluation) is the plain synchronous
+//! logic from the other modules in this crate; `run_turn` is the one place
+//! that sequences them against real I/O.
 //!
 //! # Deferred-flush events (L-E10)
 //!
-//! `retry_with_backoff_observed` returns committed retry
-//! history while synchronously exposing each failed provider attempt to the
-//! accounting path. Ordinary retry narration stays deferred until success;
-//! content-free `UsageIncomplete` envelopes are durable immediately because
-//! a later successful attempt cannot recover the failed call's usage. A
-//! caller-side hard cancel that drops the turn while an attempt is still in
-//! flight emits one `Cancelled` envelope from a drop guard
-//! (`CancelUsageGuard`) armed for exactly that window.
+//! `retry_with_backoff_observed` returns committed retry history while
+//! synchronously exposing each failed provider attempt to the accounting
+//! path. Ordinary retry narration stays deferred until success; content-free
+//! `UsageIncomplete` envelopes are durable immediately because a later
+//! successful attempt cannot recover the failed call's usage. A caller-side
+//! hard cancel that drops the turn while an attempt is still in flight emits
+//! one `Cancelled` envelope from a drop guard (`CancelUsageGuard`) armed for
+//! exactly that window.
 //!
 //! # Retry re-executes only speculation-safe read-only calls, never a mutating one
 //!
 //! `retry_with_backoff_observed` wraps the model call
 //! (`Provider::complete_observed`) together with that attempt's speculation
 //! pump (`crate::speculation`). The exactly-once guarantee is scoped to
-//! MUTATING tools: a mutating call runs once, after a model call has
-//! already succeeded and returned tool calls to run — never inside the
-//! retried closure — so a retried step structurally cannot re-execute a
-//! non-idempotent tool. See the test
-//! `retry_never_re_executes_a_tool_call` below, which proves it by counting
-//! real executions against a flaky scripted provider.
+//! MUTATING tools: a mutating call runs once, after a model call has already
+//! succeeded and returned tool calls to run — never inside the retried
+//! closure — so a retried step structurally cannot re-execute a
+//! non-idempotent tool (proven by `retry_never_re_executes_a_tool_call`
+//! below, which counts real executions against a flaky scripted provider).
 //!
-//! SPECULATED tools carry no such guarantee: a call announced by the
-//! stream DOES execute inside the retried attempt closure and can run
-//! more than once per step (a failed attempt runs it, the retry re-announces
-//! and runs it again). Which is why eligibility takes two schema claims,
-//! not one (#923): `read_only` (safe for the *workspace* — the call
-//! mutates nothing) AND `speculation_safe` (safe to run twice — no
-//! metered network read, no rate-limited API, no write to internal state
-//! like `codegraph.db` on the read path). A tool that is read-only but
-//! not speculation-safe runs only at dispatch, exactly once per committed
-//! call, with no hook to attach and nothing to remember. See
-//! `crate::speculation` for the overlap semantics: user hooks are
-//! excluded from that overlap so they still fire exactly once per committed
-//! call, and every speculative execution that never commits is reported as a
-//! `SpeculationDiscarded` event so the I/O it ran stays accountable (#370).
+//! SPECULATED tools carry no such guarantee: a call announced by the stream
+//! DOES execute inside the retried attempt closure and can run more than
+//! once per step (a failed attempt runs it, the retry re-announces and runs
+//! it again). Which is why eligibility takes two schema claims, not one
+//! (#923): `read_only` (the call mutates nothing in the workspace) AND
+//! `speculation_safe` (safe to run twice — no metered network read, no
+//! rate-limited API, no write to internal state like `codegraph.db` on the
+//! read path). A tool that is read-only but not speculation-safe runs only
+//! at dispatch, exactly once per committed call. See `crate::speculation`
+//! for the overlap semantics: user hooks are excluded from that overlap so
+//! they still fire exactly once per committed call, and every speculative
+//! execution that never commits is reported as a `SpeculationDiscarded`
+//! event so the I/O it ran stays accountable (#370).
 //!
 //! # Budget is checked between steps, never mid-tool
 //!
 //! Per [`crate::budget`]'s module contract, `run_turn` only consults
-//! [`crate::budget::BudgetGuard::evaluate`]/`record_spend` immediately
-//! after a model call completes and before the next one (or before
-//! executing this step's tool calls) — an `AbortTurn` outcome ends the turn
-//! cleanly, it never interrupts a tool already in flight.
+//! [`crate::budget::BudgetGuard::evaluate`]/`record_spend` immediately after
+//! a model call completes and before the next one (or before executing this
+//! step's tool calls) — an `AbortTurn` outcome ends the turn cleanly, it
+//! never interrupts a tool already in flight.
 //!
 //! # Malformed-call repair
 //!
 //! Every adapter's stream aggregator in `stella-model` falls back to
 //! `serde_json::Value::Null` when a tool call's streamed argument JSON
-//! doesn't parse. `run_turn`
-//! recognizes that sentinel structurally: rather than handing `Null` to a
-//! tool that expects an object, it short-circuits to a named
-//! `ToolOutput::Error` telling the model its own JSON was malformed, so the
-//! model can retry with corrected syntax on the next step. This is a real,
-//! if first-cut, repair — dialect-specific tuning
+//! doesn't parse. `run_turn` recognizes that sentinel structurally: rather
+//! than handing `Null` to a tool that expects an object, it short-circuits
+//! to a named `ToolOutput::Error` telling the model its own JSON was
+//! malformed, so the model can retry with corrected syntax on the next
+//! step. This is a real, if first-cut, repair — dialect-specific tuning
 //! ("malformed-call repair tuned to the failure shapes GLM actually
 //! produces") is a documented follow-up, not faked here.
 
@@ -409,17 +406,15 @@ pub enum TurnOutcome {
 }
 
 /// The per-turn memos a step mutates but a [`crate::step::Checkpoint`]
-/// deliberately does not carry.
-///
-/// All four exist to make repeated work cheap or repeated noise quiet within
-/// one turn: the receipt ledger remembers which blocks it already registered,
-/// the warning ledger claims the first observed-mode breach per axis, the
-/// result identities remember what a call really produced before compaction
-/// stubbed it (#554), and the summarizer latch stops a failing cheap model
-/// re-firing every step. They live in one struct, held by
-/// [`crate::step::TurnState`], because that is the whole set of per-turn state
-/// whose types are internal to this module — a resumed turn rebuilds them
-/// rather than deserializing four private caches out of a wire format.
+/// deliberately does not carry. All four make repeated work cheap or
+/// repeated noise quiet within one turn: the receipt ledger remembers which
+/// blocks it already registered, the warning ledger claims the first
+/// observed-mode breach per axis, the result identities remember what a call
+/// really produced before compaction stubbed it (#554), and the summarizer
+/// latch stops a failing cheap model re-firing every step. One struct, held
+/// by [`crate::step::TurnState`], because that is the whole set of per-turn
+/// state whose types are internal to this module — a resumed turn rebuilds
+/// them rather than deserializing four private caches out of a wire format.
 pub(crate) struct TurnMemos {
     /// Block registry + residency for this turn's context receipts.
     receipts: ReceiptLedger,
@@ -460,11 +455,10 @@ impl TurnMemos {
 
 /// The two references a turn needs to fire lifecycle hooks: the parsed
 /// workspace [`Hooks`] config and the [`HookRunner`] execution port that
-/// actually spawns the commands (the real process I/O `stella-core` never
-/// performs — see `crate::hooks`). Bundled so the engine carries a single
-/// `Option`: `None` means hooks are entirely off and the turn path is
-/// byte-for-byte the same as before this seam existed. `Copy` because both
-/// fields are shared references.
+/// spawns the commands (the process I/O `stella-core` never performs — see
+/// `crate::hooks`). Bundled so the engine carries a single `Option`: `None`
+/// means hooks are entirely off and the turn path is byte-for-byte the same
+/// as before this seam existed. `Copy`: both fields are shared references.
 #[derive(Clone, Copy)]
 pub(crate) struct HooksHandle<'a> {
     hooks: &'a Hooks,
@@ -515,15 +509,19 @@ pub struct Engine<'a> {
     /// extension can watch a step begin, it cannot veto one. The interception
     /// points stay where they already are, on the tool-call path.
     pub(crate) bus: Option<&'a crate::bus::HookBus>,
+    /// Call-outcome feedback ([`crate::ports::ProviderOutcomes`]), off by
+    /// default. Attached via [`Engine::with_provider_outcomes`]; each logical
+    /// model call reports its terminal verdict against `provider.id()` so a
+    /// router's circuit breaker trips from observed outcomes (#2673).
+    pub(crate) outcomes: Option<&'a dyn crate::ports::ProviderOutcomes>,
 }
 
-/// Why a turn that never produced a terminal step ends.
-///
-/// A function rather than an inline `format!` because it is now written by
-/// two loops: [`Engine::run_turn_with_sender`] and any host driving
-/// [`Engine::run_step`] itself (`stella-serve`, #1129). This string reaches a
-/// transcript, a log, and a user's terminal — two copies of it would drift,
-/// and the drift would read as two different failures.
+/// Why a turn that never produced a terminal step ends. A function rather
+/// than an inline `format!` because it is written by two loops —
+/// [`Engine::run_turn_with_sender`] and any host driving
+/// [`Engine::run_step`] itself (`stella-serve`, #1129) — and this string
+/// reaches transcripts and terminals, where two drifting copies would read
+/// as two different failures.
 #[must_use]
 pub fn step_cap_reason(max_steps: usize) -> String {
     format!(
@@ -562,10 +560,9 @@ const SOFT_STOP_TOOL_RESULT: &str = "not executed — turn stopped by user at a 
 /// it consume: the pre-call raw token estimate (drift feedback + telemetry
 /// — raw, never calibrated, attachments excluded, see
 /// [`Engine::run_model_call`]) and the read-only tool set for dispatch
-/// scheduling. The step's `StepUsage`
-/// metering record (retry and duration figures included) was already
-/// emitted by [`Engine::run_model_call`] at the no-await settlement
-/// boundary — it is deliberately NOT carried here.
+/// scheduling. The step's `StepUsage` metering record was already emitted by
+/// [`Engine::run_model_call`] at the no-await settlement boundary — it is
+/// deliberately NOT carried here.
 struct CommittedStep {
     result: CompletionResultAlias,
     budget_outcome: BudgetOutcome,
@@ -603,6 +600,7 @@ impl<'a> Engine<'a> {
             gate: None,
             steering: None,
             bus: None,
+            outcomes: None,
         }
     }
 
@@ -651,24 +649,23 @@ impl<'a> Engine<'a> {
             gate: self.gate,
             steering: self.steering,
             bus: self.bus,
+            outcomes: self.outcomes,
         }
     }
 
     /// A shallow copy of this engine that consults `halt` at every step
     /// boundary and ends the turn as [`TurnOutcome::Completed`] when it
-    /// fires.
-    ///
-    /// Takes `&self` and returns a new engine — the [`Self::with_turn_instance`]
-    /// shape rather than the consuming-builder shape — because the caller that
-    /// knows the goal is met is `stella-pipeline`, which is handed an
-    /// `&Engine` it does not own and needs a per-candidate variant of it.
+    /// fires. Takes `&self` and returns a new engine — the
+    /// [`Self::with_turn_instance`] shape, not the consuming-builder shape —
+    /// because the caller that knows the goal is met is `stella-pipeline`,
+    /// which is handed an `&Engine` it does not own and needs a
+    /// per-candidate variant of it.
     ///
     /// Deliberately NOT expressed through [`crate::ports::TurnSteering`]'s
-    /// soft stop, which is the other step-boundary exit: that one is a *user*
-    /// asking to stop and returns `Aborted`, which reaches the CLI as a
-    /// non-zero exit and is scored by benchmark harnesses as the agent
-    /// crashing. "The goal is met" is a success, and has to end the turn as
-    /// one.
+    /// soft stop, the other step-boundary exit: that one is a *user* asking
+    /// to stop and returns `Aborted`, which reaches the CLI as a non-zero
+    /// exit and is scored by benchmark harnesses as the agent crashing.
+    /// "The goal is met" is a success, and has to end the turn as one.
     pub fn with_turn_halt(&self, halt: Arc<dyn TurnHalt>) -> Engine<'a> {
         Engine {
             provider: self.provider,
@@ -684,6 +681,7 @@ impl<'a> Engine<'a> {
             gate: self.gate,
             steering: self.steering,
             bus: self.bus,
+            outcomes: self.outcomes,
         }
     }
 
@@ -706,6 +704,18 @@ impl<'a> Engine<'a> {
     /// built without this estimates exactly as before.
     pub fn with_calibration(mut self, calibration: &'a CalibrationMap) -> Self {
         self.calibration = Some(calibration);
+        self
+    }
+
+    /// Attach call-outcome feedback, opt-in: every logical model call
+    /// (retries collapsed) reports success or terminal failure against
+    /// `provider.id()`, so a [`crate::router::Router`]'s circuit breaker
+    /// trips failover from observed outcomes, not configuration (#2673).
+    pub fn with_provider_outcomes(
+        mut self,
+        outcomes: &'a dyn crate::ports::ProviderOutcomes,
+    ) -> Self {
+        self.outcomes = Some(outcomes);
         self
     }
 
@@ -734,13 +744,9 @@ impl<'a> Engine<'a> {
 
     /// Attach an extension hook bus, so the turn, step and model-call
     /// boundaries this engine already crosses become observable (#1133).
-    ///
-    /// Before this, the only production emitter on the bus was the tool
-    /// registry: an extension could see every tool call and nothing about the
-    /// turn that made them — not that a turn started, not that a model call
-    /// began or what it cost. The catalog and `emit_named` both already
-    /// existed; what was missing was the call sites, which are here because
-    /// this is where the boundaries are.
+    /// Before this the only production emitter on the bus was the tool
+    /// registry — the catalog and `emit_named` existed, the call sites did
+    /// not, and they are here because this is where the boundaries are.
     ///
     /// Observer-only, by construction: see the `bus` field.
     pub fn with_bus(mut self, bus: &'a crate::bus::HookBus) -> Self {
@@ -1179,26 +1185,20 @@ impl<'a> Engine<'a> {
     /// # Who calls this, and who deliberately does not
     ///
     /// This is for a host that continues an interrupted turn: it hands back a
-    /// state to keep stepping, which the host either passes to [`Self::drive`]
-    /// — the ordinary case, and what `stella-pipeline`'s resumed execute stage
-    /// does — or steps itself through [`Self::run_step`]. Neither shipping
-    /// surface accepts one from the outside today, and that is a declaration
-    /// rather than an oversight:
-    ///
-    /// - **The CLI** resumes an interrupted turn at *transcript* granularity
-    ///   instead. Its turns are dispatched through `stella-pipeline`, which
-    ///   owns turn framing and builds its own state via `run_turn`, so there is
-    ///   no seam to hand a resumed `TurnState` to without threading a
-    ///   checkpoint through the entire verification ladder. What it does do is
-    ///   reopen the conversation at the checkpoint's step boundary, so the
-    ///   completed steps' work is not re-run — see `stella-parity`'s
-    ///   `turn.checkpoint_resume` row.
-    /// - **`stella-serve`** stores one and hands it back on request but accepts
-    ///   none in return, so continuing is the host's call (same row, API side).
-    ///
-    /// So the production callers are embedders, and the in-tree exercise of it
-    /// is `stella-engine`'s test suite. Anything that changes on either surface
-    /// should change that row in the same PR.
+    /// state to keep stepping, via [`Self::drive`] (the ordinary case, and
+    /// what `stella-pipeline`'s resumed execute stage does) or
+    /// [`Self::run_step`]. Neither shipping surface accepts one from the
+    /// outside today, and that is a declaration rather than an oversight:
+    /// the CLI resumes at *transcript* granularity instead (its turns are
+    /// dispatched through `stella-pipeline`, which owns turn framing and
+    /// builds its own state via `run_turn`; it reopens the conversation at
+    /// the checkpoint's step boundary so completed steps' work is not re-run
+    /// — see `stella-parity`'s `turn.checkpoint_resume` row), and
+    /// `stella-serve` stores one and hands it back on request but accepts
+    /// none in return (same row, API side). So the production callers are
+    /// embedders, and the in-tree exercise is `stella-engine`'s test suite.
+    /// Anything that changes on either surface changes that row in the same
+    /// PR.
     #[must_use]
     pub fn resume_turn(&self, checkpoint: crate::step::Checkpoint) -> TurnState {
         TurnState::from_checkpoint(checkpoint, &self.config)
@@ -1679,16 +1679,14 @@ impl<'a> Engine<'a> {
         // Each attempt runs the provider call and the speculation pump
         // concurrently: the pump executes read-only calls the moment the
         // adapter announces them (`crate::speculation`), so their wall-clock
-        // overlaps the stream instead of following it. The gate (and with
-        // it the channel's send half) drops when the provider call resolves,
-        // which is what lets the pump finish draining. A failed attempt
-        // drops its pool with the attempt — safe to waste for the workspace,
-        // but each completed entry emits a `SpeculationDiscarded` event on
-        // the way out (#370) — and the retry builds a fresh channel and pool.
-        // Stored true exactly around each attempt's dispatch, so the drop
-        // guard below can tell "a paid call may be in flight" apart from "the
-        // ladder is asleep between attempts" — the failed attempt before a
-        // sleep already reported its own envelope through the observer.
+        // overlaps the stream. The gate (and the channel's send half) drops
+        // when the provider call resolves, letting the pump finish draining.
+        // A failed attempt drops its pool with the attempt — safe to waste,
+        // though each completed entry emits `SpeculationDiscarded` on the
+        // way out (#370) — and the retry builds a fresh channel and pool.
+        // The latch is true exactly around each attempt's dispatch, so the
+        // drop guard below can tell "a paid call may be in flight" apart
+        // from "the ladder is asleep between attempts".
         let attempt_in_flight = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let attempt_in_flight_latch = attempt_in_flight.clone();
         let attempt: RetryAttemptFn = Box::new(move || {
@@ -1713,17 +1711,15 @@ impl<'a> Engine<'a> {
                 });
                 let result = tokio::select! {
                     // `biased` makes the invariant below structural rather
-                    // than incidental: `complete` owns the gate (and with
-                    // it the channel's send half), so the pump can only
-                    // finish after `complete` has. Polling `complete`
-                    // first means the pump arm cannot be taken by an
-                    // unlucky randomized poll order (#560).
-                    //
-                    // That arm is believed unreachable, but it reports a
-                    // typed terminal error rather than panicking: this is
-                    // library code on a provider-driven path, where
-                    // invariant 5 (no panics on runtime data) outranks
-                    // asserting a structural claim (#618 item 17).
+                    // than incidental: `complete` owns the gate (and the
+                    // channel's send half), so the pump can only finish
+                    // after `complete` has, and polling `complete` first
+                    // keeps an unlucky randomized poll order from taking the
+                    // pump arm (#560). That arm is believed unreachable, but
+                    // it reports a typed terminal error rather than
+                    // panicking: this is library code on a provider-driven
+                    // path, where invariant 5 (no panics on runtime data)
+                    // outranks asserting a structural claim (#618 item 17).
                     biased;
                     result = bounded_generation(self.config.model_timeout, &progress, &mut complete) => result,
                     _ = &mut pump => Err(ProviderError::Terminal(
@@ -1744,11 +1740,9 @@ impl<'a> Engine<'a> {
         // flight: a caller-side hard cancel that drops this future mid-await
         // still leaves one content-free `Cancelled` envelope behind.
         // Disarmed on BOTH normal exits — a success reports through its
-        // `StepUsage`, and a terminal failure's attempts already reported
-        // through the per-attempt observer below. The shared latch narrows
-        // "in flight" to the dispatch itself: a drop landing in a backoff
-        // sleep emits nothing, because the failed attempt before the sleep
-        // already reported its own envelope.
+        // `StepUsage`, a terminal failure through the per-attempt observer
+        // below. The shared latch narrows "in flight" to the dispatch
+        // itself: a drop landing in a backoff sleep emits nothing.
         let mut cancel_guard = CancelUsageGuard {
             events: events.clone(),
             role: self.call_role,
@@ -1824,9 +1818,15 @@ impl<'a> Engine<'a> {
                     message: message.clone(),
                     retryable,
                 });
+                if let Some(outcomes) = self.outcomes {
+                    outcomes.record_failure(self.provider.id());
+                }
                 return Err(format!("model call failed: {message}"));
             }
         };
+        if let Some(outcomes) = self.outcomes {
+            outcomes.record_success(self.provider.id());
+        }
         // One boundary read: the call's duration and the tick's clock axis.
         let now = std::time::Instant::now();
         let call_duration_ms = now.duration_since(call_started).as_millis() as u64;

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -1414,19 +1414,17 @@ async fn empty_completion_aborts_with_a_visible_message_not_a_silent_success() {
 #[tokio::test]
 async fn a_step_out_of_time_completes_with_a_truthful_partial_instead_of_aborting() {
     // The same empty length-truncated shape as the test above, and the opposite
-    // ending, because the reason for stopping is opposite. Above, the model
+    // ending, because the reason for stopping is opposite: above, the model
     // burned every continuation and still produced nothing — a failure, and the
-    // abort says so. Here the turn simply ran out of wall clock on its FIRST cap
-    // hit, with its whole allowance untouched.
-    //
-    // Both used to return `None` from `plan_continuation` and land on the same
-    // abort. That made `--turn-budget` self-defeating: it exists to stop a turn
-    // before a harness kills it, and a nonzero exit is scored as the agent dying
-    // just as a kill is. Four of the five nonzero exits on a ten-task
-    // Terminal-Bench 2.1 gate were this, each with zero continuations spent.
-    //
-    // A zero budget makes `remaining` zero however fast the step ran, so the
-    // decline is deterministic rather than a race against the test's own clock.
+    // abort says so — while here the turn simply ran out of wall clock on its
+    // FIRST cap hit, allowance untouched. Both used to return `None` from
+    // `plan_continuation` and land on the same abort, which made
+    // `--turn-budget` self-defeating: it exists to stop a turn before a harness
+    // kills it, and a nonzero exit is scored as the agent dying just as a kill
+    // is. Four of the five nonzero exits on a ten-task Terminal-Bench 2.1 gate
+    // were this, each with zero continuations spent. A zero budget makes
+    // `remaining` zero however fast the step ran, so the decline is
+    // deterministic rather than a race against the test's own clock.
     let provider = ScriptedProvider {
         id: "scripted".into(),
         script: TokioMutex::new(vec![Ok(empty_result(Some(FinishReason::Length)))]),
@@ -3081,6 +3079,7 @@ mod context_efficiency;
 mod lifecycle_bus;
 mod loop_abort;
 mod parked_wait;
+mod provider_outcomes;
 mod steer_midturn;
 mod usage_completeness;
 mod zero_copy_request;

--- a/crates/stella-core/src/driver/tests/provider_outcomes.rs
+++ b/crates/stella-core/src/driver/tests/provider_outcomes.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Breaker feedback at the model-call boundary (#2673).
+//!
+//! The witness for wiring this crate went without: `Router` carried a
+//! `CircuitBreaker` and the engine observed every call outcome, but nothing
+//! connected them — `record_success`/`record_failure` had no production
+//! caller, so a provider could fail every call for hours and `resolve` kept
+//! routing to it. These tests drive real turns through
+//! [`Engine::with_provider_outcomes`] and assert the router's *next*
+//! resolution actually routes around the provider those turns watched fail.
+
+use super::super::*;
+use crate::ports::Clock;
+use crate::router::{CircuitBreaker, ProviderProfile, RoleTable, Router};
+use serde_json::Value;
+use stella_protocol::{CompletionResult, ModelRef, Role, ToolSchema};
+
+/// A provider whose every call fails unretryably — the transport-class
+/// terminal failure the breaker counts.
+struct FailingPrimary;
+
+#[async_trait::async_trait]
+impl Provider for FailingPrimary {
+    fn id(&self) -> &str {
+        "primary"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Err(ProviderError::Auth("primary is down".to_string()))
+    }
+}
+
+/// The same provider identity, healthy — the recovery half.
+struct HealthyPrimary;
+
+#[async_trait::async_trait]
+impl Provider for HealthyPrimary {
+    fn id(&self) -> &str {
+        "primary"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        Ok(CompletionResult {
+            text: "done".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage::default(),
+            model: "primary-strong".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+struct NoTools;
+
+#[async_trait::async_trait]
+impl ToolExecutor for NoTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        Vec::new()
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: String::new(),
+        }
+    }
+}
+
+struct NoSleep;
+
+#[async_trait::async_trait]
+impl crate::retry::Sleeper for NoSleep {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+/// Cooldown timing is irrelevant here (nothing advances), so a frozen clock
+/// keeps the breaker's open state deterministic for the whole test.
+struct FrozenClock;
+
+impl Clock for FrozenClock {
+    fn now_ms(&self) -> u64 {
+        0
+    }
+}
+
+fn tier(provider: &str) -> ModelRef {
+    ModelRef::new(provider, format!("{provider}-strong"))
+}
+
+/// Two configured providers, `primary` preferred — the router every test
+/// resolves against while turns feed its breaker.
+fn router() -> Router {
+    let profile = |id: &str| ProviderProfile::new(id, tier(id), tier(id), tier(id));
+    Router::new(
+        RoleTable::new(),
+        vec![profile("primary"), profile("standby")],
+        CircuitBreaker::new(Box::new(FrozenClock)),
+    )
+}
+
+/// One real turn whose engine reports call outcomes into `router` — the
+/// production wiring shape (`&Router`, shared, at the call site).
+async fn run_turn_feeding(provider: &dyn Provider, router: &Router) -> TurnOutcome {
+    let tools = NoTools;
+    let sleeper = NoSleep;
+    let engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper)
+        .with_provider_outcomes(router);
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("hi")];
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    engine.run_turn(&mut messages, &mut budget, &tx).await
+}
+
+/// The #2673 witness: a provider failing the threshold of consecutive calls
+/// is actually skipped by the next `resolve`, with the substitution reported
+/// as a fallback rather than made silently (L-M7).
+#[tokio::test]
+async fn a_provider_failing_the_threshold_of_calls_is_skipped_by_the_next_resolve() {
+    let router = router();
+    let before = router.resolve(Role::Worker).expect("healthy resolution");
+    assert_eq!(before.model_ref, tier("primary"));
+
+    for _ in 0..CircuitBreaker::DEFAULT_FAILURE_THRESHOLD {
+        let outcome = run_turn_feeding(&FailingPrimary, &router).await;
+        assert!(matches!(outcome, TurnOutcome::Aborted { .. }));
+    }
+
+    let after = router.resolve(Role::Worker).expect("standby is healthy");
+    assert_eq!(after.model_ref, tier("standby"));
+    let fallback = after.fallback.expect("breaker fallback is never silent");
+    assert_eq!(fallback.from, "primary");
+    assert_eq!(fallback.to, "standby");
+}
+
+/// Below the threshold the breaker stays closed: one bad turn must not
+/// reroute a provider that is merely having a moment.
+#[tokio::test]
+async fn one_failed_call_does_not_trip_failover() {
+    let router = router();
+    let outcome = run_turn_feeding(&FailingPrimary, &router).await;
+    assert!(matches!(outcome, TurnOutcome::Aborted { .. }));
+
+    let decision = router.resolve(Role::Worker).expect("still resolves");
+    assert_eq!(decision.model_ref, tier("primary"));
+    assert_eq!(decision.fallback, None);
+}
+
+/// A committed call reports success and fully closes the breaker, so
+/// resolution returns to the preferred provider.
+#[tokio::test]
+async fn a_committed_call_closes_the_breaker_again() {
+    let router = router();
+    for _ in 0..CircuitBreaker::DEFAULT_FAILURE_THRESHOLD {
+        run_turn_feeding(&FailingPrimary, &router).await;
+    }
+    assert_eq!(
+        router.resolve(Role::Worker).expect("fallback").model_ref,
+        tier("standby")
+    );
+
+    let outcome = run_turn_feeding(&HealthyPrimary, &router).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+    let healed = router.resolve(Role::Worker).expect("healed resolution");
+    assert_eq!(healed.model_ref, tier("primary"));
+    assert_eq!(healed.fallback, None);
+}

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -190,6 +190,22 @@ pub trait Clock: Send + Sync {
     fn now_ms(&self) -> u64;
 }
 
+/// Call-outcome feedback into provider routing — the write half of
+/// [`crate::router::Router`]'s circuit breaker (§7 reliability rules; L-M7),
+/// which implements it. The engine reports each *logical* model call's
+/// terminal verdict, retries collapsed: a call that eventually committed is
+/// one success, retries exhausted (or an unretryable transport-class error)
+/// is one failure. `&self` because the reporter holds the router shared —
+/// resolution keeps reading the same reference concurrently, and requiring
+/// `&mut` is exactly what left the breaker without a production caller
+/// (#2673).
+pub trait ProviderOutcomes: Send + Sync {
+    /// A call served by `provider_id` committed.
+    fn record_success(&self, provider_id: &str);
+    /// A transport-class terminal failure from `provider_id`.
+    fn record_failure(&self, provider_id: &str);
+}
+
 /// Boundary pause gate — polled by the engine between model calls, the same
 /// safe boundary as budget aborts (L-E6: never mid-tool). `wait_if_paused`
 /// returns immediately when the turn may proceed and parks (await) while it

--- a/crates/stella-core/src/router.rs
+++ b/crates/stella-core/src/router.rs
@@ -23,10 +23,11 @@
 //! fully working set of role resolutions).
 
 use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use stella_protocol::{ModelRef, Role};
 
-use crate::ports::Clock;
+use crate::ports::{Clock, ProviderOutcomes};
 
 // Provider profiles
 
@@ -351,16 +352,21 @@ pub enum RouterError {
 /// 2. Scenario defaults over the configured `ProviderProfile`s, in
 ///    preference order, skipping any whose circuit breaker is open.
 ///
-/// Construction is the only mutation-free step; `resolve` takes `&self` and
-/// is a pure query. Only `record_success`/`record_failure` mutate breaker
-/// state.
+/// `resolve` takes `&self` and is a pure query. Only
+/// `record_success`/`record_failure` mutate breaker state — through `&self`
+/// as well, so the call sites that observe outcomes (the engine's model-call
+/// boundary, the pipeline's management calls) can feed the breaker over the
+/// same shared reference resolution already uses (#2673). The
+/// [`CircuitBreaker`] itself stays a plain `&mut self` state machine; the
+/// `Mutex` here is only the sharing shell around it, never held across an
+/// await (every breaker operation is synchronous).
 pub struct Router {
     role_table: RoleTable,
     /// Configured providers in preference order — first = most preferred,
     /// mirroring `stella-cli::config::PROVIDERS`'s existing preference
     /// ordering.
     profiles: Vec<ProviderProfile>,
-    breaker: CircuitBreaker,
+    breaker: Mutex<CircuitBreaker>,
 }
 
 impl Router {
@@ -372,8 +378,17 @@ impl Router {
         Self {
             role_table,
             profiles,
-            breaker,
+            breaker: Mutex::new(breaker),
         }
+    }
+
+    /// The breaker guard, poison-proof: every mutation under this lock is a
+    /// single `HashMap` operation that cannot be observed half-done, so a
+    /// panicked peer cannot leave breaker state inconsistent — recovering
+    /// the inner value is strictly better than poisoning every later
+    /// resolution for the rest of the session.
+    fn breaker(&self) -> MutexGuard<'_, CircuitBreaker> {
+        self.breaker.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Read access to the explicit pins, e.g. for `stella config model get`.
@@ -387,28 +402,39 @@ impl Router {
     }
 
     /// Feed a successful call outcome into the breaker for `provider_id`.
-    pub fn record_success(&mut self, provider_id: &str) {
-        self.breaker.record_success(provider_id);
+    pub fn record_success(&self, provider_id: &str) {
+        self.breaker().record_success(provider_id);
     }
 
     /// Feed a failed (transport-class) call outcome into the breaker for
     /// `provider_id`; may trip it open (§2, §7; L-M7).
-    pub fn record_failure(&mut self, provider_id: &str) {
-        self.breaker.record_failure(provider_id);
+    pub fn record_failure(&self, provider_id: &str) {
+        self.breaker().record_failure(provider_id);
     }
 
     /// Resolve `role` to a model per the precedence documented on `Router`.
     pub fn resolve(&self, role: Role) -> Result<RouterDecision, RouterError> {
+        self.resolve_with(&self.breaker(), role)
+    }
+
+    /// [`Router::resolve`] against an already-taken breaker guard — one lock
+    /// per resolution, and the verifier's recursive Worker resolution reuses
+    /// the guard instead of deadlocking on a second acquisition.
+    fn resolve_with(
+        &self,
+        breaker: &CircuitBreaker,
+        role: Role,
+    ) -> Result<RouterDecision, RouterError> {
         if let Some(pinned) = self.role_table.get(role) {
             return Ok(RouterDecision::plain(pinned.clone()));
         }
 
         match role {
             Role::Worker | Role::Plan | Role::Research => {
-                self.resolve_tier(role, |p| &p.worker_model)
+                self.resolve_tier(breaker, role, |p| &p.worker_model)
             }
-            Role::Triage => self.resolve_tier(role, |p| &p.triage_model),
-            Role::Verifier => self.resolve_verifier(),
+            Role::Triage => self.resolve_tier(breaker, role, |p| &p.triage_model),
+            Role::Verifier => self.resolve_verifier(breaker),
             Role::Embed | Role::Vision | Role::Image | Role::Video => {
                 Err(RouterError::NoDefaultForRole { role })
             }
@@ -420,6 +446,7 @@ impl Router {
     /// one (and reporting it) when the preferred provider is breaker-open.
     fn resolve_tier(
         &self,
+        breaker: &CircuitBreaker,
         role: Role,
         pick: impl Fn(&ProviderProfile) -> &ModelRef,
     ) -> Result<RouterDecision, RouterError> {
@@ -428,15 +455,15 @@ impl Router {
         }
 
         let preferred = &self.profiles[0];
-        if self.breaker.is_available(&preferred.id) {
+        if breaker.is_available(&preferred.id) {
             return Ok(RouterDecision::plain(pick(preferred).clone()));
         }
 
         for candidate in &self.profiles[1..] {
-            if self.breaker.is_available(&candidate.id) {
+            if breaker.is_available(&candidate.id) {
                 return Ok(RouterDecision {
                     model_ref: pick(candidate).clone(),
-                    fallback: Some(self.fallback_from(preferred, candidate)),
+                    fallback: Some(fallback_from(breaker, preferred, candidate)),
                     caveat: None,
                 });
             }
@@ -458,7 +485,7 @@ impl Router {
     /// separate call, not a separate model. When that happens the `caveat` says
     /// so, so "different model than the worker" is a preference the router
     /// reports on, never a guarantee it can make from one key.
-    fn resolve_verifier(&self) -> Result<RouterDecision, RouterError> {
+    fn resolve_verifier(&self, breaker: &CircuitBreaker) -> Result<RouterDecision, RouterError> {
         if self.profiles.is_empty() {
             return Err(RouterError::NoProvidersConfigured {
                 role: Role::Verifier,
@@ -472,7 +499,7 @@ impl Router {
         let available: Vec<&ProviderProfile> = self
             .profiles
             .iter()
-            .filter(|p| self.breaker.is_available(&p.id))
+            .filter(|p| breaker.is_available(&p.id))
             .collect();
         let Some(&first_healthy) = available.first() else {
             return Err(RouterError::AllProvidersUnavailable {
@@ -482,7 +509,7 @@ impl Router {
 
         // What Worker actually resolves to right now (pin included) — the
         // instance Verifier must never repeat.
-        let worker_decision = self.resolve(Role::Worker)?;
+        let worker_decision = self.resolve_with(breaker, Role::Worker)?;
         let worker_family = self
             .profiles
             .iter()
@@ -507,8 +534,8 @@ impl Router {
         // because its breaker is open (L-M7: fallback events are for
         // breaker-forced substitutions, never for ordinary verifier routing).
         let preferred = &self.profiles[0];
-        let fallback = if !self.breaker.is_available(&preferred.id) && chosen.id != preferred.id {
-            Some(self.fallback_from(preferred, chosen))
+        let fallback = if !breaker.is_available(&preferred.id) && chosen.id != preferred.id {
+            Some(fallback_from(breaker, preferred, chosen))
         } else {
             None
         };
@@ -528,17 +555,37 @@ impl Router {
             caveat,
         })
     }
+}
 
-    fn fallback_from(&self, from: &ProviderProfile, to: &ProviderProfile) -> FallbackInfo {
-        FallbackInfo {
-            from: from.id.clone(),
-            to: to.id.clone(),
-            reason: format!(
-                "circuit breaker open for `{}` after {} consecutive transport failures",
-                from.id,
-                self.breaker.failure_threshold()
-            ),
-        }
+/// The [`FallbackInfo`] for a breaker-forced substitution, built against the
+/// resolution's already-taken breaker guard (see [`Router::resolve_with`]).
+fn fallback_from(
+    breaker: &CircuitBreaker,
+    from: &ProviderProfile,
+    to: &ProviderProfile,
+) -> FallbackInfo {
+    FallbackInfo {
+        from: from.id.clone(),
+        to: to.id.clone(),
+        reason: format!(
+            "circuit breaker open for `{}` after {} consecutive transport failures",
+            from.id,
+            breaker.failure_threshold()
+        ),
+    }
+}
+
+/// The router *is* the engine's outcome sink: feeding the breaker takes the
+/// same shared reference resolution reads through, so every holder of
+/// `&Router` — the pipeline's ports, a served run, the CLI's session loop —
+/// inherits breaker feedback without owning the router (#2673).
+impl ProviderOutcomes for Router {
+    fn record_success(&self, provider_id: &str) {
+        Router::record_success(self, provider_id);
+    }
+
+    fn record_failure(&self, provider_id: &str) {
+        Router::record_failure(self, provider_id);
     }
 }
 
@@ -878,6 +925,28 @@ mod tests {
         // The trial call fails — reopen without needing 3 more failures.
         breaker.record_failure("zai");
         assert_eq!(breaker.status("zai"), BreakerStatus::Open);
+    }
+
+    #[test]
+    fn breaker_feedback_flows_through_a_shared_router_reference() {
+        // The #2673 seam: outcome feedback must need only `&Router`, the
+        // same shared reference the pipeline and any host already hold —
+        // requiring `&mut` is exactly what left the breaker unwired.
+        let router = Router::new(
+            RoleTable::new(),
+            vec![zai_profile(), anthropic_profile()],
+            breaker_with_clock(ManualClock::new(0)),
+        );
+        let shared: &Router = &router;
+        for _ in 0..CircuitBreaker::DEFAULT_FAILURE_THRESHOLD {
+            shared.record_failure("zai");
+        }
+        let decision = shared.resolve(Role::Worker).expect("fallback resolves");
+        assert_eq!(decision.model_ref, model("anthropic", "claude-fable-5"));
+        assert!(decision.fallback.is_some(), "fallback must be reported");
+        shared.record_success("zai");
+        let healed = shared.resolve(Role::Worker).expect("healed resolves");
+        assert_eq!(healed.model_ref, model("zai", "glm-5.2"));
     }
 
     #[test]

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -694,6 +694,10 @@ impl Engine<'_> {
             // `agent_id`, which is what lets a consumer tell parent work from
             // child work without a second bus.
             bus: self.bus,
+            // A child's model calls are real observed outcomes for the same
+            // provider — the breaker they feed is session state, like the
+            // calibration map above (#2673).
+            outcomes: self.outcomes,
         };
 
         // The child's private transcript. It is a local: nothing outside

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -113,7 +113,7 @@ pub const COMPOSITION_SEAMS: &[&str] = &[
 /// forces this DOWN in the same PR (the win is recorded), and adding a new
 /// unwitnessed claim forces it UP — a visible review decision instead of a
 /// silent one.
-pub const UNWITNESSED_BASELINE: usize = 3;
+pub const UNWITNESSED_BASELINE: usize = 4;
 
 /// The matrix. Ordered by area; ids are stable and unique.
 pub static CAPABILITIES: &[Capability] = &[
@@ -539,6 +539,34 @@ pub static CAPABILITIES: &[Capability] = &[
                         (#1165), tool_request frames on \
                         POST /v1/turns/{id}/tool-result — the host owns keys and execution",
             witness: "an_unanswered_provider_request_fails_on_the_deadline",
+        },
+    },
+    Capability {
+        id: "provider.breaker_feedback",
+        engine_home: "stella-core router CircuitBreaker + the ProviderOutcomes port: every \
+                      logical model call's terminal verdict feeds the breaker, so `resolve` \
+                      fails over from observed outcomes, not configuration (#2673)",
+        engine_entries: &["with_provider_outcomes"],
+        cli: SurfacePosture::ShippedUnwitnessed {
+            mechanism: "the pipeline paths feed the router in PipelinePorts (attach() wires \
+                        every engine; raw_usage records management calls) — witnessed in \
+                        stella-pipeline by `pipeline_call_outcomes_reach_the_router_breaker`, \
+                        which this sweep cannot see — and the bare loops feed a session-scoped \
+                        `session_router` (run_interactive/run_raw_one_shot via run_turn, the \
+                        goal loop's round verifier)",
+            missing: "a CLI-side test pinning that `run_turn`'s engines actually attach the \
+                      session router (the stella-pipeline and stella-core witnesses prove the \
+                      layers below; the run_turn attachment itself has no witness because the \
+                      engine assembly is inline in a function that drives a full turn)",
+        },
+        api: SurfacePosture::NotApplicable {
+            reason: "a served run remotes every model call to the host, which owns keys and \
+                     real provider selection — Stella-side failover between BYOK providers \
+                     has nothing to fail over TO (the served router carries one profile per \
+                     role). The pipeline still feeds that breaker, so a host failing the \
+                     threshold of consecutive calls surfaces as AllProvidersUnavailable until \
+                     the cooldown's half-open trial (see stella-serve pipeline_run's WallClock \
+                     doc), but cross-provider failover is the host's concern by design",
         },
     },
     Capability {

--- a/crates/stella-pipeline/README.md
+++ b/crates/stella-pipeline/README.md
@@ -247,11 +247,13 @@ ran. Execution aborts (budget, loop, step-cap) keep their stop — the worker di
 - **A review waived by triage scores `Unverified`, not `DeterministicPass`** — claiming the
   strongest score would let a waived candidate tie a flip-verified sibling in best-of-N and
   then win the smaller-diff tiebreak.
-- **The pipeline holds `&Router`, so it reads resolutions but never feeds the breaker.**
-  `record_success`/`record_failure` need `&mut Router`; that feedback belongs to the glue
-  that owns the router. A headless run crossing the scope thresholds with no bypass is
-  likewise a named error (`PipelineError::ScopeReviewRequiredHeadless`), never a silent
-  auto-approve.
+- **The pipeline holds `&Router` and feeds its breaker through it (#2673).**
+  `record_success`/`record_failure` take `&self`, and both halves of the loop run here:
+  every engine the pipeline builds reports call outcomes via `attach`, and the management
+  chokepoint (`raw_usage`) records each raw call's verdict, so consecutive observed
+  failures actually trip failover at the next resolution. A headless run crossing the
+  scope thresholds with no bypass is a named error
+  (`PipelineError::ScopeReviewRequiredHeadless`), never a silent auto-approve.
 - **`docs/*.md` paths cited from rustdoc here are gated.** `make doc-citations` fails if a
   cited path — or a cited `§N` — does not resolve; `src/replay.rs` and
   `src/replay/golden.rs` both cite `docs/spec/replay-golden-trajectories.md`.

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -32,13 +32,13 @@
 //! prefix**, never mutated into the system block itself, so prompt-cache hits
 //! on the stable prefix survive across turns. See `assemble_user_message`.
 //!
-//! # Breaker feedback boundary
+//! # Breaker feedback
 //!
-//! The pipeline holds `&Router` (per its constructor contract) and so *reads*
-//! resolutions and surfaces `ProviderFallback` events, but does not feed
-//! call outcomes back into the breaker (`record_success`/`record_failure`
-//! need `&mut Router`). That feedback is the responsibility of the glue that
-//! owns the `Router` — documented here so the boundary is explicit.
+//! The pipeline holds `&Router` and both halves flow through it (#2673): it
+//! reads resolutions (surfacing `ProviderFallback` events) and feeds every
+//! observed call outcome back — each engine it builds reports via `attach`'s
+//! `with_provider_outcomes`, and `raw_usage` records each management call's
+//! verdict — so a provider failing consecutive calls is routed around.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;

--- a/crates/stella-pipeline/src/pipeline/attachments.rs
+++ b/crates/stella-pipeline/src/pipeline/attachments.rs
@@ -69,6 +69,10 @@ impl<'a> Pipeline<'a> {
         if let Some(calibration) = self.calibration {
             engine = engine.with_calibration(calibration);
         }
-        engine
+        // Breaker feedback (#2673): every engine turn the pipeline runs
+        // reports its call outcomes into the router it resolved from, so a
+        // provider observed failing here is one the NEXT resolution — a
+        // revise round, the witness author, the verifier — routes around.
+        engine.with_provider_outcomes(self.router)
     }
 }

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -364,10 +364,22 @@ impl<'a> Pipeline<'a> {
                 // duration rather than the work's, talking the estimate down
                 // exactly when a run is in trouble.
                 self.role_pace.observe(meta.role, dispatched_at.elapsed());
+                // Breaker feedback (#2673): the provider served the call, so
+                // the router's next resolution may trust it again.
+                self.router.record_success(meta.provider.id());
                 Ok(result)
             }
-            Err(AccountedCallError::Provider(_)) => Err(RawCallError::Provider),
-            Err(AccountedCallError::Timeout) => Err(RawCallError::Timeout),
+            // The two transport-class verdicts the breaker counts. Deadline
+            // is deliberately neither: nothing was dispatched (#2238), so it
+            // is a fact about the run's clock, not about the provider.
+            Err(AccountedCallError::Provider(_)) => {
+                self.router.record_failure(meta.provider.id());
+                Err(RawCallError::Provider)
+            }
+            Err(AccountedCallError::Timeout) => {
+                self.router.record_failure(meta.provider.id());
+                Err(RawCallError::Timeout)
+            }
             // Nothing was dispatched, so `total` is untouched — the run's
             // settled cost stays exactly what it was before this call.
             Err(AccountedCallError::Deadline { overrun }) => {
@@ -375,6 +387,10 @@ impl<'a> Pipeline<'a> {
             }
             Err(AccountedCallError::Budget { result, outcome }) => {
                 *total += result.cost_usd;
+                // The completion COMMITTED and was paid for — a healthy
+                // provider whose spend tripped OUR budget is a success from
+                // the breaker's point of view.
+                self.router.record_success(meta.provider.id());
                 Err(RawCallError::Budget(
                     budget_abort(outcome).expect("budget error carries abort outcome"),
                 ))

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -252,9 +252,11 @@ impl<'a> Pipeline<'a> {
         if let Some((hooks, runner)) = self.hooks {
             engine = engine.with_hooks(hooks, runner);
         }
-        if let Some(gate) = self.turn_gate {
-            engine = engine.with_gate(gate);
-        }
+        // `attach` rather than a hand-rolled gate line: this site predated it
+        // and was quietly missing the calibration (and now breaker-feedback)
+        // attachments every other pipeline engine gets — exactly the drift
+        // `attach`'s doc says it exists to prevent.
+        engine = self.attach(engine);
         // No steering view: a resume is headless by construction (the
         // interactive session it might have belonged to died with the
         // process), matching the goal and fleet pipelines.

--- a/crates/stella-pipeline/src/pipeline/tests/chaos.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/chaos.rs
@@ -203,9 +203,11 @@ impl ProviderResolver for OneChaosProvider<'_> {
 
 /// Run one scenario over WORKING session ports (so execution can actually
 /// happen when it should) and a scenario-shaped candidate port. Returns
-/// everything the invariant checker needs.
+/// everything the invariant checker needs. The router is caller-supplied so
+/// a test can inspect its breaker state after the run (#2673).
 async fn run_scenario(
     scenario: &Scenario,
+    router: &Router,
 ) -> (
     Result<PipelineOutcome, PipelineRunError>,
     Vec<AgentEvent>,
@@ -221,7 +223,6 @@ async fn run_scenario(
     let repo = NoRepoStructure;
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
-    let router = scenario.router();
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
 
     // Build the candidate port lazily so `Absent` wires none at all.
@@ -260,7 +261,7 @@ async fn run_scenario(
     let (tx, mut rx) = mpsc::unbounded_channel();
     let pipeline = Pipeline::new(
         PipelinePorts {
-            router: &router,
+            router,
             providers: &resolver,
             tools: &tools,
             recall: &recall,
@@ -441,9 +442,58 @@ async fn the_loop_never_chooses_nothing_across_the_config_environment_matrix() {
         scenarios.len()
     );
     for scenario in &scenarios {
-        let (outcome, events, base_len, final_len) = run_scenario(scenario).await;
+        let router = scenario.router();
+        let (outcome, events, base_len, final_len) = run_scenario(scenario, &router).await;
         // Reaching here at all proves the run neither panicked nor hung
         // (NoopSleeper + the step cap make a hang impossible).
         assert_loop_invariant(scenario, &outcome, &events, base_len, final_len);
+    }
+}
+
+/// The #2673 witness for the pipeline path: a run's observed call outcomes
+/// reach the breaker of the router it resolved from — on both the management
+/// chokepoint (triage, a raw call through `raw_usage`) and the engine turn
+/// (the worker, attached via `attach`). A threshold-1 breaker makes one
+/// terminal failure decisive: after the run, the sole provider's breaker is
+/// open and `resolve` refuses it, where before this wiring the breaker never
+/// heard about any outcome and kept resolving forever.
+#[tokio::test]
+async fn pipeline_call_outcomes_reach_the_router_breaker() {
+    for provider in [ProviderShape::TriageErrors, ProviderShape::WorkerErrors] {
+        let scenario = Scenario {
+            provider,
+            port: PortShape::Absent,
+            class: "single",
+            single_model: true,
+            authors_witness: false,
+            tiny_budget: false,
+            headless_bypass: true,
+        };
+        let only = ModelRef::new("chaos", "only");
+        let router = Router::new(
+            RoleTable::new(),
+            vec![ProviderProfile::new(
+                "chaos",
+                only.clone(),
+                only.clone(),
+                only,
+            )],
+            CircuitBreaker::with_thresholds(Box::new(ZeroClock), 1, 60_000),
+        );
+        assert!(
+            router.resolve(Role::Worker).is_ok(),
+            "[{}] the provider must start healthy",
+            scenario.label()
+        );
+
+        let (outcome, ..) = run_scenario(&scenario, &router).await;
+        drop(outcome);
+
+        assert!(
+            router.resolve(Role::Worker).is_err(),
+            "[{}] a terminal call failure must reach the breaker: the next \
+             resolve has to refuse the provider the run watched fail",
+            scenario.label()
+        );
     }
 }

--- a/crates/stella-serve/src/pipeline_run.rs
+++ b/crates/stella-serve/src/pipeline_run.rs
@@ -143,10 +143,12 @@ pub struct PipelineRun {
 }
 
 /// A time source for the single-profile [`CircuitBreaker`] a served pipeline
-/// run constructs. The breaker only matters when a role fails over between
-/// multiple profiles; a served run has exactly one, so nothing here ever
-/// trips it — but `CircuitBreaker::new` still wants a real clock rather than
-/// a stub that could misreport `now_ms`.
+/// run constructs. Since #2673 the pipeline feeds real call outcomes into
+/// this breaker, so a host whose remoted provider fails the threshold of
+/// consecutive calls trips it — with one profile there is nothing to fail
+/// over TO, so resolution then reports `AllProvidersUnavailable` until the
+/// cooldown's half-open trial, which is why the clock must be real rather
+/// than a stub that could misreport `now_ms`.
 struct WallClock;
 
 impl stella_core::ports::Clock for WallClock {


### PR DESCRIPTION
## What

`Router::record_success`/`record_failure` had no production caller (#2673): the per-provider `CircuitBreaker` was dead configuration, and a provider could fail every call for hours while `resolve` kept routing to it. This PR closes the loop so failover is driven by observed call outcomes on **both** the pipeline path and the bare-loop path.

## Design: interior mutability + a call-site port (option b), not a bus subscriber (option a)

The issue offered two designs. This ships **(b)**, for reasons a reviewer can check:

- **The bus is structurally the wrong channel.** The `HookBus` is *observer-only by construction* (`driver.rs`'s `bus` field doc: names off the blocking allowlist, "an extension can watch a step begin, it cannot veto one"), it is attached on **no CLI turn today** (`emit_lifecycle`'s doc: "a bus-less engine — every CLI turn today"), and its `model.request.failed` payload carries no provider id. Routing a control-plane feedback loop through an optional observability plane would make failover contingent on a telemetry switch.
- **Interior mutability keeps the decision logic pure and shares it for free.** `CircuitBreaker` is unchanged — still a plain `&mut self` synchronous state machine over owned data (invariant 2). `Router` wraps it in a `std::sync::Mutex` as a sharing shell (never held across an await; the verifier's recursive Worker resolution reuses one guard via `resolve_with`, so there is no reentrant-lock hazard). `record_*` now take `&self`, so every existing `&Router` holder — the pipeline's ports, `stella-serve`'s `pipeline_run`, the CLI session — inherits feedback with **zero re-wiring**. This is the requirement the issue's note states: breaker state stays queryable at resolution time, which is exactly the seam #2679's mid-turn fallback will read.
- **Exemplar:** `tower`'s load/balance middlewares (`tower::load`, `tower::balance`) — the component that made the routing decision observes the outcome of the call it routed, recording into shared state at the call site, rather than reconstructing outcomes from an out-of-band event stream. The engine-side seam is a port (`stella_core::ports::ProviderOutcomes`, implemented by `Router`), matching invariant 1: the engine reports through a trait, never a concretion.

The engine reports each **logical** model call's terminal verdict at the step boundary (retries collapsed — the same grain as the lifecycle events): a call that commits is one success; retries exhausted or an unretryable transport error is one failure.

## Wiring

**Pipeline** (default `stella run`, deck pipeline turns, fleet pipeline workers, goal rounds, `stella-serve`):
- `attachments.rs::attach` — every pipeline-built engine gets `.with_provider_outcomes(self.router)`.
- `raw_usage.rs::dispatch_raw` — management calls (triage/plan/verdict/witness-author) record their verdicts. `Deadline` deliberately records **nothing** (nothing was dispatched — a fact about the run's clock, not the provider); `Budget` records **success** (the completion committed and was paid for).
- `resume_stage.rs` now goes through `attach()` instead of a hand-rolled gate line — it had silently missed `with_calibration` too, the exact drift `attach`'s doc says it exists to prevent.

**Bare loop**:
- `run_interactive` holds a session-scoped router (`session_router`, new in `agent/engine.rs`), fed by every `run_turn` engine — so breaker state persists across REPL turns.
- `run_raw_one_shot` feeds the same shape; the goal loop's round verifier feeds the very router its pipeline rounds resolve against.
- `stella-core`'s subagent child engine inherits the parent's sink, so child calls count too.

**Parity matrix**: new row `provider.breaker_feedback`. CLI is `ShippedUnwitnessed` (`UNWITNESSED_BASELINE` 3 → 4 — the ratchet's visible-review-decision path; the missing piece is a CLI test pinning `run_turn`'s attachment, tracked in #2733). API is `NotApplicable` with the design reason: serve remotes every model call to the host, which owns provider selection — there is nothing Stella-side to fail over *to*.

## Witness tests (fail on main — verified by stashing the production halves and re-running)

- `stella-core` `driver::tests::provider_outcomes::a_provider_failing_the_threshold_of_calls_is_skipped_by_the_next_resolve` — three real turns through a failing provider, then `resolve(Worker)` returns the standby **with a reported fallback**. Plus `one_failed_call_does_not_trip_failover` and `a_committed_call_closes_the_breaker_again`. **On main this file does not compile** (`with_provider_outcomes` does not exist — the seam is genuinely absent): `error[E0599]: no method named 'with_provider_outcomes'`.
- `stella-pipeline` `chaos::pipeline_call_outcomes_reach_the_router_breaker` — a threshold-1 router through the existing chaos harness, for both a failing triage (raw-call path) and a failing worker (engine path). **Compiles on main and FAILS at its assertion** ("a terminal call failure must reach the breaker") — the behavioral flip, observed directly.
- `stella-core` `router::tests::breaker_feedback_flows_through_a_shared_router_reference` — feedback through `&Router` (does not compile on main: `record_failure` required `&mut`).

## Checks run

`cargo test -p stella-core -p stella-pipeline -p stella-cli -p stella-parity -p stella-serve -p stella-engine` (all green), `cargo clippy -p <same> --all-targets -- -D warnings`, `cargo fmt --all -- --check`, rustdoc `-D warnings` on touched crates, and the `file-size` / `god-files` / `invariants` / `typed-errors` / `left-behind` guards. `driver.rs`, `agent.rs`, and `driver/tests.rs` are god files at their exact ceilings: the new lines are compensated by compressing doc comments **in the same files**, meaning preserved (no baseline change).

## Stated out loud (per CLAUDE.md)

- `UNWITNESSED_BASELINE` went **up** by one — a declared debt, not a quiet one; #2733 is the handoff for writing the witness that brings it back down.
- The remaining engine-direct sites that still feed no breaker (deck direct turn, fleet raw fallback, subsession/subagent/resume drivers, the goal raw loop) and the overflow summarizer's unrecorded call are filed as #2733 with file paths and constraints.

Closes #2673
Refs #2679, #2733

## Summary by Sourcery

Wire provider call-outcome feedback into the router circuit breaker so provider failover is driven by observed call results across pipeline and bare-loop paths.

New Features:
- Introduce a ProviderOutcomes port implemented by Router so engines can report per-provider call successes and failures without owning the router.
- Add a session-scoped router for bare (non-pipeline) CLI loops to accumulate breaker state across turns, ahead of mid-turn fallback.

Bug Fixes:
- Enable router circuit-breaker driven provider failover by feeding it real call outcomes from both pipeline management calls and engine turns, fixing previously dead breaker configuration.
- Ensure resumed pipeline stages reuse the standard engine attachment path so calibration and breaker feedback are consistently wired.

Enhancements:
- Make Router’s circuit breaker interiorly mutable behind a Mutex so outcome recording works through shared router references.
- Document the new breaker-feedback capability in the parity matrix and update pipeline docs to reflect that the pipeline now feeds router breaker state.
- Propagate parent engine outcome sinks to subagents so child model calls also contribute to breaker state.
- Clarify and tighten various inline docs around engine behavior, reflection, budgets, and served pipeline breaker behavior.

Tests:
- Add stella-core driver tests verifying that model-call outcomes reported through Engine::with_provider_outcomes trip and heal the router’s circuit breaker as expected.
- Add router tests confirming breaker feedback works through a shared &Router reference and that failover is reported as an explicit fallback.
- Extend stella-pipeline chaos tests to assert that pipeline management and worker calls update the router breaker, causing subsequent resolves to refuse failing providers.